### PR TITLE
fix(site): strip script and style tags from llms markdown output

### DIFF
--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -44,12 +44,16 @@ export default function llmsMarkdown(): AstroIntegration {
               continue;
             }
 
-            // For each content element, remove [data-llms-ignore] descendants
+            // For each content element, strip non-content elements before conversion
             const contentParts: string[] = [];
             contentElements.forEach((contentEl) => {
               const clone = contentEl.cloneNode(true) as Element;
               const ignoreElements = clone.querySelectorAll('[data-llms-ignore]');
               ignoreElements.forEach((el) => el.remove());
+              // Remove script and style tags (includes Astro island hydration scripts)
+              for (const tag of clone.querySelectorAll('script, style')) {
+                tag.remove();
+              }
               contentParts.push(clone.innerHTML);
             });
 


### PR DESCRIPTION
## Summary
- Strip `<script>` and `<style>` tags from cloned HTML content before Turndown conversion in the `llms-markdown` integration
- Prevents Astro island hydration scripts from leaking into generated LLM markdown files
- Preserves server-rendered content (code samples, prose, API reference tables)

Closes #679

## Test plan
- [x] Build site (`pnpm build:site`)
- [x] Verify generated `.md` files contain no raw JavaScript
- [x] Verify code samples (inside `<TabsPanel>` islands) are still present in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)