### PR TITLE
fix(site): use overflow-auto on TabsPanel to prevent layout jump

### DIFF
--- a/site/src/components/Tabs.tsx
+++ b/site/src/components/Tabs.tsx
@@ -307,7 +307,7 @@ export function TabsPanel({ value, children, initial, className, variant = 'comp
       hidden={!isActive}
       data-value={value}
       className={twMerge(
-        clsx('overflow-scroll p-6 max-h-96 flex-1', variant === 'compact' && 'bg-faded-black dark:bg-soot'),
+        clsx('overflow-auto p-6 max-h-96 flex-1', variant === 'compact' && 'bg-faded-black dark:bg-soot'),
         className
       )}
     >


### PR DESCRIPTION
## Summary

- Change `overflow-scroll` to `overflow-auto` on `TabsPanel` in `Tabs.tsx` to fix code samples jumping when text is selected
- On platforms with non-overlay scrollbars (Windows, Linux), `overflow: scroll` always reserves scrollbar gutter space even when content doesn't overflow, causing layout shifts on text selection

Closes #831

## Test plan

- [ ] On Windows/Linux, open a docs page with tabbed code samples
- [ ] Select text inside a code block — verify no layout jump
- [ ] Verify code blocks that overflow `max-h-96` still scroll correctly

https://claude.ai/code/session_01T3aaC9EoXfSoUE1nPMZ2KQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts scrollbar behavior in `TabsPanel`; impact is limited to tab panel layout/scrolling UX on some platforms.
> 
> **Overview**
> Updates `TabsPanel` in `Tabs.tsx` to use `overflow-auto` instead of `overflow-scroll`, avoiding reserved scrollbar gutter space and reducing layout jumps (while still allowing scrolling when content actually overflows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 587caa246f092eb7612c0ca884285066f688b25d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->