### PR TITLE
feat(site): rotate poster time

### DIFF
--- a/site/src/components/home/Header.astro
+++ b/site/src/components/home/Header.astro
@@ -5,7 +5,9 @@ import HeroVideo from '@/components/home/HeroVideo';
 import SkinControl from '@/components/home/SkinControl';
 import { MUX_URL, VJS10_DEMO_VIDEO } from '@/consts';
 
-const poster = `${VJS10_DEMO_VIDEO.poster}?time=0`;
+const times = [0, 12.9, 17.61, 15.8, 7.72, 4.8, 3.3];
+const posterTime = times[Math.floor(Math.random() * times.length)];
+const poster = `${VJS10_DEMO_VIDEO.poster}?time=${posterTime}`;
 ---
 
 <link


### PR DESCRIPTION
So many great shots in the demo video. Let's randomize them as the poster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects which poster frame is preloaded/rendered; main concern is minor cache/preload variability between page loads.
> 
> **Overview**
> The home page hero video poster is now randomized by selecting from a small set of predefined timestamps instead of always using `time=0`, and the poster preload link follows this chosen frame.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9330e2cadf0d73d41d05ef807d38a5905ae2843f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->