### PR TITLE
feat(site): add cookieless Google Analytics

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -45,6 +45,20 @@ const fullTitle =
     />
     <meta name="generator" content={Astro.generator} />
 
+    {/* Google Analytics (cookieless) */}
+    <script
+      is:inline
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-WTF4CZJSGP"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-WTF4CZJSGP", { client_storage: "none" });
+    </script>
+
     {/* Important stuff */}
     <slot name="priority-head" />
 


### PR DESCRIPTION
## Summary
- Adds Google Analytics (gtag.js) to the site's `<head>` in `Base.astro`
- Uses cookieless mode (`client_storage: 'none'`) — no cookies are set on visitors
- Measurement ID: `G-WTF4CZJSGP`

Closes #732

## Test plan
- [x] `pnpm build:site` passes
- [x] gtag snippet appears in built HTML output
- [ ] Verify GA receives pageview events in the GA4 dashboard after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)