### PR TITLE
fix(site): handle remote image URLs in Img component

### DIFF
--- a/site/src/components/typography/Img.astro
+++ b/site/src/components/typography/Img.astro
@@ -5,8 +5,16 @@ import type { ComponentProps } from 'astro/types';
 import { twMerge } from '@/utils/twMerge';
 
 type Props = ComponentProps<typeof Image>;
-const { class: className, ...rest } = Astro.props;
+const { class: className, src, ...rest } = Astro.props;
+
+const isRemote = typeof src === 'string' && src.startsWith('http');
 ---
 
-{/* @ts-expect-error tbh I don't know how to tell ts that inferSize is ok */}
-<Image class={twMerge("my-8", className)} inferSize {...rest} />
+{
+  isRemote ? (
+    <img class={twMerge("my-8", className)} src={src} {...rest} />
+  ) : (
+    // @ts-expect-error tbh I don't know how to tell ts that inferSize is ok
+    <Image class={twMerge("my-8", className)} inferSize src={src} {...rest} />
+  )
+}


### PR DESCRIPTION
## Summary

Astro's `<Image>` component doesn't support remote URLs with `inferSize`. This causes build failures when MDX content includes images hosted externally (e.g., `https://...`). The fix detects remote URLs and falls back to a plain `<img>` tag.

## Changes

- Detect remote image sources by checking for `http` prefix
- Use a native `<img>` element for remote URLs, preserving class merging and props
- Keep Astro's `<Image>` with `inferSize` for local/imported images

## Testing

`pnpm build:site` — verify that pages with remote images build without errors.