### PR TITLE
fix(site): redirect trailing-slash URLs via edge function

### DIFF
--- a/site/netlify/edge-functions/trailing-slash.ts
+++ b/site/netlify/edge-functions/trailing-slash.ts
@@ -1,0 +1,21 @@
+import type { Config } from '@netlify/edge-functions';
+
+export default async (request: Request) => {
+  const url = new URL(request.url);
+  const redirectUrl = new URL(url.pathname.replace(/\/$/, ''), url.origin);
+  redirectUrl.search = url.search;
+  redirectUrl.hash = url.hash;
+
+  return new Response(null, {
+    status: 301,
+    headers: {
+      location: redirectUrl.toString(),
+      'cache-control': 'public, max-age=86400',
+    },
+  });
+};
+
+export const config: Config = {
+  cache: 'manual',
+  pattern: '.+/$',
+};

--- a/site/src/pages/rss.xml.js
+++ b/site/src/pages/rss.xml.js
@@ -9,9 +9,10 @@ export async function GET(context) {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: context.site,
+    trailingSlash: false,
     items: posts.map((post) => ({
       ...post.data,
-      link: `/blog/${post.id}/`,
+      link: `/blog/${post.id}`,
     })),
   });
 }


### PR DESCRIPTION
Fixes #886

## Summary
- Adds a Netlify edge function that 301-redirects any URL ending with `/` (except root `/`) to the same URL without the trailing slash. This fixes 404s on SSR routes like `/docs/`, `/docs/framework/`, etc., where Netlify's `trailingSlash: 'never'` config only applies to prerendered pages.
- Fixes RSS feed to emit URLs without trailing slashes (`trailingSlash: false` + removes `/` from link template).

## Historical context
See #575 for previous discussion on trailing slash handling with Netlify.

## Test plan
- [ ] Deploy to Netlify preview
- [ ] `curl -I <preview>/docs/` → expect 301 redirect to `/docs`
- [ ] `curl -I <preview>/docs/framework/` → expect 301 redirect
- [ ] `curl -I <preview>/` → expect 200 (root not redirected)
- [ ] `curl -I <preview>/docs` → expect normal response (no double redirect)
- [ ] Check `dist/rss.xml` for no trailing slashes in `<link>` elements
- [ ] If `pattern` config doesn't work on Netlify, fallback to `path: '/*'` with early-return guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)