### PR TITLE
fix(spf): prefer MediaSource over ManagedMediaSource

### DIFF
--- a/packages/spf/src/dom/features/setup-mediasource.ts
+++ b/packages/spf/src/dom/features/setup-mediasource.ts
@@ -61,7 +61,10 @@ export function setupMediaSource({
         settingUp = true;
 
         // Create MediaSource
-        const mediaSource = createMediaSource({ preferManaged: true });
+        // Note: ManagedMediaSource (Safari) requires disableRemotePlayback and
+        // startstreaming/endstreaming event handling that SPF doesn't yet implement.
+        // Use standard MediaSource until ManagedMediaSource support is added.
+        const mediaSource = createMediaSource();
 
         // Attach to element
         attachMediaSource(mediaSource, currentOwners.mediaElement!);

--- a/packages/spf/src/dom/features/tests/setup-mediasource.test.ts
+++ b/packages/spf/src/dom/features/tests/setup-mediasource.test.ts
@@ -106,7 +106,7 @@ describe('setupMediaSource', () => {
 
     // Wait for async operation
     await vi.waitFor(() => {
-      expect(createMediaSource).toHaveBeenCalledWith({ preferManaged: true });
+      expect(createMediaSource).toHaveBeenCalledWith();
     });
 
     cleanup();


### PR DESCRIPTION
ManagedMediaSource requires the host to handle startstreaming/endstreaming events and set disableRemotePlayback on the media element. Without that support, Safari creates the ManagedMediaSource but never allows SourceBuffer creation, so no segments load. Standard MediaSource is supported in Safari 17+ on desktop and works correctly.