### PR TITLE
fix(sandbox): omit storyboard metadata for live assets

### DIFF
--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -36,6 +36,7 @@ export const SOURCES = {
     url: 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8',
     type: 'hls',
     subType: 'mp4',
+    live: true,
   },
   'mp4-1': {
     label: 'MP4 - Dancing Dude',
@@ -72,6 +73,8 @@ export function getPosterSrc(source: SourceId): string | undefined {
 }
 
 export function getStoryboardSrc(source: SourceId): string | undefined {
+  const entry = SOURCES[source];
+  if ('live' in entry && entry.live) return undefined;
   const id = getMuxAssetId(source);
   return id ? `https://image.mux.com/${id}/storyboard.vtt` : undefined;
 }


### PR DESCRIPTION
## Summary

The sandbox live HLS fixture is not a VOD asset; loading a Mux `storyboard.vtt` track there was incorrect. Sources can be marked `live`, and `getStoryboardSrc` skips the storyboard URL so every example that uses the shared helper stays aligned.

## Testing

In the sandbox, choose the live HLS source and confirm the player no longer requests a storyboard metadata track (or that scrub thumbnails do not assume a VOD storyboard).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk sandbox-only change that just suppresses `storyboard.vtt` generation for sources marked live, potentially affecting scrub thumbnail behavior for that fixture.
> 
> **Overview**
> Prevents the sandbox from attaching Mux `storyboard.vtt` metadata to live streams.
> 
> This adds a `live: true` flag to the `hls-live` fixture and updates `getStoryboardSrc` to return `undefined` for sources marked live, so any consumers (e.g. CDN template rendering) stop requesting storyboard tracks for live assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1fcc2ee01842cfa898a943cfeb425ac422306ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->