### PR TITLE
chore: ignore .claude/worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ bun.lockb
 # AI Agent Config (Generated)
 # -------------------------
 .claude/settings.local.json
+.claude/worktrees/
 .opencode
 AGENTS.md
 agents


### PR DESCRIPTION
## Summary

Add `.claude/worktrees/` to `.gitignore` to prevent Claude worktree artifacts from being tracked.

## Changes

- Ignore `.claude/worktrees/` alongside the existing `.claude/settings.local.json` entry

## Testing

N/A — gitignore-only change.