### PR TITLE
refactor(store): merge getSnapshot/subscribe into attach

### DIFF
--- a/.claude/plans/store/feature-api-redesign.md
+++ b/.claude/plans/store/feature-api-redesign.md
@@ -1,5 +1,8 @@
 # Feature API Redesign
 
+**Status:** COMPLETED  
+**Branch:** `refactor/store-feature-attach`
+
 Merge `getSnapshot` and `subscribe` into a single `attach` method with explicit `set()`.
 
 ## Overview

--- a/.claude/plans/store/reactive.md
+++ b/.claude/plans/store/reactive.md
@@ -7,13 +7,13 @@
 
 Simplified state management with explicit mutations and computed values.
 
-PR #311 introduced proxy-based reactivity (Valtio-style). PR #321 replaced it with a simpler `State` + `Computed` design - explicit mutations via `set`/`patch`/`delete` instead of proxy traps, and `Computed` for derived values.
+PR #311 introduced proxy-based reactivity (Valtio-style). PR #321 replaced it with a simpler `State` + `Computed` design - explicit mutations via `patch` instead of proxy traps, and `Computed` for derived values.
 
 ## Key Decisions
 
 | Decision                | Rationale                                                    |
 | ----------------------- | ------------------------------------------------------------ |
-| Explicit mutations      | `set`/`patch`/`delete` clearer than proxy assignment         |
+| Explicit mutations      | `patch()` clearer than proxy assignment                      |
 | Frozen snapshots        | `Object.freeze()` on `current` prevents accidental mutations |
 | Key-based subscriptions | Built into State, subscribe to specific keys for efficiency  |
 | Computed class          | Lazy derivation, notifies only when result actually changes  |
@@ -27,10 +27,8 @@ import { createComputed, createState, flush } from '@videojs/store';
 // State
 const state = createState({ volume: 1, muted: false });
 state.current; // readonly snapshot
-state.set('volume', 0.5); // single key
-state.patch({ volume: 0.8 }); // multiple keys
+state.patch({ volume: 0.8 }); // update one or more keys
 state.subscribe(listener); // all changes
-state.subscribe(['volume'], fn); // specific keys
 
 // Computed
 const effective = createComputed(state, ['volume', 'muted'], ({ volume, muted }) => (muted ? 0 : volume));
@@ -43,4 +41,6 @@ effective.destroy(); // cleanup
 
 Removed from PR #311: `reactive`, `snapshot`, `track`, `batch`, `subscribe`, `subscribeKeys`
 
-Migration: Use `createState()` with explicit mutations and `createComputed()` for derived values.
+Migration: Use `createState()` with `patch()` and `createComputed()` for derived values.
+
+**Note:** `WritableState` now only exposes `patch()`. The `set()` and `delete()` methods were removed as `patch()` covers all use cases.

--- a/.claude/skills/api/references/typescript.md
+++ b/.claude/skills/api/references/typescript.md
@@ -40,12 +40,20 @@ Capture target/platform type once, let callbacks infer:
 
 ```ts
 // Capture Target type once
-const feature = createFeature<HTMLVideoElement>()({
-  initialState: { volume: 1 },
-  getSnapshot: ({ target }) => ({ volume: target.volume }),
-  subscribe: ({ target, update }) => {
-    target.addEventListener('volumechange', update);
-    return () => target.removeEventListener('volumechange', update);
+const feature = defineFeature<HTMLVideoElement>()({
+  state: ({ task }) => ({
+    volume: 1,
+    setVolume(v: number) {
+      return task({ handler: ({ target }) => { target.volume = v; } });
+    },
+  }),
+
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume });
+
+    sync();
+
+    target.addEventListener('volumechange', sync, { signal });
   },
 });
 ```

--- a/.claude/skills/docs/templates/api-reference.md
+++ b/.claude/skills/docs/templates/api-reference.md
@@ -318,29 +318,34 @@ Brief description of what state this feature manages.
 
 import { featureName } from '@videojs/core/dom';
 // or
-import { createFeature } from '@videojs/store';
+import { defineFeature } from '@videojs/store';
 
