### PR TITLE
fix: isolate preload mixin for hls delegate

### DIFF
--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -40,16 +40,21 @@ export class HlsMediaDelegateBase implements Delegate {
   #preferPlayback: PlaybackType | undefined = 'mse';
 
   constructor() {
-    this.#initialize();
+    this.initEngine();
   }
 
-  #initialize(): void {
+  destroyEngine(): void {
     this.#engine?.destroy();
     this.#engine = null;
+  }
 
-    if (this.type !== SourceTypes.M3U8) return;
-    if (this.#preferPlayback === PlaybackTypes.NATIVE) return;
-    if (!Hls.isSupported()) return;
+  initEngine(): void {
+    if (this.#engine) this.destroyEngine();
+
+    if (!Hls.isSupported() || this.type !== SourceTypes.M3U8 || this.#preferPlayback === PlaybackTypes.NATIVE) {
+      if (this.#src) this.#requestLoad();
+      return;
+    }
 
     this.#engine = new Hls({
       ...defaultConfig,
@@ -60,9 +65,7 @@ export class HlsMediaDelegateBase implements Delegate {
       this.#engine.attachMedia(this.#target as HTMLMediaElement);
     }
 
-    if (this.#src) {
-      this.#requestLoad();
-    }
+    if (this.#src) this.#requestLoad();
   }
 
   /** The target element, or `null` when not attached. */
@@ -83,7 +86,7 @@ export class HlsMediaDelegateBase implements Delegate {
   set type(value: SourceType | undefined) {
     if (this.#type === value) return;
     this.#type = value;
-    this.#initialize();
+    this.initEngine();
   }
 
   /** Enable hls.js debug logging. Re-initializes the engine when changed. */
@@ -94,12 +97,12 @@ export class HlsMediaDelegateBase implements Delegate {
   set debug(value: boolean) {
     if (this.#debug === value) return;
     this.#debug = value;
-    this.#initialize();
+    this.initEngine();
   }
 
   /**
    * Whether to prefer `'mse'` (hls.js) or `'native'` (browser-built-in) HLS
-   * playback. Changing this re-initializes the delegate.
+   * playback. Changing this re-initializes the engine.
    */
   get preferPlayback(): PlaybackType | undefined {
     return this.#preferPlayback;
@@ -108,7 +111,7 @@ export class HlsMediaDelegateBase implements Delegate {
   set preferPlayback(value: PlaybackType | undefined) {
     if (this.#preferPlayback === value) return;
     this.#preferPlayback = value;
-    this.#initialize();
+    this.initEngine();
   }
 
   /** The HLS source URL to load. */
@@ -147,8 +150,7 @@ export class HlsMediaDelegateBase implements Delegate {
   }
 
   destroy(): void {
-    this.#engine?.destroy();
-    this.#engine = null;
+    this.destroyEngine();
     this.#target = null;
   }
 }

--- a/packages/core/src/dom/media/hls/preload.ts
+++ b/packages/core/src/dom/media/hls/preload.ts
@@ -10,6 +10,7 @@ interface HlsPreloadHost {
   attach?(target: EventTarget): void;
   detach?(): void;
   destroy?(): void;
+  destroyEngine?(): void;
 }
 
 /**
@@ -23,8 +24,8 @@ interface HlsPreloadHost {
 export function HlsMediaPreloadMixin<Base extends Constructor<HlsPreloadHost>>(BaseClass: Base) {
   class HlsMediaPreload extends (BaseClass as Constructor<HlsPreloadHost>) {
     #preloadAbort?: AbortController;
-    #defaultMaxBufferLength?: number;
-    #defaultMaxBufferSize?: number;
+    #defaultMaxBufferLength: number | undefined;
+    #defaultMaxBufferSize: number | undefined;
 
     get preload(): PreloadType {
       return (this.target as HTMLMediaElement | null)?.preload || 'metadata';
@@ -47,14 +48,14 @@ export function HlsMediaPreloadMixin<Base extends Constructor<HlsPreloadHost>>(B
       this.#updatePreload();
     }
 
+    destroyEngine(): void {
+      this.#preloadAbort?.abort();
+      super.destroyEngine?.();
+    }
+
     detach(): void {
       this.#preloadAbort?.abort();
       super.detach?.();
-    }
-
-    destroy(): void {
-      this.#preloadAbort?.abort();
-      super.destroy?.();
     }
 
     #updatePreload(): void {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches HLS load/preload behavior by refactoring when `hls.js` starts buffering and when the engine is (re)initialized, which can affect startup time and network usage. Scope is limited to the HLS delegate and keeps behavior largely equivalent but should be regression-tested across `preload` modes and native fallback.
> 
> **Overview**
> Refactors the HLS delegate to **move all `preload`/buffer-start logic into a new `HlsMediaPreloadMixin`**, and composes it with the existing text-tracks mixin.
> 
> Reworks engine lifecycle into explicit `initEngine()` / `destroyEngine()` methods, and ensures that when `hls.js` isn’t used (unsupported, non-`m3u8`, or native preferred) the delegate still triggers a pending load via the native media element.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 649d1c785a3ed2f26c0713eb4f2e816203711072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->