### PR TITLE
docs: improve intro of a11y guide

### DIFF
--- a/site/src/content/docs/concepts/accessibility.mdx
+++ b/site/src/content/docs/concepts/accessibility.mdx
@@ -1,11 +1,13 @@
 ---
 title: Accessibility
-description: How Video.js approaches accessible media playback, covering standards, ARIA, keyboard, captions, contrast, touch targets, and user preferences.
+description: How Video.js approaches accessibility, and what you should consider if you're deeply customizing your player
 ---
 
 import DocsLink from '@/components/docs/DocsLink.astro';
 
-Video.js handles accessibility out of the box so your player works for everyone.
+Video.js is built with accessibility in mind so your player can reach the widest possible audience. 
+
+Here are some of the accessibility aspects we consider. You should consider them too if you're performing deeper customization.
 
 ## Standards we target
 


### PR DESCRIPTION
- reword first sentence to reflect aspirational framing. (Accessibility is never done!)
- add additional section to make clear this is not just a feature list, but also an intro for customizers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that adjusts framing and metadata without affecting runtime behavior.
> 
> **Overview**
> Updates the `Accessibility` concept doc intro to use more aspirational language and explicitly position the page as guidance for teams doing deep player customization.
> 
> Also revises the page `description` frontmatter to match the new framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58032e04eeda99ba81985a05718a6d0dc200dcdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->