### PR TITLE
fix(utils): stable sort comparator and orphaned JSDoc

### DIFF
--- a/packages/spf/src/core/types/index.ts
+++ b/packages/spf/src/core/types/index.ts
@@ -181,9 +181,6 @@ export type TextTrack = Track & {
 export type PartiallyResolvedTextTrack = PartiallyResolved<TextTrack>;
 
 /**
- * Unresolved text track (alias for backwards compatibility).
-
-/**
  * Union of all resolved track types.
  */
 export type ResolvedTrack = VideoTrack | AudioTrack | TextTrack;
@@ -195,9 +192,6 @@ export type PartiallyResolvedTrack =
   | PartiallyResolvedVideoTrack
   | PartiallyResolvedAudioTrack
   | PartiallyResolvedTextTrack;
-
-/**
- * Union of all unresolved track types (alias for backwards compatibility).
 
 // =============================================================================
 // Switching and Selection Sets

--- a/packages/utils/src/dom/text-track.ts
+++ b/packages/utils/src/dom/text-track.ts
@@ -12,5 +12,5 @@ export function getTextTrackList(media: HTMLMediaElement, filterPred: (textTrack
 }
 
 function sortByTextTrackKind(a: TextTrack, b: TextTrack): number {
-  return a.kind >= b.kind ? 1 : -1;
+  return a.kind > b.kind ? 1 : a.kind < b.kind ? -1 : 0;
 }


### PR DESCRIPTION
## Summary
- Fix `sortByTextTrackKind` comparator to return `0` for equal values, ensuring stable sort
- Remove two orphaned/unclosed JSDoc comment blocks in `@videojs/spf` types

Refs: https://github.com/videojs/v10/issues/926

## Test plan
- [x] `pnpm -F @videojs/utils test` — all tests pass
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a sort comparator (now returns `0` for equal kinds) and comment cleanup in type definitions, with no API or data-flow changes.
> 
> **Overview**
> Improves `getTextTrackList` ordering by updating `sortByTextTrackKind` to return `-1/0/1` (instead of never returning `0`), avoiding unstable results when `TextTrack.kind` values are equal.
> 
> Cleans up `@videojs/spf` type definitions by removing two orphaned/unclosed JSDoc comment blocks around track type aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95be08c2bae07a5767b3b98c9e52d0c0167979f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->