### PR TITLE
refactor(packages): move media host observed attributes to subclasses

### DIFF
--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -90,18 +90,14 @@ interface MediaHost extends EventTarget {
   [key: string]: any;
 }
 
-type MediaHostConstructor = Constructor<MediaHost> & {
-  observedAttributes?: string[];
-};
-
-type CustomMediaConstructor<T extends MediaHostConstructor> = Constructor<HTMLElement & InstanceType<T>> & {
+type CustomMediaConstructor<T extends Constructor<MediaHost>> = Constructor<HTMLElement & InstanceType<T>> & {
   properties: Record<string, { type: any; attribute?: string }>;
   getTemplateHTML: (attrs: Record<string, string>) => string;
   shadowRootOptions: ShadowRootInit;
   readonly observedAttributes: string[];
 };
 
-export function CustomMediaElement<T extends MediaHostConstructor>(
+export function CustomMediaElement<T extends Constructor<MediaHost>>(
   tag: string,
   MediaHost: T
 ): CustomMediaConstructor<T> {
@@ -134,15 +130,12 @@ export function CustomMediaElement<T extends MediaHostConstructor>(
       return [
         // biome-ignore lint/complexity/noThisInStatic: intentional use of this
         ...getAttrsFromProps(this.properties),
-        ...(MediaHost.observedAttributes ?? []),
       ];
     }
 
     static #define(ctor: typeof CustomMedia) {
       if (isDefined) return;
       isDefined = true;
-
-      const Attributes = getAttrsFromProps(ctor.properties);
 
       for (let proto = MediaHost.prototype; proto && proto !== Object.prototype; proto = Object.getPrototypeOf(proto)) {
         for (const prop of Object.getOwnPropertyNames(proto)) {
@@ -167,9 +160,7 @@ export function CustomMediaElement<T extends MediaHostConstructor>(
 
             if (descriptor.set) {
               const attr = kebabCase(prop);
-              // If explicitly observed by the media host, or it's a native attribute,
-              // route through attributeChangedCallback.
-              if (MediaHost.observedAttributes?.includes(attr) || Attributes.includes(attr)) {
+              if (ctor.observedAttributes.includes(attr)) {
                 mediaHostAttrToProp.set(attr, prop);
 
                 config.set = function (this: CustomMedia, val: any) {

--- a/packages/html/src/media/hls-video/index.ts
+++ b/packages/html/src/media/hls-video/index.ts
@@ -2,4 +2,9 @@ import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element
 import { HlsMedia } from '@videojs/core/dom/media/hls';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
-export class HlsVideo extends MediaAttachMixin(CustomMediaElement('video', HlsMedia)) {}
+export class HlsVideo extends MediaAttachMixin(CustomMediaElement('video', HlsMedia)) {
+  static get observedAttributes() {
+    // biome-ignore lint/complexity/noThisInStatic: intentional use of super
+    return [...super.observedAttributes, 'type', 'prefer-playback', 'debug'];
+  }
+}

--- a/packages/html/src/media/mux-audio/index.ts
+++ b/packages/html/src/media/mux-audio/index.ts
@@ -2,4 +2,9 @@ import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element
 import { MuxAudioMedia } from '@videojs/core/dom/media/mux';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
-export class MuxAudio extends MediaAttachMixin(CustomMediaElement('audio', MuxAudioMedia)) {}
+export class MuxAudio extends MediaAttachMixin(CustomMediaElement('audio', MuxAudioMedia)) {
+  static get observedAttributes() {
+    // biome-ignore lint/complexity/noThisInStatic: intentional use of super
+    return [...super.observedAttributes, 'type', 'prefer-playback', 'debug'];
+  }
+}

--- a/packages/html/src/media/mux-video/index.ts
+++ b/packages/html/src/media/mux-video/index.ts
@@ -2,4 +2,9 @@ import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element
 import { MuxVideoMedia } from '@videojs/core/dom/media/mux';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
-export class MuxVideo extends MediaAttachMixin(CustomMediaElement('video', MuxVideoMedia)) {}
+export class MuxVideo extends MediaAttachMixin(CustomMediaElement('video', MuxVideoMedia)) {
+  static get observedAttributes() {
+    // biome-ignore lint/complexity/noThisInStatic: intentional use of super
+    return [...super.observedAttributes, 'type', 'prefer-playback', 'debug'];
+  }
+}


### PR DESCRIPTION
## Summary

Remove the `MediaHostConstructor` type and its `observedAttributes` convention from `CustomMediaElement`. Media-host-specific attributes (`type`, `prefer-playback`, `debug`) are now declared by the concrete custom element subclasses (`HlsVideo`, `MuxVideo`, `MuxAudio`) instead of being implicitly merged from the host constructor.

This simplifies the attribute routing logic in `#define` — a single `ctor.observedAttributes.includes(attr)` check replaces the previous dual-source lookup — and makes it explicit which attributes each element observes.

<details>
<summary>Implementation details</summary>

- The base `observedAttributes` getter no longer spreads `MediaHost.observedAttributes` (it was always empty — no host ever defined one).
- The `Attributes` local in `#define` is removed; `ctor.observedAttributes` already contains the props-derived attrs via `getAttrsFromProps`.
- Re-entrant calls during `#define` are safe: the `isDefined` guard prevents infinite recursion while still returning the correct attribute list from the subclass getter.

</details>

## Testing

Covered by existing `custom-media-element` tests.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `observedAttributes` are declared/merged and how attribute-to-host-property routing is decided; behavioral risk is limited to attribute forwarding for affected custom media elements.
> 
> **Overview**
> **Moves media-host-specific attribute observation out of `CustomMediaElement` and into concrete elements.** `CustomMediaElement` no longer supports a `MediaHostConstructor.observedAttributes` convention; it now derives `observedAttributes` only from the element `properties`.
> 
> Attribute routing in `CustomMediaElement.#define` is simplified to a single `ctor.observedAttributes.includes(attr)` check, and `HlsVideo`, `MuxVideo`, and `MuxAudio` explicitly extend `observedAttributes` to include `type`, `prefer-playback`, and `debug`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5e07eda65fd1bb9d46e16a6b04999658033c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->