### PR TITLE
fix(site): center-align radio option labels in ImageRadioGroup

### DIFF
--- a/site/src/components/ImageRadioGroup.tsx
+++ b/site/src/components/ImageRadioGroup.tsx
@@ -63,7 +63,7 @@ export default function ImageRadioGroup<T extends string = string>({
               <Radio.Indicator className="sr-only" />
               <div className="flex items-center justify-center w-full h-full">{option.image}</div>
             </div>
-            <span className={clsx('text-p3', isSelected && 'font-bold')}>{option.label}</span>
+            <span className={clsx('text-center text-p3', isSelected && 'font-bold')}>{option.label}</span>
           </Radio.Root>
         );
       })}


### PR DESCRIPTION
## Summary

Add `text-center` to the radio option label in `ImageRadioGroup` so that longer labels wrap and stay centered beneath their radio image.

## Changes

- Center-align radio option label text so multi-word labels don't left-align awkwardly under the image

## Testing

1. `pnpm dev:site`
2. Navigate to the installation page
3. Verify radio option labels (e.g., package manager, skin options) are centered under their images, especially on narrower viewports where labels may wrap