### PR TITLE
feat(site): add versioned docs infrastructure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,3 +77,7 @@ jobs:
       - name: Publish
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm -r publish --filter "./packages/*" --access public --provenance --no-git-checks
+
+      - name: Update site/v10 branch
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: git push origin HEAD:refs/heads/site/v10 --force

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -8,6 +8,29 @@ The **Video.js v10 documentation site** is an Astro-based static site generator 
 
 Key architectural feature: **Multi-framework documentation** — the same content generates separate routes for different framework/style combinations (e.g., HTML + CSS, React + CSS), allowing framework-specific documentation from shared MDX sources.
 
+## Deployment
+
+The site deploys via Netlify from two branches:
+
+| Branch | Deploys to | Content |
+| --- | --- | --- |
+| `site/v10` (production) | **videojs.org** | Stable docs matching the latest release |
+| `main` (branch deploy) | **next.videojs.org** | Pre-release docs (may include unreleased APIs) |
+
+**On release:** The CD workflow (`.github/workflows/cd.yml`) publishes packages to npm, then force-pushes `main`'s HEAD to `site/v10`. This keeps the production docs in sync with the latest release.
+
+**Docs hotfixes between releases:** Fix the content on `main` first, then cherry-pick to `site/v10`:
+
+```bash
+git checkout site/v10
+git cherry-pick <sha-from-main>
+git push origin site/v10
+```
+
+The next release force-pushes `main` to `site/v10`, which already includes the cherry-picked commit (since it originated on `main`). All fixes must land on `main` first — the `site/v10` branch has branch protection that restricts direct pushes to the CD bot.
+
+**Branch deploys (next.videojs.org)** serve `X-Robots-Tag: noindex` headers to prevent search engines from indexing pre-release docs.
+
 ## Commands
 
 From `site/` directory:

--- a/site/README.md
+++ b/site/README.md
@@ -66,6 +66,19 @@ If you're in `site/`...
 | `pnpm test:ui`       | Run Vitest with its web-based UI                 |
 | `pnpm test:coverage` | Generate test coverage report                    |
 
+## Deployment
+
+The site deploys via Netlify from two branches:
+
+| Branch | Deploys to | Content |
+| :--- | :--- | :--- |
+| `site/v10` | **videojs.org** | Stable docs matching the latest release |
+| `main` | **next.videojs.org** | Pre-release docs (may include unreleased APIs) |
+
+On each release, the CD workflow force-pushes `main` to `site/v10`, keeping production docs in sync with published packages.
+
+**Fixing a typo without cutting a release:** Land the fix on `main` first, then cherry-pick to `site/v10`. The next release's force-push already includes the fix (since it came from `main`), so nothing gets lost. The `site/v10` branch is protected — direct pushes are restricted to the CD bot.
+
 ## Environment Variables
 
 The installation page's video uploader uses OAuth + Mux. See [CLAUDE.md](CLAUDE.md) for the full list of environment variables. The site works without these — the uploader just won't be available.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -17,15 +17,20 @@ import { remarkReadingTime } from './src/utils/remarkReadingTime.mjs';
 import { shikiNotationTransformers } from './src/utils/shikiNotationTransformers';
 import shikiTransformMetadata from './src/utils/shikiTransformMetadata';
 
-// On production deploys, use the custom domain — DEPLOY_PRIME_URL always returns
-// the Netlify subdomain (e.g. main--vjs10-site.netlify.app), not the custom
-// domain. On deploy previews, use DEPLOY_PRIME_URL so OG images point to a
-// reachable URL for crawlers.
+// Netlify sets CONTEXT and BRANCH for each deploy. We use them to determine
+// the correct site URL:
+//   - production (site/v10 branch)  → https://videojs.org
+//   - branch-deploy (main branch)   → https://next.videojs.org
+//   - deploy-preview (PR branches)  → DEPLOY_PRIME_URL (Netlify subdomain)
 //
 // For URLs that must always point to production regardless of deploy context
 // (e.g. canonical, JSON-LD), use PRODUCTION_URL from src/consts.ts instead.
 const SITE_URL =
