### PR TITLE
fix(site): use Consent Mode v2 for cookieless Google Analytics

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -55,8 +55,14 @@ const fullTitle =
       function gtag() {
         dataLayer.push(arguments);
       }
+      gtag("consent", "default", {
+        analytics_storage: "denied",
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+      });
       gtag("js", new Date());
-      gtag("config", "G-WTF4CZJSGP", { client_storage: "none" });
+      gtag("config", "G-WTF4CZJSGP");
     </script>
 
     {/* Important stuff */}


### PR DESCRIPTION
## Summary

- Replace invalid `client_storage: "none"` GA4 config with Google Consent Mode v2
- Set `analytics_storage`, `ad_storage`, `ad_user_data`, and `ad_personalization` to `"denied"` — the officially supported way to run GA4 without cookies
- Consent command is issued **before** `gtag("config", ...)` so GA4 respects it from the first hit

## Why

`client_storage: "none"` is **not a valid GA4 gtag.js parameter** ([config reference](https://developers.google.com/analytics/devguides/collection/ga4/reference/config)). GA4 silently ignores unknown keys and sets cookies normally (`_ga`, `_gid`, etc.). Our [privacy policy](/privacy/) claims "We have configured Google Analytics to collect this information without the use of cookies" — so the site was out of compliance.

## How to verify

1. Deploy or run `pnpm dev`
2. Open DevTools → Application → Cookies — no `_ga`/`_gid` cookies should be set
3. DevTools → Network → filter `collect` — GA4 requests should include `gcs=G100` (all consent denied)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [ ] Manual verification: no analytics cookies set in browser


🤖 Generated with [Claude Code](https://claude.com/claude-code)