### PR TITLE
fix(site): allow exact tumblr image URL

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -98,7 +98,14 @@ export default defineConfig({
   },
 
   image: {
-    domains: ['image.mux.com', '66.media.tumblr.com'],
+    domains: ['image.mux.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '66.media.tumblr.com',
+        pathname: '/tumblr_mdgad5rr0S1qzc111.png',
+      },
+    ],
   },
 
   vite: {


### PR DESCRIPTION
Allows the specific Tumblr image used by the Brightcove/Zencoder post via Astro image remotePatterns (exact host + path), instead of broad host allowlisting.