### PR TITLE
fix(core): prevent slider track click from closing popover

### DIFF
--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -35,6 +35,8 @@ export interface PopoverTriggerProps {
 export interface PopoverPopupProps {
   onPointerEnter: (event: UIPointerEvent) => void;
   onPointerLeave: (event: UIPointerEvent) => void;
+  onGotPointerCapture: (event: UIPointerEvent) => void;
+  onLostPointerCapture: (event: UIPointerEvent) => void;
   onFocusOut: (event: UIFocusEvent) => void;
 }
 
@@ -56,6 +58,7 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   let triggerEl: HTMLElement | null = null;
   let popupEl: HTMLElement | null = null;
   let hoverTimeout: ReturnType<typeof setTimeout> | null = null;
+  const capturedPointers = new Set<number>();
 
   const layer = createDismissLayer({
     transition: options.transition,
@@ -154,6 +157,7 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   // Cleanup hover timeout on destroy.
   layer.signal.addEventListener('abort', () => {
     clearHoverTimeout();
+    capturedPointers.clear();
     triggerEl = null;
     popupEl = null;
   });
@@ -227,12 +231,24 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     onPointerLeave(_event) {
       if (!options.openOnHover?.()) return;
 
+      // A descendant has pointer capture (e.g. slider drag). The leave is
+      // synthetic — the pointer hasn't actually left — so don't close.
+      if (capturedPointers.size > 0) return;
+
       clearHoverTimeout();
 
       if (!state.current.active) return;
 
       const closeDelay = options.closeDelay?.() ?? 0;
       hoverTimeout = setTimeout(() => applyClose('hover'), closeDelay);
+    },
+
+    onGotPointerCapture(event) {
+      capturedPointers.add(event.pointerId);
+    },
+
+    onLostPointerCapture(event) {
+      capturedPointers.delete(event.pointerId);
     },
 
     onFocusOut(event) {

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -131,6 +131,12 @@ export function createSlider(options: SliderOptions): SliderApi {
     onPointerDown(event) {
       if (options.isDisabled()) return;
 
+      // Prevent the browser's default mousedown focus behavior. Without this,
+      // clicking a non-focusable child (e.g. the track) causes the browser to
+      // move focus away from the thumb after our programmatic `focus()` call,
+      // which can trigger unrelated `focusout` handlers (e.g. popover close).
+      event.preventDefault();
+
       const el = options.getElement();
 
       cachedRect = el.getBoundingClientRect();

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -178,6 +178,28 @@ describe('createSlider', () => {
       slider.destroy();
     });
 
+    it('calls preventDefault to suppress default focus behavior', () => {
+      const slider = createSlider(createOptions());
+
+      const event = pointerEvent();
+      slider.rootProps.onPointerDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+
+      slider.destroy();
+    });
+
+    it('does not call preventDefault when disabled', () => {
+      const slider = createSlider(createOptions({ isDisabled: () => true }));
+
+      const event = pointerEvent();
+      slider.rootProps.onPointerDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+
+      slider.destroy();
+    });
+
     it('does nothing when disabled', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ isDisabled: () => true, onValueChange }));


### PR DESCRIPTION
## Summary

Clicking the track of a volume slider inside `<media-popover open-on-hover>` closes the popover. Two issues conspire: (1) the browser's default `mousedown` action steals focus from the thumb after our programmatic `focus()` call, firing `focusout` with `relatedTarget=null` which triggers the popover's blur-close path; (2) `setPointerCapture` on the slider root during drag fires a synthetic `pointerleave` on the popover, triggering the hover-close path.

## Changes

- `event.preventDefault()` on slider `pointerdown` to suppress default focus behavior
- Track `gotpointercapture` / `lostpointercapture` on the popover popup, suppress `onPointerLeave` close when a descendant has pointer capture

## Testing

```bash
pnpm -F @videojs/core test src/dom/ui/tests/slider.test.ts
```

Manual: open the volume popover on hover, click the slider track — popover should stay open. Drag the slider — popover should stay open.