### PR TITLE
fix(html): move TimeElement child creation from constructor to connectedCallback

### DIFF
--- a/packages/html/src/ui/time/time-element.ts
+++ b/packages/html/src/ui/time/time-element.ts
@@ -25,18 +25,15 @@ export class TimeElement extends MediaElement {
   readonly #signSpan = document.createElement('span');
   readonly #textNode = document.createTextNode('');
 
-  constructor() {
-    super();
-
-    this.#signSpan.setAttribute('aria-hidden', 'true');
-    this.#signSpan.hidden = true;
-
-    this.appendChild(this.#signSpan);
-    this.appendChild(this.#textNode);
-  }
-
   override connectedCallback(): void {
     super.connectedCallback();
+
+    if (!this.#signSpan.parentNode) {
+      this.#signSpan.setAttribute('aria-hidden', 'true');
+      this.#signSpan.hidden = true;
+      this.appendChild(this.#signSpan);
+      this.appendChild(this.#textNode);
+    }
 
     if (__DEV__ && !this.#state.value) {
       logMissingFeature(this.localName, this.#state.displayName!);


### PR DESCRIPTION
## Summary

Custom elements must not add children in the constructor per the spec. `TimeElement` (`media-time`) was appending its sign span and text node in the constructor — moved to `connectedCallback` with a `parentNode` guard to handle reconnection safely.

## Testing

Covered by existing tests: `pnpm -F @videojs/html test` (93 tests passing).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small lifecycle change limited to DOM child initialization for `media-time`, with a guard to avoid duplicate nodes on reconnect.
> 
> **Overview**
> Moves `media-time` (`TimeElement`) DOM child creation (sign span + text node) out of the constructor and into `connectedCallback` to comply with custom element lifecycle rules.
> 
> Adds a `parentNode` guard so the children are only appended once, preventing duplicates if the element is disconnected/reconnected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ba7201fa289a74faf41e520de0a92af3c48daf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->