### PR TITLE
fix(site): add visible "Details" label to API reference table toggle columns

### DIFF
--- a/site/src/components/docs/api-reference/ApiCSSVarsTable.astro
+++ b/site/src/components/docs/api-reference/ApiCSSVarsTable.astro
@@ -24,7 +24,7 @@ const vars = Object.entries(cssCustomProperties);
   <Thead>
     <Tr>
       <Th>Variable</Th>
-      <Th />
+      <Th>Details</Th>
     </Tr>
   </Thead>
   <Tbody>

--- a/site/src/components/docs/api-reference/ApiDataAttrsTable.astro
+++ b/site/src/components/docs/api-reference/ApiDataAttrsTable.astro
@@ -25,7 +25,7 @@ const attrs = Object.entries(dataAttributes);
     <Tr>
       <Th>Attribute</Th>
       <Th>Type</Th>
-      <Th />
+      <Th>Details</Th>
     </Tr>
   </Thead>
   <Tbody>

--- a/site/src/components/docs/api-reference/ApiPropsTable.astro
+++ b/site/src/components/docs/api-reference/ApiPropsTable.astro
@@ -27,7 +27,7 @@ const { props, componentName, showAttributeName } = Astro.props;
       <Th>Prop</Th>
       <Th>Type</Th>
       <Th>Default</Th>
-      <Th />
+      <Th>Details</Th>
     </Tr>
   </Thead>
   <Tbody>

--- a/site/src/components/docs/api-reference/ApiStateTable.astro
+++ b/site/src/components/docs/api-reference/ApiStateTable.astro
@@ -25,7 +25,7 @@ const stateEntries = Object.entries(state);
     <Tr>
       <Th>Property</Th>
       <Th>Type</Th>
-      <Th />
+      <Th>Details</Th>
     </Tr>
   </Thead>
   <Tbody>

--- a/site/src/components/docs/api-reference/UtilParamsTable.astro
+++ b/site/src/components/docs/api-reference/UtilParamsTable.astro
@@ -25,7 +25,7 @@ const { params, utilName } = Astro.props;
       <Th>Parameter</Th>
       <Th>Type</Th>
       <Th>Default</Th>
-      <Th />
+      <Th>Details</Th>
     </Tr>
   </Thead>
   <Tbody>

--- a/site/src/components/docs/api-reference/UtilReturnTable.astro
+++ b/site/src/components/docs/api-reference/UtilReturnTable.astro
@@ -38,7 +38,7 @@ const hasDetail = !hasFields && Boolean(returnValue.detailedType || returnValue.
         <Tr>
           <Th>Property</Th>
           <Th>Type</Th>
-          <Th />
+          <Th>Details</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -58,7 +58,7 @@ const hasDetail = !hasFields && Boolean(returnValue.detailedType || returnValue.
       <Thead>
         <Tr>
           <Th>Type</Th>
-          <Th />
+          <Th>Details</Th>
         </Tr>
       </Thead>
       <Tbody>


### PR DESCRIPTION
Closes #1063

https://claude.ai/code/session_011D8zxHx51HVuAqz7h2X3ri

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, presentation-only change that updates table header text without altering data or behavior.
> 
> **Overview**
> Adds a visible `Details` header to the previously unlabeled disclosure/toggle column across API reference tables (props, state, data attributes, CSS vars, util params/return), improving clarity and accessibility without changing the underlying row rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 460c457f27df810116feab3e975a73afede042c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->