### PR TITLE
feat(html): add ui bundles for eject

### DIFF
--- a/packages/html/src/cdn/audio-minimal-ui.ts
+++ b/packages/html/src/cdn/audio-minimal-ui.ts
@@ -1,0 +1,1 @@
+import '../define/audio/minimal-ui';

--- a/packages/html/src/cdn/audio-minimal.ts
+++ b/packages/html/src/cdn/audio-minimal.ts
@@ -1,2 +1,1 @@
-import '../define/audio/player';
 import '../define/audio/minimal-skin';

--- a/packages/html/src/cdn/audio-ui.ts
+++ b/packages/html/src/cdn/audio-ui.ts
@@ -1,0 +1,1 @@
+import '../define/audio/ui';

--- a/packages/html/src/cdn/audio.ts
+++ b/packages/html/src/cdn/audio.ts
@@ -1,2 +1,1 @@
-import '../define/audio/player';
 import '../define/audio/skin';

--- a/packages/html/src/cdn/video-minimal-ui.ts
+++ b/packages/html/src/cdn/video-minimal-ui.ts
@@ -1,0 +1,1 @@
+import '../define/video/minimal-ui';

--- a/packages/html/src/cdn/video-minimal.ts
+++ b/packages/html/src/cdn/video-minimal.ts
@@ -1,2 +1,1 @@
-import '../define/video/player';
 import '../define/video/minimal-skin';

--- a/packages/html/src/cdn/video-ui.ts
+++ b/packages/html/src/cdn/video-ui.ts
@@ -1,0 +1,1 @@
+import '../define/video/ui';

--- a/packages/html/src/cdn/video.ts
+++ b/packages/html/src/cdn/video.ts
@@ -1,2 +1,1 @@
-import '../define/video/player';
 import '../define/video/skin';

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -20,19 +20,8 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/error-dialog';
-import '../ui/mute-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './minimal-ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -4,19 +4,8 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './minimal-skin.css?inline';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/error-dialog';
-import '../ui/mute-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './minimal-ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -1,0 +1,16 @@
+// Side-effect-only module: registers the audio player, container, and all
+// audio UI custom elements used by the minimal skin without creating a skin
+// element. Use this entry when building an ejected (light DOM) player layout.
+import './player';
+
+import '../ui/error-dialog';
+import '../ui/mute-button';
+import '../ui/play-button';
+import '../ui/playback-rate-button';
+import '../ui/popover';
+import '../ui/seek-button';
+import '../ui/time';
+import '../ui/time-slider';
+import '../ui/tooltip';
+import '../ui/tooltip-group';
+import '../ui/volume-slider';

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -20,19 +20,8 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/error-dialog';
-import '../ui/mute-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -4,19 +4,8 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './skin.css?inline';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/error-dialog';
-import '../ui/mute-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -1,0 +1,16 @@
+// Side-effect-only module: registers the audio player, container, and all
+// audio UI custom elements without creating a skin element. Use this entry
+// when building an ejected (light DOM) player layout.
+import './player';
+
+import '../ui/error-dialog';
+import '../ui/mute-button';
+import '../ui/play-button';
+import '../ui/playback-rate-button';
+import '../ui/popover';
+import '../ui/seek-button';
+import '../ui/time';
+import '../ui/time-slider';
+import '../ui/tooltip';
+import '../ui/tooltip-group';
+import '../ui/volume-slider';

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -25,25 +25,8 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/buffering-indicator';
-import '../ui/captions-button';
-import '../ui/controls';
-import '../ui/error-dialog';
-import '../ui/fullscreen-button';
-import '../ui/mute-button';
-import '../ui/pip-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/poster';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './minimal-ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -4,24 +4,8 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './minimal-skin.css?inline';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/buffering-indicator';
-import '../ui/controls';
-import '../ui/error-dialog';
-import '../ui/fullscreen-button';
-import '../ui/mute-button';
-import '../ui/pip-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/poster';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './minimal-ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/video/minimal-ui.ts
+++ b/packages/html/src/define/video/minimal-ui.ts
@@ -1,0 +1,22 @@
+// Side-effect-only module: registers the video player, container, and all
+// video UI custom elements used by the minimal skin without creating a skin
+// element. Use this entry when building an ejected (light DOM) player layout.
+import './player';
+
+import '../ui/buffering-indicator';
+import '../ui/captions-button';
+import '../ui/controls';
+import '../ui/error-dialog';
+import '../ui/fullscreen-button';
+import '../ui/mute-button';
+import '../ui/pip-button';
+import '../ui/play-button';
+import '../ui/playback-rate-button';
+import '../ui/popover';
+import '../ui/poster';
+import '../ui/seek-button';
+import '../ui/time';
+import '../ui/time-slider';
+import '../ui/tooltip';
+import '../ui/tooltip-group';
+import '../ui/volume-slider';

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -25,25 +25,8 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/buffering-indicator';
-import '../ui/captions-button';
-import '../ui/error-dialog';
-import '../ui/controls';
-import '../ui/fullscreen-button';
-import '../ui/mute-button';
-import '../ui/pip-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/poster';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -4,25 +4,8 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './skin.css?inline';
 
