### PR TITLE
fix(site): work around video layout quirks in hero

### DIFF
--- a/site/src/components/home/Header.astro
+++ b/site/src/components/home/Header.astro
@@ -25,7 +25,7 @@ const poster = `${VJS10_DEMO_VIDEO.poster}?time=0`;
     style="--grid-area: title; --md-grid-area: video;"
   >
     The Open Source Player <br class="lg:hidden" /><span
-      class="text-stroke-faded-black md:text-stroke-manila-light"
+      class="text-stroke-faded-black md:text-stroke-manila-light dark:text-stroke-manila-light"
       >for the Web</span
     >
   </h1>
@@ -38,12 +38,12 @@ const poster = `${VJS10_DEMO_VIDEO.poster}?time=0`;
     rebuilt in v10 for modern development and performance.
   </p>
 
-  <HeroVideo
-    client:load
-    className="mb-3 aspect-2/1 md:mb-4 md:aspect-1180/570"
-    style={{ gridArea: "video" }}
-    poster={poster}
-  />
+  <div
+    class="relative mb-3 aspect-2/1 md:mb-4 md:aspect-1180/570"
+    style="grid-area:video"
+  >
+    <HeroVideo client:load className="absolute inset-0" poster={poster} />
+  </div>
   <p
     class="mb-11 flex items-center justify-center gap-1.5 text-p3 md:mb-20 md:justify-end md:gap-2 md:pr-6 md:font-display md:text-(length:--md-text) md:uppercase"
     style="grid-area:mux;--md-text:0.6875rem;"


### PR DESCRIPTION
This PR does 2 things. First, it fixes the color of the outline text in the h1 in dark mode.

Second: #881 caused a change in how our player participates in layout:

<img width="300" alt="Before #881, margins on the skin were observed" src="https://github.com/user-attachments/assets/6c825244-3a9c-4305-baf4-63301d0734d7" /><img width="300" alt="After #881, margins had no effect on their neighbors" src="https://github.com/user-attachments/assets/a9eae409-ec6c-4f6c-b0be-cbe5a77a079e" />

While we discuss that change, here's quick workaround

