### PR TITLE
chore: update README milestone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Video.js v10 is close to stable. Try it out in real projects and share your feed
 - **Technical Preview (Complete):** Initial showcase for Demuxed.
 - **Alpha (Jan–Feb 2026):** [See milestone](https://github.com/videojs/v10/milestone/3)
 - **Beta (Mar 2026):** [See milestone](https://github.com/videojs/v10/milestone/1)
-- **GA (Mid 2026):** [See milestone](https://github.com/videojs/v10/milestone/2) ← WIP
+- **GA (Mid 2026):** [See milestone](https://github.com/videojs/v10/milestone/6) ← WIP
 - **Video.js (End of 2026):** Video.js core/contrib parity and supported plugins migrated.
 
 ## Documentation


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates a README milestone URL; no runtime code or behavior is affected.
> 
> **Overview**
> Updates `README.md`'s **Timeline** section to change the **GA (Mid 2026)** milestone link from milestone `2` to milestone `6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434e7664d813e7b873d1d352e2119a300562e03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->