### PR TITLE
fix(html): raise testTimeout to 15s for parallel-load reliability

### DIFF
--- a/packages/html/vitest.config.ts
+++ b/packages/html/vitest.config.ts
@@ -8,5 +8,13 @@ export default defineConfig({
     passWithNoTests: true,
     onConsoleLog: (log) => !log.includes('Lit is in dev mode'),
     environment: 'happy-dom',
+    // Some define/* tests dynamically `await import()` composite modules
+    // that pull a large graph through Vite's transform pipeline. Under
+    // `pnpm test` at the workspace root (turbo runs every package's
+    // vitest in parallel, plus Chromium for spf/dom), CPU contention
+    // can push a single import past Vitest's 5s default. Raise it so the
+    // tests stay reliable under load without masking a real regression —
+    // anything approaching this ceiling would still fail.
+    testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## Summary

- Raises `testTimeout` in `packages/html/vitest.config.ts` from Vitest's 5s default to 15s so define/* tests that dynamically `await import()` composite modules stay reliable when `pnpm test` runs at the workspace root.
- Scoped to the html package — no workspace-wide config change.

## Background

Under `pnpm test` at the workspace root, turbo (`concurrency: 20`) runs every package's vitest in parallel, and `@videojs/spf` additionally spawns Chromium via Playwright for its `dom` project. On a 10-core machine this is enough CPU contention that a single `await import('../video/player')` or `await import('../video/skin')` can exceed 5s through Vite's transform pipeline and time out — observed 5006ms, just past the default ceiling.

Same suites run in 1–2s in isolation (`pnpm -F @videojs/html test`) and under `pnpm turbo run test --concurrency=1`, which confirms the issue is scheduler starvation rather than a test bug. The `ssr-safety` test amplifies this because it calls `vi.resetModules()` in `afterEach`, so each case re-transforms the full graph with no cache benefit.

CI runs per-package in isolated jobs, so CI has never observed this. The problem is purely local to anyone whose machine can't absorb the parallel load within 5s.

## Why 15s

Observed worst case is ~5s; 15s gives ~3x headroom under load. This doesn't mask regressions — a truly slow import would still fail, just at a higher threshold. The timeout is only consulted when a test exceeds it, so fast environments (CI, beefy laptops) pay nothing.

## Alternatives considered

- **Lower turbo concurrency** — would slow `pnpm build` and `pnpm dev` at root for everyone; too broad for a local-only problem.
- **Cap vitest workers per package** — invasive change to every package's vitest config.
- **Leave it; run serially locally** — fine, but the 5s cliff will keep biting new folks whose machines happen to land on the wrong side of it.

## Test plan

- [x] `pnpm -F @videojs/html test` — 14 files, 101 tests, all pass (no change in isolated behavior)
- [x] `pnpm turbo run test --force --filter='./packages/*' --filter='!@videojs/cli'` reproduced under load — all 14 packages green, html runs at 11–19s wall duration with 30–50s cumulative transform time (confirms the contention is real; timeout bump absorbs it)
- [x] Two forced re-runs in a row, both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Vitest configuration for the `html` package, with no production code or runtime behavior changes. Main impact is potentially slower feedback if a test hangs, since failures may take longer to time out.
> 
> **Overview**
> Increases the `@videojs/html` Vitest `testTimeout` to 15s to prevent timeouts in `define/*` tests that perform heavy dynamic `import()` work when the workspace runs tests in parallel.
> 
> Adds inline documentation explaining the rationale (CPU contention during root `pnpm test`) and keeps the change scoped to `packages/html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3c50d63b2134a3708d56c7a79e2ccbed6cbac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->