### PR TITLE
refactor(store): remove partial slice state updates

### DIFF
--- a/packages/core/src/dom/store/slices/buffer.ts
+++ b/packages/core/src/dom/store/slices/buffer.ts
@@ -22,9 +22,8 @@ export const bufferSlice = createSlice<HTMLMediaElement>()({
   }),
 
   subscribe: ({ target, update, signal }) => {
-    const sync = () => update();
-    listen(target, 'progress', sync, { signal });
-    listen(target, 'emptied', sync, { signal });
+    listen(target, 'progress', update, { signal });
+    listen(target, 'emptied', update, { signal });
   },
 
   request: {},

--- a/packages/core/src/dom/store/slices/playback.ts
+++ b/packages/core/src/dom/store/slices/playback.ts
@@ -28,12 +28,11 @@ export const playbackSlice = createSlice<HTMLMediaElement>()({
   }),
 
   subscribe: ({ target, update, signal }) => {
-    const sync = () => update();
-    listen(target, 'play', sync, { signal });
-    listen(target, 'pause', sync, { signal });
-    listen(target, 'ended', sync, { signal });
-    listen(target, 'playing', sync, { signal });
-    listen(target, 'waiting', sync, { signal });
+    listen(target, 'play', update, { signal });
+    listen(target, 'pause', update, { signal });
+    listen(target, 'ended', update, { signal });
+    listen(target, 'playing', update, { signal });
+    listen(target, 'waiting', update, { signal });
   },
 
   request: {

--- a/packages/core/src/dom/store/slices/source.ts
+++ b/packages/core/src/dom/store/slices/source.ts
@@ -22,11 +22,10 @@ export const sourceSlice = createSlice<HTMLMediaElement>()({
   }),
 
   subscribe: ({ target, update, signal }) => {
-    const sync = () => update();
-    listen(target, 'canplay', sync, { signal });
-    listen(target, 'canplaythrough', sync, { signal });
-    listen(target, 'loadstart', sync, { signal });
-    listen(target, 'emptied', sync, { signal });
+    listen(target, 'canplay', update, { signal });
+    listen(target, 'canplaythrough', update, { signal });
+    listen(target, 'loadstart', update, { signal });
+    listen(target, 'emptied', update, { signal });
   },
 
   request: {

--- a/packages/core/src/dom/store/slices/time.ts
+++ b/packages/core/src/dom/store/slices/time.ts
@@ -22,12 +22,11 @@ export const timeSlice = createSlice<HTMLMediaElement>()({
   }),
 
   subscribe: ({ target, update, signal }) => {
-    const sync = () => update();
-    listen(target, 'timeupdate', sync, { signal });
-    listen(target, 'durationchange', sync, { signal });
-    listen(target, 'seeked', sync, { signal });
-    listen(target, 'loadedmetadata', sync, { signal });
-    listen(target, 'emptied', sync, { signal });
+    listen(target, 'timeupdate', update, { signal });
+    listen(target, 'durationchange', update, { signal });
+    listen(target, 'seeked', update, { signal });
+    listen(target, 'loadedmetadata', update, { signal });
+    listen(target, 'emptied', update, { signal });
   },
 
   request: {

--- a/packages/core/src/dom/store/slices/volume.ts
+++ b/packages/core/src/dom/store/slices/volume.ts
@@ -22,8 +22,7 @@ export const volumeSlice = createSlice<HTMLMediaElement>()({
   }),
 
   subscribe: ({ target, update, signal }) => {
-    const sync = () => update();
-    listen(target, 'volumechange', sync, { signal });
+    listen(target, 'volumechange', update, { signal });
   },
 
   request: {

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -35,16 +35,14 @@ export interface SliceGetSnapshotContext<Target, State> {
 
 export type SliceSubscribe<Target, State extends object> = (ctx: SliceSubscribeContext<Target, State>) => void;
 
-export interface SliceSubscribeContext<Target, State extends object> {
+export interface SliceSubscribeContext<Target, _State extends object> {
   target: Target;
-  update: SliceUpdate<State>;
+  update: SliceUpdate;
   signal: AbortSignal;
 }
 
-export interface SliceUpdate<State extends object> {
-  (): void;
-  (state: Partial<State>): void;
-}
+/** Sync slice state from target via getSnapshot. */
+export type SliceUpdate = () => void;
 
 export interface SliceConfig<
   Target,

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -1,6 +1,13 @@
 import type { PendingTask, Task, TaskContext } from './queue';
 import type { RequestMeta, RequestMetaInit, ResolvedRequestConfig } from './request';
-import type { AnySlice, Slice, UnionSliceRequests, UnionSliceState, UnionSliceTarget, UnionSliceTasks } from './slice';
+import type {
+  AnySlice,
+  SliceUpdate,
+  UnionSliceRequests,
+  UnionSliceState,
+  UnionSliceTarget,
+  UnionSliceTasks,
+} from './slice';
 import type { StateFactory } from './state';
 
 import { getSelectorKeys } from '@videojs/utils/object';
@@ -115,20 +122,10 @@ export class Store<Target, Slices extends AnySlice<Target>[] = AnySlice<Target>[
     return () => this.#detach();
   }
 
-  #createUpdate<State extends object>(slice: Slice<Target, State, any>) {
-    return (partial?: Partial<State>) => {
+  #createUpdate(slice: AnySlice<Target>): SliceUpdate {
+    return () => {
       const target = this.#target;
-      if (!target) return;
-
-      try {
-        if (partial === undefined) {
-          this.#syncSlice(slice, target);
-        } else {
-          this.#state.patch(partial as Partial<UnionSliceState<Slices>>);
-        }
-      } catch (error) {
-        this.#handleError({ error });
-      }
+      if (target) this.#syncSlice(slice, target);
     };
   }
 

--- a/packages/store/src/core/tests/integration/store.test.ts
+++ b/packages/store/src/core/tests/integration/store.test.ts
@@ -15,7 +15,7 @@ describe('store lifecycle integration', () => {
       getSnapshot: ({ target }) => ({ count: target.value }),
       subscribe: ({ target, update, signal }) => {
         events.push('subscribe');
-        target.addEventListener('change', () => update(), { signal });
+        target.addEventListener('change', update, { signal });
         signal.addEventListener('abort', () => events.push('unsubscribe'));
       },
       request: {
@@ -231,7 +231,7 @@ describe('request coordination', () => {
 });
 
 describe('state syncing', () => {
-  it('partial updates only trigger relevant subscriptions', async () => {
+  it('updates only trigger subscriptions for changed keys', async () => {
     const volumeUpdates: number[] = [];
     const mutedUpdates: boolean[] = [];
 
@@ -250,21 +250,8 @@ describe('state syncing', () => {
         muted: target.muted,
       }),
       subscribe: ({ target, update, signal }) => {
-        target.addEventListener(
-          'volumechange',
-          () => {
-            update({ volume: target.volume });
-          },
-          { signal },
-        );
-
-        target.addEventListener(
-          'mutechange',
-          () => {
-            update({ muted: target.muted });
-          },
-          { signal },
-        );
+        target.addEventListener('volumechange', update, { signal });
+        target.addEventListener('mutechange', update, { signal });
       },
       request: {
         setVolume: (volume: number, { target }) => {

--- a/packages/store/src/core/tests/store.test.ts
+++ b/packages/store/src/core/tests/store.test.ts
@@ -21,10 +21,9 @@ describe('store', () => {
       muted: target.muted,
     }),
     subscribe: ({ target, update, signal }) => {
-      const handler = () => update();
-      target.addEventListener('volumechange', handler);
+      target.addEventListener('volumechange', update);
       signal.addEventListener('abort', () => {
-        target.removeEventListener('volumechange', handler);
+        target.removeEventListener('volumechange', update);
       });
     },
     request: {

--- a/packages/store/src/react/tests/create-store.test.tsx
+++ b/packages/store/src/react/tests/create-store.test.tsx
@@ -21,10 +21,9 @@ describe('createStore', () => {
       muted: target.muted,
     }),
     subscribe: ({ target, update, signal }) => {
-      const handler = () => update();
-      target.addEventListener('volumechange', handler);
+      target.addEventListener('volumechange', update);
       signal.addEventListener('abort', () => {
-        target.removeEventListener('volumechange', handler);
+        target.removeEventListener('volumechange', update);
       });
     },
     request: {

--- a/packages/store/src/react/tests/hooks.test.tsx
+++ b/packages/store/src/react/tests/hooks.test.tsx
@@ -20,10 +20,9 @@ describe('react hooks', () => {
       muted: target.muted,
     }),
     subscribe: ({ target, update, signal }) => {
-      const handler = () => update();
-      target.addEventListener('volumechange', handler);
+      target.addEventListener('volumechange', update);
       signal.addEventListener('abort', () => {
-        target.removeEventListener('volumechange', handler);
+        target.removeEventListener('volumechange', update);
       });
     },
     request: {


### PR DESCRIPTION
Remove the `(state: Partial<State>)` overload from slice `update` callback.

Previously, slices could call `update({ key: value })` to patch state directly, bypassing `getSnapshot`. This created two code paths for state derivation and risked inconsistent derived state.

Now `update()` always syncs via `getSnapshot`, ensuring a single source of truth. The store's `State.patch()` already detects changed keys and only notifies relevant subscribers, so efficiency is maintained.