### PR TITLE
fix(packages): narrow react peer dependency to v18+

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,7 +70,7 @@
     "clean": "rimraf --glob dist types '*.tsbuildinfo'"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@videojs/core": "workspace:*",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@videojs/element": "workspace:*",
-    "react": ">=16.8.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@videojs/element": {


### PR DESCRIPTION
## Summary

Narrows the React `peerDependencies` range from `>=16.8.0` to `^18.0.0 || ^19.0.0` in both `@videojs/react` and `@videojs/store`. The codebase uses React 18+ APIs (e.g., `useSyncExternalStore`), so advertising compatibility with React 16/17 is misleading and can cause runtime failures for consumers on older versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change, but it may be a breaking install-time constraint for consumers still on React 16/17.
> 
> **Overview**
> Updates `peerDependencies.react` for `@videojs/react` and `@videojs/store` from `>=16.8.0` to `^18.0.0 || ^19.0.0`, aligning the published compatibility range with React 18+ only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be327d3bf080bcaf40fd2f6a5df07a26228a32c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->