### PR TITLE
fix(typescript): resolve declaration file generation for rollup packages

### DIFF
--- a/packages/core/icons/tsconfig.build.json
+++ b/packages/core/icons/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declarationDir": "dist",
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": false,
+    "incremental": false
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/html/html-icons/tsconfig.build.json
+++ b/packages/html/html-icons/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declarationDir": "dist",
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": false,
+    "incremental": false
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/html/html/tsconfig.build.json
+++ b/packages/html/html/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declarationDir": "dist",
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": false,
+    "incremental": false
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/react/react-icons/tsconfig.build.json
+++ b/packages/react/react-icons/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declarationDir": "dist",
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": false,
+    "incremental": false
   },
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/react/react/tsconfig.build.json
+++ b/packages/react/react/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declarationDir": "dist",
     "emitDeclarationOnly": true,
     "outDir": "dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": false,
+    "incremental": false
   },
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
- Override composite project settings in tsconfig.build.json files
- Add "composite": false and "incremental": false to enable declaration emit
- Fix VS Code TypeScript errors for imports from @vjs-10/* packages
- Ensure proper .d.ts generation for all rollup-migrated packages

Resolves TypeScript import resolution issues like: Module '"@vjs-10/react-icons"' has no exported member 'VolumeOffIcon'

🤖 Generated with [Claude Code](https://claude.ai/code)