### PR TITLE
refactor(core): skip inline touch toggle when gesture coordinator exists

### DIFF
--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -172,8 +172,12 @@ export interface MediaControlsState {
   userActive: boolean;
   /** Whether controls should be visible (userActive || paused). */
   controlsVisible: boolean;
-  /** Update user activity and controls visibility. */
-  setControls(userActive: boolean, controlsVisible: boolean): void;
+  /** Mark user as active/inactive and recompute visibility. Resets idle timer when active. */
+  setUserActivity(active: boolean): void;
+  /** Show controls and reset idle timer. */
+  showControls(): void;
+  /** Hide controls immediately. */
+  hideControls(): void;
   /** Toggle controls visibility. Returns the new `controlsVisible` value. */
   toggleControls(): boolean;
 }

--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -172,6 +172,10 @@ export interface MediaControlsState {
   userActive: boolean;
   /** Whether controls should be visible (userActive || paused). */
   controlsVisible: boolean;
+  /** Mark the user as active and reset the idle timer. */
+  setActive(): void;
+  /** Mark the user as inactive and clear the idle timer. */
+  setInactive(): void;
   /** Toggle controls visibility. Returns the new `controlsVisible` value. */
   toggleControls(): boolean;
 }

--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -172,10 +172,8 @@ export interface MediaControlsState {
   userActive: boolean;
   /** Whether controls should be visible (userActive || paused). */
   controlsVisible: boolean;
-  /** Mark the user as active and reset the idle timer. */
-  setActive(): void;
-  /** Mark the user as inactive and clear the idle timer. */
-  setInactive(): void;
+  /** Update user activity and controls visibility. */
+  setControls(userActive: boolean, controlsVisible: boolean): void;
   /** Toggle controls visibility. Returns the new `controlsVisible` value. */
   toggleControls(): boolean;
 }

--- a/packages/core/src/core/ui/controls/tests/controls-core.test.ts
+++ b/packages/core/src/core/ui/controls/tests/controls-core.test.ts
@@ -73,7 +73,9 @@ function createControlsState(overrides: Partial<MediaControlsState> = {}): Media
   return {
     userActive: true,
     controlsVisible: true,
-    setControls: () => {},
+    setUserActivity: () => {},
+    showControls: () => {},
+    hideControls: () => {},
     toggleControls: () => true,
     ...overrides,
   };

--- a/packages/core/src/core/ui/controls/tests/controls-core.test.ts
+++ b/packages/core/src/core/ui/controls/tests/controls-core.test.ts
@@ -73,8 +73,7 @@ function createControlsState(overrides: Partial<MediaControlsState> = {}): Media
   return {
     userActive: true,
     controlsVisible: true,
-    setActive: () => {},
-    setInactive: () => {},
+    setControls: () => {},
     toggleControls: () => true,
     ...overrides,
   };

--- a/packages/core/src/core/ui/controls/tests/controls-core.test.ts
+++ b/packages/core/src/core/ui/controls/tests/controls-core.test.ts
@@ -73,6 +73,8 @@ function createControlsState(overrides: Partial<MediaControlsState> = {}): Media
   return {
     userActive: true,
     controlsVisible: true,
+    setActive: () => {},
+    setInactive: () => {},
     toggleControls: () => true,
     ...overrides,
   };

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -13,6 +13,7 @@ export * from './store/features';
 export * from './store/selectors';
 export * from './ui/alert-dialog';
 export * from './ui/button';
