### PR TITLE
fix(site): redirect /guides to legacy.videojs.org

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -24,6 +24,17 @@
   to = "/"
   status = 308
 
+# Redirect old v8 guides to legacy site
+[[redirects]]
+  from = "/guides"
+  to = "https://legacy.videojs.org/guides"
+  status = 308
+
+[[redirects]]
+  from = "/guides/*"
+  to = "https://legacy.videojs.org/guides/:splat"
+  status = 308
+
 # Redirect old tags pages to blog (no tag filtering in v10)
 [[redirects]]
   from = "/tags"


### PR DESCRIPTION
Add Netlify redirect rules to send `/guides` and `/guides/*` paths to `legacy.videojs.org/guides`, preserving subpaths via `:splat`. Uses 308 (permanent redirect) consistent with other legacy URL redirects.

Closes #693

Generated with [Claude Code](https://claude.ai/code)