### PR TITLE
fix(cli): correct bin path to match tsdown output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/videojs/v10",
     "directory": "packages/cli"
   },
-  "bin": "./dist/index.js",
+  "bin": "./dist/index.mjs",
   "files": [
     "dist",
     "docs"


### PR DESCRIPTION
## Summary
- Fixes `"bin"` in `packages/cli/package.json` from `./dist/index.js` to `./dist/index.mjs`
- tsdown with `format: 'es'` outputs `.mjs`, so the old path caused npm to strip the bin entry during publish
- This was the root cause of the beta.18 publish failure — npm couldn't find the bin file

## Test plan
- [ ] `pnpm -F @videojs/cli build` produces `dist/index.mjs`
- [ ] `npm publish --dry-run` in `packages/cli/` no longer warns about missing bin file
- [ ] After merge + release, `npx @videojs/cli docs` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to packaging metadata, but it directly impacts whether the CLI executable is exposed correctly when publishing/installing.
> 
> **Overview**
> Fixes the `@videojs/cli` npm executable mapping by updating `packages/cli/package.json` `bin` from `./dist/index.js` to `./dist/index.mjs` to match the `tsdown` ESM build output.
> 
> This prevents publishes/installs from missing the CLI entrypoint due to a non-existent bin target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27edd805d0e14b63c4163358549dee5a0df91b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->