### PR TITLE
feat(ci): add issue-to-pr claude workflow

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -35,7 +35,7 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           claude_args: |
-            --model sonnet
+            --model opus
             --max-turns 20
           prompt: |
             You are the issue-to-PR implementation agent for this repository.


### PR DESCRIPTION
## Summary
- add a new Issue To PR workflow triggered by issue label `agent:pr`
- Claude implements issue scope, runs checks, and opens a PR for review
- includes duplicate-PR guardrails and blocked-state issue comments