### PR TITLE
[codex] fix intrinsic media aspect ratio handling

### DIFF
--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -138,7 +138,7 @@ async function render() {
 
   root.innerHTML = html`
     <${playerTag}>
-      <${skinTag} class="w-full aspect-video max-w-4xl mx-auto">
+      <${skinTag} class="aspect-video max-w-4xl mx-auto">
         <${mediaTag} src="${src}" playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </${mediaTag}>

--- a/apps/sandbox/templates/html-dash-video/main.ts
+++ b/apps/sandbox/templates/html-dash-video/main.ts
@@ -21,7 +21,7 @@ async function render() {
 
   document.getElementById('root')!.innerHTML = html`
     <video-player>
-      <${tag} class="w-full aspect-video max-w-4xl mx-auto">
+      <${tag} class="aspect-video max-w-4xl mx-auto">
         <dash-video src="${SOURCES[state.source].url}" playsinline>
           ${renderStoryboard(storyboard)}
         </dash-video>

--- a/apps/sandbox/templates/html-hls-video/main.ts
+++ b/apps/sandbox/templates/html-hls-video/main.ts
@@ -21,7 +21,7 @@ async function render() {
 
   document.getElementById('root')!.innerHTML = html`
     <video-player>
-      <${tag} class="w-full aspect-video max-w-4xl mx-auto">
+      <${tag} class="aspect-video max-w-4xl mx-auto">
         <hls-video src="${SOURCES[state.source].url}" playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </hls-video>

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -26,7 +26,7 @@ async function render() {
 
   document.getElementById('root')!.innerHTML = html`
     <video-player>
-      <${tag} class="w-full aspect-video max-w-4xl mx-auto">
+      <${tag} class="aspect-video max-w-4xl mx-auto">
         <mux-video ${sourceAttr} debug playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </mux-video>

--- a/apps/sandbox/templates/html-simple-hls-video/main.ts
+++ b/apps/sandbox/templates/html-simple-hls-video/main.ts
@@ -21,7 +21,7 @@ async function render() {
 
   document.getElementById('root')!.innerHTML = html`
     <video-player>
-      <${tag} class="w-full aspect-video max-w-4xl mx-auto">
+      <${tag} class="aspect-video max-w-4xl mx-auto">
         <simple-hls-video src="${SOURCES[state.source].url}" playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </simple-hls-video>

--- a/apps/sandbox/templates/html-video/main.ts
+++ b/apps/sandbox/templates/html-video/main.ts
@@ -20,7 +20,7 @@ async function render() {
 
   document.getElementById('root')!.innerHTML = html`
     <video-player>
-      <${tag} class="w-full aspect-video max-w-4xl mx-auto">
+      <${tag} class="aspect-video max-w-4xl mx-auto">
         <video src="${SOURCES[state.source].url}" playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </video>

--- a/apps/sandbox/templates/react-dash-video/main.tsx
+++ b/apps/sandbox/templates/react-dash-video/main.tsx
@@ -20,7 +20,7 @@ function App() {
 
   return (
     <VideoProvider>
-      <VideoSkinComponent skin={skin} styling={styling} className="w-full aspect-video max-w-4xl mx-auto">
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <DashVideo src={SOURCES[source].url} playsInline />
       </VideoSkinComponent>
     </VideoProvider>

--- a/apps/sandbox/templates/react-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-hls-video/main.tsx
@@ -25,12 +25,7 @@ function App() {
 
   return (
     <VideoProvider>
-      <VideoSkinComponent
-        poster={poster}
-        skin={skin}
-        styling={styling}
-        className="w-full aspect-video max-w-4xl mx-auto"
-      >
+      <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <HlsVideo src={SOURCES[source].url} playsInline crossOrigin="anonymous">
           <Storyboard src={storyboard} />
         </HlsVideo>

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -28,12 +28,7 @@ function App() {
 
   return (
     <VideoProvider>
-      <VideoSkinComponent
-        poster={poster}
-        skin={skin}
-        styling={styling}
-        className="w-full aspect-video max-w-4xl mx-auto"
-      >
+      <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <MuxVideo {...sourceAttr} debug playsInline crossOrigin="anonymous">
           <Storyboard src={storyboard} />
         </MuxVideo>

--- a/apps/sandbox/templates/react-simple-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-simple-hls-video/main.tsx
@@ -25,12 +25,7 @@ function App() {
 
   return (
     <VideoProvider>
-      <VideoSkinComponent
-        poster={poster}
-        skin={skin}
-        styling={styling}
-        className="w-full aspect-video max-w-4xl mx-auto"
-      >
+      <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <SimpleHlsVideo src={SOURCES[source].url} playsInline crossOrigin="anonymous">
           <Storyboard src={storyboard} />
         </SimpleHlsVideo>

--- a/apps/sandbox/templates/react-video/main.tsx
+++ b/apps/sandbox/templates/react-video/main.tsx
@@ -25,12 +25,7 @@ function App() {
 
   return (
     <VideoProvider>
-      <VideoSkinComponent
-        poster={poster}
-        skin={skin}
-        styling={styling}
-        className="w-full aspect-video max-w-4xl mx-auto"
-      >
+      <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <Video src={SOURCES[source].url} playsInline crossOrigin="anonymous">
           <Storyboard src={storyboard} />
         </Video>

--- a/packages/html/src/define/shared.css
+++ b/packages/html/src/define/shared.css
@@ -2,9 +2,10 @@ media-tooltip-group {
   display: contents;
 }
 
-/* Fixes a weird issue with Safari when setting aspect-ratio */
 :host {
+  /* `display:grid` fixes a weird issue with Safari when setting aspect-ratio */
   display: grid;
+  width: 100%;
 }
 
 /* Hide volume popover when volume control is unsupported (e.g., iOS Safari). */

--- a/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
+++ b/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
@@ -19,7 +19,7 @@ const Player = createPlayer({ features: videoFeatures });
 export function FrostedSkinDemo() {
   return (
     <Player.Provider>
-      <VideoSkin className="w-full aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
+      <VideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </VideoSkin>
     </Player.Provider>

--- a/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
+++ b/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
@@ -17,7 +17,7 @@ const Player = createPlayer({ features: videoFeatures });
 export function MinimalSkinDemo() {
   return (
     <Player.Provider>
-      <MinimalVideoSkin className="w-full aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
+      <MinimalVideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </MinimalVideoSkin>
     </Player.Provider>


### PR DESCRIPTION
## Summary
- Fix the HTML player host so it provides width for intrinsic aspect-ratio sizing.
- Remove the hard-coded `w-full` sizing from sandbox templates and site demos that was masking the bug.

## Why
Sandbox templates and site examples were forcing full-width layouts, which hid the fact that media aspect ratios were not being driven by the intrinsic sizing path.

## Validation
- `git diff --check`
- `lint-staged` and `commitlint` during `git commit`
- `pnpm typecheck` still fails on existing unrelated workspace issues in this branch.
- `pnpm build:sandbox` and `pnpm build:site` hit sandbox `tsx` IPC permission errors (`listen EPERM` on `/tmp/tsx-501/*.pipe`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts shared `:host` styling and removes `w-full` wrappers in multiple demos/templates, which can change player sizing/layout across environments (notably Safari). Scope is broad across examples but limited to presentation behavior.
> 
> **Overview**
> Fixes intrinsic media aspect-ratio handling by updating the HTML player shared `:host` styles to use `display: grid` *and* explicitly provide `width: 100%`.
> 
> Updates sandbox templates (HTML/CDN/React variants) and site React demos to stop forcing `w-full` on video skins, so sizing is driven by the intrinsic aspect-ratio path rather than hard-coded full-width layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a438c8164db9101e39262a18b82314af06f577f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->