### PR TITLE
docs(design): add time component design

### DIFF
--- a/internal/design/time-display.md
+++ b/internal/design/time-display.md
@@ -3,7 +3,7 @@ status: draft
 date: 2025-02-04
 ---
 
-# Time Component
+# Time Display
 
 Displays current time, duration, or remaining time.
 


### PR DESCRIPTION
Refs #266

## Summary

Design doc for the Time component — displays current time, duration, or remaining time.