### PR TITLE
fix: add volume availability to skins

### DIFF
--- a/packages/core/src/core/ui/mute-button/mute-button-core.ts
+++ b/packages/core/src/core/ui/mute-button/mute-button-core.ts
@@ -14,6 +14,7 @@ export interface MuteButtonProps {
 }
 
 export interface MuteButtonState extends Pick<MediaVolumeState, 'muted'> {
+  availability: MediaVolumeState['volumeAvailability'];
   /**
    * Derived volume level:
    * - `off`: muted or volume is 0
@@ -68,6 +69,7 @@ export class MuteButtonCore {
   getState(): MuteButtonState {
     const media = this.#media!;
     return {
+      availability: media.volumeAvailability,
       muted: media.muted || media.volume === 0,
       volumeLevel: getVolumeLevel(media),
     };

--- a/packages/core/src/core/ui/mute-button/mute-button-data-attrs.ts
+++ b/packages/core/src/core/ui/mute-button/mute-button-data-attrs.ts
@@ -2,6 +2,8 @@ import type { StateAttrMap } from '../types';
 import type { MuteButtonState } from './mute-button-core';
 
 export const MuteButtonDataAttrs = {
+  /** Indicates whether volume control is available. */
+  availability: 'data-availability',
   /** Present when the media is muted. */
   muted: 'data-muted',
   /** Indicates the volume level. */

--- a/packages/core/src/core/ui/mute-button/tests/mute-button-core.test.ts
+++ b/packages/core/src/core/ui/mute-button/tests/mute-button-core.test.ts
@@ -17,6 +17,7 @@ function createMediaState(overrides: Partial<MediaVolumeState> = {}): MediaVolum
 
 function createState(overrides: Partial<MuteButtonState> = {}): MuteButtonState {
   return {
+    availability: 'available',
     muted: false,
     volumeLevel: 'high',
     ...overrides,
@@ -31,6 +32,7 @@ describe('MuteButtonCore', () => {
       core.setMedia(media);
       const state = core.getState();
 
+      expect(state.availability).toBe('available');
       expect(state.muted).toBe(false);
       expect(state.volumeLevel).toBe('high');
     });

--- a/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
+++ b/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
@@ -53,6 +53,7 @@ describe('VolumeSliderCore', () => {
       expect(state.value).toBe(75);
       expect(state.fillPercent).toBe(75);
       expect(state.volume).toBe(0.75);
+      expect(state.availability).toBe('available');
     });
 
     it('returns 0 when volume is 0', () => {
@@ -114,6 +115,15 @@ describe('VolumeSliderCore', () => {
 
       expect(state.muted).toBe(true);
       expect(state.fillPercent).toBe(0);
+    });
+
+    it('projects unsupported volume availability', () => {
+      const core = new VolumeSliderCore();
+      core.setInput(createInput());
+      core.setMedia(createMediaState({ volumeAvailability: 'unsupported' }));
+      const state = core.getState();
+
+      expect(state.availability).toBe('unsupported');
     });
   });
 

--- a/packages/core/src/core/ui/volume-slider/volume-slider-core.ts
+++ b/packages/core/src/core/ui/volume-slider/volume-slider-core.ts
@@ -14,7 +14,7 @@ export interface VolumeSliderProps extends SliderProps {
 }
 
 export interface VolumeSliderState extends SliderState, Pick<MediaVolumeState, 'volume' | 'muted'> {
-  /** Whether volume can be programmatically set on this platform. */
+  /** Availability of programmatic volume control: unavailable, available, or unsupported. */
   availability: MediaVolumeState['volumeAvailability'];
 }
 

--- a/packages/core/src/core/ui/volume-slider/volume-slider-core.ts
+++ b/packages/core/src/core/ui/volume-slider/volume-slider-core.ts
@@ -13,7 +13,10 @@ export interface VolumeSliderProps extends SliderProps {
   max?: number | undefined;
 }
 
-export interface VolumeSliderState extends SliderState, Pick<MediaVolumeState, 'volume' | 'muted'> {}
+export interface VolumeSliderState extends SliderState, Pick<MediaVolumeState, 'volume' | 'muted'> {
+  /** Whether volume can be programmatically set on this platform. */
+  availability: MediaVolumeState['volumeAvailability'];
+}
 
 /** Volume-domain slider: maps media volume/mute state to slider state. */
 export class VolumeSliderCore extends SliderCore {
@@ -51,6 +54,7 @@ export class VolumeSliderCore extends SliderCore {
       fillPercent: effectivelyMuted ? 0 : base.fillPercent,
       volume,
       muted: effectivelyMuted,
+      availability: media.volumeAvailability,
     };
   }
 

--- a/packages/core/src/core/ui/volume-slider/volume-slider-data-attrs.ts
+++ b/packages/core/src/core/ui/volume-slider/volume-slider-data-attrs.ts
@@ -4,4 +4,6 @@ import type { VolumeSliderState } from './volume-slider-core';
 
 export const VolumeSliderDataAttrs = {
   ...SliderDataAttrs,
+  /** Indicates volume availability (`available`, `unavailable`, or `unsupported`). */
+  availability: 'data-availability',
 } as const satisfies StateAttrMap<VolumeSliderState>;

--- a/packages/core/src/dom/store/features/tests/volume.test.ts
+++ b/packages/core/src/dom/store/features/tests/volume.test.ts
@@ -1,8 +1,9 @@
 import { createStore } from '@videojs/store';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import { createMockVideo } from '../../../tests/test-helpers';
-import { resetVolumeAvailabilityCache, volumeFeature } from '../volume';
+
+let volumeFeature: typeof import('../volume').volumeFeature;
 
 async function flushProbe(): Promise<void> {
   await new Promise<void>((resolve) => {
@@ -11,9 +12,13 @@ async function flushProbe(): Promise<void> {
   await Promise.resolve();
 }
 
+beforeEach(async () => {
+  vi.resetModules();
+  ({ volumeFeature } = await import('../volume'));
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
-  resetVolumeAvailabilityCache();
 });
 
 describe('volumeFeature', () => {

--- a/packages/core/src/dom/store/features/tests/volume.test.ts
+++ b/packages/core/src/dom/store/features/tests/volume.test.ts
@@ -1,8 +1,19 @@
 import { createStore } from '@videojs/store';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import { createMockVideo } from '../../../tests/test-helpers';
 import { volumeFeature } from '../volume';
+
+async function flushProbe(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('volumeFeature', () => {
   describe('attach', () => {
@@ -19,13 +30,47 @@ describe('volumeFeature', () => {
       expect(store.state.muted).toBe(false);
     });
 
-    it('sets volumeAvailability on attach', () => {
+    it('starts unavailable, then resolves volumeAvailability on attach', async () => {
       const video = createMockVideo({});
       const store = createStore<PlayerTarget>()(volumeFeature);
       store.attach({ media: video, container: null });
 
-      // Should be 'available' or 'unsupported' based on browser capability
+      expect(store.state.volumeAvailability).toBe('unavailable');
+
+      await flushProbe();
+
       expect(['available', 'unsupported']).toContain(store.state.volumeAvailability);
+    });
+
+    it('reports unsupported volume availability when the probe value does not stick', async () => {
+      const originalCreateElement = document.createElement.bind(document);
+
+      vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+        const element = originalCreateElement(tagName, options);
+
+        if (tagName !== 'video') return element;
+
+        let volume = 1;
+        Object.defineProperty(element, 'volume', {
+          configurable: true,
+          get() {
+            return volume;
+          },
+          set(_value: number) {
+            volume = 1;
+          },
+        });
+
+        return element;
+      });
+
+      const video = createMockVideo({});
+      const store = createStore<PlayerTarget>()(volumeFeature);
+      store.attach({ media: video, container: null });
+
+      await flushProbe();
+
+      expect(store.state.volumeAvailability).toBe('unsupported');
     });
 
     it('updates on volumechange event', () => {

--- a/packages/core/src/dom/store/features/tests/volume.test.ts
+++ b/packages/core/src/dom/store/features/tests/volume.test.ts
@@ -2,7 +2,7 @@ import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import { createMockVideo } from '../../../tests/test-helpers';
-import { volumeFeature } from '../volume';
+import { resetVolumeAvailabilityCache, volumeFeature } from '../volume';
 
 async function flushProbe(): Promise<void> {
   await new Promise<void>((resolve) => {
@@ -13,6 +13,7 @@ async function flushProbe(): Promise<void> {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  resetVolumeAvailabilityCache();
 });
 
 describe('volumeFeature', () => {

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -45,7 +45,10 @@ export const volumeFeature = definePlayerFeature({
   attach({ target, signal, set }) {
     const { media } = target;
 
-    set({ volumeAvailability: canSetVolume() });
+    detectVolumeAvailability().then((volumeAvailability) => {
+      if (signal.aborted) return;
+      set({ volumeAvailability });
+    });
 
     const sync = () => set({ volume: media.volume, muted: media.muted });
     sync();
@@ -54,13 +57,33 @@ export const volumeFeature = definePlayerFeature({
   },
 });
 
-/** Check if volume can be programmatically set (fails on iOS Safari). */
-function canSetVolume(): MediaFeatureAvailability {
+function detectVolumeAvailability(): Promise<MediaFeatureAvailability> {
+  return probeVolumeAvailability().catch(() => 'unsupported');
+}
+
+async function probeVolumeAvailability(): Promise<MediaFeatureAvailability> {
   const video = document.createElement('video');
+  const parent = document.body ?? document.documentElement;
+  const initialVolume = video.volume;
+  const nextVolume = initialVolume === 0.5 ? 0.25 : 0.5;
+
+  video.muted = true;
+  video.preload = 'none';
+  video.playsInline = true;
+  video.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden;opacity:0;pointer-events:none;';
+  parent?.append(video);
+
   try {
-    video.volume = 0.5;
-    return video.volume === 0.5 ? 'available' : 'unsupported';
-  } catch {
-    return 'unsupported';
+    video.volume = nextVolume;
+    await waitForProbeFrame();
+    return video.volume === nextVolume ? 'available' : 'unsupported';
+  } finally {
+    video.remove();
   }
+}
+
+function waitForProbeFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
 }

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -7,6 +7,10 @@ import { definePlayerFeature } from '../../feature';
 const UNMUTE_VOLUME = 0.25;
 let volumeAvailabilityPromise: Promise<MediaFeatureAvailability> | null = null;
 
+export function resetVolumeAvailabilityCache(): void {
+  volumeAvailabilityPromise = null;
+}
+
 export const volumeFeature = definePlayerFeature({
   name: 'volume',
   state: ({ target }): MediaVolumeState => ({

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -5,6 +5,7 @@ import { definePlayerFeature } from '../../feature';
 
 /** Volume to restore when unmuting at zero. */
 const UNMUTE_VOLUME = 0.25;
+let volumeAvailabilityPromise: Promise<MediaFeatureAvailability> | null = null;
 
 export const volumeFeature = definePlayerFeature({
   name: 'volume',
@@ -58,7 +59,8 @@ export const volumeFeature = definePlayerFeature({
 });
 
 function detectVolumeAvailability(): Promise<MediaFeatureAvailability> {
-  return probeVolumeAvailability().catch(() => 'unsupported');
+  volumeAvailabilityPromise ??= probeVolumeAvailability().catch(() => 'unsupported');
+  return volumeAvailabilityPromise;
 }
 
 async function probeVolumeAvailability(): Promise<MediaFeatureAvailability> {

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -7,10 +7,6 @@ import { definePlayerFeature } from '../../feature';
 const UNMUTE_VOLUME = 0.25;
 let volumeAvailabilityPromise: Promise<MediaFeatureAvailability> | null = null;
 
-export function resetVolumeAvailabilityCache(): void {
-  volumeAvailabilityPromise = null;
-}
-
 export const volumeFeature = definePlayerFeature({
   name: 'volume',
   state: ({ target }): MediaVolumeState => ({

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -261,14 +261,20 @@ export class PopoverElement extends MediaElement {
     }
 
     for (const node of record.addedNodes) {
-      if (node instanceof HTMLElement && this.#isLinkedTrigger(node)) return true;
+      if (this.#hasLinkedTrigger(node)) return true;
     }
 
     for (const node of record.removedNodes) {
-      if (node instanceof HTMLElement && this.#isLinkedTrigger(node)) return true;
+      if (this.#hasLinkedTrigger(node)) return true;
     }
 
     return false;
+  }
+
+  #hasLinkedTrigger(node: Node): boolean {
+    if (!(node instanceof HTMLElement)) return false;
+    if (this.#isLinkedTrigger(node)) return true;
+    return !!this.id && !!node.querySelector(`[commandfor="${this.id}"]`);
   }
 
   #isLinkedTrigger(element: HTMLElement): boolean {

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -203,7 +203,7 @@ export class PopoverElement extends MediaElement {
   #findTrigger(): HTMLElement | null {
     if (!this.id) return null;
     const root = this.getRootNode() as Document | ShadowRoot;
-    return root.querySelector<HTMLElement>(`[commandfor="${this.id}"]`);
+    return this.#findLinkedTrigger(root);
   }
 
   #isTriggerAvailable(triggerEl: HTMLElement | null): triggerEl is HTMLElement {
@@ -274,11 +274,21 @@ export class PopoverElement extends MediaElement {
   #hasLinkedTrigger(node: Node): boolean {
     if (!(node instanceof HTMLElement)) return false;
     if (this.#isLinkedTrigger(node)) return true;
-    return !!this.id && !!node.querySelector(`[commandfor="${this.id}"]`);
+    return !!this.#findLinkedTrigger(node);
   }
 
   #isLinkedTrigger(element: HTMLElement): boolean {
     return !!this.id && element.getAttribute('commandfor') === this.id;
+  }
+
+  #findLinkedTrigger(root: ParentNode): HTMLElement | null {
+    if (!this.id) return null;
+
+    for (const element of root.querySelectorAll<HTMLElement>('[commandfor]')) {
+      if (element.getAttribute('commandfor') === this.id) return element;
+    }
+
+    return null;
   }
 
   #syncTriggerLinkage(): HTMLElement | null {

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -52,10 +52,12 @@ export class PopoverElement extends MediaElement {
   #disconnect: AbortController | null = null;
   #triggerAbort: AbortController | null = null;
   #currentTrigger: HTMLElement | null = null;
+  #triggerObserver: MutationObserver | null = null;
   #positionAbort: AbortController | null = null;
   #positionFrame = 0;
   #resizeObserver: ResizeObserver | null = null;
   #positionTrigger: HTMLElement | null = null;
+  #availabilityHidden = false;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -82,6 +84,8 @@ export class PopoverElement extends MediaElement {
     // Apply popup event handlers (pointerenter/leave, focusout) to self.
     applyElementProps(this, this.#popover.popupProps, { signal: this.#disconnect.signal });
 
+    this.#observeTriggerLinkage();
+
     // Subscribe to interaction state for reactive updates.
     // Reuse the controller across connect/disconnect cycles to avoid
     // leaking stale controllers in the host's controller set.
@@ -105,12 +109,14 @@ export class PopoverElement extends MediaElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.#cleanupPositioning();
+    this.#cleanupTriggerObserver();
     this.#disconnect?.abort();
     this.#disconnect = null;
   }
 
   override destroyCallback(): void {
     this.#cleanupPositioning();
+    this.#cleanupTriggerObserver();
     this.#cleanupTrigger();
     this.#popover?.destroy();
     super.destroyCallback();
@@ -137,15 +143,7 @@ export class PopoverElement extends MediaElement {
     super.update(_changed);
     if (!this.#popover) return;
 
-    // Discover trigger via commandfor linkage.
-    const triggerEl = this.#findTrigger();
-    const availableTriggerEl = this.#isTriggerAvailable(triggerEl) ? triggerEl : null;
-    this.toggleAttribute('hidden', !availableTriggerEl);
-    this.#syncTrigger(availableTriggerEl);
-
-    if (!availableTriggerEl && this.#popover.input.current.active) {
-      this.#popover.close();
-    }
+    const availableTriggerEl = this.#syncTriggerLinkage();
 
     // Derive state from core + input.
     const input = this.#popover.input.current;
@@ -226,6 +224,89 @@ export class PopoverElement extends MediaElement {
     if (triggerEl && this.#popover) {
       this.#triggerAbort = new AbortController();
       applyElementProps(triggerEl, this.#popover.triggerProps, { signal: this.#triggerAbort.signal });
+    }
+  }
+
+  #observeTriggerLinkage(): void {
+    this.#cleanupTriggerObserver();
+
+    const root = this.getRootNode();
+    const target = root instanceof Document ? root.documentElement : root;
+
+    if (!(target instanceof Node)) return;
+
+    this.#triggerObserver = new MutationObserver((records) => {
+      if (records.some((record) => this.#isTriggerLinkageMutation(record))) {
+        this.#syncTriggerLinkage();
+        this.requestUpdate();
+      }
+    });
+
+    this.#triggerObserver.observe(target, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['commandfor', 'data-availability'],
+    });
+  }
+
+  #cleanupTriggerObserver(): void {
+    this.#triggerObserver?.disconnect();
+    this.#triggerObserver = null;
+  }
+
+  #isTriggerLinkageMutation(record: MutationRecord): boolean {
+    if (record.type === 'attributes') {
+      return record.target instanceof HTMLElement && this.#isLinkedTrigger(record.target);
+    }
+
+    for (const node of record.addedNodes) {
+      if (node instanceof HTMLElement && this.#isLinkedTrigger(node)) return true;
+    }
+
+    for (const node of record.removedNodes) {
+      if (node instanceof HTMLElement && this.#isLinkedTrigger(node)) return true;
+    }
+
+    return false;
+  }
+
+  #isLinkedTrigger(element: HTMLElement): boolean {
+    return !!this.id && element.getAttribute('commandfor') === this.id;
+  }
+
+  #syncTriggerLinkage(): HTMLElement | null {
+    const triggerEl = this.#findTrigger();
+    const availableTriggerEl = this.#isTriggerAvailable(triggerEl) ? triggerEl : null;
+
+    this.#syncAvailabilityVisibility(Boolean(availableTriggerEl));
+    this.#syncTrigger(availableTriggerEl);
+
+    if (!availableTriggerEl && this.#popover?.input.current.active) {
+      this.#popover.close();
+    }
+
+    if (!availableTriggerEl) {
+      tryHidePopover(this);
+      this.#cleanupPositioning();
+    }
+
+    return availableTriggerEl;
+  }
+
+  #syncAvailabilityVisibility(available: boolean): void {
+    if (!available) {
+      if (!this.hidden) {
+        this.hidden = true;
+        this.#availabilityHidden = true;
+      }
+
+      return;
+    }
+
+    if (this.#availabilityHidden) {
+      this.hidden = false;
+      this.#availabilityHidden = false;
     }
   }
 

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -139,7 +139,13 @@ export class PopoverElement extends MediaElement {
 
     // Discover trigger via commandfor linkage.
     const triggerEl = this.#findTrigger();
-    this.#syncTrigger(triggerEl);
+    const availableTriggerEl = this.#isTriggerAvailable(triggerEl) ? triggerEl : null;
+    this.toggleAttribute('hidden', !availableTriggerEl);
+    this.#syncTrigger(availableTriggerEl);
+
+    if (!availableTriggerEl && this.#popover.input.current.active) {
+      this.#popover.close();
+    }
 
     // Derive state from core + input.
     const input = this.#popover.input.current;
@@ -152,6 +158,12 @@ export class PopoverElement extends MediaElement {
 
     // Show/hide via Popover API AFTER data attributes are applied so
     // `data-starting-style` is present before the first visible frame.
+    if (!availableTriggerEl) {
+      tryHidePopover(this);
+      this.#cleanupPositioning();
+      return;
+    }
+
     if (state.open) {
       tryShowPopover(this);
     } else {
@@ -194,6 +206,13 @@ export class PopoverElement extends MediaElement {
     if (!this.id) return null;
     const root = this.getRootNode() as Document | ShadowRoot;
     return root.querySelector<HTMLElement>(`[commandfor="${this.id}"]`);
+  }
+
+  #isTriggerAvailable(triggerEl: HTMLElement | null): triggerEl is HTMLElement {
+    if (!triggerEl) return false;
+
+    const availability = triggerEl.getAttribute('data-availability');
+    return !availability || availability === 'available';
   }
 
   #syncTrigger(triggerEl: HTMLElement | null): void {

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -53,6 +53,9 @@ export class PopoverElement extends MediaElement {
   #triggerAbort: AbortController | null = null;
   #currentTrigger: HTMLElement | null = null;
   #triggerObserver: MutationObserver | null = null;
+  #triggerObserverTarget: Node | null = null;
+  #triggerAvailabilityObserver: MutationObserver | null = null;
+  #observedTrigger: HTMLElement | null = null;
   #positionAbort: AbortController | null = null;
   #positionFrame = 0;
   #resizeObserver: ResizeObserver | null = null;
@@ -84,7 +87,9 @@ export class PopoverElement extends MediaElement {
     // Apply popup event handlers (pointerenter/leave, focusout) to self.
     applyElementProps(this, this.#popover.popupProps, { signal: this.#disconnect.signal });
 
-    this.#observeTriggerLinkage();
+    if (this.id) {
+      this.#observeTriggerLinkage(null);
+    }
 
     // Subscribe to interaction state for reactive updates.
     // Reuse the controller across connect/disconnect cycles to avoid
@@ -110,6 +115,8 @@ export class PopoverElement extends MediaElement {
     super.disconnectedCallback();
     this.#cleanupPositioning();
     this.#cleanupTriggerObserver();
+    this.#cleanupTriggerAvailabilityObserver();
+    this.#cleanupTrigger();
     this.#disconnect?.abort();
     this.#disconnect = null;
   }
@@ -117,6 +124,7 @@ export class PopoverElement extends MediaElement {
   override destroyCallback(): void {
     this.#cleanupPositioning();
     this.#cleanupTriggerObserver();
+    this.#cleanupTriggerAvailabilityObserver();
     this.#cleanupTrigger();
     this.#popover?.destroy();
     super.destroyCallback();
@@ -156,11 +164,7 @@ export class PopoverElement extends MediaElement {
 
     // Show/hide via Popover API AFTER data attributes are applied so
     // `data-starting-style` is present before the first visible frame.
-    if (!availableTriggerEl) {
-      tryHidePopover(this);
-      this.#cleanupPositioning();
-      return;
-    }
+    if (!availableTriggerEl) return;
 
     if (state.open) {
       tryShowPopover(this);
@@ -227,11 +231,18 @@ export class PopoverElement extends MediaElement {
     }
   }
 
-  #observeTriggerLinkage(): void {
-    this.#cleanupTriggerObserver();
+  #observeTriggerLinkage(triggerEl: HTMLElement | null): void {
+    if (!this.id) {
+      this.#cleanupTriggerObserver();
+      return;
+    }
 
-    const root = this.getRootNode();
-    const target = root instanceof Document ? root.documentElement : root;
+    const target = this.#getTriggerObserverTarget(triggerEl);
+
+    if (target === this.#triggerObserverTarget) return;
+
+    this.#cleanupTriggerObserver();
+    this.#triggerObserverTarget = target;
 
     if (!(target instanceof Node)) return;
 
@@ -246,13 +257,39 @@ export class PopoverElement extends MediaElement {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ['commandfor', 'data-availability'],
+      attributeFilter: ['commandfor'],
     });
   }
 
   #cleanupTriggerObserver(): void {
     this.#triggerObserver?.disconnect();
     this.#triggerObserver = null;
+    this.#triggerObserverTarget = null;
+  }
+
+  #syncTriggerAvailabilityObserver(triggerEl: HTMLElement | null): void {
+    if (triggerEl === this.#observedTrigger) return;
+
+    this.#cleanupTriggerAvailabilityObserver();
+    this.#observedTrigger = triggerEl;
+
+    if (!triggerEl) return;
+
+    this.#triggerAvailabilityObserver = new MutationObserver(() => {
+      this.#syncTriggerLinkage();
+      this.requestUpdate();
+    });
+
+    this.#triggerAvailabilityObserver.observe(triggerEl, {
+      attributes: true,
+      attributeFilter: ['data-availability', 'commandfor'],
+    });
+  }
+
+  #cleanupTriggerAvailabilityObserver(): void {
+    this.#triggerAvailabilityObserver?.disconnect();
+    this.#triggerAvailabilityObserver = null;
+    this.#observedTrigger = null;
   }
 
   #isTriggerLinkageMutation(record: MutationRecord): boolean {
@@ -284,6 +321,11 @@ export class PopoverElement extends MediaElement {
   #findLinkedTrigger(root: ParentNode): HTMLElement | null {
     if (!this.id) return null;
 
+    if (globalThis.CSS?.escape) {
+      const selector = `[commandfor="${globalThis.CSS.escape(this.id)}"]`;
+      return root.querySelector<HTMLElement>(selector);
+    }
+
     for (const element of root.querySelectorAll<HTMLElement>('[commandfor]')) {
       if (element.getAttribute('commandfor') === this.id) return element;
     }
@@ -293,6 +335,8 @@ export class PopoverElement extends MediaElement {
 
   #syncTriggerLinkage(): HTMLElement | null {
     const triggerEl = this.#findTrigger();
+    this.#observeTriggerLinkage(triggerEl);
+    this.#syncTriggerAvailabilityObserver(triggerEl);
     const availableTriggerEl = this.#isTriggerAvailable(triggerEl) ? triggerEl : null;
 
     this.#syncAvailabilityVisibility(Boolean(availableTriggerEl));
@@ -308,6 +352,15 @@ export class PopoverElement extends MediaElement {
     }
 
     return availableTriggerEl;
+  }
+
+  #getTriggerObserverTarget(triggerEl: HTMLElement | null): Node | null {
+    const root = this.getRootNode();
+    const fallbackTarget = root instanceof Document ? (root.body ?? root.documentElement) : root;
+
+    if (!triggerEl) return fallbackTarget;
+
+    return findClosestCommonAncestor(this, triggerEl) ?? fallbackTarget;
   }
 
   #syncAvailabilityVisibility(available: boolean): void {
@@ -386,4 +439,23 @@ export class PopoverElement extends MediaElement {
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
   }
+}
+
+function findClosestCommonAncestor(a: Node, b: Node): Node | null {
+  const ancestors = new Set<Node>();
+  let current: Node | null = a;
+
+  while (current) {
+    ancestors.add(current);
+    current = current.parentNode;
+  }
+
+  current = b;
+
+  while (current) {
+    if (ancestors.has(current)) return current;
+    current = current.parentNode;
+  }
+
+  return null;
 }

--- a/packages/html/src/ui/popover/tests/popover-element.test.ts
+++ b/packages/html/src/ui/popover/tests/popover-element.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { PopoverElement } from '../popover-element';
+
+let tagCounter = 0;
+
+function uniqueTag(base: string): string {
+  return `${base}-${tagCounter++}`;
+}
+
+function createElement<Element extends HTMLElement>(Base: abstract new () => Element): Element {
+  const tag = uniqueTag('test-el');
+  customElements.define(tag, class extends (Base as unknown as typeof HTMLElement) {});
+  return document.createElement(tag) as Element;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('PopoverElement', () => {
+  it('binds trigger attributes when the linked trigger is available', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'available');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(false);
+    expect(trigger.getAttribute('aria-controls')).toBe('volume-popover');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('dialog');
+  });
+
+  it('stays hidden and unbound when the linked trigger is unsupported', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'unsupported');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(true);
+    expect(trigger.hasAttribute('aria-controls')).toBe(false);
+    expect(trigger.hasAttribute('aria-haspopup')).toBe(false);
+  });
+});

--- a/packages/html/src/ui/popover/tests/popover-element.test.ts
+++ b/packages/html/src/ui/popover/tests/popover-element.test.ts
@@ -13,6 +13,12 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
   return document.createElement(tag) as Element;
 }
 
+function waitForMutation(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 afterEach(() => {
   document.body.innerHTML = '';
 });
@@ -48,5 +54,42 @@ describe('PopoverElement', () => {
     expect(popover.hidden).toBe(true);
     expect(trigger.hasAttribute('aria-controls')).toBe(false);
     expect(trigger.hasAttribute('aria-haspopup')).toBe(false);
+  });
+
+  it('rebinds when the linked trigger availability becomes available', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'unsupported');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(true);
+
+    trigger.setAttribute('data-availability', 'available');
+    await waitForMutation();
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(false);
+    expect(trigger.getAttribute('aria-controls')).toBe('volume-popover');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('dialog');
+  });
+
+  it('preserves author-supplied hidden when the trigger is available', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'available');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+    popover.hidden = true;
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(true);
   });
 });

--- a/packages/html/src/ui/popover/tests/popover-element.test.ts
+++ b/packages/html/src/ui/popover/tests/popover-element.test.ts
@@ -92,4 +92,47 @@ describe('PopoverElement', () => {
 
     expect(popover.hidden).toBe(true);
   });
+
+  it('rebinds when a linked trigger is added inside a wrapper subtree', async () => {
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(popover);
+    await popover.updateComplete;
+
+    const wrapper = document.createElement('div');
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'available');
+    wrapper.append(trigger);
+    document.body.append(wrapper);
+
+    await waitForMutation();
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(false);
+    expect(trigger.getAttribute('aria-controls')).toBe('volume-popover');
+  });
+
+  it('cleans up when a linked trigger is removed inside a wrapper subtree', async () => {
+    const wrapper = document.createElement('div');
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'available');
+    wrapper.append(trigger);
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(wrapper, popover);
+    await popover.updateComplete;
+
+    wrapper.remove();
+
+    await waitForMutation();
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(true);
+    expect(trigger.hasAttribute('aria-controls')).toBe(false);
+  });
 });

--- a/packages/html/src/ui/popover/tests/popover-element.test.ts
+++ b/packages/html/src/ui/popover/tests/popover-element.test.ts
@@ -40,6 +40,21 @@ describe('PopoverElement', () => {
     expect(trigger.getAttribute('aria-haspopup')).toBe('dialog');
   });
 
+  it('binds trigger attributes when the popover id contains special characters', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume:popover special');
+    trigger.setAttribute('data-availability', 'available');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume:popover special';
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(false);
+    expect(trigger.getAttribute('aria-controls')).toBe('volume:popover special');
+  });
+
   it('stays hidden and unbound when the linked trigger is unsupported', async () => {
     const trigger = document.createElement('button');
     trigger.setAttribute('commandfor', 'volume-popover');
@@ -114,6 +129,27 @@ describe('PopoverElement', () => {
     expect(trigger.getAttribute('aria-controls')).toBe('volume-popover');
   });
 
+  it('rebinds when an existing element commandfor changes to the popover id', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'other-popover');
+    trigger.setAttribute('data-availability', 'available');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(true);
+
+    trigger.setAttribute('commandfor', 'volume-popover');
+    await waitForMutation();
+    await popover.updateComplete;
+
+    expect(popover.hidden).toBe(false);
+    expect(trigger.getAttribute('aria-controls')).toBe('volume-popover');
+  });
+
   it('cleans up when a linked trigger is removed inside a wrapper subtree', async () => {
     const wrapper = document.createElement('div');
     const trigger = document.createElement('button');
@@ -134,5 +170,23 @@ describe('PopoverElement', () => {
 
     expect(popover.hidden).toBe(true);
     expect(trigger.hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('cleans up trigger attributes when the popover disconnects', async () => {
+    const trigger = document.createElement('button');
+    trigger.setAttribute('commandfor', 'volume-popover');
+    trigger.setAttribute('data-availability', 'available');
+
+    const popover = createElement(PopoverElement);
+    popover.id = 'volume-popover';
+
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    popover.remove();
+
+    expect(trigger.hasAttribute('aria-controls')).toBe(false);
+    expect(trigger.hasAttribute('aria-haspopup')).toBe(false);
+    expect(trigger.style.getPropertyValue('anchor-name')).toBe('');
   });
 });

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -1,4 +1,4 @@
-import { SliderDataAttrs, VolumeSliderCore } from '@videojs/core';
+import { VolumeSliderCore, VolumeSliderDataAttrs } from '@videojs/core';
 import {
   applyElementProps,
   applyStateDataAttrs,
@@ -120,12 +120,12 @@ export class VolumeSliderElement extends MediaElement {
     applyStyles(this, cssVars);
 
     // Apply data attributes to root.
-    applyStateDataAttrs(this, state, SliderDataAttrs);
+    applyStateDataAttrs(this, state, VolumeSliderDataAttrs);
 
     // Provide context to child elements.
     this.#provider.setValue({
       state,
-      stateAttrMap: SliderDataAttrs,
+      stateAttrMap: VolumeSliderDataAttrs,
       pointerValue: this.#core.valueFromPercent(state.pointerPercent),
       thumbAttrs: this.#core.getAttrs(state),
       thumbProps: this.#slider.thumbProps,

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -34,6 +34,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import type { MinimalAudioSkinProps } from './minimal-skin';
 
 const SEEK_TIME = 10;
@@ -53,6 +54,16 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'> & { varian
     />
   );
 });
+
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button variant="icon" {...props} className={iconState.mute.button}>
+      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
+      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
+      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
+    </Button>
+  );
+};
 
 const SliderRoot = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderRoot({ className, ...props }, ref) {
   return <div ref={ref} className={cn(slider.root, className)} {...props} />;
@@ -102,6 +113,7 @@ function PlayLabel(): ReactNode {
 
 export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn(root, className)} {...rest}>
@@ -196,33 +208,25 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
               <Tooltip.Popup className={cn(popup.tooltip)}>Toggle playback rate</Tooltip.Popup>
             </Tooltip.Root>
 
-            <Popover.Root openOnHover delay={200} closeDelay={100} side="left">
-              <Popover.Trigger
-                render={
-                  <MuteButton
-                    render={(props) => (
-                      <Button variant="icon" {...props} className={iconState.mute.button}>
-                        <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
-                        <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
-                        <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
-                      </Button>
-                    )}
-                  />
-                }
-              />
-              <Popover.Popup className={cn(popup.volume)}>
-                <VolumeSlider.Root
-                  orientation="horizontal"
-                  thumbAlignment="edge"
-                  render={(props) => <SliderRoot {...props} />}
-                >
-                  <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
-                    <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Root>
+            {canShowVolumePopover ? (
+              <Popover.Root openOnHover delay={200} closeDelay={100} side="left">
+                <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+                <Popover.Popup className={cn(popup.volume)}>
+                  <VolumeSlider.Root
+                    orientation="horizontal"
+                    thumbAlignment="edge"
+                    render={(props) => <SliderRoot {...props} />}
+                  >
+                    <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
+                      <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
+                    </VolumeSlider.Track>
+                    <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
+                  </VolumeSlider.Root>
+                </Popover.Popup>
+              </Popover.Root>
+            ) : (
+              <MuteButton render={renderMuteButton} />
+            )}
           </div>
         </Tooltip.Provider>
       </div>

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -19,6 +19,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import type { BaseSkinProps } from '../types';
 
 const SEEK_TIME = 10;
@@ -29,6 +30,16 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
   return <button ref={ref} type="button" className={cn('media-button', className)} {...props} />;
 });
 
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button {...props} className="media-button--icon media-button--mute">
+      <VolumeOffIcon className="media-icon media-icon--volume-off" />
+      <VolumeLowIcon className="media-icon media-icon--volume-low" />
+      <VolumeHighIcon className="media-icon media-icon--volume-high" />
+    </Button>
+  );
+};
+
 function PlayLabel(): ReactNode {
   const paused = usePlayer((s) => Boolean(s.paused));
   const ended = usePlayer((s) => Boolean(s.ended));
@@ -38,6 +49,7 @@ function PlayLabel(): ReactNode {
 
 export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn('media-minimal-skin media-minimal-skin--audio', className)} {...rest}>
@@ -132,29 +144,21 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
               <Tooltip.Popup className="media-tooltip">Toggle playback rate</Tooltip.Popup>
             </Tooltip.Root>
 
-            <Popover.Root openOnHover delay={200} closeDelay={100} side="left">
-              <Popover.Trigger
-                render={
-                  <MuteButton
-                    render={(props) => (
-                      <Button {...props} className="media-button--icon media-button--mute">
-                        <VolumeOffIcon className="media-icon media-icon--volume-off" />
-                        <VolumeLowIcon className="media-icon media-icon--volume-low" />
-                        <VolumeHighIcon className="media-icon media-icon--volume-high" />
-                      </Button>
-                    )}
-                  />
-                }
-              />
-              <Popover.Popup className="media-popover media-popover--volume">
-                <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
-                  <VolumeSlider.Track className="media-slider__track">
-                    <VolumeSlider.Fill className="media-slider__fill" />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Root>
+            {canShowVolumePopover ? (
+              <Popover.Root openOnHover delay={200} closeDelay={100} side="left">
+                <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+                <Popover.Popup className="media-popover media-popover--volume">
+                  <VolumeSlider.Root className="media-slider" orientation="horizontal" thumbAlignment="edge">
+                    <VolumeSlider.Track className="media-slider__track">
+                      <VolumeSlider.Fill className="media-slider__fill" />
+                    </VolumeSlider.Track>
+                    <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
+                  </VolumeSlider.Root>
+                </Popover.Popup>
+              </Popover.Root>
+            ) : (
+              <MuteButton render={renderMuteButton} />
+            )}
           </div>
         </Tooltip.Provider>
       </div>

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -33,6 +33,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import type { AudioSkinProps } from './skin';
 
 const SEEK_TIME = 10;
@@ -52,6 +53,16 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'> & { varian
     />
   );
 });
+
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button variant="icon" {...props} className={iconState.mute.button}>
+      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
+      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
+      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
+    </Button>
+  );
+};
 
 const SliderRoot = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderRoot({ className, ...props }, ref) {
   return <div ref={ref} className={cn(slider.root, className)} {...props} />;
@@ -101,6 +112,7 @@ function PlayLabel(): ReactNode {
 
 export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn(root, className)} {...rest}>
@@ -188,33 +200,25 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
             <Tooltip.Popup className={cn(popup.tooltip)}>Toggle playback rate</Tooltip.Popup>
           </Tooltip.Root>
 
-          <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
-            <Popover.Trigger
-              render={
-                <MuteButton
-                  render={(props) => (
-                    <Button variant="icon" {...props} className={iconState.mute.button}>
-                      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
-                      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
-                      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
-                    </Button>
-                  )}
-                />
-              }
-            />
-            <Popover.Popup className={cn(popup.popover, popup.volume)}>
-              <VolumeSlider.Root
-                orientation="vertical"
-                thumbAlignment="edge"
-                render={(props) => <SliderRoot {...props} />}
-              >
-                <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
-                  <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
-                </VolumeSlider.Track>
-                <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
-              </VolumeSlider.Root>
-            </Popover.Popup>
-          </Popover.Root>
+          {canShowVolumePopover ? (
+            <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+              <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+              <Popover.Popup className={cn(popup.popover, popup.volume)}>
+                <VolumeSlider.Root
+                  orientation="vertical"
+                  thumbAlignment="edge"
+                  render={(props) => <SliderRoot {...props} />}
+                >
+                  <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
+                    <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
+                  </VolumeSlider.Track>
+                  <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
+                </VolumeSlider.Root>
+              </Popover.Popup>
+            </Popover.Root>
+          ) : (
+            <MuteButton render={renderMuteButton} />
+          )}
         </Tooltip.Provider>
       </div>
     </Container>

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -19,6 +19,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import type { BaseSkinProps } from '../types';
 
 const SEEK_TIME = 10;
@@ -29,6 +30,16 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
   return <button ref={ref} type="button" className={cn('media-button', className)} {...props} />;
 });
 
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button {...props} className="media-button--icon media-button--mute">
+      <VolumeOffIcon className="media-icon media-icon--volume-off" />
+      <VolumeLowIcon className="media-icon media-icon--volume-low" />
+      <VolumeHighIcon className="media-icon media-icon--volume-high" />
+    </Button>
+  );
+};
+
 function PlayLabel(): ReactNode {
   const paused = usePlayer((s) => Boolean(s.paused));
   const ended = usePlayer((s) => Boolean(s.ended));
@@ -38,6 +49,7 @@ function PlayLabel(): ReactNode {
 
 export function AudioSkin(props: AudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn('media-default-skin media-default-skin--audio', className)} {...rest}>
@@ -125,29 +137,21 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
             <Tooltip.Popup className="media-surface media-tooltip">Toggle playback rate</Tooltip.Popup>
           </Tooltip.Root>
 
-          <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
-            <Popover.Trigger
-              render={
-                <MuteButton
-                  render={(props) => (
-                    <Button {...props} className="media-button--icon media-button--mute">
-                      <VolumeOffIcon className="media-icon media-icon--volume-off" />
-                      <VolumeLowIcon className="media-icon media-icon--volume-low" />
-                      <VolumeHighIcon className="media-icon media-icon--volume-high" />
-                    </Button>
-                  )}
-                />
-              }
-            />
-            <Popover.Popup className="media-surface media-popover media-popover--volume">
-              <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
-                <VolumeSlider.Track className="media-slider__track">
-                  <VolumeSlider.Fill className="media-slider__fill" />
-                </VolumeSlider.Track>
-                <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
-              </VolumeSlider.Root>
-            </Popover.Popup>
-          </Popover.Root>
+          {canShowVolumePopover ? (
+            <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+              <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+              <Popover.Popup className="media-surface media-popover media-popover--volume">
+                <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+                  <VolumeSlider.Track className="media-slider__track">
+                    <VolumeSlider.Fill className="media-slider__fill" />
+                  </VolumeSlider.Track>
+                  <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
+                </VolumeSlider.Root>
+              </Popover.Popup>
+            </Popover.Root>
+          ) : (
+            <MuteButton render={renderMuteButton} />
+          )}
         </Tooltip.Provider>
       </div>
     </Container>

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -50,6 +50,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import { ErrorDialog } from './error-dialog';
 import type { MinimalVideoSkinProps } from './minimal-skin';
 
@@ -108,6 +109,16 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
   );
 });
 
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button variant="icon" {...props} className={iconState.mute.button}>
+      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
+      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
+      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
+    </Button>
+  );
+};
+
 const errorClasses = {
   root: error.root,
   dialog: error.dialog,
@@ -143,6 +154,7 @@ function FullscreenLabel(): ReactNode {
 
 export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn(root(false), className)} {...rest}>
@@ -257,33 +269,25 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
               <Tooltip.Popup className={cn(popup.tooltip)}>Toggle playback rate</Tooltip.Popup>
             </Tooltip.Root>
 
-            <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
-              <Popover.Trigger
-                render={
-                  <MuteButton
-                    render={(props) => (
-                      <Button variant="icon" {...props} className={iconState.mute.button}>
-                        <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
-                        <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
-                        <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
-                      </Button>
-                    )}
-                  />
-                }
-              />
-              <Popover.Popup className={cn(popup.volume)}>
-                <VolumeSlider.Root
-                  orientation="vertical"
-                  thumbAlignment="edge"
-                  render={(props) => <SliderRoot {...props} />}
-                >
-                  <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
-                    <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Root>
+            {canShowVolumePopover ? (
+              <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+                <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+                <Popover.Popup className={cn(popup.volume)}>
+                  <VolumeSlider.Root
+                    orientation="vertical"
+                    thumbAlignment="edge"
+                    render={(props) => <SliderRoot {...props} />}
+                  >
+                    <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
+                      <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
+                    </VolumeSlider.Track>
+                    <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
+                  </VolumeSlider.Root>
+                </Popover.Popup>
+              </Popover.Root>
+            ) : (
+              <MuteButton render={renderMuteButton} />
+            )}
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -31,6 +31,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import type { BaseSkinProps } from '../types';
 import { ErrorDialog } from './error-dialog';
 
@@ -41,6 +42,16 @@ export type MinimalVideoSkinProps = BaseSkinProps;
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return <button ref={ref} type="button" className={cn('media-button', className)} {...props} />;
 });
+
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button {...props} className="media-button--icon media-button--mute">
+      <VolumeOffIcon className="media-icon media-icon--volume-off" />
+      <VolumeLowIcon className="media-icon media-icon--volume-low" />
+      <VolumeHighIcon className="media-icon media-icon--volume-high" />
+    </Button>
+  );
+};
 
 const errorClasses = {
   root: 'media-error',
@@ -76,6 +87,7 @@ function FullscreenLabel(): ReactNode {
 
 export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn('media-minimal-skin media-minimal-skin--video', className)} {...rest}>
@@ -188,29 +200,21 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
               <Tooltip.Popup className="media-tooltip">Toggle playback rate</Tooltip.Popup>
             </Tooltip.Root>
 
-            <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
-              <Popover.Trigger
-                render={
-                  <MuteButton
-                    render={(props) => (
-                      <Button {...props} className="media-button--icon media-button--mute">
-                        <VolumeOffIcon className="media-icon media-icon--volume-off" />
-                        <VolumeLowIcon className="media-icon media-icon--volume-low" />
-                        <VolumeHighIcon className="media-icon media-icon--volume-high" />
-                      </Button>
-                    )}
-                  />
-                }
-              />
-              <Popover.Popup className="media-popover media-popover--volume">
-                <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
-                  <VolumeSlider.Track className="media-slider__track">
-                    <VolumeSlider.Fill className="media-slider__fill" />
-                  </VolumeSlider.Track>
-                  <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
-                </VolumeSlider.Root>
-              </Popover.Popup>
-            </Popover.Root>
+            {canShowVolumePopover ? (
+              <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+                <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+                <Popover.Popup className="media-popover media-popover--volume">
+                  <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+                    <VolumeSlider.Track className="media-slider__track">
+                      <VolumeSlider.Fill className="media-slider__fill" />
+                    </VolumeSlider.Track>
+                    <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
+                  </VolumeSlider.Root>
+                </Popover.Popup>
+              </Popover.Root>
+            ) : (
+              <MuteButton render={renderMuteButton} />
+            )}
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -49,6 +49,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import { ErrorDialog } from './error-dialog';
 import type { VideoSkinProps } from './skin';
 
@@ -107,6 +108,16 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
   );
 });
 
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button variant="icon" {...props} className={iconState.mute.button}>
+      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
+      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
+      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
+    </Button>
+  );
+};
+
 const errorClasses = {
   root: error.root,
   dialog: error.dialog,
@@ -143,6 +154,7 @@ function FullscreenLabel(): ReactNode {
 
 export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn(root(false), className)} {...rest}>
@@ -250,33 +262,25 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
             <Tooltip.Popup className={cn(popup.tooltip)}>Toggle playback rate</Tooltip.Popup>
           </Tooltip.Root>
 
-          <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
-            <Popover.Trigger
-              render={
-                <MuteButton
-                  render={(props) => (
-                    <Button variant="icon" {...props} className={iconState.mute.button}>
-                      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
-                      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
-                      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
-                    </Button>
-                  )}
-                />
-              }
-            />
-            <Popover.Popup className={cn(popup.popover, popup.volume)}>
-              <VolumeSlider.Root
-                orientation="vertical"
-                thumbAlignment="edge"
-                render={(props) => <SliderRoot {...props} />}
-              >
-                <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
-                  <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
-                </VolumeSlider.Track>
-                <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
-              </VolumeSlider.Root>
-            </Popover.Popup>
-          </Popover.Root>
+          {canShowVolumePopover ? (
+            <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+              <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+              <Popover.Popup className={cn(popup.popover, popup.volume)}>
+                <VolumeSlider.Root
+                  orientation="vertical"
+                  thumbAlignment="edge"
+                  render={(props) => <SliderRoot {...props} />}
+                >
+                  <VolumeSlider.Track render={(props) => <SliderTrack {...props} />}>
+                    <VolumeSlider.Fill render={(props) => <SliderFill {...props} />} />
+                  </VolumeSlider.Track>
+                  <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
+                </VolumeSlider.Root>
+              </Popover.Popup>
+            </Popover.Root>
+          ) : (
+            <MuteButton render={renderMuteButton} />
+          )}
 
           <Tooltip.Root side="top">
             <Tooltip.Trigger

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -31,6 +31,7 @@ import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeSlider } from '@/ui/volume-slider';
+import type { RenderProp } from '@/utils/types';
 import type { BaseSkinProps } from '../types';
 import { ErrorDialog } from './error-dialog';
 
