### PR TITLE
chore(ci): update workflows for new triage system

### DIFF
--- a/.github/workflows/api-reference-sync.yml
+++ b/.github/workflows/api-reference-sync.yml
@@ -188,7 +188,7 @@ jobs:
 
               # Check for existing open issue (dedup by drift-type + component name)
               EXISTING=$(gh issue list \
-                --label "docs:reference" \
+                --label "docs" \
                 --search "docs(reference): add $NAME API reference page" \
                 --state open \
                 --json number \
@@ -228,7 +228,7 @@ jobs:
               gh issue create \
                 --title "docs(reference): add $NAME API reference page" \
                 --body "$BODY" \
-                --label "docs,docs:reference,site,components" \
+                --label "docs,site,components" \
                 $ASSIGNEE_FLAG
 
               echo "Created issue for component $NAME"
@@ -251,7 +251,7 @@ jobs:
 
               # Check for existing open issue
               EXISTING=$(gh issue list \
-                --label "docs:reference" \
+                --label "docs" \
                 --search "docs(reference): add $NAME API reference page" \
                 --state open \
                 --json number \
@@ -291,7 +291,7 @@ jobs:
               gh issue create \
                 --title "docs(reference): add $NAME API reference page" \
                 --body "$BODY" \
-                --label "docs,docs:reference,site" \
+                --label "docs,site" \
                 $ASSIGNEE_FLAG
 
               echo "Created issue for util $NAME"
@@ -380,7 +380,7 @@ jobs:
 
             Title: `docs(site): stale docs from #$PR_NUMBER`
 
-            Labels: `docs,docs:reference,site,triage`
+            Labels: `docs,site`
 
             Body (use this structure exactly):
             ```

--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -1,0 +1,18 @@
+name: Auto-label new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-triage:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,41 +45,42 @@ jobs:
               ${{ github.event.issue.body }}
 
             Triage responsibilities:
-            1. Classify and label:
+            1. Set issue type:
+            - Assign the correct GitHub issue type: Bug, Enhancement, or Task.
+            2. Classify and label:
             - Determine best-fit labels from issue content and template sections.
-            - Review existing repository labels first and align to established taxonomy.
             - Review labels used on related/cross-referenced issues before deciding.
             - Add missing useful labels and remove clearly incorrect labels.
-            - Do not create new labels unless absolutely necessary; prefer no label over inventing a new one.
-            2. Detect probable duplicates:
+            - Do not create new labels; only use existing labels.
+            3. Detect probable duplicates:
             - Search for existing issues with the same bug/request symptoms, stack traces, repro steps, or scope.
             - If a likely duplicate is found, leave one concise comment linking the likely canonical issue and why it appears duplicated.
             - If confidence is not high, do not mark as duplicate; instead add `triage` label for human review.
             - Do not auto-close duplicates unless there is very high confidence and no meaningful unique information.
-            3. Escalate uncertainty:
+            4. Escalate uncertainty:
             - Add `triage` label when classification is ambiguous, conflicting, or needs human judgment.
-            4. Suggest docs/resources when helpful:
+            5. Suggest docs/resources when helpful:
             - Use https://videojs.org/llms.txt as the primary source to discover relevant docs links.
             - If likely already documented, suggest 1-3 relevant docs links with a short reason.
             - Prioritize repository/site docs over random sources.
-            5. Ask for missing critical info only when needed:
+            6. Ask for missing critical info only when needed:
             - If reproduction or environment details are insufficient, post a short targeted follow-up.
-            6. Help users unblock when issue is about usage:
+            7. Help users unblock when issue is about usage:
             - If the issue suggests the user is struggling to achieve something with the library, provide practical guidance.
             - Suggest the most relevant documented approach with 1-3 links (from https://videojs.org/llms.txt discovery).
             - Include concise next steps or a minimal example/snippet when it materially helps.
             - If docs appear incomplete or unclear, call that out and add `triage` for human follow-up.
-            7. Planning recommendations (comment-only):
+            8. Planning recommendations (comment-only):
             - Review roadmap context at https://github.com/orgs/videojs/projects/7 and current repository milestones.
             - Identify likely related epics/issues and related open PRs.
             - Recommend whether this issue should be added to the roadmap.
             - Recommend a milestone if one is a strong fit.
             - Recommend related epic linkage if one clearly fits.
             - Recommend obvious `blocked by` relationships when clearly implied.
-            - Recommend a priority level (P0–P3) when clearly implied by severity or urgency.
+            - Recommend a priority level (P0–P2) when clearly implied by severity or urgency.
             - Recommend other existing issues that should be included in project planning alongside this one when relevant (for example, skin integration, docs API reference coverage, or other adjacent planning gaps).
             - Do not directly add the issue to roadmap/projects, milestones, epics, blocked-by links, or priority labels.
             - Instead, leave one concise comment with recommendations only when meaningful.
-            8. Avoid noise:
+            9. Avoid noise:
             - Do not comment if there is no meaningful action or new information.
             - Keep comments concise and action-oriented.


### PR DESCRIPTION
## Summary
- **api-reference-sync**: Replace deleted `docs:reference` label with `docs` (label was removed as part of triage system cleanup)
- **issue-triage**: Add issue type assignment (Bug/Enhancement/Task), simplify label instructions to use existing labels only, fix priority range from P0–P3 to P0–P2
- **issue-label** (new): Auto-add `triage` label to all new issues without Claude — just one `gh` command

## Context
Part of the proposed [Issue Triage System for Video.js 10](https://www.notion.so/mux/Issue-Triage-System-for-Video-js-10-33797a7f89d0815a8e83d6d8b725ece2). The bulk GitHub operations (label deletion, milestone creation, priority/milestone stripping, triage label application) were done directly via API — this PR covers the workflow file changes.

## Test plan
- [ ] Open a test issue and verify `triage` label is auto-added by `issue-label.yml`
- [ ] Verify triage bot assigns issue type and doesn't recommend P3
- [ ] Merge a PR that adds a new component/util and verify `api-reference-sync` uses `docs` label correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)