### PR TITLE
fix(site): add missing slot="media" to renderer element in HTML code block

### DIFF
--- a/site/src/components/installation/HTMLUsageCodeBlock.tsx
+++ b/site/src/components/installation/HTMLUsageCodeBlock.tsx
@@ -51,7 +51,7 @@ function getSkinTag(useCase: UseCase, skin: Skin): string {
 function getRendererElement(renderer: Renderer, url: string): string {
   const tag = getRendererTag(renderer);
   const src = url.trim() || '...';
-  return `<${tag} src="${src}"></${tag}>`;
+  return `<${tag} slot="media" src="${src}"></${tag}>`;
 }
 
 function generateHTMLCode(useCase: UseCase, skin: Skin, renderer: Renderer, url: string): string {


### PR DESCRIPTION
Adds `slot="media"` to the renderer element in `getRendererElement()` so the installation page's generated HTML code block includes the required slot attribute.

Closes #723

Generated with [Claude Code](https://claude.ai/code)