### PR TITLE
fix(core): fix circular import and simplify media types

### DIFF
--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -1,5 +1,4 @@
 export * from './feature';
-export type { AudioApiProxy, MediaApiProxy, MediaApiProxyTarget, VideoApiProxy } from './media/proxy';
 export * from './media/types';
 export * from './store/features';
 export * from './store/selectors';

--- a/packages/core/src/dom/media/hls.ts
+++ b/packages/core/src/dom/media/hls.ts
@@ -1,6 +1,7 @@
-import type { MediaApiProxyTarget } from '@videojs/core';
 import type { AnyConstructor } from '@videojs/utils/types';
 import Hls from 'hls.js';
+
+import type { MediaApiProxyTarget } from '../../core/media/proxy';
 import { VideoApiProxy } from './proxy';
 
 // This is used by the web component because it needs to extend HTMLElement!

--- a/packages/core/src/dom/media/types.ts
+++ b/packages/core/src/dom/media/types.ts
@@ -19,7 +19,7 @@ export type MediaBaseApi = {
 
 export type MediaApi = WithOptional<MediaBaseApi, HTMLVideoElement>;
 
-export type Media = MediaApi | HTMLMediaElement | HTMLAudioElement | HTMLVideoElement | null;
+export type Media = HTMLMediaElement | HTMLAudioElement | HTMLVideoElement;
 
 export interface MediaContainer extends HTMLElement {}
 

--- a/packages/react/src/utils/attach-media-element.ts
+++ b/packages/react/src/utils/attach-media-element.ts
@@ -1,6 +1,9 @@
-import type { MediaApiProxy } from '@videojs/core/dom';
+interface Attachable {
+  attach(target: EventTarget): void;
+  detach(): void;
+}
 
-export function attachMediaElement<T extends HTMLVideoElement>(media: MediaApiProxy): (element: T | null) => void {
+export function attachMediaElement<T extends HTMLVideoElement>(media: Attachable): (element: T | null) => void {
   return (element: T | null) => {
     if (element) {
       media.attach(element);


### PR DESCRIPTION
## Summary

Fix circular import in `@videojs/core/dom` and simplify the `Media` type and `attachMediaElement` utility to reduce coupling between packages.

## Changes

- Remove re-export of proxy types (`MediaApiProxy`, `VideoApiProxy`, etc.) from the `core/dom` barrel to break circular import
- Switch `hls.ts` from self-referencing package import (`@videojs/core`) to relative import for `MediaApiProxyTarget`
- Simplify `Media` type to `HTMLMediaElement | HTMLAudioElement | HTMLVideoElement` (removing `MediaApi` and `null`)
- Decouple `attachMediaElement` from `MediaApiProxy` by introducing a local `Attachable` interface

## Testing

`pnpm typecheck` and `pnpm build:packages`