### PR TITLE
fix(cli): replace deprecated noExternal with deps.alwaysBundle

### DIFF
--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   format: 'es',
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
-  noExternal: ['site'],
+  deps: { alwaysBundle: ['site'] },
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),
   },


### PR DESCRIPTION
## Summary
- Replaces deprecated `noExternal` option with `deps.alwaysBundle` in CLI tsdown config
- Silences the `WARN 'noExternal' is deprecated` build warning

## Test plan
- [x] `pnpm -F @videojs/cli build` succeeds with no deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts bundling behavior for the CLI build without touching runtime logic.
> 
> **Overview**
> Replaces the deprecated `noExternal` setting in `packages/cli/tsdown.config.ts` with `deps.alwaysBundle` to keep `site` bundled into the CLI output and eliminate the deprecation warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ccc5c0d107cac0c45727e93996c2b439a0c901a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->