### PR TITLE
fix(core): preserve literal type for MEDIA_ERR_CUSTOM

### DIFF
--- a/packages/core/src/core/media/media-error.ts
+++ b/packages/core/src/core/media/media-error.ts
@@ -20,7 +20,7 @@ export class MediaError extends Error {
   static MEDIA_ERR_ENCRYPTED = 5 as const;
   // Technically this is Mux specific but it's generic enough to be used here.
   // @see https://docs.mux.com/guides/data/monitor-html5-video-element#customize-error-tracking-behavior
-  static MEDIA_ERR_CUSTOM = 100;
+  static MEDIA_ERR_CUSTOM = 100 as const;
 
   static defaultMessages: Record<number, string> = {
     1: 'You aborted the media playback',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- verify `MediaError.MEDIA_ERR_CUSTOM` was the only `MEDIA_ERR_*` static property missing a const assertion
- update `MEDIA_ERR_CUSTOM` from `100` to `100 as const` in `packages/core/src/core/media/media-error.ts`
- align its TypeScript type behavior with the other static media error code constants for consistent literal narrowing

## Testing
- attempted: `pnpm -F @videojs/core test packages/core/src/core/media/tests/media-error.test.ts`
- result: failed locally because dependencies are not installed in this environment (`vitest: command not found`, `node_modules missing`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fb77d36-164b-4a44-9397-8f90100484bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fb77d36-164b-4a44-9397-8f90100484bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

