### PR TITLE
fix: visually hidden focus guards

### DIFF
--- a/packages/html/src/components/media-popover.ts
+++ b/packages/html/src/components/media-popover.ts
@@ -385,7 +385,7 @@ function createFocusGuard(dataType: 'inside' | 'outside'): HTMLElement {
   focusGuard.setAttribute('data-type', dataType);
   focusGuard.setAttribute('tabindex', '0');
   focusGuard.toggleAttribute('data-focus-guard', true);
-  focusGuard.style = visuallyHiddenStyles;
+  focusGuard.style.cssText = visuallyHiddenStyles;
   return focusGuard;
 }
 


### PR DESCRIPTION
This pull request introduces an accessibility improvement for the focus guards in the media popover component. The key update ensures that the focus guard elements are visually hidden but remain accessible to assistive technologies.

Accessibility enhancement:

* Added a `visuallyHiddenStyles` constant and applied these styles to focus guard elements in `media-popover.ts` to make them visually hidden while still accessible for keyboard navigation.