### PR TITLE
fix(skin): bake in safari layout fix into skins

### DIFF
--- a/packages/html/src/define/audio/minimal-skin.css
+++ b/packages/html/src/define/audio/minimal-skin.css
@@ -1,2 +1,1 @@
 @import "@videojs/skins/minimal/css/audio.css";
-@import "../shared.css";

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -40,7 +40,7 @@ function getTemplateHTML() {
       <slot name="media"></slot>
 
       <div class="${controls}">
-        <media-tooltip-group class="contents">
+        <media-tooltip-group>
           <div class="${buttonGroup}">
             <span class="${tooltipState.play.wrapper}">
               <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.icon, iconState.play.button)}">

--- a/packages/html/src/define/audio/skin.css
+++ b/packages/html/src/define/audio/skin.css
@@ -1,2 +1,1 @@
 @import "@videojs/skins/default/css/audio.css";
-@import "../shared.css";

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -39,7 +39,7 @@ function getTemplateHTML() {
       <slot name="media"></slot>
 
       <div class="${controls}">
-        <media-tooltip-group class="contents">
+        <media-tooltip-group>
           <span class="${tooltipState.play.wrapper}">
             <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.icon, iconState.play.button)}">
               ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}

--- a/packages/html/src/define/shared.css
+++ b/packages/html/src/define/shared.css
@@ -2,6 +2,7 @@ media-tooltip-group {
   display: contents;
 }
 
+/* Fixes a weird issue with Safari when setting aspect-ratio */
 :host {
   display: grid;
 }

--- a/packages/html/src/define/skin-mixin.ts
+++ b/packages/html/src/define/skin-mixin.ts
@@ -1,16 +1,20 @@
 import type { ReactiveElement } from '@videojs/element';
 import type { Constructor } from '@videojs/utils/types';
-import styles from './base.css?inline';
+import rootStyles from './base.css?inline';
+import sharedStyles from './shared.css?inline';
 
 const STYLES_ID = '__media-styles';
 
-function ensureStyles(): void {
+function ensureRootStyles(): void {
   if (document.getElementById(STYLES_ID)) return;
   const style = document.createElement('style');
   style.id = STYLES_ID;
-  style.textContent = styles;
+  style.textContent = rootStyles;
   document.head.appendChild(style);
 }
+
+const sharedSheet = new CSSStyleSheet();
+sharedSheet.replaceSync(sharedStyles);
 
 /**
  * Mixin for skin elements that renders the template from a static
@@ -30,15 +34,17 @@ export function SkinMixin<Base extends Constructor<ReactiveElement>>(
     constructor(...args: any[]) {
       super(...args);
 
-      ensureStyles();
+      ensureRootStyles();
 
       if (!this.shadowRoot) {
         const ctor = this.constructor as typeof SkinElement & { getTemplateHTML?: () => string };
         this.attachShadow(ctor.shadowRootOptions);
 
+        const sheets: CSSStyleSheet[] = [sharedSheet];
         if (ctor.styles) {
-          this.shadowRoot!.adoptedStyleSheets = [ctor.styles];
+          sheets.push(ctor.styles);
         }
+        this.shadowRoot!.adoptedStyleSheets = sheets;
 
         if (ctor.getTemplateHTML) {
           this.shadowRoot!.innerHTML = ctor.getTemplateHTML();

--- a/packages/html/src/define/video/minimal-skin.css
+++ b/packages/html/src/define/video/minimal-skin.css
@@ -1,2 +1,1 @@
 @import "@videojs/skins/minimal/css/video.css";
-@import "../shared.css";

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -52,7 +52,7 @@ function getTemplateHTML() {
       </media-buffering-indicator>
 
       <media-controls data-controls="" class="${controls}">
-        <media-tooltip-group class="contents">
+        <media-tooltip-group>
           <div class="${buttonGroup}">
             <span class="${tooltipState.play.wrapper}">
               <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.icon, iconState.play.button)}">

--- a/packages/html/src/define/video/skin.css
+++ b/packages/html/src/define/video/skin.css
@@ -1,2 +1,1 @@
 @import "@videojs/skins/default/css/video.css";
-@import "../shared.css";

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -53,7 +53,7 @@ function getTemplateHTML() {
       </media-buffering-indicator>
 
       <media-controls data-controls="" class="${controls}">
-        <media-tooltip-group class="contents">
+        <media-tooltip-group>
           <span class="${tooltipState.play.wrapper}">
             <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.icon, iconState.play.button)}">
               ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}

--- a/packages/skins/src/minimal/tailwind/components/time.ts
+++ b/packages/skins/src/minimal/tailwind/components/time.ts
@@ -3,7 +3,7 @@ import { cn } from '@videojs/utils/style';
 export const time = {
   group: 'flex items-center gap-1',
   current: cn('hidden tabular-nums', '@md/media-controls:inline'),
-  separator: cn('hidden', '@md/media-controls:inline @md/media-controls:text-white/50'),
+  separator: cn('hidden', '@md/media-controls:inline @md/media-controls:text-current/60'),
   duration: cn('tabular-nums', '@md/media-controls:text-current/60'),
   controls: cn('flex flex-row-reverse items-center flex-1 gap-3', '@md/media-controls:flex-row'),
 };


### PR DESCRIPTION
Currently, there's a weird quirk where setting aspect-ratio on the skin results in rounding errors and the container is ~3px taller than it should be. Setting `display: grid` on the skin seems to fix it (others didn't work), which is obviously a bug. I've baked this into the skin mixin for now, along with a reset for `media-tooltip-group`. 