### PR TITLE
fix(core): use 0.2 and 0.7 for default playback rates

### DIFF
--- a/packages/core/src/core/ui/playback-rate-button/tests/playback-rate-button-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-button/tests/playback-rate-button-core.test.ts
@@ -6,7 +6,7 @@ import { PlaybackRateButtonCore } from '../playback-rate-button-core';
 
 function createMediaState(overrides: Partial<MediaPlaybackRateState> = {}): MediaPlaybackRateState {
   return {
-    playbackRates: [0.25, 0.5, 0.75, 1, 1.2, 1.5, 1.7, 2],
+    playbackRates: [0.2, 0.5, 0.7, 1, 1.2, 1.5, 1.7, 2],
     playbackRate: 1,
     setPlaybackRate: vi.fn(),
     ...overrides,
@@ -96,7 +96,7 @@ describe('PlaybackRateButtonCore', () => {
       const core = new PlaybackRateButtonCore();
       const media = createMediaState({ playbackRate: 2 });
       core.cycle(media);
-      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.25);
+      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.2);
     });
 
     it('advances through the middle of the list', () => {
@@ -124,12 +124,12 @@ describe('PlaybackRateButtonCore', () => {
       const core = new PlaybackRateButtonCore();
       const media = createMediaState({ playbackRate: 3 });
       core.cycle(media);
-      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.25);
+      expect(media.setPlaybackRate).toHaveBeenCalledWith(0.2);
     });
 
     it('cycles through sub-1x rates', () => {
       const core = new PlaybackRateButtonCore();
-      const media = createMediaState({ playbackRate: 0.25 });
+      const media = createMediaState({ playbackRate: 0.2 });
       core.cycle(media);
       expect(media.setPlaybackRate).toHaveBeenCalledWith(0.5);
     });

--- a/packages/core/src/dom/store/features/playback-rate.ts
+++ b/packages/core/src/dom/store/features/playback-rate.ts
@@ -3,7 +3,7 @@ import { listen } from '@videojs/utils/dom';
 import type { MediaPlaybackRateState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
 
-const DEFAULT_RATES: readonly number[] = [0.25, 0.5, 0.75, 1, 1.2, 1.5, 1.7, 2];
+const DEFAULT_RATES: readonly number[] = [0.2, 0.5, 0.7, 1, 1.2, 1.5, 1.7, 2];
 
 export const playbackRateFeature = definePlayerFeature({
   name: 'playbackRate',

--- a/site/src/content/docs/reference/playback-rate-button.mdx
+++ b/site/src/content/docs/reference/playback-rate-button.mdx
@@ -37,7 +37,7 @@ import basicUsageHtmlTs from "@/components/docs/demos/playback-rate-button/html/
 
 ## Behavior
 
-Cycles through playback rates on click. The default rate list is `[1, 1.2, 1.5, 1.7, 2]`. After the last rate, it wraps back to the first. If the current rate isn't in the list (e.g., set programmatically), the button jumps to the next rate greater than the current one.
+Cycles through playback rates on click. The default rate list is `[0.2, 0.5, 0.7, 1, 1.2, 1.5, 1.7, 2]`. After the last rate, it wraps back to the first. If the current rate isn't in the list (e.g., set programmatically), the button jumps to the next rate greater than the current one.
 
 ## Styling
 


### PR DESCRIPTION
## Summary
- Changes default sub-1x playback rates from `0.25`/`0.75` to `0.2`/`0.7`
- Updates tests and docs to match

## Test plan
- [x] `PlaybackRateButtonCore` tests pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the default playback rate list values (sub-1x rates) plus corresponding tests/docs, without altering cycling logic or media state handling.
> 
> **Overview**
> Updates the default playback rate options to use **0.2x** and **0.7x** instead of **0.25x** and **0.75x**.
> 
> Aligns behavior expectations by updating `playbackRateFeature` defaults, `PlaybackRateButtonCore` tests (wrap/cycle assertions), and the `PlaybackRateButton` documentation to reflect the new rate list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9634a9e6caf19502688ea4ddff51e14f5d9426d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->