### PR TITLE
fix(html): remove commented error dialog blocks from video skins

### DIFF
--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -5,7 +5,6 @@ import {
   button,
   buttonGroup,
   controls,
-  error,
   icon,
   iconContainer,
   iconFlipped,
@@ -49,18 +48,6 @@ function getTemplateHTML() {
       <media-buffering-indicator class="${bufferingIndicator}">
         ${renderIcon('spinner')}
       </media-buffering-indicator>
-
-      <!--<div class="${error.root}" role="alertdialog" aria-labelledby="media-error-title" aria-describedby="media-error-description">
-        <div class="${error.dialog}">
-          <div class="${error.content}">
-            <p id="media-error-title" class="${error.title}">Something went wrong.</p>
-            <p id="media-error-description">An error occurred while trying to play the video. Please try again.</p>
-          </div>
-          <div class="${error.actions}">
-            <button type="button" class="${cn(button.base, button.default)}">OK</button>
-          </div>
-        </div>
-      </div>-->
 
       <media-controls data-controls="" class="${controls}">
         <span class="${buttonGroup}">

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -30,18 +30,6 @@ function getTemplateHTML() {
         ${renderIcon('spinner', { class: 'media-icon' })}
       </media-buffering-indicator>
 
-      <!--<div class="media-error" role="alertdialog" aria-labelledby="media-error-title" aria-describedby="media-error-description">
-        <div class="media-error__dialog">
-          <div class="media-error__content">
-            <p id="media-error-title" class="media-error__title">Something went wrong.</p>
-            <p id="media-error-description" class="media-error__description">An error occurred while trying to play the video. Please try again.</p>
-          </div>
-          <div class="media-error__actions">
-            <button type="button" class="media-button">OK</button>
-          </div>
-        </div>
-      </div>-->
-
       <media-controls class="media-controls">
         <span class="media-button-group">
           <media-play-button commandfor="play-tooltip" class="media-button media-button--icon media-button--play">

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -4,7 +4,6 @@ import {
   bufferingIndicator,
   button,
   controls,
-  error,
   icon,
   iconContainer,
   iconFlipped,
@@ -50,18 +49,6 @@ function getTemplateHTML() {
           ${renderIcon('spinner')}
         </div>
       </media-buffering-indicator>
-
-      <!--<div class="${error.root}" role="alertdialog" aria-labelledby="media-error-title" aria-describedby="media-error-description">
-        <div class="${error.dialog}">
-          <div class="${error.content}">
-            <p id="media-error-title" class="${error.title}">Something went wrong.</p>
-            <p id="media-error-description" class="${error.description}">An error occurred while trying to play the video. Please try again.</p>
-          </div>
-          <div class="${error.actions}">
-            <button type="button" class="${cn(button.base, button.default)}">OK</button>
-          </div>
-        </div>
-      </div>-->
 
       <media-controls data-controls="" class="${controls}">
         <span class="${tooltipState.play.wrapper}">

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -33,18 +33,6 @@ function getTemplateHTML() {
         </div>
       </media-buffering-indicator>
 
-      <!--<div class="media-error" role="alertdialog" aria-labelledby="media-error-title" aria-describedby="media-error-description">
-        <div class="media-error__dialog media-surface">
-          <div class="media-error__content">
-            <p id="media-error-title" class="media-error__title">Something went wrong.</p>
-            <p id="media-error-description" class="media-error__description">An error occurred while trying to play the video. Please try again.</p>
-          </div>
-          <div class="media-error__actions">
-            <button type="button" class="media-button">OK</button>
-          </div>
-        </div>
-      </div>-->
-
       <media-controls class="media-surface media-controls">
         <media-play-button commandfor="play-tooltip" class="media-button media-button--icon media-button--play">
           ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}


### PR DESCRIPTION
## Summary
- remove legacy commented-out HTML error dialog markup from video skin templates
- clean up now-unused "error" imports in Tailwind skin templates

## Testing
- not run (dependencies are not installed in this worktree)