### PR TITLE
feat(core): add sub-1x playback rates to defaults

### DIFF
--- a/packages/core/src/core/ui/playback-rate-button/tests/playback-rate-button-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-button/tests/playback-rate-button-core.test.ts
@@ -6,7 +6,7 @@ import { PlaybackRateButtonCore } from '../playback-rate-button-core';
 
 function createMediaState(overrides: Partial<MediaPlaybackRateState> = {}): MediaPlaybackRateState {
   return {
-    playbackRates: [1, 1.2, 1.5, 1.7, 2],
+    playbackRates: [0.25, 0.5, 0.75, 1, 1.2, 1.5, 1.7, 2],
     playbackRate: 1,
     setPlaybackRate: vi.fn(),
     ...overrides,
@@ -96,7 +96,7 @@ describe('PlaybackRateButtonCore', () => {
       const core = new PlaybackRateButtonCore();
       const media = createMediaState({ playbackRate: 2 });
       core.cycle(media);
-      expect(media.setPlaybackRate).toHaveBeenCalledWith(1);
+      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.25);
     });
 
     it('advances through the middle of the list', () => {
@@ -108,9 +108,9 @@ describe('PlaybackRateButtonCore', () => {
 
     it('finds the first rate greater than current when not in list', () => {
       const core = new PlaybackRateButtonCore();
-      const media = createMediaState({ playbackRate: 0.75 });
+      const media = createMediaState({ playbackRate: 0.3 });
       core.cycle(media);
-      expect(media.setPlaybackRate).toHaveBeenCalledWith(1);
+      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.5);
     });
 
     it('finds the next greater rate when between list values', () => {
@@ -124,7 +124,14 @@ describe('PlaybackRateButtonCore', () => {
       const core = new PlaybackRateButtonCore();
       const media = createMediaState({ playbackRate: 3 });
       core.cycle(media);
-      expect(media.setPlaybackRate).toHaveBeenCalledWith(1);
+      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.25);
+    });
+
+    it('cycles through sub-1x rates', () => {
+      const core = new PlaybackRateButtonCore();
+      const media = createMediaState({ playbackRate: 0.25 });
+      core.cycle(media);
+      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.5);
     });
 
     it('does nothing when disabled', () => {

--- a/packages/core/src/dom/store/features/playback-rate.ts
+++ b/packages/core/src/dom/store/features/playback-rate.ts
@@ -3,7 +3,7 @@ import { listen } from '@videojs/utils/dom';
 import type { MediaPlaybackRateState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
 
-const DEFAULT_RATES: readonly number[] = [1, 1.2, 1.5, 1.7, 2];
+const DEFAULT_RATES: readonly number[] = [0.25, 0.5, 0.75, 1, 1.2, 1.5, 1.7, 2];
 
 export const playbackRateFeature = definePlayerFeature({
   name: 'playbackRate',


### PR DESCRIPTION
Closes #1117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to default `playbackRates` values and corresponding unit test updates, with no security or data-handling impact.
> 
> **Overview**
> Adds sub‑1x playback speeds (`0.25`, `0.5`, `0.75`) to the default `playbackRates` list used by the `playbackRate` feature.
> 
> Updates `PlaybackRateButtonCore` tests to reflect the new rate list, including wrap-around now returning `0.25` and adding coverage for cycling through the new sub‑1x rates and selecting the next greater rate when the current value isn’t in the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a58443be8785385fe404d30e8f1c34d3099de84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->