### PR TITLE
refactor(store): use undefined instead of null for void-input placeholder

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -177,12 +177,12 @@ await store.request.seek(30);
 Every request accepts optional metadata as the last argument.
 
 ```ts
-store.request.play(null, { source: 'user', reason: 'play-button' });
+store.request.play(undefined, { source: 'user', reason: 'play-button' });
 store.request.seek(30, { source: 'user', reason: 'slider-scrub' });
-store.request.pause(null, { source: 'system', reason: 'ad-start' });
+store.request.pause(undefined, { source: 'system', reason: 'ad-start' });
 
 // Infer metadata from DOM event
-store.request.play(null, createRequestMetaFromEvent(clickEvent)); // MouseEvent
+store.request.play(undefined, createRequestMetaFromEvent(clickEvent)); // MouseEvent
 ```
 
 Handlers receive metadata:

--- a/packages/store/src/core/request.ts
+++ b/packages/store/src/core/request.ts
@@ -105,8 +105,8 @@ export type ResolveRequestMap<Requests> = {
 
 export type ResolveRequestHandler<R>
   = R extends Request<infer I, infer O>
-    ? [I] extends [void]
-        ? (input?: null, meta?: RequestMetaInit) => Promise<O>
+    ? [I] extends [void | undefined]
+        ? (input?: undefined, meta?: RequestMetaInit) => Promise<O>
         : (input: I, meta?: RequestMetaInit) => Promise<O>
     : never;
 

--- a/packages/store/src/core/tests/store.test.ts
+++ b/packages/store/src/core/tests/store.test.ts
@@ -252,7 +252,7 @@ describe('store', () => {
 
       store.attach(new MockMedia());
 
-      await store.request.action(null, {
+      await store.request.action(undefined, {
         source: 'user',
         reason: 'test',
       });


### PR DESCRIPTION
## Summary

- Change type signature for void-input requests from `(input?: null, meta?)` to `(input?: undefined, meta?)` for more idiomatic JS/TS usage
- Also handle `undefined` input type in addition to `void`

## Changes

| File | Change |
|------|--------|
| `request.ts` | Update `ResolveRequestHandler` type |
| `store.test.ts` | Update test to use `undefined` |
| `README.md` | Update examples |

## Usage

```ts
// Before
store.request.play(null, { source: 'user' });

// After
store.request.play(undefined, { source: 'user' });
```