### PR TITLE
feat(site): ejected skins build script, docs page, and home page wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ __tests__/coverage/
 site/src/content/generated-api-reference/
 site/src/content/generated-component-reference/
 site/src/content/generated-util-reference/
+site/src/content/ejected-skins.json
 
 # -------------------------
 # Environment

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "size": "node .github/scripts/bundle-size.js | node .github/scripts/bundle-size-report.js",
     "test": "turbo run test",
     "format:astro": "prettier --write 'site/src/**/*.astro'",
-    "typecheck": "tsc --build",
-    "build:ejected-skins": "node --import tsx build/scripts/build-ejected-skins.ts"
+    "typecheck": "tsc --build"
   },
   "devDependencies": {
     "@actions/core": "^3.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.1",
   "scripts": {
     "api-docs": "tsx scripts/api-docs-builder/src/index.ts",
-    "predev": "pnpm api-docs",
+    "ejected-skins": "tsx scripts/build-ejected-skins.ts",
+    "predev": "pnpm api-docs && pnpm ejected-skins",
     "dev": "NETLIFY_DEV=1 astro dev",
-    "prebuild": "pnpm api-docs",
+    "prebuild": "pnpm api-docs && pnpm ejected-skins",
     "build": "astro build",
     "astro": "astro",
     "test": "vitest run",

--- a/site/scripts/build-ejected-skins.ts
+++ b/site/scripts/build-ejected-skins.ts
@@ -14,10 +14,17 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import ts from 'typescript';
-import { resolveImports } from '../plugins/resolve-css-imports.mjs';
+import { resolveImports } from '../../build/plugins/resolve-css-imports.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../..');
+
+const PREFIX = '\x1b[35m[ejected-skins]\x1b[0m';
+const log = {
+  info: (...args: unknown[]) => console.log(PREFIX, ...args),
+  warn: (...args: unknown[]) => console.warn(PREFIX, '\x1b[33mwarn:\x1b[0m', ...args),
+  error: (...args: unknown[]) => console.error(PREFIX, '\x1b[31merror:\x1b[0m', ...args),
+};
 
 /** Resolve a `@videojs/*` package specifier to its built dist file URL. */
 function pkgDistUrl(specifier: string): string {
@@ -538,7 +545,7 @@ async function inlineReactIcons(source: string): Promise<string> {
     const iconName = componentToIconName(componentName);
     const rawSvg = iconsMap[iconName];
     if (!rawSvg) {
-      console.warn(`    Warning: no SVG found for ${componentName} (icon: ${iconName})`);
+      log.warn(`No SVG found for ${componentName} (icon: ${iconName})`);
       continue;
     }
     const jsxSvg = svgToJsx(rawSvg);
@@ -749,12 +756,12 @@ async function processReactSkin(skin: ReactSkinDef): Promise<{ tsx: string; jsx:
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log('Building ejected skins...\n');
+  log.info('Building ejected skins...\n');
 
   const entries: EjectedSkinEntry[] = [];
 
   for (const skin of SKINS) {
-    console.log(`  Processing: ${skin.id}`);
+    log.info(`Processing: ${skin.id}`);
 
     const entry: EjectedSkinEntry = {
       id: skin.id,
@@ -782,10 +789,10 @@ async function main(): Promise<void> {
   mkdirSync(dirname(OUTPUT), { recursive: true });
   writeFileSync(OUTPUT, `${JSON.stringify(entries, null, 2)}\n`);
 
-  console.log(`\nWrote ${entries.length} entries to ${OUTPUT}`);
+  log.info(`✅ Wrote ${entries.length} entries to ${OUTPUT}`);
 }
 
 main().catch((err) => {
-  console.error(err);
+  log.error(err);
   process.exit(1);
 });

--- a/site/src/components/docs/EjectedSkin.astro
+++ b/site/src/components/docs/EjectedSkin.astro
@@ -1,0 +1,60 @@
+---
+import { getEntry } from 'astro:content';
+import ServerCode from '@/components/Code/ServerCode.astro';
+import { Tab, TabsList, TabsPanel, TabsRoot } from '@/components/Tabs.tsx';
+
+interface Props {
+  id: string;
+}
+
+const { id } = Astro.props;
+const entry = await getEntry('ejectedSkins', id);
+if (!entry) return;
+const skin = entry.data;
+---
+
+{
+  skin.platform === "react" ? (
+    <TabsRoot client:visible>
+      <TabsList client:visible label={`${skin.name} implementation`}>
+        <Tab client:visible value="tsx" initial>
+          Skin.tsx
+        </Tab>
+        {skin.css && (
+          <Tab client:visible value="css">
+            skin.css
+          </Tab>
+        )}
+      </TabsList>
+      <TabsPanel client:visible value="tsx" initial>
+        <ServerCode code={skin.tsx!} lang="tsx" />
+      </TabsPanel>
+      {skin.css && (
+        <TabsPanel client:visible value="css">
+          <ServerCode code={skin.css} lang="css" />
+        </TabsPanel>
+      )}
+    </TabsRoot>
+  ) : (
+    <TabsRoot client:visible>
+      <TabsList client:visible label={`${skin.name} implementation`}>
+        <Tab client:visible value="html" initial>
+          HTML
+        </Tab>
+        {skin.css && (
+          <Tab client:visible value="css">
+            CSS
+          </Tab>
+        )}
+      </TabsList>
+      <TabsPanel client:visible value="html" initial>
+        <ServerCode code={skin.html!} lang="html" />
+      </TabsPanel>
+      {skin.css && (
+        <TabsPanel client:visible value="css">
+          <ServerCode code={skin.css} lang="css" />
+        </TabsPanel>
+      )}
+    </TabsRoot>
+  )
+}

--- a/site/src/components/home/Demo/Base.tsx
+++ b/site/src/components/home/Demo/Base.tsx
@@ -5,8 +5,8 @@ import { framework, skin } from '@/stores/homePageDemos';
 import ClientCode from '../../Code/ClientCode';
 
 function generateHTMLCode(skin: Skin): string {
-  const skinTag = skin === 'frosted' ? 'video-skin' : 'video-minimal-skin';
-  const skinFile = skin === 'frosted' ? 'skin' : 'minimal-skin';
+  const skinTag = skin === 'default' ? 'video-skin' : 'video-minimal-skin';
+  const skinFile = skin === 'default' ? 'skin' : 'minimal-skin';
 
   return `<script type="module">
   import 'https://cdn.jsdelivr.net/npm/videojs/html/video/player.js';
@@ -22,8 +22,8 @@ function generateHTMLCode(skin: Skin): string {
 }
 
 function generateReactCode(skin: Skin): string {
-  const skinComponent = skin === 'frosted' ? 'VideoSkin' : 'MinimalVideoSkin';
-  const skinCss = skin === 'frosted' ? 'skin' : 'minimal-skin';
+  const skinComponent = skin === 'default' ? 'VideoSkin' : 'MinimalVideoSkin';
+  const skinCss = skin === 'default' ? 'skin' : 'minimal-skin';
 
   return `import { createPlayer, Poster } from '@videojs/react';
 import { ${skinComponent}, Video, videoFeatures } from '@videojs/react/video';

--- a/site/src/components/home/Demo/Demo.tsx
+++ b/site/src/components/home/Demo/Demo.tsx
@@ -2,6 +2,17 @@ import FrameworkControl from '../FrameworkControl';
 import BaseDemo from './Base';
 import EjectDemo from './Eject';
 
+interface DemoProps {
+  defaultHtmlCode: React.ReactNode;
+  defaultHtmlCss: React.ReactNode;
+  defaultReactCode: React.ReactNode;
+  defaultReactCss: React.ReactNode;
+  minimalHtmlCode: React.ReactNode;
+  minimalHtmlCss: React.ReactNode;
+  minimalReactCode: React.ReactNode;
+  minimalReactCss: React.ReactNode;
+}
+
 /**
  * Both BaseDemo and EjectDemo use ClientCode which has a top-level await (Shiki highlighter).
  * If they're in separate Astro islands, Safari may throw a hydration error.
@@ -9,7 +20,7 @@ import EjectDemo from './Eject';
  *
  * Keep them in a single island to work around this.
  */
-export default function Demo() {
+export default function Demo(props: DemoProps) {
   return (
     <section className="grid gap-y-20 lg:gap-y-0 gap-x-5 lg:grid-cols-2 mb-10 lg:mb-0 w-full max-w-305 mx-auto px-5">
       <section className="grid lg:grid-rows-subgrid row-span-4 lg:border-t lg:py-10 border-faded-black dark:border-manila-light">
@@ -31,7 +42,17 @@ export default function Demo() {
           Make your player truly your own with fully-editable components
         </p>
         <FrameworkControl className="mb-5 md:hidden" />
-        <EjectDemo className="lg:h-100 m-0" />
+        <EjectDemo
+          className="lg:h-100 m-0"
+          defaultHtmlCode={props.defaultHtmlCode}
+          defaultHtmlCss={props.defaultHtmlCss}
+          defaultReactCode={props.defaultReactCode}
+          defaultReactCss={props.defaultReactCss}
+          minimalHtmlCode={props.minimalHtmlCode}
+          minimalHtmlCss={props.minimalHtmlCss}
+          minimalReactCode={props.minimalReactCode}
+          minimalReactCss={props.minimalReactCss}
+        />
       </section>
     </section>
   );

--- a/site/src/components/home/Demo/Eject.tsx
+++ b/site/src/components/home/Demo/Eject.tsx
@@ -1,76 +1,58 @@
 import { useStore } from '@nanostores/react';
 import { Tab, TabsList, TabsPanel, TabsRoot } from '@/components/Tabs';
-import type { Skin } from '@/stores/homePageDemos';
 import { framework, skin } from '@/stores/homePageDemos';
-import ClientCode from '../../Code/ClientCode';
 
-function generateReactCode(skin: Skin): string {
-  return `react`;
+interface EjectDemoProps {
+  className?: string;
+  defaultHtmlCode: React.ReactNode;
+  defaultHtmlCss: React.ReactNode;
+  defaultReactCode: React.ReactNode;
+  defaultReactCss: React.ReactNode;
+  minimalHtmlCode: React.ReactNode;
+  minimalHtmlCss: React.ReactNode;
+  minimalReactCode: React.ReactNode;
+  minimalReactCss: React.ReactNode;
 }
 
-function generateReactCSS(skin: Skin): string {
-  return `css`;
-}
-
-function generateHTMLCode(skin: Skin): string {
-  return `html`;
-}
-
-function generateCSS(skin: Skin): string {
-  return `css`;
-}
-
-function generateJS(skin: Skin): string {
-  return `js`;
-}
-
-export default function EjectDemo({ className }: { className?: string }) {
+export default function EjectDemo(props: EjectDemoProps) {
   const $framework = useStore(framework);
   const $skin = useStore(skin);
 
-  if ($framework === 'html') {
-    return (
-      <TabsRoot variant="expanded" key={$framework} className={className} maxWidth={false}>
-        <TabsList variant="expanded" label="HTML implementation">
-          <Tab variant="expanded" value="html" initial>
-            HTML
-          </Tab>
-          <Tab variant="expanded" value="css">
-            CSS
-          </Tab>
-          <Tab variant="expanded" value="javascript">
-            <span className="sm:hidden">JS</span>
-            <span className="hidden sm:inline">JavaScript</span>
-          </Tab>
-        </TabsList>
-        <TabsPanel variant="expanded" value="html" initial className="bg-faded-black dark:bg-soot m-2.5 mt-0">
-          <ClientCode code={generateHTMLCode($skin)} lang="html" />
-        </TabsPanel>
-        <TabsPanel variant="expanded" value="css" className="bg-faded-black dark:bg-soot m-2.5 mt-0">
-          <ClientCode code={generateCSS($skin)} lang="css" />
-        </TabsPanel>
-        <TabsPanel variant="expanded" value="javascript" className="bg-faded-black dark:bg-soot m-2.5 mt-0">
-          <ClientCode code={generateJS($skin)} lang="javascript" />
-        </TabsPanel>
-      </TabsRoot>
-    );
-  }
+  const isHtml = $framework === 'html';
+  const isDefault = $skin === 'default';
+
+  const codeSlot = isHtml
+    ? isDefault
+      ? props.defaultHtmlCode
+      : props.minimalHtmlCode
+    : isDefault
+      ? props.defaultReactCode
+      : props.minimalReactCode;
+  const cssSlot = isHtml
+    ? isDefault
+      ? props.defaultHtmlCss
+      : props.minimalHtmlCss
+    : isDefault
+      ? props.defaultReactCss
+      : props.minimalReactCss;
+
+  const codeLabel = isHtml ? 'HTML' : 'React';
 
   return (
-    <TabsRoot variant="expanded" key={$framework} className={className} maxWidth={false}>
-      <TabsList variant="expanded" label="React implementation">
-        <Tab variant="expanded" value="react" initial>
-          React
+    <TabsRoot variant="expanded" key={`${$framework}-${$skin}`} className={props.className} maxWidth={false}>
+      <TabsList variant="expanded" label={`${codeLabel} implementation`}>
+        <Tab variant="expanded" value="code" initial>
+          {codeLabel}
         </Tab>
         <Tab variant="expanded" value="css">
           CSS
         </Tab>
       </TabsList>
-      <TabsPanel variant="expanded" value="react" initial className="bg-faded-black dark:bg-soot m-2.5 mt-0">
-        <ClientCode code={generateReactCode($skin)} lang="tsx" />
+      <TabsPanel variant="expanded" value="code" initial className="bg-faded-black dark:bg-soot m-2.5 mt-0">
+        {codeSlot}
       </TabsPanel>
       <TabsPanel variant="expanded" value="css" className="bg-faded-black dark:bg-soot m-2.5 mt-0">
-        <ClientCode code={generateReactCSS($skin)} lang="css" />
+        {cssSlot}
       </TabsPanel>
     </TabsRoot>
   );

--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -19,7 +19,7 @@ export default function HeroVideo({
   poster: string;
 }) {
   const $skin = useStore(skin);
-  const SkinComponent = $skin === 'frosted' ? VideoSkin : MinimalVideoSkin;
+  const SkinComponent = $skin === 'default' ? VideoSkin : MinimalVideoSkin;
 
   return (
     <Player.Provider>

--- a/site/src/components/home/SkinControl.tsx
+++ b/site/src/components/home/SkinControl.tsx
@@ -13,7 +13,7 @@ export default function SkinControl({ className }: { className?: string }) {
         if (values.length > 0) skin.set(values[0]);
       }}
       options={[
-        { value: 'frosted', label: 'Frosted' },
+        { value: 'default', label: 'Default' },
         { value: 'minimal', label: 'Minimal' },
       ]}
       aria-label="Select skin"

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -124,4 +124,18 @@ const utilReference = defineCollection({
   schema: UtilReferenceSchema,
 });
 
-export const collections = { blog, docs, authors, componentReference, utilReference };
+const ejectedSkins = defineCollection({
+  loader: file('./src/content/ejected-skins.json'),
+  schema: z.object({
+    id: z.string(),
+    name: z.string(),
+    platform: z.enum(['html', 'react']),
+    style: z.enum(['css', 'tailwind']),
+    html: z.string().optional(),
+    tsx: z.string().optional(),
+    jsx: z.string().optional(),
+    css: z.string().optional(),
+  }),
+});
+
+export const collections = { blog, docs, authors, componentReference, utilReference, ejectedSkins };

--- a/site/src/content/docs/how-to/_customize-skins.mdx
+++ b/site/src/content/docs/how-to/_customize-skins.mdx
@@ -1,8 +1,0 @@
----
-title: Customize skins
-description: Learn how to customize Video.js skins
----
-
-Video.js v10 comes with pre-built skins like Frosted and Minimal, but you can fully customize them by "ejecting" the code and making it your own.
-
-🚧 Under construction 🚧

--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -1,0 +1,53 @@
+---
+title: Customize Skins
+description: Learn how to customize Video.js v10 skins by copying and modifying them
+---
+
+import FrameworkCase from '@/components/docs/FrameworkCase.astro';
+import EjectedSkin from '@/components/docs/EjectedSkin.astro';
+
+Video.js v10 comes with pre-built skins like Default and Minimal. If you'd like to customize them you can fully customize them by "ejecting" the code and making it your own.
+
+While eventually we’ll have a CLI that will eject skins in your preferred framework and style, for now we invite you to try it out with these copy-paste-ready implementations.
+
+{/* TODO: Add StyleCase for tailwind variants once tailwind is a supported style (see #840) */}
+
+## Default Video Skin
+
+<FrameworkCase frameworks={["react"]}>
+  <EjectedSkin id="default-video-react" />
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <EjectedSkin id="default-video" />
+</FrameworkCase>
+
+## Default Audio Skin
+
+<FrameworkCase frameworks={["react"]}>
+  <EjectedSkin id="default-audio-react" />
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <EjectedSkin id="default-audio" />
+</FrameworkCase>
+
+## Minimal Video Skin
+
+<FrameworkCase frameworks={["react"]}>
+  <EjectedSkin id="minimal-video-react" />
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <EjectedSkin id="minimal-video" />
+</FrameworkCase>
+
+## Minimal Audio Skin
+
+<FrameworkCase frameworks={["react"]}>
+  <EjectedSkin id="minimal-audio-react" />
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <EjectedSkin id="minimal-audio" />
+</FrameworkCase>

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -26,10 +26,10 @@ export const sidebar: Sidebar = [
   //     { slug: 'concepts/ui-components' }
   //   ],
   // },
-  // {
-  //   sidebarLabel: 'How to',
-  //   contents: [{ slug: 'how-to/customize-skins' }],
-  // },
+  {
+    sidebarLabel: 'How to',
+    contents: [{ slug: 'how-to/customize-skins' }],
+  },
   {
     sidebarLabel: 'Components',
     contents: [

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,5 +1,7 @@
 ---
 
+import { getEntry } from 'astro:content';
+import ServerCode from '@/components/Code/ServerCode.astro';
 import Footer from '@/components/Footer.astro';
 import FooterEasterEgg from '@/components/FooterEasterEgg.astro';
 import Built from '@/components/home/Built/BuiltSection.astro';
@@ -11,13 +13,51 @@ import Sponsors from '@/components/home/Sponsors.astro';
 import NavBar from '@/components/NavBar/NavBar.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '@/consts';
 import Base from '@/layouts/Base.astro';
+
+const defaultVideo = (await getEntry('ejectedSkins', 'default-video'))!.data;
+const defaultVideoReact = (await getEntry('ejectedSkins', 'default-video-react'))!.data;
+const minimalVideo = (await getEntry('ejectedSkins', 'minimal-video'))!.data;
+const minimalVideoReact = (await getEntry('ejectedSkins', 'minimal-video-react'))!.data;
 ---
 
 <Base title={SITE_TITLE} description={SITE_DESCRIPTION}>
   <NavBar />
   <Header />
   <main>
-    <Demo client:idle />
+    <Demo client:idle>
+      <ServerCode
+        slot="defaultHtmlCode"
+        code={defaultVideo.html!}
+        lang="html"
+      />
+      <ServerCode slot="defaultHtmlCss" code={defaultVideo.css!} lang="css" />
+      <ServerCode
+        slot="defaultReactCode"
+        code={defaultVideoReact.tsx!}
+        lang="tsx"
+      />
+      <ServerCode
+        slot="defaultReactCss"
+        code={defaultVideoReact.css!}
+        lang="css"
+      />
+      <ServerCode
+        slot="minimalHtmlCode"
+        code={minimalVideo.html!}
+        lang="html"
+      />
+      <ServerCode slot="minimalHtmlCss" code={minimalVideo.css!} lang="css" />
+      <ServerCode
+        slot="minimalReactCode"
+        code={minimalVideoReact.tsx!}
+        lang="tsx"
+      />
+      <ServerCode
+        slot="minimalReactCss"
+        code={minimalVideoReact.css!}
+        lang="css"
+      />
+    </Demo>
     <GetStartedBanner />
     <Built />
     <RoadMap />

--- a/site/src/stores/homePageDemos.ts
+++ b/site/src/stores/homePageDemos.ts
@@ -1,7 +1,7 @@
 import { atom } from 'nanostores';
 
 export type Framework = 'html' | 'react';
-export type Skin = 'frosted' | 'minimal';
+export type Skin = 'default' | 'minimal';
 
 export const framework = atom<Framework>('react');
-export const skin = atom<Skin>('frosted');
+export const skin = atom<Skin>('default');


### PR DESCRIPTION
## Summary
- Add `site/scripts/build-ejected-skins.ts` that produces copy-paste skin snippets (Shadcn-style eject) for all 4 skins across HTML and React, in both CSS and Tailwind variants (16 entries total)
- Output written to `site/src/content/ejected-skins.json` (gitignored); run with `pnpm -F site ejected-skins` (requires `pnpm build:packages` first)
- Wire real ejected skin data to home page "Take full control" (Eject) demo using ServerCode + Astro named slots for build-time syntax highlighting — no client-side Shiki needed
- Rename `'frosted'` skin to `'default'` across home page components
- Add `EjectedSkin.astro` component and `customize-skins.mdx` docs page
- All private package dependencies resolved at build time: icons inlined as SVG, Tailwind tokens serialized as consts, `cn()` replaced with `[].filter(Boolean).join(' ')`, internal path aliases rewritten to `@videojs/react`

Closes #701

## Test plan
- [ ] `pnpm build:packages && pnpm -F site ejected-skins` succeeds
- [ ] `site/src/content/ejected-skins.json` contains 16 entries
- [ ] HTML entries contain inline SVGs (`<svg`)
- [ ] React entries have both `tsx` and `jsx` fields with inline SVGs
- [ ] CSS variant entries have `css` field with no remaining `@import` statements
- [ ] Tailwind variant entries have no `css` field
- [ ] No imports from private packages (`@videojs/icons`, `@videojs/skins`, `@videojs/utils`) in React output
- [ ] Home page Eject demo shows syntax-highlighted code before hydration (ServerCode)
- [ ] Toggling framework (HTML/React) and skin (Default/Minimal) updates Eject code
- [ ] Hero video skin toggle still works (Default/Minimal)
- [ ] Eject HTML shows 2 tabs (HTML, CSS); React shows 2 tabs (React, CSS)
- [ ] Customize skins docs page renders with ejected skin code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)