### PR TITLE
feat(html): add error dialog to HTML skins

### DIFF
--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -6,6 +6,7 @@ import styles from './skin.css?inline';
 
 // Side-effect imports: register all custom elements used in the template.
 import '../media/container';
+import '../ui/error-dialog';
 import '../ui/mute-button';
 import '../ui/play-button';
 import '../ui/playback-rate-button';
@@ -25,6 +26,18 @@ function getTemplateHTML() {
       <!-- @deprecated slot="media" is no longer required, use the default slot instead -->
       <slot name="media"></slot>
       <slot></slot>
+
+      <media-error-dialog class="media-error">
+        <div class="media-error__dialog media-surface">
+          <div class="media-error__content">
+            <media-alert-dialog-title class="media-error__title">Something went wrong.</media-alert-dialog-title>
+            <media-alert-dialog-description class="media-error__description"></media-alert-dialog-description>
+          </div>
+          <div class="media-error__actions">
+            <media-alert-dialog-close class="media-button media-button--primary">OK</media-alert-dialog-close>
+          </div>
+        </div>
+      </media-error-dialog>
 
       <div class="media-surface media-controls">
         <media-tooltip-group>

--- a/packages/html/src/define/ui/error-dialog.ts
+++ b/packages/html/src/define/ui/error-dialog.ts
@@ -1,0 +1,17 @@
+import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
+import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
+import { safeDefine } from '../safe-define';
+
+// Parent first — child elements consume its context.
+safeDefine(ErrorDialogElement);
+safeDefine(AlertDialogCloseElement);
+safeDefine(AlertDialogDescriptionElement);
+safeDefine(AlertDialogTitleElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [ErrorDialogElement.tagName]: ErrorDialogElement;
+  }
+}

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -8,6 +8,7 @@ import styles from './skin.css?inline';
 import '../media/container';
 import '../ui/buffering-indicator';
 import '../ui/captions-button';
+import '../ui/error-dialog';
 import '../ui/controls';
 import '../ui/fullscreen-button';
 import '../ui/mute-button';