-const featureName = createFeature<HTMLMediaElement>()({
-initialState: {
-property1: defaultValue,
-property2: defaultValue,
-},
+const featureName = defineFeature<HTMLMediaElement>()({
+  state: ({ task }) => ({
+    property1: defaultValue,
+    property2: defaultValue,
 
-getSnapshot: ({ target }) => ({
-property1: target.property1,
-property2: target.property2,
-}),
+    actionName(input: InputType) {
+      return task({
+        key: 'actionKey',
+        handler({ target }) {
+          target.property = input;
+          return target.property;
+        },
+      });
+    },
+  }),
 
-subscribe: ({ target, update, signal }) => {
-listen(target, 'eventname', update, { signal });
-},
+  attach({ target, signal, set }) {
+    const sync = () => set({
+      property1: target.property1,
+      property2: target.property2,
+    });
 
-request: {
-requestName: (input, { target }) => {
-target.property = input;
-return target.property;
-},
-},
+    sync();
+
+    listen(target, 'eventname', sync, { signal });
+  },
 });
 
 ### State
@@ -350,11 +355,11 @@ return target.property;
 | `property1` | `type` | Description |
 | `property2` | `type` | Description |
 
-### Requests
+### Actions
 
-| Request       | Input       | Output       | Description  |
-| ------------- | ----------- | ------------ | ------------ |
-| `requestName` | `InputType` | `OutputType` | What it does |
+| Action       | Input       | Output       | Description  |
+| ------------ | ----------- | ------------ | ------------ |
+| `actionName` | `InputType` | `OutputType` | What it does |
 
 ### Type Inference
 

--- a/packages/core/src/dom/store/features/buffer.ts
+++ b/packages/core/src/dom/store/features/buffer.ts
@@ -11,14 +11,17 @@ export const bufferFeature = defineFeature<HTMLMediaElement>()({
     seekable: [] as [number, number][],
   }),
 
-  getSnapshot: ({ target }) => ({
-    buffered: serializeTimeRanges(target.buffered),
-    seekable: serializeTimeRanges(target.seekable),
-  }),
+  attach({ target, signal, set }) {
+    const sync = () =>
+      set({
+        buffered: serializeTimeRanges(target.buffered),
+        seekable: serializeTimeRanges(target.seekable),
+      });
 
-  subscribe: ({ target, update, signal }) => {
-    listen(target, 'progress', update, { signal });
-    listen(target, 'emptied', update, { signal });
+    sync();
+
+    listen(target, 'progress', sync, { signal });
+    listen(target, 'emptied', sync, { signal });
   },
 });
 

--- a/packages/core/src/dom/store/features/playback.ts
+++ b/packages/core/src/dom/store/features/playback.ts
@@ -36,19 +36,22 @@ export const playbackFeature = defineFeature<HTMLMediaElement>()({
     },
   }),
 
-  getSnapshot: ({ target }) => ({
-    paused: target.paused,
-    ended: target.ended,
-    started: !target.paused || target.currentTime > 0,
-    waiting: target.readyState < HTMLMediaElement.HAVE_FUTURE_DATA && !target.paused,
-  }),
+  attach({ target, signal, set }) {
+    const sync = () =>
+      set({
+        paused: target.paused,
+        ended: target.ended,
+        started: !target.paused || target.currentTime > 0,
+        waiting: target.readyState < HTMLMediaElement.HAVE_FUTURE_DATA && !target.paused,
+      });
 
-  subscribe: ({ target, update, signal }) => {
-    listen(target, 'play', update, { signal });
-    listen(target, 'pause', update, { signal });
-    listen(target, 'ended', update, { signal });
-    listen(target, 'playing', update, { signal });
-    listen(target, 'waiting', update, { signal });
+    sync();
+
+    listen(target, 'play', sync, { signal });
+    listen(target, 'pause', sync, { signal });
+    listen(target, 'ended', sync, { signal });
+    listen(target, 'playing', sync, { signal });
+    listen(target, 'waiting', sync, { signal });
   },
 });
 

