### PR TITLE
feat(react): support native caption track shifting in video skins

### DIFF
--- a/packages/react/src/presets/video/minimal-skin.css
+++ b/packages/react/src/presets/video/minimal-skin.css
@@ -573,15 +573,7 @@
   z-index: 20;
   font-size: 1rem;
   text-wrap: balance;
-  /* The delay must account for the controls delay/duration */
-  transition: transform 150ms ease-out;
-  transition-delay: 600ms;
   pointer-events: none;
-}
-@media (prefers-reduced-motion: reduce) {
-  .media-minimal-skin .media-captions {
-    transition-duration: 50ms;
-  }
 }
 .media-minimal-skin .media-captions__container {
   display: flex;
@@ -630,8 +622,33 @@
   }
 }
 
-/* Shift captions up when controls visible */
+/* Caption shifting styles (custom and native) */
+.media-minimal-skin {
+  --media-caption-track-delay: 600ms;
+  --media-caption-track-y: -0.5rem;
+}
+.media-minimal-skin:has(.media-controls[data-visible]) {
+  --media-caption-track-delay: 25ms;
+  --media-caption-track-y: -3rem;
+}
+.media-minimal-skin .media-captions,
+.media-minimal-skin video::-webkit-media-text-track-container {
+  /* NOTE: The delay must account for the controls delay/duration */
+  transition: transform 150ms ease-out;
+  transition-delay: var(--media-caption-track-delay);
+}
+.media-minimal-skin video::-webkit-media-text-track-container {
+  transform: translateY(var(--media-caption-track-y)) scale(0.98);
+  z-index: 1;
+  font-family: inherit;
+}
+/* When controls are visible, shift captions up to avoid overlap */
 .media-minimal-skin .media-controls[data-visible] ~ .media-captions {
-  transform: translateY(-2.5rem);
-  transition-delay: 25ms;
+  transform: translateY(calc(var(--media-caption-track-y) - 0.5rem));
+}
+@media (prefers-reduced-motion: reduce) {
+  .media-minimal-skin .media-captions,
+  .media-minimal-skin video::-webkit-media-text-track-container {
+    transition-duration: 50ms;
+  }
 }

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -149,14 +149,27 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
         '[&>img]:object-cover [&>img]:pointer-events-none',
         '[&>img]:transition-opacity [&>img]:duration-[250ms]',
         '[&>img:not([data-visible])]:opacity-0',
+        // Caption track CSS variables (consumed by native track container below)
+        '[--media-caption-track-delay:600ms]',
+        '[--media-caption-track-y:-0.5rem]',
+        'has-[[data-controls][data-visible]]:[--media-caption-track-delay:25ms]',
+        'has-[[data-controls][data-visible]]:[--media-caption-track-y:-3.5rem]',
+        // Native caption track container
+        '[&_video::-webkit-media-text-track-container]:transition-transform',
+        '[&_video::-webkit-media-text-track-container]:duration-150',
+        '[&_video::-webkit-media-text-track-container]:ease-out',
+        '[&_video::-webkit-media-text-track-container]:delay-(--media-caption-track-delay)',
+        '[&_video::-webkit-media-text-track-container]:translate-y-(--media-caption-track-y)',
+        '[&_video::-webkit-media-text-track-container]:scale-98',
+        '[&_video::-webkit-media-text-track-container]:z-1',
+        '[&_video::-webkit-media-text-track-container]:font-[inherit]',
+        'motion-reduce:[&_video::-webkit-media-text-track-container]:duration-50',
         // Fullscreen
         '[&:fullscreen]:rounded-none',
         className
       )}
       {...rest}
     >
-      {children}
-
       <BufferingIndicator
         render={(props, state) =>
           state.visible ? (
@@ -203,6 +216,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
       />
 
       <Controls.Root
+        data-controls="" // Used as a hook for Tailwind has-[] styles
         className={cn(
           // Peer marker for overlay/captions
           'peer/controls',
@@ -368,6 +382,8 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
           'motion-reduce:duration-100'
         )}
       />
+
+      {children}
     </Container>
   );
 }

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -84,8 +84,6 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
 
   return (
     <Container className={cn('media-minimal-skin', className)} {...rest}>
-      {children}
-
       <BufferingIndicator
         render={(props, state) =>
           state.visible ? (
@@ -209,6 +207,8 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
       </div> */}
 
       <div className="media-overlay" />
+
+      {children}
     </Container>
   );
 }

--- a/packages/react/src/presets/video/skin.css
+++ b/packages/react/src/presets/video/skin.css
@@ -574,15 +574,7 @@
   z-index: 20;
   font-size: 1rem;
   text-wrap: balance;
-  /* The delay must account for the controls delay/duration */
-  transition: transform 150ms ease-out;
-  transition-delay: 600ms;
   pointer-events: none;
