### PR TITLE
fix(site): use first-match-wins for multipart primary selection

### DIFF
--- a/site/scripts/api-docs-builder/src/index.ts
+++ b/site/scripts/api-docs-builder/src/index.ts
@@ -254,8 +254,14 @@ function discoverParts(source: ComponentSource, program: ts.Program): PartSource
     const subPartElementFile = path.join(htmlDir, `${componentKebab}-${kebab}-element.ts`);
     const hasSubPartElement = fs.existsSync(subPartElementFile);
 
-    // Primary part: no matching sub-part element, but main element exists
-    const isPrimary = !hasSubPartElement && !!source.htmlPath;
+    // Primary part: no matching sub-part element, main element exists, and first match wins.
+    const isPrimary = !hasSubPartElement && !!source.htmlPath && !hasPrimary;
+
+    if (!hasSubPartElement && !!source.htmlPath && hasPrimary) {
+      log.warn(
+        `${source.name}: Part "${partExport.name}" also matches primary criteria and was skipped (first-match-wins)`
+      );
+    }
 
     if (isPrimary) hasPrimary = true;
 


### PR DESCRIPTION
## Summary
- apply first-match-wins logic for multipart primary selection
- keep behavior non-fatal while ensuring only one part is marked primary
- add warning log when additional primary candidates are skipped

## Validation
- `pnpm -C site test scripts/api-docs-builder/src/tests`
- `pnpm -C site api-docs`
