### PR TITLE
fix(core): use camelCase attribute names in slider for react

### DIFF
--- a/packages/core/src/core/ui/slider/slider-core.ts
+++ b/packages/core/src/core/ui/slider/slider-core.ts
@@ -138,8 +138,8 @@ export class SliderCore {
   getAttrs(state: SliderState) {
     return {
       role: 'slider',
-      tabindex: state.disabled ? -1 : 0,
-      autocomplete: 'off',
+      tabIndex: state.disabled ? -1 : 0,
+      autoComplete: 'off',
       'aria-label': this.getLabel(state),
       'aria-valuemin': this.#props.min,
       'aria-valuemax': this.#props.max,

--- a/packages/core/src/core/ui/slider/tests/slider-core.test.ts
+++ b/packages/core/src/core/ui/slider/tests/slider-core.test.ts
@@ -137,8 +137,8 @@ describe('SliderCore', () => {
       const attrs = core.getAttrs(state);
 
       expect(attrs.role).toBe('slider');
-      expect(attrs.tabindex).toBe(0);
-      expect(attrs.autocomplete).toBe('off');
+      expect(attrs.tabIndex).toBe(0);
+      expect(attrs.autoComplete).toBe('off');
       expect(attrs['aria-label']).toBe('');
       expect(attrs['aria-valuemin']).toBe(0);
       expect(attrs['aria-valuemax']).toBe(100);
@@ -153,7 +153,7 @@ describe('SliderCore', () => {
       const state = core.getSliderState(0);
       const attrs = core.getAttrs(state);
 
-      expect(attrs.tabindex).toBe(-1);
+      expect(attrs.tabIndex).toBe(-1);
       expect(attrs['aria-disabled']).toBe('true');
     });
 

--- a/packages/core/src/core/ui/time-slider/tests/time-slider-core.test.ts
+++ b/packages/core/src/core/ui/time-slider/tests/time-slider-core.test.ts
@@ -226,7 +226,7 @@ describe('TimeSliderCore', () => {
 
       const attrs = core.getAttrs(state);
       expect(attrs['aria-disabled']).toBe('true');
-      expect(attrs.tabindex).toBe(-1);
+      expect(attrs.tabIndex).toBe(-1);
     });
 
     it('preserves thumbAlignment across getState calls', () => {

--- a/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
+++ b/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
@@ -184,7 +184,7 @@ describe('VolumeSliderCore', () => {
 
       const attrs = core.getAttrs(state);
       expect(attrs['aria-disabled']).toBe('true');
-      expect(attrs.tabindex).toBe(-1);
+      expect(attrs.tabIndex).toBe(-1);
     });
   });
 });


### PR DESCRIPTION
## Summary

`SliderCore.getAttrs()` returned lowercase HTML attribute names (`tabindex`, `autocomplete`) which caused React console warnings when passed through to `createElement`. This aligns slider attributes with the existing `createButton()` convention that already uses camelCase (`tabIndex`).

## Changes

- Use `tabIndex` / `autoComplete` (camelCase) in `SliderCore.getAttrs()` instead of `tabindex` / `autocomplete`
- Update test assertions across slider, time-slider, and volume-slider core tests

<details>
<summary>Implementation details</summary>

The HTML custom element path (`applyElementProps`) calls `setAttribute()` which normalizes attribute names to lowercase per the DOM spec, so camelCase keys still produce correct `tabindex="0"` attributes in the DOM. The HTML element tests (`getAttribute('tabindex')`) pass without changes.

</details>

## Testing

`pnpm -F @videojs/core test src/core/ui/slider src/core/ui/time-slider src/core/ui/volume-slider` — 69 tests pass.
`pnpm -F @videojs/html test src/ui/slider` — 23 tests pass.