@@ -41,6 +42,16 @@ export type VideoSkinProps = BaseSkinProps;
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return <button ref={ref} type="button" className={cn('media-button', className)} {...props} />;
 });
+
+const renderMuteButton: RenderProp<MuteButton.State> = (props) => {
+  return (
+    <Button {...props} className="media-button--icon media-button--mute">
+      <VolumeOffIcon className="media-icon media-icon--volume-off" />
+      <VolumeLowIcon className="media-icon media-icon--volume-low" />
+      <VolumeHighIcon className="media-icon media-icon--volume-high" />
+    </Button>
+  );
+};
 
 const errorClasses = {
   root: 'media-error',
@@ -76,6 +87,7 @@ function FullscreenLabel(): ReactNode {
 
 export function VideoSkin(props: VideoSkinProps): ReactNode {
   const { children, className, ...rest } = props;
+  const canShowVolumePopover = usePlayer((s) => s.volumeAvailability === 'available');
 
   return (
     <Container className={cn('media-default-skin media-default-skin--video', className)} {...rest}>
@@ -181,29 +193,21 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
             <Tooltip.Popup className="media-surface media-tooltip">Toggle playback rate</Tooltip.Popup>
           </Tooltip.Root>
 
-          <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
-            <Popover.Trigger
-              render={
-                <MuteButton
-                  render={(props) => (
-                    <Button {...props} className="media-button--icon media-button--mute">
-                      <VolumeOffIcon className="media-icon media-icon--volume-off" />
-                      <VolumeLowIcon className="media-icon media-icon--volume-low" />
-                      <VolumeHighIcon className="media-icon media-icon--volume-high" />
-                    </Button>
-                  )}
-                />
-              }
-            />
-            <Popover.Popup className="media-surface media-popover media-popover--volume">
-              <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
-                <VolumeSlider.Track className="media-slider__track">
-                  <VolumeSlider.Fill className="media-slider__fill" />
-                </VolumeSlider.Track>
-                <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
-              </VolumeSlider.Root>
-            </Popover.Popup>
-          </Popover.Root>
+          {canShowVolumePopover ? (
+            <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+              <Popover.Trigger render={<MuteButton render={renderMuteButton} />} />
+              <Popover.Popup className="media-surface media-popover media-popover--volume">
+                <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+                  <VolumeSlider.Track className="media-slider__track">
+                    <VolumeSlider.Fill className="media-slider__fill" />
+                  </VolumeSlider.Track>
+                  <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
+                </VolumeSlider.Root>
+              </Popover.Popup>
+            </Popover.Root>
+          ) : (
+            <MuteButton render={renderMuteButton} />
+          )}
 
           <Tooltip.Root side="top">
             <Tooltip.Trigger

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render } from '@testing-library/react';
+import type { MediaVolumeState } from '@videojs/core/dom';
 import { createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -39,10 +40,10 @@ const { mockSliderApi, mockVolumeState } = vi.hoisted(() => ({
   mockVolumeState: {
     volume: 0.8,
     muted: false,
-    volumeAvailability: 'available' as const,
+    volumeAvailability: 'available',
     setVolume: vi.fn(),
     toggleMuted: vi.fn(),
-  },
+  } satisfies MediaVolumeState,
 }));
 
 // --- Module mocks ---
@@ -57,16 +58,12 @@ vi.mock('@videojs/store/react', () => ({
   useStore: vi.fn((_store: unknown, selector?: (state: object) => unknown) => {
     if (!selector) return _store;
     try {
-      const result = selector({ volume: mockVolumeState });
+      const result = selector(mockVolumeState);
       if (result !== undefined) return result;
     } catch {
       // fall through
     }
-    try {
-      return selector(mockVolumeState);
-    } catch {
-      return undefined;
-    }
+    return undefined;
   }),
 }));
 
@@ -134,6 +131,40 @@ describe('VolumeSliderRoot', () => {
     const el = container.querySelector('[data-orientation]') as HTMLElement;
     expect(el?.style.getPropertyValue('--media-slider-fill')).toBeTruthy();
     expect(el?.style.getPropertyValue('--media-slider-pointer')).toBeTruthy();
+  });
+
+  it('sets data-availability from the volume feature', () => {
+    const { Wrapper } = createPlayerWrapper();
+    mockVolumeState.volumeAvailability = 'unsupported';
+
+    const { container } = render(
+      <Wrapper>
+        <VolumeSliderRoot />
+      </Wrapper>
+    );
+
+    const el = container.querySelector('[data-orientation]');
+    expect(el?.getAttribute('data-availability')).toBe('unsupported');
+
+    mockVolumeState.volumeAvailability = 'available';
+  });
+
+  it('exposes availability to render state', () => {
+    const { Wrapper } = createPlayerWrapper();
+    mockVolumeState.volumeAvailability = 'unsupported';
+
+    const { container } = render(
+      <Wrapper>
+        <VolumeSliderRoot
+          render={(props, state) => <div {...props} data-testid="vol-slider" data-state={state.availability} />}
+        />
+      </Wrapper>
+    );
+
+    const el = container.querySelector('[data-testid="vol-slider"]');
+    expect(el?.getAttribute('data-state')).toBe('unsupported');
+
+    mockVolumeState.volumeAvailability = 'available';
   });
 });
 

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -71,7 +71,10 @@ vi.mock('@videojs/store/react', () => ({
   }),
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  mockVolumeState.volumeAvailability = 'available';
+});
 
 // --- Tests ---
 
