### PR TITLE
feat(ci): add skin and UI component breakdowns to bundle size report

### DIFF
--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -60,12 +60,25 @@ function deltaBar(current, previous, maxAbsPct) {
 function groupByPackage(entries) {
   const groups = new Map();
   for (const entry of entries) {
+    // Skip skin and ui entries from package grouping (they're reported separately)
+    if (entry.type === 'skin' || entry.type === 'ui') continue;
+
     const match = entry.name.match(/^@videojs\/([^/]+)/);
     const pkg = match ? match[1] : 'other';
     if (!groups.has(pkg)) groups.set(pkg, []);
     groups.get(pkg).push(entry);
   }
   return groups;
+}
+
+/** Extract skin entries (absolute sizes). */
+function getSkinEntries(entries) {
+  return entries.filter((e) => e.type === 'skin');
+}
+
+/** Extract UI component entries. */
+function getUIEntries(entries) {
+  return entries.filter((e) => e.type === 'ui');
 }
 
 function computePackageData(groups, baseMap) {
@@ -195,6 +208,77 @@ function generateComparisonReport(current, base) {
     }
   }
 
+  // Skins section (absolute sizes)
+  const skinEntries = getSkinEntries(current);
+  const skinsSection = [];
+
+  if (skinEntries.length > 0) {
+    skinsSection.push('#### Skins');
+    skinsSection.push('');
+    skinsSection.push(
+      'Absolute bundle sizes when importing a skin (includes all dependencies).',
+    );
+    skinsSection.push('');
+    skinsSection.push('| Skin | Base | PR | Diff | % | |');
+    skinsSection.push('|---|--:|--:|--:|--:|:-:|');
+
+    for (const entry of skinEntries) {
+      // Strip the ~skin suffix for display, keep it for lookup
+      const skinName = entry.name.replace('@videojs/html/', '').replace('~skin', '');
+      const prev = baseMap[entry.name];
+      const d = formatDelta(entry.size, prev);
+      skinsSection.push(
+        `| \`${skinName}\` | ${prev !== undefined ? formatBytes(prev) : '—'} | **${formatBytes(entry.size)}** | ${d.bytes} | ${d.pct} | ${statusIcon(entry.size, prev)} |`,
+      );
+    }
+    skinsSection.push('');
+  }
+
+  // UI Components section
+  const uiEntries = getUIEntries(current);
+  const uiSection = [];
+
+  if (uiEntries.length > 0) {
+    uiSection.push('#### UI Components');
+    uiSection.push('');
+    uiSection.push(
+      'Marginal size of each UI component (additional bytes on top of `@videojs/html`).',
+    );
+    uiSection.push('');
+    uiSection.push('<details>');
+    uiSection.push('<summary>Component breakdown</summary>');
+    uiSection.push('');
+    uiSection.push('| Component | Base | PR | Diff | % | |');
+    uiSection.push('|---|--:|--:|--:|--:|:-:|');
+
+    // Sort by size (largest first)
+    const sortedUI = [...uiEntries].sort((a, b) => b.size - a.size);
+
+    for (const entry of sortedUI) {
+      const componentName = entry.name.replace('@videojs/html/ui/', '');
+      const prev = baseMap[entry.name];
+      const d = formatDelta(entry.size, prev);
+      uiSection.push(
+        `| \`${componentName}\` | ${prev !== undefined ? formatBytes(prev) : '—'} | **${formatBytes(entry.size)}** | ${d.bytes} | ${d.pct} | ${statusIcon(entry.size, prev)} |`,
+      );
+    }
+
+    const uiTotal = uiEntries.reduce((s, e) => s + e.size, 0);
+    const uiBaseTotal = uiEntries.reduce(
+      (s, e) => s + (baseMap[e.name] ?? 0),
+      0,
+    );
+    const hasUIBase = uiEntries.some((e) => baseMap[e.name] !== undefined);
+    const uiDelta = formatDelta(uiTotal, hasUIBase ? uiBaseTotal : undefined);
+    uiSection.push(
+      `| **total** | **${hasUIBase ? formatBytes(uiBaseTotal) : '—'}** | **${formatBytes(uiTotal)}** | **${hasUIBase ? uiDelta.bytes : '—'}** | **${hasUIBase ? uiDelta.pct : ''}** | |`,
+    );
+
+    uiSection.push('');
+    uiSection.push('</details>');
+    uiSection.push('');
+  }
+
   const grandDelta = formatDelta(grandTotalCurrent, grandTotalBase);
 
   const marker = '<!-- bundle-size-report -->';
@@ -209,6 +293,8 @@ function generateComparisonReport(current, base) {
     '---',
     '',
     ...details,
+    ...skinsSection,
+    ...uiSection,
     '---',
     '',
     '<details>',
@@ -217,6 +303,7 @@ function generateComparisonReport(current, base) {
     'Sizes are minified + brotli, measured with esbuild.',
     'Package totals are computed as root size + marginal subpath costs.',
     'Subpath marginal cost = (root + subpath bundled together) − root alone.',
+    'Skin sizes are absolute (total bundle size when importing).',
     '',
     '| Icon | Meaning |',
     '|---|---|',
@@ -338,6 +425,45 @@ function generateLocalReport(current) {
 
       lines.push(printTable(rows));
     }
+  }
+
+  // Skins section
+  const skinEntries = getSkinEntries(current);
+  if (skinEntries.length > 0) {
+    lines.push('');
+    lines.push(ansi.bold('Skins (absolute sizes)'));
+
+    const skinRows = [['Skin', 'Size']];
+    for (const entry of skinEntries) {
+      // Strip the ~skin suffix for display
+      const skinName = entry.name.replace('@videojs/html/', '').replace('~skin', '');
+      skinRows.push([{ text: skinName, style: ansi.cyan }, colorSize(entry.size)]);
+    }
+    lines.push(printTable(skinRows));
+  }
+
+  // UI Components section
+  const uiEntries = getUIEntries(current);
+  if (uiEntries.length > 0) {
+    lines.push('');
+    lines.push(ansi.bold('UI Components (marginal sizes)'));
+
+    const uiRows = [['Component', 'Size']];
+    // Sort by size (largest first)
+    const sortedUI = [...uiEntries].sort((a, b) => b.size - a.size);
+    for (const entry of sortedUI) {
+      const componentName = entry.name.replace('@videojs/html/ui/', '');
+      uiRows.push([
+        { text: componentName, style: ansi.cyan },
+        colorSize(entry.size),
+      ]);
+    }
+    const uiTotal = uiEntries.reduce((s, e) => s + e.size, 0);
+    uiRows.push([
+      { text: 'total', style: ansi.bold },
+      { text: formatBytes(uiTotal), style: ansi.bold },
+    ]);
+    lines.push(printTable(uiRows));
   }
 
   lines.push('');

--- a/.github/scripts/bundle-size.js
+++ b/.github/scripts/bundle-size.js
@@ -9,13 +9,23 @@
  * shared minification and compression, avoiding the inflated totals you get
  * from summing independently-measured subpaths.
  *
+ * Also measures:
+ * - Skin scenarios: Absolute sizes for complete skin bundles (root + skin subpath)
+ * - UI components: Individual component sizes from @videojs/html/ui/*
+ *
  * Usage: node .github/scripts/bundle-size.js [--json output.json]
  */
 
 import { build } from 'esbuild';
 import { brotliCompressSync, constants } from 'node:zlib';
-import { readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
-import { resolve, dirname, join } from 'node:path';
+import {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  existsSync,
+  statSync,
+} from 'node:fs';
+import { resolve, dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -27,8 +37,8 @@ const SKIP_PACKAGES = new Set(['sandbox', '__tech-preview__', 'react-native']);
 /**
  * @typedef {object} SizeEntry
  * @property {string} name
- * @property {number} size - Root: brotli size. Subpath: marginal cost over root.
- * @property {'root' | 'subpath'} type
+ * @property {number} size - Root: brotli size. Subpath: marginal cost over root. Scenario/UI: absolute size.
+ * @property {'root' | 'subpath' | 'skin' | 'ui'} type
  */
 
 /** Bundle entry points with esbuild and return the minified + brotli size. */
@@ -66,6 +76,41 @@ function resolveDefault(exportValue) {
     return exportValue.default ?? null;
   }
   return null;
+}
+
+/** Expand wildcard exports by scanning the filesystem. */
+function expandWildcardExport(pkgDir, pattern, exportValue) {
+  // Pattern like "./ui/*" with value like { default: "./dist/default/define/ui/*.js" }
+  const defaultPath = resolveDefault(exportValue);
+  if (!defaultPath) return [];
+
+  // Extract the directory from the pattern (e.g., "./dist/default/define/ui")
+  const pathWithoutWildcard = defaultPath.replace('*', '');
+  const dir = resolve(pkgDir, dirname(pathWithoutWildcard));
+
+  if (!existsSync(dir)) return [];
+
+  const results = [];
+  const exportPrefix = pattern.replace('*', ''); // e.g., "./ui/"
+
+  for (const file of readdirSync(dir)) {
+    // Only .js files, skip .map and .d.ts
+    if (!file.endsWith('.js') || file.endsWith('.d.ts')) continue;
+
+    const filePath = join(dir, file);
+    if (!statSync(filePath).isFile()) continue;
+
+    // Skip empty files
+    if (readFileSync(filePath, 'utf8').trim().length === 0) continue;
+
+    const name = basename(file, '.js');
+    results.push({
+      exportKey: `${exportPrefix}${name}`,
+      path: filePath,
+    });
+  }
+
+  return results;
 }
 
 /** Discover packages and their entry points from the filesystem. */
@@ -142,9 +187,16 @@ async function main() {
   /** @type {SizeEntry[]} */
   const results = [];
 
+  // Track @videojs/html for skin and UI measurements
+  let htmlPkg = null;
+
   for (const pkg of packages) {
     const rootSize = await measure([pkg.rootPath], pkg.external);
     results.push({ name: pkg.name, size: rootSize, type: 'root' });
+
+    if (pkg.name === '@videojs/html') {
+      htmlPkg = { ...pkg, rootSize };
+    }
 
     for (const sub of pkg.subpaths) {
       const combinedSize = await measure(
@@ -154,6 +206,57 @@ async function main() {
       const marginal = combinedSize - rootSize;
 
       results.push({ name: sub.name, size: marginal, type: 'subpath' });
+    }
+  }
+
+  // Measure skin scenarios (absolute sizes for complete skin bundles)
+  if (htmlPkg) {
+    const skinSubpaths = ['video', 'audio', 'background'];
+
+    for (const skin of skinSubpaths) {
+      const subpath = htmlPkg.subpaths.find(
+        (s) => s.name === `@videojs/html/${skin}`,
+      );
+      if (subpath) {
+        // Measure absolute size (root + skin together)
+        const absoluteSize = await measure(
+          [htmlPkg.rootPath, subpath.path],
+          htmlPkg.external,
+        );
+        // Use ~skin suffix to distinguish from marginal subpath entries
+        results.push({
+          name: `@videojs/html/${skin}~skin`,
+          size: absoluteSize,
+          type: 'skin',
+        });
+      }
+    }
+
+    // Measure individual UI components
+    const htmlDir = join(PACKAGES_DIR, 'html');
+    const pkgJson = JSON.parse(
+      readFileSync(join(htmlDir, 'package.json'), 'utf8'),
+    );
+
+    // Find the ./ui/* wildcard export
+    const uiExport = pkgJson.exports['./ui/*'];
+    if (uiExport) {
+      const uiComponents = expandWildcardExport(htmlDir, './ui/*', uiExport);
+
+      for (const component of uiComponents) {
+        // Measure each UI component as standalone (with root as shared deps)
+        const componentSize = await measure(
+          [htmlPkg.rootPath, component.path],
+          htmlPkg.external,
+        );
+        const marginalSize = componentSize - htmlPkg.rootSize;
+
+        results.push({
+          name: `@videojs/html${component.exportKey.slice(1)}`,
+          size: marginalSize,
+          type: 'ui',
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Adds two new sections to the CI bundle size report:

- **Skins**: Absolute bundle sizes when importing a skin preset (e.g., video skin = 16.26 kB total including all dependencies)

- **UI Components**: Marginal sizes of individual UI components, sorted by size (largest first)

This gives better visibility into "if I import the video skin, what's the total bundle size" vs just seeing marginal subpath costs.

Changes:
- bundle-size.js: Add skin (type: 'skin') and UI component (type: 'ui') measurements. Uses ~skin suffix for skin entries to avoid collision with subpath entries of the same name.
- bundle-size-report.js: Add Skins and UI Components sections to both markdown (PR comments) and terminal (local pnpm size) reports.

https://claude.ai/code/session_012KHSNd6GtEhaYnMvhd2H4X