### PR TITLE
refactor(html): split UI define modules and narrow slider imports

### DIFF
--- a/packages/html/src/define/ui/controls-group.ts
+++ b/packages/html/src/define/ui/controls-group.ts
@@ -1,0 +1,9 @@
+import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
+
+customElements.define(ControlsGroupElement.tagName, ControlsGroupElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [ControlsGroupElement.tagName]: ControlsGroupElement;
+  }
+}

--- a/packages/html/src/define/ui/controls.ts
+++ b/packages/html/src/define/ui/controls.ts
@@ -1,12 +1,11 @@
 import { ControlsElement } from '../../ui/controls/controls-element';
-import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
+
+import './controls-group';
 
 customElements.define(ControlsElement.tagName, ControlsElement);
-customElements.define(ControlsGroupElement.tagName, ControlsGroupElement);
 
 declare global {
   interface HTMLElementTagNameMap {
     [ControlsElement.tagName]: ControlsElement;
-    [ControlsGroupElement.tagName]: ControlsGroupElement;
   }
 }

--- a/packages/html/src/define/ui/slider-buffer.ts
+++ b/packages/html/src/define/ui/slider-buffer.ts
@@ -1,0 +1,9 @@
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+
+customElements.define(SliderBufferElement.tagName, SliderBufferElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [SliderBufferElement.tagName]: SliderBufferElement;
+  }
+}

--- a/packages/html/src/define/ui/slider-fill.ts
+++ b/packages/html/src/define/ui/slider-fill.ts
@@ -1,0 +1,9 @@
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+
+customElements.define(SliderFillElement.tagName, SliderFillElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [SliderFillElement.tagName]: SliderFillElement;
+  }
+}

--- a/packages/html/src/define/ui/slider-thumb.ts
+++ b/packages/html/src/define/ui/slider-thumb.ts
@@ -1,0 +1,9 @@
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+
+customElements.define(SliderThumbElement.tagName, SliderThumbElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [SliderThumbElement.tagName]: SliderThumbElement;
+  }
+}

--- a/packages/html/src/define/ui/slider-track.ts
+++ b/packages/html/src/define/ui/slider-track.ts
@@ -1,0 +1,9 @@
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+
+customElements.define(SliderTrackElement.tagName, SliderTrackElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [SliderTrackElement.tagName]: SliderTrackElement;
+  }
+}

--- a/packages/html/src/define/ui/slider-value.ts
+++ b/packages/html/src/define/ui/slider-value.ts
@@ -1,0 +1,9 @@
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
+
+customElements.define(SliderValueElement.tagName, SliderValueElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [SliderValueElement.tagName]: SliderValueElement;
+  }
+}

--- a/packages/html/src/define/ui/slider.ts
+++ b/packages/html/src/define/ui/slider.ts
@@ -1,24 +1,14 @@
-import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
 import { SliderElement } from '../../ui/slider/slider-element';
-import { SliderFillElement } from '../../ui/slider/slider-fill-element';
-import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
-import { SliderTrackElement } from '../../ui/slider/slider-track-element';
-import { SliderValueElement } from '../../ui/slider/slider-value-element';
+
+import './slider-fill';
+import './slider-thumb';
+import './slider-track';
+import './slider-value';
 
 customElements.define(SliderElement.tagName, SliderElement);
-customElements.define(SliderTrackElement.tagName, SliderTrackElement);
-customElements.define(SliderFillElement.tagName, SliderFillElement);
-customElements.define(SliderBufferElement.tagName, SliderBufferElement);
-customElements.define(SliderThumbElement.tagName, SliderThumbElement);
-customElements.define(SliderValueElement.tagName, SliderValueElement);
 
 declare global {
   interface HTMLElementTagNameMap {
     [SliderElement.tagName]: SliderElement;
-    [SliderTrackElement.tagName]: SliderTrackElement;
-    [SliderFillElement.tagName]: SliderFillElement;
-    [SliderBufferElement.tagName]: SliderBufferElement;
-    [SliderThumbElement.tagName]: SliderThumbElement;
-    [SliderValueElement.tagName]: SliderValueElement;
   }
 }

--- a/packages/html/src/define/ui/time-group.ts
+++ b/packages/html/src/define/ui/time-group.ts
@@ -1,0 +1,9 @@
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+
+customElements.define(TimeGroupElement.tagName, TimeGroupElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [TimeGroupElement.tagName]: TimeGroupElement;
+  }
+}

--- a/packages/html/src/define/ui/time-separator.ts
+++ b/packages/html/src/define/ui/time-separator.ts
@@ -1,0 +1,9 @@
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+
+customElements.define(TimeSeparatorElement.tagName, TimeSeparatorElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [TimeSeparatorElement.tagName]: TimeSeparatorElement;
+  }
+}

--- a/packages/html/src/define/ui/time-slider.ts
+++ b/packages/html/src/define/ui/time-slider.ts
@@ -1,6 +1,10 @@
 import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
 
-import './slider';
+import './slider-buffer';
+import './slider-fill';
+import './slider-thumb';
+import './slider-track';
+import './slider-value';
 
 customElements.define(TimeSliderElement.tagName, TimeSliderElement);
 

--- a/packages/html/src/define/ui/time.ts
+++ b/packages/html/src/define/ui/time.ts
@@ -1,15 +1,12 @@
 import { TimeElement } from '../../ui/time/time-element';
-import { TimeGroupElement } from '../../ui/time/time-group-element';
-import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+
+import './time-group';
+import './time-separator';
 
 customElements.define(TimeElement.tagName, TimeElement);
-customElements.define(TimeGroupElement.tagName, TimeGroupElement);
-customElements.define(TimeSeparatorElement.tagName, TimeSeparatorElement);
 
 declare global {
   interface HTMLElementTagNameMap {
     [TimeElement.tagName]: TimeElement;
-    [TimeGroupElement.tagName]: TimeGroupElement;
-    [TimeSeparatorElement.tagName]: TimeSeparatorElement;
   }
 }

--- a/packages/html/src/define/ui/volume-slider.ts
+++ b/packages/html/src/define/ui/volume-slider.ts
@@ -1,6 +1,9 @@
 import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
 
-import './slider';
+import './slider-fill';
+import './slider-thumb';
+import './slider-track';
+import './slider-value';
 
 customElements.define(VolumeSliderElement.tagName, VolumeSliderElement);
 


### PR DESCRIPTION
## Summary
- Add per-element define files for compound UI parts: controls-group, time-group, time-separator, and slider track/fill/thumb/value/buffer.
- Refactor compound define modules (controls, time, slider) to compose via specific imports.
- Narrow domain slider imports so time-slider and volume-slider import only required slider parts.
- Remove buffer auto-registration from base slider and volume-slider definitions; keep buffer explicit and included by time-slider.

## Notes
- Tests were not run in this worktree because dependencies are not installed.