### PR TITLE
fix(html): replace bare side-effect imports with explicit safeDefine() in define modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,9 @@ pnpm lint:fix:file <file>
 # Remove all dist and types outputs
 pnpm clean
 
+# Validate workspace consistency (CI coverage, scopes, define imports, etc.)
+pnpm check:workspace
+
 # Measure bundle size (SPF only)
 pnpm -F @videojs/spf size        # Public API (minified + gzipped)
 pnpm -F @videojs/spf size:all    # All exports (minified + gzipped)
@@ -118,8 +121,9 @@ pnpm -F @videojs/spf size:all    # All exports (minified + gzipped)
 4. Run test/s, fix all issues. If there are no tests add them.
 5. Lint file/s, fix all issues.
 6. Run build/s, fix all errors.
-7. Before creating a PR `pnpm test`.
-8. If your changes introduced new patterns or conventions, ask the user to run `/claude-update`.
+7. Run `pnpm check:workspace` — fix any consistency warnings.
+8. Before creating a PR `pnpm test`.
+9. If your changes introduced new patterns or conventions, ask the user to run `/claude-update`.
 
 Be efficient when running operations, see "Common Root Commands".
 

--- a/build/scripts/check-workspace.mjs
+++ b/build/scripts/check-workspace.mjs
@@ -10,6 +10,7 @@
  * 3. Root tsconfig references — every composite project is referenced
  * 4. Package metadata — non-private packages have required fields
  * 5. Release-please config — every versioned package is registered
+ * 6. Define imports — no bare side-effect imports from relative paths
  */
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -230,6 +231,64 @@ function checkReleasePleaseConfig() {
   return { ok: warnings.length === 0, warnings };
 }
 
