### PR TITLE
fix(core): prevent sprite tile bleeding in thumbnail component

### DIFF
--- a/packages/core/src/core/ui/thumbnail/tests/thumbnail-core.test.ts
+++ b/packages/core/src/core/ui/thumbnail/tests/thumbnail-core.test.ts
@@ -357,6 +357,22 @@ describe('ThumbnailCore', () => {
       expect(heights.size).toBe(1);
     });
 
+    it('clamps container dimensions to zero at extreme scales', () => {
+      const core = new ThumbnailCore();
+      const thumbnail = createImage();
+
+      // maxWidth 3 / tileWidth 256 → scale so small that floor(h*s) - 2 would be negative.
+      const result = core.resize(thumbnail, 2560, 1600, {
+        minWidth: 0,
+        maxWidth: 3,
+        minHeight: 0,
+        maxHeight: Infinity,
+      });
+
+      expect(result!.containerWidth).toBeGreaterThanOrEqual(0);
+      expect(result!.containerHeight).toBeGreaterThanOrEqual(0);
+    });
+
     it('returns undefined when dimensions are unavailable', () => {
       const core = new ThumbnailCore();
       const thumbnail: ThumbnailImage = { url: 'thumb.jpg', startTime: 0, endTime: 5 };

--- a/packages/core/src/core/ui/thumbnail/thumbnail-core.ts
+++ b/packages/core/src/core/ui/thumbnail/thumbnail-core.ts
@@ -127,8 +127,8 @@ export class ThumbnailCore {
     return {
       scale,
       // Floor container so it never extends past the tile boundary.
-      containerWidth: Math.floor(tileWidth * scale) - inset * 2,
-      containerHeight: Math.floor(tileHeight * scale) - inset * 2,
+      containerWidth: Math.max(0, Math.floor(tileWidth * scale) - inset * 2),
+      containerHeight: Math.max(0, Math.floor(tileHeight * scale) - inset * 2),
       // Ceil image so the sprite sheet always fills the container.
       imageWidth: Math.ceil(imgNaturalWidth * scale),
       imageHeight: Math.ceil(imgNaturalHeight * scale),


### PR DESCRIPTION
## Summary

- Derive container dimensions from the relationship between ceiled offset and floored far edge, ensuring the visible sprite area is always tightly bounded within a single tile
- Ceil offsets so they never undershoot the tile origin (prevents top/left bleed)
- Floor the far edge so the visible area never extends into adjacent tiles (prevents right/bottom bleed)
- Ceil image dimensions so the sprite sheet always fills the container (prevents sub-pixel gaps)

Closes #996

## Test plan

- [x] Updated existing rounding test expectations
- [x] Added test: container never exceeds scaled tile dimensions
- [x] Added test: offsets never undershoot tile origin (prevents top/left bleed)
- [x] Added test: visible edges do not extend past tile boundary
- [ ] Visual check: inspect thumbnail preview on slider in Chrome — no light line on any edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thumbnail sprite scaling/rounding math (floor/ceil + 1px inset) which can subtly affect rendered size/position across browsers and edge scales. Risk is contained to the thumbnail UI but could cause off-by-one visual regressions if assumptions elsewhere rely on previous rounding.
> 
> **Overview**
> Prevents sprite-sheet tile bleeding in `ThumbnailCore.resize` by changing how scaled dimensions and offsets are rounded: **container size is floored (and optionally inset by 1px when scaled), sprite sheet dimensions are ceiled, and offsets are ceiled** to keep the visible region strictly within a single tile.
> 
> Updates and expands unit tests to match the new rounding/inset behavior and adds coverage for tile-boundary invariants (no overshoot/undershoot, stable dimensions across tile positions, and clamping at extreme small scales).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e2f70c2dc0cece990c9345f943c4f909c5ffc65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->