### PR TITLE
refactor(site): inline ejected React skin into VideoPlayer on home page

### DIFF
--- a/site/src/components/home/Demo/Demo.astro
+++ b/site/src/components/home/Demo/Demo.astro
@@ -3,13 +3,16 @@ import { getEntry } from 'astro:content';
 import ServerCode from '@/components/Code/ServerCode.astro';
 import FrameworkControl from '../FrameworkControl';
 import BaseDemo from './Base';
-import { generateHTMLCode, generateReactCode } from './baseCode';
+import { generateHTMLCode, generateReactCode, transformEjectedReactCode } from './baseCode';
 import EjectDemo from './Eject';
 
 const defaultVideo = (await getEntry('ejectedSkins', 'default-video'))!.data;
 const defaultVideoReact = (await getEntry('ejectedSkins', 'default-video-react'))!.data;
 const minimalVideo = (await getEntry('ejectedSkins', 'minimal-video'))!.data;
 const minimalVideoReact = (await getEntry('ejectedSkins', 'minimal-video-react'))!.data;
+
+const defaultVideoReactCode = transformEjectedReactCode(defaultVideoReact.tsx!, 'default');
+const minimalVideoReactCode = transformEjectedReactCode(minimalVideoReact.tsx!, 'minimal');
 ---
 
 <section
@@ -76,7 +79,7 @@ const minimalVideoReact = (await getEntry('ejectedSkins', 'minimal-video-react')
       <ServerCode slot="defaultHtmlCss" code={defaultVideo.css!} lang="css" />
       <ServerCode
         slot="defaultReactCode"
-        code={defaultVideoReact.tsx!}
+        code={defaultVideoReactCode}
         lang="tsx"
       />
       <ServerCode
@@ -92,7 +95,7 @@ const minimalVideoReact = (await getEntry('ejectedSkins', 'minimal-video-react')
       <ServerCode slot="minimalHtmlCss" code={minimalVideo.css!} lang="css" />
       <ServerCode
         slot="minimalReactCode"
-        code={minimalVideoReact.tsx!}
+        code={minimalVideoReactCode}
         lang="tsx"
       />
       <ServerCode

--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -36,3 +36,101 @@ export function VideoPlayer() {
   );
 }`;
 }
+
+/**
+ * Transform ejected React skin TSX into a self-contained VideoPlayer component
+ * that wraps `Player.Provider` > `Container` with the skin body inline.
+ *
+ * The skin's props are preserved as-is (poster render prop, className, style).
+ * `children` is replaced with a `src` prop passed to `<Video>`.
+ */
+export function transformEjectedReactCode(tsx: string, skin: Skin): string {
+  const skinClass =
+    skin === 'default'
+      ? 'media-default-skin media-default-skin--video'
+      : 'media-minimal-skin media-minimal-skin--video';
+
+  let code = tsx;
+
+  // 1. Rename the SkinProps interface → VideoPlayerProps.
+  //    Replace `children?: ReactNode` with `src: string`. Keep everything else.
+  code = code.replace(/export interface (\w+)SkinProps/, 'export interface VideoPlayerProps');
+  code = code.replace(/(\s*)children\?: ReactNode;\n/, '$1src: string;\n');
+
+  // 2. Add createPlayer, Video, videoFeatures to the @videojs/react import.
+  code = code.replace(
+    /import \{([^}]+)\} from '@videojs\/react';/,
+    (_, names: string) => `import { ${names.trim()}, createPlayer, Video, videoFeatures } from '@videojs/react';`
+  );
+
+  // 3. Move SEEK_TIME above the injected Player const.
+  const seekMatch = code.match(/\n*const SEEK_TIME = \d+;\n*/);
+  const seekLine = seekMatch ? seekMatch[0].trim() : '';
+  if (seekMatch) {
+    code = code.replace(seekMatch[0], '\n');
+  }
+
+  // 4. Inject CSS import, SEEK_TIME, and Player const after the import block.
+  const lastImportEnd = findLastImportIndex(code);
+  const injected = [
+    "import './player.css';",
+    '',
+    seekLine,
+    '',
+    'const Player = createPlayer({ features: videoFeatures });',
+  ].join('\n');
+  code = `${code.slice(0, lastImportEnd)}\n${injected}\n${code.slice(lastImportEnd)}`;
+
+  // 5. Replace {children} with <Video src={src} playsInline />.
+  code = code.replace(/(\s*)\{children\}\n/, '$1<Video src={src} playsInline />\n');
+
+  // 6. Transform the exported skin function into VideoPlayer.
+  //    Swap `children` for `src` in destructuring, wrap body in Player.Provider.
+  code = code.replace(
+    /export function \w+Skin\(props: \w+SkinProps\): ReactNode \{\s*const \{ children, className, poster, \.\.\.rest \} = props;\s*\n\s*return \(\s*\n\s*<Container className=\{`[^`]*`\} \{\.\.\.rest\}>([\s\S]*?)\s*<\/Container>\s*\n\s*\);\s*\n\}/,
+    (_, body: string) => {
+      const reindented = body
+        .replace(/^\n+/, '')
+        .split('\n')
+        .map((line) => (line.trim() === '' ? '' : `  ${line}`))
+        .join('\n');
+      return [
+        '/**',
+        ' * @example',
+        ' * ```tsx',
+        ' * <VideoPlayer',
+        ` *   src="${VJS10_DEMO_VIDEO.mp4}"`,
+        ` *   poster="${VJS10_DEMO_VIDEO.poster}"`,
+        ' * />',
+        ' * ```',
+        ' */',
+        'export function VideoPlayer(props: VideoPlayerProps): ReactNode {',
+        '  const { src, className, poster, ...rest } = props;',
+        '',
+        '  return (',
+        '    <Player.Provider>',
+        `      <Container className={\`${skinClass} \${className ?? ''}\`} {...rest}>`,
+        `${reindented}`,
+        '      </Container>',
+        '    </Player.Provider>',
+        '  );',
+        '}',
+      ].join('\n');
+    }
+  );
+
+  // 7. Clean up any triple+ blank lines.
+  code = code.replace(/\n{3,}/g, '\n\n');
+
+  return code;
+}
+
+function findLastImportIndex(source: string): number {
+  const importRegex = /^import\s+.+from\s+['"][^'"]+['"];?\s*$/gm;
+  let lastEnd = 0;
+  let match: RegExpExecArray | null;
+  while ((match = importRegex.exec(source)) !== null) {
+    lastEnd = match.index + match[0].length;
+  }
+  return lastEnd;
+}


### PR DESCRIPTION
## Summary

The home page "Take full control" section showed the ejected React skin as a standalone `VideoSkin` component. This transforms it at display time into a complete `VideoPlayer` component that wraps `Player.Provider` > `Container` with the skin body inline — matching how users would actually use the ejected code.

## Changes

- Add `transformEjectedReactCode()` that rewrites the ejected React TSX into a self-contained `VideoPlayer` component with `Player.Provider`, `Container`, `Video`, and hardcoded `Poster`
- Remove the `VideoSkin`/`MinimalVideoSkin` abstraction, `SkinProps` interface, and unused utilities (`isString`, `isRenderProp`) from the displayed code
- Apply the transformation in `Demo.astro` for both default and minimal React skin variants

## Testing

1. `pnpm -F site dev` → navigate to home page
2. Toggle to React in the "Take full control" demo
3. Verify the code tab shows a `VideoPlayer` component wrapping `Player.Provider` > `Container` instead of a `VideoSkin` component
4. Toggle between default and minimal skins — both should show the correct container className