### PR TITLE
docs: add captions button

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export {
 // UI
 export { AlertDialog, type AlertDialogContextValue, useAlertDialogContext } from './ui/alert-dialog';
 export { BufferingIndicator, type BufferingIndicatorProps } from './ui/buffering-indicator/buffering-indicator';
+export { CaptionsButton, type CaptionsButtonProps } from './ui/captions-button/captions-button';
 export { Controls } from './ui/controls';
 export type { ControlsGroupProps } from './ui/controls/controls-group';
 export type { ControlsRootProps } from './ui/controls/controls-root';

--- a/site/public/docs/demos/captions-button/captions.vtt
+++ b/site/public/docs/demos/captions-button/captions.vtt
@@ -1,0 +1,10 @@
+WEBVTT
+
+00:00.000 --> 00:03.000
+This is a demo of the captions button.
+
+00:03.000 --> 00:06.000
+Captions help make video accessible to everyone.
+
+00:06.000 --> 00:09.000
+Toggle captions on and off with a single click.

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.astro
@@ -1,0 +1,10 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+import './BasicUsage.css';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
@@ -1,0 +1,34 @@
+.html-captions-button-basic {
+  position: relative;
+}
+
+.html-captions-button-basic video {
+  width: 100%;
+}
+
+.html-captions-button-basic__button {
+  padding-block: 8px;
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(10px);
+  color: black;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 9999px;
+  padding-inline: 20px;
+  cursor: pointer;
+}
+
+.html-captions-button-basic__button .show-when-active {
+  display: none;
+}
+.html-captions-button-basic__button .show-when-inactive {
+  display: none;
+}
+.html-captions-button-basic__button[data-active] .show-when-active {
+  display: inline;
+}
+.html-captions-button-basic__button:not([data-active]) .show-when-inactive {
+  display: inline;
+}

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
@@ -1,0 +1,17 @@
+<video-player class="html-captions-button-basic">
+    <media-container>
+        <video
+            src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
+            autoplay
+            muted
+            playsinline
+            loop
+        >
+            <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
+        </video>
+        <media-captions-button class="html-captions-button-basic__button">
+            <span class="show-when-active">Captions Off</span>
+            <span class="show-when-inactive">Captions On</span>
+        </media-captions-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/captions-button';

--- a/site/src/components/docs/demos/captions-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/react/css/BasicUsage.css
@@ -1,0 +1,21 @@
+.react-captions-button-basic {
+  position: relative;
+}
+
+.react-captions-button-basic video {
+  width: 100%;
+}
+
+.react-captions-button-basic__button {
+  padding-block: 8px;
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(10px);
+  color: black;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 9999px;
+  padding-inline: 20px;
+  cursor: pointer;
+}

--- a/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
@@ -1,0 +1,30 @@
+import { CaptionsButton, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+import './BasicUsage.css';
+
+const Player = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player.Provider>
+      <Player.Container className="react-captions-button-basic">
+        <Video
+          src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
+          autoPlay
+          muted
+          playsInline
+          loop
+        >
+          <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
+        </Video>
+        <CaptionsButton
+          className="react-captions-button-basic__button"
+          render={(props, state) => (
+            <button {...props}>{state.subtitlesShowing ? 'Captions Off' : 'Captions On'}</button>
+          )}
+        />
+      </Player.Container>
+    </Player.Provider>
+  );
+}

