### PR TITLE
fix(ci): prevent shell injection from PR title/body in sync workflow

### DIFF
--- a/.github/workflows/api-reference-sync.yml
+++ b/.github/workflows/api-reference-sync.yml
@@ -36,13 +36,16 @@ jobs:
 
       - name: Set PR context
         id: context
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
         run: |
           echo "pr_number=${{ github.event.pull_request.number || '' }}" >> "$GITHUB_OUTPUT"
-          echo "pr_title=${{ github.event.pull_request.title || '' }}" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
           echo "pr_url=${{ github.event.pull_request.html_url || '' }}" >> "$GITHUB_OUTPUT"
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "pr_body<<$EOF" >> "$GITHUB_OUTPUT"
-          echo "${{ github.event.pull_request.body || '' }}" >> "$GITHUB_OUTPUT"
+          echo "$PR_BODY" >> "$GITHUB_OUTPUT"
           echo "$EOF" >> "$GITHUB_OUTPUT"
 
       - name: Check for API-relevant changes


### PR DESCRIPTION
## Summary
- Pass PR title and body through `env:` vars instead of inline `${{ }}` expression interpolation in the `analyze` job's "Set PR context" step
- Fixes shell syntax errors when PR bodies contain quotes, backticks, or other special characters (e.g. [run #22676877014](https://github.com/videojs/v10/actions/runs/22676877014))

## Test plan
- [ ] Merge a PR whose body contains markdown backticks/quotes and verify the sync workflow's `analyze` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)