### PR TITLE
docs(design): add player-container separation decision

### DIFF
--- a/internal/decisions/player-container-separation.md
+++ b/internal/decisions/player-container-separation.md
@@ -23,7 +23,7 @@ The HTML equivalent:
 
 ```html
 <video-player>
-  <video-skin> {/* Container + UI */}
+  <video-skin> <!-- Container + UI -->
     <video src="video.mp4"></video>
   </video-skin>
 </video-player>


### PR DESCRIPTION
## Summary

Documents the decision to keep `<video-player>` as a provider-only element with a separate `<media-container>` for layout, media attachment, and fullscreen — mirroring the React architecture where Provider, Container, and media components are distinct.

## Changes

- Formalizes player-container separation as the default HTML architecture
- Explains cross-platform skin parity rationale (skins mean the same thing on React and HTML)
- Documents how separated provider enables extended player applications (playlist, transcript, sidebar outside fullscreen target)
- Notes the trade-off of ergonomic friction with nested elements and `display: contents`

## Testing

Documentation only — no code changes.