### PR TITLE
chore: gitignore `.claude/settings.local.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ bun.lockb
 # -------------------------
 # AI Agent Config (Generated)
 # -------------------------
+.claude/settings.local.json
 .opencode
 AGENTS.md
 agents


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.gitignore` to prevent local Claude Code settings from being committed.

## Test plan
- [x] Verify `.claude/settings.local.json` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)