### PR TITLE
feat(react): use popover and anchor position API

### DIFF
--- a/examples/react-demo/src/skins/frosted-eject/FrostedSkin.tsx
+++ b/examples/react-demo/src/skins/frosted-eject/FrostedSkin.tsx
@@ -32,14 +32,12 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <PauseIcon className="icon pause-icon" />
             </PlayButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className="tooltip-popup surface popup-animation">
-                <span className="tooltip play-tooltip">Play</span>
-                <span className="tooltip pause-tooltip">Pause</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className="tooltip-popup surface popup-animation">
+              <span className="tooltip play-tooltip">Play</span>
+              <span className="tooltip pause-tooltip">Pause</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className="time-controls">
@@ -59,13 +57,11 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
                 <TimeSlider.Thumb className="slider-thumb" />
               </TimeSlider.Root>
             </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Positioner side="top" sideOffset={18} collisionPadding={12}>
-                <Tooltip.Popup className="surface popup-animation tooltip-popup">
-                  <PreviewTimeDisplay className="time-display media-preview-time-display" />
-                </Tooltip.Popup>
-              </Tooltip.Positioner>
-            </Tooltip.Portal>
+            <Tooltip.Positioner side="top" sideOffset={18} collisionPadding={12}>
+              <Tooltip.Popup className="surface popup-animation tooltip-popup">
+                <PreviewTimeDisplay className="time-display media-preview-time-display" />
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
           </Tooltip.Root>
 
           <DurationDisplay className="time-display" />
@@ -79,18 +75,16 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <VolumeOffIcon className="icon volume-off-icon" />
             </MuteButton>
           </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner side="top" sideOffset={12}>
-              <Popover.Popup className="surface popup-animation popover-popup">
-                <VolumeSlider.Root className="slider" orientation="vertical">
-                  <VolumeSlider.Track className="slider-track">
-                    <VolumeSlider.Progress className="slider-progress" />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb className="slider-thumb" />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
+          <Popover.Positioner side="top" sideOffset={12}>
+            <Popover.Popup className="surface popup-animation popover-popup">
+              <VolumeSlider.Root className="slider" orientation="vertical">
+                <VolumeSlider.Track className="slider-track">
+                  <VolumeSlider.Progress className="slider-progress" />
+                </VolumeSlider.Track>
+                <VolumeSlider.Thumb className="slider-thumb" />
+              </VolumeSlider.Root>
+            </Popover.Popup>
+          </Popover.Positioner>
         </Popover.Root>
 
         <Tooltip.Root delay={500}>
@@ -100,14 +94,12 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <FullscreenExitIcon className="icon fullscreen-exit-icon" />
             </FullscreenButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className="surface popup-animation tooltip-popup">
-                <span className="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                <span className="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className="surface popup-animation tooltip-popup">
+              <span className="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+              <span className="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
       </div>
     </MediaContainer>

--- a/examples/react-demo/src/skins/frosted-eject/frosted.css
+++ b/examples/react-demo/src/skins/frosted-eject/frosted.css
@@ -328,8 +328,6 @@
 .vjs-frosted-skin .popover-popup {
   margin: 0;
   border: none;
-  box-shadow: none;
-  background: transparent;
   padding: 0.75rem 0.25rem;
   border-radius: calc(infinity * 1px);
 }

--- a/examples/react-demo/src/skins/frosted/FrostedSkin.tsx
+++ b/examples/react-demo/src/skins/frosted/FrostedSkin.tsx
@@ -45,14 +45,12 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <PauseIcon className={styles.PauseIcon}></PauseIcon>
             </PlayButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className={`${styles.TooltipPopup} ${styles.PlayTooltipPopup}`}>
-                <span className={styles.PlayTooltip}>Play</span>
-                <span className={styles.PauseTooltip}>Pause</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className={`${styles.TooltipPopup} ${styles.PlayTooltipPopup}`}>
+              <span className={styles.PlayTooltip}>Play</span>
+              <span className={styles.PauseTooltip}>Pause</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className={styles.TimeControls}>
@@ -81,18 +79,16 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <VolumeOffIcon className={styles.VolumeOffIcon} />
             </MuteButton>
           </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner side="top" sideOffset={12}>
