### PR TITLE
fix(react): correct buffer selector names in minimal skin CSS

### DIFF
--- a/packages/react/src/presets/video/minimal-skin.css
+++ b/packages/react/src/presets/video/minimal-skin.css
@@ -527,15 +527,14 @@
 /* Buffer */
 .media-minimal-skin .media-slider__buffer {
   background-color: oklch(1 0 0 / 0.2);
-  width: var(--media-slider-buffer, 0%);
   transition-duration: 0.25s;
   transition-timing-function: ease-out;
 }
-.media-default-skin .media-slider__buffer[data-orientation="horizontal"] {
+.media-minimal-skin .media-slider__buffer[data-orientation="horizontal"] {
   width: var(--media-slider-buffer);
   transition-property: width;
 }
-.media-default-skin .media-slider__buffer[data-orientation="vertical"] {
+.media-minimal-skin .media-slider__buffer[data-orientation="vertical"] {
   height: var(--media-slider-buffer);
   transition-property: height;
 }


### PR DESCRIPTION
## Summary
- Fixed orientation-specific buffer selectors using `.media-default-skin` instead of `.media-minimal-skin`, causing the rules not to match in the minimal skin preset.
- Removed redundant `width` property from the base buffer rule (orientation-specific rules already set width/height).

## Test plan
- [x] Verify minimal skin buffer track renders correctly for horizontal sliders
- [x] Verify minimal skin buffer track renders correctly for vertical sliders (volume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)