### PR TITLE
test(spf): restore headless browser config for vitest

### DIFF
--- a/packages/spf/vitest.config.ts
+++ b/packages/spf/vitest.config.ts
@@ -30,11 +30,8 @@ export default defineConfig({
           include: ['src/dom/**/*.test.ts'],
           browser: {
             enabled: true,
-            provider: playwright({
-              launch: {
-                headless: true,
-              },
-            }),
+            headless: true,
+            provider: playwright(),
             screenshotFailures: false,
             instances: [{ browser: 'chromium' }],
           },


### PR DESCRIPTION
## Summary

- Moves `headless: true` back to `test.browser.headless` where Vitest reads it
- The previous migration (#1101) incorrectly placed it inside `playwright({ launch: { headless: true } })` which Vitest ignores — `launch` isn't even the correct key (`launchOptions` is)
- Without `browser.headless`, Vitest defaults to `process.env.CI`, so local runs open a visible Chromium window

## Test plan

- [x] `pnpm -F @videojs/spf test` — 44 files, 716 tests pass headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change to test runner settings; main impact is how DOM tests launch Playwright locally/CI.
> 
> **Overview**
> Ensures the `dom` Vitest project runs Playwright in **headless mode** by moving the setting to `test.browser.headless`, and simplifies the provider configuration to `provider: playwright()` (removing the unused `launch` override).
> 
> This prevents local runs from opening a visible Chromium window and makes headless behavior consistent across environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ad1764bc5258c73831c9fa5fe9ad35047c6eb1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->