--- a/packages/core/src/dom/store/features/source.ts
+++ b/packages/core/src/dom/store/features/source.ts
@@ -9,6 +9,7 @@ export const sourceFeature = defineFeature<HTMLMediaElement>()({
     source: null as string | null,
     /** Whether enough data is loaded to begin playback. */
     canPlay: false,
+
     /** Load a new media source. Cancels all pending operations. Returns the new source URL. */
     loadSource(src: string) {
       return task({
@@ -23,16 +24,19 @@ export const sourceFeature = defineFeature<HTMLMediaElement>()({
     },
   }),
 
-  getSnapshot: ({ target }) => ({
-    source: target.currentSrc || target.src || null,
-    canPlay: target.readyState >= HTMLMediaElement.HAVE_ENOUGH_DATA,
-  }),
+  attach({ target, signal, set }) {
+    const sync = () =>
+      set({
+        source: target.currentSrc || target.src || null,
+        canPlay: target.readyState >= HTMLMediaElement.HAVE_ENOUGH_DATA,
+      });
 
-  subscribe: ({ target, update, signal }) => {
-    listen(target, 'canplay', update, { signal });
-    listen(target, 'canplaythrough', update, { signal });
-    listen(target, 'loadstart', update, { signal });
-    listen(target, 'emptied', update, { signal });
+    sync();
+
+    listen(target, 'canplay', sync, { signal });
+    listen(target, 'canplaythrough', sync, { signal });
+    listen(target, 'loadstart', sync, { signal });
+    listen(target, 'emptied', sync, { signal });
   },
 });
 

--- a/packages/core/src/dom/store/features/time.ts
+++ b/packages/core/src/dom/store/features/time.ts
@@ -23,17 +23,20 @@ export const timeFeature = defineFeature<HTMLMediaElement>()({
     },
   }),
 
-  getSnapshot: ({ target }) => ({
-    currentTime: target.currentTime,
-    duration: target.duration || 0,
-  }),
+  attach({ target, signal, set }) {
+    const sync = () =>
+      set({
+        currentTime: target.currentTime,
+        duration: target.duration || 0,
+      });
 
-  subscribe: ({ target, update, signal }) => {
-    listen(target, 'timeupdate', update, { signal });
-    listen(target, 'durationchange', update, { signal });
-    listen(target, 'seeked', update, { signal });
-    listen(target, 'loadedmetadata', update, { signal });
-    listen(target, 'emptied', update, { signal });
+    sync();
+
+    listen(target, 'timeupdate', sync, { signal });
+    listen(target, 'durationchange', sync, { signal });
+    listen(target, 'seeked', sync, { signal });
+    listen(target, 'loadedmetadata', sync, { signal });
+    listen(target, 'emptied', sync, { signal });
   },
 });
 

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -33,13 +33,12 @@ export const volumeFeature = defineFeature<HTMLMediaElement>()({
     },
   }),
 
-  getSnapshot: ({ target }) => ({
-    volume: target.volume,
-    muted: target.muted,
-  }),
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume, muted: target.muted });
 
-  subscribe: ({ target, update, signal }) => {
-    listen(target, 'volumechange', update, { signal });
+    sync();
+
+    listen(target, 'volumechange', sync, { signal });
   },
 });
 

--- a/packages/store/src/core/feature.ts
+++ b/packages/store/src/core/feature.ts
@@ -31,40 +31,25 @@ export interface TaskContext<Target, State extends object> {
 }
 
 // ----------------------------------------
-// Sync Config
+// Attach
 // ----------------------------------------
 
-export type GetSnapshot<Target, State extends object> = (ctx: GetSnapshotContext<Target, State>) => Partial<State>;
+export type Attach<Target, State extends object> = (ctx: AttachContext<Target, State>) => void;
 
