### PR TITLE
fix(html): restore deprecated slot="media" for backwards compatibility

### DIFF
--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -37,6 +37,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${root}">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <div class="${controls}">

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -21,6 +21,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--audio">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <div class="media-controls">

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -36,6 +36,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${root}">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <div class="${controls}">

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -21,6 +21,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--audio">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <div class="media-surface media-controls">

--- a/packages/html/src/define/background/skin.ts
+++ b/packages/html/src/define/background/skin.ts
@@ -5,6 +5,8 @@ import { safeDefine } from '../safe-define';
 function getTemplateHTML(_attrs: Record<string, string>) {
   return /*html*/ `
     <media-container>
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
     </media-container>
   `;

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -47,6 +47,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${root(true)}">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <media-poster class="${poster(true)}">

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -26,6 +26,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-minimal-skin media-minimal-skin--video">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <media-poster>

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -46,6 +46,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="${root(true)}">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <media-poster class="${poster(true)}">

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -27,6 +27,8 @@ const SEEK_TIME = 10;
 function getTemplateHTML() {
   return /*html*/ `
     <media-container class="media-default-skin media-default-skin--video">
+      <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
+      <slot name="media"></slot>
       <slot></slot>
 
       <media-poster>


### PR DESCRIPTION
## Summary

- PR #997 removed `slot="media"` from all HTML skin templates in favor of context-based media discovery
- This restores `<slot name="media"></slot>` alongside the new `<slot></slot>` in all 9 skin templates to avoid breaking users who pass `slot="media"` on their media elements
- The named slot is marked with `<!-- @deprecated slot="media" is no longer required, use the default slot instead -->` to signal migration

**How it works:** Web Components named slots take priority over the default slot. Elements with `slot="media"` are captured by the named slot; everything else falls into the default slot. Both work simultaneously.

## Affected files

All in `packages/html/src/define/`:
- `video/skin.ts`, `video/minimal-skin.ts`, `video/skin.tailwind.ts`, `video/minimal-skin.tailwind.ts`
- `audio/skin.ts`, `audio/minimal-skin.ts`, `audio/skin.tailwind.ts`, `audio/minimal-skin.tailwind.ts`
- `background/skin.ts`

## Test plan

- [ ] Build passes: `pnpm -F @videojs/html build`
- [ ] Media element with `slot="media"` still renders correctly inside skin
- [ ] Media element without `slot="media"` (default slot) also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)