### PR TITLE
docs: improve intro of a11y guide

### DIFF
--- a/site/src/content/docs/concepts/accessibility.mdx
+++ b/site/src/content/docs/concepts/accessibility.mdx
@@ -1,11 +1,13 @@
 ---
 title: Accessibility
-description: How Video.js approaches accessible media playback, covering standards, ARIA, keyboard, captions, contrast, touch targets, and user preferences.
+description: How Video.js approaches accessibility, and what you should consider if you're deeply customizing your player
 ---
 
 import DocsLink from '@/components/docs/DocsLink.astro';
 
-Video.js handles accessibility out of the box so your player works for everyone.
+Video.js is built with accessibility in mind so your player can reach the widest possible audience. 
+
+Here are some of the accessibility aspects we consider. You should consider them too if you're performing deeper customization.
 
 ## Standards we target
 


### PR DESCRIPTION
## Summary

- Soften the description and intro of the accessibility guide to be less prescriptive and more inviting
- Reframe from "we handle it for you" to "we build with a11y in mind, and here's what to consider if you customize"

## Test plan

- [ ] Content reads well on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only wording changes; no functional or API impact.
> 
> **Overview**
> Updates the `Accessibility` guide’s frontmatter description and opening copy to be less prescriptive.
> 
> Reframes messaging from “accessibility handled out of the box” to “built with accessibility in mind,” and explicitly calls out that the listed considerations are especially relevant when deeply customizing the player.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58032e04eeda99ba81985a05718a6d0dc200dcdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->