### PR TITLE
feat(packages): export media component building blocks

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1,3 +1,4 @@
+export * from './media/delegate';
 export * from './media/proxy';
 export * from './media/state';
 export * from './ui/alert-dialog/alert-dialog-core';

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -1,4 +1,5 @@
 export * from './feature';
+export * from './media/proxy';
 export * from './media/types';
 export * from './store/features';
 export * from './store/selectors';

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,4 +1,6 @@
 // Core
+export type { Delegate } from '@videojs/core';
+export { DelegateMixin } from '@videojs/core';
 export * from '@videojs/core/dom';
 
 // Store

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,8 @@
 'use client';
 
 // Core
+export type { Delegate } from '@videojs/core';
+export { DelegateMixin } from '@videojs/core';
 export * from '@videojs/core/dom';
 
 // Store
@@ -17,10 +19,10 @@ export {
   useContainerAttach,
   useMedia,
   useMediaAttach,
+  useOptionalPlayer,
   usePlayer,
   usePlayerContext,
 } from './player/context';
-
 // Player API
 export {
   type CreatePlayerConfig,
@@ -60,7 +62,14 @@ export { TimeSlider } from './ui/time-slider';
 export { Tooltip, type TooltipContextValue, useTooltipContext } from './ui/tooltip';
 export { VolumeSlider } from './ui/volume-slider';
 
+// Media utilities
+export { attachMediaElement } from './utils/attach-media-element';
+export { mediaProps } from './utils/media-props';
 // Utilities
 export { mergeProps } from './utils/merge-props';
 export type { HTMLProps, RenderFunction, RenderProp, UIComponentProps } from './utils/types';
+export { composeRefs, useComposedRefs } from './utils/use-composed-refs';
+export { useDestroy } from './utils/use-destroy';
+export { useLatestRef } from './utils/use-latest-ref';
+export { useMediaInstance } from './utils/use-media-instance';
 export { renderElement } from './utils/use-render';


### PR DESCRIPTION
Closes #1099

## Summary

Export internal media component building blocks so external consumers can build custom media components (e.g., new streaming protocol integrations) without reaching into internal module paths.

## Changes

- Export `Delegate` interface and `DelegateMixin` from `@videojs/core`, re-exported through `@videojs/html` and `@videojs/react`
- Export `MediaProxyMixin` from `@videojs/core/dom` (auto-flows to `@videojs/html` and `@videojs/react`)
- Export `useOptionalPlayer` hook from `@videojs/react`
- Export media utilities from `@videojs/react`: `useMediaInstance`, `attachMediaElement`, `mediaProps`, `composeRefs`, `useComposedRefs`, `useDestroy`, `useLatestRef`

<details>
<summary>Implementation details</summary>

All items were already exported from their source files but not re-exported from package entry points. The built-in HLS, DASH, and SimpleHLS components used them via relative imports. This change makes the same APIs available to external consumers.

`Delegate` requires `export type` due to `verbatimModuleSyntax`.

`MediaProxyMixin` added to `@videojs/core/dom` automatically flows to both `@videojs/html` and `@videojs/react` via their existing `export * from '@videojs/core/dom'` re-exports.

</details>

## Testing

Covered by existing tests — re-exports only, no behavior changes. All 956 tests pass across core, react, and html packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is limited to package entry-point re-exports (types/mixins/hooks/utilities) with no runtime behavior changes, but it does expand the public API surface that must be supported going forward.
> 
> **Overview**
> Exposes previously-internal media building blocks via public package entry points so downstream consumers can build custom media components without importing internal paths.
> 
> `@videojs/core` now re-exports `Delegate`/`DelegateMixin`, and `@videojs/core/dom` re-exports `MediaProxyMixin`, which then flow through `@videojs/html` and `@videojs/react`. `@videojs/react` also re-exports `useOptionalPlayer` plus several media/React utilities (`attachMediaElement`, `mediaProps`, `useMediaInstance`, `composeRefs`/`useComposedRefs`, `useDestroy`, `useLatestRef`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90b64f02a7fb65da385a533b14b7d3da70aa5b76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->