### PR TITLE
feat: port floating-ui to utils for html elements

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -52,8 +52,6 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@floating-ui/core": "^1.6.13",
-    "@floating-ui/dom": "^1.6.13",
     "@open-wc/context-protocol": "^0.0.9",
     "@videojs/core": "workspace:*",
     "@videojs/icons": "workspace:*",

--- a/packages/html/src/elements/popover.ts
+++ b/packages/html/src/elements/popover.ts
@@ -1,7 +1,15 @@
-import type { ComputePositionReturn } from '@floating-ui/core';
-import type { Placement } from '@floating-ui/dom';
-import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
-import { contains, getDocument, getDocumentOrShadowRoot, safePolygon } from '@videojs/utils/dom';
+import type { ComputePositionReturn, Placement } from '@videojs/utils/dom';
+
+import {
+  autoUpdate,
+  computePosition,
+  contains,
+  getDocument,
+  getDocumentOrShadowRoot,
+  offset,
+  safePolygon,
+  shift,
+} from '@videojs/utils/dom';
 
 type Prettify<T> = {
   [K in keyof T]: T[K];
@@ -105,12 +113,11 @@ export class PopoverElement extends HTMLElement {
     this.#open = open;
 
     if (open) {
-      this.#setupFloating();
-
       this.#transitionStatus = 'initial';
       this.#updateVisibility();
 
       this.showPopover();
+      this.#setupFloating();
 
       requestAnimationFrame(() => {
         this.#transitionStatus = 'open';
@@ -151,7 +158,7 @@ export class PopoverElement extends HTMLElement {
     const updatePosition = () => {
       computePosition(trigger, this, {
         placement,
-        middleware: [offset(sideOffset), flip(), shift()],
+        middleware: [offset(sideOffset), shift()],
         strategy: 'fixed',
       }).then((data: ComputePositionReturn) => {
         this.#floatingContext = {

--- a/packages/utils/src/dom/element.ts
+++ b/packages/utils/src/dom/element.ts
@@ -1,3 +1,5 @@
+type OverflowAncestors = Array<Element | Window | VisualViewport>;
+
 /**
  * Get the active element, accounting for Shadow DOM subtrees.
  *
@@ -30,8 +32,18 @@ export function getDocumentOrShadowRoot(
   return null;
 }
 
-export function getDocument(node: Element | null): Document {
-  return node?.ownerDocument ?? document;
+export function getDocumentElement(node: Node | Window): HTMLElement {
+  return (
+    (isNode(node) ? node.ownerDocument : node.document) || window.document
+  )?.documentElement;
+}
+
+export function isNode(value: unknown): value is Node {
+  if (!hasWindow()) {
+    return false;
+  }
+
+  return value instanceof Node || value instanceof getWindow(value).Node;
 }
 
 export function isElement(value: unknown): value is Element {
@@ -40,6 +52,21 @@ export function isElement(value: unknown): value is Element {
   }
 
   return value instanceof Element || value instanceof getWindow(value).Element;
+}
+
+export function isHTMLElement(value: unknown): value is HTMLElement {
+  if (!hasWindow()) {
+    return false;
+  }
+
+  return (
+    value instanceof HTMLElement
+    || value instanceof getWindow(value).HTMLElement
+  );
+}
+
+export function getDocument(node: Element | null): Document {
+  return node?.ownerDocument ?? document;
 }
 
 export function contains(parent?: Element | null, child?: Element | null): boolean {
@@ -120,4 +147,95 @@ export function getNodeChildren(
     child,
     ...getNodeChildren(nodes, child.id, onlyOpenChildren),
   ]);
+}
+
+export function getNodeName(node: Node | Window): string {
+  if (isNode(node)) {
+    return (node.nodeName || '').toLowerCase();
+  }
+  // Mocked nodes in testing environments may not be instances of Node. By
+  // returning `#document` an infinite loop won't occur.
+  // https://github.com/floating-ui/floating-ui/issues/2317
+  return '#document';
+}
+
+export function getParentNode(node: Node): Node {
+  if (getNodeName(node) === 'html') {
+    return node;
+  }
+
+  const result
+    // Step into the shadow DOM of the parent of a slotted node.
+    = (node as any).assignedSlot
+    // DOM Element detected.
+      || node.parentNode
+    // ShadowRoot detected.
+      || (isShadowRoot(node) && node.host)
+    // Fallback.
+      || getDocumentElement(node);
+
+  return isShadowRoot(result) ? result.host : result;
+}
+
+const invalidOverflowDisplayValues = new Set(['inline', 'contents']);
+
+export function isOverflowElement(element: Element): boolean {
+  const { overflow, overflowX, overflowY, display } = getComputedStyle(element);
+  return (
+    /auto|scroll|overlay|hidden|clip/.test(overflow + overflowY + overflowX)
+    && !invalidOverflowDisplayValues.has(display)
+  );
+}
+
+const lastTraversableNodeNames = new Set(['html', 'body', '#document']);
+
+export function isLastTraversableNode(node: Node): boolean {
+  return lastTraversableNodeNames.has(getNodeName(node));
+}
+
+export function getNearestOverflowAncestor(node: Node): HTMLElement {
+  const parentNode = getParentNode(node);
+
+  if (isLastTraversableNode(parentNode)) {
+    return node.ownerDocument
+      ? node.ownerDocument.body
+      : (node as Document).body;
+  }
+
+  if (isHTMLElement(parentNode) && isOverflowElement(parentNode)) {
+    return parentNode;
+  }
+
+  return getNearestOverflowAncestor(parentNode);
+}
+
+export function getOverflowAncestors(
+  node: Node,
+  list: OverflowAncestors = [],
+  traverseIframes = true,
+): OverflowAncestors {
+  const scrollableAncestor = getNearestOverflowAncestor(node);
+  const isBody = scrollableAncestor === node.ownerDocument?.body;
+  const win = getWindow(scrollableAncestor);
+
+  if (isBody) {
+    const frameElement = getFrameElement(win);
+    return list.concat(
+      win,
+      win.visualViewport || [],
+      isOverflowElement(scrollableAncestor) ? scrollableAncestor : [],
+      frameElement && traverseIframes ? getOverflowAncestors(frameElement) : [],
+    );
+  }
+
+  return list.concat(
+    scrollableAncestor,
+    getOverflowAncestors(scrollableAncestor, [], traverseIframes),
+  );
+}
+
+export function getFrameElement(win: Window): Element | null {
+  return win.parent && Object.getPrototypeOf(win.parent)
+    ? win.frameElement
+    : null;
 }

--- a/packages/utils/src/dom/floating-ui/LICENSE
+++ b/packages/utils/src/dom/floating-ui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Floating UI contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/utils/src/dom/floating-ui/auto-update.ts
+++ b/packages/utils/src/dom/floating-ui/auto-update.ts
@@ -1,0 +1,240 @@
+import type { ClientRectObject, FloatingElement, ReferenceElement } from './types';
+
+import { getDocumentElement, getOverflowAncestors } from '../element';
+
+export interface AutoUpdateOptions {
+  /**
+   * Whether to update the position when an overflow ancestor is scrolled.
+   * @default true
+   */
+  ancestorScroll?: boolean;
+  /**
+   * Whether to update the position when an overflow ancestor is resized. This
+   * uses the native `resize` event.
+   * @default true
+   */
+  ancestorResize?: boolean;
+  /**
+   * Whether to update the position when either the reference or floating
+   * elements resized. This uses a `ResizeObserver`.
+   * @default true
+   */
+  elementResize?: boolean;
+  /**
+   * Whether to update the position when the reference relocated on the screen
+   * due to layout shift.
+   * @default true
+   */
+  layoutShift?: boolean;
+  /**
+   * Whether to update on every animation frame if necessary. Only use if you
+   * need to update the position in response to an animation using transforms.
+   * @default false
+   */
+  animationFrame?: boolean;
+}
+
+// https://samthor.au/2021/observing-dom/
+function observeMove(element: Element, onMove: () => void) {
+  let io: IntersectionObserver | null = null;
+  let timeoutId: NodeJS.Timeout;
+
+  const root = getDocumentElement(element);
+
+  function cleanup() {
+    clearTimeout(timeoutId);
+    io?.disconnect();
+    io = null;
+  }
+
+  function refresh(skip = false, threshold = 1) {
+    cleanup();
+
+    const elementRectForRootMargin = element.getBoundingClientRect();
+    const { left, top, width, height } = elementRectForRootMargin;
+
+    if (!skip) {
+      onMove();
+    }
+
+    if (!width || !height) {
+      return;
+    }
+
+    const insetTop = Math.floor(top);
+    const insetRight = Math.floor(root.clientWidth - (left + width));
+    const insetBottom = Math.floor(root.clientHeight - (top + height));
+    const insetLeft = Math.floor(left);
+    const rootMargin = `${-insetTop}px ${-insetRight}px ${-insetBottom}px ${-insetLeft}px`;
+
+    const options = {
+      rootMargin,
+      threshold: Math.max(0, Math.min(1, threshold)) || 1,
+    };
+
+    let isFirstUpdate = true;
+
+    function handleObserve(entries: IntersectionObserverEntry[]) {
+      const ratio = entries[0]?.intersectionRatio;
+
+      if (ratio !== threshold) {
+        if (!isFirstUpdate) {
+          return refresh();
+        }
+
+        if (!ratio) {
+          // If the reference is clipped, the ratio is 0. Throttle the refresh
+          // to prevent an infinite loop of updates.
+          timeoutId = setTimeout(() => {
+            refresh(false, 1e-7);
+          }, 1000);
+        } else {
+          refresh(false, ratio);
+        }
+      }
+
+      if (
+        ratio === 1
+        && !rectsAreEqual(
+          elementRectForRootMargin,
+          element.getBoundingClientRect(),
+        )
+      ) {
+        // It's possible that even though the ratio is reported as 1, the
+        // element is not actually fully within the IntersectionObserver's root
+        // area anymore. This can happen under performance constraints. This may
+        // be a bug in the browser's IntersectionObserver implementation. To
+        // work around this, we compare the element's bounding rect now with
+        // what it was at the time we created the IntersectionObserver. If they
+        // are not equal then the element moved, so we refresh.
+        refresh();
+      }
+
+      isFirstUpdate = false;
+    }
+
+    // Older browsers don't support a `document` as the root and will throw an
+    // error.
+    try {
+      io = new IntersectionObserver(handleObserve, {
+        ...options,
+        // Handle <iframe>s
+        root: root.ownerDocument,
+      });
+    } catch {
+      io = new IntersectionObserver(handleObserve, options);
+    }
+
+    io.observe(element);
+  }
+
+  refresh(true);
+
+  return cleanup;
+}
+
+/**
+ * Automatically updates the position of the floating element when necessary.
+ * Should only be called when the floating element is mounted on the DOM or
+ * visible on the screen.
+ * @returns cleanup function that should be invoked when the floating element is
+ * removed from the DOM or hidden from the screen.
+ * @see https://floating-ui.com/docs/autoUpdate
+ */
+export function autoUpdate(
+  reference: ReferenceElement,
+  floating: FloatingElement,
+  update: () => void,
+  options: AutoUpdateOptions = {},
+) {
+  const {
+    ancestorScroll = true,
+    ancestorResize = true,
+    elementResize = typeof ResizeObserver === 'function',
+    layoutShift = typeof IntersectionObserver === 'function',
+    animationFrame = false,
+  } = options;
+
+  const referenceEl = reference;
+
+  const ancestors
+    = ancestorScroll || ancestorResize
+      ? [
+          ...(referenceEl ? getOverflowAncestors(referenceEl) : []),
+          ...getOverflowAncestors(floating),
+        ]
+      : [];
+
+  ancestors.forEach((ancestor) => {
+    ancestorScroll
+    && ancestor.addEventListener('scroll', update, { passive: true });
+    ancestorResize && ancestor.addEventListener('resize', update);
+  });
+
+  const cleanupIo
+    = referenceEl && layoutShift ? observeMove(referenceEl, update) : null;
+
+  let reobserveFrame = -1;
+  let resizeObserver: ResizeObserver | null = null;
+
+  if (elementResize) {
+    resizeObserver = new ResizeObserver(([firstEntry]) => {
+      if (firstEntry && firstEntry.target === referenceEl && resizeObserver) {
+        // Prevent update loops when using the `size` middleware.
+        // https://github.com/floating-ui/floating-ui/issues/1740
+        resizeObserver.unobserve(floating);
+        cancelAnimationFrame(reobserveFrame);
+        reobserveFrame = requestAnimationFrame(() => {
+          resizeObserver?.observe(floating);
+        });
+      }
+      update();
+    });
+
+    if (referenceEl && !animationFrame) {
+      resizeObserver.observe(referenceEl);
+    }
+    resizeObserver.observe(floating);
+  }
+
+  let frameId: number;
+  let prevRefRect = animationFrame ? reference.getBoundingClientRect() : null;
+
+  if (animationFrame) {
+    frameLoop();
+  }
+
+  function frameLoop() {
+    const nextRefRect = reference.getBoundingClientRect();
+
+    if (prevRefRect && !rectsAreEqual(prevRefRect, nextRefRect)) {
+      update();
+    }
+
+    prevRefRect = nextRefRect;
+    frameId = requestAnimationFrame(frameLoop);
+  }
+
+  update();
+
+  return (): void => {
+    ancestors.forEach((ancestor) => {
+      ancestorScroll && ancestor.removeEventListener('scroll', update);
+      ancestorResize && ancestor.removeEventListener('resize', update);
+    });
+
+    cleanupIo?.();
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+
+    if (animationFrame) {
+      cancelAnimationFrame(frameId);
+    }
+  };
+}
+
+function rectsAreEqual(a: ClientRectObject, b: ClientRectObject): boolean {
+  return (
+    a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+  );
+}

--- a/packages/utils/src/dom/floating-ui/compute-position.ts
+++ b/packages/utils/src/dom/floating-ui/compute-position.ts
@@ -1,0 +1,138 @@
+/* Adapted from floating-ui - The MIT License - Floating UI contributors */
+
+import type {
+  ComputePositionConfig,
+  ComputePositionReturn,
+  ElementRects,
+  FloatingElement,
+  Middleware,
+  MiddlewareData,
+  Placement,
+  Point,
+  ReferenceElement,
+} from './types';
+
+import * as defaultPlatform from './platform';
+
+export async function computePosition(
+  reference: ReferenceElement,
+  floating: FloatingElement,
+  config: ComputePositionConfig,
+): Promise<ComputePositionReturn> {
+  const { placement = 'bottom', strategy = 'absolute', middleware = [], platform = defaultPlatform } = config;
+
+  const validMiddleware = middleware.filter(Boolean) as Middleware[];
+
+  // Removed RTL check.
+
+  let rects = await platform.getElementRects({ reference, floating, strategy });
+  let { x, y } = computeCoordsFromPlacement(rects, placement);
+  let statefulPlacement = placement;
+  let middlewareData: MiddlewareData = {};
+  let resetCount = 0;
+
+  for (let i = 0; i < validMiddleware.length; i++) {
+    const { name, fn } = validMiddleware[i] as Middleware;
+
+    const {
+      x: nextX,
+      y: nextY,
+      data,
+      reset,
+    } = await fn({
+      x,
+      y,
+      initialPlacement: placement,
+      placement: statefulPlacement,
+      strategy,
+      middlewareData,
+      rects,
+      platform,
+      elements: { reference, floating },
+    });
+
+    x = nextX ?? x;
+    y = nextY ?? y;
+
+    middlewareData = {
+      ...middlewareData,
+      [name]: {
+        ...middlewareData[name],
+        ...data,
+      },
+    };
+
+    if (reset && resetCount <= 50) {
+      resetCount++;
+
+      if (typeof reset === 'object') {
+        if (reset.placement) {
+          statefulPlacement = reset.placement;
+        }
+
+        if (reset.rects) {
+          rects = reset.rects === true ? await platform.getElementRects({ reference, floating, strategy }) : reset.rects;
+        }
+
+        ({ x, y } = computeCoordsFromPlacement(rects, statefulPlacement));
+      }
+
+      i = -1;
+    }
+  }
+
+  return {
+    x,
+    y,
+    placement: statefulPlacement,
+    strategy,
+    middlewareData,
+  };
+}
+
+function computeCoordsFromPlacement({ reference, floating }: ElementRects, placement: Placement): Point {
+  const alignmentAxis = getSideAxis(placement) === 'x' ? 'y' : 'x';
+  const alignLength = alignmentAxis === 'y' ? 'height' : 'width';
+  const side = getSide(placement);
+
+  const commonX = reference.x + reference.width / 2 - floating.width / 2;
+  const commonY = reference.y + reference.height / 2 - floating.height / 2;
+  const commonAlign = reference[alignLength] / 2 - floating[alignLength] / 2;
+
+  let coords;
+  switch (side) {
+    case 'top':
+      coords = { x: commonX, y: reference.y - floating.height };
+      break;
+    case 'bottom':
+      coords = { x: commonX, y: reference.y + reference.height };
+      break;
+    case 'right':
+      coords = { x: reference.x + reference.width, y: commonY };
+      break;
+    case 'left':
+      coords = { x: reference.x - floating.width, y: commonY };
+      break;
+    default:
+      coords = { x: reference.x, y: reference.y };
+  }
+
+  switch (placement.split('-')[1]) {
+    case 'start':
+      coords[alignmentAxis] -= commonAlign;
+      break;
+    case 'end':
+      coords[alignmentAxis] += commonAlign;
+      break;
+  }
+
+  return coords;
+}
+
+function getSide(placement: Placement): Placement | undefined {
+  return placement.split('-')[0] as Placement | undefined;
+}
+
+function getSideAxis(placement: Placement): 'x' | 'y' {
+  return ['top', 'bottom'].includes(getSide(placement) ?? '') ? 'y' : 'x';
+}

--- a/packages/utils/src/dom/floating-ui/index.ts
+++ b/packages/utils/src/dom/floating-ui/index.ts
@@ -1,0 +1,5 @@
+export * from './auto-update';
+export * from './compute-position';
+export * from './middleware/offset';
+export * from './middleware/shift';
+export * from './types';

--- a/packages/utils/src/dom/floating-ui/middleware/offset.ts
+++ b/packages/utils/src/dom/floating-ui/middleware/offset.ts
@@ -1,0 +1,43 @@
+import type { Middleware, Placement } from '../types';
+
+function getSide(placement: Placement): string {
+  return placement.split('-')[0] ?? '';
+}
+
+export function offset(offset: number): Middleware {
+  return {
+    name: 'offset',
+    fn: (state) => {
+      const { x, y, placement } = state;
+      const side = getSide(placement);
+
+      let newX = x;
+      let newY = y;
+
+      switch (side) {
+        case 'top':
+          newY = y - offset;
+          break;
+        case 'bottom':
+          newY = y + offset;
+          break;
+        case 'left':
+          newX = x - offset;
+          break;
+        case 'right':
+          newX = x + offset;
+          break;
+      }
+
+      return {
+        x: newX,
+        y: newY,
+        data: {
+          x: newX - x,
+          y: newY - y,
+          placement,
+        },
+      };
+    },
+  };
+}

--- a/packages/utils/src/dom/floating-ui/middleware/shift.ts
+++ b/packages/utils/src/dom/floating-ui/middleware/shift.ts
@@ -1,0 +1,105 @@
+import type { Middleware, MiddlewareState, Rect } from '../types';
+
+export interface ShiftOptions {
+  boundary?: HTMLElement;
+  padding?: number;
+}
+
+function getRectRelativeToOffsetParent(element: Element, offsetParent: Element | null): Rect {
+  const rect = element.getBoundingClientRect();
+  const offsetRect = offsetParent?.getBoundingClientRect() ?? { x: 0, y: 0 };
+  return {
+    x: rect.x - offsetRect.x,
+    y: rect.y - offsetRect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function getBoundaryRect(boundary: HTMLElement | undefined, floating: HTMLElement): Rect {
+  if (boundary) {
+    return getRectRelativeToOffsetParent(boundary, floating.offsetParent);
+  }
+
+  // Use viewport as boundary
+  const offsetParent = floating.offsetParent;
+  const offsetRect = offsetParent?.getBoundingClientRect() ?? { x: 0, y: 0 };
+
+  return {
+    x: -offsetRect.x,
+    y: -offsetRect.y,
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+export function shift(options: ShiftOptions = {}): Middleware {
+  const { boundary, padding = 0 } = options;
+
+  return {
+    name: 'shift',
+    fn: (state: MiddlewareState) => {
+      const { x, y, elements, rects } = state;
+      const { floating } = elements;
+
+      const boundaryRect = getBoundaryRect(boundary, floating);
+
+      // Apply padding to boundary
+      const paddedBoundary = {
+        x: boundaryRect.x + padding,
+        y: boundaryRect.y + padding,
+        width: boundaryRect.width - padding * 2,
+        height: boundaryRect.height - padding * 2,
+      };
+
+      // Calculate floating element bounds at current position
+      const floatingLeft = x;
+      const floatingTop = y;
+      const floatingRight = x + rects.floating.width;
+      const floatingBottom = y + rects.floating.height;
+
+      // Calculate boundary bounds
+      const boundaryLeft = paddedBoundary.x;
+      const boundaryTop = paddedBoundary.y;
+      const boundaryRight = paddedBoundary.x + paddedBoundary.width;
+      const boundaryBottom = paddedBoundary.y + paddedBoundary.height;
+
+      // Calculate how much to shift
+      let newX = x;
+      let newY = y;
+      let xShifted = false;
+      let yShifted = false;
+
+      // Shift horizontally if needed
+      if (floatingLeft < boundaryLeft) {
+        newX = boundaryLeft;
+        xShifted = true;
+      } else if (floatingRight > boundaryRight) {
+        newX = boundaryRight - rects.floating.width;
+        xShifted = true;
+      }
+
+      // Shift vertically if needed
+      if (floatingTop < boundaryTop) {
+        newY = boundaryTop;
+        yShifted = true;
+      } else if (floatingBottom > boundaryBottom) {
+        newY = boundaryBottom - rects.floating.height;
+        yShifted = true;
+      }
+
+      return {
+        x: newX,
+        y: newY,
+        data: {
+          x: newX - x,
+          y: newY - y,
+          enabled: {
+            x: xShifted,
+            y: yShifted,
+          },
+        },
+      };
+    },
+  };
+}

--- a/packages/utils/src/dom/floating-ui/platform.ts
+++ b/packages/utils/src/dom/floating-ui/platform.ts
@@ -1,0 +1,40 @@
+import type { ElementRects, PositionElements, Rect, Strategy } from './types';
+
+export function getElementRects({ reference, floating, strategy }: PositionElements): ElementRects {
+  return {
+    reference: getRectRelativeToOffsetParent(reference, floating.offsetParent, strategy),
+    floating: {
+      x: 0,
+      y: 0,
+      width: floating.offsetWidth,
+      height: floating.offsetHeight,
+    },
+  };
+}
+
+function getRectRelativeToOffsetParent(element: Element, offsetParent: Element | null, strategy: Strategy): Rect {
+  const rect = element.getBoundingClientRect();
+
+  // For fixed positioning, coordinates are relative to the viewport
+  if (strategy === 'fixed') {
+    return {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  // For absolute positioning, coordinates are relative to the offset parent
+  // offsetParent returns null in the following situations:
+  // - The element or any ancestor has the display property set to none.
+  // - The element has the position property set to fixed (Firefox returns <body>).
+  // - The element is <body> or <html>.
+  const offsetRect = offsetParent?.getBoundingClientRect() ?? { x: 0, y: 0 };
+  return {
+    x: rect.x - offsetRect.x,
+    y: rect.y - offsetRect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}

--- a/packages/utils/src/dom/floating-ui/types.ts
+++ b/packages/utils/src/dom/floating-ui/types.ts
@@ -1,0 +1,146 @@
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
+export type Alignment = 'start' | 'end';
+export type Side = 'top' | 'right' | 'bottom' | 'left';
+export type AlignedPlacement = `${Side}-${Alignment}`;
+export type Placement = Prettify<Side | AlignedPlacement>;
+export type Strategy = 'absolute' | 'fixed';
+export type Axis = 'x' | 'y';
+export type Coords = { [key in Axis]: number };
+export type Length = 'width' | 'height';
+export type Dimensions = { [key in Length]: number };
+export type SideObject = { [key in Side]: number };
+export type Rect = Prettify<Coords & Dimensions>;
+export type Padding = number | Prettify<Partial<SideObject>>;
+export type ClientRectObject = Prettify<Rect & SideObject>;
+
+export interface ElementRects {
+  reference: Rect;
+  floating: Rect;
+}
+
+type Promisable<T> = T | Promise<T>;
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface PositionElements {
+  reference: ReferenceElement;
+  floating: FloatingElement;
+  strategy: Strategy;
+}
+
+export interface PositionRects {
+  reference: Rect;
+  floating: Rect;
+}
+
+export interface ComputePositionConfig {
+  /**
+   * Object to interface with the current platform.
+   */
+  platform?: Platform;
+  /**
+   * Where to place the floating element relative to the reference element.
+   */
+  placement?: Placement;
+  /**
+   * The strategy to use when positioning the floating element.
+   */
+  strategy?: Strategy;
+  /**
+   * Array of middleware objects to modify the positioning or provide data for
+   * rendering.
+   */
+  middleware?: Array<Middleware | null | undefined | false>;
+}
+
+export interface ComputePositionReturn extends Coords {
+  /**
+   * The final chosen placement of the floating element.
+   */
+  placement: Placement;
+  /**
+   * The strategy used to position the floating element.
+   */
+  strategy: Strategy;
+  /**
+   * Object containing data returned from all middleware, keyed by their name.
+   */
+  middlewareData: MiddlewareData;
+}
+
+export type Positions = PositionElements & {
+  placement?: Placement;
+};
+
+export interface Middleware {
+  name: string;
+  options?: any;
+  fn: (state: MiddlewareState) => Promisable<MiddlewareReturn>;
+}
+
+export type ReferenceElement = any;
+export type FloatingElement = any;
+
+export interface Elements {
+  reference: ReferenceElement;
+  floating: FloatingElement;
+}
+
+export interface MiddlewareState extends Coords {
+  initialPlacement: Placement;
+  placement: Placement;
+  strategy: Strategy;
+  middlewareData: MiddlewareData;
+  elements: Elements;
+  rects: ElementRects;
+  platform: Platform;
+}
+
+export interface MiddlewareReturn extends Partial<Coords> {
+  data?: {
+    [key: string]: any;
+  };
+  reset?:
+    | boolean
+    | {
+      placement?: Placement;
+      rects?: boolean | ElementRects;
+    };
+}
+
+export interface MiddlewareData {
+  [key: string]: any;
+  arrow?: Partial<Coords> & {
+    centerOffset: number;
+    alignmentOffset?: number;
+  };
+  offset?: Coords & { placement: Placement };
+  shift?: Coords & {
+    enabled: { [key in Axis]: boolean };
+  };
+}
+
+export interface Platform {
+  // Required
+  getElementRects: (args: {
+    reference: ReferenceElement;
+    floating: FloatingElement;
+    strategy: Strategy;
+  }) => Promisable<ElementRects>;
+  getClippingRect?: (args: {
+    element: any;
+    boundary: Boundary;
+    rootBoundary: RootBoundary;
+    strategy: Strategy;
+  }) => Promisable<Rect>;
+  getDimensions?: (element: any) => Promisable<Dimensions>;
+}
+
+export type Boundary = any;
+export type RootBoundary = 'viewport' | 'document' | Rect;

--- a/packages/utils/src/dom/index.ts
+++ b/packages/utils/src/dom/index.ts
@@ -1,5 +1,6 @@
 export * from './attributes';
 export * from './element';
 export * from './event';
+export * from './floating-ui';
 export * from './safe-polygon';
 export * from './shadow-dom';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,12 +198,6 @@ importers:
 
   packages/html:
     dependencies:
-      '@floating-ui/core':
-        specifier: ^1.6.13
-        version: 1.7.3
-      '@floating-ui/dom':
-        specifier: ^1.6.13
-        version: 1.7.4
       '@open-wc/context-protocol':
         specifier: ^0.0.9
         version: 0.0.9


### PR DESCRIPTION
This is a 90% working port of floating UI for HTML elements.

The only bug I could see is that when scrolling while the volume slider popup is open and you scroll down enough the popup will stick to the bottom of the window instead of continuing down with the trigger button.

I'm just not liking the amount of code it is adding. It's worth trying to see if the anchor positioning API can be used and save bytes!