@@ -149,8 +152,6 @@ describe('VolumeSliderRoot', () => {
 
     const el = container.querySelector('[data-orientation]');
     expect(el?.getAttribute('data-availability')).toBe('unsupported');
-
-    mockVolumeState.volumeAvailability = 'available';
   });
 
   it('exposes availability to render state', () => {
@@ -167,8 +168,6 @@ describe('VolumeSliderRoot', () => {
 
     const el = container.querySelector('[data-testid="vol-slider"]');
     expect(el?.getAttribute('data-state')).toBe('unsupported');
-
-    mockVolumeState.volumeAvailability = 'available';
   });
 });
 

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -12,39 +12,43 @@ import { VolumeSliderRoot } from '../volume-slider-root';
 
 // --- Hoisted mock data (available inside vi.mock factories) ---
 
-const { mockSliderApi, mockVolumeState } = vi.hoisted(() => ({
-  mockSliderApi: () => ({
-    input: {
-      current: {
-        pointerPercent: 0,
-        dragPercent: 0,
-        dragging: false,
-        pointing: false,
-        focused: false,
-      },
-      subscribe: vi.fn(() => vi.fn()),
-    },
-    rootProps: {
-      onPointerDown: vi.fn(),
-      onPointerMove: vi.fn(),
-      onPointerLeave: vi.fn(),
-    },
-    thumbProps: {
-      onKeyDown: vi.fn(),
-      onFocus: vi.fn(),
-      onBlur: vi.fn(),
-    },
-    adjustForAlignment: <S,>(state: S): S => state,
-    destroy: vi.fn(),
-  }),
-  mockVolumeState: {
+const { mockSliderApi, mockVolumeState } = vi.hoisted(() => {
+  const mockVolumeState: MediaVolumeState = {
     volume: 0.8,
     muted: false,
     volumeAvailability: 'available',
     setVolume: vi.fn(),
     toggleMuted: vi.fn(),
-  } satisfies MediaVolumeState,
-}));
+  };
+
+  return {
+    mockSliderApi: () => ({
+      input: {
+        current: {
+          pointerPercent: 0,
+          dragPercent: 0,
+          dragging: false,
+          pointing: false,
+          focused: false,
+        },
+        subscribe: vi.fn(() => vi.fn()),
+      },
+      rootProps: {
+        onPointerDown: vi.fn(),
+        onPointerMove: vi.fn(),
+        onPointerLeave: vi.fn(),
+      },
+      thumbProps: {
+        onKeyDown: vi.fn(),
+        onFocus: vi.fn(),
+        onBlur: vi.fn(),
+      },
+      adjustForAlignment: <S,>(state: S): S => state,
+      destroy: vi.fn(),
+    }),
+    mockVolumeState,
+  };
+});
 
 // --- Module mocks ---
 

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from '@testing-library/react';
-import type { MediaVolumeState } from '@videojs/core/dom';
+import type { MediaVolumeState } from '@videojs/core';
 import { createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SliderDataAttrs, VolumeSliderCore } from '@videojs/core';
