### PR TITLE
fix: disabled default tracks in React

### DIFF
--- a/packages/core/src/core/media/proxy.ts
+++ b/packages/core/src/core/media/proxy.ts
@@ -14,7 +14,7 @@ import { defineClassPropHooks } from '../utils/define-class-prop-hooks';
  */
 export const ProxyMixin = <T extends EventTarget>(
   PrimaryClass: AnyConstructor<T>,
-  ...AdditionalClasses: AnyConstructor<EventTarget>[]
+  ...AdditionalClasses: AnyConstructor<any>[]
 ) => {
   class MediaProxy {
     #target: EventTarget | null = null;

--- a/packages/core/src/dom/media/proxy.ts
+++ b/packages/core/src/dom/media/proxy.ts
@@ -3,5 +3,8 @@ import { ProxyMixin } from '../../core/media/proxy';
 export const VideoProxy = ProxyMixin(
   globalThis.HTMLVideoElement ?? class {},
   globalThis.HTMLMediaElement ?? class {},
-  globalThis.EventTarget ?? class {}
+  globalThis.EventTarget ?? class {},
+  class {
+    querySelectorAll(_selector: string) {}
+  }
 );

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -43,6 +43,18 @@ export const textTrackFeature = definePlayerFeature({
       const textTrackList: MediaTextTrack<TextTrackKind>[] = [];
       let subtitlesShowing = false;
 
+      // Browsers don't honor the `default` attribute if a track is added via JS.
+      // Enable default tracks for chapters or metadata.
+      for (const trackEl of media.querySelectorAll?.('track') ?? []) {
+        if (
+          trackEl.default &&
+          (trackEl.kind === 'chapters' || trackEl.kind === 'metadata') &&
+          trackEl.track?.mode === 'disabled'
+        ) {
+          trackEl.track.mode = 'hidden';
+        }
+      }
+
       for (let i = 0; i < media.textTracks.length; i++) {
         const track = media.textTracks[i]!;
         if (!chaptersTrack && track.kind === 'chapters') chaptersTrack = track;


### PR DESCRIPTION
fix #1095

I'm not 100% sure about this fix but it does resolve the issue. I know we had to do this in the custom media element because there we clone the track element to the native video element in JS.

Not sure why React would not support this, it does also render in JS, but this seems like it should work.

From asking Claude about the React source code and special handling of `<track>`.

> What this means in practice
This is a gap in React's DOM handling. In browsers, the default attribute on a <track> element tells the browser to activate the text track (setting TextTrack.mode to "showing") during initial HTML parsing. However, when the default attribute is added or removed dynamically via JavaScript -- which is what React does during reconciliation -- the browser does not automatically update TextTrack.mode.

> Contrast this with how React gives special treatment to form elements like <input> (where it imperatively manages value, checked, etc. via dedicated functions like initInput/updateInput). The <track> element receives no such special treatment -- it just gets the generic setProp path, which only sets/removes the default HTML attribute without touching the mode DOM property.

> So if you're toggling default on a <track> in React, the attribute will be set/removed correctly in the DOM, but the associated TextTrack.mode won't change. You'd need to use a ref and imperatively set trackElement.track.mode = "showing" (or "disabled") yourself.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how default `TextTrack` modes are auto-enabled and tweaks the proxy type surface used by React/media delegates, which could affect track visibility behavior across browsers.
> 
> **Overview**
> Fixes cases where `default` chapter/metadata `<track>` elements added via JS (e.g., React-rendered media) stay disabled by explicitly switching their underlying `TextTrack.mode` to `hidden` during `textTrackFeature` sync.
> 
> To support this with proxied media elements, `VideoProxy` now exposes a stubbed `querySelectorAll` and `ProxyMixin` relaxes additional class typing so non-`EventTarget` shapes can be included for proxying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc68a45a82ba879cd7253fbb2ae66a350fb902f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->