### PR TITLE
fix(site): prevent images from overflowing on narrow viewports

### DIFF
--- a/site/src/components/typography/Img.astro
+++ b/site/src/components/typography/Img.astro
@@ -12,9 +12,9 @@ const isRemote = typeof src === 'string' && src.startsWith('http');
 
 {
   isRemote ? (
-    <img class={twMerge("my-8", className)} src={src} {...rest} />
+    <img class={twMerge("my-8 max-w-full h-auto", className)} src={src} {...rest} />
   ) : (
     // @ts-expect-error tbh I don't know how to tell ts that inferSize is ok
-    <Image class={twMerge("my-8", className)} inferSize src={src} {...rest} />
+    <Image class={twMerge("my-8 max-w-full h-auto", className)} inferSize src={src} {...rest} />
   )
 }


### PR DESCRIPTION
Add max-w-full and h-auto to Img component so images are constrained
to their container width while maintaining aspect ratio.

Closes #1097

https://claude.ai/code/session_014zb8xkPmByCyJ9YZNfneuh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change: adds responsive sizing classes to images, which may slightly alter layout but doesn’t affect data, auth, or runtime behavior.
> 
> **Overview**
> Prevents images rendered via `Img.astro` from overflowing on narrow viewports by adding Tailwind classes `max-w-full` and `h-auto` to both remote (`<img>`) and local (`astro:assets` `Image`) rendering paths, keeping images within their container while preserving aspect ratio.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3721bde6ecd51a9ddacc9a3906245b7940d23d22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->