### PR TITLE
fix(ci): allow OIDC token in issue sync workflow

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: read
   issues: write
+  id-token: write
 
 concurrency:
   group: issue-sync-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- add missing `id-token: write` permission to the Issue Sync workflow
- fixes Claude action OIDC token acquisition on merged PR runs