### PR TITLE
fix(site): fix invalid import specifiers in ejected React skins

### DIFF
--- a/site/scripts/build-ejected-skins.ts
+++ b/site/scripts/build-ejected-skins.ts
@@ -15,6 +15,7 @@ import { dirname, relative as relativePath, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import ts from 'typescript';
 import { resolveImports } from '../../build/plugins/resolve-css-imports.ts';
+import { normalizeImports } from './normalize-imports.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../..');
@@ -396,65 +397,6 @@ function collectDeclarationClosure(
   );
 
   return [...dependencyTexts, declarationText];
-}
-
-function normalizeImports(source: string): string {
-  const sourceFile = createSourceFile('imports.tsx', source);
-  const sideEffectImports = new Set<string>();
-  const namedImports = new Map<string, Set<string>>();
-  const rawImports: string[] = [];
-  let bodyStart = 0;
-
-  for (const statement of sourceFile.statements) {
-    if (isDirectivePrologueStatement(statement)) {
-      bodyStart = statement.getEnd();
-      continue;
-    }
-
-    if (!ts.isImportDeclaration(statement)) {
-      break;
-    }
-
-    bodyStart = statement.getEnd();
-    const specifier = statement.moduleSpecifier.getText(sourceFile).slice(1, -1);
-    const importClause = statement.importClause;
-
-    if (!importClause) {
-      sideEffectImports.add(specifier);
-      continue;
-    }
-
-    const namedBindings = importClause.namedBindings;
-    if (importClause.name || (namedBindings && !ts.isNamedImports(namedBindings))) {
-      rawImports.push(getImportStatementText(source, statement));
-      continue;
-    }
-
-    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue;
-
-    const names = namedImports.get(specifier) ?? new Set<string>();
-    for (const element of namedBindings.elements) {
-      const isTypeImport = element.isTypeOnly || /^import\s+type\s/.test(statement.getText(sourceFile));
-      names.add(isTypeImport ? `type ${element.getText(sourceFile)}` : element.getText(sourceFile));
-    }
-
-    namedImports.set(specifier, names);
-  }
-
-  const importLines = [
-    ...[...sideEffectImports].map((specifier) => `import '${specifier}';`),
-    ...rawImports,
-    ...[...namedImports.entries()].map(
-      ([specifier, names]) => `import { ${[...names].join(', ')} } from '${specifier}';`
-    ),
-  ];
-  const body = source.slice(bodyStart).replace(/^\s+/, '');
-
-  if (importLines.length === 0) {
-    return body;
-  }
-
-  return `${importLines.join('\n')}\n\n${body}`;
 }
 
 function inlineModuleExport(

--- a/site/scripts/normalize-imports.ts
+++ b/site/scripts/normalize-imports.ts
@@ -1,0 +1,86 @@
+import ts from 'typescript';
+
+function createSourceFile(filePath: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+function isDirectivePrologueStatement(statement: ts.Statement): boolean {
+  return ts.isExpressionStatement(statement) && ts.isStringLiteral(statement.expression);
+}
+
+function getImportStatementText(source: string, node: ts.ImportDeclaration): string {
+  return source.slice(node.getFullStart(), node.getEnd()).trim();
+}
+
+export function normalizeImports(source: string): string {
+  const sourceFile = createSourceFile('imports.tsx', source);
+  const sideEffectImports = new Set<string>();
+  // Map<module, Map<identifierName, { isType, alias? }>>
+  const namedImports = new Map<string, Map<string, { isType: boolean; alias: string | undefined }>>();
+  const rawImports: string[] = [];
+  let bodyStart = 0;
+
+  for (const statement of sourceFile.statements) {
+    if (isDirectivePrologueStatement(statement)) {
+      bodyStart = statement.getEnd();
+      continue;
+    }
+
+    if (!ts.isImportDeclaration(statement)) {
+      break;
+    }
+
+    bodyStart = statement.getEnd();
+    const specifier = statement.moduleSpecifier.getText(sourceFile).slice(1, -1);
+    const importClause = statement.importClause;
+
+    if (!importClause) {
+      sideEffectImports.add(specifier);
+      continue;
+    }
+
+    const namedBindings = importClause.namedBindings;
+    if (importClause.name || (namedBindings && !ts.isNamedImports(namedBindings))) {
+      rawImports.push(getImportStatementText(source, statement));
+      continue;
+    }
+
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue;
+
+    const names = namedImports.get(specifier) ?? new Map<string, { isType: boolean; alias: string | undefined }>();
+    const isStatementTypeOnly = Boolean(importClause.isTypeOnly);
+
+    for (const element of namedBindings.elements) {
+      const isType = element.isTypeOnly || isStatementTypeOnly;
+      const name = (element.propertyName ?? element.name).text;
+      const alias = element.propertyName ? element.name.text : undefined;
+      const existing = names.get(name);
+
+      // Value import subsumes type — if already seen as value, keep it
+      if (!existing || (!isType && existing.isType)) {
+        names.set(name, { isType, alias });
+      }
+    }
+
+    namedImports.set(specifier, names);
+  }
+
+  const importLines = [
+    ...[...sideEffectImports].map((specifier) => `import '${specifier}';`),
+    ...rawImports,
+    ...[...namedImports.entries()].map(([specifier, names]) => {
+      const specifiers = [...names.entries()].map(([name, { isType, alias }]) => {
+        const prefix = isType ? 'type ' : '';
+        return alias ? `${prefix}${name} as ${alias}` : `${prefix}${name}`;
+      });
+      return `import { ${specifiers.join(', ')} } from '${specifier}';`;
+    }),
+  ];
+  const body = source.slice(bodyStart).replace(/^\s+/, '');
+
+  if (importLines.length === 0) {
+    return body;
+  }
+
+  return `${importLines.join('\n')}\n\n${body}`;
+}

--- a/site/scripts/tests/normalize-imports.test.ts
+++ b/site/scripts/tests/normalize-imports.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeImports } from '../normalize-imports.js';
+
+describe('normalizeImports', () => {
+  it('consolidates named imports from the same module', () => {
+    const input = ["import { Foo } from 'mod';", "import { Bar } from 'mod';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import { Foo, Bar } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('converts statement-level import type to inline type specifiers', () => {
+    const input = ["import type { Poster } from 'mod';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import { type Poster } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('preserves inline type specifiers without duplicating the type keyword', () => {
+    const input = ["import { type CSSProperties, forwardRef, type ReactNode } from 'react';", '', 'const x = 1;'].join(
+      '\n'
+    );
+
+    expect(normalizeImports(input)).toBe(
+      "import { type CSSProperties, forwardRef, type ReactNode } from 'react';\n\nconst x = 1;"
+    );
+  });
+
+  it('deduplicates when same name is imported as both value and type', () => {
+    const input = ["import { Poster } from 'mod';", "import type { Poster } from 'mod';", '', 'const x = 1;'].join(
+      '\n'
+    );
+
+    // Value import subsumes type import
+    expect(normalizeImports(input)).toBe("import { Poster } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('deduplicates when type appears before value', () => {
+    const input = ["import type { Poster } from 'mod';", "import { Poster } from 'mod';", '', 'const x = 1;'].join(
+      '\n'
+    );
+
+    expect(normalizeImports(input)).toBe("import { Poster } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('keeps type when only imported as type across statements', () => {
+    const input = [
+      "import type { Poster } from 'mod';",
+      "import type { RenderProp } from 'mod';",
+      '',
+      'const x = 1;',
+    ].join('\n');
+
+    expect(normalizeImports(input)).toBe("import { type Poster, type RenderProp } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('handles mixed value and type imports from the same module', () => {
+    const input = ["import { Foo } from 'mod';", "import type { Bar } from 'mod';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import { Foo, type Bar } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('handles aliased imports', () => {
+    const input = ["import { Foo as Bar } from 'mod';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import { Foo as Bar } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('handles type aliased imports', () => {
+    const input = ["import type { Foo as Bar } from 'mod';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import { type Foo as Bar } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('preserves side-effect imports', () => {
+    const input = ["import './styles.css';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import './styles.css';\n\nconst x = 1;");
+  });
+
+  it('preserves default imports as raw imports', () => {
+    const input = ["import React from 'react';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import React from 'react';\n\nconst x = 1;");
+  });
+
+  it('preserves namespace imports as raw imports', () => {
+    const input = ["import * as React from 'react';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("import * as React from 'react';\n\nconst x = 1;");
+  });
+
+  it('orders: side-effect, raw, then named imports', () => {
+    const input = [
+      "import { useState } from 'react';",
+      "import './styles.css';",
+      "import React from 'react';",
+      '',
+      'const x = 1;',
+    ].join('\n');
+
+    const result = normalizeImports(input);
+    const lines = result.split('\n');
+    expect(lines[0]).toBe("import './styles.css';");
+    expect(lines[1]).toBe("import React from 'react';");
+    expect(lines[2]).toBe("import { useState } from 'react';");
+  });
+
+  it('returns only body when there are no imports', () => {
+    expect(normalizeImports('const x = 1;')).toBe('const x = 1;');
+  });
+
+  it('handles the exact broken example from the issue', () => {
+    const input = [
+      "import { type CSSProperties, type ComponentProps, forwardRef, type ReactNode, isValidElement } from 'react';",
+      "import { Poster, Container, usePlayer, BufferingIndicator } from '@videojs/react';",
+      "import type { Poster, RenderProp } from '@videojs/react';",
+      '',
+      'const x = 1;',
+    ].join('\n');
+
+    const result = normalizeImports(input);
+
+    // No duplicate type keyword
+    expect(result).not.toContain('type type');
+    // No duplicate Poster (value subsumes type)
+    expect(result).not.toMatch(/Poster.*type Poster|type Poster.*Poster/);
+    // Value imports preserved
+    expect(result).toContain('Poster');
+    expect(result).toContain('Container');
+    // Type-only imports preserved as type
+    expect(result).toContain('type RenderProp');
+    // Inline type specifiers preserved correctly
+    expect(result).toContain('type CSSProperties');
+    expect(result).toContain('type ComponentProps');
+    expect(result).toContain('type ReactNode');
+    // Value imports remain as values
+    expect(result).toContain('forwardRef');
+    expect(result).toContain('isValidElement');
+  });
+});


### PR DESCRIPTION


Closes #1187

## Test plan

- [x] All 15 unit tests pass (`pnpm vitest run scripts/tests/normalize-imports.test.ts`)
- [x] Run full ejected skins build (`pnpm -F site eject`) and verify output compiles
- [x] Verify ejected React skin output on the docs site

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how ejected React skin source code is rewritten and deduplicated, which could subtly alter generated imports/types and break downstream compilation if edge cases are missed.
> 
> **Overview**
> Fixes ejected React skin generation by extracting `normalizeImports` into a dedicated module and improving its import-merging logic.
> 
> The new `normalizeImports` correctly handles `import type` vs inline `type` specifiers, deduplicates value+type imports (value wins), and preserves aliased, side-effect, default, and namespace imports; a new Vitest suite covers these cases and the reported broken example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e0803ec0ef83e859180208b21c1d15f0e79a81b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->