+import { VolumeSliderCore, VolumeSliderDataAttrs } from '@videojs/core';
 import { getSliderCSSVars, logMissingFeature, selectVolume } from '@videojs/core/dom';
 import { forwardRef, useState } from 'react';
 
@@ -85,7 +85,7 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
           pointerValue: core.valueFromPercent(state.pointerPercent),
           thumbRef,
           thumbProps,
-          stateAttrMap: SliderDataAttrs,
+          stateAttrMap: VolumeSliderDataAttrs,
           getAttrs: (sliderState) => core.getAttrs(sliderState as VolumeSliderCore.State),
           formatValue: (value) => `${Math.round(value)}%`,
         }}
@@ -95,7 +95,7 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
           { render, className, style },
           {
             state,
-            stateAttrMap: SliderDataAttrs,
+            stateAttrMap: VolumeSliderDataAttrs,
             ref: [forwardedRef, rootRef],
             props: [{ style: { ...cssVars, ...rootStyle } }, rootProps, elementProps],
           }

--- a/packages/utils/src/dom/tests/slotted.test.ts
+++ b/packages/utils/src/dom/tests/slotted.test.ts
@@ -88,7 +88,7 @@ describe('getSlottedElement', () => {
 
       const isMedia = (el: Element): el is HTMLMediaElement => el instanceof HTMLMediaElement;
 
-      const result = getSlottedElement(host.shadowRoot!, '', (el) => (isMedia(el) ? el : null));
+      const result = getSlottedElement<HTMLMediaElement>(host.shadowRoot!, '', (el) => (isMedia(el) ? el : null));
 
       expect(result).toBe(video);
       expect(result?.play).toBeDefined();

--- a/site/src/content/docs/reference/feature-volume.mdx
+++ b/site/src/content/docs/reference/feature-volume.mdx
@@ -40,7 +40,7 @@ import { selectVolume, usePlayer } from '@videojs/react';
 
 function VolumeSlider() {
   const vol = usePlayer(selectVolume);
-  if (!vol) return null;
+  if (!vol || vol.volumeAvailability !== 'available') return null;
 
   return (
     <input
@@ -65,6 +65,10 @@ const { PlayerController, context } = createPlayer({ features: videoFeatures });
 
 class VolumeSlider extends MediaElement {
   readonly #volume = new PlayerController(this, context, selectVolume);
+
+  get availability(): string | undefined {
+    return this.#volume.value?.volumeAvailability;
+  }
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/feature-volume.mdx
+++ b/site/src/content/docs/reference/feature-volume.mdx
@@ -58,6 +58,7 @@ function VolumeSlider() {
 
 <FrameworkCase frameworks={["html"]}>
 ```ts title="volume-slider.ts"
+import type { MediaFeatureAvailability } from '@videojs/core';
 import { createPlayer, MediaElement, selectVolume } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
@@ -66,7 +67,7 @@ const { PlayerController, context } = createPlayer({ features: videoFeatures });
 class VolumeSlider extends MediaElement {
   readonly #volume = new PlayerController(this, context, selectVolume);
 
-  get availability(): string | undefined {
+  get availability(): MediaFeatureAvailability | undefined {
     return this.#volume.value?.volumeAvailability;
   }
 }

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -39,6 +39,8 @@ import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/With
 
 Controls the media volume level. The slider maps its 0–100 internal range to the media's 0–1 volume scale. When the media is muted, the fill level drops to 0 regardless of the stored volume value.
 
+The root also reflects volume control availability with `data-availability`. On platforms where volume cannot be changed programmatically, such as iOS, the slider exposes `data-availability="unsupported"`.
+
 ## Styling
 
 Use [CSS custom properties](#root-css-custom-properties) to style the fill and pointer levels:
@@ -57,6 +59,24 @@ React renders a `<div>` element. Add a `className` to style it:
 ```css
 .volume-slider::before {
   width: calc(var(--media-slider-fill) * 1%);
+}
+```
+</FrameworkCase>
+
+You can also hide the slider when volume control is unavailable:
+
+<FrameworkCase frameworks={["html"]}>
+```css
+media-volume-slider[data-availability="unsupported"] {
+  display: none;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```css
+.volume-slider[data-availability="unsupported"] {
+  display: none;
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -39,7 +39,7 @@ import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/With
 
 Controls the media volume level. The slider maps its 0–100 internal range to the media's 0–1 volume scale. When the media is muted, the fill level drops to 0 regardless of the stored volume value.
 
-The root also reflects volume control availability with `data-availability`. On platforms where volume cannot be changed programmatically, such as iOS, the slider exposes `data-availability="unsupported"`.
+The root also reflects volume control availability with `data-availability`. It starts at `unavailable` while the runtime capability probe resolves, then settles on `available` or `unsupported`. On platforms where volume cannot be changed programmatically, such as iOS, the slider exposes `data-availability="unsupported"`.
 
 ## Styling
 
@@ -63,10 +63,11 @@ React renders a `<div>` element. Add a `className` to style it:
 ```
 </FrameworkCase>
 
-You can also hide the slider when volume control is unavailable:
+You can also hide the slider while availability is unresolved or unsupported:
 
 <FrameworkCase frameworks={["html"]}>
 ```css
+media-volume-slider[data-availability="unavailable"],
 media-volume-slider[data-availability="unsupported"] {
   display: none;
 }
@@ -75,6 +76,7 @@ media-volume-slider[data-availability="unsupported"] {
 
 <FrameworkCase frameworks={["react"]}>
 ```css
+.volume-slider[data-availability="unavailable"],
 .volume-slider[data-availability="unsupported"] {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Add volume availability state/data attrs to the volume slider and mute button
- Detect volume support with a runtime probe and use it to gate React and HTML volume popovers
- Add coverage for the feature detection and HTML popover gating, and update the volume docs

## Testing
- pnpm -F @videojs/core test src/core/ui/mute-button/tests/mute-button-core.test.ts
- pnpm -F @videojs/html test src/ui/popover/tests/popover-element.test.ts
- pnpm -F @videojs/core build
- pnpm -F @videojs/react build
- pnpm -F @videojs/html build

Closes #961