-export interface GetSnapshotContext<Target, State extends object> {
+export interface AttachContext<Target, State extends object> {
   target: Target;
-  get: () => Readonly<State>;
-  initialState: Readonly<State>;
-}
-
-export type Subscribe<Target, State extends object> = (ctx: SubscribeContext<Target, State>) => void;
-
-export interface SubscribeContext<Target, State extends object> {
-  target: Target;
-  update: () => void;
   signal: AbortSignal;
   get: () => Readonly<State>;
+  set: (partial: Partial<State>) => void;
 }
 
 // ----------------------------------------
 // Feature Context
 // ----------------------------------------
 
-export interface FeatureContext<Target, State extends object> {
-  task: Task<Target, State>;
-  get: () => Readonly<State>;
-  target: () => Target;
-}
-
 /** Context passed to state factory - uses loose types to enable State inference. */
 export interface StateFactoryContext<Target> {
   task: Task<Target, any>;
-  get: () => Readonly<object>;
   target: () => Target;
 }
 
@@ -76,8 +61,7 @@ export type StateFactory<Target, State extends object> = (ctx: StateFactoryConte
 
 export interface FeatureConfig<Target, State extends object> {
   state: StateFactory<Target, State>;
-  getSnapshot: GetSnapshot<Target, State>;
-  subscribe: Subscribe<Target, State>;
+  attach?: Attach<Target, State>;
 }
 
 export interface Feature<Target, State extends object> extends FeatureConfig<Target, State> {

--- a/packages/store/src/core/tests/state.test.ts
+++ b/packages/store/src/core/tests/state.test.ts
@@ -23,35 +23,11 @@ describe('createState', () => {
       expect(state.current.muted).toBe(false);
     });
 
-    it('reflects changes after set', () => {
-      const state = createTestState();
-      state.set('volume', 0.5);
-      expect(state.current.volume).toBe(0.5);
-    });
-
     it('reflects changes after patch', () => {
       const state = createTestState();
       state.patch({ volume: 0.5, muted: true });
       expect(state.current.volume).toBe(0.5);
       expect(state.current.muted).toBe(true);
-    });
-  });
-
-  describe('set', () => {
-    it('updates a single key', () => {
-      const state = createTestState();
-      state.set('volume', 0.5);
-      expect(state.current.volume).toBe(0.5);
-    });
-
-    it('does not notify if value is the same', () => {
-      const state = createTestState();
-      const listener = vi.fn();
-      state.subscribe(listener);
-
-      state.set('volume', 1); // same as initial
-      flush();
-      expect(listener).not.toHaveBeenCalled();
     });
   });
 
@@ -81,7 +57,7 @@ describe('createState', () => {
       const listener = vi.fn();
       state.subscribe(listener);
 
-      state.set('volume', 0.5);
+      state.patch({ volume: 0.5 });
 
       expect(listener).not.toHaveBeenCalled();
       await Promise.resolve();
@@ -93,21 +69,21 @@ describe('createState', () => {
       const listener = vi.fn();
       state.subscribe(listener);
 
-      state.set('volume', 0.5);
+      state.patch({ volume: 0.5 });
       expect(listener).not.toHaveBeenCalled();
 
       flush();
       expect(listener).toHaveBeenCalledOnce();
     });
 
-    it('batches multiple mutations into one notification', () => {
+    it('batches multiple patches into one notification', () => {
       const state = createTestState();
       const listener = vi.fn();
       state.subscribe(listener);
 
-      state.set('volume', 0.5);
-      state.set('muted', true);
-      state.set('currentTime', 10);
+      state.patch({ volume: 0.5 });
+      state.patch({ muted: true });
+      state.patch({ currentTime: 10 });
 
       flush();
       expect(listener).toHaveBeenCalledOnce();
@@ -118,12 +94,12 @@ describe('createState', () => {
       const listener = vi.fn();
 
       const unsub = state.subscribe(listener);
-      state.set('volume', 0.5);
+      state.patch({ volume: 0.5 });
       flush();
       expect(listener).toHaveBeenCalledOnce();
 
       unsub();
-      state.set('volume', 0.3);
+      state.patch({ volume: 0.3 });
       flush();
       expect(listener).toHaveBeenCalledOnce(); // still 1
     });

--- a/packages/store/src/core/tests/store.test.ts
+++ b/packages/store/src/core/tests/store.test.ts
@@ -31,14 +31,15 @@ describe('store', () => {
         });
       },
     }),
-    getSnapshot: ({ target }) => ({
-      volume: target.volume,
-      muted: target.muted,
-    }),
-    subscribe: ({ target, update, signal }) => {
-      target.addEventListener('volumechange', update);
+
+    attach({ target, signal, set }) {
+      const sync = () => set({ volume: target.volume, muted: target.muted });
+
+      sync();
+
+      target.addEventListener('volumechange', sync);
       signal.addEventListener('abort', () => {
-        target.removeEventListener('volumechange', update);
+        target.removeEventListener('volumechange', sync);
       });
     },
   });
@@ -65,8 +66,10 @@ describe('store', () => {
         });
       },
     }),
