### PR TITLE
fix(skin): fix fullscreen video clipping and border-radius handling

### DIFF
--- a/packages/skins/src/default/css/components/media.css
+++ b/packages/skins/src/default/css/components/media.css
@@ -7,7 +7,12 @@
   display: block;
   width: 100%;
   height: 100%;
+}
+.media-default-skin ::slotted(video) {
   border-radius: var(--media-border-radius, 2rem);
+}
+.media-default-skin video {
+  border-radius: inherit;
 }
 
 /* ==========================================================================
@@ -27,4 +32,17 @@
   &:not([data-visible]) {
     opacity: 0;
   }
+}
+
+/* ==========================================================================
+   Fullscreen
+   ========================================================================== */
+
+.media-default-skin:fullscreen video,
+.media-default-skin:fullscreen ::slotted(video),
+.media-default-skin > img {
+  object-fit: contain;
+}
+.media-default-skin:fullscreen ::slotted(video) {
+  border-radius: 0;
 }

--- a/packages/skins/src/default/css/components/root.css
+++ b/packages/skins/src/default/css/components/root.css
@@ -21,8 +21,4 @@
   letter-spacing: normal;
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
-
-  &:fullscreen {
-    border-radius: 0;
-  }
 }

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -42,6 +42,10 @@
     box-shadow: inset 0 0 0 1px var(--media-border-color);
     pointer-events: none;
   }
+
+  &:fullscreen {
+    border-radius: 0;
+  }
 }
 
 /* ==========================================================================

--- a/packages/skins/src/default/tailwind/components/root.ts
+++ b/packages/skins/src/default/tailwind/components/root.ts
@@ -9,7 +9,5 @@ export const root = cn(
   // Resets
   '**:box-border **:m-0',
   '[&_button]:font-[inherit]',
-  'motion-safe:[interpolate-size:allow-keywords]',
-  // Fullscreen
-  '[&:fullscreen]:rounded-none'
+  'motion-safe:[interpolate-size:allow-keywords]'
 );

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -49,7 +49,12 @@ export const root = (isShadowDOM: boolean) =>
         ]
       : [],
     // Fullscreen
-    '[&:fullscreen]:rounded-none'
+    '[&:fullscreen]:rounded-none',
+    {
+      '[&:fullscreen_video]:object-contain': !isShadowDOM,
+      '[&:fullscreen_::slotted(video)]:object-contain [&:fullscreen_::slotted(video)]:rounded-none': isShadowDOM,
+    },
+    '[&:fullscreen>img]:object-contain'
   );
 
 /* ==========================================================================

--- a/packages/skins/src/minimal/css/components/media.css
+++ b/packages/skins/src/minimal/css/components/media.css
@@ -7,7 +7,12 @@
   display: block;
   width: 100%;
   height: 100%;
+}
+.media-minimal-skin ::slotted(video) {
   border-radius: var(--media-border-radius, 0.75rem);
+}
+.media-minimal-skin video {
+  border-radius: inherit;
 }
 
 /* ==========================================================================
@@ -27,4 +32,17 @@
   &:not([data-visible]) {
     opacity: 0;
   }
+}
+
+/* ==========================================================================
+   Fullscreen
+   ========================================================================== */
+
+.media-minimal-skin:fullscreen video,
+.media-minimal-skin:fullscreen ::slotted(video),
+.media-minimal-skin > img {
+  object-fit: contain;
+}
+.media-minimal-skin:fullscreen ::slotted(video) {
+  border-radius: 0;
 }

--- a/packages/skins/src/minimal/css/components/root.css
+++ b/packages/skins/src/minimal/css/components/root.css
@@ -21,8 +21,4 @@
   letter-spacing: normal;
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
-
-  &:fullscreen {
-    border-radius: 0;
-  }
 }

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -20,20 +20,21 @@
 
 .media-minimal-skin--video {
   background: oklch(0 0 0);
+  --media-border-color: oklch(0 0 0 / 0.15);
 
-  /* Border ring */
+  @media (prefers-color-scheme: dark) {
+    --media-border-color: oklch(1 0 0 / 0.15);
+  }
+
+  /* Inner border ring */
   &::after {
     content: "";
     position: absolute;
     inset: 0;
     z-index: 10;
     border-radius: inherit;
-    box-shadow: inset 0 0 0 1px oklch(0 0 0 / 0.15);
+    box-shadow: inset 0 0 0 1px var(--media-border-color);
     pointer-events: none;
-
-    @media (prefers-color-scheme: dark) {
-      box-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.15);
-    }
   }
 
   /* Fullscreen */

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -47,7 +47,12 @@ export const root = (isShadowDOM: boolean) =>
         ]
       : [],
     // Fullscreen
-    '[&:fullscreen]:rounded-none'
+    '[&:fullscreen]:rounded-none',
+    {
+      '[&:fullscreen_video]:object-contain': !isShadowDOM,
+      '[&:fullscreen_::slotted(video)]:object-contain [&:fullscreen_::slotted(video)]:rounded-none': isShadowDOM,
+    },
+    '[&:fullscreen>img]:object-contain'
   );
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary

Fix video being clipped in fullscreen due to `border-radius` applied to the media container. The border-radius is now applied directly to the `::slotted(video)` element (shadow DOM) or `video` element (light DOM) so it can be properly reset to `0` in fullscreen without clipping. Also adds `object-fit: contain` for fullscreen video and poster images.

Closes #869

## Changes

- Move `border-radius` from the shared media slot rule to the slotted/video element selectors in both default and minimal skins
- Add fullscreen rules that reset `border-radius` to `0` and set `object-fit: contain` on video and poster images
- Move `border-radius: 0` fullscreen override from root component to the video component where it belongs
- Update Tailwind equivalents to match the CSS changes
- Refactor minimal skin border color to use a CSS custom property with dark mode support

## Testing

Manual: enter fullscreen and verify the video is not clipped at the corners and fills the viewport correctly. Test in both light and dark mode for the minimal skin border changes.