### PR TITLE
fix(site): use absolute URLs in generated LLM markdown files

### DIFF
--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -14,12 +14,16 @@ interface PageEntry {
 }
 
 export default function llmsMarkdown(): AstroIntegration {
+  let siteUrl = '';
+
   return {
     name: 'llms-markdown',
     hooks: {
-      'astro:build:done': async ({ dir, pages, logger, config }) => {
+      'astro:config:done': ({ config }) => {
+        siteUrl = config.site?.replace(/\/$/, '') ?? '';
+      },
+      'astro:build:done': async ({ dir, pages, logger }) => {
         const siteDir = fileURLToPath(dir);
-        const siteUrl = config.site?.replace(/\/$/, '') ?? '';
         const turndown = new TurndownService({
           headingStyle: 'atx',
           codeBlockStyle: 'fenced',


### PR DESCRIPTION
## Summary
- Uses Astro's `config.site` to prefix all links in `llms.txt`, sub-indexes, and per-page `.md` index entries with absolute URLs
- Environment-aware: uses `https://videojs.org` in production, Netlify preview URL on deploy previews
- Aligns with the [llms.txt spec](https://llmstxt.org) convention where all examples use absolute URLs

Closes #1199

## Test plan
- [ ] Build site locally and verify `dist/llms.txt` links are absolute (`https://videojs.org/...`)
- [ ] Verify framework sub-indexes (`dist/docs/framework/html/llms.txt`) use absolute URLs
- [ ] Verify blog index (`dist/blog/llms.txt`) uses absolute URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts generated `llms.txt`/sub-index link formatting by prefixing with `config.site`, without changing page discovery or markdown generation logic.
> 
> **Overview**
> Updates the `llms-markdown` Astro integration to emit **absolute URLs** in the generated `llms.txt` root index, framework sub-indexes, and blog index entries.
> 
> It captures `config.site` during `astro:config:done` (trimming any trailing slash) and threads it through the index generators so all links are prefixed with the site base URL instead of using relative paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14dd14d13ca5d7929211be4c38609aa663814d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->