### PR TITLE
fix(html): add destroy guards to connectedCallback

### DIFF
--- a/packages/html/src/ui/alert-dialog/alert-dialog-element.ts
+++ b/packages/html/src/ui/alert-dialog/alert-dialog-element.ts
@@ -40,6 +40,7 @@ export class AlertDialogElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#dialog = createAlertDialog({
       transition: createTransition(),

--- a/packages/html/src/ui/buffering-indicator/buffering-indicator-element.ts
+++ b/packages/html/src/ui/buffering-indicator/buffering-indicator-element.ts
@@ -22,6 +22,7 @@ export class BufferingIndicatorElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#disconnect = new AbortController();
 

--- a/packages/html/src/ui/error-dialog/error-dialog-element.ts
+++ b/packages/html/src/ui/error-dialog/error-dialog-element.ts
@@ -41,6 +41,7 @@ export class ErrorDialogElement extends MediaElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     this.#dialog = createAlertDialog({
       transition: createTransition(),

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -41,6 +41,7 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
 
   override connectedCallback(): void {
     super.connectedCallback();
+    if (this.destroyed) return;
 
     if (this.hotkeyAction && !this.#hotkeyRegistry) {
       this.#hotkeyRegistry = new AriaKeyShortcutsController(this, this.hotkeyAction);


### PR DESCRIPTION
## Summary
- Add `if (this.destroyed) return` guard to `connectedCallback()` in:
  - `AlertDialogElement`
  - `ErrorDialogElement`
  - `BufferingIndicatorElement`
  - `MediaButtonElement` (abstract base for all 7 button elements)
- Prevents resource leaks if `connectedCallback` runs on an already-destroyed element
- Matches existing pattern in SliderElement, TimeSliderElement, VolumeSliderElement, PopoverElement, ThumbnailElement

Refs: https://github.com/videojs/v10/issues/926

## Test plan
- [x] `pnpm -F @videojs/html test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds early-return guards to prevent initializing controllers/dialogs on already-destroyed custom elements, reducing potential leaks without changing core behavior for normal lifecycles.
> 
> **Overview**
> Adds `if (this.destroyed) return;` guards to `connectedCallback()` in `AlertDialogElement`, `ErrorDialogElement`, `BufferingIndicatorElement`, and the `MediaButtonElement` base class to avoid creating dialogs, subscriptions, and hotkey registries when an element has already been destroyed.
> 
> This aligns these components with existing lifecycle patterns elsewhere and helps prevent resource leaks from late `connectedCallback()` invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936247e0c4cb8b141cfad7b6bda64f276545e7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->