### PR TITLE
docs: add 'use client' to React install example

### DIFF
--- a/site/src/components/installation/ReactCreateCodeBlock.tsx
+++ b/site/src/components/installation/ReactCreateCodeBlock.tsx
@@ -109,7 +109,9 @@ function generateReactCode(useCase: UseCase, skin: Skin, renderer: Renderer): st
     ...(mediaImport ? [mediaImport] : []),
   ].join('\n');
 
-  return `${imports}
+  return `'use client';
+
+${imports}
 
 const Player = createPlayer({ features: ${featureType} });
 


### PR DESCRIPTION
Adds a Next.js App Router-safe 'use client' directive to the React installation docs player component snippet.