### PR TITLE
chore(root): add dependency graph to turbo dev and test tasks

### DIFF
--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -39,4 +39,4 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Run website tests
-        run: pnpm --filter site test
+        run: turbo run test --filter=site

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
       "outputs": ["dist/**", ".netlify/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true,
       "interactive": false
@@ -16,6 +17,7 @@
       "cache": false
     },
     "test": {
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "lint": {


### PR DESCRIPTION
## Summary

Ensure dependent packages are built before running `dev` or `test` via Turbo by adding `"dependsOn": ["^build"]` to both tasks. Also switches the website tests CI workflow to use `turbo run test --filter=site` so it respects the dependency graph.

## Changes

- Add `"dependsOn": ["^build"]` to `dev` and `test` tasks in `turbo.json`
- Update website tests workflow to use Turbo CLI instead of pnpm filter

## Testing

`pnpm dev` and `pnpm test` now automatically build upstream dependencies first. Verify with `turbo run test --filter=site --dry` to see the dependency graph.