### PR TITLE
fix(site): use MUX_URL const with UTM params for mux.com links

### DIFF
--- a/site/src/components/installation/RendererPicker.tsx
+++ b/site/src/components/installation/RendererPicker.tsx
@@ -1,3 +1,4 @@
+import { MUX_URL } from '@/consts';
 import MuxUploaderPanel from './MuxUploaderPanel';
 import RendererSelect from './RendererSelect';
 
@@ -11,7 +12,7 @@ export default function RendererPicker() {
       <div className="flex flex-col gap-4">
         <p className="font-bold">
           Or upload your media for free to{' '}
-          <a href="https://mux.com" target="_blank" rel="noopener" className="underline intent:no-underline">
+          <a href={MUX_URL} target="_blank" rel="noopener" className="underline intent:no-underline">
             Mux
           </a>
         </p>

--- a/site/src/components/installation/UploaderOverlay.tsx
+++ b/site/src/components/installation/UploaderOverlay.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { CheckCircle } from 'lucide-react';
+import { MUX_URL } from '@/consts';
 
 export type UploaderState = 'idle' | 'needs_login' | 'uploading' | 'preparing' | 'ready' | 'polling_error';
 
@@ -44,7 +45,7 @@ export default function UploaderOverlay({ state, error, playbackId, onLogin, onR
       <OverlayWrapper>
         <p className="text-p3 font-bold">
           To upload this video to{' '}
-          <a href="https://mux.com" target="_blank" rel="noopener" className="underline intent:no-underline">
+          <a href={MUX_URL} target="_blank" rel="noopener" className="underline intent:no-underline">
             Mux
           </a>
           &hellip;

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -35,7 +35,7 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
 
 `Thumbnail` can read thumbnail cues directly from your video track. Add a `<track>` with `kind="metadata"` and `label="thumbnails"` to your media element.
 
-[Mux](https://mux.com) provides this as `storyboard.vtt`:
+[Mux](https://www.mux.com?utm_source=videojs&utm_campaign=vjs10) provides this as `storyboard.vtt`:
 
 `https://image.mux.com/{PLAYBACK_ID}/storyboard.vtt`
 

--- a/site/src/content/docs/reference/write-references.mdx
+++ b/site/src/content/docs/reference/write-references.mdx
@@ -100,7 +100,7 @@ React and HTML demos for the same variant should use matching BEM structures.
 
 All demos use these URLs:
 
-These demo assets are hosted by [Mux](https://mux.com):
+These demo assets are hosted by [Mux](https://www.mux.com?utm_source=videojs&utm_campaign=vjs10):
 
 ```
 Video: https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4


### PR DESCRIPTION
## Summary

- Mux links added in #819 used bare `https://mux.com` without UTM parameters
- Replace with the `MUX_URL` constant from `@/consts` in TSX files (`RendererPicker`, `UploaderOverlay`)
- Use the full UTM URL inline in MDX files (`thumbnail.mdx`, `write-references.mdx`)

## Test plan

- [ ] Verify Mux links in the installation page uploader overlay include UTM params
- [ ] Verify Mux link in the Thumbnail reference page includes UTM params
- [ ] Verify Mux link in the Write References page includes UTM params

🤖 Generated with [Claude Code](https://claude.com/claude-code)