### PR TITLE
docs(rfc): update player api to match implementation

### DIFF
--- a/rfc/player-api/index.md
+++ b/rfc/player-api/index.md
@@ -1,20 +1,20 @@
 ---
-status: draft
+status: accepted
 ---
 
 # Player API Design
 
-| Document                           | Purpose                                    |
-| ---------------------------------- | ------------------------------------------ |
-| [index.md](index.md)               | Overview, principles, model                |
-| [api.md](api.md)                   | Surface API (usePlayer, store, controller) |
-| [features.md](features.md)         | Feature definition, keys, bundles          |
-| [primitives.md](primitives.md)     | Library author patterns                    |
-| [architecture.md](architecture.md) | Two-store internals                        |
-| [decisions.md](decisions.md)       | Problem statement, design rationale        |
-| [examples.md](examples.md)         | Progressive journey examples               |
-| [html.md](html.md)                 | HTML elements, imports, skins              |
-| [feedback.md](feedback.md)         | Collected feedback                         |
+| Document                           | Purpose                                   |
+| ---------------------------------- | ----------------------------------------- |
+| [index.md](index.md)               | Overview, principles, model               |
+| [api.md](api.md)                   | Surface API (usePlayer, controller)       |
+| [features.md](features.md)         | Feature definition, slices, bundles       |
+| [primitives.md](primitives.md)     | Library author patterns                   |
+| [architecture.md](architecture.md) | Single-store internals                    |
+| [decisions.md](decisions.md)       | Problem statement, design rationale       |
+| [examples.md](examples.md)         | Progressive journey examples              |
+| [html.md](html.md)                 | HTML elements, imports, skins             |
+| [feedback.md](feedback.md)         | Collected feedback                        |
 
 ## Principles
 
@@ -76,11 +76,12 @@ Start simple                          Add as needed
 ```tsx
 import '@videojs/react/skin/video.css';
 
-import { createPlayer, features } from '@videojs/react';
+import { createPlayer } from '@videojs/react';
+import { features } from '@videojs/core/dom';
 import { VideoSkin } from '@videojs/react/skin/video';
 
-const { Provider: VideoProvider, usePlayer } = createPlayer({
-  features: [features.video]
+const { Provider: VideoProvider } = createPlayer({
+  features: [...features.video],
 });
 
 function App() {


### PR DESCRIPTION
## Summary

Update all RFC documentation to accurately reflect the implemented Player API architecture.

### Key Changes

| Before (RFC) | After (Implementation) |
|-------------|----------------------|
| Two stores (media + player) | Single store with `PlayerTarget` |
| `usePlayer(feature)` → slice | `usePlayer(selector)` → selected state |
| `store.get(feature)` | Selectors (`selectPlayback`, etc.) |
| Feature-scoped hooks | Selector-based subscriptions |

### Files Updated

- **index.md** - Status `draft` → `accepted`, updated overview examples
- **architecture.md** - Rewritten for single store with `PlayerTarget`
- **api.md** - Rewritten with actual API surface (React & HTML)
- **features.md** - Updated to slice/combine pattern, selectors
- **primitives.md** - Selector-based access patterns
- **html.md** - `PlayerElement`, mixins, `PlayerController`
- **examples.md** - All examples fixed to match actual API
- **decisions.md** - Single store rationale, selector-based access

### API Summary

**React:**
```tsx
const { Provider, Container, usePlayer, useMedia } = createPlayer({
  features: [...features.video],
});

const playback = usePlayer(selectPlayback);
```

**HTML:**
```ts
const { PlayerElement, PlayerController, context } = createPlayer({
  features: [...features.video],
});

class PlayButton extends MediaElement {
  #playback = new PlayerController(this, context, selectPlayback);
}
```

Closes #369
Closes #320