### PR TITLE
fix(html): thumb edge alignment jump

### DIFF
--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -36,6 +36,8 @@ export interface SliderOptions {
   onValueCommit?: ((percent: number) => void) | undefined;
   onDragStart?: (() => void) | undefined;
   onDragEnd?: (() => void) | undefined;
+  /** Called when the root element resizes (e.g. gains layout inside a popover). */
+  onResize?: (() => void) | undefined;
 }
 
 export interface SliderRootProps {
@@ -304,6 +306,13 @@ export function createSlider(options: SliderOptions): SliderApi {
     };
   }
 
+  let resizeObserver: ResizeObserver | null = null;
+
+  if (options.onResize) {
+    resizeObserver = new ResizeObserver(() => options.onResize!());
+    resizeObserver.observe(options.getElement());
+  }
+
   const rootStyle: SliderRootStyle = { touchAction: 'none', userSelect: 'none' };
 
   return {
@@ -315,6 +324,7 @@ export function createSlider(options: SliderOptions): SliderApi {
     destroy() {
       if (abort.signal.aborted) return;
       abort.abort();
+      resizeObserver?.disconnect();
       releaseCapture();
       cleanup();
     },

--- a/packages/html/src/ui/slider/slider-element.ts
+++ b/packages/html/src/ui/slider/slider-element.ts
@@ -75,6 +75,7 @@ export class SliderElement extends MediaElement {
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),
+      onResize: () => this.requestUpdate(),
     });
 
     applyElementProps(this, this.#slider.rootProps, { signal });

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -80,6 +80,7 @@ export class TimeSliderElement extends MediaElement {
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),
+      onResize: () => this.requestUpdate(),
     });
 
     applyElementProps(this, this.#slider.rootProps, { signal });

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -76,6 +76,7 @@ export class VolumeSliderElement extends MediaElement {
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),
+      onResize: () => this.requestUpdate(),
     });
 
     applyElementProps(this, this.#slider.rootProps, { signal });


### PR DESCRIPTION
## Summary

Sliders with `thumb-alignment="edge"` jump visibly on first interaction because `adjustForAlignment()` returns raw percentages when the element has no layout (e.g. inside a closed popover, or before first paint). A ResizeObserver on each slider element detects when it gains layout and re-runs the update, applying correct edge-adjusted CSS vars before the first visible frame.

## Changes

- Add ResizeObserver in `connectedCallback()` of `SliderElement`, `TimeSliderElement`, and `VolumeSliderElement` that calls `requestUpdate()` on resize
- Observer cleanup via the existing `AbortController` signal on disconnect

## Testing

```bash
pnpm -F @videojs/html test
```

Manual: set `thumb-alignment="edge"` on a volume slider inside a hover popover. Open the popover — thumb and fill should render at the correct position immediately, with no visible jump.