### PR TITLE
fix(ci): gate AI workflows behind org membership

### DIFF
--- a/.github/workflows/ci-diagnose.yml
+++ b/.github/workflows/ci-diagnose.yml
@@ -37,8 +37,20 @@ jobs:
         if: steps.context.outputs.pr_number == ''
         run: echo "Failed CI run is not attached to a pull request. Skipping PR diagnosis comment."
 
-      - name: Run Claude CI diagnostician
+      - name: Check org membership
         if: steps.context.outputs.pr_number != ''
+        id: auth
+        run: |
+          if gh api orgs/videojs/members/${{ github.event.workflow_run.actor.login }} --silent 2>/dev/null; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Claude CI diagnostician
+        if: steps.context.outputs.pr_number != '' && steps.auth.outputs.authorized == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,7 +1,7 @@
 name: Issue Triage
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, labeled]
 
 permissions:
   actions: read
@@ -14,8 +14,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  label-for-triage:
+    if: >
+      github.event.action != 'labeled' &&
+      !github.event.issue.pull_request &&
+      !contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.issue.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add triage label for non-members
+        run: gh issue edit ${{ github.event.issue.number }} --add-label "triage" --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   triage:
-    if: github.event.issue.pull_request == null
+    if: >
+      !github.event.issue.pull_request && (
+        (github.event.action == 'labeled' && github.event.label.name == 'agent:triage') ||
+        (github.event.action != 'labeled' && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Prevent external contributors from triggering AI-powered workflows that consume Anthropic API credits.

## Changes

- **issue-triage.yml**: Gate AI triage behind `author_association` — only MEMBER/OWNER/COLLABORATOR get automatic AI triage. Non-members get a `triage` label added for manual review. Adding the `agent:triage` label triggers AI triage on demand (only triage+ permissions can add labels).
- **ci-diagnose.yml**: Check `videojs` org membership via GitHub API before running Claude. Fork PR CI failures from non-members are skipped.

<details>
<summary>What was the risk?</summary>

- `issue-triage.yml` could be triggered by any GitHub user opening or editing an issue — no author check, consuming Anthropic credits with each invocation
- `ci-diagnose.yml` runs on `workflow_run` events which execute in the default branch context with secret access. A fork PR with intentionally broken code would trigger CI failure → AI diagnosis → Anthropic API cost

All other workflows were audited and are safe:
- `ci.yml`, `bundle-size.yml`, `website-tests.yml` — `pull_request` event = read-only sandbox, no secret access
- `cd.yml` — push to main only
- `issue-sync.yml` — requires PR merge (maintainer action)
- `issue-to-pr.yml` — requires `agent:pr` label (triage+ permissions only)
- `api-reference-sync.yml` — requires merge to main or workflow_dispatch

</details>

## Triage trigger paths

| Event | Who | What happens |
|---|---|---|
| Issue opened/edited/reopened | Non-member | `triage` label added, no AI |
| Issue opened/edited/reopened | Org member/collaborator | AI triage runs automatically |
| `agent:triage` label added | Anyone with triage+ permission | AI triage runs on demand |

## Testing

- Open an issue from a non-org-member account → should get `triage` label, no AI comment
- Open an issue from an org member → AI triage runs as before
- Add `agent:triage` label to any issue → AI triage runs
- Fork PR with failing CI from non-member → diagnosis skipped