### PR TITLE
feat(examples): configure separate default ports for React and HTML demos

### DIFF
--- a/examples/html-demo/vite.config.mts
+++ b/examples/html-demo/vite.config.mts
@@ -5,4 +5,8 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   root: __dirname,
+  server: {
+    port: 5174,
+    strictPort: false, // Allow Vite to try other ports if 5174 is taken
+  },
 });

--- a/examples/react-demo/vite.config.mts
+++ b/examples/react-demo/vite.config.mts
@@ -3,4 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: false, // Allow Vite to try other ports if 5173 is taken
+  },
 });


### PR DESCRIPTION
- Set React demo to use port 5173 (Vite's default)
- Set HTML demo to use port 5174 to avoid conflicts
- Enable strictPort: false to allow automatic fallback to next available port
- Allow simultaneous development of both React and HTML demos
- Maintain existing development workflow while preventing port conflicts

This enables developers to run `npm run dev:react` and `npm run dev:html` concurrently without manual port management.

🤖 Generated with [Claude Code](https://claude.ai/code)