### PR TITLE
chore(site): add Algolia site verification meta tag

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -55,6 +55,7 @@ const fullTitle =
       href={new URL("rss.xml", Astro.site)}
     />
     <meta name="generator" content={Astro.generator} />
+    <meta name="algolia-site-verification" content="9CE2D1D6448256D3" />
 
     {/* Analytics (production only) */}
     {import.meta.env.PROD && <Posthog />}


### PR DESCRIPTION
## Summary
- Adds `<meta name="algolia-site-verification" content="9CE2D1D6448256D3" />` to `Base.astro` for Algolia site ownership verification

Ref #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)