### PR TITLE
feat(site): preserve scroll position on framework switch (ClientRouter)

### DIFF
--- a/site/src/components/ThemeInit.astro
+++ b/site/src/components/ThemeInit.astro
@@ -3,7 +3,7 @@ import { THEME_KEY } from '@/consts';
 ---
 
 {/* Dark mode initialization script - runs before paint to prevent FOUC */}
-<script is:inline define:vars={{ localStorageKey: THEME_KEY }}>
+<script is:inline data-astro-rerun define:vars={{ localStorageKey: THEME_KEY }}>
   if (
     typeof localStorage !== 'undefined' &&
     typeof document !== 'undefined' &&

--- a/site/src/components/docs/DocsSidebarRestoration.astro
+++ b/site/src/components/docs/DocsSidebarRestoration.astro
@@ -14,7 +14,27 @@ const { docsSidebarId } = Astro.props;
 <script is:inline define:vars={{ docsSidebarId }}>
   const STORAGE_KEY = 'vjs-sidebar-state';
 
-  window.addEventListener('pagereveal', () => {
+  function saveSidebarState() {
+    const aside = document.getElementById(docsSidebarId);
+    if (!aside) return;
+    const detailsState = {};
+    document.querySelectorAll(`#${docsSidebarId} details[id]`).forEach((details) => {
+      detailsState[details.id] = details.open;
+    });
+
+    const state = {
+      sidebarScroll: aside.scrollTop,
+      detailsState,
+    };
+
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (e) {
+      console.error('[Sidebar] Failed to save state', e);
+    }
+  }
+
+  function restoreSidebarState() {
     const aside = document.getElementById(docsSidebarId);
     if (!aside) return;
     const stored = sessionStorage.getItem(STORAGE_KEY);
@@ -49,27 +69,18 @@ const { docsSidebarId } = Astro.props;
         parent = parent.parentElement?.closest('details') ?? null;
       }
     }
-  });
+  }
 
-  window.addEventListener('pageswap', () => {
-    const aside = document.getElementById(docsSidebarId);
-    if (!aside) return;
-    const detailsState = {};
-    document.querySelectorAll(`#${docsSidebarId} details[id]`).forEach((details) => {
-      detailsState[details.id] = details.open;
-    });
+  // Native view transition events (hard refresh / initial load fallback)
+  window.addEventListener('pageswap', saveSidebarState);
+  window.addEventListener('pagereveal', restoreSidebarState);
 
-    const state = {
-      sidebarScroll: aside.scrollTop,
-      detailsState,
-    };
+  // Astro ClientRouter lifecycle events (SPA navigation)
+  document.addEventListener('astro:before-swap', saveSidebarState);
+  document.addEventListener('astro:after-swap', restoreSidebarState);
 
-    try {
-      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    } catch (e) {
-      console.error('[Sidebar] Failed to save state', e);
-    }
-  });
+  // Restore on initial page load
+  restoreSidebarState();
 </script>
 
 {

--- a/site/src/components/docs/Selectors.tsx
+++ b/site/src/components/docs/Selectors.tsx
@@ -1,3 +1,4 @@
+import { navigate } from 'astro:transitions/client';
 import { useStore } from '@nanostores/react';
 import { Select } from '@/components/Select';
 import { currentStyle as styleStore } from '@/stores/preferences';
@@ -35,11 +36,12 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
     });
 
     if (shouldReplace) {
-      // Maintaining the current slug, navigate without pushing onto the history stack
-      window.location.replace(url);
+      const currentScrollY = window.scrollY;
+      navigate(url, { history: 'replace' }).then(() => {
+        window.scrollTo(0, currentScrollY);
+      });
     } else {
-      // Changing slug, use normal navigation
-      window.location.href = url;
+      navigate(url);
     }
   };
 

--- a/site/src/components/docs/StyleInit.astro
+++ b/site/src/components/docs/StyleInit.astro
@@ -28,6 +28,7 @@ const allStyles = [...new Set(Object.values(FRAMEWORK_STYLES).flat())];
 */}
 <script
   is:inline
