### PR TITLE
refactor(store): simplify create store implementations

### DIFF
--- a/packages/store/src/lit/create-store.ts
+++ b/packages/store/src/lit/create-store.ts
@@ -7,7 +7,7 @@ import type { AnyFeature, UnionFeatureRequests, UnionFeatureState, UnionFeatureT
 import type { StoreConfig, StoreConsumer, StoreProvider } from '../core/store';
 
 import { Store } from '../core/store';
-import { createStoreAttachMixin, createStoreMixin, createStoreProviderMixin } from './mixins';
+import { createContainerMixin, createProviderMixin, createStoreMixin } from './mixins';
 
 export const contextKey = Symbol('@videojs/store');
 
@@ -37,10 +37,10 @@ export interface CreateStoreResult<Features extends AnyFeature[]> {
    *
    * @example
    * ```ts
-   * class MyProvider extends StoreProviderMixin(LitElement) {}
+   * class MyProvider extends ProviderMixin(LitElement) {}
    * ```
    */
-  StoreProviderMixin: <T extends Constructor<ReactiveElement>>(Base: T) => T & Constructor<StoreProvider<Features>>;
+  ProviderMixin: <T extends Constructor<ReactiveElement>>(Base: T) => T & Constructor<StoreProvider<Features>>;
 
   /**
    * Mixin that auto-attaches slotted media elements (requires store from context).
@@ -49,10 +49,10 @@ export interface CreateStoreResult<Features extends AnyFeature[]> {
    *
    * @example
    * ```ts
-   * class MyControls extends StoreAttachMixin(LitElement) {}
+   * class MyControls extends ContainerMixin(LitElement) {}
    * ```
    */
-  StoreAttachMixin: <T extends Constructor<ReactiveElement>>(Base: T) => T & Constructor<StoreConsumer<Features>>;
+  ContainerMixin: <T extends Constructor<ReactiveElement>>(Base: T) => T & Constructor<StoreConsumer<Features>>;
 
   /**
    * Context for consuming store in controllers.
@@ -156,8 +156,8 @@ export function createStore<Features extends AnyFeature[]>(
     return new Store(config);
   }
 
-  const StoreProviderMixin = createStoreProviderMixin<Features>(context, create);
-  const StoreAttachMixin = createStoreAttachMixin<Features>(context);
+  const ProviderMixin = createProviderMixin<Features>(context, create);
+  const ContainerMixin = createContainerMixin<Features>(context);
   const StoreMixin = createStoreMixin<Features>(context, create);
 
   class StoreController {
@@ -208,8 +208,8 @@ export function createStore<Features extends AnyFeature[]>(
 
   return {
     StoreMixin,
-    StoreProviderMixin,
-    StoreAttachMixin,
+    ProviderMixin,
+    ContainerMixin,
     context,
     create,
     StoreController,

--- a/packages/store/src/lit/index.ts
+++ b/packages/store/src/lit/index.ts
@@ -15,9 +15,9 @@ export { createStore } from './create-store';
 
 // Mixin factories (for advanced use cases)
 export {
-  createStoreAttachMixin,
+  createContainerMixin,
+  createProviderMixin,
   createStoreMixin,
-  createStoreProviderMixin,
 } from './mixins';
 export type { StoreSource } from './store-accessor';
 // StoreAccessor (for custom controllers)

--- a/packages/store/src/lit/mixins/combined-mixin.ts
+++ b/packages/store/src/lit/mixins/combined-mixin.ts
@@ -5,8 +5,8 @@ import type { AnyFeature, UnionFeatureTarget } from '../../core/feature';
 
 import type { Store, StoreProvider } from '../../core/store';
 
-import { createStoreAttachMixin } from './attach-mixin';
-import { createStoreProviderMixin } from './provider-mixin';
+import { createContainerMixin } from './container-mixin';
+import { createProviderMixin } from './provider-mixin';
 
 /**
  * Creates a combined mixin that both provides a store and auto-attaches media elements.
@@ -29,13 +29,13 @@ export function createStoreMixin<Features extends AnyFeature[]>(
   context: Context<unknown, Store<UnionFeatureTarget<Features>, Features>>,
   factory: () => Store<UnionFeatureTarget<Features>, Features>
 ): Mixin<ReactiveElement, StoreProvider<Features>> {
-  const ProviderMixin = createStoreProviderMixin<Features>(context, factory);
-  const AttachMixin = createStoreAttachMixin<Features>(context);
+  const ProviderMixin = createProviderMixin<Features>(context, factory);
+  const ContainerMixin = createContainerMixin<Features>(context);
 
   return <Base extends Constructor<ReactiveElement>>(BaseClass: Base) => {
     // ProviderMixin wraps AttachMixin so during connectedCallback:
     // 1. ProviderMixin runs first (provides store via context)
     // 2. AttachMixin runs second (consumes store from context)
-    return ProviderMixin(AttachMixin(BaseClass));
+    return ProviderMixin(ContainerMixin(BaseClass));
   };
 }

--- a/packages/store/src/lit/mixins/container-mixin.ts
+++ b/packages/store/src/lit/mixins/container-mixin.ts
@@ -20,12 +20,12 @@ import type { Store, StoreConsumer } from '../../core/store';
  *
  * @example
  * ```ts
- * const { StoreAttachMixin } = createStore({ features: [playbackFeature] });
+ * const { ContainerMixin } = createStore({ features: [playbackFeature] });
  *
- * class MyControls extends StoreAttachMixin(LitElement) {}
+ * class MyControls extends ContainerMixin(LitElement) {}
  * ```
  */
-export function createStoreAttachMixin<Features extends AnyFeature[]>(
+export function createContainerMixin<Features extends AnyFeature[]>(
   context: Context<unknown, Store<UnionFeatureTarget<Features>, Features>>
 ): Mixin<ReactiveElement, StoreConsumer<Features>> {
   type ConsumedStore = Store<UnionFeatureTarget<Features>, Features>;

--- a/packages/store/src/lit/mixins/index.ts
+++ b/packages/store/src/lit/mixins/index.ts
@@ -1,3 +1,3 @@
-export { createStoreAttachMixin } from './attach-mixin';
 export { createStoreMixin } from './combined-mixin';
-export { createStoreProviderMixin } from './provider-mixin';
+export { createContainerMixin } from './container-mixin';
+export { createProviderMixin } from './provider-mixin';

--- a/packages/store/src/lit/mixins/provider-mixin.ts
+++ b/packages/store/src/lit/mixins/provider-mixin.ts
@@ -16,18 +16,18 @@ import type { Store, StoreProvider } from '../../core/store';
  *
  * @example
  * ```ts
- * const { StoreProviderMixin } = createStore({
+ * const { ProviderMixin } = createStore({
  *   features: [playbackFeature]
  * });
  *
- * class MyPlayer extends StoreProviderMixin(LitElement) {
+ * class MyPlayer extends ProviderMixin(LitElement) {
  *   render() {
  *     return html`<slot></slot>`;
  *   }
  * }
  * ```
  */
-export function createStoreProviderMixin<Features extends AnyFeature[]>(
+export function createProviderMixin<Features extends AnyFeature[]>(
   context: Context<unknown, Store<UnionFeatureTarget<Features>, Features>>,
   factory: () => Store<UnionFeatureTarget<Features>, Features>
 ): <Base extends Constructor<ReactiveElement>>(BaseClass: Base) => Base & Constructor<StoreProvider<Features>> {

--- a/packages/store/src/lit/mixins/tests/container-mixin.test.ts
+++ b/packages/store/src/lit/mixins/tests/container-mixin.test.ts
@@ -4,12 +4,12 @@ import { createLitTestStore, setupDomCleanup, TestBaseElement, uniqueTag } from 
 
 setupDomCleanup();
 
-describe('createStoreAttachMixin', () => {
+describe('createContainerMixin', () => {
   it('exposes store property (initially null without context)', async () => {
-    const { StoreAttachMixin } = createLitTestStore();
-    const tagName = uniqueTag('test-attach-standalone');
+    const { ContainerMixin } = createLitTestStore();
+    const tagName = uniqueTag('test-container-standalone');
 
-    class TestElement extends StoreAttachMixin(TestBaseElement) {}
+    class TestElement extends ContainerMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;
@@ -21,9 +21,9 @@ describe('createStoreAttachMixin', () => {
   });
 
   it('can be applied to TestBaseElement', () => {
-    const { StoreAttachMixin } = createLitTestStore();
+    const { ContainerMixin } = createLitTestStore();
 
-    class MixedElement extends StoreAttachMixin(TestBaseElement) {}
+    class MixedElement extends ContainerMixin(TestBaseElement) {}
 
     expect(MixedElement.prototype).toBeInstanceOf(TestBaseElement);
   });

--- a/packages/store/src/lit/mixins/tests/provider-mixin.test.ts
+++ b/packages/store/src/lit/mixins/tests/provider-mixin.test.ts
@@ -4,12 +4,12 @@ import { createLitTestStore, setupDomCleanup, TestBaseElement, uniqueTag } from 
 
 setupDomCleanup();
 
-describe('createStoreProviderMixin', () => {
+describe('createProviderMixin', () => {
   it('creates store lazily on first access', async () => {
-    const { StoreProviderMixin } = createLitTestStore();
+    const { ProviderMixin } = createLitTestStore();
     const tagName = uniqueTag('test-provider');
 
-    class TestElement extends StoreProviderMixin(TestBaseElement) {}
+    class TestElement extends ProviderMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;
@@ -21,10 +21,10 @@ describe('createStoreProviderMixin', () => {
   });
 
   it('reuses same store instance', async () => {
-    const { StoreProviderMixin } = createLitTestStore();
+    const { ProviderMixin } = createLitTestStore();
     const tagName = uniqueTag('test-provider-reuse');
 
-    class TestElement extends StoreProviderMixin(TestBaseElement) {}
+    class TestElement extends ProviderMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;
@@ -38,10 +38,10 @@ describe('createStoreProviderMixin', () => {
   });
 
   it('destroys owned store on disconnect', async () => {
-    const { StoreProviderMixin } = createLitTestStore();
+    const { ProviderMixin } = createLitTestStore();
     const tagName = uniqueTag('test-provider-destroy');
 
-    class TestElement extends StoreProviderMixin(TestBaseElement) {}
+    class TestElement extends ProviderMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;
@@ -57,10 +57,10 @@ describe('createStoreProviderMixin', () => {
   });
 
   it('allows setting custom store via setter', async () => {
-    const { StoreProviderMixin, create } = createLitTestStore();
+    const { ProviderMixin, create } = createLitTestStore();
     const tagName = uniqueTag('test-provider-setter');
 
-    class TestElement extends StoreProviderMixin(TestBaseElement) {}
+    class TestElement extends ProviderMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;
@@ -74,10 +74,10 @@ describe('createStoreProviderMixin', () => {
   });
 
   it('does not destroy externally provided store on disconnect', async () => {
-    const { StoreProviderMixin, create } = createLitTestStore();
+    const { ProviderMixin, create } = createLitTestStore();
     const tagName = uniqueTag('test-provider-external');
 
-    class TestElement extends StoreProviderMixin(TestBaseElement) {}
+    class TestElement extends ProviderMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;
@@ -93,10 +93,10 @@ describe('createStoreProviderMixin', () => {
   });
 
   it('destroys old owned store when setting new store', async () => {
-    const { StoreProviderMixin, create } = createLitTestStore();
+    const { ProviderMixin, create } = createLitTestStore();
     const tagName = uniqueTag('test-provider-replace');
 
-    class TestElement extends StoreProviderMixin(TestBaseElement) {}
+    class TestElement extends ProviderMixin(TestBaseElement) {}
     customElements.define(tagName, TestElement);
 
     const el = document.createElement(tagName) as TestElement;

--- a/packages/store/src/lit/mixins/tests/types.test.ts
+++ b/packages/store/src/lit/mixins/tests/types.test.ts
@@ -12,18 +12,18 @@ describe('mixin types', () => {
     expectTypeOf<Instance>().toHaveProperty('store');
   });
 
-  it('storeProviderMixin adds store property', () => {
-    const { StoreProviderMixin } = createLitTestStore();
-    const _MixedElement = StoreProviderMixin(TestBaseElement);
+  it('providerMixin adds store property', () => {
+    const { ProviderMixin } = createLitTestStore();
+    const _MixedElement = ProviderMixin(TestBaseElement);
     type Instance = InstanceType<typeof _MixedElement>;
 
     // Verify store property exists on the mixed type
     expectTypeOf<Instance>().toHaveProperty('store');
   });
 
-  it('storeAttachMixin adds store property', () => {
-    const { StoreAttachMixin } = createLitTestStore();
-    const _MixedElement = StoreAttachMixin(TestBaseElement);
+  it('containerMixin adds store property', () => {
+    const { ContainerMixin } = createLitTestStore();
+    const _MixedElement = ContainerMixin(TestBaseElement);
     type Instance = InstanceType<typeof _MixedElement>;
 
     // Verify store property exists on the mixed type

--- a/packages/store/src/lit/tests/create-store.test.ts
+++ b/packages/store/src/lit/tests/create-store.test.ts
@@ -76,26 +76,26 @@ describe('createStore', () => {
       expect(typeof StoreMixin).toBe('function');
     });
 
-    it('returns StoreProviderMixin', () => {
-      const { StoreProviderMixin } = createStore({ features: [audioFeature] });
+    it('returns ProviderMixin', () => {
+      const { ProviderMixin } = createStore({ features: [audioFeature] });
 
-      expect(typeof StoreProviderMixin).toBe('function');
+      expect(typeof ProviderMixin).toBe('function');
     });
 
-    it('returns StoreAttachMixin', () => {
-      const { StoreAttachMixin } = createStore({ features: [audioFeature] });
+    it('returns ContainerMixin', () => {
+      const { ContainerMixin } = createStore({ features: [audioFeature] });
 
-      expect(typeof StoreAttachMixin).toBe('function');
+      expect(typeof ContainerMixin).toBe('function');
     });
 
     it('mixins can be applied to TestBaseElement', () => {
-      const { StoreMixin, StoreProviderMixin, StoreAttachMixin } = createStore({
+      const { StoreMixin, ProviderMixin, ContainerMixin } = createStore({
         features: [audioFeature],
       });
 
       const Mixed1 = StoreMixin(TestBaseElement);
-      const Mixed2 = StoreProviderMixin(TestBaseElement);
-      const Mixed3 = StoreAttachMixin(TestBaseElement);
+      const Mixed2 = ProviderMixin(TestBaseElement);
+      const Mixed3 = ContainerMixin(TestBaseElement);
 
       expect(Mixed1.prototype).toBeInstanceOf(TestBaseElement);
       expect(Mixed2.prototype).toBeInstanceOf(TestBaseElement);
@@ -108,8 +108,8 @@ describe('createStore', () => {
       const result = createStore({ features: [audioFeature] });
 
       expect(result).toHaveProperty('StoreMixin');
-      expect(result).toHaveProperty('StoreProviderMixin');
-      expect(result).toHaveProperty('StoreAttachMixin');
+      expect(result).toHaveProperty('ProviderMixin');
+      expect(result).toHaveProperty('ContainerMixin');
       expect(result).toHaveProperty('context');
       expect(result).toHaveProperty('create');
       expect(result).toHaveProperty('StoreController');

--- a/packages/store/src/react/context.tsx
+++ b/packages/store/src/react/context.tsx
@@ -25,15 +25,6 @@ export function useStoreContext(): AnyStore {
 }
 
 /**
- * Internal hook to get parent store from context.
- * Returns null if no parent Provider exists.
- * Used by Provider to implement the `inherit` prop.
- */
-export function useParentStore(): AnyStore | null {
-  return useContext(StoreContext);
-}
-
-/**
  * Internal provider component that wraps children with store context.
  */
 export function StoreContextProvider({ store, children }: { store: AnyStore; children: ReactNode }): ReactNode {


### PR DESCRIPTION
## Summary

Simplifies the store bindings for both React and Lit by removing unused patterns and renaming mixins to clearer names. This is part of the Store v2 plan (Phase 2: Bindings Cleanup).

## Changes

**React:**
- Remove `inherit` prop from Provider (single-store pattern makes nested inheritance unnecessary)
- Remove `useParentStore()` hook
- Delegate `useStore` to base hook instead of duplicating logic

**Lit:**
- Rename `StoreAttachMixin` → `ContainerMixin` (describes role, not implementation)
- Rename `StoreProviderMixin` → `ProviderMixin` (shorter, clearer)
- `StoreMixin` unchanged (combines Provider + Container)

## Testing

```bash
pnpm -F @videojs/store test  # 163 tests pass
pnpm typecheck               # passes
```