### PR TITLE
fix(html): add destroy

### DIFF
--- a/internal/design/reactive-element-lit-compat.md
+++ b/internal/design/reactive-element-lit-compat.md
@@ -1,0 +1,52 @@
+---
+status: decided
+date: 2026-03-05
+---
+
+# Destroy Lifecycle: DestroyMixin
+
+## Decision
+
+The deferred destruction lifecycle is implemented as a **composable mixin** (`DestroyMixin`)
+exported from `@videojs/element`, rather than being added directly to `ReactiveElement`.
+
+`ReactiveElement` stays structurally compatible with Lit's `ReactiveElement`.
+
+## Architecture
+
+```
+@videojs/utils/dom   → deferFrames() composable utility
+@videojs/element     → DestroyMixin(HTMLElement) — generic, works with any base
+@videojs/html        → MediaElement = DestroyMixin(ReactiveElement) + hostDestroyed()
+@videojs/core        → HlsCustomMedia = DestroyMixin(HTMLElement) via CustomMediaMixin
+```
+
+### DestroyMixin
+
+Adds `destroyed`, `destroy()`, `destroyCallback()`, deferred 2-rAF scheduling on
+disconnect, cancel on reconnect, and `keep-alive` attribute support. Works with any
+`HTMLElement` subclass.
+
+### MediaElement
+
+Composes `DestroyMixin(ReactiveElement)` and bridges `destroyCallback()` to
+`hostDestroyed()` on reactive controllers. Also guards `performUpdate()` when destroyed.
+
+### HlsCustomMedia
+
+Uses `DestroyMixin(HTMLElement)` as the base for `CustomMediaMixin`. The `DelegateMedia`
+class (from `MediaDelegateMixin`) overrides `destroyCallback()` to call
+`this.#delegate.destroy?.()`, which destroys the HLS engine.
+
+## Why a Mixin
+
+- `ReactiveElement` stays Lit-compatible (no added public surface)
+- Works with `HTMLElement` directly (no `ReactiveElement` required for custom media elements)
+- Composable — any element can opt in
+
+## Alternatives Considered
+
+- **Put everything on `ReactiveElement`** — Simpler (direct `#controllers`
+  access), but breaks Lit structural compat. Rejected.
+- **Separate `MediaElement` class without mixin** — Doesn't compose with
+  `CustomMediaMixin(HTMLElement)` for custom media elements. Rejected.

--- a/packages/element/src/destroy-mixin.ts
+++ b/packages/element/src/destroy-mixin.ts
@@ -1,0 +1,83 @@
+import type { ReactiveElement } from './reactive-element';
+import type { ReactiveController } from './types';
+
+export interface Destroyable {
+  readonly destroyed: boolean;
+  destroy(): void;
+  destroyCallback(): void;
+}
+
+/**
+ * Mixin that adds a deferred destruction lifecycle to a `ReactiveElement`.
+ *
+ * On disconnect, schedules destruction after two animation frames.
+ * If the element reconnects before the frames fire (e.g. DOM shuffling,
+ * framework reconciliation), the `isConnected` check prevents destruction.
+ *
+ * The `keep-alive` attribute prevents automatic destruction entirely —
+ * call `destroy()` manually when done.
+ *
+ * Subclasses override `destroyCallback()` (calling `super.destroyCallback()`)
+ * to release heavy resources like stores or imperative APIs.
+ *
+ * Mirrors `addController`/`removeController` to track controllers
+ * (needed because `ReactiveElement.#controllers` is hard-private),
+ * calls `hostDestroyed()` on all tracked controllers in `destroyCallback`,
+ * and guards `performUpdate()` so no updates run after destruction.
+ */
+export function DestroyMixin<Base extends new (...args: any[]) => ReactiveElement>(SuperClass: Base) {
+  class DestroyableElement extends SuperClass {
+    #destroyed = false;
+    #trackedControllers = new Set<ReactiveController>();
+
+    get destroyed(): boolean {
+      return this.#destroyed;
+    }
+
+    destroy(): void {
+      if (this.#destroyed) return;
+      this.#destroyed = true;
+      this.destroyCallback();
+    }
+
+    destroyCallback(): void {
+      for (const c of this.#trackedControllers) {
+        c.hostDestroyed?.();
+      }
+    }
+
+    addController(controller: ReactiveController): void {
+      super.addController(controller);
+      this.#trackedControllers.add(controller);
+    }
+
+    removeController(controller: ReactiveController): void {
+      super.removeController(controller);
+      this.#trackedControllers.delete(controller);
+    }
+
+    connectedCallback(): void {
+      if (this.#destroyed) return;
+      super.connectedCallback();
+    }
+
+    disconnectedCallback(): void {
+      super.disconnectedCallback();
+
+      if (!this.#destroyed && !this.hasAttribute('keep-alive')) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            if (!this.isConnected) this.destroy();
+          });
+        });
+      }
+    }
+
+    protected performUpdate(): void {
+      if (this.#destroyed) return;
+      super.performUpdate();
+    }
+  }
+
+  return DestroyableElement as unknown as Base & (new (...args: any[]) => Destroyable);
+}

