### PR TITLE
fix(site): revert FrameworkCase conditional rendering

### DIFF
--- a/site/src/components/docs/FrameworkCase.astro
+++ b/site/src/components/docs/FrameworkCase.astro
@@ -11,7 +11,27 @@ const { framework } = Astro.params;
 
 // Only render if current framework matches, or if no frameworks specified (all frameworks)
 const shouldRender = !frameworks || frameworks.includes(framework as SupportedFramework);
-const html = shouldRender ? await Astro.slots.render('default') : '';
 ---
 
-{shouldRender && <Fragment set:html={html} />}
+{
+  /*
+    What I WANT to do is
+    ```
+    {shouldRender && <slot />}
+    ```
+
+    But I'm running into some crazy problems with hydration.
+    Putting client:* in one of these conditionals causes Astro to just give up hydrating the whole app for some reason.
+    TODO: fix this
+
+    So, while I debug those... let's do this
+  */
+}
+<div
+  class="contents"
+  hidden={!shouldRender}
+  data-search-ignore={shouldRender ? undefined : "all"}
+  data-llms-ignore={shouldRender ? undefined : "all"}
+>
+  <slot />
+</div>


### PR DESCRIPTION
## Summary

- Reverts #1223 (commit `55a07559`) which broke Astro hydration on HTML reference pages
- Restores the `hidden`-attribute workaround in `FrameworkCase.astro` until a proper fix is found

Closes #1316

## Context

The conditional rendering approach using `Astro.slots.render()` + `set:html` broke `client:*` island hydration. Confirmed via manual bisect — reverting this single commit restores hydration.

## Test plan

- [ ] Verify hydration works on `/docs/framework/html/reference/buffering-indicator`
- [ ] Spot-check other HTML reference pages with interactive components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conditional rendering behavior in a shared docs component and can affect island hydration and DOM visibility across many pages. Risk is mitigated by being a small, localized revert-style change but should be validated on interactive reference pages.
> 
> **Overview**
> Reverts `FrameworkCase.astro` to always render its slot content inside a wrapper `div` and toggles visibility via the `hidden` attribute, instead of conditionally injecting pre-rendered HTML via `Astro.slots.render()`/`set:html`.
> 
> When not applicable to the current framework, the wrapper also sets `data-search-ignore` and `data-llms-ignore` to prevent indexing, while keeping the markup present to avoid Astro `client:*` hydration failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d059498591760bcfe06b95fa1f0232dad4017c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->