### PR TITLE
refactor(store): replace signal/abort with signals namespace

### DIFF
--- a/packages/core/src/dom/store/features/source.ts
+++ b/packages/core/src/dom/store/features/source.ts
@@ -4,11 +4,11 @@ import type { SourceState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
 
 export const sourceFeature = definePlayerFeature({
-  state: ({ target, abort }): SourceState => ({
+  state: ({ target, signals }): SourceState => ({
     source: null,
     canPlay: false,
     loadSource(src: string) {
-      abort(); // Cancel pending operations (e.g., seek)
+      signals.clear(); // Cancel pending operations (e.g., seek)
 
       const { media } = target();
       media.src = src;

--- a/packages/core/src/dom/store/signal-keys.ts
+++ b/packages/core/src/dom/store/signal-keys.ts
@@ -1,0 +1,3 @@
+export const signalKeys = {
+  seek: Symbol.for('@videojs/seek'),
+} as const;

--- a/packages/store/src/core/index.ts
+++ b/packages/store/src/core/index.ts
@@ -4,6 +4,7 @@ export * from './errors';
 export { createSelector } from './selector';
 export type { Comparator, Selector } from './shallow-equal';
 export { shallowEqual } from './shallow-equal';
+export * from './signals';
 export * from './slice';
 export * from './state';
 export * from './store';

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -1,11 +1,11 @@
 import { pick } from '@videojs/utils/object';
 import { throwNoTargetError } from './errors';
+import { Signals } from './signals';
 import type { AnySlice, InferSliceState, StateContext } from './slice';
 
 const stateContext: StateContext<unknown> = {
   target: throwNoTargetError,
-  signal: throwNoTargetError,
-  abort: throwNoTargetError,
+  signals: new Signals(),
 };
 
 /**

--- a/packages/store/src/core/signals.ts
+++ b/packages/store/src/core/signals.ts
@@ -1,0 +1,34 @@
+export type SignalKey = PropertyKey;
+
+export class Signals {
+  #base = new AbortController();
+  #keys = new Map<SignalKey, AbortController>();
+
+  /** The attach-scoped signal. Aborts on detach or reattach. */
+  get base(): AbortSignal {
+    return this.#base.signal;
+  }
+
+  /** Clears all keyed signals, leaving base intact. */
+  clear(): void {
+    for (const controller of this.#keys.values()) {
+      controller.abort();
+    }
+    this.#keys.clear();
+  }
+
+  /** Resets base and clears all keyed signals. */
+  reset(): void {
+    this.clear();
+    this.#base.abort();
+    this.#base = new AbortController();
+  }
+
+  /** Creates a new signal for the key, superseding any previous signal. */
+  supersede(key: SignalKey): AbortSignal {
+    this.#keys.get(key)?.abort();
+    const controller = new AbortController();
+    this.#keys.set(key, controller);
+    return AbortSignal.any([this.#base.signal, controller.signal]);
+  }
+}

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -1,4 +1,5 @@
 import type { Simplify, UnionToIntersection } from '@videojs/utils/types';
+import type { Signals } from './signals';
 import type { UnknownState } from './state';
 
 // ----------------------------------------
@@ -28,10 +29,17 @@ export interface AttachContext<Target, State> {
 export interface StateContext<Target> {
   /** Returns the current target. Throws if not attached. */
   target: () => Target;
-  /** Returns a signal that aborts on detach or when `abort()` is called. Throws if not attached. */
-  signal: () => AbortSignal;
-  /** Aborts the current signal and creates a new one. Use to cancel pending operations. */
-  abort: () => void;
+  /**
+   * Cancellation signals for async operations.
+   *
+   * - `signals.base` — Aborts on detach or reattach. Use for cleanup.
+   * - `signals.supersede(key)` — Returns a signal that aborts when the same key
+   *   is superseded or when base aborts. Use for operations that should cancel
+   *   previous in-flight work (e.g., seek superseding seek).
+   * - `signals.clear()` — Aborts all keyed signals. Use when starting fresh
+   *   (e.g., loading a new source cancels pending seeks).
+   */
+  signals: Signals;
 }
 
 // ----------------------------------------

--- a/packages/store/src/core/tests/signals.test.ts
+++ b/packages/store/src/core/tests/signals.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { Signals } from '../signals';
+
+describe('Signals', () => {
+  describe('base', () => {
+    it('returns an AbortSignal', () => {
+      const signals = new Signals();
+      expect(signals.base).toBeInstanceOf(AbortSignal);
+    });
+
+    it('is not aborted initially', () => {
+      const signals = new Signals();
+      expect(signals.base.aborted).toBe(false);
+    });
+
+    it('is aborted after reset()', () => {
+      const signals = new Signals();
+      const base = signals.base;
+
+      signals.reset();
+
+      expect(base.aborted).toBe(true);
+    });
+
+    it('returns new signal after reset()', () => {
+      const signals = new Signals();
+      const base1 = signals.base;
+
+      signals.reset();
+
+      const base2 = signals.base;
+      expect(base1).not.toBe(base2);
+      expect(base2.aborted).toBe(false);
+    });
+
+    it('is not aborted after clear()', () => {
+      const signals = new Signals();
+      const base = signals.base;
+
+      signals.clear();
+
+      expect(base.aborted).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('aborts keyed signals', () => {
+      const signals = new Signals();
+      const signal = signals.supersede('test');
+
+      signals.clear();
+
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('does not abort base', () => {
+      const signals = new Signals();
+      const base = signals.base;
+      signals.supersede('test');
+
+      signals.clear();
+
+      expect(base.aborted).toBe(false);
+    });
+
+    it('clears all keyed signals', () => {
+      const signals = new Signals();
+      const signal1 = signals.supersede('key1');
+      const signal2 = signals.supersede('key2');
+
+      signals.clear();
+
+      expect(signal1.aborted).toBe(true);
+      expect(signal2.aborted).toBe(true);
+    });
+  });
+
+  describe('reset', () => {
+    it('aborts base signal', () => {
+      const signals = new Signals();
+      const base = signals.base;
+
+      signals.reset();
+
+      expect(base.aborted).toBe(true);
+    });
+
+    it('aborts keyed signals', () => {
+      const signals = new Signals();
+      const signal = signals.supersede('test');
+
+      signals.reset();
+
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('creates new base signal', () => {
+      const signals = new Signals();
+      const base1 = signals.base;
+
+      signals.reset();
+
+      const base2 = signals.base;
+      expect(base1).not.toBe(base2);
+      expect(base2.aborted).toBe(false);
+    });
+  });
+
+  describe('supersede', () => {
+    it('returns an AbortSignal', () => {
+      const signals = new Signals();
+      const signal = signals.supersede('test');
+
+      expect(signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('is not aborted initially', () => {
+      const signals = new Signals();
+      const signal = signals.supersede('test');
+
+      expect(signal.aborted).toBe(false);
+    });
+
+    it('aborts when base is reset', () => {
+      const signals = new Signals();
+      const signal = signals.supersede('test');
+
+      signals.reset();
+
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('aborts previous signal for same key', () => {
+      const signals = new Signals();
+      const signal1 = signals.supersede('seek');
+
+      const signal2 = signals.supersede('seek');
+
+      expect(signal1.aborted).toBe(true);
+      expect(signal2.aborted).toBe(false);
+    });
+
+    it('does not abort signals with different keys', () => {
+      const signals = new Signals();
+      const signal1 = signals.supersede('key1');
+      const signal2 = signals.supersede('key2');
+
+      expect(signal1.aborted).toBe(false);
+      expect(signal2.aborted).toBe(false);
+    });
+
+    it('supports symbol keys', () => {
+      const signals = new Signals();
+      const key = Symbol('test');
+      const signal1 = signals.supersede(key);
+      const signal2 = signals.supersede(key);
+
+      expect(signal1.aborted).toBe(true);
+      expect(signal2.aborted).toBe(false);
+    });
+
+    it('allows reusing key after clear()', () => {
+      const signals = new Signals();
+      const signal1 = signals.supersede('test');
+
+      signals.clear();
+
+      const signal2 = signals.supersede('test');
+      expect(signal1.aborted).toBe(true);
+      expect(signal2.aborted).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replace `signal()` and `abort()` on `StateContext` with a `Signals` class that provides keyed cancellation and a supersede pattern for async operations.

## Usage

```ts
state: ({ target, signals }) => ({
  async seek(time: number) {
    const signal = signals.supersede(signalKeys.seek);
    // ...
  },

  loadSource(src: string) {
    signals.clear();
    // ...
  },
}),
```