### PR TITLE
fix(spf): add missing repository field

### DIFF
--- a/packages/spf/package.json
+++ b/packages/spf/package.json
@@ -4,6 +4,11 @@
   "version": "10.0.0-alpha.10",
   "description": "Stream Processing Framework for Video.js 10",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/videojs/v10",
+    "directory": "packages/spf"
+  },
   "keywords": [
     "video",
     "hls",


### PR DESCRIPTION
## Summary
- Adds the missing `repository` field to `@videojs/spf` `package.json`, matching all other published packages
- This is a no-op fix to trigger release-please after PR #835's merge commit had a malformed conventional commit message (`fix(spf) ...` missing the colon), causing release-please to skip it

## Test plan
- [ ] Verify release-please creates a release PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)