### PR TITLE
chore(ci): add agent automation workflows and expand CI pipeline

### DIFF
--- a/.github/scripts/validate-docs-imports.js
+++ b/.github/scripts/validate-docs-imports.js
@@ -1,0 +1,223 @@
+/**
+ * Validates that @videojs/* imports in documentation code blocks and demo files
+ * match actual package export paths declared in their respective package.json.
+ *
+ * Exits with code 1 if any invalid imports are found.
+ *
+ * Usage: node .github/scripts/validate-docs-imports.js
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, relative, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '../..');
+
+// ---------------------------------------------------------------------------
+// Package export map loading
+// ---------------------------------------------------------------------------
+
+function loadPackageExports() {
+  const packagesDir = join(ROOT, 'packages');
+  const packages = new Map();
+
+  for (const dir of readdirSync(packagesDir)) {
+    if (dir === '__tech-preview__' || dir === 'sandbox') continue;
+
+    const pkgJsonPath = join(packagesDir, dir, 'package.json');
+    if (!existsSync(pkgJsonPath)) continue;
+
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+    if (!pkg.name || !pkg.exports) continue;
+
+    packages.set(pkg.name, {
+      name: pkg.name,
+      exportPaths: Object.keys(pkg.exports),
+    });
+  }
+
+  return packages;
+}
+
+// ---------------------------------------------------------------------------
+// Import specifier parsing and matching
+// ---------------------------------------------------------------------------
+
+/** Parse `@videojs/html/video/player` into `{ packageName, subpath }`. */
+function parseSpecifier(specifier) {
+  const match = specifier.match(/^(@[^/]+\/[^/]+)(\/.*)?$/);
+  if (!match) return null;
+
+  return {
+    packageName: match[1],
+    subpath: match[2] ? `.${match[2]}` : '.',
+  };
+}
+
+/**
+ * Check if `subpath` matches an export `pattern`.
+ * Handles literal paths and single-`*` wildcards per Node.js subpath patterns.
+ */
+function matchesExport(subpath, pattern) {
+  if (pattern === subpath) return true;
+
+  if (!pattern.includes('*')) return false;
+
+  const starIndex = pattern.indexOf('*');
+  const prefix = pattern.slice(0, starIndex);
+  const suffix = pattern.slice(starIndex + 1);
+
+  if (!subpath.startsWith(prefix)) return false;
+  if (suffix && !subpath.endsWith(suffix)) return false;
+
+  const captured = subpath.slice(
+    prefix.length,
+    suffix ? subpath.length - suffix.length : undefined,
+  );
+
+  return captured.length > 0;
+}
+
+function validateImport(specifier, packages) {
+  const parsed = parseSpecifier(specifier);
+  if (!parsed) return { valid: false, reason: 'unparseable specifier' };
+
+  const pkg = packages.get(parsed.packageName);
+  if (!pkg) {
+    return { valid: false, reason: `unknown package "${parsed.packageName}"` };
+  }
+
+  const matches = pkg.exportPaths.some((p) =>
+    matchesExport(parsed.subpath, p),
+  );
+
+  if (!matches) {
+    return {
+      valid: false,
+      reason: `subpath "${parsed.subpath}" not in exports of ${parsed.packageName}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+// ---------------------------------------------------------------------------
+// Import extraction
+// ---------------------------------------------------------------------------
+
+const IMPORT_RE = /(?:import|from)\s+['"](@videojs\/[^'"]+)['"]/g;
+
+/** Extract @videojs/* imports from fenced code blocks in an MDX file. */
+function extractMdxImports(content, filePath) {
+  const imports = [];
+  const fenceRe =
+    /```(?:ts|tsx|js|jsx|html|typescript|javascript)[^\n]*\n([\s\S]*?)```/g;
+
+  let fence;
+
+  while ((fence = fenceRe.exec(content)) !== null) {
+    let m;
+
+    while ((m = IMPORT_RE.exec(fence[1])) !== null) {
+      imports.push({ specifier: m[1], file: filePath });
+    }
+  }
+
+  return imports;
+}
+
+/** Extract @videojs/* imports from a TypeScript / JavaScript source file. */
+function extractSourceImports(content, filePath) {
+  const imports = [];
+  let m;
+
+  while ((m = IMPORT_RE.exec(content)) !== null) {
+    imports.push({ specifier: m[1], file: filePath });
+  }
+
+  return imports;
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+function findFiles(dir, extensions) {
+  const files = [];
+  if (!existsSync(dir)) return files;
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...findFiles(fullPath, extensions));
+    } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const packages = loadPackageExports();
+const errors = [];
+
+// 1. MDX documentation pages (code fences only)
+const mdxFiles = findFiles(join(ROOT, 'site/src/content/docs'), ['.mdx']);
+
+for (const file of mdxFiles) {
+  const content = readFileSync(file, 'utf8');
+
+  for (const imp of extractMdxImports(content, relative(ROOT, file))) {
+    const result = validateImport(imp.specifier, packages);
+
+    if (!result.valid) {
+      errors.push({ ...imp, reason: result.reason });
+    }
+  }
+}
+
+// 2. Demo source files (real imports)
+const demoFiles = findFiles(join(ROOT, 'site/src/components/docs/demos'), [
+  '.ts',
+  '.tsx',
+]);
+
+for (const file of demoFiles) {
+  const content = readFileSync(file, 'utf8');
+
+  for (const imp of extractSourceImports(content, relative(ROOT, file))) {
+    const result = validateImport(imp.specifier, packages);
+
+    if (!result.valid) {
+      errors.push({ ...imp, reason: result.reason });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+if (errors.length > 0) {
+  console.error(
+    `\nFound ${errors.length} invalid @videojs/* import(s) in documentation:\n`,
+  );
+
+  for (const err of errors) {
+    console.error(`  ${err.file}: "${err.specifier}" — ${err.reason}`);
+  }
+
+  console.error(
+    '\nFix these imports to match the export paths in the corresponding package.json.\n',
+  );
+
+  process.exit(1);
+} else {
+  console.log('All @videojs/* imports in documentation are valid.');
+}

--- a/.github/workflows/agent-api-reference.yml
+++ b/.github/workflows/agent-api-reference.yml
@@ -1,0 +1,177 @@
+name: API Reference Sync
+
+on:
+  # Weekly audit on Monday mornings
+  schedule:
+    - cron: '0 6 * * 1'
+
+  # When package source changes land on main
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core/src/**'
+      - 'packages/html/src/**'
+      - 'packages/react/src/**'
+      - 'packages/store/src/**'
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Check for existing sync PR
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=$(gh pr list --head agent/api-reference-sync --json number --jq '.[0].number // empty')
+          echo "pr_number=${pr}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if sync PR already open
+        if: steps.existing.outputs.pr_number != ''
+        run: |
+          echo "Sync PR #${{ steps.existing.outputs.pr_number }} already open, skipping."
+          exit 0
+
+      - name: Create agent branch
+        if: steps.existing.outputs.pr_number == ''
+        run: |
+          git checkout -b agent/api-reference-sync
+          git push origin agent/api-reference-sync 2>/dev/null || true
+
+      - name: Setup pnpm
+        if: steps.existing.outputs.pr_number == ''
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.existing.outputs.pr_number == ''
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.existing.outputs.pr_number == ''
+        run: pnpm install
+
+      - name: Cache turbo build setup
+        if: steps.existing.outputs.pr_number == ''
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build packages
+        if: steps.existing.outputs.pr_number == ''
+        run: pnpm build:packages
+
+      - name: Generate API docs JSON
+        if: steps.existing.outputs.pr_number == ''
+        run: pnpm -F site api-docs
+
+      - name: Sync API references with Claude
+        if: steps.existing.outputs.pr_number == ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            BRANCH: agent/api-reference-sync
+
+            You are an API reference sync agent for the Video.js 10 monorepo.
+            Read CLAUDE.md at the repo root for coding conventions.
+            Load the `api-reference` skill from `.claude/skills/api-reference/SKILL.md`
+            for the exact page structure, demo conventions, and builder rules.
+
+            ## Context
+
+            The api-docs-builder has just run. Generated JSON files are in:
+            - `site/src/content/generated-component-reference/*.json`
+            - `site/src/content/generated-util-reference/*.json`
+
+            Existing reference pages are in:
+            - `site/src/content/docs/reference/*.mdx`
+
+            The sidebar config is in `site/src/docs.config.ts`.
+
+            ## Your task
+
+            ### 1. Discover gaps
+
+            List all generated component JSON files and check which ones have a
+            corresponding MDX reference page. Report your findings.
+
+            ### 2. Scaffold new reference pages
+
+            For each component with generated JSON but NO reference page:
+            - Create the MDX page at `site/src/content/docs/reference/{name}.mdx`
+            - Create 6 demo files (HTML + React) following the patterns from
+              existing reference pages like `poster.mdx` or `controls.mdx`
+            - Add a sidebar entry in `site/src/docs.config.ts` (alphabetical order)
+
+            ### 3. Audit existing reference pages
+
+            For each component that already has a reference page:
+            - Compare the generated JSON (props, state, data attributes) against
+              the page's anatomy section and demos
+            - If props were added/removed/renamed, update the anatomy code snippets
+            - If data attributes changed, update the Styling section
+            - If the page references APIs that no longer exist, fix the references
+            - Leave well-written prose (Behavior, Accessibility) unchanged unless
+              it references stale API names
+
+            ### 4. Check sidebar completeness
+
+            Verify every file in `site/src/content/docs/reference/` has a sidebar
+            entry in `site/src/docs.config.ts`. Add any missing entries.
+
+            ### 5. Verify
+
+            Run `pnpm -F site build` to confirm the site builds with your changes.
+            Fix any build errors.
+
+            ### 6. Commit and open PR
+
+            If you made any changes:
+            - Commit with message `docs(site): sync API reference pages`
+            - Push branch: `git push origin agent/api-reference-sync`
+            - Open a PR:
+              ```
+              gh pr create \
+                --title "docs(site): sync API reference pages" \
+                --body "Automated API reference sync.
+
+              ## Changes
+              <list what was added/updated/fixed>" \
+                --base main \
+                --head agent/api-reference-sync
+              ```
+
+            If everything is already up to date, just output "All API references
+            are in sync." and do not create a PR.
+
+            ## Rules
+
+            - Follow the exact file structure documented in the api-reference skill.
+            - Use existing reference pages as templates — match their style.
+            - Do not modify package source code — only site/ files.
+            - Do not modify CLAUDE.md, workflow files, or CI configuration.
+
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(pnpm:*),Bash(git:*),Bash(gh:*),Bash(ls:*),Bash(cat:*)"

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -1,0 +1,121 @@
+name: Agent Implementation
+
+on:
+  issues:
+    types: [labeled]
+  repository_dispatch:
+    types: [agent_task]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to implement
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  implement:
+    # Run when the "agent" label is added, or via dispatch
+    if: >
+      (github.event_name == 'issues' && github.event.label.name == 'agent') ||
+      github.event_name == 'repository_dispatch' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Resolve issue number
+        id: issue
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.client_payload.issue_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Create agent branch
+        run: git checkout -b agent/${{ steps.issue.outputs.number }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build packages
+        run: pnpm build:packages
+
+      - name: Implement with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE: ${{ steps.issue.outputs.number }}
+            BRANCH: agent/${{ steps.issue.outputs.number }}
+
+            You are an autonomous implementation agent for the Video.js 10 monorepo.
+            Read CLAUDE.md at the repo root — it contains all coding conventions,
+            naming rules, and the dev workflow you must follow.
+
+            ## Your task
+
+            1. Read the issue: `gh issue view ${{ steps.issue.outputs.number }}`
+            2. Understand what needs to be done. If the issue lacks sufficient detail
+               to proceed, comment on the issue explaining what's missing and stop.
+            3. Explore the relevant code to understand the current state.
+            4. Implement the change following all conventions in CLAUDE.md.
+            5. Write or update tests for any new/changed behavior.
+            6. Verify your work:
+               - `pnpm typecheck` — fix all type errors
+               - Run tests for affected packages: `pnpm -F <pkg> test`
+               - Lint changed files: `pnpm lint:fix:file <file>`
+            7. Commit with a conventional commit message (the repo uses commitlint).
+               Use the appropriate type (feat, fix, refactor, etc.) and scope.
+            8. Push the branch:
+               `git push origin agent/${{ steps.issue.outputs.number }}`
+            9. Open a PR:
+               ```
+               gh pr create \
+                 --title "<conventional commit title>" \
+                 --body "Closes #${{ steps.issue.outputs.number }}" \
+                 --base main \
+                 --head agent/${{ steps.issue.outputs.number }}
+               ```
+
+            ## Rules
+
+            - ONE focused change per commit. Don't mix unrelated updates.
+            - Never skip typecheck, tests, or lint.
+            - If you can't complete the task, comment on the issue with what you found
+              and what's blocking you, then stop.
+            - Do not modify CLAUDE.md, workflow files, or CI configuration.
+
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(pnpm:*),Bash(git:*),Bash(gh:*),Bash(node:*),Bash(npx:*)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,31 @@ on:
   pull_request:
     branches-ignore:
       - 'rfc/**'
+  workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint
+
   build:
     runs-on: ubuntu-latest
 
@@ -38,3 +61,86 @@ jobs:
 
       - name: Build
         run: pnpm build:packages
+
+  typecheck:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build packages
+        run: pnpm build:packages
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build packages
+        run: pnpm build:packages
+
+      - name: Test
+        run: pnpm test
+
+  validate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Validate documentation imports
+        run: node .github/scripts/validate-docs-imports.js


### PR DESCRIPTION
## Summary

Adds autonomous agent workflows and fills CI gaps. CI currently only runs `build` — this adds lint, typecheck, test, and a docs import validator. Two new Claude Code Action workflows enable issue-to-PR automation and automated API reference page maintenance.

## Changes

- **CI pipeline**: add `lint`, `typecheck`, `test`, and `validate-docs` jobs (typecheck/test depend on build via turbo cache, lint and validate-docs run in parallel)
- **Docs import validation**: new script that checks all `@videojs/*` imports in MDX code blocks and demo files resolve against package exports — already catches 4 stale `@videojs/react-preview` references
- **Issue → PR agent**: label an issue `agent` and Claude implements the change, runs checks, opens a PR for review
- **API reference sync agent**: weekly + on package changes, audits reference pages against generated JSON — scaffolds new pages, updates stale ones, checks sidebar completeness

## Testing

- `node .github/scripts/validate-docs-imports.js` runs locally and correctly reports 4 stale imports
- Workflow YAML validated for correct structure
- Agent workflows require `ANTHROPIC_API_KEY` secret (already configured)