### PR TITLE
feat(core): mux stream url params and mux data mixin

### DIFF
--- a/packages/core/src/dom/media/mux/index.ts
+++ b/packages/core/src/dom/media/mux/index.ts
@@ -1,28 +1,29 @@
-import Mux from 'mux-embed';
-
+import { shallowEqual } from '@videojs/utils/object';
 import { DelegateMixin } from '../../../core/media/delegate';
+import type { InferDelegateProps } from '../../../core/media/types';
 import { CustomAudioElement, CustomVideoElement } from '../custom-media-element';
-import { Hls, HlsMediaDelegate } from '../hls';
+import { HlsMediaDelegate } from '../hls';
 import { AudioProxy, VideoProxy } from '../proxy';
-import { getPlayerVersion } from './env';
-import type { MuxDataSdk } from './types';
+import { MuxDataMediaMixin } from './mux-data';
+import type { MaxResolutionValue, MinResolutionValue, RenditionOrderValue, Tokens } from './types';
 
 const MUX_VIDEO_DOMAIN = 'mux.com';
 
-export class MuxMediaDelegate extends HlsMediaDelegate {
+export class MuxMediaDelegate extends MuxDataMediaMixin(HlsMediaDelegate) {
   static PLAYER_SOFTWARE_NAME = '';
 
-  #MuxDataSdk: MuxDataSdk | undefined = Mux;
-  #MuxDataSdkInitializedBefore: boolean = false;
   #playbackId: string | null = null;
   #customDomain: string = MUX_VIDEO_DOMAIN;
-  #beaconCollectionDomain: string | undefined;
-  #disableCookies: boolean = false;
-  #metadata: Record<string, any> | undefined;
-  #envKey: string | undefined;
-  #playerSoftwareName: string | undefined = (this.constructor as typeof MuxMediaDelegate).PLAYER_SOFTWARE_NAME;
-  #playerSoftwareVersion: string | undefined = getPlayerVersion();
-  #playerInitTime: number | undefined = this.#generatePlayerInitTime();
+  #maxResolution: MaxResolutionValue | undefined;
+  #minResolution: MinResolutionValue | undefined;
+  #renditionOrder: RenditionOrderValue | undefined;
+  #programStartTime: number | undefined;
+  #programEndTime: number | undefined;
+  #assetStartTime: number | undefined;
+  #assetEndTime: number | undefined;
+  #playbackToken: string | undefined;
+  #tokens: Tokens | undefined;
+  #extraSourceParams: Record<string, any> | undefined;
 
   get playbackId() {
     return this.#playbackId;
@@ -45,180 +46,192 @@ export class MuxMediaDelegate extends HlsMediaDelegate {
     this.#syncSrc();
   }
 
-  get MuxDataSdk() {
-    return this.#MuxDataSdk;
+  get maxResolution(): MaxResolutionValue | undefined {
+    return this.#maxResolution;
   }
 
-  set MuxDataSdk(value) {
-    this.#MuxDataSdk = value;
+  set maxResolution(value: MaxResolutionValue | undefined) {
+    if (this.#maxResolution === value) return;
+    this.#maxResolution = value;
+    this.#syncSrc();
   }
 
-  get beaconCollectionDomain(): string | undefined {
-    return this.#beaconCollectionDomain;
+  get minResolution(): MinResolutionValue | undefined {
+    return this.#minResolution;
   }
 
-  set beaconCollectionDomain(value: string | undefined) {
-    this.#beaconCollectionDomain = value;
+  set minResolution(value: MinResolutionValue | undefined) {
+    if (this.#minResolution === value) return;
+    this.#minResolution = value;
+    this.#syncSrc();
   }
 
-  get disableCookies(): boolean {
-    return this.#disableCookies;
+  get renditionOrder(): RenditionOrderValue | undefined {
+    return this.#renditionOrder;
   }
 
-  set disableCookies(value: boolean) {
-    this.#disableCookies = value;
+  set renditionOrder(value: RenditionOrderValue | undefined) {
+    if (this.#renditionOrder === value) return;
+    this.#renditionOrder = value;
+    this.#syncSrc();
   }
 
-  get envKey(): string | undefined {
-    return this.#envKey;
+  get programStartTime(): number | undefined {
+    return this.#programStartTime;
   }
 
-  set envKey(value: string | undefined) {
-    this.#envKey = value;
+  set programStartTime(value: number | undefined) {
+    if (this.#programStartTime === value) return;
+    this.#programStartTime = value;
+    this.#syncSrc();
   }
 
-  get playerSoftwareName(): string | undefined {
-    return this.#playerSoftwareName;
+  get programEndTime(): number | undefined {
+    return this.#programEndTime;
   }
 
-  set playerSoftwareName(value: string | undefined) {
-    this.#playerSoftwareName = value;
+  set programEndTime(value: number | undefined) {
+    if (this.#programEndTime === value) return;
+    this.#programEndTime = value;
+    this.#syncSrc();
   }
 
-  get playerSoftwareVersion(): string | undefined {
-    return this.#playerSoftwareVersion;
+  get assetStartTime(): number | undefined {
+    return this.#assetStartTime;
   }
 
-  set playerSoftwareVersion(value: string | undefined) {
-    this.#playerSoftwareVersion = value;
+  set assetStartTime(value: number | undefined) {
+    if (this.#assetStartTime === value) return;
+    this.#assetStartTime = value;
+    this.#syncSrc();
   }
 
-  get playerInitTime(): number | undefined {
-    return this.#playerInitTime;
+  get assetEndTime(): number | undefined {
+    return this.#assetEndTime;
   }
 
-  set playerInitTime(value: number | undefined) {
-    this.#playerInitTime = value;
+  set assetEndTime(value: number | undefined) {
+    if (this.#assetEndTime === value) return;
+    this.#assetEndTime = value;
+    this.#syncSrc();
   }
 
-  get metadata(): Record<string, any> | undefined {
-    return this.#metadata;
+  get playbackToken(): string | undefined {
+    return this.#playbackToken;
   }
 
-  set metadata(value: Record<string, any> | undefined) {
-    this.#metadata = value;
+  set playbackToken(value: string | undefined) {
+    if (this.#playbackToken === value) return;
+    this.#playbackToken = value;
+    this.#syncSrc();
   }
 
-  attach(target: HTMLMediaElement): void {
-    super.attach(target);
+  get tokens(): Tokens | undefined {
+    return this.#tokens;
+  }
 
-    // Only initialize Mux Data SDK if it was already initialized before in attach,
-    // the first initializeMuxDataSdk call should be done in the deferred load hook
-    // so all the properties are set before the Mux Data SDK is initialized.
-    if (this.#MuxDataSdkInitializedBefore) {
-      this.#initializeMuxDataSdk();
+  set tokens(value: Tokens | undefined) {
+    if (this.#tokens !== undefined && value !== undefined && shallowEqual(this.#tokens, value)) {
+      return;
     }
+    this.#tokens = value;
+    this.#syncSrc();
   }
 
-  detach(): void {
-    if (this.target?.mux) {
-      this.target.mux.destroy();
-      delete this.target.mux;
+  get extraSourceParams(): Record<string, any> | undefined {
+    return this.#extraSourceParams;
+  }
+
+  set extraSourceParams(value: Record<string, any> | undefined) {
+    if (this.#extraSourceParams === value) return;
+    if (this.#extraSourceParams !== undefined && value !== undefined && shallowEqual(this.#extraSourceParams, value)) {
+      return;
     }
-    super.detach();
-  }
-
-  load(): void {
-    super.load();
-    this.#initializeMuxDataSdk();
+    this.#extraSourceParams = value;
+    this.#syncSrc();
   }
 
   #syncSrc(): void {
-    this.src = this.#playbackId ? toSrc(this.#playbackId, this.#customDomain) : '';
+    this.src = this.playbackId ? (toMuxVideoURL(this) ?? '') : '';
   }
+}
 
-  #initializeMuxDataSdk(): void {
-    const target = this.target as HTMLMediaElement;
-
-    if (!this.MuxDataSdk || !target || (target.mux && !target.mux.deleted)) return;
-
-    this.#MuxDataSdkInitializedBefore = true;
-
-    const {
-      debug,
-      beaconCollectionDomain,
-      disableCookies,
-      engine: hlsjs,
-      envKey: env_key,
-      playerSoftwareName: player_software_name,
-      playerSoftwareVersion: player_software_version,
-      playerInitTime: player_init_time,
-      metadata = {},
-    } = this;
-
-    const { view_session_id = this.MuxDataSdk?.utils.generateUUID() } = metadata;
-    const video_id = toVideoId(this);
-    metadata.view_session_id = view_session_id;
-    metadata.video_id = video_id;
-
-    this.MuxDataSdk?.monitor(target, {
-      debug,
-      ...(beaconCollectionDomain ? { beaconCollectionDomain } : {}),
-      ...(disableCookies ? { disableCookies } : {}),
-      ...(hlsjs ? { hlsjs } : {}),
-      Hls,
-      data: {
-        ...(env_key ? { env_key } : {}),
-        ...(player_software_name ? { player_software_name } : {}),
-        // NOTE: Adding this because there appears to be some instability on whether
-        // player_software_name or player_software "wins" for Mux Data (CJP)
-        ...(player_software_name ? { player_software: player_software_name } : {}),
-        ...(player_software_version ? { player_software_version } : {}),
-        ...(player_init_time ? { player_init_time } : {}),
-        // Use any metadata passed in programmatically (which may override the defaults above)
-        ...metadata,
-      },
+export const toMuxVideoURL = ({
+  playbackId: playbackIdWithParams,
+  customDomain: domain = MUX_VIDEO_DOMAIN,
+  maxResolution,
+  minResolution,
+  renditionOrder,
+  programStartTime,
+  programEndTime,
+  assetStartTime,
+  assetEndTime,
+  // Normalizes different ways of providing playback token
+  playbackToken,
+  tokens: { playback: token = playbackToken } = {},
+  extraSourceParams = {},
+}: InferDelegateProps<typeof MuxMediaDelegate> = {}) => {
+  if (!playbackIdWithParams) return undefined;
+  // Normalizes different ways of providing playback id
+  const [playbackId, queryPart = ''] = toPlaybackIdParts(playbackIdWithParams);
+  const url = new URL(`https://stream.${domain}/${playbackId}.m3u8${queryPart}`);
+  /*
+   * All identified query params here can only be added to public
+   * playback IDs. In order to use these features with signed URLs
+   * the query param must be added to the signing token.
+   *
+   * */
+  if (token || url.searchParams.has('token')) {
+    url.searchParams.forEach((_, key) => {
+      if (key !== 'token') url.searchParams.delete(key);
+    });
+    if (token) url.searchParams.set('token', token);
+  } else {
+    if (maxResolution) {
+      url.searchParams.set('max_resolution', maxResolution);
+    }
+    if (minResolution) {
+      url.searchParams.set('min_resolution', minResolution);
+      if (maxResolution && +maxResolution.slice(0, -1) < +minResolution.slice(0, -1)) {
+        console.error(
+          'minResolution must be <= maxResolution',
+          'minResolution',
+          minResolution,
+          'maxResolution',
+          maxResolution
+        );
+      }
+    }
+    if (renditionOrder) {
+      url.searchParams.set('rendition_order', renditionOrder);
+    }
+    if (programStartTime) {
+      url.searchParams.set('program_start_time', `${programStartTime}`);
+    }
+    if (programEndTime) {
+      url.searchParams.set('program_end_time', `${programEndTime}`);
+    }
+    if (assetStartTime) {
+      url.searchParams.set('asset_start_time', `${assetStartTime}`);
+    }
+    if (assetEndTime) {
+      url.searchParams.set('asset_end_time', `${assetEndTime}`);
+    }
+    Object.entries(extraSourceParams).forEach(([k, v]) => {
+      if (v == null) return;
+      url.searchParams.set(k, `${v}`);
     });
   }
+  return url.toString();
+};
 
-  #generatePlayerInitTime(): number | undefined {
-    if (!this.MuxDataSdk) return undefined;
-    return this.MuxDataSdk.utils.now();
-  }
-}
-
-function toSrc(playbackId: string, customDomain: string): string {
-  return `https://stream.${customDomain}/${playbackId}.m3u8`;
-}
-
-type MuxSrcProps = Pick<MuxMediaDelegate, 'playbackId' | 'src' | 'customDomain'>;
-
-export function toVideoId(props: MuxSrcProps & Pick<MuxMediaDelegate, 'metadata'>): string | undefined {
-  if (props.metadata?.video_id) return props.metadata.video_id;
-  if (!isMuxVideoSrc(props)) return props.src;
-  return toPlaybackIdFromParameterized(props.playbackId) ?? toPlaybackIdFromSrc(props.src) ?? props.src;
-}
-
-function toPlaybackIdFromParameterized(playbackId: MuxMediaDelegate['playbackId']): string | undefined {
-  if (!playbackId) return undefined;
-  const [id] = playbackId.split('?');
-  return id || undefined;
-}
-
-export function toPlaybackIdFromSrc(src: MuxMediaDelegate['src']): string | undefined {
-  if (!src || !src.startsWith('https://stream.')) return undefined;
-  const [playbackId] = new URL(src).pathname.slice(1).split(/\.m3u8|\//);
-  return playbackId || undefined;
-}
-
-export function isMuxVideoSrc({ playbackId, src, customDomain }: MuxSrcProps): boolean {
-  if (playbackId) return true;
-  if (typeof src !== 'string') return false;
-  const base = window?.location.href;
-  const hostname = new URL(src, base).hostname.toLocaleLowerCase();
-
-  return hostname.includes(MUX_VIDEO_DOMAIN) || (!!customDomain && hostname.includes(customDomain.toLocaleLowerCase()));
-}
+export const toPlaybackIdParts = (playbackIdWithOptionalParams: string): [string, string?] => {
+  const qIndex = playbackIdWithOptionalParams.indexOf('?');
+  if (qIndex < 0) return [playbackIdWithOptionalParams];
+  const idPart = playbackIdWithOptionalParams.slice(0, qIndex);
+  const queryPart = playbackIdWithOptionalParams.slice(qIndex);
+  return [idPart, queryPart];
+};
 
 export class MuxVideoDelegate extends MuxMediaDelegate {
   static PLAYER_SOFTWARE_NAME = 'mux-video';

--- a/packages/core/src/dom/media/mux/index.ts
+++ b/packages/core/src/dom/media/mux/index.ts
@@ -182,9 +182,9 @@ export const toMuxVideoURL = ({
    *
    * */
   if (token || url.searchParams.has('token')) {
-    url.searchParams.forEach((_, key) => {
+    for (const key of Array.from(url.searchParams.keys())) {
       if (key !== 'token') url.searchParams.delete(key);
-    });
+    }
     if (token) url.searchParams.set('token', token);
   } else {
     if (maxResolution) {
@@ -205,16 +205,16 @@ export const toMuxVideoURL = ({
     if (renditionOrder) {
       url.searchParams.set('rendition_order', renditionOrder);
     }
-    if (programStartTime) {
+    if (programStartTime != null) {
       url.searchParams.set('program_start_time', `${programStartTime}`);
     }
-    if (programEndTime) {
+    if (programEndTime != null) {
       url.searchParams.set('program_end_time', `${programEndTime}`);
     }
-    if (assetStartTime) {
+    if (assetStartTime != null) {
       url.searchParams.set('asset_start_time', `${assetStartTime}`);
     }
-    if (assetEndTime) {
+    if (assetEndTime != null) {
       url.searchParams.set('asset_end_time', `${assetEndTime}`);
     }
     Object.entries(extraSourceParams).forEach(([k, v]) => {

--- a/packages/core/src/dom/media/mux/mux-data.ts
+++ b/packages/core/src/dom/media/mux/mux-data.ts
@@ -1,0 +1,205 @@
+import type { Constructor } from '@videojs/utils/types';
+import Mux from 'mux-embed';
+
+import { Hls, type HlsMediaDelegate } from '../hls';
+import { getPlayerVersion } from './env';
+import type { MuxDataOptions, MuxDataSdk } from './types';
+
+export interface MuxDataMediaHost {
+  readonly target: HTMLMediaElement | null;
+  readonly debug: boolean;
+  readonly engine: HlsMediaDelegate['engine'];
+  attach(target: HTMLMediaElement): void;
+  detach(): void;
+  load(): void;
+}
+
+export function MuxDataMediaMixin<Base extends Constructor<MuxDataMediaHost>>(BaseClass: Base) {
+  class MuxDataMedia extends BaseClass {
+    #MuxDataSdk: MuxDataSdk | undefined = Mux;
+    #MuxDataSdkInitializedBefore: boolean = false;
+    #beaconCollectionDomain: MuxDataOptions['beaconCollectionDomain'] | undefined;
+    #disableCookies: MuxDataOptions['disableCookies'] = false;
+    #metadata: MuxDataOptions['data'] | undefined;
+    #envKey: string | undefined;
+    #playerSoftwareName: string | undefined = (this.constructor as { PLAYER_SOFTWARE_NAME?: string })
+      .PLAYER_SOFTWARE_NAME;
+    #playerSoftwareVersion: string | undefined = getPlayerVersion();
+    #playerInitTime: number | undefined = this.#generatePlayerInitTime();
+
+    get MuxDataSdk() {
+      return this.#MuxDataSdk;
+    }
+
+    set MuxDataSdk(value) {
+      this.#MuxDataSdk = value;
+    }
+
+    get beaconCollectionDomain(): string | undefined {
+      return this.#beaconCollectionDomain;
+    }
+
+    set beaconCollectionDomain(value: string | undefined) {
+      this.#beaconCollectionDomain = value;
+    }
+
+    get disableCookies(): MuxDataOptions['disableCookies'] {
+      return this.#disableCookies;
+    }
+
+    set disableCookies(value: MuxDataOptions['disableCookies']) {
+      this.#disableCookies = value;
+    }
+
+    get envKey(): string | undefined {
+      return this.#envKey;
+    }
+
+    set envKey(value: string | undefined) {
+      this.#envKey = value;
+    }
+
+    get playerSoftwareName(): string | undefined {
+      return this.#playerSoftwareName;
+    }
+
+    set playerSoftwareName(value: string | undefined) {
+      this.#playerSoftwareName = value;
+    }
+
+    get playerSoftwareVersion(): string | undefined {
+      return this.#playerSoftwareVersion;
+    }
+
+    set playerSoftwareVersion(value: string | undefined) {
+      this.#playerSoftwareVersion = value;
+    }
+
+    get playerInitTime(): number | undefined {
+      return this.#playerInitTime;
+    }
+
+    set playerInitTime(value: number | undefined) {
+      this.#playerInitTime = value;
+    }
+
+    get metadata(): MuxDataOptions['data'] | undefined {
+      return this.#metadata;
+    }
+
+    set metadata(value: MuxDataOptions['data'] | undefined) {
+      this.#metadata = value;
+    }
+
+    attach(target: HTMLMediaElement): void {
+      super.attach(target);
+
+      // Only initialize Mux Data SDK if it was already initialized before in attach;
+      // the first initializeMuxDataSdk call should be done in the deferred load hook
+      // so all the properties are set before the Mux Data SDK is initialized.
+      if (this.#MuxDataSdkInitializedBefore) {
+        this.#initializeMuxDataSdk();
+      }
+    }
+
+    detach(): void {
+      if (this.target?.mux) {
+        this.target.mux.destroy();
+        delete this.target.mux;
+      }
+      super.detach();
+    }
+
+    load(): void {
+      super.load();
+      this.#initializeMuxDataSdk();
+    }
+
+    #initializeMuxDataSdk(): void {
+      const target = this.target as HTMLMediaElement;
+
+      if (!this.MuxDataSdk || !target || (target.mux && !target.mux.deleted)) return;
+
+      this.#MuxDataSdkInitializedBefore = true;
+
+      const {
+        debug,
+        beaconCollectionDomain,
+        disableCookies,
+        engine: hlsjs,
+        envKey: env_key,
+        playerSoftwareName: player_software_name,
+        playerSoftwareVersion: player_software_version,
+        playerInitTime: player_init_time,
+        metadata = {},
+      } = this;
+
+      const { view_session_id = this.MuxDataSdk?.utils.generateUUID() } = metadata;
+      const video_id = toVideoId(this as unknown as MuxVideoIdProps);
+      metadata.view_session_id = view_session_id;
+      if (video_id) metadata.video_id = video_id;
+
+      this.MuxDataSdk?.monitor(target, {
+        debug,
+        ...(beaconCollectionDomain ? { beaconCollectionDomain } : {}),
+        ...(disableCookies ? { disableCookies } : {}),
+        ...(hlsjs ? { hlsjs } : {}),
+        Hls,
+        data: {
+          ...(env_key ? { env_key } : {}),
+          ...(player_software_name ? { player_software_name } : {}),
+          // NOTE: Adding this because there appears to be some instability on whether
+          // player_software_name or player_software "wins" for Mux Data (CJP)
+          ...(player_software_name ? { player_software: player_software_name } : {}),
+          ...(player_software_version ? { player_software_version } : {}),
+          ...(player_init_time ? { player_init_time } : {}),
+          // Use any metadata passed in programmatically (which may override the defaults above)
+          ...metadata,
+        },
+      });
+    }
+
+    #generatePlayerInitTime(): number | undefined {
+      if (!this.MuxDataSdk) return undefined;
+      return this.MuxDataSdk.utils.now();
+    }
+  }
+
+  return MuxDataMedia as unknown as Base;
+}
+
+const MUX_VIDEO_DOMAIN = 'mux.com';
+
+export type MuxVideoIdProps = {
+  playbackId: string | null;
+  src: string;
+  customDomain: string;
+  metadata?: Record<string, any>;
+};
+
+export function toVideoId(props: MuxVideoIdProps): string | undefined {
+  if (props.metadata?.video_id) return props.metadata.video_id;
+  if (!isMuxVideoSrc(props)) return props.src;
+  return toPlaybackIdFromParameterized(props.playbackId) ?? toPlaybackIdFromSrc(props.src) ?? props.src;
+}
+
+function toPlaybackIdFromParameterized(playbackId: string | null): string | undefined {
+  if (!playbackId) return undefined;
+  const [id] = playbackId.split('?');
+  return id || undefined;
+}
+
+export function toPlaybackIdFromSrc(src: string): string | undefined {
+  if (!src || !src.startsWith('https://stream.')) return undefined;
+  const [playbackId] = new URL(src).pathname.slice(1).split(/\.m3u8|\//);
+  return playbackId || undefined;
+}
+
+export function isMuxVideoSrc({ playbackId, src, customDomain }: MuxVideoIdProps): boolean {
+  if (playbackId) return true;
+  if (typeof src !== 'string') return false;
+  const base = window?.location.href;
+  const hostname = new URL(src, base).hostname.toLocaleLowerCase();
+
+  return hostname.includes(MUX_VIDEO_DOMAIN) || (!!customDomain && hostname.includes(customDomain.toLocaleLowerCase()));
+}

--- a/packages/core/src/dom/media/mux/mux-data.ts
+++ b/packages/core/src/dom/media/mux/mux-data.ts
@@ -5,6 +5,8 @@ import { Hls, type HlsMediaDelegate } from '../hls';
 import { getPlayerVersion } from './env';
 import type { MuxDataOptions, MuxDataSdk } from './types';
 
+const MUX_VIDEO_DOMAIN = 'mux.com';
+
 export interface MuxDataMediaHost {
   readonly target: HTMLMediaElement | null;
   readonly debug: boolean;
@@ -167,8 +169,6 @@ export function MuxDataMediaMixin<Base extends Constructor<MuxDataMediaHost>>(Ba
 
   return MuxDataMedia as unknown as Base;
 }
-
-const MUX_VIDEO_DOMAIN = 'mux.com';
 
 export type MuxVideoIdProps = {
   playbackId: string | null;

--- a/packages/core/src/dom/media/mux/tests/index.test.ts
+++ b/packages/core/src/dom/media/mux/tests/index.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { MuxMediaDelegate } from '..';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MuxMediaDelegate, toMuxVideoURL } from '..';
+import { MaxResolution, MinResolution, RenditionOrder } from '../types';
 
 describe('MuxMediaDelegate', () => {
   it('defaults playbackId to null', () => {
@@ -72,5 +73,141 @@ describe('MuxMediaDelegate', () => {
     delegate.customDomain = 'custom.tv';
 
     expect(delegate.src).toBe('');
+  });
+});
+
+describe('toMuxVideoURL', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when playbackId is missing', () => {
+    expect(toMuxVideoURL()).toBeUndefined();
+    expect(toMuxVideoURL({})).toBeUndefined();
+  });
+
+  it('returns undefined when playbackId is null', () => {
+    expect(toMuxVideoURL({ playbackId: null })).toBeUndefined();
+  });
+
+  it('returns undefined when playbackId is an empty string', () => {
+    expect(toMuxVideoURL({ playbackId: '' })).toBeUndefined();
+  });
+
+  it('uses customDomain in the hostname', () => {
+    const url = toMuxVideoURL({
+      playbackId: 'abc123',
+      customDomain: 'example.com',
+    });
+    expect(url).toBe('https://stream.example.com/abc123.m3u8');
+  });
+
+  it('preserves query string from playbackId in public (non-token) mode', () => {
+    const href = toMuxVideoURL({
+      playbackId: 'abc123?foo=bar',
+    });
+    const parsed = new URL(href!);
+    expect(parsed.hostname).toBe('stream.mux.com');
+    expect(parsed.pathname).toBe('/abc123.m3u8');
+    expect(parsed.searchParams.get('foo')).toBe('bar');
+  });
+
+  it('accepts tokens.playback as an alias for playbackToken', () => {
+    const url = toMuxVideoURL({
+      playbackId: 'abc123?noise=1',
+      tokens: { playback: 'from-tokens' },
+    });
+    expect(url).toBe('https://stream.mux.com/abc123.m3u8?token=from-tokens');
+  });
+
+  it('keeps only token from the URL when token is present in the playback id and no override is passed', () => {
+    const url = toMuxVideoURL({
+      playbackId: 'abc123?token=embedded&other=strip',
+    });
+    expect(url).toBe('https://stream.mux.com/abc123.m3u8?token=embedded');
+  });
+
+  it('removes every non-token query param when a playback token is set (no iterator skip)', () => {
+    const url = toMuxVideoURL({
+      playbackId: 'abc123?a=1&b=2&c=3&d=4',
+      playbackToken: 'signed-token',
+    });
+    expect(url).toBe('https://stream.mux.com/abc123.m3u8?token=signed-token');
+  });
+
+  it('does not add public-only params when a playback token is set', () => {
+    const href = toMuxVideoURL({
+      playbackId: 'abc123',
+      playbackToken: 'tok',
+      maxResolution: MaxResolution.upTo720p,
+      programStartTime: 10,
+      extraSourceParams: { custom: 'x' },
+    });
+    const parsed = new URL(href!);
+    expect(parsed.searchParams.get('token')).toBe('tok');
+    expect(parsed.searchParams.has('max_resolution')).toBe(false);
+    expect(parsed.searchParams.has('program_start_time')).toBe(false);
+    expect(parsed.searchParams.has('custom')).toBe(false);
+  });
+
+  it('sets max_resolution, min_resolution, and rendition_order in public mode', () => {
+    const href = toMuxVideoURL({
+      playbackId: 'abc123',
+      maxResolution: MaxResolution.upTo1080p,
+      minResolution: MinResolution.noLessThan720p,
+      renditionOrder: RenditionOrder.DESCENDING,
+    });
+    const parsed = new URL(href!);
+    expect(parsed.searchParams.get('max_resolution')).toBe('1080p');
+    expect(parsed.searchParams.get('min_resolution')).toBe('720p');
+    expect(parsed.searchParams.get('rendition_order')).toBe('desc');
+  });
+
+  it('includes program_start_time when the value is 0', () => {
+    const url = toMuxVideoURL({
+      playbackId: 'abc123',
+      programStartTime: 0,
+    });
+    expect(url).toBe('https://stream.mux.com/abc123.m3u8?program_start_time=0');
+  });
+
+  it('includes program_end_time, asset_start_time, and asset_end_time when the value is 0', () => {
+    const href = toMuxVideoURL({
+      playbackId: 'abc123',
+      programEndTime: 0,
+      assetStartTime: 0,
+      assetEndTime: 0,
+    });
+    const parsed = new URL(href!);
+    expect(parsed.searchParams.get('program_end_time')).toBe('0');
+    expect(parsed.searchParams.get('asset_start_time')).toBe('0');
+    expect(parsed.searchParams.get('asset_end_time')).toBe('0');
+  });
+
+  it('merges extraSourceParams and skips nullish values', () => {
+    const href = toMuxVideoURL({
+      playbackId: 'abc123',
+      extraSourceParams: {
+        kept: '1',
+        omitted: null,
+        alsoOmitted: undefined,
+        flag: true,
+      },
+    });
+    const parsed = new URL(href!);
+    expect(parsed.searchParams.get('kept')).toBe('1');
+    expect(parsed.searchParams.get('flag')).toBe('true');
+    expect(parsed.searchParams.has('omitted')).toBe(false);
+    expect(parsed.searchParams.has('alsoOmitted')).toBe(false);
+  });
+
+  it('logs when minResolution is greater than maxResolution', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    toMuxVideoURL({
+      playbackId: 'abc123',
+      maxResolution: MaxResolution.upTo720p,
+      minResolution: MinResolution.noLessThan1080p,
+    });
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/dom/media/mux/types.ts
+++ b/packages/core/src/dom/media/mux/types.ts
@@ -1,2 +1,43 @@
 /// <reference path="../../../../node_modules/mux-embed/dist/types/mux-embed.d.ts" preserve="true" />
-export type { Mux as MuxDataSdk } from 'mux-embed';
+export type { Mux as MuxDataSdk, Options as MuxDataOptions } from 'mux-embed';
+
+export type ValueOf<T> = T[keyof T];
+
+export const MaxResolution = {
+  upTo720p: '720p',
+  upTo1080p: '1080p',
+  upTo1440p: '1440p',
+  upTo2160p: '2160p',
+} as const;
+
+export const MinResolution = {
+  noLessThan480p: '480p',
+  noLessThan540p: '540p',
+  noLessThan720p: '720p',
+  noLessThan1080p: '1080p',
+  noLessThan1440p: '1440p',
+  noLessThan2160p: '2160p',
+} as const;
+
+export const RenditionOrder = {
+  DESCENDING: 'desc',
+} as const;
+
+export const MaxAutoResolution = {
+  upTo720p: '720p',
+  upTo1080p: '1080p',
+  upTo1440p: '1440p',
+  upTo2160p: '2160p',
+} as const;
+
+export type MaxResolutionValue = ValueOf<typeof MaxResolution>;
+export type MinResolutionValue = ValueOf<typeof MinResolution>;
+export type RenditionOrderValue = ValueOf<typeof RenditionOrder>;
+export type MaxAutoResolutionValue = ValueOf<typeof MaxAutoResolution>;
+
+export type Tokens = {
+  playback?: string;
+  drm?: string;
+  thumbnail?: string;
+  storyboard?: string;
+};


### PR DESCRIPTION
## Summary

Mux media delegates now build stream URLs with the same query parameters supported for public playback IDs (resolution bounds, rendition order, program/asset time windows, tokens, and extra params). Mux Data monitoring moves into a dedicated mixin so URL construction and analytics stay separate.

## Changes

- `toMuxVideoURL` / `toPlaybackIdParts` for parameterized playback IDs and signed-vs-public token behavior
- Delegate properties mirror those inputs and refresh `src` when they change
- `MuxDataMediaMixin` holds mux-embed integration; metadata typing aligns with `mux-embed` options
- Shared resolution / rendition / token types and constants in `types.ts`

## Testing

`pnpm -F @videojs/core build` and `pnpm typecheck` run locally before commit.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Mux `src` URLs are constructed (query-param and token handling), which can directly affect playback and signed URL behavior; analytics wiring is refactored into a mixin but should be functionally equivalent.
> 
> **Overview**
> Mux delegates now build stream `src` via `toMuxVideoURL`, supporting additional Mux playback query params (resolution bounds, rendition order, program/asset time windows) plus `extraSourceParams`, and normalizing `playbackId` values that already include a query string.
> 
> Signed playback behavior is made explicit: when a `token` is present (from `playbackToken`, `tokens.playback`, or the incoming URL), *all non-token params are stripped* and only `token` is retained/overridden.
> 
> Mux Data monitoring (`mux-embed`) setup is moved out of `MuxMediaDelegate` into a new `MuxDataMediaMixin`, and shared enums/types for resolution, rendition order, and `Tokens` are added; tests are expanded to cover the new URL construction rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1e461ddbe15871a232fe67801cc1a4cabd6e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->