### PR TITLE
fix(site): quote poster prop value in react demo code template

### DIFF
--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -29,7 +29,7 @@ const Player = createPlayer({ features: videoFeatures });
 export function VideoPlayer() {
   return (
     <Player.Provider>
-      <${skinComponent} poster={VJS10_DEMO_VIDEO.poster}>
+      <${skinComponent} poster="${VJS10_DEMO_VIDEO.poster}">
         <Video src="${VJS10_DEMO_VIDEO.mp4}" playsInline />
       </${skinComponent}>
     </Player.Provider>


### PR DESCRIPTION
## Summary

Fix the React demo code template on the homepage where the `poster` prop value was not wrapped in quotes. Since `baseCode.ts` generates JSX as a string, the poster value needs string quotes (like the `src` prop already has) to produce valid JSX output.

## Changes

- Wrap `poster` prop value in quotes in the React code template to match how `src` is already handled

## Testing

1. `pnpm dev` and verify the homepage React demo code snippet shows valid JSX with a quoted `poster` prop