### PR TITLE
fix(site): use custom domain for og:image on production deploys

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -17,14 +17,15 @@ import remarkConditionalHeadings from './src/utils/remarkConditionalHeadings';
 import { remarkReadingTime } from './src/utils/remarkReadingTime.mjs';
 import shikiTransformMetadata from './src/utils/shikiTransformMetadata';
 
-// Astro docs say `site` should be "your final, deployed URL", but we override
-// it per-deploy so that generated absolute URLs (OG images, RSS, etc.) resolve
-// correctly on Netlify deploy previews. On production, DEPLOY_PRIME_URL is the
-// primary site URL so it's equivalent.
+// On production deploys, use the custom domain — DEPLOY_PRIME_URL always returns
+// the Netlify subdomain (e.g. main--vjs10-site.netlify.app), not the custom
+// domain. On deploy previews, use DEPLOY_PRIME_URL so OG images point to a
+// reachable URL for crawlers.
 //
 // For URLs that must always point to production regardless of deploy context
 // (e.g. canonical, JSON-LD), use PRODUCTION_URL from src/consts.ts instead.
-const SITE_URL = process.env.DEPLOY_PRIME_URL || 'https://videojs.org';
+const SITE_URL =
+  process.env.CONTEXT === 'production' ? 'https://videojs.org' : process.env.DEPLOY_PRIME_URL || 'https://videojs.org';
 
 // https://astro.build/config
 export default defineConfig({

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
   "concurrency": "20",
-  "globalEnv": ["DEPLOY_PRIME_URL"],
+  "globalEnv": ["CONTEXT", "DEPLOY_PRIME_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- `DEPLOY_PRIME_URL` always returns the Netlify subdomain (e.g. `main--vjs10-site.netlify.app`), never the custom domain — so `og:image` URLs on production resolve to the wrong host
- Use Netlify's `CONTEXT` env var to set `Astro.site` to `https://videojs.org` on production, while keeping the preview URL on deploy previews
- Add `CONTEXT` to `turbo.json` `globalEnv` so Turbo invalidates cache when deploy context changes

## Test plan

- [ ] Build locally succeeds (`pnpm -F site build` — falls back to `https://videojs.org`)
- [ ] After deploy preview: `og:image` uses the preview URL (reachable by crawlers)
- [ ] After merge to main: `og:image` uses `https://videojs.org/...`
- [ ] Canonical/og:url/twitter:url still use `https://videojs.org` in all contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)