### PR TITLE
fix(skin): temporarily hide the caption button

### DIFF
--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -290,18 +290,18 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
           <Time.Value type="duration" className="text-shadow-2xs text-shadow-black/25 tabular-nums" />
         </Time.Group>
 
-        <CaptionsButton
-          render={(props, state) => (
-            <Button variant="icon" {...props}>
-              <CaptionsButtonIcon state={state} className={icon} />
-            </Button>
-          )}
-        />
-
         <MuteButton
           render={(props, state) => (
             <Button variant="icon" {...props}>
               <MuteButtonIcon state={state} className={icon} />
+            </Button>
+          )}
+        />
+
+        <CaptionsButton
+          render={(props, state) => (
+            <Button variant="icon" {...props}>
+              <CaptionsButtonIcon state={state} className={icon} />
             </Button>
           )}
         />

--- a/packages/react/src/ui/captions-button/captions-button.tsx
+++ b/packages/react/src/ui/captions-button/captions-button.tsx
@@ -25,6 +25,8 @@ const CaptionButtonDataAttrs = {
 
 export interface CaptionsButtonProps extends UIComponentProps<'button', CaptionsButtonState>, CaptionButtonCoreProps {}
 
+const DEBUG = false;
+
 /**
  * A button that toggles captions.
  *
@@ -55,6 +57,8 @@ export const CaptionsButton = forwardRef(function CaptionsButton(
     onActivate: () => setIsActive((active) => !active), // FIXME: Replace with actual toggle logic
     isDisabled: () => disabled ?? false,
   });
+
+  if (!DEBUG) return null;
 
   return renderElement(
     'button',


### PR DESCRIPTION
While the caption button does nothing for now, we should hide it in the UI. I also fixed a positioning error in the Tailwind default skin. 