### PR TITLE
revert(html): remove double raf hls destroy

### DIFF
--- a/packages/html/src/media/hls-video/index.ts
+++ b/packages/html/src/media/hls-video/index.ts
@@ -30,11 +30,7 @@ export class HlsVideo extends HlsCustomMedia {
     super.disconnectedCallback?.();
 
     if (!this.hasAttribute('keep-alive')) {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (!this.isConnected) this.destroy();
-        });
-      });
+      this.destroy();
     }
   }
 }


### PR DESCRIPTION
## Summary

Revert the double `requestAnimationFrame` guard on `hls-video` disconnect — destroy immediately when `keep-alive` is absent.

## Changes

- Remove double rAF + `isConnected` check from `disconnectedCallback`, call `destroy()` directly

## Testing

Covered by existing tests.