### PR TITLE
chore(ci): exclude epic and priority labels from triage agent

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -60,6 +60,10 @@ jobs:
             - Review labels used on related/cross-referenced issues before deciding.
             - Add missing useful labels and remove clearly incorrect labels.
             - Do not create new labels; only use existing labels.
+            - Never apply these labels — they are managed manually:
+              - `epic` (epic linkage is curated by maintainers)
+              - Priority labels (`P0`, `P1`, `P2`)
+              Surface these as recommendations in step 8 instead.
             3. Detect probable duplicates:
             - Search for existing issues with the same bug/request symptoms, stack traces, repro steps, or scope.
             - If a likely duplicate is found, leave one concise comment linking the likely canonical issue and why it appears duplicated.


### PR DESCRIPTION
## Summary
- The issue-triage workflow's label step (step 2) was free to apply any existing label, so it sometimes auto-applied `epic` and priority labels (`P0`/`P1`/`P2`) that we curate by hand.
- Added a "never apply" list for those labels and pointed the agent at step 8 (recommendations-only) instead.

## Test plan
- [ ] Watch the next few auto-triaged issues land without `epic` or `P*` labels
- [ ] Confirm the agent still surfaces milestone/priority/epic *recommendations* as comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to a CI workflow; impacts labeling behavior but does not touch runtime code or sensitive data.
> 
> **Overview**
> Updates the `issue-triage` GitHub Actions prompt to **forbid auto-applying** manually curated labels (`epic` and priority `P0`/`P1`/`P2`) during the classification step.
> 
> The triage agent is instead instructed to surface epic/priority suggestions only as *planning recommendations* in step 8 (comment-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4761805e41cc6f06f224154fe46d382112175049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->