### PR TITLE
fix(site): replace deprecated `turbo-ignore` with `turbo query affected`

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "pnpm build:site"
   publish = "site/dist"
-  ignore = "pnpm turbo query affected --packages site --tasks build --base origin/main --exit-code"
+  ignore = "pnpm turbo query affected --packages site --tasks build --exit-code"
 
 # PostHog reverse proxy (ad-blocker bypass)
 [[redirects]]


### PR DESCRIPTION
## Summary

- Replace deprecated `turbo-ignore` with `turbo query affected --exit-code` in Netlify's build skip check
- `turbo-ignore` was deprecated in Turbo 2.9 (#1167)

Closes #1177

## Test plan

- [ ] Verify Netlify build skips correctly when no site changes are present
- [ ] Verify Netlify build proceeds when site or upstream packages change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates Netlify’s build-skip `ignore` command, affecting CI/build behavior but not runtime site code.
> 
> **Overview**
> Updates `site/netlify.toml` to replace the deprecated `pnpm dlx turbo-ignore` Netlify build-skip check with `pnpm turbo query affected --packages site --tasks build --exit-code`, so deploys are skipped based on Turbo’s affected-graph query instead of the old helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10c9138322dcedd2d677f92c4cd0df779c152ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->