### PR TITLE
fix(react): prevent gesture tap from firing on slider interactions

### DIFF
--- a/apps/e2e/tests/gestures.spec.ts
+++ b/apps/e2e/tests/gestures.spec.ts
@@ -58,9 +58,11 @@ test.describe('Mouse Gestures', () => {
     await player.play();
     await page.waitForTimeout(500);
 
-    // Click the time slider — should seek, not toggle play/pause
+    // Click the time slider — should seek, not toggle play/pause.
+    // Wait briefly after seek to give any leaked gesture time to fire.
     await player.seekTo(50);
-    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+    await page.waitForTimeout(300);
+    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused);
   });
 });
 
@@ -93,9 +95,11 @@ test.describe('React Mouse Gestures', () => {
     await player.play();
     await page.waitForTimeout(500);
 
-    // Click the time slider — should seek, not toggle play/pause
+    // Click the time slider — should seek, not toggle play/pause.
+    // Wait briefly after seek to give any leaked gesture time to fire.
     await player.seekTo(50);
-    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+    await page.waitForTimeout(300);
+    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused);
   });
 });
 

--- a/apps/e2e/tests/gestures.spec.ts
+++ b/apps/e2e/tests/gestures.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
+import { DATA_ATTRS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 /**
@@ -50,6 +50,51 @@ test.describe('Mouse Gestures', () => {
     // container gesture. If both fired, play would toggle twice (no-op).
     await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
     await player.playButton.click();
+    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+  });
+
+  test('click on slider does not trigger container gesture', async ({ page }) => {
+    // Start playback so the slider has a seekable range
+    await player.play();
+    await page.waitForTimeout(500);
+
+    // Click the time slider — should seek, not toggle play/pause
+    await player.seekTo(50);
+    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+  });
+});
+
+// --- React gestures (verify slider interaction isolation) ---
+
+test.describe('React Mouse Gestures', () => {
+  let player: PlayerPage;
+
+  test.beforeEach(async ({ page }) => {
+    player = new PlayerPage(page);
+    await page.goto('/pages/react-video-mp4.html');
+    await player.waitForMediaReady();
+  });
+
+  test('click center of container toggles play/pause', async ({ page }) => {
+    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
+
+    const { x, y } = await getCenter(player);
+    await page.mouse.click(x, y);
+    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+  });
+
+  test('click on button does not trigger container gesture', async () => {
+    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
+    await player.playButton.click();
+    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+  });
+
+  test('click on slider does not trigger container gesture', async ({ page }) => {
+    await player.play();
+    await page.waitForTimeout(500);
+
+    // Click the time slider — should seek, not toggle play/pause
+    await player.seekTo(50);
     await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
   });
 });

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -85,6 +85,7 @@ export const controlsFeature = definePlayerFeature({
       if (event.pointerType === 'touch' && Date.now() - pointerDownTime < TAP_THRESHOLD) {
         // When a toggleControls touch tap gesture is registered, it handles toggle — skip inline handler.
         const coordinator = findGestureCoordinator(container as HTMLElement);
+
         if (
           coordinator?.bindings.some(
             (b) => b.type === 'tap' && b.action === 'toggleControls' && (!b.pointer || b.pointer === 'touch')

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -215,6 +215,8 @@ export function createSlider(options: SliderOptions): SliderApi {
     },
 
     onPointerUp(event) {
+      if (options.isDisabled()) return;
+
       // The slider fully owns pointer interactions — prevent parent gesture
       // coordinators from misinterpreting slider taps as surface gestures.
       event.stopPropagation();

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -215,9 +215,11 @@ export function createSlider(options: SliderOptions): SliderApi {
     },
 
     onPointerUp(event) {
-      if (isNull(capturedPointerId)) return;
-
+      // The slider fully owns pointer interactions — prevent parent gesture
+      // coordinators from misinterpreting slider taps as surface gestures.
       event.stopPropagation();
+
+      if (isNull(capturedPointerId)) return;
 
       const percent = getPercentFromPointerEvent(event, cachedRect!, options.getOrientation(), cachedRTL);
 

--- a/packages/utils/src/dom/interactive.ts
+++ b/packages/utils/src/dom/interactive.ts
@@ -1,6 +1,7 @@
 import { resolveEventTarget } from './event';
 
-export const INTERACTIVE_SELECTOR = 'button,input,select,textarea,a[href],[role="slider"],[role="button"]';
+export const INTERACTIVE_SELECTOR =
+  'button,input,select,textarea,a[href],[role="slider"],[role="button"],[data-interactive]';
 
 const EDITABLE_INPUT_TYPES = ['text', 'search', 'url', 'tel', 'email', 'password', 'number'];
 


### PR DESCRIPTION
## Summary
- Move `stopPropagation()` before the early return guard in the slider's `onPointerUp` handler so pointer events always stop propagating to parent gesture coordinators, even when no pointer was captured
- Add `[data-interactive]` to `INTERACTIVE_SELECTOR` so any element can opt into gesture filtering via a data attribute — workaround for React's synthetic `stopPropagation` not blocking native events in time

## Test plan
- [x] Tap on slider in React player — should not trigger parent gesture (e.g., togglePaused)
- [x] Doubletap on slider regions — should not trigger seek/fullscreen gestures
- [x] Normal slider drag interaction still works
- [x] Tap on non-interactive areas still fires gestures correctly
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pointer-event propagation and gesture filtering around sliders, which can subtly affect click/tap behavior across players. Risk is moderate due to cross-cutting input/gesture handling, but the logic change is small and covered by new e2e tests.
> 
> **Overview**
> Prevents slider taps/clicks from leaking to parent gesture coordinators by ensuring the slider’s `onPointerUp` always calls `stopPropagation()` (even when no pointer capture occurred) and by bailing early when disabled.
> 
> Extends gesture-interactive filtering to allow any element to opt-in via `[data-interactive]`, and adds Playwright coverage (HTML and React players) asserting slider clicks seek without triggering container tap gestures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bb36bb6e0db0b9fe2f24d4c791f27689d6db58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->