### PR TITLE
fix(site): only report Sentry errors from deployed function runtime

### DIFF
--- a/site/sentry.server.config.ts
+++ b/site/sentry.server.config.ts
@@ -1,9 +1,21 @@
+import process from 'node:process';
+
 import * as Sentry from '@sentry/astro';
+
+// Only the deployed Netlify Function runtime sets AWS_LAMBDA_FUNCTION_NAME;
+// it's absent during `astro build`. Gating on it keeps errors from pre-render
+// (e.g. a broken PR) out of Sentry — we only want live request failures.
+const isLambdaRuntime = Boolean(process.env.AWS_LAMBDA_FUNCTION_NAME);
+
+// Alert for production (videojs.org) and branch-deploy (next.videojs.org) only.
+// Deploy-preview errors are the PR author's to triage before merge.
+const context = import.meta.env.CONTEXT;
+const isAlertingContext = context === 'production' || context === 'branch-deploy';
 
 Sentry.init({
   dsn: 'https://6bcdfa6b82da6dd4d7753618a9a69c7c@o43841.ingest.us.sentry.io/4510671167160320',
-  environment: import.meta.env.CONTEXT || 'development',
-  enabled: import.meta.env.PROD,
+  environment: context || 'development',
+  enabled: import.meta.env.PROD && isLambdaRuntime && isAlertingContext,
   release: import.meta.env.COMMIT_REF || import.meta.env.DEPLOY_ID || undefined,
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/astro/configuration/options/#sendDefaultPii


### PR DESCRIPTION
## Summary

`Sentry.init` was gated only on `import.meta.env.PROD`, which is `true` during `astro build`. That meant an error thrown while pre-rendering a page (e.g. a broken PR build on Netlify) could ship to Sentry as if it were a real production bug.

This tightens the gate in `site/sentry.server.config.ts`:

- **Runtime-only**: add `AWS_LAMBDA_FUNCTION_NAME` check. That var is set by Netlify Functions at request time and absent during the build container, so pre-render failures no longer fire.
- **Environment scoped**: only `CONTEXT === 'production'` (videojs.org) and `CONTEXT === 'branch-deploy'` (next.videojs.org) enable Sentry. `deploy-preview` errors stay with the PR author.

No changes to DSN, release tagging, or `sendDefaultPii`. No client/edge config is added — this is the only Sentry config file in the repo.

## Behavior matrix

| Context            | Build phase | Runtime phase |
| ------------------ | ----------- | ------------- |
| `pnpm dev`         | off         | off           |
| PR build / preview | off         | off           |
| `branch-deploy`    | off         | **on**        |
| `production`       | off         | **on**        |

## Test plan

- [ ] Verify `pnpm build` in `site/` completes without sending any events to Sentry (no `SENTRY_AUTH_TOKEN` locally = integration skipped entirely; with token, Sentry init still short-circuits via `isLambdaRuntime=false`).
- [ ] On next `branch-deploy` (main → next.videojs.org), confirm a thrown error in a route handler appears in Sentry with `environment: branch-deploy`.
- [ ] On a deploy-preview, confirm a thrown runtime error does **not** appear in Sentry.
- [ ] Confirm a forced build failure on a PR does not generate a Sentry issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: this changes when Sentry is enabled, and mis-detected Netlify env/context values could suppress production error reporting.
> 
> **Overview**
> Sentry server reporting is now **gated to live Netlify Function requests** by requiring `AWS_LAMBDA_FUNCTION_NAME`, preventing `astro build`/pre-render failures from being sent to Sentry.
> 
> Alerting is further **scoped to Netlify `CONTEXT` values** `production` and `branch-deploy` (excluding deploy previews), while keeping the same DSN, release tagging, and PII settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e216c54ae86e79360443b38931d654ad7a9e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->