### PR TITLE
fix: improve error message when no slotted media element is found

### DIFF
--- a/packages/store/src/core/errors.ts
+++ b/packages/store/src/core/errors.ts
@@ -26,7 +26,11 @@ export function isStoreError(error: unknown): error is StoreError {
 }
 
 export function throwNoTargetError(): never {
-  throw new StoreError('NO_TARGET');
+  throw new StoreError('NO_TARGET', {
+    message:
+      'NO_TARGET — No media element found. Make sure your media element ' +
+      '(e.g., <video>, <hls-video>) has slot="media" so it can be discovered by the player.',
+  });
 }
 
 export function throwDestroyedError(): never {


### PR DESCRIPTION
Fixes #724

## Summary
Add a descriptive error message to the `NO_TARGET` error that explains what went wrong and how to fix it.

## Changes
- Updated `throwNoTargetError()` in `packages/store/src/core/errors.ts`
- Error message now includes clear guidance on the issue and solution
- Provides examples of valid media elements (e.g., `<video>`, `<hls-video>`)

## Before
```
StoreError: NO_TARGET
```

## After
```
StoreError: NO_TARGET — No media element found. Make sure your media element
(e.g., <video>, <hls-video>) has slot="media" so it can be discovered by the player.
```

## Impact
This addresses one of the most common setup mistakes. The improved error message will save users significant debugging time by clearly explaining the issue and how to resolve it.

## Testing
- Existing tests continue to pass (no functional changes)
- Error code behavior unchanged
- Only the default message text is enhanced