-}
-@media (prefers-reduced-motion: reduce) {
-  .media-default-skin .media-captions {
-    transition-duration: 50ms;
-  }
 }
 .media-default-skin .media-captions__container {
   display: flex;
@@ -631,8 +623,33 @@
   }
 }
 
-/* Shift captions up when controls visible */
+/* Caption shifting styles (custom and native) */
+.media-default-skin {
+  --media-caption-track-delay: 600ms;
+  --media-caption-track-y: -0.5rem;
+}
+.media-default-skin:has(.media-controls[data-visible]) {
+  --media-caption-track-delay: 25ms;
+  --media-caption-track-y: -3.5rem;
+}
+.media-default-skin .media-captions,
+.media-default-skin video::-webkit-media-text-track-container {
+  /* NOTE: The delay must account for the controls delay/duration */
+  transition: transform 150ms ease-out;
+  transition-delay: var(--media-caption-track-delay);
+}
+.media-default-skin video::-webkit-media-text-track-container {
+  transform: translateY(var(--media-caption-track-y)) scale(0.98);
+  z-index: 1;
+  font-family: inherit;
+}
+/* When controls are visible, shift captions up to avoid overlap */
 .media-default-skin .media-controls[data-visible] ~ .media-captions {
-  transform: translateY(-3rem);
-  transition-delay: 25ms;
+  transform: translateY(calc(var(--media-caption-track-y) - 0.5rem));
+}
+@media (prefers-reduced-motion: reduce) {
+  .media-default-skin .media-captions,
+  .media-default-skin video::-webkit-media-text-track-container {
+    transition-duration: 50ms;
+  }
 }

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -165,14 +165,27 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
         '[&>img]:object-cover [&>img]:pointer-events-none',
         '[&>img]:transition-opacity [&>img]:duration-[250ms]',
         '[&>img:not([data-visible])]:opacity-0',
+        // Caption track CSS variables (consumed by native track container below)
+        '[--media-caption-track-delay:600ms]',
+        '[--media-caption-track-y:-0.5rem]',
+        'has-[[data-controls][data-visible]]:[--media-caption-track-delay:25ms]',
+        'has-[[data-controls][data-visible]]:[--media-caption-track-y:-3.5rem]',
+        // Native caption track container
+        '[&_video::-webkit-media-text-track-container]:transition-transform',
+        '[&_video::-webkit-media-text-track-container]:duration-150',
+        '[&_video::-webkit-media-text-track-container]:ease-out',
+        '[&_video::-webkit-media-text-track-container]:delay-(--media-caption-track-delay)',
+        '[&_video::-webkit-media-text-track-container]:translate-y-(--media-caption-track-y)',
+        '[&_video::-webkit-media-text-track-container]:scale-98',
+        '[&_video::-webkit-media-text-track-container]:z-1',
+        '[&_video::-webkit-media-text-track-container]:font-[inherit]',
+        'motion-reduce:[&_video::-webkit-media-text-track-container]:duration-50',
         // Fullscreen
         '[&:fullscreen]:rounded-none',
         className
       )}
       {...rest}
     >
-      {children}
-
       <BufferingIndicator
         render={(props, state) =>
           state.visible ? (
@@ -223,6 +236,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       />
 
       <Controls.Root
+        data-controls="" // Used as a hook for Tailwind has-[] styles
         className={cn(
           // Peer marker for overlay/captions
           'peer/controls',
@@ -374,6 +388,8 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
           'motion-reduce:duration-100'
         )}
       />
+
+      {children}
     </Container>
   );
 }

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -84,8 +84,6 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
 
   return (
     <Container className={cn('media-default-skin', className)} {...rest}>
-      {children}
-
       <BufferingIndicator
         render={(props, state) =>
           state.visible ? (
@@ -203,6 +201,8 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       </div> */}
 
       <div className="media-overlay" />
+
+      {children}
     </Container>
   );
 }


### PR DESCRIPTION
## Summary

Native browser captions (rendered via `<track>` elements) now shift vertically in sync with control visibility, matching the existing custom caption behavior. This uses CSS custom properties and `::-webkit-media-text-track-container` to animate the native track container alongside the custom `.media-captions` overlay.

Closes #640 

## Changes

- Introduce `--media-caption-track-delay` and `--media-caption-track-y` CSS custom properties to unify caption shifting for both custom and native tracks
- Style `video::-webkit-media-text-track-container` to shift native captions up when controls are visible
- Move the `children` slot to the end of the component render tree so native captions stack correctly
- Add `data-controls` attribute to `Controls.Root` in Tailwind skins as a hook for `has-[]` selectors
- Apply equivalent Tailwind utility classes for the native track container in both skin variants
- Respect `prefers-reduced-motion` for both custom and native caption transitions

## Testing

1. Render a video with a `<track>` element using native captions (no custom captions component)
2. Verify captions shift up when controls become visible and shift back down when controls hide
3. Verify the same behavior works with custom captions
4. Test in both the default skin and minimal skin variants
5. Verify `prefers-reduced-motion` reduces transition duration