### PR TITLE
fix(core): stub pointer:fine in tooltip touch suppression tests

### DIFF
--- a/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
+++ b/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
@@ -107,10 +107,10 @@ describe('createTooltip', () => {
     describe('touch pointer suppression', () => {
       beforeEach(() => {
         vi.useFakeTimers();
-        // jsdom lacks matchMedia — stub so popover's canHover() returns true,
-        // allowing us to test that the tooltip layer blocks touch independently.
+        // jsdom lacks matchMedia — stub so popover's canHover() and canOpenOnFocus()
+        // return true, allowing us to test that the tooltip layer blocks touch independently.
         vi.stubGlobal('matchMedia', (query: string) => ({
-          matches: query === '(hover: hover)',
+          matches: query === '(hover: hover)' || query === '(pointer: fine)',
           media: query,
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),


### PR DESCRIPTION
## Summary

- The `matchMedia` stub in tooltip touch suppression tests only matched `(hover: hover)`, but the popover's `canOpenOnFocus()` also checks `(pointer: fine)`
- Without both matches, focus-triggered opens were blocked at the popover level, causing the keyboard Tab tests to fail

## Test plan

- [x] All 22 tooltip tests pass locally
- [x] Specifically fixes "opens via focus when no pointer down (keyboard Tab)" and "opens via keyboard focus after tap-triggered focus was suppressed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)