### PR TITLE
feat(html): add `<media-gesture>` element

### DIFF
--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -301,5 +301,5 @@ export interface MediaPictureInPictureState {
    */
   exitPictureInPicture(): Promise<void>;
   /** Toggle picture-in-picture mode. */
-  togglePiP(): Promise<void>;
+  togglePictureInPicture(): Promise<void>;
 }

--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -33,6 +33,8 @@ export interface MediaPlaybackState {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause
    */
   pause(): void;
+  /** Toggle play/pause. Returns `true` if playback started. */
+  togglePaused(): boolean;
 }
 
 /** Indicates whether a feature can be programmatically controlled on this platform. */
@@ -161,6 +163,8 @@ export interface MediaFullscreenState {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/exitFullscreen
    */
   exitFullscreen(): Promise<void>;
+  /** Toggle fullscreen mode. */
+  toggleFullscreen(): Promise<void>;
 }
 
 export interface MediaControlsState {
@@ -296,4 +300,6 @@ export interface MediaPictureInPictureState {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/exitPictureInPicture
    */
   exitPictureInPicture(): Promise<void>;
+  /** Toggle picture-in-picture mode. */
+  togglePiP(): Promise<void>;
 }

--- a/packages/core/src/core/ui/buffering-indicator/tests/buffering-indicator-core.test.ts
+++ b/packages/core/src/core/ui/buffering-indicator/tests/buffering-indicator-core.test.ts
@@ -12,6 +12,7 @@ function createMediaState(overrides: Partial<MediaPlaybackState> = {}): MediaPla
     waiting: false,
     play: vi.fn(async () => {}),
     pause: vi.fn(),
+    togglePaused: vi.fn(() => true),
     ...overrides,
   };
 }

--- a/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
+++ b/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
@@ -10,6 +10,7 @@ function createMediaState(overrides: Partial<MediaFullscreenState> = {}): MediaF
     fullscreenAvailability: 'available',
     requestFullscreen: vi.fn(async () => {}),
     exitFullscreen: vi.fn(async () => {}),
+    toggleFullscreen: vi.fn(async () => {}),
     ...overrides,
   };
 }

--- a/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
+++ b/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
@@ -10,7 +10,7 @@ function createMediaState(overrides: Partial<MediaPictureInPictureState> = {}): 
     pipAvailability: 'available',
     requestPictureInPicture: vi.fn(async () => {}),
     exitPictureInPicture: vi.fn(async () => {}),
-    togglePiP: vi.fn(async () => {}),
+    togglePictureInPicture: vi.fn(async () => {}),
     ...overrides,
   };
 }

--- a/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
+++ b/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
@@ -10,6 +10,7 @@ function createMediaState(overrides: Partial<MediaPictureInPictureState> = {}): 
     pipAvailability: 'available',
     requestPictureInPicture: vi.fn(async () => {}),
     exitPictureInPicture: vi.fn(async () => {}),
+    togglePiP: vi.fn(async () => {}),
     ...overrides,
   };
 }

--- a/packages/core/src/core/ui/play-button/tests/play-button-core.test.ts
+++ b/packages/core/src/core/ui/play-button/tests/play-button-core.test.ts
@@ -12,6 +12,7 @@ function createMediaState(overrides: Partial<MediaPlaybackState> = {}): MediaPla
     waiting: false,
     play: vi.fn(async () => {}),
     pause: vi.fn(),
+    togglePaused: vi.fn(() => true),
     ...overrides,
   };
 }

--- a/packages/core/src/core/ui/poster/tests/poster-core.test.ts
+++ b/packages/core/src/core/ui/poster/tests/poster-core.test.ts
@@ -11,6 +11,7 @@ function createMediaState(overrides: Partial<MediaPlaybackState> = {}): MediaPla
     waiting: false,
     play: vi.fn(async () => {}),
     pause: vi.fn(),
+    togglePaused: vi.fn(() => true),
     ...overrides,
   };
 }

--- a/packages/core/src/dom/gesture/actions.ts
+++ b/packages/core/src/dom/gesture/actions.ts
@@ -58,7 +58,7 @@ const GESTURE_ACTION_OVERRIDES: Partial<Record<GestureActionName, GestureActionR
   },
 };
 
