### PR TITLE
fix(core): reduce doubletap window from 300ms to 200ms

### DIFF
--- a/packages/core/src/dom/gesture/tap.ts
+++ b/packages/core/src/dom/gesture/tap.ts
@@ -1,6 +1,6 @@
 import type { GestureMatchResult, GestureRecognizer } from './gesture';
 
-const DOUBLETAP_WINDOW = 300;
+const DOUBLETAP_WINDOW = 200;
 
 /**
  * Recognizes tap vs doubletap from quick pointer-up events.

--- a/packages/core/src/dom/gesture/tests/gesture.test.ts
+++ b/packages/core/src/dom/gesture/tests/gesture.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createDoubleTapGesture, createTapGesture } from '../create-tap-gesture';
 
-const DOUBLETAP_WINDOW = 300;
+const DOUBLETAP_WINDOW = 200;
 
 function setup() {
   const container = document.createElement('div');

--- a/packages/core/src/dom/gesture/tests/tap.test.ts
+++ b/packages/core/src/dom/gesture/tests/tap.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GestureMatchResult, GestureType } from '../gesture';
 import { TapRecognizer } from '../tap';
 
-const DOUBLETAP_WINDOW = 300;
+const DOUBLETAP_WINDOW = 200;
 
 const NOOP_RECOGNIZER = { handleUp: () => {}, reset: () => {} };
 


### PR DESCRIPTION
Closes #1323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small timing-tweak in gesture recognition plus test updates, with no security or data handling impact. Main risk is subtle UX/regression for users who double-tap more slowly.
> 
> **Overview**
> Reduces the double-tap recognition window in `TapRecognizer` from **300ms to 200ms**, making double-taps require a tighter second tap.
> 
> Updates gesture unit tests to use the new `DOUBLETAP_WINDOW` so tap/doubletap disambiguation assertions match the revised timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c792a5ae1eecdf92be1859e2422fc6a4873846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->