+export * from './ui/controls-activity';
 export * from './ui/dismiss-layer';
 export * from './ui/event';
 export * from './ui/popover/popover';

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -1,18 +1,109 @@
+import { listen } from '@videojs/utils/dom';
+import { isNull } from '@videojs/utils/predicate';
+
 import type { MediaControlsState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
+
+const IDLE_DELAY = 2000;
 
 export const controlsFeature = definePlayerFeature({
   name: 'controls',
   state: ({ get, set }): MediaControlsState => ({
     userActive: true,
     controlsVisible: true,
-    setControls(userActive: boolean, controlsVisible: boolean) {
-      set({ userActive, controlsVisible });
-    },
+    setUserActivity() {},
+    showControls() {},
+    hideControls() {},
     toggleControls() {
+      // Fallback before attach — no idle timer, just flip state.
       const next = !get().controlsVisible;
       set({ userActive: next, controlsVisible: next });
       return next as boolean;
     },
   }),
+
+  attach({ target, signal, get, set }) {
+    const { media, container } = target;
+
+    if (isNull(container)) {
+      if (__DEV__) {
+        console.warn('[vjs] controlsFeature requires a container element for activity tracking.');
+      }
+      return;
+    }
+
+    function computeVisible(userActive: boolean): boolean {
+      return userActive || media.paused;
+    }
+
+    // Idle timer
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function clearIdle() {
+      clearTimeout(idleTimer);
+      idleTimer = undefined;
+    }
+
+    function scheduleIdle() {
+      clearIdle();
+      idleTimer = setTimeout(() => {
+        clearIdle();
+        set({ userActive: false, controlsVisible: computeVisible(false) });
+      }, IDLE_DELAY);
+    }
+
+    // Recompute visibility when playback state changes.
+    function onPlaybackChange() {
+      const { userActive } = get();
+      set({ controlsVisible: computeVisible(userActive) });
+
+      if (!media.paused && userActive) {
+        scheduleIdle();
+      }
+    }
+
+    // Expose methods with idle timer access.
+    set({
+      setUserActivity(active: boolean) {
+        if (active) {
+          if (!get().userActive) {
+            set({ userActive: true, controlsVisible: true });
+          }
+          scheduleIdle();
+        } else {
+          clearIdle();
+          set({ userActive: false, controlsVisible: computeVisible(false) });
+        }
+      },
+      showControls() {
+        set({ userActive: true, controlsVisible: true });
+        scheduleIdle();
+      },
+      hideControls() {
+        clearIdle();
+        set({ userActive: false, controlsVisible: computeVisible(false) });
+      },
+      toggleControls() {
+        if (get().controlsVisible) {
+          clearIdle();
+          set({ userActive: false, controlsVisible: computeVisible(false) });
+        } else {
+          set({ userActive: true, controlsVisible: true });
+          scheduleIdle();
+        }
+        return get().controlsVisible;
+      },
+    });
+
+    // Media event listeners for playback state changes.
+    listen(media, 'play', onPlaybackChange, { signal });
+    listen(media, 'pause', onPlaybackChange, { signal });
+    listen(media, 'ended', onPlaybackChange, { signal });
+
+    // Clean up timer on signal abort.
+    signal.addEventListener('abort', clearIdle, { once: true });
+
+    // Schedule initial idle.
+    scheduleIdle();
+  },
 });

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -3,16 +3,21 @@ import { isNull } from '@videojs/utils/predicate';
 
 import type { MediaControlsState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
-import { findGestureCoordinator } from '../../gesture/coordinator';
 
 const IDLE_DELAY = 2000;
-const TAP_THRESHOLD = 250;
 
 export const controlsFeature = definePlayerFeature({
   name: 'controls',
   state: ({ get, set }): MediaControlsState => ({
     userActive: true,
     controlsVisible: true,
+    setActive() {
+      const next = !get().userActive;
+      if (next) set({ userActive: true, controlsVisible: true });
+    },
+    setInactive() {
+      set({ userActive: false, controlsVisible: false });
+    },
     toggleControls() {
       // Fallback before attach — no idle timer, just flip state.
       const next = !get().userActive;
@@ -60,8 +65,10 @@ export const controlsFeature = definePlayerFeature({
       set({ userActive: false, controlsVisible: computeVisible(false) });
     }
 
-    // Replace toggleControls with version that has idle timer access.
+    // Expose methods with access to idle timer.
     set({
+      setActive,
+      setInactive,
       toggleControls() {
         if (get().controlsVisible) {
           setInactive();
@@ -71,34 +78,6 @@ export const controlsFeature = definePlayerFeature({
         return get().controlsVisible;
       },
     });
-
-    // Touch tap-to-toggle — only when no gesture coordinator is managing this container.
-    // When gestures are registered, a `<media-gesture type="tap" action="toggleControls">`
-    // handles touch taps instead, avoiding conflict with this handler.
-    let pointerDownTime = 0;
-
-    function onPointerDown() {
-      pointerDownTime = Date.now();
-    }
-
-    function onPointerUp(event: PointerEvent) {
-      if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
-        // If a gesture coordinator exists, gestures handle touch tap — skip.
-        if (findGestureCoordinator(container as HTMLElement)) {
-          return;
-        }
-
-        // Inline touch tap-to-toggle for standalone use (no gestures).
-        const isMediaOrContainer = [media, container].includes(event.target as HTMLElement);
-        if (get().controlsVisible && isMediaOrContainer) {
-          setInactive();
-        } else {
-          setActive();
-        }
-      } else {
-        setActive();
-      }
-    }
 
     // Recompute visibility when playback state changes.
     function onPlaybackChange() {
@@ -110,16 +89,6 @@ export const controlsFeature = definePlayerFeature({
         scheduleIdle();
       }
     }
-
-    // Container event listeners
-    listen(container, 'pointermove', setActive, { signal });
-    listen(container, 'pointerdown', onPointerDown, { signal });
-    listen(container, 'pointerup', onPointerUp, { signal });
-    listen(container, 'keyup', setActive, { signal });
-    listen(container, 'focusin', setActive, { signal });
-    // On touch devices pointerleave would fire after a pointerup event which hides the controls.
-    // https://w3c.github.io/pointerevents/#dfn-pointerup
-    listen(container, 'mouseleave', setInactive, { signal });
 
     // Media event listeners for playback state changes.
     listen(media, 'play', onPlaybackChange, { signal });

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -3,6 +3,7 @@ import { isNull } from '@videojs/utils/predicate';
 
 import type { MediaControlsState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
+import { findGestureCoordinator } from '../../gesture/coordinator';
 
 const IDLE_DELAY = 2000;
 const TAP_THRESHOLD = 250;
@@ -59,7 +60,7 @@ export const controlsFeature = definePlayerFeature({
       set({ userActive: false, controlsVisible: computeVisible(false) });
     }
 
-    // Expose toggleControls with access to idle timer.
+    // Replace toggleControls with version that has idle timer access.
     set({
       toggleControls() {
         if (get().controlsVisible) {
@@ -71,7 +72,9 @@ export const controlsFeature = definePlayerFeature({
       },
     });
 
-    // Touch tap-to-toggle
+    // Touch tap-to-toggle — only when no gesture coordinator is managing this container.
+    // When gestures are registered, a `<media-gesture type="tap" action="toggleControls">`
+    // handles touch taps instead, avoiding conflict with this handler.
     let pointerDownTime = 0;
 
     function onPointerDown() {
@@ -80,7 +83,12 @@ export const controlsFeature = definePlayerFeature({
 
     function onPointerUp(event: PointerEvent) {
       if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
-        // If the event target is in the controls don't set inactive because that sets pointer-events: none in CSS.
+        // If a gesture coordinator exists, gestures handle touch tap — skip.
+        if (findGestureCoordinator(container as HTMLElement)) {
+          return;
+        }
+
+        // Inline touch tap-to-toggle for standalone use (no gestures).
         const isMediaOrContainer = [media, container].includes(event.target as HTMLElement);
         if (get().controlsVisible && isMediaOrContainer) {
           setInactive();

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -1,105 +1,18 @@
-import { listen } from '@videojs/utils/dom';
-import { isNull } from '@videojs/utils/predicate';
-
 import type { MediaControlsState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
-
-const IDLE_DELAY = 2000;
 
 export const controlsFeature = definePlayerFeature({
   name: 'controls',
   state: ({ get, set }): MediaControlsState => ({
     userActive: true,
     controlsVisible: true,
-    setActive() {
-      const next = !get().userActive;
-      if (next) set({ userActive: true, controlsVisible: true });
-    },
-    setInactive() {
-      set({ userActive: false, controlsVisible: false });
+    setControls(userActive: boolean, controlsVisible: boolean) {
+      set({ userActive, controlsVisible });
     },
     toggleControls() {
-      // Fallback before attach — no idle timer, just flip state.
-      const next = !get().userActive;
+      const next = !get().controlsVisible;
       set({ userActive: next, controlsVisible: next });
       return next as boolean;
     },
   }),
-
-  attach({ target, signal, get, set }) {
-    const { media, container } = target;
-
-    if (isNull(container)) {
-      if (__DEV__) {
-        console.warn('[vjs] controlsFeature requires a container element for activity tracking.');
-      }
-      return;
-    }
-
-    function computeVisible(userActive: boolean): boolean {
-      return userActive || media.paused;
-    }
-
-    // Idle timer
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-
-    function clearIdle() {
-      clearTimeout(idleTimer);
-      idleTimer = undefined;
-    }
-
-    function scheduleIdle() {
-      clearIdle();
-      idleTimer = setTimeout(setInactive, IDLE_DELAY);
-    }
-
-    function setActive() {
-      if (!get().userActive) {
-        set({ userActive: true, controlsVisible: true });
-      }
-      scheduleIdle();
-    }
-
-    function setInactive() {
-      clearIdle();
-      set({ userActive: false, controlsVisible: computeVisible(false) });
-    }
-
-    // Expose methods with access to idle timer.
-    set({
-      setActive,
-      setInactive,
-      toggleControls() {
-        if (get().controlsVisible) {
-          setInactive();
-        } else {
-          setActive();
-        }
-        return get().controlsVisible;
-      },
-    });
-
-    // Recompute visibility when playback state changes.
-    function onPlaybackChange() {
-      const { userActive } = get();
-      set({ controlsVisible: computeVisible(userActive) });
-
-      // When playback starts, schedule idle if user is active.
-      if (!media.paused && userActive) {
-        scheduleIdle();
-      }
-    }
-
-    // Media event listeners for playback state changes.
-    listen(media, 'play', onPlaybackChange, { signal });
-    listen(media, 'pause', onPlaybackChange, { signal });
-    listen(media, 'ended', onPlaybackChange, { signal });
-
-    // Clean up timer on signal abort.
-    signal.addEventListener('abort', clearIdle, { once: true });
-
-    // Always schedule idle initially. When paused, userActive will go false
-    // but controlsVisible stays true (because paused keeps controls visible).
-    scheduleIdle();
-  },
 });

--- a/packages/core/src/dom/store/features/tests/controls.test.ts
+++ b/packages/core/src/dom/store/features/tests/controls.test.ts
@@ -48,181 +48,67 @@ describe('controlsFeature', () => {
     });
   });
 
-  describe('activity detection', () => {
-    it('resets idle timer on pointermove', () => {
+  describe('setActive', () => {
+    it('sets user as active', () => {
       const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
+      const { store } = createPlayerStore(video);
 
-      // Advance partway through idle delay
-      vi.advanceTimersByTime(IDLE_DELAY - 500);
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
 
-      container!.dispatchEvent(new Event('pointermove'));
+      expect(store.state.userActive).toBe(false);
+
+      store.state.setActive();
       flush();
 
       expect(store.state.userActive).toBe(true);
       expect(store.state.controlsVisible).toBe(true);
+    });
 
-      // Advance past original delay — still active since timer was reset
+    it('resets idle timer', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      // Advance partway through idle delay
+      vi.advanceTimersByTime(IDLE_DELAY - 500);
+
+      store.state.setActive();
+      flush();
+
+      // Advance past original delay
       vi.advanceTimersByTime(500);
       flush();
 
       expect(store.state.userActive).toBe(true);
 
-      // Now wait full delay from the pointermove
+      // Now wait full delay from the setActive call
       vi.advanceTimersByTime(IDLE_DELAY - 500);
       flush();
 
       expect(store.state.userActive).toBe(false);
     });
-
-    it('sets active on keyup', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-
-      container!.dispatchEvent(new Event('keyup'));
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('reactivates on pointermove after idle', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(false);
-
-      container!.dispatchEvent(new Event('pointermove'));
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('sets active on focusin', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-
-      container!.dispatchEvent(new Event('focusin'));
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-    });
-
-    it('sets inactive immediately on mouseleave', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      container!.dispatchEvent(new Event('mouseleave'));
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(false);
-    });
-
-    it('keeps controlsVisible true on mouseleave when paused', () => {
-      const video = createMockVideo({ paused: true });
-      const { store, container } = createPlayerStore(video);
-
-      container!.dispatchEvent(new Event('mouseleave'));
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(true);
-    });
   });
 
-  describe('touch tap-to-toggle', () => {
-    it('hides controls on tap when visible and playing', () => {
+  describe('setInactive', () => {
+    it('sets user as inactive', () => {
       const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
+      const { store } = createPlayerStore(video);
 
-      container!.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(100);
-
-      container!.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
+      store.state.setInactive();
       flush();
 
       expect(store.state.userActive).toBe(false);
       expect(store.state.controlsVisible).toBe(false);
     });
 
-    it('keeps controls visible on tap when paused', () => {
+    it('keeps controlsVisible true when paused', () => {
       const video = createMockVideo({ paused: true });
-      const { store, container } = createPlayerStore(video);
+      const { store } = createPlayerStore(video);
 
-      container!.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(100);
-
-      container!.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
+      store.state.setInactive();
       flush();
 
-      // userActive goes false but controlsVisible stays true (paused)
       expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('shows controls on tap when hidden', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      // First tap to hide
-      container!.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(100);
-      container!.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
-      flush();
-
-      expect(store.state.controlsVisible).toBe(false);
-
-      // Second tap to show
-      container!.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(100);
-      container!.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('does not toggle on long press', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      container!.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(300);
-
-      container!.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('does not toggle for mouse clicks', () => {
-      const video = createMockVideo({ paused: false });
-      const { store, container } = createPlayerStore(video);
-
-      container!.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(100);
-
-      container!.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'mouse' }));
-      flush();
-
-      expect(store.state.userActive).toBe(true);
       expect(store.state.controlsVisible).toBe(true);
     });
   });
@@ -266,10 +152,10 @@ describe('controlsFeature', () => {
 
     it('schedules idle when playback resumes and user is active', () => {
       const video = createMockVideo({ paused: true });
-      const { store, container } = createPlayerStore(video);
+      const { store } = createPlayerStore(video);
 
-      // Trigger activity to keep user active
-      container!.dispatchEvent(new Event('pointermove'));
+      // Keep user active
+      store.state.setActive();
       flush();
 
       // Resume playback
@@ -432,12 +318,6 @@ describe('controlsFeature', () => {
 
 function createContainer(): HTMLElement {
   return document.createElement('div');
-}
-
-function createPointerEvent(type: string, init?: { pointerType?: string }): Event {
-  const event = new Event(type, { bubbles: true });
-  (event as unknown as Record<string, unknown>).pointerType = init?.pointerType ?? '';
-  return event;
 }
 
 function createPlayerStore(video?: HTMLVideoElement, container?: HTMLElement | null) {

--- a/packages/core/src/dom/store/features/tests/controls.test.ts
+++ b/packages/core/src/dom/store/features/tests/controls.test.ts
@@ -1,10 +1,15 @@
 import { createStore, flush } from '@videojs/store';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import { createMockVideo } from '../../../tests/test-helpers';
 import { controlsFeature } from '../controls';
 
+const IDLE_DELAY = 2000;
+
 describe('controlsFeature', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   describe('initial state', () => {
     it('starts with userActive: true and controlsVisible: true', () => {
       const { store } = createPlayerStore();
@@ -14,21 +19,90 @@ describe('controlsFeature', () => {
     });
   });
 
-  describe('setControls', () => {
-    it('updates userActive and controlsVisible', () => {
-      const { store } = createPlayerStore();
+  describe('idle timeout', () => {
+    it('sets inactive after idle delay when playing', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
 
-      store.state.setControls(false, false);
+      vi.advanceTimersByTime(IDLE_DELAY);
       flush();
 
       expect(store.state.userActive).toBe(false);
       expect(store.state.controlsVisible).toBe(false);
     });
 
-    it('allows independent values', () => {
-      const { store } = createPlayerStore();
+    it('keeps controlsVisible true when paused', () => {
+      const video = createMockVideo({ paused: true });
+      const { store } = createPlayerStore(video);
 
-      store.state.setControls(false, true);
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(true);
+    });
+  });
+
+  describe('setUserActivity', () => {
+    it('sets active and resets idle timer', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+
+      store.state.setUserActivity(true);
+      flush();
+
+      expect(store.state.userActive).toBe(true);
+      expect(store.state.controlsVisible).toBe(true);
+    });
+
+    it('sets inactive and clears idle timer', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      store.state.setUserActivity(false);
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(false);
+    });
+  });
+
+  describe('showControls / hideControls', () => {
+    it('showControls sets active and visible', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      store.state.hideControls();
+      flush();
+
+      store.state.showControls();
+      flush();
+
+      expect(store.state.userActive).toBe(true);
+      expect(store.state.controlsVisible).toBe(true);
+    });
+
+    it('hideControls sets inactive', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      store.state.hideControls();
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(false);
+    });
+
+    it('hideControls keeps controlsVisible true when paused', () => {
+      const video = createMockVideo({ paused: true });
+      const { store } = createPlayerStore(video);
+
+      store.state.hideControls();
       flush();
 
       expect(store.state.userActive).toBe(false);
@@ -37,8 +111,9 @@ describe('controlsFeature', () => {
   });
 
   describe('toggleControls', () => {
-    it('hides controls when visible', () => {
-      const { store } = createPlayerStore();
+    it('hides controls when visible and playing', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
 
       const result = store.state.toggleControls();
       flush();
@@ -49,7 +124,8 @@ describe('controlsFeature', () => {
     });
 
     it('shows controls when hidden', () => {
-      const { store } = createPlayerStore();
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
 
       store.state.toggleControls();
       flush();
@@ -61,6 +137,90 @@ describe('controlsFeature', () => {
       expect(store.state.controlsVisible).toBe(true);
       expect(result).toBe(true);
     });
+
+    it('reschedules idle timer when showing', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      store.state.toggleControls();
+      flush();
+
+      store.state.toggleControls();
+      flush();
+
+      expect(store.state.controlsVisible).toBe(true);
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.controlsVisible).toBe(false);
+    });
+  });
+
+  describe('playback state interaction', () => {
+    it('shows controls when media pauses', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.controlsVisible).toBe(false);
+
+      Object.defineProperty(video, 'paused', { value: true, configurable: true });
+      video.dispatchEvent(new Event('pause'));
+      flush();
+
+      expect(store.state.controlsVisible).toBe(true);
+    });
+
+    it('hides controls when media resumes and user is inactive', () => {
+      const video = createMockVideo({ paused: true });
+      const { store } = createPlayerStore(video);
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(true);
+
+      Object.defineProperty(video, 'paused', { value: false, configurable: true });
+      video.dispatchEvent(new Event('play'));
+      flush();
+
+      expect(store.state.controlsVisible).toBe(false);
+    });
+  });
+
+  describe('null container', () => {
+    it('does not attach without container', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video, null);
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(true);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('clears idle timer on detach', () => {
+      const video = createMockVideo({ paused: false });
+      const store = createStore<PlayerTarget>()(controlsFeature);
+      const container = document.createElement('div');
+
+      const detach = store.attach({ media: video, container });
+      flush();
+
+      detach();
+      flush();
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(true);
+    });
   });
 });
 
@@ -68,14 +228,14 @@ describe('controlsFeature', () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createPlayerStore() {
+function createPlayerStore(video?: HTMLVideoElement, container?: HTMLElement | null) {
   const store = createStore<PlayerTarget>()(controlsFeature);
 
-  const media = createMockVideo({ paused: true });
-  const container = document.createElement('div');
+  const media = video ?? createMockVideo({ paused: true });
+  const cont = container === undefined ? document.createElement('div') : container;
 
-  store.attach({ media, container });
+  store.attach({ media, container: cont });
   flush();
 
-  return { store, media, container };
+  return { store, media, container: cont };
 }

--- a/packages/core/src/dom/store/features/tests/controls.test.ts
+++ b/packages/core/src/dom/store/features/tests/controls.test.ts
@@ -1,20 +1,10 @@
 import { createStore, flush } from '@videojs/store';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import { createMockVideo } from '../../../tests/test-helpers';
 import { controlsFeature } from '../controls';
 
-const IDLE_DELAY = 2000;
-
 describe('controlsFeature', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   describe('initial state', () => {
     it('starts with userActive: true and controlsVisible: true', () => {
       const { store } = createPlayerStore();
@@ -24,159 +14,31 @@ describe('controlsFeature', () => {
     });
   });
 
-  describe('idle timeout', () => {
-    it('sets inactive after idle delay when playing', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
+  describe('setControls', () => {
+    it('updates userActive and controlsVisible', () => {
+      const { store } = createPlayerStore();
 
-      vi.advanceTimersByTime(IDLE_DELAY);
+      store.state.setControls(false, false);
       flush();
 
       expect(store.state.userActive).toBe(false);
       expect(store.state.controlsVisible).toBe(false);
     });
 
-    it('sets userActive false but keeps controlsVisible true when paused', () => {
-      const video = createMockVideo({ paused: true });
-      const { store } = createPlayerStore(video);
+    it('allows independent values', () => {
+      const { store } = createPlayerStore();
 
-      vi.advanceTimersByTime(IDLE_DELAY);
+      store.state.setControls(false, true);
       flush();
 
       expect(store.state.userActive).toBe(false);
       expect(store.state.controlsVisible).toBe(true);
-    });
-  });
-
-  describe('setActive', () => {
-    it('sets user as active', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-
-      store.state.setActive();
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('resets idle timer', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
-
-      // Advance partway through idle delay
-      vi.advanceTimersByTime(IDLE_DELAY - 500);
-
-      store.state.setActive();
-      flush();
-
-      // Advance past original delay
-      vi.advanceTimersByTime(500);
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-
-      // Now wait full delay from the setActive call
-      vi.advanceTimersByTime(IDLE_DELAY - 500);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-    });
-  });
-
-  describe('setInactive', () => {
-    it('sets user as inactive', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
-
-      store.state.setInactive();
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(false);
-    });
-
-    it('keeps controlsVisible true when paused', () => {
-      const video = createMockVideo({ paused: true });
-      const { store } = createPlayerStore(video);
-
-      store.state.setInactive();
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-  });
-
-  describe('playback state interaction', () => {
-    it('shows controls when media pauses', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.controlsVisible).toBe(false);
-
-      // Pause media
-      Object.defineProperty(video, 'paused', { value: true, configurable: true });
-      video.dispatchEvent(new Event('pause'));
-      flush();
-
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('hides controls when media resumes and user is inactive', () => {
-      const video = createMockVideo({ paused: true });
-      const { store } = createPlayerStore(video);
-
-      // Let idle expire — user inactive, but visible because paused
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(true);
-
-      // Resume playback while user is still inactive
-      Object.defineProperty(video, 'paused', { value: false, configurable: true });
-      video.dispatchEvent(new Event('play'));
-      flush();
-
-      expect(store.state.controlsVisible).toBe(false);
-    });
-
-    it('schedules idle when playback resumes and user is active', () => {
-      const video = createMockVideo({ paused: true });
-      const { store } = createPlayerStore(video);
-
-      // Keep user active
-      store.state.setActive();
-      flush();
-
-      // Resume playback
-      Object.defineProperty(video, 'paused', { value: false, configurable: true });
-      video.dispatchEvent(new Event('play'));
-      flush();
-
-      expect(store.state.controlsVisible).toBe(true);
-
-      // After idle delay, should hide
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.controlsVisible).toBe(false);
     });
   });
 
   describe('toggleControls', () => {
-    it('hides controls when visible and playing', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
+    it('hides controls when visible', () => {
+      const { store } = createPlayerStore();
 
       const result = store.state.toggleControls();
       flush();
@@ -187,127 +49,17 @@ describe('controlsFeature', () => {
     });
 
     it('shows controls when hidden', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
+      const { store } = createPlayerStore();
 
-      // First toggle to hide
       store.state.toggleControls();
       flush();
 
-      expect(store.state.controlsVisible).toBe(false);
-
-      // Second toggle to show
       const result = store.state.toggleControls();
       flush();
 
       expect(store.state.userActive).toBe(true);
       expect(store.state.controlsVisible).toBe(true);
       expect(result).toBe(true);
-    });
-
-    it('reschedules idle timer when showing controls', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
-
-      // Hide controls
-      store.state.toggleControls();
-      flush();
-
-      // Show controls
-      store.state.toggleControls();
-      flush();
-
-      expect(store.state.controlsVisible).toBe(true);
-
-      // Should hide again after idle delay
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(false);
-    });
-
-    it('keeps controlsVisible true when toggling off while paused', () => {
-      const video = createMockVideo({ paused: true });
-      const { store } = createPlayerStore(video);
-
-      const result = store.state.toggleControls();
-      flush();
-
-      expect(store.state.userActive).toBe(false);
-      expect(store.state.controlsVisible).toBe(true);
-      expect(result).toBe(true);
-    });
-  });
-
-  describe('null container', () => {
-    it('does not track activity without container', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video, null);
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-  });
-
-  describe('cleanup', () => {
-    it('stops listening when store is destroyed', () => {
-      const video = createMockVideo({ paused: false });
-      const { store } = createPlayerStore(video);
-
-      store.destroy();
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-    });
-
-    it('clears idle timer on detach', () => {
-      const video = createMockVideo({ paused: false });
-      const store = createStore<PlayerTarget>()(controlsFeature);
-
-      const container = createContainer();
-      const detach = store.attach({ media: video, container });
-      flush();
-
-      detach();
-      flush();
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
-    });
-
-    it('does not react to media events after detach', () => {
-      const video = createMockVideo({ paused: false });
-      const store = createStore<PlayerTarget>()(controlsFeature);
-
-      const container = createContainer();
-      const detach = store.attach({ media: video, container });
-      flush();
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-      flush();
-
-      expect(store.state.controlsVisible).toBe(false);
-
-      detach();
-      flush();
-
-      // Pause after detach — should not affect state
-      Object.defineProperty(video, 'paused', { value: true, configurable: true });
-      video.dispatchEvent(new Event('pause'));
-      flush();
-
-      // State was reset to initial on detach
-      expect(store.state.userActive).toBe(true);
-      expect(store.state.controlsVisible).toBe(true);
     });
   });
 });
@@ -316,18 +68,14 @@ describe('controlsFeature', () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createContainer(): HTMLElement {
-  return document.createElement('div');
-}
-
-function createPlayerStore(video?: HTMLVideoElement, container?: HTMLElement | null) {
+function createPlayerStore() {
   const store = createStore<PlayerTarget>()(controlsFeature);
 
-  const media = video ?? createMockVideo({ paused: true });
-  const cont = container === undefined ? createContainer() : container;
+  const media = createMockVideo({ paused: true });
+  const container = document.createElement('div');
 
-  store.attach({ media, container: cont });
+  store.attach({ media, container });
   flush();
 
-  return { store, media, container: cont };
+  return { store, media, container };
 }

--- a/packages/core/src/dom/ui/controls-activity.ts
+++ b/packages/core/src/dom/ui/controls-activity.ts
@@ -1,0 +1,83 @@
+import { isInteractiveTarget, listen } from '@videojs/utils/dom';
+
+const TAP_THRESHOLD = 250;
+
+export interface ControlsActivityOptions {
+  setActive: () => void;
+  setInactive: () => void;
+  toggleControls: () => void;
+}
+
+export interface ControlsActivityProps {
+  onPointerMove: () => void;
+  onPointerDown: () => void;
+  onPointerUp: (event: PointerEvent) => void;
+  onKeyUp: () => void;
+  onFocusIn: () => void;
+  onMouseLeave: () => void;
+}
+
+export interface ControlsActivityApi {
+  props: ControlsActivityProps;
+}
+
+/**
+ * Create controls activity tracking event handlers.
+ *
+ * Returns props that should be applied to the player container.
+ * Handles idle timer reset on pointer/keyboard activity and
+ * touch tap-to-toggle controls visibility.
+ */
+export function createControlsActivity(options: ControlsActivityOptions): ControlsActivityApi {
+  let pointerDownTime = 0;
+
+  const props: ControlsActivityProps = {
+    onPointerMove() {
+      options.setActive();
+    },
+    onPointerDown() {
+      pointerDownTime = Date.now();
+    },
+    onPointerUp(event: PointerEvent) {
+      if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
+        // Touch tap on interactive controls (buttons, sliders) — skip toggle.
+        if (isInteractiveTarget(event)) return;
+
+        options.toggleControls();
+        return;
+      }
+
+      // Non-touch pointer up (mouse click, pen) — treat as activity.
+      options.setActive();
+    },
+    onKeyUp() {
+      options.setActive();
+    },
+    onFocusIn() {
+      options.setActive();
+    },
+    onMouseLeave() {
+      options.setInactive();
+    },
+  };
+
+  return { props };
+}
+
+/** Wire up controls activity tracking on a container element. */
+export function attachControlsActivity(
+  container: HTMLElement,
+  options: ControlsActivityOptions,
+  signal: AbortSignal
+): ControlsActivityApi {
+  const activity = createControlsActivity(options);
+
+  listen(container, 'pointermove', activity.props.onPointerMove, { signal });
+  listen(container, 'pointerdown', activity.props.onPointerDown, { signal });
+  listen(container, 'pointerup', activity.props.onPointerUp as EventListener, { signal });
+  listen(container, 'keyup', activity.props.onKeyUp, { signal });
+  listen(container, 'focusin', activity.props.onFocusIn, { signal });
+  listen(container, 'mouseleave', activity.props.onMouseLeave, { signal });
+
+  return activity;
+}

--- a/packages/core/src/dom/ui/controls-activity.ts
+++ b/packages/core/src/dom/ui/controls-activity.ts
@@ -1,83 +1,124 @@
 import { isInteractiveTarget, listen } from '@videojs/utils/dom';
 
+const IDLE_DELAY = 2000;
 const TAP_THRESHOLD = 250;
 
 export interface ControlsActivityOptions {
-  setActive: () => void;
-  setInactive: () => void;
-  toggleControls: () => void;
-}
-
-export interface ControlsActivityProps {
-  onPointerMove: () => void;
-  onPointerDown: () => void;
-  onPointerUp: (event: PointerEvent) => void;
-  onKeyUp: () => void;
-  onFocusIn: () => void;
-  onMouseLeave: () => void;
+  getContainer: () => HTMLElement;
+  getMedia: () => HTMLMediaElement;
+  getControlsVisible: () => boolean;
+  getUserActive: () => boolean;
+  setControls: (userActive: boolean, controlsVisible: boolean) => void;
 }
 
 export interface ControlsActivityApi {
-  props: ControlsActivityProps;
+  destroy: () => void;
 }
 
 /**
- * Create controls activity tracking event handlers.
+ * Wire up controls activity tracking on a container element.
  *
- * Returns props that should be applied to the player container.
- * Handles idle timer reset on pointer/keyboard activity and
- * touch tap-to-toggle controls visibility.
+ * Manages idle timer, pointer/keyboard activity detection, touch
+ * tap-to-toggle, and playback state visibility recomputation.
  */
 export function createControlsActivity(options: ControlsActivityOptions): ControlsActivityApi {
+  const container = options.getContainer();
+  const media = options.getMedia();
+  const disconnect = new AbortController();
+  const { signal } = disconnect;
+
+  // Idle timer
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function clearIdle() {
+    clearTimeout(idleTimer);
+    idleTimer = undefined;
+  }
+
+  function scheduleIdle() {
+    clearIdle();
+    idleTimer = setTimeout(setInactive, IDLE_DELAY);
+  }
+
+  function computeVisible(userActive: boolean): boolean {
+    return userActive || media.paused;
+  }
+
+  function setActive() {
+    if (!options.getUserActive()) {
+      options.setControls(true, true);
+    }
+    scheduleIdle();
+  }
+
+  function setInactive() {
+    clearIdle();
+    options.setControls(false, computeVisible(false));
+  }
+
+  function toggleControls() {
+    if (options.getControlsVisible()) {
+      setInactive();
+    } else {
+      setActive();
+    }
+  }
+
+  // Touch tap-to-toggle
   let pointerDownTime = 0;
 
-  const props: ControlsActivityProps = {
-    onPointerMove() {
-      options.setActive();
-    },
-    onPointerDown() {
-      pointerDownTime = Date.now();
-    },
-    onPointerUp(event: PointerEvent) {
-      if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
-        // Touch tap on interactive controls (buttons, sliders) — skip toggle.
-        if (isInteractiveTarget(event)) return;
+  function onPointerDown() {
+    pointerDownTime = Date.now();
+  }
 
-        options.toggleControls();
-        return;
-      }
+  function onPointerUp(event: PointerEvent) {
+    if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
+      // Touch tap on interactive controls (buttons, sliders) — skip toggle.
+      if (isInteractiveTarget(event)) return;
 
-      // Non-touch pointer up (mouse click, pen) — treat as activity.
-      options.setActive();
-    },
-    onKeyUp() {
-      options.setActive();
-    },
-    onFocusIn() {
-      options.setActive();
-    },
-    onMouseLeave() {
-      options.setInactive();
+      toggleControls();
+      return;
+    }
+
+    // Non-touch pointer up (mouse click, pen) — treat as activity.
+    setActive();
+  }
+
+  // Recompute visibility when playback state changes.
+  function onPlaybackChange() {
+    const userActive = options.getUserActive();
+    options.setControls(userActive, computeVisible(userActive));
+
+    // When playback starts, schedule idle if user is active.
+    if (!media.paused && userActive) {
+      scheduleIdle();
+    }
+  }
+
+  // Container event listeners
+  listen(container, 'pointermove', setActive, { signal });
+  listen(container, 'pointerdown', onPointerDown, { signal });
+  listen(container, 'pointerup', onPointerUp as EventListener, { signal });
+  listen(container, 'keyup', setActive, { signal });
+  listen(container, 'focusin', setActive, { signal });
+  // On touch devices pointerleave would fire after a pointerup event which hides the controls.
+  // https://w3c.github.io/pointerevents/#dfn-pointerup
+  listen(container, 'mouseleave', setInactive, { signal });
+
+  // Media event listeners for playback state changes.
+  listen(media, 'play', onPlaybackChange, { signal });
+  listen(media, 'pause', onPlaybackChange, { signal });
+  listen(media, 'ended', onPlaybackChange, { signal });
+
+  // Clean up timer on signal abort.
+  signal.addEventListener('abort', clearIdle, { once: true });
+
+  // Schedule initial idle.
+  scheduleIdle();
+
+  return {
+    destroy() {
+      disconnect.abort();
     },
   };
-
-  return { props };
-}
-
-/** Wire up controls activity tracking on a container element. */
-export function attachControlsActivity(
-  container: HTMLElement,
-  options: ControlsActivityOptions,
-  signal: AbortSignal
-): ControlsActivityApi {
-  const activity = createControlsActivity(options);
-
-  listen(container, 'pointermove', activity.props.onPointerMove, { signal });
-  listen(container, 'pointerdown', activity.props.onPointerDown, { signal });
-  listen(container, 'pointerup', activity.props.onPointerUp as EventListener, { signal });
-  listen(container, 'keyup', activity.props.onKeyUp, { signal });
-  listen(container, 'focusin', activity.props.onFocusIn, { signal });
-  listen(container, 'mouseleave', activity.props.onMouseLeave, { signal });
-
-  return activity;
 }

--- a/packages/core/src/dom/ui/controls-activity.ts
+++ b/packages/core/src/dom/ui/controls-activity.ts
@@ -1,14 +1,11 @@
 import { isInteractiveTarget, listen } from '@videojs/utils/dom';
 
-const IDLE_DELAY = 2000;
 const TAP_THRESHOLD = 250;
 
 export interface ControlsActivityOptions {
-  getContainer: () => HTMLElement;
-  getMedia: () => HTMLMediaElement;
-  getControlsVisible: () => boolean;
-  getUserActive: () => boolean;
-  setControls: (userActive: boolean, controlsVisible: boolean) => void;
+  setUserActivity: (active: boolean) => void;
+  hideControls: () => void;
+  toggleControls: () => void;
 }
 
 export interface ControlsActivityApi {
@@ -18,103 +15,46 @@ export interface ControlsActivityApi {
 /**
  * Wire up controls activity tracking on a container element.
  *
- * Manages idle timer, pointer/keyboard activity detection, touch
- * tap-to-toggle, and playback state visibility recomputation.
+ * Maps DOM pointer/keyboard events to store methods. The store
+ * feature owns idle timer, visibility computation, and state.
  */
-export function createControlsActivity(options: ControlsActivityOptions): ControlsActivityApi {
-  const container = options.getContainer();
-  const media = options.getMedia();
+export function createControlsActivity(container: HTMLElement, options: ControlsActivityOptions): ControlsActivityApi {
   const disconnect = new AbortController();
   const { signal } = disconnect;
 
-  // Idle timer
-  let idleTimer: ReturnType<typeof setTimeout> | undefined;
-
-  function clearIdle() {
-    clearTimeout(idleTimer);
-    idleTimer = undefined;
-  }
-
-  function scheduleIdle() {
-    clearIdle();
-    idleTimer = setTimeout(setInactive, IDLE_DELAY);
-  }
-
-  function computeVisible(userActive: boolean): boolean {
-    return userActive || media.paused;
-  }
-
-  function setActive() {
-    if (!options.getUserActive()) {
-      options.setControls(true, true);
-    }
-    scheduleIdle();
-  }
-
-  function setInactive() {
-    clearIdle();
-    options.setControls(false, computeVisible(false));
-  }
-
-  function toggleControls() {
-    if (options.getControlsVisible()) {
-      setInactive();
-    } else {
-      setActive();
-    }
-  }
-
-  // Touch tap-to-toggle
   let pointerDownTime = 0;
 
-  function onPointerDown() {
-    pointerDownTime = Date.now();
-  }
+  listen(container, 'pointermove', () => options.setUserActivity(true), { signal });
+  listen(container, 'keyup', () => options.setUserActivity(true), { signal });
+  listen(container, 'focusin', () => options.setUserActivity(true), { signal });
 
-  function onPointerUp(event: PointerEvent) {
-    if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
-      // Touch tap on interactive controls (buttons, sliders) — skip toggle.
-      if (isInteractiveTarget(event)) return;
+  listen(
+    container,
+    'pointerdown',
+    () => {
+      pointerDownTime = Date.now();
+    },
+    { signal }
+  );
 
-      toggleControls();
-      return;
-    }
+  listen(
+    container,
+    'pointerup',
+    ((event: PointerEvent) => {
+      if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
+        if (isInteractiveTarget(event)) return;
+        options.toggleControls();
+        return;
+      }
 
-    // Non-touch pointer up (mouse click, pen) — treat as activity.
-    setActive();
-  }
+      options.setUserActivity(true);
+    }) as EventListener,
+    { signal }
+  );
 
-  // Recompute visibility when playback state changes.
-  function onPlaybackChange() {
-    const userActive = options.getUserActive();
-    options.setControls(userActive, computeVisible(userActive));
-
-    // When playback starts, schedule idle if user is active.
-    if (!media.paused && userActive) {
-      scheduleIdle();
-    }
-  }
-
-  // Container event listeners
-  listen(container, 'pointermove', setActive, { signal });
-  listen(container, 'pointerdown', onPointerDown, { signal });
-  listen(container, 'pointerup', onPointerUp as EventListener, { signal });
-  listen(container, 'keyup', setActive, { signal });
-  listen(container, 'focusin', setActive, { signal });
-  // On touch devices pointerleave would fire after a pointerup event which hides the controls.
+  // On touch devices pointerleave fires after pointerup which would hide controls.
   // https://w3c.github.io/pointerevents/#dfn-pointerup
-  listen(container, 'mouseleave', setInactive, { signal });
-
-  // Media event listeners for playback state changes.
-  listen(media, 'play', onPlaybackChange, { signal });
-  listen(media, 'pause', onPlaybackChange, { signal });
-  listen(media, 'ended', onPlaybackChange, { signal });
-
-  // Clean up timer on signal abort.
-  signal.addEventListener('abort', clearIdle, { once: true });
-
-  // Schedule initial idle.
-  scheduleIdle();
+  listen(container, 'mouseleave', () => options.hideControls(), { signal });
 
   return {
     destroy() {

--- a/packages/core/src/dom/ui/tests/controls-activity.test.ts
+++ b/packages/core/src/dom/ui/tests/controls-activity.test.ts
@@ -2,141 +2,98 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createControlsActivity } from '../controls-activity';
 
-const IDLE_DELAY = 2000;
-
 describe('createControlsActivity', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  describe('idle timer', () => {
-    it('sets inactive after idle delay', () => {
-      const { setControls } = setup();
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-
-      expect(setControls).toHaveBeenCalledWith(false, false);
-    });
-
-    it('keeps controlsVisible true when paused', () => {
-      const { setControls } = setup({ paused: true });
-
-      vi.advanceTimersByTime(IDLE_DELAY);
-
-      expect(setControls).toHaveBeenCalledWith(false, true);
-    });
-  });
-
   describe('pointer activity', () => {
-    it('resets idle on pointermove', () => {
-      const { container, setControls } = setup();
+    it('calls setUserActivity(true) on pointermove', () => {
+      const { container, setUserActivity } = setup();
 
-      vi.advanceTimersByTime(IDLE_DELAY - 500);
       container.dispatchEvent(new Event('pointermove'));
 
-      vi.advanceTimersByTime(500);
-      expect(setControls).not.toHaveBeenCalledWith(false, false);
-
-      vi.advanceTimersByTime(IDLE_DELAY - 500);
-      expect(setControls).toHaveBeenCalledWith(false, false);
+      expect(setUserActivity).toHaveBeenCalledWith(true);
     });
 
-    it('sets active on mouse pointerup', () => {
-      const { container, setControls } = setup({ userActive: false });
+    it('calls setUserActivity(true) on mouse pointerup', () => {
+      const { container, setUserActivity } = setup();
 
       container.dispatchEvent(new Event('pointerdown'));
       vi.advanceTimersByTime(100);
       container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'mouse' }));
 
-      expect(setControls).toHaveBeenCalledWith(true, true);
+      expect(setUserActivity).toHaveBeenCalledWith(true);
     });
 
-    it('sets active on keyup', () => {
-      const { container, setControls } = setup({ userActive: false });
+    it('calls setUserActivity(true) on keyup', () => {
+      const { container, setUserActivity } = setup();
 
       container.dispatchEvent(new Event('keyup'));
 
-      expect(setControls).toHaveBeenCalledWith(true, true);
+      expect(setUserActivity).toHaveBeenCalledWith(true);
     });
 
-    it('sets active on focusin', () => {
-      const { container, setControls } = setup({ userActive: false });
+    it('calls setUserActivity(true) on focusin', () => {
+      const { container, setUserActivity } = setup();
 
       container.dispatchEvent(new Event('focusin'));
 
-      expect(setControls).toHaveBeenCalledWith(true, true);
+      expect(setUserActivity).toHaveBeenCalledWith(true);
     });
 
-    it('sets inactive on mouseleave', () => {
-      const { container, setControls } = setup();
+    it('calls hideControls on mouseleave', () => {
+      const { container, hideControls } = setup();
 
       container.dispatchEvent(new Event('mouseleave'));
 
-      expect(setControls).toHaveBeenCalledWith(false, false);
+      expect(hideControls).toHaveBeenCalledOnce();
     });
   });
 
   describe('touch tap-to-toggle', () => {
-    it('toggles controls on touch tap', () => {
-      const { container, setControls, state } = setup({ controlsVisible: true });
+    it('calls toggleControls on touch tap', () => {
+      const { container, toggleControls } = setup();
 
       container.dispatchEvent(new Event('pointerdown'));
       vi.advanceTimersByTime(100);
-      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch', target: container }));
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
 
-      // Toggle: was visible → should hide
-      expect(setControls).toHaveBeenCalledWith(false, false);
-
-      // Now hidden → tap again to show
-      state.controlsVisible = false;
-      state.userActive = false;
-      container.dispatchEvent(new Event('pointerdown'));
-      vi.advanceTimersByTime(100);
-      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch', target: container }));
-
-      expect(setControls).toHaveBeenCalledWith(true, true);
+      expect(toggleControls).toHaveBeenCalledOnce();
     });
 
     it('does not toggle on long press', () => {
-      const { container, setControls } = setup();
+      const { container, toggleControls, setUserActivity } = setup();
 
       container.dispatchEvent(new Event('pointerdown'));
       vi.advanceTimersByTime(300);
-      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch', target: container }));
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch' }));
 
-      // Long press → treated as activity (setActive), not toggle.
-      // Since user is already active, setControls is not called — only idle timer resets.
-      expect(setControls).not.toHaveBeenCalledWith(false, false);
+      expect(toggleControls).not.toHaveBeenCalled();
+      expect(setUserActivity).toHaveBeenCalledWith(true);
     });
-  });
 
-  describe('playback state', () => {
-    it('recomputes visibility when media pauses', () => {
-      const { media, setControls, state } = setup();
+    it('does not toggle for mouse clicks', () => {
+      const { container, toggleControls, setUserActivity } = setup();
 
-      // Become inactive first
-      vi.advanceTimersByTime(IDLE_DELAY);
-      setControls.mockClear();
-      state.userActive = false;
+      container.dispatchEvent(new Event('pointerdown'));
+      vi.advanceTimersByTime(100);
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'mouse' }));
 
-      // Pause
-      Object.defineProperty(media, 'paused', { value: true, configurable: true });
-      media.dispatchEvent(new Event('pause'));
-
-      expect(setControls).toHaveBeenCalledWith(false, true);
+      expect(toggleControls).not.toHaveBeenCalled();
+      expect(setUserActivity).toHaveBeenCalledWith(true);
     });
   });
 
   describe('cleanup', () => {
     it('stops tracking on destroy', () => {
-      const { activity, container, setControls } = setup();
+      const { activity, container, setUserActivity } = setup();
 
       activity.destroy();
-      setControls.mockClear();
+      setUserActivity.mockClear();
 
-      vi.advanceTimersByTime(IDLE_DELAY);
       container.dispatchEvent(new Event('pointermove'));
 
-      expect(setControls).not.toHaveBeenCalled();
+      expect(setUserActivity).not.toHaveBeenCalled();
     });
   });
 });
@@ -145,39 +102,23 @@ describe('createControlsActivity', () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-interface SetupOptions {
-  paused?: boolean;
-  userActive?: boolean;
-  controlsVisible?: boolean;
-}
-
-function setup(options: SetupOptions = {}) {
+function setup() {
   const container = document.createElement('div');
-  const media = document.createElement('video') as HTMLVideoElement;
-  Object.defineProperty(media, 'paused', { value: options.paused ?? false, configurable: true });
 
-  const state = {
-    userActive: options.userActive ?? true,
-    controlsVisible: options.controlsVisible ?? true,
-  };
+  const setUserActivity = vi.fn();
+  const hideControls = vi.fn();
+  const toggleControls = vi.fn();
 
-  const setControls = vi.fn((userActive: boolean, controlsVisible: boolean) => {
-    state.userActive = userActive;
-    state.controlsVisible = controlsVisible;
+  const activity = createControlsActivity(container, {
+    setUserActivity,
+    hideControls,
+    toggleControls,
   });
 
-  const activity = createControlsActivity({
-    getContainer: () => container,
-    getMedia: () => media,
-    getControlsVisible: () => state.controlsVisible,
-    getUserActive: () => state.userActive,
-    setControls,
-  });
-
-  return { container, media, state, setControls, activity };
+  return { container, setUserActivity, hideControls, toggleControls, activity };
 }
 
-function createPointerEvent(type: string, init?: { pointerType?: string; target?: EventTarget }): Event {
+function createPointerEvent(type: string, init?: { pointerType?: string }): Event {
   const event = new Event(type, { bubbles: true });
   if (init?.pointerType) {
     Object.defineProperty(event, 'pointerType', { value: init.pointerType });

--- a/packages/core/src/dom/ui/tests/controls-activity.test.ts
+++ b/packages/core/src/dom/ui/tests/controls-activity.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createControlsActivity } from '../controls-activity';
+
+const IDLE_DELAY = 2000;
+
+describe('createControlsActivity', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  describe('idle timer', () => {
+    it('sets inactive after idle delay', () => {
+      const { setControls } = setup();
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+
+      expect(setControls).toHaveBeenCalledWith(false, false);
+    });
+
+    it('keeps controlsVisible true when paused', () => {
+      const { setControls } = setup({ paused: true });
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+
+      expect(setControls).toHaveBeenCalledWith(false, true);
+    });
+  });
+
+  describe('pointer activity', () => {
+    it('resets idle on pointermove', () => {
+      const { container, setControls } = setup();
+
+      vi.advanceTimersByTime(IDLE_DELAY - 500);
+      container.dispatchEvent(new Event('pointermove'));
+
+      vi.advanceTimersByTime(500);
+      expect(setControls).not.toHaveBeenCalledWith(false, false);
+
+      vi.advanceTimersByTime(IDLE_DELAY - 500);
+      expect(setControls).toHaveBeenCalledWith(false, false);
+    });
+
+    it('sets active on mouse pointerup', () => {
+      const { container, setControls } = setup({ userActive: false });
+
+      container.dispatchEvent(new Event('pointerdown'));
+      vi.advanceTimersByTime(100);
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'mouse' }));
+
+      expect(setControls).toHaveBeenCalledWith(true, true);
+    });
+
+    it('sets active on keyup', () => {
+      const { container, setControls } = setup({ userActive: false });
+
+      container.dispatchEvent(new Event('keyup'));
+
+      expect(setControls).toHaveBeenCalledWith(true, true);
+    });
+
+    it('sets active on focusin', () => {
+      const { container, setControls } = setup({ userActive: false });
+
+      container.dispatchEvent(new Event('focusin'));
+
+      expect(setControls).toHaveBeenCalledWith(true, true);
+    });
+
+    it('sets inactive on mouseleave', () => {
+      const { container, setControls } = setup();
+
+      container.dispatchEvent(new Event('mouseleave'));
+
+      expect(setControls).toHaveBeenCalledWith(false, false);
+    });
+  });
+
+  describe('touch tap-to-toggle', () => {
+    it('toggles controls on touch tap', () => {
+      const { container, setControls, state } = setup({ controlsVisible: true });
+
+      container.dispatchEvent(new Event('pointerdown'));
+      vi.advanceTimersByTime(100);
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch', target: container }));
+
+      // Toggle: was visible → should hide
+      expect(setControls).toHaveBeenCalledWith(false, false);
+
+      // Now hidden → tap again to show
+      state.controlsVisible = false;
+      state.userActive = false;
+      container.dispatchEvent(new Event('pointerdown'));
+      vi.advanceTimersByTime(100);
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch', target: container }));
+
+      expect(setControls).toHaveBeenCalledWith(true, true);
+    });
+
+    it('does not toggle on long press', () => {
+      const { container, setControls } = setup();
+
+      container.dispatchEvent(new Event('pointerdown'));
+      vi.advanceTimersByTime(300);
+      container.dispatchEvent(createPointerEvent('pointerup', { pointerType: 'touch', target: container }));
+
+      // Long press → treated as activity (setActive), not toggle.
+      // Since user is already active, setControls is not called — only idle timer resets.
+      expect(setControls).not.toHaveBeenCalledWith(false, false);
+    });
+  });
+
+  describe('playback state', () => {
+    it('recomputes visibility when media pauses', () => {
+      const { media, setControls, state } = setup();
+
+      // Become inactive first
+      vi.advanceTimersByTime(IDLE_DELAY);
+      setControls.mockClear();
+      state.userActive = false;
+
+      // Pause
+      Object.defineProperty(media, 'paused', { value: true, configurable: true });
+      media.dispatchEvent(new Event('pause'));
+
+      expect(setControls).toHaveBeenCalledWith(false, true);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('stops tracking on destroy', () => {
+      const { activity, container, setControls } = setup();
+
+      activity.destroy();
+      setControls.mockClear();
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      container.dispatchEvent(new Event('pointermove'));
+
+      expect(setControls).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SetupOptions {
+  paused?: boolean;
+  userActive?: boolean;
+  controlsVisible?: boolean;
+}
+
+function setup(options: SetupOptions = {}) {
+  const container = document.createElement('div');
+  const media = document.createElement('video') as HTMLVideoElement;
+  Object.defineProperty(media, 'paused', { value: options.paused ?? false, configurable: true });
+
+  const state = {
+    userActive: options.userActive ?? true,
+    controlsVisible: options.controlsVisible ?? true,
+  };
+
+  const setControls = vi.fn((userActive: boolean, controlsVisible: boolean) => {
+    state.userActive = userActive;
+    state.controlsVisible = controlsVisible;
+  });
+
+  const activity = createControlsActivity({
+    getContainer: () => container,
+    getMedia: () => media,
+    getControlsVisible: () => state.controlsVisible,
+    getUserActive: () => state.userActive,
+    setControls,
+  });
+
+  return { container, media, state, setControls, activity };
+}
+
+function createPointerEvent(type: string, init?: { pointerType?: string; target?: EventTarget }): Event {
+  const event = new Event(type, { bubbles: true });
+  if (init?.pointerType) {
+    Object.defineProperty(event, 'pointerType', { value: init.pointerType });
+  }
+  return event;
+}

--- a/packages/html/src/ui/controls/controls-element.ts
+++ b/packages/html/src/ui/controls/controls-element.ts
@@ -1,9 +1,15 @@
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
-import { applyStateDataAttrs, attachControlsActivity, logMissingFeature, selectControls } from '@videojs/core/dom';
+import {
+  applyStateDataAttrs,
+  type ControlsActivityApi,
+  createControlsActivity,
+  logMissingFeature,
+  selectControls,
+} from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
 import { ContextConsumer, ContextProvider } from '@videojs/element/context';
 
-import { containerContext, playerContext } from '../../player/context';
+import { containerContext, mediaContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaElement } from '../media-element';
 import { controlsContext } from './context';
@@ -19,8 +25,13 @@ export class ControlsElement extends MediaElement {
     callback: () => this.#connectActivity(),
     subscribe: true,
   });
+  readonly #media = new ContextConsumer(this, {
+    context: mediaContext,
+    callback: () => this.#connectActivity(),
+    subscribe: true,
+  });
 
-  #activityDisconnect: AbortController | null = null;
+  #activity: ControlsActivityApi | null = null;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -34,7 +45,8 @@ export class ControlsElement extends MediaElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#disconnectActivity();
+    this.#activity?.destroy();
+    this.#activity = null;
   }
 
   protected override update(_changed: PropertyValues): void {
@@ -55,27 +67,20 @@ export class ControlsElement extends MediaElement {
   }
 
   #connectActivity(): void {
-    this.#disconnectActivity();
+    this.#activity?.destroy();
+    this.#activity = null;
 
     const controls = this.#mediaState.value;
     const container = this.#container.value?.container;
-    if (!controls || !container) return;
+    const media = this.#media.value?.media;
+    if (!controls || !container || !media) return;
 
-    this.#activityDisconnect = new AbortController();
-
-    attachControlsActivity(
-      container as HTMLElement,
-      {
-        setActive: () => controls.setActive(),
-        setInactive: () => controls.setInactive(),
-        toggleControls: () => controls.toggleControls(),
-      },
-      this.#activityDisconnect.signal
-    );
-  }
-
-  #disconnectActivity(): void {
-    this.#activityDisconnect?.abort();
-    this.#activityDisconnect = null;
+    this.#activity = createControlsActivity({
+      getContainer: () => container as HTMLElement,
+      getMedia: () => media,
+      getControlsVisible: () => controls.controlsVisible,
+      getUserActive: () => controls.userActive,
+      setControls: (userActive, controlsVisible) => controls.setControls(userActive, controlsVisible),
+    });
   }
 }

--- a/packages/html/src/ui/controls/controls-element.ts
+++ b/packages/html/src/ui/controls/controls-element.ts
@@ -1,9 +1,9 @@
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
-import { applyStateDataAttrs, logMissingFeature, selectControls } from '@videojs/core/dom';
+import { applyStateDataAttrs, attachControlsActivity, logMissingFeature, selectControls } from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
-import { ContextProvider } from '@videojs/element/context';
+import { ContextConsumer, ContextProvider } from '@videojs/element/context';
 
-import { playerContext } from '../../player/context';
+import { containerContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaElement } from '../media-element';
 import { controlsContext } from './context';
@@ -14,6 +14,13 @@ export class ControlsElement extends MediaElement {
   readonly #core = new ControlsCore();
   readonly #mediaState = new PlayerController(this, playerContext, selectControls);
   readonly #provider = new ContextProvider(this, { context: controlsContext });
+  readonly #container = new ContextConsumer(this, {
+    context: containerContext,
+    callback: () => this.#connectActivity(),
+    subscribe: true,
+  });
+
+  #activityDisconnect: AbortController | null = null;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -21,6 +28,13 @@ export class ControlsElement extends MediaElement {
     if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }
+
+    this.#connectActivity();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#disconnectActivity();
   }
 
   protected override update(_changed: PropertyValues): void {
@@ -38,5 +52,30 @@ export class ControlsElement extends MediaElement {
       state,
       stateAttrMap: ControlsDataAttrs,
     });
+  }
+
+  #connectActivity(): void {
+    this.#disconnectActivity();
+
+    const controls = this.#mediaState.value;
+    const container = this.#container.value?.container;
+    if (!controls || !container) return;
+
+    this.#activityDisconnect = new AbortController();
+
+    attachControlsActivity(
+      container as HTMLElement,
+      {
+        setActive: () => controls.setActive(),
+        setInactive: () => controls.setInactive(),
+        toggleControls: () => controls.toggleControls(),
+      },
+      this.#activityDisconnect.signal
+    );
+  }
+
+  #disconnectActivity(): void {
+    this.#activityDisconnect?.abort();
+    this.#activityDisconnect = null;
   }
 }

--- a/packages/html/src/ui/controls/controls-element.ts
+++ b/packages/html/src/ui/controls/controls-element.ts
@@ -9,7 +9,7 @@ import {
 import type { PropertyValues } from '@videojs/element';
 import { ContextConsumer, ContextProvider } from '@videojs/element/context';
 
-import { containerContext, mediaContext, playerContext } from '../../player/context';
+import { containerContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaElement } from '../media-element';
 import { controlsContext } from './context';
@@ -22,11 +22,6 @@ export class ControlsElement extends MediaElement {
   readonly #provider = new ContextProvider(this, { context: controlsContext });
   readonly #container = new ContextConsumer(this, {
     context: containerContext,
-    callback: () => this.#connectActivity(),
-    subscribe: true,
-  });
-  readonly #media = new ContextConsumer(this, {
-    context: mediaContext,
     callback: () => this.#connectActivity(),
     subscribe: true,
   });
@@ -72,15 +67,12 @@ export class ControlsElement extends MediaElement {
 
     const controls = this.#mediaState.value;
     const container = this.#container.value?.container;
-    const media = this.#media.value?.media;
-    if (!controls || !container || !media) return;
+    if (!controls || !container) return;
 
-    this.#activity = createControlsActivity({
-      getContainer: () => container as HTMLElement,
-      getMedia: () => media,
-      getControlsVisible: () => controls.controlsVisible,
-      getUserActive: () => controls.userActive,
-      setControls: (userActive, controlsVisible) => controls.setControls(userActive, controlsVisible),
+    this.#activity = createControlsActivity(container as HTMLElement, {
+      setUserActivity: (active) => controls.setUserActivity(active),
+      hideControls: () => controls.hideControls(),
+      toggleControls: () => controls.toggleControls(),
     });
   }
 }

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
-import { attachControlsActivity, logMissingFeature, selectControls } from '@videojs/core/dom';
+import { createControlsActivity, logMissingFeature, selectControls } from '@videojs/core/dom';
 import type { ForwardedRef, ReactNode } from 'react';
 import { forwardRef, useEffect, useState } from 'react';
 
-import { useContainer, usePlayer } from '../../player/context';
+import { useContainer, useMedia, usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
 import { ControlsContextProvider } from './context';
@@ -23,27 +23,24 @@ export const ControlsRoot = forwardRef(function ControlsRoot(
 
   const controls = usePlayer(selectControls);
   const container = useContainer();
+  const media = useMedia();
 
   const [core] = useState(() => new ControlsCore());
 
   // Wire up activity tracking on the container.
   useEffect(() => {
-    if (!controls || !container) return;
+    if (!controls || !container || !media) return;
 
-    const abort = new AbortController();
+    const activity = createControlsActivity({
+      getContainer: () => container as HTMLElement,
+      getMedia: () => media,
+      getControlsVisible: () => controls.controlsVisible,
+      getUserActive: () => controls.userActive,
+      setControls: (userActive, controlsVisible) => controls.setControls(userActive, controlsVisible),
+    });
 
-    attachControlsActivity(
-      container as HTMLElement,
-      {
-        setActive: () => controls.setActive(),
-        setInactive: () => controls.setInactive(),
-        toggleControls: () => controls.toggleControls(),
-      },
-      abort.signal
-    );
-
-    return () => abort.abort();
-  }, [controls, container]);
+    return () => activity.destroy();
+  }, [controls, container, media]);
 
   if (!controls) {
     if (__DEV__) logMissingFeature('Controls.Root', 'controls');

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -5,7 +5,7 @@ import { createControlsActivity, logMissingFeature, selectControls } from '@vide
 import type { ForwardedRef, ReactNode } from 'react';
 import { forwardRef, useEffect, useState } from 'react';
 
-import { useContainer, useMedia, usePlayer } from '../../player/context';
+import { useContainer, usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
 import { ControlsContextProvider } from './context';
@@ -23,24 +23,20 @@ export const ControlsRoot = forwardRef(function ControlsRoot(
 
   const controls = usePlayer(selectControls);
   const container = useContainer();
-  const media = useMedia();
 
   const [core] = useState(() => new ControlsCore());
 
-  // Wire up activity tracking on the container.
   useEffect(() => {
-    if (!controls || !container || !media) return;
+    if (!controls || !container) return;
 
-    const activity = createControlsActivity({
-      getContainer: () => container as HTMLElement,
-      getMedia: () => media,
-      getControlsVisible: () => controls.controlsVisible,
-      getUserActive: () => controls.userActive,
-      setControls: (userActive, controlsVisible) => controls.setControls(userActive, controlsVisible),
+    const activity = createControlsActivity(container as HTMLElement, {
+      setUserActivity: (active) => controls.setUserActivity(active),
+      hideControls: () => controls.hideControls(),
+      toggleControls: () => controls.toggleControls(),
     });
 
     return () => activity.destroy();
-  }, [controls, container, media]);
+  }, [controls, container]);
 
   if (!controls) {
     if (__DEV__) logMissingFeature('Controls.Root', 'controls');

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectControls } from '@videojs/core/dom';
+import { attachControlsActivity, logMissingFeature, selectControls } from '@videojs/core/dom';
 import type { ForwardedRef, ReactNode } from 'react';
-import { forwardRef, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
-import { usePlayer } from '../../player/context';
+import { useContainer, usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
 import { ControlsContextProvider } from './context';
@@ -22,8 +22,28 @@ export const ControlsRoot = forwardRef(function ControlsRoot(
   const { render, className, style, children, ...elementProps } = componentProps;
 
   const controls = usePlayer(selectControls);
+  const container = useContainer();
 
   const [core] = useState(() => new ControlsCore());
+
+  // Wire up activity tracking on the container.
+  useEffect(() => {
+    if (!controls || !container) return;
+
+    const abort = new AbortController();
+
+    attachControlsActivity(
+      container as HTMLElement,
+      {
+        setActive: () => controls.setActive(),
+        setInactive: () => controls.setInactive(),
+        toggleControls: () => controls.toggleControls(),
+      },
+      abort.signal
+    );
+
+    return () => abort.abort();
+  }, [controls, container]);
 
   if (!controls) {
     if (__DEV__) logMissingFeature('Controls.Root', 'controls');

--- a/packages/utils/src/dom/index.ts
+++ b/packages/utils/src/dom/index.ts
@@ -12,6 +12,7 @@ export {
   isHTMLAudioElement,
   isHTMLMediaElement,
   isHTMLVideoElement,
+  isInteractiveTarget,
 } from './predicates';
 export { type RafThrottled, rafThrottle } from './raf-throttle';
 export {

--- a/packages/utils/src/dom/predicates.ts
+++ b/packages/utils/src/dom/predicates.ts
@@ -33,3 +33,12 @@ export function isEditableTarget(event: KeyboardEvent): boolean {
   const target = resolveEventTarget(event);
   return target instanceof Element && isEditableElement(target);
 }
+
+const INTERACTIVE_SELECTOR = 'button, input, select, textarea, [role="button"], [role="slider"]';
+
+/** Whether the event originated from an interactive control (button, slider, etc). */
+export function isInteractiveTarget(event: Event): boolean {
+  const target = resolveEventTarget(event);
+  if (!(target instanceof Element)) return false;
+  return target.closest(INTERACTIVE_SELECTOR) !== null;
+}


### PR DESCRIPTION
Closes #1311

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate behavior change to controls visibility/idle handling by moving DOM-driven activity detection out of the store feature and introducing new public control methods; could affect tap/hover/idle interactions across platforms.
> 
> **Overview**
> Refactors controls visibility and idle handling by **separating DOM activity tracking from the `controlsFeature`**: the store feature now owns only idle timing + `controlsVisible` computation, while a new `createControlsActivity` helper maps pointer/keyboard events (including touch tap-to-toggle) to store methods.
> 
> Extends `MediaControlsState` with `setUserActivity`, `showControls`, and `hideControls`, updates HTML and React controls roots to wire activity using the new helper, and adds `isInteractiveTarget` to avoid toggling controls when taps originate from interactive elements. Tests are updated to cover the new API boundaries and event-mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b89597b0672009f7a3179085bab12844210c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->