### PR TITLE
docs(design): cross-reference feature-slice and feature-availability

### DIFF
--- a/internal/design/feature-availability-design.md
+++ b/internal/design/feature-availability-design.md
@@ -38,11 +38,11 @@ type FeatureAvailability = 'available' | 'unavailable' | 'unsupported';
 
 ## Related: Missing Feature vs Unavailable Capability
 
-See [player-api](/rfc/player-api/index.md) for feature access patterns.
+See [feature-slice-design](feature-slice-design.md) for feature access patterns.
 
 | Concept                | Cause               | Detection                         |
 | ---------------------- | ------------------- | --------------------------------- |
-| Missing feature        | Composition error   | `hasFeature()` returns `false`    |
+| Missing feature        | Feature not included| `slice === undefined`             |
 | Unavailable capability | Platform limitation | `*Availability === 'unsupported'` |
 
 ---
@@ -104,24 +104,6 @@ const volumeFeature = createFeature<HTMLMediaElement>()({
 ### Guards
 
 Guards receive `{ target, signal }`, not state. Check capability on target directly.
-
-### UI Usage
-
-```tsx
-function VolumeSlider() {
-  const player = usePlayer();
-
-  if (!hasFeature(player, features.volume)) return null;
-
-  const { volume, volumeAvailability } = player;
-
-  if (volumeAvailability === 'unsupported') return null;
-  if (volumeAvailability === 'unavailable') return <Slider disabled />;
-  return <Slider value={volume} />;
-}
-```
-
----
 
 ## References
 

--- a/internal/design/feature-slice-design.md
+++ b/internal/design/feature-slice-design.md
@@ -154,9 +154,9 @@ A thin lens over the store — flat access, scoped subscription:
 3. **Layered API** — Primitive layer is generic, player layer is typed and convenient
 4. **Familiar pattern** — Similar to Jotai atoms, Vue InjectionKey
 
-## Alternatives Considered
+## Related
 
-See [`rfc/player-api/primitives.md`](../../rfc/player-api/primitives.md) for the proxy-level API.
+See [feature-availability-design](feature-availability-design.md) for capability detection patterns.
 
 ## Files
 


### PR DESCRIPTION
## Summary

Updates cross-references between design docs:
- `feature-availability-design.md` → references `feature-slice-design.md` for feature access patterns
- `feature-slice-design.md` → references `feature-availability-design.md` for capability detection

Part of #350.