### PR TITLE
feat(packages): add hold-to-speed-boost hotkey action

### DIFF
--- a/packages/core/src/dom/hotkey/actions.ts
+++ b/packages/core/src/dom/hotkey/actions.ts
@@ -19,6 +19,7 @@ export type HotkeyActionName =
   | 'togglePiP'
   | 'seekStep'
   | 'volumeStep'
+  | 'speedBoost'
   | 'speedUp'
   | 'speedDown'
   | 'seekToPercent';
@@ -30,7 +31,7 @@ export interface HotkeyActionContext {
   key: string;
 }
 
-export type HotkeyActionResolver = (context: HotkeyActionContext) => void;
+export type HotkeyActionResolver = (context: HotkeyActionContext) => void | (() => void);
 
 export function isHotkeyToggleAction(action: string): boolean {
   return action.startsWith('toggle');
@@ -75,6 +76,14 @@ const HOTKEY_ACTIONS: Record<HotkeyActionName, HotkeyActionResolver> = {
     const vol = selectVolume(store.state);
     if (!vol) return;
     vol.setVolume(vol.volume + value);
+  },
+
+  speedBoost({ store, value }) {
+    const rate = selectPlaybackRate(store.state);
+    if (!rate) return;
+    const previousRate = rate.playbackRate;
+    rate.setPlaybackRate(value ?? 2);
+    return () => rate.setPlaybackRate(previousRate);
   },
 
   speedUp({ store }) {

--- a/packages/core/src/dom/hotkey/coordinator.ts
+++ b/packages/core/src/dom/hotkey/coordinator.ts
@@ -25,6 +25,12 @@ interface HotkeyBinding {
   id: number;
 }
 
+interface ActiveHold {
+  key: string;
+  cleanup: () => void;
+  repeated: boolean;
+}
+
 export class HotkeyCoordinator {
   #target: HTMLElement;
   #bindings: HotkeyBinding[] = [];
@@ -33,6 +39,7 @@ export class HotkeyCoordinator {
   #docDisconnect: AbortController | null = null;
   /** Action name → bound keys. Controls query this to set `aria-keyshortcuts`. */
   #ariaRegistry = new Map<string, ParsedHotkeyBinding[]>();
+  #activeHold: ActiveHold | null = null;
   #destroyed = false;
 
   constructor(target: HTMLElement) {
@@ -82,6 +89,8 @@ export class HotkeyCoordinator {
   destroy(): void {
     if (this.#destroyed) return;
     this.#destroyed = true;
+    this.#activeHold?.cleanup();
+    this.#activeHold = null;
     this.#disconnect?.abort();
     this.#disconnect = null;
     this.#docDisconnect?.abort();
@@ -97,6 +106,10 @@ export class HotkeyCoordinator {
       // Higher specificity (more modifiers) first.
       const specDiff = b.parsed[0]!.modifiers.size - a.parsed[0]!.modifiers.size;
       if (specDiff !== 0) return specDiff;
+      // Repeatable before non-repeatable (hold bindings take priority).
+      const aRepeatable = a.options.repeatable !== false ? 1 : 0;
+      const bRepeatable = b.options.repeatable !== false ? 1 : 0;
+      if (bRepeatable !== aRepeatable) return bRepeatable - aRepeatable;
       // Then registration order.
       return a.id - b.id;
     });
@@ -105,13 +118,17 @@ export class HotkeyCoordinator {
   #connect(): void {
     if (this.#disconnect) return;
     this.#disconnect = new AbortController();
-    listen(this.#target, 'keydown', this.#handleEvent, { signal: this.#disconnect.signal });
+    const signal = this.#disconnect.signal;
+    listen(this.#target, 'keydown', this.#handleKeyDown, { signal });
+    listen(this.#target, 'keyup', this.#handleKeyUp, { signal });
   }
 
   #connectDocument(): void {
     if (this.#docDisconnect) return;
     this.#docDisconnect = new AbortController();
-    listen(document, 'keydown', this.#handleEvent, { signal: this.#docDisconnect.signal });
+    const signal = this.#docDisconnect.signal;
+    listen(document, 'keydown', this.#handleKeyDown, { signal });
+    listen(document, 'keyup', this.#handleKeyUp, { signal });
   }
 
   #maybeDisconnect(): void {
@@ -129,12 +146,16 @@ export class HotkeyCoordinator {
     }
   }
 
-  #handleEvent = (event: KeyboardEvent): void => {
-    // IME composition filtering.
+  #handleKeyDown = (event: KeyboardEvent): void => {
     if (event.key === 'Unidentified') return;
-
-    // Let interactive elements handle their own activation keys.
     if (isInteractiveActivation(event)) return;
+
+    // If a hold is active and this is a repeat of the same key, just prevent default.
+    if (this.#activeHold && event.repeat && event.key.toLowerCase() === this.#activeHold.key) {
+      this.#activeHold.repeated = true;
+      event.preventDefault();
+      return;
+    }
 
     const editable = isEditableTarget(event);
 
@@ -144,23 +165,61 @@ export class HotkeyCoordinator {
       if (options.disabled) continue;
       if (event.repeat && options.repeatable === false) continue;
 
-      // Only consider bindings matching the event's target scope.
       const isDocBinding = options.target === 'document';
       const isDocEvent = event.currentTarget === document;
       if (isDocBinding !== isDocEvent) continue;
 
       for (const p of parsed) {
         if (!matchesHotkeyEvent(p, event)) continue;
-
-        // Input safety: single-key shortcuts suppressed in editable fields.
         if (editable && p.modifiers.size === 0) continue;
 
         event.preventDefault();
-        options.onActivate(event, p.originalKey);
+        const cleanup = options.onActivate(event, p.originalKey);
+
+        // If onActivate returned a cleanup, this is a hold action.
+        if (typeof cleanup === 'function') {
+          this.#activeHold = { key: p.key, cleanup, repeated: false };
+        }
+
         return;
       }
     }
   };
+
+  #handleKeyUp = (event: KeyboardEvent): void => {
+    const hold = this.#activeHold;
+    if (!hold || event.key.toLowerCase() !== hold.key) return;
+
+    hold.cleanup();
+
+    // Tap (no repeat) → dispatch deferred non-repeatable bindings.
+    if (!hold.repeated) {
+      this.#dispatchDeferred(event);
+    }
+
+    this.#activeHold = null;
+  };
+
+  /** Dispatch the first matching non-repeatable binding (e.g. togglePaused on tap). */
+  #dispatchDeferred(event: KeyboardEvent): void {
+    const editable = isEditableTarget(event);
+
+    for (const binding of this.#bindings) {
+      const { options, parsed } = binding;
+      if (options.disabled || options.repeatable !== false) continue;
+
+      const isDocBinding = options.target === 'document';
+      const isDocEvent = event.currentTarget === document;
+      if (isDocBinding !== isDocEvent) continue;
+
+      for (const p of parsed) {
+        if (!matchesHotkeyEvent(p, event)) continue;
+        if (editable && p.modifiers.size === 0) continue;
+        options.onActivate(event, p.originalKey);
+        return;
+      }
+    }
+  }
 
   #addToAriaRegistry(action: string, bindings: ParsedHotkeyBinding[]): void {
     let existing = this.#ariaRegistry.get(action);

--- a/packages/core/src/dom/hotkey/hotkey.ts
+++ b/packages/core/src/dom/hotkey/hotkey.ts
@@ -14,7 +14,7 @@ export interface ParsedHotkeyBinding {
 
 export interface HotkeyOptions {
   keys: string;
-  onActivate: (event: KeyboardEvent, key: string) => void;
+  onActivate: (event: KeyboardEvent, key: string) => void | (() => void);
   /** Where to listen — `'player'` (container) or `'document'`. */
   target?: 'player' | 'document' | undefined;
   /** Whether `event.repeat` should fire the callback. */

--- a/packages/core/src/dom/hotkey/tests/actions.test.ts
+++ b/packages/core/src/dom/hotkey/tests/actions.test.ts
@@ -175,6 +175,30 @@ describe('volumeStep', () => {
   });
 });
 
+describe('speedBoost', () => {
+  it('sets rate to value and returns cleanup to restore', () => {
+    const setPlaybackRate = vi.fn();
+    const store = mockStore({ playbackRates: [1, 1.5, 2], playbackRate: 1, setPlaybackRate });
+
+    const cleanup = resolveHotkeyAction('speedBoost')!({ store, value: 2, key: '' });
+
+    expect(setPlaybackRate).toHaveBeenCalledWith(2);
+    expect(cleanup).toBeTypeOf('function');
+
+    (cleanup as () => void)();
+    expect(setPlaybackRate).toHaveBeenCalledWith(1);
+  });
+
+  it('defaults to 2x when no value provided', () => {
+    const setPlaybackRate = vi.fn();
+    const store = mockStore({ playbackRates: [1, 1.5, 2], playbackRate: 1, setPlaybackRate });
+
+    resolveHotkeyAction('speedBoost')!({ store, key: '' });
+
+    expect(setPlaybackRate).toHaveBeenCalledWith(2);
+  });
+});
+
 describe('speedUp', () => {
   it('steps to next rate', () => {
     const setPlaybackRate = vi.fn();

--- a/packages/core/src/dom/hotkey/tests/coordinator.test.ts
+++ b/packages/core/src/dom/hotkey/tests/coordinator.test.ts
@@ -8,6 +8,12 @@ function keydown(target: EventTarget, key: string, mods?: Partial<KeyboardEventI
   return event;
 }
 
+function keyup(target: EventTarget, key: string, mods?: Partial<KeyboardEventInit>): KeyboardEvent {
+  const event = new KeyboardEvent('keyup', { key, bubbles: true, cancelable: true, ...mods });
+  target.dispatchEvent(event);
+  return event;
+}
+
 describe('HotkeyCoordinator', () => {
   let container: HTMLElement;
   let coordinator: HotkeyCoordinator;
@@ -353,6 +359,71 @@ describe('HotkeyCoordinator', () => {
       remove();
 
       expect(c.getAriaKeys('togglePaused')).toBeUndefined();
+    });
+  });
+
+  describe('hold (speed boost)', () => {
+    it('calls cleanup on keyup when onActivate returns a function', () => {
+      const c = setup();
+      const cleanup = vi.fn();
+      c.add({ keys: 'k', onActivate: () => cleanup });
+
+      keydown(container, 'k');
+      expect(cleanup).not.toHaveBeenCalled();
+
+      keyup(container, 'k');
+      expect(cleanup).toHaveBeenCalledOnce();
+    });
+
+    it('defers non-repeatable sibling to keyup on tap (no repeat)', () => {
+      const c = setup();
+      const toggle = vi.fn();
+      const cleanup = vi.fn();
+
+      c.add({ keys: 'Space', onActivate: toggle, repeatable: false });
+      c.add({ keys: 'Space', onActivate: () => cleanup });
+
+      // First keydown — hold action fires, toggle deferred.
+      keydown(container, ' ');
+      expect(toggle).not.toHaveBeenCalled();
+
+      // Keyup with no repeat — tap. Deferred toggle fires.
+      keyup(container, ' ');
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(toggle).toHaveBeenCalledOnce();
+    });
+
+    it('skips deferred on keyup after repeat (hold)', () => {
+      const c = setup();
+      const toggle = vi.fn();
+      const cleanup = vi.fn();
+
+      c.add({ keys: 'Space', onActivate: toggle, repeatable: false });
+      c.add({ keys: 'Space', onActivate: () => cleanup });
+
+      // First keydown — hold starts.
+      keydown(container, ' ');
+
+      // Repeat keydowns — holding.
+      keydown(container, ' ', { repeat: true });
+      keydown(container, ' ', { repeat: true });
+
+      // Keyup after repeat — cleanup fires, toggle does NOT.
+      keyup(container, ' ');
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(toggle).not.toHaveBeenCalled();
+    });
+
+    it('does not track hold when onActivate returns void', () => {
+      const c = setup();
+      const onActivate = vi.fn();
+      c.add({ keys: 'k', onActivate });
+
+      keydown(container, 'k');
+      keyup(container, 'k');
+
+      // No hold behavior — just fires normally.
+      expect(onActivate).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -110,6 +110,7 @@ function getTemplateHTML() {
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
       <media-hotkey keys="Shift+>" action="speedUp"></media-hotkey>
       <media-hotkey keys="Shift+<" action="speedDown"></media-hotkey>
+      <media-hotkey keys="Space" action="speedBoost" value="2"></media-hotkey>
     </media-container>
   `;
 }

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -149,6 +149,7 @@ function getTemplateHTML() {
       <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
       <media-hotkey keys="Shift+>" action="speedUp"></media-hotkey>
       <media-hotkey keys="Shift+<" action="speedDown"></media-hotkey>
+      <media-hotkey keys="Space" action="speedBoost" value="2"></media-hotkey>
     </media-container>
   `;
 }

--- a/packages/html/src/ui/hotkey/hotkey-element.ts
+++ b/packages/html/src/ui/hotkey/hotkey-element.ts
@@ -68,9 +68,7 @@ export class HotkeyElement extends MediaElement {
       target: this.target,
       disabled: this.disabled,
       repeatable: !isHotkeyToggleAction(action),
-      onActivate: (_event, key) => {
-        resolver({ store, key, value });
-      },
+      onActivate: (_event, key) => resolver({ store, key, value }),
     });
   }
 

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -172,6 +172,7 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
       <MediaHotkey keys="End" action="seekToPercent" value={100} />
       <MediaHotkey keys="Shift+>" action="speedUp" />
       <MediaHotkey keys="Shift+<" action="speedDown" />
+      <MediaHotkey keys="Space" action="speedBoost" value={2} />
     </Container>
   );
 }

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -249,6 +249,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <MediaHotkey keys="End" action="seekToPercent" value={100} />
       <MediaHotkey keys="Shift+>" action="speedUp" />
       <MediaHotkey keys="Shift+<" action="speedDown" />
+      <MediaHotkey keys="Space" action="speedBoost" value={2} />
     </Container>
   );
 }

--- a/packages/react/src/ui/hotkey/media-hotkey.tsx
+++ b/packages/react/src/ui/hotkey/media-hotkey.tsx
@@ -36,9 +36,7 @@ export function MediaHotkey({ keys, action, value, disabled, target }: MediaHotk
       target,
       disabled,
       repeatable: !isHotkeyToggleAction(action),
-      onActivate: (_event, key) => {
-        resolver({ store, key, value });
-      },
+      onActivate: (_event, key) => resolver({ store, key, value }),
     });
   }, [container, store, keys, action, value, disabled, target]);
 


### PR DESCRIPTION
## Summary

Add a `speedBoost` hotkey action that temporarily increases playback rate while a key is held, then restores the original rate on release. Bound to Space by default in all preset skins, it shares the key with `togglePaused`—a tap toggles pause while a hold activates the speed boost.

## Changes

- New `speedBoost` action that sets playback rate (default 2x) and returns a cleanup function to restore the previous rate
- `HotkeyCoordinator` now supports hold semantics: when `onActivate` returns a cleanup function, the coordinator tracks the hold and calls cleanup on `keyup`
- Non-repeatable sibling bindings on the same key (e.g. `togglePaused`) are deferred on hold and only fire on tap (keyup without repeat)
- Binding sort order updated so repeatable bindings take priority over non-repeatable ones on the same key
- Space bound to `speedBoost` in all HTML and React preset skins

<details>
<summary>Implementation details</summary>

The coordinator introduces an `ActiveHold` state that tracks the held key, cleanup callback, deferred sibling, and whether a repeat occurred. On keydown, if `onActivate` returns a function, it enters hold mode and finds a deferred non-repeatable sibling. On keyup, it runs cleanup and conditionally fires the deferred binding based on whether any repeat events occurred (tap vs hold).

</details>

## Testing

```bash
pnpm -F @videojs/core test src/dom/hotkey
```

New tests in `actions.test.ts` cover `speedBoost` action behavior. New tests in `coordinator.test.ts` cover hold lifecycle, deferred binding on tap, skipping deferred on hold, and void-returning onActivate.