### PR TITLE
fix(html): create HotkeyRegistryController once in connectedCallback

### DIFF
--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -42,7 +42,7 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
   override connectedCallback(): void {
     super.connectedCallback();
 
-    if (this.hotkeyAction) {
+    if (this.hotkeyAction && !this.#hotkeyRegistry) {
       this.#hotkeyRegistry = new HotkeyRegistryController(this, this.hotkeyAction);
     }
 


### PR DESCRIPTION
Controller was instantiated in `connectedCallback` without a guard, creating a new instance on every reconnection. Now guarded to create once on first connection.