### PR TITLE
feat(core): add HLS stream-type detection and live duration

### DIFF
--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -31,6 +31,12 @@ export const SOURCES = {
     type: 'hls',
     subType: 'mp4',
   },
+  'hls-live': {
+    label: 'HLS - Live Stream Big Buck Bunny',
+    url: 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8',
+    type: 'hls',
+    subType: 'mp4',
+  },
   'mp4-1': {
     label: 'MP4 - Dancing Dude',
     url: 'https://stream.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/highest.mp4',

--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -1,3 +1,5 @@
+import type { MediaFeatureAvailability, MediaStreamType } from './types';
+
 export interface MediaPlaybackState {
   /**
    * Whether playback is paused.
@@ -36,8 +38,6 @@ export interface MediaPlaybackState {
   /** Toggle play/pause. Returns `true` if playback started. */
   togglePaused(): boolean;
 }
-
-import type { MediaFeatureAvailability } from './types';
 
 export interface MediaVolumeState {
   /**
@@ -120,6 +120,19 @@ export interface MediaSourceState {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load
    */
   loadSource(src: string): string;
+}
+
+export interface MediaStreamTypeState {
+  /**
+   * Current stream delivery type.
+   *
+   * Components use this to toggle live-specific UI (e.g. a live indicator,
+   * a "jump to live edge" affordance, or hiding the time display).
+   *
+   * @see {@link MediaStreamTypes} for the canonical string values.
+   * @see https://github.com/video-dev/media-ui-extensions/blob/main/proposals/0010-stream-type.md
+   */
+  streamType: MediaStreamType;
 }
 
 export interface MediaBufferState {

--- a/packages/core/src/core/media/types.ts
+++ b/packages/core/src/core/media/types.ts
@@ -185,6 +185,32 @@ export interface MediaRemotePlaybackCapability {
   readonly remote: RemotePlaybackLike;
 }
 
+export interface MediaStreamTypeEvents {
+  streamtypechange: EventLike;
+}
+
+/**
+ * Canonical values for {@link MediaStreamType}.
+ *
+ * - `ON_DEMAND` — a finite-duration asset (VOD). Scrubbing is generally
+ *   supported across the full timeline.
+ * - `LIVE` — a live or DVR stream. The seekable window may slide as new
+ *   segments are published, and `duration` is typically `Infinity`.
+ * - `UNKNOWN` — the stream type has not been determined yet (no source,
+ *   or metadata has not loaded).
+ */
+export const MediaStreamTypes = {
+  ON_DEMAND: 'on-demand',
+  LIVE: 'live',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type MediaStreamType = (typeof MediaStreamTypes)[keyof typeof MediaStreamTypes];
+
+export interface MediaStreamTypeCapability {
+  readonly streamType: MediaStreamType;
+}
+
 interface MediaEvents extends MediaPlaybackEvents {}
 
 export interface Media extends MediaPlaybackCapability, EventTargetLike<MediaEvents> {

--- a/packages/core/src/dom/media/google-cast/types.ts
+++ b/packages/core/src/dom/media/google-cast/types.ts
@@ -1,4 +1,5 @@
 import type { RemotePlaybackLike } from '../../../core/media/types';
+import type { StreamType } from '../hls/index';
 import type { RemotePlayback } from './remote-playback';
 import type { CastOptions } from './utils';
 
@@ -35,7 +36,7 @@ export interface GoogleCastMediaHost extends EventTarget {
   readyState: number;
   volume: number;
   playbackRate: number;
-  streamType?: string;
+  streamType?: StreamType;
   textTracks: TextTrackList;
   disableRemotePlayback: boolean;
   load(): void | Promise<void>;

--- a/packages/core/src/dom/media/hls/hlsjs.ts
+++ b/packages/core/src/dom/media/hls/hlsjs.ts
@@ -4,6 +4,7 @@ import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsMediaErrorsMixin } from './errors';
 import { HlsJsMediaMetadataTracksMixin } from './metadata-tracks';
 import { HlsJsMediaPreloadMixin } from './preload';
+import { HlsJsMediaStreamTypeMixin } from './stream-type';
 import { HlsJsMediaTextTracksMixin } from './text-tracks';
 
 export const defaultHlsConfig: Partial<HlsConfig> = {
@@ -56,5 +57,7 @@ class HlsJsMediaBase extends HTMLVideoElementHost implements MediaEngineHost<Hls
 }
 
 export class HlsJsMedia extends HlsJsMediaPreloadMixin(
-  HlsJsMediaMetadataTracksMixin(HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase)))
+  HlsJsMediaStreamTypeMixin(
+    HlsJsMediaMetadataTracksMixin(HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase)))
+  )
 ) {}

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -212,13 +212,12 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   #engineDestroy() {
-    const prevStreamType = this.streamType;
     this.#delegate?.destroy();
     this.#delegate = null;
     this.#prevEngineProps = null;
     this.#loadRequested = null;
+    // Delegate teardown already emits `streamtypechange` (bridged); only sync cache.
     if (!this.#isUserStreamType) this.#streamType = StreamTypes.UNKNOWN;
-    if (prevStreamType !== this.streamType) this.dispatchEvent(new Event('streamtypechange'));
   }
 }
 

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -1,5 +1,6 @@
 import { shallowEqual } from '@videojs/utils/object';
 import Hls from 'hls.js';
+import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { bridgeEvents } from '../../../core/utils/bridge-events';
 import { NativeHlsMedia } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
@@ -11,7 +12,7 @@ export { Hls };
 
 export type PlaybackType = (typeof PlaybackTypes)[keyof typeof PlaybackTypes];
 export type SourceType = (typeof SourceTypes)[keyof typeof SourceTypes];
