### PR TITLE
docs(design): draft composable media design

### DIFF
--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -27,8 +27,6 @@ and progressing to the underlying primitive.
    instance composition (`new HlsMedia({ features })` / `.use(f)`).
 4. Add class-time composition (`HlsMedia.with(...)`) for custom-element
    authors.
-5. Optional: side-effect import entry points (`@videojs/html/auto`) as
-   sugar only — **not** the only path.
 
 Keep existing mixins usable internally; migrate leaf-first (`live`,
 `errors`, `streamType`) where the lifecycle is already clean, and then
@@ -264,7 +262,7 @@ or use the existing `containerContext` / `playerContext` pattern).
 
 ## Option 2 — `defineMediaFeature` primitive
 
-Underlying primitive that Option 1's child elements (and Options 5–9)
+Underlying primitive that Option 1's child elements (and Options 3–5)
 are built on. Mirrors `defineSlice` on the media side.
 
 ```ts
@@ -273,7 +271,24 @@ export interface MediaFeatureContext<Host> {
   engine?: unknown;
   target: HTMLMediaElement | null;
   signal: AbortSignal;
+  // Install a *new* member on the host (e.g. `liveEdgeStart`).
   define: (name: string, desc: PropertyDescriptor) => void;
+  // Wrap an *existing* method on the host (e.g. `play`, `pause`,
+  // `load`). The wrapper receives the previous implementation and must
+  // return a replacement; wrappers compose LIFO and are restored on
+  // `signal` abort.
+  override: <K extends FunctionKeys<Host>>(
+    name: K,
+    wrap: (original: Host[K]) => Host[K]
+  ) => void;
+  // Same idea for getters/setters (e.g. `currentTime`, `volume`,
+  // `paused`). The wrapper receives the previous descriptor and
+  // returns a replacement descriptor.
+  overrideAccessor: <K extends keyof Host>(
+    name: K,
+    wrap: (prev: { get?: () => Host[K]; set?: (v: Host[K]) => void }) =>
+      { get?: () => Host[K]; set?: (v: Host[K]) => void }
+  ) => void;
   emit: (type: string) => void;
 }
 
@@ -294,7 +309,7 @@ across delegates, types via `UnionToIntersection<InferAPI<F[number]>>`
 **Cons:** reliance on `Object.defineProperty` for per-feature props
 (already used across the codebase).
 
-### Worked example: `live` on `HlsMedia`
+### Worked example: `live` on `HlsJsMedia`
 
 Today's equivalent is a mixin that does a constructor-time
 `engine.on(...)`, holds private state, and has no standard teardown
@@ -418,9 +433,56 @@ What the shape buys us:
   plus an `AbortController`, drive it, then `controller.abort()`. No
   class instantiation, no mixin composition.
 
+### Overriding host members
+
+`define()` installs *new* members; `override()` and `overrideAccessor()`
+wrap *existing* ones. This is the answer to "how does a feature swap
+behaviour on `play` / `pause` / `currentTime` when casting?"
+
+Under the hood each helper does the same thing as a classical mixin
+override, just scoped to a feature + `AbortSignal`:
+
+```ts
+// packages/core/src/dom/feature.ts (sketch — inside the host registry)
+
+function override<K extends FunctionKeys<Host>>(name: K, wrap: Wrapper) {
+  const proto = Object.getPrototypeOf(host);
+  const prevDesc = findDescriptor(proto, name);
+  const original = prevDesc.value as Host[K];
+  const replacement = wrap(original);
+  Object.defineProperty(host, name, { ...prevDesc, value: replacement });
+  signal.addEventListener('abort', () => {
+    Object.defineProperty(host, name, prevDesc);
+  });
+}
+
+function overrideAccessor<K extends keyof Host>(name: K, wrap: AccessorWrapper) {
+  const prevDesc = findDescriptor(Object.getPrototypeOf(host), name);
+  const next = wrap({ get: prevDesc.get, set: prevDesc.set });
+  Object.defineProperty(host, name, { ...prevDesc, ...next });
+  signal.addEventListener('abort', () => {
+    Object.defineProperty(host, name, prevDesc);
+  });
+}
+```
+
+Two guarantees:
+
+- **Wrappers see the previous implementation.** A second feature
+  overriding the same member gets *this feature's* wrapped version as
+  its `original`, so multi-feature overrides compose LIFO — identical
+  to a mixin chain, but declarative.
+- **Cleanup is automatic.** `signal.abort()` (detach / destroy /
+  element removal) restores the exact descriptor present before this
+  feature installed its wrapper. No bookkeeping on the host.
+
 ### Sketch: `googleCastFeature`
 
-Same primitive, wrapping the side-effecty Cast framework:
+Same primitive, wrapping the side-effecty Cast framework. The current
+`GoogleCastMixin` overrides ~14 members on the host (`play`, `pause`,
+`load`, `currentTime`, `volume`, `muted`, `paused`, `ended`, `seeking`,
+`readyState`, `duration`, `playbackRate`, `remote`). Each is the same
+shape: "if casting, defer to `provider`, else `super`". As a feature:
 
 ```ts
 // packages/core/src/dom/media/google-cast/feature.ts
