### PR TITLE
feat(site): add Mux health check action

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -649,6 +649,8 @@ The site uses OAuth for authentication and Mux for video management. Required va
 | Variable | Purpose |
 | --- | --- |
 | `MUX_API_URL` | Override Mux API endpoint (defaults to `https://api.mux.com`) |
+| `MUX_TOKEN_ID` | Mux API token ID (for server-side health checks) |
+| `MUX_TOKEN_SECRET` | Mux API token secret (for server-side health checks) |
 | `SENTRY_AUTH_TOKEN` | Sentry error tracking auth token |
 
 ## Authentication & Mux Integration

--- a/site/src/middleware/index.ts
+++ b/site/src/middleware/index.ts
@@ -22,6 +22,9 @@ function isGated(actionName: string | undefined) {
   // detect UNAUTHORIZED and show a login UI before uploading
   if (actionName === 'mux.createDirectUpload') return false;
 
+  // Health check uses server-side credentials, not user OAuth
+  if (actionName === 'mux.health') return false;
+
   // I don't love the magic string nature of this pattern but it's what is recommended in the docs
   return actionName.startsWith('mux');
 }

--- a/site/src/pages/api/health/mux.ts
+++ b/site/src/pages/api/health/mux.ts
@@ -1,0 +1,14 @@
+import { actions } from 'astro:actions';
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+export const GET: APIRoute = async (context) => {
+  const { data, error } = await context.callAction(actions.mux.health, {});
+
+  if (error) {
+    return Response.json({ ok: false, error: error.message }, { status: 502 });
+  }
+
+  return Response.json(data);
+};


### PR DESCRIPTION
## Summary

- Adds `mux.health` action using server-side credentials (`MUX_TOKEN_ID` / `MUX_TOKEN_SECRET`) to make a lightweight round-trip to the Mux API
- Adds `GET /api/health/mux` route that wraps the action for synthetic monitoring
- Exempts `mux.health` from middleware auth gating so it doesn't require a user session
- Documents the new env vars in `site/CLAUDE.md`

Closes #341

## Test plan

- [ ] `pnpm -F site build` passes
- [ ] `curl http://localhost:4321/api/health/mux` returns `{ "ok": true }` with credentials set
- [ ] Without credentials, returns a 502 with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)