### PR TITLE
fix(html,react): move @videojs/skins to devDependencies

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -89,13 +89,13 @@
   "dependencies": {
     "@videojs/core": "workspace:*",
     "@videojs/element": "workspace:*",
-    "@videojs/skins": "workspace:*",
     "@videojs/store": "workspace:*",
     "@videojs/utils": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
     "@videojs/icons": "workspace:*",
+    "@videojs/skins": "workspace:*",
     "happy-dom": "^18.0.1",
     "tsdown": "^0.20.3",
     "typescript": "^5.9.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,13 +47,13 @@
   },
   "dependencies": {
     "@videojs/core": "workspace:*",
-    "@videojs/skins": "workspace:*",
     "@videojs/store": "workspace:*",
     "@videojs/utils": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
     "@videojs/icons": "workspace:*",
+    "@videojs/skins": "workspace:*",
     "@types/react": "^19.2.7",
     "jsdom": "^26.1.0",
     "react": "^19.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,9 +220,6 @@ importers:
       '@videojs/element':
         specifier: workspace:*
         version: link:../element
-      '@videojs/skins':
-        specifier: workspace:*
-        version: link:../skins
       '@videojs/store':
         specifier: workspace:*
         version: link:../store
@@ -236,6 +233,9 @@ importers:
       '@videojs/icons':
         specifier: workspace:*
         version: link:../icons
+      '@videojs/skins':
+        specifier: workspace:*
+        version: link:../skins
       happy-dom:
         specifier: ^18.0.1
         version: 18.0.1
@@ -285,9 +285,6 @@ importers:
       '@videojs/core':
         specifier: workspace:*
         version: link:../core
-      '@videojs/skins':
-        specifier: workspace:*
-        version: link:../skins
       '@videojs/store':
         specifier: workspace:*
         version: link:../store
@@ -304,6 +301,9 @@ importers:
       '@videojs/icons':
         specifier: workspace:*
         version: link:../icons
+      '@videojs/skins':
+        specifier: workspace:*
+        version: link:../skins
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -10575,7 +10575,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Moves `@videojs/skins` from `dependencies` to `devDependencies` in both `packages/html` and `packages/react`
- Same root cause as #712 — PR #698 (`feat(skin)`) added unpublished internal packages to `dependencies`, causing `npm install` failures for consumers
- `@videojs/skins` is not published to npm and is bundled at build time

## Test plan
- [ ] Verify `npm i @videojs/html@next @videojs/react@next` works from a fresh consumer project

🤖 Generated with [Claude Code](https://claude.com/claude-code)