### PR TITLE
fix(ci): reuse diagnosis comment per PR instead of per run

### DIFF
--- a/.github/workflows/ci-diagnose.yml
+++ b/.github/workflows/ci-diagnose.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ci-diagnosis-${{ github.event.workflow_run.id }}
+  group: ci-diagnosis-pr-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
   cancel-in-progress: true
 
 jobs:
@@ -70,13 +70,13 @@ jobs:
             5. If the failure is only simple lint/style warnings, keep it brief and generic; do not enumerate every file.
             6. Avoid noise:
             - Do not post redundant comments.
-            - Use one comment per CI run.
-            - If a comment already exists with marker `<!-- ci-diagnosis:run-${{ github.event.workflow_run.id }} -->`, update it instead of creating a new one.
+            - Use one comment per PR.
+            - If a comment already exists with marker `<!-- ci-diagnosis:pr-${{ steps.context.outputs.pr_number }} -->`, update it instead of creating a new one.
             - Do not include stack traces or long command output in comments.
 
             Post or update a single PR comment on #${{ steps.context.outputs.pr_number }} using this template exactly:
 
-            <!-- ci-diagnosis:run-${{ github.event.workflow_run.id }} -->
+            <!-- ci-diagnosis:pr-${{ steps.context.outputs.pr_number }} -->
             ### CI Failure Diagnosis
             - Run: ${{ github.event.workflow_run.html_url }}
             - Commit: `${{ github.event.workflow_run.head_sha }}`


### PR DESCRIPTION
## Summary

CI diagnosis was creating a new comment on every failed run because the comment marker included the run ID. Changed to a per-PR marker so subsequent failures update the same comment.

## Changes

- Comment marker keyed by PR number instead of run ID
- Concurrency group scoped per-PR to prevent racing diagnoses

## Testing

Next CI failure on a PR will update the existing diagnosis comment instead of creating a new one.