### PR TITLE
fix(site): skip error pages and strip styles in llms-markdown integration

### DIFF
--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -32,16 +32,26 @@ export default function llmsMarkdown(): AstroIntegration {
 
         logger.info('Generating LLM-optimized markdown files...');
 
+        // Standalone error pages emit e.g. 404.html, not 404/index.html
+        const SKIP_PAGES = new Set(['404', '500']);
+
         for (const page of pages) {
           const { pathname } = page;
+
+          if (SKIP_PAGES.has(pathname.replace(/\/$/, ''))) continue;
 
           try {
             // Construct path to HTML file
             const htmlPath = join(siteDir, pathname, 'index.html');
             const html = await readFile(htmlPath, 'utf-8');
 
+            // Strip styles before JSDOM to avoid "Could not parse CSS stylesheet" warnings
+            const cleanHtml = html
+              .replace(/<style[\s\S]*?<\/style>/gi, '')
+              .replace(/<link[^>]*rel=["']stylesheet["'][^>]*\/?>/gi, '');
+
             // Parse HTML with jsdom
-            const dom = new JSDOM(html);
+            const dom = new JSDOM(cleanHtml);
             const document = dom.window.document;
 
             // Check if page has llms content


### PR DESCRIPTION
## Summary

Fix two issues in the `llms-markdown` Astro integration that cause build errors and noisy warnings:

1. Standalone error pages (404, 500) emit flat HTML files (e.g., `404.html`) instead of `404/index.html`, causing `readFile` to fail during LLM markdown generation.
2. JSDOM logs "Could not parse CSS stylesheet" warnings for every `<style>` and `<link rel="stylesheet">` tag in the parsed HTML.

## Changes

- Skip standalone error pages (404, 500) that don't follow the `{pathname}/index.html` convention
- Strip `<style>` tags and stylesheet `<link>` elements before passing HTML to JSDOM

## Testing

`pnpm build:site` — verify no errors or CSS parse warnings from the llms-markdown integration.