### PR TITLE
refactor(ci): collapse unchanged packages in bundle size report

### DIFF
--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -221,8 +221,6 @@ function generateComparisonReport(current, base) {
     const entries = groups.get(pkg) ?? [];
     const baseEntries = baseGroups.get(pkg) ?? [];
     const pkgIcon = pkgIcons[pkg] ?? '📦';
-    lines.push(`## ${pkgIcon} @videojs/${pkg}`);
-    lines.push('');
 
     // Entries with meaningful size changes (>300 B threshold).
     // For UI components, gate on standalone size to filter out phantom diffs
@@ -238,10 +236,20 @@ function generateComparisonReport(current, base) {
     // Entries that existed in base but are missing in PR (removed)
     const removed = baseEntries.filter((e) => currentMap[e.name] === undefined);
 
-    if (changed.length === 0 && removed.length === 0) {
-      lines.push('(no changes)');
+    const hasChanges = changed.length > 0 || removed.length > 0;
+
+    // Category breakdowns for packages with categories (html, react)
+    const hasCategories = entries.some((e) => e.category);
+    const breakdownLines = hasCategories
+      ? generateCategoryBreakdowns(entries, pkg)
+      : entries.length > 1
+        ? generateFlatBreakdown(entries, pkg)
+        : [];
+
+    if (hasChanges) {
+      lines.push(`## ${pkgIcon} @videojs/${pkg}`);
       lines.push('');
-    } else {
+
       lines.push('| Path | Base | PR | Diff | % | |');
       lines.push('|---|--:|--:|--:|--:|:-:|');
 
@@ -264,15 +272,14 @@ function generateComparisonReport(current, base) {
       }
 
       lines.push('');
-    }
-
-    // Category breakdowns for packages with categories (html, react)
-    const hasCategories = entries.some((e) => e.category);
-    if (hasCategories) {
-      lines.push(...generateCategoryBreakdowns(entries, pkg));
-    } else if (entries.length > 1) {
-      // Flat breakdown for other packages with multiple entries
-      lines.push(...generateFlatBreakdown(entries, pkg));
+      lines.push(...breakdownLines);
+    } else {
+      lines.push('<details>');
+      lines.push(`<summary><b>${pkgIcon} @videojs/${pkg}</b> — no changes</summary>`);
+      lines.push('');
+      lines.push(...breakdownLines);
+      lines.push('</details>');
+      lines.push('');
     }
   }
 


### PR DESCRIPTION
## Summary

Unchanged packages in the bundle size report were previously rendered as top-level `## Package` headers with a "(no changes)" label, making PR comments noisy when most packages haven't changed. This refactor collapses them into `<details>` elements so the report stays scannable.

## Changes

- Packages with no size changes render as collapsed `<details>` sections instead of full headers
- Breakdown lines (category or flat) are computed upfront and reused in both the changed and unchanged branches
- Packages with actual changes continue to render as before with the full header and diff table

## Testing

Covered by the existing bundle size report script — verify by running a CI bundle size comparison on a PR where only some packages change.