+  data-astro-rerun
   define:vars={{ keyPrefix: STYLE_KEY_PREFIX, frameworkStyles: frameworkStylesConfig, defaultStyle: defaultStyleConfig }}
 >
   if (typeof localStorage !== 'undefined' && typeof document !== 'undefined') {

--- a/site/src/components/installation/JSPickerClient.tsx
+++ b/site/src/components/installation/JSPickerClient.tsx
@@ -1,3 +1,4 @@
+import { navigate } from 'astro:transitions/client';
 import { Atom, Globe } from 'lucide-react';
 import type { ReactNode } from 'react';
 import ImageRadioGroup from '@/components/ImageRadioGroup';
@@ -17,7 +18,6 @@ interface Props {
 }
 
 export default function JSPickerClient({ currentFramework, currentStyle, currentSlug }: Props) {
-  // TODO: use astro view transitions to preserve scroll position when switching from the same slug to the same slug
   const handleFrameworkChange = (newFramework: SupportedFramework | null) => {
     if (newFramework === null) return;
     if (!isValidFramework(newFramework)) return;
@@ -30,11 +30,12 @@ export default function JSPickerClient({ currentFramework, currentStyle, current
     });
 
     if (shouldReplace) {
-      // Maintaining the current slug, navigate without pushing onto the history stack
-      window.location.replace(url);
+      const currentScrollY = window.scrollY;
+      navigate(url, { history: 'replace' }).then(() => {
+        window.scrollTo(0, currentScrollY);
+      });
     } else {
-      // Changing slug, use normal navigation
-      window.location.href = url;
+      navigate(url);
     }
   };
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 
 
 import { Font } from 'astro:assets';
+import { ClientRouter } from 'astro:transitions';
 import type { ImageMetadata } from 'astro';
 
 import { SEO_SUFFIX, SITE_TITLE } from '@/consts';
@@ -42,6 +43,8 @@ const fullTitle =
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="alternate" type="application/rss+xml" title={SITE_TITLE} href={new URL('rss.xml', Astro.site)} />
     <meta name="generator" content={Astro.generator} />
+
+    <ClientRouter />
 
     {/* Important stuff */}
     <slot name="priority-head" />


### PR DESCRIPTION
## Summary

Preserves scroll position when switching frameworks (React ↔ HTML) on docs pages where the slug stays the same. Converts the site to an SPA hybrid using Astro's `ClientRouter`, which intercepts navigation and swaps DOM without a full page reload.

- Uses `navigate()` from `astro:transitions/client` instead of `window.location` assignment
- Captures `scrollY` before navigation, restores in `.then()` after DOM swap
- Adds `data-astro-rerun` to `ThemeInit` and `StyleInit` so inline scripts re-execute after SPA swap
- Adapts `DocsSidebarRestoration` to listen for both native and Astro lifecycle events

**Bake-off companion:** #608 (pagereveal approach)

Closes #484 

## Approach: Why `ClientRouter`?

Astro's `ClientRouter` turns navigation into DOM swaps — no full page reload means scroll position can be trivially captured and restored via a promise. Side benefits include faster navigation and smoother transitions across the entire site.

## Changes

| File | What |
|------|------|
| `Base.astro` | Added `<ClientRouter />` to `<head>` — enables SPA mode site-wide |
| `Selectors.tsx` | Replaced `window.location` with `navigate()` + scroll restore |
| `JSPickerClient.tsx` | Same pattern; removed TODO comment |
| `StyleInit.astro` | Added `data-astro-rerun` so `html[data-style]` updates after SPA swap |
| `ThemeInit.astro` | Added `data-astro-rerun` so dark mode class persists after SPA swap |
| `DocsSidebarRestoration.astro` | Extracted save/restore helpers; added `astro:before-swap`/`astro:after-swap` listeners alongside native events; added initial load restore |

## Risks

| Risk | Severity | Mitigation |
|------|----------|------------|
| `is:inline` scripts not re-running after SPA nav | High | `data-astro-rerun` on StyleInit + ThemeInit |
| Safari/FilmGrain flickering | Medium | Kept existing `view-transition-name: none` on html/body |
| ClientRouter in Base.astro affects ALL pages | Medium | Blog/home get SPA nav for free; needs regression testing |
| Island re-hydration timing after swap | Medium | Test thoroughly |

## Test plan

- [ ] `pnpm dev`, navigate to a docs page, scroll to middle, switch framework via sidebar dropdown → scroll preserved, no flicker
- [ ] Switch framework via JSPicker on installation page → scroll preserved
- [ ] Navigate to page where slug changes on framework switch → scrolls to top
- [ ] Sidebar state (scroll + details open/closed) persists across navigation
- [ ] Dark mode and style preference persist
- [ ] Browser back/forward work correctly
- [ ] Hard refresh works correctly
- [ ] Navigate between non-docs pages (home → blog → docs) — no visual glitches or flicker
- [ ] Test Safari, Chrome, Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)