### PR TITLE
feat(skin): add basic color customization

### DIFF
--- a/packages/react/src/presets/video/minimal-skin.css
+++ b/packages/react/src/presets/video/minimal-skin.css
@@ -45,6 +45,17 @@
   letter-spacing: normal;
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
+  --color-primary: var(--media-color-primary, oklch(1 0 0));
+  --color-on-primary: color(
+    from var(--color-primary) xyz clamp(0, (0.36 / y - 1) * infinity, 1) clamp(0, (0.36 / y - 1) * infinity, 1)
+      clamp(0, (0.36 / y - 1) * infinity, 1) /
+    1
+  );
+  --color-primary-shadow: color(
+    from var(--color-primary) xyz round(up, min(1, max(0, 0.18 - y))) round(up, min(1, max(0, 0.18 - y)))
+      round(up, min(1, max(0, 0.18 - y))) /
+    0.2
+  );
 }
 
 /* Border ring */
@@ -137,7 +148,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: oklch(1 0 0);
+  color: var(--color-primary);
   pointer-events: none;
 }
 
@@ -181,7 +192,6 @@
   gap: 0.75rem;
   max-width: 16rem;
   padding: 1rem;
-  color: oklch(1 0 0);
   font-size: 0.875rem;
   text-shadow: 0 1px 0 oklch(0 0 0 / 0.5);
   pointer-events: auto;
@@ -203,6 +213,9 @@
 .media-minimal-skin .media-error__title {
   font-weight: 600;
   line-height: 1.25;
+}
+.media-minimal-skin .media-error__description {
+  opacity: 0.7;
 }
 .media-minimal-skin .media-error__actions {
   display: flex;
@@ -226,7 +239,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 2rem 0.375rem 0.375rem 0.375rem;
-  color: oklch(1 0 0);
+  color: var(--color-primary);
   will-change: transform, filter, opacity;
   transition-property: transform, filter, opacity;
   transition-duration: 75ms;
@@ -274,7 +287,7 @@
 }
 .media-minimal-skin .media-time__value {
   font-variant-numeric: tabular-nums;
-  text-shadow: 0 1px 0 oklch(0 0 0 / 0.2);
+  text-shadow: 0 1px 0 var(--color-primary-shadow);
 }
 .media-minimal-skin .media-time__value--current,
 .media-minimal-skin .media-time__separator {
@@ -286,7 +299,7 @@
   }
   .media-minimal-skin .media-time__value--duration,
   .media-minimal-skin .media-time__separator {
-    color: oklch(1 0 0 / 0.5);
+    color: color-mix(in oklch, var(--color-primary) 60%, transparent);
   }
   .media-minimal-skin .media-time__value--current,
   .media-minimal-skin .media-time__separator {
@@ -320,12 +333,12 @@
   justify-content: center;
   flex-shrink: 0;
   padding: 0.5rem 1rem;
-  background: oklch(1 0 0);
+  background: var(--color-primary);
   border: none;
   border-radius: 0.5rem;
   outline: 2px solid transparent;
   outline-offset: -2px;
-  color: oklch(0 0 0);
+  color: var(--color-on-primary);
   font-weight: 500;
   transition-property: background-color, color, outline-offset;
   transition-duration: 150ms;
@@ -334,7 +347,7 @@
   user-select: none;
 }
 .media-minimal-skin .media-button:focus-visible {
-  outline-color: oklch(1 0 0);
+  outline-color: var(--color-primary);
   outline-offset: 2px;
 }
 .media-minimal-skin .media-button[disabled] {
@@ -348,16 +361,16 @@
   display: grid;
   padding: 0.625rem;
   background: transparent;
-  color: oklch(1 0 0);
+  color: var(--color-primary);
 }
 .media-minimal-skin .media-button--icon:hover,
 .media-minimal-skin .media-button--icon:focus-visible,
 .media-minimal-skin .media-button--icon[aria-expanded="true"] {
-  color: oklch(1 0 0 / 0.8);
+  color: color-mix(in oklch, var(--color-primary) 80%, transparent);
   text-decoration: none;
 }
 .media-minimal-skin .media-button--icon .media-icon {
-  filter: drop-shadow(0 1px 0 oklch(0 0 0 / 0.25));
+  filter: drop-shadow(0 1px 0 var(--color-primary-shadow));
 }
 
 /* Seek button variant — hidden at small sizes */
