### PR TITLE
fix(site): add missing slot="media" to HTML demo video elements

### DIFF
--- a/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-buffering-indicator-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-captions-button-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-controls-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-fullscreen-button-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <demo-video-player class="html-create-player-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-mute-button-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.html
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.html
@@ -1,6 +1,7 @@
 <video-player class="html-mute-button-volume-levels">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-pip-button-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-play-button-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
@@ -1,5 +1,6 @@
 <video-player class="html-playback-rate-button-basic">
     <video
+        slot="media"
         src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
         autoplay
         muted

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <demo-ctrl-player class="html-player-controller-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/popover/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/popover/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-popover-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.html
@@ -2,6 +2,7 @@
 <video-player class="html-poster-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             playsinline
         ></video>

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <video-player class="html-seek-button-basic">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.html
@@ -2,6 +2,7 @@
     <video-player>
         <media-container>
             <video
+                slot="media"
                 class="html-thumbnail-text-track__media"
                 src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
                 preload="auto"

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.html
@@ -1,6 +1,7 @@
 <video-player class="html-time-slider-parts">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.html
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.html
@@ -1,6 +1,7 @@
 <video-player class="html-time-current-duration">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.html
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.html
@@ -1,6 +1,7 @@
 <video-player class="html-time-current-time">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.html
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.html
@@ -1,6 +1,7 @@
 <video-player class="html-time-custom-negative-sign">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.html
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.html
@@ -1,6 +1,7 @@
 <video-player class="html-time-custom-separator">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/time/html/css/Remaining.html
+++ b/site/src/components/docs/demos/time/html/css/Remaining.html
@@ -1,6 +1,7 @@
 <video-player class="html-time-remaining">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
@@ -1,6 +1,7 @@
 <video-player class="html-volume-slider-parts">
     <media-container>
         <video
+            slot="media"
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             autoplay
             muted

--- a/site/src/components/home/Demo/Base.tsx
+++ b/site/src/components/home/Demo/Base.tsx
@@ -16,7 +16,7 @@ function generateHTMLCode(skin: Skin): string {
 
 <video-player>
   <${skinTag}>
-    <video src="${VJS10_DEMO_VIDEO.mp4}"></video>
+    <video slot="media" src="${VJS10_DEMO_VIDEO.mp4}"></video>
   </${skinTag}>
 </video-player>`;
 }


### PR DESCRIPTION
ty @dh-mux for the report

## Summary
- Adds `slot="media"` to all `<video>` elements across 22 HTML demo files in `site/src/components/docs/demos/`
- Adds `slot="media"` to the homepage `Base.tsx` demo code snippet
- The installation page (`HTMLUsageCodeBlock`) already had the correct markup — these demos were out of sync

## Test plan
- [ ] Verify HTML demos still render correctly on the docs site
- [ ] Verify homepage HTML code snippet shows `slot="media"` on the video element

🤖 Generated with [Claude Code](https://claude.com/claude-code)