--- a/packages/element/src/index.ts
+++ b/packages/element/src/index.ts
@@ -1,3 +1,4 @@
+export { type Destroyable, DestroyMixin } from './destroy-mixin';
 export { ReactiveElement } from './reactive-element';
 export type {
   PropertyDeclaration,

--- a/packages/element/src/tests/destroy-mixin.test.ts
+++ b/packages/element/src/tests/destroy-mixin.test.ts
@@ -1,0 +1,227 @@
+import type { ReactiveController } from '@videojs/element';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DestroyMixin } from '../destroy-mixin';
+import { ReactiveElement } from '../reactive-element';
+
+const DestroyableElement = DestroyMixin(ReactiveElement);
+
+let tagCounter = 0;
+
+function uniqueTag(base: string): string {
+  return `${base}-${tagCounter++}`;
+}
+
+function createElement<T extends HTMLElement>(ctor: abstract new () => T): T {
+  const tag = uniqueTag('test-destroy');
+  customElements.define(tag, class extends (ctor as unknown as typeof HTMLElement) {});
+  return document.createElement(tag) as T;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// destroy()
+// ---------------------------------------------------------------------------
+
+describe('DestroyMixin', () => {
+  it('destroyed is false by default', () => {
+    const el = createElement(DestroyableElement);
+    expect(el.destroyed).toBe(false);
+  });
+
+  it('destroy() sets destroyed to true', () => {
+    const el = createElement(DestroyableElement);
+    el.destroy();
+    expect(el.destroyed).toBe(true);
+  });
+
+  it('destroy() is idempotent', () => {
+    const destroyCallback = vi.fn();
+
+    class TestElement extends DestroyableElement {
+      override destroyCallback(): void {
+        destroyCallback();
+        super.destroyCallback();
+      }
+    }
+
+    const el = createElement(TestElement);
+    el.destroy();
+    el.destroy();
+
+    expect(destroyCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroyCallback() is called by destroy()', () => {
+    const destroyCallback = vi.fn();
+
+    class TestElement extends DestroyableElement {
+      override destroyCallback(): void {
+        destroyCallback();
+        super.destroyCallback();
+      }
+    }
+
+    const el = createElement(TestElement);
+    el.destroy();
+
+    expect(destroyCallback).toHaveBeenCalledOnce();
+  });
+
+  it('connectedCallback no-ops after destroy', () => {
+    const el = createElement(DestroyableElement);
+
+    document.body.appendChild(el);
+    el.destroy();
+    el.remove();
+
+    document.body.appendChild(el);
+
+    expect(el.destroyed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deferred destruction (2 rAF)
+// ---------------------------------------------------------------------------
+
+describe('DestroyMixin deferred destruction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('destroys after 2 animation frames when disconnected', () => {
+    const el = createElement(DestroyableElement);
+
+    document.body.appendChild(el);
+    el.remove();
+
+    // After first rAF — not yet destroyed.
+    vi.advanceTimersByTime(16);
+    expect(el.destroyed).toBe(false);
+
+    // After second rAF — destroyed.
+    vi.advanceTimersByTime(16);
+    expect(el.destroyed).toBe(true);
+  });
+
+  it('cancels destruction when reconnected before 2 rAFs', () => {
+    const el = createElement(DestroyableElement);
+
+    document.body.appendChild(el);
+    el.remove();
+    vi.advanceTimersByTime(16); // 1 rAF
+
+    // Reconnect before second rAF fires.
+    document.body.appendChild(el);
+
+    vi.advanceTimersByTime(16); // 2nd rAF — but cancelled by reconnect
+    expect(el.destroyed).toBe(false);
+  });
+
+  it('keep-alive attribute prevents deferred destruction', () => {
+    const el = createElement(DestroyableElement);
+    el.setAttribute('keep-alive', '');
+
+    document.body.appendChild(el);
+    el.remove();
+
+    vi.advanceTimersByTime(100);
+    expect(el.destroyed).toBe(false);
+  });
+
+  it('manual destroy() works even with keep-alive', () => {
+    const el = createElement(DestroyableElement);
+    el.setAttribute('keep-alive', '');
+
+    document.body.appendChild(el);
+    el.destroy();
+    expect(el.destroyed).toBe(true);
+  });
+
+  it('calls destroyCallback when deferred destruction fires', () => {
+    const destroyCallback = vi.fn();
+
+    class TestElement extends DestroyableElement {
+      override destroyCallback(): void {
+        destroyCallback();
+        super.destroyCallback();
+      }
+    }
+
+    const el = createElement(TestElement);
+
+    document.body.appendChild(el);
+    el.remove();
+    vi.advanceTimersByTime(32);
+
+    expect(destroyCallback).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controller tracking & performUpdate guard
+// ---------------------------------------------------------------------------
+
+describe('DestroyMixin controller lifecycle', () => {
+  it('hostDestroyed() is called on controllers', () => {
+    const hostDestroyed = vi.fn();
+    const controller: ReactiveController = { hostDestroyed };
+
+    const el = createElement(DestroyableElement);
+    el.addController(controller);
+    el.destroy();
+
+    expect(hostDestroyed).toHaveBeenCalledOnce();
+  });
+
+  it('connectedCallback no-ops after destroy', async () => {
+    const el = createElement(DestroyableElement);
+
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    el.destroy();
+    el.remove();
+
+    // Re-insert — should not re-initialize.
+    const hostConnected = vi.fn();
+    const controller: ReactiveController = { hostConnected };
+    el.addController(controller);
+
+    document.body.appendChild(el);
+
+    expect(hostConnected).not.toHaveBeenCalled();
+  });
+
+  it('performUpdate no-ops after destroy', async () => {
+    class TestElement extends DestroyableElement {
+      updateRan = false;
+
+      protected override update(changed: Map<string, unknown>): void {
+        super.update(changed);
+        this.updateRan = true;
+      }
+    }
+
+    const el = createElement(TestElement);
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    el.updateRan = false;
+    el.destroy();
+    el.requestUpdate();
+
+    // Flush microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.updateRan).toBe(false);
+  });
+});

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -56,6 +56,13 @@ export interface ReactiveController {
   hostDisconnected?(): void;
 
   /**
+   * Called when the host is permanently destroyed. Unlike `hostDisconnected`,
+   * this signals that the host will not reconnect — all resources should be
+   * released.
+   */
+  hostDestroyed?(): void;
+
+  /**
    * Called during the client-side host update, just before the host calls
    * its own update.
    */

--- a/packages/html/src/media/hls-video/index.ts
+++ b/packages/html/src/media/hls-video/index.ts
@@ -30,7 +30,11 @@ export class HlsVideo extends HlsCustomMedia {
     super.disconnectedCallback?.();
 
     if (!this.hasAttribute('keep-alive')) {
-      this.destroy();
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (!this.isConnected) this.destroy();
+        });
+      });
     }
   }
 }

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -41,10 +41,10 @@ export function createProviderMixin<Store extends PlayerStore>(
         this.#provider.setValue(this.store);
       }
 
-      override disconnectedCallback() {
-        super.disconnectedCallback();
+      override destroyCallback() {
         this.#store?.destroy();
         this.#store = null;
+        super.destroyCallback();
       }
     }
 

--- a/packages/html/src/ui/media-element.ts
+++ b/packages/html/src/ui/media-element.ts
@@ -1,6 +1,7 @@
-import { ReactiveElement } from '@videojs/element';
+import { DestroyMixin, ReactiveElement } from '@videojs/element';
 import type { Constructor } from '@videojs/utils/types';
 
-export class MediaElement extends ReactiveElement {}
+/** Base class for interactive media UI elements. */
+export class MediaElement extends DestroyMixin(ReactiveElement) {}
 
 export interface MediaElementConstructor extends Constructor<MediaElement> {}

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -54,6 +54,8 @@ export class PopoverElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
+
     this.#disconnect = new AbortController();
 
     this.#popover = createPopover({
@@ -97,11 +99,14 @@ export class PopoverElement extends MediaElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#cleanupTrigger();
-    this.#popover?.destroy();
-    this.#popover = null;
     this.#disconnect?.abort();
     this.#disconnect = null;
+  }
+
+  override destroyCallback(): void {
+    this.#cleanupTrigger();
+    this.#popover?.destroy();
+    super.destroyCallback();
   }
 
   protected override willUpdate(changed: PropertyValues): void {

--- a/packages/html/src/ui/slider/slider-element.ts
+++ b/packages/html/src/ui/slider/slider-element.ts
@@ -46,6 +46,7 @@ export class SliderElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#disconnect = new AbortController();
     const signal = this.#disconnect.signal;
@@ -86,10 +87,13 @@ export class SliderElement extends MediaElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#slider?.destroy();
-    this.#slider = null;
     this.#disconnect?.abort();
     this.#disconnect = null;
+  }
+
+  override destroyCallback(): void {
+    this.#slider?.destroy();
+    super.destroyCallback();
   }
 
   protected override willUpdate(_changed: PropertyValues): void {

--- a/packages/html/src/ui/tests/media-element.test.ts
+++ b/packages/html/src/ui/tests/media-element.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MediaElement } from '../media-element';
+
+let tagCounter = 0;
+
+function uniqueTag(base: string): string {
+  return `${base}-${tagCounter++}`;
+}
+
+function createElement<T extends HTMLElement>(ctor: abstract new () => T): T {
+  const tag = uniqueTag('test-media');
+  customElements.define(tag, class extends (ctor as unknown as typeof HTMLElement) {});
+  return document.createElement(tag) as T;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('MediaElement', () => {
+  it('extends DestroyMixin(ReactiveElement)', () => {
+    const el = createElement(MediaElement);
+    expect(el).toBeInstanceOf(MediaElement);
+    expect(el.destroyed).toBe(false);
+  });
+});

--- a/packages/html/src/ui/thumbnail/thumbnail-element.ts
+++ b/packages/html/src/ui/thumbnail/thumbnail-element.ts
@@ -78,6 +78,7 @@ export class ThumbnailElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#api = createThumbnail({
       getContainer: () => this,
@@ -88,8 +89,11 @@ export class ThumbnailElement extends MediaElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
+  }
+
+  override destroyCallback(): void {
     this.#api?.destroy();
-    this.#api = null;
+    super.destroyCallback();
   }
 
   protected override update(changed: PropertyValues): void {

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -50,6 +50,7 @@ export class TimeSliderElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#disconnect = new AbortController();
     const signal = this.#disconnect.signal;
@@ -95,10 +96,13 @@ export class TimeSliderElement extends MediaElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#slider?.destroy();
-    this.#slider = null;
     this.#disconnect?.abort();
     this.#disconnect = null;
+  }
+
+  override destroyCallback(): void {
+    this.#slider?.destroy();
+    super.destroyCallback();
   }
 
   protected override willUpdate(_changed: PropertyValues): void {

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -45,6 +45,7 @@ export class VolumeSliderElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#disconnect = new AbortController();
     const signal = this.#disconnect.signal;
@@ -91,10 +92,13 @@ export class VolumeSliderElement extends MediaElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#slider?.destroy();
-    this.#slider = null;
     this.#disconnect?.abort();
     this.#disconnect = null;
+  }
+
+  override destroyCallback(): void {
+    this.#slider?.destroy();
+    super.destroyCallback();
   }
 
   protected override willUpdate(_changed: PropertyValues): void {


### PR DESCRIPTION
Closes #689

## Summary

Prevents `StoreError: DESTROYED` when frameworks (React, Lit, etc.) temporarily disconnect and reconnect custom elements during reconciliation. Elements now defer destruction by 2 rAF ticks after disconnect — if still disconnected, they destroy; if reconnected, the `isConnected` check skips destruction.

## Changes

- `DestroyMixin` in `@videojs/element` — composable mixin on `ReactiveElement` that adds `destroy()`, `destroyCallback()`, `destroyed`, deferred 2-rAF destruction on disconnect, `keep-alive` attribute opt-out, controller tracking with `hostDestroyed()` notification, and `performUpdate` guard
- `MediaElement` simplified to `DestroyMixin(ReactiveElement)` — all destruction logic lives in the mixin
- `HlsVideo` defers `this.destroy()` by 2 rAFs (goes through delegate proxy to HLS engine)
- Store destruction moved from `disconnectedCallback` to `destroyCallback` in `ProviderMixin`
- Imperative API destruction (slider, popover, thumbnail) moved to `destroyCallback`
- `hostDestroyed?()` added to `ReactiveController` interface

<details>
<summary>Implementation details</summary>

**Why not on `ReactiveElement`?** It's used as a structural type constraint by `SkinMixin` and other composites. Adding public members would break Lit compatibility. The destroy lifecycle lives in `DestroyMixin`; `ReactiveElement` gets a minimal `hostDestroyed?()` hook on the controller interface. See `internal/design/reactive-element-lit-compat.md`.

**Why 2 rAF ticks?** A single rAF can fire before the browser has processed the re-insertion. Two ticks ensure the element has had a full frame to reconnect. The callback checks `isConnected` so reconnected elements survive.

**ContainerMixin unchanged** — It already detaches immediately (lightweight) and re-attaches on reconnect. The store survives because the provider's destruction is deferred.

**HlsVideo uses inline rAFs** — `DestroyMixin` is not applied to `HlsCustomMedia` because it would shadow the delegate-proxied `destroy()` (fixed in #751). Instead, `HlsVideo.disconnectedCallback` schedules the 2-rAF check directly.

</details>

## Testing

```bash
pnpm -F @videojs/element test src/tests/destroy-mixin.test.ts
pnpm -F @videojs/html test
```

13 new tests in `destroy-mixin.test.ts` covering: destroy flag, idempotency, destroyCallback, hostDestroyed notification, connectedCallback guard, performUpdate guard, 2-rAF deferred destruction, reconnect survival, keep-alive attribute.