### PR TITLE
feat(site): preserve scroll position on framework switch (pagereveal)

### DIFF
--- a/site/src/components/docs/DocsSidebarRestoration.astro
+++ b/site/src/components/docs/DocsSidebarRestoration.astro
@@ -58,7 +58,7 @@ const { docsSidebarId } = Astro.props;
       if (scrollData) {
         sessionStorage.removeItem('vjs-page-scroll');
         const { url, scrollY } = JSON.parse(scrollData);
-        if (url === window.location.pathname) {
+        if (url.replace(/\/$/, '') === window.location.pathname.replace(/\/$/, '')) {
           window.scrollTo(0, scrollY);
         }
       }

--- a/site/src/components/docs/Selectors.tsx
+++ b/site/src/components/docs/Selectors.tsx
@@ -35,10 +35,14 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
     });
 
     if (shouldReplace) {
+      // Base UI's scroll lock transfers html.scrollTop → body.scrollTop
+      const scrollLocked = document.documentElement.hasAttribute('data-base-ui-scroll-locked');
+      const scrollY = scrollLocked ? document.body.scrollTop : window.scrollY;
+
       try {
         sessionStorage.setItem(
           'vjs-page-scroll',
-          JSON.stringify({ url: new URL(url, window.location.origin).pathname, scrollY: window.scrollY })
+          JSON.stringify({ url: new URL(url, window.location.origin).pathname, scrollY })
         );
       } catch {
         // Ignore storage errors

--- a/site/src/components/installation/JSPickerClient.tsx
+++ b/site/src/components/installation/JSPickerClient.tsx
@@ -29,10 +29,14 @@ export default function JSPickerClient({ currentFramework, currentStyle, current
     });
 
     if (shouldReplace) {
+      // Base UI's scroll lock transfers html.scrollTop → body.scrollTop
+      const scrollLocked = document.documentElement.hasAttribute('data-base-ui-scroll-locked');
+      const scrollY = scrollLocked ? document.body.scrollTop : window.scrollY;
+
       try {
         sessionStorage.setItem(
           'vjs-page-scroll',
-          JSON.stringify({ url: new URL(url, window.location.origin).pathname, scrollY: window.scrollY })
+          JSON.stringify({ url: new URL(url, window.location.origin).pathname, scrollY })
         );
       } catch {
         // Ignore storage errors


### PR DESCRIPTION
## Summary

Preserves scroll position when switching frameworks (React ↔ HTML) on docs pages where the slug stays the same. Uses the existing native view transition infrastructure (`pagereveal`/`pageswap` events) that sidebar scroll restoration already relies on.

- Before navigating, saves `{ url, scrollY }` to `sessionStorage` from the React call sites
- In the `pagereveal` handler (fires before the new page is revealed), restores scroll position if the URL matches
- No architectural changes — still MPA, 3 files modified, ~15 lines of new code

**Bake-off companion:** #609 (ClientRouter approach)

Closes #484 

## Approach: Why `pagereveal`?

The `@view-transition { navigation: auto }` CSS (already in `DocsSidebarRestoration.astro`) makes the browser hold a screenshot of the old page while the new page loads. The `pagereveal` event fires before the screenshot is swapped out, so restoring `window.scrollY` here is flicker-free — the same mechanism sidebar restoration uses today.

## Changes

| File | What |
|------|------|
| `DocsSidebarRestoration.astro` | Restructured `pagereveal` handler to not early-return when sidebar is absent; added page scroll restoration from `sessionStorage` |
| `Selectors.tsx` | Saves scroll position to `sessionStorage` before `window.location.replace()` |
| `JSPickerClient.tsx` | Same pattern; removed TODO comment |

## Test plan

- [ ] `pnpm dev`, navigate to a docs page, scroll to middle, switch framework via sidebar dropdown → scroll preserved, no flicker
- [ ] Switch framework via JSPicker on installation page → scroll preserved
- [ ] Navigate to page where slug changes on framework switch → scrolls to top
- [ ] Sidebar state (scroll + details open/closed) persists across navigation
- [ ] Dark mode and style preference persist
- [ ] Browser back/forward work correctly
- [ ] Hard refresh works correctly
- [ ] Test Safari, Chrome, Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)