### PR TITLE
chore(ci): clarify Docs and Design prefix descriptions in triage bot

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -51,10 +51,10 @@ jobs:
             - Prefixes:
               - `Feature:` — New capability or behavior
               - `Bug:` — Something broken or not working as expected
-              - `Docs:` — Documentation additions or improvements
+              - `Docs:` — Writing or improving documentation content (not tooling)
               - `Architecture:` — Internal structure, design patterns, core refactoring
               - `Chore:` — Maintenance, deps, tooling, CI
-              - `Design:` — Design docs, component specs, visual design
+              - `Design:` — Design docs, component specs, discovery/research
             2. Classify and label:
             - Determine best-fit labels from issue content and template sections.
             - Review labels used on related/cross-referenced issues before deciding.


### PR DESCRIPTION
## Summary
- **Docs:** clarified as "Writing or improving documentation content (not tooling)" — docs tooling/features should use `Feature:` or `Chore:`
- **Design:** swapped "visual design" for "discovery/research" to match how we actually use the prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts descriptive text in the issue-triage workflow prompt and does not change any execution logic or permissions.
> 
> **Overview**
> Updates the `issue-triage.yml` workflow prompt to better define the `Docs:` and `Design:` issue title prefixes: `Docs` is now explicitly limited to documentation content (not tooling), and `Design` is reframed to include discovery/research instead of visual design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8b1006c2aa959d7314a77222a005acb2991ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->