### PR TITLE
fix(cli): normalize repository URL to match npm convention

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/videojs/v10",
+    "url": "git+https://github.com/videojs/v10.git",
     "directory": "packages/cli"
   },
   "bin": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Normalizes `repository.url` to `git+https://...git` format
- Silences `npm warn publish "repository.url" was normalized` on every publish

## Test plan
- [x] `pnpm -F @videojs/cli build` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata change in `packages/cli/package.json` that only affects how npm interprets the repository link during publish; no runtime or build logic is modified.
> 
> **Overview**
> Normalizes `@videojs/cli` package metadata by updating `repository.url` to the npm-preferred `git+https://... .git` format, avoiding npm’s auto-normalization warning during publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f85c1138c8d7ab829ed6d5bcde98b824a98d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->