### PR TITLE
fix(core): ignore non-primary pointer buttons in tap gesture

### DIFF
--- a/packages/core/src/dom/gesture/coordinator.ts
+++ b/packages/core/src/dom/gesture/coordinator.ts
@@ -48,7 +48,8 @@ export class GestureCoordinator {
     listen(
       this.#target,
       'pointerdown',
-      () => {
+      (event) => {
+        if (event.button !== 0) return;
         pointerDownTime = Date.now();
       },
       { signal }
@@ -58,6 +59,7 @@ export class GestureCoordinator {
       this.#target,
       'pointerup',
       (event) => {
+        if (event.button !== 0) return;
         if (Date.now() - pointerDownTime > TAP_THRESHOLD) return;
         if (isInteractiveTarget(event)) return;
 

--- a/packages/core/src/dom/gesture/tests/gesture.test.ts
+++ b/packages/core/src/dom/gesture/tests/gesture.test.ts
@@ -48,6 +48,30 @@ describe('createTapGesture', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('does not fire on secondary button (right-click)', () => {
+    const container = setup();
+    const handler = vi.fn();
+    createTapGesture(container, handler);
+
+    pointerDown(container, { button: 2 });
+    vi.advanceTimersByTime(50);
+    pointerUp(container, { pointerType: 'mouse', clientX: 150, button: 2 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not fire on auxiliary button (middle-click)', () => {
+    const container = setup();
+    const handler = vi.fn();
+    createTapGesture(container, handler);
+
+    pointerDown(container, { button: 1 });
+    vi.advanceTimersByTime(50);
+    pointerUp(container, { pointerType: 'mouse', clientX: 150, button: 1 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('does not fire when disabled', () => {
     const container = setup();
     const handler = vi.fn();
@@ -456,13 +480,16 @@ describe('interactive child filtering', () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function pointerDown(target: HTMLElement): void {
-  target.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+function pointerDown(target: HTMLElement, init: { button?: number } = {}): void {
+  const event = new Event('pointerdown', { bubbles: true });
+  Object.defineProperty(event, 'button', { value: init.button ?? 0 });
+  target.dispatchEvent(event);
 }
 
-function pointerUp(target: HTMLElement, init: { pointerType: string; clientX: number }): void {
+function pointerUp(target: HTMLElement, init: { pointerType: string; clientX: number; button?: number }): void {
   const event = new Event('pointerup', { bubbles: true });
   Object.defineProperty(event, 'pointerType', { value: init.pointerType });
   Object.defineProperty(event, 'clientX', { value: init.clientX });
+  Object.defineProperty(event, 'button', { value: init.button ?? 0 });
   target.dispatchEvent(event);
 }


### PR DESCRIPTION
closes https://github.com/videojs/v10/issues/1324

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small conditional change to tap recognition plus added tests; main risk is behavior change for apps that relied on right/middle clicks triggering tap gestures.
> 
> **Overview**
> Tap gesture recognition now ignores non-primary pointer buttons by early-returning on `pointerdown`/`pointerup` when `event.button !== 0`, preventing right/middle clicks from being treated as taps.
> 
> Tests are expanded to cover secondary (right) and auxiliary (middle) clicks, and the pointer event helpers are updated to allow setting `button` on synthetic events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d6539c14557c18467ccfb9ed78a2ed629112b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->