@@ -41,6 +42,18 @@ function getTemplateHTML() {
           ${renderIcon('spinner', { class: 'media-icon' })}
         </div>
       </media-buffering-indicator>
+
+      <media-error-dialog class="media-error">
+        <div class="media-error__dialog media-surface">
+          <div class="media-error__content">
+            <media-alert-dialog-title class="media-error__title">Something went wrong.</media-alert-dialog-title>
+            <media-alert-dialog-description class="media-error__description"></media-alert-dialog-description>
+          </div>
+          <div class="media-error__actions">
+            <media-alert-dialog-close class="media-button media-button--primary">OK</media-alert-dialog-close>
+          </div>
+        </div>
+      </media-error-dialog>
 
       <media-controls class="media-surface media-controls">
         <media-tooltip-group>

--- a/packages/html/src/ui/error-dialog/error-dialog-element.ts
+++ b/packages/html/src/ui/error-dialog/error-dialog-element.ts
@@ -1,0 +1,112 @@
+import { AlertDialogCore, AlertDialogDataAttrs, type AlertDialogInput } from '@videojs/core';
+import {
+  type AlertDialogApi,
+  applyElementProps,
+  applyStateDataAttrs,
+  createAlertDialog,
+  createTransition,
+  selectError,
+} from '@videojs/core/dom';
+import type { PropertyValues } from '@videojs/element';
+import { ContextProvider } from '@videojs/element/context';
+import { SnapshotController } from '@videojs/store/html';
+
+import { playerContext } from '../../player/context';
+import { PlayerController } from '../../player/player-controller';
+import { alertDialogContext } from '../alert-dialog/context';
+import { MediaElement } from '../media-element';
+
+const DEFAULT_ERROR_MESSAGE = 'An error occurred. Please try again.';
+
+let idCounter = 0;
+
+/**
+ * Self-contained error dialog that subscribes to the player's error state
+ * and shows/hides an alert dialog automatically. Provides `alertDialogContext`
+ * so child `media-alert-dialog-*` elements work as expected.
+ */
+export class ErrorDialogElement extends MediaElement {
+  static readonly tagName = 'media-error-dialog';
+
+  readonly #core = new AlertDialogCore();
+  readonly #provider = new ContextProvider(this, { context: alertDialogContext });
+  readonly #titleId = `vjs-error-dialog-title-${idCounter++}`;
+  readonly #descriptionId = `vjs-error-dialog-desc-${idCounter++}`;
+  readonly #errorState = new PlayerController(this, playerContext, selectError);
+
+  #dialog: AlertDialogApi | null = null;
+  #snapshot: SnapshotController<AlertDialogInput> | null = null;
+  #lastErrorMessage: string = '';
+
+  constructor() {
+    super();
+    this.#core.setTitleId(this.#titleId);
+    this.#core.setDescriptionId(this.#descriptionId);
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    this.#dialog = createAlertDialog({
+      transition: createTransition(),
+      onOpenChange: (open: boolean) => {
+        if (!open) {
+          this.#errorState.value?.dismissError();
+        }
+      },
+    });
+
+    this.#dialog.setElement(this);
+
+    if (this.#snapshot) {
+      this.#snapshot.track(this.#dialog.input);
+    } else {
+      this.#snapshot = new SnapshotController(this, this.#dialog.input);
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#dialog?.destroy();
+    this.#dialog = null;
+  }
+
+  protected override update(_changed: PropertyValues): void {
+    super.update(_changed);
+    if (!this.#dialog) return;
+
+    const errorState = this.#errorState.value;
+    const hasError = Boolean(errorState?.error);
+
+    if (errorState?.error) {
+      this.#lastErrorMessage = errorState.error.message || DEFAULT_ERROR_MESSAGE;
+    }
+
+    // Sync dialog open/close with error presence.
+    const { active: isOpen } = this.#dialog.input.current;
+    if (hasError && !isOpen) {
+      this.#dialog.open();
+    } else if (!hasError && isOpen) {
+      this.#dialog.close();
+    }
+
+    const input = this.#dialog.input.current;
+    this.#core.setInput(input);
+    const state = this.#core.getState();
+
+    applyElementProps(this, this.#core.getAttrs(state));
+    applyStateDataAttrs(this, state, AlertDialogDataAttrs);
+
+    this.#provider.setValue({
+      state,
+      stateAttrMap: AlertDialogDataAttrs,
+      close: () => this.#dialog?.close(),
+    });
+
+    // Push the error message into the description element.
+    const desc = this.querySelector('media-alert-dialog-description');
+    if (desc && this.#lastErrorMessage) {
+      desc.textContent = this.#lastErrorMessage;
+    }
+  }
+}

--- a/packages/skins/src/default/css/components/error.css
+++ b/packages/skins/src/default/css/components/error.css
@@ -6,6 +6,10 @@
   outline: none;
 }
 
+.media-default-skin .media-error:not([data-open]) {
+  display: none;
+}
+
 .media-default-skin .media-error__title {
   font-weight: 600;
   line-height: 1.25;

--- a/packages/skins/src/minimal/css/components/error.css
+++ b/packages/skins/src/minimal/css/components/error.css
@@ -2,6 +2,10 @@
    Error Dialog
    ========================================================================== */
 
+.media-minimal-skin .media-error:not([data-open]) {
+  display: none;
+}
+
 .media-minimal-skin .media-error__title {
   font-weight: 600;
   line-height: 1.25;


### PR DESCRIPTION
This is all done by Claude. It works but thought it would be good to open a separate PR for this.
Will do a review myself in a bit.

- This adds the HTML media-error-dialog element and co

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new reactive UI behavior tied to player error state (auto-open/close and dismiss), which could affect playback UX and error handling across all HTML skins if the state wiring is incorrect.
> 
> **Overview**
> Adds a new `media-error-dialog` custom element that subscribes to the player error state and automatically opens/closes an alert-style dialog, dismissing the player error when the dialog is closed.
> 
> Updates both `audio-skin` and `video-skin` templates to include the error dialog markup (title, description, and OK close action) and registers the new element via a `define/ui/error-dialog` side-effect import.
> 
> Adjusts default and minimal skin CSS so `.media-error` is hidden unless `[data-open]` is set, preventing the dialog wrapper from affecting layout when inactive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0ee8d4418001230c1d278e961108ae93c425551. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->