-  process.env.CONTEXT === 'production' ? 'https://videojs.org' : process.env.DEPLOY_PRIME_URL || 'https://videojs.org';
+  process.env.CONTEXT === 'production'
+    ? 'https://videojs.org'
+    : process.env.BRANCH === 'main'
+      ? 'https://next.videojs.org'
+      : process.env.DEPLOY_PRIME_URL || 'https://videojs.org';
 
 // https://astro.build/config
 export default defineConfig({

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -3,17 +3,18 @@
   publish = "site/dist"
   ignore = "pnpm turbo query affected --packages site --tasks build --exit-code"
 
-[build.environment]
-  # turbo query affected defaults to comparing against the merge-base with main.
-  # On the production branch (site/v10) and main itself, that merge-base is HEAD,
-  # so turbo finds zero changes and skips the build. HEAD~1 compares against the
-  # previous commit instead, which is correct for all deploy contexts.
+# turbo query affected defaults to comparing against the merge-base with main.
+# On the production branch (site/v10) and main itself, that merge-base is HEAD,
+# so turbo finds zero changes and skips the build. HEAD~1 compares against the
+# previous commit instead. We scope this to production and branch-deploy only —
+# PR previews keep the default merge-base behavior so multi-commit pushes work.
+[context.production.environment]
   TURBO_SCM_BASE = "HEAD~1"
 
 # Prevent search engines from indexing branch deploys (next.videojs.org).
 # Stable docs at videojs.org (production context) are not affected.
 [context.branch-deploy.environment]
-  X_ROBOTS_TAG = "noindex"
+  TURBO_SCM_BASE = "HEAD~1"
 
 [[context.branch-deploy.headers]]
   for = "/*"

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -3,6 +3,23 @@
   publish = "site/dist"
   ignore = "pnpm turbo query affected --packages site --tasks build --exit-code"
 
+[build.environment]
+  # turbo query affected defaults to comparing against the merge-base with main.
+  # On the production branch (site/v10) and main itself, that merge-base is HEAD,
+  # so turbo finds zero changes and skips the build. HEAD~1 compares against the
+  # previous commit instead, which is correct for all deploy contexts.
+  TURBO_SCM_BASE = "HEAD~1"
+
+# Prevent search engines from indexing branch deploys (next.videojs.org).
+# Stable docs at videojs.org (production context) are not affected.
+[context.branch-deploy.environment]
+  X_ROBOTS_TAG = "noindex"
+
+[[context.branch-deploy.headers]]
+  for = "/*"
+  [context.branch-deploy.headers.values]
+    X-Robots-Tag = "noindex"
+
 # PostHog reverse proxy (ad-blocker bypass)
 [[redirects]]
   from = "/ph/static/*"

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -11,15 +11,8 @@
 [context.production.environment]
   TURBO_SCM_BASE = "HEAD~1"
 
-# Prevent search engines from indexing branch deploys (next.videojs.org).
-# Stable docs at videojs.org (production context) are not affected.
 [context.branch-deploy.environment]
   TURBO_SCM_BASE = "HEAD~1"
-
-[[context.branch-deploy.headers]]
-  for = "/*"
-  [context.branch-deploy.headers.values]
-    X-Robots-Tag = "noindex"
 
 # PostHog reverse proxy (ad-blocker bypass)
 [[redirects]]

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -58,6 +58,7 @@ const fullTitle =
     />
     <meta name="generator" content={Astro.generator} />
     <meta name="algolia-site-verification" content="9CE2D1D6448256D3" />
+    {Astro.site?.origin !== PRODUCTION_URL.origin && <meta name="robots" content="noindex" />}
 
     {/* Analytics (production only) */}
     {import.meta.env.PROD && <Posthog />}

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
   "concurrency": "20",
-  "globalEnv": ["CONTEXT", "DEPLOY_PRIME_URL"],
+  "globalEnv": ["BRANCH", "CONTEXT", "DEPLOY_PRIME_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build", "^build:cdn"],


### PR DESCRIPTION
## Summary

Implements the infrastructure for versioned docs (#645). After this PR merges, the docs deploy pipeline works like this:

### How it works

**Two sites, two branches:**

| Branch | Deploys to | Content |
|---|---|---|
| `site/v10` (production) | **videojs.org** | Stable docs matching the latest release |
| `main` (branch deploy) | **next.videojs.org** | Pre-release docs (may include unreleased APIs) |

**Release flow:**

```
Commit merges to main
  → release-please detects release-worthy commits
  → creates release PR on release-please--branches--main
  → release PR merges to main
  → cd.yml fires:
      1. Publishes packages to npm
      2. Force-pushes site/v10 to main's HEAD  ← NEW
  → Netlify rebuilds videojs.org from site/v10
```

Between releases, `main` keeps advancing with new features and docs. `site/v10` stays pinned to the last release point. Netlify builds `main` on every push and deploys it to `next.videojs.org`, so unreleased docs are always accessible without polluting the stable site.

**Docs hotfixes between releases:**

If a typo or content fix lands on `main` and needs to go live before the next release, cherry-pick it from `main` to `site/v10`:

```bash
git checkout site/v10
git cherry-pick <sha-from-main>
git push origin site/v10
# → Netlify auto-deploys to videojs.org
```

All fixes must land on `main` first. The `site/v10` branch should have branch protection restricting direct pushes to the CD bot (see manual steps below). On the next release, the force-push resets `site/v10` to `main`'s HEAD, which already includes the cherry-picked commit.

### Changes

**`.github/workflows/cd.yml`**
- Added a step after npm publish that force-pushes `HEAD` to `site/v10`. This ensures the docs branch only advances after packages are successfully published. Uses `contents: write` permission already present on the job.

**`site/astro.config.mjs`**
- Updated `SITE_URL` to resolve per Netlify deploy context using the `CONTEXT` and `BRANCH` env vars that Netlify provides automatically:
  - `CONTEXT=production` → `https://videojs.org` (stable docs from `site/v10`)
  - `BRANCH=main` → `https://next.videojs.org` (pre-release docs)
  - Deploy previews → `DEPLOY_PRIME_URL` (Netlify subdomain, for PR previews)
- `PRODUCTION_URL` in `consts.ts` is unchanged — canonical URLs and JSON-LD always point to `videojs.org` regardless of deploy context.

**`site/netlify.toml`**
- Added `TURBO_SCM_BASE = "HEAD~1"` scoped to `context.production` and `context.branch-deploy`. Without this, `turbo query affected` computes the merge-base of the current branch with `main`. On `site/v10` (which is a point on `main`'s history) and on `main` itself, that merge-base is `HEAD` — meaning zero changes, meaning the build gets skipped. `HEAD~1` compares against the previous commit instead. This is scoped to production and branch-deploy only so PR previews keep the default merge-base behavior (which correctly detects all changes across a PR's commits).
- Added `X-Robots-Tag: noindex` header for branch deploys. This prevents search engines from indexing `next.videojs.org`, so pre-release docs don't compete with stable docs in search results. The production context (videojs.org) is not affected.

**`site/CLAUDE.md` and `site/README.md`**
- Added Deployment section documenting the two-branch model, the cherry-pick hotfix workflow, and the branch protection requirement.

### Manual steps required after merge

These are Netlify UI settings that can't be configured via `netlify.toml`:

1. **Change production branch** from `main` to `site/v10` in Netlify site settings → Build & deploy → Continuous Deployment → Branches and deploy contexts
2. **Enable branch deploys** for `main` in the same settings panel
3. **Set up `next.videojs.org`** for the `main` branch deploy (exact approach TBD — branch subdomain vs. separate domain alias)
4. **Add branch protection** on `site/v10` — restrict direct pushes to the CD workflow's token only. Human contributors cherry-pick via PR targeting `site/v10`.

### Future versioning

When v11 ships someday, the pattern extends naturally:
- `site/v11` becomes the new production branch → `videojs.org`
- `site/v10` gets pointed at `v10.videojs.org` (the existing redirect would be updated)
- `main` continues serving `next.videojs.org`

### Related

- Closes #645
- Follow-up: #1306 (pre-release banner on next.videojs.org)
- Related: #462, #1031 (changelog infrastructure)

## Test plan

- [ ] Verify `cd.yml` change: the `Update site/v10 branch` step has the correct `if` guard and runs after publish
- [ ] Verify `astro.config.mjs`: local dev still works (`CONTEXT` and `BRANCH` are undefined → falls back to `https://videojs.org`)
- [ ] After merge: change Netlify production branch to `site/v10`, enable branch deploys for `main`, set up `next.videojs.org` domain
- [ ] After merge: add branch protection on `site/v10` (restrict pushes to CD bot)
- [ ] After merge: verify videojs.org still deploys correctly
- [ ] After merge: verify next.videojs.org deploys from `main`
- [ ] After merge: verify `X-Robots-Tag: noindex` header is present on next.videojs.org responses
- [ ] After next release: verify `site/v10` gets force-pushed to the release commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a force-push-based release step and deploy-context URL/SEO behavior changes, which can affect production docs publishing and indexing if misconfigured.
> 
> **Overview**
> Implements a **two-branch docs deployment flow**: releases now publish to npm and then force-push the release commit to `site/v10` so Netlify production can track stable docs, while `main` remains a pre-release branch deploy.
> 
> Updates the Astro/Netlify build and SEO behavior for this split: `SITE_URL` now resolves based on Netlify `CONTEXT`/`BRANCH`, Turbo build skipping is avoided via `TURBO_SCM_BASE=HEAD~1` on production/branch-deploy, and non-production origins emit `robots: noindex`.
> 
> Adds documentation in `site/CLAUDE.md` and `site/README.md` describing the release sync, hotfix cherry-pick workflow, and branch protection expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75222bf2a52ad41129e22248d29dbed455d6778a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->