### PR TITLE
fix(packages): update package READMEs for beta

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 [![package-badge]][package]
 
-> **⚠️ Alpha - SUBJECT TO CHANGE** Not recommended for production use.
+> **⚠️ Beta** Close to stable. Experimental adoption in real projects.
 
 ## Overview
 
@@ -23,6 +23,6 @@ members:
 [Apache-2.0](./LICENSE)
 
 [package]: https://www.npmjs.com/package/@videojs/core
-[package-badge]: https://img.shields.io/npm/v/@videojs/core/next?label=@videojs/core@next
+[package-badge]: https://img.shields.io/npm/v/@videojs/core?label=@videojs/core
 [discord]: https://discord.gg/JBqHh485uF
 [gh-discussions]: https://github.com/videojs/v10/discussions

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -2,7 +2,7 @@
 
 [![package-badge]][package]
 
-> **Warning: Alpha - SUBJECT TO CHANGE** Not recommended for production use.
+> **⚠️ Beta** Close to stable. Experimental adoption in real projects.
 
 A lightweight reactive custom element base class for Video.js. Type-aligned with [Lit's ReactiveElement](https://github.com/lit/lit/tree/main/packages/reactive-element) but stripped down to only what we use.
 
@@ -109,6 +109,6 @@ members:
 [Apache-2.0](./LICENSE)
 
 [package]: https://www.npmjs.com/package/@videojs/element
-[package-badge]: https://img.shields.io/npm/v/@videojs/element/next?label=@videojs/element@next
+[package-badge]: https://img.shields.io/npm/v/@videojs/element?label=@videojs/element
 [discord]: https://discord.gg/JBqHh485uF
 [gh-discussions]: https://github.com/videojs/v10/discussions

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -2,7 +2,7 @@
 
 [![package-badge]][package]
 
-> **⚠️ Alpha - SUBJECT TO CHANGE** Not recommended for production use.
+> **⚠️ Beta** Close to stable. Experimental adoption in real projects.
 
 ## Overview
 
@@ -23,6 +23,6 @@ members:
 [Apache-2.0](./LICENSE)
 
 [package]: https://www.npmjs.com/package/@videojs/html
-[package-badge]: https://img.shields.io/npm/v/@videojs/html/next?label=@videojs/html@next
+[package-badge]: https://img.shields.io/npm/v/@videojs/html?label=@videojs/html
 [discord]: https://discord.gg/JBqHh485uF
 [gh-discussions]: https://github.com/videojs/v10/discussions

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,7 @@
 
 [![package-badge]][package]
 
-> **⚠️ Alpha - SUBJECT TO CHANGE** Not recommended for production use.
+> **⚠️ Beta** Close to stable. Experimental adoption in real projects.
 
 ## Overview
 
@@ -23,6 +23,6 @@ members:
 [Apache-2.0](./LICENSE)
 
 [package]: https://www.npmjs.com/package/@videojs/react
-[package-badge]: https://img.shields.io/npm/v/@videojs/react/next?label=@videojs/react@next
+[package-badge]: https://img.shields.io/npm/v/@videojs/react?label=@videojs/react
 [discord]: https://discord.gg/JBqHh485uF
 [gh-discussions]: https://github.com/videojs/v10/discussions

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -2,7 +2,7 @@
 
 [![package-badge]][package]
 
-> **⚠️ Alpha - SUBJECT TO CHANGE** Not recommended for production use.
+> **⚠️ Beta** Close to stable. Experimental adoption in real projects.
 
 A reactive store for managing state owned by external systems. Built for media players, streaming libraries, and real-time systems where you don't own the state.
 
@@ -377,6 +377,6 @@ members:
 [Apache-2.0](./LICENSE)
 
 [package]: https://www.npmjs.com/package/@videojs/store
-[package-badge]: https://img.shields.io/npm/v/@videojs/store/next?label=@videojs/store@next
+[package-badge]: https://img.shields.io/npm/v/@videojs/store?label=@videojs/store
 [discord]: https://discord.gg/JBqHh485uF
 [gh-discussions]: https://github.com/videojs/v10/discussions

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -2,7 +2,7 @@
 
 [![package-badge]][package]
 
-> **⚠️ Alpha - SUBJECT TO CHANGE** Not recommended for production use.
+> **⚠️ Beta** Close to stable. Experimental adoption in real projects.
 
 ## Community
 
@@ -17,6 +17,6 @@ members:
 [Apache-2.0](./LICENSE)
 
 [package]: https://www.npmjs.com/package/@videojs/utils
-[package-badge]: https://img.shields.io/npm/v/@videojs/utils?label=@videojs/utils@next
+[package-badge]: https://img.shields.io/npm/v/@videojs/utils?label=@videojs/utils
 [discord]: https://discord.gg/JBqHh485uF
 [gh-discussions]: https://github.com/videojs/v10/discussions


### PR DESCRIPTION
## Summary

- Update alpha warning to beta across 6 package READMEs (core, element, html, react, store, utils)
- Update npm badge URLs from `/next` to `latest`

This is a `fix` commit to trigger release-please after the `chore(cd)` config change in #846.

## Test plan

- [ ] Verify no remaining alpha references in package READMEs
- [ ] Release-please should open a release PR bumping to `beta.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)