### PR TITLE
feat: add slider preview thumbnails

### DIFF
--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -155,7 +155,11 @@ export function createSlider(options: SliderOptions): SliderApi {
       options.onValueChange?.(percent);
 
       // Focus the thumb for keyboard follow-up and screen reader tracking.
-      options.getThumbElement?.()?.focus();
+      options.getThumbElement?.()?.focus({
+        preventScroll: true,
+        // @ts-expect-error -- focusVisible is not yet in TypeScript's lib.dom typings.
+        focusVisible: false,
+      });
     },
 
     onPointerMove(event) {

--- a/packages/core/src/dom/ui/tests/thumbnail.test.ts
+++ b/packages/core/src/dom/ui/tests/thumbnail.test.ts
@@ -308,6 +308,104 @@ describe('createThumbnail', () => {
 
       handle.destroy();
     });
+
+    it('React lifecycle: updateSrc before img available, then connect after mount', () => {
+      let img: HTMLImageElement | null = null;
+      const onStateChange = vi.fn();
+
+      const handle = createThumbnail(
+        createOptions({
+          getImg: () => img,
+          onStateChange,
+        })
+      );
+
+      // 1. Render phase: updateSrc called but img ref is null (not mounted yet).
+      handle.updateSrc('sprite.jpg');
+      expect(handle.loading).toBe(true);
+
+      // 2. Commit phase: img becomes available (React sets ref) but image is still loading.
+      img = document.createElement('img');
+      // Simulate a loading image: in a real browser, an img with src set is !complete
+      // while the network request is in flight.
+      Object.defineProperty(img, 'complete', { value: false, configurable: true });
+
+      // 3. useEffect: connect() binds events and checks img.complete.
+      handle.connect();
+
+      // Image is not complete, so loading should remain true.
+      expect(handle.loading).toBe(true);
+
+      // 4. Image loads — event listener should catch it.
+      Object.defineProperty(img, 'naturalWidth', { value: 2560, configurable: true });
+      Object.defineProperty(img, 'naturalHeight', { value: 1600, configurable: true });
+      img.dispatchEvent(new Event('load'));
+
+      expect(handle.loading).toBe(false);
+      expect(handle.naturalWidth).toBe(2560);
+      expect(onStateChange).toHaveBeenCalled();
+
+      handle.destroy();
+    });
+
+    it('React lifecycle: handles already-loaded img when ref was null during updateSrc', () => {
+      let img: HTMLImageElement | null = null;
+      const onStateChange = vi.fn();
+
+      const handle = createThumbnail(
+        createOptions({
+          getImg: () => img,
+          onStateChange,
+        })
+      );
+
+      // 1. Render phase: updateSrc called but img ref is null.
+      handle.updateSrc('sprite.jpg');
+      expect(handle.loading).toBe(true);
+
+      // 2. Commit phase: img becomes available and is already cached/complete.
+      img = createMockImg();
+      Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+      // 3. useEffect: connect() should detect the already-loaded image.
+      handle.connect();
+
+      expect(handle.loading).toBe(false);
+      expect(handle.naturalWidth).toBe(2560);
+      expect(onStateChange).toHaveBeenCalled();
+
+      handle.destroy();
+    });
+
+    it('React lifecycle: handles errored img when ref was null during updateSrc', () => {
+      let img: HTMLImageElement | null = null;
+      const onStateChange = vi.fn();
+
+      const handle = createThumbnail(
+        createOptions({
+          getImg: () => img,
+          onStateChange,
+        })
+      );
+
+      // 1. Render phase: updateSrc called but img ref is null.
+      handle.updateSrc('bad.jpg');
+      expect(handle.loading).toBe(true);
+
+      // 2. Commit phase: img becomes available but image errored (complete but no dimensions).
+      img = document.createElement('img');
+      Object.defineProperty(img, 'complete', { value: true, configurable: true });
+      // naturalWidth defaults to 0 in jsdom — simulates an errored image.
+
+      // 3. useEffect: connect() should detect the errored image.
+      handle.connect();
+
+      expect(handle.loading).toBe(false);
+      expect(handle.error).toBe(true);
+      expect(onStateChange).toHaveBeenCalled();
+
+      handle.destroy();
+    });
   });
 
   describe('destroy', () => {

--- a/packages/core/src/dom/ui/thumbnail.ts
+++ b/packages/core/src/dom/ui/thumbnail.ts
@@ -108,15 +108,21 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
   function connect(): void {
     ensureBindings();
 
-    // Handle the case where the img already loaded before listeners were bound
-    // (e.g., cached image in React where mount happens before useEffect).
+    // Handle the case where the img already loaded or errored before listeners
+    // were bound (e.g., cached image in React where mount happens before useEffect).
     const img = getImg();
 
-    if (img?.complete && img.naturalWidth > 0 && lastSrc) {
-      naturalWidth = img.naturalWidth;
-      naturalHeight = img.naturalHeight;
-      loading = false;
-      error = false;
+    if (img?.complete && lastSrc) {
+      if (img.naturalWidth > 0) {
+        naturalWidth = img.naturalWidth;
+        naturalHeight = img.naturalHeight;
+        loading = false;
+        error = false;
+      } else {
+        loading = false;
+        error = true;
+      }
+
       onStateChange();
     }
   }

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -11,6 +11,7 @@ import {
   iconState,
   overlay,
   popup,
+  preview,
   root,
   seek,
   slider,
@@ -100,6 +101,14 @@ function getTemplateHTML() {
                 <media-slider-buffer class="${cn(slider.fill.base, slider.fill.buffer)}"></media-slider-buffer>
               </media-slider-track>
               <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.interactive)}"></media-slider-thumb>
+
+              <div class="${preview.root}">
+                <div class="${preview.thumbnailWrapper}">
+                  <media-slider-thumbnail class="${preview.thumbnail}"></media-slider-thumbnail>
+                </div>
+                <media-slider-value type="pointer" class="${preview.timestamp}"></media-slider-value>
+                ${renderIcon('spinner', { class: cn(icon, preview.spinner) })}
+              </div>
             </media-time-slider>
           </div>
 

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -79,6 +79,14 @@ function getTemplateHTML() {
                 <media-slider-buffer class="media-slider__buffer"></media-slider-buffer>
               </media-slider-track>
               <media-slider-thumb class="media-slider__thumb"></media-slider-thumb>
+
+              <div class="media-preview media-slider__preview">
+                <div class="media-preview__thumbnail-wrapper">
+                  <media-slider-thumbnail class="media-preview__thumbnail"></media-slider-thumbnail>
+                </div>
+                <media-slider-value type="pointer" class="media-preview__timestamp"></media-slider-value>
+                ${renderIcon('spinner', { class: 'media-preview__spinner media-icon' })}
+              </div>
             </media-time-slider>
           </div>
 

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -11,6 +11,7 @@ import {
   overlay,
   playbackRate,
   popup,
+  preview,
   root,
   seek,
   slider,
@@ -94,6 +95,12 @@ function getTemplateHTML() {
                 <media-slider-buffer class="${cn(slider.fill.base, slider.fill.buffer)}"></media-slider-buffer>
               </media-slider-track>
               <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.interactive)}"></media-slider-thumb>
+
+              <div class="${preview.root}">
+                <media-slider-thumbnail class="${preview.thumbnail}"></media-slider-thumbnail>
+                <media-slider-value type="pointer" class="${preview.timestamp}"></media-slider-value>
+                ${renderIcon('spinner', { class: cn(icon, preview.spinner) })}
+              </div>
             </media-time-slider>
             <media-time type="duration" class="${time.duration}"></media-time>
           </media-time-group>

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -75,6 +75,12 @@ function getTemplateHTML() {
                 <media-slider-buffer class="media-slider__buffer"></media-slider-buffer>
               </media-slider-track>
               <media-slider-thumb class="media-slider__thumb"></media-slider-thumb>
+
+              <div class="media-surface media-preview media-slider__preview">
+                <media-slider-thumbnail class="media-preview__thumbnail"></media-slider-thumbnail>
+                <media-slider-value type="pointer" class="media-preview__timestamp"></media-slider-value>
+                ${renderIcon('spinner', { class: 'media-preview__spinner media-icon' })}
+              </div>
             </media-time-slider>
             <media-time type="duration" class="media-time__value"></media-time>
           </media-time-group>

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -26,6 +26,7 @@ import {
   iconState,
   overlay,
   popup,
+  preview,
   root,
   seek,
   slider,
@@ -44,6 +45,7 @@ import { PlayButton } from '@/ui/play-button';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
+import { Slider } from '@/ui/slider';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
@@ -233,6 +235,13 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
                 <TimeSlider.Buffer render={(props) => <SliderFill type="buffer" {...props} />} />
               </TimeSlider.Track>
               <TimeSlider.Thumb render={(props) => <SliderThumb {...props} />} />
+              <div className={preview.root}>
+                <div className={preview.thumbnailWrapper}>
+                  <Slider.Thumbnail className={preview.thumbnail} />
+                </div>
+                <TimeSlider.Value type="pointer" className={preview.timestamp} />
+                <SpinnerIcon className={cn(icon, preview.spinner)} />
+              </div>
             </TimeSlider.Root>
           </div>
 

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -26,6 +26,7 @@ import { PlayButton } from '@/ui/play-button';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
+import { Slider } from '@/ui/slider';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
@@ -164,6 +165,14 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
                 <TimeSlider.Buffer className="media-slider__buffer" />
               </TimeSlider.Track>
               <TimeSlider.Thumb className="media-slider__thumb" />
+
+              <div className="media-preview media-slider__preview">
+                <div className="media-preview__thumbnail-wrapper">
+                  <Slider.Thumbnail className="media-preview__thumbnail" />
+                </div>
+                <TimeSlider.Value type="pointer" className="media-preview__timestamp" />
+                <SpinnerIcon className="media-preview__spinner media-icon" />
+              </div>
             </TimeSlider.Root>
           </div>
 

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -25,6 +25,7 @@ import {
   overlay,
   playbackRate,
   popup,
+  preview,
   root,
   seek,
   slider,
@@ -43,6 +44,7 @@ import { PlayButton } from '@/ui/play-button';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
+import { Slider } from '@/ui/slider';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
@@ -228,6 +230,11 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
                 <TimeSlider.Buffer render={(props) => <SliderFill type="buffer" {...props} />} />
               </TimeSlider.Track>
               <TimeSlider.Thumb render={(props) => <SliderThumb {...props} />} />
+              <div className={preview.root}>
+                <Slider.Thumbnail className={preview.thumbnail} />
+                <TimeSlider.Value type="pointer" className={preview.timestamp} />
+                <SpinnerIcon className={cn(icon, preview.spinner)} />
+              </div>
             </TimeSlider.Root>
             <Time.Value type="duration" className={time.duration} />
           </Time.Group>

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -26,6 +26,7 @@ import { PlayButton } from '@/ui/play-button';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
+import { Slider } from '@/ui/slider';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
@@ -159,6 +160,12 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
                 <TimeSlider.Buffer className="media-slider__buffer" />
               </TimeSlider.Track>
               <TimeSlider.Thumb className="media-slider__thumb" />
+
+              <div className="media-surface media-preview media-slider__preview">
+                <Slider.Thumbnail className="media-preview__thumbnail" />
+                <TimeSlider.Value type="pointer" className="media-preview__timestamp" />
+                <SpinnerIcon className="media-preview__spinner media-icon" />
+              </div>
             </TimeSlider.Root>
             <Time.Value type="duration" className="media-time__value" />
           </Time.Group>

--- a/packages/react/src/ui/thumbnail/index.ts
+++ b/packages/react/src/ui/thumbnail/index.ts
@@ -1,0 +1,1 @@
+export * from './thumbnail';

--- a/packages/sandbox/app/shared/html/mux-storyboard.ts
+++ b/packages/sandbox/app/shared/html/mux-storyboard.ts
@@ -1,0 +1,9 @@
+import { getMuxAssetId } from '../mux';
+import type { SourceId } from '../sources';
+
+export function renderMuxStoryboard(source: SourceId): string {
+  const id = getMuxAssetId(source);
+  return id
+    ? `<track kind="metadata" label="thumbnails" src="https://image.mux.com/${id}/storyboard.vtt" default />`
+    : '';
+}

--- a/packages/sandbox/app/shared/mux.ts
+++ b/packages/sandbox/app/shared/mux.ts
@@ -1,0 +1,10 @@
+import { SOURCES, type SourceId } from './sources';
+
+export function getMuxAssetId(source: SourceId): string | undefined {
+  return SOURCES[source].url.match(/stream\.mux\.com\/([a-zA-Z0-9]+)/)?.[1];
+}
+
+export function getMuxPosterSrc(source: SourceId): string | undefined {
+  const id = getMuxAssetId(source);
+  return id ? `https://image.mux.com/${id}/thumbnail.jpg` : undefined;
+}

--- a/packages/sandbox/app/shared/react/mux-poster.tsx
+++ b/packages/sandbox/app/shared/react/mux-poster.tsx
@@ -1,0 +1,14 @@
+import { Poster } from '@videojs/react';
+
+import { getMuxAssetId } from '../mux';
+import type { SourceId } from '../sources';
+
+type MuxPosterProps = {
+  source: SourceId;
+};
+
+export function MuxPoster({ source }: MuxPosterProps) {
+  const id = getMuxAssetId(source);
+  if (!id) return null;
+  return <Poster src={`https://image.mux.com/${id}/thumbnail.jpg`} />;
+}

--- a/packages/sandbox/app/shared/react/mux-storyboard.tsx
+++ b/packages/sandbox/app/shared/react/mux-storyboard.tsx
@@ -1,0 +1,12 @@
+import { getMuxAssetId } from '../mux';
+import type { SourceId } from '../sources';
+
+type MuxStoryboardProps = {
+  source: SourceId;
+};
+
+export function MuxStoryboard({ source }: MuxStoryboardProps) {
+  const id = getMuxAssetId(source);
+  if (!id) return null;
+  return <track kind="metadata" label="thumbnails" src={`https://image.mux.com/${id}/storyboard.vtt`} default />;
+}

--- a/packages/sandbox/templates/html-hls-video/main.ts
+++ b/packages/sandbox/templates/html-hls-video/main.ts
@@ -3,6 +3,7 @@ import '@videojs/html/video/player';
 import '@videojs/html/media/hls-video';
 import '@videojs/html/video/skin';
 import '@videojs/html/video/minimal-skin';
+import { renderMuxStoryboard } from '@app/shared/html/mux-storyboard';
 import { CSS_SKIN_TAGS } from '@app/shared/html/skin-tags';
 import { loadVideoStylesheets } from '@app/shared/html/stylesheets';
 import { getInitialSkin, getInitialSource, onSkinChange, onSourceChange } from '@app/shared/sandbox-listener';
@@ -23,7 +24,9 @@ function render() {
   document.getElementById('root')!.innerHTML = html`
     <video-player>
       <${tag} class="w-full aspect-video max-w-4xl mx-auto">
-        <hls-video slot="media" src="${SOURCES[currentSource].url}" playsinline></hls-video>
+        <hls-video slot="media" src="${SOURCES[currentSource].url}" playsinline crossorigin="anonymous">
+          ${renderMuxStoryboard(currentSource)}
+        </hls-video>
       </${tag}>
     </video-player>
   `;

--- a/packages/sandbox/templates/html-simple-hls-video/main.ts
+++ b/packages/sandbox/templates/html-simple-hls-video/main.ts
@@ -3,6 +3,7 @@ import '@videojs/html/video/player';
 import '@videojs/html/media/simple-hls-video';
 import '@videojs/html/video/skin';
 import '@videojs/html/video/minimal-skin';
+import { renderMuxStoryboard } from '@app/shared/html/mux-storyboard';
 import { CSS_SKIN_TAGS } from '@app/shared/html/skin-tags';
 import { loadVideoStylesheets } from '@app/shared/html/stylesheets';
 import { getInitialSkin, getInitialSource, onSkinChange, onSourceChange } from '@app/shared/sandbox-listener';
@@ -23,7 +24,9 @@ function render() {
   document.getElementById('root')!.innerHTML = html`
     <video-player>
       <${tag} class="w-full aspect-video max-w-4xl mx-auto">
-        <simple-hls-video slot="media" src="${SOURCES[currentSource].url}" playsinline></simple-hls-video>
+        <simple-hls-video slot="media" src="${SOURCES[currentSource].url}" playsinline crossorigin="anonymous">
+          ${renderMuxStoryboard(currentSource)}
+        </simple-hls-video>
       </${tag}>
     </video-player>
   `;

--- a/packages/sandbox/templates/html-video-tailwind/main.ts
+++ b/packages/sandbox/templates/html-video-tailwind/main.ts
@@ -1,7 +1,9 @@
 import '@app/styles.css';
+import '@videojs/html/ui/poster';
 import '@videojs/html/video/player';
 import '@videojs/html/video/skin.tailwind';
 import '@videojs/html/video/minimal-skin.tailwind';
+import { renderMuxStoryboard } from '@app/shared/html/mux-storyboard';
 import { TAILWIND_SKIN_TAGS } from '@app/shared/html/skin-tags';
 import { setupVideoTailwind } from '@app/shared/html/tailwind-setup';
 import { getInitialSkin, getInitialSource, onSkinChange, onSourceChange } from '@app/shared/sandbox-listener';
@@ -22,7 +24,9 @@ function render() {
   document.getElementById('root')!.innerHTML = html`
     <video-player>
       <${tag} class="w-full aspect-video max-w-4xl mx-auto">
-        <video slot="media" src="${SOURCES[currentSource].url}" playsinline></video>
+        <video slot="media" src="${SOURCES[currentSource].url}" playsinline crossorigin="anonymous">
+          ${renderMuxStoryboard(currentSource)}
+        </video>
       </${tag}>
     </video-player>
   `;

--- a/packages/sandbox/templates/html-video/main.ts
+++ b/packages/sandbox/templates/html-video/main.ts
@@ -2,6 +2,8 @@ import '@app/styles.css';
 import '@videojs/html/video/player';
 import '@videojs/html/video/skin';
 import '@videojs/html/video/minimal-skin';
+import '@videojs/html/ui/poster';
+import { renderMuxStoryboard } from '@app/shared/html/mux-storyboard';
 import { CSS_SKIN_TAGS } from '@app/shared/html/skin-tags';
 import { loadVideoStylesheets } from '@app/shared/html/stylesheets';
 import { getInitialSkin, getInitialSource, onSkinChange, onSourceChange } from '@app/shared/sandbox-listener';
@@ -22,7 +24,9 @@ function render() {
   document.getElementById('root')!.innerHTML = html`
     <video-player>
       <${tag} class="w-full aspect-video max-w-4xl mx-auto">
-        <video slot="media" src="${SOURCES[currentSource].url}" playsinline></video>
+        <video slot="media" src="${SOURCES[currentSource].url}" playsinline crossorigin="anonymous">
+          ${renderMuxStoryboard(currentSource)}
+        </video>
       </${tag}>
     </video-player>
   `;

--- a/packages/sandbox/templates/react-hls-video/main.tsx
+++ b/packages/sandbox/templates/react-hls-video/main.tsx
@@ -1,6 +1,8 @@
 import '@app/styles.css';
 import '@videojs/react/video/skin.css';
 import '@videojs/react/video/minimal-skin.css';
+import { MuxPoster } from '@app/shared/react/mux-poster';
+import { MuxStoryboard } from '@app/shared/react/mux-storyboard';
 import { VideoProvider } from '@app/shared/react/providers';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSkin } from '@app/shared/react/use-skin';
@@ -16,7 +18,10 @@ function App() {
   return (
     <VideoProvider>
       <VideoSkinComponent skin={skin} styling="css" className="w-full aspect-video max-w-4xl mx-auto">
-        <HlsVideo src={SOURCES[source].url} playsInline />
+        <HlsVideo src={SOURCES[source].url} playsInline crossOrigin="anonymous">
+          <MuxStoryboard source={source} />
+        </HlsVideo>
+        <MuxPoster source={source} />
       </VideoSkinComponent>
     </VideoProvider>
   );

--- a/packages/sandbox/templates/react-simple-hls-video/main.tsx
+++ b/packages/sandbox/templates/react-simple-hls-video/main.tsx
@@ -1,6 +1,8 @@
 import '@app/styles.css';
 import '@videojs/react/video/skin.css';
 import '@videojs/react/video/minimal-skin.css';
+import { MuxPoster } from '@app/shared/react/mux-poster';
+import { MuxStoryboard } from '@app/shared/react/mux-storyboard';
 import { VideoProvider } from '@app/shared/react/providers';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSkin } from '@app/shared/react/use-skin';
@@ -16,7 +18,10 @@ function App() {
   return (
     <VideoProvider>
       <VideoSkinComponent skin={skin} styling="css" className="w-full aspect-video max-w-4xl mx-auto">
-        <SimpleHlsVideo src={SOURCES[source].url} playsInline />
+        <SimpleHlsVideo src={SOURCES[source].url} playsInline crossOrigin="anonymous">
+          <MuxStoryboard source={source} />
+        </SimpleHlsVideo>
+        <MuxPoster source={source} />
       </VideoSkinComponent>
     </VideoProvider>
   );

--- a/packages/sandbox/templates/react-video-tailwind/main.tsx
+++ b/packages/sandbox/templates/react-video-tailwind/main.tsx
@@ -1,4 +1,6 @@
 import '@app/styles.css';
+import { MuxPoster } from '@app/shared/react/mux-poster';
+import { MuxStoryboard } from '@app/shared/react/mux-storyboard';
 import { VideoProvider } from '@app/shared/react/providers';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSkin } from '@app/shared/react/use-skin';
@@ -14,7 +16,10 @@ function App() {
   return (
     <VideoProvider>
       <VideoSkinComponent skin={skin} styling="tailwind" className="w-full aspect-video max-w-4xl mx-auto">
-        <Video src={SOURCES[source].url} playsInline />
+        <Video src={SOURCES[source].url} playsInline crossOrigin="anonymous">
+          <MuxStoryboard source={source} />
+        </Video>
+        <MuxPoster source={source} />
       </VideoSkinComponent>
     </VideoProvider>
   );

--- a/packages/sandbox/templates/react-video/main.tsx
+++ b/packages/sandbox/templates/react-video/main.tsx
@@ -1,6 +1,8 @@
 import '@app/styles.css';
 import '@videojs/react/video/skin.css';
 import '@videojs/react/video/minimal-skin.css';
+import { MuxPoster } from '@app/shared/react/mux-poster';
+import { MuxStoryboard } from '@app/shared/react/mux-storyboard';
 import { VideoProvider } from '@app/shared/react/providers';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSkin } from '@app/shared/react/use-skin';
@@ -16,7 +18,10 @@ function App() {
   return (
     <VideoProvider>
       <VideoSkinComponent skin={skin} styling="css" className="w-full aspect-video max-w-4xl mx-auto">
-        <Video src={SOURCES[source].url} playsInline />
+        <Video src={SOURCES[source].url} playsInline crossOrigin="anonymous">
+          <MuxStoryboard source={source} />
+        </Video>
+        <MuxPoster source={source} />
       </VideoSkinComponent>
     </VideoProvider>
   );

--- a/packages/skins/src/default/css/components/buttons.css
+++ b/packages/skins/src/default/css/components/buttons.css
@@ -22,6 +22,7 @@
   transition-timing-function: ease-out;
   cursor: pointer;
   user-select: none;
+  touch-action: manipulation;
 
   &:focus-visible {
     outline-color: oklch(62.3% 0.214 259.815);

--- a/packages/skins/src/default/css/components/media.css
+++ b/packages/skins/src/default/css/components/media.css
@@ -24,10 +24,10 @@
   inset: 0;
   width: 100%;
   height: 100%;
-  border-radius: inherit;
   object-fit: cover;
   transition: opacity 0.25s;
   pointer-events: none;
+  border-radius: inherit;
 
   &:not([data-visible]) {
     opacity: 0;

--- a/packages/skins/src/default/css/components/popup.css
+++ b/packages/skins/src/default/css/components/popup.css
@@ -9,12 +9,12 @@
   color: inherit;
   overflow: visible;
   transition-property: transform, scale, opacity, filter;
-  transition-duration: 200ms;
+  transition-duration: 150ms;
 
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: scale(0);
+    transform: scale(0.5);
     filter: blur(8px);
   }
 
@@ -49,5 +49,5 @@
   border-radius: calc(infinity * 1px);
   font-size: 0.75rem;
   white-space: nowrap;
-  --media-tooltip-side-offset: 0.5rem;
+  --media-tooltip-side-offset: 0.75rem;
 }

--- a/packages/skins/src/default/css/components/preview.css
+++ b/packages/skins/src/default/css/components/preview.css
@@ -1,0 +1,56 @@
+/* ==========================================================================
+   Media preview
+   ========================================================================== */
+.media-default-skin .media-preview {
+  background-color: oklch(0 0 0 / 0.9);
+  border-radius: 0.75rem;
+
+  & .media-preview__thumbnail {
+    display: block;
+    position: relative;
+    border-radius: inherit;
+    overflow: clip;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background-image: linear-gradient(to top, oklch(0 0 0 / 0.8), oklch(0 0 0 / 0.3), oklch(0 0 0 / 0));
+    }
+  }
+
+  & .media-preview__timestamp {
+    position: absolute;
+    bottom: 0.5rem;
+    inset-inline: 0;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  & .media-overlay {
+    opacity: 1;
+  }
+
+  & .media-preview__spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+  }
+
+  & .media-preview__thumbnail,
+  & .media-preview__spinner {
+    transition: opacity 150ms ease-out;
+  }
+
+  &:has(.media-preview__thumbnail[data-loading]) {
+    & .media-preview__thumbnail {
+      opacity: 0;
+    }
+    & .media-preview__spinner {
+      opacity: 1;
+    }
+  }
+}

--- a/packages/skins/src/default/css/components/reset.css
+++ b/packages/skins/src/default/css/components/reset.css
@@ -6,7 +6,6 @@
 .media-default-skin *::before,
 .media-default-skin *::after {
   box-sizing: border-box;
-  margin: 0;
 }
 .media-default-skin img,
 .media-default-skin video,

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -10,6 +10,7 @@
   flex: 1;
   border-radius: calc(infinity * 1px);
   outline: none;
+  cursor: pointer;
 
   &[data-orientation="horizontal"] {
     min-width: 5rem;
@@ -140,9 +141,4 @@
   &[data-orientation="vertical"] {
     height: var(--media-slider-fill);
   }
-}
-
-/* Time display within slider */
-.media-default-skin .media-slider__time-display {
-  font-variant-numeric: tabular-nums;
 }

--- a/packages/skins/src/default/css/components/surface.css
+++ b/packages/skins/src/default/css/components/surface.css
@@ -6,7 +6,7 @@
   background-color: var(--media-surface-background-color);
   backdrop-filter: var(--media-surface-backdrop-filter);
   box-shadow:
-    inset 0 0 0 1px var(--media-surface-inner-border-color),
+    0 0 0 1px var(--media-surface-outer-border-color),
     0 1px 3px 0 var(--media-surface-shadow-color),
     0 1px 2px -1px var(--media-surface-shadow-color);
 
@@ -17,7 +17,7 @@
     inset: 0;
     z-index: 10;
     border-radius: inherit;
-    box-shadow: 0 0 0 1px var(--media-surface-outer-border-color);
+    box-shadow: inset 0 0 0 1px var(--media-surface-inner-border-color);
     pointer-events: none;
   }
 

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -11,6 +11,7 @@
 @import "./components/time.css";
 @import "./components/buttons.css";
 @import "./components/icons.css";
+@import "./components/preview.css";
 @import "./components/slider.css";
 @import "./components/popup.css";
 @import "./components/captions.css";
@@ -98,4 +99,30 @@
 .media-default-skin--video .media-slider__track {
   background-color: oklch(1 0 0 / 0.2);
   box-shadow: 0 0 0 1px oklch(0 0 0 / 0.05);
+}
+
+.media-default-skin .media-slider__preview {
+  position: absolute;
+  left: var(--media-slider-pointer);
+  bottom: calc(100% + 1.2rem);
+  translate: -50%;
+  opacity: 0;
+  scale: 0.8;
+  filter: blur(8px);
+  transition-property: scale, opacity, filter;
+  transition-duration: 150ms;
+  transform-origin: bottom;
+
+  & .media-preview__thumbnail {
+    max-width: 11rem;
+  }
+
+  &:has(.media-preview__thumbnail[data-loading]) {
+    max-height: 6rem;
+  }
+}
+.media-default-skin .media-slider[data-pointing] .media-slider__preview:has([role="img"]:not([data-hidden])) {
+  opacity: 1;
+  scale: 1;
+  filter: blur(0);
 }

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const button = {
   base: cn(
-    'items-center justify-center shrink-0 border-none cursor-pointer select-none text-center',
+    'items-center justify-center shrink-0 border-none cursor-pointer select-none text-center touch-manipulation',
     'font-medium',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,color,outline-offset,scale] duration-150 ease-out',

--- a/packages/skins/src/default/tailwind/components/popup.ts
+++ b/packages/skins/src/default/tailwind/components/popup.ts
@@ -4,9 +4,9 @@ const base = cn(
   // Reset default popover styles
   'm-0 border-0 text-inherit overflow-visible',
   // Animation
-  'transition-[transform,scale,opacity,filter] duration-200',
-  'data-starting-style:opacity-0 data-starting-style:scale-0 data-starting-style:blur-sm',
-  'data-ending-style:opacity-0 data-ending-style:scale-0 data-ending-style:blur-sm',
+  'transition-[transform,scale,opacity,filter] duration-150',
+  'data-starting-style:opacity-0 data-starting-style:scale-50 data-starting-style:blur-sm',
+  'data-ending-style:opacity-0 data-ending-style:scale-50 data-ending-style:blur-sm',
   'data-instant:duration-0',
   // Ensure we animate from the correct origin based on the side the popover is on
   'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left'
@@ -17,7 +17,7 @@ export const popup = {
   tooltip: cn(
     base,
     'py-1 px-2.5 rounded-full text-[0.75rem] whitespace-nowrap',
-    '[--media-tooltip-side-offset:0.5rem]'
+    '[--media-tooltip-side-offset:0.75rem]'
   ),
   volume: 'py-2.5 px-1 rounded-full',
 };

--- a/packages/skins/src/default/tailwind/components/preview.ts
+++ b/packages/skins/src/default/tailwind/components/preview.ts
@@ -1,0 +1,18 @@
+import { cn } from '@videojs/utils/style';
+
+export const preview = {
+  root: cn('group/preview pointer-events-none bg-black/90 rounded-xl'),
+  thumbnail: cn(
+    'block relative overflow-clip rounded-[inherit]',
+    'transition-opacity duration-150 ease-out',
+    'after:absolute after:inset-0 after:rounded-[inherit]',
+    'after:bg-linear-to-t after:from-black/80 after:via-black/30 after:to-black/0',
+    'data-loading:opacity-0'
+  ),
+  timestamp: 'absolute bottom-2 inset-x-0 text-center tabular-nums',
+  spinner: cn(
+    'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0',
+    'transition-opacity duration-150 ease-out',
+    'group-has-[[role=img][data-loading]]/preview:opacity-100'
+  ),
+};

--- a/packages/skins/src/default/tailwind/components/root.ts
+++ b/packages/skins/src/default/tailwind/components/root.ts
@@ -7,7 +7,7 @@ export const root = cn(
   'rounded-(--media-border-radius,2rem)',
   'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-[0.8125rem] leading-normal subpixel-antialiased',
   // Resets
-  '**:box-border **:m-0',
+  '**:box-border',
   '[&_button]:font-[inherit]',
   'motion-safe:[interpolate-size:allow-keywords]'
 );

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const slider = {
   root: cn(
-    'group/slider relative flex flex-1 items-center justify-center rounded-full outline-none',
+    'group/slider relative flex flex-1 items-center justify-center rounded-full outline-none cursor-pointer',
     // Horizontal
     'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-5',
     // Vertical

--- a/packages/skins/src/default/tailwind/components/surface.ts
+++ b/packages/skins/src/default/tailwind/components/surface.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const surface = cn(
   // Border and shadow
-  'ring ring-inset shadow-sm',
+  'ring shadow-sm',
   // Border to enhance contrast on lighter videos
-  'after:absolute after:inset-0 after:ring after:rounded-[inherit] after:pointer-events-none after:z-10'
+  'after:absolute after:inset-0 after:ring after:ring-inset after:rounded-[inherit] after:pointer-events-none after:z-10'
 );

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -3,6 +3,7 @@ import { bufferingIndicator as baseBufferingIndicator } from './components/buffe
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
 import { popup as basePopup } from './components/popup';
+import { preview as basePreview } from './components/preview';
 import { root as baseRoot } from './components/root';
 import { slider as baseSlider } from './components/slider';
 import { surface as baseSurface } from './components/surface';
@@ -66,9 +67,9 @@ export const surface = cn(
   'bg-white/10',
   'backdrop-saturate-150 backdrop-blur-lg',
   // Border and shadow
-  'ring-white/5 shadow-black/10',
+  'ring-black/15 shadow-black/10',
   // Border to enhance contrast on lighter videos
-  'after:ring-black/15',
+  'after:ring-white/5',
   // Reduced transparency for users with preference
   '[@media(prefers-reduced-transparency:reduce)]:bg-black/70',
   // High contrast mode
@@ -100,6 +101,25 @@ export const controls = cn(
   'motion-reduce:not-data-visible:blur-none',
   'motion-reduce:not-data-visible:scale-100'
 );
+
+/* ==========================================================================
+   Preview (with video surface)
+   ========================================================================== */
+
+export const preview = {
+  ...basePreview,
+  root: cn(
+    'absolute left-(--media-slider-pointer) bottom-[calc(100%+1.2rem)] -translate-x-1/2',
+    'opacity-0 scale-80 blur-sm origin-bottom',
+    'transition-[scale,opacity,filter] duration-150',
+    'group-data-pointing/slider:opacity-100 group-data-pointing/slider:scale-100 group-data-pointing/slider:blur-none',
+    '[&:has([role=img][data-hidden])]:opacity-0 [&:has([role=img][data-hidden])]:scale-80 [&:has([role=img][data-hidden])]:blur-sm',
+    '[&:has([role=img][data-loading])]:max-h-24',
+    surface,
+    basePreview.root
+  ),
+  thumbnail: cn(basePreview.thumbnail, 'max-w-44'),
+};
 
 /* ==========================================================================
    Sliders

--- a/packages/skins/src/minimal/css/components/buttons.css
+++ b/packages/skins/src/minimal/css/components/buttons.css
@@ -37,6 +37,7 @@
   transition-timing-function: ease-out;
   cursor: pointer;
   user-select: none;
+  touch-action: manipulation;
 
   &:focus-visible {
     outline-color: currentColor;

--- a/packages/skins/src/minimal/css/components/popup.css
+++ b/packages/skins/src/minimal/css/components/popup.css
@@ -9,12 +9,12 @@
   color: inherit;
   overflow: visible;
   transition-property: transform, scale, opacity, filter;
-  transition-duration: 200ms;
+  transition-duration: 150ms;
 
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: scale(0);
+    transform: scale(0.5);
     filter: blur(8px);
   }
 
@@ -46,7 +46,7 @@
     0 2px 4px -2px oklch(0 0 0 / 0.1);
   font-size: 0.75rem;
   white-space: nowrap;
-  --media-tooltip-side-offset: 0.5rem;
+  --media-tooltip-side-offset: 0.75rem;
 
   @media (prefers-reduced-transparency: reduce) {
     background-color: oklch(0 0 0 / 0.7);

--- a/packages/skins/src/minimal/css/components/preview.css
+++ b/packages/skins/src/minimal/css/components/preview.css
@@ -1,0 +1,47 @@
+/* ==========================================================================
+   Media preview
+   ========================================================================== */
+.media-minimal-skin .media-preview {
+  & .media-preview__thumbnail-wrapper {
+    position: relative;
+    border-radius: 0.5rem;
+    background-color: oklch(0 0 0 / 0.9);
+  }
+  & .media-preview__thumbnail {
+    display: block;
+    border-radius: inherit;
+  }
+
+  & .media-preview__timestamp {
+    display: block;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    margin-top: 0.5rem;
+  }
+
+  & .media-overlay {
+    opacity: 1;
+  }
+
+  & .media-preview__spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+  }
+
+  & .media-preview__thumbnail,
+  & .media-preview__spinner {
+    transition: opacity 150ms ease-out;
+  }
+
+  &:has(.media-preview__thumbnail[data-loading]) {
+    & .media-preview__thumbnail {
+      opacity: 0;
+    }
+    & .media-preview__spinner {
+      opacity: 1;
+    }
+  }
+}

--- a/packages/skins/src/minimal/css/components/reset.css
+++ b/packages/skins/src/minimal/css/components/reset.css
@@ -6,7 +6,6 @@
 .media-minimal-skin *::before,
 .media-minimal-skin *::after {
   box-sizing: border-box;
-  margin: 0;
 }
 .media-minimal-skin img,
 .media-minimal-skin video,

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -10,6 +10,7 @@
   flex: 1;
   border-radius: calc(infinity * 1px);
   outline: none;
+  cursor: pointer;
 
   &[data-orientation="horizontal"] {
     min-width: 5rem;
@@ -137,9 +138,4 @@
   &[data-orientation="vertical"] {
     height: var(--media-slider-fill);
   }
-}
-
-/* Time display within slider */
-.media-minimal-skin .media-slider__time-display {
-  font-variant-numeric: tabular-nums;
 }

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -10,6 +10,7 @@
 @import "./components/time.css";
 @import "./components/buttons.css";
 @import "./components/icons.css";
+@import "./components/preview.css";
 @import "./components/slider.css";
 @import "./components/popup.css";
 @import "./components/captions.css";
@@ -105,4 +106,49 @@
   --media-popover-side-offset: 0.5rem;
   background: transparent;
   padding: 0.25rem;
+}
+
+/* ==========================================================================
+   Slider preview
+   ========================================================================== */
+
+.media-minimal-skin .media-slider__preview {
+  position: absolute;
+  left: var(--media-slider-pointer);
+  bottom: calc(100% + 0.5rem);
+  translate: -50%;
+  opacity: 0;
+  scale: 0.8;
+  filter: blur(8px);
+  transition-property: scale, opacity, filter;
+  transition-duration: 150ms;
+  transform-origin: bottom;
+
+  & .media-preview__thumbnail-wrapper {
+    position: relative;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      box-shadow:
+        0 0 0 1px oklch(0 0 0 / 0.05),
+        0 1px 3px 0 oklch(0 0 0 / 0.2),
+        0 1px 2px -1px oklch(0 0 0 / 0.2);
+    }
+  }
+
+  & .media-preview__thumbnail {
+    max-width: 11rem;
+  }
+
+  &:has(.media-preview__thumbnail[data-loading]) {
+    max-height: 6rem;
+  }
+}
+.media-minimal-skin .media-slider[data-pointing] .media-slider__preview:has([role="img"]:not([data-hidden])) {
+  opacity: 1;
+  scale: 1;
+  filter: blur(0);
 }

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const button = {
   base: cn(
-    'items-center justify-center shrink-0 border-none cursor-pointer select-none text-center',
+    'items-center justify-center shrink-0 border-none cursor-pointer select-none text-center touch-manipulation',
     'outline-2 outline-transparent -outline-offset-2',
     'font-medium text-shadow-inherit',
     'transition-[background-color,color,outline-offset,scale] duration-150 ease-out',

--- a/packages/skins/src/minimal/tailwind/components/popup.ts
+++ b/packages/skins/src/minimal/tailwind/components/popup.ts
@@ -4,19 +4,19 @@ const base = cn(
   // Reset default popover styles
   'm-0 border-0 text-inherit overflow-visible',
   // Animation
-  'transition-[transform,scale,opacity,filter] duration-200',
-  'data-starting-style:opacity-0 data-starting-style:scale-0 data-starting-style:blur-sm',
-  'data-ending-style:opacity-0 data-ending-style:scale-0 data-ending-style:blur-sm',
+  'transition-[transform,scale,opacity,filter] duration-150',
+  'data-starting-style:opacity-0 data-starting-style:scale-50 data-starting-style:blur-sm',
+  'data-ending-style:opacity-0 data-ending-style:scale-50 data-ending-style:blur-sm',
   'data-instant:duration-0',
   // Ensure we animate from the correct origin based on the side the popover is on
   'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left'
 );
 
 export const popup = {
+  base,
   tooltip: cn(
     base,
     'px-2 py-1 rounded-sm shadow-md shadow-black/10 bg-white/10 backdrop-blur-lg backdrop-saturate-150 text-[0.75rem] whitespace-nowrap',
-    '[--media-tooltip-side-offset:0.5rem]'
+    '[--media-tooltip-side-offset:0.75rem]'
   ),
-  volume: cn(base, 'py-2.5 px-1 rounded-full'),
 };

--- a/packages/skins/src/minimal/tailwind/components/preview.ts
+++ b/packages/skins/src/minimal/tailwind/components/preview.ts
@@ -1,0 +1,13 @@
+import { cn } from '@videojs/utils/style';
+
+export const preview = {
+  root: 'group/preview pointer-events-none',
+  thumbnailWrapper: 'relative rounded-lg bg-black/90',
+  thumbnail: cn('block rounded-[inherit] transition-opacity duration-150 ease-out', 'data-loading:opacity-0'),
+  timestamp: 'mt-2 block text-center tabular-nums',
+  spinner: cn(
+    'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0',
+    'transition-opacity duration-150 ease-out',
+    'group-has-[[role=img][data-loading]]/preview:opacity-100'
+  ),
+};

--- a/packages/skins/src/minimal/tailwind/components/root.ts
+++ b/packages/skins/src/minimal/tailwind/components/root.ts
@@ -7,7 +7,7 @@ export const root = cn(
   'rounded-(--media-border-radius,0.75rem)',
   'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-[0.8125rem] leading-normal subpixel-antialiased',
   // Resets
-  '**:box-border **:m-0',
+  '**:box-border',
   '[&_button]:font-[inherit]',
   'motion-safe:[interpolate-size:allow-keywords]'
 );

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const slider = {
   root: cn(
-    'group/slider relative flex flex-1 items-center justify-center rounded-full outline-none',
+    'group/slider relative flex flex-1 items-center justify-center rounded-full outline-none cursor-pointer',
     // Horizontal
     'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-5',
     // Vertical

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -1,6 +1,7 @@
 import { cn } from '@videojs/utils/style';
 import { controls as baseControls } from './components/controls';
 import { popup as basePopup } from './components/popup';
+import { preview as basePreview } from './components/preview';
 import { root as baseRoot } from './components/root';
 import { slider as baseSlider } from './components/slider';
 
@@ -86,12 +87,35 @@ export const controls = cn(
 );
 
 /* ==========================================================================
+   Preview
+   ========================================================================== */
+
+export const preview = {
+  ...basePreview,
+  root: cn(
+    'absolute left-(--media-slider-pointer) bottom-[calc(100%+0.5rem)] -translate-x-1/2',
+    'opacity-0 scale-80 blur-sm origin-bottom',
+    'transition-[scale,opacity,filter] duration-150',
+    'group-data-pointing/slider:opacity-100 group-data-pointing/slider:scale-100 group-data-pointing/slider:blur-none',
+    '[&:has([role=img][data-hidden])]:opacity-0 [&:has([role=img][data-hidden])]:scale-80 [&:has([role=img][data-hidden])]:blur-sm',
+    '[&:has([role=img][data-loading])]:max-h-24',
+    basePreview.root
+  ),
+  thumbnailWrapper: cn(
+    basePreview.thumbnailWrapper,
+    'after:absolute after:inset-0 after:rounded-[inherit]',
+    'after:ring-1 after:ring-black/5 after:shadow-sm after:shadow-black/20'
+  ),
+  thumbnail: cn(basePreview.thumbnail, 'max-w-44'),
+};
+
+/* ==========================================================================
    Sliders
    ========================================================================== */
 
 export const slider = {
   ...baseSlider,
-  track: cn(baseSlider.track, 'shadow-[0_0_0_1px_oklch(0_0_0/0.05)]'),
+  track: cn(baseSlider.track, 'ring-1 ring-black/5'),
 };
 
 /* ==========================================================================
@@ -100,7 +124,7 @@ export const slider = {
 
 export const popup = {
   ...basePopup,
-  volume: cn('[--media-popover-side-offset:0.5rem] p-1 bg-transparent'),
+  volume: cn(basePopup.base, '[--media-popover-side-offset:0.5rem] p-1 bg-transparent'),
 };
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- add slider preview thumbnail UI to the default and minimal HTML and React video skins
- wire sandbox templates to Mux storyboard and poster assets so previews render in demos
- fix thumbnail state when React connects after an image has already loaded or errored

## Testing
- pnpm -F @videojs/core test src/dom/ui/tests/thumbnail.test.ts
- pnpm exec biome check packages/core/src/dom/ui/thumbnail.ts packages/core/src/dom/ui/tests/thumbnail.test.ts packages/html/src/define/video/skin.ts packages/html/src/define/video/minimal-skin.ts packages/react/src/presets/video/skin.tsx packages/react/src/presets/video/minimal-skin.tsx packages/react/src/ui/thumbnail/index.ts packages/sandbox/app/shared/mux.ts packages/sandbox/app/shared/html/mux-storyboard.ts packages/sandbox/app/shared/react/mux-storyboard.tsx packages/sandbox/app/shared/react/mux-poster.tsx packages/skins/src/default/css/video.css packages/skins/src/minimal/css/video.css

Closes #814