### PR TITLE
docs: remove spread from videoFeatures examples

### DIFF
--- a/site/src/components/home/Demo/Base.tsx
+++ b/site/src/components/home/Demo/Base.tsx
@@ -29,7 +29,7 @@ function generateReactCode(skin: Skin): string {
 import { ${skinComponent}, Video, videoFeatures } from '@videojs/react/video';
 import '@videojs/react/video/${skinCss}.css';
 
-const Player = createPlayer({ features: [...videoFeatures] });
+const Player = createPlayer({ features: videoFeatures });
 
 export function VideoPlayer() {
   return (

--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -6,7 +6,7 @@ import { skin } from '@/stores/homePageDemos';
 import '@videojs/react/video/skin.css';
 import '@videojs/react/video/minimal-skin.css';
 
-const Player = createPlayer({ features: [...videoFeatures] });
+const Player = createPlayer({ features: videoFeatures });
 
 export default function HeroVideo({
   className,


### PR DESCRIPTION
## Summary
- replace standalone `features: [...videoFeatures]` with `features: videoFeatures` in home demo usage and generated React snippet

## Testing
- not run (docs/example-only change)
