### PR TITLE
fix(html): export SliderPreviewElement and ContextPartElement

### DIFF
--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -23,6 +23,7 @@ export { AlertDialogTitleElement } from './ui/alert-dialog/alert-dialog-title-el
 export { type AlertDialogContextValue, alertDialogContext } from './ui/alert-dialog/context';
 export { BufferingIndicatorElement } from './ui/buffering-indicator/buffering-indicator-element';
 export { CaptionsButtonElement } from './ui/captions-button/captions-button-element';
+export { ContextPartElement, type PartContextValue } from './ui/context-part-element';
 export { ControlsElement } from './ui/controls/controls-element';
 export { ControlsGroupElement } from './ui/controls/controls-group-element';
 export { ErrorDialogElement } from './ui/error-dialog/error-dialog-element';
@@ -45,6 +46,7 @@ export { SliderBufferElement } from './ui/slider/slider-buffer-element';
 export { SliderElement } from './ui/slider/slider-element';
 export type { SliderEventMap, SliderValueEventDetail } from './ui/slider/slider-events';
 export { SliderFillElement } from './ui/slider/slider-fill-element';
+export { SliderPreviewElement } from './ui/slider/slider-preview-element';
 export { SliderThumbElement } from './ui/slider/slider-thumb-element';
 export { SliderThumbnailElement } from './ui/slider/slider-thumbnail-element';
 export { SliderTrackElement } from './ui/slider/slider-track-element';


### PR DESCRIPTION
## Summary
- Export `SliderPreviewElement` from `./ui/slider/slider-preview-element`
- Export `ContextPartElement` and `PartContextValue` type from `./ui/context-part-element`

These were defined, registered via `safeDefine`, and tested, but missing from the main barrel export.

Refs: https://github.com/videojs/v10/issues/926

## Test plan
- [x] `pnpm -F @videojs/html test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds barrel exports with no behavioral/runtime logic changes, aside from potential minor bundling/tree-shaking surface changes.
> 
> **Overview**
> Fixes missing public exports in the `@videojs/html` barrel by adding `ContextPartElement` (and `PartContextValue`) and `SliderPreviewElement` to `packages/html/src/index.ts`.
> 
> This makes these already-implemented UI primitives importable from the package root without reaching into internal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bea1418c134a9d1a14050cec6c68d1daaa1508a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->