### PR TITLE
fix(site): redirect vjs10-site.netlify.app to videojs.org

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -37,6 +37,12 @@
   status = 301
   force = true
 
+[[redirects]]
+  from = "https://vjs10-site.netlify.app/*"
+  to   = "https://videojs.org/:splat"
+  status = 301
+  force = true
+
 
 # Redirect old theme demo pages to home
 [[redirects]]


### PR DESCRIPTION
## Summary
- Adds a 301 redirect from `vjs10-site.netlify.app` to `videojs.org`, matching the existing alias redirects for `videojs.com`, `www.videojs.com`, and `v10.videojs.org`.

Closes #1037

## Test plan
- [ ] Deploy to Netlify and verify `vjs10-site.netlify.app` redirects to `videojs.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)