### PR TITLE
fix: ssr issue with hls.js

### DIFF
--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -14,30 +14,30 @@ const defaultConfig = {
 };
 
 export class HlsMediaDelegateBase implements MediaDelegate {
-  #engine = new Hls(defaultConfig);
+  #engine = Hls.isSupported() ? new Hls(defaultConfig) : null;
 
-  get engine(): Hls {
+  get engine(): Hls | null {
     return this.#engine;
   }
 
   attach(target: EventTarget): void {
-    this.#engine.attachMedia(target as HTMLMediaElement);
+    this.#engine?.attachMedia(target as HTMLMediaElement);
   }
 
   detach(): void {
-    this.#engine.detachMedia();
+    this.#engine?.detachMedia();
   }
 
   destroy(): void {
-    this.#engine.destroy();
+    this.#engine?.destroy();
   }
 
   set src(src: string) {
-    this.#engine.loadSource(src);
+    this.#engine?.loadSource(src);
   }
 
   get src(): string {
-    return this.#engine.url ?? '';
+    return this.#engine?.url ?? '';
   }
 }
 

--- a/packages/core/src/dom/media/hls/text-tracks.ts
+++ b/packages/core/src/dom/media/hls/text-tracks.ts
@@ -4,7 +4,7 @@ import type { CuesParsedData, NonNativeTextTracksData } from 'hls.js';
 import Hls from 'hls.js';
 
 interface HlsEngineHost {
-  readonly engine: Hls;
+  readonly engine: Hls | null;
   attach?(target: EventTarget): void;
   detach?(): void;
 }
@@ -43,6 +43,8 @@ export function HlsMediaTextTracksMixin<Base extends Constructor<HlsEngineHost>>
 
       const { signal } = this.#disconnect;
       const { engine } = this;
+      if (!engine) return;
+
       const media = this.#target!;
 
       const onTracksFound = (_event: string, data: NonNativeTextTracksData) => {


### PR DESCRIPTION
fix: #757

This pull request improves the robustness of HLS media handling by ensuring that the HLS engine is only used when supported and gracefully handles cases where it may be unavailable. The changes update type definitions, add null checks, and prevent errors when HLS is not supported.

### Robustness improvements for HLS engine usage

* Updated the initialization of the `#engine` property in `HlsMediaDelegateBase` to only create an instance of `Hls` if it is supported, otherwise set it to `null`. All methods now use optional chaining to safely interact with the engine. (`packages/core/src/dom/media/hls/index.ts`)
* Changed the `engine` property type in `HlsEngineHost` interface from `Hls` to `Hls | null` to reflect the possibility of the engine being unavailable. (`packages/core/src/dom/media/hls/text-tracks.ts`)
* Added a null check for `engine` in the `HlsMediaTextTracksMixin` function to prevent execution when the engine is not present. (`packages/core/src/dom/media/hls/text-tracks.ts`)