### PR TITLE
chore(claude): add session start hook to run gh-setup-hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
   "enabledMcpjsonServers": ["astro-docs"],
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook to `.claude/settings.json` that automatically runs `npx -y gh-setup-hooks` at the start of each Claude Code session, ensuring GitHub hooks are set up in the environment without manual intervention.

## Changes

- `SessionStart` hook configured to run `npx -y gh-setup-hooks` with a 120-second timeout

## Testing

Covered by manual session startup — the hook runs automatically when a new Claude Code session begins.