### PR TITLE
fix(site): site accessibility rough edges

### DIFF
--- a/site/src/content/docs/concepts/accessibility.mdx
+++ b/site/src/content/docs/concepts/accessibility.mdx
@@ -1,11 +1,13 @@
 ---
 title: Accessibility
-description: How Video.js approaches accessible media playback, covering standards, ARIA, keyboard, captions, contrast, touch targets, and user preferences.
+description: How Video.js approaches accessibility, and what you should consider if you're deeply customizing your player
 ---
 
 import DocsLink from '@/components/docs/DocsLink.astro';
 
-Video.js handles accessibility out of the box so your player works for everyone.
+Video.js is built with accessibility in mind so your player can reach the widest possible audience. 
+
+Here are some of the accessibility aspects we consider. You should consider them too if you're performing deeper customization.
 
 ## Standards we target
 


### PR DESCRIPTION
## Summary

- Add skip-to-content link in `Base.astro`
- Add `aria-label` to nav landmarks (sidebar, docs pagination, navbars)
- Add `id="main-content"` to `<main>` elements across all layouts and pages

Closes #1319

## Test plan

- [ ] Tab from page top — skip link appears and jumps to main content
- [ ] Screen reader landmark list shows distinct, labeled navigations
- [ ] Verify no regressions in visual layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)