-// Side-effect imports: register all custom elements used in the template.
-import '../media/container';
-import '../ui/buffering-indicator';
-import '../ui/captions-button';
-import '../ui/error-dialog';
-import '../ui/controls';
-import '../ui/fullscreen-button';
-import '../ui/mute-button';
-import '../ui/pip-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/poster';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Register the player, container, and all UI custom elements.
+import './ui';
 
 const SEEK_TIME = 10;
 

--- a/packages/html/src/define/video/ui.ts
+++ b/packages/html/src/define/video/ui.ts
@@ -1,0 +1,22 @@
+// Side-effect-only module: registers the video player, container, and all
+// video UI custom elements without creating a skin element. Use this entry
+// when building an ejected (light DOM) player layout.
+import './player';
+
+import '../ui/buffering-indicator';
+import '../ui/captions-button';
+import '../ui/controls';
+import '../ui/error-dialog';
+import '../ui/fullscreen-button';
+import '../ui/mute-button';
+import '../ui/pip-button';
+import '../ui/play-button';
+import '../ui/playback-rate-button';
+import '../ui/popover';
+import '../ui/poster';
+import '../ui/seek-button';
+import '../ui/time';
+import '../ui/time-slider';
+import '../ui/tooltip';
+import '../ui/tooltip-group';
+import '../ui/volume-slider';

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -12,7 +12,17 @@ const skinsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../skins/src'
 
 const buildModes: BuildMode[] = ['dev', 'prod'];
 
-const presets = ['video', 'video-minimal', 'audio', 'audio-minimal', 'background'];
+const presets = [
+  'video',
+  'video-minimal',
+  'video-ui',
+  'video-minimal-ui',
+  'audio',
+  'audio-minimal',
+  'audio-ui',
+  'audio-minimal-ui',
+  'background',
+];
 const media = ['hls-video', 'mux-video', 'simple-hls-video', 'dash-video'];
 
 const entries = [

--- a/packages/skins/src/default/css/components/poster.css
+++ b/packages/skins/src/default/css/components/poster.css
@@ -15,7 +15,8 @@
 .media-default-skin > img:not([data-visible]) {
   opacity: 0;
 }
-.media-default-skin media-poster ::slotted(img) {
+.media-default-skin media-poster ::slotted(img),
+.media-default-skin media-poster img {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -31,6 +32,7 @@
 }
 
 .media-default-skin:fullscreen media-poster ::slotted(img),
+.media-default-skin:fullscreen media-poster img,
 .media-default-skin:fullscreen > img {
   object-fit: contain;
 }

--- a/packages/skins/src/minimal/css/components/poster.css
+++ b/packages/skins/src/minimal/css/components/poster.css
@@ -15,7 +15,8 @@
 .media-minimal-skin > img:not([data-visible]) {
   opacity: 0;
 }
-.media-minimal-skin media-poster ::slotted(img) {
+.media-minimal-skin media-poster ::slotted(img),
+.media-minimal-skin media-poster img {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -31,6 +32,7 @@
 }
 
 .media-minimal-skin:fullscreen media-poster ::slotted(img),
+.media-minimal-skin:fullscreen media-poster img,
 .media-minimal-skin:fullscreen > img {
   object-fit: contain;
 }

--- a/site/scripts/build-ejected-skins.ts
+++ b/site/scripts/build-ejected-skins.ts
@@ -679,19 +679,10 @@ function resolveCss(cssPath: string): string {
 }
 
 function getHtmlSkinCdnFileName(skin: HtmlSkinDef): string {
-  if (skin.id.includes('minimal-video')) {
-    return 'video-minimal';
-  }
+  const isMinimal = skin.id.includes('minimal');
+  const prefix = skin.id.includes('video') ? 'video' : 'audio';
 
-  if (skin.id.includes('minimal-audio')) {
-    return 'audio-minimal';
-  }
-
-  if (skin.id.includes('video')) {
-    return 'video';
-  }
-
-  return 'audio';
+  return isMinimal ? `${prefix}-minimal-ui` : `${prefix}-ui`;
 }
 
 function prependHtmlSkinScripts(html: string, skin: HtmlSkinDef): string {


### PR DESCRIPTION
## Summary

- Add UI-only CDN presets (`cdn/video-ui.js`, `cdn/video-minimal-ui.js`, `cdn/audio-ui.js`, `cdn/audio-minimal-ui.js`) that register the player, container, and all UI custom elements without creating a skin element — for ejected (light DOM) player layouts
- Fix poster `<img>` missing `border-radius`, `object-fit`, and `object-position` in ejected markup by adding `media-poster img` selectors alongside the existing `::slotted(img)` rules (which only work inside shadow DOM)
- Consolidate duplicated UI element side-effect imports: skins now import `./ui` or `./minimal-ui` instead of repeating the full list
- Remove redundant `player` imports from skin CDN entries (skins already pull in player via their ui module)
- Update ejected skin build script to reference the new CDN paths

## Test plan

- [x] `pnpm build:packages` succeeds
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 1348 tests pass
- [x] Verify ejected HTML page loads `cdn/video-ui.js` and controls connect to `<video>`
- [x] Verify poster `<img>` has correct `border-radius` in ejected markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)