### PR TITLE
refactor(site): replace BEM class names with @scope-based CSS isolation in demos

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -197,13 +197,12 @@ Demos use component-mapped class names scoped via CSS `@scope`. Class names map 
 
 | What | Class Name | Example |
 |------|-----------|---------|
-| Player container (`Player.Container` / `<media-container>`) | `.media-container` | Always when demo has a player |
+| Any element | Match its tag name | `.video-player`, `.media-container`, `.media-play-button` |
 | Root for non-player demos | `.demo` | Standalone slider, tooltip |
-| Component elements | Match tag name | `.media-play-button`, `.media-controls` |
 | Slider sub-parts | Match tag name | `.media-slider-track`, `.media-slider-fill` |
 | Generic wrappers | Short semantic names | `.controls`, `.button`, `.panel` |
 
-React `.css` and HTML `.css` files for the same demo should use **identical** class names.
+Class names always match the component/tag they style. In HTML demos the root is `<video-player class="video-player">`. In React demos `Player.Container` renders `<media-container>`, so it uses `className="media-container"`. This means HTML and React CSS files may differ on the root class but share all inner class names.
 
 **How scoping works:** `Demo.astro` reads the CSS from the `files` prop, generates a deterministic hash, wraps the CSS in `@scope ([data-demo-scope="demo-{hash}"])`, and injects it as an inline `<style>`. Demo authors write clean CSS — the scoping is invisible in source tabs.
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -189,16 +189,25 @@ src/components/docs/demos/
     └── BasicUsage.ts       # HTML: side-effect imports for custom element registration
 ```
 
-### CSS Scoping with BEM
+### CSS Scoping and Class Naming
 
-Demos use BEM class names for scoping. Block = `{component}-{variant}`, element = `__{part}`:
+Demos use component-mapped class names scoped via CSS `@scope`. Class names map to the component or tag they style — no framework prefixes or BEM notation.
 
-```
-.play-button-basic              /* block */
-.play-button-basic__button      /* element */
-```
+**Naming rules:**
 
-React `.css` and HTML `.css` files for the same demo should use identical BEM names.
+| What | Class Name | Example |
+|------|-----------|---------|
+| Player container (`Player.Container` / `<media-container>`) | `.media-container` | Always when demo has a player |
+| Root for non-player demos | `.demo` | Standalone slider, tooltip |
+| Component elements | Match tag name | `.media-play-button`, `.media-controls` |
+| Slider sub-parts | Match tag name | `.media-slider-track`, `.media-slider-fill` |
+| Generic wrappers | Short semantic names | `.controls`, `.button`, `.panel` |
+
+React `.css` and HTML `.css` files for the same demo should use **identical** class names.
+
+**How scoping works:** `Demo.astro` reads the CSS from the `files` prop, generates a deterministic hash, wraps the CSS in `@scope ([data-demo-scope="demo-{hash}"])`, and injects it as an inline `<style>`. Demo authors write clean CSS — the scoping is invisible in source tabs.
+
+**No CSS side-effect imports in demos.** Do not `import './X.css'` in `.tsx` or `.astro` files. CSS is injected by `Demo.astro` via the `files` prop.
 
 ### React Demos
 
@@ -221,12 +230,11 @@ import basicUsageCss from "@/components/docs/demos/play-button/react/css/BasicUs
 
 Four files per demo: `.html` (markup only), `.css` (styles), `.ts` (custom element registration), and `.astro` (wrapper that ties them together). The `.astro` wrapper is needed because only Astro `<script>` tags go through Vite's bundling pipeline — MDX `<script>` tags compile as JSX and aren't bundled.
 
-**`.astro` wrapper** (imports CSS for live demo, renders HTML, bundles the `.ts` script):
+**`.astro` wrapper** (renders HTML, bundles the `.ts` script — no CSS import):
 ```astro
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 <HtmlDemo html={html} />
 <script>
@@ -255,16 +263,16 @@ import basicUsageHtmlTs from "@/components/docs/demos/play-button/html/css/Basic
 HTML custom elements expose state via `data-*` attributes. Use CSS to toggle labels:
 
 ```html
-<media-play-button class="play-button-basic__button">
+<media-play-button class="media-play-button">
   <span class="show-when-paused">Play</span>
   <span class="show-when-playing">Pause</span>
 </media-play-button>
 ```
 ```css
-.play-button-basic__button .show-when-paused { display: none; }
-.play-button-basic__button .show-when-playing { display: none; }
-.play-button-basic__button[data-paused] .show-when-paused { display: inline; }
-.play-button-basic__button:not([data-paused]) .show-when-playing { display: inline; }
+.media-play-button .show-when-paused { display: none; }
+.media-play-button .show-when-playing { display: none; }
+.media-play-button[data-paused] .show-when-paused { display: inline; }
+.media-play-button:not([data-paused]) .show-when-playing { display: inline; }
 ```
 
 The React equivalent uses the `render` prop: `render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}`.

--- a/site/src/components/Tabs.tsx
+++ b/site/src/components/Tabs.tsx
@@ -271,32 +271,44 @@ interface TabsPanelProps {
 }
 export function TabsPanel({ value, children, initial, className, variant = 'compact' }: TabsPanelProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const isHydrated = useIsHydrated();
   const [isActive, setIsActive] = useState(initial);
 
   // Observe the corresponding Tab element's data-tab-active attribute
-  // to sync panel visibility with tab activation
+  // to sync panel visibility with tab activation.
+  //
+  // With Astro islands, Tab and TabsPanel hydrate independently via client:idle.
+  // We observe the tabs root subtree so that we detect data-tab-active changes
+  // regardless of hydration order between Tab and TabsPanel islands.
   useEffect(() => {
+    if (!isHydrated) return;
+
     const tabsRoot = ref.current?.closest('[data-tabs-root]');
-    const correspondingTab = tabsRoot?.querySelector(`[role="tab"][data-value="${value}"]`);
+    if (!tabsRoot) return;
 
-    if (!correspondingTab) return;
+    function sync() {
+      const tab = tabsRoot!.querySelector(`[role="tab"][data-value="${value}"]`);
+      if (!tab) return;
+      const attr = tab.getAttribute('data-tab-active');
+      if (attr !== null) {
+        setIsActive(attr === 'true');
+      }
+    }
 
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.type === 'attributes' && mutation.attributeName === 'data-tab-active') {
-          const target = mutation.target as Element;
-          const newValue = target.getAttribute('data-tab-active') === 'true';
-          setIsActive(newValue);
-        }
-      });
+    // Sync current state immediately
+    sync();
+
+    // Watch the tabs root for any data-tab-active changes and subtree mutations
+    // (handles both click-driven attribute changes and late-hydrating Tab islands)
+    const observer = new MutationObserver(sync);
+    observer.observe(tabsRoot, {
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-tab-active'],
     });
 
