### PR TITLE
docs: add mux.com links in install/docs

### DIFF
--- a/site/src/components/installation/RendererPicker.tsx
+++ b/site/src/components/installation/RendererPicker.tsx
@@ -9,7 +9,12 @@ export default function RendererPicker() {
         <RendererSelect />
       </div>
       <div className="flex flex-col gap-4">
-        <p className="font-bold">Or upload your media for free to Mux</p>
+        <p className="font-bold">
+          Or upload your media for free to{' '}
+          <a href="https://mux.com" target="_blank" rel="noopener" className="underline intent:no-underline">
+            Mux
+          </a>
+        </p>
         <MuxUploaderPanel />
       </div>
     </div>

--- a/site/src/components/installation/UploaderOverlay.tsx
+++ b/site/src/components/installation/UploaderOverlay.tsx
@@ -42,7 +42,13 @@ export default function UploaderOverlay({ state, error, playbackId, onLogin, onR
   if (state === 'needs_login') {
     return (
       <OverlayWrapper>
-        <p className="text-p3 font-bold">To upload this video to Mux&hellip;</p>
+        <p className="text-p3 font-bold">
+          To upload this video to{' '}
+          <a href="https://mux.com" target="_blank" rel="noopener" className="underline intent:no-underline">
+            Mux
+          </a>
+          &hellip;
+        </p>
         <button
           type="button"
           onClick={onLogin}

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -35,7 +35,7 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
 
 `Thumbnail` can read thumbnail cues directly from your video track. Add a `<track>` with `kind="metadata"` and `label="thumbnails"` to your media element.
 
-Mux provides this as `storyboard.vtt`:
+[Mux](https://mux.com) provides this as `storyboard.vtt`:
 
 `https://image.mux.com/{PLAYBACK_ID}/storyboard.vtt`
 

--- a/site/src/content/docs/reference/write-references.mdx
+++ b/site/src/content/docs/reference/write-references.mdx
@@ -100,6 +100,8 @@ React and HTML demos for the same variant should use matching BEM structures.
 
 All demos use these URLs:
 
+These demo assets are hosted by [Mux](https://mux.com):
+
 ```
 Video: https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4
 Poster: https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/thumbnail.jpg


### PR DESCRIPTION
## Summary
- add https://mux.com links to user-facing Mux mentions in installation/docs copy
- keep existing functional Mux URLs unchanged