### PR TITLE
fix(site): add playsinline to home and installation snippets

### DIFF
--- a/site/src/components/home/Demo/Base.tsx
+++ b/site/src/components/home/Demo/Base.tsx
@@ -16,7 +16,7 @@ function generateHTMLCode(skin: Skin): string {
 
 <video-player>
   <${skinTag}>
-    <video slot="media" src="${VJS10_DEMO_VIDEO.mp4}"></video>
+    <video slot="media" src="${VJS10_DEMO_VIDEO.mp4}" playsinline></video>
   </${skinTag}>
 </video-player>`;
 }

--- a/site/src/components/installation/HTMLUsageCodeBlock.tsx
+++ b/site/src/components/installation/HTMLUsageCodeBlock.tsx
@@ -49,10 +49,15 @@ function getSkinTag(useCase: UseCase, skin: Skin): string {
   return map[skin];
 }
 
+function isVideoLikeRenderer(renderer: Renderer): boolean {
+  return renderer === 'html5-video' || renderer === 'hls' || renderer === 'background-video';
+}
+
 function getRendererElement(renderer: Renderer, url: string): string {
   const tag = getRendererTag(renderer);
   const src = url.trim() || getDefaultSourceUrl(renderer);
-  return `<${tag} slot="media" src="${src}"></${tag}>`;
+  const playsInline = isVideoLikeRenderer(renderer) ? ' playsinline' : '';
+  return `<${tag} slot="media" src="${src}"${playsInline}></${tag}>`;
 }
 
 function getDefaultSourceUrl(renderer: Renderer): string {

--- a/site/src/components/installation/ReactCreateCodeBlock.tsx
+++ b/site/src/components/installation/ReactCreateCodeBlock.tsx
@@ -54,6 +54,10 @@ function isPresetRenderer(renderer: Renderer): boolean {
   return renderer === 'html5-video' || renderer === 'html5-audio' || renderer === 'background-video';
 }
 
+function isVideoLikeRenderer(renderer: Renderer): boolean {
+  return renderer === 'html5-video' || renderer === 'hls' || renderer === 'background-video';
+}
+
 function getRendererMediaSubpath(renderer: Renderer): string {
   const map: Partial<Record<Renderer, string>> = {
     // cloudflare: 'cloudflare-video',
@@ -100,7 +104,8 @@ function generateReactCode(useCase: UseCase, skin: Skin, renderer: Renderer): st
   // Determine props — mux variants use src with stream.mux.com URL
   const propsInterface = 'interface MyPlayerProps {\n  src: string;\n}';
   const destructuredProp = 'src';
-  const rendererJsx = `<${rendererComponent} src={src} />`;
+  const rendererProps = isVideoLikeRenderer(renderer) ? 'src={src} playsInline' : 'src={src}';
+  const rendererJsx = `<${rendererComponent} ${rendererProps} />`;
 
   const imports = [
     `import '${skinCssImport}';`,


### PR DESCRIPTION
## Summary
- add `playsinline` to the home HTML snippet generator
- add renderer-aware `playsinline` for docs installation HTML snippets (video-like renderers only)
- add renderer-aware `playsInline` for docs installation React snippets (video-like renderers only)

## Testing
- not run in this environment (missing local CLIs: `biome`, `astro`)