### PR TITLE
fix(core): use double-RAF in transition open to enable entry animations

### DIFF
--- a/packages/core/src/dom/ui/tests/transition.test.ts
+++ b/packages/core/src/dom/ui/tests/transition.test.ts
@@ -16,7 +16,7 @@ describe('createTransition', () => {
       expect(handler.state.current).toEqual({ active: true, status: 'starting' });
     });
 
-    it('transitions to idle after one RAF', async () => {
+    it('transitions to idle after a double-RAF', async () => {
       const handler = createTransition();
 
       const promise = handler.open();

--- a/packages/core/src/dom/ui/transition.ts
+++ b/packages/core/src/dom/ui/transition.ts
@@ -13,9 +13,9 @@ export interface TransitionApi {
 /**
  * Manages open/close transition lifecycle via `createState`.
  *
- * **Open:** patches `{ active: true, status: 'starting' }`, then after one
- * RAF patches `{ status: 'idle' }` so the browser paints the initial
- * state before transitioning.
+ * **Open:** patches `{ active: true, status: 'starting' }`, then after a
+ * double-RAF patches `{ status: 'idle' }` so the browser paints the
+ * initial ("from") state before transitioning.
  *
  * **Close:** patches `{ status: 'ending' }` (keeping `active: true` so the
  * element stays mounted), then after a double-RAF waits for
@@ -39,9 +39,12 @@ export function createTransition(): TransitionApi {
     return new Promise<void>((resolve) => {
       rafId1 = requestAnimationFrame(() => {
         rafId1 = 0;
-        if (destroyed || !state.current.active) return resolve();
-        state.patch({ status: 'idle' });
-        resolve();
+        rafId2 = requestAnimationFrame(() => {
+          rafId2 = 0;
+          if (destroyed || !state.current.active) return resolve();
+          state.patch({ status: 'idle' });
+          resolve();
+        });
       });
     });
   }


### PR DESCRIPTION
## Summary

Popover entry animations were missing — popovers jumped in instantly while exit animations worked fine. The root cause was `createTransition().open()` using a single `requestAnimationFrame` to clear the `'starting'` status, which meant `data-starting-style` was added and removed within the same paint frame.

## Changes

- Use a double-RAF in `open()` to match what `close()` already does, guaranteeing a browser paint between applying and removing `data-starting-style`

<details>
<summary>Implementation details</summary>

The browser rendering pipeline processes microtasks (framework applies `data-starting-style`) and RAF callbacks (transition clears it) before painting. With a single RAF, both happen in the same frame — the browser never computes the "from" state, so no CSS transition fires.

The double-RAF ensures one paint between setting and clearing:

```
patch('starting') → RAF₁ → [browser paints "from" state] → RAF₂ → patch('idle')
```

This is the same pattern `close()` uses for exit animations, which is why those already worked.

</details>

## Testing

1. `pnpm -F @videojs/core test src/dom/ui/tests/transition.test.ts` — 11 tests pass
2. Manual: hover the volume icon on the default/minimal skin player and verify the popover animates in