### PR TITLE
docs: fix install tab label casing

### DIFF
--- a/site/src/components/installation/HTMLInstallTabs.tsx
+++ b/site/src/components/installation/HTMLInstallTabs.tsx
@@ -37,7 +37,7 @@ export default function HTMLInstallTabs() {
       <TabsRoot>
         <TabsList label="Installation">
           <Tab value="cdn" initial>
-            cdns
+            cdn
           </Tab>
           <Tab value="npm">npm</Tab>
           <Tab value="pnpm">pnpm</Tab>


### PR DESCRIPTION
Change install docs tab label from 'cdns' to 'cdn'.