### PR TITLE
feat(site): add storyboard to home page hero video

### DIFF
--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -34,7 +34,14 @@ export default function HeroVideo({
         }
         poster={poster}
       >
-        <HlsVideo src={VJS10_DEMO_VIDEO.hls} playsInline />
+        <HlsVideo src={VJS10_DEMO_VIDEO.hls} playsInline crossOrigin="anonymous">
+          <track
+            kind="metadata"
+            label="thumbnails"
+            src={`https://image.mux.com/${VJS10_DEMO_VIDEO.id}/storyboard.vtt`}
+            default
+          />
+        </HlsVideo>
       </SkinComponent>
     </Player.Provider>
   );


### PR DESCRIPTION
## Summary
- Add Mux storyboard thumbnail track to home page hero video

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that adds an external storyboard VTT track and sets `crossOrigin="anonymous"` on the hero HLS video; main risk is CORS/mixed-origin loading behavior for the track asset.
> 
> **Overview**
> Adds Mux storyboard thumbnail support to the home page hero video by attaching a `kind="metadata"` `track` that points to `https://image.mux.com/.../storyboard.vtt`.
> 
> Updates the hero `HlsVideo` to use `crossOrigin="anonymous"` to allow the remote storyboard asset to load correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5677918dceaa234605816a7e79226a818a622939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->