### PR TITLE
chore: resolve alias during build

### DIFF
--- a/packages/core/core/tsdown.config.ts
+++ b/packages/core/core/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/core/icons/tsdown.config.ts
+++ b/packages/core/icons/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/core/media-store/tsdown.config.ts
+++ b/packages/core/media-store/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/core/media/tsdown.config.ts
+++ b/packages/core/media/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/core/playback-engine/tsdown.config.ts
+++ b/packages/core/playback-engine/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/html/html-icons/tsdown.config.ts
+++ b/packages/html/html-icons/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/html/html-media-elements/tsdown.config.ts
+++ b/packages/html/html-media-elements/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/html/html-media-store/tsdown.config.ts
+++ b/packages/html/html-media-store/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/html/html/tsdown.config.ts
+++ b/packages/html/html/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/react/react-icons/tsdown.config.ts
+++ b/packages/react/react-icons/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/react/react-media-elements/tsdown.config.ts
+++ b/packages/react/react-media-elements/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/react/react-media-store/tsdown.config.ts
+++ b/packages/react/react-media-store/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },

--- a/packages/react/react/tsdown.config.ts
+++ b/packages/react/react/tsdown.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
@@ -6,6 +7,9 @@ export default defineConfig({
   format: 'es',
   sourcemap: true,
   clean: true,
+  alias: {
+    '@': path.resolve(__dirname, 'src'),
+  },
   dts: {
     oxc: true,
   },


### PR DESCRIPTION
Adds `alias` field to `tsdown.config` files to ensure `@` alias is resolved correctly so builds don't fail.