### PR TITLE
fix(site): strip trailing slashes via Netlify redirect

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -3,6 +3,12 @@
   publish = "site/dist"
   ignore = "pnpm dlx turbo-ignore site --task=build --fallback=origin/main"
 
+# Strip trailing slashes to match Astro's trailingSlash: 'never' config
+[[redirects]]
+  from = "/*/"
+  to = "/:splat"
+  status = 301
+
 # Redirect old theme demo pages to home
 [[redirects]]
   from = "/city"


### PR DESCRIPTION
## Summary
- URLs with trailing slashes (e.g., `/docs/`) return 404 because Astro is configured with `trailingSlash: 'never'`
- Adds a catch-all Netlify redirect (`/*/ → /:splat`) with a 301 to strip trailing slashes before other rules are evaluated

## Test plan
- [ ] Verify `https://vjs10-site.netlify.app/docs/` no longer 404s and redirects to `/docs`
- [ ] Verify existing routes without trailing slashes still work normally
- [ ] Verify other redirects (e.g., `/city` → `/`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)