@@ -454,7 +467,7 @@
   height: 100%;
 }
 .media-minimal-skin .media-slider:focus-visible .media-slider__track {
-  outline-color: oklch(1 0 0);
+  outline-color: var(--color-primary);
   outline-offset: 6px;
 }
 
@@ -463,7 +476,7 @@
   z-index: 10;
   width: 0.75rem;
   height: 0.75rem;
-  background-color: oklch(1 0 0);
+  background-color: var(--color-primary);
   border-radius: calc(infinity * 1px);
   box-shadow:
     0 0 0 1px oklch(0 0 0 / 0.1),
@@ -496,7 +509,7 @@
 
 /* Progress fill */
 .media-minimal-skin .media-slider__progress {
-  background-color: oklch(1 0 0);
+  background-color: var(--color-primary);
   border-radius: inherit;
 }
 

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -33,9 +33,26 @@ const SEEK_TIME = 10;
 
 /* ------------------------------------ Reused fragments ------------------------------------- */
 
+// TBD: Should these live in an inline style (easier to use) or go shadcn style and add it to their stylesheet?
+const defaultStyles = {
+  '--color-primary': 'var(--media-color-primary, oklch(1 0 0))',
+  '--color-on-primary': `color(from var(--color-primary) xyz
+    clamp(0, (.36 / y - 1) * infinity, 1)
+    clamp(0, (.36 / y - 1) * infinity, 1)
+    clamp(0, (.36 / y - 1) * infinity, 1)
+    / 1
+  )`,
+  '--color-primary-shadow': `color(from var(--color-primary) xyz
+    round(up, min(1, max(0, 0.18 - y)))
+    round(up, min(1, max(0, 0.18 - y)))
+    round(up, min(1, max(0, 0.18 - y)))
+    / 0.2
+  )`,
+} as const;
+
 const icon = cn(
   '[grid-area:1/1] size-4.5',
-  'drop-shadow-[0_1px_0_var(--tw-drop-shadow-color)] drop-shadow-black/25',
+  'drop-shadow-[0_1px_0_var(--color-primary-shadow)]',
   'transition-discrete transition-[display,opacity] duration-150 ease-out'
 );
 
@@ -61,16 +78,16 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'> & { varian
         variant === 'icon'
           ? cn(
               'grid p-2.5 bg-transparent rounded-md',
-              'text-white',
-              'hover:text-white/80 hover:no-underline',
-              'focus-visible:text-white/80',
-              'focus-visible:outline-white focus-visible:outline-offset-2',
-              'aria-expanded:text-white/80'
+              'text-[color:var(--color-primary)]',
+              'hover:text-[color:color-mix(in_oklch,var(--color-primary)_80%,transparent)] hover:no-underline',
+              'focus-visible:text-[color:color-mix(in_oklch,var(--color-primary)_80%,transparent)]',
+              'focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2',
+              'aria-expanded:text-[color:color-mix(in_oklch,var(--color-primary)_80%,transparent)]'
             )
           : cn(
-              'flex items-center justify-center py-2 px-4 bg-white rounded-lg',
-              'text-black font-medium',
-              'focus-visible:outline-white focus-visible:outline-offset-2'
+              'flex items-center justify-center py-2 px-4 bg-[var(--color-primary)] rounded-lg',
+              'text-[color:var(--color-on-primary)] font-medium',
+              'focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2'
             ),
         className
       )}
