### PR TITLE
fix(site): remove default attr from storyboard track elements

### DIFF
--- a/apps/sandbox/app/shared/html/storyboard.ts
+++ b/apps/sandbox/app/shared/html/storyboard.ts
@@ -1,3 +1,3 @@
 export function renderStoryboard(src?: string | undefined): string {
-  return src ? `<track kind="metadata" label="thumbnails" src="${src}" default />` : '';
+  return src ? `<track kind="metadata" label="thumbnails" src="${src}" />` : '';
 }

--- a/apps/sandbox/app/shared/react/storyboard.tsx
+++ b/apps/sandbox/app/shared/react/storyboard.tsx
@@ -4,5 +4,5 @@ type StoryboardProps = {
 
 export function Storyboard({ src }: StoryboardProps) {
   if (!src) return null;
-  return <track kind="metadata" label="thumbnails" src={src} default />;
+  return <track kind="metadata" label="thumbnails" src={src} />;
 }

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -16,6 +16,7 @@ export const textTrackFeature = definePlayerFeature({
         target().media,
         (track) => track.kind === 'subtitles' || track.kind === 'captions'
       );
+
       if (!subtitlesTracks.length) return false;
 
       const showing = subtitlesTracks.some((track: TextTrack) => track.mode === 'showing');

--- a/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.html
@@ -13,7 +13,6 @@
                     kind="metadata"
                     label="thumbnails"
                     src="/docs/demos/thumbnail/basic.vtt"
-                    default
                 />
             </video>
             <media-thumbnail class="html-thumbnail-text-track__thumbnail" time="12"></media-thumbnail>

--- a/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
@@ -17,7 +17,7 @@ export default function TextTrackUsage() {
           playsInline
           crossOrigin="anonymous"
         >
-          <track kind="metadata" label="thumbnails" src="/docs/demos/thumbnail/basic.vtt" default />
+          <track kind="metadata" label="thumbnails" src="/docs/demos/thumbnail/basic.vtt" />
         </Video>
         <Thumbnail className="react-thumbnail-text-track__thumbnail" time={12} />
       </Player.Container>

--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -39,7 +39,6 @@ export default function HeroVideo({
             kind="metadata"
             label="thumbnails"
             src={`https://image.mux.com/${VJS10_DEMO_VIDEO.id}/storyboard.vtt`}
-            default
           />
         </HlsVideo>
       </SkinComponent>

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -46,7 +46,6 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
       kind="metadata"
       label="thumbnails"
       src="https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/storyboard.vtt"
-      default
     />
   </Video>
   <Thumbnail time={12} />
@@ -60,7 +59,6 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
       kind="metadata"
       label="thumbnails"
       src="https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/storyboard.vtt"
-      default
     />
   </video>
   <media-thumbnail time="12"></media-thumbnail>


### PR DESCRIPTION
## Summary

Remove the `default` attribute from all `<track kind="metadata" label="thumbnails">` elements. With SSR (Astro), `default` causes the browser to pre-load the storyboard VTT before React hydrates. When hls.js then attaches a MediaSource (changing `video.src`), the browser resets text tracks and clears cues but doesn't re-fire the `load` event — leaving thumbnails permanently empty.

## Changes

- Remove `default` from storyboard `<track>` elements across the site, sandbox, and docs
- The `textTrackFeature` already handles setting `mode='hidden'` when it discovers a metadata/thumbnails track, so `default` was always redundant

## Testing

Covered by existing tests. Manual: hover the time slider on the hero video — storyboard thumbnails should appear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an HTML attribute from thumbnail storyboard `<track>` elements and makes a small early-return tweak in subtitle toggling, with no API or data model changes.
> 
> **Overview**
> Removes the `default` attribute from all storyboard/thumbnails `<track kind="metadata" label="thumbnails">` usages across sandbox renderers, the site hero video, and docs/demos to prevent premature VTT loading and track resets during hydration/HLS source swaps.
> 
> Also adds a guard in `textTrackFeature.toggleSubtitles` to immediately return `false` when no subtitles/captions tracks exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38f974c1d677d04ffae78c34e97ae55f3f896d6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->