### PR TITLE
fix(html): preserve side-effect imports and fix context upgrade order

### DIFF
--- a/packages/html/src/define/ui/controls-group.ts
+++ b/packages/html/src/define/ui/controls-group.ts
@@ -1,7 +1,5 @@
 import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
 
-export { ControlsGroupElement };
-
 customElements.define(ControlsGroupElement.tagName, ControlsGroupElement);
 
 declare global {

--- a/packages/html/src/define/ui/controls.ts
+++ b/packages/html/src/define/ui/controls.ts
@@ -1,8 +1,13 @@
 import { ControlsElement } from '../../ui/controls/controls-element';
+import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
 
-export { ControlsGroupElement } from './controls-group';
+export { ControlsGroupElement };
 
 customElements.define(ControlsElement.tagName, ControlsElement);
+
+if (!customElements.get(ControlsGroupElement.tagName)) {
+  customElements.define(ControlsGroupElement.tagName, ControlsGroupElement);
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/html/src/define/ui/slider-buffer.ts
+++ b/packages/html/src/define/ui/slider-buffer.ts
@@ -1,7 +1,5 @@
 import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
 
-export { SliderBufferElement };
-
 customElements.define(SliderBufferElement.tagName, SliderBufferElement);
 
 declare global {

--- a/packages/html/src/define/ui/slider-fill.ts
+++ b/packages/html/src/define/ui/slider-fill.ts
@@ -1,7 +1,5 @@
 import { SliderFillElement } from '../../ui/slider/slider-fill-element';
 
-export { SliderFillElement };
-
 customElements.define(SliderFillElement.tagName, SliderFillElement);
 
 declare global {

--- a/packages/html/src/define/ui/slider-thumb.ts
+++ b/packages/html/src/define/ui/slider-thumb.ts
@@ -1,7 +1,5 @@
 import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
 
-export { SliderThumbElement };
-
 customElements.define(SliderThumbElement.tagName, SliderThumbElement);
 
 declare global {

--- a/packages/html/src/define/ui/slider-track.ts
+++ b/packages/html/src/define/ui/slider-track.ts
@@ -1,7 +1,5 @@
 import { SliderTrackElement } from '../../ui/slider/slider-track-element';
 
-export { SliderTrackElement };
-
 customElements.define(SliderTrackElement.tagName, SliderTrackElement);
 
 declare global {

--- a/packages/html/src/define/ui/slider-value.ts
+++ b/packages/html/src/define/ui/slider-value.ts
@@ -1,7 +1,5 @@
 import { SliderValueElement } from '../../ui/slider/slider-value-element';
 
-export { SliderValueElement };
-
 customElements.define(SliderValueElement.tagName, SliderValueElement);
 
 declare global {

--- a/packages/html/src/define/ui/slider.ts
+++ b/packages/html/src/define/ui/slider.ts
@@ -1,11 +1,28 @@
 import { SliderElement } from '../../ui/slider/slider-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
 
-export { SliderFillElement } from './slider-fill';
-export { SliderThumbElement } from './slider-thumb';
-export { SliderTrackElement } from './slider-track';
-export { SliderValueElement } from './slider-value';
+export { SliderFillElement, SliderThumbElement, SliderTrackElement, SliderValueElement };
 
 customElements.define(SliderElement.tagName, SliderElement);
+
+if (!customElements.get(SliderFillElement.tagName)) {
+  customElements.define(SliderFillElement.tagName, SliderFillElement);
+}
+
+if (!customElements.get(SliderThumbElement.tagName)) {
+  customElements.define(SliderThumbElement.tagName, SliderThumbElement);
+}
+
+if (!customElements.get(SliderTrackElement.tagName)) {
+  customElements.define(SliderTrackElement.tagName, SliderTrackElement);
+}
+
+if (!customElements.get(SliderValueElement.tagName)) {
+  customElements.define(SliderValueElement.tagName, SliderValueElement);
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/html/src/define/ui/time-group.ts
+++ b/packages/html/src/define/ui/time-group.ts
@@ -1,7 +1,5 @@
 import { TimeGroupElement } from '../../ui/time/time-group-element';
 
-export { TimeGroupElement };
-
 customElements.define(TimeGroupElement.tagName, TimeGroupElement);
 
 declare global {

--- a/packages/html/src/define/ui/time-separator.ts
+++ b/packages/html/src/define/ui/time-separator.ts
@@ -1,7 +1,5 @@
 import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
 
-export { TimeSeparatorElement };
-
 customElements.define(TimeSeparatorElement.tagName, TimeSeparatorElement);
 
 declare global {

--- a/packages/html/src/define/ui/time-slider.ts
+++ b/packages/html/src/define/ui/time-slider.ts
@@ -1,12 +1,33 @@
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
 import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
 
-export { SliderBufferElement } from './slider-buffer';
-export { SliderFillElement } from './slider-fill';
-export { SliderThumbElement } from './slider-thumb';
-export { SliderTrackElement } from './slider-track';
-export { SliderValueElement } from './slider-value';
+export { SliderBufferElement, SliderFillElement, SliderThumbElement, SliderTrackElement, SliderValueElement };
 
 customElements.define(TimeSliderElement.tagName, TimeSliderElement);
+
+if (!customElements.get(SliderBufferElement.tagName)) {
+  customElements.define(SliderBufferElement.tagName, SliderBufferElement);
+}
+
+if (!customElements.get(SliderFillElement.tagName)) {
+  customElements.define(SliderFillElement.tagName, SliderFillElement);
+}
+
+if (!customElements.get(SliderThumbElement.tagName)) {
+  customElements.define(SliderThumbElement.tagName, SliderThumbElement);
+}
+
+if (!customElements.get(SliderTrackElement.tagName)) {
+  customElements.define(SliderTrackElement.tagName, SliderTrackElement);
+}
+
+if (!customElements.get(SliderValueElement.tagName)) {
+  customElements.define(SliderValueElement.tagName, SliderValueElement);
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/html/src/define/ui/time.ts
+++ b/packages/html/src/define/ui/time.ts
@@ -1,9 +1,18 @@
 import { TimeElement } from '../../ui/time/time-element';
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
 
-export { TimeGroupElement } from './time-group';
-export { TimeSeparatorElement } from './time-separator';
+export { TimeGroupElement, TimeSeparatorElement };
 
 customElements.define(TimeElement.tagName, TimeElement);
+
+if (!customElements.get(TimeGroupElement.tagName)) {
+  customElements.define(TimeGroupElement.tagName, TimeGroupElement);
+}
+
+if (!customElements.get(TimeSeparatorElement.tagName)) {
+  customElements.define(TimeSeparatorElement.tagName, TimeSeparatorElement);
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/html/src/define/ui/volume-slider.ts
+++ b/packages/html/src/define/ui/volume-slider.ts
@@ -1,11 +1,28 @@
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
 import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
 
-export { SliderFillElement } from './slider-fill';
-export { SliderThumbElement } from './slider-thumb';
-export { SliderTrackElement } from './slider-track';
-export { SliderValueElement } from './slider-value';
+export { SliderFillElement, SliderThumbElement, SliderTrackElement, SliderValueElement };
 
 customElements.define(VolumeSliderElement.tagName, VolumeSliderElement);
+
+if (!customElements.get(SliderFillElement.tagName)) {
+  customElements.define(SliderFillElement.tagName, SliderFillElement);
+}
+
+if (!customElements.get(SliderThumbElement.tagName)) {
+  customElements.define(SliderThumbElement.tagName, SliderThumbElement);
+}
+
+if (!customElements.get(SliderTrackElement.tagName)) {
+  customElements.define(SliderTrackElement.tagName, SliderTrackElement);
+}
+
+if (!customElements.get(SliderValueElement.tagName)) {
+  customElements.define(SliderValueElement.tagName, SliderValueElement);
+}
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
## Summary

Fixes two bugs introduced by PR #635 (provider/container split) that both manifest as `StoreError: NO_TARGET`:

- **tsdown unbundle mode strips side-effect imports** — bare `import './slider-fill'` in composite define files gets tree-shaken away, so sub-element `customElements.define()` calls never run. Fixed by inlining registrations directly in composite files with `customElements.get()` guards.

  - Initial fix attempt (re-exports) didn't work — tsdown resolves re-export chains to source modules, bypassing leaf define files entirely. See #688 for the full investigation.

- **`@lit/context` upgrade order** — ES import hoisting caused `<media-container>` to upgrade before `<video-player>`, so the consumer's `context-request` event fired before the provider existed. Fixed by extracting `MediaContainerElement` class to a separate file (no auto-registration) and registering container after player.

Also removes the `PlayerMixin` migration doc (not needed since the site isn't public yet) and fixes the playback-rate-button demo's missing `<media-container>`.

**Note:** A third related bug (shared slider sub-elements across multiple slider types on the same page) is documented in #688 but not fixed in this PR.

## Changes

**Upgrade order fix:**
- New `define/media/container-element.ts` — class-only, no registration
- `define/media/container.ts` — simplified, imports from element file
- `define/video/player.ts`, `define/audio/player.ts`, `define/background/player.ts` — import from `container-element`, register player first, then container with guard

**Inlined sub-element registrations:**
- `define/ui/slider.ts`, `time-slider.ts`, `volume-slider.ts` — inline `customElements.define()` for slider sub-elements
- `define/ui/time.ts` — inline registration for time-group, time-separator
- `define/ui/controls.ts` — inline registration for controls-group
- Leaf define files (`slider-fill.ts`, `slider-thumb.ts`, etc.) reverted to original state

**Docs cleanup:**
- Deleted `reference/player-mixin.mdx`
- Removed sidebar entry from `docs.config.ts`
- Fixed `playback-rate-button` demo HTML (added `<media-container>`)

## Test plan

- [x] `pnpm -F @videojs/html build` — clean build
- [x] Built output confirms `customElements.define()` calls present for all sub-elements
- [x] `pnpm -F @videojs/html test` — all tests pass
- [x] `pnpm typecheck` — no new errors
- [x] Play button demo works (upgrade order fix verified)
- [x] Playback rate button demo works
- [x] Time slider sub-elements receive `data-*` attributes and ARIA (tree-shaking fix verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)