### PR TITLE
feat(site): improve ejected skin output with usage examples and media elements

### DIFF
--- a/site/scripts/build-ejected-skins.ts
+++ b/site/scripts/build-ejected-skins.ts
@@ -1502,6 +1502,18 @@ function flattenErrorClasses(source: string): string {
 }
 
 /**
+ * Move the destructured props from the skin function body into the function
+ * argument so the signature reads e.g.:
+ *   `function VideoSkin({ children, className, poster, ...rest }: VideoSkinProps)`
+ */
+function destructureSkinProps(source: string): string {
+  return source.replace(
+    /export function (\w+Skin\w*)\(props: (\w+Props)\): ReactNode \{\n\s*const \{ (.+?) \} = props;\n/,
+    'export function $1({ $3 }: $2): ReactNode {\n'
+  );
+}
+
+/**
  * Add a Player section to the ejected React output: imports for createPlayer,
  * Video/Audio, and features; an exported Player instance; a typed Props
  * interface; and an exported VideoPlayer/AudioPlayer component with @example.
@@ -1615,6 +1627,9 @@ async function processReactSkin(skin: ReactSkinDef): Promise<{ tsx: string; jsx:
 
   // 11. Add Player section (createPlayer, imports, VideoPlayer/AudioPlayer component)
   tsx = addPlayerSection(tsx, getSkinMediaType(skin));
+
+  // 12. Destructure skin props in function argument instead of body
+  tsx = destructureSkinProps(tsx);
 
   const jsx = tsxToJsx(tsx);
 


### PR DESCRIPTION
Closes https://github.com/videojs/v10/issues/1119, #1113 

## Summary

Ejected skins now produce self-contained, copy-pasteable code. Slots are replaced with real elements, the player wrapper is included, and a ready-to-use component ties it all together.

## HTML

```html
<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
<link rel="stylesheet" href="./player.css">

<video-player>
  <media-container class="media-default-skin media-default-skin--video">
    <video src="https://stream.mux.com/.../highest.mp4" playsinline></video>
    <!-- ... controls ... -->
  </media-container>
</video-player>
```

- `<slot name="media">` and `<slot>` replaced with concrete `<video>`/`<audio>` element
- Wrapped in `<video-player>`/`<audio-player>`
- Added `<link rel="stylesheet" href="./player.css">`
- Dedented from 6-space to 2-space indentation

## React

```tsx
import { createPlayer, usePlayer, Container, ... } from '@videojs/react';
import { Video, videoFeatures } from '@videojs/react/video';
import './player.css';

// ================================================================
// Player
// ================================================================

export const Player = createPlayer({ features: videoFeatures });

export interface VideoPlayerProps {
  src: string;
}

/**
 * @example
 * ```tsx
 * <VideoPlayer src="https://stream.mux.com/.../highest.mp4" />
 * ```
 */
export function VideoPlayer({ src }: VideoPlayerProps) {
  return (
    <Player.Provider>
      <VideoSkin>
        <Video src={src} playsInline />
      </VideoSkin>
    </Player.Provider>
  );
}

// ================================================================
// Skin
// ================================================================

export interface VideoSkinProps { ... }

export function VideoSkin(props: VideoSkinProps): ReactNode {
  // ... full skin implementation
}
```

- Added `createPlayer` import + `Video`/`Audio` + features import
- Added `import './player.css'`
- Exported `Player` instance, typed `VideoPlayerProps`/`AudioPlayerProps`, and `VideoPlayer`/`AudioPlayer` component
- Player section at top of file, Skin section with clear header below
- Audio skins use `audioFeatures`, `Audio`, `AudioPlayer` accordingly

## Testing

```bash
node --import tsx site/scripts/build-ejected-skins.ts
```

All 16 skin entries (default/minimal × video/audio × css/tailwind × html/react) build successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to the site build script that generates `ejected-skins.json`; main risk is producing malformed snippets due to regex-based transforms and template rewrites.
> 
> **Overview**
> Ejected skin generation now outputs **copy‑pasteable, self-contained snippets** for both HTML and React.
> 
> For **HTML skins**, the script dedents evaluated templates, replaces media `<slot>` placeholders with a concrete `<video>`/`<audio>` element using a demo `src`, injects a `./player.css` stylesheet link, and wraps the skin markup in `<video-player>`/`<audio-player>`.
> 
> For **React skins**, the ejected TSX is augmented with a new **Player** section (adds `createPlayer`, media-specific `Video`/`Audio` + feature imports, `import './player.css'`, a `Player` instance, and an exported `VideoPlayer`/`AudioPlayer` component with an `@example`). Output cleanup also improves import handling (supports side-effect imports) and moves skin prop destructuring into the function signature; `SEEK_TIME` is grouped with the Skin types section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29e4a0b1dc6566ca2dff12a06be9679cb6df9082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->