### PR TITLE
fix(element): coerce property setters to declared type

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -60,6 +60,10 @@ jobs:
             - Review labels used on related/cross-referenced issues before deciding.
             - Add missing useful labels and remove clearly incorrect labels.
             - Do not create new labels; only use existing labels.
+            - Never apply these labels — they are managed manually:
+              - `epic` (epic linkage is curated by maintainers)
+              - Priority labels (`P0`, `P1`, `P2`)
+              Surface these as recommendations in step 8 instead.
             3. Detect probable duplicates:
             - Search for existing issues with the same bug/request symptoms, stack traces, repro steps, or scope.
             - If a likely duplicate is found, leave one concise comment linking the likely canonical issue and why it appears duplicated.

--- a/packages/element/src/reactive-element.ts
+++ b/packages/element/src/reactive-element.ts
@@ -9,6 +9,22 @@ const cache = new WeakMap<typeof ReactiveElement, ResolvedMeta>();
 const propertyKeys = new Map<string, symbol>();
 
 /**
+ * Coerce a property value to match its declared `type`. Applied in the
+ * property setter so direct assignments (e.g. `el.seconds = "10"` from a
+ * framework that passes attributes as string properties) are normalized
+ * the same way attribute-to-property conversion already normalizes them.
+ *
+ * Null and undefined pass through so consumers can reset a property.
+ */
+function coerce(value: unknown, type: PropertyDeclaration['type']): unknown {
+  if (value == null) return value;
+  if (type === Number) return typeof value === 'number' ? value : Number(value);
+  if (type === Boolean) return typeof value === 'boolean' ? value : Boolean(value);
+  if (type === String) return typeof value === 'string' ? value : String(value);
+  return value;
+}
+
+/**
  * Lightweight reactive custom element base class.
  *
  * Drop-in subset of Lit's `ReactiveElement` — supports `static properties`,
@@ -181,13 +197,9 @@ export class ReactiveElement extends HTMLElement {
     const decl = props.get(propName);
     if (!decl) return;
 
-    let value: unknown = newValue;
-
-    if (decl.type === Boolean) {
-      value = newValue !== null;
-    } else if (decl.type === Number) {
-      value = newValue === null ? null : Number(newValue);
-    }
+    // Boolean attributes map presence (non-null) to `true`, absence (null) to
+    // `false`. Other types flow through the setter, which coerces them.
+    const value: unknown = decl.type === Boolean ? newValue !== null : newValue;
     (this as Record<string, unknown>)[propName] = value;
   }
 
@@ -383,15 +395,18 @@ function resolve(ctor: typeof ReactiveElement): ResolvedMeta {
         propertyKeys.set(name, key);
       }
 
+      const type = decl.type;
+
       Object.defineProperty(ctor.prototype, name, {
         get(this: ReactiveElement) {
           return (this as unknown as Record<symbol, unknown>)[key];
         },
         set(this: ReactiveElement, value: unknown) {
+          const coerced = coerce(value, type);
           const old = (this as unknown as Record<symbol, unknown>)[key];
-          (this as unknown as Record<symbol, unknown>)[key] = value;
+          (this as unknown as Record<symbol, unknown>)[key] = coerced;
 
-          if (!Object.is(old, value)) {
+          if (!Object.is(old, coerced)) {
             this.requestUpdate(name, old);
           }
         },

--- a/packages/element/src/tests/reactive-element.test.ts
+++ b/packages/element/src/tests/reactive-element.test.ts
@@ -142,6 +142,102 @@ describe('ReactiveElement properties', () => {
     expect(el.count).toBeNaN();
   });
 
+  it('coerces number property assignments to numbers', () => {
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        count: { type: Number },
+      };
+      count = 0;
+    }
+
+    const el = createElement(TestElement);
+
+    // Frameworks like Vue pass static custom-element prop values as strings.
+    // The setter coerces so downstream consumers see the declared type.
+    (el as unknown as { count: unknown }).count = '42';
+    expect(el.count).toBe(42);
+    expect(typeof el.count).toBe('number');
+
+    (el as unknown as { count: unknown }).count = '-10';
+    expect(el.count).toBe(-10);
+
+    (el as unknown as { count: unknown }).count = '3.14';
+    expect(el.count).toBe(3.14);
+  });
+
+  it('coerces boolean property assignments to booleans', () => {
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        disabled: { type: Boolean },
+      };
+      disabled = false;
+    }
+
+    const el = createElement(TestElement);
+
+    (el as unknown as { disabled: unknown }).disabled = 'true';
+    expect(el.disabled).toBe(true);
+
+    (el as unknown as { disabled: unknown }).disabled = '';
+    expect(el.disabled).toBe(false);
+
+    (el as unknown as { disabled: unknown }).disabled = 1;
+    expect(el.disabled).toBe(true);
+
+    (el as unknown as { disabled: unknown }).disabled = 0;
+    expect(el.disabled).toBe(false);
+  });
+
+  it('coerces string property assignments to strings', () => {
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        label: { type: String },
+      };
+      label = '';
+    }
+
+    const el = createElement(TestElement);
+
+    (el as unknown as { label: unknown }).label = 42;
+    expect(el.label).toBe('42');
+    expect(typeof el.label).toBe('string');
+  });
+
+  it('preserves null and undefined on typed property assignments', () => {
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        count: { type: Number },
+      };
+      count: number | null = 0;
+    }
+
+    const el = createElement(TestElement);
+
+    el.count = null;
+    expect(el.count).toBeNull();
+
+    (el as unknown as { count: unknown }).count = undefined;
+    expect(el.count).toBeUndefined();
+  });
+
+  it('attribute and property paths produce the same typed value', () => {
+    class TestElement extends ReactiveElement {
+      static override properties = {
+        count: { type: Number },
+      };
+      count = 0;
+    }
+
+    const a = createElement(TestElement);
+    const b = createElement(TestElement);
+
+    a.setAttribute('count', '-10');
+    (b as unknown as { count: unknown }).count = '-10';
+
+    expect(a.count).toBe(b.count);
+    expect(typeof a.count).toBe(typeof b.count);
+  });
+
   it('supports custom attribute names', () => {
     class TestElement extends ReactiveElement {
       static override properties = {


### PR DESCRIPTION
## Summary

`ReactiveElement` already coerces in `attributeChangedCallback` (Number/Boolean) but its property setter is a raw pass-through. When a framework like Vue assigns a custom-element prop as a string (`element.seconds = "-10"`), the string is stored as-is. Downstream consumers that perform arithmetic on the value get string concatenation:

```js
media.currentTime + this.#props.seconds // 60 + "-10" === "60-10" → NaN
```

This is the root cause of #1352 (ejected skin seek-buttons via Vue produce non-finite `currentTime` assignments and wildly wrong seek targets).

The fix: coerce in the property setter the same way the attribute path already does. `setAttribute('seconds', '-10')` and `el.seconds = '-10'` now produce the same typed value.

## Comparison with Lit

This is a deliberate **superset** of Lit's behavior. Lit's generated setter is pass-through; coercion only happens in `_$attributeToProperty` via `defaultConverter.fromAttribute` ([reactive-element.ts ~line 784, main branch](https://github.com/lit/lit/blob/main/packages/reactive-element/src/reactive-element.ts)).

We chose to coerce in the setter because:

- Property and attribute assignment paths now produce the same typed value (the semantic the `type:` declaration implies).
- Custom elements consumed from frameworks that pass props-as-strings (Vue, Solid SSR, etc.) work correctly without the consumer remembering to convert.
- Numeric/boolean coercion is cheap and short-circuits when the value is already the right type.

We don't reflect properties back to attributes today, so we don't need Lit's `__reflectingProperty` guard against setter↔attribute loops. Worth being aware of if reflection is added later.

## Behavior changes

| Before | After |
|---|---|
| `el.seconds = "-10"` → stored as `"-10"` | stored as `-10` |
| `el.disabled = "true"` → stored as `"true"` (truthy string) | stored as `true` |
| `el.seconds = null` | unchanged — null/undefined preserved |
| `el.seconds = 30` | unchanged — typeof short-circuits |

## Test plan

- [x] New regression tests in `packages/element/src/tests/reactive-element.test.ts` cover Number/Boolean/String setter coercion, null/undefined preservation, and attribute-vs-property parity.
- [x] All 47 element tests pass.
- [x] `pnpm test` passes across the workspace.
- [x] `pnpm typecheck` clean.
- [x] `pnpm check:workspace` clean.
- [x] End-to-end repro verified manually in Safari with the actual built `@videojs/html` package — seek buttons with string-prop assignment seek correctly by ±10s after the fix; throw `non-finite currentTime` before.

Closes #1352

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime semantics of `ReactiveElement` property setters by coercing assigned values based on declared types, which could affect downstream code that relied on uncoerced string/boolean-ish values. Scope is contained to typed reactive properties and is covered by new unit tests.
> 
> **Overview**
> `ReactiveElement` now coerces direct property assignments to the declared `type` (`Number`/`Boolean`/`String`), aligning setter behavior with the existing attribute-to-property conversion path and ensuring attribute vs property assignment produce the same typed values.
> 
> Adds targeted tests covering numeric/boolean/string coercion, preservation of `null`/`undefined`, and parity between attribute and property assignment. Separately updates the issue-triage workflow prompt to avoid auto-applying `epic` and priority labels, surfacing them as recommendations instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bda2e0b2f814719215cdaf4d1a1bbcbf2edaeba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->