### PR TITLE
fix(site): filter devOnly posts from RSS feed

### DIFF
--- a/site/src/pages/rss.xml.js
+++ b/site/src/pages/rss.xml.js
@@ -4,7 +4,10 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '@/consts';
 
 // TODO cache idk this can be static
 export async function GET(context) {
-  const posts = await getCollection('blog');
+  const posts = (await getCollection('blog'))
+    .filter((post) => !post.data.devOnly || import.meta.env.DEV)
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
   return rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,


### PR DESCRIPTION
## Summary

- Filter out `devOnly: true` blog posts from the RSS feed, matching the existing blog listing page behavior
- Add date sorting to RSS items (was missing)

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)