-    getSnapshot: ({ target }) => ({ paused: target.paused }),
-    subscribe: () => {},
+
+    attach({ target, set }) {
+      set({ paused: target.paused });
+    },
   });
 
   describe('creation', () => {
@@ -234,8 +237,6 @@ describe('store', () => {
             });
           },
         }),
-        getSnapshot: () => ({ value: 0 }),
-        subscribe: () => {},
       });
 
       const store = createStore({
@@ -272,8 +273,6 @@ describe('store', () => {
             });
           },
         }),
-        getSnapshot: () => ({ value: 0 }),
-        subscribe: () => {},
       });
 
       const store = createStore({
@@ -306,8 +305,6 @@ describe('store', () => {
             });
           },
         }),
-        getSnapshot: () => ({ value: 0 }),
-        subscribe: () => {},
       });
 
       const store = createStore({
@@ -404,8 +401,6 @@ describe('store', () => {
             });
           },
         }),
-        getSnapshot: () => ({ value: 0 }),
-        subscribe: () => {},
       });
 
       const store = createStore({

--- a/packages/store/src/lit/tests/create-store.test.ts
+++ b/packages/store/src/lit/tests/create-store.test.ts
@@ -23,15 +23,15 @@ describe('createStore', () => {
         });
       },
     }),
-    getSnapshot: ({ target }) => ({
-      volume: target.volume,
-      muted: target.muted,
-    }),
-    subscribe: ({ target, update, signal }) => {
-      const handler = () => update();
-      target.addEventListener('volumechange', handler);
+
+    attach({ target, signal, set }) {
+      const sync = () => set({ volume: target.volume, muted: target.muted });
+
+      sync();
+
+      target.addEventListener('volumechange', sync);
       signal.addEventListener('abort', () => {
-        target.removeEventListener('volumechange', handler);
+        target.removeEventListener('volumechange', sync);
       });
     },
   });

--- a/packages/store/src/lit/tests/test-utils.ts
+++ b/packages/store/src/lit/tests/test-utils.ts
@@ -54,15 +54,15 @@ export const audioFeature = defineFeature<MockMedia>()({
       });
     },
   }),
-  getSnapshot: ({ target }) => ({
-    volume: target.volume,
-    muted: target.muted,
-  }),
-  subscribe: ({ target, update, signal }) => {
-    const handler = () => update();
-    target.addEventListener('volumechange', handler);
+
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume, muted: target.muted });
+
+    sync();
+
+    target.addEventListener('volumechange', sync);
     signal.addEventListener('abort', () => {
-      target.removeEventListener('volumechange', handler);
+      target.removeEventListener('volumechange', sync);
     });
   },
 });
@@ -97,15 +97,15 @@ export const customKeyFeature = defineFeature<MockMedia>()({
       });
     },
   }),
-  getSnapshot: ({ target }) => ({
-    volume: target.volume,
-    muted: target.muted,
-  }),
-  subscribe: ({ target, update, signal }) => {
-    const handler = () => update();
-    target.addEventListener('volumechange', handler);
+
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume, muted: target.muted });
+
+    sync();
+
+    target.addEventListener('volumechange', sync);
     signal.addEventListener('abort', () => {
-      target.removeEventListener('volumechange', handler);
+      target.removeEventListener('volumechange', sync);
     });
   },
 });

--- a/packages/store/src/react/hooks/tests/test-utils.ts
+++ b/packages/store/src/react/hooks/tests/test-utils.ts
@@ -29,14 +29,15 @@ export const audioFeature = defineFeature<MockMedia>()({
       });
     },
   }),