-              <Popover.Popup className={styles.PopoverPopup}>
-                <VolumeSlider.Root className={styles.SliderRoot} orientation="vertical">
-                  <VolumeSlider.Track className={styles.SliderTrack}>
-                    <VolumeSlider.Progress className={styles.SliderProgress} />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb className={styles.SliderThumb} />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
+          <Popover.Positioner side="top" sideOffset={12}>
+            <Popover.Popup className={styles.PopoverPopup}>
+              <VolumeSlider.Root className={styles.SliderRoot} orientation="vertical">
+                <VolumeSlider.Track className={styles.SliderTrack}>
+                  <VolumeSlider.Progress className={styles.SliderProgress} />
+                </VolumeSlider.Track>
+                <VolumeSlider.Thumb className={styles.SliderThumb} />
+              </VolumeSlider.Root>
+            </Popover.Popup>
+          </Popover.Positioner>
         </Popover.Root>
 
         <Tooltip.Root delay={600} closeDelay={0}>
@@ -102,14 +98,12 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <FullscreenExitIcon className={styles.FullScreenExitIcon} />
             </FullscreenButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className={`${styles.TooltipPopup} ${styles.FullScreenTooltipPopup}`}>
-                <span className={styles.FullScreenEnterTooltip}>Enter Fullscreen</span>
-                <span className={styles.FullScreenExitTooltip}>Exit Fullscreen</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className={`${styles.TooltipPopup} ${styles.FullScreenTooltipPopup}`}>
+              <span className={styles.FullScreenEnterTooltip}>Enter Fullscreen</span>
+              <span className={styles.FullScreenExitTooltip}>Exit Fullscreen</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
       </div>
     </MediaContainer>

--- a/examples/react-demo/src/skins/minimal-eject/MinimalSkin.tsx
+++ b/examples/react-demo/src/skins/minimal-eject/MinimalSkin.tsx
@@ -32,14 +32,12 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
               <PauseIcon className="icon pause-icon" />
             </PlayButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top-start" sideOffset={6} collisionPadding={12}>
-              <Tooltip.Popup className="popup-animation tooltip-popup">
-                <span className="tooltip play-tooltip">Play</span>
-                <span className="tooltip pause-tooltip">Pause</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top-start" sideOffset={6} collisionPadding={12}>
+            <Tooltip.Popup className="popup-animation tooltip-popup">
+              <span className="tooltip play-tooltip">Play</span>
+              <span className="tooltip pause-tooltip">Pause</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className="time-display-group">
@@ -65,13 +63,11 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
               <TimeSlider.Thumb className="slider-thumb" />
             </TimeSlider.Root>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className="popup-animation tooltip-popup">
-                <PreviewTimeDisplay className="time-display media-preview-time-display" />
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className="popup-animation tooltip-popup">
+              <PreviewTimeDisplay className="time-display media-preview-time-display" />
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className="button-group">
@@ -83,18 +79,16 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
                 <VolumeOffIcon className="icon volume-off-icon" />
               </MuteButton>
             </Popover.Trigger>
-            <Popover.Portal>
-              <Popover.Positioner side="top" sideOffset={2}>
-                <Popover.Popup className="popup-animation popover-popup">
-                  <VolumeSlider.Root className="slider" orientation="vertical">
-                    <VolumeSlider.Track className="slider-track">
-                      <VolumeSlider.Progress className="slider-progress" />
-                    </VolumeSlider.Track>
-                    <VolumeSlider.Thumb className="slider-thumb" />
-                  </VolumeSlider.Root>
-                </Popover.Popup>
-              </Popover.Positioner>
-            </Popover.Portal>
+            <Popover.Positioner side="top" sideOffset={2}>
+              <Popover.Popup className="popup-animation popover-popup">
+                <VolumeSlider.Root className="slider" orientation="vertical">
+                  <VolumeSlider.Track className="slider-track">
+                    <VolumeSlider.Progress className="slider-progress" />
+                  </VolumeSlider.Track>
+                  <VolumeSlider.Thumb className="slider-thumb" />
+                </VolumeSlider.Root>
+              </Popover.Popup>
+            </Popover.Positioner>
           </Popover.Root>
 
           <Tooltip.Root delay={500} closeDelay={0}>
