### PR TITLE
fix(site): correct homepage download comparison

### DIFF
--- a/site/src/components/home/Built/DataViz.astro
+++ b/site/src/components/home/Built/DataViz.astro
@@ -22,7 +22,7 @@ const seconds = [0, 5, 10, 15, 20];
   </p>
   <div
     class="mt-4 mb-2 data-bar w-full md:mt-5 md:mb-2.5"
-    style="--data-bar-duration: 3.96s;"
+    style="--data-bar-width: 100%; --data-bar-duration: 3.96s;"
   >
   </div>
   <div class="flex items-center gap-2.5">
@@ -46,7 +46,7 @@ const seconds = [0, 5, 10, 15, 20];
   </p>
   <div
     class="mt-4 mb-2 data-bar data-bar-orange md:mt-5 md:mb-2.5"
-    style="max-width: 18.75%; --data-bar-duration: 0.75s;"
+    style="--data-bar-width: 18.75%; --data-bar-duration: 0.75s;"
   >
   </div>
 

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -215,10 +215,10 @@
 
 @utility data-bar {
   height: 2.5rem;
+  width: var(--data-bar-width, 100%);
   background-image: url("/data-bar-white.svg");
   background-repeat: repeat-x;
   background-size: auto 100%;
-  transform-origin: left center;
   animation: grow-bar var(--data-bar-duration, 1.5s) ease-out forwards;
   animation-play-state: paused;
 
@@ -320,10 +320,10 @@
 
 @keyframes grow-bar {
   from {
-    transform: scaleX(0);
+    width: 0%;
   }
   to {
-    transform: scaleX(1);
+    width: var(--data-bar-width, 100%);
   }
 }
 


### PR DESCRIPTION
Update homepage chart values to VJS 8: 200kB and VJS 10: 38kB, with matching v10 timing/bar visuals.