### PR TITLE
feat: update html tooltip API / use command attr

### DIFF
--- a/examples/html-eject-frosted/index.html
+++ b/examples/html-eject-frosted/index.html
@@ -51,50 +51,50 @@
           <div class="overlay"></div>
 
           <div class="control-bar surface">
-            <media-tooltip delay="500" close-delay="0">
-              <media-tooltip-trigger>
-                <media-play-button class="button">
-                  <media-play-icon class="icon play-icon"></media-play-icon>
-                  <media-pause-icon class="icon pause-icon"></media-pause-icon>
-                </media-play-button>
-              </media-tooltip-trigger>
-              <media-tooltip-portal>
-                <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-                  <media-tooltip-popup class="surface popup-animation">
-                    <span class="tooltip play-tooltip">Play</span>
-                    <span class="tooltip pause-tooltip">Pause</span>
-                  </media-tooltip-popup>
-                </media-tooltip-positioner>
-              </media-tooltip-portal>
+            <media-play-button commandfor="play-tooltip" class="button">
+              <media-play-icon class="icon play-icon"></media-play-icon>
+              <media-pause-icon class="icon pause-icon"></media-pause-icon>
+            </media-play-button>
+            <media-tooltip
+              id="play-tooltip"
+              class="surface popup-animation"
+              popover="manual"
+              delay="500"
+              side="top"
+              side-offset="12"
+              collision-padding="12"
+            >
+              <span class="tooltip play-tooltip">Play</span>
+              <span class="tooltip pause-tooltip">Pause</span>
             </media-tooltip>
 
             <div class="time-controls">
               <!-- Use the show-remaining attribute to show count down/remaining time -->
               <media-current-time-display></media-current-time-display>
 
-              <media-tooltip track-cursor-axis="x">
-                <media-tooltip-trigger>
-                  <media-time-slider class="slider">
-                    <media-time-slider-track class="slider-track">
-                      <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
-                      <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
-                    </media-time-slider-track>
-                    <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
-                  </media-time-slider>
-                </media-tooltip-trigger>
-                <media-tooltip-portal>
-                  <media-tooltip-positioner side="top" side-offset="18" collision-padding="12">
-                    <media-tooltip-popup class="surface popup-animation">
-                      <media-preview-time-display></media-preview-time-display>
-                    </media-tooltip-popup>
-                  </media-tooltip-positioner>
-                </media-tooltip-portal>
+              <media-time-slider commandfor="time-slider-tooltip" class="slider">
+                <media-time-slider-track class="slider-track">
+                  <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
+                  <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
+                </media-time-slider-track>
+                <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
+              </media-time-slider>
+              <media-tooltip
+                id="time-slider-tooltip"
+                class="surface popup-animation"
+                popover="manual"
+                track-cursor-axis="x"
+                side="top"
+                side-offset="18"
+                collision-padding="12"
+              >
+                <media-preview-time-display></media-preview-time-display>
               </media-tooltip>
 
               <media-duration-display></media-duration-display>
             </div>
 
-            <media-mute-button popovertarget="volume-slider-popover" class="button">
+            <media-mute-button commandfor="volume-slider-popover" command="toggle-popover" class="button">
               <media-volume-high-icon class="icon volume-high-icon"></media-volume-high-icon>
               <media-volume-low-icon class="icon volume-low-icon"></media-volume-low-icon>
               <media-volume-off-icon class="icon volume-off-icon"></media-volume-off-icon>
@@ -102,7 +102,7 @@
             <media-popover
               id="volume-slider-popover"
               class="surface popup-animation"
-              popover
+              popover="manual"
               open-on-hover
               delay="200"
               close-delay="100"
@@ -112,27 +112,27 @@
             >
               <media-volume-slider class="slider" orientation="vertical">
                 <media-volume-slider-track class="slider-track">
-                  <media-volume-slider-progress class="slider-progress"></media-volume-slider-progress>
+                  <media-volume-slider-indicator class="slider-progress"></media-volume-slider-indicator>
                 </media-volume-slider-track>
                 <media-volume-slider-thumb class="slider-thumb"></media-volume-slider-thumb>
               </media-volume-slider>
             </media-popover>
 
-            <media-tooltip delay="500" close-delay="0">
-              <media-tooltip-trigger>
-                <media-fullscreen-button class="button">
-                  <media-fullscreen-enter-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-icon>
-                  <media-fullscreen-exit-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
-                </media-fullscreen-button>
-              </media-tooltip-trigger>
-              <media-tooltip-portal>
-                <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-                  <media-tooltip-popup class="surface popup-animation">
-                    <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                    <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-                  </media-tooltip-popup>
-                </media-tooltip-positioner>
-              </media-tooltip-portal>
+            <media-fullscreen-button commandfor="fullscreen-tooltip" class="button">
+              <media-fullscreen-enter-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-icon>
+              <media-fullscreen-exit-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
+            </media-fullscreen-button>
+            <media-tooltip
+              id="fullscreen-tooltip"
+              class="surface popup-animation"
+              popover="manual"
+              delay="500"
+              side="top"
+              side-offset="12"
+              collision-padding="12"
+            >
+              <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+              <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
             </media-tooltip>
           </div>
         </media-container>

--- a/examples/html-eject-frosted/src/frosted.css
+++ b/examples/html-eject-frosted/src/frosted.css
@@ -337,7 +337,11 @@ media-popover {
 }
 
 /* Tooltip Component Styles */
