### PR TITLE
fix: use popover core in react popover

### DIFF
--- a/packages/core/src/components/popover.ts
+++ b/packages/core/src/components/popover.ts
@@ -132,6 +132,7 @@ export class Popover {
     } else {
       this.setState({ _transitionStatus: 'close' });
 
+      // This requestAnimationFrame is required for React because the data- attributes are not updated immediately.
       requestAnimationFrame(() => {
         const transitions = this.#popoverElement?.getAnimations().filter(anim => anim instanceof CSSTransition);
         if (transitions && transitions.length > 0) {

--- a/packages/html/src/elements/popover.ts
+++ b/packages/html/src/elements/popover.ts
@@ -2,7 +2,6 @@ import type { Prettify } from '../types';
 import type { ConnectedComponentConstructor, PropsHook, StateHook } from '../utils/component-factory';
 
 import { Popover as CorePopover } from '@videojs/core';
-
 import { getDocumentOrShadowRoot } from '@videojs/utils/dom';
 import { getCoreState, getPropsFromAttrs, toConnectedHTMLComponent } from '../utils/component-factory';
 

--- a/packages/react/src/components/Popover.tsx
+++ b/packages/react/src/components/Popover.tsx
@@ -49,8 +49,6 @@ export function usePopoverRootState(props: PopoverRootProps): PopoverState {
 
   return {
     ...coreState,
-    placement,
-    sideOffset,
     popupId,
     updatePositioning,
   };


### PR DESCRIPTION
This PR makes the React Popover component use the Core component removing duplicated code.