### PR TITLE
fix(site): use client:idle for ejected skin tabs so hidden panels hydrate

### DIFF
--- a/site/src/components/docs/EjectedSkin.astro
+++ b/site/src/components/docs/EjectedSkin.astro
@@ -15,43 +15,43 @@ const skin = entry.data;
 
 {
   skin.platform === "react" ? (
-    <TabsRoot client:visible>
-      <TabsList client:visible label={`${skin.name} implementation`}>
-        <Tab client:visible value="tsx" initial>
+    <TabsRoot client:idle>
+      <TabsList client:idle label={`${skin.name} implementation`}>
+        <Tab client:idle value="tsx" initial>
           Skin.tsx
         </Tab>
         {skin.css && (
-          <Tab client:visible value="css">
+          <Tab client:idle value="css">
             skin.css
           </Tab>
         )}
       </TabsList>
-      <TabsPanel client:visible value="tsx" initial>
+      <TabsPanel client:idle value="tsx" initial>
         <ServerCode code={skin.tsx!} lang="tsx" />
       </TabsPanel>
       {skin.css && (
-        <TabsPanel client:visible value="css">
+        <TabsPanel client:idle value="css">
           <ServerCode code={skin.css} lang="css" />
         </TabsPanel>
       )}
     </TabsRoot>
   ) : (
-    <TabsRoot client:visible>
-      <TabsList client:visible label={`${skin.name} implementation`}>
-        <Tab client:visible value="html" initial>
+    <TabsRoot client:idle>
+      <TabsList client:idle label={`${skin.name} implementation`}>
+        <Tab client:idle value="html" initial>
           HTML
         </Tab>
         {skin.css && (
-          <Tab client:visible value="css">
+          <Tab client:idle value="css">
             CSS
           </Tab>
         )}
       </TabsList>
-      <TabsPanel client:visible value="html" initial>
+      <TabsPanel client:idle value="html" initial>
         <ServerCode code={skin.html!} lang="html" />
       </TabsPanel>
       {skin.css && (
-        <TabsPanel client:visible value="css">
+        <TabsPanel client:idle value="css">
           <ServerCode code={skin.css} lang="css" />
         </TabsPanel>
       )}


### PR DESCRIPTION
Closes #1136

## Summary

The "skin.css" / "CSS" tab on the skins docs page doesn't reveal its code snippet when clicked. Non-initial `TabsPanel` islands start with `hidden`, which prevents `client:visible` (Intersection Observer) from ever triggering hydration — so the MutationObserver that toggles panel visibility never gets set up.

## Changes

- Switch all `client:visible` to `client:idle` in `EjectedSkin.astro` so hidden panels hydrate after page idle

This follows the existing guidance in the `Tabs.tsx` component comment (lines 11-14).

## Testing

1. `pnpm build:site` — builds clean
2. Manual: visit `/docs/framework/react/concepts/skins`, click "skin.css" tab — code snippet should now appear

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-site change that only alters Astro island hydration timing for tabs; main risk is minor performance/behavior differences from earlier hydration.
> 
> **Overview**
> Fixes the ejected skin docs tabs so non-initial panels (e.g. `skin.css`/`CSS`) reliably hydrate and reveal their code when selected.
> 
> This switches the tabs islands in `EjectedSkin.astro` from `client:visible` to `client:idle`, avoiding the case where initially `hidden` panels never become “visible” to trigger hydration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a691cccf89293e5ab7a43dac4964e7541005151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->