-media-tooltip-popup {
+media-tooltip {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
   color: oklab(1 0 0);
   padding: 0.25rem 0.625rem;
   border-radius: calc(infinity * 1px);
@@ -349,12 +353,12 @@ media-tooltip-popup {
   white-space: nowrap;
 }
 
-media-tooltip-popup[data-paused] .play-tooltip,
-media-tooltip-popup:not([data-paused]) .pause-tooltip {
+[data-paused] + media-tooltip .play-tooltip,
+:not([data-paused]) + media-tooltip .pause-tooltip {
   display: block;
 }
 
-media-tooltip-popup[data-fullscreen] .fullscreen-exit-tooltip,
-media-tooltip-popup:not([data-fullscreen]) .fullscreen-enter-tooltip {
+[data-fullscreen] + media-tooltip .fullscreen-exit-tooltip,
+:not([data-fullscreen]) + media-tooltip .fullscreen-enter-tooltip {
   display: block;
 }

--- a/examples/html-eject-minimal/index.html
+++ b/examples/html-eject-minimal/index.html
@@ -52,21 +52,22 @@
 
           <div class="control-bar">
             <!-- NOTE: We can decide if we further want to provide a further, "themed" media-play-button that comes with baked in default styles and icons. (CJP) -->
-            <media-tooltip delay="500" close-delay="0">
-              <media-tooltip-trigger>
-                <media-play-button class="button">
-                  <media-play-icon class="icon play-icon"></media-play-icon>
-                  <media-pause-icon class="icon pause-icon"></media-pause-icon>
-                </media-play-button>
-              </media-tooltip-trigger>
-              <media-tooltip-portal>
-                <media-tooltip-positioner side="top" side-offset="6" collision-padding="12">
-                  <media-tooltip-popup class="popup-animation">
-                    <span class="tooltip play-tooltip">Play</span>
-                    <span class="tooltip pause-tooltip">Pause</span>
-                  </media-tooltip-popup>
-                </media-tooltip-positioner>
-              </media-tooltip-portal>
+
+            <media-play-button commandfor="play-tooltip" class="button">
+              <media-play-icon class="icon play-icon"></media-play-icon>
+              <media-pause-icon class="icon pause-icon"></media-pause-icon>
+            </media-play-button>
+            <media-tooltip
+              id="play-tooltip"
+              class="popup-animation"
+              popover="manual"
+              delay="500"
+              side="top"
+              side-offset="6"
+              collision-padding="12"
+            >
+              <span class="tooltip play-tooltip">Play</span>
+              <span class="tooltip pause-tooltip">Pause</span>
             </media-tooltip>
 
             <div class="time-display-group">
@@ -79,27 +80,27 @@
               </span>
             </div>
 
-            <media-tooltip track-cursor-axis="x">
-              <media-tooltip-trigger>
-                <media-time-slider class="slider">
-                  <media-time-slider-track class="slider-track">
-                    <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
-                    <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
-                  </media-time-slider-track>
-                  <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
-                </media-time-slider>
-              </media-tooltip-trigger>
-              <media-tooltip-portal>
-                <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-                  <media-tooltip-popup class="popup-animation">
-                    <media-preview-time-display></media-preview-time-display>
-                  </media-tooltip-popup>
-                </media-tooltip-positioner>
-              </media-tooltip-portal>
+            <media-time-slider commandfor="time-slider-tooltip" class="slider">
+              <media-time-slider-track class="slider-track">
+                <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
+                <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
+              </media-time-slider-track>
+              <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
+            </media-time-slider>
+            <media-tooltip
+              id="time-slider-tooltip"
+              class="popup-animation"
+              popover="manual"
+              track-cursor-axis="x"
+              side="top"
+              side-offset="12"
+              collision-padding="12"
+            >
+              <media-preview-time-display></media-preview-time-display>
             </media-tooltip>
 
             <div class="button-group">
-              <media-mute-button popovertarget="volume-slider-popover" class="button">
+              <media-mute-button commandfor="volume-slider-popover" command="toggle-popover" class="button">
                 <media-volume-high-icon class="icon volume-high-icon"></media-volume-high-icon>
                 <media-volume-low-icon class="icon volume-low-icon"></media-volume-low-icon>
                 <media-volume-off-icon class="icon volume-off-icon"></media-volume-off-icon>
@@ -107,7 +108,7 @@
               <media-popover
                 id="volume-slider-popover"
                 class="popup-animation"
-                popover
+                popover="manual"
                 open-on-hover
                 delay="200"
                 close-delay="100"
@@ -117,29 +118,27 @@
               >
                 <media-volume-slider class="slider" orientation="vertical">
                   <media-volume-slider-track class="slider-track">
-                    <media-volume-slider-progress class="slider-progress"></media-volume-slider-progress>
+                    <media-volume-slider-indicator class="slider-progress"></media-volume-slider-indicator>
                   </media-volume-slider-track>
                   <media-volume-slider-thumb class="slider-thumb"></media-volume-slider-thumb>
                 </media-volume-slider>
               </media-popover>
 
-              <media-tooltip delay="500" close-delay="0">
-                <media-tooltip-trigger>
-                  <media-fullscreen-button class="button">
-                    <media-fullscreen-enter-alt-icon
-                      class="icon fullscreen-enter-icon"
-                    ></media-fullscreen-enter-alt-icon>
-                    <media-fullscreen-exit-alt-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-alt-icon>
-                  </media-fullscreen-button>
-                </media-tooltip-trigger>
-                <media-tooltip-portal>
-                  <media-tooltip-positioner side="top" side-offset="6" collision-padding="12">
-                    <media-tooltip-popup class="popup-animation">
-                      <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                      <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-                    </media-tooltip-popup>
-                  </media-tooltip-positioner>
-                </media-tooltip-portal>
+              <media-fullscreen-button commandfor="fullscreen-tooltip" class="button">
+                <media-fullscreen-enter-alt-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-alt-icon>
+                <media-fullscreen-exit-alt-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-alt-icon>
+              </media-fullscreen-button>
+              <media-tooltip
+                id="fullscreen-tooltip"
+                class="popup-animation"
+                popover="manual"
+                delay="500"
+                side="top"
+                side-offset="6"
+                collision-padding="12"
+              >
+                <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+                <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
               </media-tooltip>
             </div>
           </div>

--- a/examples/html-eject-minimal/src/minimal.css
+++ b/examples/html-eject-minimal/src/minimal.css
@@ -314,7 +314,11 @@ media-popover {
 }
 
 /* Tooltip Component Styles */
-media-tooltip-popup {
+media-tooltip {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
   color: oklab(1 0 0);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
@@ -326,12 +330,12 @@ media-tooltip-popup {
     0 2px 4px -2px oklab(0 0 0 / 0.1);
 }
 @media (prefers-reduced-transparency: reduce) {
-  media-tooltip-popup {
+  media-tooltip {
     background-color: oklab(0 0 0 / 0.7);
   }
 }
 @media (prefers-contrast: more) {
-  media-tooltip-popup {
+  media-tooltip {
     background-color: oklab(0 0 0 / 0.9);
   }
 }
@@ -341,12 +345,12 @@ media-tooltip-popup {
   white-space: nowrap;
 }
 
-media-tooltip-popup[data-paused] .play-tooltip,
-media-tooltip-popup:not([data-paused]) .pause-tooltip {
+[data-paused] + media-tooltip .play-tooltip,
+:not([data-paused]) + media-tooltip .pause-tooltip {
   display: block;
 }
 
-media-tooltip-popup[data-fullscreen] .fullscreen-exit-tooltip,
-media-tooltip-popup:not([data-fullscreen]) .fullscreen-enter-tooltip {
+[data-fullscreen] + media-tooltip .fullscreen-exit-tooltip,
+:not([data-fullscreen]) + media-tooltip .fullscreen-enter-tooltip {
   display: block;
 }

--- a/packages/html/src/define/media-tooltip.ts
+++ b/packages/html/src/define/media-tooltip.ts
@@ -1,10 +1,4 @@
-import { TooltipArrowElement, TooltipPopupElement, TooltipPortalElement, TooltipPositionerElement, TooltipRootElement, TooltipTriggerElement } from '@/elements/tooltip';
+import { TooltipElement } from '@/elements/tooltip';
 import { defineCustomElement } from '@/utils/custom-element';
 
-defineCustomElement('media-tooltip', TooltipRootElement);
-defineCustomElement('media-tooltip-trigger', TooltipTriggerElement);
-defineCustomElement('media-tooltip-portal', TooltipPortalElement);
-defineCustomElement('media-tooltip-positioner', TooltipPositionerElement);
-defineCustomElement('media-tooltip-portal', TooltipPortalElement);
-defineCustomElement('media-tooltip-popup', TooltipPopupElement);
-defineCustomElement('media-tooltip-arrow', TooltipArrowElement);
+defineCustomElement('media-tooltip', TooltipElement);

--- a/packages/html/src/elements/popover.ts
+++ b/packages/html/src/elements/popover.ts
@@ -96,7 +96,7 @@ export class PopoverElement extends HTMLElement {
   }
 
   get #triggerElement(): HTMLElement | null {
-    return getDocumentOrShadowRoot(this)?.querySelector(`[popovertarget="${this.id}"]`) as HTMLElement | null;
+    return getDocumentOrShadowRoot(this)?.querySelector(`[commandfor="${this.id}"]`) as HTMLElement | null;
   }
 
   #setOpen(open: boolean): void {
@@ -128,6 +128,9 @@ export class PopoverElement extends HTMLElement {
       } else {
         this.hidePopover();
       }
+
+      this.#cleanup?.();
+      this.#cleanup = null;
     }
   }
 

--- a/packages/html/src/skins/frosted/index.ts
+++ b/packages/html/src/skins/frosted/index.ts
@@ -27,50 +27,51 @@ export function getTemplateHTML() {
 
       <div class="control-bar surface">
         <!-- NOTE: We can decide if we further want to provide a further, "themed" media-play-button that comes with baked in default styles and icons. (CJP) -->
-        <media-tooltip delay="500" close-delay="0">
-          <media-tooltip-trigger>
-            <media-play-button class="button">
-              <media-play-icon class="icon play-icon"></media-play-icon>
-              <media-pause-icon class="icon pause-icon"></media-pause-icon>
-            </media-play-button>
-          </media-tooltip-trigger>
-          <media-tooltip-portal>
-            <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-              <media-tooltip-popup class="surface popup-animation">
-                <span class="tooltip play-tooltip">Play</span>
-                <span class="tooltip pause-tooltip">Pause</span>
-              </media-tooltip-popup>
-            </media-tooltip-positioner>
-          </media-tooltip-portal>
+
+        <media-play-button commandfor="play-tooltip" class="button">
+          <media-play-icon class="icon play-icon"></media-play-icon>
+          <media-pause-icon class="icon pause-icon"></media-pause-icon>
+        </media-play-button>
+        <media-tooltip
+          id="play-tooltip"
+          class="surface popup-animation"
+          popover="manual"
+          delay="500"
+          side="top"
+          side-offset="12"
+          collision-padding="12"
+        >
+          <span class="tooltip play-tooltip">Play</span>
+          <span class="tooltip pause-tooltip">Pause</span>
         </media-tooltip>
 
         <div class="time-controls">
           <!-- Use the show-remaining attribute to show count down/remaining time -->
           <media-current-time-display></media-current-time-display>
 
-          <media-tooltip track-cursor-axis="x">
-            <media-tooltip-trigger>
-              <media-time-slider class="slider">
-                <media-time-slider-track class="slider-track">
-                  <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
-                  <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
-                </media-time-slider-track>
-                <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
-              </media-time-slider>
-            </media-tooltip-trigger>
-            <media-tooltip-portal>
-              <media-tooltip-positioner side="top" side-offset="18" collision-padding="12">
-                <media-tooltip-popup class="surface popup-animation">
-                  <media-preview-time-display></media-preview-time-display>
-                </media-tooltip-popup>
-              </media-tooltip-positioner>
-            </media-tooltip-portal>
+          <media-time-slider commandfor="time-slider-tooltip" class="slider">
+            <media-time-slider-track class="slider-track">
+              <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
+              <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
+            </media-time-slider-track>
+            <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
+          </media-time-slider>
+          <media-tooltip 
+            id="time-slider-tooltip"
+            class="surface popup-animation"
+            popover="manual"
+            track-cursor-axis="x"
+            side="top"
+            side-offset="18"
+            collision-padding="12"
+          >
+            <media-preview-time-display></media-preview-time-display>
           </media-tooltip>
 
           <media-duration-display></media-duration-display>
         </div>
 
-        <media-mute-button popovertarget="volume-slider-popover" class="button">
+        <media-mute-button commandfor="volume-slider-popover" command="toggle-popover" class="button">
           <media-volume-high-icon class="icon volume-high-icon"></media-volume-high-icon>
           <media-volume-low-icon class="icon volume-low-icon"></media-volume-low-icon>
           <media-volume-off-icon class="icon volume-off-icon"></media-volume-off-icon>
@@ -78,7 +79,7 @@ export function getTemplateHTML() {
         <media-popover 
           id="volume-slider-popover" 
           class="surface popup-animation" 
-          popover
+          popover="manual"
           open-on-hover
           delay="200"
           close-delay="100"
@@ -94,21 +95,21 @@ export function getTemplateHTML() {
           </media-volume-slider>
         </media-popover>
 
-        <media-tooltip delay="500" close-delay="0">
-          <media-tooltip-trigger>
-            <media-fullscreen-button class="button">
-              <media-fullscreen-enter-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-icon>
-              <media-fullscreen-exit-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
-            </media-fullscreen-button>
-          </media-tooltip-trigger>
-          <media-tooltip-portal>
-            <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-              <media-tooltip-popup class="surface popup-animation">
-                <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-              </media-tooltip-popup>
-            </media-tooltip-positioner>
-          </media-tooltip-portal>
+        <media-fullscreen-button commandfor="fullscreen-tooltip" class="button">
+          <media-fullscreen-enter-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-icon>
+          <media-fullscreen-exit-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
+        </media-fullscreen-button>
+        <media-tooltip 
+          id="fullscreen-tooltip"
+          class="surface popup-animation"
+          popover="manual"
+          delay="500"
+          side="top"
+          side-offset="12"
+          collision-padding="12"
+        >
+          <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+          <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
         </media-tooltip>
       </div>
     </media-container>

--- a/packages/html/src/skins/frosted/styles.css
+++ b/packages/html/src/skins/frosted/styles.css
@@ -335,7 +335,11 @@ media-popover {
 }
 
 /* Tooltip Component Styles */
-media-tooltip-popup {
+media-tooltip {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
   color: oklab(1 0 0);
   padding: 0.25rem 0.625rem;
   border-radius: calc(infinity * 1px);
@@ -347,12 +351,12 @@ media-tooltip-popup {
   white-space: nowrap;
 }
 
-media-tooltip-popup[data-paused] .play-tooltip,
-media-tooltip-popup:not([data-paused]) .pause-tooltip {
+[data-paused] + media-tooltip .play-tooltip,
+:not([data-paused]) + media-tooltip .pause-tooltip {
   display: block;
 }
 
-media-tooltip-popup[data-fullscreen] .fullscreen-exit-tooltip,
-media-tooltip-popup:not([data-fullscreen]) .fullscreen-enter-tooltip {
+[data-fullscreen] + media-tooltip .fullscreen-exit-tooltip,
+:not([data-fullscreen]) + media-tooltip .fullscreen-enter-tooltip {
   display: block;
 }

--- a/packages/html/src/skins/minimal/index.ts
+++ b/packages/html/src/skins/minimal/index.ts
@@ -28,21 +28,22 @@ export function getTemplateHTML() {
 
       <div class="control-bar">
         <!-- NOTE: We can decide if we further want to provide a further, "themed" media-play-button that comes with baked in default styles and icons. (CJP) -->
-        <media-tooltip delay="500" close-delay="0">
-          <media-tooltip-trigger>
-            <media-play-button class="button">
-              <media-play-icon class="icon play-icon"></media-play-icon>
-              <media-pause-icon class="icon pause-icon"></media-pause-icon>
-            </media-play-button>
-          </media-tooltip-trigger>
-          <media-tooltip-portal>
-            <media-tooltip-positioner side="top" side-offset="6" collision-padding="12">
-              <media-tooltip-popup class="popup-animation">
-                <span class="tooltip play-tooltip">Play</span>
-                <span class="tooltip pause-tooltip">Pause</span>
-              </media-tooltip-popup>
-            </media-tooltip-positioner>
-          </media-tooltip-portal>
+
+        <media-play-button commandfor="play-tooltip" class="button">
+          <media-play-icon class="icon play-icon"></media-play-icon>
+          <media-pause-icon class="icon pause-icon"></media-pause-icon>
+        </media-play-button>
+        <media-tooltip
+          id="play-tooltip"
+          class="popup-animation"
+          popover="manual"
+          delay="500"
+          side="top"
+          side-offset="6"
+          collision-padding="12"
+        >
+          <span class="tooltip play-tooltip">Play</span>
+          <span class="tooltip pause-tooltip">Pause</span>
         </media-tooltip>
 
         <div class="time-display-group">
@@ -55,27 +56,27 @@ export function getTemplateHTML() {
           </span>
         </div>
 
-        <media-tooltip track-cursor-axis="x">
-          <media-tooltip-trigger>
-            <media-time-slider class="slider">
-              <media-time-slider-track class="slider-track">
-                <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
-                <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
-              </media-time-slider-track>
-              <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
-            </media-time-slider>
-          </media-tooltip-trigger>
-          <media-tooltip-portal>
-            <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-              <media-tooltip-popup class="popup-animation">
-                <media-preview-time-display></media-preview-time-display>
-              </media-tooltip-popup>
-            </media-tooltip-positioner>
-          </media-tooltip-portal>
+        <media-time-slider commandfor="time-slider-tooltip" class="slider">
+          <media-time-slider-track class="slider-track">
+            <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
+            <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
+          </media-time-slider-track>
+          <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
+        </media-time-slider>
+        <media-tooltip 
+          id="time-slider-tooltip"
+          class="popup-animation"
+          popover="manual"
+          track-cursor-axis="x"
+          side="top"
+          side-offset="12"
+          collision-padding="12"
+        >
+          <media-preview-time-display></media-preview-time-display>
         </media-tooltip>
 
         <div class="button-group">
-          <media-mute-button popovertarget="volume-slider-popover" class="button">
+          <media-mute-button commandfor="volume-slider-popover" command="toggle-popover" class="button">
             <media-volume-high-icon class="icon volume-high-icon"></media-volume-high-icon>
             <media-volume-low-icon class="icon volume-low-icon"></media-volume-low-icon>
             <media-volume-off-icon class="icon volume-off-icon"></media-volume-off-icon>
@@ -83,7 +84,7 @@ export function getTemplateHTML() {
           <media-popover 
             id="volume-slider-popover" 
             class="popup-animation"
-            popover
+            popover="manual"
             open-on-hover
             delay="200"
             close-delay="100"
@@ -99,21 +100,21 @@ export function getTemplateHTML() {
             </media-volume-slider>
           </media-popover>
 
-          <media-tooltip delay="500" close-delay="0">
-            <media-tooltip-trigger>
-              <media-fullscreen-button class="button">
-                <media-fullscreen-enter-alt-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-alt-icon>
-                <media-fullscreen-exit-alt-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-alt-icon>
-              </media-fullscreen-button>
-            </media-tooltip-trigger>
-            <media-tooltip-portal>
-              <media-tooltip-positioner side="top" side-offset="6" collision-padding="12">
-                <media-tooltip-popup class="popup-animation">
-                  <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                  <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-                </media-tooltip-popup>
-              </media-tooltip-positioner>
-            </media-tooltip-portal>
+          <media-fullscreen-button commandfor="fullscreen-tooltip" class="button">
+            <media-fullscreen-enter-alt-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-alt-icon>
+            <media-fullscreen-exit-alt-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
+          </media-fullscreen-button>
+          <media-tooltip 
+            id="fullscreen-tooltip" 
+            class="popup-animation"
+            popover="manual"
+            delay="500"
+            side="top"
+            side-offset="6"
+            collision-padding="12"
+          >
+            <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+            <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
           </media-tooltip>
         </div>
       </div>

--- a/packages/html/src/skins/minimal/styles.css
+++ b/packages/html/src/skins/minimal/styles.css
@@ -312,7 +312,11 @@ media-popover {
 }
 
 /* Tooltip Component Styles */
-media-tooltip-popup {
+media-tooltip {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
   color: oklab(1 0 0);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
@@ -324,12 +328,12 @@ media-tooltip-popup {
     0 2px 4px -2px oklab(0 0 0 / 0.1);
 }
 @media (prefers-reduced-transparency: reduce) {
-  media-tooltip-popup {
+  media-tooltip {
     background-color: oklab(0 0 0 / 0.7);
   }
 }
 @media (prefers-contrast: more) {
-  media-tooltip-popup {
+  media-tooltip {
     background-color: oklab(0 0 0 / 0.9);
   }
 }
@@ -339,12 +343,12 @@ media-tooltip-popup {
   white-space: nowrap;
 }
 
-media-tooltip-popup[data-paused] .play-tooltip,
-media-tooltip-popup:not([data-paused]) .pause-tooltip {
+[data-paused] + media-tooltip .play-tooltip,
+:not([data-paused]) + media-tooltip .pause-tooltip {
   display: block;
 }
 
-media-tooltip-popup[data-fullscreen] .fullscreen-exit-tooltip,
-media-tooltip-popup:not([data-fullscreen]) .fullscreen-enter-tooltip {
+[data-fullscreen] + media-tooltip .fullscreen-exit-tooltip,
+:not([data-fullscreen]) + media-tooltip .fullscreen-enter-tooltip {
   display: block;
 }

--- a/site/src/utils/ejectCodeGenerator.ts
+++ b/site/src/utils/ejectCodeGenerator.ts
@@ -983,58 +983,58 @@ export function generateHTMLMarkup(skin: Skin): string {
     <div class="overlay"></div>
 
     <div class="control-bar surface">
-      <media-tooltip delay="500" close-delay="0">
-        <media-tooltip-trigger>
-          <media-play-button class="button">
-            <media-play-icon class="icon play-icon"></media-play-icon>
-            <media-pause-icon class="icon pause-icon"></media-pause-icon>
-          </media-play-button>
-        </media-tooltip-trigger>
-        <media-tooltip-portal>
-          <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-            <media-tooltip-popup class="surface popup-animation">
-              <span class="tooltip play-tooltip">Play</span>
-              <span class="tooltip pause-tooltip">Pause</span>
-            </media-tooltip-popup>
-          </media-tooltip-positioner>
-        </media-tooltip-portal>
+      <media-play-button commandfor="play-tooltip" class="button">
+        <media-play-icon class="icon play-icon"></media-play-icon>
+        <media-pause-icon class="icon pause-icon"></media-pause-icon>
+      </media-play-button>
+      <media-tooltip
+        id="play-tooltip"
+        class="surface popup-animation"
+        popover="manual"
+        delay="500"
+        side="top"
+        side-offset="12"
+        collision-padding="12"
+      >
+        <span class="tooltip play-tooltip">Play</span>
+        <span class="tooltip pause-tooltip">Pause</span>
       </media-tooltip>
 
       <div class="time-controls">
         <!-- Use the show-remaining attribute to show count down/remaining time -->
         <media-current-time-display></media-current-time-display>
 
-        <media-tooltip track-cursor-axis="x">
-          <media-tooltip-trigger>
-            <media-time-slider class="slider">
-              <media-time-slider-track class="slider-track">
-                <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
-                <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
-              </media-time-slider-track>
-              <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
-            </media-time-slider>
-          </media-tooltip-trigger>
-          <media-tooltip-portal>
-            <media-tooltip-positioner side="top" side-offset="18" collision-padding="12">
-              <media-tooltip-popup class="surface popup-animation">
-                <media-preview-time-display></media-preview-time-display>
-              </media-tooltip-popup>
-            </media-tooltip-positioner>
-          </media-tooltip-portal>
+        <media-time-slider commandfor="time-slider-tooltip" class="slider">
+          <media-time-slider-track class="slider-track">
+            <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
+            <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
+          </media-time-slider-track>
+          <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
+        </media-time-slider>
+        <media-tooltip 
+          id="time-slider-tooltip"
+          class="surface popup-animation"
+          popover="manual"
+          track-cursor-axis="x"
+          side="top"
+          side-offset="18"
+          collision-padding="12"
+        >
+          <media-preview-time-display></media-preview-time-display>
         </media-tooltip>
 
         <media-duration-display></media-duration-display>
       </div>
 
-      <media-mute-button popovertarget="volume-slider-popover" class="button">
+      <media-mute-button commandfor="volume-slider-popover" command="toggle-popover" class="button">
         <media-volume-high-icon class="icon volume-high-icon"></media-volume-high-icon>
         <media-volume-low-icon class="icon volume-low-icon"></media-volume-low-icon>
         <media-volume-off-icon class="icon volume-off-icon"></media-volume-off-icon>
       </media-mute-button>
-      <media-popover
-        id="volume-slider-popover"
-        class="surface popup-animation"
-        popover
+      <media-popover 
+        id="volume-slider-popover" 
+        class="surface popup-animation" 
+        popover="manual"
         open-on-hover
         delay="200"
         close-delay="100"
@@ -1044,27 +1044,27 @@ export function generateHTMLMarkup(skin: Skin): string {
       >
         <media-volume-slider class="slider" orientation="vertical">
           <media-volume-slider-track class="slider-track">
-            <media-volume-slider-progress class="slider-progress"></media-volume-slider-progress>
+            <media-volume-slider-indicator class="slider-progress"></media-volume-slider-indicator>
           </media-volume-slider-track>
           <media-volume-slider-thumb class="slider-thumb"></media-volume-slider-thumb>
         </media-volume-slider>
       </media-popover>
 
-      <media-tooltip delay="500" close-delay="0">
-        <media-tooltip-trigger>
-          <media-fullscreen-button class="button">
-            <media-fullscreen-enter-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-icon>
-            <media-fullscreen-exit-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
-          </media-fullscreen-button>
-        </media-tooltip-trigger>
-        <media-tooltip-portal>
-          <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-            <media-tooltip-popup class="surface popup-animation">
-              <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-              <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-            </media-tooltip-popup>
-          </media-tooltip-positioner>
-        </media-tooltip-portal>
+      <media-fullscreen-button commandfor="fullscreen-tooltip" class="button">
+        <media-fullscreen-enter-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-icon>
+        <media-fullscreen-exit-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-icon>
+      </media-fullscreen-button>
+      <media-tooltip 
+        id="fullscreen-tooltip"
+        class="surface popup-animation"
+        popover="manual"
+        delay="500"
+        side="top"
+        side-offset="12"
+        collision-padding="12"
+      >
+        <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+        <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
       </media-tooltip>
     </div>
   </media-container>
@@ -1082,21 +1082,21 @@ export function generateHTMLMarkup(skin: Skin): string {
     <div class="overlay"></div>
 
     <div class="control-bar">
-      <media-tooltip delay="500" close-delay="0">
-        <media-tooltip-trigger>
-          <media-play-button class="button">
-            <media-play-icon class="icon play-icon"></media-play-icon>
-            <media-pause-icon class="icon pause-icon"></media-pause-icon>
-          </media-play-button>
-        </media-tooltip-trigger>
-        <media-tooltip-portal>
-          <media-tooltip-positioner side="top" side-offset="6" collision-padding="12">
-            <media-tooltip-popup class="popup-animation">
-              <span class="tooltip play-tooltip">Play</span>
-              <span class="tooltip pause-tooltip">Pause</span>
-            </media-tooltip-popup>
-          </media-tooltip-positioner>
-        </media-tooltip-portal>
+      <media-play-button commandfor="play-tooltip" class="button">
+        <media-play-icon class="icon play-icon"></media-play-icon>
+        <media-pause-icon class="icon pause-icon"></media-pause-icon>
+      </media-play-button>
+      <media-tooltip
+        id="play-tooltip"
+        class="popup-animation"
+        popover="manual"
+        delay="500"
+        side="top"
+        side-offset="6"
+        collision-padding="12"
+      >
+        <span class="tooltip play-tooltip">Play</span>
+        <span class="tooltip pause-tooltip">Pause</span>
       </media-tooltip>
 
       <div class="time-display-group">
@@ -1109,35 +1109,35 @@ export function generateHTMLMarkup(skin: Skin): string {
         </span>
       </div>
 
-      <media-tooltip track-cursor-axis="x">
-        <media-tooltip-trigger>
-          <media-time-slider class="slider">
-            <media-time-slider-track class="slider-track">
-              <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
-              <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
-            </media-time-slider-track>
-            <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
-          </media-time-slider>
-        </media-tooltip-trigger>
-        <media-tooltip-portal>
-          <media-tooltip-positioner side="top" side-offset="12" collision-padding="12">
-            <media-tooltip-popup class="popup-animation">
-              <media-preview-time-display></media-preview-time-display>
-            </media-tooltip-popup>
-          </media-tooltip-positioner>
-        </media-tooltip-portal>
+      <media-time-slider commandfor="time-slider-tooltip" class="slider">
+        <media-time-slider-track class="slider-track">
+          <media-time-slider-progress class="slider-progress"></media-time-slider-progress>
+          <media-time-slider-pointer class="slider-pointer"></media-time-slider-pointer>
+        </media-time-slider-track>
+        <media-time-slider-thumb class="slider-thumb"></media-time-slider-thumb>
+      </media-time-slider>
+      <media-tooltip 
+        id="time-slider-tooltip"
+        class="popup-animation"
+        popover="manual"
+        track-cursor-axis="x"
+        side="top"
+        side-offset="12"
+        collision-padding="12"
+      >
+        <media-preview-time-display></media-preview-time-display>
       </media-tooltip>
 
       <div class="button-group">
-        <media-mute-button popovertarget="volume-slider-popover" class="button">
+        <media-mute-button commandfor="volume-slider-popover" command="toggle-popover" class="button">
           <media-volume-high-icon class="icon volume-high-icon"></media-volume-high-icon>
           <media-volume-low-icon class="icon volume-low-icon"></media-volume-low-icon>
           <media-volume-off-icon class="icon volume-off-icon"></media-volume-off-icon>
         </media-mute-button>
-        <media-popover
-          id="volume-slider-popover"
+        <media-popover 
+          id="volume-slider-popover" 
           class="popup-animation"
-          popover
+          popover="manual"
           open-on-hover
           delay="200"
           close-delay="100"
@@ -1147,29 +1147,27 @@ export function generateHTMLMarkup(skin: Skin): string {
         >
           <media-volume-slider class="slider" orientation="vertical">
             <media-volume-slider-track class="slider-track">
-              <media-volume-slider-progress class="slider-progress"></media-volume-slider-progress>
+              <media-volume-slider-indicator class="slider-progress"></media-volume-slider-indicator>
             </media-volume-slider-track>
             <media-volume-slider-thumb class="slider-thumb"></media-volume-slider-thumb>
           </media-volume-slider>
         </media-popover>
 
-        <media-tooltip delay="500" close-delay="0">
-          <media-tooltip-trigger>
-            <media-fullscreen-button class="button">
-              <media-fullscreen-enter-alt-icon
-                class="icon fullscreen-enter-icon"
-              ></media-fullscreen-enter-alt-icon>
-              <media-fullscreen-exit-alt-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-alt-icon>
-            </media-fullscreen-button>
-          </media-tooltip-trigger>
-          <media-tooltip-portal>
-            <media-tooltip-positioner side="top" side-offset="6" collision-padding="12">
-              <media-tooltip-popup class="popup-animation">
-                <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-              </media-tooltip-popup>
-            </media-tooltip-positioner>
-          </media-tooltip-portal>
+        <media-fullscreen-button commandfor="fullscreen-tooltip" class="button">
+          <media-fullscreen-enter-alt-icon class="icon fullscreen-enter-icon"></media-fullscreen-enter-alt-icon>
+          <media-fullscreen-exit-alt-icon class="icon fullscreen-exit-icon"></media-fullscreen-exit-alt-icon>
+        </media-fullscreen-button>
+        <media-tooltip 
+          id="fullscreen-tooltip" 
+          class="popup-animation"
+          popover="manual"
+          delay="500"
+          side="top"
+          side-offset="6"
+          collision-padding="12"
+        >
+          <span class="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+          <span class="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
         </media-tooltip>
       </div>
     </div>
@@ -1523,7 +1521,11 @@ media-popover {
 }
 
 /* Tooltip Component Styles */
-media-tooltip-popup {
+media-tooltip {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
   color: oklab(1 0 0);
   padding: 0.25rem 0.625rem;
   border-radius: calc(infinity * 1px);
@@ -1535,13 +1537,13 @@ media-tooltip-popup {
   white-space: nowrap;
 }
 
-media-tooltip-popup[data-paused] .play-tooltip,
-media-tooltip-popup:not([data-paused]) .pause-tooltip {
+[data-paused] + media-tooltip .play-tooltip,
+:not([data-paused]) + media-tooltip .pause-tooltip {
   display: block;
 }
 
-media-tooltip-popup[data-fullscreen] .fullscreen-exit-tooltip,
-media-tooltip-popup:not([data-fullscreen]) .fullscreen-enter-tooltip {
+[data-fullscreen] + media-tooltip .fullscreen-exit-tooltip,
+:not([data-fullscreen]) + media-tooltip .fullscreen-enter-tooltip {
   display: block;
 }`;
   } else {
@@ -1861,7 +1863,11 @@ media-popover {
 }
 
 /* Tooltip Component Styles */
-media-tooltip-popup {
+media-tooltip {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
   color: oklab(1 0 0);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
@@ -1873,12 +1879,12 @@ media-tooltip-popup {
     0 2px 4px -2px oklab(0 0 0 / 0.1);
 }
 @media (prefers-reduced-transparency: reduce) {
-  media-tooltip-popup {
+  media-tooltip {
     background-color: oklab(0 0 0 / 0.7);
   }
 }
 @media (prefers-contrast: more) {
-  media-tooltip-popup {
+  media-tooltip {
     background-color: oklab(0 0 0 / 0.9);
   }
 }
@@ -1888,13 +1894,13 @@ media-tooltip-popup {
   white-space: nowrap;
 }
 
-media-tooltip-popup[data-paused] .play-tooltip,
-media-tooltip-popup:not([data-paused]) .pause-tooltip {
+[data-paused] + media-tooltip .play-tooltip,
+:not([data-paused]) + media-tooltip .pause-tooltip {
   display: block;
 }
 
-media-tooltip-popup[data-fullscreen] .fullscreen-exit-tooltip,
-media-tooltip-popup:not([data-fullscreen]) .fullscreen-enter-tooltip {
+[data-fullscreen] + media-tooltip .fullscreen-exit-tooltip,
+:not([data-fullscreen]) + media-tooltip .fullscreen-enter-tooltip {
   display: block;
 }`;
   }


### PR DESCRIPTION
This pull request refactors the tooltip and popover components in the HTML media player examples and supporting code, simplifying their structure and improving accessibility and maintainability. The most significant changes include consolidating the tooltip implementation, updating the way tooltips and popovers are triggered, and streamlining the CSS selectors and styles.

**Component Structure and Triggering**

* Refactored tooltip markup in `index.html` files (`examples/html-eject-frosted/index.html`, `examples/html-eject-minimal/index.html`) to use a single `media-tooltip` element with direct attributes for configuration, replacing the previous complex nested structure (`media-tooltip-trigger`, `media-tooltip-portal`, etc.). Tooltip and popover triggers now use the `commandfor` attribute instead of `popovertarget`, and popovers use `popover="manual"` for explicit control. [[1]](diffhunk://#diff-6090d09b41c5f6abf489f5fc052fee8d8eeeba73f8c572d723db3cd2a1c3292cL54-R105) [[2]](diffhunk://#diff-8317583b6d827d262ee7d915c043aeb1c187c9766cf3bfb354d086836a510b8bL55-L69) [[3]](diffhunk://#diff-8317583b6d827d262ee7d915c043aeb1c187c9766cf3bfb354d086836a510b8bL82-R111) [[4]](diffhunk://#diff-8317583b6d827d262ee7d915c043aeb1c187c9766cf3bfb354d086836a510b8bL120-L142)

* Updated the popover and tooltip JavaScript classes to use the new `commandfor` attribute for trigger association and simplified custom element definitions to only require `media-tooltip`. [[1]](diffhunk://#diff-b8a805aa0fb265254f5f2bed416d56d607ac1b13b774d4b7c141788f68807918L99-R99) [[2]](diffhunk://#diff-d054b42eaacd63a714eb2c36134e1972d636008ab88cdd241cd2c33c1137eeceL1-R4)

**Tooltip and Popover Styling**

* Changed CSS selectors and styles in both frosted and minimal themes to style `media-tooltip` directly instead of `media-tooltip-popup`, and updated selectors for showing/hiding tooltip text based on media state. [[1]](diffhunk://#diff-a6a2b282d65776b08d71d032b6eba13d5da32f781729fbe39123fd26c1b76f8cL340-R344) [[2]](diffhunk://#diff-a6a2b282d65776b08d71d032b6eba13d5da32f781729fbe39123fd26c1b76f8cL352-R362) [[3]](diffhunk://#diff-7bbd5f352ed975d5a399e5c68a58085d2ee542fff5ac8af57a63c2ab9dde9044L317-R321) [[4]](diffhunk://#diff-7bbd5f352ed975d5a399e5c68a58085d2ee542fff5ac8af57a63c2ab9dde9044L329-R338) [[5]](diffhunk://#diff-7bbd5f352ed975d5a399e5c68a58085d2ee542fff5ac8af57a63c2ab9dde9044L344-R354)

**Tooltip Functionality and Accessibility**

* Refactored the tooltip element implementation in TypeScript to consolidate logic into a single `TooltipElement` class, add accessibility roles, support new attributes (`side`, `side-offset`, `collision-padding`), and use `AbortController` for event listener cleanup. [[1]](diffhunk://#diff-657f5587a2ccf7dbc57df5c9b18a34ba2209f2d5b6e36e3b1815847fadb57f06L5-R61) [[2]](diffhunk://#diff-657f5587a2ccf7dbc57df5c9b18a34ba2209f2d5b6e36e3b1815847fadb57f06L64-R90)

**Component API Consistency**

* Updated the volume slider indicator element in both HTML examples to use `media-volume-slider-indicator` instead of `media-volume-slider-progress` for consistency with the component API. [[1]](diffhunk://#diff-6090d09b41c5f6abf489f5fc052fee8d8eeeba73f8c572d723db3cd2a1c3292cL115-L135) [[2]](diffhunk://#diff-8317583b6d827d262ee7d915c043aeb1c187c9766cf3bfb354d086836a510b8bL120-L142)

**Popover Lifecycle Management**

* Improved popover lifecycle management by ensuring cleanup functions are called when popovers are closed, preventing memory leaks.

This refactor streamlines the tooltip and popover implementation, making the codebase easier to maintain and improving the accessibility and configurability of media controls.