### PR TITLE
fix(site): resolve aliased part descriptions in api docs

### DIFF
--- a/packages/react/src/ui/controls/controls-group.tsx
+++ b/packages/react/src/ui/controls/controls-group.tsx
@@ -12,6 +12,7 @@ export interface ControlsGroupProps extends UIComponentProps<'div', GroupState> 
   children?: ReactNode | undefined;
 }
 
+/** Layout group for related controls; sets `role="group"` when labeled. */
 export const ControlsGroup = forwardRef(function ControlsGroup(
   componentProps: ControlsGroupProps,
   forwardedRef: ForwardedRef<HTMLDivElement>

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -13,6 +13,7 @@ export interface ControlsRootProps extends UIComponentProps<'div', ControlsCore.
   children?: ReactNode | undefined;
 }
 
+/** Root container for player controls state and rendered control content. */
 export const ControlsRoot = forwardRef(function ControlsRoot(
   componentProps: ControlsRootProps,
   forwardedRef: ForwardedRef<HTMLDivElement>

--- a/site/scripts/api-docs-builder/src/index.ts
+++ b/site/scripts/api-docs-builder/src/index.ts
@@ -265,6 +265,7 @@ function discoverParts(source: ComponentSource, program: ts.Program): PartSource
 
     const part: PartSource = {
       name: partExport.name,
+      localName: partExport.localName,
       kebab,
       isPrimary,
       htmlPath: hasSubPartElement ? subPartElementFile : isPrimary ? source.htmlPath : undefined,
@@ -310,7 +311,10 @@ function buildMultiPartApiReference(
 
   for (const part of parts) {
     // Extract JSDoc description from React component file
-    const description = part.reactPath ? extractPartDescription(part.reactPath, program, part.name) : undefined;
+    const description = part.reactPath
+      ? (extractPartDescription(part.reactPath, program, part.localName) ??
+        extractPartDescription(part.reactPath, program, part.name))
+      : undefined;
 
     if (part.isPrimary) {
       // Primary part: extract from shared core and data-attrs

--- a/site/scripts/api-docs-builder/src/parts-handler.ts
+++ b/site/scripts/api-docs-builder/src/parts-handler.ts
@@ -2,8 +2,10 @@ import * as ts from 'typescript';
 import * as tae from 'typescript-api-extractor';
 
 export interface PartExport {
-  /** PascalCase export name (e.g., "Value", "Group", "Separator"). */
+  /** PascalCase exported part name (e.g., "Value", "Group", "Separator"). */
   name: string;
+  /** Local symbol name in the source module before aliasing. */
+  localName: string;
   /** Source path (e.g., "./time-value", "./time-group"). */
   source: string;
 }
@@ -39,8 +41,10 @@ export function extractParts(filePath: string, program: ts.Program): PartExport[
           // Skip type-only specifiers (e.g., `type GroupProps`)
           if (element.isTypeOnly) continue;
 
+          const localName = element.propertyName?.text ?? element.name.text;
           parts.push({
             name: element.name.text,
+            localName,
             source,
           });
         }

--- a/site/scripts/api-docs-builder/src/types.ts
+++ b/site/scripts/api-docs-builder/src/types.ts
@@ -18,6 +18,8 @@ export { ComponentApiReferenceSchema, PartApiReferenceSchema } from '../../../sr
 export interface PartSource {
   /** PascalCase name (e.g., "Value", "Group", "Separator"). */
   name: string;
+  /** Local symbol name in the source module (before any aliasing). */
+  localName: string;
   /** Kebab-case segment (e.g., "value", "group", "separator"). */
   kebab: string;
   /** True if this part gets the shared core/data-attrs. */


### PR DESCRIPTION
## Summary
- capture both exported and local symbol names when parsing `index.parts.ts`
- resolve part descriptions via local symbol first, with exported-name fallback
- add concise JSDoc to `ControlsRoot` and `ControlsGroup` to validate extraction output
- add alias-focused regression tests for parts extraction/description behavior

## Validation
- `pnpm -C site test scripts/api-docs-builder/src/tests`
- `pnpm -C site api-docs`

Closes #516
