### PR TITLE
fix(core): fixed fullscreen on ios safari

### DIFF
--- a/packages/core/src/store/mediators/fullscreenable.ts
+++ b/packages/core/src/store/mediators/fullscreenable.ts
@@ -66,7 +66,7 @@ export const fullscreenable = {
           // Enter fullscreen
           if (container.requestFullscreen) {
             container.requestFullscreen();
-          } else if (media._playbackEngine.element.webkitEnterFullscreen) {
+          } else if (media._playbackEngine?.element?.webkitEnterFullscreen) {
             // Safari support (IOS)
             media._playbackEngine.element.webkitEnterFullscreen();
           } else if (container.webkitRequestFullscreen) {


### PR DESCRIPTION
This PR is aiming to fix the issue where fullscreen on safari does not work (issue #209). The issue related to requesting full screen on the container, but in IOS Safari you need to request full screen on the video element. 

Therefore, I added a check to determine if the user is on safari & IOS and if so request full screen on the video element.


```js
const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
const isSafari = typeof navigator !== 'undefined' && navigator.userAgent.includes('Safari');

...


if (isIOS && isSafari) {
    // Safari (IOS Support)
    const videoElement = media?._playbackEngine?.element || media;
    (videoElement as any).webkitEnterFullscreen();
}
```


Let me know if you need me to make any changes or want me to explain something a bit better.