+// ── Check 6: Define imports ──────────────────────────────────────────────────
+
+/**
+ * Bare side-effect imports from relative paths in the define directory cause
+ * non-deterministic registration order when loaded as native ESM in the
+ * browser. All registration must go through explicit safeDefine() calls.
+ */
+function checkDefineImports() {
+  const warnings = [];
+  const defineDir = join(PACKAGES_DIR, 'html/src/define');
+
+  if (!existsSync(defineDir)) {
+    return { ok: true, warnings: [] };
+  }
+
+  // Matches: import './foo';  import "../bar";  import './foo/bar';
+  // Ignores value imports: import { X } from './foo';  import X from './foo';
+  // Ignores CSS imports: import './foo.css';  import './foo.css?inline';
+  const sideEffectImportRe = /^import\s+['"](\.[^'"]+)['"]\s*;/gm;
+  const cssSpecifierRe = /\.css(?:\?|$)/;
+
+  function findTsFiles(dir, results = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === 'tests') continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        findTsFiles(full, results);
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+        results.push(full);
+      }
+    }
+    return results;
+  }
+
+  for (const filePath of findTsFiles(defineDir)) {
+    const content = readText(filePath);
+    const relative = filePath.slice(ROOT.length + 1);
+
+    const sideEffects = [];
+    for (const match of content.matchAll(sideEffectImportRe)) {
+      const specifier = match[1];
+      if (cssSpecifierRe.test(specifier)) continue;
+      sideEffects.push(specifier);
+    }
+
+    // A single side-effect import (e.g. skin importing its ui module) is safe
+    // because ESM evaluates it synchronously before the importing module's body.
+    // Multiple side-effect imports are the problem — they race in the browser.
+    if (sideEffects.length > 1) {
+      for (const specifier of sideEffects) {
+        warnings.push(`${relative}: bare side-effect import "${specifier}" — use safeDefine() instead`);
+      }
+    }
+  }
+
+  return { ok: warnings.length === 0, warnings };
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 
 const checks = [
@@ -238,6 +297,7 @@ const checks = [
   { name: 'Root tsconfig references', fn: checkTsconfigReferences },
   { name: 'Package metadata', fn: checkPackageMetadata },
   { name: 'Release-please config', fn: checkReleasePleaseConfig },
+  { name: 'Define imports', fn: checkDefineImports },
 ];
 
 let failed = 0;

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -2,29 +2,15 @@
 // used by the minimal skin without creating a skin element. Use this entry
 // when building an ejected (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
-import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
-import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
-import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
-import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
 import { PlayButtonElement } from '../../ui/play-button/play-button-element';
 import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playback-rate-button-element';
 import { PopoverElement } from '../../ui/popover/popover-element';
 import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
-import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
-import { SliderFillElement } from '../../ui/slider/slider-fill-element';
-import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
-import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
-import { SliderTrackElement } from '../../ui/slider/slider-track-element';
-import { SliderValueElement } from '../../ui/slider/slider-value-element';
-import { TimeElement } from '../../ui/time/time-element';
-import { TimeGroupElement } from '../../ui/time/time-group-element';
-import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
-import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
-import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
 import { safeDefine } from '../safe-define';
+import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { AudioPlayerElement } from './player';
@@ -34,22 +20,11 @@ import { AudioPlayerElement } from './player';
 safeDefine(AudioPlayerElement);
 safeDefine(MediaContainerElement);
 
-// Parent/composite elements before their children.
-safeDefine(ErrorDialogElement);
-safeDefine(AlertDialogCloseElement);
-safeDefine(AlertDialogDescriptionElement);
-safeDefine(AlertDialogTitleElement);
-safeDefine(TimeSliderElement);
-safeDefine(SliderBufferElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
-safeDefine(VolumeSliderElement);
-safeDefine(TimeElement);
-safeDefine(TimeGroupElement);
-safeDefine(TimeSeparatorElement);
+// Compound groups.
+defineErrorDialog();
+defineTimeSlider();
+defineVolumeSlider();
+defineTime();
 
 // Standalone elements.
 safeDefine(MuteButtonElement);

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -1,16 +1,61 @@
-// Side-effect-only module: registers the audio player, container, and all
-// audio UI custom elements used by the minimal skin without creating a skin
-// element. Use this entry when building an ejected (light DOM) player layout.
-import './player';
+// Registers the audio player, container, and all audio UI custom elements
+// used by the minimal skin without creating a skin element. Use this entry
+// when building an ejected (light DOM) player layout.
+import { MediaContainerElement } from '../../media/container-element';
+import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
+import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
+import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
+import { PlayButtonElement } from '../../ui/play-button/play-button-element';
+import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playback-rate-button-element';
+import { PopoverElement } from '../../ui/popover/popover-element';
+import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
+import { TimeElement } from '../../ui/time/time-element';
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
+import { TooltipElement } from '../../ui/tooltip/tooltip-element';
+import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
+import { safeDefine } from '../safe-define';
 
-import '../ui/error-dialog';
-import '../ui/mute-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Value import — player.ts body runs before this module's body.
+import { AudioPlayerElement } from './player';
+
+// ── Registration (providers / parents first) ────────────────────────────
+
+safeDefine(AudioPlayerElement);
+safeDefine(MediaContainerElement);
+
+// Parent/composite elements before their children.
+safeDefine(ErrorDialogElement);
+safeDefine(AlertDialogCloseElement);
+safeDefine(AlertDialogDescriptionElement);
+safeDefine(AlertDialogTitleElement);
+safeDefine(TimeSliderElement);
+safeDefine(SliderBufferElement);
+safeDefine(SliderFillElement);
+safeDefine(SliderPreviewElement);
+safeDefine(SliderThumbElement);
+safeDefine(SliderTrackElement);
+safeDefine(SliderValueElement);
+safeDefine(VolumeSliderElement);
+safeDefine(TimeElement);
+safeDefine(TimeGroupElement);
+safeDefine(TimeSeparatorElement);
+
+// Standalone elements.
+safeDefine(MuteButtonElement);
+safeDefine(PlayButtonElement);
+safeDefine(PlaybackRateButtonElement);
+safeDefine(PopoverElement);
+safeDefine(SeekButtonElement);
+safeDefine(TooltipElement);
+safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -1,17 +1,63 @@
-// Side-effect-only module: registers the audio player, container, and all
-// audio UI custom elements without creating a skin element. Use this entry
-// when building an ejected (light DOM) player layout.
-import './player';
+// Registers the audio player, container, and all audio UI custom elements
+// without creating a skin element. Use this entry when building an ejected
+// (light DOM) player layout.
+import { MediaContainerElement } from '../../media/container-element';
+import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
+import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
+import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
+import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
+import { PlayButtonElement } from '../../ui/play-button/play-button-element';
+import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playback-rate-button-element';
+import { PopoverElement } from '../../ui/popover/popover-element';
+import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
+import { TimeElement } from '../../ui/time/time-element';
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
+import { TooltipElement } from '../../ui/tooltip/tooltip-element';
+import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
+import { safeDefine } from '../safe-define';
 
-import '../ui/error-dialog';
-import '../ui/hotkey';
-import '../ui/mute-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Value import — player.ts body runs before this module's body.
+import { AudioPlayerElement } from './player';
+
+// ── Registration (providers / parents first) ────────────────────────────
+
+safeDefine(AudioPlayerElement);
+safeDefine(MediaContainerElement);
+
+// Parent/composite elements before their children.
+safeDefine(ErrorDialogElement);
+safeDefine(AlertDialogCloseElement);
+safeDefine(AlertDialogDescriptionElement);
+safeDefine(AlertDialogTitleElement);
+safeDefine(TimeSliderElement);
+safeDefine(SliderBufferElement);
+safeDefine(SliderFillElement);
+safeDefine(SliderPreviewElement);
+safeDefine(SliderThumbElement);
+safeDefine(SliderTrackElement);
+safeDefine(SliderValueElement);
+safeDefine(VolumeSliderElement);
+safeDefine(TimeElement);
+safeDefine(TimeGroupElement);
+safeDefine(TimeSeparatorElement);
+
+// Standalone elements.
+safeDefine(HotkeyElement);
+safeDefine(MuteButtonElement);
+safeDefine(PlayButtonElement);
+safeDefine(PlaybackRateButtonElement);
+safeDefine(PopoverElement);
+safeDefine(SeekButtonElement);
+safeDefine(TooltipElement);
+safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -2,30 +2,16 @@
 // without creating a skin element. Use this entry when building an ejected
 // (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
-import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
-import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
-import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
-import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
 import { PlayButtonElement } from '../../ui/play-button/play-button-element';
 import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playback-rate-button-element';
 import { PopoverElement } from '../../ui/popover/popover-element';
 import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
-import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
-import { SliderFillElement } from '../../ui/slider/slider-fill-element';
-import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
-import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
-import { SliderTrackElement } from '../../ui/slider/slider-track-element';
-import { SliderValueElement } from '../../ui/slider/slider-value-element';
-import { TimeElement } from '../../ui/time/time-element';
-import { TimeGroupElement } from '../../ui/time/time-group-element';
-import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
-import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
-import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
 import { safeDefine } from '../safe-define';
+import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { AudioPlayerElement } from './player';
@@ -35,22 +21,11 @@ import { AudioPlayerElement } from './player';
 safeDefine(AudioPlayerElement);
 safeDefine(MediaContainerElement);
 
-// Parent/composite elements before their children.
-safeDefine(ErrorDialogElement);
-safeDefine(AlertDialogCloseElement);
-safeDefine(AlertDialogDescriptionElement);
-safeDefine(AlertDialogTitleElement);
-safeDefine(TimeSliderElement);
-safeDefine(SliderBufferElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
-safeDefine(VolumeSliderElement);
-safeDefine(TimeElement);
-safeDefine(TimeGroupElement);
-safeDefine(TimeSeparatorElement);
+// Compound groups.
+defineErrorDialog();
+defineTimeSlider();
+defineVolumeSlider();
+defineTime();
 
 // Standalone elements.
 safeDefine(HotkeyElement);

--- a/packages/html/src/define/ui/compounds.ts
+++ b/packages/html/src/define/ui/compounds.ts
@@ -1,0 +1,67 @@
+import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
+import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { ControlsElement } from '../../ui/controls/controls-element';
+import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
+import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+import { SliderElement } from '../../ui/slider/slider-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderThumbnailElement } from '../../ui/slider/slider-thumbnail-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
+import { TimeElement } from '../../ui/time/time-element';
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
+import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
+import { safeDefine } from '../safe-define';
+
+// ── Define functions ────────────────────────────────────────────────────
+
+export function defineControls(): void {
+  safeDefine(ControlsElement);
+  safeDefine(ControlsGroupElement);
+}
+
+export function defineErrorDialog(): void {
+  // Parent first — child elements consume its context.
+  safeDefine(ErrorDialogElement);
+  safeDefine(AlertDialogCloseElement);
+  safeDefine(AlertDialogDescriptionElement);
+  safeDefine(AlertDialogTitleElement);
+}
+
+/** Shared slider sub-elements used by all slider types. */
+export function defineSliderParts(): void {
+  safeDefine(SliderFillElement);
+  safeDefine(SliderPreviewElement);
+  safeDefine(SliderThumbElement);
+  safeDefine(SliderTrackElement);
+  safeDefine(SliderValueElement);
+}
+
+export function defineSlider(): void {
+  safeDefine(SliderElement);
+  defineSliderParts();
+}
+
+export function defineTime(): void {
+  safeDefine(TimeElement);
+  safeDefine(TimeGroupElement);
+  safeDefine(TimeSeparatorElement);
+}
+
+export function defineTimeSlider(): void {
+  safeDefine(TimeSliderElement);
+  defineSliderParts();
+  safeDefine(SliderBufferElement);
+  safeDefine(SliderThumbnailElement);
+}
+
+export function defineVolumeSlider(): void {
+  safeDefine(VolumeSliderElement);
+  defineSliderParts();
+}

--- a/packages/html/src/define/ui/controls.ts
+++ b/packages/html/src/define/ui/controls.ts
@@ -1,12 +1,12 @@
 import { ControlsElement } from '../../ui/controls/controls-element';
 import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
-import { safeDefine } from '../safe-define';
+import { defineControls } from './compounds';
 
-safeDefine(ControlsElement);
-safeDefine(ControlsGroupElement);
+defineControls();
 
 declare global {
   interface HTMLElementTagNameMap {
     [ControlsElement.tagName]: ControlsElement;
+    [ControlsGroupElement.tagName]: ControlsGroupElement;
   }
 }

--- a/packages/html/src/define/ui/error-dialog.ts
+++ b/packages/html/src/define/ui/error-dialog.ts
@@ -2,16 +2,15 @@ import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-clos
 import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
 import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
 import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
-import { safeDefine } from '../safe-define';
+import { defineErrorDialog } from './compounds';
 
-// Parent first — child elements consume its context.
-safeDefine(ErrorDialogElement);
-safeDefine(AlertDialogCloseElement);
-safeDefine(AlertDialogDescriptionElement);
-safeDefine(AlertDialogTitleElement);
+defineErrorDialog();
 
 declare global {
   interface HTMLElementTagNameMap {
     [ErrorDialogElement.tagName]: ErrorDialogElement;
+    [AlertDialogCloseElement.tagName]: AlertDialogCloseElement;
+    [AlertDialogDescriptionElement.tagName]: AlertDialogDescriptionElement;
+    [AlertDialogTitleElement.tagName]: AlertDialogTitleElement;
   }
 }

--- a/packages/html/src/define/ui/slider.ts
+++ b/packages/html/src/define/ui/slider.ts
@@ -4,18 +4,17 @@ import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
 import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
 import { SliderTrackElement } from '../../ui/slider/slider-track-element';
 import { SliderValueElement } from '../../ui/slider/slider-value-element';
-import { safeDefine } from '../safe-define';
+import { defineSlider } from './compounds';
 
-// Parent slider first — sub-elements consume its context.
-safeDefine(SliderElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
+defineSlider();
 
 declare global {
   interface HTMLElementTagNameMap {
     [SliderElement.tagName]: SliderElement;
+    [SliderFillElement.tagName]: SliderFillElement;
+    [SliderPreviewElement.tagName]: SliderPreviewElement;
+    [SliderThumbElement.tagName]: SliderThumbElement;
+    [SliderTrackElement.tagName]: SliderTrackElement;
+    [SliderValueElement.tagName]: SliderValueElement;
   }
 }

--- a/packages/html/src/define/ui/time-slider.ts
+++ b/packages/html/src/define/ui/time-slider.ts
@@ -6,20 +6,19 @@ import { SliderThumbnailElement } from '../../ui/slider/slider-thumbnail-element
 import { SliderTrackElement } from '../../ui/slider/slider-track-element';
 import { SliderValueElement } from '../../ui/slider/slider-value-element';
 import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
-import { safeDefine } from '../safe-define';
+import { defineTimeSlider } from './compounds';
 
-// Parent slider first — sub-elements consume its context.
-safeDefine(TimeSliderElement);
-safeDefine(SliderBufferElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderThumbnailElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
+defineTimeSlider();
 
 declare global {
   interface HTMLElementTagNameMap {
     [TimeSliderElement.tagName]: TimeSliderElement;
+    [SliderBufferElement.tagName]: SliderBufferElement;
+    [SliderFillElement.tagName]: SliderFillElement;
+    [SliderPreviewElement.tagName]: SliderPreviewElement;
+    [SliderThumbElement.tagName]: SliderThumbElement;
+    [SliderThumbnailElement.tagName]: SliderThumbnailElement;
+    [SliderTrackElement.tagName]: SliderTrackElement;
+    [SliderValueElement.tagName]: SliderValueElement;
   }
 }

--- a/packages/html/src/define/ui/time.ts
+++ b/packages/html/src/define/ui/time.ts
@@ -1,14 +1,14 @@
 import { TimeElement } from '../../ui/time/time-element';
 import { TimeGroupElement } from '../../ui/time/time-group-element';
 import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
-import { safeDefine } from '../safe-define';
+import { defineTime } from './compounds';
 
-safeDefine(TimeElement);
-safeDefine(TimeGroupElement);
-safeDefine(TimeSeparatorElement);
+defineTime();
 
 declare global {
   interface HTMLElementTagNameMap {
     [TimeElement.tagName]: TimeElement;
+    [TimeGroupElement.tagName]: TimeGroupElement;
+    [TimeSeparatorElement.tagName]: TimeSeparatorElement;
   }
 }

--- a/packages/html/src/define/ui/volume-slider.ts
+++ b/packages/html/src/define/ui/volume-slider.ts
@@ -4,18 +4,17 @@ import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
 import { SliderTrackElement } from '../../ui/slider/slider-track-element';
 import { SliderValueElement } from '../../ui/slider/slider-value-element';
 import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
-import { safeDefine } from '../safe-define';
+import { defineVolumeSlider } from './compounds';
 
-// Parent slider first — sub-elements consume its context.
-safeDefine(VolumeSliderElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
+defineVolumeSlider();
 
 declare global {
   interface HTMLElementTagNameMap {
     [VolumeSliderElement.tagName]: VolumeSliderElement;
+    [SliderFillElement.tagName]: SliderFillElement;
+    [SliderPreviewElement.tagName]: SliderPreviewElement;
+    [SliderThumbElement.tagName]: SliderThumbElement;
+    [SliderTrackElement.tagName]: SliderTrackElement;
+    [SliderValueElement.tagName]: SliderValueElement;
   }
 }

--- a/packages/html/src/define/video/minimal-ui.ts
+++ b/packages/html/src/define/video/minimal-ui.ts
@@ -1,22 +1,77 @@
-// Side-effect-only module: registers the video player, container, and all
-// video UI custom elements used by the minimal skin without creating a skin
-// element. Use this entry when building an ejected (light DOM) player layout.
-import './player';
+// Registers the video player, container, and all video UI custom elements
+// used by the minimal skin without creating a skin element. Use this entry
+// when building an ejected (light DOM) player layout.
+import { MediaContainerElement } from '../../media/container-element';
+import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
+import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
+import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
+import { ControlsElement } from '../../ui/controls/controls-element';
+import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
+import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
+import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
+import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
+import { PiPButtonElement } from '../../ui/pip-button/pip-button-element';
+import { PlayButtonElement } from '../../ui/play-button/play-button-element';
+import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playback-rate-button-element';
+import { PopoverElement } from '../../ui/popover/popover-element';
+import { PosterElement } from '../../ui/poster/poster-element';
+import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderThumbnailElement } from '../../ui/slider/slider-thumbnail-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
+import { TimeElement } from '../../ui/time/time-element';
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
+import { TooltipElement } from '../../ui/tooltip/tooltip-element';
+import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
+import { safeDefine } from '../safe-define';
 
-import '../ui/buffering-indicator';
-import '../ui/captions-button';
-import '../ui/controls';
-import '../ui/error-dialog';
-import '../ui/fullscreen-button';
-import '../ui/mute-button';
-import '../ui/pip-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/poster';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Value import — player.ts body runs before this module's body.
+import { VideoPlayerElement } from './player';
+
+// ── Registration (providers / parents first) ────────────────────────────
+
+safeDefine(VideoPlayerElement);
+safeDefine(MediaContainerElement);
+
+// Parent/composite elements before their children.
+safeDefine(ControlsElement);
+safeDefine(ControlsGroupElement);
+safeDefine(ErrorDialogElement);
+safeDefine(AlertDialogCloseElement);
+safeDefine(AlertDialogDescriptionElement);
+safeDefine(AlertDialogTitleElement);
+safeDefine(TimeSliderElement);
+safeDefine(SliderBufferElement);
+safeDefine(SliderFillElement);
+safeDefine(SliderPreviewElement);
+safeDefine(SliderThumbElement);
+safeDefine(SliderThumbnailElement);
+safeDefine(SliderTrackElement);
+safeDefine(SliderValueElement);
+safeDefine(VolumeSliderElement);
+safeDefine(TimeElement);
+safeDefine(TimeGroupElement);
+safeDefine(TimeSeparatorElement);
+
+// Standalone elements.
+safeDefine(BufferingIndicatorElement);
+safeDefine(CaptionsButtonElement);
+safeDefine(FullscreenButtonElement);
+safeDefine(MuteButtonElement);
+safeDefine(PiPButtonElement);
+safeDefine(PlayButtonElement);
+safeDefine(PlaybackRateButtonElement);
+safeDefine(PopoverElement);
+safeDefine(PosterElement);
+safeDefine(SeekButtonElement);
+safeDefine(TooltipElement);
+safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/video/minimal-ui.ts
+++ b/packages/html/src/define/video/minimal-ui.ts
@@ -2,14 +2,8 @@
 // used by the minimal skin without creating a skin element. Use this entry
 // when building an ejected (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
-import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
-import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
-import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
-import { ControlsElement } from '../../ui/controls/controls-element';
-import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
-import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
 import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
 import { PiPButtonElement } from '../../ui/pip-button/pip-button-element';
@@ -18,21 +12,10 @@ import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playbac
 import { PopoverElement } from '../../ui/popover/popover-element';
 import { PosterElement } from '../../ui/poster/poster-element';
 import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
-import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
-import { SliderFillElement } from '../../ui/slider/slider-fill-element';
-import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
-import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
-import { SliderThumbnailElement } from '../../ui/slider/slider-thumbnail-element';
-import { SliderTrackElement } from '../../ui/slider/slider-track-element';
-import { SliderValueElement } from '../../ui/slider/slider-value-element';
-import { TimeElement } from '../../ui/time/time-element';
-import { TimeGroupElement } from '../../ui/time/time-group-element';
-import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
-import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
-import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
 import { safeDefine } from '../safe-define';
+import { defineControls, defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { VideoPlayerElement } from './player';
@@ -42,25 +25,12 @@ import { VideoPlayerElement } from './player';
 safeDefine(VideoPlayerElement);
 safeDefine(MediaContainerElement);
 
-// Parent/composite elements before their children.
-safeDefine(ControlsElement);
-safeDefine(ControlsGroupElement);
-safeDefine(ErrorDialogElement);
-safeDefine(AlertDialogCloseElement);
-safeDefine(AlertDialogDescriptionElement);
-safeDefine(AlertDialogTitleElement);
-safeDefine(TimeSliderElement);
-safeDefine(SliderBufferElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderThumbnailElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
-safeDefine(VolumeSliderElement);
-safeDefine(TimeElement);
-safeDefine(TimeGroupElement);
-safeDefine(TimeSeparatorElement);
+// Compound groups.
+defineControls();
+defineErrorDialog();
+defineTimeSlider();
+defineVolumeSlider();
+defineTime();
 
 // Standalone elements.
 safeDefine(BufferingIndicatorElement);

--- a/packages/html/src/define/video/ui.ts
+++ b/packages/html/src/define/video/ui.ts
@@ -1,23 +1,79 @@
-// Side-effect-only module: registers the video player, container, and all
-// video UI custom elements without creating a skin element. Use this entry
-// when building an ejected (light DOM) player layout.
-import './player';
+// Registers the video player, container, and all video UI custom elements
+// without creating a skin element. Use this entry when building an ejected
+// (light DOM) player layout.
+import { MediaContainerElement } from '../../media/container-element';
+import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
+import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
+import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
+import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
+import { ControlsElement } from '../../ui/controls/controls-element';
+import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
+import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
+import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
+import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
+import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
+import { PiPButtonElement } from '../../ui/pip-button/pip-button-element';
+import { PlayButtonElement } from '../../ui/play-button/play-button-element';
+import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playback-rate-button-element';
+import { PopoverElement } from '../../ui/popover/popover-element';
+import { PosterElement } from '../../ui/poster/poster-element';
+import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
+import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
+import { SliderFillElement } from '../../ui/slider/slider-fill-element';
+import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
+import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
+import { SliderThumbnailElement } from '../../ui/slider/slider-thumbnail-element';
+import { SliderTrackElement } from '../../ui/slider/slider-track-element';
+import { SliderValueElement } from '../../ui/slider/slider-value-element';
+import { TimeElement } from '../../ui/time/time-element';
+import { TimeGroupElement } from '../../ui/time/time-group-element';
+import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
+import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
+import { TooltipElement } from '../../ui/tooltip/tooltip-element';
+import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
+import { safeDefine } from '../safe-define';
 
-import '../ui/buffering-indicator';
-import '../ui/captions-button';
-import '../ui/controls';
-import '../ui/error-dialog';
-import '../ui/fullscreen-button';
-import '../ui/hotkey';
-import '../ui/mute-button';
-import '../ui/pip-button';
-import '../ui/play-button';
-import '../ui/playback-rate-button';
-import '../ui/popover';
-import '../ui/poster';
-import '../ui/seek-button';
-import '../ui/time';
-import '../ui/time-slider';
-import '../ui/tooltip';
-import '../ui/tooltip-group';
-import '../ui/volume-slider';
+// Value import — player.ts body runs before this module's body.
+import { VideoPlayerElement } from './player';
+
+// ── Registration (providers / parents first) ────────────────────────────
+
+safeDefine(VideoPlayerElement);
+safeDefine(MediaContainerElement);
+
+// Parent/composite elements before their children.
+safeDefine(ControlsElement);
+safeDefine(ControlsGroupElement);
+safeDefine(ErrorDialogElement);
+safeDefine(AlertDialogCloseElement);
+safeDefine(AlertDialogDescriptionElement);
+safeDefine(AlertDialogTitleElement);
+safeDefine(TimeSliderElement);
+safeDefine(SliderBufferElement);
+safeDefine(SliderFillElement);
+safeDefine(SliderPreviewElement);
+safeDefine(SliderThumbElement);
+safeDefine(SliderThumbnailElement);
+safeDefine(SliderTrackElement);
+safeDefine(SliderValueElement);
+safeDefine(VolumeSliderElement);
+safeDefine(TimeElement);
+safeDefine(TimeGroupElement);
+safeDefine(TimeSeparatorElement);
+
+// Standalone elements.
+safeDefine(BufferingIndicatorElement);
+safeDefine(CaptionsButtonElement);
+safeDefine(FullscreenButtonElement);
+safeDefine(HotkeyElement);
+safeDefine(MuteButtonElement);
+safeDefine(PiPButtonElement);
+safeDefine(PlayButtonElement);
+safeDefine(PlaybackRateButtonElement);
+safeDefine(PopoverElement);
+safeDefine(PosterElement);
+safeDefine(SeekButtonElement);
+safeDefine(TooltipElement);
+safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/video/ui.ts
+++ b/packages/html/src/define/video/ui.ts
@@ -2,14 +2,8 @@
 // without creating a skin element. Use this entry when building an ejected
 // (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
-import { AlertDialogCloseElement } from '../../ui/alert-dialog/alert-dialog-close-element';
-import { AlertDialogDescriptionElement } from '../../ui/alert-dialog/alert-dialog-description-element';
-import { AlertDialogTitleElement } from '../../ui/alert-dialog/alert-dialog-title-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
-import { ControlsElement } from '../../ui/controls/controls-element';
-import { ControlsGroupElement } from '../../ui/controls/controls-group-element';
-import { ErrorDialogElement } from '../../ui/error-dialog/error-dialog-element';
 import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
@@ -19,21 +13,10 @@ import { PlaybackRateButtonElement } from '../../ui/playback-rate-button/playbac
 import { PopoverElement } from '../../ui/popover/popover-element';
 import { PosterElement } from '../../ui/poster/poster-element';
 import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
-import { SliderBufferElement } from '../../ui/slider/slider-buffer-element';
-import { SliderFillElement } from '../../ui/slider/slider-fill-element';
-import { SliderPreviewElement } from '../../ui/slider/slider-preview-element';
-import { SliderThumbElement } from '../../ui/slider/slider-thumb-element';
-import { SliderThumbnailElement } from '../../ui/slider/slider-thumbnail-element';
-import { SliderTrackElement } from '../../ui/slider/slider-track-element';
-import { SliderValueElement } from '../../ui/slider/slider-value-element';
-import { TimeElement } from '../../ui/time/time-element';
-import { TimeGroupElement } from '../../ui/time/time-group-element';
-import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
-import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
-import { VolumeSliderElement } from '../../ui/volume-slider/volume-slider-element';
 import { safeDefine } from '../safe-define';
+import { defineControls, defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { VideoPlayerElement } from './player';
@@ -43,25 +26,12 @@ import { VideoPlayerElement } from './player';
 safeDefine(VideoPlayerElement);
 safeDefine(MediaContainerElement);
 
-// Parent/composite elements before their children.
-safeDefine(ControlsElement);
-safeDefine(ControlsGroupElement);
-safeDefine(ErrorDialogElement);
-safeDefine(AlertDialogCloseElement);
-safeDefine(AlertDialogDescriptionElement);
-safeDefine(AlertDialogTitleElement);
-safeDefine(TimeSliderElement);
-safeDefine(SliderBufferElement);
-safeDefine(SliderFillElement);
-safeDefine(SliderPreviewElement);
-safeDefine(SliderThumbElement);
-safeDefine(SliderThumbnailElement);
-safeDefine(SliderTrackElement);
-safeDefine(SliderValueElement);
-safeDefine(VolumeSliderElement);
-safeDefine(TimeElement);
-safeDefine(TimeGroupElement);
-safeDefine(TimeSeparatorElement);
+// Compound groups.
+defineControls();
+defineErrorDialog();
+defineTimeSlider();
+defineVolumeSlider();
+defineTime();
 
 // Standalone elements.
 safeDefine(BufferingIndicatorElement);


### PR DESCRIPTION
Closing #1301

## Summary

Bare side-effect imports from relative paths in define modules cause non-deterministic registration order when loaded as native ESM in the browser. This replaces them with explicit value imports and ordered `safeDefine()` calls, and adds a workspace check to prevent regressions.

## Changes

- Replace all bare side-effect imports in audio/video `ui.ts` and `minimal-ui.ts` with value imports and explicit `safeDefine()` registration in dependency order (providers/parents first)
- Add Check 6 (`checkDefineImports`) to the workspace checker that flags multiple bare side-effect imports from relative paths in the define directory

## Testing

`node build/scripts/check-workspace.mjs` — the new check passes with no warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how HTML custom elements are registered in audio/video define entrypoints to avoid non-deterministic ESM evaluation order, which could impact runtime behavior if any element dependencies were missed. Adds a new workspace consistency check to prevent regressions.
> 
> **Overview**
> Fixes non-deterministic custom-element registration when consuming `packages/html` define entrypoints as native ESM by replacing multiple bare side-effect imports with explicit value imports and ordered `safeDefine()` / `define*()` calls in audio/video `ui.ts` and `minimal-ui.ts`.
> 
> Introduces `define` “compound” helpers in `define/ui/compounds.ts` and refactors existing `define/ui/*` modules to use them for consistent parent/child registration ordering.
> 
> Extends `pnpm check:workspace` with a new `Define imports` check that flags multiple bare relative side-effect imports under `html/src/define`, and updates `CLAUDE.md` to include the new workflow step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5f99b1f71ccdb9ee9506fdff5e43c4abbd2d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->