-export function resolveGestureAction(name: string): GestureActionResolver | undefined {
+export function resolveGestureAction(name: GestureActionName | (string & {})): GestureActionResolver | undefined {
   const override = GESTURE_ACTION_OVERRIDES[name as GestureActionName];
   if (override) return override;
 

--- a/packages/core/src/dom/gesture/actions.ts
+++ b/packages/core/src/dom/gesture/actions.ts
@@ -1,16 +1,7 @@
-import { isUndefined } from '@videojs/utils/predicate';
+import { isFunction, isUndefined } from '@videojs/utils/predicate';
 
 import type { AnyPlayerStore } from '../media/types';
-import {
-  selectControls,
-  selectFullscreen,
-  selectPiP,
-  selectPlayback,
-  selectPlaybackRate,
-  selectTextTrack,
-  selectTime,
-  selectVolume,
-} from '../store/selectors';
+import { selectPlaybackRate, selectTime, selectVolume } from '../store/selectors';
 
 export type GestureActionName =
   | 'togglePaused'
@@ -32,37 +23,8 @@ export interface GestureActionContext {
 
 export type GestureActionResolver = (context: GestureActionContext) => void;
 
-const GESTURE_ACTIONS: Record<GestureActionName, GestureActionResolver> = {
-  togglePaused({ store }) {
-    const playback = selectPlayback(store.state);
-    if (!playback) return;
-    playback.paused ? playback.play() : playback.pause();
-  },
-
-  toggleMuted({ store }) {
-    selectVolume(store.state)?.toggleMuted();
-  },
-
-  toggleFullscreen({ store }) {
-    const fs = selectFullscreen(store.state);
-    if (!fs) return;
-    fs.fullscreen ? fs.exitFullscreen() : fs.requestFullscreen();
-  },
-
-  toggleSubtitles({ store }) {
-    selectTextTrack(store.state)?.toggleSubtitles();
-  },
-
-  togglePiP({ store }) {
-    const pip = selectPiP(store.state);
-    if (!pip) return;
-    pip.pip ? pip.exitPictureInPicture() : pip.requestPictureInPicture();
-  },
-
-  toggleControls({ store }) {
-    selectControls(store.state)?.toggleControls();
-  },
-
+/** Actions that need custom logic beyond `store.state[action]()`. */
+const GESTURE_ACTION_OVERRIDES: Partial<Record<GestureActionName, GestureActionResolver>> = {
   seekStep({ store, value }) {
     if (isUndefined(value)) return;
     const time = selectTime(store.state);
@@ -97,11 +59,13 @@ const GESTURE_ACTIONS: Record<GestureActionName, GestureActionResolver> = {
 };
 
 export function resolveGestureAction(name: string): GestureActionResolver | undefined {
-  const resolver = GESTURE_ACTIONS[name as GestureActionName];
+  const override = GESTURE_ACTION_OVERRIDES[name as GestureActionName];
+  if (override) return override;
 
-  if (__DEV__ && !resolver) {
-    console.warn(`[vjs-gesture] Unknown action: "${name}"`);
-  }
-
-  return resolver;
+  // Direct store method call — togglePaused, toggleMuted, toggleFullscreen, etc.
+  return ({ store }) => {
+    const method = (store.state as Record<string, unknown>)[name];
+    if (isFunction(method)) method();
+    else if (__DEV__) console.warn(`[vjs-gesture] Unknown action: "${name}"`);
+  };
 }

--- a/packages/core/src/dom/gesture/actions.ts
+++ b/packages/core/src/dom/gesture/actions.ts
@@ -1,0 +1,107 @@
+import { isUndefined } from '@videojs/utils/predicate';
+
+import type { AnyPlayerStore } from '../media/types';
+import {
+  selectControls,
+  selectFullscreen,
+  selectPiP,
+  selectPlayback,
+  selectPlaybackRate,
+  selectTextTrack,
+  selectTime,
+  selectVolume,
+} from '../store/selectors';
+
+export type GestureActionName =
+  | 'togglePaused'
+  | 'toggleMuted'
+  | 'toggleFullscreen'
+  | 'toggleSubtitles'
+  | 'togglePiP'
+  | 'toggleControls'
+  | 'seekStep'
+  | 'volumeStep'
+  | 'speedUp'
+  | 'speedDown';
+
+export interface GestureActionContext {
+  store: AnyPlayerStore;
+  value?: number | undefined;
+  event: PointerEvent;
+}
+
+export type GestureActionResolver = (context: GestureActionContext) => void;
+
+const GESTURE_ACTIONS: Record<GestureActionName, GestureActionResolver> = {
+  togglePaused({ store }) {
+    const playback = selectPlayback(store.state);
+    if (!playback) return;
+    playback.paused ? playback.play() : playback.pause();
+  },
+
+  toggleMuted({ store }) {
+    selectVolume(store.state)?.toggleMuted();
+  },
+
+  toggleFullscreen({ store }) {
+    const fs = selectFullscreen(store.state);
+    if (!fs) return;
+    fs.fullscreen ? fs.exitFullscreen() : fs.requestFullscreen();
+  },
+
+  toggleSubtitles({ store }) {
+    selectTextTrack(store.state)?.toggleSubtitles();
+  },
+
+  togglePiP({ store }) {
+    const pip = selectPiP(store.state);
+    if (!pip) return;
+    pip.pip ? pip.exitPictureInPicture() : pip.requestPictureInPicture();
+  },
+
+  toggleControls({ store }) {
+    selectControls(store.state)?.toggleControls();
+  },
+
+  seekStep({ store, value }) {
+    if (isUndefined(value)) return;
+    const time = selectTime(store.state);
+    if (!time) return;
+    time.seek(time.currentTime + value);
+  },
+
+  volumeStep({ store, value }) {
+    if (isUndefined(value)) return;
+    const vol = selectVolume(store.state);
+    if (!vol) return;
+    vol.setVolume(vol.volume + value);
+  },
+
+  speedUp({ store }) {
+    const rate = selectPlaybackRate(store.state);
+    if (!rate) return;
+    const { playbackRates, playbackRate } = rate;
+    const idx = playbackRates.indexOf(playbackRate);
+    const next = idx < 0 || idx >= playbackRates.length - 1 ? 0 : idx + 1;
+    rate.setPlaybackRate(playbackRates[next]!);
+  },
+
+  speedDown({ store }) {
+    const rate = selectPlaybackRate(store.state);
+    if (!rate) return;
+    const { playbackRates, playbackRate } = rate;
+    const idx = playbackRates.indexOf(playbackRate);
+    const next = idx <= 0 ? playbackRates.length - 1 : idx - 1;
+    rate.setPlaybackRate(playbackRates[next]!);
+  },
+};
+
+export function resolveGestureAction(name: string): GestureActionResolver | undefined {
+  const resolver = GESTURE_ACTIONS[name as GestureActionName];
+
+  if (__DEV__ && !resolver) {
+    console.warn(`[vjs-gesture] Unknown action: "${name}"`);
+  }
+
+  return resolver;
+}

--- a/packages/core/src/dom/gesture/actions.ts
+++ b/packages/core/src/dom/gesture/actions.ts
@@ -8,7 +8,7 @@ export type GestureActionName =
   | 'toggleMuted'
   | 'toggleFullscreen'
   | 'toggleSubtitles'
-  | 'togglePiP'
+  | 'togglePictureInPicture'
   | 'toggleControls'
   | 'seekStep'
   | 'volumeStep'

--- a/packages/core/src/dom/gesture/tests/actions.test.ts
+++ b/packages/core/src/dom/gesture/tests/actions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GestureActionContext } from '../actions';
+import { resolveGestureAction } from '../actions';
+
+describe('resolveGestureAction', () => {
+  it('returns a resolver for known actions', () => {
+    expect(resolveGestureAction('togglePaused')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleMuted')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleFullscreen')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleSubtitles')).toBeTypeOf('function');
+    expect(resolveGestureAction('togglePiP')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleControls')).toBeTypeOf('function');
+    expect(resolveGestureAction('seekStep')).toBeTypeOf('function');
+    expect(resolveGestureAction('volumeStep')).toBeTypeOf('function');
+    expect(resolveGestureAction('speedUp')).toBeTypeOf('function');
+    expect(resolveGestureAction('speedDown')).toBeTypeOf('function');
+  });
+
+  it('returns undefined for unknown actions', () => {
+    expect(resolveGestureAction('nonexistent')).toBeUndefined();
+  });
+
+  it('warns in __DEV__ for unknown actions', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    resolveGestureAction('nonexistent');
+    expect(spy).toHaveBeenCalledWith('[vjs-gesture] Unknown action: "nonexistent"');
+    spy.mockRestore();
+  });
+});
+
+describe('togglePaused', () => {
+  it('calls play when paused', () => {
+    const play = vi.fn();
+    const resolver = resolveGestureAction('togglePaused')!;
+    resolver(ctx({ paused: true, ended: false, started: false, waiting: false, play, pause: vi.fn() }));
+    expect(play).toHaveBeenCalledOnce();
+  });
+
+  it('calls pause when playing', () => {
+    const pause = vi.fn();
+    const resolver = resolveGestureAction('togglePaused')!;
+    resolver(ctx({ paused: false, ended: false, started: true, waiting: false, play: vi.fn(), pause }));
+    expect(pause).toHaveBeenCalledOnce();
+  });
+});
+
+describe('toggleMuted', () => {
+  it('calls toggleMuted on volume state', () => {
+    const toggleMuted = vi.fn();
+    const resolver = resolveGestureAction('toggleMuted')!;
+    resolver(ctx({ volume: 1, muted: false, volumeAvailability: 'available', setVolume: vi.fn(), toggleMuted }));
+    expect(toggleMuted).toHaveBeenCalledOnce();
+  });
+});
+
+describe('toggleFullscreen', () => {
+  it('calls requestFullscreen when not fullscreen', () => {
+    const requestFullscreen = vi.fn();
+    const resolver = resolveGestureAction('toggleFullscreen')!;
+    resolver(
+      ctx({
+        fullscreen: false,
+        fullscreenAvailability: 'available',
+        requestFullscreen,
+        exitFullscreen: vi.fn(),
+      })
+    );
+    expect(requestFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('calls exitFullscreen when fullscreen', () => {
+    const exitFullscreen = vi.fn();
+    const resolver = resolveGestureAction('toggleFullscreen')!;
+    resolver(
+      ctx({ fullscreen: true, fullscreenAvailability: 'available', requestFullscreen: vi.fn(), exitFullscreen })
+    );
+    expect(exitFullscreen).toHaveBeenCalledOnce();
+  });
+});
+
+describe('toggleControls', () => {
+  it('calls toggleControls on controls state', () => {
+    const toggleControls = vi.fn();
+    const resolver = resolveGestureAction('toggleControls')!;
+    resolver(ctx({ userActive: true, controlsVisible: true, toggleControls }));
+    expect(toggleControls).toHaveBeenCalledOnce();
+  });
+});
+
+describe('seekStep', () => {
+  it('seeks by value offset', () => {
+    const seek = vi.fn();
+    const resolver = resolveGestureAction('seekStep')!;
+    resolver(ctx({ currentTime: 10, duration: 60, seeking: false, seek }, 5));
+    expect(seek).toHaveBeenCalledWith(15);
+  });
+
+  it('does nothing without value', () => {
+    const seek = vi.fn();
+    const resolver = resolveGestureAction('seekStep')!;
+    resolver(ctx({ currentTime: 10, duration: 60, seeking: false, seek }));
+    expect(seek).not.toHaveBeenCalled();
+  });
+});
+
+describe('volumeStep', () => {
+  it('adjusts volume by value offset', () => {
+    const setVolume = vi.fn();
+    const resolver = resolveGestureAction('volumeStep')!;
+    resolver(ctx({ volume: 0.5, muted: false, volumeAvailability: 'available', setVolume, toggleMuted: vi.fn() }, 0.1));
+    expect(setVolume).toHaveBeenCalledWith(0.6);
+  });
+});
+
+describe('speedUp', () => {
+  it('cycles to next playback rate', () => {
+    const setPlaybackRate = vi.fn();
+    const resolver = resolveGestureAction('speedUp')!;
+    resolver(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1, setPlaybackRate }));
+    expect(setPlaybackRate).toHaveBeenCalledWith(1.5);
+  });
+
+  it('wraps to first rate at end', () => {
+    const setPlaybackRate = vi.fn();
+    const resolver = resolveGestureAction('speedUp')!;
+    resolver(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 2, setPlaybackRate }));
+    expect(setPlaybackRate).toHaveBeenCalledWith(0.5);
+  });
+});
+
+describe('speedDown', () => {
+  it('cycles to previous playback rate', () => {
+    const setPlaybackRate = vi.fn();
+    const resolver = resolveGestureAction('speedDown')!;
+    resolver(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1.5, setPlaybackRate }));
+    expect(setPlaybackRate).toHaveBeenCalledWith(1);
+  });
+
+  it('wraps to last rate at beginning', () => {
+    const setPlaybackRate = vi.fn();
+    const resolver = resolveGestureAction('speedDown')!;
+    resolver(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 0.5, setPlaybackRate }));
+    expect(setPlaybackRate).toHaveBeenCalledWith(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock GestureActionContext. The state object's keys are spread directly
+ * so selectors (which check `firstKey in state`) find them.
+ */
+function ctx(stateProps: Record<string, unknown>, value?: number): GestureActionContext {
+  return {
+    store: { state: stateProps } as unknown as GestureActionContext['store'],
+    value,
+    event: new Event('pointerup') as PointerEvent,
+  };
+}

--- a/packages/core/src/dom/gesture/tests/actions.test.ts
+++ b/packages/core/src/dom/gesture/tests/actions.test.ts
@@ -4,102 +4,81 @@ import type { GestureActionContext } from '../actions';
 import { resolveGestureAction } from '../actions';
 
 describe('resolveGestureAction', () => {
-  it('returns a resolver for known actions', () => {
-    expect(resolveGestureAction('togglePaused')).toBeTypeOf('function');
-    expect(resolveGestureAction('toggleMuted')).toBeTypeOf('function');
-    expect(resolveGestureAction('toggleFullscreen')).toBeTypeOf('function');
-    expect(resolveGestureAction('toggleSubtitles')).toBeTypeOf('function');
-    expect(resolveGestureAction('togglePiP')).toBeTypeOf('function');
-    expect(resolveGestureAction('toggleControls')).toBeTypeOf('function');
+  it('returns a resolver for override actions', () => {
     expect(resolveGestureAction('seekStep')).toBeTypeOf('function');
     expect(resolveGestureAction('volumeStep')).toBeTypeOf('function');
     expect(resolveGestureAction('speedUp')).toBeTypeOf('function');
     expect(resolveGestureAction('speedDown')).toBeTypeOf('function');
   });
 
-  it('returns undefined for unknown actions', () => {
-    expect(resolveGestureAction('nonexistent')).toBeUndefined();
+  it('returns a resolver for direct store actions', () => {
+    expect(resolveGestureAction('togglePaused')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleMuted')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleFullscreen')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleSubtitles')).toBeTypeOf('function');
+    expect(resolveGestureAction('togglePiP')).toBeTypeOf('function');
+    expect(resolveGestureAction('toggleControls')).toBeTypeOf('function');
   });
 
-  it('warns in __DEV__ for unknown actions', () => {
+  it('always returns a resolver (warns for unknown in __DEV__)', () => {
+    const resolver = resolveGestureAction('nonexistent');
+    expect(resolver).toBeTypeOf('function');
+
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    resolveGestureAction('nonexistent');
+    resolver!(ctx({}));
     expect(spy).toHaveBeenCalledWith('[vjs-gesture] Unknown action: "nonexistent"');
     spy.mockRestore();
   });
 });
 
-describe('togglePaused', () => {
-  it('calls play when paused', () => {
-    const play = vi.fn();
-    const resolver = resolveGestureAction('togglePaused')!;
-    resolver(ctx({ paused: true, ended: false, started: false, waiting: false, play, pause: vi.fn() }));
-    expect(play).toHaveBeenCalledOnce();
+describe('direct store actions', () => {
+  it('calls togglePaused on store state', () => {
+    const togglePaused = vi.fn();
+    resolveGestureAction('togglePaused')!(ctx({ togglePaused }));
+    expect(togglePaused).toHaveBeenCalledOnce();
   });
 
-  it('calls pause when playing', () => {
-    const pause = vi.fn();
-    const resolver = resolveGestureAction('togglePaused')!;
-    resolver(ctx({ paused: false, ended: false, started: true, waiting: false, play: vi.fn(), pause }));
-    expect(pause).toHaveBeenCalledOnce();
-  });
-});
-
-describe('toggleMuted', () => {
-  it('calls toggleMuted on volume state', () => {
+  it('calls toggleMuted on store state', () => {
     const toggleMuted = vi.fn();
-    const resolver = resolveGestureAction('toggleMuted')!;
-    resolver(ctx({ volume: 1, muted: false, volumeAvailability: 'available', setVolume: vi.fn(), toggleMuted }));
+    resolveGestureAction('toggleMuted')!(ctx({ toggleMuted }));
     expect(toggleMuted).toHaveBeenCalledOnce();
   });
-});
 
-describe('toggleFullscreen', () => {
-  it('calls requestFullscreen when not fullscreen', () => {
-    const requestFullscreen = vi.fn();
-    const resolver = resolveGestureAction('toggleFullscreen')!;
-    resolver(
-      ctx({
-        fullscreen: false,
-        fullscreenAvailability: 'available',
-        requestFullscreen,
-        exitFullscreen: vi.fn(),
-      })
-    );
-    expect(requestFullscreen).toHaveBeenCalledOnce();
+  it('calls toggleFullscreen on store state', () => {
+    const toggleFullscreen = vi.fn();
+    resolveGestureAction('toggleFullscreen')!(ctx({ toggleFullscreen }));
+    expect(toggleFullscreen).toHaveBeenCalledOnce();
   });
 
-  it('calls exitFullscreen when fullscreen', () => {
-    const exitFullscreen = vi.fn();
-    const resolver = resolveGestureAction('toggleFullscreen')!;
-    resolver(
-      ctx({ fullscreen: true, fullscreenAvailability: 'available', requestFullscreen: vi.fn(), exitFullscreen })
-    );
-    expect(exitFullscreen).toHaveBeenCalledOnce();
-  });
-});
-
-describe('toggleControls', () => {
-  it('calls toggleControls on controls state', () => {
+  it('calls toggleControls on store state', () => {
     const toggleControls = vi.fn();
-    const resolver = resolveGestureAction('toggleControls')!;
-    resolver(ctx({ userActive: true, controlsVisible: true, toggleControls }));
+    resolveGestureAction('toggleControls')!(ctx({ toggleControls }));
     expect(toggleControls).toHaveBeenCalledOnce();
+  });
+
+  it('calls toggleSubtitles on store state', () => {
+    const toggleSubtitles = vi.fn();
+    resolveGestureAction('toggleSubtitles')!(ctx({ toggleSubtitles }));
+    expect(toggleSubtitles).toHaveBeenCalledOnce();
+  });
+
+  it('calls togglePiP on store state', () => {
+    const togglePiP = vi.fn();
+    resolveGestureAction('togglePiP')!(ctx({ togglePiP }));
+    expect(togglePiP).toHaveBeenCalledOnce();
   });
 });
 
 describe('seekStep', () => {
   it('seeks by value offset', () => {
     const seek = vi.fn();
-    const resolver = resolveGestureAction('seekStep')!;
-    resolver(ctx({ currentTime: 10, duration: 60, seeking: false, seek }, 5));
+    resolveGestureAction('seekStep')!(ctx({ currentTime: 10, duration: 60, seeking: false, seek }, 5));
     expect(seek).toHaveBeenCalledWith(15);
   });
 
   it('does nothing without value', () => {
     const seek = vi.fn();
-    const resolver = resolveGestureAction('seekStep')!;
-    resolver(ctx({ currentTime: 10, duration: 60, seeking: false, seek }));
+    resolveGestureAction('seekStep')!(ctx({ currentTime: 10, duration: 60, seeking: false, seek }));
     expect(seek).not.toHaveBeenCalled();
   });
 });
@@ -107,8 +86,9 @@ describe('seekStep', () => {
 describe('volumeStep', () => {
   it('adjusts volume by value offset', () => {
     const setVolume = vi.fn();
-    const resolver = resolveGestureAction('volumeStep')!;
-    resolver(ctx({ volume: 0.5, muted: false, volumeAvailability: 'available', setVolume, toggleMuted: vi.fn() }, 0.1));
+    resolveGestureAction('volumeStep')!(
+      ctx({ volume: 0.5, muted: false, volumeAvailability: 'available', setVolume, toggleMuted: vi.fn() }, 0.1)
+    );
     expect(setVolume).toHaveBeenCalledWith(0.6);
   });
 });
@@ -116,15 +96,13 @@ describe('volumeStep', () => {
 describe('speedUp', () => {
   it('cycles to next playback rate', () => {
     const setPlaybackRate = vi.fn();
-    const resolver = resolveGestureAction('speedUp')!;
-    resolver(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1, setPlaybackRate }));
+    resolveGestureAction('speedUp')!(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1, setPlaybackRate }));
     expect(setPlaybackRate).toHaveBeenCalledWith(1.5);
   });
 
   it('wraps to first rate at end', () => {
     const setPlaybackRate = vi.fn();
-    const resolver = resolveGestureAction('speedUp')!;
-    resolver(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 2, setPlaybackRate }));
+    resolveGestureAction('speedUp')!(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 2, setPlaybackRate }));
     expect(setPlaybackRate).toHaveBeenCalledWith(0.5);
   });
 });
@@ -132,15 +110,13 @@ describe('speedUp', () => {
 describe('speedDown', () => {
   it('cycles to previous playback rate', () => {
     const setPlaybackRate = vi.fn();
-    const resolver = resolveGestureAction('speedDown')!;
-    resolver(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1.5, setPlaybackRate }));
+    resolveGestureAction('speedDown')!(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1.5, setPlaybackRate }));
     expect(setPlaybackRate).toHaveBeenCalledWith(1);
   });
 
   it('wraps to last rate at beginning', () => {
     const setPlaybackRate = vi.fn();
-    const resolver = resolveGestureAction('speedDown')!;
-    resolver(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 0.5, setPlaybackRate }));
+    resolveGestureAction('speedDown')!(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 0.5, setPlaybackRate }));
     expect(setPlaybackRate).toHaveBeenCalledWith(2);
   });
 });
@@ -149,10 +125,6 @@ describe('speedDown', () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Create a mock GestureActionContext. The state object's keys are spread directly
- * so selectors (which check `firstKey in state`) find them.
- */
 function ctx(stateProps: Record<string, unknown>, value?: number): GestureActionContext {
   return {
     store: { state: stateProps } as unknown as GestureActionContext['store'],

--- a/packages/core/src/dom/gesture/tests/actions.test.ts
+++ b/packages/core/src/dom/gesture/tests/actions.test.ts
@@ -16,7 +16,7 @@ describe('resolveGestureAction', () => {
     expect(resolveGestureAction('toggleMuted')).toBeTypeOf('function');
     expect(resolveGestureAction('toggleFullscreen')).toBeTypeOf('function');
     expect(resolveGestureAction('toggleSubtitles')).toBeTypeOf('function');
-    expect(resolveGestureAction('togglePiP')).toBeTypeOf('function');
+    expect(resolveGestureAction('togglePictureInPicture')).toBeTypeOf('function');
     expect(resolveGestureAction('toggleControls')).toBeTypeOf('function');
   });
 
@@ -62,10 +62,10 @@ describe('direct store actions', () => {
     expect(toggleSubtitles).toHaveBeenCalledOnce();
   });
 
-  it('calls togglePiP on store state', () => {
-    const togglePiP = vi.fn();
-    resolveGestureAction('togglePiP')!(ctx({ togglePiP }));
-    expect(togglePiP).toHaveBeenCalledOnce();
+  it('calls togglePictureInPicture on store state', () => {
+    const togglePictureInPicture = vi.fn();
+    resolveGestureAction('togglePictureInPicture')!(ctx({ togglePictureInPicture }));
+    expect(togglePictureInPicture).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/core/src/dom/hotkey/actions.ts
+++ b/packages/core/src/dom/hotkey/actions.ts
@@ -16,7 +16,7 @@ export type HotkeyActionName =
   | 'toggleMuted'
   | 'toggleFullscreen'
   | 'toggleSubtitles'
-  | 'togglePiP'
+  | 'togglePictureInPicture'
   | 'seekStep'
   | 'volumeStep'
   | 'speedUp'
@@ -57,7 +57,7 @@ const HOTKEY_ACTIONS: Record<HotkeyActionName, HotkeyActionResolver> = {
     selectTextTrack(store.state)?.toggleSubtitles();
   },
 
-  togglePiP({ store }) {
+  togglePictureInPicture({ store }) {
     const pip = selectPiP(store.state);
     if (!pip) return;
     pip.pip ? pip.exitPictureInPicture() : pip.requestPictureInPicture();

--- a/packages/core/src/dom/hotkey/tests/actions.test.ts
+++ b/packages/core/src/dom/hotkey/tests/actions.test.ts
@@ -36,7 +36,7 @@ describe('isHotkeyToggleAction', () => {
     expect(isHotkeyToggleAction('toggleMuted')).toBe(true);
     expect(isHotkeyToggleAction('toggleFullscreen')).toBe(true);
     expect(isHotkeyToggleAction('toggleSubtitles')).toBe(true);
-    expect(isHotkeyToggleAction('togglePiP')).toBe(true);
+    expect(isHotkeyToggleAction('togglePictureInPicture')).toBe(true);
   });
 
   it('returns false for non-toggle actions', () => {

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -1,4 +1,5 @@
 export * from './feature';
+export * from './gesture/actions';
 export * from './gesture/coordinator';
 export * from './gesture/create-tap-gesture';
 export * from './gesture/gesture';

--- a/packages/core/src/dom/store/features/fullscreen.ts
+++ b/packages/core/src/dom/store/features/fullscreen.ts
@@ -32,6 +32,20 @@ export const fullscreenFeature = definePlayerFeature({
       const { media } = target();
       return exitFullscreen(media);
     },
+
+    async toggleFullscreen() {
+      const { media, container } = target();
+
+      if (isFullscreenElement(container, media)) {
+        return exitFullscreen(media);
+      }
+
+      if (isPictureInPictureElement(media)) {
+        await exitPictureInPicture(media);
+      }
+
+      return requestFullscreen(container, media);
+    },
   }),
 
   attach({ target, signal, set }) {

--- a/packages/core/src/dom/store/features/pip.ts
+++ b/packages/core/src/dom/store/features/pip.ts
@@ -32,6 +32,20 @@ export const pipFeature = definePlayerFeature({
       const { media } = target();
       return exitPictureInPicture(media);
     },
+
+    async togglePiP() {
+      const { media, container } = target();
+
+      if (isPictureInPictureElement(media)) {
+        return exitPictureInPicture(media);
+      }
+
+      if (isFullscreenElement(container, media)) {
+        await exitFullscreen();
+      }
+
+      return requestPictureInPicture(media);
+    },
   }),
 
   attach({ target, signal, set }) {

--- a/packages/core/src/dom/store/features/pip.ts
+++ b/packages/core/src/dom/store/features/pip.ts
@@ -33,7 +33,7 @@ export const pipFeature = definePlayerFeature({
       return exitPictureInPicture(media);
     },
 
-    async togglePiP() {
+    async togglePictureInPicture() {
       const { media, container } = target();
 
       if (isPictureInPictureElement(media)) {

--- a/packages/core/src/dom/store/features/playback.ts
+++ b/packages/core/src/dom/store/features/playback.ts
@@ -16,6 +16,15 @@ export const playbackFeature = definePlayerFeature({
     pause() {
       target().media.pause();
     },
+    togglePaused() {
+      const media = target().media;
+      if (media.paused) {
+        media.play();
+        return true;
+      }
+      media.pause();
+      return false;
+    },
   }),
 
   attach({ target, signal, set }) {

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -137,7 +137,7 @@ function getTemplateHTML() {
       <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
       <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
       <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
-      <media-hotkey keys="i" action="togglePiP"></media-hotkey>
+      <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
       <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
       <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
       <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -28,6 +28,7 @@ export { ControlsElement } from './ui/controls/controls-element';
 export { ControlsGroupElement } from './ui/controls/controls-group-element';
 export { ErrorDialogElement } from './ui/error-dialog/error-dialog-element';
 export { FullscreenButtonElement } from './ui/fullscreen-button/fullscreen-button-element';
+export { GestureElement } from './ui/gesture/gesture-element';
 export { AriaKeyShortcutsController } from './ui/hotkey/aria-key-shortcuts-controller';
 export { HotkeyElement } from './ui/hotkey/hotkey-element';
 export { MediaButtonElement } from './ui/media-button-element';

--- a/packages/html/src/ui/gesture/gesture-element.ts
+++ b/packages/html/src/ui/gesture/gesture-element.ts
@@ -1,0 +1,95 @@
+import {
+  createDoubleTapGesture,
+  createTapGesture,
+  type GestureActionName,
+  type GesturePointerType,
+  type GestureRegion,
+  resolveGestureAction,
+} from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
+import { ContextConsumer } from '@videojs/element/context';
+
+import { containerContext, playerContext } from '../../player/context';
+import { PlayerController } from '../../player/player-controller';
+import { MediaElement } from '../media-element';
+
+export class GestureElement extends MediaElement {
+  static readonly tagName = 'media-gesture';
+
+  static override properties: PropertyDeclarationMap = {
+    type: { type: String },
+    action: { type: String },
+    value: { type: Number },
+    pointer: { type: String },
+    region: { type: String },
+    disabled: { type: Boolean },
+  };
+
+  type: 'tap' | 'doubletap' | (string & {}) = '';
+  action: GestureActionName | (string & {}) = '';
+  value: number | undefined = undefined;
+  pointer: GesturePointerType | undefined = undefined;
+  region: GestureRegion | undefined = undefined;
+  disabled = false;
+
+  readonly #player = new PlayerController(this, playerContext);
+  readonly #container = new ContextConsumer(this, {
+    context: containerContext,
+    callback: () => this.requestUpdate(),
+    subscribe: true,
+  });
+  #cleanup: (() => void) | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.style.display = 'none';
+    this.#register();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#unregister();
+  }
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+
+    // Re-register when attributes change.
+    if (this.isConnected) {
+      this.#unregister();
+      this.#register();
+    }
+  }
+
+  #register(): void {
+    const store = this.#player.value;
+    const container = this.#container.value?.container;
+    if (!this.type || !this.action || !store || !container) return;
+
+    const resolver = resolveGestureAction(this.action);
+    if (!resolver) return;
+
+    const { value } = this;
+
+    const onActivate = (event: PointerEvent) => {
+      resolver({ store, value, event });
+    };
+
+    const options = {
+      pointer: this.pointer,
+      region: this.region,
+      disabled: this.disabled,
+    };
+
+    if (this.type === 'doubletap') {
+      this.#cleanup = createDoubleTapGesture(container, onActivate, options);
+    } else {
+      this.#cleanup = createTapGesture(container, onActivate, options);
+    }
+  }
+
+  #unregister(): void {
+    this.#cleanup?.();
+    this.#cleanup = null;
+  }
+}

--- a/packages/html/src/ui/gesture/tests/gesture-element.test.ts
+++ b/packages/html/src/ui/gesture/tests/gesture-element.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { GestureElement } from '../gesture-element';
+
+beforeAll(() => {
+  customElements.define('media-gesture', GestureElement);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('GestureElement', () => {
+  it('has the correct tag name', () => {
+    expect(GestureElement.tagName).toBe('media-gesture');
+  });
+
+  it('declares expected properties', () => {
+    const props = GestureElement.properties;
+    expect(props).toHaveProperty('type');
+    expect(props).toHaveProperty('action');
+    expect(props).toHaveProperty('value');
+    expect(props).toHaveProperty('pointer');
+    expect(props).toHaveProperty('region');
+    expect(props).toHaveProperty('disabled');
+  });
+
+  it('initializes with default property values', () => {
+    const el = document.createElement('media-gesture') as GestureElement;
+    expect(el.type).toBe('');
+    expect(el.action).toBe('');
+    expect(el.value).toBeUndefined();
+    expect(el.pointer).toBeUndefined();
+    expect(el.region).toBeUndefined();
+    expect(el.disabled).toBe(false);
+  });
+
+  it('is hidden when connected', () => {
+    const el = document.createElement('media-gesture') as GestureElement;
+    document.body.appendChild(el);
+    expect(el.style.display).toBe('none');
+  });
+});

--- a/packages/html/src/ui/pip-button/pip-button-element.ts
+++ b/packages/html/src/ui/pip-button/pip-button-element.ts
@@ -11,7 +11,7 @@ export class PiPButtonElement extends MediaButtonElement<PiPButtonCore> {
   protected readonly core = new PiPButtonCore();
   protected readonly stateAttrMap = PiPButtonDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectPiP);
-  protected override readonly hotkeyAction = 'togglePiP';
+  protected override readonly hotkeyAction = 'togglePictureInPicture';
 
   protected activate(state: MediaPictureInPictureState): void {
     this.core.toggle(state);

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -237,7 +237,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <MediaHotkey keys="m" action="toggleMuted" />
       <MediaHotkey keys="f" action="toggleFullscreen" />
       <MediaHotkey keys="c" action="toggleSubtitles" />
-      <MediaHotkey keys="i" action="togglePiP" />
+      <MediaHotkey keys="i" action="togglePictureInPicture" />
       <MediaHotkey keys="ArrowRight" action="seekStep" value={5} />
       <MediaHotkey keys="ArrowLeft" action="seekStep" value={-5} />
       <MediaHotkey keys="l" action="seekStep" value={10} />

--- a/packages/react/src/ui/pip-button/pip-button.tsx
+++ b/packages/react/src/ui/pip-button/pip-button.tsx
@@ -15,7 +15,7 @@ export const PiPButton = createMediaButton<PiPButtonCore, PiPButtonProps>({
   stateAttrMap: PiPButtonDataAttrs,
   selector: selectPiP,
   action: (core, state) => core.toggle(state),
-  hotkeyAction: 'togglePiP',
+  hotkeyAction: 'togglePictureInPicture',
 });
 
 export namespace PiPButton {


### PR DESCRIPTION
Closes #1273

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new gesture-action plumbing and new media state methods (`togglePaused`/`toggleFullscreen`/`togglePictureInPicture`) that become part of the public store/state surface, which could affect integrators and input handling across platforms.
> 
> **Overview**
> Adds a new `media-gesture` custom element (exported from `@videojs/html`) that registers tap/double-tap gesture handlers on the player container and dispatches them to player/store actions via a new core `resolveGestureAction` helper.
> 
> Extends core media state with `togglePaused`, `toggleFullscreen`, and `togglePictureInPicture`, implements these toggles in the DOM store features (handling fullscreen/PiP mutual exclusion), and updates hotkey/PiP action naming from `togglePiP` to `togglePictureInPicture` across HTML/React skins and button components/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78bd7e7247d8cd4ec0a949dd924685a305fcc04c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->