### PR TITLE
fix(site): prevent images from overflowing on narrow viewports

### DIFF
--- a/site/src/components/typography/Img.astro
+++ b/site/src/components/typography/Img.astro
@@ -18,7 +18,6 @@ const isRemote = typeof src === 'string' && src.startsWith('http');
       {...rest}
     />
   ) : (
-    // @ts-expect-error tbh I don't know how to tell ts that inferSize is ok
     <Image
       class={twMerge("my-8 h-auto max-w-full", className)}
       inferSize

--- a/site/src/components/typography/Img.astro
+++ b/site/src/components/typography/Img.astro
@@ -12,9 +12,18 @@ const isRemote = typeof src === 'string' && src.startsWith('http');
 
 {
   isRemote ? (
-    <img class={twMerge("my-8", className)} src={src} {...rest} />
+    <img
+      class={twMerge("my-8 h-auto max-w-full", className)}
+      src={src}
+      {...rest}
+    />
   ) : (
     // @ts-expect-error tbh I don't know how to tell ts that inferSize is ok
-    <Image class={twMerge("my-8", className)} inferSize src={src} {...rest} />
+    <Image
+      class={twMerge("my-8 h-auto max-w-full", className)}
+      inferSize
+      src={src}
+      {...rest}
+    />
   )
 }

--- a/site/src/components/typography/styles.ts
+++ b/site/src/components/typography/styles.ts
@@ -7,7 +7,7 @@
  */
 export const shared = {
   a: 'underline intent:no-underline',
-  code: 'border border-manila-75 bg-manila-25 dark:bg-soot dark:border-warm-gray px-1 rounded font-mono text-code normal-case',
+  code: 'border border-manila-75 bg-manila-25 dark:bg-soot dark:border-warm-gray px-1 rounded font-mono text-code normal-case break-words',
   codeBlock: 'font-mono text-code text-manila-light',
   pre: 'shiki astro-code',
   em: 'italic',

--- a/site/src/content/docs/how-to/build-with-ai.mdx
+++ b/site/src/content/docs/how-to/build-with-ai.mdx
@@ -26,7 +26,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <ContentWidth><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" /></ContentWidth>
+   <ContentWidth class="max-w-md"><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" /></ContentWidth>
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/react/reference/play-button.md`](https://videojs.org/docs/framework/react/reference/play-button.md).
 </FrameworkCase>
 
@@ -37,7 +37,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <ContentWidth><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" /></ContentWidth>
+   <ContentWidth class="max-w-md"><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" /></ContentWidth>
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/html/reference/play-button.md`](https://videojs.org/docs/framework/html/reference/play-button.md).
 </FrameworkCase>
 

--- a/site/src/content/docs/how-to/build-with-ai.mdx
+++ b/site/src/content/docs/how-to/build-with-ai.mdx
@@ -3,6 +3,7 @@ title: 'Build with AI'
 description: 'How to give AI tools the context they need to build Video.js players alongside you'
 ---
 
+import ContentWidth from '@/components/frames/ContentWidth.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 import CopyMarkdownButton from '@/components/CopyMarkdownButton.tsx';
 import Img from '@/components/typography/Img.astro';
@@ -25,7 +26,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" />
+   <ContentWidth><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" /></ContentWidth>
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/react/reference/play-button.md`](https://videojs.org/docs/framework/react/reference/play-button.md).
 </FrameworkCase>
 
@@ -36,7 +37,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" />
+   <ContentWidth><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" /></ContentWidth>
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/html/reference/play-button.md`](https://videojs.org/docs/framework/html/reference/play-button.md).
 </FrameworkCase>
 

--- a/site/src/content/docs/how-to/build-with-ai.mdx
+++ b/site/src/content/docs/how-to/build-with-ai.mdx
@@ -26,7 +26,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <ContentWidth class="max-w-md"><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" /></ContentWidth>
+   <ContentWidth><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="w-full max-w-md" /></ContentWidth>
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/react/reference/play-button.md`](https://videojs.org/docs/framework/react/reference/play-button.md).
 </FrameworkCase>
 
@@ -37,7 +37,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <ContentWidth class="max-w-md"><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" /></ContentWidth>
+   <ContentWidth><Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="w-full max-w-md" /></ContentWidth>
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/html/reference/play-button.md`](https://videojs.org/docs/framework/html/reference/play-button.md).
 </FrameworkCase>
 

--- a/site/src/content/docs/how-to/build-with-ai.mdx
+++ b/site/src/content/docs/how-to/build-with-ai.mdx
@@ -5,6 +5,8 @@ description: 'How to give AI tools the context they need to build Video.js playe
 
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 import CopyMarkdownButton from '@/components/CopyMarkdownButton.tsx';
+import Img from '@/components/typography/Img.astro';
+import markdownNegotiation from '@/assets/docs/how-to/build-with-ai/markdown-negotiation.png';
 
 Video.js publishes all of its documentation in AI-friendly formats. This page covers how to feed that documentation to your tools.
 
@@ -23,7 +25,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   ![Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown](../../../assets/docs/how-to/build-with-ai/markdown-negotiation.png)
+   <Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" />
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/react/reference/play-button.md`](https://videojs.org/docs/framework/react/reference/play-button.md).
 </FrameworkCase>
 
@@ -34,7 +36,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   ![Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown](../../../assets/docs/how-to/build-with-ai/markdown-negotiation.png)
+   <Img src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" class="max-w-md" />
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/html/reference/play-button.md`](https://videojs.org/docs/framework/html/reference/play-button.md).
 </FrameworkCase>
 

--- a/site/src/content/docs/how-to/build-with-ai.mdx
+++ b/site/src/content/docs/how-to/build-with-ai.mdx
@@ -3,10 +3,8 @@ title: 'Build with AI'
 description: 'How to give AI tools the context they need to build Video.js players alongside you'
 ---
 
-import { Image } from 'astro:assets';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 import CopyMarkdownButton from '@/components/CopyMarkdownButton.tsx';
-import markdownNegotiation from '@/assets/docs/how-to/build-with-ai/markdown-negotiation.png';
 
 Video.js publishes all of its documentation in AI-friendly formats. This page covers how to feed that documentation to your tools.
 
@@ -25,7 +23,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <Image src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" inferSize class="max-w-md" />
+   ![Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown](../../../assets/docs/how-to/build-with-ai/markdown-negotiation.png)
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/react/reference/play-button.md`](https://videojs.org/docs/framework/react/reference/play-button.md).
 </FrameworkCase>
 
@@ -36,7 +34,7 @@ Every doc page is available as markdown, so you can provide your model with focu
 
 2. **`Accept: text/markdown` header**: AI tools that send this header when fetching a Video.js doc URL will receive markdown instead of HTML.
 
-   <Image src={markdownNegotiation} alt="Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown" inferSize />
+   ![Fetching a doc URL returns 188.7KB of HTML; fetching the same URL with .md returns 3.4KB of markdown](../../../assets/docs/how-to/build-with-ai/markdown-negotiation.png)
 3. **Add `.md` to any URL**: append `.md` to any doc URL to get its markdown directly. For example, the PlayButton reference is available at [`videojs.org/docs/framework/html/reference/play-button.md`](https://videojs.org/docs/framework/html/reference/play-button.md).
 </FrameworkCase>
 


### PR DESCRIPTION
Closes #1097

## Summary

Images in doc pages could overflow their container on narrow viewports, causing horizontal scrolling. This adds responsive constraints to the shared `Img` typography component and switches `build-with-ai.mdx` to use standard markdown image syntax so images route through that component.

## Changes

- Add `max-w-full` and `h-auto` classes to the `Img.astro` component so all content images are constrained to their parent width
- Replace raw Astro `<Image>` usage in `build-with-ai.mdx` with markdown image syntax, ensuring it flows through the `Img` typography component like all other content images

## Testing

1. `pnpm -F site dev` and navigate to the "Build with AI" page
2. Resize the browser to a narrow viewport — images should scale down instead of overflowing

https://claude.ai/code/session_01WHw6nf9MthPQbw35hiB2TY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: styling-only changes to typography components and one doc page; main risk is minor layout regressions in image sizing/wrapping on some pages.
> 
> **Overview**
> Prevents horizontal scrolling on narrow viewports by making the shared `Img.astro` component render images with `max-w-full` and `h-auto` (for both remote `<img>` and local `astro:assets` `Image`).
> 
> Updates `build-with-ai.mdx` to route its screenshot through the shared `Img` component (wrapped in `ContentWidth`) instead of using `astro:assets` `Image` directly, and tweaks shared inline `code` styles to `break-words` to avoid long-token overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1cc3eb2002d2e7cfda807e17ad7cd5709de2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->