-export type StreamType = (typeof StreamTypes)[keyof typeof StreamTypes];
+export type StreamType = MediaStreamType;
 
 export const PlaybackTypes = {
   MSE: 'mse',
@@ -23,11 +24,7 @@ export const SourceTypes = {
   MP4: 'video/mp4',
 };
 
-export const StreamTypes = {
-  ON_DEMAND: 'on-demand',
-  LIVE: 'live',
-  UNKNOWN: 'unknown',
-} as const;
+export const StreamTypes = MediaStreamTypes;
 
 export interface HlsMediaProps {
   src: string;
@@ -46,7 +43,7 @@ export const hlsMediaDefaultProps: HlsMediaProps = {
   config: {},
   debug: false,
   preload: 'metadata',
-  streamType: 'unknown',
+  streamType: MediaStreamTypes.UNKNOWN,
 };
 
 export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -58,7 +58,6 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #debug = hlsMediaDefaultProps.debug;
   #preload = hlsMediaDefaultProps.preload;
   #streamType: StreamType = hlsMediaDefaultProps.streamType;
-  #streamTypeUserSet = false;
   #loadRequested?: Promise<void> | null;
   #prevEngineProps?: Record<string, any> | null;
 
@@ -135,8 +134,6 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   set streamType(value: StreamType) {
-    this.#streamTypeUserSet = value !== StreamTypes.UNKNOWN;
-
     if (this.#delegate) {
       this.#delegate.streamType = value;
       this.#streamType = this.#delegate.streamType;
@@ -184,10 +181,6 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       }
 
       this.#delegate.preload = this.preload;
-
-      if (this.#streamTypeUserSet && this.#streamType !== StreamTypes.UNKNOWN) {
-        this.#delegate.streamType = this.#streamType;
-      }
     }
 
     if (this.#delegate) {
@@ -216,10 +209,13 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   #engineDestroy() {
+    const hadStreamType = this.#streamType !== StreamTypes.UNKNOWN;
     this.#delegate?.destroy();
     this.#delegate = null;
     this.#prevEngineProps = null;
     this.#loadRequested = null;
+    this.#streamType = StreamTypes.UNKNOWN;
+    if (hadStreamType) this.dispatchEvent(new Event('streamtypechange'));
   }
 }
 

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -58,6 +58,7 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #debug = hlsMediaDefaultProps.debug;
   #preload = hlsMediaDefaultProps.preload;
   #streamType: StreamType = hlsMediaDefaultProps.streamType;
+  #isUserStreamType = false;
   #loadRequested?: Promise<void> | null;
   #prevEngineProps?: Record<string, any> | null;
 
@@ -134,6 +135,8 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   set streamType(value: StreamType) {
+    this.#isUserStreamType = value !== StreamTypes.UNKNOWN;
+
     if (this.#delegate) {
       this.#delegate.streamType = value;
       this.#streamType = this.#delegate.streamType;
@@ -181,6 +184,9 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       }
 
       this.#delegate.preload = this.preload;
+      if (this.#isUserStreamType) {
+        this.#delegate.streamType = this.#streamType;
+      }
     }
 
     if (this.#delegate) {
@@ -209,13 +215,13 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   #engineDestroy() {
-    const hadStreamType = this.#streamType !== StreamTypes.UNKNOWN;
+    const prevStreamType = this.streamType;
     this.#delegate?.destroy();
     this.#delegate = null;
     this.#prevEngineProps = null;
     this.#loadRequested = null;
-    this.#streamType = StreamTypes.UNKNOWN;
-    if (hadStreamType) this.dispatchEvent(new Event('streamtypechange'));
+    if (!this.#isUserStreamType) this.#streamType = StreamTypes.UNKNOWN;
+    if (prevStreamType !== this.streamType) this.dispatchEvent(new Event('streamtypechange'));
   }
 }
 

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -11,6 +11,7 @@ export { Hls };
 
 export type PlaybackType = (typeof PlaybackTypes)[keyof typeof PlaybackTypes];
 export type SourceType = (typeof SourceTypes)[keyof typeof SourceTypes];
+export type StreamType = (typeof StreamTypes)[keyof typeof StreamTypes];
 
 export const PlaybackTypes = {
   MSE: 'mse',
@@ -22,6 +23,12 @@ export const SourceTypes = {
   MP4: 'video/mp4',
 };
 
+export const StreamTypes = {
+  ON_DEMAND: 'on-demand',
+  LIVE: 'live',
+  UNKNOWN: 'unknown',
+} as const;
+
 export interface HlsMediaProps {
   src: string;
   type: SourceType | undefined;
@@ -29,6 +36,7 @@ export interface HlsMediaProps {
   config: Record<string, any>;
   debug: boolean;
   preload: PreloadType;
+  streamType: StreamType;
 }
 
 export const hlsMediaDefaultProps: HlsMediaProps = {
@@ -38,6 +46,7 @@ export const hlsMediaDefaultProps: HlsMediaProps = {
   config: {},
   debug: false,
   preload: 'metadata',
+  streamType: 'unknown',
 };
 
 export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
@@ -48,6 +57,8 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #config = { ...hlsMediaDefaultProps.config };
   #debug = hlsMediaDefaultProps.debug;
   #preload = hlsMediaDefaultProps.preload;
+  #streamType: StreamType = hlsMediaDefaultProps.streamType;
+  #streamTypeUserSet = false;
   #loadRequested?: Promise<void> | null;
   #prevEngineProps?: Record<string, any> | null;
 
@@ -106,6 +117,7 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
     this.#requestLoad();
   }
 
+  /** Preload type (`'none'` / `'metadata'` / `'auto'`). */
   get preload() {
     return this.#preload;
   }
@@ -115,6 +127,25 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
     if (this.#delegate) {
       this.#delegate.preload = value;
     }
+  }
+
+  /** Current stream type (`'on-demand'` / `'live'` / `'unknown'`). */
+  get streamType(): StreamType {
+    return this.#delegate?.streamType ?? this.#streamType;
+  }
+
+  set streamType(value: StreamType) {
+    this.#streamTypeUserSet = value !== StreamTypes.UNKNOWN;
+
+    if (this.#delegate) {
+      this.#delegate.streamType = value;
+      this.#streamType = this.#delegate.streamType;
+      return;
+    }
+
+    if (this.#streamType === value) return;
+    this.#streamType = value;
+    this.dispatchEvent(new Event('streamtypechange'));
   }
 
   attach(target: HTMLVideoElement) {
@@ -153,6 +184,10 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       }
 
       this.#delegate.preload = this.preload;
+
+      if (this.#streamTypeUserSet && this.#streamType !== StreamTypes.UNKNOWN) {
+        this.#delegate.streamType = this.#streamType;
+      }
     }
 
     if (this.#delegate) {

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -176,13 +176,16 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
       bridgeEvents(this.#delegate, this);
 
-      if (this.target) {
-        this.#delegate.attach(this.target);
+      // Apply user `streamType` before `attach()` so native delegates do not run
+      // synchronous duration-based detection first and emit a transient value.
+      if (this.#isUserStreamType) {
+        this.#delegate.streamType = this.#streamType;
       }
 
       this.#delegate.preload = this.preload;
-      if (this.#isUserStreamType) {
-        this.#delegate.streamType = this.#streamType;
+
+      if (this.target) {
+        this.#delegate.attach(this.target);
       }
     }
 

--- a/packages/core/src/dom/media/hls/stream-type.ts
+++ b/packages/core/src/dom/media/hls/stream-type.ts
@@ -4,20 +4,10 @@ import Hls from 'hls.js';
 import { type StreamType, StreamTypes } from './index';
 import type { HlsEngineHost } from './types';
 
-/**
- * Exposes a settable `streamType` (`'on-demand' | 'live' | 'unknown'`) on the
- * hls.js delegate. Auto-detects from `LEVEL_LOADED` (`details.live`) and
- * resets to `'unknown'` on `MANIFEST_LOADING` / `DESTROYING`.
- *
- * Setting `streamType` to a concrete value (`'live'` / `'on-demand'`) pins
- * the value and suppresses auto-detection; setting `'unknown'` clears the
- * override and re-enables detection. Dispatches `streamtypechange` on the
- * host when the value actually changes.
- */
 export function HlsJsMediaStreamTypeMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaStreamType extends (BaseClass as Constructor<HlsEngineHost>) {
     #streamType: StreamType = StreamTypes.UNKNOWN;
-    #userSet = false;
+    #isUserStreamType = false;
 
     constructor(...args: any[]) {
       super(...args);
@@ -35,17 +25,17 @@ export function HlsJsMediaStreamTypeMixin<Base extends Constructor<HlsEngineHost
 
     set streamType(value: StreamType) {
       if (value === StreamTypes.UNKNOWN) {
-        this.#userSet = false;
+        this.#isUserStreamType = false;
         this.#update(StreamTypes.UNKNOWN);
         return;
       }
 
-      this.#userSet = true;
+      this.#isUserStreamType = true;
       this.#update(value);
     }
 
     #setDetected(value: StreamType): void {
-      if (this.#userSet) return;
+      if (this.#isUserStreamType) return;
       this.#update(value);
     }
 

--- a/packages/core/src/dom/media/hls/stream-type.ts
+++ b/packages/core/src/dom/media/hls/stream-type.ts
@@ -1,32 +1,32 @@
 import type { Constructor } from '@videojs/utils/types';
 import type { LevelLoadedData } from 'hls.js';
 import Hls from 'hls.js';
-import { type StreamType, StreamTypes } from './index';
+import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import type { HlsEngineHost } from './types';
 
 export function HlsJsMediaStreamTypeMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaStreamType extends (BaseClass as Constructor<HlsEngineHost>) {
-    #streamType: StreamType = StreamTypes.UNKNOWN;
+    #streamType: MediaStreamType = MediaStreamTypes.UNKNOWN;
     #isUserStreamType = false;
 
     constructor(...args: any[]) {
       super(...args);
 
-      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#setDetected(StreamTypes.UNKNOWN));
-      this.engine?.on(Hls.Events.DESTROYING, () => this.#setDetected(StreamTypes.UNKNOWN));
+      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#setDetected(MediaStreamTypes.UNKNOWN));
+      this.engine?.on(Hls.Events.DESTROYING, () => this.#setDetected(MediaStreamTypes.UNKNOWN));
       this.engine?.on(Hls.Events.LEVEL_LOADED, (_event: string, data: LevelLoadedData) => {
-        this.#setDetected(data.details.live ? StreamTypes.LIVE : StreamTypes.ON_DEMAND);
+        this.#setDetected(data.details.live ? MediaStreamTypes.LIVE : MediaStreamTypes.ON_DEMAND);
       });
     }
 
-    get streamType(): StreamType {
+    get streamType(): MediaStreamType {
       return this.#streamType;
     }
 
-    set streamType(value: StreamType) {
-      if (value === StreamTypes.UNKNOWN) {
+    set streamType(value: MediaStreamType) {
+      if (value === MediaStreamTypes.UNKNOWN) {
         this.#isUserStreamType = false;
-        this.#update(StreamTypes.UNKNOWN);
+        this.#update(MediaStreamTypes.UNKNOWN);
         return;
       }
 
@@ -34,17 +34,17 @@ export function HlsJsMediaStreamTypeMixin<Base extends Constructor<HlsEngineHost
       this.#update(value);
     }
 
-    #setDetected(value: StreamType): void {
+    #setDetected(value: MediaStreamType): void {
       if (this.#isUserStreamType) return;
       this.#update(value);
     }
 
-    #update(value: StreamType): void {
+    #update(value: MediaStreamType): void {
       if (this.#streamType === value) return;
       this.#streamType = value;
       this.dispatchEvent(new Event('streamtypechange'));
     }
   }
 
-  return HlsJsMediaStreamType as unknown as Base & Constructor<{ streamType: StreamType }>;
+  return HlsJsMediaStreamType as unknown as Base & Constructor<{ streamType: MediaStreamType }>;
 }

--- a/packages/core/src/dom/media/hls/stream-type.ts
+++ b/packages/core/src/dom/media/hls/stream-type.ts
@@ -1,0 +1,60 @@
+import type { Constructor } from '@videojs/utils/types';
+import type { LevelLoadedData } from 'hls.js';
+import Hls from 'hls.js';
+import { type StreamType, StreamTypes } from './index';
+import type { HlsEngineHost } from './types';
+
+/**
+ * Exposes a settable `streamType` (`'on-demand' | 'live' | 'unknown'`) on the
+ * hls.js delegate. Auto-detects from `LEVEL_LOADED` (`details.live`) and
+ * resets to `'unknown'` on `MANIFEST_LOADING` / `DESTROYING`.
+ *
+ * Setting `streamType` to a concrete value (`'live'` / `'on-demand'`) pins
+ * the value and suppresses auto-detection; setting `'unknown'` clears the
+ * override and re-enables detection. Dispatches `streamtypechange` on the
+ * host when the value actually changes.
+ */
+export function HlsJsMediaStreamTypeMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
+  class HlsJsMediaStreamType extends (BaseClass as Constructor<HlsEngineHost>) {
+    #streamType: StreamType = StreamTypes.UNKNOWN;
+    #userSet = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#setDetected(StreamTypes.UNKNOWN));
+      this.engine?.on(Hls.Events.DESTROYING, () => this.#setDetected(StreamTypes.UNKNOWN));
+      this.engine?.on(Hls.Events.LEVEL_LOADED, (_event: string, data: LevelLoadedData) => {
+        this.#setDetected(data.details.live ? StreamTypes.LIVE : StreamTypes.ON_DEMAND);
+      });
+    }
+
+    get streamType(): StreamType {
+      return this.#streamType;
+    }
+
+    set streamType(value: StreamType) {
+      if (value === StreamTypes.UNKNOWN) {
+        this.#userSet = false;
+        this.#update(StreamTypes.UNKNOWN);
+        return;
+      }
+
+      this.#userSet = true;
+      this.#update(value);
+    }
+
+    #setDetected(value: StreamType): void {
+      if (this.#userSet) return;
+      this.#update(value);
+    }
+
+    #update(value: StreamType): void {
+      if (this.#streamType === value) return;
+      this.#streamType = value;
+      this.dispatchEvent(new Event('streamtypechange'));
+    }
+  }
+
+  return HlsJsMediaStreamType as unknown as Base & Constructor<{ streamType: StreamType }>;
+}

--- a/packages/core/src/dom/media/hls/tests/hls-media.test.ts
+++ b/packages/core/src/dom/media/hls/tests/hls-media.test.ts
@@ -169,6 +169,27 @@ describe('HlsMedia', () => {
       expect(handler).toHaveBeenCalledOnce();
     });
 
+    it('dispatches `streamtypechange` once per transition when the engine is recreated', () => {
+      const { media, video } = setup();
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      fireDurationChange(video, Infinity);
+      expect(media.streamType).toBe('live');
+
+      handler.mockClear();
+      // `debug` is part of `HlsMedia`'s engine props — toggling it recreates the
+      // native delegate without switching playback engines.
+      media.debug = true;
+      media.load();
+
+      // Teardown: a single `live` → `unknown`, then the new delegate re-detects
+      // `live` from the same element during `attach`.
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(media.streamType).toBe('live');
+    });
+
     it('lets user-set values win over auto-detection', () => {
       const { media, video } = setup();
 

--- a/packages/core/src/dom/media/hls/tests/hls-media.test.ts
+++ b/packages/core/src/dom/media/hls/tests/hls-media.test.ts
@@ -190,6 +190,26 @@ describe('HlsMedia', () => {
       expect(media.streamType).toBe('live');
     });
 
+    it('does not emit a transient auto-detected `streamType` before a user override when the native delegate is recreated', () => {
+      const { media, video } = setup();
+
+      Object.defineProperty(video, 'duration', { value: 120, configurable: true });
+      media.streamType = 'live';
+      expect(media.streamType).toBe('live');
+
+      const seen: string[] = [];
+      media.addEventListener('streamtypechange', () => {
+        seen.push(media.streamType);
+      });
+
+      // Recreates the native delegate; duration would otherwise sync-detect as `on-demand`.
+      media.debug = true;
+      media.load();
+
+      expect(seen).not.toContain('on-demand');
+      expect(media.streamType).toBe('live');
+    });
+
     it('lets user-set values win over auto-detection', () => {
       const { media, video } = setup();
 

--- a/packages/core/src/dom/media/hls/tests/hls-media.test.ts
+++ b/packages/core/src/dom/media/hls/tests/hls-media.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MediaError } from '../../../../core/media/media-error';
+import { NativeHlsMedia } from '../../native-hls';
 import { HlsMedia, SourceTypes } from '../index';
 
 afterEach(() => {
   document.body.innerHTML = '';
 });
+
+function fireDurationChange(video: HTMLVideoElement, duration: number) {
+  Object.defineProperty(video, 'duration', { value: duration, configurable: true });
+  video.dispatchEvent(new Event('durationchange'));
+}
 
 function fireNativeError(video: HTMLVideoElement, code: number, message = '') {
   Object.defineProperty(video, 'error', {
@@ -119,5 +125,136 @@ describe('HlsMedia', () => {
       media.volume = 0.5;
       expect(video.volume).toBe(0.5);
     });
+  });
+
+  describe('streamType', () => {
+    it('defaults to `unknown` before load', () => {
+      const media = new HlsMedia();
+      expect(media.streamType).toBe('unknown');
+    });
+
+    it('auto-detects `live` from a native delegate with infinite duration', () => {
+      const { media, video } = setup();
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      fireDurationChange(video, Infinity);
+
+      expect(media.streamType).toBe('live');
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('auto-detects `on-demand` from a native delegate with finite duration', () => {
+      const { media, video } = setup();
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      fireDurationChange(video, 120);
+
+      expect(media.streamType).toBe('on-demand');
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('dedupes `streamtypechange` when the detected value does not change', () => {
+      const { media, video } = setup();
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      fireDurationChange(video, 120);
+      fireDurationChange(video, 240);
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('lets user-set values win over auto-detection', () => {
+      const { media, video } = setup();
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      media.streamType = 'live';
+      expect(media.streamType).toBe('live');
+      expect(handler).toHaveBeenCalledOnce();
+
+      fireDurationChange(video, 120);
+      expect(media.streamType).toBe('live');
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('clears the user override when set back to `unknown`', () => {
+      const { media, video } = setup();
+
+      media.streamType = 'live';
+      fireDurationChange(video, 120);
+      expect(media.streamType).toBe('live');
+
+      media.streamType = 'unknown';
+
+      expect(media.streamType).toBe('on-demand');
+    });
+
+    it('dispatches `streamtypechange` when set before a delegate exists', () => {
+      const media = new HlsMedia();
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      media.streamType = 'live';
+
+      expect(media.streamType).toBe('live');
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('resets on engine recreation', () => {
+      const { media } = setup();
+
+      media.streamType = 'live';
+      expect(media.streamType).toBe('live');
+
+      media.preferPlayback = 'mse';
+      media.load();
+
+      expect(media.streamType).toBe('unknown');
+    });
+  });
+});
+
+describe('NativeHlsMedia streamType', () => {
+  function setupNative() {
+    const video = document.createElement('video');
+    document.body.appendChild(video);
+    const media = new NativeHlsMedia();
+    media.attach(video);
+    return { media, video };
+  }
+
+  it('defaults to `unknown`', () => {
+    const media = new NativeHlsMedia();
+    expect(media.streamType).toBe('unknown');
+  });
+
+  it('detects `live` and fires `streamtypechange`', () => {
+    const { media, video } = setupNative();
+
+    const handler = vi.fn();
+    media.addEventListener('streamtypechange', handler);
+
+    fireDurationChange(video, Infinity);
+
+    expect(media.streamType).toBe('live');
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('honors a user override and clears it on `unknown`', () => {
+    const { media, video } = setupNative();
+
+    media.streamType = 'live';
+    fireDurationChange(video, 120);
+    expect(media.streamType).toBe('live');
+
+    media.streamType = 'unknown';
+    expect(media.streamType).toBe('on-demand');
   });
 });

--- a/packages/core/src/dom/media/hls/tests/hls-media.test.ts
+++ b/packages/core/src/dom/media/hls/tests/hls-media.test.ts
@@ -207,11 +207,41 @@ describe('HlsMedia', () => {
       expect(handler).toHaveBeenCalledOnce();
     });
 
-    it('resets on engine recreation', () => {
+    it('preserves a user-set value across `load()` on the same engine', () => {
+      const { media, video } = setup();
+
+      media.streamType = 'live';
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      media.load();
+
+      expect(media.streamType).toBe('live');
+      expect(handler).not.toHaveBeenCalled();
+
+      fireDurationChange(video, 120);
+      expect(media.streamType).toBe('live');
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('preserves a user-set value across engine recreation', () => {
       const { media } = setup();
 
       media.streamType = 'live';
       expect(media.streamType).toBe('live');
+
+      media.preferPlayback = 'mse';
+      media.load();
+
+      expect(media.streamType).toBe('live');
+    });
+
+    it('stops preserving after the user override is cleared with `unknown`', () => {
+      const { media } = setup();
+
+      media.streamType = 'live';
+      media.streamType = 'unknown';
 
       media.preferPlayback = 'mse';
       media.load();

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -1,15 +1,12 @@
+import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { NativeHlsMediaErrorsMixin } from './errors';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
-export type StreamType = (typeof StreamTypes)[keyof typeof StreamTypes];
+export type StreamType = MediaStreamType;
 
-export const StreamTypes = {
-  ON_DEMAND: 'on-demand',
-  LIVE: 'live',
-  UNKNOWN: 'unknown',
-} as const;
+export const StreamTypes = MediaStreamTypes;
 
 export interface NativeHlsMediaProps {
   src: string;
@@ -20,7 +17,7 @@ export interface NativeHlsMediaProps {
 export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {
   src: '',
   preload: 'metadata',
-  streamType: 'unknown',
+  streamType: MediaStreamTypes.UNKNOWN,
 };
 
 class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsMediaProps, 'streamType'> {

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -1,19 +1,23 @@
+import type { StreamType } from '../hls/index';
 import { HTMLVideoElementHost } from '../video-host';
 import { NativeHlsMediaErrorsMixin } from './errors';
+import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
 
 export interface NativeHlsMediaProps {
   src: string;
   preload: PreloadType;
+  streamType: StreamType;
 }
 
 export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {
   src: '',
   preload: 'metadata',
+  streamType: 'unknown',
 };
 
-class NativeHlsMediaBase extends HTMLVideoElementHost implements NativeHlsMediaProps {
+class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsMediaProps, 'streamType'> {
   #src = nativeHlsMediaDefaultProps.src;
   #preload = nativeHlsMediaDefaultProps.preload;
 
@@ -54,4 +58,4 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements NativeHlsMediaP
   }
 }
 
-export class NativeHlsMedia extends NativeHlsMediaErrorsMixin(NativeHlsMediaBase) {}
+export class NativeHlsMedia extends NativeHlsMediaStreamTypeMixin(NativeHlsMediaErrorsMixin(NativeHlsMediaBase)) {}

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -1,9 +1,15 @@
-import type { StreamType } from '../hls/index';
 import { HTMLVideoElementHost } from '../video-host';
 import { NativeHlsMediaErrorsMixin } from './errors';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
+export type StreamType = (typeof StreamTypes)[keyof typeof StreamTypes];
+
+export const StreamTypes = {
+  ON_DEMAND: 'on-demand',
+  LIVE: 'live',
+  UNKNOWN: 'unknown',
+} as const;
 
 export interface NativeHlsMediaProps {
   src: string;

--- a/packages/core/src/dom/media/native-hls/stream-type.ts
+++ b/packages/core/src/dom/media/native-hls/stream-type.ts
@@ -1,0 +1,93 @@
+import type { Constructor } from '@videojs/utils/types';
+import { type StreamType, StreamTypes } from '../hls/index';
+import type { NativeMediaHost } from './errors';
+
+/**
+ * Exposes a settable `streamType` (`'on-demand' | 'live' | 'unknown'`) on the
+ * native HLS delegate. Auto-detects from the media element's `duration`:
+ * `Infinity` → `'live'`, finite positive → `'on-demand'`. Resets to
+ * `'unknown'` on `emptied` and on detach.
+ *
+ * Setting `streamType` to a concrete value (`'live'` / `'on-demand'`) pins
+ * the value and suppresses auto-detection; setting `'unknown'` clears the
+ * override and re-enables detection. Dispatches `streamtypechange` on the
+ * host when the value actually changes.
+ */
+export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMediaHost>>(BaseClass: Base) {
+  class NativeHlsMediaStreamType extends (BaseClass as Constructor<NativeMediaHost>) {
+    #streamType: StreamType = StreamTypes.UNKNOWN;
+    #userSet = false;
+    #disconnect: AbortController | null = null;
+
+    get streamType(): StreamType {
+      return this.#streamType;
+    }
+
+    set streamType(value: StreamType) {
+      if (value === StreamTypes.UNKNOWN) {
+        this.#userSet = false;
+        this.#setDetected(this.#detect());
+        return;
+      }
+
+      this.#userSet = true;
+      this.#update(value);
+    }
+
+    attach(target: EventTarget): void {
+      super.attach?.(target);
+      this.#init(target as HTMLMediaElement);
+    }
+
+    detach(): void {
+      this.#destroy();
+      this.#setDetected(StreamTypes.UNKNOWN);
+      super.detach?.();
+    }
+
+    destroy(): void {
+      this.#destroy();
+      super.destroy?.();
+    }
+
+    #destroy(): void {
+      this.#disconnect?.abort();
+      this.#disconnect = null;
+    }
+
+    #init(target: HTMLMediaElement): void {
+      this.#destroy();
+      this.#disconnect = new AbortController();
+      const { signal } = this.#disconnect;
+
+      const detect = () => this.#setDetected(this.#detect(target));
+
+      target.addEventListener('durationchange', detect, { signal });
+      target.addEventListener('loadedmetadata', detect, { signal });
+      target.addEventListener('emptied', () => this.#setDetected(StreamTypes.UNKNOWN), { signal });
+
+      detect();
+    }
+
+    #detect(target: HTMLMediaElement | null = this.target as HTMLMediaElement | null): StreamType {
+      if (!target) return StreamTypes.UNKNOWN;
+      const { duration } = target;
+      if (duration === Infinity) return StreamTypes.LIVE;
+      if (Number.isFinite(duration) && duration > 0) return StreamTypes.ON_DEMAND;
+      return StreamTypes.UNKNOWN;
+    }
+
+    #setDetected(value: StreamType): void {
+      if (this.#userSet) return;
+      this.#update(value);
+    }
+
+    #update(value: StreamType): void {
+      if (this.#streamType === value) return;
+      this.#streamType = value;
+      this.dispatchEvent(new Event('streamtypechange'));
+    }
+  }
+
+  return NativeHlsMediaStreamType as unknown as Base & Constructor<{ streamType: StreamType }>;
+}

--- a/packages/core/src/dom/media/native-hls/stream-type.ts
+++ b/packages/core/src/dom/media/native-hls/stream-type.ts
@@ -1,6 +1,6 @@
 import type { Constructor } from '@videojs/utils/types';
-import { type StreamType, StreamTypes } from '../hls/index';
 import type { NativeMediaHost } from './errors';
+import { type StreamType, StreamTypes } from './index';
 
 /**
  * Exposes a settable `streamType` (`'on-demand' | 'live' | 'unknown'`) on the

--- a/packages/core/src/dom/media/native-hls/stream-type.ts
+++ b/packages/core/src/dom/media/native-hls/stream-type.ts
@@ -1,19 +1,19 @@
 import type { Constructor } from '@videojs/utils/types';
+import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import type { NativeMediaHost } from './errors';
-import { type StreamType, StreamTypes } from './index';
 
 export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMediaHost>>(BaseClass: Base) {
   class NativeHlsMediaStreamType extends (BaseClass as Constructor<NativeMediaHost>) {
-    #streamType: StreamType = StreamTypes.UNKNOWN;
+    #streamType: MediaStreamType = MediaStreamTypes.UNKNOWN;
     #isUserStreamType = false;
     #disconnect: AbortController | null = null;
 
-    get streamType(): StreamType {
+    get streamType(): MediaStreamType {
       return this.#streamType;
     }
 
-    set streamType(value: StreamType) {
-      if (value === StreamTypes.UNKNOWN) {
+    set streamType(value: MediaStreamType) {
+      if (value === MediaStreamTypes.UNKNOWN) {
         this.#isUserStreamType = false;
         this.#setDetected(this.#detect());
         return;
@@ -30,7 +30,7 @@ export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMed
 
     detach(): void {
       this.#destroy();
-      this.#setDetected(StreamTypes.UNKNOWN);
+      this.#setDetected(MediaStreamTypes.UNKNOWN);
       super.detach?.();
     }
 
@@ -53,30 +53,30 @@ export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMed
 
       target.addEventListener('durationchange', detect, { signal });
       target.addEventListener('loadedmetadata', detect, { signal });
-      target.addEventListener('emptied', () => this.#setDetected(StreamTypes.UNKNOWN), { signal });
+      target.addEventListener('emptied', () => this.#setDetected(MediaStreamTypes.UNKNOWN), { signal });
 
       detect();
     }
 
-    #detect(target: HTMLMediaElement | null = this.target as HTMLMediaElement | null): StreamType {
-      if (!target) return StreamTypes.UNKNOWN;
+    #detect(target: HTMLMediaElement | null = this.target as HTMLMediaElement | null): MediaStreamType {
+      if (!target) return MediaStreamTypes.UNKNOWN;
       const { duration } = target;
-      if (duration === Infinity) return StreamTypes.LIVE;
-      if (Number.isFinite(duration) && duration > 0) return StreamTypes.ON_DEMAND;
-      return StreamTypes.UNKNOWN;
+      if (duration === Infinity) return MediaStreamTypes.LIVE;
+      if (Number.isFinite(duration) && duration > 0) return MediaStreamTypes.ON_DEMAND;
+      return MediaStreamTypes.UNKNOWN;
     }
 
-    #setDetected(value: StreamType): void {
+    #setDetected(value: MediaStreamType): void {
       if (this.#isUserStreamType) return;
       this.#update(value);
     }
 
-    #update(value: StreamType): void {
+    #update(value: MediaStreamType): void {
       if (this.#streamType === value) return;
       this.#streamType = value;
       this.dispatchEvent(new Event('streamtypechange'));
     }
   }
 
-  return NativeHlsMediaStreamType as unknown as Base & Constructor<{ streamType: StreamType }>;
+  return NativeHlsMediaStreamType as unknown as Base & Constructor<{ streamType: MediaStreamType }>;
 }

--- a/packages/core/src/dom/media/native-hls/stream-type.ts
+++ b/packages/core/src/dom/media/native-hls/stream-type.ts
@@ -2,21 +2,10 @@ import type { Constructor } from '@videojs/utils/types';
 import type { NativeMediaHost } from './errors';
 import { type StreamType, StreamTypes } from './index';
 
-/**
- * Exposes a settable `streamType` (`'on-demand' | 'live' | 'unknown'`) on the
- * native HLS delegate. Auto-detects from the media element's `duration`:
- * `Infinity` → `'live'`, finite positive → `'on-demand'`. Resets to
- * `'unknown'` on `emptied` and on detach.
- *
- * Setting `streamType` to a concrete value (`'live'` / `'on-demand'`) pins
- * the value and suppresses auto-detection; setting `'unknown'` clears the
- * override and re-enables detection. Dispatches `streamtypechange` on the
- * host when the value actually changes.
- */
 export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMediaHost>>(BaseClass: Base) {
   class NativeHlsMediaStreamType extends (BaseClass as Constructor<NativeMediaHost>) {
     #streamType: StreamType = StreamTypes.UNKNOWN;
-    #userSet = false;
+    #isUserStreamType = false;
     #disconnect: AbortController | null = null;
 
     get streamType(): StreamType {
@@ -25,12 +14,12 @@ export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMed
 
     set streamType(value: StreamType) {
       if (value === StreamTypes.UNKNOWN) {
-        this.#userSet = false;
+        this.#isUserStreamType = false;
         this.#setDetected(this.#detect());
         return;
       }
 
-      this.#userSet = true;
+      this.#isUserStreamType = true;
       this.#update(value);
     }
 
@@ -78,7 +67,7 @@ export function NativeHlsMediaStreamTypeMixin<Base extends Constructor<NativeMed
     }
 
     #setDetected(value: StreamType): void {
-      if (this.#userSet) return;
+      if (this.#isUserStreamType) return;
       this.#update(value);
     }
 

--- a/packages/core/src/dom/media/predicate.ts
+++ b/packages/core/src/dom/media/predicate.ts
@@ -8,6 +8,7 @@ import type {
   MediaRemotePlaybackCapability,
   MediaSeekCapability,
   MediaSourceCapability,
+  MediaStreamTypeCapability,
   MediaTextTrackCapability,
   MediaVolumeCapability,
 } from '../../core/media/types';
@@ -58,6 +59,10 @@ export function isMediaTextTrackCapable(value: unknown): value is MediaTextTrack
 
 export function isMediaRemotePlaybackCapable(value: unknown): value is MediaRemotePlaybackCapability {
   return isObject(value) && 'remote' in value && isObject((value as Record<string, unknown>).remote);
+}
+
+export function isMediaStreamTypeCapable(value: unknown): value is MediaStreamTypeCapability {
+  return isObject(value) && 'streamType' in value;
 }
 
 export function isQuerySelectorAllCapable<T extends string>(

--- a/packages/core/src/dom/media/types.ts
+++ b/packages/core/src/dom/media/types.ts
@@ -9,6 +9,7 @@ import type {
   MediaPlaybackState,
   MediaRemotePlaybackState,
   MediaSourceState,
+  MediaStreamTypeState,
   MediaTextTrackState,
   MediaTimeState,
   MediaVolumeState,
@@ -44,6 +45,7 @@ export type VideoFeatures = [
   PlayerFeature<MediaVolumeState>,
   PlayerFeature<MediaTimeState>,
   PlayerFeature<MediaSourceState>,
+  PlayerFeature<MediaStreamTypeState>,
   PlayerFeature<MediaBufferState>,
   PlayerFeature<MediaFullscreenState>,
   PlayerFeature<MediaPictureInPictureState>,
@@ -59,6 +61,7 @@ export type AudioFeatures = [
   PlayerFeature<MediaVolumeState>,
   PlayerFeature<MediaTimeState>,
   PlayerFeature<MediaSourceState>,
+  PlayerFeature<MediaStreamTypeState>,
   PlayerFeature<MediaBufferState>,
   PlayerFeature<MediaErrorState>,
 ];
@@ -66,8 +69,25 @@ export type AudioFeatures = [
 // TODO: Define background video features (e.g., playback, source, buffer)
 export type BackgroundFeatures = [];
 
+/**
+ * Features for a live video player. Structurally identical to
+ * {@link VideoFeatures} — the "live" presets share the same store but ship a
+ * skin that omits duration-oriented UI.
+ */
+export type LiveVideoFeatures = VideoFeatures;
+
+/**
+ * Features for a live audio player. Structurally identical to
+ * {@link AudioFeatures}.
+ */
+export type LiveAudioFeatures = AudioFeatures;
+
 export type VideoPlayerStore = PlayerStore<VideoFeatures>;
 
 export type AudioPlayerStore = PlayerStore<AudioFeatures>;
 
 export type BackgroundPlayerStore = PlayerStore<BackgroundFeatures>;
+
+export type LiveVideoPlayerStore = PlayerStore<LiveVideoFeatures>;
+
+export type LiveAudioPlayerStore = PlayerStore<LiveAudioFeatures>;

--- a/packages/core/src/dom/store/features/feature.parts.ts
+++ b/packages/core/src/dom/store/features/feature.parts.ts
@@ -6,6 +6,7 @@ import { playbackFeature } from './playback';
 import { playbackRateFeature } from './playback-rate';
 import { remotePlaybackFeature } from './remote-playback';
 import { sourceFeature } from './source';
+import { streamTypeFeature } from './stream-type';
 import { textTrackFeature } from './text-track';
 import { timeFeature } from './time';
 import { volumeFeature } from './volume';
@@ -22,6 +23,7 @@ export {
   playbackRateFeature as playbackRate,
   remotePlaybackFeature as remotePlayback,
   sourceFeature as source,
+  streamTypeFeature as streamType,
   textTrackFeature as textTrack,
   timeFeature as time,
   volumeFeature as volume,

--- a/packages/core/src/dom/store/features/index.ts
+++ b/packages/core/src/dom/store/features/index.ts
@@ -9,6 +9,7 @@ export * from './playback-rate';
 export * from './presets';
 export * from './remote-playback';
 export * from './source';
+export * from './stream-type';
 export * from './text-track';
 export * from './time';
 export * from './volume';

--- a/packages/core/src/dom/store/features/presets.ts
+++ b/packages/core/src/dom/store/features/presets.ts
@@ -8,6 +8,7 @@ import { playbackFeature } from './playback';
 import { playbackRateFeature } from './playback-rate';
 import { remotePlaybackFeature } from './remote-playback';
 import { sourceFeature } from './source';
+import { streamTypeFeature } from './stream-type';
 import { textTrackFeature } from './text-track';
 import { timeFeature } from './time';
 import { volumeFeature } from './volume';
@@ -18,6 +19,7 @@ export const videoFeatures: VideoFeatures = [
   volumeFeature,
   timeFeature,
   sourceFeature,
+  streamTypeFeature,
   bufferFeature,
   fullscreenFeature,
   pipFeature,
@@ -33,6 +35,7 @@ export const audioFeatures: AudioFeatures = [
   volumeFeature,
   timeFeature,
   sourceFeature,
+  streamTypeFeature,
   bufferFeature,
   errorFeature,
 ];

--- a/packages/core/src/dom/store/features/stream-type.ts
+++ b/packages/core/src/dom/store/features/stream-type.ts
@@ -1,0 +1,50 @@
+import { listen } from '@videojs/utils/dom';
+
+import type { MediaStreamTypeState } from '../../../core/media/state';
+import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
+import { definePlayerFeature } from '../../feature';
+import { isMediaBufferCapable, isMediaSeekCapable, isMediaStreamTypeCapable } from '../../media/predicate';
+
+export const streamTypeFeature = definePlayerFeature({
+  name: 'streamType',
+  state: (): MediaStreamTypeState => ({
+    streamType: MediaStreamTypes.UNKNOWN,
+  }),
+
+  // Prefer the media's own `streamType` (e.g. `HlsMedia`, which derives it from
+  // manifest metadata and dispatches `streamtypechange`).  For plain elements
+  // without that capability, fall back to duration-based detection so the
+  // store still reports `live`/`on-demand` for native MP4 / native HLS.
+  attach({ target, signal, set }) {
+    const { media } = target;
+
+    if (isMediaStreamTypeCapable(media)) {
+      const sync = () => set({ streamType: media.streamType });
+      sync();
+      listen(media, 'streamtypechange', sync, { signal });
+      return;
+    }
+
+    if (!isMediaSeekCapable(media)) return;
+
+    const detect = (): MediaStreamType => {
+      const { duration } = media;
+      if (duration === Number.POSITIVE_INFINITY) return MediaStreamTypes.LIVE;
+      if (Number.isFinite(duration) && duration > 0) return MediaStreamTypes.ON_DEMAND;
+      return MediaStreamTypes.UNKNOWN;
+    };
+
+    const sync = () => set({ streamType: detect() });
+
+    sync();
+
+    listen(media, 'durationchange', sync, { signal });
+    listen(media, 'loadedmetadata', sync, { signal });
+    listen(media, 'emptied', sync, { signal });
+    // `progress` widens the seekable window for DVR streams — treat it as a
+    // hint that the duration may now be usable.
+    if (isMediaBufferCapable(media)) {
+      listen(media, 'progress', sync, { signal });
+    }
+  },
+});

--- a/packages/core/src/dom/store/features/tests/stream-type.test.ts
+++ b/packages/core/src/dom/store/features/tests/stream-type.test.ts
@@ -1,0 +1,112 @@
+import { createStore } from '@videojs/store';
+import { describe, expect, it } from 'vitest';
+import { type MediaStreamType, MediaStreamTypes } from '../../../../core/media/types';
+import type { PlayerTarget } from '../../../media/types';
+import { createMockVideo } from '../../../tests/test-helpers';
+import { streamTypeFeature } from '../stream-type';
+
+describe('streamTypeFeature', () => {
+  describe('fallback (no `streamType` property on media)', () => {
+    it('defaults to `unknown` when duration is not known', () => {
+      const video = createMockVideo({ duration: Number.NaN });
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.UNKNOWN);
+    });
+
+    it('detects `live` from infinite duration', () => {
+      const video = createMockVideo({ duration: Number.POSITIVE_INFINITY });
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.LIVE);
+    });
+
+    it('detects `on-demand` from a finite duration', () => {
+      const video = createMockVideo({ duration: 120 });
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+    });
+
+    it('updates on `durationchange`', () => {
+      const video = createMockVideo({ duration: Number.NaN });
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.UNKNOWN);
+
+      Object.defineProperty(video, 'duration', { value: 120, configurable: true });
+      video.dispatchEvent(new Event('durationchange'));
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+    });
+
+    it('resets to `unknown` on `emptied`', () => {
+      const video = createMockVideo({ duration: 120 });
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+
+      Object.defineProperty(video, 'duration', { value: Number.NaN, configurable: true });
+      video.dispatchEvent(new Event('emptied'));
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.UNKNOWN);
+    });
+  });
+
+  describe('native (media exposes `streamType`)', () => {
+    it('reads `streamType` directly when available', () => {
+      const media = new EventTarget() as EventTarget & { streamType: MediaStreamType };
+      media.streamType = MediaStreamTypes.LIVE;
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      // The store target accepts any `Media`-shaped object; cast for the test.
+      store.attach({ media: media as unknown as PlayerTarget['media'], container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.LIVE);
+    });
+
+    it('syncs on `streamtypechange`', () => {
+      const media = new EventTarget() as EventTarget & { streamType: MediaStreamType };
+      media.streamType = MediaStreamTypes.UNKNOWN;
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: media as unknown as PlayerTarget['media'], container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.UNKNOWN);
+
+      media.streamType = MediaStreamTypes.LIVE;
+      media.dispatchEvent(new Event('streamtypechange'));
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.LIVE);
+
+      media.streamType = MediaStreamTypes.ON_DEMAND;
+      media.dispatchEvent(new Event('streamtypechange'));
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+    });
+
+    it('prefers native `streamType` over duration-based fallback', () => {
+      // Build an object that has both a finite duration and a user-asserted
+      // `streamType` — the feature should trust the explicit stream type.
+      const media = Object.assign(new EventTarget(), {
+        duration: 120,
+        streamType: MediaStreamTypes.LIVE,
+      });
+
+      const store = createStore<PlayerTarget>()(streamTypeFeature);
+      store.attach({ media: media as unknown as PlayerTarget['media'], container: null });
+
+      expect(store.state.streamType).toBe(MediaStreamTypes.LIVE);
+    });
+  });
+});

--- a/packages/core/src/dom/store/features/tests/time.test.ts
+++ b/packages/core/src/dom/store/features/tests/time.test.ts
@@ -283,6 +283,29 @@ describe('timeFeature', () => {
         expect(store.state.seeking).toBe(true);
       });
 
+      it('progress during seek does not overwrite optimistic currentTime', () => {
+        const video = createMockVideo({
+          currentTime: 10,
+          duration: 120,
+          readyState: HTMLMediaElement.HAVE_METADATA,
+        });
+
+        const store = createStore<PlayerTarget>()(timeFeature);
+        store.attach({ media: video, container: null });
+
+        store.seek(60);
+        expect(store.state.currentTime).toBe(60);
+        expect(store.state.seeking).toBe(true);
+
+        // Browser fires progress (buffering at the seek target) with a stale
+        // currentTime still reflecting the pre-seek position.
+        video.currentTime = 12;
+        video.dispatchEvent(new Event('progress'));
+
+        expect(store.state.currentTime).toBe(60);
+        expect(store.state.seeking).toBe(true);
+      });
+
       it('timeupdate resumes syncing after seeked', async () => {
         const video = createMockVideo({
           currentTime: 10,

--- a/packages/core/src/dom/store/features/tests/time.test.ts
+++ b/packages/core/src/dom/store/features/tests/time.test.ts
@@ -1,7 +1,7 @@
 import { createStore } from '@videojs/store';
 import { describe, expect, it } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { createMockVideo, createTimeRanges } from '../../../tests/test-helpers';
 import { timeFeature } from '../time';
 
 describe('timeFeature', () => {
@@ -72,6 +72,66 @@ describe('timeFeature', () => {
       video.dispatchEvent(new Event('seeked'));
 
       expect(store.state.currentTime).toBe(50);
+    });
+
+    it('uses seekable end as duration for live streams (Infinity)', () => {
+      const video = createMockVideo({
+        currentTime: 0,
+        duration: Number.POSITIVE_INFINITY,
+        seekable: createTimeRanges([[0, 300]]),
+      });
+
+      const store = createStore<PlayerTarget>()(timeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.duration).toBe(300);
+    });
+
+    it('returns 0 duration for live streams with no seekable range', () => {
+      const video = createMockVideo({
+        duration: Number.POSITIVE_INFINITY,
+        seekable: createTimeRanges([]),
+      });
+
+      const store = createStore<PlayerTarget>()(timeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.duration).toBe(0);
+    });
+
+    it('updates live duration as seekable range grows on progress', () => {
+      const video = createMockVideo({
+        duration: Number.POSITIVE_INFINITY,
+        seekable: createTimeRanges([[0, 300]]),
+      });
+
+      const store = createStore<PlayerTarget>()(timeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.duration).toBe(300);
+
+      Object.defineProperty(video, 'seekable', {
+        value: createTimeRanges([[10, 320]]),
+        configurable: true,
+      });
+      video.dispatchEvent(new Event('progress'));
+
+      expect(store.state.duration).toBe(320);
+    });
+
+    it('uses end of last seekable range when multiple ranges exist', () => {
+      const video = createMockVideo({
+        duration: Number.POSITIVE_INFINITY,
+        seekable: createTimeRanges([
+          [0, 100],
+          [150, 300],
+        ]),
+      });
+
+      const store = createStore<PlayerTarget>()(timeFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.duration).toBe(300);
     });
 
     it('updates on emptied event', () => {

--- a/packages/core/src/dom/store/features/time.ts
+++ b/packages/core/src/dom/store/features/time.ts
@@ -2,7 +2,7 @@ import { listen, onEvent } from '@videojs/utils/dom';
 import { noop } from '@videojs/utils/function';
 import type { MediaTimeState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
-import { hasMetadata, isMediaSeekCapable, isMediaSourceCapable } from '../../media/predicate';
+import { hasMetadata, isMediaBufferCapable, isMediaSeekCapable, isMediaSourceCapable } from '../../media/predicate';
 import { signalKeys } from '../signal-keys';
 
 export const timeFeature = definePlayerFeature({
@@ -38,10 +38,22 @@ export const timeFeature = definePlayerFeature({
 
     if (!isMediaSeekCapable(media)) return;
 
+    // For live streams `media.duration` is `Infinity` — fall back to the end
+    // of the last seekable range, which represents the live edge and tracks
+    // the sliding DVR window as new segments become available.
+    const resolveDuration = () => {
+      const { duration } = media;
+      if (duration === Number.POSITIVE_INFINITY && isMediaBufferCapable(media)) {
+        const { seekable } = media;
+        return seekable.length > 0 ? seekable.end(seekable.length - 1) : 0;
+      }
+      return Number.isFinite(duration) ? duration : 0;
+    };
+
     const sync = () =>
       set({
         currentTime: media.currentTime,
-        duration: Number.isFinite(media.duration) ? media.duration : 0,
+        duration: resolveDuration(),
         seeking: media.seeking,
       });
 
@@ -63,5 +75,8 @@ export const timeFeature = definePlayerFeature({
     listen(media, 'seeked', sync, { signal });
     listen(media, 'loadedmetadata', sync, { signal });
     listen(media, 'emptied', sync, { signal });
+    // `progress` fires as the seekable range grows, so the live-edge duration
+    // tracks the DVR window without requiring a separate durationchange event.
+    listen(media, 'progress', sync, { signal });
   },
 });

--- a/packages/core/src/dom/store/features/time.ts
+++ b/packages/core/src/dom/store/features/time.ts
@@ -58,18 +58,19 @@ export const timeFeature = definePlayerFeature({
       });
 
     // While a seek is in-flight the store holds an optimistic `currentTime`
-    // that reflects the user's target position.  Browser `timeupdate` events
-    // during seeking carry an unreliable intermediate value that would snap
-    // the time-slider back to the old position, so skip `currentTime` sync
-    // from `timeupdate` while the store indicates an active seek.
-    const onTimeUpdate = () => {
+    // that reflects the user's target position.  Browser `timeupdate` and
+    // `progress` events during seeking carry an unreliable intermediate
+    // `currentTime` that would snap the time-slider back to the old
+    // position, so skip sync from those events while the store indicates an
+    // active seek.
+    const syncUnlessSeeking = () => {
       if (get().seeking) return;
       sync();
     };
 
     sync();
 
-    listen(media, 'timeupdate', onTimeUpdate, { signal });
+    listen(media, 'timeupdate', syncUnlessSeeking, { signal });
     listen(media, 'durationchange', sync, { signal });
     listen(media, 'seeking', sync, { signal });
     listen(media, 'seeked', sync, { signal });
@@ -77,6 +78,6 @@ export const timeFeature = definePlayerFeature({
     listen(media, 'emptied', sync, { signal });
     // `progress` fires as the seekable range grows, so the live-edge duration
     // tracks the DVR window without requiring a separate durationchange event.
-    listen(media, 'progress', sync, { signal });
+    listen(media, 'progress', syncUnlessSeeking, { signal });
   },
 });

--- a/packages/core/src/dom/store/selectors.ts
+++ b/packages/core/src/dom/store/selectors.ts
@@ -9,6 +9,7 @@ import { playbackFeature } from './features/playback';
 import { playbackRateFeature } from './features/playback-rate';
 import { remotePlaybackFeature } from './features/remote-playback';
 import { sourceFeature } from './features/source';
+import { streamTypeFeature } from './features/stream-type';
 import { textTrackFeature } from './features/text-track';
 import { timeFeature } from './features/time';
 import { volumeFeature } from './features/volume';
@@ -31,6 +32,8 @@ export const selectPlaybackRate = createSelector(playbackRateFeature);
 export const selectRemotePlayback = createSelector(remotePlaybackFeature);
 /** Select the source state (src, type). */
 export const selectSource = createSelector(sourceFeature);
+/** Select the stream type state (`'on-demand' | 'live' | 'unknown'`). */
+export const selectStreamType = createSelector(streamTypeFeature);
 /** Select the text track state (chapters cues, thumbnail cues). */
 export const selectTextTrack = createSelector(textTrackFeature);
 /** Select the time state (currentTime, duration, seek). */

--- a/site/src/content/docs/reference/feature-stream-type.mdx
+++ b/site/src/content/docs/reference/feature-stream-type.mdx
@@ -1,0 +1,50 @@
+---
+title: Stream type
+description: Stream delivery type (live / on-demand) state for the player store
+---
+
+import FeatureReference from "@/components/docs/api-reference/FeatureReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+
+Tracks the current stream delivery type so components can toggle live-specific UI (a live indicator, "jump to live edge" affordance, hiding the time display, etc.).
+
+When the media exposes its own `streamType` (e.g. HLS sources derive it from the manifest), the feature syncs on `streamtypechange`. For plain media elements without that capability, it falls back to duration-based detection: an infinite `duration` reports `'live'`, a finite positive `duration` reports `'on-demand'`, and anything else reports `'unknown'`.
+
+<FeatureReference feature="streamType" />
+
+### Selector
+
+<FrameworkCase frameworks={["react"]}>
+Pass `selectStreamType` to <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> to subscribe to stream type state. Returns `undefined` if the stream type feature is not configured.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Pass `selectStreamType` to <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> to subscribe to stream type state. Returns `undefined` if the stream type feature is not configured.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="LiveIndicator.tsx"
+import { selectStreamType, usePlayer } from '@videojs/react';
+
+function LiveIndicator() {
+  const stream = usePlayer(selectStreamType);
+  if (stream?.streamType !== 'live') return null;
+
+  return <span className="live-indicator">LIVE</span>;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="live-indicator.ts"
+import { createPlayer, MediaElement, selectStreamType } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const { PlayerController, context } = createPlayer({ features: videoFeatures });
+
+class LiveIndicator extends MediaElement {
+  readonly #stream = new PlayerController(this, context, selectStreamType);
+}
+```
+</FrameworkCase>

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -132,6 +132,7 @@ export const sidebar: Sidebar = [
       { slug: 'reference/feature-playback-rate' },
       { slug: 'reference/feature-remote-playback' },
       { slug: 'reference/feature-source' },
+      { slug: 'reference/feature-stream-type' },
       { slug: 'reference/feature-text-tracks' },
       { slug: 'reference/feature-time' },
       { slug: 'reference/feature-volume' },


### PR DESCRIPTION
Refs #1040
fix #1389 

## Summary

First building blocks for live streaming support: detect HLS stream type (on-demand, live, DVR) on both hls.js and native engines, and resolve duration from the seekable window when `media.duration` is `Infinity`.

## Changes

- `streamType` exposed on HLS media (hls.js + native-hls) — derived from manifest targetDuration and live flag
- Time feature falls back to the end of the last seekable range when duration is `Infinity`, so the time-slider and time displays get a meaningful live duration
- Listens on `progress` so the live-edge duration tracks the sliding DVR window as segments are appended
- Sandbox gains a live HLS source for manual verification

## Testing

Covered by new unit tests in `hls-media.test.ts` and additional live-duration cases in `time.test.ts`. Manual verification via the live source in the sandbox app.

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core media/store state and HLS engine wrappers, which can affect time display/seek UI and event behavior across players, but changes are additive and covered by new unit tests.
> 
> **Overview**
> Adds first-class `streamType` support (`'on-demand' | 'live' | 'unknown'`) across core media types/state, HLS engines, and the player store so UIs can react to live vs VOD.
> 
> `HlsMedia`/`NativeHlsMedia`/`HlsJsMedia` now expose `streamType` with a `streamtypechange` event, including auto-detection (native via duration, hls.js via manifest `LEVEL_LOADED`) plus user override semantics that persist across loads/engine recreation.
> 
> Improves `timeFeature` to treat `duration === Infinity` as live by deriving a meaningful duration from the end of the last `seekable` range and updating it on `progress`, while avoiding overwriting optimistic seek state during `timeupdate`/`progress`.
> 
> Wires the new `streamTypeFeature` into default audio/video presets and selectors (`selectStreamType`), adds tests and docs, and includes a live HLS source in the sandbox for manual verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f2b9830d34f4cfca1b503122945fb7f907d8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->