### PR TITLE
fix(packages): set release-please manifest and package versions to beta.0

### DIFF
--- a/.github/release-please/.release-please-manifest.json
+++ b/.github/release-please/.release-please-manifest.json
@@ -1,10 +1,10 @@
 {
-  "packages/core": "10.0.0-alpha.11",
-  "packages/element": "10.0.0-alpha.11",
-  "packages/html": "10.0.0-alpha.11",
-  "packages/icons": "10.0.0-alpha.11",
-  "packages/react": "10.0.0-alpha.11",
-  "packages/store": "10.0.0-alpha.11",
-  "packages/utils": "10.0.0-alpha.11",
-  "packages/spf": "10.0.0-alpha.11"
+  "packages/core": "10.0.0-beta.0",
+  "packages/element": "10.0.0-beta.0",
+  "packages/html": "10.0.0-beta.0",
+  "packages/icons": "10.0.0-beta.0",
+  "packages/react": "10.0.0-beta.0",
+  "packages/store": "10.0.0-beta.0",
+  "packages/utils": "10.0.0-beta.0",
+  "packages/spf": "10.0.0-beta.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/core",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "Core components and utilities for Video.js",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/element",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "Lightweight reactive custom element base for Video.js",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/html",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "HTML library for building media players",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -2,7 +2,7 @@
   "name": "@videojs/icons",
   "type": "module",
   "private": true,
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "SVG icon library for Video.js",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/react",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "React library for building media players",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/spf/package.json
+++ b/packages/spf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/spf",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "Stream Processing Framework for Video.js 10",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/store",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "Reactive state management for external systems.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@videojs/utils",
   "type": "module",
-  "version": "10.0.0-alpha.11",
+  "version": "10.0.0-beta.0",
   "description": "Utility functions and helpers for Video.js",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- Update `.release-please-manifest.json` to `10.0.0-beta.0` for all 8 packages
- Update all 8 `package.json` versions to match

Release-please [doesn't auto-switch prerelease types](https://github.com/googleapis/release-please/issues/2447) when `prerelease-type` changes in the config. This manually seeds the manifest so the next releasable commit produces `beta.1`.

Closes the incorrectly generated alpha.12 release PR (#849).

## Test plan

- [ ] After merge, next releasable commit should produce a release PR for `beta.1`
- [ ] `npm view @videojs/html dist-tags` should show `latest` at `beta.1` after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)