### PR TITLE
fix(core): fix media proxy for React

### DIFF
--- a/packages/core/src/core/media/proxy.ts
+++ b/packages/core/src/core/media/proxy.ts
@@ -16,7 +16,7 @@ export const ProxyMixin = <T extends EventTarget>(
   PrimaryClass: AnyConstructor<T>,
   ...AdditionalClasses: AnyConstructor<EventTarget>[]
 ) => {
-  class MediaProxy extends EventTarget {
+  class MediaProxy {
     #target: EventTarget | null = null;
 
     get target() {
@@ -46,6 +46,26 @@ export const ProxyMixin = <T extends EventTarget>(
     detach(): void {
       if (!this.#target) return;
       this.#target = null;
+    }
+
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ): void {
+      this.#target?.addEventListener(type, listener, options);
+    }
+
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions
+    ): void {
+      this.#target?.removeEventListener(type, listener, options);
+    }
+
+    dispatchEvent(event: Event): boolean {
+      return this.#target?.dispatchEvent(event) ?? false;
     }
   }
 

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -47,6 +47,14 @@ export class NativeHlsMediaDelegate extends EventTarget {
 
   attach(target: HTMLMediaElement) {
     this.#target = target;
+
+    if (this.preload !== this.#target.preload) {
+      this.#target.preload = this.preload;
+    }
+
+    if (this.src !== this.#target.src) {
+      this.#target.src = this.src;
+    }
   }
 
   detach() {


### PR DESCRIPTION
Fixes an issue where the events were being attached to the delegate class instance instead of the media target because now the delegates also extend EventTarget and those methods were chosen because they existed. The fix was to add manual event listeners to the proxy. When the delegate mixin sees there are already methods there it will not provide hooks and overrides. That's why HTML was not affected because the HTMLElement already has EventTarget methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core media proxying and event wiring; mistakes could break event listeners or dispatch behavior across multiple media implementations, though the change is small and localized.
> 
> **Overview**
> Fixes event handling in `ProxyMixin` by **stopping `MediaProxy` from inheriting `EventTarget`** and instead explicitly forwarding `addEventListener`, `removeEventListener`, and `dispatchEvent` to the attached target, avoiding listeners binding to the proxy/delegate instance.
> 
> Updates `NativeHlsMediaDelegate.attach()` to **re-apply stored `preload` and `src` values** onto the `HTMLMediaElement` when a target is attached, keeping delegate state and the underlying element in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17acd61214a862b3d2a8c108ece77f0fa93a8113. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->