@@ -124,7 +141,7 @@ function FullscreenButtonIcon({ state, className, ...rest }: { state: Fullscreen
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNode {
-  const { children, className, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container
@@ -135,8 +152,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
         'rounded-[var(--media-border-radius,0.75rem)] bg-black',
         'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-[0.8125rem] leading-normal subpixel-antialiased',
         // Resets
-        '**:box-border **:m-0',
-        '[&_button]:font-[inherit]',
+        // NOTE: Some styles are omitted from the vanilla CSS because Tailwind has it's own reset.
         'motion-safe:[interpolate-size:allow-keywords]',
         // Outer border ring (::after only)
         'after:absolute after:pointer-events-none after:rounded-[inherit] after:z-10',
@@ -168,6 +184,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
         '[&:fullscreen]:rounded-none',
         className
       )}
+      style={{ ...defaultStyles, ...style }}
       {...rest}
     >
       <BufferingIndicator
@@ -175,7 +192,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
           state.visible ? (
             <div
               {...props}
-              className="absolute inset-0 flex items-center justify-center pointer-events-none z-10 text-white"
+              className="absolute inset-0 flex items-center justify-center pointer-events-none z-10 text-[color:var(--color-primary)]"
             >
               <SpinnerIcon className={icon} />
             </div>
@@ -205,7 +222,9 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
                 <p id="media-error-title" className="font-semibold leading-tight">
                   Something went wrong.
                 </p>
-                <p id="media-error-description">An error occurred while trying to play the video. Please try again.</p>
+                <p id="media-error-description" className="opacity-70">
+                  An error occurred while trying to play the video. Please try again.
+                </p>
               </div>
               <div className="flex gap-2 *:flex-1">
                 <Button onClick={onDismiss}>OK</Button>
@@ -223,7 +242,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
           // Layout
           'absolute @container/media-controls bottom-0 inset-x-0',
           'pt-8 px-1.5 pb-1.5 flex items-center gap-2',
-          'text-white z-10',
+          'text-[color:var(--color-primary)] z-10',
           // Transitions
           'will-change-[translate,filter,opacity]',
           'transition-[translate,filter,opacity] ease-out',
@@ -283,12 +302,23 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
           <Time.Group className="flex items-center gap-1">
             <Time.Value
               type="current"
-              className={cn('hidden tabular-nums text-shadow-2xs text-shadow-black/25', '@md/media-controls:inline')}
+              className={cn(
+                'hidden tabular-nums [text-shadow:0_1px_0_var(--color-primary-shadow)]',
+                '@md/media-controls:inline'
+              )}
             />
-            <Time.Separator className={cn('hidden', '@md/media-controls:inline @md/media-controls:text-white/50')} />
+            <Time.Separator
+              className={cn(
+                'hidden',
+                '@md/media-controls:inline @md/media-controls:text-[color:color-mix(in_oklch,var(--color-primary)_60%,transparent)]'
+              )}
+            />
             <Time.Value
               type="duration"
-              className={cn('tabular-nums text-shadow-2xs text-shadow-black/25', '@md/media-controls:text-white/50')}
+              className={cn(
+                'tabular-nums [text-shadow:0_1px_0_var(--color-primary-shadow)]',
+                '@md/media-controls:text-[color:color-mix(in_oklch,var(--color-primary)_60%,transparent)]'
+              )}
             />
           </Time.Group>
 

--- a/packages/react/src/presets/video/skin.css
+++ b/packages/react/src/presets/video/skin.css
@@ -45,6 +45,17 @@
   letter-spacing: normal;
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
+  --color-primary: var(--media-color-primary, oklch(1 0 0));
+  --color-on-primary: color(
+    from var(--color-primary) xyz clamp(0, (0.36 / y - 1) * infinity, 1) clamp(0, (0.36 / y - 1) * infinity, 1)
+      clamp(0, (0.36 / y - 1) * infinity, 1) /
+    1
+  );
+  --color-primary-shadow: color(
+    from var(--color-primary) xyz round(up, min(1, max(0, 0.18 - y))) round(up, min(1, max(0, 0.18 - y)))
+      round(up, min(1, max(0, 0.18 - y))) /
+    0.2
+  );
 }
 
 /* Inner border rings */
@@ -140,7 +151,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: oklch(1 0 0);
+  color: var(--color-primary);
   pointer-events: none;
 }
 .media-default-skin .media-buffering-indicator .media-surface {
@@ -266,7 +277,7 @@
   gap: 0.075rem;
   padding: 0.175rem;
   border-radius: calc(infinity * 1px);
-  color: oklch(1 0 0);
+  color: var(--color-primary);
   will-change: scale, transform, filter, opacity;
   transition-property: scale, transform, filter, opacity;
   transition-duration: 100ms;
@@ -310,7 +321,7 @@
 }
 .media-default-skin .media-time__value {
   font-variant-numeric: tabular-nums;
-  text-shadow: 0 1px 0 oklch(0 0 0 / 0.25);
+  text-shadow: 0 1px 0 var(--color-primary-shadow);
 }
 .media-default-skin .media-time .media-time__value:first-child {
   display: none;
@@ -332,12 +343,12 @@
   justify-content: center;
   flex-shrink: 0;
   padding: 0.5rem 1rem;
-  background: oklch(1 0 0);
+  background: var(--color-primary);
   border: none;
   border-radius: calc(infinity * 1px);
   outline: 2px solid transparent;
   outline-offset: -2px;
-  color: oklch(0 0 0);
+  color: var(--color-on-primary);
   font-weight: 500;
   transition-property: background-color, color, outline-offset;
   transition-duration: 150ms;
@@ -346,7 +357,7 @@
   user-select: none;
 }
 .media-default-skin .media-button:focus-visible {
-  outline-color: oklch(62.3% 0.214 259.815);
+  outline-color: var(--color-primary);
   outline-offset: 2px;
 }
 .media-default-skin .media-button[disabled] {
@@ -360,18 +371,18 @@
   display: grid;
   padding: 0.5rem;
   background: transparent;
-  color: oklch(1 0 0 / 0.9);
-  text-shadow: 0 1px 0 oklch(0 0 0 / 0.25);
+  color: var(--color-primary);
+  text-shadow: 0 1px 0 var(--color-primary-shadow);
 }
 .media-default-skin .media-button--icon:hover,
 .media-default-skin .media-button--icon:focus-visible,
 .media-default-skin .media-button--icon[aria-expanded="true"] {
   background-color: oklch(1 0 0 / 0.1);
-  color: oklch(1 0 0);
+  color: var(--color-primary);
   text-decoration: none;
 }
 .media-default-skin .media-button--icon .media-icon {
-  filter: drop-shadow(0 1px 0 oklch(0 0 0 / 0.25));
+  filter: drop-shadow(0 1px 0 var(--color-primary-shadow));
 }
 
 /* Seek button variant — hidden at small sizes */
@@ -477,7 +488,7 @@
   z-index: 10;
   width: 0.625rem;
   height: 0.625rem;
-  background-color: oklch(1 0 0);
+  background-color: var(--color-primary);
   border-radius: calc(infinity * 1px);
   box-shadow:
     0 0 0 1px oklch(0 0 0 / 0.1),
@@ -512,7 +523,7 @@
 
 /* Progress fill */
 .media-default-skin .media-slider__progress {
-  background-color: oklch(1 0 0);
+  background-color: var(--color-primary);
   border-radius: inherit;
 }
 
@@ -560,7 +571,7 @@
 .media-default-skin .media-tooltip-popup {
   padding: 0.25rem 0.625rem;
   border-radius: calc(infinity * 1px);
-  color: oklch(1 0 0);
+  color: var(--color-primary);
   font-size: 0.75rem;
 }
 

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -33,6 +33,23 @@ const SEEK_TIME = 10;
 
 /* ------------------------------------ Reused fragments ------------------------------------- */
 
+// TBD: Should these live in an inline style (easier to use) or go shadcn style and add it to their stylesheet?
+const defaultStyles = {
+  '--color-primary': 'var(--media-color-primary, oklch(1 0 0))',
+  '--color-on-primary': `color(from var(--color-primary) xyz
+    clamp(0, (.36 / y - 1) * infinity, 1)
+    clamp(0, (.36 / y - 1) * infinity, 1)
+    clamp(0, (.36 / y - 1) * infinity, 1)
+    / 1
+  )`,
+  '--color-primary-shadow': `color(from var(--color-primary) xyz
+    round(up, min(1, max(0, 0.18 - y)))
+    round(up, min(1, max(0, 0.18 - y)))
+    round(up, min(1, max(0, 0.18 - y)))
+    / 0.2
+  )`,
+} as const;
+
 const surface = cn(
   'bg-white/10',
   'backdrop-blur-3xl backdrop-brightness-90 backdrop-saturate-150',
@@ -48,7 +65,7 @@ const surface = cn(
 
 const icon = cn(
   '[grid-area:1/1] size-4.5 shrink-0',
-  'drop-shadow-[0_1px_0_var(--tw-drop-shadow-color)] drop-shadow-black/25',
+  'drop-shadow-[0_1px_0_var(--color-primary-shadow)]',
   'transition-discrete transition-[display,opacity] duration-150 ease-out'
 );
 
@@ -74,17 +91,17 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'> & { varian
         variant === 'icon'
           ? cn(
               'grid p-2 bg-transparent rounded-full',
-              'text-white/90',
-              'text-shadow-2xs text-shadow-black/25',
-              'hover:bg-white/10 hover:text-white hover:no-underline',
-              'focus-visible:bg-white/10 focus-visible:text-white',
-              'focus-visible:outline-blue-500 focus-visible:outline-offset-2',
-              'aria-expanded:bg-white/10 aria-expanded:text-white'
+              'text-[color:var(--color-primary)]',
+              '[text-shadow:0_1px_0_var(--color-primary-shadow)]',
+              'hover:bg-white/10 hover:no-underline',
+              'focus-visible:bg-white/10',
+              'focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2',
+              'aria-expanded:bg-white/10'
             )
           : cn(
-              'flex items-center justify-center py-2 px-4 bg-white rounded-full',
-              'text-black font-medium',
-              'focus-visible:outline-blue-500 focus-visible:outline-offset-2'
+              'flex items-center justify-center py-2 px-4 bg-[var(--color-primary)] rounded-full',
+              'text-[color:var(--color-on-primary)] font-medium',
+              'focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2'
             ),
         className
       )}
@@ -138,7 +155,7 @@ function FullscreenButtonIcon({ state, className, ...rest }: { state: Fullscreen
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
-  const { children, className, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container
@@ -149,8 +166,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
         'rounded-[var(--media-border-radius,2rem)] bg-black',
         'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-[0.8125rem] leading-normal subpixel-antialiased',
         // Resets
-        '**:box-border **:m-0',
-        '[&_button]:font-[inherit]',
+        // NOTE: Some styles are omitted from the vanilla CSS because Tailwind has it's own reset.
         'motion-safe:[interpolate-size:allow-keywords]',
         // Inner highlight ring (::before)
         'before:absolute before:pointer-events-none before:rounded-[inherit] before:z-10',
@@ -184,6 +200,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
         '[&:fullscreen]:rounded-none',
         className
       )}
+      style={{ ...defaultStyles, ...style }}
       {...rest}
     >
       <BufferingIndicator
@@ -191,7 +208,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
           state.visible ? (
             <div
               {...props}
-              className="absolute inset-0 flex items-center justify-center pointer-events-none z-10 text-white"
+              className="absolute inset-0 flex items-center justify-center pointer-events-none z-10 text-[color:var(--color-primary)]"
             >
               <div className={cn('p-1 rounded-full', surface)}>
                 <SpinnerIcon className={icon} />
@@ -245,7 +262,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
           // Layout
           'absolute @container/media-controls bottom-3 inset-x-3',
           'p-[0.175rem] flex items-center gap-[0.075rem]',
-          'text-white rounded-full z-10',
+          'text-[color:var(--color-primary)] rounded-full z-10',
           // Transitions
           'will-change-[scale,transform,filter,opacity]',
           'transition-[scale,transform,filter,opacity] ease-out',
@@ -297,11 +314,11 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
         <Time.Group className="@container/media-time flex items-center flex-1 gap-3 px-2">
           <Time.Value
             type="current"
-            className="hidden @2xs/media-time:block text-shadow-2xs text-shadow-black/25 tabular-nums"
+            className="hidden @2xs/media-time:block [text-shadow:0_1px_0_var(--color-primary-shadow)] tabular-nums"
           />
           {/* Temporary spacer */}
           <div className="flex-1 h-1 rounded-full bg-white/20" />
-          <Time.Value type="duration" className="text-shadow-2xs text-shadow-black/25 tabular-nums" />
+          <Time.Value type="duration" className="[text-shadow:0_1px_0_var(--color-primary-shadow)] tabular-nums" />
         </Time.Group>
 
         <MuteButton


### PR DESCRIPTION
## Summary
- Adds a `--media-color-primary` CSS custom property to both the default and minimal video skins, allowing consumers to customise the primary fill color used across the player UI.
- Derives `--color-on-primary` (auto-contrasting text) and `--color-primary-shadow` (auto drop-shadow) from the primary color using relative color syntax — no manual pairing needed.
- Replaces all hardcoded `oklch(1 0 0)` / `text-white` references with the new custom property tokens across both CSS and Tailwind skin variants.

Closes #549

## Test plan
- [ ] Set `--media-color-primary` to a light color (e.g. `oklch(0.8 0.15 80)`) and verify all controls, text, and slider fills update.
- [ ] Set `--media-color-primary` to a dark color and verify `--color-on-primary` flips to white text on buttons.
- [ ] Verify the default (no custom property set) renders identically to the previous white-on-black appearance.
- [ ] Check both default skin and minimal skin variants.
- [ ] Check both CSS and Tailwind skin variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)