### PR TITLE
fix(ci): prevent non-fast-forward push in release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'release-please--branches--main'
 
+concurrency:
+  group: release-pr
+  cancel-in-progress: false
+
 jobs:
   changelog:
     runs-on: ubuntu-latest
@@ -99,4 +103,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md site/src/content/changelog/
           git diff --cached --quiet || git commit -m "chore(release): update root changelog"
+          git pull --rebase
           git push


### PR DESCRIPTION
## Summary

Fix the release-pr workflow failing with a non-fast-forward push rejection when the `release-please--branches--main` branch advances between checkout and push.

## Changes

- Add `concurrency` group to serialize workflow runs and prevent parallel races
- Add `git pull --rebase` before `git push` so the changelog commit rebases on top of any new remote commits


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation behavior (workflow concurrency and git history handling), which can affect changelog publishing if misconfigured.
> 
> **Overview**
> Prevents `release-pr` workflow push failures when the remote branch advances during a run.
> 
> Adds workflow-level `concurrency` to serialize runs for the release PR branch, and updates the changelog commit step to `git pull --rebase` before `git push` to avoid non-fast-forward rejections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 057af0923f3733d96d3e9ecfa2807f63c1168662. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->