### PR TITLE
fix(core): fix Mux data initialization

### DIFF
--- a/packages/core/src/dom/media/mux/index.ts
+++ b/packages/core/src/dom/media/mux/index.ts
@@ -12,9 +12,10 @@ const MUX_VIDEO_DOMAIN = 'mux.com';
 export class MuxMediaDelegate extends HlsMediaDelegate {
   static PLAYER_SOFTWARE_NAME = '';
 
+  #MuxDataSdk: MuxDataSdk | undefined = Mux;
+  #MuxDataSdkInitializedBefore: boolean = false;
   #playbackId: string | null = null;
   #customDomain: string = MUX_VIDEO_DOMAIN;
-  #MuxDataSdk: MuxDataSdk | undefined = Mux;
   #beaconCollectionDomain: string | undefined;
   #disableCookies: boolean = false;
   #metadata: Record<string, any> | undefined;
@@ -110,7 +111,13 @@ export class MuxMediaDelegate extends HlsMediaDelegate {
 
   attach(target: HTMLMediaElement): void {
     super.attach(target);
-    this.#initializeMuxDataSdk();
+
+    // Only initialize Mux Data SDK if it was already initialized before in attach,
+    // the first initializeMuxDataSdk call should be done in the deferred load hook
+    // so all the properties are set before the Mux Data SDK is initialized.
+    if (this.#MuxDataSdkInitializedBefore) {
+      this.#initializeMuxDataSdk();
+    }
   }
 
   detach(): void {
@@ -132,7 +139,10 @@ export class MuxMediaDelegate extends HlsMediaDelegate {
 
   #initializeMuxDataSdk(): void {
     const target = this.target as HTMLMediaElement;
-    if (!this.#MuxDataSdk || !target || (target.mux && !target.mux.deleted)) return;
+
+    if (!this.MuxDataSdk || !target || (target.mux && !target.mux.deleted)) return;
+
+    this.#MuxDataSdkInitializedBefore = true;
 
     const {
       debug,
@@ -146,12 +156,12 @@ export class MuxMediaDelegate extends HlsMediaDelegate {
       metadata = {},
     } = this;
 
-    const { view_session_id = this.#MuxDataSdk?.utils.generateUUID() } = metadata;
+    const { view_session_id = this.MuxDataSdk?.utils.generateUUID() } = metadata;
     const video_id = toVideoId(this);
     metadata.view_session_id = view_session_id;
     metadata.video_id = video_id;
 
-    this.#MuxDataSdk?.monitor(target, {
+    this.MuxDataSdk?.monitor(target, {
       debug,
       ...(beaconCollectionDomain ? { beaconCollectionDomain } : {}),
       ...(disableCookies ? { disableCookies } : {}),
@@ -172,8 +182,8 @@ export class MuxMediaDelegate extends HlsMediaDelegate {
   }
 
   #generatePlayerInitTime(): number | undefined {
-    if (!this.#MuxDataSdk) return undefined;
-    return this.#MuxDataSdk.utils.now();
+    if (!this.MuxDataSdk) return undefined;
+    return this.MuxDataSdk.utils.now();
   }
 }
 

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -43,8 +43,6 @@ export class NativeHlsMediaDelegate {
 
   attach(target: HTMLMediaElement) {
     this.#target = target;
-    this.#target.src = this.src;
-    this.#target.preload = this.preload;
   }
 
   detach() {


### PR DESCRIPTION
Fixes an issue where Mux data was initialized too early on attach losing the props set after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes initialization timing for Mux analytics and native HLS media element setup, which could affect when monitoring starts and when `src`/`preload` are applied. Scope is small but touches media playback/telemetry lifecycle hooks.
> 
> **Overview**
> Fixes Mux analytics being initialized too early by deferring `MuxDataSdk.monitor()` setup from `attach()` to `load()`, while keeping a guard to re-initialize on subsequent `attach()` calls only after an initial init has occurred.
> 
> Simplifies `NativeHlsMediaDelegate.attach()` so it no longer forces `src` and `preload` onto the element during attach, relying on the existing property setters to sync values when they change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25da2b756d369a3d780e652f94aa867ebb5b0cfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->