### PR TITLE
fix(skin): fix button text alignment and text shadow

### DIFF
--- a/packages/skins/src/default/css/components/buttons.css
+++ b/packages/skins/src/default/css/components/buttons.css
@@ -18,6 +18,7 @@
   transition-timing-function: ease-out;
   cursor: pointer;
   user-select: none;
+  text-align: center;
   touch-action: manipulation;
 
   &:focus-visible {
@@ -45,7 +46,7 @@
   background: oklch(1 0 0);
   color: oklch(0 0 0);
   font-weight: 500;
-  text-align: center;
+  text-shadow: none;
 }
 
 /* Subtle button variant */

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -11,7 +11,7 @@ export const button = {
     'focus-visible:outline-current focus-visible:outline-offset-2',
     'data-[availability=unavailable]:hidden'
   ),
-  primary: 'bg-white text-black font-medium text-center',
+  primary: 'bg-white text-black font-medium text-shadow-none',
   subtle: cn(
     'bg-transparent text-inherit text-shadow-inherit',
     'hover:bg-current/10 hover:no-underline',

--- a/packages/skins/src/minimal/css/components/buttons.css
+++ b/packages/skins/src/minimal/css/components/buttons.css
@@ -32,6 +32,7 @@
   transition-timing-function: ease-out;
   cursor: pointer;
   user-select: none;
+  text-align: center;
   touch-action: manipulation;
 
   &:focus-visible {
@@ -68,7 +69,7 @@
   background: oklch(1 0 0);
   color: oklch(0 0 0);
   font-weight: 500;
-  text-align: center;
+  text-shadow: none;
 }
 
 /* Subtle button variant */

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -13,7 +13,7 @@ export const button = {
     'supports-[corner-shape:squircle]:[corner-shape:squircle]',
     'data-[availability=unavailable]:hidden'
   ),
-  primary: 'bg-white text-black font-medium text-center',
+  primary: 'bg-white text-black font-medium text-shadow-none',
   subtle: cn(
     'bg-transparent text-inherit text-shadow-inherit',
     'hover:bg-current/10',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk styling-only change affecting button alignment and typography; main risk is minor visual regressions across default/minimal skins.
> 
> **Overview**
> Fixes button label presentation across *default* and *minimal* skins by ensuring base `.media-button` text is consistently centered.
> 
> Updates the primary button variant (CSS + Tailwind config) to explicitly disable text shadow (`text-shadow: none` / `text-shadow-none`) instead of applying per-variant `text-align`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0743e4c9686b315b8f98bf341f568ba6f8671808. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->