### PR TITLE
docs(site): document wheelStep prop and scroll support in VolumeSlider

### DIFF
--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -70,6 +70,10 @@ Renders with `role="slider"` and automatic `aria-label` of "Volume". Override wi
 - <kbd>Home</kbd>: set volume to 0
 - <kbd>End</kbd>: set volume to max
 
+Scroll wheel support:
+
+- **Mouse wheel / trackpad scroll**: adjusts volume by `wheelStep` increment (default `5`)
+
 ## Examples
 
 Nest sub-components for full control over the slider's DOM structure. This example includes a track, fill bar, draggable thumb, and a tooltip that shows the volume percentage on hover.


### PR DESCRIPTION
Update the VolumeSlider reference page Accessibility section to document wheel/scroll interaction and the `wheelStep` prop added in #1175.

Closes #1194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for an already-supported interaction; no runtime code or behavior is modified.
> 
> **Overview**
> Updates the `VolumeSlider` reference docs to explicitly document *scroll wheel / trackpad* interaction in the Accessibility section, noting it adjusts volume by the new `wheelStep` increment (default `5`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74a6da96a109f9213c2057bb21d9cf8301027049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->