### PR TITLE
feat(html): add native hls video to cdn

### DIFF
--- a/packages/html/src/cdn/media/native-hls-video.ts
+++ b/packages/html/src/cdn/media/native-hls-video.ts
@@ -1,0 +1,1 @@
+import '../../define/media/native-hls-video';

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -23,7 +23,7 @@ const presets = [
   'audio-minimal-ui',
   'background',
 ];
-const media = ['hls-video', 'mux-video', 'simple-hls-video', 'dash-video'];
+const media = ['hls-video', 'mux-video', 'native-hls-video', 'simple-hls-video', 'dash-video'];
 
 const entries = [
   ...presets.map((name) => ({ src: `src/cdn/${name}.ts`, name })),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new side-effect-only CDN entry point and wires it into the existing build entry list, with no changes to runtime logic beyond making the element importable via the CDN bundle.
> 
> **Overview**
> Adds a new CDN entry module `cdn/media/native-hls-video` that side-effect imports `define/media/native-hls-video` so the `native-hls-video` custom element can be loaded via the CDN build.
> 
> Updates `tsdown.cdn.config.ts` to include `native-hls-video` in the media entry list, causing it to be emitted in both dev and prod CDN bundles alongside the other media entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4a7ba4c63278f0f24d734e9810c6e57d7f79a01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->