### PR TITLE
fix(core): sync playback feature state on seeked event

### DIFF
--- a/packages/core/src/dom/store/features/playback.ts
+++ b/packages/core/src/dom/store/features/playback.ts
@@ -37,5 +37,6 @@ export const playbackFeature = definePlayerFeature({
     listen(media, 'ended', sync, { signal });
     listen(media, 'playing', sync, { signal });
     listen(media, 'waiting', sync, { signal });
+    listen(media, 'seeked', sync, { signal });
   },
 });

--- a/packages/core/src/dom/store/features/tests/playback.test.ts
+++ b/packages/core/src/dom/store/features/tests/playback.test.ts
@@ -104,6 +104,21 @@ describe('playbackFeature', () => {
       expect(store.state.ended).toBe(true);
     });
 
+    it('clears ended state on seeked event', () => {
+      const video = createMockVideo({ ended: true });
+
+      const store = createStore<PlayerTarget>()(playbackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.ended).toBe(true);
+
+      // Simulate seeking: browser clears ended when user seeks
+      Object.defineProperty(video, 'ended', { value: false, writable: false, configurable: true });
+      video.dispatchEvent(new Event('seeked'));
+
+      expect(store.state.ended).toBe(false);
+    });
+
     it('stops listening when store is destroyed', () => {
       const video = createMockVideo({});
 


### PR DESCRIPTION
Closes https://github.com/videojs/v10/issues/962

## Summary

The playback feature's `ended` state was not being cleared when the user seeked back into the media after it had ended. This adds a listener for the `seeked` event so the store stays in sync with the actual media element state.

## Test plan

- [x] Added test: `clears ended state on seeked event`
- [x] `pnpm -F @videojs/core test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)