### PR TITLE
fix(core): suppress tooltip hover on touch pointer events

### DIFF
--- a/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
+++ b/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
@@ -1,5 +1,5 @@
 import { flush } from '@videojs/store';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TooltipGroupCore } from '../../../../core/ui/tooltip/tooltip-group-core';
 import { createTestTooltip } from './tooltip-helpers';
 
@@ -102,6 +102,106 @@ describe('createTooltip', () => {
       });
 
       expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    describe('touch pointer suppression', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        // jsdom lacks matchMedia — stub so popover's canHover() returns true,
+        // allowing us to test that the tooltip layer blocks touch independently.
+        vi.stubGlobal('matchMedia', (query: string) => ({
+          matches: query === '(hover: hover)',
+          media: query,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        }));
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+      });
+
+      it('does not open on touch pointer enter', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+
+        tooltip.triggerProps.onPointerEnter({
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'touch',
+          buttons: 0,
+          preventDefault: vi.fn(),
+        });
+
+        vi.advanceTimersByTime(600);
+
+        expect(onOpenChange).not.toHaveBeenCalled();
+      });
+
+      it('opens on mouse pointer enter', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+
+        tooltip.triggerProps.onPointerEnter({
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'mouse',
+          buttons: 0,
+          preventDefault: vi.fn(),
+        });
+
+        vi.advanceTimersByTime(600);
+
+        expect(onOpenChange).toHaveBeenCalledWith(true, { reason: 'hover' });
+      });
+
+      it('does not open via focus after pointer down (tap)', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+        const pointerEvent = {
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'touch' as const,
+          buttons: 0,
+          preventDefault: vi.fn(),
+        };
+
+        // Simulate tap: pointerdown → focusin (flag consumed and reset)
+        tooltip.triggerProps.onPointerDown(pointerEvent);
+        tooltip.triggerProps.onFocusIn({ relatedTarget: null, preventDefault: vi.fn() });
+
+        expect(onOpenChange).not.toHaveBeenCalled();
+      });
+
+      it('opens via focus when no pointer down (keyboard Tab)', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+
+        // Simulate keyboard Tab: focusin without preceding pointerdown
+        tooltip.triggerProps.onFocusIn({ relatedTarget: null, preventDefault: vi.fn() });
+
+        expect(onOpenChange).toHaveBeenCalledWith(true, { reason: 'focus' });
+      });
+
+      it('opens via keyboard focus after tap-triggered focus was suppressed', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+        const pointerEvent = {
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'touch' as const,
+          buttons: 0,
+          preventDefault: vi.fn(),
+        };
+
+        // Tap: pointerdown → focusin (suppressed, flag consumed)
+        tooltip.triggerProps.onPointerDown(pointerEvent);
+        tooltip.triggerProps.onFocusIn({ relatedTarget: null, preventDefault: vi.fn() });
+        expect(onOpenChange).not.toHaveBeenCalled();
+
+        // Later keyboard Tab: flag is clean, focus opens tooltip
+        tooltip.triggerProps.onFocusIn({ relatedTarget: null, preventDefault: vi.fn() });
+        expect(onOpenChange).toHaveBeenCalledWith(true, { reason: 'focus' });
+      });
     });
 
     it('does not open via focus when disabled', () => {

--- a/packages/core/src/dom/ui/tooltip/tooltip.ts
+++ b/packages/core/src/dom/ui/tooltip/tooltip.ts
@@ -1,4 +1,5 @@
 import type { TooltipGroupCore } from '../../../core/ui/tooltip/tooltip-group-core';
+import type { UIPointerEvent } from '../event';
 import {
   createPopover,
   type PopoverApi,
@@ -27,7 +28,9 @@ export interface TooltipOptions {
   group?: () => TooltipGroupCore | undefined;
 }
 
-export interface TooltipTriggerProps extends Omit<PopoverTriggerProps, 'onClick'> {}
+export interface TooltipTriggerProps extends Omit<PopoverTriggerProps, 'onClick'> {
+  onPointerDown: (event: UIPointerEvent) => void;
+}
 
 export interface TooltipPopupProps extends PopoverPopupProps {}
 
@@ -80,16 +83,29 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
 
   const popover = createPopover(popoverOpts);
 
-  // Spread popover trigger props, omit onClick, guard disabled on open handlers.
+  // Track whether a pointer is currently down so focus-triggered opens can be
+  // suppressed during tap. The browser fires pointerdown → focus → pointerup,
+  // so the flag is true during tap-triggered focus but false during keyboard Tab.
+  let isPointerDown = false;
+
+  // Spread popover trigger props, omit onClick, guard disabled/touch on open handlers.
   const { onClick: _, ...baseTriggerProps } = popover.triggerProps;
   const triggerProps: TooltipTriggerProps = {
     ...baseTriggerProps,
+    onPointerDown() {
+      isPointerDown = true;
+    },
     onPointerEnter(event) {
       if (options.disabled?.()) return;
+      if (event.pointerType === 'touch') return;
       baseTriggerProps.onPointerEnter(event);
     },
     onFocusIn(event) {
       if (options.disabled?.()) return;
+      if (isPointerDown) {
+        isPointerDown = false;
+        return;
+      }
       baseTriggerProps.onFocusIn(event);
     },
   };


### PR DESCRIPTION
Closes #921

## Summary

Tooltips incorrectly open on touch interactions on hybrid devices (e.g. touchscreen laptops). The popover layer's `canHover()` guard uses `matchMedia('(hover: hover)')` which describes device capability, not current input method — so it always matches on hybrid devices even during touch input.

Adds a two-part touch suppression in the **tooltip** layer, following the pattern used by Radix UI:

1. **`pointerType === 'touch'` guard** in `onPointerEnter` — blocks touch-triggered hover
2. **`isPointerDown` flag** via `onPointerDown`/`onPointerUp` in `triggerProps`, checked in `onFocusIn` — suppresses tap-triggered focus (browser fires `pointerdown → focus → pointerup`, so the flag is set during tap but not during keyboard Tab)

Both handlers are exposed through `triggerProps` so the framework layer (HTML/React) attaches them — no imperative `listen()` calls.

## Changes

- Add `onPointerDown` and `onPointerUp` to `TooltipTriggerProps` interface
- Add `event.pointerType === 'touch'` early return in `onPointerEnter`
- Add `isPointerDown` flag checked in `onFocusIn` to distinguish tap-focus from keyboard-focus
- Mouse/pen hover and keyboard Tab focus continue to open tooltips normally
- Popovers are unaffected — hover-based popovers still respond to touch

<details>
<summary>Design decisions</summary>

**Why tooltip layer, not popover?** Base UI recommends `Popover` with `openOnHover` as the touch-accessible alternative to tooltips. Blocking touch in the popover layer would break that use case. The guard belongs specifically in the tooltip layer.

**Why not long-press?** Researched Base UI and Radix — both disable tooltips on touch entirely. Long-press conflicts with browser context menus and delays primary button actions in a video player.

**Why `pointerType` over `(hover: hover)`?** The media query is device-level; `pointerType` is per-event. On a hybrid device with trackpad + touchscreen, `(hover: hover)` is always true, but `pointerType` correctly reports `'touch'` vs `'mouse'` per interaction.

**Why the `isPointerDown` pattern?** A touch tap fires `pointerdown → focus → pointerup`. Without this guard, the tooltip would open via the `focusin` handler even though hover was suppressed. The flag distinguishes tap-triggered focus (pointer is down) from keyboard Tab focus (pointer is not down). This is the same pattern Radix uses.

</details>

## Testing

```bash
pnpm -F @videojs/core test src/dom/ui/tooltip
```

5 new tests in "touch pointer suppression" block:
- Does not open on touch pointer enter
- Opens on mouse pointer enter
- Does not open via focus when pointer is down (tap)
- Opens via focus when no pointer is down (keyboard Tab)
- Opens via focus after pointer is released