@@ -438,7 +500,7 @@ export function googleCastFeature(config: {
   return defineMediaFeature<GoogleCastMediaHost>({
     name: 'google-cast',
     supports: () => requiresCastFramework(),
-    setup({ host, signal, define }) {
+    setup({ host, signal, define, override, overrideAccessor }) {
       if (!host.disableRemotePlayback) loadCastFramework();
 
       const provider = new GoogleCastProvider(host, {
@@ -449,9 +511,32 @@ export function googleCastFeature(config: {
         customData: () => config.customData,
       });
 
-      // Only `remote` needs to be on the host — the rest live in `config`
-      // and reach the Cast framework through the provider above. No more
-      // `castSrc` / `castReceiver` / `castContentType` on the element.
+      // Method overrides — same shape as today's mixin, minus the
+      // `super.*` boilerplate.
+      override('play',  (base) => () => provider.isCasting ? provider.play()  : base.call(host));
+      override('pause', (base) => () => provider.isCasting ? provider.pause() : base.call(host));
+      override('load',  (base) => () => provider.isCasting ? provider.load()  : base.call(host));
+
+      // Accessor overrides — read-only state.
+      for (const key of ['paused', 'ended', 'seeking', 'readyState', 'duration'] as const) {
+        overrideAccessor(key, ({ get }) => ({
+          get: () => (provider.isCasting ? provider[key] : get!.call(host)),
+        }));
+      }
+
+      // Accessor overrides — read/write state.
+      for (const key of ['currentTime', 'volume', 'muted', 'playbackRate'] as const) {
+        overrideAccessor(key, ({ get, set }) => ({
+          get: () => (provider.isCasting ? provider[key] : get!.call(host)),
+          set: (v) => {
+            if (provider.isCasting) (provider as any)[key] = v;
+            else set!.call(host, v);
+          },
+        }));
+      }
+
+      // `remote` is a *new* member that cast adds on top of the host
+      // surface — no prior descriptor to wrap.
       define('remote', { get: () => provider.remote });
 
       signal.addEventListener('abort', () => provider.destroy());
@@ -460,32 +545,174 @@ export function googleCastFeature(config: {
 }
 ```
 
-The element authors of `<media-feature-google-cast>` (Option 1) and React
-authors of `<MediaFeatureGoogleCast />` both import this single feature
-factory — no parallel class hierarchies.
+The loop reuses the same one-line wrapper per key — ~15 lines replace
+~150 lines of mixin override boilerplate, and the "if casting, else
+super" shape is expressed exactly once. The element authors of
+`<media-feature-google-cast>` (Option 1) and React authors of
+`<MediaFeatureGoogleCast />` both import this single feature factory
+— no parallel class hierarchies.
 
----
+### Facade hosts: `HlsMedia` over `HlsJsMedia` + `NativeHlsMedia`
 
-## Option 3 — Reactive Controllers
-
-OO flavour of Option 2. Features implement a controller interface.
+`HlsMedia` (`packages/core/src/dom/media/hls/index.ts`) is a facade: at
+`load()` it instantiates **either** `HlsJsMedia` (hls.js / MSE) **or**
+`NativeHlsMedia` (browser-built-in HLS) as `#delegate`, swaps on
+`src` / `type` / `preferPlayback` change, bridges events via
+`bridgeEvents`, and manually forwards a handful of props
+(`streamType`, `preload`). Today each delegate carries its own mixin
+stack:
 
 ```ts
-interface MediaController {
-  hostAttach?(host, target, signal): void;
-  hostDetach?(): void;
-  hostDestroy?(): void;
-}
-media.addController(new GoogleCastController({ receiver: 'CC1AD845' }));
+// hlsjs.ts
+export class HlsJsMedia extends HlsJsMediaPreloadMixin(
+  HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase)))
+) {}
+
+// native-hls/index.ts
+export class NativeHlsMedia extends NativeHlsMediaStreamTypeMixin(NativeHlsMediaErrorsMixin(NativeHlsMediaBase)) {}
 ```
 
-**Pros:** holds state on `this`, familiar to Lit users, plays well with
-existing `*Controller` classes.
-**Cons:** less data-like, needs `new`, not as uniform with store slices.
+Two concerns the new design has to answer:
+
+1. **Where does a feature live** when the two delegates genuinely
+   require different engine-specific code (hls.js listens to
+   `LEVEL_LOADED`; native listens to `durationchange` + `seekable`)?
+2. **How does the facade expose it**, so a user who writes
+   `<media-feature-live>` on `<hls-video>` gets the same
+   `liveEdgeStart` / `targetLiveWindow` surface no matter which
+   delegate ends up active?
+
+The answer is *two layers of features* that mirror the existing two
+layers of classes:
+
+**Layer 1 — delegate features.** One per engine, each targets its own
+host. Exactly the Option 2 `hlsjsLive` shown above, plus a
+`nativeHlsLive` sibling under `packages/core/src/dom/media/native-hls/features/`.
+These replace the delegate-specific mixins 1:1.
+
+```ts
+// packages/core/src/dom/media/hls/features/hlsjs-live.ts  → HlsJsMedia
+export const hlsjsLive = defineMediaFeature<HlsJsMedia>({ /* Option 2 example */ });
+
+// packages/core/src/dom/media/native-hls/features/live.ts → NativeHlsMedia
+export const nativeHlsLive = defineMediaFeature<NativeHlsMedia>({
+  name: 'native-hls:live',
+  setup({ host, target, signal, define, emit }) {
+    let targetLiveWindow = Number.NaN;
+    define('targetLiveWindow', { get: () => targetLiveWindow });
+    define('liveEdgeStart',    { get: () => { /* derive from seekable */ } });
+    // listen to durationchange / seekable on target, …
+    signal.addEventListener('abort', () => { /* tear down */ });
+  },
+});
+```
+
+**Layer 2 — facade features.** One per user-facing surface, targets
+the facade host, and does three small jobs: expose getters that
+forward to the active delegate, run the right delegate feature on
+each delegate swap (with its own `AbortSignal`), and let existing
+event-bridging carry through.
+
+```ts
+// packages/core/src/dom/media/hls/features/live.ts → HlsMedia
+import { defineMediaFeature } from '../../feature';
+import { HlsJsMedia } from '../hlsjs';
+import { NativeHlsMedia } from '../../native-hls';
+import { hlsjsLive } from './hlsjs-live';
+import { nativeHlsLive } from '../../native-hls/features/live';
+
+export const hlsLive = defineMediaFeature<HlsMedia>({
+  name: 'hls:live',
+  setup({ host, signal, define }) {
+    // Facade surface — same members the delegate features define,
+    // just read through whichever delegate is currently active.
+    // Replaces today's hand-written `streamType` / `preload` getters.
+    define('targetLiveWindow', { get: () => host.delegate?.targetLiveWindow ?? Number.NaN });
+    define('liveEdgeStart',    { get: () => host.delegate?.liveEdgeStart    ?? Number.NaN });
+
+    // Re-run the matching delegate feature on every delegate swap.
+    // Each swap gets its own AbortSignal — teardown is automatic.
+    let delegateCtrl: AbortController | null = null;
+    const onSwap = () => {
+      delegateCtrl?.abort();
+      const delegate = host.delegate;
+      if (!delegate) return;
+      const feature =
+        delegate instanceof HlsJsMedia    ? hlsjsLive    :
+        delegate instanceof NativeHlsMedia ? nativeHlsLive : null;
+      if (!feature) return;
+      delegateCtrl = new AbortController();
+      delegate.use(feature, { signal: delegateCtrl.signal });
+    };
+
+    host.addEventListener('delegatechange', onSwap, { signal });
+    onSwap();
+    signal.addEventListener('abort', () => delegateCtrl?.abort());
+
+    // `targetlivewindowchange` fires on the delegate; `bridgeEvents`
+    // already forwards it to the facade, so consumers listening on
+    // `<hls-video>` get it automatically — no extra wiring.
+  },
+});
+```
+
+And the registration site:
+
+```ts
+// packages/core/src/dom/media/hls/index.ts
+export const hlsFeatures = [hlsStreamType, hlsLive, hlsErrors /* , … */];
+```
+
+The `<media-feature-live>` child element (Option 1) mounts `hlsLive`
+onto `<hls-video>`, which then runs `hlsjsLive` **or** `nativeHlsLive`
+against the delegate depending on which one `load()` picked. Delegate
+swap → old feature aborts, new feature runs. Users and UI code only
+see one API surface.
+
+Host-level prerequisites — small, self-contained changes to `HlsMedia`:
+
+- **Expose `delegate`.** Already tracked internally via `#delegate`;
+  add a `get delegate()` getter so facade features can read it.
+- **Emit `delegatechange`.** In `load()` / `#engineDestroy()`, dispatch
+  an event whenever `#delegate` reassigns. One line each.
+- **Generalise property forwarding.** Today's manual
+  `streamType` / `preload` getters become `define` calls from their
+  respective facade features (`hlsStreamType`, `hlsPreload`). The
+  facade class keeps `src` / `type` / `preferPlayback` / `config` /
+  `debug` — the inputs that decide *which* delegate to build, not
+  anything the delegate produces.
+
+If this pattern recurs (`MuxMedia` over `HlsMedia`, future
+`DashMedia` variants), wrap it in a helper so feature authors don't
+write the swap plumbing by hand:
+
+```ts
+// packages/core/src/dom/feature.ts
+export function defineDelegateFeature<Facade, Delegate>(cfg: {
+  name: string;
+  forward: Array<keyof Delegate>;           // auto `define` + getter
+  pick: (delegate: Delegate | null) => AnyMediaFeature | null;
+}) { /* wraps `defineMediaFeature` with the swap + forward plumbing */ }
+
+// Consumer:
+export const hlsLive = defineDelegateFeature<HlsMedia, HlsJsMedia | NativeHlsMedia>({
+  name: 'hls:live',
+  forward: ['liveEdgeStart', 'targetLiveWindow'],
+  pick: (d) =>
+    d instanceof HlsJsMedia    ? hlsjsLive    :
+    d instanceof NativeHlsMedia ? nativeHlsLive : null,
+});
+```
+
+Bottom line: **the two-delegate split stays; mixins become features,
+one layer per class layer.** The feature model doesn't flatten
+`HlsMedia`, it just gives each mixin tier a cleaner lifecycle and
+unifies the facade's manual forwarding into the same `define` /
+`forward` primitive the delegate features already use.
 
 ---
 
-## Option 4 — Class-time composition (`.with(...)`)
+## Option 3 — Class-time composition (`.with(...)`)
 
 Factory that returns a constructable class. Solves the custom-element
 and "declare a tagName" use case.
@@ -510,7 +737,7 @@ customElements.define(
 
 ---
 
-## Option 5 — `features: []` escape hatch
+## Option 4 — `features: []` escape hatch
 
 Smallest migration. Keep the existing mixin-composed classes; add an
 optional `features` constructor option that runs additional features on
@@ -526,45 +753,7 @@ the built-in stack — more a bridge than a destination.
 
 ---
 
-## Option 6 — `features="…"` attribute
-
-Registry-backed attribute for quick presets with no config.
-
-```html
-<hls-video src="live.m3u8" features="live google-cast" />
-```
-
-```ts
-registerMediaFeature('live', liveMediaFeature);
-registerMediaFeature('google-cast', googleCastFeature());
-// host reads + diffs `features` attribute
-```
-
-**Pros:** shortest markup, attribute-reactive.
-**Cons:** no per-feature config (every config-bearing feature needs a
-companion `<media-feature-*>` child anyway); global registry side
-effects (see Option 9 caveats).
-
----
-
-## Option 7 — Named preset tags
-
-Different element for different preset bundle.
-
-```html
-<hls-video src="vod.m3u8" />
-<live-hls-video src="live.m3u8" />
-```
-
-`<live-hls-video>` = `HlsVideoElement` with a `liveFeatures` default
-array. Twin of `liveVideoFeatures` vs `videoFeatures` on the store side.
-
-**Pros:** zero-config for common cases.
-**Cons:** combinatorial as features grow.
-
----
-
-## Option 8 — React: `useMediaFeature` hook + `features` prop
+## Option 5 — React: `useMediaFeature` hook + `features` prop
 
 The hook is the primitive behind every `<MediaFeature*>` component in
 Option 1; the `features` prop mirrors the store's `<PlayerProvider features>`.
@@ -599,40 +788,6 @@ than iterating `useMediaFeature`.
 
 ---
 
-## Option 9 — Global side-effect imports
-
-```ts
-import '@videojs/core/media/features/live';
-import '@videojs/core/media/features/google-cast';
-// every HlsMedia instance now has these attached
-```
-
-Classic plugin pattern (jQuery, `chart.js/auto`, Video.js 7).
-
-**Pros:** zero opt-in boilerplate; feels like "batteries included".
-**Cons — real ones:**
-
-- Breaks tree-shaking; invalidates `sideEffects: false`.
-- Module-graph ordering across code-splitting, dynamic `import()`, SSR,
-  late `<script>` tags leads to "works in dev, breaks in prod".
-- Duplicate copies of `@videojs/core` = duplicate registries (monorepos,
-  linked packages). Mitigate with `Symbol.for('@videojs/media-features')`.
-- No configuration story — `configureGoogleCast({ receiver })` shows up
-  next to it, defeating the "just import it" promise.
-- No per-instance opt-out — every media pays for every feature.
-- Discoverability: feature set is a property of the bundle, not the
-  component. Bug triage is harder.
-- Testing: test-file registration leakage unless `vi.resetModules()`.
-- HMR double-registration unless registry is idempotent by name.
-- React SSR / RSC: server-rendered tree may not run the side-effect
-  import → hydration mismatch.
-
-**Verdict:** offer as sugar (`@videojs/html/auto`,
-`@videojs/html/features/live`) backed by the same primitive, but **not**
-as the only path.
-
----
-
 ## Comparison
 
 | Option | Runtime opt-in | Markup | Per-instance | Config | Tree-shakes | Typed | DX cost |
@@ -640,20 +795,17 @@ as the only path.
 | 0. Mixins (today) | ✗ | ✗ | ✗ | N/A | ✓ | ✓✓ | high (authors) |
 | 1. `<media-feature-*>` / `<MediaFeature*>` | ✓ | ✓✓ | ✓ | ✓ (attrs/props) | ✓ | ✓ | medium |
 | 2. `defineMediaFeature` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
-| 3. Controllers | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
-| 4. `.with(...)` | class-time | ✓ (via `define`) | ✗ | ✓ | ✓ | ✓ | low |
-| 5. `features:` escape | ✓ | ✗ | partial | ✓ | ✓ | ✓ | minimal |
-| 6. `features="…"` attr | ✓ | ✓ | ✓ | ✗ | needs care | ✓ | low |
-| 7. Preset tags | class-time | ✓✓ | ✗ | ✗ | ✓ | ✓ | low |
-| 8. `useMediaFeature` + prop | ✓ | ✓✓ (JSX) | ✓ | ✓ | ✓ | ✓ | low |
-| 9. Global imports | import-time | ✗ | ✗ | awkward | ✗ | ✓ | very low |
+| 3. `.with(...)` | class-time | ✓ (via `define`) | ✗ | ✓ | ✓ | ✓ | low |
+| 4. `features:` escape | ✓ | ✗ | partial | ✓ | ✓ | ✓ | minimal |
+| 5. `useMediaFeature` + prop | ✓ | ✓✓ (JSX) | ✓ | ✓ | ✓ | ✓ | low |
 
 ---
 
 ## Recommended rollout
 
 1. **Primitive** — `defineMediaFeature` next to `definePlayerFeature`
-   (`packages/core/src/dom/feature.ts`). Same mental model.
+   (`packages/core/src/dom/feature.ts`). Same mental model. Includes
+   `define` / `override` / `overrideAccessor` in the context.
 2. **Host registry** — extend `MediaHost` / `HTMLVideoElementHost` with
    `use(feature, { signal })`; run in `attach`, abort on `detach` /
    `destroy`.
@@ -663,16 +815,15 @@ as the only path.
    lifecycle already in `packages/core/src/dom/media/hls/live.ts` and
    `packages/core/src/dom/media/native-hls/live.ts`). Then `errors`,
    `streamType`. `google-cast` last — it's the highest-value
-   user-opt-in feature and exercises the config path end-to-end.
+   user-opt-in feature and exercises `override` /
+   `overrideAccessor` end-to-end.
 5. **Markup (Option 1)** — `MediaFeatureElement` base +
    `<media-feature-live>` and `<media-feature-google-cast>` as the two
    driving examples. Populate `packages/html/src/define/feature/video.ts`
    (currently a TODO stub).
-6. **React (Option 1 + 8)** — `useMediaFeature` + one
+6. **React (Option 1 + 5)** — `useMediaFeature` + one
    `<MediaFeature*>` wrapper per feature, mirroring the HTML tags 1:1.
    Wire through existing `useMedia()` context.
-7. **Optional sugar** — `@videojs/html/auto` side-effect entry calling
-   the same `registerMediaFeature` primitive, keyed + idempotent.
 
 Keep mixins internally for anything too intrusive to express as a
 feature (e.g. `HTMLVideoElementHost` itself).
@@ -685,6 +836,16 @@ feature (e.g. `HTMLVideoElementHost` itself).
   registration order, and should features declare dependencies
   (`requires: ['streamType']`)? `google-cast` reaches into `streamType`
   and `remote`, making this the most likely first case to hit.
+- **Override arbitration.** Two features overriding the same member
+  compose LIFO (last registered wraps first) — good default, matches
+  mixin order. Do we also need an explicit priority, or is
+  registration order enough? What about features that want to
+  *replace* rather than wrap (e.g. a test harness)?
+- **Conflicting active overrides.** Cast and AirPlay both override
+  `play` with "if active, defer to provider". Both can't be active at
+  once today, but the feature layer doesn't know that. Do we add a
+  "takeover" concept (one active per group) or leave coordination to
+  the features themselves?
 - Shared helpers: `listenEngine(engine, event, fn, { signal })` so
   engine events get the same `AbortSignal`-scoped cleanup as DOM
   events.
@@ -697,6 +858,39 @@ feature (e.g. `HTMLVideoElementHost` itself).
 - Naming of the primitive: `defineMediaFeature` (parallel with
   `definePlayerFeature`), or something unique like `defineMediaPlugin`
   to avoid conflation?
+
+---
+
+## Considered but not pursued
+
+- **Named preset tags** (`<live-hls-video>` alongside `<hls-video>`) —
+  a separate element per feature bundle, twin of `liveVideoFeatures`
+  vs `videoFeatures` on the store side. Zero-config for common cases,
+  but combinatorial as features grow (`<live-castable-hls-video>`?),
+  and `HlsMedia.with(...)` + `customElements.define(...)` (Option 3)
+  already covers the "I want a preset tag" use case with no new
+  concepts.
+- **Reactive Controllers** — OO variant of `defineMediaFeature` where
+  features implement a `MediaController` interface
+  (`hostAttach` / `hostDetach` / `hostDestroy`, `new
+  GoogleCastController(...)`). Familiar to Lit users, but redundant
+  with `defineMediaFeature` and less uniform with store slices.
+  `defineMediaFeature` already gives us `this`-free closures over the
+  same lifecycle via `AbortSignal`.
+- **`features="live google-cast"` attribute** — registry-backed
+  attribute listing feature names. Short to write but every
+  config-bearing feature (cast, thumbnails, …) still needs a
+  `<media-feature-*>` child for its config, so the attribute ends up
+  duplicating Option 1 rather than replacing it. Also inherits the
+  global-registry problems below.
+- **Global side-effect imports** (`import '@videojs/core/features/live'`)
+  — classic plugin pattern. Rejected as a primary path because it
+  breaks tree-shaking, has load-order problems across code-splitting /
+  SSR / late scripts, duplicates registries when `@videojs/core` is
+  deduped, has no configuration story, offers no per-instance opt-out,
+  and hides the feature set from the component (harder bug triage).
+  Can still be offered later as thin sugar over `defineMediaFeature`
+  if there's demand.
 
 ---
 

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -8,33 +8,35 @@ date: 2026-04-22
 ## Summary
 
 The media layer today composes features via static TypeScript mixins
-(`HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(...))`). Great DX for
-library authors, closed to app authors. The store layer has already solved
-this with **declarative feature arrays** (`defineSlice` /
+(`HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(...))`, `GoogleCastMixin(...)`).
+Great DX for library authors, closed to app authors. The store layer has
+already solved this with **declarative feature arrays** (`defineSlice` /
 `createPlayer({ features })`).
 
 This doc lays out ways to bring the same compositional freedom to the
-media layer, in order from smallest change to most user-facing, so they
-can be adopted together or one at a time.
+media layer, starting with the most user-facing path (markup composition)
+and progressing to the underlying primitive.
 
 **Recommended shape:**
 
-1. Introduce `defineMediaFeature` as the primitive — mirror `defineSlice`
-   1:1.
-2. Ship preset arrays (`hlsjsFeatures`, `nativeHlsFeatures`).
-3. Expose instance composition (`new HlsMedia({ features })` / `.use(f)`).
-4. Add class-time composition (`HlsMedia.with(...)`) for custom elements.
-5. Add HTML child elements (`<media-live>`) and a `features="…"` attribute.
-6. Add React mirror: `useMediaFeature` + `<MediaLive />` + `features` prop.
-7. Optional: side-effect import entry points (`@videojs/html/auto`) as
+1. Ship HTML child elements (`<media-feature-*>`) and React child
+   components (`<MediaFeature*>`) as the primary composition surface.
+2. Back them with a `defineMediaFeature` primitive — mirror
+   `defineSlice` 1:1.
+3. Ship preset arrays (`hlsjsFeatures`, `nativeHlsFeatures`) and
+   instance composition (`new HlsMedia({ features })` / `.use(f)`).
+4. Add class-time composition (`HlsMedia.with(...)`) for custom-element
+   authors.
+5. Optional: side-effect import entry points (`@videojs/html/auto`) as
    sugar only — **not** the only path.
 
 Keep existing mixins usable internally; migrate leaf-first (`live`,
-`errors`, `streamType`) where the lifecycle is already clean.
+`errors`, `streamType`) where the lifecycle is already clean, and then
+bigger surfaces like `google-cast`.
 
 > If/when we commit to this direction, the public-API-facing pieces
-> (`defineMediaFeature`, `features: []`, `<media-*>` children, React
-> hook/component) belong in an RFC. This doc exists to scope the options.
+> (`<media-feature-*>`, `<MediaFeature*>`, `defineMediaFeature`,
+> `features: []`) belong in an RFC. This doc exists to scope the options.
 
 ---
 
@@ -44,12 +46,12 @@ Keep existing mixins usable internally; migrate leaf-first (`live`,
 export class HlsJsMedia extends HlsJsMediaPreloadMixin(
   HlsJsMediaLiveMixin(
     HlsJsMediaStreamTypeMixin(
-      HlsJsMediaMetadataTracksMixin(
-        HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase))
-      )
+      HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase))
     )
   )
 ) {}
+
+export class MuxVideoMedia extends GoogleCastMixin(MuxMedia) {}
 ```
 
 **Pros:** precise types, `#private` fields, zero runtime overhead.
@@ -58,9 +60,212 @@ lifecycle boilerplate per mixin, no user extension without subclassing.
 
 ---
 
-## Option 1 — `defineMediaFeature` primitive
+## Option 1 — HTML child elements + React child components
 
-Mirror `defineSlice` on the media side.
+The primary user-facing path: compose features as children of a media
+element. Element authors declare `<media-feature-google-cast>` (HTML) or
+`<MediaFeatureGoogleCast />` (React); the child finds its host, calls
+`host.use(feature, { signal })`, and cleans up on disconnect/unmount.
+
+Naming convention:
+
+- HTML tag: `media-feature-<kebab-name>` — e.g. `<media-feature-google-cast>`,
+  `<media-feature-live>`.
+- React component: `MediaFeature<PascalName>` — e.g. `<MediaFeatureGoogleCast />`,
+  `<MediaFeatureLive />`.
+
+The prefix makes features self-identifying in markup, groups them in IDE
+autocomplete, and cleanly distinguishes them from content children like
+`<source>` / `<track>`.
+
+### Worked example: `<media-feature-google-cast>` (HTML)
+
+Google Cast is today a heavy mixin (`GoogleCastMixin` in
+`packages/core/src/dom/media/google-cast/index.ts`) that adds `castSrc`,
+`castReceiver`, `castContentType`, `castStreamType`, `castCustomData`,
+loads the Cast framework on attach, and overrides `play` / `pause` /
+`currentTime` / `volume` when casting. As a child element:
+
+```html
+<hls-video id="player" src="live.m3u8" controls>
+  <source src="live.m3u8" type="application/vnd.apple.mpegurl" />
+  <track kind="captions" src="en.vtt" default />
+
+  <media-feature-live></media-feature-live>
+  <media-feature-google-cast
+    receiver="CC1AD845"
+    content-type="application/vnd.apple.mpegurl"
+  ></media-feature-google-cast>
+</hls-video>
+```
+
+Features can reach back onto the host via `define()` — so declaring
+`<media-feature-live>` adds `liveEdgeStart` and `targetLiveWindow`
+(plus the `targetlivewindowchange` event) to the `<hls-video>` element
+itself. Same API surface as today's mixin, just opt-in:
+
+```ts
+const player = document.getElementById('player') as HTMLVideoElement & {
+  liveEdgeStart: number;
+  targetLiveWindow: number;
+};
+
+player.addEventListener('targetlivewindowchange', () => {
+  console.log('live window:', player.targetLiveWindow);
+  if (player.currentTime >= player.liveEdgeStart) showLiveBadge();
+});
+```
+
+Remove the child element and the properties go away — the host is a
+plain `<hls-video>` again. No subclass, no global augmentation.
+
+Shape:
+
+```ts
+import { defineMediaFeature } from '@videojs/core/dom/feature';
+import { googleCastFeature } from '@videojs/core/dom/media/google-cast';
+
+abstract class MediaFeatureElement extends HTMLElement {
+  abstract getFeature(): AnyMediaFeature;
+  #disconnect: AbortController | null = null;
+
+  connectedCallback() {
+    const host = this.closest<MediaHostElement>('[data-media-host]');
+    if (!host) return;
+    this.#disconnect = new AbortController();
+    host.use(this.getFeature(), { signal: this.#disconnect.signal });
+  }
+
+  disconnectedCallback() {
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+}
+
+class MediaFeatureGoogleCast extends MediaFeatureElement {
+  static observedAttributes = ['receiver', 'content-type', 'stream-type'];
+  getFeature() {
+    return googleCastFeature({
+      receiver: this.getAttribute('receiver') ?? undefined,
+      contentType: this.getAttribute('content-type') ?? undefined,
+      streamType: this.getAttribute('stream-type') ?? undefined,
+    });
+  }
+}
+
+class MediaFeatureLive extends MediaFeatureElement {
+  // No attributes — the `liveEdgeStart` / `targetLiveWindow` props it
+  // defines on the host are its entire public surface.
+  getFeature() { return liveFeature; }
+}
+
+customElements.define('media-feature-google-cast', MediaFeatureGoogleCast);
+customElements.define('media-feature-live', MediaFeatureLive);
+```
+
+The host (`<hls-video>`, `<video-player>`) marks itself with
+`data-media-host` and exposes `use(feature, { signal })` — the same
+method the instance API uses. Feature registrations that arrive before
+the host's `connectedCallback` get buffered and flushed once it's ready.
+
+### Worked example: `<MediaFeatureGoogleCast />` (React)
+
+The React twin is a 1:1 JSX wrapper that uses `useMedia()` plus an
+`AbortController`-scoped effect. No DOM dance — the component returns
+`null` and registers side-effectfully:
+
+```tsx
+// packages/react/src/media/feature/google-cast.tsx
+'use client';
+
+import { useMemo } from 'react';
+import { useMediaFeature } from '../../utils/use-media-feature';
+import { googleCastFeature } from '@videojs/core/dom/media/google-cast';
+
+export interface MediaFeatureGoogleCastProps {
+  receiver?: string;
+  contentType?: string;
+  streamType?: 'on-demand' | 'live';
+  customData?: Record<string, unknown>;
+}
+
+export function MediaFeatureGoogleCast({
+  receiver,
+  contentType,
+  streamType,
+  customData,
+}: MediaFeatureGoogleCastProps) {
+  const feature = useMemo(
+    () => googleCastFeature({ receiver, contentType, streamType, customData }),
+    [receiver, contentType, streamType, customData]
+  );
+  useMediaFeature(feature);
+  return null;
+}
+```
+
+App markup becomes declarative and React-idiomatic:
+
+```tsx
+<PlayerProvider features={liveVideoFeatures}>
+  <VideoContainer>
+    <HlsVideo src="live.m3u8">
+      <MediaFeatureGoogleCast receiver="CC1AD845" />
+      <MediaFeatureLive />
+    </HlsVideo>
+    <PlayButton /><TimeSlider /><MuteButton /><CastButton />
+  </VideoContainer>
+</PlayerProvider>
+```
+
+Store features (`liveVideoFeatures`) shape the store state; media
+features (`<MediaFeatureLive />`, `<MediaFeatureGoogleCast />`) shape
+engine behaviour. Both are arrays of "what do I want this player to
+do" — now at parity.
+
+Because `<MediaFeatureLive />` registers the feature on the underlying
+`HlsMedia`, the same `liveEdgeStart` / `targetLiveWindow` props and the
+`targetlivewindowchange` event are available through `useMedia()` —
+for a consumer-side hook:
+
+```tsx
+function useAtLiveEdge() {
+  const media = useMedia<HlsMedia>();
+  return useSyncExternalStore(
+    (cb) => {
+      media?.addEventListener('targetlivewindowchange', cb);
+      media?.addEventListener('timeupdate', cb);
+      return () => {
+        media?.removeEventListener('targetlivewindowchange', cb);
+        media?.removeEventListener('timeupdate', cb);
+      };
+    },
+    () => !!media && media.currentTime >= media.liveEdgeStart
+  );
+}
+```
+
+**Pros:** HTML-native, declarative, serialisable, SSR-safe; mirrors
+`<source>` / `<track>` handling; add/remove a feature by
+adding/removing DOM; reactive config via attributes; React component is
+a trivial wrapper. Discoverable in markup: `grep media-feature-` shows
+exactly what's loaded.
+**Cons:** a thin element/component per feature; startup-timing
+handshake (buffer registrations until the host's `connectedCallback`,
+or use the existing `containerContext` / `playerContext` pattern).
+
+> **How this works underneath.** Each `<media-feature-*>` reads its
+> attributes into a config object and hands the resulting feature to
+> the host's `use()` method. That `use()` method, the feature object
+> itself, and the `AbortSignal` lifecycle all come from the
+> `defineMediaFeature` primitive — see **Option 2**.
+
+---
+
+## Option 2 — `defineMediaFeature` primitive
+
+Underlying primitive that Option 1's child elements (and Options 5–9)
+are built on. Mirrors `defineSlice` on the media side.
 
 ```ts
 export interface MediaFeatureContext<Host> {
@@ -213,126 +418,57 @@ What the shape buys us:
   plus an `AbortController`, drive it, then `controller.abort()`. No
   class instantiation, no mixin composition.
 
-### Worked example: `<hls-video>` custom element
+### Sketch: `googleCastFeature`
 
-Today `HlsVideo` just wraps `HlsMedia` with `CustomMediaElement`
-(`packages/html/src/media/hls-video/index.ts`). With features, the
-element exposes a `features` init hook — no new classes, just a config:
+Same primitive, wrapping the side-effecty Cast framework:
 
 ```ts
-// packages/html/src/media/hls-video/index.ts
-import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
-import { HlsMedia, hlsMediaFeatures } from '@videojs/core/dom/media/hls';
-import { MediaAttachMixin } from '../../store/media-attach-mixin';
+// packages/core/src/dom/media/google-cast/feature.ts
+import { defineMediaFeature } from '../../feature';
+import { GoogleCastProvider } from './google-cast-provider';
+import { loadCastFramework, requiresCastFramework } from './utils';
 
-export class HlsVideo extends MediaAttachMixin(
-  CustomMediaElement('video', HlsMedia, { features: hlsMediaFeatures })
-) {
-  static get observedAttributes() {
-    // biome-ignore lint/complexity/noThisInStatic: intentional use of super
-    return [...super.observedAttributes, 'type', 'prefer-playback', 'debug'];
-  }
+export function googleCastFeature(config: {
+  src?: string;
+  receiver?: string;
+  contentType?: string;
+  streamType?: 'on-demand' | 'live';
+  customData?: Record<string, unknown>;
+}) {
+  return defineMediaFeature<GoogleCastMediaHost>({
+    name: 'google-cast',
+    supports: () => requiresCastFramework(),
+    setup({ host, signal, define }) {
+      if (!host.disableRemotePlayback) loadCastFramework();
+
+      const provider = new GoogleCastProvider(host, {
+        src: () => config.src ?? host.src,
+        receiver: () => config.receiver,
+        contentType: () => config.contentType,
+        streamType: () => config.streamType ?? host.streamType,
+        customData: () => config.customData,
+      });
+
+      // Only `remote` needs to be on the host — the rest live in `config`
+      // and reach the Cast framework through the provider above. No more
+      // `castSrc` / `castReceiver` / `castContentType` on the element.
+      define('remote', { get: () => provider.remote });
+
+      signal.addEventListener('abort', () => provider.destroy());
+    },
+  });
 }
 ```
 
-App authors pick their own composition without subclassing:
-
-```html
-<!-- Default preset -->
-<hls-video src="live.m3u8" controls></hls-video>
-
-<!-- Custom element wrapping a trimmed feature set -->
-<script type="module">
-  import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
-  import { HlsMedia, hlsjsLive, hlsjsStreamType } from '@videojs/core/dom/media/hls';
-  import { myAnalytics } from './my-analytics.js';
-
-  customElements.define(
-    'my-hls-video',
-    class extends CustomMediaElement('video', HlsMedia, {
-      features: [hlsjsStreamType, hlsjsLive, myAnalytics],
-    }) {}
-  );
-</script>
-<my-hls-video src="live.m3u8" controls></my-hls-video>
-```
-
-Attributes still flow through `observedAttributes` and the
-`CustomMediaElement` reflection — features add behaviour, they don't
-take over the element.
-
-### Worked example: `<HlsVideo />` React component
-
-Mirror the HTML story with a `features` prop. The prop is consumed once
-at mount by `useMediaInstance`, which already owns the media instance
-lifecycle (`packages/react/src/utils/use-media-instance.ts`):
-
-```tsx
-// packages/react/src/media/hls-video/index.tsx
-'use client';
-
-import type { HlsMediaProps, AnyMediaFeature } from '@videojs/core/dom/media/hls';
-import { HlsMedia, hlsMediaFeatures } from '@videojs/core/dom/media/hls';
-import { forwardRef, useMemo, type ReactNode, type VideoHTMLAttributes } from 'react';
-import { useAttachMedia } from '../../utils/use-attach-media';
-import { useComposedRefs } from '../../utils/use-composed-refs';
-import { useMediaInstance } from '../../utils/use-media-instance';
-import { useSyncProps } from '../../utils/use-sync-props';
-
-export interface HlsVideoProps
-  extends Omit<VideoHTMLAttributes<HTMLVideoElement>, keyof HlsMediaProps>,
-    Partial<HlsMediaProps> {
-  features?: readonly AnyMediaFeature[];
-  children?: ReactNode;
-}
-
-export const HlsVideo = forwardRef<HTMLVideoElement, HlsVideoProps>(function HlsVideo(
-  { features = hlsMediaFeatures, children, ...props },
-  ref
-) {
-  // `useMediaInstance` creates the media once; pass features as part of init.
-  const init = useMemo(() => ({ features }), [features]);
-  const media = useMediaInstance(HlsMedia, init);
-  const attachRef = useAttachMedia(media);
-  const composedRef = useComposedRefs(attachRef, ref);
-  const htmlProps = useSyncProps(media, props);
-
-  return (
-    <video ref={composedRef} {...htmlProps}>
-      {children}
-    </video>
-  );
-});
-```
-
-Usage stays declarative and React-idiomatic:
-
-```tsx
-import { HlsVideo, hlsjsLive, hlsjsStreamType } from '@videojs/react/hls-video';
-import { myAnalytics } from './my-analytics';
-
-// Default preset
-<HlsVideo src="live.m3u8" controls />
-
-// Custom composition — memoised array to keep the reference stable
-const features = [hlsjsStreamType, hlsjsLive, myAnalytics];
-
-<HlsVideo src="live.m3u8" controls features={features} />
-```
-
-Both surfaces bottom out on the same `defineMediaFeature` primitive —
-HTML composes at element-definition time, React composes per-instance
-through props. Options 5–8 later in this doc build on top of this by
-adding _incremental_ composition (adding a single feature at runtime via
-`<media-live>` or `useMediaFeature`); this worked example shows only
-the "set the full feature array at construction" story, which is the
-minimum needed for Option 1 to stand on its own.
+The element authors of `<media-feature-google-cast>` (Option 1) and React
+authors of `<MediaFeatureGoogleCast />` both import this single feature
+factory — no parallel class hierarchies.
 
 ---
 
-## Option 2 — Reactive Controllers
+## Option 3 — Reactive Controllers
 
-OO flavour of Option 1. Features implement a controller interface.
+OO flavour of Option 2. Features implement a controller interface.
 
 ```ts
 interface MediaController {
@@ -340,7 +476,7 @@ interface MediaController {
   hostDetach?(): void;
   hostDestroy?(): void;
 }
-media.addController(new HlsLiveController());
+media.addController(new GoogleCastController({ receiver: 'CC1AD845' }));
 ```
 
 **Pros:** holds state on `this`, familiar to Lit users, plays well with
@@ -349,7 +485,7 @@ existing `*Controller` classes.
 
 ---
 
-## Option 3 — Class-time composition (`.with(...)`)
+## Option 4 — Class-time composition (`.with(...)`)
 
 Factory that returns a constructable class. Solves the custom-element
 and "declare a tagName" use case.
@@ -363,7 +499,10 @@ class HlsMedia extends MediaHost {
   }
 }
 
-customElements.define('hls-media', HlsMedia.with(...hlsjsFeatures));
+customElements.define(
+  'castable-hls-media',
+  HlsMedia.with(...hlsjsFeatures, googleCastFeature({ receiver: 'CC1AD845' }))
+);
 ```
 
 **Pros:** markup-ready, typed, composes from data.
@@ -371,14 +510,14 @@ customElements.define('hls-media', HlsMedia.with(...hlsjsFeatures));
 
 ---
 
-## Option 4 — `features: []` escape hatch
+## Option 5 — `features: []` escape hatch
 
 Smallest migration. Keep the existing mixin-composed classes; add an
 optional `features` constructor option that runs additional features on
 top.
 
 ```ts
-new HlsJsMedia({ features: [myRecorderFeature] });
+new HlsJsMedia({ features: [googleCastFeature({ receiver: 'CC1AD845' })] });
 ```
 
 **Pros:** zero churn, additive.
@@ -387,64 +526,24 @@ the built-in stack — more a bridge than a destination.
 
 ---
 
-## Option 5 — HTML child elements
-
-Each feature gets a thin custom element that finds its media host and
-registers on `connectedCallback`.
-
-```html
-<hls-video src="live.m3u8">
-  <source src="live.m3u8" type="application/vnd.apple.mpegurl" />
-  <track kind="captions" src="en.vtt" default />
-
-  <media-live></media-live>
-  <media-thumbnails src="thumbs.vtt"></media-thumbnails>
-  <media-metadata-tracks></media-metadata-tracks>
-</hls-video>
-```
-
-```ts
-abstract class MediaFeatureElement extends HTMLElement {
-  abstract getFeature(): AnyMediaFeature;
-  #disconnect: AbortController | null = null;
-
-  connectedCallback() {
-    const host = this.closest<MediaHostElement>('[data-media-host]');
-    if (!host) return;
-    this.#disconnect = new AbortController();
-    host.addFeature(this.getFeature(), { signal: this.#disconnect.signal });
-  }
-  disconnectedCallback() { this.#disconnect?.abort(); this.#disconnect = null; }
-}
-```
-
-**Pros:** HTML-native, declarative, serialisable, SSR-safe, mirrors
-existing `<source>` / `<track>` handling; add/remove a feature by
-adding/removing DOM; reactive config via attributes; React works
-identically (1:1 JSX wrapper).
-**Cons:** a thin element per feature; tag-name conventions to decide;
-startup-timing handshake (buffer feature registrations until the host's
-`connectedCallback`, or use the existing `containerContext` /
-`playerContext` pattern).
-
----
-
 ## Option 6 — `features="…"` attribute
 
 Registry-backed attribute for quick presets with no config.
 
 ```html
-<hls-video src="live.m3u8" features="live metadata-tracks thumbnails" />
+<hls-video src="live.m3u8" features="live google-cast" />
 ```
 
 ```ts
 registerMediaFeature('live', liveMediaFeature);
+registerMediaFeature('google-cast', googleCastFeature());
 // host reads + diffs `features` attribute
 ```
 
 **Pros:** shortest markup, attribute-reactive.
-**Cons:** no per-feature config; global registry side effects (see
-Option 9 caveats).
+**Cons:** no per-feature config (every config-bearing feature needs a
+companion `<media-feature-*>` child anyway); global registry side
+effects (see Option 9 caveats).
 
 ---
 
@@ -465,9 +564,10 @@ array. Twin of `liveVideoFeatures` vs `videoFeatures` on the store side.
 
 ---
 
-## Option 8 — React: hook + component + prop
+## Option 8 — React: `useMediaFeature` hook + `features` prop
 
-All three layers stack on Option 1's primitive.
+The hook is the primitive behind every `<MediaFeature*>` component in
+Option 1; the `features` prop mirrors the store's `<PlayerProvider features>`.
 
 ### Hook
 
@@ -475,57 +575,27 @@ All three layers stack on Option 1's primitive.
 export function useMediaFeature(feature: AnyMediaFeature): void {
   const media = useMedia();
   useEffect(() => {
-    if (!media?.addFeature) return;
+    if (!media?.use) return;
     const ctrl = new AbortController();
-    media.addFeature(feature, { signal: ctrl.signal });
+    media.use(feature, { signal: ctrl.signal });
     return () => ctrl.abort();
   }, [media, feature]);
-}
-```
-
-### Component (sugar)
-
-```tsx
-export const MediaLive = () => <MediaFeature feature={liveMediaFeature} />;
-
-export function MediaThumbnails({ src }: { src?: string }) {
-  const feature = useMemo(() => thumbnailsMediaFeature({ src }), [src]);
-  useMediaFeature(feature);
-  return null;
 }
 ```
 
 ### Prop (store-parity)
 
 ```tsx
-<HlsVideo src="live.m3u8" features={liveMediaFeatures} />
+<HlsVideo src="live.m3u8" features={hlsMediaFeatures} />
 ```
 
 **Pros:** `useMedia()` from `PlayerContext` already wires this up;
 SSR-safe (effects run client-only); `AbortController` cleanup handles
 unmount / media swap / StrictMode double-mount; tests can assert
 `feature.setup` called against a mock host.
-**Cons:** `features` prop array must be stable reference; hooks-in-loops
-rule — register the whole array in one effect rather than iterating
-`useMediaFeature`.
-
-### App example
-
-```tsx
-<PlayerProvider features={liveVideoFeatures}>
-  <VideoContainer>
-    <HlsVideo src="live.m3u8">
-      <MediaLive />
-      <MediaThumbnails src="thumbs.vtt" />
-    </HlsVideo>
-    <PlayButton /><TimeSlider /><MuteButton />
-  </VideoContainer>
-</PlayerProvider>
-```
-
-Store features (`liveVideoFeatures`) shape the store state; media
-features (`<MediaLive />`) shape engine behaviour. Both declarative,
-both cleanup-safe.
+**Cons:** `features` prop array must be a stable reference; apply the
+hooks-in-loops rule — register the whole array in one effect rather
+than iterating `useMediaFeature`.
 
 ---
 
@@ -533,7 +603,7 @@ both cleanup-safe.
 
 ```ts
 import '@videojs/core/media/features/live';
-import '@videojs/core/media/features/thumbnails';
+import '@videojs/core/media/features/google-cast';
 // every HlsMedia instance now has these attached
 ```
 
@@ -547,8 +617,8 @@ Classic plugin pattern (jQuery, `chart.js/auto`, Video.js 7).
   late `<script>` tags leads to "works in dev, breaks in prod".
 - Duplicate copies of `@videojs/core` = duplicate registries (monorepos,
   linked packages). Mitigate with `Symbol.for('@videojs/media-features')`.
-- No configuration story — `configureThumbnails({ src })` shows up next
-  to it, defeating the "just import it" promise.
+- No configuration story — `configureGoogleCast({ receiver })` shows up
+  next to it, defeating the "just import it" promise.
 - No per-instance opt-out — every media pays for every feature.
 - Discoverability: feature set is a property of the bundle, not the
   component. Bug triage is harder.
@@ -568,14 +638,14 @@ as the only path.
 | Option | Runtime opt-in | Markup | Per-instance | Config | Tree-shakes | Typed | DX cost |
 |---|---|---|---|---|---|---|---|
 | 0. Mixins (today) | ✗ | ✗ | ✗ | N/A | ✓ | ✓✓ | high (authors) |
-| 1. `defineMediaFeature` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
-| 2. Controllers | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
-| 3. `.with(...)` | class-time | ✓ (via `define`) | ✗ | ✓ | ✓ | ✓ | low |
-| 4. `features:` escape | ✓ | ✗ | partial | ✓ | ✓ | ✓ | minimal |
-| 5. `<media-*>` children | ✓ | ✓✓ | ✓ | ✓ (attrs) | ✓ | ✓ | medium |
+| 1. `<media-feature-*>` / `<MediaFeature*>` | ✓ | ✓✓ | ✓ | ✓ (attrs/props) | ✓ | ✓ | medium |
+| 2. `defineMediaFeature` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
+| 3. Controllers | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
+| 4. `.with(...)` | class-time | ✓ (via `define`) | ✗ | ✓ | ✓ | ✓ | low |
+| 5. `features:` escape | ✓ | ✗ | partial | ✓ | ✓ | ✓ | minimal |
 | 6. `features="…"` attr | ✓ | ✓ | ✓ | ✗ | needs care | ✓ | low |
 | 7. Preset tags | class-time | ✓✓ | ✗ | ✗ | ✓ | ✓ | low |
-| 8. React hook/comp/prop | ✓ | ✓✓ (JSX) | ✓ | ✓ | ✓ | ✓ | low |
+| 8. `useMediaFeature` + prop | ✓ | ✓✓ (JSX) | ✓ | ✓ | ✓ | ✓ | low |
 | 9. Global imports | import-time | ✗ | ✗ | awkward | ✗ | ✓ | very low |
 
 ---
@@ -585,19 +655,22 @@ as the only path.
 1. **Primitive** — `defineMediaFeature` next to `definePlayerFeature`
    (`packages/core/src/dom/feature.ts`). Same mental model.
 2. **Host registry** — extend `MediaHost` / `HTMLVideoElementHost` with
-   `use(feature)` / `addFeature(feature, { signal })`; run in `attach`,
-   abort on `detach` / `destroy`.
-3. **Preset arrays** — `hlsjsFeatures`, `nativeHlsFeatures`, and matching
-   `HlsMedia.with(...)` for default custom-element exports.
+   `use(feature, { signal })`; run in `attach`, abort on `detach` /
+   `destroy`.
+3. **Preset arrays** — `hlsjsFeatures`, `nativeHlsFeatures`, and
+   matching `HlsMedia.with(...)` for default custom-element exports.
 4. **Pilot migration** — `live` first (small, two delegates, clean
    lifecycle already in `packages/core/src/dom/media/hls/live.ts` and
    `packages/core/src/dom/media/native-hls/live.ts`). Then `errors`,
-   `streamType`. Big ones (`metadata-tracks`, `text-tracks`) last.
-5. **Markup** — add `MediaFeatureElement` base + `<media-live>` first.
-   Populate `packages/html/src/define/feature/video.ts` (currently a
-   TODO stub).
-6. **React** — `useMediaFeature` + `MediaFeature` + per-feature
-   wrappers. Wire through existing `useMedia()` context.
+   `streamType`. `google-cast` last — it's the highest-value
+   user-opt-in feature and exercises the config path end-to-end.
+5. **Markup (Option 1)** — `MediaFeatureElement` base +
+   `<media-feature-live>` and `<media-feature-google-cast>` as the two
+   driving examples. Populate `packages/html/src/define/feature/video.ts`
+   (currently a TODO stub).
+6. **React (Option 1 + 8)** — `useMediaFeature` + one
+   `<MediaFeature*>` wrapper per feature, mirroring the HTML tags 1:1.
+   Wire through existing `useMedia()` context.
 7. **Optional sugar** — `@videojs/html/auto` side-effect entry calling
    the same `registerMediaFeature` primitive, keyed + idempotent.
 
@@ -610,10 +683,14 @@ feature (e.g. `HTMLVideoElementHost` itself).
 
 - Ordering guarantees: should feature order in the array imply
   registration order, and should features declare dependencies
-  (`requires: ['streamType']`)?
+  (`requires: ['streamType']`)? `google-cast` reaches into `streamType`
+  and `remote`, making this the most likely first case to hit.
 - Shared helpers: `listenEngine(engine, event, fn, { signal })` so
   engine events get the same `AbortSignal`-scoped cleanup as DOM
   events.
+- Attribute reflection: for `<media-feature-*>` elements, who owns
+  attribute → config re-derivation — the element, the feature factory,
+  or a shared `attributeChangedCallback` helper?
 - Type augmentation strategy: per-feature `API` generic (seen by
   `WithFeatures`) vs. `declare module` merging keyed by feature `name`.
   The store side uses the generic route — recommend matching.
@@ -630,3 +707,5 @@ feature (e.g. `HTMLVideoElementHost` itself).
   `defineSlice` — the shape to mirror.
 - `packages/core/src/dom/store/features/presets.ts` — preset array
   pattern (`videoFeatures`, `liveVideoFeatures`).
+- `packages/core/src/dom/media/google-cast/` — the mixin this doc
+  proposes reshaping as a feature factory.

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -7,899 +7,441 @@ date: 2026-04-22
 
 ## Summary
 
-The media layer today composes features via static TypeScript mixins
-(`HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(...))`, `GoogleCastMixin(...)`).
-Great DX for library authors, closed to app authors. The store layer has
-already solved this with **declarative feature arrays** (`defineSlice` /
-`createPlayer({ features })`).
+The store layer already lets app authors compose behaviour from a flat
+list of features:
 
-This doc lays out ways to bring the same compositional freedom to the
-media layer, starting with the most user-facing path (markup composition)
-and progressing to the underlying primitive.
+```ts
+createPlayer({ features: [playbackFeature, volumeFeature, /* … */] });
+```
 
-**Recommended shape:**
+We want the same shape on the media layer. Each media class binds an
+**engine** — a function that takes a config and returns a variant —
+to a flat list of features:
 
-1. Ship HTML child elements (`<media-feature-*>`) and React child
-   components (`<MediaFeature*>`) as the primary composition surface.
-2. Back them with a `defineMediaFeature` primitive — mirror
-   `defineSlice` 1:1.
-3. Ship preset arrays (`hlsjsFeatures`, `nativeHlsFeatures`) and
-   instance composition (`new HlsMedia({ features })` / `.use(f)`).
-4. Add class-time composition (`HlsMedia.with(...)`) for custom-element
-   authors.
+```ts
+import { createVideo } from '@videojs/core/dom/media';
+import { hlsJs, live, streamType, errors, googleCast, muxData } from '@videojs/core/dom/media/hls';
 
-Keep existing mixins usable internally; migrate leaf-first (`live`,
-`errors`, `streamType`) where the lifecycle is already clean, and then
-bigger surfaces like `google-cast`.
+const HlsJsMedia = createVideo(
+  hlsJs({ features: [live, streamType, errors, googleCast, muxData] }),
+);
+```
 
-> If/when we commit to this direction, the public-API-facing pieces
-> (`<media-feature-*>`, `<MediaFeature*>`, `defineMediaFeature`,
-> `features: []`) belong in an RFC. This doc exists to scope the options.
+Multi-engine playback (hls.js with native-HLS fallback) is the same
+function called with multiple variants:
+
+```ts
+import { hlsJs, live, streamType, googleCast, muxData } from '@videojs/core/dom/media/hls';
+import {
+  nativeHls,
+  live as nativeLive,
+  streamType as nativeStreamType,
+  googleCast as nativeCast,
+  muxData as nativeMuxData,
+} from '@videojs/core/dom/media/native-hls';
+
+const HlsMedia = createVideo(
+  hlsJs    ({ features: [live,       streamType,       googleCast, muxData] }),
+  nativeHls({ features: [nativeLive, nativeStreamType, nativeCast, nativeMuxData] }),
+);
+```
+
+`createVideo` is variadic: one variant = single-engine class, two or
+more = a class that picks an engine at runtime based on the source.
+
+Every feature — engine plumbing (`hlsJs`), capability (`live`,
+`streamType`), or cross-cutting facade-only (`googleCast`, `muxData`) —
+ships from the engine-specific subpath. **One engine = one import
+path.**
+
+Internally each feature is a class mixin — exactly what we have today.
 
 ---
 
 ## Today: Static Mixins
 
+Mixins are composed at module load:
+
 ```ts
 export class HlsJsMedia extends HlsJsMediaPreloadMixin(
-  HlsJsMediaLiveMixin(
-    HlsJsMediaStreamTypeMixin(
-      HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase))
-    )
+  HlsJsMediaStreamTypeMixin(
+    HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase))
   )
 ) {}
 
-export class MuxVideoMedia extends GoogleCastMixin(MuxMedia) {}
+export class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia)) {}
 ```
 
-**Pros:** precise types, `#private` fields, zero runtime overhead.
-**Cons:** closed at build time, duplicated per engine delegate, lots of
-lifecycle boilerplate per mixin, no user extension without subclassing.
+Great for library authors, closed for everyone else. There's no way to
+opt out of a built-in mixin or layer in a new one without subclassing
+the whole stack. Engine selection (hls.js vs native HLS) is hand-coded
+inside `HlsMedia` (`packages/core/src/dom/media/hls/index.ts`).
 
 ---
 
-## Option 1 — HTML child elements + React child components
+## The API
 
-The primary user-facing path: compose features as children of a media
-element. Element authors declare `<media-feature-google-cast>` (HTML) or
-`<MediaFeatureGoogleCast />` (React); the child finds its host, calls
-`host.use(feature, { signal })`, and cleans up on disconnect/unmount.
-
-Naming convention:
-
-- HTML tag: `media-feature-<kebab-name>` — e.g. `<media-feature-google-cast>`,
-  `<media-feature-live>`.
-- React component: `MediaFeature<PascalName>` — e.g. `<MediaFeatureGoogleCast />`,
-  `<MediaFeatureLive />`.
-
-The prefix makes features self-identifying in markup, groups them in IDE
-autocomplete, and cleanly distinguishes them from content children like
-`<source>` / `<track>`.
-
-### Worked example: `<media-feature-google-cast>` (HTML)
-
-Google Cast is today a heavy mixin (`GoogleCastMixin` in
-`packages/core/src/dom/media/google-cast/index.ts`) that adds `castSrc`,
-`castReceiver`, `castContentType`, `castStreamType`, `castCustomData`,
-loads the Cast framework on attach, and overrides `play` / `pause` /
-`currentTime` / `volume` when casting. As a child element:
-
-```html
-<hls-video id="player" src="live.m3u8" controls>
-  <source src="live.m3u8" type="application/vnd.apple.mpegurl" />
-  <track kind="captions" src="en.vtt" default />
-
-  <media-feature-live></media-feature-live>
-  <media-feature-google-cast
-    receiver="CC1AD845"
-    content-type="application/vnd.apple.mpegurl"
-  ></media-feature-google-cast>
-</hls-video>
-```
-
-Features can reach back onto the host via `define()` — so declaring
-`<media-feature-live>` adds `liveEdgeStart` and `targetLiveWindow`
-(plus the `targetlivewindowchange` event) to the `<hls-video>` element
-itself. Same API surface as today's mixin, just opt-in:
+Two factory functions, one per media kind. Both are variadic:
 
 ```ts
-const player = document.getElementById('player') as HTMLVideoElement & {
-  liveEdgeStart: number;
-  targetLiveWindow: number;
-};
-
-player.addEventListener('targetlivewindowchange', () => {
-  console.log('live window:', player.targetLiveWindow);
-  if (player.currentTime >= player.liveEdgeStart) showLiveBadge();
-});
-```
-
-Remove the child element and the properties go away — the host is a
-plain `<hls-video>` again. No subclass, no global augmentation.
-
-Shape:
-
-```ts
-import { defineMediaFeature } from '@videojs/core/dom/feature';
-import { googleCastFeature } from '@videojs/core/dom/media/google-cast';
-
-abstract class MediaFeatureElement extends HTMLElement {
-  abstract getFeature(): AnyMediaFeature;
-  #disconnect: AbortController | null = null;
-
-  connectedCallback() {
-    const host = this.closest<MediaHostElement>('[data-media-host]');
-    if (!host) return;
-    this.#disconnect = new AbortController();
-    host.use(this.getFeature(), { signal: this.#disconnect.signal });
-  }
-
-  disconnectedCallback() {
-    this.#disconnect?.abort();
-    this.#disconnect = null;
-  }
-}
-
-class MediaFeatureGoogleCast extends MediaFeatureElement {
-  static observedAttributes = ['receiver', 'content-type', 'stream-type'];
-  getFeature() {
-    return googleCastFeature({
-      receiver: this.getAttribute('receiver') ?? undefined,
-      contentType: this.getAttribute('content-type') ?? undefined,
-      streamType: this.getAttribute('stream-type') ?? undefined,
-    });
-  }
-}
-
-class MediaFeatureLive extends MediaFeatureElement {
-  // No attributes — the `liveEdgeStart` / `targetLiveWindow` props it
-  // defines on the host are its entire public surface.
-  getFeature() { return liveFeature; }
-}
-
-customElements.define('media-feature-google-cast', MediaFeatureGoogleCast);
-customElements.define('media-feature-live', MediaFeatureLive);
-```
-
-The host (`<hls-video>`, `<video-player>`) marks itself with
-`data-media-host` and exposes `use(feature, { signal })` — the same
-method the instance API uses. Feature registrations that arrive before
-the host's `connectedCallback` get buffered and flushed once it's ready.
-
-### Worked example: `<MediaFeatureGoogleCast />` (React)
-
-The React twin is a 1:1 JSX wrapper that uses `useMedia()` plus an
-`AbortController`-scoped effect. No DOM dance — the component returns
-`null` and registers side-effectfully:
-
-```tsx
-// packages/react/src/media/feature/google-cast.tsx
-'use client';
-
-import { useMemo } from 'react';
-import { useMediaFeature } from '../../utils/use-media-feature';
-import { googleCastFeature } from '@videojs/core/dom/media/google-cast';
-
-export interface MediaFeatureGoogleCastProps {
-  receiver?: string;
-  contentType?: string;
-  streamType?: 'on-demand' | 'live';
-  customData?: Record<string, unknown>;
-}
-
-export function MediaFeatureGoogleCast({
-  receiver,
-  contentType,
-  streamType,
-  customData,
-}: MediaFeatureGoogleCastProps) {
-  const feature = useMemo(
-    () => googleCastFeature({ receiver, contentType, streamType, customData }),
-    [receiver, contentType, streamType, customData]
-  );
-  useMediaFeature(feature);
-  return null;
-}
-```
-
-App markup becomes declarative and React-idiomatic:
-
-```tsx
-<PlayerProvider features={liveVideoFeatures}>
-  <VideoContainer>
-    <HlsVideo src="live.m3u8">
-      <MediaFeatureGoogleCast receiver="CC1AD845" />
-      <MediaFeatureLive />
-    </HlsVideo>
-    <PlayButton /><TimeSlider /><MuteButton /><CastButton />
-  </VideoContainer>
-</PlayerProvider>
-```
-
-Store features (`liveVideoFeatures`) shape the store state; media
-features (`<MediaFeatureLive />`, `<MediaFeatureGoogleCast />`) shape
-engine behaviour. Both are arrays of "what do I want this player to
-do" — now at parity.
-
-Because `<MediaFeatureLive />` registers the feature on the underlying
-`HlsMedia`, the same `liveEdgeStart` / `targetLiveWindow` props and the
-`targetlivewindowchange` event are available through `useMedia()` —
-for a consumer-side hook:
-
-```tsx
-function useAtLiveEdge() {
-  const media = useMedia<HlsMedia>();
-  return useSyncExternalStore(
-    (cb) => {
-      media?.addEventListener('targetlivewindowchange', cb);
-      media?.addEventListener('timeupdate', cb);
-      return () => {
-        media?.removeEventListener('targetlivewindowchange', cb);
-        media?.removeEventListener('timeupdate', cb);
-      };
-    },
-    () => !!media && media.currentTime >= media.liveEdgeStart
-  );
-}
-```
-
-**Pros:** HTML-native, declarative, serialisable, SSR-safe; mirrors
-`<source>` / `<track>` handling; add/remove a feature by
-adding/removing DOM; reactive config via attributes; React component is
-a trivial wrapper. Discoverable in markup: `grep media-feature-` shows
-exactly what's loaded.
-**Cons:** a thin element/component per feature; startup-timing
-handshake (buffer registrations until the host's `connectedCallback`,
-or use the existing `containerContext` / `playerContext` pattern).
-
-> **How this works underneath.** Each `<media-feature-*>` reads its
-> attributes into a config object and hands the resulting feature to
-> the host's `use()` method. That `use()` method, the feature object
-> itself, and the `AbortSignal` lifecycle all come from the
-> `defineMediaFeature` primitive — see **Option 2**.
-
----
-
-## Option 2 — `defineMediaFeature` primitive
-
-Underlying primitive that Option 1's child elements (and Options 3–5)
-are built on. Mirrors `defineSlice` on the media side.
-
-```ts
-export interface MediaFeatureContext<Host> {
-  host: Host;
-  engine?: unknown;
-  target: HTMLMediaElement | null;
-  signal: AbortSignal;
-  // Install a *new* member on the host (e.g. `liveEdgeStart`).
-  define: (name: string, desc: PropertyDescriptor) => void;
-  // Wrap an *existing* method on the host (e.g. `play`, `pause`,
-  // `load`). The wrapper receives the previous implementation and must
-  // return a replacement; wrappers compose LIFO and are restored on
-  // `signal` abort.
-  override: <K extends FunctionKeys<Host>>(
-    name: K,
-    wrap: (original: Host[K]) => Host[K]
-  ) => void;
-  // Same idea for getters/setters (e.g. `currentTime`, `volume`,
-  // `paused`). The wrapper receives the previous descriptor and
-  // returns a replacement descriptor.
-  overrideAccessor: <K extends keyof Host>(
-    name: K,
-    wrap: (prev: { get?: () => Host[K]; set?: (v: Host[K]) => void }) =>
-      { get?: () => Host[K]; set?: (v: Host[K]) => void }
-  ) => void;
-  emit: (type: string) => void;
-}
-
-export function defineMediaFeature<Host, API = void>(cfg: {
-  name: string;
-  supports?: (host: Host) => boolean;
-  setup: (ctx: MediaFeatureContext<Host>) => API | void;
-}) { return cfg; }
-```
-
-Each feature is a plain object. A tiny registry on the base `MediaHost`
-runs features in `attach()` and tears them down via `AbortSignal` on
-`detach()` / `destroy()`.
-
-**Pros:** data-shaped, typeable, uniform lifecycle, testable, reusable
-across delegates, types via `UnionToIntersection<InferAPI<F[number]>>`
-(same pattern as `UnionSliceState`).
-**Cons:** reliance on `Object.defineProperty` for per-feature props
-(already used across the codebase).
-
-### Worked example: `live` on `HlsJsMedia`
-
-Today's equivalent is a mixin that does a constructor-time
-`engine.on(...)`, holds private state, and has no standard teardown
-(compare `HlsJsMediaStreamTypeMixin` in
-`packages/core/src/dom/media/hls/stream-type.ts`):
-
-```ts
-export function HlsJsMediaLiveMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
-  class HlsJsMediaLive extends (BaseClass as Constructor<HlsEngineHost>) {
-    #targetLiveWindow = Number.NaN;
-    #liveEdgeStartOffset: number | undefined;
-
-    constructor(...args: any[]) {
-      super(...args);
-      this.engine?.on(Hls.Events.LEVEL_LOADED, (_e, data) => this.#derive(data.details));
-      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#reset());
-      this.engine?.on(Hls.Events.DESTROYING, () => this.#reset());
-    }
-
-    get targetLiveWindow() { return this.#targetLiveWindow; }
-    get liveEdgeStart() { /* derive from seekable + offset */ }
-
-    // #derive / #reset / #setTargetLiveWindow …
-  }
-  return HlsJsMediaLive as unknown as Base &
-    Constructor<{ readonly liveEdgeStart: number; readonly targetLiveWindow: number }>;
-}
-
-export class HlsJsMedia extends HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(HlsJsMediaBase)) {}
-```
-
-Reshaped as a feature:
-
-```ts
-// packages/core/src/dom/media/hls/features/live.ts
-import Hls, { type LevelLoadedData } from 'hls.js';
-import { defineMediaFeature } from '../../feature';
-import type { HlsEngineHost } from '../types';
-
-export const hlsjsLive = defineMediaFeature<HlsEngineHost>({
-  name: 'hlsjs:live',
-  setup({ host, target, signal, define, emit }) {
-    let targetLiveWindow = Number.NaN;
-    let liveEdgeStartOffset: number | undefined;
-
-    define('targetLiveWindow', { get: () => targetLiveWindow });
-    define('liveEdgeStart', {
-      get: () => {
-        if (liveEdgeStartOffset === undefined || !target) return Number.NaN;
-        const { seekable } = target;
-        return seekable.length ? seekable.end(seekable.length - 1) - liveEdgeStartOffset : Number.NaN;
-      },
-    });
-
-    const setWindow = (value: number) => {
-      if (Object.is(targetLiveWindow, value)) return;
-      targetLiveWindow = value;
-      emit('targetlivewindowchange');
-    };
-
-    const derive = (details: LevelLoadedData['details']) => {
-      if (!details.live) return reset();
-      const lowLatency = !!details.partList?.length;
-      liveEdgeStartOffset = lowLatency
-        ? details.partHoldBack || details.partTarget * 2
-        : details.holdBack || details.targetduration * 3;
-      setWindow(details.type === 'EVENT' ? Number.POSITIVE_INFINITY : 0);
-    };
-
-    const reset = () => {
-      liveEdgeStartOffset = undefined;
-      setWindow(Number.NaN);
-    };
-
-    const engine = host.engine;
-    const onLevel = (_e: string, data: LevelLoadedData) => derive(data.details);
-    engine?.on(Hls.Events.LEVEL_LOADED, onLevel);
-    engine?.on(Hls.Events.MANIFEST_LOADING, reset);
-    engine?.on(Hls.Events.DESTROYING, reset);
-
-    // Every subscription is undone when `signal` aborts — no custom
-    // `detach()` / `destroy()` wiring required on the host.
-    signal.addEventListener('abort', () => {
-      engine?.off(Hls.Events.LEVEL_LOADED, onLevel);
-      engine?.off(Hls.Events.MANIFEST_LOADING, reset);
-      engine?.off(Hls.Events.DESTROYING, reset);
-      reset();
-    });
-  },
-});
-```
-
-And the registration site — no mixin chain, just an array:
-
-```ts
-// packages/core/src/dom/media/hls/hlsjs.ts
-import { hlsjsLive } from './features/live';
-import { hlsjsStreamType } from './features/stream-type';
-
-export const hlsjsFeatures = [hlsjsStreamType, hlsjsLive /* , … */];
-
-export class HlsJsMedia extends HlsJsMediaBase {
-  constructor(init?: HlsJsMediaInit) {
-    super(init);
-    for (const f of hlsjsFeatures) this.use(f);
-  }
-}
-```
-
-What the shape buys us:
-
-- **Lifecycle.** One `AbortSignal` replaces the ad-hoc `destroy()` /
-  `#reset()` dance — same pattern already used by
-  `NativeHlsMediaLiveMixin` and store `listen()` helpers.
-- **Reuse.** `hlsjsLive` and `nativeHlsLive` are two `defineMediaFeature`
-  calls sitting in the same folder; users pick one or both instead of
-  inheriting a whole class.
-- **User extension.** `new HlsJsMedia({ features: [...hlsjsFeatures, myRecorder] })`
-  needs no subclass.
-- **Tests.** Setup is a pure function — pass a fake host/engine/target
-  plus an `AbortController`, drive it, then `controller.abort()`. No
-  class instantiation, no mixin composition.
-
-### Overriding host members
-
-`define()` installs *new* members; `override()` and `overrideAccessor()`
-wrap *existing* ones. This is the answer to "how does a feature swap
-behaviour on `play` / `pause` / `currentTime` when casting?"
-
-Under the hood each helper does the same thing as a classical mixin
-override, just scoped to a feature + `AbortSignal`:
-
-```ts
-// packages/core/src/dom/feature.ts (sketch — inside the host registry)
-
-function override<K extends FunctionKeys<Host>>(name: K, wrap: Wrapper) {
-  const proto = Object.getPrototypeOf(host);
-  const prevDesc = findDescriptor(proto, name);
-  const original = prevDesc.value as Host[K];
-  const replacement = wrap(original);
-  Object.defineProperty(host, name, { ...prevDesc, value: replacement });
-  signal.addEventListener('abort', () => {
-    Object.defineProperty(host, name, prevDesc);
-  });
-}
-
-function overrideAccessor<K extends keyof Host>(name: K, wrap: AccessorWrapper) {
-  const prevDesc = findDescriptor(Object.getPrototypeOf(host), name);
-  const next = wrap({ get: prevDesc.get, set: prevDesc.set });
-  Object.defineProperty(host, name, { ...prevDesc, ...next });
-  signal.addEventListener('abort', () => {
-    Object.defineProperty(host, name, prevDesc);
-  });
-}
-```
-
-Two guarantees:
-
-- **Wrappers see the previous implementation.** A second feature
-  overriding the same member gets *this feature's* wrapped version as
-  its `original`, so multi-feature overrides compose LIFO — identical
-  to a mixin chain, but declarative.
-- **Cleanup is automatic.** `signal.abort()` (detach / destroy /
-  element removal) restores the exact descriptor present before this
-  feature installed its wrapper. No bookkeeping on the host.
-
-### Sketch: `googleCastFeature`
-
-Same primitive, wrapping the side-effecty Cast framework. The current
-`GoogleCastMixin` overrides ~14 members on the host (`play`, `pause`,
-`load`, `currentTime`, `volume`, `muted`, `paused`, `ended`, `seeking`,
-`readyState`, `duration`, `playbackRate`, `remote`). Each is the same
-shape: "if casting, defer to `provider`, else `super`". As a feature:
-
-```ts
-// packages/core/src/dom/media/google-cast/feature.ts
-import { defineMediaFeature } from '../../feature';
-import { GoogleCastProvider } from './google-cast-provider';
-import { loadCastFramework, requiresCastFramework } from './utils';
-
-export function googleCastFeature(config: {
-  src?: string;
-  receiver?: string;
-  contentType?: string;
-  streamType?: 'on-demand' | 'live';
-  customData?: Record<string, unknown>;
-}) {
-  return defineMediaFeature<GoogleCastMediaHost>({
-    name: 'google-cast',
-    supports: () => requiresCastFramework(),
-    setup({ host, signal, define, override, overrideAccessor }) {
-      if (!host.disableRemotePlayback) loadCastFramework();
-
-      const provider = new GoogleCastProvider(host, {
-        src: () => config.src ?? host.src,
-        receiver: () => config.receiver,
-        contentType: () => config.contentType,
-        streamType: () => config.streamType ?? host.streamType,
-        customData: () => config.customData,
-      });
-
-      // Method overrides — same shape as today's mixin, minus the
-      // `super.*` boilerplate.
-      override('play',  (base) => () => provider.isCasting ? provider.play()  : base.call(host));
-      override('pause', (base) => () => provider.isCasting ? provider.pause() : base.call(host));
-      override('load',  (base) => () => provider.isCasting ? provider.load()  : base.call(host));
-
-      // Accessor overrides — read-only state.
-      for (const key of ['paused', 'ended', 'seeking', 'readyState', 'duration'] as const) {
-        overrideAccessor(key, ({ get }) => ({
-          get: () => (provider.isCasting ? provider[key] : get!.call(host)),
-        }));
-      }
-
-      // Accessor overrides — read/write state.
-      for (const key of ['currentTime', 'volume', 'muted', 'playbackRate'] as const) {
-        overrideAccessor(key, ({ get, set }) => ({
-          get: () => (provider.isCasting ? provider[key] : get!.call(host)),
-          set: (v) => {
-            if (provider.isCasting) (provider as any)[key] = v;
-            else set!.call(host, v);
-          },
-        }));
-      }
-
-      // `remote` is a *new* member that cast adds on top of the host
-      // surface — no prior descriptor to wrap.
-      define('remote', { get: () => provider.remote });
-
-      signal.addEventListener('abort', () => provider.destroy());
-    },
-  });
-}
-```
-
-The loop reuses the same one-line wrapper per key — ~15 lines replace
-~150 lines of mixin override boilerplate, and the "if casting, else
-super" shape is expressed exactly once. The element authors of
-`<media-feature-google-cast>` (Option 1) and React authors of
-`<MediaFeatureGoogleCast />` both import this single feature factory
-— no parallel class hierarchies.
-
-### Facade hosts: `HlsMedia` over `HlsJsMedia` + `NativeHlsMedia`
-
-`HlsMedia` (`packages/core/src/dom/media/hls/index.ts`) is a facade: at
-`load()` it instantiates **either** `HlsJsMedia` (hls.js / MSE) **or**
-`NativeHlsMedia` (browser-built-in HLS) as `#delegate`, swaps on
-`src` / `type` / `preferPlayback` change, bridges events via
-`bridgeEvents`, and manually forwards a handful of props
-(`streamType`, `preload`). Today each delegate carries its own mixin
-stack:
-
-```ts
-// hlsjs.ts
-export class HlsJsMedia extends HlsJsMediaPreloadMixin(
-  HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase)))
-) {}
-
-// native-hls/index.ts
-export class NativeHlsMedia extends NativeHlsMediaStreamTypeMixin(NativeHlsMediaErrorsMixin(NativeHlsMediaBase)) {}
-```
-
-Two concerns the new design has to answer:
-
-1. **Where does a feature live** when the two delegates genuinely
-   require different engine-specific code (hls.js listens to
-   `LEVEL_LOADED`; native listens to `durationchange` + `seekable`)?
-2. **How does the facade expose it**, so a user who writes
-   `<media-feature-live>` on `<hls-video>` gets the same
-   `liveEdgeStart` / `targetLiveWindow` surface no matter which
-   delegate ends up active?
-
-The answer is *two layers of features* that mirror the existing two
-layers of classes:
-
-**Layer 1 — delegate features.** One per engine, each targets its own
-host. Exactly the Option 2 `hlsjsLive` shown above, plus a
-`nativeHlsLive` sibling under `packages/core/src/dom/media/native-hls/features/`.
-These replace the delegate-specific mixins 1:1.
-
-```ts
-// packages/core/src/dom/media/hls/features/hlsjs-live.ts  → HlsJsMedia
-export const hlsjsLive = defineMediaFeature<HlsJsMedia>({ /* Option 2 example */ });
-
-// packages/core/src/dom/media/native-hls/features/live.ts → NativeHlsMedia
-export const nativeHlsLive = defineMediaFeature<NativeHlsMedia>({
-  name: 'native-hls:live',
-  setup({ host, target, signal, define, emit }) {
-    let targetLiveWindow = Number.NaN;
-    define('targetLiveWindow', { get: () => targetLiveWindow });
-    define('liveEdgeStart',    { get: () => { /* derive from seekable */ } });
-    // listen to durationchange / seekable on target, …
-    signal.addEventListener('abort', () => { /* tear down */ });
-  },
-});
-```
-
-**Layer 2 — facade features.** One per user-facing surface, targets
-the facade host, and does three small jobs: expose getters that
-forward to the active delegate, run the right delegate feature on
-each delegate swap (with its own `AbortSignal`), and let existing
-event-bridging carry through.
-
-```ts
-// packages/core/src/dom/media/hls/features/live.ts → HlsMedia
-import { defineMediaFeature } from '../../feature';
-import { HlsJsMedia } from '../hlsjs';
-import { NativeHlsMedia } from '../../native-hls';
-import { hlsjsLive } from './hlsjs-live';
-import { nativeHlsLive } from '../../native-hls/features/live';
-
-export const hlsLive = defineMediaFeature<HlsMedia>({
-  name: 'hls:live',
-  setup({ host, signal, define }) {
-    // Facade surface — same members the delegate features define,
-    // just read through whichever delegate is currently active.
-    // Replaces today's hand-written `streamType` / `preload` getters.
-    define('targetLiveWindow', { get: () => host.delegate?.targetLiveWindow ?? Number.NaN });
-    define('liveEdgeStart',    { get: () => host.delegate?.liveEdgeStart    ?? Number.NaN });
-
-    // Re-run the matching delegate feature on every delegate swap.
-    // Each swap gets its own AbortSignal — teardown is automatic.
-    let delegateCtrl: AbortController | null = null;
-    const onSwap = () => {
-      delegateCtrl?.abort();
-      const delegate = host.delegate;
-      if (!delegate) return;
-      const feature =
-        delegate instanceof HlsJsMedia    ? hlsjsLive    :
-        delegate instanceof NativeHlsMedia ? nativeHlsLive : null;
-      if (!feature) return;
-      delegateCtrl = new AbortController();
-      delegate.use(feature, { signal: delegateCtrl.signal });
-    };
-
-    host.addEventListener('delegatechange', onSwap, { signal });
-    onSwap();
-    signal.addEventListener('abort', () => delegateCtrl?.abort());
-
-    // `targetlivewindowchange` fires on the delegate; `bridgeEvents`
-    // already forwards it to the facade, so consumers listening on
-    // `<hls-video>` get it automatically — no extra wiring.
-  },
-});
-```
-
-And the registration site:
-
-```ts
-// packages/core/src/dom/media/hls/index.ts
-export const hlsFeatures = [hlsStreamType, hlsLive, hlsErrors /* , … */];
-```
-
-The `<media-feature-live>` child element (Option 1) mounts `hlsLive`
-onto `<hls-video>`, which then runs `hlsjsLive` **or** `nativeHlsLive`
-against the delegate depending on which one `load()` picked. Delegate
-swap → old feature aborts, new feature runs. Users and UI code only
-see one API surface.
-
-Host-level prerequisites — small, self-contained changes to `HlsMedia`:
-
-- **Expose `delegate`.** Already tracked internally via `#delegate`;
-  add a `get delegate()` getter so facade features can read it.
-- **Emit `delegatechange`.** In `load()` / `#engineDestroy()`, dispatch
-  an event whenever `#delegate` reassigns. One line each.
-- **Generalise property forwarding.** Today's manual
-  `streamType` / `preload` getters become `define` calls from their
-  respective facade features (`hlsStreamType`, `hlsPreload`). The
-  facade class keeps `src` / `type` / `preferPlayback` / `config` /
-  `debug` — the inputs that decide *which* delegate to build, not
-  anything the delegate produces.
-
-If this pattern recurs (`MuxMedia` over `HlsMedia`, future
-`DashMedia` variants), wrap it in a helper so feature authors don't
-write the swap plumbing by hand:
-
-```ts
-// packages/core/src/dom/feature.ts
-export function defineDelegateFeature<Facade, Delegate>(cfg: {
-  name: string;
-  forward: Array<keyof Delegate>;           // auto `define` + getter
-  pick: (delegate: Delegate | null) => AnyMediaFeature | null;
-}) { /* wraps `defineMediaFeature` with the swap + forward plumbing */ }
-
-// Consumer:
-export const hlsLive = defineDelegateFeature<HlsMedia, HlsJsMedia | NativeHlsMedia>({
-  name: 'hls:live',
-  forward: ['liveEdgeStart', 'targetLiveWindow'],
-  pick: (d) =>
-    d instanceof HlsJsMedia    ? hlsjsLive    :
-    d instanceof NativeHlsMedia ? nativeHlsLive : null,
-});
-```
-
-Bottom line: **the two-delegate split stays; mixins become features,
-one layer per class layer.** The feature model doesn't flatten
-`HlsMedia`, it just gives each mixin tier a cleaner lifecycle and
-unifies the facade's manual forwarding into the same `define` /
-`forward` primitive the delegate features already use.
-
----
-
-## Option 3 — Class-time composition (`.with(...)`)
-
-Factory that returns a constructable class. Solves the custom-element
-and "declare a tagName" use case.
-
-```ts
-class HlsMedia extends MediaHost {
-  static with<F extends AnyMediaFeature[]>(...features: F) {
-    return class extends HlsMedia {
-      constructor(init?) { super(init); features.forEach((f) => this.use(f)); }
-    } as Constructor<HlsMedia & WithFeatures<HlsMedia, F>>;
-  }
-}
-
-customElements.define(
-  'castable-hls-media',
-  HlsMedia.with(...hlsjsFeatures, googleCastFeature({ receiver: 'CC1AD845' }))
+const HlsJsMedia = createVideo(hlsJs({ features: […] }));
+const HlsMedia   = createVideo(
+  hlsJs    ({ features: […] }),
+  nativeHls({ features: […] }),
+);
+
+const HlsJsAudio = createAudio(hlsJs({ features: […] }));
+const HlsAudio   = createAudio(
+  hlsJs    ({ features: […] }),
+  nativeHls({ features: […] }),
 );
 ```
 
-**Pros:** markup-ready, typed, composes from data.
-**Cons:** returns a new class per call — keep callers module-scoped.
+`createVideo` returns a class that extends `HTMLVideoElementHost`;
+`createAudio` extends `HTMLAudioElementHost`. Both return a
+constructable class typed end-to-end with the union of every feature's
+added members.
 
----
+Each engine call (`hlsJs(...)`, `nativeHls(...)`) describes one engine
+variant. With multiple variants, the resulting class:
 
-## Option 4 — `features: []` escape hatch
+- Asks each variant's `supports({ src, type, preferPlayback })` in
+  order.
+- Instantiates the first match's composed inner class as the active
+  delegate.
+- Forwards facade-side calls to it.
+- Re-evaluates on `src` / `type` change. Aborts the old delegate,
+  builds the new one.
 
-Smallest migration. Keep the existing mixin-composed classes; add an
-optional `features` constructor option that runs additional features on
-top.
+With one variant, there's no selection — the class is just the
+composed mixin chain.
+
+### Engine config
+
+Engines accept their own configuration alongside the features array:
 
 ```ts
-new HlsJsMedia({ features: [googleCastFeature({ receiver: 'CC1AD845' })] });
+const HlsJsMedia = createVideo(
+  hlsJs({
+    config: { backBufferLength: 30 },
+    debug: true,
+    features: [live, streamType, errors, googleCast({ receiver: 'CC1AD845' })],
+  }),
+);
 ```
 
-**Pros:** zero churn, additive.
-**Cons:** doesn't fix per-engine duplication or per-instance opt-out of
-the built-in stack — more a bridge than a destination.
+`config`, `debug`, etc. are engine-specific options. `features` is
+universal across engines.
+
+### Configurable features
+
+Features may take options. Call the factory to get a configured
+variant — same convention as store features:
+
+```ts
+hlsJs({
+  features: [
+    live,
+    streamType,
+    googleCast({ receiver: 'CC1AD845' }),
+    muxData({ envKey: '…' }),
+  ],
+});
+```
+
+The bare symbol (`live`, `googleCast`) is shorthand for the default
+config; calling it (`googleCast({…})`) returns a configured variant.
+
+### Composing presets
+
+Each engine ships preset feature arrays — the media-side twins of
+`videoFeatures` / `liveVideoFeatures`:
+
+```ts
+import { hlsJs, hlsJsFeatures, googleCast } from '@videojs/core/dom/media/hls';
+
+const Player = createVideo(
+  hlsJs({ features: [...hlsJsFeatures, googleCast({ receiver: 'CC1AD845' })] }),
+);
+```
+
+### Audio mirror
+
+```ts
+const HlsAudio = createAudio(
+  hlsJs    ({ features: [live,       googleCast] }),
+  nativeHls({ features: [nativeLive, nativeCast] }),
+);
+```
+
+Same pattern, audio base class.
 
 ---
 
-## Option 5 — React: `useMediaFeature` hook + `features` prop
+## Engines
 
-The hook is the primitive behind every `<MediaFeature*>` component in
-Option 1; the `features` prop mirrors the store's `<PlayerProvider features>`.
+An engine is a function: it takes an options object (`config`,
+`features`, engine-specific knobs) and returns a variant descriptor
+that `createVideo` understands.
 
-### Hook
+```ts
+// packages/core/src/dom/media/hls/index.ts → @videojs/core/dom/media/hls
+import Hls, { type HlsConfig } from 'hls.js';
+import { HlsJsMediaBaseMixin } from './base';
 
-```tsx
-export function useMediaFeature(feature: AnyMediaFeature): void {
-  const media = useMedia();
-  useEffect(() => {
-    if (!media?.use) return;
-    const ctrl = new AbortController();
-    media.use(feature, { signal: ctrl.signal });
-    return () => ctrl.abort();
-  }, [media, feature]);
+interface HlsJsOptions {
+  config?: Partial<HlsConfig>;
+  debug?: boolean;
+  features: AnyHlsJsFeature[];
+}
+
+export function hlsJs(options: HlsJsOptions) {
+  return {
+    name: 'hlsJs' as const,
+    // Adds `engine`, `src`, `attach`, `detach`, `destroy` plumbing —
+    // closes over `options.config` / `options.debug`.
+    mixin: HlsJsMediaBaseMixin(options),
+    features: options.features,
+    supports: ({ type, preferPlayback }) =>
+      Hls.isSupported() &&
+      type === 'application/vnd.apple.mpegurl' &&
+      preferPlayback !== 'native',
+  };
 }
 ```
 
-### Prop (store-parity)
+`HlsJsMediaBaseMixin` is exactly today's
+`packages/core/src/dom/media/hls/hlsjs.ts:19-57` body, lifted to a
+mixin (it currently extends `HTMLVideoElementHost` directly). The
+mixin chain on lines 59-63 disappears: those mixins become engine-
+specific feature descriptors.
 
-```tsx
-<HlsVideo src="live.m3u8" features={hlsMediaFeatures} />
+`nativeHls` ships from `@videojs/core/dom/media/native-hls` with the
+same shape over `NativeHlsMediaBaseMixin`. Future engines (`dash`,
+`shaka`) drop in under their own subpath. An app that imports only
+`hlsJs` never reaches native-HLS code, and vice versa.
+
+---
+
+## Features
+
+Every feature is a tiny descriptor wrapping a class mixin, exported
+from an engine's subpath. Two flavours, distinguished by what code
+they wrap:
+
+### Engine-specific features
+
+The mixin uses engine internals (e.g. `this.engine` for hls.js).
+Lives next to the engine's source:
+
+```ts
+// packages/core/src/dom/media/hls/features/live.ts
+import { HlsJsMediaLiveMixin } from '../live';
+
+export const live = {
+  name: 'live',
+  mixin: HlsJsMediaLiveMixin,
+};
 ```
 
-**Pros:** `useMedia()` from `PlayerContext` already wires this up;
-SSR-safe (effects run client-only); `AbortController` cleanup handles
-unmount / media swap / StrictMode double-mount; tests can assert
-`feature.setup` called against a mock host.
-**Cons:** `features` prop array must be a stable reference; apply the
-hooks-in-loops rule — register the whole array in one effect rather
-than iterating `useMediaFeature`.
+Examples: `live`, `streamType`, `errors`, `preload`, `textTracks`.
+
+`live` from `@videojs/core/dom/media/hls` only fits in a `hlsJs(...)`
+variant. `live` from `@videojs/core/dom/media/native-hls` is a
+different descriptor that wraps `NativeHlsMediaLiveMixin`. Same name,
+different import path, different mixin.
+
+### Engine-agnostic features
+
+The mixin only uses public media APIs (`play`, `pause`, `currentTime`).
+Implementation lives in a shared location — typically wrapping the
+existing engine-agnostic mixin like `GoogleCastMixin` — and gets
+**re-exported from each engine subpath**:
+
+```ts
+// packages/core/src/dom/media/google-cast/index.ts (implementation)
+export const googleCast = (config: GoogleCastConfig = {}) => ({
+  name: 'googleCast',
+  mixin: GoogleCastMixin(config),
+});
+
+// packages/core/src/dom/media/hls/index.ts
+export { googleCast, muxData, airPlay } from '../google-cast';
+
+// packages/core/src/dom/media/native-hls/index.ts
+export { googleCast, muxData, airPlay } from '../google-cast';
+```
+
+Examples: `googleCast`, `muxData`, `airPlay`. Each engine path
+re-exports them so users have one curated import location per engine.
+
+The implementation isn't duplicated — each subpath re-exports the same
+module, so the bundler still sees one copy.
+
+When using multi-engine `createVideo(...)`, engine-agnostic features
+go into each variant's `features` array. Cast and analytics attach
+per-delegate; only the active delegate runs them at any moment, so
+the cost is the same as today's single mixin chain.
 
 ---
 
-## Comparison
+## Internals
 
-| Option | Runtime opt-in | Markup | Per-instance | Config | Tree-shakes | Typed | DX cost |
-|---|---|---|---|---|---|---|---|
-| 0. Mixins (today) | ✗ | ✗ | ✗ | N/A | ✓ | ✓✓ | high (authors) |
-| 1. `<media-feature-*>` / `<MediaFeature*>` | ✓ | ✓✓ | ✓ | ✓ (attrs/props) | ✓ | ✓ | medium |
-| 2. `defineMediaFeature` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
-| 3. `.with(...)` | class-time | ✓ (via `define`) | ✗ | ✓ | ✓ | ✓ | low |
-| 4. `features:` escape | ✓ | ✗ | partial | ✓ | ✓ | ✓ | minimal |
-| 5. `useMediaFeature` + prop | ✓ | ✓✓ (JSX) | ✓ | ✓ | ✓ | ✓ | low |
+`createVideo` builds an inner class per variant and (when there's more
+than one) wraps them in a thin selection facade:
 
----
+```ts
+// packages/core/src/dom/media/create-video.ts (sketch)
+export function createVideo<Variants extends [MediaVariant, ...MediaVariant[]]>(
+  ...variants: Variants
+): VideoMediaResult<Variants> {
+  const composed = variants.map((variant) => {
+    let cls: Constructor = HTMLVideoElementHost;
+    cls = variant.mixin(cls);
+    for (const feature of variant.features) cls = feature.mixin(cls);
+    return { variant, cls };
+  });
 
-## Recommended rollout
+  if (composed.length === 1) return composed[0].cls as VideoMediaResult<Variants>;
 
-1. **Primitive** — `defineMediaFeature` next to `definePlayerFeature`
-   (`packages/core/src/dom/feature.ts`). Same mental model. Includes
-   `define` / `override` / `overrideAccessor` in the context.
-2. **Host registry** — extend `MediaHost` / `HTMLVideoElementHost` with
-   `use(feature, { signal })`; run in `attach`, abort on `detach` /
-   `destroy`.
-3. **Preset arrays** — `hlsjsFeatures`, `nativeHlsFeatures`, and
-   matching `HlsMedia.with(...)` for default custom-element exports.
-4. **Pilot migration** — `live` first (small, two delegates, clean
-   lifecycle already in `packages/core/src/dom/media/hls/live.ts` and
-   `packages/core/src/dom/media/native-hls/live.ts`). Then `errors`,
-   `streamType`. `google-cast` last — it's the highest-value
-   user-opt-in feature and exercises `override` /
-   `overrideAccessor` end-to-end.
-5. **Markup (Option 1)** — `MediaFeatureElement` base +
-   `<media-feature-live>` and `<media-feature-google-cast>` as the two
-   driving examples. Populate `packages/html/src/define/feature/video.ts`
-   (currently a TODO stub).
-6. **React (Option 1 + 5)** — `useMediaFeature` + one
-   `<MediaFeature*>` wrapper per feature, mirroring the HTML tags 1:1.
-   Wire through existing `useMedia()` context.
+  // Selection facade: holds an active delegate, asks each variant's
+  // `supports()` at load(), instantiates the first match.
+  return withVariantSelection(HTMLVideoElementHost, composed) as VideoMediaResult<Variants>;
+}
+```
 
-Keep mixins internally for anything too intrusive to express as a
-feature (e.g. `HTMLVideoElementHost` itself).
+`createAudio` is identical except it starts from `HTMLAudioElementHost`.
+
+No new lifecycle, no new primitive, no runtime registry. Each variant
+is a declarative description of which mixins to compose, in which
+order, on which base.
 
 ---
 
-## Open questions
+## Bundle cost
 
-- Ordering guarantees: should feature order in the array imply
-  registration order, and should features declare dependencies
-  (`requires: ['streamType']`)? `google-cast` reaches into `streamType`
-  and `remote`, making this the most likely first case to hit.
-- **Override arbitration.** Two features overriding the same member
-  compose LIFO (last registered wraps first) — good default, matches
-  mixin order. Do we also need an explicit priority, or is
-  registration order enough? What about features that want to
-  *replace* rather than wrap (e.g. a test harness)?
-- **Conflicting active overrides.** Cast and AirPlay both override
-  `play` with "if active, defer to provider". Both can't be active at
-  once today, but the feature layer doesn't know that. Do we add a
-  "takeover" concept (one active per group) or leave coordination to
-  the features themselves?
-- Shared helpers: `listenEngine(engine, event, fn, { signal })` so
-  engine events get the same `AbortSignal`-scoped cleanup as DOM
-  events.
-- Attribute reflection: for `<media-feature-*>` elements, who owns
-  attribute → config re-derivation — the element, the feature factory,
-  or a shared `attributeChangedCallback` helper?
-- Type augmentation strategy: per-feature `API` generic (seen by
-  `WithFeatures`) vs. `declare module` merging keyed by feature `name`.
-  The store side uses the generic route — recommend matching.
-- Naming of the primitive: `defineMediaFeature` (parallel with
-  `definePlayerFeature`), or something unique like `defineMediaPlugin`
-  to avoid conflation?
+Tree-shake follows import paths.
+
+**Engine-specific code is never cross-referenced.**
+`@videojs/core/dom/media/hls` exports `hlsJs`, `live`, `streamType`,
+`errors`, `hlsJsFeatures`, plus re-exports of engine-agnostic features
+(`googleCast`, `muxData`).
+`@videojs/core/dom/media/native-hls` exports its own variants of the
+same names. Neither path imports the other.
+
+**A single-engine app pays for one engine.** A `createVideo(hlsJs({…}))`
+call only references hls.js code plus whatever engine-agnostic features
+were imported. A native-only build never touches `Hls` or any
+`HlsJs*Mixin`.
+
+**Multi-engine apps pay for both engines.** `createVideo(hlsJs({…}),
+nativeHls({…}))` necessarily references both engine bases and both
+feature sets. That's the user opting in to multi-engine playback —
+same trade-off they make today by importing `HlsMedia`.
+
+**Engine-agnostic features pay for themselves only.** The
+implementation module (`google-cast/`) is a single module re-exported
+from each engine path; the bundler dedupes it. Importing
+`googleCast` from `hls` and `googleCast` from `native-hls` in the same
+build resolves to one copy of `GoogleCastMixin`.
 
 ---
 
-## Considered but not pursued
+## Why
 
-- **Named preset tags** (`<live-hls-video>` alongside `<hls-video>`) —
-  a separate element per feature bundle, twin of `liveVideoFeatures`
-  vs `videoFeatures` on the store side. Zero-config for common cases,
-  but combinatorial as features grow (`<live-castable-hls-video>`?),
-  and `HlsMedia.with(...)` + `customElements.define(...)` (Option 3)
-  already covers the "I want a preset tag" use case with no new
-  concepts.
-- **Reactive Controllers** — OO variant of `defineMediaFeature` where
-  features implement a `MediaController` interface
-  (`hostAttach` / `hostDetach` / `hostDestroy`, `new
-  GoogleCastController(...)`). Familiar to Lit users, but redundant
-  with `defineMediaFeature` and less uniform with store slices.
-  `defineMediaFeature` already gives us `this`-free closures over the
-  same lifecycle via `AbortSignal`.
-- **`features="live google-cast"` attribute** — registry-backed
-  attribute listing feature names. Short to write but every
-  config-bearing feature (cast, thumbnails, …) still needs a
-  `<media-feature-*>` child for its config, so the attribute ends up
-  duplicating Option 1 rather than replacing it. Also inherits the
-  global-registry problems below.
-- **Global side-effect imports** (`import '@videojs/core/features/live'`)
-  — classic plugin pattern. Rejected as a primary path because it
-  breaks tree-shaking, has load-order problems across code-splitting /
-  SSR / late scripts, duplicates registries when `@videojs/core` is
-  deduped, has no configuration story, offers no per-instance opt-out,
-  and hides the feature set from the component (harder bug triage).
-  Can still be offered later as thin sugar over `defineMediaFeature`
-  if there's demand.
+- **Parity with the store.** Both layers read the same way:
+  `{ features: [...] }`, plus the engine function call.
+- **One function for one or many engines.** No separate router
+  primitive. Pass one variant or many — the API surface is the same.
+- **One import path per engine.** Everything you need for hls.js
+  comes from `@videojs/core/dom/media/hls`. The next-most-common
+  question — "which `googleCast` do I import?" — answers itself.
+- **Tree-shake by intent.** Pick one engine path and that's all you
+  pay for. Pass a second variant to opt in to fallback.
+- **No churn underneath.** Mixins keep their `#private` fields,
+  precise types, and zero runtime overhead. We're only changing the
+  composition surface.
+- **One concept to learn.** Library authors still write mixins.
+  App authors see one variadic factory per media kind.
+- **Audio is real.** `createAudio` extends `HTMLAudioElementHost`
+  properly, fixing the `packages/core/src/dom/media/mux/index.ts:20-21`
+  TODO.
+
+---
+
+## Migration sketch
+
+| Today | Tomorrow |
+| --- | --- |
+| `HlsJsMediaBase` (lines 19-57 of `hls/hlsjs.ts`) | `hlsJs(...).mixin` (engine function) |
+| `class HlsJsMedia extends HlsJsMediaPreloadMixin(...)` | `createVideo(hlsJs({ features: [live, streamType, errors, preload] }))` |
+| `class NativeHlsMedia` | `createVideo(nativeHls({ features: [live, streamType, errors] }))` |
+| `class HlsMedia { … delegate selection … }` | `createVideo(hlsJs({ features: [...] }), nativeHls({ features: [...] }))` |
+| `GoogleCastMixin` | `googleCast.mixin` (re-exported from each engine path) |
+| `MuxDataMediaMixin` | `muxData.mixin` (re-exported from each engine path) |
+| `class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia))` | `createVideo(hlsJs({ features: [..., muxData, googleCast] }), nativeHls({ features: [..., muxData, googleCast] }))` |
+| `class MuxAudioMedia` (TODO: should extend audio) | `createAudio(...)` mirroring the video version |
+
+Engine classes shrink to bare bases. Mixins keep their bodies and just
+get exposed as feature descriptors under their engine's subpath. The
+hand-coded selection logic in `HlsMedia` moves into `createVideo`'s
+multi-variant branch.
+
+---
+
+## Open Questions
+
+- **Variant type surface.** When multiple variants are passed, is the
+  resulting class's public type the *intersection* of the variants
+  (only members on every variant — simplest contract) or the *union*
+  (everything any variant exposes, narrowed via `instanceof` on
+  `delegate`)? Today's `HlsMedia` hand-picks forwarders; the new
+  multi-variant branch needs a principled answer.
+- **`supports` contract.** Engines contribute it; what signature?
+  Today's `HlsMedia` reads `src`, `type`, `preferPlayback`,
+  `config`, `debug`. A canonical `MediaSupportContext` type lives in
+  `@videojs/core/dom/media`.
+- **Variant ordering.** First match wins, with `preferPlayback` as a
+  tiebreaker (matching today's logic). Do we expose
+  `preferPlayback` as a special-cased prop, or generalise to a
+  per-variant `priority`?
+- **Feature ordering.** Array order is registration order. Mixin
+  order matters today (preload wraps stream-type wraps errors, …) —
+  encode the recommended order in each engine's preset (`hlsJsFeatures`).
+- **Override conflicts.** Two features wrapping the same method
+  (e.g. cast and AirPlay both wrapping `play`) compose in array
+  order. Same as today's mixin chain — likely fine, worth confirming.
+- **Naming.** `createVideo` / `createAudio` parallel `createPlayer`.
+  Alternatives: `defineVideo` / `defineAudio` to mirror
+  `defineSlice` / `definePlayerFeature`.
+- **Repeated cross-cutting features.** Putting `googleCast`, `muxData`
+  in every variant is verbose. Worth a sugar like
+  `createVideo(variant1, variant2, { features: sharedFeatures })`
+  (trailing options apply to all variants)? Or leave it to user-side
+  helpers?
+- **Re-exports vs duplicate descriptors.** `googleCast` re-exported
+  from each engine path — does TypeScript's instance type stay
+  identical across import paths? (Should — re-export preserves
+  identity.) Worth a sanity test.
+- **Custom engines / features.** Type-ergonomic helpers
+  (`defineFeature`, `defineEngine`) for third-party authors? Or is
+  the descriptor shape simple enough to write by hand?
 
 ---
 
 ## See Also
 
-- `internal/design/media.md` — Media contract work this builds on.
-- `packages/core/src/dom/feature.ts` — `definePlayerFeature` /
-  `defineSlice` — the shape to mirror.
-- `packages/core/src/dom/store/features/presets.ts` — preset array
-  pattern (`videoFeatures`, `liveVideoFeatures`).
-- `packages/core/src/dom/media/google-cast/` — the mixin this doc
-  proposes reshaping as a feature factory.
+- `packages/core/src/dom/store/features/presets.ts` — preset arrays
+  on the store side. The shape we're mirroring.
+- `packages/core/src/dom/media/hls/hlsjs.ts` — the current static
+  mixin chain `createVideo` replaces; lines 19-57 become the body of
+  the `hlsJs` engine function's mixin.
+- `packages/core/src/dom/media/hls/index.ts` — today's `HlsMedia`
+  facade with hand-coded delegate selection; replaced by
+  `createVideo`'s multi-variant branch.
+- `packages/core/src/dom/media/google-cast/index.ts` — the heaviest
+  engine-agnostic mixin, becomes `googleCast.mixin` re-exported from
+  each engine path.
+- `packages/core/src/dom/media/mux/index.ts` — `MuxVideoMedia` /
+  `MuxAudioMedia`, the canonical multi-layer composition. The audio
+  TODO on line 20-21 resolves naturally with `createAudio`.

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -1,0 +1,632 @@
+---
+status: draft
+date: 2026-04-22
+---
+
+# Composable Media Features
+
+## Summary
+
+The media layer today composes features via static TypeScript mixins
+(`HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(...))`). Great DX for
+library authors, closed to app authors. The store layer has already solved
+this with **declarative feature arrays** (`defineSlice` /
+`createPlayer({ features })`).
+
+This doc lays out ways to bring the same compositional freedom to the
+media layer, in order from smallest change to most user-facing, so they
+can be adopted together or one at a time.
+
+**Recommended shape:**
+
+1. Introduce `defineMediaFeature` as the primitive — mirror `defineSlice`
+   1:1.
+2. Ship preset arrays (`hlsjsFeatures`, `nativeHlsFeatures`).
+3. Expose instance composition (`new HlsMedia({ features })` / `.use(f)`).
+4. Add class-time composition (`HlsMedia.with(...)`) for custom elements.
+5. Add HTML child elements (`<media-live>`) and a `features="…"` attribute.
+6. Add React mirror: `useMediaFeature` + `<MediaLive />` + `features` prop.
+7. Optional: side-effect import entry points (`@videojs/html/auto`) as
+   sugar only — **not** the only path.
+
+Keep existing mixins usable internally; migrate leaf-first (`live`,
+`errors`, `streamType`) where the lifecycle is already clean.
+
+> If/when we commit to this direction, the public-API-facing pieces
+> (`defineMediaFeature`, `features: []`, `<media-*>` children, React
+> hook/component) belong in an RFC. This doc exists to scope the options.
+
+---
+
+## Today: Static Mixins
+
+```ts
+export class HlsJsMedia extends HlsJsMediaPreloadMixin(
+  HlsJsMediaLiveMixin(
+    HlsJsMediaStreamTypeMixin(
+      HlsJsMediaMetadataTracksMixin(
+        HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase))
+      )
+    )
+  )
+) {}
+```
+
+**Pros:** precise types, `#private` fields, zero runtime overhead.
+**Cons:** closed at build time, duplicated per engine delegate, lots of
+lifecycle boilerplate per mixin, no user extension without subclassing.
+
+---
+
+## Option 1 — `defineMediaFeature` primitive
+
+Mirror `defineSlice` on the media side.
+
+```ts
+export interface MediaFeatureContext<Host> {
+  host: Host;
+  engine?: unknown;
+  target: HTMLMediaElement | null;
+  signal: AbortSignal;
+  define: (name: string, desc: PropertyDescriptor) => void;
+  emit: (type: string) => void;
+}
+
+export function defineMediaFeature<Host, API = void>(cfg: {
+  name: string;
+  supports?: (host: Host) => boolean;
+  setup: (ctx: MediaFeatureContext<Host>) => API | void;
+}) { return cfg; }
+```
+
+Each feature is a plain object. A tiny registry on the base `MediaHost`
+runs features in `attach()` and tears them down via `AbortSignal` on
+`detach()` / `destroy()`.
+
+**Pros:** data-shaped, typeable, uniform lifecycle, testable, reusable
+across delegates, types via `UnionToIntersection<InferAPI<F[number]>>`
+(same pattern as `UnionSliceState`).
+**Cons:** reliance on `Object.defineProperty` for per-feature props
+(already used across the codebase).
+
+### Worked example: `live` on `HlsMedia`
+
+Today's equivalent is a mixin that does a constructor-time
+`engine.on(...)`, holds private state, and has no standard teardown
+(compare `HlsJsMediaStreamTypeMixin` in
+`packages/core/src/dom/media/hls/stream-type.ts`):
+
+```ts
+export function HlsJsMediaLiveMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
+  class HlsJsMediaLive extends (BaseClass as Constructor<HlsEngineHost>) {
+    #targetLiveWindow = Number.NaN;
+    #liveEdgeStartOffset: number | undefined;
+
+    constructor(...args: any[]) {
+      super(...args);
+      this.engine?.on(Hls.Events.LEVEL_LOADED, (_e, data) => this.#derive(data.details));
+      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#reset());
+      this.engine?.on(Hls.Events.DESTROYING, () => this.#reset());
+    }
+
+    get targetLiveWindow() { return this.#targetLiveWindow; }
+    get liveEdgeStart() { /* derive from seekable + offset */ }
+
+    // #derive / #reset / #setTargetLiveWindow …
+  }
+  return HlsJsMediaLive as unknown as Base &
+    Constructor<{ readonly liveEdgeStart: number; readonly targetLiveWindow: number }>;
+}
+
+export class HlsJsMedia extends HlsJsMediaLiveMixin(HlsJsMediaStreamTypeMixin(HlsJsMediaBase)) {}
+```
+
+Reshaped as a feature:
+
+```ts
+// packages/core/src/dom/media/hls/features/live.ts
+import Hls, { type LevelLoadedData } from 'hls.js';
+import { defineMediaFeature } from '../../feature';
+import type { HlsEngineHost } from '../types';
+
+export const hlsjsLive = defineMediaFeature<HlsEngineHost>({
+  name: 'hlsjs:live',
+  setup({ host, target, signal, define, emit }) {
+    let targetLiveWindow = Number.NaN;
+    let liveEdgeStartOffset: number | undefined;
+
+    define('targetLiveWindow', { get: () => targetLiveWindow });
+    define('liveEdgeStart', {
+      get: () => {
+        if (liveEdgeStartOffset === undefined || !target) return Number.NaN;
+        const { seekable } = target;
+        return seekable.length ? seekable.end(seekable.length - 1) - liveEdgeStartOffset : Number.NaN;
+      },
+    });
+
+    const setWindow = (value: number) => {
+      if (Object.is(targetLiveWindow, value)) return;
+      targetLiveWindow = value;
+      emit('targetlivewindowchange');
+    };
+
+    const derive = (details: LevelLoadedData['details']) => {
+      if (!details.live) return reset();
+      const lowLatency = !!details.partList?.length;
+      liveEdgeStartOffset = lowLatency
+        ? details.partHoldBack || details.partTarget * 2
+        : details.holdBack || details.targetduration * 3;
+      setWindow(details.type === 'EVENT' ? Number.POSITIVE_INFINITY : 0);
+    };
+
+    const reset = () => {
+      liveEdgeStartOffset = undefined;
+      setWindow(Number.NaN);
+    };
+
+    const engine = host.engine;
+    const onLevel = (_e: string, data: LevelLoadedData) => derive(data.details);
+    engine?.on(Hls.Events.LEVEL_LOADED, onLevel);
+    engine?.on(Hls.Events.MANIFEST_LOADING, reset);
+    engine?.on(Hls.Events.DESTROYING, reset);
+
+    // Every subscription is undone when `signal` aborts — no custom
+    // `detach()` / `destroy()` wiring required on the host.
+    signal.addEventListener('abort', () => {
+      engine?.off(Hls.Events.LEVEL_LOADED, onLevel);
+      engine?.off(Hls.Events.MANIFEST_LOADING, reset);
+      engine?.off(Hls.Events.DESTROYING, reset);
+      reset();
+    });
+  },
+});
+```
+
+And the registration site — no mixin chain, just an array:
+
+```ts
+// packages/core/src/dom/media/hls/hlsjs.ts
+import { hlsjsLive } from './features/live';
+import { hlsjsStreamType } from './features/stream-type';
+
+export const hlsjsFeatures = [hlsjsStreamType, hlsjsLive /* , … */];
+
+export class HlsJsMedia extends HlsJsMediaBase {
+  constructor(init?: HlsJsMediaInit) {
+    super(init);
+    for (const f of hlsjsFeatures) this.use(f);
+  }
+}
+```
+
+What the shape buys us:
+
+- **Lifecycle.** One `AbortSignal` replaces the ad-hoc `destroy()` /
+  `#reset()` dance — same pattern already used by
+  `NativeHlsMediaLiveMixin` and store `listen()` helpers.
+- **Reuse.** `hlsjsLive` and `nativeHlsLive` are two `defineMediaFeature`
+  calls sitting in the same folder; users pick one or both instead of
+  inheriting a whole class.
+- **User extension.** `new HlsJsMedia({ features: [...hlsjsFeatures, myRecorder] })`
+  needs no subclass.
+- **Tests.** Setup is a pure function — pass a fake host/engine/target
+  plus an `AbortController`, drive it, then `controller.abort()`. No
+  class instantiation, no mixin composition.
+
+### Worked example: `<hls-video>` custom element
+
+Today `HlsVideo` just wraps `HlsMedia` with `CustomMediaElement`
+(`packages/html/src/media/hls-video/index.ts`). With features, the
+element exposes a `features` init hook — no new classes, just a config:
+
+```ts
+// packages/html/src/media/hls-video/index.ts
+import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
+import { HlsMedia, hlsMediaFeatures } from '@videojs/core/dom/media/hls';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+export class HlsVideo extends MediaAttachMixin(
+  CustomMediaElement('video', HlsMedia, { features: hlsMediaFeatures })
+) {
+  static get observedAttributes() {
+    // biome-ignore lint/complexity/noThisInStatic: intentional use of super
+    return [...super.observedAttributes, 'type', 'prefer-playback', 'debug'];
+  }
+}
+```
+
+App authors pick their own composition without subclassing:
+
+```html
+<!-- Default preset -->
+<hls-video src="live.m3u8" controls></hls-video>
+
+<!-- Custom element wrapping a trimmed feature set -->
+<script type="module">
+  import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
+  import { HlsMedia, hlsjsLive, hlsjsStreamType } from '@videojs/core/dom/media/hls';
+  import { myAnalytics } from './my-analytics.js';
+
+  customElements.define(
+    'my-hls-video',
+    class extends CustomMediaElement('video', HlsMedia, {
+      features: [hlsjsStreamType, hlsjsLive, myAnalytics],
+    }) {}
+  );
+</script>
+<my-hls-video src="live.m3u8" controls></my-hls-video>
+```
+
+Attributes still flow through `observedAttributes` and the
+`CustomMediaElement` reflection — features add behaviour, they don't
+take over the element.
+
+### Worked example: `<HlsVideo />` React component
+
+Mirror the HTML story with a `features` prop. The prop is consumed once
+at mount by `useMediaInstance`, which already owns the media instance
+lifecycle (`packages/react/src/utils/use-media-instance.ts`):
+
+```tsx
+// packages/react/src/media/hls-video/index.tsx
+'use client';
+
+import type { HlsMediaProps, AnyMediaFeature } from '@videojs/core/dom/media/hls';
+import { HlsMedia, hlsMediaFeatures } from '@videojs/core/dom/media/hls';
+import { forwardRef, useMemo, type ReactNode, type VideoHTMLAttributes } from 'react';
+import { useAttachMedia } from '../../utils/use-attach-media';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface HlsVideoProps
+  extends Omit<VideoHTMLAttributes<HTMLVideoElement>, keyof HlsMediaProps>,
+    Partial<HlsMediaProps> {
+  features?: readonly AnyMediaFeature[];
+  children?: ReactNode;
+}
+
+export const HlsVideo = forwardRef<HTMLVideoElement, HlsVideoProps>(function HlsVideo(
+  { features = hlsMediaFeatures, children, ...props },
+  ref
+) {
+  // `useMediaInstance` creates the media once; pass features as part of init.
+  const init = useMemo(() => ({ features }), [features]);
+  const media = useMediaInstance(HlsMedia, init);
+  const attachRef = useAttachMedia(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const htmlProps = useSyncProps(media, props);
+
+  return (
+    <video ref={composedRef} {...htmlProps}>
+      {children}
+    </video>
+  );
+});
+```
+
+Usage stays declarative and React-idiomatic:
+
+```tsx
+import { HlsVideo, hlsjsLive, hlsjsStreamType } from '@videojs/react/hls-video';
+import { myAnalytics } from './my-analytics';
+
+// Default preset
+<HlsVideo src="live.m3u8" controls />
+
+// Custom composition — memoised array to keep the reference stable
+const features = [hlsjsStreamType, hlsjsLive, myAnalytics];
+
+<HlsVideo src="live.m3u8" controls features={features} />
+```
+
+Both surfaces bottom out on the same `defineMediaFeature` primitive —
+HTML composes at element-definition time, React composes per-instance
+through props. Options 5–8 later in this doc build on top of this by
+adding _incremental_ composition (adding a single feature at runtime via
+`<media-live>` or `useMediaFeature`); this worked example shows only
+the "set the full feature array at construction" story, which is the
+minimum needed for Option 1 to stand on its own.
+
+---
+
+## Option 2 — Reactive Controllers
+
+OO flavour of Option 1. Features implement a controller interface.
+
+```ts
+interface MediaController {
+  hostAttach?(host, target, signal): void;
+  hostDetach?(): void;
+  hostDestroy?(): void;
+}
+media.addController(new HlsLiveController());
+```
+
+**Pros:** holds state on `this`, familiar to Lit users, plays well with
+existing `*Controller` classes.
+**Cons:** less data-like, needs `new`, not as uniform with store slices.
+
+---
+
+## Option 3 — Class-time composition (`.with(...)`)
+
+Factory that returns a constructable class. Solves the custom-element
+and "declare a tagName" use case.
+
+```ts
+class HlsMedia extends MediaHost {
+  static with<F extends AnyMediaFeature[]>(...features: F) {
+    return class extends HlsMedia {
+      constructor(init?) { super(init); features.forEach((f) => this.use(f)); }
+    } as Constructor<HlsMedia & WithFeatures<HlsMedia, F>>;
+  }
+}
+
+customElements.define('hls-media', HlsMedia.with(...hlsjsFeatures));
+```
+
+**Pros:** markup-ready, typed, composes from data.
+**Cons:** returns a new class per call — keep callers module-scoped.
+
+---
+
+## Option 4 — `features: []` escape hatch
+
+Smallest migration. Keep the existing mixin-composed classes; add an
+optional `features` constructor option that runs additional features on
+top.
+
+```ts
+new HlsJsMedia({ features: [myRecorderFeature] });
+```
+
+**Pros:** zero churn, additive.
+**Cons:** doesn't fix per-engine duplication or per-instance opt-out of
+the built-in stack — more a bridge than a destination.
+
+---
+
+## Option 5 — HTML child elements
+
+Each feature gets a thin custom element that finds its media host and
+registers on `connectedCallback`.
+
+```html
+<hls-video src="live.m3u8">
+  <source src="live.m3u8" type="application/vnd.apple.mpegurl" />
+  <track kind="captions" src="en.vtt" default />
+
+  <media-live></media-live>
+  <media-thumbnails src="thumbs.vtt"></media-thumbnails>
+  <media-metadata-tracks></media-metadata-tracks>
+</hls-video>
+```
+
+```ts
+abstract class MediaFeatureElement extends HTMLElement {
+  abstract getFeature(): AnyMediaFeature;
+  #disconnect: AbortController | null = null;
+
+  connectedCallback() {
+    const host = this.closest<MediaHostElement>('[data-media-host]');
+    if (!host) return;
+    this.#disconnect = new AbortController();
+    host.addFeature(this.getFeature(), { signal: this.#disconnect.signal });
+  }
+  disconnectedCallback() { this.#disconnect?.abort(); this.#disconnect = null; }
+}
+```
+
+**Pros:** HTML-native, declarative, serialisable, SSR-safe, mirrors
+existing `<source>` / `<track>` handling; add/remove a feature by
+adding/removing DOM; reactive config via attributes; React works
+identically (1:1 JSX wrapper).
+**Cons:** a thin element per feature; tag-name conventions to decide;
+startup-timing handshake (buffer feature registrations until the host's
+`connectedCallback`, or use the existing `containerContext` /
+`playerContext` pattern).
+
+---
+
+## Option 6 — `features="…"` attribute
+
+Registry-backed attribute for quick presets with no config.
+
+```html
+<hls-video src="live.m3u8" features="live metadata-tracks thumbnails" />
+```
+
+```ts
+registerMediaFeature('live', liveMediaFeature);
+// host reads + diffs `features` attribute
+```
+
+**Pros:** shortest markup, attribute-reactive.
+**Cons:** no per-feature config; global registry side effects (see
+Option 9 caveats).
+
+---
+
+## Option 7 — Named preset tags
+
+Different element for different preset bundle.
+
+```html
+<hls-video src="vod.m3u8" />
+<live-hls-video src="live.m3u8" />
+```
+
+`<live-hls-video>` = `HlsVideoElement` with a `liveFeatures` default
+array. Twin of `liveVideoFeatures` vs `videoFeatures` on the store side.
+
+**Pros:** zero-config for common cases.
+**Cons:** combinatorial as features grow.
+
+---
+
+## Option 8 — React: hook + component + prop
+
+All three layers stack on Option 1's primitive.
+
+### Hook
+
+```tsx
+export function useMediaFeature(feature: AnyMediaFeature): void {
+  const media = useMedia();
+  useEffect(() => {
+    if (!media?.addFeature) return;
+    const ctrl = new AbortController();
+    media.addFeature(feature, { signal: ctrl.signal });
+    return () => ctrl.abort();
+  }, [media, feature]);
+}
+```
+
+### Component (sugar)
+
+```tsx
+export const MediaLive = () => <MediaFeature feature={liveMediaFeature} />;
+
+export function MediaThumbnails({ src }: { src?: string }) {
+  const feature = useMemo(() => thumbnailsMediaFeature({ src }), [src]);
+  useMediaFeature(feature);
+  return null;
+}
+```
+
+### Prop (store-parity)
+
+```tsx
+<HlsVideo src="live.m3u8" features={liveMediaFeatures} />
+```
+
+**Pros:** `useMedia()` from `PlayerContext` already wires this up;
+SSR-safe (effects run client-only); `AbortController` cleanup handles
+unmount / media swap / StrictMode double-mount; tests can assert
+`feature.setup` called against a mock host.
+**Cons:** `features` prop array must be stable reference; hooks-in-loops
+rule — register the whole array in one effect rather than iterating
+`useMediaFeature`.
+
+### App example
+
+```tsx
+<PlayerProvider features={liveVideoFeatures}>
+  <VideoContainer>
+    <HlsVideo src="live.m3u8">
+      <MediaLive />
+      <MediaThumbnails src="thumbs.vtt" />
+    </HlsVideo>
+    <PlayButton /><TimeSlider /><MuteButton />
+  </VideoContainer>
+</PlayerProvider>
+```
+
+Store features (`liveVideoFeatures`) shape the store state; media
+features (`<MediaLive />`) shape engine behaviour. Both declarative,
+both cleanup-safe.
+
+---
+
+## Option 9 — Global side-effect imports
+
+```ts
+import '@videojs/core/media/features/live';
+import '@videojs/core/media/features/thumbnails';
+// every HlsMedia instance now has these attached
+```
+
+Classic plugin pattern (jQuery, `chart.js/auto`, Video.js 7).
+
+**Pros:** zero opt-in boilerplate; feels like "batteries included".
+**Cons — real ones:**
+
+- Breaks tree-shaking; invalidates `sideEffects: false`.
+- Module-graph ordering across code-splitting, dynamic `import()`, SSR,
+  late `<script>` tags leads to "works in dev, breaks in prod".
+- Duplicate copies of `@videojs/core` = duplicate registries (monorepos,
+  linked packages). Mitigate with `Symbol.for('@videojs/media-features')`.
+- No configuration story — `configureThumbnails({ src })` shows up next
+  to it, defeating the "just import it" promise.
+- No per-instance opt-out — every media pays for every feature.
+- Discoverability: feature set is a property of the bundle, not the
+  component. Bug triage is harder.
+- Testing: test-file registration leakage unless `vi.resetModules()`.
+- HMR double-registration unless registry is idempotent by name.
+- React SSR / RSC: server-rendered tree may not run the side-effect
+  import → hydration mismatch.
+
+**Verdict:** offer as sugar (`@videojs/html/auto`,
+`@videojs/html/features/live`) backed by the same primitive, but **not**
+as the only path.
+
+---
+
+## Comparison
+
+| Option | Runtime opt-in | Markup | Per-instance | Config | Tree-shakes | Typed | DX cost |
+|---|---|---|---|---|---|---|---|
+| 0. Mixins (today) | ✗ | ✗ | ✗ | N/A | ✓ | ✓✓ | high (authors) |
+| 1. `defineMediaFeature` | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
+| 2. Controllers | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | low |
+| 3. `.with(...)` | class-time | ✓ (via `define`) | ✗ | ✓ | ✓ | ✓ | low |
+| 4. `features:` escape | ✓ | ✗ | partial | ✓ | ✓ | ✓ | minimal |
+| 5. `<media-*>` children | ✓ | ✓✓ | ✓ | ✓ (attrs) | ✓ | ✓ | medium |
+| 6. `features="…"` attr | ✓ | ✓ | ✓ | ✗ | needs care | ✓ | low |
+| 7. Preset tags | class-time | ✓✓ | ✗ | ✗ | ✓ | ✓ | low |
+| 8. React hook/comp/prop | ✓ | ✓✓ (JSX) | ✓ | ✓ | ✓ | ✓ | low |
+| 9. Global imports | import-time | ✗ | ✗ | awkward | ✗ | ✓ | very low |
+
+---
+
+## Recommended rollout
+
+1. **Primitive** — `defineMediaFeature` next to `definePlayerFeature`
+   (`packages/core/src/dom/feature.ts`). Same mental model.
+2. **Host registry** — extend `MediaHost` / `HTMLVideoElementHost` with
+   `use(feature)` / `addFeature(feature, { signal })`; run in `attach`,
+   abort on `detach` / `destroy`.
+3. **Preset arrays** — `hlsjsFeatures`, `nativeHlsFeatures`, and matching
+   `HlsMedia.with(...)` for default custom-element exports.
+4. **Pilot migration** — `live` first (small, two delegates, clean
+   lifecycle already in `packages/core/src/dom/media/hls/live.ts` and
+   `packages/core/src/dom/media/native-hls/live.ts`). Then `errors`,
+   `streamType`. Big ones (`metadata-tracks`, `text-tracks`) last.
+5. **Markup** — add `MediaFeatureElement` base + `<media-live>` first.
+   Populate `packages/html/src/define/feature/video.ts` (currently a
+   TODO stub).
+6. **React** — `useMediaFeature` + `MediaFeature` + per-feature
+   wrappers. Wire through existing `useMedia()` context.
+7. **Optional sugar** — `@videojs/html/auto` side-effect entry calling
+   the same `registerMediaFeature` primitive, keyed + idempotent.
+
+Keep mixins internally for anything too intrusive to express as a
+feature (e.g. `HTMLVideoElementHost` itself).
+
+---
+
+## Open questions
+
+- Ordering guarantees: should feature order in the array imply
+  registration order, and should features declare dependencies
+  (`requires: ['streamType']`)?
+- Shared helpers: `listenEngine(engine, event, fn, { signal })` so
+  engine events get the same `AbortSignal`-scoped cleanup as DOM
+  events.
+- Type augmentation strategy: per-feature `API` generic (seen by
+  `WithFeatures`) vs. `declare module` merging keyed by feature `name`.
+  The store side uses the generic route — recommend matching.
+- Naming of the primitive: `defineMediaFeature` (parallel with
+  `definePlayerFeature`), or something unique like `defineMediaPlugin`
+  to avoid conflation?
+
+---
+
+## See Also
+
+- `internal/design/media.md` — Media contract work this builds on.
+- `packages/core/src/dom/feature.ts` — `definePlayerFeature` /
+  `defineSlice` — the shape to mirror.
+- `packages/core/src/dom/store/features/presets.ts` — preset array
+  pattern (`videoFeatures`, `liveVideoFeatures`).

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -45,7 +45,7 @@ Two roles, one host:
 
 - **Media Extension** — installs itself on a media host, owns its lifecycle
   and state, and may push one or more layers (or only observe). Usually
-  produced by a factory like `googleCast({ … })`.
+  constructed through a factory like `googleCast({ … })`.
 - **Media Layer** — anything pushed onto the layer stack via
   `addLayer(media, layer)`.
 
@@ -131,39 +131,44 @@ export default function HlsVideoWithExtensions() {
 ### Media Extension
 
 ```ts
-import { defineExtension, getExtensions } from '@videojs/core/media/media-extension';
+import { getExtensions, installExtension, type MediaExtension } from '@videojs/core/media/media-extension';
 import { addLayer } from '@videojs/core/media/media-layer';
+import type { GoogleCastMedia } from './google-cast-layer';
 
-const googleCast = defineExtension((props: GoogleCastProps) => ({
-  install(media, { signal }) {
-    // Target-bound state belongs on a layer — override `set target` to react.
-    const layer = addLayer(media, new GoogleCastLayer(props));
-    // `signal` aborts on destroy — pass it to anything signal-aware.
-    return layer;
-  },
-}));
+class GoogleCast implements GoogleCastProps, MediaExtension {
+  #destroy = () => {};
+
+  install(media: GoogleCastMedia) {
+    installExtension(googleCast, media, this);
+    this.#destroy = addLayer(media, new GoogleCastLayer(this));
+  }
+
+  destroy() {
+    this.#destroy();
+    this.#destroy = () => {};
+  }
+}
+
+export function googleCast(props: GoogleCastProps = {}) {
+  return new GoogleCast(props);
+}
 
 const cast = googleCast({ receiverApplicationId: '…' });
-const destroy = cast.install(media);
+cast.install(media);
 
 // lookup + mutate from anywhere with the media reference
-getExtensions(media).get(googleCast)?.receiverApplicationId = 'new-id';
+getExtensions(media).get(googleCast)!.receiverApplicationId = 'new-id';
 
 // iterate every installed extension
 for (const ext of getExtensions(media)) console.log(ext);
 
-destroy();
+cast.destroy();
 ```
 
-`getExtensions(media)` returns a `MediaExtensionList` bound to that host —
-the single entry point for installing, looking up, and iterating extensions.
-`defineExtension` brands each instance so that `ext.install(media)` and
-`getExtensions(media).install(ext)` share the same dedup state.
-
-The framework creates one `AbortController` per install and passes its
-signal to `install(media, { signal })`. The returned destroy aborts that
-signal, then runs any teardown the extension returned — so most extensions
-never need to manage their own controller.
+`getExtensions(media)` is the registry for that host. Extensions register
+themselves by factory during `install()`, consumers look them up with the same
+factory, and teardown is explicit through `extension.destroy()` or host
+destruction.
 
 ### Media Layer
 

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -5,54 +5,49 @@ date: 2026-05-14
 
 # Composable Media
 
-Compose media behavior by registering host extensions and swapping the active
-strategy at runtime.
+Compose media behavior by registering host extensions and adding media
+layers at runtime.
 
 ## Problem
 
 Today, behavior on top of the base media classes is layered with class
-mixins with mixin-prefixed props:
+mixins and mixin-prefixed props:
 
 ```ts
-// packages/core/src/dom/media/mux/index.ts (legacy pattern)
-export class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia))
-  implements MuxMediaProps {}
+export class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia)) {}
 
-// MuxMediaProps surfaces the union of every mixin's props on the host:
 type MuxMediaProps = HlsMediaProps & GoogleCastMediaProps & MuxDataMediaProps;
 // e.g. castSrc, castContentType, castReceiverApplicationId, muxEnvKey, …
 ```
 
 That pattern has costs we want to remove:
 
-1. **Static composition.** The class is baked at module load. Cast can't be
-   code-split or lazy loaded. Once mixed in, behavior can't be added,
-   removed, or swapped at runtime. Cast doesn't have a way to truly turn
-   itself off.
-2. **Muddled media API.** Mixins add config props to the media API surface
-   which need to be prefixed to avoid conflicts.
-
-We want a model where Cast, Ads, and future extensions are independent
-modules that attach to a host at runtime, and where redirecting playback
-(Cast, ads, ...) is a single instance swap.
+1. **Static composition.** The class is baked at module load — Cast can't
+   be code-split or lazy loaded, and once mixed in, behavior can't be
+   added, removed, or swapped at runtime.
+2. **Muddled media API.** Mixin config props leak onto the media surface
+   and need prefixing to avoid conflicts.
 
 ## Solution
 
 Two roles, one host:
 
-- **Extension** — A small class registered via `host.use(extension)`. Owns its
-  own lifecycle (`install` → uninstaller) and any state it needs. May install
-  a strategy. May only observe.
-- **Strategy** — A class extending `BaseMediaStrategy` that handles the host's
-  full media surface while it's active. Inherits the "do the native thing"
-  behavior for accessors it doesn't override.
+- **Media Extension** — installs itself on a media host, owns its lifecycle
+  and state, and may push one or more layers (or only observe). Usually
+  produced by a factory like `googleCast({ … })`.
+- **Media Layer** — anything pushed onto the layer stack via
+  `addLayer(media, layer)`.
 
-The host owns **one active strategy at a time** (`host.strategy`). All accessors and
-methods on the host are one-liner forwarders to `host.strategy`. Extensions
-decide when to swap it via `host.route(strategy)`.
+## Features
 
-This generalizes the existing `HlsMedia.#delegate` pattern (swap between
-`HlsJsMedia` / `NativeHlsMedia`) and reuses it everywhere.
+- Extensions and layers can be pre-composed into a single media host.
+  e.g. MuxVideo is composed of HlsMedia, GoogleCast, and MuxData.
+- Extensions and layers can be installed and removed at runtime.
+- Extensions have their own API surface and lifecycle.
+- Extensions are deduplicated and only installed once per media host.
+- Extensions can be looked up and updated from anywhere with the media reference.
+- Extensions can't extend the media host's API surface — strict by default,
+  however the host can still be easily extended by subclassing.
 
 ## Quick Start
 
@@ -60,33 +55,31 @@ This generalizes the existing `HlsMedia.#delegate` pattern (swap between
 
 ```ts
 import { createHlsMedia } from '@videojs/core/dom/media/hls';
-import { GoogleCast } from '@videojs/core/dom/media/google-cast';
-import { MuxData } from '@videojs/core/dom/media/mux';
+import { googleCast } from '@videojs/core/dom/media/google-cast';
+import { muxData } from '@videojs/core/dom/media/mux';
 
 const media = createHlsMedia();
-media.attach(videoElement);
+media.target = mediaElement;
 
-media.use(new GoogleCast({ receiverApplicationId: '…' }));
-media.use(new MuxData({ envKey: '…' }));
+googleCast({ receiverApplicationId: '…' }).install(media);
+muxData({ envKey: '…' }).install(media);
 ```
 
 ### Dynamic import
 
 ```ts
+import { createHlsMedia } from '@videojs/core/dom/media/hls';
+
 const media = createHlsMedia();
-media.attach(videoElement);
+media.target = mediaElement;
 
 if (userWantsCast) {
-  const { GoogleCast } = await import('@videojs/core/dom/media/google-cast');
-  media.use(new GoogleCast({ receiverApplicationId: '…' }));
+  const { googleCast } = await import('@videojs/core/dom/media/google-cast');
+  googleCast({ receiverApplicationId: '…' }).install(media);
 }
 ```
 
 ### Factory style
-
-`createHlsMedia` is the convenience factory: it constructs an
-`HTMLVideoElementHost`, installs the built-in HLS engine-selection
-extension, and registers any additional extensions passed in.
 
 ```ts
 import { createHlsMedia } from '@videojs/core/dom/media/hls';
@@ -98,38 +91,14 @@ const media = createHlsMedia([
   muxData({ envKey: '…' }),
 ]);
 
-media.attach(videoElement);
+media.target = videoElement;
 ```
-
-Each lowercase factory (`googleCast`, `muxData`, …) is a one-liner that
-returns its `Extension` instance:
-
-```ts
-export const googleCast = (options: GoogleCastOptions) => new GoogleCast(options);
-export const muxData = (options: MuxDataOptions) => new MuxData(options);
-```
-
-`createHlsMedia` itself is a thin wrapper around the imperative API:
-
-```ts
-export function createHlsMedia(
-  extensions: ReadonlyArray<Extension<HTMLVideoElementHost<any, any>>> = []
-): HTMLVideoElementHost {
-  const media = new HTMLVideoElementHost();
-  media.use(hls()); // built-in: routes between HlsJsMedia and NativeHlsMedia
-  for (const extension of extensions) media.use(extension);
-  return media;
-}
-```
-
-There's no `HlsMedia` class anymore — HLS engine selection is just another
-extension (`hls()`) baked into the factory. Custom hosts compose the same
-way (`createAudioMedia`, `createBackgroundMedia`, …), each opting into the
-extensions they need.
 
 ### React
 
-We don't need to go this route yet, but it leaves the door open for it.
+Not needed today, but the door stays open. The `<GoogleCast>` child would be
+a one-line `useEffect` that calls `googleCast(props).install(media)` on
+mount.
 
 ```tsx
 import { lazy } from '@videojs/react/utils/lazy';
@@ -146,483 +115,114 @@ export default function HlsVideoWithExtensions() {
 }
 ```
 
-The React `<GoogleCast>` child is a one-line `useEffect` that calls
-`media.use(new GoogleCast(props))` on mount and returns the disposer. The
-React component and the core class share a name; the import path
-disambiguates them (`@videojs/react/media/google-cast` for the component,
-`@videojs/core/dom/media/google-cast` for the class).
-
 ## API Surface
 
-### Host
-
-`HTMLMediaElementHost` (see [`media.md`](./media.md) for the host hierarchy)
-extends an abstract `Host<MediaStrategy>` that provides the composition
-primitives:
+### Media Extension
 
 ```ts
-abstract class Host<Surface extends object> extends EventTarget {
-  use(extension: Extension<this>): () => void;
-  route(strategy: (Surface & Strategy<this>) | null, options?: { base?: boolean }): () => void;
-}
+import { defineExtension, getExtensions } from '@videojs/core/media/media-extension';
+import { addLayer } from '@videojs/core/media/media-layer';
 
-class HTMLMediaElementHost<T, Events> extends Host<MediaStrategy> { … }
+const googleCast = defineExtension((props: GoogleCastProps) => ({
+  install(media, { signal }) {
+    // Target-bound state belongs on a layer — override `set target` to react.
+    const layer = addLayer(media, new GoogleCastLayer(props));
+    // `signal` aborts on destroy — pass it to anything signal-aware.
+    return layer;
+  },
+}));
+
+const cast = googleCast({ receiverApplicationId: '…' });
+const destroy = cast.install(media);
+
+// lookup + mutate from anywhere with the media reference
+getExtensions(media).get(googleCast)?.receiverApplicationId = 'new-id';
+
+// iterate every installed extension
+for (const ext of getExtensions(media)) console.log(ext);
+
+destroy();
 ```
 
-Every accessor and method on the host (`paused`, `currentTime`, `play`, …) is
-a one-liner that forwards to the currently active strategy.
+`getExtensions(media)` returns a `MediaExtensionList` bound to that host —
+the single entry point for installing, looking up, and iterating extensions.
+`defineExtension` brands each instance so that `ext.install(media)` and
+`getExtensions(media).install(ext)` share the same dedup state.
 
-| Member | Purpose |
-| - | - |
-| `use(extension)` | Register an extension. Returns a disposer that detaches it. Calling `use()` twice with the same `id` is a no-op. |
-| `route(strategy)` | Route the host's media surface to a strategy. Returns a disposer that restores the previous routing *only if* this strategy is still the active one when called — so an extension never accidentally clears a strategy that another extension has since installed. Pass `null` to clear the routed slot. |
-| `route(strategy, { base: true })` | Same shape, different slot: replaces the host's always-on **base** strategy instead of layering on top of it. Used by extensions that want to extend defaults rather than take over (e.g. cast adds a `remote` accessor to the base so it's available even when no session is connected). The active routed strategy still overlays the base; clearing the base disposer restores the host's built-in default. |
+The framework creates one `AbortController` per install and passes its
+signal to `install(media, { signal })`. The returned destroy aborts that
+signal, then runs any teardown the extension returned — so most extensions
+never need to manage their own controller.
 
-That's the entire new surface. The base strategy (the direct-to-`target`
-`BaseMediaStrategy`) and the currently routed strategy are both internal
-state, accessed via the protected `strategy` getter.
-
-### Extension
+### Media Layer
 
 ```ts
-interface Extension<HostType = unknown> {
-  readonly id: string;
-  install?(host: HostType): (() => void) | void;
-}
+import { addLayer } from '@videojs/core/media/media-layer';
+
+function addLayer(media: MediaLayer, layer: Layer): () => void;
+
+interface Layer extends MediaLayer {}
 ```
 
-An `id` for dedup, and an optional `install` that returns an optional
-uninstaller. Extensions are plain classes that `implements Extension<Host>`.
-Everything else is implementation.
+`addLayer(media, layer)` pushes the layer onto the stack and returns a
+destroy that pops it. Most code calls this transitively through an
+extension, but it can be called directly when no surrounding extension is
+needed.
 
-### BaseMediaStrategy and strategies
+#### Chain anatomy
 
-```ts
-class BaseMediaStrategy<T extends HTMLMediaElement>
-  implements MediaStrategy, Strategy<HTMLMediaElementHost<T, any>>
-{
-  #host: HTMLMediaElementHost<T, any> | null = null;
-  get #target(): T | null { return this.#host?.target ?? null; }
+A host and its layers form a singly-linked list. The host sits at the top,
+the underlying `HTMLMediaElement` sits at the bottom (the chain's `target`),
+and every `addLayer` call inserts the new layer **right below the host** —
+newest closest to the host, oldest closest to the target.
 
-  activate(host: HTMLMediaElementHost<T, any>): void;
-  deactivate(): void;
-
-  get paused(): boolean;
-  get currentTime(): number;
-  set currentTime(v: number);
-  // …full MediaStrategy, all forwarding to this.#target
-}
+```text
+HlsMedia          ← host (root)
+   │ next
+   ▼
+MuxDataLayer      ← addLayer(host, muxData)   (added last)
+   │ next
+   ▼
+GoogleCastLayer   ← addLayer(host, cast)      (added first)
+   │ next
+   ▼
+<video>           ← target (tail of the chain)
 ```
 
-A strategy is any class extending `BaseMediaStrategy` that overrides the
-parts it owns. Native `super` + inheritance — no chain machinery. The
-`#host` reference (and hence `#target`) is per-class private, so subclasses
-that need their own host reference declare their own `#host`; calling
-`super.activate(host)` keeps the base-class plumbing working.
+Every `MediaLayer` exposes three navigation properties:
 
-`activate(host)` and `deactivate()` are called by the host on `route`
-swaps — strategies don't need a host at construction time. Override
-`activate` / `deactivate` to wire and unwire host-level listeners; always
-call `super.activate` / `super.deactivate` so the base forwarders keep
-working.
+| Property | Points to                                                          |
+| -------- | ------------------------------------------------------------------ |
+| `root`   | the host at the top — walks parent links until there is no parent. |
+| `next`   | the immediate neighbour beneath — a layer, or the `target`.        |
+| `target` | the `HTMLMediaElement` at the bottom — shared by every layer.      |
 
-### MediaStrategy
+Layers forward via `super`: a subclass's `override play()` calls
+`super.play()`, which the base class walks one step down the chain. So
+`host.play()` cascades through every layer until it reaches the `target`.
 
-A single interface defines the interceptable shape, composed from the
-framework-agnostic capability interfaces in `core/media/types.ts`.
-`BaseMediaStrategy` and every strategy implements it, so TypeScript catches
-drift between the two.
+#### Reacting to target changes
 
-```ts
-export interface MediaStrategy
-  extends MediaPlaybackCapability,
-    MediaPauseCapability,
-    MediaSeekCapability,
-    MediaSourceCapability,
-    MediaVolumeCapability,
-    MediaPlaybackRateCapability,
-    MediaBufferCapability,
-    MediaErrorCapability,
-    MediaTextTrackCapability,
-    MediaRemotePlaybackCapability {}
-```
-
-Adding a new interceptable accessor is two steps: declare it on the
-relevant capability interface (or extend `MediaStrategy` with a new one),
-then implement it in `BaseMediaStrategy`. Strategies inherit the default
-automatically.
-
-## Examples
-
-### Google Cast — strategy + extension
-
-`GoogleCastProvider` IS the strategy. It extends `BaseMediaStrategy` and
-owns the media surface while a cast session is connected, falling through
-to `super.x` (the underlying `<video>`) for the brief window between
-`caststart` and the remote media loading:
+`set target` propagates by invoking the next layer's setter, so any layer
+can react by overriding it. Each call to `super.target = value` migrates
+this layer's forwarders and hands off to the next layer down. When the
+layer is removed via `addLayer`'s destroy, the override is invoked one
+last time with `null` so target-bound state tears down cleanly.
 
 ```ts
-export class GoogleCastProvider extends BaseMediaStrategy<HTMLMediaElement> {
-  constructor(host: HTMLMediaElementHost<HTMLMediaElement, any>, cast: CastConfig) {
-    super();
-    this.activate(host); // bind the base-strategy host eagerly: init() reads from it
-    this.#host = host;
-    this.#cast = cast;
-    this.init();
+class MyLayer extends HTMLMediaElementLayer {
+  #abort: AbortController | null = null;
+
+  override set target(value: HTMLMediaElement | null) {
+    this.#abort?.abort();
+    this.#abort = null;
+
+    if (value) {
+      this.#abort = new AbortController();
+      value.addEventListener('error', onError, { signal: this.#abort.signal });
+    }
+
+    super.target = value;
   }
-
-  override get paused()      { return this.#remote?.isMediaLoaded ? this.#remote.isPaused || this.ended : super.paused; }
-  override get currentTime() { return this.#remote?.isMediaLoaded ? this.#remote.currentTime ?? 0      : super.currentTime; }
-  override set currentTime(v) { this.#remote.currentTime = v; this.#remote.controller?.seek(); }
-  override get muted()       { return this.#remote.isMuted; }
-  override set muted(v)      { if (v !== this.#remote.isMuted) this.#remote.controller?.muteOrUnmute(); }
-  // …rest of the surface
-
-  override async play()  { /* drive the cast receiver */ }
-  override pause()       { /* drive the cast receiver */ }
-}
-```
-
-There's no separate `GoogleCastMedia` wrapper — the provider does double
-duty as the strategy (routed while casting) and as the long-lived object
-that drives cast lifecycle (events, session management) outside of any
-active routing.
-
-The extension owns the install lifecycle and toggles routing:
-
-```ts
-export class GoogleCast implements Extension<HTMLMediaElementHost<HTMLMediaElement, any>> {
-  readonly id = 'google-cast';
-
-  constructor(private options: GoogleCastOptions) {}
-
-  install(host: HTMLMediaElementHost<HTMLMediaElement, any>) {
-    const provider = new GoogleCastProvider(host, this.options);
-    const remote = new RemotePlayback(provider);
-
-    // Always-on base strategy: makes `host.remote` return our RemotePlayback
-    // even when no cast session is connected, so consumers can subscribe to
-    // `connect` / `disconnect` from day one.
-    const BaseStrategy = class extends BaseMediaStrategy<HTMLMediaElement> {
-      get remote() { return remote; }
-    };
-    const baseRouteOff = host.route(new BaseStrategy(), { base: true });
-
-    // While a cast session is connected, route the provider as the active
-    // strategy. `host.route` returns a clear-if-still-active disposer, so
-    // concurrent routings from other extensions are never clobbered.
-    const cleanup = new AbortController();
-    let routeOff: (() => void) | null = null;
-    const onState = (event: Event) => {
-      routeOff?.();
-      routeOff = event.type === 'connect' ? host.route(provider) : null;
-    };
-    remote.addEventListener('connect',    onState, { signal: cleanup.signal });
-    remote.addEventListener('disconnect', onState, { signal: cleanup.signal });
-
-    return () => {
-      cleanup.abort();
-      routeOff?.();
-      baseRouteOff();
-      provider.destroy();
-    };
-  }
-}
-```
-
-Two distinct routing slots are at work:
-
-- **Base** (`{ base: true }`) — the always-on fallback. The cast extension
-  uses this to shadow only `remote` while leaving every other accessor
-  flowing through the default `BaseMediaStrategy` (so `host.currentTime`
-  still reads the local `<video>` when no session is connected). The base
-  slot replaces the host's built-in default for as long as the extension
-  is installed; `baseRouteOff()` restores the original on uninstall.
-- **Routed** (default) — the active session. Layered on top of the base
-  via `host.route(provider)` when `remote` emits `connect`, cleared on
-  `disconnect`. The provider's overrides take precedence over base while
-  it's active.
-
-Usage is one line — `host.use(new GoogleCast(options))` — and the
-extension constructs the provider on install, exposes `remote` immediately
-via the base route, routes the provider as the active strategy when a
-cast session connects, and clears it when the session ends.
-
-`host.route` returns a clear-if-still-active disposer for both slots, so
-the extension never has to ask "is my strategy still the active one?" —
-and the host doesn't have to expose `activeStrategy`.
-
-The ~245-line `GoogleCastMixin` (with its 15 redirecting accessors)
-collapses to one strategy class that owns the redirect and one extension
-class that owns the on/off.
-
-### Mux Data — observer only
-
-No strategy needed — Mux Data observes lifecycle and initializes the SDK
-against the underlying element.
-
-```ts
-export class MuxData implements Extension<HTMLMediaElementHost<HTMLMediaElement, any>> {
-  readonly id = 'mux-data';
-
-  constructor(private options: MuxDataOptions) {}
-
-  install(host: HTMLMediaElementHost<HTMLMediaElement, any>) {
-    const off = new AbortController();
-    host.addEventListener('load',   () => initMuxDataSdk(host, this.options),  { signal: off.signal });
-    host.addEventListener('detach', () => host.target?.mux?.destroy(),         { signal: off.signal });
-    return () => off.abort();
-  }
-}
-```
-
-### HLS — engine selection as an extension
-
-HLS engine selection (MSE vs native) used to live inside an `HlsMedia`
-class. With the new model it's an extension that listens for `load` and
-routes the appropriate strategy:
-
-```ts
-import HlsJs from 'hls.js';
-
-export class HlsExtension implements Extension<HTMLVideoElementHost<any, any>> {
-  readonly id = 'hls';
-
-  constructor(private options: HlsOptions = {}) {}
-
-  install(host: HTMLVideoElementHost<any, any>) {
-    const off = new AbortController();
-    host.addEventListener('load', () => {
-      const useMse =
-        HlsJs.isSupported() &&
-        host.type === 'application/vnd.apple.mpegurl' &&
-        this.options.preferPlayback !== 'native';
-
-      host.route(useMse
-        ? new HlsJsMedia({ config: this.options.config, debug: this.options.debug })
-        : new NativeHlsMedia());
-    }, { signal: off.signal });
-    return () => off.abort();
-  }
-}
-
-export const hls = (options?: HlsOptions) => new HlsExtension(options);
-```
-
-`HlsJsMedia` and `NativeHlsMedia` are `BaseMediaStrategy` subclasses — same
-shape as `GoogleCastProvider`, just owning their own engine. The legacy
-`HlsMedia` class, its `#delegate` field, the manual `bridgeEvents`
-plumbing, and the `#shouldEngineUpdate` book-keeping collapse to one
-extension + two strategies. `createHlsMedia` installs `hls()` for you;
-custom hosts can install it (or a different engine extension) the same
-way.
-
-## Behavior
-
-### Lifecycle
-
-- `use(extension)` calls `extension.install(host)`; the returned function is
-  the uninstaller.
-- The disposer returned from `use()` calls the extension's disposer and
-  removes it from the host's internal registry.
-- An extension that installed a strategy should call the disposer returned
-  from `route` in its own disposer. That disposer is a no-op if another
-  strategy has since taken over.
-
-### Strategy switching
-
-- One active strategy at a time per slot (base and routed). Calling `route`
-  while another strategy is active in the same slot replaces it.
-- `route` calls `prevStrategy.deactivate()` on the outgoing strategy,
-  swaps the slot, then calls `strategy.activate(host)` on the incoming one.
-- Strategies are constructed without a host. They get the host in
-  `activate(host)` and lose it in `deactivate()`. Accessors that fall
-  through to the underlying element (`super.paused`, `super.currentTime`)
-  just work once activated.
-- Strategies are responsible for controlling event propagation during
-  their tenure. `GoogleCastProvider`, for example, swallows or synthesizes
-  `timeupdate` to reflect the cast receiver's clock, not the local
-  `<video>`. Wire those listeners in `activate`, unwire them in
-  `deactivate`.
-
-### Disposal
-
-- Each `use(extension)` and `route(strategy, …)` call returns its own
-  disposer. Holding onto them lets callers unregister or unroute
-  individually.
-- Tearing down a host means calling every disposer the caller held. The
-  host itself doesn't expose a bulk `destroy()` today — see
-  [Open Questions](#open-questions).
-
-## Trade-offs
-
-| Gain | Cost |
-| - | - |
-| Behavior is composable at runtime and code-splittable | One active strategy at a time — no multi-extension overlap on the same property |
-| Cast's per-accessor redirects collapse into one strategy class | Each strategy must extend `BaseMediaStrategy` even if it only overrides one property |
-| `super` and native class inheritance — no Proxy, no prototype mutation, no chain dispatcher | Adding a new interceptable accessor touches two places (`MediaStrategy` + `BaseMediaStrategy`) |
-| Extensions are tree-shakeable, independently testable modules | Combined behaviors that aren't naturally mutually exclusive (e.g. ads-while-casting) must be modeled at the strategy level (subclass one from the other) |
-| Generalizes the existing `HlsMedia.#delegate` pattern; no new mental model | A handful of features (HLS engine selection) drop a private idiom for a public API call |
-| Stable, owner-controlled host API surface | Extensions can't add public accessors / methods to the host the way mixins do |
-
-### About a fixed host surface
-
-Mixins extended the host's public API: installing `GoogleCastMixin` added
-`castSrc`, `castReceiver`, `castContentType`, `castStreamType`, and
-`castCustomData` to the host's surface; `MuxDataMediaMixin` added another set
-of props. Each extra prop had to be prefixed to avoid collisions, leaked
-into TypeScript types regardless of whether the extension was actually
-installed at runtime, and made the host's public shape depend on which
-mixins happened to be applied.
-
-Extensions intentionally **do not** widen `HTMLMediaElementHost`'s API.
-`host.use(extension)` registers behavior — it doesn't add accessors or
-methods. The host's public surface is whatever `MediaStrategy` defines, full
-stop. Trade-offs:
-
-- The host API is stable, predictable, and owned by us. Adding a new
-  extension never changes the host's public shape.
-- TypeScript types don't have to encode every possible mixin combination.
-- Extensions own their own configuration (passed to their constructor) and
-  their own events (dispatched on the host or on objects they expose). Cast
-  config is `new GoogleCast({ receiverApplicationId: '…' })`, not
-  `host.castReceiver = '…'`.
-- Extension-private state stays in the extension. Callers who need to reach
-  it can keep the instance reference returned from `new GoogleCast(...)` and
-  talk to it directly.
-
-Escape hatches we can add later if real use-cases demand them, none of which
-require redesigning the core:
-
-- A generic `host.extensions` registry (`host.extensions.get('google-cast')`)
-  for opt-in lookup by id.
-- A typed proxy / forwarder helper that lets an extension declare a small
-  set of accessors it wants surfaced on the host, with explicit conflict
-  rules.
-- Per-extension events bridged onto the host's `EventTarget` for the cases
-  where dispatching on the extension itself isn't ergonomic.
-
-Starting from a closed, controlled surface and opening it deliberately is
-the inverse of where mixins land — wide surface first, conflicts and
-ergonomics second — and we'd rather be the ones to choose when to widen.
-
-### About single-strategy
-
-The current set of features is naturally mutually exclusive:
-
-- Cast takes over while casting.
-- Ads take over while an ad plays.
-- HLS engine selection picks one engine at a time.
-- Mux Data doesn't take over anything.
-
-"Ads while casting" is a product decision (pause cast for the ad, or play
-ads on the cast receiver) that resolves at the strategy level — not in the
-extension dispatcher. If a future need genuinely requires per-property
-stacking across extensions, the same `use()` API could grow into a more
-complex view (see [Open Questions](#open-questions)).
-
-## Beyond Media
-
-`HTMLMediaElementHost` is a specialization of a smaller pattern: a host that
-accepts extensions and routes its public surface to a swappable strategy.
-The pattern doesn't care that the surface is `MediaStrategy` — it works
-anywhere "one active implementation at a time, with pluggable lifecycle
-behavior around it" applies.
-
-The shared machinery already lives in an abstract `Host<Surface>` in
-`@videojs/core/dom/media/host` so future hosts can reuse it directly:
-
-```ts
-abstract class Host<Surface extends object> extends EventTarget {
-  use(extension: Extension<this>): () => void;
-  route(strategy: (Surface & Strategy<this>) | null, options?: { base?: boolean }): () => void;
-}
-
-class HTMLMediaElementHost<T, Events> extends Host<MediaStrategy> { … }
-// future:
-class IframePlayerHost<Events> extends Host<IframePlayerSurface> { … }
-```
-
-Concretely, future iframe-based players (YouTube, Vimeo, …) don't share
-`HTMLMediaElement` semantics, but they want the same composition story:
-swap implementations at runtime, attach Mux Data or other extensions
-identically. They'd extend `Host` with their own surface and reuse
-`Extension` / `route` unchanged.
-
-`Host` is deliberately the most boring noun — it pairs with the existing
-`HTMLMediaElementHost` naming, scales to `IframePlayerHost`, `EditorHost`,
-etc., and reads as "this class is what makes it a host." The two operations
-on it (`use`, `route`) describe its capabilities; neither verb on its own is
-strong enough to headline the class name.
-
-## Prior Art
-
-- **`HlsMedia.#delegate`** in this repo — the swap-the-implementation pattern,
-  scoped to engine selection. The new design lifts it to a first-class host
-  API.
-- **HTMLMediaElement / MediaSession** — the native platform's "one active
-  media element at a time" model.
-- **Lit `ReactiveController`** — the lifecycle-attach-with-disposer pattern.
-  Not reused directly (`ReactiveController` is bound to
-  `ReactiveControllerHost`, which the media host isn't), but the shape is
-  intentionally similar.
-- **CodeMirror 6 extensions** — `EditorView.dispatch({ effects: … })` to
-  reconfigure behavior at runtime. Same registration model, no class
-  inheritance.
-- **Strategy pattern (GoF)** — what's happening here, applied to media.
-
-## Open Questions
-
-- **Event bridging during strategy swaps.** `bridgeEvents` today forwards
-  every event from a delegate up to the host. With strategies swapping in
-  and out, we want the host to keep firing events for the currently active
-  source of truth. Two options:
-  1. Strategy `activate`/`deactivate` hooks responsible for hooking and unhooking
-     event forwarding (mirrors today's `bridgeEvents` per delegate).
-  2. The host centralizes a small forwarder that re-targets on every
-     `route` call. Would also need a hook (e.g. a `strategychange` event)
-     so external code can react to swaps.
-
-  Leaning toward (1) — each strategy already owns its source, so it owns
-  its events.
-
-- **Multi-host extensions.** A single `Extension` instance is currently
-  scoped to one host (it captures `host` in its `install` closure). Should
-  the contract require fresh instances per host, or allow one instance to
-  install into multiple hosts? Today's Mux Data and Cast are per-host anyway,
-  so the simpler "one instance per host" contract is the starting point.
-
-- **Bulk teardown.** Callers track individual disposers returned from `use`
-  and `route` today. A bulk `host.destroy()` (uninstall every extension,
-  clear every routing slot, abort outstanding work) would simplify lifecycle
-  for hosts created and discarded as a unit — but raises questions about
-  re-use after destroy and interaction with custom elements'
-  `disconnectedCallback`. Out of scope for the initial migration.
-
-## HLS media composition
-
-Again not part of the initial migration, but it leaves the door open for it.
-Lazy load the much heavier HlsJsVideo component only when needed.
-
-```tsx
-import { lazy } from '@videojs/react/utils/lazy';
-import { MediaRouter } from '@videojs/react/media/media-router';
-import { SimpleHlsVideo } from '@videojs/react/media/simple-hls-video';
-import { NativeHlsVideo } from '@videojs/react/media/native-hls-video';
-
-const HlsJsVideo = lazy(() => import('@videojs/react/media/hls-js-video'));
-
-export default function HlsVideo({ src, preferPlayback = 'mse', children }) {
-  return (
-    <MediaRouter 
-      src={src} 
-      preferPlayback={preferPlayback}
-    >
-      <SimpleHlsVideo />
-      <HlsJsVideo  />
-      <NativeHlsVideo  />
-      {children}
-    </MediaRouter>
-  );
 }
 ```

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -1,447 +1,572 @@
 ---
 status: draft
-date: 2026-04-22
+date: 2026-05-14
 ---
 
-# Composable Media Features
+# Composable Media
 
-## Summary
+Compose media behavior by registering small extensions and swapping the active
+strategy at runtime.
 
-The store layer already lets app authors compose behaviour from a flat
-list of features:
+## Problem
 
-```ts
-createPlayer({ features: [playbackFeature, volumeFeature, /* … */] });
-```
-
-We want the same shape on the media layer. Each media class binds an
-**engine** — a function that takes a config and returns a variant —
-to a flat list of features:
+Today, behavior on top of the base media classes is layered with class mixins
+with mixin-prefixed props:
 
 ```ts
-import { createVideo } from '@videojs/core/dom/media';
-import { hlsJs, live, streamType, errors, googleCast, muxData } from '@videojs/core/dom/media/hls';
-
-const HlsJsMedia = createVideo(
-  hlsJs({ features: [live, streamType, errors, googleCast, muxData] }),
-);
-```
-
-Multi-engine playback (hls.js with native-HLS fallback) is the same
-function called with multiple variants:
-
-```ts
-import { hlsJs, live, streamType, googleCast, muxData } from '@videojs/core/dom/media/hls';
-import {
-  nativeHls,
-  live as nativeLive,
-  streamType as nativeStreamType,
-  googleCast as nativeCast,
-  muxData as nativeMuxData,
-} from '@videojs/core/dom/media/native-hls';
-
-const HlsMedia = createVideo(
-  hlsJs    ({ features: [live,       streamType,       googleCast, muxData] }),
-  nativeHls({ features: [nativeLive, nativeStreamType, nativeCast, nativeMuxData] }),
-);
-```
-
-`createVideo` is variadic: one variant = single-engine class, two or
-more = a class that picks an engine at runtime based on the source.
-
-Every feature — engine plumbing (`hlsJs`), capability (`live`,
-`streamType`), or cross-cutting facade-only (`googleCast`, `muxData`) —
-ships from the engine-specific subpath. **One engine = one import
-path.**
-
-Internally each feature is a class mixin — exactly what we have today.
-
----
-
-## Today: Static Mixins
-
-Mixins are composed at module load:
-
-```ts
-export class HlsJsMedia extends HlsJsMediaPreloadMixin(
-  HlsJsMediaStreamTypeMixin(
-    HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(HlsJsMediaBase))
-  )
-) {}
-
-export class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia)) {}
-```
-
-Great for library authors, closed for everyone else. There's no way to
-opt out of a built-in mixin or layer in a new one without subclassing
-the whole stack. Engine selection (hls.js vs native HLS) is hand-coded
-inside `HlsMedia` (`packages/core/src/dom/media/hls/index.ts`).
-
----
-
-## The API
-
-Two factory functions, one per media kind. Both are variadic:
-
-```ts
-const HlsJsMedia = createVideo(hlsJs({ features: […] }));
-const HlsMedia   = createVideo(
-  hlsJs    ({ features: […] }),
-  nativeHls({ features: […] }),
-);
-
-const HlsJsAudio = createAudio(hlsJs({ features: […] }));
-const HlsAudio   = createAudio(
-  hlsJs    ({ features: […] }),
-  nativeHls({ features: […] }),
-);
-```
-
-`createVideo` returns a class that extends `HTMLVideoElementHost`;
-`createAudio` extends `HTMLAudioElementHost`. Both return a
-constructable class typed end-to-end with the union of every feature's
-added members.
-
-Each engine call (`hlsJs(...)`, `nativeHls(...)`) describes one engine
-variant. With multiple variants, the resulting class:
-
-- Asks each variant's `supports({ src, type, preferPlayback })` in
-  order.
-- Instantiates the first match's composed inner class as the active
-  delegate.
-- Forwards facade-side calls to it.
-- Re-evaluates on `src` / `type` change. Aborts the old delegate,
-  builds the new one.
-
-With one variant, there's no selection — the class is just the
-composed mixin chain.
-
-### Engine config
-
-Engines accept their own configuration alongside the features array:
-
-```ts
-const HlsJsMedia = createVideo(
-  hlsJs({
-    config: { backBufferLength: 30 },
-    debug: true,
-    features: [live, streamType, errors, googleCast({ receiver: 'CC1AD845' })],
-  }),
-);
-```
-
-`config`, `debug`, etc. are engine-specific options. `features` is
-universal across engines.
-
-### Configurable features
-
-Features may take options. Call the factory to get a configured
-variant — same convention as store features:
-
-```ts
-hlsJs({
-  features: [
-    live,
-    streamType,
-    googleCast({ receiver: 'CC1AD845' }),
-    muxData({ envKey: '…' }),
-  ],
-});
-```
-
-The bare symbol (`live`, `googleCast`) is shorthand for the default
-config; calling it (`googleCast({…})`) returns a configured variant.
-
-### Composing presets
-
-Each engine ships preset feature arrays — the media-side twins of
-`videoFeatures` / `liveVideoFeatures`:
-
-```ts
-import { hlsJs, hlsJsFeatures, googleCast } from '@videojs/core/dom/media/hls';
-
-const Player = createVideo(
-  hlsJs({ features: [...hlsJsFeatures, googleCast({ receiver: 'CC1AD845' })] }),
-);
-```
-
-### Audio mirror
-
-```ts
-const HlsAudio = createAudio(
-  hlsJs    ({ features: [live,       googleCast] }),
-  nativeHls({ features: [nativeLive, nativeCast] }),
-);
-```
-
-Same pattern, audio base class.
-
----
-
-## Engines
-
-An engine is a function: it takes an options object (`config`,
-`features`, engine-specific knobs) and returns a variant descriptor
-that `createVideo` understands.
-
-```ts
-// packages/core/src/dom/media/hls/index.ts → @videojs/core/dom/media/hls
-import Hls, { type HlsConfig } from 'hls.js';
-import { HlsJsMediaBaseMixin } from './base';
-
-interface HlsJsOptions {
-  config?: Partial<HlsConfig>;
-  debug?: boolean;
-  features: AnyHlsJsFeature[];
-}
-
-export function hlsJs(options: HlsJsOptions) {
-  return {
-    name: 'hlsJs' as const,
-    // Adds `engine`, `src`, `attach`, `detach`, `destroy` plumbing —
-    // closes over `options.config` / `options.debug`.
-    mixin: HlsJsMediaBaseMixin(options),
-    features: options.features,
-    supports: ({ type, preferPlayback }) =>
-      Hls.isSupported() &&
-      type === 'application/vnd.apple.mpegurl' &&
-      preferPlayback !== 'native',
-  };
-}
-```
-
-`HlsJsMediaBaseMixin` is exactly today's
-`packages/core/src/dom/media/hls/hlsjs.ts:19-57` body, lifted to a
-mixin (it currently extends `HTMLVideoElementHost` directly). The
-mixin chain on lines 59-63 disappears: those mixins become engine-
-specific feature descriptors.
-
-`nativeHls` ships from `@videojs/core/dom/media/native-hls` with the
-same shape over `NativeHlsMediaBaseMixin`. Future engines (`dash`,
-`shaka`) drop in under their own subpath. An app that imports only
-`hlsJs` never reaches native-HLS code, and vice versa.
-
----
-
-## Features
-
-Every feature is a tiny descriptor wrapping a class mixin, exported
-from an engine's subpath. Two flavours, distinguished by what code
-they wrap:
-
-### Engine-specific features
-
-The mixin uses engine internals (e.g. `this.engine` for hls.js).
-Lives next to the engine's source:
-
-```ts
-// packages/core/src/dom/media/hls/features/live.ts
-import { HlsJsMediaLiveMixin } from '../live';
-
-export const live = {
-  name: 'live',
-  mixin: HlsJsMediaLiveMixin,
+type MuxMediaProps = {
+  src: string;
+  type: 'video/mp4' | 'application/vnd.apple.mpegurl';
+  castSrc: string;
+  castContentType: 'video/mp4' | 'application/vnd.apple.mpegurl';
+  castReceiverApplicationId: string;
 };
+
+// packages/core/src/dom/media/mux/index.ts
+export class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia))
+  implements MuxMediaProps {}
 ```
 
-Examples: `live`, `streamType`, `errors`, `preload`, `textTracks`.
+That pattern has costs we want to remove:
 
-`live` from `@videojs/core/dom/media/hls` only fits in a `hlsJs(...)`
-variant. `live` from `@videojs/core/dom/media/native-hls` is a
-different descriptor that wraps `NativeHlsMediaLiveMixin`. Same name,
-different import path, different mixin.
+1. **Static composition.** The class is baked at module load. Cast can't be
+   code-split or lazy loaded. Once mixed in, behavior can't be added,
+   removed, or swapped at runtime. Cast doesn't have a way to truly turn
+   itself off.
+2. **Muddled mixin API.** Mixins add config props to the media API surface
+   which need to be prefixed to avoid conflicts.
 
-### Engine-agnostic features
+We want a model where Cast, Ads, and future extensions are independent
+modules that attach to a host at runtime, and where redirecting playback
+(Cast, ads, ...) is a single instance swap.
 
-The mixin only uses public media APIs (`play`, `pause`, `currentTime`).
-Implementation lives in a shared location — typically wrapping the
-existing engine-agnostic mixin like `GoogleCastMixin` — and gets
-**re-exported from each engine subpath**:
+## Solution
+
+Two roles, one host:
+
+- **Extension** — A small class registered via `host.use(extension)`. Owns its
+  own lifecycle (`install` → uninstaller) and any state it needs. May install
+  a strategy. May only observe.
+- **Strategy** — A class extending `BaseMediaStrategy` that handles the host's
+  full media surface while it's active. Inherits the "do the native thing"
+  behavior for accessors it doesn't override.
+
+The host owns **one active strategy at a time** (`host.strategy`). All accessors and
+methods on the host are one-liner forwarders to `host.strategy`. Extensions
+decide when to swap it via `host.route(strategy)`.
+
+This generalizes the existing `HlsMedia.#delegate` pattern (swap between
+`HlsJsMedia` / `NativeHlsMedia`) and reuses it everywhere.
+
+## Quick Start
+
+### Imperative
 
 ```ts
-// packages/core/src/dom/media/google-cast/index.ts (implementation)
-export const googleCast = (config: GoogleCastConfig = {}) => ({
-  name: 'googleCast',
-  mixin: GoogleCastMixin(config),
-});
+import { createHlsMedia } from '@videojs/core/dom/media/hls';
+import { GoogleCast } from '@videojs/core/dom/media/google-cast';
+import { MuxData } from '@videojs/core/dom/media/mux';
 
-// packages/core/src/dom/media/hls/index.ts
-export { googleCast, muxData, airPlay } from '../google-cast';
+const media = createHlsMedia();
+media.attach(videoElement);
 
-// packages/core/src/dom/media/native-hls/index.ts
-export { googleCast, muxData, airPlay } from '../google-cast';
+media.use(new GoogleCast({ receiverApplicationId: '…' }));
+media.use(new MuxData({ envKey: '…' }));
 ```
 
-Examples: `googleCast`, `muxData`, `airPlay`. Each engine path
-re-exports them so users have one curated import location per engine.
-
-The implementation isn't duplicated — each subpath re-exports the same
-module, so the bundler still sees one copy.
-
-When using multi-engine `createVideo(...)`, engine-agnostic features
-go into each variant's `features` array. Cast and analytics attach
-per-delegate; only the active delegate runs them at any moment, so
-the cost is the same as today's single mixin chain.
-
----
-
-## Internals
-
-`createVideo` builds an inner class per variant and (when there's more
-than one) wraps them in a thin selection facade:
+### Dynamic import
 
 ```ts
-// packages/core/src/dom/media/create-video.ts (sketch)
-export function createVideo<Variants extends [MediaVariant, ...MediaVariant[]]>(
-  ...variants: Variants
-): VideoMediaResult<Variants> {
-  const composed = variants.map((variant) => {
-    let cls: Constructor = HTMLVideoElementHost;
-    cls = variant.mixin(cls);
-    for (const feature of variant.features) cls = feature.mixin(cls);
-    return { variant, cls };
-  });
+const media = createHlsMedia();
+media.attach(videoElement);
 
-  if (composed.length === 1) return composed[0].cls as VideoMediaResult<Variants>;
-
-  // Selection facade: holds an active delegate, asks each variant's
-  // `supports()` at load(), instantiates the first match.
-  return withVariantSelection(HTMLVideoElementHost, composed) as VideoMediaResult<Variants>;
+if (userWantsCast) {
+  const { GoogleCast } = await import('@videojs/core/dom/media/google-cast');
+  media.use(new GoogleCast({ receiverApplicationId: '…' }));
 }
 ```
 
-`createAudio` is identical except it starts from `HTMLAudioElementHost`.
+### Factory style
 
-No new lifecycle, no new primitive, no runtime registry. Each variant
-is a declarative description of which mixins to compose, in which
-order, on which base.
+`createHlsMedia` is the convenience factory: it constructs an
+`HTMLVideoElementHost`, installs the built-in HLS engine-selection
+extension, and registers any additional extensions passed in.
 
----
+```ts
+import { createHlsMedia } from '@videojs/core/dom/media/hls';
+import { googleCast } from '@videojs/core/dom/media/google-cast';
+import { muxData } from '@videojs/core/dom/media/mux';
 
-## Bundle cost
+const media = createHlsMedia([
+  googleCast({ receiverApplicationId: '…' }),
+  muxData({ envKey: '…' }),
+]);
 
-Tree-shake follows import paths.
+media.attach(videoElement);
+```
 
-**Engine-specific code is never cross-referenced.**
-`@videojs/core/dom/media/hls` exports `hlsJs`, `live`, `streamType`,
-`errors`, `hlsJsFeatures`, plus re-exports of engine-agnostic features
-(`googleCast`, `muxData`).
-`@videojs/core/dom/media/native-hls` exports its own variants of the
-same names. Neither path imports the other.
+Each lowercase factory (`googleCast`, `muxData`, …) is a one-liner that
+returns its `Extension` instance:
 
-**A single-engine app pays for one engine.** A `createVideo(hlsJs({…}))`
-call only references hls.js code plus whatever engine-agnostic features
-were imported. A native-only build never touches `Hls` or any
-`HlsJs*Mixin`.
+```ts
+export const googleCast = (options: GoogleCastOptions) => new GoogleCast(options);
+export const muxData = (options: MuxDataOptions) => new MuxData(options);
+```
 
-**Multi-engine apps pay for both engines.** `createVideo(hlsJs({…}),
-nativeHls({…}))` necessarily references both engine bases and both
-feature sets. That's the user opting in to multi-engine playback —
-same trade-off they make today by importing `HlsMedia`.
+`createHlsMedia` itself is a thin wrapper around the imperative API:
 
-**Engine-agnostic features pay for themselves only.** The
-implementation module (`google-cast/`) is a single module re-exported
-from each engine path; the bundler dedupes it. Importing
-`googleCast` from `hls` and `googleCast` from `native-hls` in the same
-build resolves to one copy of `GoogleCastMixin`.
+```ts
+export function createHlsMedia(
+  extensions: ReadonlyArray<Extension<HTMLVideoElementHost<any, any>>> = []
+): HTMLVideoElementHost {
+  const media = new HTMLVideoElementHost();
+  media.use(hls()); // built-in: routes between HlsJsMedia and NativeHlsMedia
+  for (const extension of extensions) media.use(extension);
+  return media;
+}
+```
 
----
+There's no `HlsMedia` class anymore — HLS engine selection is just another
+extension (`hls()`) baked into the factory. Custom hosts compose the same
+way (`createAudioMedia`, `createBackgroundMedia`, …), each opting into the
+extensions they need.
 
-## Why
+### React
 
-- **Parity with the store.** Both layers read the same way:
-  `{ features: [...] }`, plus the engine function call.
-- **One function for one or many engines.** No separate router
-  primitive. Pass one variant or many — the API surface is the same.
-- **One import path per engine.** Everything you need for hls.js
-  comes from `@videojs/core/dom/media/hls`. The next-most-common
-  question — "which `googleCast` do I import?" — answers itself.
-- **Tree-shake by intent.** Pick one engine path and that's all you
-  pay for. Pass a second variant to opt in to fallback.
-- **No churn underneath.** Mixins keep their `#private` fields,
-  precise types, and zero runtime overhead. We're only changing the
-  composition surface.
-- **One concept to learn.** Library authors still write mixins.
-  App authors see one variadic factory per media kind.
-- **Audio is real.** `createAudio` extends `HTMLAudioElementHost`
-  properly, fixing the `packages/core/src/dom/media/mux/index.ts:20-21`
-  TODO.
+We don't need to go this route yet, but it leaves the door open for it.
 
----
+```tsx
+import { lazy } from '@videojs/react/utils/lazy';
+import { HlsVideo } from '@videojs/react/media/hls-video';
 
-## Migration sketch
+const GoogleCast = lazy(() => import('@videojs/react/media/google-cast'));
 
-| Today | Tomorrow |
-| --- | --- |
-| `HlsJsMediaBase` (lines 19-57 of `hls/hlsjs.ts`) | `hlsJs(...).mixin` (engine function) |
-| `class HlsJsMedia extends HlsJsMediaPreloadMixin(...)` | `createVideo(hlsJs({ features: [live, streamType, errors, preload] }))` |
-| `class NativeHlsMedia` | `createVideo(nativeHls({ features: [live, streamType, errors] }))` |
-| `class HlsMedia { … delegate selection … }` | `createVideo(hlsJs({ features: [...] }), nativeHls({ features: [...] }))` |
-| `GoogleCastMixin` | `googleCast.mixin` (re-exported from each engine path) |
-| `MuxDataMediaMixin` | `muxData.mixin` (re-exported from each engine path) |
-| `class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia))` | `createVideo(hlsJs({ features: [..., muxData, googleCast] }), nativeHls({ features: [..., muxData, googleCast] }))` |
-| `class MuxAudioMedia` (TODO: should extend audio) | `createAudio(...)` mirroring the video version |
+export default function HlsVideoWithExtensions() {
+  return (
+    <HlsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8">
+      <GoogleCast receiverAppId="1234567890" customData={{ foo: 'bar' }} />
+    </HlsVideo>
+  );
+}
+```
 
-Engine classes shrink to bare bases. Mixins keep their bodies and just
-get exposed as feature descriptors under their engine's subpath. The
-hand-coded selection logic in `HlsMedia` moves into `createVideo`'s
-multi-variant branch.
+The React `<GoogleCast>` child is a one-line `useEffect` that calls
+`media.use(new GoogleCast(props))` on mount and returns the disposer. The
+React component and the core class share a name; the import path
+disambiguates them (`@videojs/react/media/google-cast` for the component,
+`@videojs/core/dom/media/google-cast` for the class).
 
----
+## API Surface
+
+### Host
+
+`HTMLMediaElementHost` (see [`media.md`](./media.md) for the host hierarchy)
+gains two methods:
+
+```ts
+class HTMLMediaElementHost<T, Events> extends EventTarget {
+  use(extension: Extension<this>): () => void;
+  route(strategy: MediaStrategy | null, options?: { base?: boolean }): () => void;
+}
+```
+
+Every accessor and method on the host (`paused`, `currentTime`, `play`, …) is
+a one-liner that forwards to the currently active strategy.
+
+| Member | Purpose |
+| - | - |
+| `use(extension)` | Register an extension. Returns a disposer that detaches it. Calling `use()` twice with the same `id` warns in `__DEV__` and is a no-op. |
+| `route(strategy)` | Route the host's media surface to a strategy. Returns a disposer that restores the previous routing *only if* this strategy is still the active one when called — so an extension never accidentally clears a strategy that another extension has since installed. Pass `null` to route back to the default unconditionally. Dispatches a `strategychange` event. |
+| `route(strategy, { base: true })` | Same shape, different slot: replaces the host's always-on **base** strategy instead of layering on top of it. Used by extensions that want to extend defaults rather than take over (e.g. cast adds a `remote` accessor to the base so it's available even when no session is connected). The active routed strategy still overlays the base; clearing the base disposer restores the host's built-in default. |
+
+That's the entire new surface. The default strategy (the direct-to-`target`
+`BaseMediaStrategy`) and the currently active strategy are both internal state.
+External code observes changes via the `strategychange` event.
+
+### MediaExtension
+
+```ts
+abstract class MediaExtension {
+  abstract readonly id: string;
+  install?(host: HTMLMediaElementHost<any, any>): (() => void) | void;
+}
+```
+
+An `id` for dedup/lookup, and an optional `install` that returns an optional
+uninstaller. That's it. Everything else is implementation.
+
+### BaseMediaStrategy and strategies
+
+```ts
+class BaseMediaStrategy<T extends HTMLMediaElement> implements MediaStrategy {
+  protected host: HTMLMediaElementHost<T, any> | null;
+  protected get target(): T | null;
+
+  activate(host: HTMLMediaElementHost<T, any>): void;
+  deactivate(): void;
+
+  get paused(): boolean;
+  get currentTime(): number;
+  set currentTime(v: number);
+  // …full MediaStrategy, all forwarding to this.target
+}
+```
+
+A strategy is any class extending `BaseMediaStrategy` that overrides the parts it
+owns. Native `super` + inheritance — no chain machinery.
+
+`activate(host)` and `deactivate()` are called by the host on `route`
+swaps — strategies don't need a host at construction time. Override
+`activate` / `deactivate` to wire and unwire host-level listeners; always
+call `super.activate` / `super.deactivate`.
+
+### MediaStrategy
+
+A single interface defines the interceptable shape. `BaseMediaStrategy` and every
+strategy implements it, so TypeScript catches drift between the two.
+
+```ts
+interface MediaStrategy {
+  paused: boolean;
+  ended: boolean;
+  seeking: boolean;
+  readyState: number;
+  duration: number;
+  currentTime: number;
+  muted: boolean;
+  volume: number;
+  playbackRate: number;
+  // …
+  play(): Promise<void>;
+  pause(): void;
+  load(): void;
+}
+```
+
+Adding a new interceptable accessor is two lines: extend `MediaStrategy`,
+implement it in `BaseMediaStrategy`. Strategies inherit the default automatically.
+
+## Examples
+
+### Google Cast — strategy + extension
+
+`GoogleCastProvider` IS the strategy. It extends `BaseMediaStrategy` and
+owns the media surface while a cast session is connected, falling through
+to `super.x` (the underlying `<video>`) for the brief window between
+`caststart` and the remote media loading:
+
+```ts
+export class GoogleCastProvider extends BaseMediaStrategy<HTMLMediaElement> {
+  constructor(host: HTMLMediaElementHost<HTMLMediaElement, any>, cast: CastConfig) {
+    super();
+    this.activate(host); // bind the base-strategy host eagerly: init() reads from it
+    this.#host = host;
+    this.#cast = cast;
+    this.init();
+  }
+
+  override get paused()      { return this.#remote?.isMediaLoaded ? this.#remote.isPaused || this.ended : super.paused; }
+  override get currentTime() { return this.#remote?.isMediaLoaded ? this.#remote.currentTime ?? 0      : super.currentTime; }
+  override set currentTime(v) { this.#remote.currentTime = v; this.#remote.controller?.seek(); }
+  override get muted()       { return this.#remote.isMuted; }
+  override set muted(v)      { if (v !== this.#remote.isMuted) this.#remote.controller?.muteOrUnmute(); }
+  // …rest of the surface
+
+  override async play()  { /* drive the cast receiver */ }
+  override pause()       { /* drive the cast receiver */ }
+}
+```
+
+There's no separate `GoogleCastMedia` wrapper — the provider does double
+duty as the strategy (routed while casting) and as the long-lived object
+that drives cast lifecycle (events, session management) outside of any
+active routing.
+
+The extension owns the install lifecycle and toggles routing:
+
+```ts
+export class GoogleCast implements Extension<HTMLMediaElementHost<HTMLMediaElement, any>> {
+  readonly id = 'google-cast';
+
+  constructor(private options: GoogleCastOptions) {}
+
+  install(host: HTMLMediaElementHost<HTMLMediaElement, any>) {
+    const provider = new GoogleCastProvider(host, this.options);
+    const remote = new RemotePlayback(provider);
+
+    // Always-on base strategy: makes `host.remote` return our RemotePlayback
+    // even when no cast session is connected, so consumers can subscribe to
+    // `connect` / `disconnect` from day one.
+    const BaseStrategy = class extends BaseMediaStrategy<HTMLMediaElement> {
+      get remote() { return remote; }
+    };
+    const baseRouteOff = host.route(new BaseStrategy(), { base: true });
+
+    // While a cast session is connected, route the provider as the active
+    // strategy. `host.route` returns a clear-if-still-active disposer, so
+    // concurrent routings from other extensions are never clobbered.
+    const cleanup = new AbortController();
+    let routeOff: (() => void) | null = null;
+    const onState = (event: Event) => {
+      routeOff?.();
+      routeOff = event.type === 'connect' ? host.route(provider) : null;
+    };
+    remote.addEventListener('connect',    onState, { signal: cleanup.signal });
+    remote.addEventListener('disconnect', onState, { signal: cleanup.signal });
+
+    return () => {
+      cleanup.abort();
+      routeOff?.();
+      baseRouteOff();
+      provider.destroy();
+    };
+  }
+}
+```
+
+Two distinct routing slots are at work:
+
+- **Base** (`{ base: true }`) — the always-on fallback. The cast extension
+  uses this to shadow only `remote` while leaving every other accessor
+  flowing through the default `BaseMediaStrategy` (so `host.currentTime`
+  still reads the local `<video>` when no session is connected). The base
+  slot replaces the host's built-in default for as long as the extension
+  is installed; `baseRouteOff()` restores the original on uninstall.
+- **Routed** (default) — the active session. Layered on top of the base
+  via `host.route(provider)` when `remote` emits `connect`, cleared on
+  `disconnect`. The provider's overrides take precedence over base while
+  it's active.
+
+Usage is one line — `host.use(new GoogleCast(options))` — and the
+extension constructs the provider on install, exposes `remote` immediately
+via the base route, routes the provider as the active strategy when a
+cast session connects, and clears it when the session ends.
+
+`host.route` returns a clear-if-still-active disposer for both slots, so
+the extension never has to ask "is my strategy still the active one?" —
+and the host doesn't have to expose `activeStrategy`.
+
+The ~245-line `GoogleCastMixin` (with its 15 redirecting accessors)
+collapses to one strategy class that owns the redirect and one extension
+class that owns the on/off.
+
+### Mux Data — observer only
+
+No strategy needed — Mux Data observes lifecycle and initializes the SDK
+against the underlying element.
+
+```ts
+export class MuxData extends MediaExtension {
+  readonly id = 'mux-data';
+
+  constructor(private options: MuxDataOptions) { super(); }
+
+  install(host: HTMLMediaElementHost<HTMLMediaElement, any>) {
+    const off = new AbortController();
+    host.addEventListener('load',   () => initMuxDataSdk(host, this.options),  { signal: off.signal });
+    host.addEventListener('detach', () => host.target?.mux?.destroy(),         { signal: off.signal });
+    return () => off.abort();
+  }
+}
+```
+
+### HLS — engine selection as an extension
+
+HLS engine selection (MSE vs native) used to live inside an `HlsMedia`
+class. With the new model it's an extension that listens for `load` and
+routes the appropriate strategy:
+
+```ts
+import HlsJs from 'hls.js';
+
+export class HlsExtension extends MediaExtension {
+  readonly id = 'hls';
+
+  constructor(private options: HlsOptions = {}) { super(); }
+
+  install(host: HTMLVideoElementHost<any, any>) {
+    const off = new AbortController();
+    host.addEventListener('load', () => {
+      const useMse =
+        HlsJs.isSupported() &&
+        host.type === 'application/vnd.apple.mpegurl' &&
+        this.options.preferPlayback !== 'native';
+
+      host.route(useMse
+        ? new HlsJsMedia({ config: this.options.config, debug: this.options.debug })
+        : new NativeHlsMedia());
+    }, { signal: off.signal });
+    return () => off.abort();
+  }
+}
+
+export const hls = (options?: HlsOptions) => new HlsExtension(options);
+```
+
+`HlsJsMedia` and `NativeHlsMedia` are `BaseMediaStrategy` subclasses — same
+shape as `GoogleCastMedia`, just owning their own engine. The legacy
+`HlsMedia` class, its `#delegate` field, the manual `bridgeEvents`
+plumbing, and the `#shouldEngineUpdate` book-keeping collapse to one
+extension + two strategies. `createHlsMedia` installs `hls()` for you;
+custom hosts can install it (or a different engine extension) the same
+way.
+
+## Behavior
+
+### Lifecycle
+
+- `use(extension)` calls `extension.install(host)`; the returned function is
+  the uninstaller.
+- The disposer returned from `use()` calls the extension's disposer and
+  removes it from the host's internal registry.
+- An extension that installed a strategy should call the disposer returned
+  from `route` in its own disposer. That disposer is a no-op if another
+  strategy has since taken over.
+
+### Strategy switching
+
+- One active strategy at a time. Calling `route` while another strategy is
+  active replaces it. No stacking.
+- `route` calls `strategy.activate(host)` on the incoming strategy and
+  `prevStrategy.deactivate()` on the outgoing one before swapping `#active`,
+  then dispatches `strategychange`. UI code can listen for that event to
+  react ("we're now casting").
+- Strategies are constructed without a host. They get the host in
+  `activate(host)` and lose it in `deactivate()`. `super.target` reads
+  through the host once activated, so accessors that fall through to the
+  underlying element (`super.paused`, `super.currentTime`) just work.
+- Strategies are responsible for controlling event propagation during their
+  tenure. `GoogleCastMedia`, for example, swallows or synthesizes
+  `timeupdate` to reflect the cast receiver's clock, not the local
+  `<video>`. Wire those listeners in `activate`, unwire them in `deactivate`.
+
+### Disposal order
+
+- Calling `host.destroy()` (or the equivalent teardown) iterates registered
+  extensions in registration order and runs each disposer, then resets the
+  active strategy to the default.
+
+## Trade-offs
+
+| Gain | Cost |
+| - | - |
+| Behavior is composable at runtime and code-splittable | One active strategy at a time — no multi-extension overlap on the same property |
+| Cast's per-accessor redirects collapse into one strategy class | Each strategy must extend `BaseMediaStrategy` even if it only overrides one property |
+| `super` and native class inheritance — no Proxy, no prototype mutation, no chain dispatcher | Adding a new interceptable accessor touches two places (`MediaStrategy` + `BaseMediaStrategy`) |
+| Extensions are tree-shakeable, independently testable modules | Combined behaviors that aren't naturally mutually exclusive (e.g. ads-while-casting) must be modeled at the strategy level (subclass one from the other) |
+| Generalizes the existing `HlsMedia.#delegate` pattern; no new mental model | A handful of features (HLS engine selection) drop a private idiom for a public API call |
+
+### About single-strategy
+
+The current set of features is naturally mutually exclusive:
+
+- Cast takes over while casting.
+- Ads take over while an ad plays.
+- HLS engine selection picks one engine at a time.
+- Mux Data doesn't take over anything.
+
+"Ads while casting" is a product decision (pause cast for the ad, or play
+ads on the cast receiver) that resolves at the strategy level — not in the
+extension dispatcher. If a future need genuinely requires per-property
+stacking across extensions, the same `use()` API could grow into a more
+complex view (see [Open Questions](#open-questions)).
+
+## Beyond Media
+
+`HTMLMediaElementHost` is a specialization of a smaller pattern: a host that
+accepts extensions and routes its public surface to a swappable strategy.
+The pattern doesn't care that the surface is `MediaStrategy` — it works
+anywhere "one active implementation at a time, with pluggable lifecycle
+behavior around it" applies.
+
+Concretely, future iframe-based players (YouTube, Vimeo, …) don't share
+`HTMLMediaElement` semantics, but they want the same composition story:
+swap implementations at runtime, attach Mux Data or other extensions
+identically. They'd extend their own host with their own surface and reuse
+`Extension` / `route` unchanged.
+
+When a second concrete host appears, the shared machinery can be lifted
+into an abstract `Host<Surface>`:
+
+```ts
+abstract class Host<Surface> {
+  use(extension: Extension<this>): () => void;
+  route(strategy: Surface | null): () => void;
+}
+
+class HTMLMediaElementHost<T, Events> extends Host<MediaStrategy> { … }
+class IframePlayerHost<Events> extends Host<IframePlayerSurface> { … }
+```
+
+`Host` is deliberately the most boring noun — it pairs with the existing
+`HTMLMediaElementHost` naming, scales to `IframePlayerHost`, `EditorHost`,
+etc., and reads as "this class is what makes it a host." The two operations
+on it (`use`, `route`) describe its capabilities; neither verb on its own is
+strong enough to headline the class name.
+
+This is a forward-looking note, not part of the initial migration. The
+abstract base gets extracted when the second concrete host arrives — until
+then, the pattern lives on `HTMLMediaElementHost` directly.
+
+## Prior Art
+
+- **`HlsMedia.#delegate`** in this repo — the swap-the-implementation pattern,
+  scoped to engine selection. The new design lifts it to a first-class host
+  API.
+- **HTMLMediaElement / MediaSession** — the native platform's "one active
+  media element at a time" model.
+- **Lit `ReactiveController`** — the lifecycle-attach-with-disposer pattern.
+  Not reused directly (`ReactiveController` is bound to
+  `ReactiveControllerHost`, which the media host isn't), but the shape is
+  intentionally similar.
+- **CodeMirror 6 extensions** — `EditorView.dispatch({ effects: … })` to
+  reconfigure behavior at runtime. Same registration model, no class
+  inheritance.
+- **Strategy pattern (GoF)** — what's happening here, applied to media.
 
 ## Open Questions
 
-- **Variant type surface.** When multiple variants are passed, is the
-  resulting class's public type the *intersection* of the variants
-  (only members on every variant — simplest contract) or the *union*
-  (everything any variant exposes, narrowed via `instanceof` on
-  `delegate`)? Today's `HlsMedia` hand-picks forwarders; the new
-  multi-variant branch needs a principled answer.
-- **`supports` contract.** Engines contribute it; what signature?
-  Today's `HlsMedia` reads `src`, `type`, `preferPlayback`,
-  `config`, `debug`. A canonical `MediaSupportContext` type lives in
-  `@videojs/core/dom/media`.
-- **Variant ordering.** First match wins, with `preferPlayback` as a
-  tiebreaker (matching today's logic). Do we expose
-  `preferPlayback` as a special-cased prop, or generalise to a
-  per-variant `priority`?
-- **Feature ordering.** Array order is registration order. Mixin
-  order matters today (preload wraps stream-type wraps errors, …) —
-  encode the recommended order in each engine's preset (`hlsJsFeatures`).
-- **Override conflicts.** Two features wrapping the same method
-  (e.g. cast and AirPlay both wrapping `play`) compose in array
-  order. Same as today's mixin chain — likely fine, worth confirming.
-- **Naming.** `createVideo` / `createAudio` parallel `createPlayer`.
-  Alternatives: `defineVideo` / `defineAudio` to mirror
-  `defineSlice` / `definePlayerFeature`.
-- **Repeated cross-cutting features.** Putting `googleCast`, `muxData`
-  in every variant is verbose. Worth a sugar like
-  `createVideo(variant1, variant2, { features: sharedFeatures })`
-  (trailing options apply to all variants)? Or leave it to user-side
-  helpers?
-- **Re-exports vs duplicate descriptors.** `googleCast` re-exported
-  from each engine path — does TypeScript's instance type stay
-  identical across import paths? (Should — re-export preserves
-  identity.) Worth a sanity test.
-- **Custom engines / features.** Type-ergonomic helpers
-  (`defineFeature`, `defineEngine`) for third-party authors? Or is
-  the descriptor shape simple enough to write by hand?
+- **Event bridging during strategy swaps.** `bridgeEvents` today forwards
+  every event from a delegate up to the host. With strategies swapping in
+  and out, we want the host to keep firing events for the currently active
+  source of truth. Two options:
+  1. Strategy `activate`/`deactivate` hooks responsible for hooking and unhooking
+     event forwarding (mirrors today's `bridgeEvents` per delegate).
+  2. The host centralizes a small forwarder that re-targets when
+     `route` fires `strategychange`.
 
----
+  Leaning toward (1) — each strategy already owns its source, so it owns
+  its events.
 
-## See Also
+- **Multi-host extensions.** A single `MediaExtension` instance is currently
+  scoped to one host (it captures `host` in its `install` closure). Should
+  the contract require fresh instances per host, or allow one instance to
+  install into multiple hosts? Today's Mux Data and Cast are per-host anyway,
+  so the simpler "one instance per host" contract is the starting point.
 
-- `packages/core/src/dom/store/features/presets.ts` — preset arrays
-  on the store side. The shape we're mirroring.
-- `packages/core/src/dom/media/hls/hlsjs.ts` — the current static
-  mixin chain `createVideo` replaces; lines 19-57 become the body of
-  the `hlsJs` engine function's mixin.
-- `packages/core/src/dom/media/hls/index.ts` — today's `HlsMedia`
-  facade with hand-coded delegate selection; replaced by
-  `createVideo`'s multi-variant branch.
-- `packages/core/src/dom/media/google-cast/index.ts` — the heaviest
-  engine-agnostic mixin, becomes `googleCast.mixin` re-exported from
-  each engine path.
-- `packages/core/src/dom/media/mux/index.ts` — `MuxVideoMedia` /
-  `MuxAudioMedia`, the canonical multi-layer composition. The audio
-  TODO on line 20-21 resolves naturally with `createAudio`.
+## HLS media composition
+
+Lazy load the much heavier HlsJsVideo component only when needed.
+
+```tsx
+import { lazy } from '@videojs/react/utils/lazy';
+import { MediaRouter } from '@videojs/react/media/media-router';
+import { SimpleHlsVideo } from '@videojs/react/media/simple-hls-video';
+import { NativeHlsVideo } from '@videojs/react/media/native-hls-video';
+
+const HlsJsVideo = lazy(() => import('@videojs/react/media/hls-js-video'));
+
+export default function HlsVideo({ src, preferPlayback = 'mse', children }) {
+  return (
+    <MediaRouter 
+      src={src} 
+      preferPlayback={preferPlayback}
+    >
+      <SimpleHlsVideo />
+      <HlsJsVideo  />
+      <NativeHlsVideo  />
+      {children}
+    </MediaRouter>
+  );
+}
+```

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -136,16 +136,20 @@ import { addLayer } from '@videojs/core/media/media-layer';
 import type { GoogleCastMedia } from './google-cast-layer';
 
 class GoogleCast implements GoogleCastProps, MediaExtension {
-  #destroy = () => {};
+  #destroy: (() => void) | null = null;
 
   install(media: GoogleCastMedia) {
-    installExtension(googleCast, media, this);
-    this.#destroy = addLayer(media, new GoogleCastLayer(this));
+    const uninstall = installExtension(googleCast, media, this);
+    const removeLayer = addLayer(media, new GoogleCastLayer(this));
+    this.#destroy = () => {
+      uninstall();
+      removeLayer();
+    };
   }
 
   destroy() {
-    this.#destroy();
-    this.#destroy = () => {};
+    this.#destroy?.();
+    this.#destroy = null;
   }
 }
 
@@ -166,9 +170,11 @@ cast.destroy();
 ```
 
 `getExtensions(media)` is the registry for that host. Extensions register
-themselves by factory during `install()`, consumers look them up with the same
-factory, and teardown is explicit through `extension.destroy()` or host
-destruction.
+themselves by factory during `install()` — `installExtension` returns an
+uninstall callback that removes the entry from the registry, which the
+extension pairs with its layer cleanup in `destroy()`. Consumers look them up
+with the same factory, and teardown is explicit through `extension.destroy()`
+or host destruction.
 
 ### Media Layer
 

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -8,6 +8,17 @@ date: 2026-05-14
 Compose media behavior by registering host extensions and adding media
 layers at runtime.
 
+## Background
+
+A **media host** (`HTMLMediaElementHost`) is a thin `EventTarget` that
+mirrors `HTMLMediaElement` and forwards to a `target` — usually a real
+`<video>` or `<audio>`. Properties and methods proxy to the target (with
+safe fallbacks when detached), and `addEventListener` lazily wires a
+forwarder on the target so consumers only ever listen on the host.
+
+That indirection is what makes composition possible — extensions and
+layers talk to the host, rarely the `<video>` directly.
+
 ## Problem
 
 Today, behavior on top of the base media classes is layered with class

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -5,26 +5,22 @@ date: 2026-05-14
 
 # Composable Media
 
-Compose media behavior by registering small extensions and swapping the active
+Compose media behavior by registering host extensions and swapping the active
 strategy at runtime.
 
 ## Problem
 
-Today, behavior on top of the base media classes is layered with class mixins
-with mixin-prefixed props:
+Today, behavior on top of the base media classes is layered with class
+mixins with mixin-prefixed props:
 
 ```ts
-type MuxMediaProps = {
-  src: string;
-  type: 'video/mp4' | 'application/vnd.apple.mpegurl';
-  castSrc: string;
-  castContentType: 'video/mp4' | 'application/vnd.apple.mpegurl';
-  castReceiverApplicationId: string;
-};
-
-// packages/core/src/dom/media/mux/index.ts
+// packages/core/src/dom/media/mux/index.ts (legacy pattern)
 export class MuxVideoMedia extends MuxDataMediaMixin(GoogleCastMixin(HlsMedia))
   implements MuxMediaProps {}
+
+// MuxMediaProps surfaces the union of every mixin's props on the host:
+type MuxMediaProps = HlsMediaProps & GoogleCastMediaProps & MuxDataMediaProps;
+// e.g. castSrc, castContentType, castReceiverApplicationId, muxEnvKey, …
 ```
 
 That pattern has costs we want to remove:
@@ -33,7 +29,7 @@ That pattern has costs we want to remove:
    code-split or lazy loaded. Once mixed in, behavior can't be added,
    removed, or swapped at runtime. Cast doesn't have a way to truly turn
    itself off.
-2. **Muddled mixin API.** Mixins add config props to the media API surface
+2. **Muddled media API.** Mixins add config props to the media API surface
    which need to be prefixed to avoid conflicts.
 
 We want a model where Cast, Ads, and future extensions are independent
@@ -161,13 +157,16 @@ disambiguates them (`@videojs/react/media/google-cast` for the component,
 ### Host
 
 `HTMLMediaElementHost` (see [`media.md`](./media.md) for the host hierarchy)
-gains two methods:
+extends an abstract `Host<MediaStrategy>` that provides the composition
+primitives:
 
 ```ts
-class HTMLMediaElementHost<T, Events> extends EventTarget {
+abstract class Host<Surface extends object> extends EventTarget {
   use(extension: Extension<this>): () => void;
-  route(strategy: MediaStrategy | null, options?: { base?: boolean }): () => void;
+  route(strategy: (Surface & Strategy<this>) | null, options?: { base?: boolean }): () => void;
 }
+
+class HTMLMediaElementHost<T, Events> extends Host<MediaStrategy> { … }
 ```
 
 Every accessor and method on the host (`paused`, `currentTime`, `play`, …) is
@@ -175,32 +174,35 @@ a one-liner that forwards to the currently active strategy.
 
 | Member | Purpose |
 | - | - |
-| `use(extension)` | Register an extension. Returns a disposer that detaches it. Calling `use()` twice with the same `id` warns in `__DEV__` and is a no-op. |
-| `route(strategy)` | Route the host's media surface to a strategy. Returns a disposer that restores the previous routing *only if* this strategy is still the active one when called — so an extension never accidentally clears a strategy that another extension has since installed. Pass `null` to route back to the default unconditionally. Dispatches a `strategychange` event. |
+| `use(extension)` | Register an extension. Returns a disposer that detaches it. Calling `use()` twice with the same `id` is a no-op. |
+| `route(strategy)` | Route the host's media surface to a strategy. Returns a disposer that restores the previous routing *only if* this strategy is still the active one when called — so an extension never accidentally clears a strategy that another extension has since installed. Pass `null` to clear the routed slot. |
 | `route(strategy, { base: true })` | Same shape, different slot: replaces the host's always-on **base** strategy instead of layering on top of it. Used by extensions that want to extend defaults rather than take over (e.g. cast adds a `remote` accessor to the base so it's available even when no session is connected). The active routed strategy still overlays the base; clearing the base disposer restores the host's built-in default. |
 
-That's the entire new surface. The default strategy (the direct-to-`target`
-`BaseMediaStrategy`) and the currently active strategy are both internal state.
-External code observes changes via the `strategychange` event.
+That's the entire new surface. The base strategy (the direct-to-`target`
+`BaseMediaStrategy`) and the currently routed strategy are both internal
+state, accessed via the protected `strategy` getter.
 
-### MediaExtension
+### Extension
 
 ```ts
-abstract class MediaExtension {
-  abstract readonly id: string;
-  install?(host: HTMLMediaElementHost<any, any>): (() => void) | void;
+interface Extension<HostType = unknown> {
+  readonly id: string;
+  install?(host: HostType): (() => void) | void;
 }
 ```
 
-An `id` for dedup/lookup, and an optional `install` that returns an optional
-uninstaller. That's it. Everything else is implementation.
+An `id` for dedup, and an optional `install` that returns an optional
+uninstaller. Extensions are plain classes that `implements Extension<Host>`.
+Everything else is implementation.
 
 ### BaseMediaStrategy and strategies
 
 ```ts
-class BaseMediaStrategy<T extends HTMLMediaElement> implements MediaStrategy {
-  protected host: HTMLMediaElementHost<T, any> | null;
-  protected get target(): T | null;
+class BaseMediaStrategy<T extends HTMLMediaElement>
+  implements MediaStrategy, Strategy<HTMLMediaElementHost<T, any>>
+{
+  #host: HTMLMediaElementHost<T, any> | null = null;
+  get #target(): T | null { return this.#host?.target ?? null; }
 
   activate(host: HTMLMediaElementHost<T, any>): void;
   deactivate(): void;
@@ -208,43 +210,47 @@ class BaseMediaStrategy<T extends HTMLMediaElement> implements MediaStrategy {
   get paused(): boolean;
   get currentTime(): number;
   set currentTime(v: number);
-  // …full MediaStrategy, all forwarding to this.target
+  // …full MediaStrategy, all forwarding to this.#target
 }
 ```
 
-A strategy is any class extending `BaseMediaStrategy` that overrides the parts it
-owns. Native `super` + inheritance — no chain machinery.
+A strategy is any class extending `BaseMediaStrategy` that overrides the
+parts it owns. Native `super` + inheritance — no chain machinery. The
+`#host` reference (and hence `#target`) is per-class private, so subclasses
+that need their own host reference declare their own `#host`; calling
+`super.activate(host)` keeps the base-class plumbing working.
 
 `activate(host)` and `deactivate()` are called by the host on `route`
 swaps — strategies don't need a host at construction time. Override
 `activate` / `deactivate` to wire and unwire host-level listeners; always
-call `super.activate` / `super.deactivate`.
+call `super.activate` / `super.deactivate` so the base forwarders keep
+working.
 
 ### MediaStrategy
 
-A single interface defines the interceptable shape. `BaseMediaStrategy` and every
-strategy implements it, so TypeScript catches drift between the two.
+A single interface defines the interceptable shape, composed from the
+framework-agnostic capability interfaces in `core/media/types.ts`.
+`BaseMediaStrategy` and every strategy implements it, so TypeScript catches
+drift between the two.
 
 ```ts
-interface MediaStrategy {
-  paused: boolean;
-  ended: boolean;
-  seeking: boolean;
-  readyState: number;
-  duration: number;
-  currentTime: number;
-  muted: boolean;
-  volume: number;
-  playbackRate: number;
-  // …
-  play(): Promise<void>;
-  pause(): void;
-  load(): void;
-}
+export interface MediaStrategy
+  extends MediaPlaybackCapability,
+    MediaPauseCapability,
+    MediaSeekCapability,
+    MediaSourceCapability,
+    MediaVolumeCapability,
+    MediaPlaybackRateCapability,
+    MediaBufferCapability,
+    MediaErrorCapability,
+    MediaTextTrackCapability,
+    MediaRemotePlaybackCapability {}
 ```
 
-Adding a new interceptable accessor is two lines: extend `MediaStrategy`,
-implement it in `BaseMediaStrategy`. Strategies inherit the default automatically.
+Adding a new interceptable accessor is two steps: declare it on the
+relevant capability interface (or extend `MediaStrategy` with a new one),
+then implement it in `BaseMediaStrategy`. Strategies inherit the default
+automatically.
 
 ## Examples
 
@@ -356,10 +362,10 @@ No strategy needed — Mux Data observes lifecycle and initializes the SDK
 against the underlying element.
 
 ```ts
-export class MuxData extends MediaExtension {
+export class MuxData implements Extension<HTMLMediaElementHost<HTMLMediaElement, any>> {
   readonly id = 'mux-data';
 
-  constructor(private options: MuxDataOptions) { super(); }
+  constructor(private options: MuxDataOptions) {}
 
   install(host: HTMLMediaElementHost<HTMLMediaElement, any>) {
     const off = new AbortController();
@@ -379,10 +385,10 @@ routes the appropriate strategy:
 ```ts
 import HlsJs from 'hls.js';
 
-export class HlsExtension extends MediaExtension {
+export class HlsExtension implements Extension<HTMLVideoElementHost<any, any>> {
   readonly id = 'hls';
 
-  constructor(private options: HlsOptions = {}) { super(); }
+  constructor(private options: HlsOptions = {}) {}
 
   install(host: HTMLVideoElementHost<any, any>) {
     const off = new AbortController();
@@ -404,7 +410,7 @@ export const hls = (options?: HlsOptions) => new HlsExtension(options);
 ```
 
 `HlsJsMedia` and `NativeHlsMedia` are `BaseMediaStrategy` subclasses — same
-shape as `GoogleCastMedia`, just owning their own engine. The legacy
+shape as `GoogleCastProvider`, just owning their own engine. The legacy
 `HlsMedia` class, its `#delegate` field, the manual `bridgeEvents`
 plumbing, and the `#shouldEngineUpdate` book-keeping collapse to one
 extension + two strategies. `createHlsMedia` installs `hls()` for you;
@@ -425,26 +431,28 @@ way.
 
 ### Strategy switching
 
-- One active strategy at a time. Calling `route` while another strategy is
-  active replaces it. No stacking.
-- `route` calls `strategy.activate(host)` on the incoming strategy and
-  `prevStrategy.deactivate()` on the outgoing one before swapping `#active`,
-  then dispatches `strategychange`. UI code can listen for that event to
-  react ("we're now casting").
+- One active strategy at a time per slot (base and routed). Calling `route`
+  while another strategy is active in the same slot replaces it.
+- `route` calls `prevStrategy.deactivate()` on the outgoing strategy,
+  swaps the slot, then calls `strategy.activate(host)` on the incoming one.
 - Strategies are constructed without a host. They get the host in
-  `activate(host)` and lose it in `deactivate()`. `super.target` reads
-  through the host once activated, so accessors that fall through to the
-  underlying element (`super.paused`, `super.currentTime`) just work.
-- Strategies are responsible for controlling event propagation during their
-  tenure. `GoogleCastMedia`, for example, swallows or synthesizes
+  `activate(host)` and lose it in `deactivate()`. Accessors that fall
+  through to the underlying element (`super.paused`, `super.currentTime`)
+  just work once activated.
+- Strategies are responsible for controlling event propagation during
+  their tenure. `GoogleCastProvider`, for example, swallows or synthesizes
   `timeupdate` to reflect the cast receiver's clock, not the local
-  `<video>`. Wire those listeners in `activate`, unwire them in `deactivate`.
+  `<video>`. Wire those listeners in `activate`, unwire them in
+  `deactivate`.
 
-### Disposal order
+### Disposal
 
-- Calling `host.destroy()` (or the equivalent teardown) iterates registered
-  extensions in registration order and runs each disposer, then resets the
-  active strategy to the default.
+- Each `use(extension)` and `route(strategy, …)` call returns its own
+  disposer. Holding onto them lets callers unregister or unroute
+  individually.
+- Tearing down a host means calling every disposer the caller held. The
+  host itself doesn't expose a bulk `destroy()` today — see
+  [Open Questions](#open-questions).
 
 ## Trade-offs
 
@@ -455,6 +463,48 @@ way.
 | `super` and native class inheritance — no Proxy, no prototype mutation, no chain dispatcher | Adding a new interceptable accessor touches two places (`MediaStrategy` + `BaseMediaStrategy`) |
 | Extensions are tree-shakeable, independently testable modules | Combined behaviors that aren't naturally mutually exclusive (e.g. ads-while-casting) must be modeled at the strategy level (subclass one from the other) |
 | Generalizes the existing `HlsMedia.#delegate` pattern; no new mental model | A handful of features (HLS engine selection) drop a private idiom for a public API call |
+| Stable, owner-controlled host API surface | Extensions can't add public accessors / methods to the host the way mixins do |
+
+### About a fixed host surface
+
+Mixins extended the host's public API: installing `GoogleCastMixin` added
+`castSrc`, `castReceiver`, `castContentType`, `castStreamType`, and
+`castCustomData` to the host's surface; `MuxDataMediaMixin` added another set
+of props. Each extra prop had to be prefixed to avoid collisions, leaked
+into TypeScript types regardless of whether the extension was actually
+installed at runtime, and made the host's public shape depend on which
+mixins happened to be applied.
+
+Extensions intentionally **do not** widen `HTMLMediaElementHost`'s API.
+`host.use(extension)` registers behavior — it doesn't add accessors or
+methods. The host's public surface is whatever `MediaStrategy` defines, full
+stop. Trade-offs:
+
+- The host API is stable, predictable, and owned by us. Adding a new
+  extension never changes the host's public shape.
+- TypeScript types don't have to encode every possible mixin combination.
+- Extensions own their own configuration (passed to their constructor) and
+  their own events (dispatched on the host or on objects they expose). Cast
+  config is `new GoogleCast({ receiverApplicationId: '…' })`, not
+  `host.castReceiver = '…'`.
+- Extension-private state stays in the extension. Callers who need to reach
+  it can keep the instance reference returned from `new GoogleCast(...)` and
+  talk to it directly.
+
+Escape hatches we can add later if real use-cases demand them, none of which
+require redesigning the core:
+
+- A generic `host.extensions` registry (`host.extensions.get('google-cast')`)
+  for opt-in lookup by id.
+- A typed proxy / forwarder helper that lets an extension declare a small
+  set of accessors it wants surfaced on the host, with explicit conflict
+  rules.
+- Per-extension events bridged onto the host's `EventTarget` for the cases
+  where dispatching on the extension itself isn't ergonomic.
+
+Starting from a closed, controlled surface and opening it deliberately is
+the inverse of where mixins land — wide surface first, conflicts and
+ergonomics second — and we'd rather be the ones to choose when to widen.
 
 ### About single-strategy
 
@@ -479,34 +529,31 @@ The pattern doesn't care that the surface is `MediaStrategy` — it works
 anywhere "one active implementation at a time, with pluggable lifecycle
 behavior around it" applies.
 
-Concretely, future iframe-based players (YouTube, Vimeo, …) don't share
-`HTMLMediaElement` semantics, but they want the same composition story:
-swap implementations at runtime, attach Mux Data or other extensions
-identically. They'd extend their own host with their own surface and reuse
-`Extension` / `route` unchanged.
-
-When a second concrete host appears, the shared machinery can be lifted
-into an abstract `Host<Surface>`:
+The shared machinery already lives in an abstract `Host<Surface>` in
+`@videojs/core/dom/media/host` so future hosts can reuse it directly:
 
 ```ts
-abstract class Host<Surface> {
+abstract class Host<Surface extends object> extends EventTarget {
   use(extension: Extension<this>): () => void;
-  route(strategy: Surface | null): () => void;
+  route(strategy: (Surface & Strategy<this>) | null, options?: { base?: boolean }): () => void;
 }
 
 class HTMLMediaElementHost<T, Events> extends Host<MediaStrategy> { … }
+// future:
 class IframePlayerHost<Events> extends Host<IframePlayerSurface> { … }
 ```
+
+Concretely, future iframe-based players (YouTube, Vimeo, …) don't share
+`HTMLMediaElement` semantics, but they want the same composition story:
+swap implementations at runtime, attach Mux Data or other extensions
+identically. They'd extend `Host` with their own surface and reuse
+`Extension` / `route` unchanged.
 
 `Host` is deliberately the most boring noun — it pairs with the existing
 `HTMLMediaElementHost` naming, scales to `IframePlayerHost`, `EditorHost`,
 etc., and reads as "this class is what makes it a host." The two operations
 on it (`use`, `route`) describe its capabilities; neither verb on its own is
 strong enough to headline the class name.
-
-This is a forward-looking note, not part of the initial migration. The
-abstract base gets extracted when the second concrete host arrives — until
-then, the pattern lives on `HTMLMediaElementHost` directly.
 
 ## Prior Art
 
@@ -532,20 +579,29 @@ then, the pattern lives on `HTMLMediaElementHost` directly.
   source of truth. Two options:
   1. Strategy `activate`/`deactivate` hooks responsible for hooking and unhooking
      event forwarding (mirrors today's `bridgeEvents` per delegate).
-  2. The host centralizes a small forwarder that re-targets when
-     `route` fires `strategychange`.
+  2. The host centralizes a small forwarder that re-targets on every
+     `route` call. Would also need a hook (e.g. a `strategychange` event)
+     so external code can react to swaps.
 
   Leaning toward (1) — each strategy already owns its source, so it owns
   its events.
 
-- **Multi-host extensions.** A single `MediaExtension` instance is currently
+- **Multi-host extensions.** A single `Extension` instance is currently
   scoped to one host (it captures `host` in its `install` closure). Should
   the contract require fresh instances per host, or allow one instance to
   install into multiple hosts? Today's Mux Data and Cast are per-host anyway,
   so the simpler "one instance per host" contract is the starting point.
 
+- **Bulk teardown.** Callers track individual disposers returned from `use`
+  and `route` today. A bulk `host.destroy()` (uninstall every extension,
+  clear every routing slot, abort outstanding work) would simplify lifecycle
+  for hosts created and discarded as a unit — but raises questions about
+  re-use after destroy and interaction with custom elements'
+  `disconnectedCallback`. Out of scope for the initial migration.
+
 ## HLS media composition
 
+Again not part of the initial migration, but it leaves the door open for it.
 Lazy load the much heavier HlsJsVideo component only when needed.
 
 ```tsx

--- a/internal/design/media-features.md
+++ b/internal/design/media-features.md
@@ -5,19 +5,8 @@ date: 2026-05-14
 
 # Composable Media
 
-Compose media behavior by registering host extensions and adding media
-layers at runtime.
-
-## Background
-
-A **media host** (`HTMLMediaElementHost`) is a thin `EventTarget` that
-mirrors `HTMLMediaElement` and forwards to a `target` — usually a real
-`<video>` or `<audio>`. Properties and methods proxy to the target (with
-safe fallbacks when detached), and `addEventListener` lazily wires a
-forwarder on the target so consumers only ever listen on the host.
-
-That indirection is what makes composition possible — extensions and
-layers talk to the host, rarely the `<video>` directly.
+Compose media behavior from media extensions and layers — pre-composed into a
+host or added and removed at runtime.
 
 ## Problem
 
@@ -33,32 +22,41 @@ type MuxMediaProps = HlsMediaProps & GoogleCastMediaProps & MuxDataMediaProps;
 
 That pattern has costs we want to remove:
 
-1. **Static composition.** The class is baked at module load — Cast can't
-   be code-split or lazy loaded, and once mixed in, behavior can't be
-   added, removed, or swapped at runtime.
-2. **Muddled media API.** Mixin config props leak onto the media surface
-   and need prefixing to avoid conflicts.
+1. **Inheritance doesn't scale.** Features (HLS, Cast, Data, …) are
+   independent axes, but inheritance forces them into one linear chain — `N`
+   freely-combinable features need a class per combination, combinatorial not
+   linear.
+2. **Features are bound to their base.** A mixin extends a _specific_ class,
+   so `GoogleCastMixin` must be re-applied to every media implementation
+   (`HlsMedia`, `NativeHlsMedia`, …) instead of authored once and reused.
+3. **Mixins can't augment an instance.** A mixin yields a _new subclass_, so a
+   component already holding an `HlsMedia` instance can't gain Cast without
+   building a different class and a fresh instance — discarding the one it has.
+4. **The class is fixed at module load.** Mixins resolve when the class is
+   defined, so features can't be code-split or lazy loaded, nor added,
+   removed, or swapped at runtime.
 
 ## Solution
 
 Two roles, one host:
 
 - **Media Extension** — installs itself on a media host, owns its lifecycle
-  and state, and may push one or more layers (or only observe). Usually
-  constructed through a factory like `googleCast({ … })`.
+  and state, and may push one or more layers (or only observe).
 - **Media Layer** — anything pushed onto the layer stack via
   `addLayer(media, layer)`.
 
 ## Features
 
-- Extensions and layers can be pre-composed into a single media host.
-  e.g. MuxVideo is composed of HlsMedia, GoogleCast, and MuxData.
-- Extensions and layers can be installed and removed at runtime.
-- Extensions have their own API surface and lifecycle.
-- Extensions are deduplicated and only installed once per media host.
-- Extensions can be looked up and updated from anywhere with the media reference.
-- Extensions can't extend the media host's API surface — strict by default,
-  however the host can still be easily extended by subclassing.
+- **Pre-composed or runtime.** Bake extensions and layers into a host
+  (e.g. MuxVideo = HlsMedia + GoogleCast + MuxData), or install and remove
+  them at runtime.
+- **Own API and lifecycle.** Each extension owns its state, surface, and
+  teardown.
+- **Deduplicated.** An extension installs only once per host.
+- **Lookup from anywhere.** Extensions can be found and updated from any
+  reference to the media.
+- **Strict by default.** Extensions can't extend the host's API surface;
+  subclass the host when you need to.
 
 ## Quick Start
 
@@ -70,7 +68,7 @@ import { googleCast } from '@videojs/core/dom/media/google-cast';
 import { muxData } from '@videojs/core/dom/media/mux';
 
 const media = createHlsMedia();
-media.target = mediaElement;
+media.target = videoElement;
 
 googleCast({ receiverApplicationId: '…' }).install(media);
 muxData({ envKey: '…' }).install(media);
@@ -82,7 +80,7 @@ muxData({ envKey: '…' }).install(media);
 import { createHlsMedia } from '@videojs/core/dom/media/hls';
 
 const media = createHlsMedia();
-media.target = mediaElement;
+media.target = videoElement;
 
 if (userWantsCast) {
   const { googleCast } = await import('@videojs/core/dom/media/google-cast');
@@ -120,7 +118,7 @@ const GoogleCast = lazy(() => import('@videojs/react/media/google-cast'));
 export default function HlsVideoWithExtensions() {
   return (
     <HlsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8">
-      <GoogleCast receiverAppId="1234567890" customData={{ foo: 'bar' }} />
+      <GoogleCast receiverApplicationId="1234567890" customData={{ foo: 'bar' }} />
     </HlsVideo>
   );
 }
@@ -130,6 +128,20 @@ export default function HlsVideoWithExtensions() {
 
 ### Media Extension
 
+An extension is a plain class that implements the `MediaExtension` interface and
+is responsible for installing itself on a media host by calling `installExtension`.
+
+Each host gets a `Map` of its extensions keyed by their factory.
+
+(`packages/core/src/core/media/media-extension.ts`: brotli 151 B)
+
+```ts
+interface MediaExtension {
+  install(media: Media): void;
+  destroy(): void;
+}
+```
+
 ```ts
 import { getExtensions, installExtension, type MediaExtension } from '@videojs/core/media/media-extension';
 import { addLayer } from '@videojs/core/media/media-layer';
@@ -137,6 +149,10 @@ import type { GoogleCastMedia } from './google-cast-layer';
 
 class GoogleCast implements GoogleCastProps, MediaExtension {
   #destroy: (() => void) | null = null;
+
+  constructor(props: GoogleCastProps) {
+    Object.assign(this, props);
+  }
 
   install(media: GoogleCastMedia) {
     const uninstall = installExtension(googleCast, media, this);
@@ -164,32 +180,41 @@ cast.install(media);
 getExtensions(media).get(googleCast)!.receiverApplicationId = 'new-id';
 
 // iterate every installed extension
-for (const ext of getExtensions(media)) console.log(ext);
+for (const ext of getExtensions(media).values()) console.log(ext);
 
 cast.destroy();
 ```
 
-`getExtensions(media)` is the registry for that host. Extensions register
-themselves by factory during `install()` — `installExtension` returns an
-uninstall callback that removes the entry from the registry, which the
-extension pairs with its layer cleanup in `destroy()`. Consumers look them up
-with the same factory, and teardown is explicit through `extension.destroy()`
+`getExtensions(media)` is the host's registry. During `install()`, an
+extension registers by factory; `installExtension` returns an uninstall
+callback it pairs with its layer cleanup in `destroy()`. Consumers look
+extensions up by the same factory, and teardown runs on `extension.destroy()`
 or host destruction.
 
 ### Media Layer
 
+A layer is a subclass of `MediaLayer` that overrides the media host's methods.
+
+(`packages/core/src/core/media/media-layer.ts`: brotli 543 B)
+
+```ts
+interface MediaLayer {
+  root: MediaHost;
+  next: MediaLayer | HTMLMediaElement | null;
+  target: HTMLMediaElement | null;
+}
+```
+
 ```ts
 import { addLayer } from '@videojs/core/media/media-layer';
 
-function addLayer(media: MediaLayer, layer: Layer): () => void;
+interface MediaHost extends MediaLayer {}
 
-interface Layer extends MediaLayer {}
+function addLayer(media: MediaHost, layer: MediaLayer): () => void;
 ```
 
 `addLayer(media, layer)` pushes the layer onto the stack and returns a
-destroy that pops it. Most code calls this transitively through an
-extension, but it can be called directly when no surrounding extension is
-needed.
+destroy that pops it.
 
 #### Chain anatomy
 
@@ -222,29 +247,3 @@ Every `MediaLayer` exposes three navigation properties:
 Layers forward via `super`: a subclass's `override play()` calls
 `super.play()`, which the base class walks one step down the chain. So
 `host.play()` cascades through every layer until it reaches the `target`.
-
-#### Reacting to target changes
-
-`set target` propagates by invoking the next layer's setter, so any layer
-can react by overriding it. Each call to `super.target = value` migrates
-this layer's forwarders and hands off to the next layer down. When the
-layer is removed via `addLayer`'s destroy, the override is invoked one
-last time with `null` so target-bound state tears down cleanly.
-
-```ts
-class MyLayer extends HTMLMediaElementLayer {
-  #abort: AbortController | null = null;
-
-  override set target(value: HTMLMediaElement | null) {
-    this.#abort?.abort();
-    this.#abort = null;
-
-    if (value) {
-      this.#abort = new AbortController();
-      value.addEventListener('error', onError, { signal: this.#abort.signal });
-    }
-
-    super.target = value;
-  }
-}
-```


### PR DESCRIPTION
## Good to know

No new methods on the host: extensions install themselves via `installExtension`, layers attach via `addLayer`, and consumers reach them through `getExtensions(media)` — all imported functions. The host also keeps a single `target` getter/setter instead of attach/detach/getTarget, shrinking the public surface. Happy to discuss.

## Summary

Draft design doc for replacing the static media-mixin chain with a runtime-composable model. Two roles, one host:

- **Media Extension** — installs itself on a host, owns its lifecycle and state, and may push one or more layers (or only observe). Usually produced by a factory like `googleCast({ … })`.
- **Media Layer** — anything pushed onto the layer stack via `addLayer(media, layer)`.

## Problem

The current `MuxDataMediaMixin(GoogleCastMixin(HlsMedia))` pattern doesn't scale:

- Inheritance forces independent feature axes onto one linear chain — combining `N` needs a class per combination.
- A mixin is bound to its base, so each feature must be re-applied per media implementation.
- A mixin yields a new subclass, so you can't augment an instance you already hold.
- The class is fixed at module load — no code-splitting, lazy loading, or runtime add/remove/swap.

## Solution

A host and its layers form a singly-linked list rooted at the host with `HTMLMediaElement` at the tail. `addLayer` inserts new layers right below the host and returns a destroy that pops them. Layers forward through the chain via `super` — `host.play()` cascades down until it reaches the target.

Extensions are deduplicated per host (keyed by factory), looked up via `getExtensions(media)`, and torn down through `extension.destroy()` or host destruction. Strict by default: extensions can't extend the host's API surface — subclass the host when you need to.

## What's in the doc

- **Quick Start** — imperative, dynamic import, factory style, and a forward-looking React `<GoogleCast>` sketch.
- **API Surface** — `MediaExtension` + `installExtension` / `getExtensions`, `MediaLayer` (`root` / `next` / `target`) + `addLayer`, and the chain-anatomy diagram.
- **Bundle cost** noted inline (brotli: extension ~151 B, layer ~543 B).

## Testing

Docs-only — no code paths touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modified.
> 
> **Overview**
> Adds a **draft design doc** (`internal/design/media-features.md`) proposing **composable media**: replace static mixin inheritance with **media extensions** (install/destroy, deduped per host via factory-keyed registry) and **media layers** (stacked under the host via `addLayer`, singly-linked chain to the `HTMLMediaElement`).
> 
> The doc frames **why** mixins fail (combinatorial classes, no runtime add/remove, no code-splitting) and documents **how** consumers would compose features—imperative install, dynamic import, factory `createHlsMedia([…])`, and a sketch React child pattern—plus API shapes for `MediaExtension`, `installExtension` / `getExtensions`, `MediaLayer` (`root` / `next` / `target`), and call forwarding through the layer stack.
> 
> **No implementation** in this PR; it is documentation only ahead of a future refactor away from patterns like `MuxDataMediaMixin(GoogleCastMixin(HlsMedia))`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a947ef8cef3dd04f837a0830f28aecd348fc5957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