-  getSnapshot: ({ target }) => ({
-    volume: target.volume,
-    muted: target.muted,
-  }),
-  subscribe: ({ target, update, signal }) => {
-    target.addEventListener('volumechange', update);
+
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume, muted: target.muted });
+
+    sync();
+
+    target.addEventListener('volumechange', sync);
     signal.addEventListener('abort', () => {
-      target.removeEventListener('volumechange', update);
+      target.removeEventListener('volumechange', sync);
     });
   },
 });
@@ -87,15 +88,15 @@ export const asyncAudioFeature = defineFeature<AsyncMockMedia>()({
       });
     },
   }),
-  getSnapshot: ({ target }) => ({
-    volume: target.volume,
-    muted: target.muted,
-  }),
-  subscribe: ({ target, update, signal }) => {
-    const handler = () => update();
-    target.addEventListener('volumechange', handler);
+
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume, muted: target.muted });
+
+    sync();
+
+    target.addEventListener('volumechange', sync);
     signal.addEventListener('abort', () => {
-      target.removeEventListener('volumechange', handler);
+      target.removeEventListener('volumechange', sync);
     });
   },
 });
@@ -142,15 +143,15 @@ export const customKeyFeature = defineFeature<MockMedia>()({
       });
     },
   }),
-  getSnapshot: ({ target }) => ({
-    volume: target.volume,
-    muted: target.muted,
-  }),
-  subscribe: ({ target, update, signal }) => {
-    const handler = () => update();
-    target.addEventListener('volumechange', handler);
+
+  attach({ target, signal, set }) {
+    const sync = () => set({ volume: target.volume, muted: target.muted });
+
+    sync();
+
+    target.addEventListener('volumechange', sync);
     signal.addEventListener('abort', () => {
-      target.removeEventListener('volumechange', handler);
+      target.removeEventListener('volumechange', sync);
     });
   },
 });

--- a/packages/store/src/react/tests/context.test.tsx
+++ b/packages/store/src/react/tests/context.test.tsx
@@ -17,8 +17,9 @@ describe('context', () => {
     state: () => ({
       volume: 1,
     }),
-    getSnapshot: ({ target }) => ({ volume: target.volume }),
-    subscribe: () => {},
+    attach({ target, set }) {
+      set({ volume: target.volume });
+    },
   });
 
   describe('useStoreContext', () => {

--- a/packages/store/src/react/tests/create-store.test.tsx
+++ b/packages/store/src/react/tests/create-store.test.tsx
@@ -31,14 +31,18 @@ describe('createStore', () => {
         });
       },
     }),
-    getSnapshot: ({ target }) => ({
-      volume: target.volume,
-      muted: target.muted,
-    }),
-    subscribe: ({ target, update, signal }) => {
-      target.addEventListener('volumechange', update);
+    attach({ target, signal, set }) {
+      const sync = () =>
+        set({
+          volume: target.volume,
+          muted: target.muted,
+        });
+
+      sync();
+
+      target.addEventListener('volumechange', sync);
       signal.addEventListener('abort', () => {
-        target.removeEventListener('volumechange', update);
+        target.removeEventListener('volumechange', sync);
       });
     },
   });


### PR DESCRIPTION
## Summary

- Merge `getSnapshot` + `subscribe` into single `attach` method with explicit `set()`
- Remove `set()` and `delete()` from `WritableState`, only `patch()` remains
- Update all core features to use new attach pattern
- Prefer `handler({ target })` over `target()` closure in task handlers

## Before

```ts
defineFeature<HTMLMediaElement>()({
  state: ({ task }) => ({ volume: 1 }),
  getSnapshot: ({ target }) => ({ volume: target.volume }),
  subscribe: ({ target, update, signal }) => {
    listen(target, 'volumechange', update, { signal });
  },
});
```

## After

```ts
defineFeature<HTMLMediaElement>()({
  state: ({ task }) => ({ volume: 1 }),
  attach({ target, signal, set }) {
    const sync = () => set({ volume: target.volume });

    sync();

    listen(target, 'volumechange', sync, { signal });
  },
});
```

## BREAKING CHANGES

- `getSnapshot` and `subscribe` replaced by `attach`
- `WritableState.set()` and `WritableState.delete()` removed (use `patch()`)

Closes #363