### PR TITLE
fix(slider): keep pointer position after pointerleave

### DIFF
--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -112,10 +112,10 @@ export function createSlider(options: SliderOptions): SliderApi {
 
   function endDrag(): void {
     if (!isDragging) {
-      input.patch({ pointing: false, pointerPercent: 0 });
+      input.patch({ pointing: false });
     } else {
       isDragging = false;
-      input.patch({ dragging: false, pointing: false, pointerPercent: 0 });
+      input.patch({ dragging: false, pointing: false });
       options.onDragEnd?.();
     }
 
@@ -211,7 +211,7 @@ export function createSlider(options: SliderOptions): SliderApi {
 
     onPointerLeave() {
       if (!isNull(capturedPointerId)) return;
-      input.patch({ pointing: false, pointerPercent: 0 });
+      input.patch({ pointing: false });
     },
 
     onLostPointerCapture() {

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -348,7 +348,7 @@ describe('createSlider', () => {
       flush();
 
       expect(slider.input.current.pointing).toBe(false);
-      expect(slider.input.current.pointerPercent).toBe(0);
+      expect(slider.input.current.pointerPercent).toBe(25);
 
       slider.destroy();
     });
@@ -413,7 +413,7 @@ describe('createSlider', () => {
       slider.destroy();
     });
 
-    it('resets on pointerleave', () => {
+    it('clears pointing on pointerleave and keeps last pointerPercent', () => {
       const el = createMockElement({ left: 0, width: 200 });
       const slider = createSlider(createOptions({ getElement: () => el }));
 
@@ -422,7 +422,7 @@ describe('createSlider', () => {
       flush();
 
       expect(slider.input.current.pointing).toBe(false);
-      expect(slider.input.current.pointerPercent).toBe(0);
+      expect(slider.input.current.pointerPercent).toBe(30);
 
       slider.destroy();
     });


### PR DESCRIPTION
## Summary
- stop resetting `pointerPercent` to `0` on `pointerleave` and drag-end cleanup
- keep the last pointer position so tooltip/preview fade-outs do not jump to slider start
- update slider DOM tests to assert preserved pointer position after leave/lost capture

## Testing
- not run (worktree is missing dependencies: `vitest` / `node_modules` not installed)
