### PR TITLE
fix(site): true conditional rendering in FrameworkCase

### DIFF
--- a/site/src/components/docs/FrameworkCase.astro
+++ b/site/src/components/docs/FrameworkCase.astro
@@ -11,27 +11,7 @@ const { framework } = Astro.params;
 
 // Only render if current framework matches, or if no frameworks specified (all frameworks)
 const shouldRender = !frameworks || frameworks.includes(framework as SupportedFramework);
+const html = shouldRender ? await Astro.slots.render('default') : '';
 ---
 
-{
-  /*
-    What I WANT to do is
-    ```
-    {shouldRender && <slot />}
-    ```
-
-    But I'm running into some crazy problems with hydration.
-    Putting client:* in one of these conditionals causes Astro to just give up hydrating the whole app for some reason.
-    TODO: fix this
-
-    So, while I debug those... let's do this
-  */
-}
-<div
-  class="contents"
-  hidden={!shouldRender}
-  data-search-ignore={shouldRender ? undefined : "all"}
-  data-llms-ignore={shouldRender ? undefined : "all"}
->
-  <slot />
-</div>
+{shouldRender && <Fragment set:html={html} />}


### PR DESCRIPTION
## Summary

- Replace the `hidden`-div workaround in `FrameworkCase.astro` with `Astro.slots.render()` + `set:html` for true conditional rendering
- Non-matching framework content is now completely absent from the DOM instead of rendered and hidden
- Zero DOM pollution: no wrapper `<div>`, no `hidden` attribute, no `data-search-ignore` / `data-llms-ignore` attributes needed

Closes #1224

## Context

The original implementation always rendered all framework variants and hid non-matching ones with the `hidden` attribute. This was a workaround for an Astro bug where `{shouldRender && <slot />}` broke hydration for the entire page.

The root cause is that Astro's `<slot />` mechanism renders children (including their hydration scripts) regardless of whether the slot is actually placed in the output. When a conditional prevents the `<slot />` from rendering, the hydration scripts are consumed but never emitted, breaking all `client:*` islands on the page.

`Astro.slots.render('default')` sidesteps this entirely — it's only called when `shouldRender` is true, so hydration scripts are never processed for content that won't be output.

## Verified

- Build completes with no errors
- LLMs markdown output compared across 10 representative pages — identical to prod (with two minor improvements to heading rendering in reference pages)
- DOM comparison on `/docs/framework/html/concepts/overview`:
  - Article payload 42% smaller (70KB → 41KB)
  - Astro islands halved (41 → 21 — hidden islands no longer hydrate)
  - Zero React-specific content leaking into HTML framework pages
  - All HTML-framework content preserved identically
  - Heading structure unchanged

## Test plan

- [x] Verify hydration works in the browser on pages with `client:*` components inside `FrameworkCase` blocks (e.g. installation page interactive demos)
- [x] Verify React-only content is absent (not just hidden) on HTML framework pages and vice versa
- [x] Spot-check TOC filtering still works correctly

https://claude.ai/code/session_018wYM6TgaaHbvBXMRx2q9VT
