### PR TITLE
fix(core): skip delay when switching between grouped tooltips

### DIFF
--- a/packages/core/src/core/ui/tooltip/tests/tooltip-group-core.test.ts
+++ b/packages/core/src/core/ui/tooltip/tests/tooltip-group-core.test.ts
@@ -58,7 +58,7 @@ describe('TooltipGroupCore', () => {
     expect(group.shouldSkipDelay()).toBe(false);
   });
 
-  it('clears skip-delay when a new tooltip opens', () => {
+  it('should skip delay when another tooltip is already open', () => {
     const group = new TooltipGroupCore({ timeout: 400 });
 
     group.notifyOpen();
@@ -66,15 +66,15 @@ describe('TooltipGroupCore', () => {
     // A new tooltip opens before timeout expires
     group.notifyOpen();
 
-    expect(group.shouldSkipDelay()).toBe(false);
+    expect(group.shouldSkipDelay()).toBe(true);
   });
 
-  it('should not skip delay when a tooltip is currently open', () => {
+  it('should skip delay when a tooltip is currently open', () => {
     const group = new TooltipGroupCore();
 
     group.notifyOpen();
 
-    expect(group.shouldSkipDelay()).toBe(false);
+    expect(group.shouldSkipDelay()).toBe(true);
   });
 
   it('respects updated timeout via setProps', () => {

--- a/packages/core/src/core/ui/tooltip/tooltip-group-core.ts
+++ b/packages/core/src/core/ui/tooltip/tooltip-group-core.ts
@@ -38,7 +38,7 @@ export class TooltipGroupCore {
   }
 
   shouldSkipDelay(): boolean {
-    if (this.#isOpen) return false;
+    if (this.#isOpen) return true;
     return Date.now() - this.#lastCloseTime < this.#props.timeout;
   }
 

--- a/packages/html/src/ui/tooltip/tooltip-group-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-group-element.ts
@@ -19,7 +19,7 @@ export class TooltipGroupElement extends MediaElement {
   timeout = TooltipGroupCore.defaultProps.timeout;
 
   readonly #core = new TooltipGroupCore();
-  readonly #provider = new ContextProvider(this, { context: tooltipGroupContext });
+  readonly #provider = new ContextProvider(this, { context: tooltipGroupContext, initialValue: this.#core });
 
   protected override update(_changed: PropertyValues): void {
     super.update(_changed);


### PR DESCRIPTION
## Summary

- **`shouldSkipDelay()` returned `false` when `#isOpen` was `true`** — this prevented instant tooltip switching because the previous tooltip's async close hadn't fired yet when the next tooltip checked the delay.
- **HTML `ContextProvider` had no `initialValue`** — `@lit/context` consumers without `subscribe: true` only get the value at request time. Since `TooltipGroupElement` set the value in `update()` (async), tooltips connected before that got `undefined` and never received the group reference.

Closes #898

## Test plan

- [x] `pnpm -F @videojs/core test src/core/ui/tooltip` — all 21 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Manual: hover between grouped tooltips in video/audio skins — second tooltip should appear instantly (no 600ms delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)