### PR TITLE
fix(cd): use namespace imports for actions packages

### DIFF
--- a/.github/scripts/label-issue.js
+++ b/.github/scripts/label-issue.js
@@ -1,5 +1,5 @@
-import core from '@actions/core';
-import github from '@actions/github';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
 
 const GH_TOKEN = process.env.GITHUB_TOKEN;
 


### PR DESCRIPTION
## Summary

Fix default imports for `@actions/core` and `@actions/github` in the label-issue script. These packages use CommonJS exports and require namespace imports (`import * as`) to work correctly with ESM.

## Changes

- Switch from default imports to namespace imports for `@actions/core` and `@actions/github`

## Testing

Covered by CI — the label-issue workflow will run on the next issue event.