-    observer.observe(correspondingTab, { attributes: true });
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [value]);
+    return () => observer.disconnect();
+  }, [value, isHydrated]);
 
   return (
     <div

--- a/site/src/components/Tabs.tsx
+++ b/site/src/components/Tabs.tsx
@@ -271,44 +271,32 @@ interface TabsPanelProps {
 }
 export function TabsPanel({ value, children, initial, className, variant = 'compact' }: TabsPanelProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const isHydrated = useIsHydrated();
   const [isActive, setIsActive] = useState(initial);
 
   // Observe the corresponding Tab element's data-tab-active attribute
-  // to sync panel visibility with tab activation.
-  //
-  // With Astro islands, Tab and TabsPanel hydrate independently via client:idle.
-  // We observe the tabs root subtree so that we detect data-tab-active changes
-  // regardless of hydration order between Tab and TabsPanel islands.
+  // to sync panel visibility with tab activation
   useEffect(() => {
-    if (!isHydrated) return;
-
     const tabsRoot = ref.current?.closest('[data-tabs-root]');
-    if (!tabsRoot) return;
+    const correspondingTab = tabsRoot?.querySelector(`[role="tab"][data-value="${value}"]`);
 
-    function sync() {
-      const tab = tabsRoot!.querySelector(`[role="tab"][data-value="${value}"]`);
-      if (!tab) return;
-      const attr = tab.getAttribute('data-tab-active');
-      if (attr !== null) {
-        setIsActive(attr === 'true');
-      }
-    }
+    if (!correspondingTab) return;
 
-    // Sync current state immediately
-    sync();
-
-    // Watch the tabs root for any data-tab-active changes and subtree mutations
-    // (handles both click-driven attribute changes and late-hydrating Tab islands)
-    const observer = new MutationObserver(sync);
-    observer.observe(tabsRoot, {
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['data-tab-active'],
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-tab-active') {
+          const target = mutation.target as Element;
+          const newValue = target.getAttribute('data-tab-active') === 'true';
+          setIsActive(newValue);
+        }
+      });
     });
 
-    return () => observer.disconnect();
-  }, [value, isHydrated]);
+    observer.observe(correspondingTab, { attributes: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [value]);
 
   return (
     <div

--- a/site/src/components/docs/Selectors.tsx
+++ b/site/src/components/docs/Selectors.tsx
@@ -12,17 +12,28 @@ import {
 } from '@/types/docs';
 import { setStylePreferenceClient, updateStyleAttribute } from '@/utils/docs/preferences';
 import { resolveFrameworkChange } from '@/utils/docs/routing';
-import useIsHydrated from '@/utils/useIsHydrated';
 
 interface SelectorProps {
   currentFramework: SupportedFramework;
   currentSlug: string;
 }
 
+/** Read the style from the DOM attribute set by StyleInit (runs before paint). */
+function getInitialStyle(framework: SupportedFramework): AnySupportedStyle {
+  if (typeof document !== 'undefined') {
+    const domStyle = document.documentElement.dataset.style;
+    if (domStyle && isValidStyleForFramework(framework, domStyle)) {
+      return domStyle as AnySupportedStyle;
+    }
+  }
+  return FRAMEWORK_STYLES[framework][0];
+}
+
 export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
   const currentStyle = useStore(styleStore);
-  const isHydrated = useIsHydrated();
-  const hydrationSafeCurrentStyle = isHydrated ? currentStyle : null;
+
+  // Use nanostore value when available, otherwise read from DOM (set by StyleInit before paint)
+  const resolvedStyle = currentStyle ?? getInitialStyle(currentFramework);
 
   const handleFrameworkChange = (newFramework: SupportedFramework | null) => {
     if (newFramework === null) return;
@@ -34,11 +45,18 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
       newFramework,
     });
 
-    if (shouldReplace) {
-      // Base UI's scroll lock transfers html.scrollTop → body.scrollTop
-      const scrollLocked = document.documentElement.hasAttribute('data-base-ui-scroll-locked');
-      const scrollY = scrollLocked ? document.body.scrollTop : window.scrollY;
+    // Base UI's scroll lock transfers html.scrollTop → body.scrollTop.
+    // Capture scroll position before releasing the lock.
+    const scrollLocked = document.documentElement.hasAttribute('data-base-ui-scroll-locked');
+    const scrollY = scrollLocked ? document.body.scrollTop : window.scrollY;
 
+    // Release scroll lock before navigating so the page doesn't appear frozen
+    if (scrollLocked) {
+      document.documentElement.removeAttribute('data-base-ui-scroll-locked');
+      document.documentElement.style.overflow = '';
+    }
+
+    if (shouldReplace) {
       try {
         sessionStorage.setItem(
           'vjs-page-scroll',
@@ -93,7 +111,7 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
         />
         <span className="text-p3 text-faded-black dark:text-manila-light">Style</span>
         <Select
-          value={hydrationSafeCurrentStyle}
+          value={resolvedStyle}
           onChange={handleStyleChange}
           options={styleOptions}
           aria-label="Select style"

--- a/site/src/components/docs/Selectors.tsx
+++ b/site/src/components/docs/Selectors.tsx
@@ -12,28 +12,17 @@ import {
 } from '@/types/docs';
 import { setStylePreferenceClient, updateStyleAttribute } from '@/utils/docs/preferences';
 import { resolveFrameworkChange } from '@/utils/docs/routing';
+import useIsHydrated from '@/utils/useIsHydrated';
 
 interface SelectorProps {
   currentFramework: SupportedFramework;
   currentSlug: string;
 }
 
-/** Read the style from the DOM attribute set by StyleInit (runs before paint). */
-function getInitialStyle(framework: SupportedFramework): AnySupportedStyle {
-  if (typeof document !== 'undefined') {
-    const domStyle = document.documentElement.dataset.style;
-    if (domStyle && isValidStyleForFramework(framework, domStyle)) {
-      return domStyle as AnySupportedStyle;
-    }
-  }
-  return FRAMEWORK_STYLES[framework][0];
-}
-
 export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
   const currentStyle = useStore(styleStore);
-
-  // Use nanostore value when available, otherwise read from DOM (set by StyleInit before paint)
-  const resolvedStyle = currentStyle ?? getInitialStyle(currentFramework);
+  const isHydrated = useIsHydrated();
+  const hydrationSafeCurrentStyle = isHydrated ? currentStyle : null;
 
   const handleFrameworkChange = (newFramework: SupportedFramework | null) => {
     if (newFramework === null) return;
@@ -45,18 +34,11 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
       newFramework,
     });
 
-    // Base UI's scroll lock transfers html.scrollTop → body.scrollTop.
-    // Capture scroll position before releasing the lock.
-    const scrollLocked = document.documentElement.hasAttribute('data-base-ui-scroll-locked');
-    const scrollY = scrollLocked ? document.body.scrollTop : window.scrollY;
-
-    // Release scroll lock before navigating so the page doesn't appear frozen
-    if (scrollLocked) {
-      document.documentElement.removeAttribute('data-base-ui-scroll-locked');
-      document.documentElement.style.overflow = '';
-    }
-
     if (shouldReplace) {
+      // Base UI's scroll lock transfers html.scrollTop → body.scrollTop
+      const scrollLocked = document.documentElement.hasAttribute('data-base-ui-scroll-locked');
+      const scrollY = scrollLocked ? document.body.scrollTop : window.scrollY;
+
       try {
         sessionStorage.setItem(
           'vjs-page-scroll',
@@ -111,7 +93,7 @@ export function Selectors({ currentFramework, currentSlug }: SelectorProps) {
         />
         <span className="text-p3 text-faded-black dark:text-manila-light">Style</span>
         <Select
-          value={resolvedStyle}
+          value={hydrationSafeCurrentStyle}
           onChange={handleStyleChange}
           options={styleOptions}
           aria-label="Select style"

--- a/site/src/components/docs/demos/Demo.astro
+++ b/site/src/components/docs/demos/Demo.astro
@@ -15,12 +15,29 @@ interface Props {
 }
 
 const { files } = Astro.props;
+
+function hash(input: string): string {
+  let value = 5381;
+  for (let i = 0; i < input.length; i++) {
+    value = ((value << 5) + value) ^ input.charCodeAt(i);
+  }
+  return Math.abs(value >>> 0).toString(36);
+}
+
+const cssFile = files.find((file) => file.lang === 'css');
+const scopeSeed = files.map((file) => `${file.title}:${file.lang}\n${file.code}`).join('\n\n');
+const scopeId = cssFile ? `demo-${hash(scopeSeed)}` : null;
+const scopedCss = cssFile && scopeId ? `@scope ([data-demo-scope="${scopeId}"]) {\n${cssFile.code}\n}` : null;
 ---
 
 <div
   class="mx-auto my-6 flex w-full max-w-3xl flex-col overflow-hidden rounded-xs border border-faded-black dark:border-manila-dark"
 >
-  <div class="relative z-20 bg-manila-light dark:bg-faded-black">
+  {scopedCss && <style is:inline set:html={scopedCss} />}
+  <div
+    class="relative z-20 bg-manila-light dark:bg-faded-black"
+    data-demo-scope={scopeId}
+  >
     <slot />
   </div>
   <TabsRoot

--- a/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.html-buffering-indicator-basic {
+.media-container {
   display: flex;
   width: 100%;
   height: 100%;
   position: relative;
 }
 
-.html-buffering-indicator-basic__overlay {
+.media-buffering-indicator {
   position: absolute;
   inset: 0;
   display: flex;
@@ -15,7 +15,7 @@
   z-index: 30;
 }
 
-.html-buffering-indicator-basic__spinner {
+.spinner {
   width: 48px;
   height: 48px;
   border: 4px solid rgba(255, 255, 255, 0.3);
@@ -25,7 +25,7 @@
   display: none;
 }
 
-.html-buffering-indicator-basic__overlay[data-visible] .html-buffering-indicator-basic__spinner {
+.media-buffering-indicator[data-visible] .spinner {
   display: block;
 }
 

--- a/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.css
@@ -1,4 +1,4 @@
-.media-container {
+.video-player {
   display: flex;
   width: 100%;
   height: 100%;

--- a/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/buffering-indicator/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-buffering-indicator-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,8 +7,8 @@
             playsinline
             loop
         ></video>
-        <media-buffering-indicator class="html-buffering-indicator-basic__overlay">
-            <div class="html-buffering-indicator-basic__spinner"></div>
+        <media-buffering-indicator class="media-buffering-indicator">
+            <div class="spinner"></div>
         </media-buffering-indicator>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.react-buffering-indicator-basic {
+.media-container {
   display: flex;
   width: 100%;
   height: 100%;
   position: relative;
 }
 
-.react-buffering-indicator-basic__overlay {
+.media-buffering-indicator {
   position: absolute;
   inset: 0;
   display: flex;
@@ -15,7 +15,7 @@
   z-index: 30;
 }
 
-.react-buffering-indicator-basic__spinner {
+.spinner {
   width: 48px;
   height: 48px;
   border: 4px solid rgba(255, 255, 255, 0.3);
@@ -25,7 +25,7 @@
   display: none;
 }
 
-.react-buffering-indicator-basic__overlay[data-visible] .react-buffering-indicator-basic__spinner {
+.media-buffering-indicator[data-visible] .spinner {
   display: block;
 }
 

--- a/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { BufferingIndicator, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-buffering-indicator-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,10 +15,8 @@ export default function BasicUsage() {
           loop
         />
         <BufferingIndicator
-          className="react-buffering-indicator-basic__overlay"
-          render={(props, state) => (
-            <div {...props}>{state.visible && <div className="react-buffering-indicator-basic__spinner" />}</div>
-          )}
+          className="media-buffering-indicator"
+          render={(props, state) => <div {...props}>{state.visible && <div className="spinner" />}</div>}
         />
       </Player.Container>
     </Player.Provider>

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
@@ -20,15 +20,15 @@
   cursor: pointer;
 }
 
-.media-captions-button .show-when-active {
+.media-captions-button .active {
   display: none;
 }
-.media-captions-button .show-when-inactive {
+.media-captions-button .inactive {
   display: none;
 }
-.media-captions-button[data-active] .show-when-active {
+.media-captions-button[data-active] .active {
   display: inline;
 }
-.media-captions-button:not([data-active]) .show-when-inactive {
+.media-captions-button:not([data-active]) .inactive {
   display: inline;
 }

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-captions-button-basic {
+.media-container {
   position: relative;
 }
 
-.html-captions-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-captions-button-basic__button {
+.media-captions-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -20,15 +20,15 @@
   cursor: pointer;
 }
 
-.html-captions-button-basic__button .show-when-active {
+.media-captions-button .show-when-active {
   display: none;
 }
-.html-captions-button-basic__button .show-when-inactive {
+.media-captions-button .show-when-inactive {
   display: none;
 }
-.html-captions-button-basic__button[data-active] .show-when-active {
+.media-captions-button[data-active] .show-when-active {
   display: inline;
 }
-.html-captions-button-basic__button:not([data-active]) .show-when-inactive {
+.media-captions-button:not([data-active]) .show-when-inactive {
   display: inline;
 }

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
@@ -10,8 +10,8 @@
             <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
         </video>
         <media-captions-button class="media-captions-button">
-            <span class="show-when-active">Captions Off</span>
-            <span class="show-when-inactive">Captions On</span>
+            <span class="active">Captions Off</span>
+            <span class="inactive">Captions On</span>
         </media-captions-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-captions-button-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -9,7 +9,7 @@
         >
             <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
         </video>
-        <media-captions-button class="html-captions-button-basic__button">
+        <media-captions-button class="media-captions-button">
             <span class="show-when-active">Captions Off</span>
             <span class="show-when-inactive">Captions On</span>
         </media-captions-button>

--- a/site/src/components/docs/demos/captions-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-captions-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-captions-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-captions-button-basic__button {
+.media-captions-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { CaptionsButton, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-captions-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -19,7 +17,7 @@ export default function BasicUsage() {
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
         </Video>
         <CaptionsButton
-          className="react-captions-button-basic__button"
+          className="media-captions-button"
           render={(props, state) => (
             <button {...props}>{state.subtitlesShowing ? 'Captions Off' : 'Captions On'}</button>
           )}

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.css
@@ -59,15 +59,15 @@
   cursor: pointer;
 }
 
-.button .show-when-paused,
-.button .show-when-playing {
+.button .paused,
+.button .playing {
   display: none;
 }
 
-.media-play-button[data-paused] .show-when-paused {
+.media-play-button[data-paused] .paused {
   display: inline;
 }
 
-.media-play-button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.css
@@ -1,9 +1,9 @@
-.media-container {
+.video-player {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.css
@@ -1,13 +1,13 @@
-.html-controls-basic {
+.media-container {
   display: block;
   position: relative;
 }
 
-.html-controls-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-controls-basic__root {
+.media-controls {
   position: absolute;
   inset: 0;
   display: flex;
@@ -18,15 +18,15 @@
   transition: opacity 0.25s;
 }
 
-.html-controls-basic__root:not([data-visible]) {
+.media-controls:not([data-visible]) {
   opacity: 0;
 }
 
-.html-controls-basic__bottom {
+.controls-group {
   pointer-events: auto;
 }
 
-.html-controls-basic__time {
+.time {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -40,14 +40,14 @@
   font-size: 14px;
 }
 
-.html-controls-basic__bottom {
+.controls-group {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
 }
 
-.html-controls-basic__button {
+.button {
   padding-block: 8px;
   background: rgba(255, 255, 255, 0.75);
   backdrop-filter: blur(10px);
@@ -59,15 +59,15 @@
   cursor: pointer;
 }
 
-.html-controls-basic__button .show-when-paused,
-.html-controls-basic__button .show-when-playing {
+.button .show-when-paused,
+.button .show-when-playing {
   display: none;
 }
 
-.html-controls-basic__play[data-paused] .show-when-paused {
+.media-play-button[data-paused] .show-when-paused {
   display: inline;
 }
 
-.html-controls-basic__play:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .show-when-playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-controls-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -8,13 +8,13 @@
             loop
         ></video>
 
-        <media-controls class="html-controls-basic__root">
-            <media-controls-group class="html-controls-basic__bottom" aria-label="Playback controls">
-                <media-play-button class="html-controls-basic__button html-controls-basic__play">
+        <media-controls class="media-controls">
+            <media-controls-group class="controls-group" aria-label="Playback controls">
+                <media-play-button class="button media-play-button">
                     <span class="show-when-paused">Play</span>
                     <span class="show-when-playing">Pause</span>
                 </media-play-button>
-                <media-time class="html-controls-basic__time" type="current"></media-time>
+                <media-time class="time" type="current"></media-time>
             </media-controls-group>
         </media-controls>
     </media-container>

--- a/site/src/components/docs/demos/controls/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/controls/html/css/BasicUsage.html
@@ -11,8 +11,8 @@
         <media-controls class="media-controls">
             <media-controls-group class="controls-group" aria-label="Playback controls">
                 <media-play-button class="button media-play-button">
-                    <span class="show-when-paused">Play</span>
-                    <span class="show-when-playing">Pause</span>
+                    <span class="paused">Play</span>
+                    <span class="playing">Pause</span>
                 </media-play-button>
                 <media-time class="time" type="current"></media-time>
             </media-controls-group>

--- a/site/src/components/docs/demos/controls/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/controls/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-controls-basic {
+.media-container {
   position: relative;
 }
 
-.react-controls-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-controls-basic__root {
+.media-controls {
   position: absolute;
   inset: 0;
   display: flex;
@@ -17,15 +17,15 @@
   transition: opacity 0.25s;
 }
 
-.react-controls-basic__root:not([data-visible]) {
+.media-controls:not([data-visible]) {
   opacity: 0;
 }
 
-.react-controls-basic__bottom {
+.controls-group {
   pointer-events: auto;
 }
 
-.react-controls-basic__time {
+.time {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -39,14 +39,14 @@
   font-size: 14px;
 }
 
-.react-controls-basic__bottom {
+.controls-group {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
 }
 
-.react-controls-basic__button {
+.button {
   padding-block: 8px;
   background: rgba(255, 255, 255, 0.75);
   backdrop-filter: blur(10px);

--- a/site/src/components/docs/demos/controls/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/controls/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { Controls, createPlayer, PlayButton, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-controls-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,14 +15,14 @@ export default function BasicUsage() {
           loop
         />
 
-        <Controls.Root className="react-controls-basic__root">
-          <Controls.Group className="react-controls-basic__bottom" aria-label="Playback controls">
+        <Controls.Root className="media-controls">
+          <Controls.Group className="controls-group" aria-label="Playback controls">
             <PlayButton
-              className="react-controls-basic__button"
+              className="button"
               render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}
             />
 
-            <Time.Value type="current" className="react-controls-basic__time" />
+            <Time.Value type="current" className="time" />
           </Controls.Group>
         </Controls.Root>
       </Player.Container>

--- a/site/src/components/docs/demos/create-player/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/create-player/react/css/BasicUsage.css
@@ -1,18 +1,18 @@
-.react-create-player-basic {
+.media-container {
   position: relative;
 }
 
-.react-create-player-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-create-player-basic__controls {
+.controls {
   position: absolute;
   bottom: 10px;
   left: 10px;
 }
 
-.react-create-player-basic__button {
+.button {
   padding-block: 8px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);

--- a/site/src/components/docs/demos/create-player/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/create-player/react/css/BasicUsage.tsx
@@ -1,8 +1,6 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({
   features: videoFeatures,
 });
@@ -12,12 +10,8 @@ function Controls() {
   const paused = Player.usePlayer((s) => s.paused);
 
   return (
-    <div className="react-create-player-basic__controls">
-      <button
-        type="button"
-        className="react-create-player-basic__button"
-        onClick={() => (paused ? store.play() : store.pause())}
-      >
+    <div className="controls">
+      <button type="button" className="button" onClick={() => (paused ? store.play() : store.pause())}>
         {paused ? 'Play' : 'Pause'}
       </button>
     </div>
@@ -27,7 +21,7 @@ function Controls() {
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-create-player-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.css
@@ -1,9 +1,9 @@
-.media-container {
+.video-player {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.css
@@ -21,15 +21,15 @@
   cursor: pointer;
 }
 
-.media-fullscreen-button .show-when-fullscreen {
+.media-fullscreen-button .fullscreen {
   display: none;
 }
-.media-fullscreen-button .show-when-not-fullscreen {
+.media-fullscreen-button .not-fullscreen {
   display: none;
 }
-.media-fullscreen-button[data-fullscreen] .show-when-fullscreen {
+.media-fullscreen-button[data-fullscreen] .fullscreen {
   display: inline;
 }
-.media-fullscreen-button:not([data-fullscreen]) .show-when-not-fullscreen {
+.media-fullscreen-button:not([data-fullscreen]) .not-fullscreen {
   display: inline;
 }

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.css
@@ -1,13 +1,13 @@
-.html-fullscreen-button-basic {
+.media-container {
   display: block;
   position: relative;
 }
 
-.html-fullscreen-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-fullscreen-button-basic__button {
+.media-fullscreen-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -21,15 +21,15 @@
   cursor: pointer;
 }
 
-.html-fullscreen-button-basic__button .show-when-fullscreen {
+.media-fullscreen-button .show-when-fullscreen {
   display: none;
 }
-.html-fullscreen-button-basic__button .show-when-not-fullscreen {
+.media-fullscreen-button .show-when-not-fullscreen {
   display: none;
 }
-.html-fullscreen-button-basic__button[data-fullscreen] .show-when-fullscreen {
+.media-fullscreen-button[data-fullscreen] .show-when-fullscreen {
   display: inline;
 }
-.html-fullscreen-button-basic__button:not([data-fullscreen]) .show-when-not-fullscreen {
+.media-fullscreen-button:not([data-fullscreen]) .show-when-not-fullscreen {
   display: inline;
 }

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-fullscreen-button-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,7 +7,7 @@
             playsinline
             loop
         ></video>
-        <media-fullscreen-button class="html-fullscreen-button-basic__button">
+        <media-fullscreen-button class="media-fullscreen-button">
             <span class="show-when-fullscreen">Exit Fullscreen</span>
             <span class="show-when-not-fullscreen">Fullscreen</span>
         </media-fullscreen-button>

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/fullscreen-button/html/css/BasicUsage.html
@@ -8,8 +8,8 @@
             loop
         ></video>
         <media-fullscreen-button class="media-fullscreen-button">
-            <span class="show-when-fullscreen">Exit Fullscreen</span>
-            <span class="show-when-not-fullscreen">Fullscreen</span>
+            <span class="fullscreen">Exit Fullscreen</span>
+            <span class="not-fullscreen">Fullscreen</span>
         </media-fullscreen-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-fullscreen-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-fullscreen-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-fullscreen-button-basic__button {
+.media-fullscreen-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, FullscreenButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-fullscreen-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,7 +15,7 @@ export default function BasicUsage() {
           loop
         />
         <FullscreenButton
-          className="react-fullscreen-button-basic__button"
+          className="media-fullscreen-button"
           render={(props, state) => <button {...props}>{state.fullscreen ? 'Exit Fullscreen' : 'Fullscreen'}</button>}
         />
       </Player.Container>

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.css
@@ -20,18 +20,18 @@
   cursor: pointer;
 }
 
-.media-play-button .show-when-paused {
+.media-play-button .paused {
   display: none;
 }
 
-.media-play-button .show-when-playing {
+.media-play-button .playing {
   display: none;
 }
 
-.media-play-button[data-paused] .show-when-paused {
+.media-play-button[data-paused] .paused {
   display: inline;
 }
 
-.media-play-button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.demo-video-player {
   position: relative;
 }
 
-.media-container video {
+.demo-video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-create-player-basic {
+.media-container {
   position: relative;
 }
 
-.html-create-player-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-create-player-basic__button {
+.media-play-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -20,18 +20,18 @@
   cursor: pointer;
 }
 
-.html-create-player-basic__button .show-when-paused {
+.media-play-button .show-when-paused {
   display: none;
 }
 
-.html-create-player-basic__button .show-when-playing {
+.media-play-button .show-when-playing {
   display: none;
 }
 
-.html-create-player-basic__button[data-paused] .show-when-paused {
+.media-play-button[data-paused] .show-when-paused {
   display: inline;
 }
 
-.html-create-player-basic__button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .show-when-playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
@@ -7,8 +7,8 @@
             playsinline
         ></video>
         <demo-play-toggle class="media-play-button">
-            <span class="show-when-paused">Play</span>
-            <span class="show-when-playing">Pause</span>
+            <span class="paused">Play</span>
+            <span class="playing">Pause</span>
         </demo-play-toggle>
     </media-container>
 </demo-video-player>

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<demo-video-player class="html-create-player-basic">
+<demo-video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -6,7 +6,7 @@
             muted
             playsinline
         ></video>
-        <demo-play-toggle class="html-create-player-basic__button">
+        <demo-play-toggle class="media-play-button">
             <span class="show-when-paused">Play</span>
             <span class="show-when-playing">Pause</span>
         </demo-play-toggle>

--- a/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/html-create-player/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<demo-video-player class="media-container">
+<demo-video-player class="demo-video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
@@ -20,15 +20,15 @@
   cursor: pointer;
 }
 
-.media-mute-button .show-when-muted {
+.media-mute-button .muted {
   display: none;
 }
-.media-mute-button .show-when-unmuted {
+.media-mute-button .unmuted {
   display: none;
 }
-.media-mute-button[data-muted] .show-when-muted {
+.media-mute-button[data-muted] .muted {
   display: inline;
 }
-.media-mute-button:not([data-muted]) .show-when-unmuted {
+.media-mute-button:not([data-muted]) .unmuted {
   display: inline;
 }

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-mute-button-basic {
+.media-container {
   position: relative;
 }
 
-.html-mute-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-mute-button-basic__button {
+.media-mute-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -20,15 +20,15 @@
   cursor: pointer;
 }
 
-.html-mute-button-basic__button .show-when-muted {
+.media-mute-button .show-when-muted {
   display: none;
 }
-.html-mute-button-basic__button .show-when-unmuted {
+.media-mute-button .show-when-unmuted {
   display: none;
 }
-.html-mute-button-basic__button[data-muted] .show-when-muted {
+.media-mute-button[data-muted] .show-when-muted {
   display: inline;
 }
-.html-mute-button-basic__button:not([data-muted]) .show-when-unmuted {
+.media-mute-button:not([data-muted]) .show-when-unmuted {
   display: inline;
 }

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
@@ -8,8 +8,8 @@
             loop
         ></video>
         <media-mute-button class="media-mute-button">
-            <span class="show-when-muted">Unmute</span>
-            <span class="show-when-unmuted">Mute</span>
+            <span class="muted">Unmute</span>
+            <span class="unmuted">Mute</span>
         </media-mute-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-mute-button-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,7 +7,7 @@
             playsinline
             loop
         ></video>
-        <media-mute-button class="html-mute-button-basic__button">
+        <media-mute-button class="media-mute-button">
             <span class="show-when-muted">Unmute</span>
             <span class="show-when-unmuted">Mute</span>
         </media-mute-button>

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.astro
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './VolumeLevels.html?raw';
-import './VolumeLevels.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
@@ -1,12 +1,12 @@
-.html-mute-button-volume-levels {
+.media-container {
   position: relative;
 }
 
-.html-mute-button-volume-levels video {
+.media-container video {
   width: 100%;
 }
 
-.html-mute-button-volume-levels__button {
+.media-mute-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -20,22 +20,22 @@
   cursor: pointer;
 }
 
-.html-mute-button-volume-levels__button .level-off,
-.html-mute-button-volume-levels__button .level-low,
-.html-mute-button-volume-levels__button .level-medium,
-.html-mute-button-volume-levels__button .level-high {
+.media-mute-button .level-off,
+.media-mute-button .level-low,
+.media-mute-button .level-medium,
+.media-mute-button .level-high {
   display: none;
 }
 
-.html-mute-button-volume-levels__button[data-volume-level="off"] .level-off {
+.media-mute-button[data-volume-level="off"] .level-off {
   display: inline;
 }
-.html-mute-button-volume-levels__button[data-volume-level="low"] .level-low {
+.media-mute-button[data-volume-level="low"] .level-low {
   display: inline;
 }
-.html-mute-button-volume-levels__button[data-volume-level="medium"] .level-medium {
+.media-mute-button[data-volume-level="medium"] .level-medium {
   display: inline;
 }
-.html-mute-button-volume-levels__button[data-volume-level="high"] .level-high {
+.media-mute-button[data-volume-level="high"] .level-high {
   display: inline;
 }

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.html
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.html
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.html
@@ -1,4 +1,4 @@
-<video-player class="html-mute-button-volume-levels">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,7 +7,7 @@
             playsinline
             loop
         ></video>
-        <media-mute-button class="html-mute-button-volume-levels__button">
+        <media-mute-button class="media-mute-button">
             <span class="level-off">Off</span>
             <span class="level-low">Low</span>
             <span class="level-medium">Medium</span>

--- a/site/src/components/docs/demos/mute-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/mute-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-mute-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-mute-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-mute-button-basic__button {
+.media-mute-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/mute-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/mute-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-mute-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,7 +15,7 @@ export default function BasicUsage() {
           loop
         />
         <MuteButton
-          className="react-mute-button-basic__button"
+          className="media-mute-button"
           render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
         />
       </Player.Container>

--- a/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.css
+++ b/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.css
@@ -1,12 +1,12 @@
-.react-mute-button-volume-levels {
+.media-container {
   position: relative;
 }
 
-.react-mute-button-volume-levels video {
+.media-container video {
   width: 100%;
 }
 
-.react-mute-button-volume-levels__button {
+.media-mute-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.tsx
+++ b/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './VolumeLevels.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function VolumeLevels() {
   return (
     <Player.Provider>
-      <Player.Container className="react-mute-button-volume-levels">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,7 +15,7 @@ export default function VolumeLevels() {
           loop
         />
         <MuteButton
-          className="react-mute-button-volume-levels__button"
+          className="media-mute-button"
           render={(props, state) => (
             <button {...props}>
               {state.volumeLevel === 'off'

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.css
@@ -1,13 +1,13 @@
-.html-pip-button-basic {
+.media-container {
   display: block;
   position: relative;
 }
 
-.html-pip-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-pip-button-basic__button {
+.media-pip-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -21,15 +21,15 @@
   cursor: pointer;
 }
 
-.html-pip-button-basic__button .show-when-pip {
+.media-pip-button .show-when-pip {
   display: none;
 }
-.html-pip-button-basic__button .show-when-not-pip {
+.media-pip-button .show-when-not-pip {
   display: none;
 }
-.html-pip-button-basic__button[data-pip] .show-when-pip {
+.media-pip-button[data-pip] .show-when-pip {
   display: inline;
 }
-.html-pip-button-basic__button:not([data-pip]) .show-when-not-pip {
+.media-pip-button:not([data-pip]) .show-when-not-pip {
   display: inline;
 }

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.css
@@ -1,9 +1,9 @@
-.media-container {
+.video-player {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.css
@@ -21,15 +21,15 @@
   cursor: pointer;
 }
 
-.media-pip-button .show-when-pip {
+.media-pip-button .pip {
   display: none;
 }
-.media-pip-button .show-when-not-pip {
+.media-pip-button .not-pip {
   display: none;
 }
-.media-pip-button[data-pip] .show-when-pip {
+.media-pip-button[data-pip] .pip {
   display: inline;
 }
-.media-pip-button:not([data-pip]) .show-when-not-pip {
+.media-pip-button:not([data-pip]) .not-pip {
   display: inline;
 }

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
@@ -8,8 +8,8 @@
             loop
         ></video>
         <media-pip-button class="media-pip-button">
-            <span class="show-when-pip">Exit PiP</span>
-            <span class="show-when-not-pip">Enter PiP</span>
+            <span class="pip">Exit PiP</span>
+            <span class="not-pip">Enter PiP</span>
         </media-pip-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-pip-button-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,7 +7,7 @@
             playsinline
             loop
         ></video>
-        <media-pip-button class="html-pip-button-basic__button">
+        <media-pip-button class="media-pip-button">
             <span class="show-when-pip">Exit PiP</span>
             <span class="show-when-not-pip">Enter PiP</span>
         </media-pip-button>

--- a/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/pip-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/pip-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/pip-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-pip-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-pip-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-pip-button-basic__button {
+.media-pip-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/pip-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/pip-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, PiPButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-pip-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,7 +15,7 @@ export default function BasicUsage() {
           loop
         />
         <PiPButton
-          className="react-pip-button-basic__button"
+          className="media-pip-button"
           render={(props, state) => <button {...props}>{state.pip ? 'Exit PiP' : 'Enter PiP'}</button>}
         />
       </Player.Container>

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
@@ -20,27 +20,27 @@
   cursor: pointer;
 }
 
-.media-play-button .show-when-paused {
+.media-play-button .paused {
   display: none;
 }
-.media-play-button .show-when-playing {
+.media-play-button .playing {
   display: none;
 }
-.media-play-button .show-when-ended {
+.media-play-button .ended {
   display: none;
 }
-.media-play-button[data-paused]:not([data-ended]) .show-when-paused {
+.media-play-button[data-paused]:not([data-ended]) .paused {
   display: inline;
 }
-.media-play-button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .playing {
   display: inline;
 }
-.media-play-button[data-ended] .show-when-ended {
+.media-play-button[data-ended] .ended {
   display: inline;
 }
-.media-play-button[data-ended] .show-when-paused {
+.media-play-button[data-ended] .paused {
   display: none;
 }
-.media-play-button[data-ended] .show-when-playing {
+.media-play-button[data-ended] .playing {
   display: none;
 }

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-play-button-basic {
+.media-container {
   position: relative;
 }
 
-.html-play-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-play-button-basic__button {
+.media-play-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -20,27 +20,27 @@
   cursor: pointer;
 }
 
-.html-play-button-basic__button .show-when-paused {
+.media-play-button .show-when-paused {
   display: none;
 }
-.html-play-button-basic__button .show-when-playing {
+.media-play-button .show-when-playing {
   display: none;
 }
-.html-play-button-basic__button .show-when-ended {
+.media-play-button .show-when-ended {
   display: none;
 }
-.html-play-button-basic__button[data-paused]:not([data-ended]) .show-when-paused {
+.media-play-button[data-paused]:not([data-ended]) .show-when-paused {
   display: inline;
 }
-.html-play-button-basic__button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .show-when-playing {
   display: inline;
 }
-.html-play-button-basic__button[data-ended] .show-when-ended {
+.media-play-button[data-ended] .show-when-ended {
   display: inline;
 }
-.html-play-button-basic__button[data-ended] .show-when-paused {
+.media-play-button[data-ended] .show-when-paused {
   display: none;
 }
-.html-play-button-basic__button[data-ended] .show-when-playing {
+.media-play-button[data-ended] .show-when-playing {
   display: none;
 }

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-play-button-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -6,7 +6,7 @@
             muted
             playsinline
         ></video>
-        <media-play-button class="html-play-button-basic__button">
+        <media-play-button class="media-play-button">
             <span class="show-when-paused">Play</span>
             <span class="show-when-playing">Pause</span>
             <span class="show-when-ended">Replay</span>

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.html
@@ -7,9 +7,9 @@
             playsinline
         ></video>
         <media-play-button class="media-play-button">
-            <span class="show-when-paused">Play</span>
-            <span class="show-when-playing">Pause</span>
-            <span class="show-when-ended">Replay</span>
+            <span class="paused">Play</span>
+            <span class="playing">Pause</span>
+            <span class="ended">Replay</span>
         </media-play-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/play-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/play-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-play-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-play-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-play-button-basic__button {
+.media-play-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/play-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/play-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-play-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,7 +14,7 @@ export default function BasicUsage() {
           playsInline
         />
         <PlayButton
-          className="react-play-button-basic__button"
+          className="media-play-button"
           render={(props, state) => (
             <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
           )}

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-playback-rate-button-basic {
+.media-container {
   position: relative;
 }
 
-.html-playback-rate-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-playback-rate-button-basic__button {
+.media-playback-rate-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;
@@ -20,6 +20,6 @@
   cursor: pointer;
 }
 
-.html-playback-rate-button-basic__button::after {
+.media-playback-rate-button::after {
   content: attr(data-rate) "\00D7";
 }

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-playback-rate-button-basic">
+<video-player class="media-container">
     <video
         src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
         autoplay
@@ -6,6 +6,6 @@
         playsinline
         loop
     ></video>
-    <media-playback-rate-button class="html-playback-rate-button-basic__button">
+    <media-playback-rate-button class="media-playback-rate-button">
     </media-playback-rate-button>
 </video-player>

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <video
         src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
         autoplay

--- a/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-playback-rate-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-playback-rate-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-playback-rate-button-basic__button {
+.media-playback-rate-button {
   padding-block: 8px;
   position: absolute;
   bottom: 10px;

--- a/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, PlaybackRateButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-playback-rate-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,7 +15,7 @@ export default function BasicUsage() {
           loop
         />
         <PlaybackRateButton
-          className="react-playback-rate-button-basic__button"
+          className="media-playback-rate-button"
           render={(props, state) => <button {...props}>{Math.round(state.rate * 10) / 10}&times;</button>}
         />
       </Player.Container>

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.demo-ctrl-player {
   position: relative;
 }
 
-.media-container video {
+.demo-ctrl-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-player-controller-basic {
+.media-container {
   position: relative;
 }
 
-.html-player-controller-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-player-controller-basic__panel {
+.panel {
   display: flex;
   gap: 16px;
   padding: 12px;
@@ -15,12 +15,12 @@
   align-items: center;
 }
 
-.html-player-controller-basic__actions {
+.actions {
   display: flex;
   gap: 6px;
 }
 
-.html-player-controller-basic__actions button {
+.actions button {
   padding: 4px 12px;
   border-radius: 6px;
   border: 1px solid #ccc;
@@ -29,7 +29,7 @@
   font-size: 0.8125rem;
 }
 
-.html-player-controller-basic__state {
+.state {
   font-size: 0.8125rem;
   color: #374151;
   font-variant-numeric: tabular-nums;

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
@@ -8,12 +8,12 @@
         ></video>
         <div class="panel">
             <demo-ctrl-actions class="actions">
-                <button type="button" class="action-play">Play</button>
-                <button type="button" class="action-pause">Pause</button>
-                <button type="button" class="action-volume">50% Volume</button>
+                <button type="button" class="play">Play</button>
+                <button type="button" class="pause">Pause</button>
+                <button type="button" class="volume">50% Volume</button>
             </demo-ctrl-actions>
             <demo-ctrl-state class="state">
-                <span class="state-text">Paused: Yes | Time: 0.0s | Volume: 100%</span>
+                <span class="text">Paused: Yes | Time: 0.0s | Volume: 100%</span>
             </demo-ctrl-state>
         </div>
     </media-container>

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<demo-ctrl-player class="media-container">
+<demo-ctrl-player class="demo-ctrl-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<demo-ctrl-player class="html-player-controller-basic">
+<demo-ctrl-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -6,13 +6,13 @@
             muted
             playsinline
         ></video>
-        <div class="html-player-controller-basic__panel">
-            <demo-ctrl-actions class="html-player-controller-basic__actions">
+        <div class="panel">
+            <demo-ctrl-actions class="actions">
                 <button type="button" class="action-play">Play</button>
                 <button type="button" class="action-pause">Pause</button>
                 <button type="button" class="action-volume">50% Volume</button>
             </demo-ctrl-actions>
-            <demo-ctrl-state class="html-player-controller-basic__state">
+            <demo-ctrl-state class="state">
                 <span class="state-text">Paused: Yes | Time: 0.0s | Volume: 100%</span>
             </demo-ctrl-state>
         </div>

--- a/site/src/components/docs/demos/player-controller/html/css/BasicUsage.ts
+++ b/site/src/components/docs/demos/player-controller/html/css/BasicUsage.ts
@@ -22,9 +22,9 @@ class PlayerActions extends MediaElement {
     this.#disconnect = new AbortController();
     const signal = this.#disconnect.signal;
 
-    const playBtn = this.querySelector<HTMLButtonElement>('.action-play')!;
-    const pauseBtn = this.querySelector<HTMLButtonElement>('.action-pause')!;
-    const volumeBtn = this.querySelector<HTMLButtonElement>('.action-volume')!;
+    const playBtn = this.querySelector<HTMLButtonElement>('.play')!;
+    const pauseBtn = this.querySelector<HTMLButtonElement>('.pause')!;
+    const volumeBtn = this.querySelector<HTMLButtonElement>('.volume')!;
 
     const bind = (el: HTMLElement, action: () => void) => {
       const props = createButton({ onActivate: action, isDisabled: () => !this.#player.value });
@@ -57,7 +57,7 @@ class PlayerState extends MediaElement {
     const state = this.#state.value;
     if (!state) return;
 
-    const el = this.querySelector('.state-text');
+    const el = this.querySelector('.text');
     if (el) {
       el.textContent = `Paused: ${state.paused ? 'Yes' : 'No'} | Time: ${state.currentTime.toFixed(1)}s | Volume: ${Math.round(state.volume * 100)}%`;
     }

--- a/site/src/components/docs/demos/popover/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/popover/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/popover/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/popover/html/css/BasicUsage.css
@@ -1,10 +1,10 @@
-.media-container,
-.media-container media-container {
+.video-player,
+.video-player media-container {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/popover/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/popover/html/css/BasicUsage.css
@@ -1,20 +1,20 @@
-.html-popover-basic,
-.html-popover-basic media-container {
+.media-container,
+.media-container media-container {
   display: block;
   position: relative;
 }
 
-.html-popover-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-popover-basic__bar {
+.bar {
   position: absolute;
   bottom: 10px;
   left: 10px;
 }
 
-.html-popover-basic__trigger {
+.trigger {
   padding: 6px 16px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -24,7 +24,7 @@
   cursor: pointer;
 }
 
-.html-popover-basic__popover {
+.media-popover {
   background: rgba(0, 0, 0, 0.85);
   backdrop-filter: blur(10px);
   color: white;

--- a/site/src/components/docs/demos/popover/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/popover/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/popover/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/popover/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-popover-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,10 +7,10 @@
             playsinline
             loop
         ></video>
-        <div class="html-popover-basic__bar">
-            <button type="button" commandfor="popover-demo" class="html-popover-basic__trigger">Settings</button>
-            <media-popover id="popover-demo" class="html-popover-basic__popover">
-                <div class="html-popover-basic__popup">
+        <div class="bar">
+            <button type="button" commandfor="popover-demo" class="trigger">Settings</button>
+            <media-popover id="popover-demo" class="media-popover">
+                <div class="popup">
                     Popover content
                 </div>
             </media-popover>

--- a/site/src/components/docs/demos/popover/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/popover/react/css/BasicUsage.css
@@ -1,18 +1,18 @@
-.react-popover-basic {
+.media-container {
   position: relative;
 }
 
-.react-popover-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-popover-basic__bar {
+.bar {
   position: absolute;
   bottom: 10px;
   left: 10px;
 }
 
-.react-popover-basic__trigger {
+.trigger {
   padding: 6px 16px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -22,7 +22,7 @@
   cursor: pointer;
 }
 
-.react-popover-basic__popup {
+.popup {
   /* Reset UA [popover] defaults */
   margin: 0;
   border: 0;
@@ -36,10 +36,10 @@
   font-size: 14px;
 }
 
-.react-popover-basic__arrow {
+.arrow {
   fill: rgba(0, 0, 0, 0.85);
 }
 
-.react-popover-basic__content {
+.content {
   white-space: nowrap;
 }

--- a/site/src/components/docs/demos/popover/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/popover/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, Popover } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-popover-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,12 +14,12 @@ export default function BasicUsage() {
           playsInline
           loop
         />
-        <div className="react-popover-basic__bar">
+        <div className="bar">
           <Popover.Root>
-            <Popover.Trigger className="react-popover-basic__trigger">Settings</Popover.Trigger>
-            <Popover.Popup className="react-popover-basic__popup">
-              <Popover.Arrow className="react-popover-basic__arrow" />
-              <div className="react-popover-basic__content">Popover content</div>
+            <Popover.Trigger className="trigger">Settings</Popover.Trigger>
+            <Popover.Popup className="popup">
+              <Popover.Arrow className="arrow" />
+              <div className="content">Popover content</div>
             </Popover.Popup>
           </Popover.Root>
         </div>

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.css
@@ -38,15 +38,15 @@
   cursor: pointer;
 }
 
-.media-play-button .show-when-paused,
-.media-play-button .show-when-playing {
+.media-play-button .paused,
+.media-play-button .playing {
   display: none;
 }
 
-.media-play-button[data-paused] .show-when-paused {
+.media-play-button[data-paused] .paused {
   display: inline;
 }
 
-.media-play-button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.css
@@ -1,9 +1,9 @@
-.media-container {
+.video-player {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.css
@@ -1,30 +1,30 @@
-.html-poster-basic {
+.media-container {
   display: block;
   position: relative;
 }
 
-.html-poster-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-poster-basic__poster {
+.media-poster {
   position: absolute;
   inset: 0;
   pointer-events: none;
   transition: opacity 0.25s;
 }
 
-.html-poster-basic__poster:not([data-visible]) {
+.media-poster:not([data-visible]) {
   opacity: 0;
 }
 
-.html-poster-basic__poster img {
+.media-poster img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.html-poster-basic__button {
+.media-play-button {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -38,15 +38,15 @@
   cursor: pointer;
 }
 
-.html-poster-basic__button .show-when-paused,
-.html-poster-basic__button .show-when-playing {
+.media-play-button .show-when-paused,
+.media-play-button .show-when-playing {
   display: none;
 }
 
-.html-poster-basic__button[data-paused] .show-when-paused {
+.media-play-button[data-paused] .show-when-paused {
   display: inline;
 }
 
-.html-poster-basic__button:not([data-paused]) .show-when-playing {
+.media-play-button:not([data-paused]) .show-when-playing {
   display: inline;
 }

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.html
@@ -1,5 +1,5 @@
 <!-- biome-ignore-all lint/a11y/useMediaCaption: TODO -->
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.html
@@ -1,19 +1,19 @@
 <!-- biome-ignore-all lint/a11y/useMediaCaption: TODO -->
-<video-player class="html-poster-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
             playsinline
         ></video>
 
-        <media-poster class="html-poster-basic__poster">
+        <media-poster class="media-poster">
             <img
                 src="https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/thumbnail.jpg"
                 alt="Video thumbnail"
                 />
             </media-poster>
 
-            <media-play-button class="html-poster-basic__button">
+            <media-play-button class="media-play-button">
                 <span class="show-when-paused">Play</span>
                 <span class="show-when-playing">Pause</span>
             </media-play-button>

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.html
@@ -14,8 +14,8 @@
             </media-poster>
 
             <media-play-button class="media-play-button">
-                <span class="show-when-paused">Play</span>
-                <span class="show-when-playing">Pause</span>
+                <span class="paused">Play</span>
+                <span class="playing">Pause</span>
             </media-play-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/poster/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/poster/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-poster-basic {
+.media-container {
   position: relative;
 }
 
-.react-poster-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-poster-basic__poster {
+.media-poster {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -16,11 +16,11 @@
   transition: opacity 0.25s;
 }
 
-.react-poster-basic__poster:not([data-visible]) {
+.media-poster:not([data-visible]) {
   opacity: 0;
 }
 
-.react-poster-basic__button {
+.media-play-button {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
@@ -1,23 +1,21 @@
 import { createPlayer, PlayButton, Poster } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-poster-basic">
+      <Player.Container className="media-container">
         <Video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4" playsInline />
 
         <Poster
-          className="react-poster-basic__poster"
+          className="media-poster"
           src="https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/thumbnail.jpg"
         />
 
         <PlayButton
-          className="react-poster-basic__button"
+          className="media-play-button"
           render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}
         />
       </Player.Container>

--- a/site/src/components/docs/demos/render-element/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/render-element/react/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.react-render-element-basic {
+.demo {
   display: flex;
   flex-direction: column;
   gap: 16px;
   padding: 16px;
 }
 
-.react-render-element-basic__toggle {
+.toggle {
   align-self: flex-start;
   padding: 6px 16px;
   border-radius: 6px;
@@ -14,13 +14,13 @@
   cursor: pointer;
 }
 
-.react-render-element-basic__tags {
+.tags {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
 }
 
-.react-render-element-basic__tag {
+.tag {
   display: inline-flex;
   align-items: center;
   padding: 6px 12px;
@@ -30,7 +30,7 @@
   transition: all 0.2s ease;
 }
 
-.react-render-element-basic__tag--active {
+.tag--active {
   background: #3b82f6;
   color: white;
 }

--- a/site/src/components/docs/demos/render-element/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/render-element/react/css/BasicUsage.tsx
@@ -1,8 +1,6 @@
 import { renderElement } from '@videojs/react';
 import { type ReactNode, useState } from 'react';
 
-import './BasicUsage.css';
-
 interface TagState {
   active: boolean;
 }
@@ -30,20 +28,19 @@ function Tag({
 export default function BasicUsage() {
   const [active, setActive] = useState(false);
 
-  const className = (state: TagState) =>
-    `react-render-element-basic__tag${state.active ? ' react-render-element-basic__tag--active' : ''}`;
+  const className = (state: TagState) => `tag${state.active ? ' tag--active' : ''}`;
 
   const style = (state: TagState) => ({
     fontSize: state.active ? '1.125rem' : '0.875rem',
   });
 
   return (
-    <div className="react-render-element-basic">
-      <button type="button" className="react-render-element-basic__toggle" onClick={() => setActive((prev) => !prev)}>
+    <div className="demo">
+      <button type="button" className="toggle" onClick={() => setActive((prev) => !prev)}>
         {active ? 'Deactivate' : 'Activate'}
       </button>
 
-      <div className="react-render-element-basic__tags">
+      <div className="tags">
         <Tag active={active} className={className} style={style}>
           Default &lt;span&gt;
         </Tag>

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.html-seek-button-basic {
+.media-container {
   position: relative;
 }
 
-.html-seek-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.html-seek-button-basic__buttons {
+.buttons {
   display: flex;
   gap: 8px;
   position: absolute;
@@ -14,7 +14,7 @@
   left: 10px;
 }
 
-.html-seek-button-basic__button {
+.media-seek-button {
   padding-block: 8px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -26,15 +26,15 @@
   cursor: pointer;
 }
 
-.html-seek-button-basic__button .show-when-backward {
+.media-seek-button .show-when-backward {
   display: none;
 }
-.html-seek-button-basic__button .show-when-forward {
+.media-seek-button .show-when-forward {
   display: none;
 }
-.html-seek-button-basic__button[data-direction="backward"] .show-when-backward {
+.media-seek-button[data-direction="backward"] .show-when-backward {
   display: inline;
 }
-.html-seek-button-basic__button[data-direction="forward"] .show-when-forward {
+.media-seek-button[data-direction="forward"] .show-when-forward {
   display: inline;
 }

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
@@ -26,15 +26,15 @@
   cursor: pointer;
 }
 
-.media-seek-button .show-when-backward {
+.media-seek-button .backward {
   display: none;
 }
-.media-seek-button .show-when-forward {
+.media-seek-button .forward {
   display: none;
 }
-.media-seek-button[data-direction="backward"] .show-when-backward {
+.media-seek-button[data-direction="backward"] .backward {
   display: inline;
 }
-.media-seek-button[data-direction="forward"] .show-when-forward {
+.media-seek-button[data-direction="forward"] .forward {
   display: inline;
 }

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
@@ -9,10 +9,10 @@
         ></video>
         <div class="buttons">
             <media-seek-button seconds="-5" class="media-seek-button">
-                <span class="show-when-backward">&#9194; 5s</span>
+                <span class="backward">&#9194; 5s</span>
             </media-seek-button>
             <media-seek-button seconds="10" class="media-seek-button">
-                <span class="show-when-forward">10s &#9193;</span>
+                <span class="forward">10s &#9193;</span>
             </media-seek-button>
         </div>
     </media-container>

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="html-seek-button-basic">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,11 +7,11 @@
             playsinline
             loop
         ></video>
-        <div class="html-seek-button-basic__buttons">
-            <media-seek-button seconds="-5" class="html-seek-button-basic__button">
+        <div class="buttons">
+            <media-seek-button seconds="-5" class="media-seek-button">
                 <span class="show-when-backward">&#9194; 5s</span>
             </media-seek-button>
-            <media-seek-button seconds="10" class="html-seek-button-basic__button">
+            <media-seek-button seconds="10" class="media-seek-button">
                 <span class="show-when-forward">10s &#9193;</span>
             </media-seek-button>
         </div>

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/seek-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-button/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-seek-button-basic {
+.media-container {
   position: relative;
 }
 
-.react-seek-button-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-seek-button-basic__buttons {
+.buttons {
   display: flex;
   gap: 8px;
   position: absolute;
@@ -14,7 +14,7 @@
   left: 10px;
 }
 
-.react-seek-button-basic__button {
+.media-seek-button {
   padding-block: 8px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);

--- a/site/src/components/docs/demos/seek-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/seek-button/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, SeekButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-seek-button-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,10 +14,10 @@ export default function BasicUsage() {
           playsInline
           loop
         />
-        <div className="react-seek-button-basic__buttons">
+        <div className="buttons">
           <SeekButton
             seconds={-5}
-            className="react-seek-button-basic__button"
+            className="media-seek-button"
             render={(props, state) => (
               <button {...props}>
                 {state.direction === 'backward' ? '\u23EA' : '\u23E9'} {5}s
@@ -28,7 +26,7 @@ export default function BasicUsage() {
           />
           <SeekButton
             seconds={10}
-            className="react-seek-button-basic__button"
+            className="media-seek-button"
             render={(props, state) => (
               <button {...props}>
                 {10}s {state.direction === 'forward' ? '\u23E9' : '\u23EA'}

--- a/site/src/components/docs/demos/slider/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/slider/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/slider/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/slider/html/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.html-slider-basic {
+.demo {
   display: flex;
   align-items: center;
   padding: 24px;
   background: #1a1a1a;
 }
 
-.html-slider-basic__slider {
+.media-slider {
   position: relative;
   width: 100%;
   display: flex;
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-.html-slider-basic__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -24,11 +24,11 @@
   transition: height 150ms ease;
 }
 
-.html-slider-basic__slider[data-interactive] .html-slider-basic__track {
+.media-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.html-slider-basic__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -38,7 +38,7 @@
   border-radius: 9999px;
 }
 
-.html-slider-basic__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -50,10 +50,10 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.html-slider-basic__slider[data-interactive] .html-slider-basic__thumb {
+.media-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.html-slider-basic__slider[data-dragging] .html-slider-basic__thumb {
+.media-slider[data-dragging] .media-slider-thumb {
   transform: translateX(-50%) scale(1.1);
 }

--- a/site/src/components/docs/demos/slider/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/slider/html/css/BasicUsage.html
@@ -1,8 +1,8 @@
-<div class="html-slider-basic">
-    <media-slider class="html-slider-basic__slider" value="50">
-        <media-slider-track class="html-slider-basic__track">
-            <media-slider-fill class="html-slider-basic__fill"></media-slider-fill>
+<div class="demo">
+    <media-slider class="media-slider" value="50">
+        <media-slider-track class="media-slider-track">
+            <media-slider-fill class="media-slider-fill"></media-slider-fill>
         </media-slider-track>
-        <media-slider-thumb class="html-slider-basic__thumb"></media-slider-thumb>
+        <media-slider-thumb class="media-slider-thumb"></media-slider-thumb>
     </media-slider>
 </div>

--- a/site/src/components/docs/demos/slider/html/css/WithPreview.astro
+++ b/site/src/components/docs/demos/slider/html/css/WithPreview.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './WithPreview.html?raw';
-import './WithPreview.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/slider/html/css/WithPreview.css
+++ b/site/src/components/docs/demos/slider/html/css/WithPreview.css
@@ -1,11 +1,11 @@
-.html-slider-preview {
+.demo {
   display: flex;
   align-items: center;
   padding: 40px 24px;
   background: #1a1a1a;
 }
 
-.html-slider-preview__slider {
+.media-slider {
   position: relative;
   width: 100%;
   display: flex;
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-.html-slider-preview__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -24,11 +24,11 @@
   transition: height 150ms ease;
 }
 
-.html-slider-preview__slider[data-interactive] .html-slider-preview__track {
+.media-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.html-slider-preview__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -38,7 +38,7 @@
   border-radius: 9999px;
 }
 
-.html-slider-preview__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -50,15 +50,15 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.html-slider-preview__slider[data-interactive] .html-slider-preview__thumb {
+.media-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.html-slider-preview__slider[data-dragging] .html-slider-preview__thumb {
+.media-slider[data-dragging] .media-slider-thumb {
   transform: translateX(-50%) scale(1.1);
 }
 
-.html-slider-preview__preview {
+.preview {
   position: absolute;
   bottom: 100%;
   margin-bottom: 6px;
@@ -67,11 +67,11 @@
   transition: opacity 150ms ease;
 }
 
-.html-slider-preview__slider[data-pointing] .html-slider-preview__preview {
+.media-slider[data-pointing] .preview {
   opacity: 1;
 }
 
-.html-slider-preview__value {
+.media-slider-value {
   background: rgba(0, 0, 0, 0.8);
   color: white;
   font-size: 12px;

--- a/site/src/components/docs/demos/slider/html/css/WithPreview.html
+++ b/site/src/components/docs/demos/slider/html/css/WithPreview.html
@@ -1,11 +1,11 @@
-<div class="html-slider-preview">
-    <media-slider class="html-slider-preview__slider" value="50">
-        <media-slider-track class="html-slider-preview__track">
-            <media-slider-fill class="html-slider-preview__fill"></media-slider-fill>
+<div class="demo">
+    <media-slider class="media-slider" value="50">
+        <media-slider-track class="media-slider-track">
+            <media-slider-fill class="media-slider-fill"></media-slider-fill>
         </media-slider-track>
-        <media-slider-thumb class="html-slider-preview__thumb"></media-slider-thumb>
-        <media-slider-preview class="html-slider-preview__preview">
-            <media-slider-value type="pointer" class="html-slider-preview__value"></media-slider-value>
+        <media-slider-thumb class="media-slider-thumb"></media-slider-thumb>
+        <media-slider-preview class="preview">
+            <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
         </media-slider-preview>
     </media-slider>
 </div>

--- a/site/src/components/docs/demos/slider/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/slider/react/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.react-slider-basic {
+.demo {
   display: flex;
   align-items: center;
   padding: 24px;
   background: #1a1a1a;
 }
 
-.react-slider-basic__slider {
+.media-slider {
   position: relative;
   width: 100%;
   display: flex;
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-.react-slider-basic__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -24,11 +24,11 @@
   transition: height 150ms ease;
 }
 
-.react-slider-basic__slider[data-interactive] .react-slider-basic__track {
+.media-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.react-slider-basic__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -38,7 +38,7 @@
   border-radius: 9999px;
 }
 
-.react-slider-basic__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -50,10 +50,10 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.react-slider-basic__slider[data-interactive] .react-slider-basic__thumb {
+.media-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.react-slider-basic__slider[data-dragging] .react-slider-basic__thumb {
+.media-slider[data-dragging] .media-slider-thumb {
   transform: translateX(-50%) scale(1.1);
 }

--- a/site/src/components/docs/demos/slider/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/slider/react/css/BasicUsage.tsx
@@ -1,18 +1,16 @@
 import { Slider } from '@videojs/react';
 import { useState } from 'react';
 
-import './BasicUsage.css';
-
 export default function BasicUsage() {
   const [value, setValue] = useState(50);
 
   return (
-    <div className="react-slider-basic">
-      <Slider.Root className="react-slider-basic__slider" value={value} onValueChange={setValue}>
-        <Slider.Track className="react-slider-basic__track">
-          <Slider.Fill className="react-slider-basic__fill" />
+    <div className="demo">
+      <Slider.Root className="media-slider" value={value} onValueChange={setValue}>
+        <Slider.Track className="media-slider-track">
+          <Slider.Fill className="media-slider-fill" />
         </Slider.Track>
-        <Slider.Thumb className="react-slider-basic__thumb" />
+        <Slider.Thumb className="media-slider-thumb" />
       </Slider.Root>
     </div>
   );

--- a/site/src/components/docs/demos/slider/react/css/WithPreview.css
+++ b/site/src/components/docs/demos/slider/react/css/WithPreview.css
@@ -1,11 +1,11 @@
-.react-slider-preview {
+.demo {
   display: flex;
   align-items: center;
   padding: 40px 24px;
   background: #1a1a1a;
 }
 
-.react-slider-preview__slider {
+.media-slider {
   position: relative;
   width: 100%;
   display: flex;
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-.react-slider-preview__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -24,11 +24,11 @@
   transition: height 150ms ease;
 }
 
-.react-slider-preview__slider[data-interactive] .react-slider-preview__track {
+.media-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.react-slider-preview__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -38,7 +38,7 @@
   border-radius: 9999px;
 }
 
-.react-slider-preview__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -50,15 +50,15 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.react-slider-preview__slider[data-interactive] .react-slider-preview__thumb {
+.media-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.react-slider-preview__slider[data-dragging] .react-slider-preview__thumb {
+.media-slider[data-dragging] .media-slider-thumb {
   transform: translateX(-50%) scale(1.1);
 }
 
-.react-slider-preview__preview {
+.preview {
   position: absolute;
   bottom: 100%;
   margin-bottom: 6px;
@@ -67,11 +67,11 @@
   transition: opacity 150ms ease;
 }
 
-.react-slider-preview__slider[data-pointing] .react-slider-preview__preview {
+.media-slider[data-pointing] .preview {
   opacity: 1;
 }
 
-.react-slider-preview__value {
+.media-slider-value {
   background: rgba(0, 0, 0, 0.8);
   color: white;
   font-size: 12px;

--- a/site/src/components/docs/demos/slider/react/css/WithPreview.tsx
+++ b/site/src/components/docs/demos/slider/react/css/WithPreview.tsx
@@ -1,20 +1,18 @@
 import { Slider } from '@videojs/react';
 import { useState } from 'react';
 
-import './WithPreview.css';
-
 export default function WithPreview() {
   const [value, setValue] = useState(50);
 
   return (
-    <div className="react-slider-preview">
-      <Slider.Root className="react-slider-preview__slider" value={value} onValueChange={setValue}>
-        <Slider.Track className="react-slider-preview__track">
-          <Slider.Fill className="react-slider-preview__fill" />
+    <div className="demo">
+      <Slider.Root className="media-slider" value={value} onValueChange={setValue}>
+        <Slider.Track className="media-slider-track">
+          <Slider.Fill className="media-slider-fill" />
         </Slider.Track>
-        <Slider.Thumb className="react-slider-preview__thumb" />
-        <Slider.Preview className="react-slider-preview__preview">
-          <Slider.Value type="pointer" className="react-slider-preview__value" />
+        <Slider.Thumb className="media-slider-thumb" />
+        <Slider.Preview className="preview">
+          <Slider.Value type="pointer" className="media-slider-value" />
         </Slider.Preview>
       </Slider.Root>
     </div>

--- a/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.css
@@ -1,10 +1,10 @@
-.html-thumbnail-text-track {
+.demo {
   position: relative;
   display: block;
   max-width: 280px;
 }
 
-.html-thumbnail-text-track__media {
+.media {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -12,13 +12,13 @@
   pointer-events: none;
 }
 
-.html-thumbnail-text-track__thumbnail {
+.media-thumbnail {
   display: block;
   width: auto;
   min-width: 0;
   max-width: 240px;
 }
 
-.html-thumbnail-text-track__thumbnail[data-hidden] {
+.media-thumbnail[data-hidden] {
   display: none;
 }

--- a/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/thumbnail/html/css/BasicUsage.html
@@ -1,8 +1,8 @@
-<section class="html-thumbnail-text-track">
+<section class="demo">
     <video-player>
         <media-container>
             <video
-                class="html-thumbnail-text-track__media"
+                class="media"
                 src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
                 preload="auto"
                 muted
@@ -16,7 +16,7 @@
                     default
                 />
             </video>
-            <media-thumbnail class="html-thumbnail-text-track__thumbnail" time="12"></media-thumbnail>
+            <media-thumbnail class="media-thumbnail" time="12"></media-thumbnail>
         </media-container>
     </video-player>
 </section>

--- a/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.css
@@ -1,9 +1,9 @@
-.react-thumbnail-text-track {
+.demo {
   position: relative;
   max-width: 280px;
 }
 
-.react-thumbnail-text-track__media {
+.media {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -11,13 +11,13 @@
   pointer-events: none;
 }
 
-.react-thumbnail-text-track__thumbnail {
+.media-thumbnail {
   display: block;
   width: auto;
   min-width: 0;
   max-width: 240px;
 }
 
-.react-thumbnail-text-track__thumbnail[data-hidden] {
+.media-thumbnail[data-hidden] {
   display: none;
 }

--- a/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
@@ -1,16 +1,14 @@
 import { createPlayer, Thumbnail } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function TextTrackUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-thumbnail-text-track">
+      <Player.Container className="demo">
         <Video
-          className="react-thumbnail-text-track__media"
+          className="media"
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           preload="auto"
           muted
@@ -19,7 +17,7 @@ export default function TextTrackUsage() {
         >
           <track kind="metadata" label="thumbnails" src="/docs/demos/thumbnail/basic.vtt" default />
         </Video>
-        <Thumbnail className="react-thumbnail-text-track__thumbnail" time={12} />
+        <Thumbnail className="media-thumbnail" time={12} />
       </Player.Container>
     </Player.Provider>
   );

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.astro
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './WithParts.html?raw';
-import './WithParts.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.css
@@ -1,14 +1,14 @@
-.html-time-slider-parts,
-.html-time-slider-parts media-container {
+.media-container,
+.media-container media-container {
   display: block;
   position: relative;
 }
 
-.html-time-slider-parts video {
+.media-container video {
   width: 100%;
 }
 
-.html-time-slider-parts__slider {
+.media-time-slider {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -19,7 +19,7 @@
   cursor: pointer;
 }
 
-.html-time-slider-parts__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -29,11 +29,11 @@
   transition: height 150ms ease;
 }
 
-.html-time-slider-parts__slider[data-interactive] .html-time-slider-parts__track {
+.media-time-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.html-time-slider-parts__buffer {
+.media-slider-buffer {
   position: absolute;
   top: 0;
   left: 0;
@@ -43,7 +43,7 @@
   border-radius: 9999px;
 }
 
-.html-time-slider-parts__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -53,7 +53,7 @@
   border-radius: 9999px;
 }
 
-.html-time-slider-parts__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -65,20 +65,20 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.html-time-slider-parts__slider[data-interactive] .html-time-slider-parts__thumb {
+.media-time-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.html-time-slider-parts__slider[data-dragging] .html-time-slider-parts__thumb {
+.media-time-slider[data-dragging] .media-slider-thumb {
   left: var(--media-slider-pointer);
   transform: translateX(-50%) scale(1.1);
 }
 
-.html-time-slider-parts__slider[data-dragging] .html-time-slider-parts__fill {
+.media-time-slider[data-dragging] .media-slider-fill {
   width: var(--media-slider-pointer);
 }
 
-.html-time-slider-parts__value {
+.media-slider-value {
   position: absolute;
   left: var(--media-slider-pointer);
   bottom: 100%;
@@ -95,6 +95,6 @@
   transition: opacity 150ms ease;
 }
 
-.html-time-slider-parts__slider[data-pointing] .html-time-slider-parts__value {
+.media-time-slider[data-pointing] .media-slider-value {
   opacity: 1;
 }

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.css
@@ -1,10 +1,10 @@
-.media-container,
-.media-container media-container {
+.video-player,
+.video-player media-container {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/time-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/time-slider/html/css/WithParts.html
@@ -1,4 +1,4 @@
-<video-player class="html-time-slider-parts">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,13 +7,13 @@
             playsinline
             loop
         ></video>
-        <media-time-slider class="html-time-slider-parts__slider">
-            <media-slider-track class="html-time-slider-parts__track">
-                <media-slider-buffer class="html-time-slider-parts__buffer"></media-slider-buffer>
-                <media-slider-fill class="html-time-slider-parts__fill"></media-slider-fill>
+        <media-time-slider class="media-time-slider">
+            <media-slider-track class="media-slider-track">
+                <media-slider-buffer class="media-slider-buffer"></media-slider-buffer>
+                <media-slider-fill class="media-slider-fill"></media-slider-fill>
             </media-slider-track>
-            <media-slider-thumb class="html-time-slider-parts__thumb"></media-slider-thumb>
-            <media-slider-value type="pointer" class="html-time-slider-parts__value"></media-slider-value>
+            <media-slider-thumb class="media-slider-thumb"></media-slider-thumb>
+            <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
         </media-time-slider>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/time-slider/react/css/WithParts.css
+++ b/site/src/components/docs/demos/time-slider/react/css/WithParts.css
@@ -1,12 +1,12 @@
-.react-time-slider-parts {
+.media-container {
   position: relative;
 }
 
-.react-time-slider-parts video {
+.media-container video {
   width: 100%;
 }
 
-.react-time-slider-parts__slider {
+.media-time-slider {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -17,7 +17,7 @@
   cursor: pointer;
 }
 
-.react-time-slider-parts__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -27,11 +27,11 @@
   transition: height 150ms ease;
 }
 
-.react-time-slider-parts__slider[data-interactive] .react-time-slider-parts__track {
+.media-time-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.react-time-slider-parts__buffer {
+.media-slider-buffer {
   position: absolute;
   top: 0;
   left: 0;
@@ -41,7 +41,7 @@
   border-radius: 9999px;
 }
 
-.react-time-slider-parts__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -51,7 +51,7 @@
   border-radius: 9999px;
 }
 
-.react-time-slider-parts__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -63,20 +63,20 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.react-time-slider-parts__slider[data-interactive] .react-time-slider-parts__thumb {
+.media-time-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.react-time-slider-parts__slider[data-dragging] .react-time-slider-parts__thumb {
+.media-time-slider[data-dragging] .media-slider-thumb {
   left: var(--media-slider-pointer);
   transform: translateX(-50%) scale(1.1);
 }
 
-.react-time-slider-parts__slider[data-dragging] .react-time-slider-parts__fill {
+.media-time-slider[data-dragging] .media-slider-fill {
   width: var(--media-slider-pointer);
 }
 
-.react-time-slider-parts__value {
+.media-slider-value {
   position: absolute;
   left: var(--media-slider-pointer);
   bottom: 100%;
@@ -93,6 +93,6 @@
   transition: opacity 150ms ease;
 }
 
-.react-time-slider-parts__slider[data-pointing] .react-time-slider-parts__value {
+.media-time-slider[data-pointing] .media-slider-value {
   opacity: 1;
 }

--- a/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, TimeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './WithParts.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function WithParts() {
   return (
     <Player.Provider>
-      <Player.Container className="react-time-slider-parts">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,13 +14,13 @@ export default function WithParts() {
           playsInline
           loop
         />
-        <TimeSlider.Root className="react-time-slider-parts__slider">
-          <TimeSlider.Track className="react-time-slider-parts__track">
-            <TimeSlider.Buffer className="react-time-slider-parts__buffer" />
-            <TimeSlider.Fill className="react-time-slider-parts__fill" />
+        <TimeSlider.Root className="media-time-slider">
+          <TimeSlider.Track className="media-slider-track">
+            <TimeSlider.Buffer className="media-slider-buffer" />
+            <TimeSlider.Fill className="media-slider-fill" />
           </TimeSlider.Track>
-          <TimeSlider.Thumb className="react-time-slider-parts__thumb" />
-          <TimeSlider.Value type="pointer" className="react-time-slider-parts__value" />
+          <TimeSlider.Thumb className="media-slider-thumb" />
+          <TimeSlider.Value type="pointer" className="media-slider-value" />
         </TimeSlider.Root>
       </Player.Container>
     </Player.Provider>

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.astro
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './CurrentDuration.html?raw';
-import './CurrentDuration.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.css
@@ -1,12 +1,12 @@
-.html-time-current-duration {
+.media-container {
   position: relative;
 }
 
-.html-time-current-duration video {
+.media-container video {
   width: 100%;
 }
 
-.html-time-current-duration__group {
+.time-group {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.html
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.html
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.html
@@ -1,4 +1,4 @@
-<video-player class="html-time-current-duration">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,7 +7,7 @@
             playsinline
             loop
         ></video>
-        <media-time-group class="html-time-current-duration__group">
+        <media-time-group class="time-group">
             <media-time type="current"></media-time>
             <media-time-separator></media-time-separator>
             <media-time type="duration"></media-time>

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.astro
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './CurrentTime.html?raw';
-import './CurrentTime.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.css
@@ -1,12 +1,12 @@
-.html-time-current-time {
+.media-container {
   position: relative;
 }
 
-.html-time-current-time video {
+.media-container video {
   width: 100%;
 }
 
-.html-time-current-time__value {
+.media-time {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.html
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.html
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.html
@@ -1,4 +1,4 @@
-<video-player class="html-time-current-time">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,6 +7,6 @@
             playsinline
             loop
         ></video>
-        <media-time class="html-time-current-time__value" type="current"></media-time>
+        <media-time class="media-time" type="current"></media-time>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.astro
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './CustomNegativeSign.html?raw';
-import './CustomNegativeSign.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
@@ -1,12 +1,12 @@
-.html-time-custom-negative-sign {
+.media-container {
   position: relative;
 }
 
-.html-time-custom-negative-sign video {
+.media-container video {
   width: 100%;
 }
 
-.html-time-custom-negative-sign__value {
+.media-time {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.html
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.html
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.html
@@ -1,4 +1,4 @@
-<video-player class="html-time-custom-negative-sign">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -8,7 +8,7 @@
             loop
         ></video>
         <media-time
-            class="html-time-custom-negative-sign__value"
+            class="media-time"
             type="remaining"
             negative-sign="~"
             ></media-time>

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.astro
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './CustomSeparator.html?raw';
-import './CustomSeparator.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.css
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.css
@@ -1,12 +1,12 @@
-.html-time-custom-separator {
+.media-container {
   position: relative;
 }
 
-.html-time-custom-separator video {
+.media-container video {
   width: 100%;
 }
 
-.html-time-custom-separator__group {
+.time-group {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.css
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.html
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.html
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.html
@@ -1,4 +1,4 @@
-<video-player class="html-time-custom-separator">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,7 +7,7 @@
             playsinline
             loop
         ></video>
-        <media-time-group class="html-time-custom-separator__group">
+        <media-time-group class="time-group">
             <media-time type="current"></media-time>
             <media-time-separator> of </media-time-separator>
             <media-time type="duration"></media-time>

--- a/site/src/components/docs/demos/time/html/css/Remaining.astro
+++ b/site/src/components/docs/demos/time/html/css/Remaining.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './Remaining.html?raw';
-import './Remaining.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/time/html/css/Remaining.css
+++ b/site/src/components/docs/demos/time/html/css/Remaining.css
@@ -1,8 +1,8 @@
-.media-container {
+.video-player {
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/time/html/css/Remaining.css
+++ b/site/src/components/docs/demos/time/html/css/Remaining.css
@@ -1,12 +1,12 @@
-.html-time-remaining {
+.media-container {
   position: relative;
 }
 
-.html-time-remaining video {
+.media-container video {
   width: 100%;
 }
 
-.html-time-remaining__value {
+.media-time {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/time/html/css/Remaining.html
+++ b/site/src/components/docs/demos/time/html/css/Remaining.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/time/html/css/Remaining.html
+++ b/site/src/components/docs/demos/time/html/css/Remaining.html
@@ -1,4 +1,4 @@
-<video-player class="html-time-remaining">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,6 +7,6 @@
             playsinline
             loop
         ></video>
-        <media-time class="html-time-remaining__value" type="remaining"></media-time>
+        <media-time class="media-time" type="remaining"></media-time>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/time/react/css/CurrentDuration.css
+++ b/site/src/components/docs/demos/time/react/css/CurrentDuration.css
@@ -1,12 +1,12 @@
-.react-time-current-duration {
+.media-container {
   position: relative;
 }
 
-.react-time-current-duration video {
+.media-container video {
   width: 100%;
 }
 
-.react-time-current-duration__group {
+.time-group {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/site/src/components/docs/demos/time/react/css/CurrentDuration.tsx
+++ b/site/src/components/docs/demos/time/react/css/CurrentDuration.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './CurrentDuration.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function CurrentDuration() {
   return (
     <Player.Provider>
-      <Player.Container className="react-time-current-duration">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,7 +14,7 @@ export default function CurrentDuration() {
           playsInline
           loop
         />
-        <Time.Group className="react-time-current-duration__group">
+        <Time.Group className="time-group">
           <Time.Value type="current" />
           <Time.Separator />
           <Time.Value type="duration" />

--- a/site/src/components/docs/demos/time/react/css/CurrentTime.css
+++ b/site/src/components/docs/demos/time/react/css/CurrentTime.css
@@ -1,12 +1,12 @@
-.react-time-current-time {
+.media-container {
   position: relative;
 }
 
-.react-time-current-time video {
+.media-container video {
   width: 100%;
 }
 
-.react-time-current-time__value {
+.media-time {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/time/react/css/CurrentTime.tsx
+++ b/site/src/components/docs/demos/time/react/css/CurrentTime.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './CurrentTime.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function CurrentTime() {
   return (
     <Player.Provider>
-      <Player.Container className="react-time-current-time">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,7 +14,7 @@ export default function CurrentTime() {
           playsInline
           loop
         />
-        <Time.Value type="current" className="react-time-current-time__value" />
+        <Time.Value type="current" className="media-time" />
       </Player.Container>
     </Player.Provider>
   );

--- a/site/src/components/docs/demos/time/react/css/CustomNegativeSign.css
+++ b/site/src/components/docs/demos/time/react/css/CustomNegativeSign.css
@@ -1,12 +1,12 @@
-.react-time-custom-negative-sign {
+.media-container {
   position: relative;
 }
 
-.react-time-custom-negative-sign video {
+.media-container video {
   width: 100%;
 }
 
-.react-time-custom-negative-sign__value {
+.media-time {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/time/react/css/CustomNegativeSign.tsx
+++ b/site/src/components/docs/demos/time/react/css/CustomNegativeSign.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './CustomNegativeSign.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function CustomNegativeSign() {
   return (
     <Player.Provider>
-      <Player.Container className="react-time-custom-negative-sign">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,7 +14,7 @@ export default function CustomNegativeSign() {
           playsInline
           loop
         />
-        <Time.Value type="remaining" negativeSign="~" className="react-time-custom-negative-sign__value" />
+        <Time.Value type="remaining" negativeSign="~" className="media-time" />
       </Player.Container>
     </Player.Provider>
   );

--- a/site/src/components/docs/demos/time/react/css/CustomSeparator.css
+++ b/site/src/components/docs/demos/time/react/css/CustomSeparator.css
@@ -1,12 +1,12 @@
-.react-time-custom-separator {
+.media-container {
   position: relative;
 }
 
-.react-time-custom-separator video {
+.media-container video {
   width: 100%;
 }
 
-.react-time-custom-separator__group {
+.time-group {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/site/src/components/docs/demos/time/react/css/CustomSeparator.tsx
+++ b/site/src/components/docs/demos/time/react/css/CustomSeparator.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './CustomSeparator.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function CustomSeparator() {
   return (
     <Player.Provider>
-      <Player.Container className="react-time-custom-separator">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,7 +14,7 @@ export default function CustomSeparator() {
           playsInline
           loop
         />
-        <Time.Group className="react-time-custom-separator__group">
+        <Time.Group className="time-group">
           <Time.Value type="current" />
           <Time.Separator> of </Time.Separator>
           <Time.Value type="duration" />

--- a/site/src/components/docs/demos/time/react/css/Remaining.css
+++ b/site/src/components/docs/demos/time/react/css/Remaining.css
@@ -1,12 +1,12 @@
-.react-time-remaining {
+.media-container {
   position: relative;
 }
 
-.react-time-remaining video {
+.media-container video {
   width: 100%;
 }
 
-.react-time-remaining__value {
+.media-time {
   position: absolute;
   bottom: 10px;
   left: 10px;

--- a/site/src/components/docs/demos/time/react/css/Remaining.tsx
+++ b/site/src/components/docs/demos/time/react/css/Remaining.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './Remaining.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function Remaining() {
   return (
     <Player.Provider>
-      <Player.Container className="react-time-remaining">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -16,7 +14,7 @@ export default function Remaining() {
           playsInline
           loop
         />
-        <Time.Value type="remaining" className="react-time-remaining__value" />
+        <Time.Value type="remaining" className="media-time" />
       </Player.Container>
     </Player.Provider>
   );

--- a/site/src/components/docs/demos/tooltip/html/css/BasicUsage.astro
+++ b/site/src/components/docs/demos/tooltip/html/css/BasicUsage.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './BasicUsage.html?raw';
-import './BasicUsage.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/tooltip/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/tooltip/html/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.html-tooltip-basic {
+.demo {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
 }
 
-.html-tooltip-basic__trigger {
+.trigger {
   padding: 6px 16px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -15,7 +15,7 @@
   cursor: pointer;
 }
 
-.html-tooltip-basic__popup {
+.media-tooltip {
   --media-tooltip-side-offset: 8px;
   background: rgba(0, 0, 0, 0.85);
   backdrop-filter: blur(10px);

--- a/site/src/components/docs/demos/tooltip/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/tooltip/html/css/BasicUsage.html
@@ -1,6 +1,6 @@
-<div class="html-tooltip-basic">
-    <button type="button" commandfor="tooltip-demo" class="html-tooltip-basic__trigger">Hover me</button>
-    <media-tooltip id="tooltip-demo" class="html-tooltip-basic__popup">
+<div class="demo">
+    <button type="button" commandfor="tooltip-demo" class="trigger">Hover me</button>
+    <media-tooltip id="tooltip-demo" class="media-tooltip">
         Tooltip content
     </media-tooltip>
 </div>

--- a/site/src/components/docs/demos/tooltip/html/css/Grouping.astro
+++ b/site/src/components/docs/demos/tooltip/html/css/Grouping.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './Grouping.html?raw';
-import './Grouping.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/tooltip/html/css/Grouping.css
+++ b/site/src/components/docs/demos/tooltip/html/css/Grouping.css
@@ -1,11 +1,11 @@
-.html-tooltip-grouping {
+.demo {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
 }
 
-.html-tooltip-grouping__trigger {
+.trigger {
   padding: 6px 16px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-.html-tooltip-grouping__popup {
+.media-tooltip {
   --media-tooltip-side-offset: 8px;
   background: rgba(0, 0, 0, 0.85);
   backdrop-filter: blur(10px);

--- a/site/src/components/docs/demos/tooltip/html/css/Grouping.html
+++ b/site/src/components/docs/demos/tooltip/html/css/Grouping.html
@@ -1,10 +1,10 @@
-<media-tooltip-group class="html-tooltip-grouping">
-    <button type="button" commandfor="tooltip-play" class="html-tooltip-grouping__trigger">Play</button>
-    <media-tooltip id="tooltip-play" class="html-tooltip-grouping__popup">Play video</media-tooltip>
+<media-tooltip-group class="demo">
+    <button type="button" commandfor="tooltip-play" class="trigger">Play</button>
+    <media-tooltip id="tooltip-play" class="media-tooltip">Play video</media-tooltip>
 
-    <button type="button" commandfor="tooltip-mute" class="html-tooltip-grouping__trigger">Mute</button>
-    <media-tooltip id="tooltip-mute" class="html-tooltip-grouping__popup">Mute audio</media-tooltip>
+    <button type="button" commandfor="tooltip-mute" class="trigger">Mute</button>
+    <media-tooltip id="tooltip-mute" class="media-tooltip">Mute audio</media-tooltip>
 
-    <button type="button" commandfor="tooltip-fullscreen" class="html-tooltip-grouping__trigger">Fullscreen</button>
-    <media-tooltip id="tooltip-fullscreen" class="html-tooltip-grouping__popup">Enter fullscreen</media-tooltip>
+    <button type="button" commandfor="tooltip-fullscreen" class="trigger">Fullscreen</button>
+    <media-tooltip id="tooltip-fullscreen" class="media-tooltip">Enter fullscreen</media-tooltip>
 </media-tooltip-group>

--- a/site/src/components/docs/demos/tooltip/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/tooltip/react/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.react-tooltip-basic {
+.demo {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
 }
 
-.react-tooltip-basic__trigger {
+.trigger {
   padding: 6px 16px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -15,7 +15,7 @@
   cursor: pointer;
 }
 
-.react-tooltip-basic__popup {
+.media-tooltip {
   --media-tooltip-side-offset: 8px;
   margin: 0;
   border: 0;
@@ -29,6 +29,6 @@
   pointer-events: none;
 }
 
-.react-tooltip-basic__arrow {
+.arrow {
   fill: rgba(0, 0, 0, 0.85);
 }

--- a/site/src/components/docs/demos/tooltip/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/tooltip/react/css/BasicUsage.tsx
@@ -1,14 +1,12 @@
 import { Tooltip } from '@videojs/react';
 
-import './BasicUsage.css';
-
 export default function BasicUsage() {
   return (
-    <div className="react-tooltip-basic">
+    <div className="demo">
       <Tooltip.Root>
-        <Tooltip.Trigger className="react-tooltip-basic__trigger">Hover me</Tooltip.Trigger>
-        <Tooltip.Popup className="react-tooltip-basic__popup">
-          <Tooltip.Arrow className="react-tooltip-basic__arrow" />
+        <Tooltip.Trigger className="trigger">Hover me</Tooltip.Trigger>
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Arrow className="arrow" />
           Tooltip content
         </Tooltip.Popup>
       </Tooltip.Root>

--- a/site/src/components/docs/demos/tooltip/react/css/Grouping.css
+++ b/site/src/components/docs/demos/tooltip/react/css/Grouping.css
@@ -1,11 +1,11 @@
-.react-tooltip-grouping {
+.demo {
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
 }
 
-.react-tooltip-grouping__trigger {
+.trigger {
   padding: 6px 16px;
   background: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(10px);
@@ -14,7 +14,7 @@
   cursor: pointer;
 }
 
-.react-tooltip-grouping__popup {
+.media-tooltip {
   --media-tooltip-side-offset: 8px;
   margin: 0;
   border: 0;
@@ -28,6 +28,6 @@
   pointer-events: none;
 }
 
-.react-tooltip-grouping__arrow {
+.arrow {
   fill: rgba(0, 0, 0, 0.85);
 }

--- a/site/src/components/docs/demos/tooltip/react/css/Grouping.tsx
+++ b/site/src/components/docs/demos/tooltip/react/css/Grouping.tsx
@@ -1,29 +1,27 @@
 import { Tooltip } from '@videojs/react';
 
-import './Grouping.css';
-
 export default function Grouping() {
   return (
-    <div className="react-tooltip-grouping">
+    <div className="demo">
       <Tooltip.Provider>
         <Tooltip.Root>
-          <Tooltip.Trigger className="react-tooltip-grouping__trigger">Play</Tooltip.Trigger>
-          <Tooltip.Popup className="react-tooltip-grouping__popup">
-            <Tooltip.Arrow className="react-tooltip-grouping__arrow" />
+          <Tooltip.Trigger className="trigger">Play</Tooltip.Trigger>
+          <Tooltip.Popup className="media-tooltip">
+            <Tooltip.Arrow className="arrow" />
             Play video
           </Tooltip.Popup>
         </Tooltip.Root>
         <Tooltip.Root>
-          <Tooltip.Trigger className="react-tooltip-grouping__trigger">Mute</Tooltip.Trigger>
-          <Tooltip.Popup className="react-tooltip-grouping__popup">
-            <Tooltip.Arrow className="react-tooltip-grouping__arrow" />
+          <Tooltip.Trigger className="trigger">Mute</Tooltip.Trigger>
+          <Tooltip.Popup className="media-tooltip">
+            <Tooltip.Arrow className="arrow" />
             Mute audio
           </Tooltip.Popup>
         </Tooltip.Root>
         <Tooltip.Root>
-          <Tooltip.Trigger className="react-tooltip-grouping__trigger">Fullscreen</Tooltip.Trigger>
-          <Tooltip.Popup className="react-tooltip-grouping__popup">
-            <Tooltip.Arrow className="react-tooltip-grouping__arrow" />
+          <Tooltip.Trigger className="trigger">Fullscreen</Tooltip.Trigger>
+          <Tooltip.Popup className="media-tooltip">
+            <Tooltip.Arrow className="arrow" />
             Enter fullscreen
           </Tooltip.Popup>
         </Tooltip.Root>

--- a/site/src/components/docs/demos/use-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/use-button/react/css/BasicUsage.css
@@ -1,11 +1,11 @@
-.react-use-button-basic {
+.demo {
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 16px;
 }
 
-.react-use-button-basic__button {
+.button {
   align-self: flex-start;
   padding: 8px 20px;
   border-radius: 6px;
@@ -16,12 +16,12 @@
   transition: opacity 0.2s;
 }
 
-.react-use-button-basic__button[disabled] {
+.button[disabled] {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.react-use-button-basic__label {
+.label {
   display: flex;
   align-items: center;
   gap: 6px;

--- a/site/src/components/docs/demos/use-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-button/react/css/BasicUsage.tsx
@@ -1,8 +1,6 @@
 import { useButton } from '@videojs/react';
 import { useState } from 'react';
 
-import './BasicUsage.css';
-
 export default function BasicUsage() {
   const [count, setCount] = useState(0);
   const [disabled, setDisabled] = useState(false);
@@ -14,11 +12,11 @@ export default function BasicUsage() {
   });
 
   return (
-    <div className="react-use-button-basic">
-      <button ref={buttonRef} {...getButtonProps()} className="react-use-button-basic__button" disabled={disabled}>
+    <div className="demo">
+      <button ref={buttonRef} {...getButtonProps()} className="button" disabled={disabled}>
         Activated {count} times
       </button>
-      <label className="react-use-button-basic__label">
+      <label className="label">
         <input type="checkbox" checked={disabled} onChange={(e) => setDisabled(e.target.checked)} />
         Disabled
       </label>

--- a/site/src/components/docs/demos/use-media/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/use-media/react/css/BasicUsage.css
@@ -1,12 +1,12 @@
-.react-use-media-basic {
+.media-container {
   position: relative;
 }
 
-.react-use-media-basic video {
+.media-container video {
   width: 100%;
 }
 
-.react-use-media-basic__info {
+.info-panel {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -17,17 +17,17 @@
   font-size: 0.8125rem;
 }
 
-.react-use-media-basic__info div {
+.info-panel div {
   display: flex;
   gap: 8px;
 }
 
-.react-use-media-basic__info dt {
+.info-panel dt {
   color: #6b7280;
   min-width: 80px;
 }
 
-.react-use-media-basic__info dd {
+.info-panel dd {
   margin: 0;
   font-variant-numeric: tabular-nums;
   overflow: hidden;

--- a/site/src/components/docs/demos/use-media/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-media/react/css/BasicUsage.tsx
@@ -1,8 +1,6 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './BasicUsage.css';
-
 const Player = createPlayer({
   features: videoFeatures,
 });
@@ -13,7 +11,7 @@ function MediaInfo() {
   if (!media) return null;
 
   return (
-    <dl className="react-use-media-basic__info">
+    <dl className="info-panel">
       <div>
         <dt>tagName</dt>
         <dd>{media.tagName.toLowerCase()}</dd>
@@ -37,7 +35,7 @@ function MediaInfo() {
 export default function BasicUsage() {
   return (
     <Player.Provider>
-      <Player.Container className="react-use-media-basic">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay

--- a/site/src/components/docs/demos/use-player/react/css/Selector.css
+++ b/site/src/components/docs/demos/use-player/react/css/Selector.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.state-panel {
+.panel {
   display: flex;
   gap: 16px;
   padding: 12px;
@@ -16,16 +16,16 @@
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.state-panel div {
+.panel div {
   display: flex;
   gap: 8px;
 }
 
-.state-panel dt {
+.panel dt {
   color: #6b7280;
 }
 
-.state-panel dd {
+.panel dd {
   margin: 0;
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/use-player/react/css/Selector.css
+++ b/site/src/components/docs/demos/use-player/react/css/Selector.css
@@ -1,12 +1,12 @@
-.react-use-player-selector {
+.media-container {
   position: relative;
 }
 
-.react-use-player-selector video {
+.media-container video {
   width: 100%;
 }
 
-.react-use-player-selector__state {
+.state-panel {
   display: flex;
   gap: 16px;
   padding: 12px;
@@ -16,16 +16,16 @@
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.react-use-player-selector__state div {
+.state-panel div {
   display: flex;
   gap: 8px;
 }
 
-.react-use-player-selector__state dt {
+.state-panel dt {
   color: #6b7280;
 }
 
-.react-use-player-selector__state dd {
+.state-panel dd {
   margin: 0;
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/use-player/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/Selector.tsx
@@ -1,8 +1,6 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './Selector.css';
-
 const Player = createPlayer({
   features: videoFeatures,
 });
@@ -15,7 +13,7 @@ function StateDisplay() {
   }));
 
   return (
-    <dl className="react-use-player-selector__state">
+    <dl className="state-panel">
       <div>
         <dt>Paused</dt>
         <dd>{String(state.paused)}</dd>
@@ -33,7 +31,7 @@ function StateDisplay() {
 export default function Selector() {
   return (
     <Player.Provider>
-      <Player.Container className="react-use-player-selector">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay

--- a/site/src/components/docs/demos/use-player/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/Selector.tsx
@@ -13,7 +13,7 @@ function StateDisplay() {
   }));
 
   return (
-    <dl className="state-panel">
+    <dl className="panel">
       <div>
         <dt>Paused</dt>
         <dd>{String(state.paused)}</dd>

--- a/site/src/components/docs/demos/use-player/react/css/StoreAccess.css
+++ b/site/src/components/docs/demos/use-player/react/css/StoreAccess.css
@@ -1,12 +1,12 @@
-.react-use-player-store {
+.media-container {
   position: relative;
 }
 
-.react-use-player-store video {
+.media-container video {
   width: 100%;
 }
 
-.react-use-player-store__controls {
+.controls {
   display: flex;
   gap: 6px;
   padding: 12px;
@@ -14,7 +14,7 @@
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.react-use-player-store__controls button {
+.controls button {
   padding: 4px 12px;
   border-radius: 6px;
   border: 1px solid #ccc;

--- a/site/src/components/docs/demos/use-player/react/css/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/StoreAccess.tsx
@@ -1,8 +1,6 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './StoreAccess.css';
-
 const Player = createPlayer({
   features: videoFeatures,
 });
@@ -11,7 +9,7 @@ function Controls() {
   const store = Player.usePlayer();
 
   return (
-    <div className="react-use-player-store__controls">
+    <div className="controls">
       <button type="button" onClick={() => store.play()}>
         Play
       </button>
@@ -25,7 +23,7 @@ function Controls() {
 export default function StoreAccess() {
   return (
     <Player.Provider>
-      <Player.Container className="react-use-player-store">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay

--- a/site/src/components/docs/demos/use-store/react/css/Selector.css
+++ b/site/src/components/docs/demos/use-store/react/css/Selector.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.state-panel {
+.panel {
   display: flex;
   gap: 16px;
   padding: 12px;
@@ -16,16 +16,16 @@
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.state-panel div {
+.panel div {
   display: flex;
   gap: 8px;
 }
 
-.state-panel dt {
+.panel dt {
   color: #6b7280;
 }
 
-.state-panel dd {
+.panel dd {
   margin: 0;
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/use-store/react/css/Selector.css
+++ b/site/src/components/docs/demos/use-store/react/css/Selector.css
@@ -1,12 +1,12 @@
-.react-use-store-selector {
+.media-container {
   position: relative;
 }
 
-.react-use-store-selector video {
+.media-container video {
   width: 100%;
 }
 
-.react-use-store-selector__state {
+.state-panel {
   display: flex;
   gap: 16px;
   padding: 12px;
@@ -16,16 +16,16 @@
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.react-use-store-selector__state div {
+.state-panel div {
   display: flex;
   gap: 8px;
 }
 
-.react-use-store-selector__state dt {
+.state-panel dt {
   color: #6b7280;
 }
 
-.react-use-store-selector__state dd {
+.state-panel dd {
   margin: 0;
   font-variant-numeric: tabular-nums;
 }

--- a/site/src/components/docs/demos/use-store/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/Selector.tsx
@@ -13,7 +13,7 @@ function DerivedState() {
   }));
 
   return (
-    <dl className="state-panel">
+    <dl className="panel">
       <div>
         <dt>Remaining</dt>
         <dd>{derived.remaining.toFixed(1)}s</dd>

--- a/site/src/components/docs/demos/use-store/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/Selector.tsx
@@ -1,8 +1,6 @@
 import { createPlayer, useStore } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './Selector.css';
-
 const Player = createPlayer({
   features: videoFeatures,
 });
@@ -15,7 +13,7 @@ function DerivedState() {
   }));
 
   return (
-    <dl className="react-use-store-selector__state">
+    <dl className="state-panel">
       <div>
         <dt>Remaining</dt>
         <dd>{derived.remaining.toFixed(1)}s</dd>
@@ -31,7 +29,7 @@ function DerivedState() {
 export default function Selector() {
   return (
     <Player.Provider>
-      <Player.Container className="react-use-store-selector">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay

--- a/site/src/components/docs/demos/use-store/react/css/StoreAccess.css
+++ b/site/src/components/docs/demos/use-store/react/css/StoreAccess.css
@@ -1,12 +1,12 @@
-.react-use-store-access {
+.media-container {
   position: relative;
 }
 
-.react-use-store-access video {
+.media-container video {
   width: 100%;
 }
 
-.react-use-store-access__controls {
+.controls {
   display: flex;
   gap: 6px;
   padding: 12px;
@@ -14,7 +14,7 @@
   border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-.react-use-store-access__controls button {
+.controls button {
   padding: 4px 12px;
   border-radius: 6px;
   border: 1px solid #ccc;

--- a/site/src/components/docs/demos/use-store/react/css/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/StoreAccess.tsx
@@ -1,8 +1,6 @@
 import { createPlayer, useStore } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './StoreAccess.css';
-
 const Player = createPlayer({
   features: videoFeatures,
 });
@@ -12,7 +10,7 @@ function SeekControls() {
   const s = useStore(store);
 
   return (
-    <div className="react-use-store-access__controls">
+    <div className="controls">
       <button type="button" onClick={() => s.seek(0)}>
         Go to start
       </button>
@@ -26,7 +24,7 @@ function SeekControls() {
 export default function StoreAccess() {
   return (
     <Player.Provider>
-      <Player.Container className="react-use-store-access">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.astro
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.astro
@@ -1,7 +1,6 @@
 ---
 import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
 import html from './WithParts.html?raw';
-import './WithParts.css';
 ---
 
 <HtmlDemo html={html} />

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
@@ -22,16 +22,16 @@
   cursor: pointer;
 }
 
-.media-mute-button .show-when-muted {
+.media-mute-button .muted {
   display: none;
 }
-.media-mute-button .show-when-unmuted {
+.media-mute-button .unmuted {
   display: none;
 }
-.media-mute-button[data-muted] .show-when-muted {
+.media-mute-button[data-muted] .muted {
   display: inline;
 }
-.media-mute-button:not([data-muted]) .show-when-unmuted {
+.media-mute-button:not([data-muted]) .unmuted {
   display: inline;
 }
 

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
@@ -1,10 +1,10 @@
-.media-container,
-.media-container media-container {
+.video-player,
+.video-player media-container {
   display: block;
   position: relative;
 }
 
-.media-container video {
+.video-player video {
   width: 100%;
 }
 

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.css
@@ -1,14 +1,14 @@
-.html-volume-slider-parts,
-.html-volume-slider-parts media-container {
+.media-container,
+.media-container media-container {
   display: block;
   position: relative;
 }
 
-.html-volume-slider-parts video {
+.media-container video {
   width: 100%;
 }
 
-.html-volume-slider-parts__mute-button {
+.media-mute-button {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -22,20 +22,20 @@
   cursor: pointer;
 }
 
-.html-volume-slider-parts__mute-button .show-when-muted {
+.media-mute-button .show-when-muted {
   display: none;
 }
-.html-volume-slider-parts__mute-button .show-when-unmuted {
+.media-mute-button .show-when-unmuted {
   display: none;
 }
-.html-volume-slider-parts__mute-button[data-muted] .show-when-muted {
+.media-mute-button[data-muted] .show-when-muted {
   display: inline;
 }
-.html-volume-slider-parts__mute-button:not([data-muted]) .show-when-unmuted {
+.media-mute-button:not([data-muted]) .show-when-unmuted {
   display: inline;
 }
 
-.html-volume-slider-parts__slider {
+.media-volume-slider {
   position: absolute;
   bottom: 10px;
   right: 10px;
@@ -46,7 +46,7 @@
   cursor: pointer;
 }
 
-.html-volume-slider-parts__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -57,11 +57,11 @@
   transition: height 150ms ease;
 }
 
-.html-volume-slider-parts__slider[data-interactive] .html-volume-slider-parts__track {
+.media-volume-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.html-volume-slider-parts__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -71,7 +71,7 @@
   border-radius: 9999px;
 }
 
-.html-volume-slider-parts__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -83,15 +83,15 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.html-volume-slider-parts__slider[data-interactive] .html-volume-slider-parts__thumb {
+.media-volume-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.html-volume-slider-parts__slider[data-dragging] .html-volume-slider-parts__thumb {
+.media-volume-slider[data-dragging] .media-slider-thumb {
   transform: translateX(-50%) scale(1.1);
 }
 
-.html-volume-slider-parts__value {
+.media-slider-value {
   position: absolute;
   left: var(--media-slider-pointer);
   bottom: 100%;
@@ -108,6 +108,6 @@
   transition: opacity 150ms ease;
 }
 
-.html-volume-slider-parts__slider[data-pointing] .html-volume-slider-parts__value {
+.media-volume-slider[data-pointing] .media-slider-value {
   opacity: 1;
 }

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
@@ -1,4 +1,4 @@
-<video-player class="media-container">
+<video-player class="video-player">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
@@ -8,8 +8,8 @@
             loop
         ></video>
         <media-mute-button class="media-mute-button">
-            <span class="show-when-muted">Unmute</span>
-            <span class="show-when-unmuted">Mute</span>
+            <span class="muted">Unmute</span>
+            <span class="unmuted">Mute</span>
         </media-mute-button>
         <media-volume-slider class="media-volume-slider">
             <media-slider-track class="media-slider-track">

--- a/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
+++ b/site/src/components/docs/demos/volume-slider/html/css/WithParts.html
@@ -1,4 +1,4 @@
-<video-player class="html-volume-slider-parts">
+<video-player class="media-container">
     <media-container>
         <video
             src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
@@ -7,16 +7,16 @@
             playsinline
             loop
         ></video>
-        <media-mute-button class="html-volume-slider-parts__mute-button">
+        <media-mute-button class="media-mute-button">
             <span class="show-when-muted">Unmute</span>
             <span class="show-when-unmuted">Mute</span>
         </media-mute-button>
-        <media-volume-slider class="html-volume-slider-parts__slider">
-            <media-slider-track class="html-volume-slider-parts__track">
-                <media-slider-fill class="html-volume-slider-parts__fill"></media-slider-fill>
+        <media-volume-slider class="media-volume-slider">
+            <media-slider-track class="media-slider-track">
+                <media-slider-fill class="media-slider-fill"></media-slider-fill>
             </media-slider-track>
-            <media-slider-thumb class="html-volume-slider-parts__thumb"></media-slider-thumb>
-            <media-slider-value type="pointer" class="html-volume-slider-parts__value"></media-slider-value>
+            <media-slider-thumb class="media-slider-thumb"></media-slider-thumb>
+            <media-slider-value type="pointer" class="media-slider-value"></media-slider-value>
         </media-volume-slider>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/volume-slider/react/css/WithParts.css
+++ b/site/src/components/docs/demos/volume-slider/react/css/WithParts.css
@@ -1,12 +1,12 @@
-.react-volume-slider-parts {
+.media-container {
   position: relative;
 }
 
-.react-volume-slider-parts video {
+.media-container video {
   width: 100%;
 }
 
-.react-volume-slider-parts__mute-button {
+.media-mute-button {
   position: absolute;
   bottom: 10px;
   left: 10px;
@@ -20,7 +20,7 @@
   cursor: pointer;
 }
 
-.react-volume-slider-parts__slider {
+.media-volume-slider {
   position: absolute;
   bottom: 10px;
   right: 10px;
@@ -31,7 +31,7 @@
   cursor: pointer;
 }
 
-.react-volume-slider-parts__track {
+.media-slider-track {
   position: absolute;
   left: 0;
   right: 0;
@@ -42,11 +42,11 @@
   transition: height 150ms ease;
 }
 
-.react-volume-slider-parts__slider[data-interactive] .react-volume-slider-parts__track {
+.media-volume-slider[data-interactive] .media-slider-track {
   height: 6px;
 }
 
-.react-volume-slider-parts__fill {
+.media-slider-fill {
   position: absolute;
   top: 0;
   left: 0;
@@ -56,7 +56,7 @@
   border-radius: 9999px;
 }
 
-.react-volume-slider-parts__thumb {
+.media-slider-thumb {
   position: absolute;
   left: var(--media-slider-fill);
   width: 14px;
@@ -68,15 +68,15 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-.react-volume-slider-parts__slider[data-interactive] .react-volume-slider-parts__thumb {
+.media-volume-slider[data-interactive] .media-slider-thumb {
   transform: translateX(-50%) scale(1);
 }
 
-.react-volume-slider-parts__slider[data-dragging] .react-volume-slider-parts__thumb {
+.media-volume-slider[data-dragging] .media-slider-thumb {
   transform: translateX(-50%) scale(1.1);
 }
 
-.react-volume-slider-parts__value {
+.media-slider-value {
   position: absolute;
   left: var(--media-slider-pointer);
   bottom: 100%;
@@ -93,6 +93,6 @@
   transition: opacity 150ms ease;
 }
 
-.react-volume-slider-parts__slider[data-pointing] .react-volume-slider-parts__value {
+.media-volume-slider[data-pointing] .media-slider-value {
   opacity: 1;
 }

--- a/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
@@ -1,14 +1,12 @@
 import { createPlayer, MuteButton, VolumeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-import './WithParts.css';
-
 const Player = createPlayer({ features: videoFeatures });
 
 export default function WithParts() {
   return (
     <Player.Provider>
-      <Player.Container className="react-volume-slider-parts">
+      <Player.Container className="media-container">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -17,15 +15,15 @@ export default function WithParts() {
           loop
         />
         <MuteButton
-          className="react-volume-slider-parts__mute-button"
+          className="media-mute-button"
           render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
         />
-        <VolumeSlider.Root className="react-volume-slider-parts__slider">
-          <VolumeSlider.Track className="react-volume-slider-parts__track">
-            <VolumeSlider.Fill className="react-volume-slider-parts__fill" />
+        <VolumeSlider.Root className="media-volume-slider">
+          <VolumeSlider.Track className="media-slider-track">
+            <VolumeSlider.Fill className="media-slider-fill" />
           </VolumeSlider.Track>
-          <VolumeSlider.Thumb className="react-volume-slider-parts__thumb" />
-          <VolumeSlider.Value type="pointer" className="react-volume-slider-parts__value" />
+          <VolumeSlider.Thumb className="media-slider-thumb" />
+          <VolumeSlider.Value type="pointer" className="media-slider-value" />
         </VolumeSlider.Root>
       </Player.Container>
     </Player.Provider>


### PR DESCRIPTION
## Summary

Replaces the BEM naming convention and CSS side-effect imports in demo components with a centralized `@scope`-based CSS isolation strategy. `Demo.astro` now generates a deterministic hash from demo file contents, wraps CSS in `@scope ([data-demo-scope="demo-{hash}"])`, and injects it as an inline `<style>` — eliminating class name collisions without requiring framework-prefixed BEM names.

## Changes

- Add `@scope` injection to `Demo.astro`: hash demo files, wrap CSS in `@scope`, inject via inline `<style>` with a `data-demo-scope` attribute on the demo container
- Remove `import './X.css'` side-effect imports from all `.astro` wrappers and React `.tsx` demo files — CSS is now injected by `Demo.astro` via the `files` prop
- Replace BEM class names (`.html-play-button-basic__button`, `.react-play-button-basic__button`) with component-mapped names (`.media-play-button`, `.media-container`) across all HTML, CSS, and React demo files
- Unify React and HTML CSS files to use identical class names per demo
- Update `site/CLAUDE.md` to document the new CSS scoping strategy and naming conventions

## Testing

- Verify demos render correctly on the docs site — styles should be scoped and not leak between demos
- Check the source code tabs still display clean CSS without the `@scope` wrapper

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared `Demo.astro` rendering path and rewires how demo CSS is applied, so styling regressions across many docs demos are possible despite limited impact outside the docs site.
> 
> **Overview**
> **Docs demos now use centralized CSS isolation.** `Demo.astro` computes a deterministic hash from the demo `files` content, injects the demo CSS inline, and wraps it in `@scope` targeting a `data-demo-scope` attribute on the demo container.
> 
> Across HTML and React demos, this removes per-demo CSS side-effect imports and replaces framework/BEM-style classnames with *component-mapped* names (e.g., `.media-container`, `.media-play-button`, `.demo`) so demos rely on scoped CSS rather than globally unique class naming. `site/CLAUDE.md` is updated to document the new naming/scoping rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e166600ab3f5eff45f7a763ab91950f73f69ee1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->