### PR TITLE
refactor(store): rename `Signals` to `AbortControllerRegistry`

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -229,7 +229,7 @@ Mutations are auto-batched—multiple changes in the same tick trigger only one 
 
 ## Cancellation Signals
 
-Use `signals` to manage cancellation for async operations. The store provides a `Signals` instance that tracks the attach lifecycle and supports keyed cancellation for superseding work.
+Use `signals` to manage cancellation for async operations. The store provides an `AbortControllerRegistry` instance that tracks the attach lifecycle and supports keyed cancellation for superseding work.
 
 ```ts
 state: ({ target, signals }) => ({

--- a/packages/store/src/core/abort-controller-registry.ts
+++ b/packages/store/src/core/abort-controller-registry.ts
@@ -1,6 +1,6 @@
 export type SignalKey = PropertyKey;
 
-export class Signals {
+export class AbortControllerRegistry {
   #base = new AbortController();
   #keys = new Map<SignalKey, AbortController>();
 

--- a/packages/store/src/core/index.ts
+++ b/packages/store/src/core/index.ts
@@ -1,10 +1,10 @@
+export * from './abort-controller-registry';
 export { combine } from './combine';
 export * from './config';
 export * from './errors';
 export { createSelector } from './selector';
 export type { Comparator, Selector } from './shallow-equal';
 export { shallowEqual } from './shallow-equal';
-export * from './signals';
 export * from './slice';
 export * from './state';
 export * from './store';

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -1,11 +1,11 @@
 import { pick } from '@videojs/utils/object';
+import { AbortControllerRegistry } from './abort-controller-registry';
 import { throwNoTargetError } from './errors';
-import { Signals } from './signals';
 import type { AnySlice, InferSliceState, StateContext } from './slice';
 
 const stateContext: StateContext<unknown> = {
   target: throwNoTargetError,
-  signals: new Signals(),
+  signals: new AbortControllerRegistry(),
 };
 
 /**

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -1,5 +1,5 @@
 import type { Simplify, UnionToIntersection } from '@videojs/utils/types';
-import type { Signals } from './signals';
+import type { AbortControllerRegistry } from './abort-controller-registry';
 import type { UnknownState } from './state';
 
 // ----------------------------------------
@@ -39,7 +39,7 @@ export interface StateContext<Target> {
    * - `signals.clear()` — Aborts all keyed signals. Use when starting fresh
    *   (e.g., loading a new source cancels pending seeks).
    */
-  signals: Signals;
+  signals: AbortControllerRegistry;
 }
 
 // ----------------------------------------

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -1,7 +1,7 @@
 import { isNull, isObject } from '@videojs/utils/predicate';
+import { AbortControllerRegistry } from './abort-controller-registry';
 import type { StoreCallbacks } from './config';
 import { throwDestroyedError, throwNoTargetError } from './errors';
-import { Signals } from './signals';
 import type { AttachContext, Slice, StateContext } from './slice';
 import type { StateChange, SubscribeOptions, UnknownState, WritableState } from './state';
 import { createState } from './state';
@@ -22,7 +22,7 @@ export function createStore<Target = unknown>(): <State>(
     let destroyed = false;
 
     const setupAbort = new AbortController();
-    const signals = new Signals();
+    const signals = new AbortControllerRegistry();
 
     // Reactive state - initialized after building slice state
     let state: WritableState<State>;

--- a/packages/store/src/core/tests/abort-controller-registry.test.ts
+++ b/packages/store/src/core/tests/abort-controller-registry.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { Signals } from '../signals';
+import { AbortControllerRegistry } from '../abort-controller-registry';
 
-describe('Signals', () => {
+describe('AbortControllerRegistry', () => {
   describe('base', () => {
     it('returns an AbortSignal', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       expect(signals.base).toBeInstanceOf(AbortSignal);
     });
 
     it('is not aborted initially', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       expect(signals.base.aborted).toBe(false);
     });
 
     it('is aborted after reset()', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const base = signals.base;
 
       signals.reset();
@@ -23,7 +23,7 @@ describe('Signals', () => {
     });
 
     it('returns new signal after reset()', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const base1 = signals.base;
 
       signals.reset();
@@ -34,7 +34,7 @@ describe('Signals', () => {
     });
 
     it('is not aborted after clear()', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const base = signals.base;
 
       signals.clear();
@@ -45,7 +45,7 @@ describe('Signals', () => {
 
   describe('clear', () => {
     it('aborts keyed signals', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal = signals.supersede('test');
 
       signals.clear();
@@ -54,7 +54,7 @@ describe('Signals', () => {
     });
 
     it('does not abort base', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const base = signals.base;
       signals.supersede('test');
 
@@ -64,7 +64,7 @@ describe('Signals', () => {
     });
 
     it('clears all keyed signals', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal1 = signals.supersede('key1');
       const signal2 = signals.supersede('key2');
 
@@ -77,7 +77,7 @@ describe('Signals', () => {
 
   describe('reset', () => {
     it('aborts base signal', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const base = signals.base;
 
       signals.reset();
@@ -86,7 +86,7 @@ describe('Signals', () => {
     });
 
     it('aborts keyed signals', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal = signals.supersede('test');
 
       signals.reset();
@@ -95,7 +95,7 @@ describe('Signals', () => {
     });
 
     it('creates new base signal', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const base1 = signals.base;
 
       signals.reset();
@@ -108,21 +108,21 @@ describe('Signals', () => {
 
   describe('supersede', () => {
     it('returns an AbortSignal', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal = signals.supersede('test');
 
       expect(signal).toBeInstanceOf(AbortSignal);
     });
 
     it('is not aborted initially', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal = signals.supersede('test');
 
       expect(signal.aborted).toBe(false);
     });
 
     it('aborts when base is reset', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal = signals.supersede('test');
 
       signals.reset();
@@ -131,7 +131,7 @@ describe('Signals', () => {
     });
 
     it('aborts previous signal for same key', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal1 = signals.supersede('seek');
 
       const signal2 = signals.supersede('seek');
@@ -141,7 +141,7 @@ describe('Signals', () => {
     });
 
     it('does not abort signals with different keys', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal1 = signals.supersede('key1');
       const signal2 = signals.supersede('key2');
 
@@ -150,7 +150,7 @@ describe('Signals', () => {
     });
 
     it('supports symbol keys', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const key = Symbol('test');
       const signal1 = signals.supersede(key);
       const signal2 = signals.supersede(key);
@@ -160,7 +160,7 @@ describe('Signals', () => {
     });
 
     it('allows reusing key after clear()', () => {
-      const signals = new Signals();
+      const signals = new AbortControllerRegistry();
       const signal1 = signals.supersede('test');
 
       signals.clear();


### PR DESCRIPTION
## Summary
- rename core cancellation class `Signals` to `AbortControllerRegistry`
- rename the module file to `abort-controller-registry.ts` and update all imports/usages
- rename `signals.test.ts` to `abort-controller-registry.test.ts`
- update core barrel export and README wording to match the new class name
