### PR TITLE
chore: workaround race condition build-styles.ts

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,8 +10,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "interactive": false,
-      "dependsOn": ["^build"]
+      "interactive": false
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
with tsdown don't think dev requires a depends on a build task

looks like a race condition because dev and build were running in parallel?

<img width="935" height="643" alt="SCR-20251114-jbnd" src="https://github.com/user-attachments/assets/61c308f0-9df3-461f-a5c2-38d9eaa49e7f" />
