### PR TITLE
fix(build): auto-stamp changelog version from release manifest

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,11 +16,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Read version from manifest
+        id: version
+        run: |
+          VERSION=$(jq -r '."packages/core"' .github/release-please/.release-please-manifest.json)
+          echo "tag=@videojs/core@${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Update root changelog
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --verbose
+          args: --verbose --tag ${{ steps.version.outputs.tag }}
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Reads the version from `.release-please-manifest.json` and passes it to git-cliff via `--tag` in the release PR workflow
- The root `CHANGELOG.md` now renders `## [@videojs/core@X.Y.Z] - DATE` instead of `## [Unreleased]`
- Eliminates the need for manual changelog PRs like #1168

## How it works
The `release-please--branches--main` branch already has the bumped version in the manifest when `release-pr.yml` runs. We just weren't using it. Now we read `packages/core` from the manifest and pass `--tag @videojs/core@{version}` to git-cliff so it stamps the heading correctly.

## Test plan
- [ ] Trigger a release (or manually run git-cliff with `--tag`) and verify the root CHANGELOG.md no longer has `[Unreleased]`
- [ ] Verify the site changelog extraction step still parses the heading correctly

Closes #987

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release PR GitHub Actions workflow and changelog generation; a wrong manifest lookup or tag format could cause incorrect/missing changelog headings in automated releases.
> 
> **Overview**
> The `release-pr.yml` workflow now reads the current `packages/core` version from `.github/release-please/.release-please-manifest.json` and passes it to `git-cliff` via `--tag`, so the generated root `CHANGELOG.md` is stamped with the release version instead of `[Unreleased]`.
> 
> This wires the manifest-derived tag through a new step output (`steps.version.outputs.tag`) without changing the downstream site extraction/commit steps, other than ensuring they see versioned headings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673cf22087c0ea228fc573c0c10be37b305adf26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->