### PR TITLE
feat(core): add AlertDialog data attributes

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './media/proxy';
 export * from './media/state';
+export * from './ui/alert-dialog/alert-dialog-data-attrs';
 export * from './ui/buffering-indicator/buffering-indicator-core';
 export * from './ui/buffering-indicator/buffering-indicator-data-attrs';
 export * from './ui/controls/controls-core';

--- a/packages/core/src/core/ui/alert-dialog/alert-dialog-data-attrs.ts
+++ b/packages/core/src/core/ui/alert-dialog/alert-dialog-data-attrs.ts
@@ -1,0 +1,5 @@
+import type { StateAttrMap } from '../types';
+
+export const AlertDialogDataAttrs = {
+  open: 'data-open',
+} as const satisfies StateAttrMap<{ open: boolean }>;


### PR DESCRIPTION
## Summary

Add `AlertDialogDataAttrs` mapping (`open → data-open`) for the AlertDialog component. This is the core foundation that React and HTML AlertDialog implementations will build on.

## Changes

- `AlertDialogDataAttrs` constant mapping `open` state to `data-open` attribute
- Exported from `@videojs/core`

## Testing

`pnpm -F @videojs/core build` — builds clean