### PR TITLE
docs(site): rename commitThrottle to changeThrottle in time-slider reference

### DIFF
--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -39,7 +39,7 @@ import withPartsHtmlTs from "@/components/docs/demos/time-slider/html/css/WithPa
 
 Displays and controls the current playback position. Dragging the slider seeks the media. The fill level reflects `currentTime / duration` as a percentage, and the buffer level shows how much media has been buffered.
 
-Seeking is throttled via the `commitThrottle` prop (default 100ms) to avoid overwhelming the media element during drag operations.
+Value changes during drag are throttled via the `changeThrottle` prop (default 100ms) using a leading+trailing throttle to keep the UI responsive without overwhelming the media element.
 
 ## Styling
 


### PR DESCRIPTION
Update stale documentation from #1219: the `commitThrottle` prop was renamed to `changeThrottle` and now uses leading+trailing throttle for `onValueChange` during drag.

Closes #1220

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating a prop name/description; no runtime or API behavior is modified in code.
> 
> **Overview**
> Updates the `TimeSlider` reference doc to replace the stale `commitThrottle` wording with `changeThrottle`, and clarifies that drag-time value updates use a *leading+trailing* throttle (default 100ms) to balance responsiveness with avoiding excessive media seeks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2e03d9970f8a894b7559721e02cfc050b01e0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->