### PR TITLE
fix(site): add pointer-events-none to hero heading

### DIFF
--- a/site/src/components/home/Header.astro
+++ b/site/src/components/home/Header.astro
@@ -28,7 +28,7 @@ const poster = `${VJS10_DEMO_VIDEO.poster}?time=${posterTime}`;
     style={{ gridArea: "pill" }}
   />
   <h1
-    class="z-10 mb-5 w-full self-center justify-self-center text-center font-display text-h2 text-balance uppercase [grid-area:var(--grid-area)] md:mb-0 md:px-5 md:text-h15 md:text-manila-light md:[grid-area:var(--md-grid-area)] lg:text-h1"
+    class="pointer-events-none z-10 mb-5 w-full self-center justify-self-center text-center font-display text-h2 text-balance uppercase [grid-area:var(--grid-area)] md:mb-0 md:px-5 md:text-h15 md:text-manila-light md:[grid-area:var(--md-grid-area)] lg:text-h1"
     style="--grid-area: title; --md-grid-area: video;"
   >
     The Open Source Player <br class="lg:hidden" /><span


### PR DESCRIPTION
## Summary

The hero `<h1>` heading overlays the video player area on medium+ breakpoints (via `grid-area: video`). Without `pointer-events-none`, the heading intercepts clicks and hover events meant for the video beneath it, making the player difficult to interact with. Adding `pointer-events-none` lets those events pass through to the video.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single CSS utility change to the home page hero heading; main risk is minor UX impact if the heading needed to be selectable/clickable.
> 
> **Overview**
> The home page hero `h1` now includes `pointer-events-none` so it no longer captures hover/click events when it overlays the hero video at larger breakpoints, improving video player interactivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1080b6967530f45c7b042e1d30d9f75e018aa517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->