### PR TITLE
feat(sandbox): dark mode support and template entry files

### DIFF
--- a/packages/sandbox/.gitignore
+++ b/packages/sandbox/.gitignore
@@ -1,3 +1,1 @@
 src/*
-!src/index.html
-!src/main.tsx

--- a/packages/sandbox/templates/index.html
+++ b/packages/sandbox/templates/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="font-sans text-zinc-950 antialiased h-screen overflow-hidden">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/sandbox/templates/main.tsx
+++ b/packages/sandbox/templates/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client';
+import { App } from './shell/app';
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/sandbox/templates/shell/navbar.tsx
+++ b/packages/sandbox/templates/shell/navbar.tsx
@@ -53,10 +53,12 @@ export function Navbar({
   sources,
 }: NavbarProps) {
   return (
-    <header className="shrink-0 border-b border-zinc-200 bg-white flex items-center px-4 h-14 gap-6">
-      <span className="text-sm font-semibold tracking-tight whitespace-nowrap text-zinc-950">Video.js v10</span>
+    <header className="shrink-0 border-b border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 flex items-center px-4 h-14 gap-6">
+      <span className="text-sm font-semibold tracking-tight whitespace-nowrap text-zinc-950 dark:text-zinc-50">
+        Video.js v10
+      </span>
 
-      <div className="h-5 w-px bg-zinc-200" />
+      <div className="h-5 w-px bg-zinc-200 dark:bg-zinc-800" />
 
       <div className="flex items-center gap-4">
         <Select
@@ -106,7 +108,7 @@ export function Navbar({
           href="https://github.com/videojs/v10"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center size-8 rounded-md text-zinc-500 hover:text-zinc-950 hover:bg-zinc-100 transition-colors"
+          className="inline-flex items-center justify-center size-8 rounded-md text-zinc-500 dark:text-zinc-400 hover:text-zinc-950 dark:hover:text-zinc-50 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
         >
           <span className="sr-only">GitHub repository</span>
           <svg
@@ -145,13 +147,13 @@ type SelectProps = {
 function Select({ label, value, onChange, options, disabled }: SelectProps) {
   return (
     <div className="flex items-center gap-2">
-      <span className="text-[13px] font-medium text-zinc-500">{label}</span>
+      <span className="text-[13px] font-medium text-zinc-500 dark:text-zinc-400">{label}</span>
       <div className="relative">
         <select
           value={value}
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
-          className="h-8 appearance-none rounded-md border-none bg-clip-border ring ring-zinc-800/10 bg-white pl-3 pr-8 text-[13px] font-medium text-zinc-950 shadow-xs shadow-black/20 transition-colors hover:bg-zinc-50 focus:outline-2 focus:outline-zinc-950 focus:outline-offset-2 disabled:pointer-events-none disabled:opacity-50"
+          className="h-8 appearance-none rounded-md border-none bg-clip-border ring ring-zinc-800/10 dark:ring-white/10 bg-white dark:bg-zinc-900 pl-3 pr-8 text-[13px] font-medium text-zinc-950 dark:text-zinc-50 shadow-xs shadow-black/20 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900 focus:outline-2 focus:outline-zinc-950 dark:focus:outline-zinc-50 focus:outline-offset-2 disabled:pointer-events-none disabled:opacity-50"
         >
           {options.map((opt) => (
             <option key={opt.value} value={opt.value} disabled={opt.disabled}>
@@ -160,7 +162,7 @@ function Select({ label, value, onChange, options, disabled }: SelectProps) {
           ))}
         </select>
         <svg
-          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 size-3.5 text-zinc-500"
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 size-3.5 text-zinc-500 dark:text-zinc-400"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"

--- a/packages/sandbox/templates/shell/preview.tsx
+++ b/packages/sandbox/templates/shell/preview.tsx
@@ -12,12 +12,12 @@ export const Preview = forwardRef<HTMLIFrameElement, PreviewProps>(function Prev
   const openUrl = `${pagePath}?skin=${encodeURIComponent(skin)}&source=${encodeURIComponent(source)}`;
 
   return (
-    <main className="flex-1 min-h-0 relative bg-zinc-50">
+    <main className="flex-1 min-h-0 relative bg-zinc-50 dark:bg-zinc-900">
       <a
         href={openUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="absolute top-3 right-3 z-10 inline-flex items-center gap-1 h-7 rounded-md bg-clip-border ring ring-zinc-800/10 bg-white px-2.5 text-xs font-medium text-zinc-600 shadow-xs shadow-black/20 transition-colors hover:bg-zinc-50 hover:text-zinc-950"
+        className="absolute top-3 right-3 z-10 inline-flex items-center gap-1 h-7 rounded-md bg-clip-border ring ring-zinc-800/10 dark:ring-white/10 bg-white dark:bg-zinc-800 px-2.5 text-xs font-medium text-zinc-600 dark:text-zinc-300 shadow-xs shadow-black/20 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800 hover:text-zinc-950 dark:hover:text-zinc-50"
         title="Open in new tab"
       >
         Open

--- a/packages/sandbox/templates/vite-env.d.ts
+++ b/packages/sandbox/templates/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- Add dark mode variants (`dark:` classes) to the sandbox shell UI — navbar, preview panel, and select controls
- Move `index.html` and `main.tsx` into `templates/` so they're included when generating sandboxes
- Remove unused `vite-env.d.ts` from templates
- Simplify `.gitignore` now that entry files live in templates

## Test plan
- [x] Run `pnpm dev` and verify sandbox loads correctly
- [x] Toggle system dark mode and verify shell UI adapts (navbar, dropdowns, preview background, open button)
- [x] Create a new sandbox and verify it includes `index.html` and `main.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)