### PR TITLE
refactor: replace URL.pathname with fileURLToPath for cross-platform …

### DIFF
--- a/packages/__tech-preview__/html/tsdown.config.ts
+++ b/packages/__tech-preview__/html/tsdown.config.ts
@@ -1,7 +1,8 @@
 import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsdown';
 
-const defineDir = new URL('./src/define', import.meta.url).pathname;
+const defineDir = fileURLToPath(new URL('./src/define', import.meta.url));
 const defineFiles = readdirSync(defineDir).filter(file => file.endsWith('.ts'));
 
 export default defineConfig({
@@ -22,7 +23,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   alias: {
-    '@': new URL('./src', import.meta.url).pathname,
+    '@': fileURLToPath(new URL('./src', import.meta.url)),
   },
   dts: {
     oxc: true,

--- a/packages/__tech-preview__/react/tsdown.config.ts
+++ b/packages/__tech-preview__/react/tsdown.config.ts
@@ -1,8 +1,9 @@
 import { existsSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsdown';
 import buildStyles from './build/build-styles.ts';
 
-const GENERATED_ICONS_DIR = new URL('./src/icons/generated-icons', import.meta.url).pathname;
+const GENERATED_ICONS_DIR = fileURLToPath(new URL('./src/icons/generated-icons', import.meta.url));
 
 function hasGeneratedIcons(): boolean {
   if (!existsSync(GENERATED_ICONS_DIR)) return false;
@@ -23,7 +24,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   alias: {
-    '@': new URL('./src', import.meta.url).pathname,
+    '@': fileURLToPath(new URL('./src', import.meta.url)),
   },
   dts: {
     oxc: true,


### PR DESCRIPTION
In the  tsdown.config.ts files fileURLToPath from 'node:url' and wrapped the new URL() requests with the fileURLToPath to support cross platform (windows and mac) development and building.

validated with a fresh git pull, pnpm install, pnpm build, pnpm dev. 