### PR TITLE
fix(site): add missing space in navbar

### DIFF
--- a/site/src/components/NavBar/NavBar.astro
+++ b/site/src/components/NavBar/NavBar.astro
@@ -44,7 +44,7 @@ const { class: className, dark = false } = Astro.props;
     <span
       class="hidden h-full items-center justify-center rounded-full border border-orange px-3 font-display text-(length:--text) font-bold text-orange sm:inline-flex lg:border-2 lg:px-4 lg:text-h4"
       style={{ "--text": "0.75rem" }}
-      >v10 <span class="whitespace-pre uppercase">beta</span></span
+      >v10 <span class="whitespace-pre uppercase"> beta</span></span
     >
   </a>
   <Search client:load className="mr-4 ml-auto sm:self-center" />


### PR DESCRIPTION
oops in #1138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single text/whitespace change in a static navbar label with no behavioral impact.
> 
> **Overview**
> Updates the `NavBar` version badge text to include a missing space so the label renders as `v10 beta` instead of `v10beta`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 302b0b5f9c4bacb670fe577f00bf1053ebc6df50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->