### PR TITLE
chore: use title prefixes instead of issue types for triage

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -30,20 +30,7 @@ $ARGUMENTS
 
 ### Title Format
 
-**`Type: Title Case Description`**
-
-Use Title Case for the description portion. The type prefix is followed by a colon and space.
-
-| Prefix           | When to Use                                           | Example                                          |
-| ---------------- | ----------------------------------------------------- | ------------------------------------------------ |
-| `Feature:`       | New capability or behavior                            | Feature: Add OAuth Support                       |
-| `Bug:`           | Something broken or not working as expected           | Bug: Playback Stalls on iOS Safari               |
-| `Docs:`          | Documentation additions or improvements               | Docs: Add Getting Started Guide                  |
-| `Architecture:`  | Internal structure, design patterns, core refactoring | Architecture: Redesign State Management Layer    |
-| `Chore:`         | Maintenance, deps, tooling, CI                        | Chore: Upgrade Vitest to v3                      |
-| `Design:`        | Design docs, component specs, visual design           | Design: Component Spec for Slider                |
-
-**Not** conventional commit prefixes (`feat:`, `fix:`, `docs:`) -- those are for commits only.
+Use Title Case. The triage bot will add the appropriate type prefix (`Bug:`, `Feature:`, etc.) automatically.
 
 ### Labels
 
@@ -118,15 +105,14 @@ When creating **Feature**, **Architecture**, or **Design** issues, research how 
 ### Step 1: Gather Information
 
 If $ARGUMENTS provides enough detail, extract:
-1. **Type** -- Which prefix applies (Feature, Bug, Docs, Architecture, Chore, Design)
-2. **Title** -- Short, descriptive, Title Case
-3. **Description** -- The what and why
+1. **Title** -- Short, descriptive, Title Case
+2. **Description** -- The what and why
 
 If details are missing, use the `question` tool to ask the user.
 
 ### Step 2: Format Title
 
-Construct the title as `Type: Title Case Description`.
+Construct the title in Title Case (no type prefix — the triage bot adds that).
 
 **Title Case rules:**
 - Capitalize the first and last word
@@ -159,7 +145,7 @@ Ask for confirmation using the `question` tool.
 
 ```bash
 gh issue create --repo videojs/v10 \
-  --title "Type: Title Case Description" \
+  --title "Title Case Description" \
   --body "body content"
 ```
 
@@ -167,7 +153,7 @@ Use a HEREDOC for the body to preserve formatting:
 
 ```bash
 gh issue create --repo videojs/v10 \
-  --title "Feature: Add OAuth Support" \
+  --title "Add OAuth Support" \
   --body "$(cat <<'EOF'
 Description text here.
 

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -2,7 +2,7 @@ name: 💎 Feature Request
 description: Request a new feature or enhancement
 type: enhancement
 labels: [triage]
-title: 'Feature Request: '
+title: 'Feature: '
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -45,8 +45,16 @@ jobs:
               ${{ github.event.issue.body }}
 
             Triage responsibilities:
-            1. Set issue type:
-            - Assign the correct GitHub issue type: Bug, Enhancement, or Task.
+            1. Ensure title prefix:
+            - Every issue title must start with a type prefix. If the prefix is missing or wrong, fix the title. Preserve the rest of the title as-is.
+            - Use Title Case for the description after the prefix (e.g., "Bug: Playback Stalls on iOS Safari").
+            - Prefixes:
+              - `Feature:` — New capability or behavior
+              - `Bug:` — Something broken or not working as expected
+              - `Docs:` — Documentation additions or improvements
+              - `Architecture:` — Internal structure, design patterns, core refactoring
+              - `Chore:` — Maintenance, deps, tooling, CI
+              - `Design:` — Design docs, component specs, visual design
             2. Classify and label:
             - Determine best-fit labels from issue content and template sections.
             - Review labels used on related/cross-referenced issues before deciding.


### PR DESCRIPTION
## Summary
- **issue-triage bot**: Replace GitHub issue type assignment with title prefix enforcement (`Bug:`, `Feature:`, `Docs:`, `Architecture:`, `Chore:`, `Design:`) — the bot is now the single source of truth for prefixes
- **create-issue skill**: Remove prefix/type responsibility — the triage bot handles it. Same deal as the labels.
- **feature request template**: `Feature Request:` → `Feature:` to match the prefix taxonomy

## Context
Part of the [Issue Triage System for Video.js 10](https://www.notion.so/mux/Issue-Triage-System-for-Video-js-10-33797a7f89d0815a8e83d6d8b725ece2). We couldn't use custom GitHub issue types (needs `admin:org` scope), so title prefixes remain the type mechanism.

## Test plan
- [ ] Open a test issue without a prefix and verify the triage bot adds one
- [ ] Open a feature request via template and verify title starts with `Feature:`
- [ ] Run `/create-issue` and verify it creates an issue without a prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates automated issue triage behavior to rewrite issue titles, which could mis-prefix or rename issues if the prompt logic is wrong. Changes are limited to GitHub issue templates/docs and the triage workflow.
> 
> **Overview**
> Shifts issue classification from GitHub issue *types* to **title prefix enforcement** in the `issue-triage` workflow, defining the allowed prefixes (`Bug:`, `Feature:`, `Docs:`, `Architecture:`, `Chore:`, `Design:`) and instructing the bot to correct missing/incorrect prefixes while preserving the rest of the title.
> 
> Aligns issue creation guidance and templates with this approach by updating the `/create-issue` skill to omit prefixes (Title Case only) and changing the feature request template default title from `Feature Request:` to `Feature:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bfc4c2a58853e46966ae0f83ac78e4f9fd2d51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->