### PR TITLE
refactor(core): extract structured CSSVars for media element templates

### DIFF
--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -81,9 +81,6 @@ export const VideoCSSVars = {
 /** CSS custom property names for audio elements. */
 export const AudioCSSVars = {} as const;
 
-export const VideoSlots = ['media', ''] as const;
-export const AudioSlots = ['media', ''] as const;
-
 /**
  * Helper function to generate the HTML template for audio elements.
  */


### PR DESCRIPTION
## Summary

- Adds `VideoCSSVars` and `AudioCSSVars` as exported objects in `custom-media-element/index.ts`
- CSS var names are interpolated into `getVideoTemplateHTML` so the structured objects are the single source of truth
- `AudioCSSVars` is empty (the audio template has no CSS vars currently)
- JSDoc on each property provides descriptions for the api-docs-builder to extract
- Template HTML output is byte-for-byte identical — this is a pure refactor

**No slot exports.** Slots are structural HTML that can't be interpolated from an array. The builder will parse `<slot>` elements from the template HTML instead.

This is a prerequisite for the media element API reference builder (#1252), which will read these exported objects to generate reference JSON.

## Test plan

- [x] Lint passes
- [x] Typecheck passes (no new errors)
- [x] Template output verified identical via string comparison
- [ ] CI tests pass

Closes #1251
Parent issue: #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)