### PR TITLE
chore(root): add postinstall symlinks for generic agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ bun.lockb
 # AI Agent Config (Generated)
 # -------------------------
 .opencode
+AGENTS.md
+agents

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "prepare": "simple-git-hooks",
-    "postinstall": "pnpm link:opencode",
+    "postinstall": "pnpm link:opencode && pnpm link:agents",
     "build:packages": "turbo run build --filter='./packages/*'",
     "build:site": "turbo run build --filter=site",
     "build": "turbo run build",
@@ -29,6 +29,7 @@
     "lint:fix": "biome check . --write",
     "lint:fix:file": "biome check --write",
     "link:opencode": "[ -e .opencode ] || ln -s .claude .opencode",
+    "link:agents": "[ -e AGENTS.md ] || ln -s CLAUDE.md AGENTS.md; [ -e agents ] || ln -s .claude agents",
     "test": "turbo run test",
     "typecheck": "tsc --build"
   },


### PR DESCRIPTION
## Summary

- Add `link:agents` script to create symlinks for generic agent paths (`AGENTS.md` → `CLAUDE.md`, `agents` → `.claude`)
- Update `postinstall` to run both `link:opencode` and `link:agents`
- Gitignore the generated symlinks