--- a/site/src/content/docs/reference/captions-button.mdx
+++ b/site/src/content/docs/reference/captions-button.mdx
@@ -1,0 +1,92 @@
+---
+title: CaptionsButton
+frameworkTitle:
+  html: media-captions-button
+description: Accessible captions toggle button with availability detection and state reflection
+---
+
+import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+import StyleCase from "@/components/docs/StyleCase.astro";
+import Demo from "@/components/docs/demos/Demo.astro";
+
+{/* React demos */}
+import BasicUsageDemoReact from "@/components/docs/demos/captions-button/react/css/BasicUsage";
+import basicUsageReactTsx from "@/components/docs/demos/captions-button/react/css/BasicUsage.tsx?raw";
+import basicUsageReactCss from "@/components/docs/demos/captions-button/react/css/BasicUsage.css?raw";
+
+{/* HTML demos */}
+import BasicUsageDemoHtml from "@/components/docs/demos/captions-button/html/css/BasicUsage.astro";
+import basicUsageHtml from "@/components/docs/demos/captions-button/html/css/BasicUsage.html?raw";
+import basicUsageHtmlCss from "@/components/docs/demos/captions-button/html/css/BasicUsage.css?raw";
+import basicUsageHtmlTs from "@/components/docs/demos/captions-button/html/css/BasicUsage.ts?raw";
+
+## Anatomy
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<CaptionsButton />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-captions-button></media-captions-button>
+```
+</FrameworkCase>
+
+## Behavior
+
+Toggles captions and subtitles on and off. The button checks the media's text track list for tracks with `kind="captions"` or `kind="subtitles"` and reflects availability via `data-availability`.
+
+When no caption or subtitle tracks are present, `data-availability="unavailable"` is set. Use this to hide the button when there are no tracks to toggle.
+
+## Styling
+
+Style the button based on active state:
+
+```css
+media-captions-button[data-active] .icon-on { display: inline; }
+media-captions-button:not([data-active]) .icon-off { display: inline; }
+```
+
+Hide when no caption tracks are available:
+
+```css
+media-captions-button[data-availability="unavailable"] {
+  display: none;
+}
+```
+
+## Accessibility
+
+Renders a `<button>` with an automatic `aria-label`: "Disable captions" when active, "Enable captions" when inactive. Override with the `label` prop. Keyboard activation: <kbd>Enter</kbd> / <kbd>Space</kbd>.
+
+## Examples
+
+### Basic Usage
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<ComponentReference component="CaptionsButton" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -35,6 +35,7 @@ export const sidebar: Sidebar = [
     contents: [
       // sorted alphabetically
       { slug: 'reference/buffering-indicator' },
+      { slug: 'reference/captions-button' },
       { slug: 'reference/controls' },
       { slug: 'reference/fullscreen-button' },
       { slug: 'reference/mute-button' },


### PR DESCRIPTION
This pull request introduces a new `CaptionsButton` component for toggling captions and subtitles in video players, along with comprehensive documentation and demo examples for both React and HTML usage. The changes include the component export, demo files, styling, accessibility guidance, and an entry in the documentation sidebar.

**CaptionsButton component integration and documentation:**

* Added `CaptionsButton` and its props to the React package exports in `index.ts`, making it available for use in React projects.
* Created a new documentation page `captions-button.mdx` detailing usage, behavior, accessibility, styling, and examples for both React and HTML frameworks.
* Added the `captions-button` reference to the documentation sidebar configuration for discoverability.

**Demo implementations and assets:**

* Provided React and HTML demo implementations, including example code, CSS styling, and a sample captions VTT file to showcase basic usage of the `CaptionsButton`. [[1]](diffhunk://#diff-e5238a3ce56d7fd2490bc9cf0447ae17cbdb408dd8e6cddf865297f352c0468eR1-R30) [[2]](diffhunk://#diff-7019fea9eb40f877971c7cd8ce3e4ceeb124629990d36aa16b1cdace124e949fR1-R21) [[3]](diffhunk://#diff-3335931869cb0a5cfa6f1c91a8e703cc97c9766a48de4bde144804db736769cdR1-R17) [[4]](diffhunk://#diff-05402a465cfe235022bd92d1091fd357aef7ff0c72a517570310a4c9e639322dR1-R34) [[5]](diffhunk://#diff-5c4a9436fc0b680e1431c7353f181da67dd476b089de7bfcc02223b25b4e0476R1-R10) [[6]](diffhunk://#diff-bf193bb93834f29b2e5473b9643e3fb00feffe917b02658b498c2f9383448453R1-R2) [[7]](diffhunk://#diff-7c2c5639cf431463e507ca218266ad9c8892889b496a25cbbbcafd9652644743R1-R10)

These changes collectively enable developers to easily add, style, and understand the `CaptionsButton` functionality, improving accessibility and user experience in video applications.