### PR TITLE
fix(site): restore blank lines in code blocks

### DIFF
--- a/site/src/styles/shiki-transformers.css
+++ b/site/src/styles/shiki-transformers.css
@@ -1,15 +1,10 @@
 @layer base {
-  .astro-code code {
-    display: flex;
-    flex-direction: column;
-  }
   .astro-code .line {
-    display: inline-flex;
-    position: relative;
-    line-height: 1.75;
+    display: inline-block;
   }
   .astro-code .line.diff,
   .astro-code .line.focused {
+    position: relative;
     width: calc(100% + var(--spacing) * 12);
     margin-inline: calc(var(--spacing) * -6);
     padding-inline: calc(var(--spacing) * 6);


### PR DESCRIPTION
## Summary

- Remove `flex`/`flex-direction: column`/`inline-flex`/`line-height` overrides from shiki transformer CSS that collapsed empty `.line` spans (blank newlines in code blocks)
- Use `display: inline-block` on `.line` so empty lines retain their natural height
- Scope `position: relative` to only `.line.diff` and `.line.focused` where `::before` pseudo-elements need it

Closes #936

## Test plan

- [ ] `pnpm dev` from site/ — verify code blocks with blank newlines render correctly (e.g., background video example on installation page)
- [ ] Verify diff, focus, and word-highlight annotations still render correctly on the write-guides page
- [ ] `pnpm build` — no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)