### PR TITLE
chore(ci): add SPF to issue template package options

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -32,6 +32,7 @@ body:
         - Icons (@videojs/icons)
         - HTML (@videojs/html)
         - React (@videojs/react)
+        - SPF (@videojs/spf)
         - Utils (@videojs/utils)
         - HTML Example
         - React Example

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -39,6 +39,7 @@ body:
         - Icons (@videojs/icons)
         - HTML (@videojs/html)
         - React (@videojs/react)
+        - SPF (@videojs/spf)
         - Utils (@videojs/utils)
   - type: textarea
     id: motivation

--- a/.github/ISSUE_TEMPLATE/3.docs_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/3.docs_feedback.yml
@@ -27,6 +27,7 @@ body:
         - Icons (@videojs/icons)
         - HTML (@videojs/html)
         - React (@videojs/react)
+        - SPF (@videojs/spf)
         - general framework documentation
     validations:
       required: true


### PR DESCRIPTION
## Summary

Adds `@videojs/spf` as a selectable package option in all three GitHub issue templates (bug report, feature request, docs feedback) so reporters can properly attribute issues to the SPF package.

## Changes

- Added `SPF (@videojs/spf)` to the package dropdown in the bug report, feature request, and docs feedback issue templates

## Testing

- Open a new issue on GitHub and verify `SPF (@videojs/spf)` appears in the package selection dropdown across all three templates