@@ -104,14 +98,12 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
                 <FullscreenExitAltIcon className="icon fullscreen-exit-icon" />
               </FullscreenButton>
             </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Positioner side="top-end" sideOffset={6} collisionPadding={12}>
-                <Tooltip.Popup className="popup-animation tooltip-popup">
-                  <span className="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
-                  <span className="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
-                </Tooltip.Popup>
-              </Tooltip.Positioner>
-            </Tooltip.Portal>
+            <Tooltip.Positioner side="top-end" sideOffset={6} collisionPadding={12}>
+              <Tooltip.Popup className="popup-animation tooltip-popup">
+                <span className="tooltip fullscreen-enter-tooltip">Enter Fullscreen</span>
+                <span className="tooltip fullscreen-exit-tooltip">Exit Fullscreen</span>
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
           </Tooltip.Root>
         </div>
       </div>

--- a/packages/html/src/elements/popover.ts
+++ b/packages/html/src/elements/popover.ts
@@ -1,6 +1,6 @@
 import { contains, getDocument, getDocumentOrShadowRoot, safePolygon } from '@videojs/utils/dom';
 
-type Placement = 'top' | 'bottom' | 'left' | 'right';
+type Placement = 'top' | 'top-start' | 'top-end';
 
 export class PopoverElement extends HTMLElement {
   static get observedAttributes(): string[] {
@@ -18,9 +18,14 @@ export class PopoverElement extends HTMLElement {
       this.style.setProperty('position-anchor', `--${newValue}`);
     }
 
-    this.style.setProperty('top', `calc(anchor(${this.side}) - ${this.sideOffset}px)`);
+    const [side, alignment] = this.side.split('-');
+    this.style.setProperty('top', `calc(anchor(${side}) - ${this.sideOffset}px)`);
     this.style.setProperty('translate', `0 -100%`);
-    this.style.setProperty('justify-self', 'anchor-center');
+    this.style.setProperty('justify-self', alignment === 'start'
+      ? 'anchor-start'
+      : alignment === 'end'
+        ? 'anchor-end'
+        : 'anchor-center');
   }
 
   connectedCallback(): void {

--- a/packages/html/src/elements/tooltip.ts
+++ b/packages/html/src/elements/tooltip.ts
@@ -6,7 +6,7 @@ import {
   getInBoundsAdjustments,
 } from '@videojs/utils/dom';
 
-type Placement = 'top' | 'bottom' | 'left' | 'right';
+type Placement = 'top' | 'top-start' | 'top-end';
 
 export class TooltipElement extends HTMLElement {
   static get observedAttributes(): string[] {
@@ -30,14 +30,18 @@ export class TooltipElement extends HTMLElement {
     if (name === 'id') {
       this.style.setProperty('position-anchor', `--${newValue}`);
     }
-
-    this.style.setProperty('top', `calc(anchor(${this.side}) - ${this.sideOffset}px)`);
+    const [side, alignment] = this.side.split('-');
+    this.style.setProperty('top', `calc(anchor(${side}) - ${this.sideOffset}px)`);
 
     if (this.trackCursorAxis) {
       this.style.setProperty('translate', `-50% -100%`);
     } else {
       this.style.setProperty('translate', `0 -100%`);
-      this.style.setProperty('justify-self', 'anchor-center');
+      this.style.setProperty('justify-self', alignment === 'start'
+        ? 'anchor-start'
+        : alignment === 'end'
+          ? 'anchor-end'
+          : 'anchor-center');
     }
   }
 

--- a/packages/html/src/media/media-container.ts
+++ b/packages/html/src/media/media-container.ts
@@ -2,14 +2,10 @@ import type { Constructor, CustomElement } from '@open-wc/context-protocol';
 
 import { ConsumerMixin } from '@open-wc/context-protocol';
 
-/* @TODO We need to make sure portal logic is non-brittle longer term (CJP) */
 export function getTemplateHTML() {
   return /* html */ `
     <slot name="media"></slot>
     <slot></slot>
-    <div id="@default_portal_id" style={ position: absolute; zIndex: 10; }>
-      <slot name="portal"></slot>
-    </div>
   `;
 }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,6 @@
     "react": ">=16.8.0"
   },
   "dependencies": {
-    "@floating-ui/react": "^0.27.16",
     "@videojs/core": "workspace:*",
     "@videojs/icons": "workspace:*",
     "@videojs/utils": "workspace:*"

--- a/packages/react/src/components/MediaContainer.tsx
+++ b/packages/react/src/components/MediaContainer.tsx
@@ -54,8 +54,8 @@ export function useMediaContainerRef(): RefCallback<HTMLElement | null> {
  *   </MediaContainer>
  * );
  */
-export const MediaContainer: FC<PropsWithChildren<HTMLProps<HTMLDivElement> & { portalId?: string }>> = forwardRef(
-  ({ children, portalId = '@default_portal_id', ...props }, ref) => {
+export const MediaContainer: FC<PropsWithChildren<HTMLProps<HTMLDivElement>>> = forwardRef(
+  ({ children, ...props }, ref) => {
     const containerRef = useMediaContainerRef();
     const composedRef = useComposedRefs(ref, containerRef);
 
@@ -78,11 +78,10 @@ export const MediaContainer: FC<PropsWithChildren<HTMLProps<HTMLDivElement> & { 
       <div
         ref={composedRef}
         onClick={handleClick}
+        data-media-container
         {...props}
       >
         {children}
-        {/* @TODO We need to make sure this is non-brittle longer term (CJP) */}
-        <div id={portalId} style={{ position: 'absolute', zIndex: 10 }} />
       </div>
     );
   },

--- a/packages/react/src/skins/frosted/FrostedSkin.tsx
+++ b/packages/react/src/skins/frosted/FrostedSkin.tsx
@@ -41,14 +41,12 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <PauseIcon className={`${styles.Icon} ${styles.PauseIcon}`} />
             </PlayButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className={`${styles.TooltipPopup} ${styles.Surface} ${styles.PopupAnimation} ${styles.PlayTooltipPopup}`}>
-                <span className={styles.PlayTooltip}>Play</span>
-                <span className={styles.PauseTooltip}>Pause</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className={`${styles.TooltipPopup} ${styles.Surface} ${styles.PopupAnimation} ${styles.PlayTooltipPopup}`}>
+              <span className={styles.PlayTooltip}>Play</span>
+              <span className={styles.PauseTooltip}>Pause</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className={styles.TimeControls}>
@@ -68,13 +66,11 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
                 <TimeSlider.Thumb className={styles.SliderThumb} />
               </TimeSlider.Root>
             </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Positioner side="top" sideOffset={18} collisionPadding={12}>
-                <Tooltip.Popup className={`${styles.Surface} ${styles.PopupAnimation} ${styles.TooltipPopup}`}>
-                  <PreviewTimeDisplay className={styles.TimeDisplay} />
-                </Tooltip.Popup>
-              </Tooltip.Positioner>
-            </Tooltip.Portal>
+            <Tooltip.Positioner side="top" sideOffset={18} collisionPadding={12}>
+              <Tooltip.Popup className={`${styles.Surface} ${styles.PopupAnimation} ${styles.TooltipPopup}`}>
+                <PreviewTimeDisplay className={styles.TimeDisplay} />
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
           </Tooltip.Root>
 
           <DurationDisplay className={styles.TimeDisplay} />
@@ -88,18 +84,16 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <VolumeOffIcon className={`${styles.Icon} ${styles.VolumeOffIcon}`} />
             </MuteButton>
           </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner side="top" sideOffset={12}>
-              <Popover.Popup className={`${styles.Surface} ${styles.PopupAnimation} ${styles.PopoverPopup}`}>
-                <VolumeSlider.Root className={styles.SliderRoot} orientation="vertical">
-                  <VolumeSlider.Track className={styles.SliderTrack}>
-                    <VolumeSlider.Progress className={styles.SliderProgress} />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb className={styles.SliderThumb} />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
+          <Popover.Positioner side="top" sideOffset={12}>
+            <Popover.Popup className={`${styles.Surface} ${styles.PopupAnimation} ${styles.PopoverPopup}`}>
+              <VolumeSlider.Root className={styles.SliderRoot} orientation="vertical">
+                <VolumeSlider.Track className={styles.SliderTrack}>
+                  <VolumeSlider.Progress className={styles.SliderProgress} />
+                </VolumeSlider.Track>
+                <VolumeSlider.Thumb className={styles.SliderThumb} />
+              </VolumeSlider.Root>
+            </Popover.Popup>
+          </Popover.Positioner>
         </Popover.Root>
 
         <Tooltip.Root delay={500}>
@@ -109,14 +103,12 @@ export default function FrostedSkin({ children, className = '' }: SkinProps): JS
               <FullscreenExitIcon className={`${styles.Icon} ${styles.FullscreenExitIcon}`} />
             </FullscreenButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className={`${styles.Surface} ${styles.PopupAnimation} ${styles.TooltipPopup} ${styles.FullscreenTooltipPopup}`}>
-                <span className={styles.FullscreenEnterTooltip}>Enter Fullscreen</span>
-                <span className={styles.FullscreenExitTooltip}>Exit Fullscreen</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className={`${styles.Surface} ${styles.PopupAnimation} ${styles.TooltipPopup} ${styles.FullscreenTooltipPopup}`}>
+              <span className={styles.FullscreenEnterTooltip}>Enter Fullscreen</span>
+              <span className={styles.FullscreenExitTooltip}>Exit Fullscreen</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
       </div>
     </MediaContainer>

--- a/packages/react/src/skins/minimal/MinimalSkin.tsx
+++ b/packages/react/src/skins/minimal/MinimalSkin.tsx
@@ -41,14 +41,12 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
               <PauseIcon className={`${styles.Icon} ${styles.PauseIcon}`} />
             </PlayButton>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top-start" sideOffset={6} collisionPadding={12}>
-              <Tooltip.Popup className={`${styles.PopupAnimation} ${styles.TooltipPopup} ${styles.PlayTooltipPopup}`}>
-                <span className={styles.PlayTooltip}>Play</span>
-                <span className={styles.PauseTooltip}>Pause</span>
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top-start" sideOffset={6} collisionPadding={12}>
+            <Tooltip.Popup className={`${styles.PopupAnimation} ${styles.TooltipPopup} ${styles.PlayTooltipPopup}`}>
+              <span className={styles.PlayTooltip}>Play</span>
+              <span className={styles.PauseTooltip}>Pause</span>
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className={styles.TimeDisplayGroup}>
@@ -74,13 +72,11 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
               <TimeSlider.Thumb className={styles.SliderThumb} />
             </TimeSlider.Root>
           </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
-              <Tooltip.Popup className={`${styles.PopupAnimation} ${styles.TooltipPopup}`}>
-                <PreviewTimeDisplay className={styles.TimeDisplay} />
-              </Tooltip.Popup>
-            </Tooltip.Positioner>
-          </Tooltip.Portal>
+          <Tooltip.Positioner side="top" sideOffset={12} collisionPadding={12}>
+            <Tooltip.Popup className={`${styles.PopupAnimation} ${styles.TooltipPopup}`}>
+              <PreviewTimeDisplay className={styles.TimeDisplay} />
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
         </Tooltip.Root>
 
         <div className={styles.ButtonGroup}>
@@ -92,18 +88,16 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
                 <VolumeOffIcon className={`${styles.Icon} ${styles.VolumeOffIcon}`} />
               </MuteButton>
             </Popover.Trigger>
-            <Popover.Portal>
-              <Popover.Positioner side="top" sideOffset={2}>
-                <Popover.Popup className={`${styles.PopupAnimation} ${styles.PopoverPopup}`}>
-                  <VolumeSlider.Root className={styles.SliderRoot} orientation="vertical">
-                    <VolumeSlider.Track className={styles.SliderTrack}>
-                      <VolumeSlider.Progress className={styles.SliderProgress} />
-                    </VolumeSlider.Track>
-                    <VolumeSlider.Thumb className={styles.SliderThumb} />
-                  </VolumeSlider.Root>
-                </Popover.Popup>
-              </Popover.Positioner>
-            </Popover.Portal>
+            <Popover.Positioner side="top" sideOffset={2}>
+              <Popover.Popup className={`${styles.PopupAnimation} ${styles.PopoverPopup}`}>
+                <VolumeSlider.Root className={styles.SliderRoot} orientation="vertical">
+                  <VolumeSlider.Track className={styles.SliderTrack}>
+                    <VolumeSlider.Progress className={styles.SliderProgress} />
+                  </VolumeSlider.Track>
+                  <VolumeSlider.Thumb className={styles.SliderThumb} />
+                </VolumeSlider.Root>
+              </Popover.Popup>
+            </Popover.Positioner>
           </Popover.Root>
 
           <Tooltip.Root delay={500} closeDelay={0}>
@@ -113,14 +107,12 @@ export default function MinimalSkin({ children, className = '' }: SkinProps): JS
                 <FullscreenExitAltIcon className={`${styles.Icon} ${styles.FullscreenExitIcon}`} />
               </FullscreenButton>
             </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Positioner side="top-end" sideOffset={6} collisionPadding={12}>
-                <Tooltip.Popup className={`${styles.PopupAnimation} ${styles.TooltipPopup} ${styles.FullscreenTooltipPopup}`}>
-                  <span className={styles.FullscreenEnterTooltip}>Enter Fullscreen</span>
-                  <span className={styles.FullscreenExitTooltip}>Exit Fullscreen</span>
-                </Tooltip.Popup>
-              </Tooltip.Positioner>
-            </Tooltip.Portal>
+            <Tooltip.Positioner side="top-end" sideOffset={6} collisionPadding={12}>
+              <Tooltip.Popup className={`${styles.PopupAnimation} ${styles.TooltipPopup} ${styles.FullscreenTooltipPopup}`}>
+                <span className={styles.FullscreenEnterTooltip}>Enter Fullscreen</span>
+                <span className={styles.FullscreenExitTooltip}>Exit Fullscreen</span>
+              </Tooltip.Popup>
+            </Tooltip.Positioner>
           </Tooltip.Root>
         </div>
       </div>

--- a/packages/react/src/skins/minimal/styles.ts
+++ b/packages/react/src/skins/minimal/styles.ts
@@ -131,7 +131,7 @@ const styles: MinimalSkinStyles = {
     'vjs:data-starting-style:scale-0 vjs:data-starting-style:opacity-0 vjs:data-starting-style:blur-sm',
     'vjs:data-ending-style:scale-0 vjs:data-ending-style:opacity-0 vjs:data-ending-style:blur-sm',
   ),
-  PopoverPopup: cn('vjs:py-2'),
+  PopoverPopup: cn('vjs:py-2 vjs:bg-transparent'),
   TooltipPopup: cn(
     'vjs:whitespace-nowrap vjs:flex vjs:flex-col vjs:rounded vjs:text-white vjs:text-xs vjs:@7xl/root:text-sm vjs:px-2 vjs:py-1 vjs:bg-white/20 vjs:backdrop-blur-3xl vjs:backdrop-saturate-150 vjs:backdrop-brightness-90 vjs:shadow-md vjs:shadow-black/5',
   ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,9 +226,6 @@ importers:
 
   packages/react:
     dependencies:
-      '@floating-ui/react':
-        specifier: ^0.27.16
-        version: 0.27.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@videojs/core':
         specifier: workspace:*
         version: link:../core
@@ -1055,12 +1052,6 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
-
-  '@floating-ui/react@0.27.16':
-    resolution: {integrity: sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==}
-    peerDependencies:
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
@@ -7397,14 +7388,6 @@ snapshots:
       '@floating-ui/dom': 1.7.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@floating-ui/react@0.27.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.10
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.10': {}
 


### PR DESCRIPTION
This pull request refactors how popover and tooltip portals are handled in the React demo skins and the core HTML/React packages. The main change is the removal of custom portal logic and the adoption of a simpler, more direct positioning approach for overlays. This reduces complexity, removes reliance on external libraries, and aligns the implementation across different skins and core components.

**Popover & Tooltip Portal Refactoring**

* Removed all usages of `Tooltip.Portal` and `Popover.Portal` in the React demo skins (`FrostedSkin.tsx`, `MinimalSkin.tsx`, etc.), simplifying the overlay rendering logic. [[1]](diffhunk://#diff-6dd6c990cd6a970b21c27717b72ab0081f92341a306b5924d942029f10ebd39aL35-L42) [[2]](diffhunk://#diff-6dd6c990cd6a970b21c27717b72ab0081f92341a306b5924d942029f10ebd39aL62-L68) [[3]](diffhunk://#diff-6dd6c990cd6a970b21c27717b72ab0081f92341a306b5924d942029f10ebd39aL82) [[4]](diffhunk://#diff-6dd6c990cd6a970b21c27717b72ab0081f92341a306b5924d942029f10ebd39aL93) [[5]](diffhunk://#diff-6dd6c990cd6a970b21c27717b72ab0081f92341a306b5924d942029f10ebd39aL103-L110) [[6]](diffhunk://#diff-79c822c1384d307a60cd7985fc4f9af9e42e5e0909e4df345d93914f84e310c5L48-L55) [[7]](diffhunk://#diff-79c822c1384d307a60cd7985fc4f9af9e42e5e0909e4df345d93914f84e310c5L84) [[8]](diffhunk://#diff-79c822c1384d307a60cd7985fc4f9af9e42e5e0909e4df345d93914f84e310c5L95) [[9]](diffhunk://#diff-79c822c1384d307a60cd7985fc4f9af9e42e5e0909e4df345d93914f84e310c5L105-L112) [[10]](diffhunk://#diff-27ea2236818176d278a53d4996a4a20fa92d76e30d98c5f9454a51766a312144L35-L42) [[11]](diffhunk://#diff-27ea2236818176d278a53d4996a4a20fa92d76e30d98c5f9454a51766a312144L68-L74) [[12]](diffhunk://#diff-27ea2236818176d278a53d4996a4a20fa92d76e30d98c5f9454a51766a312144L86) [[13]](diffhunk://#diff-27ea2236818176d278a53d4996a4a20fa92d76e30d98c5f9454a51766a312144L97) [[14]](diffhunk://#diff-27ea2236818176d278a53d4996a4a20fa92d76e30d98c5f9454a51766a312144L107-L114)
* Removed portal slot and related logic from the HTML media container template (`media-container.ts`), and the React `MediaContainer` component no longer includes a `portalId` prop or portal div. [[1]](diffhunk://#diff-539c272e70bca5c44ad5429f4e9c6e083ee9f2b930a100fc0a5e1edb584059ceL5-L12) [[2]](diffhunk://#diff-e517e2b7a9b37fee92cca584247d47a7726f28ee7773de86f2eea807758ac759L57-R58) [[3]](diffhunk://#diff-e517e2b7a9b37fee92cca584247d47a7726f28ee7773de86f2eea807758ac759R81-L85)

**Positioning and Placement Improvements**

* Updated the popover and tooltip core HTML elements to support new placement values (`top`, `top-start`, `top-end`) and improved alignment logic, enabling more flexible positioning. [[1]](diffhunk://#diff-b8a805aa0fb265254f5f2bed416d56d607ac1b13b774d4b7c141788f68807918L3-R3) [[2]](diffhunk://#diff-b8a805aa0fb265254f5f2bed416d56d607ac1b13b774d4b7c141788f68807918L21-R28) [[3]](diffhunk://#diff-657f5587a2ccf7dbc57df5c9b18a34ba2209f2d5b6e36e3b1815847fadb57f06L9-R9) [[4]](diffhunk://#diff-657f5587a2ccf7dbc57df5c9b18a34ba2209f2d5b6e36e3b1815847fadb57f06L33-R44)
* Synced the React popover/tooltip types and context to match the new placement values and removed dependencies on `@floating-ui/react`. [[1]](diffhunk://#diff-3c9c812ee86e6553f76fee0e345b349d7b8f443c4455d6cdf88d40be1daa685dL1-R3) [[2]](diffhunk://#diff-3c9c812ee86e6553f76fee0e345b349d7b8f443c4455d6cdf88d40be1daa685dR13-R29) [[3]](diffhunk://#diff-3c9c812ee86e6553f76fee0e345b349d7b8f443c4455d6cdf88d40be1daa685dR50-L72) [[4]](diffhunk://#diff-1f344ac391eeecc21ec0f01fb07430a47f4b80d20485c125447d54c33c4bbfc4L58)

**CSS and Style Adjustments**

* Updated popover popup styles in the frosted skin CSS to remove transparent backgrounds and box shadows, further simplifying overlay appearance.

**Dependency Clean-up**

* Removed `@floating-ui/react` from the React package dependencies, as it is no longer needed for popover/tooltip positioning.

These changes make the overlay system more maintainable and consistent, while reducing reliance on external libraries and custom portal logic.