### PR TITLE
docs: add missing slot="media" to installation page HTML examples

### DIFF
--- a/site/src/components/installation/HTMLUsageCodeBlock.tsx
+++ b/site/src/components/installation/HTMLUsageCodeBlock.tsx
@@ -51,7 +51,7 @@ function getSkinTag(useCase: UseCase, skin: Skin): string {
 function getRendererElement(renderer: Renderer, url: string): string {
   const tag = getRendererTag(renderer);
   const src = url.trim() || '...';
-  return `<${tag} src="${src}"></${tag}>`;
+  return `<${tag} slot="media" src="${src}"></${tag}>`;
 }
 
 function generateHTMLCode(useCase: UseCase, skin: Skin, renderer: Renderer, url: string): string {


### PR DESCRIPTION
Fixes #723

## Summary
Add the required `slot="media"` attribute to renderer elements in the installation page's generated HTML code blocks.

## Changes
- Updated `getRendererElement()` in `site/src/components/installation/HTMLUsageCodeBlock.tsx`
- All generated HTML examples now include the correct `slot="media"` attribute

## Before
```html
<video-player>
  <video-skin>
    <video src="..."></video>
  </video-skin>
</video-player>
```

## After
```html
<video-player>
  <video-skin>
    <video slot="media" src="..."></video>
  </video-skin>
</video-player>
```

## Impact
Without `slot="media"`, the media element isn't discovered by the player, causing `StoreError: NO_TARGET` when interacting with controls. This fix ensures the documentation shows the correct, working syntax that users can copy-paste without errors.