### PR TITLE
fix: safari track bug, no playback

### DIFF
--- a/packages/core/src/dom/media/hls/metadata-tracks.ts
+++ b/packages/core/src/dom/media/hls/metadata-tracks.ts
@@ -39,11 +39,14 @@ export function HlsJsMediaMetadataTracksMixin<Base extends Constructor<HlsEngine
 
         // Only reset the track if it was loaded before and had no cues.
         if (src && trackEl.readyState === TRACK_LOADED && !track.cues?.length) {
-          const newTrackEl = target.replaceChild(trackEl.cloneNode(), trackEl);
+          const clonedTrackEl = trackEl.cloneNode() as HTMLTrackElement;
+          target.replaceChild(clonedTrackEl, trackEl);
+        }
 
-          if (newTrackEl?.default && newTrackEl.track.mode !== 'hidden') {
-            newTrackEl.track.mode = 'hidden';
-          }
+        // Force mode to 'hidden' for default tracks (independent of replacement).
+        const currentTrackEl = target.querySelector(selector) as HTMLTrackElement | null;
+        if (currentTrackEl?.default && currentTrackEl.track.mode !== 'hidden') {
+          currentTrackEl.track.mode = 'hidden';
         }
       });
     }


### PR DESCRIPTION
Safari did not like resetting the src on the track element, replacing a track clone seemed to solve the issue.

I first thought it had to do with the video not being ready but waiting after the loadedmetadata event and setting the track src did not solve the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `<track>` elements are refreshed after hls.js clears cues by replacing DOM nodes instead of toggling `src`, which could affect text-track behavior across browsers and playback stability (notably Safari). Scope is small but in a media pipeline area.
> 
> **Overview**
> Fixes a Safari playback issue by changing the metadata/chapters track “reload” behavior in `metadata-tracks.ts`: when a loaded track has had its cues wiped, the code now **replaces the `<track>` element with a cloned node** instead of removing/re-setting its `src`.
> 
> Also ensures *default* tracks are always forced to `hidden` by re-querying the (possibly replaced) element and updating `track.mode` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c761ba39a0a8b3e3410f61c5152fad65a0ffd43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->