### PR TITLE
fix(utils): handle missing media.querySelectorAll for HLS

### DIFF
--- a/packages/utils/src/dom/text-track.ts
+++ b/packages/utils/src/dom/text-track.ts
@@ -1,6 +1,6 @@
 /** Find the `<track>` element that owns the given `TextTrack`. */
 export function findTrackElement(media: HTMLMediaElement, track: TextTrack): HTMLTrackElement | null {
-  for (const el of media.querySelectorAll('track')) {
+  for (const el of media.querySelectorAll?.('track') ?? []) {
     if (el.track === track) return el;
   }
   return null;


### PR DESCRIPTION
HLS sources throw an error because `querySelectorAll` is undefined. This check fixes the logic for the missing function and then captions work as expected. This may not be the "right" fix though. 