### PR TITLE
feat(packages): support cli:omit markers for llm-only doc content

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -6,7 +6,7 @@ import { getConfigValue } from '../utils/config.js';
 import { docExistsInAnyFramework, readBundledDoc, readLlmsTxt } from '../utils/docs.js';
 import { formatInstallationCode } from '../utils/format.js';
 import { mapRawSkin, type PartialInstallFlags, promptFramework, promptInstallOptions } from '../utils/prompts.js';
-import { replaceMarker } from '../utils/replace.js';
+import { replaceMarker, stripOmitMarkers } from '../utils/replace.js';
 
 interface ParsedFlags {
   framework?: string;
@@ -178,7 +178,7 @@ export async function handleDocs(flags: ParsedFlags, positionals: string[]): Pro
     }
 
     const generated = formatInstallationCode(opts);
-    const output = replaceMarker(markdown, 'installation', generated);
+    const output = stripOmitMarkers(replaceMarker(markdown, 'installation', generated));
     printVersionHeader();
     console.log(output);
     return;
@@ -186,5 +186,5 @@ export async function handleDocs(flags: ParsedFlags, positionals: string[]): Pro
 
   // Regular doc: print as-is
   printVersionHeader();
-  console.log(markdown);
+  console.log(stripOmitMarkers(markdown));
 }

--- a/packages/cli/src/commands/tests/docs.test.ts
+++ b/packages/cli/src/commands/tests/docs.test.ts
@@ -6,6 +6,10 @@ const INSTALLATION_DOC = `# Installation
 
 Intro paragraph.
 
+<!-- cli:omit installation -->
+Run the CLI to generate install code.
+<!-- /cli:omit installation -->
+
 <!-- cli:replace installation -->
 Placeholder for CLI-generated code.
 <!-- /cli:replace installation -->
@@ -205,6 +209,8 @@ describe('handleDocs', () => {
         expect(out).toContain('## HTML');
         expect(out).toContain('<video-player>');
         expect(out).not.toContain('<!-- cli:replace');
+        expect(out).not.toContain('<!-- cli:omit');
+        expect(out).not.toContain('Run the CLI to generate install code');
         expect(out).toContain('Intro paragraph');
         expect(out).toContain('## Next steps');
       });

--- a/packages/cli/src/utils/replace.ts
+++ b/packages/cli/src/utils/replace.ts
@@ -2,3 +2,8 @@ export function replaceMarker(markdown: string, id: string, replacement: string)
   const re = new RegExp(`<!-- cli:replace ${id} -->\\n[\\s\\S]*?\\n<!-- /cli:replace ${id} -->`);
   return markdown.replace(re, () => replacement);
 }
+
+export function stripOmitMarkers(markdown: string): string {
+  const re = /\n?<!-- cli:omit \S+ -->\n[\s\S]*?\n<!-- \/cli:omit \S+ -->\n?/g;
+  return markdown.replace(re, '\n');
+}

--- a/packages/cli/src/utils/tests/replace.test.ts
+++ b/packages/cli/src/utils/tests/replace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { replaceMarker } from '../replace.js';
+import { replaceMarker, stripOmitMarkers } from '../replace.js';
 
 describe('replaceMarker', () => {
   it('replaces content between markers', () => {
@@ -61,5 +61,59 @@ end`;
 
     const result = replaceMarker(markdown, 'multi', 'single line');
     expect(result).toBe('start\nsingle line\nend');
+  });
+});
+
+describe('stripOmitMarkers', () => {
+  it('removes content between omit markers', () => {
+    const markdown = `# Title
+
+<!-- cli:omit installation -->
+CLI-only hint
+<!-- /cli:omit installation -->
+
+## Footer`;
+
+    const result = stripOmitMarkers(markdown);
+    expect(result).not.toContain('CLI-only hint');
+    expect(result).not.toContain('cli:omit');
+    expect(result).toContain('# Title');
+    expect(result).toContain('## Footer');
+  });
+
+  it('returns unchanged markdown when no markers are present', () => {
+    const markdown = '# Title\n\nSome content';
+    expect(stripOmitMarkers(markdown)).toBe(markdown);
+  });
+
+  it('removes multiple omit blocks with different ids', () => {
+    const markdown = `before
+<!-- cli:omit one -->
+alpha
+<!-- /cli:omit one -->
+middle
+<!-- cli:omit two -->
+beta
+<!-- /cli:omit two -->
+after`;
+
+    const result = stripOmitMarkers(markdown);
+    expect(result).not.toContain('alpha');
+    expect(result).not.toContain('beta');
+    expect(result).toContain('before');
+    expect(result).toContain('middle');
+    expect(result).toContain('after');
+  });
+
+  it('handles multiline content inside an omit block', () => {
+    const markdown = `start
+<!-- cli:omit multi -->
+line 1
+line 2
+line 3
+<!-- /cli:omit multi -->
+end`;
+
+    expect(stripOmitMarkers(markdown)).toBe('start\nend');
   });
 });

--- a/site/integrations/llms-markdown.ts
+++ b/site/integrations/llms-markdown.ts
@@ -49,6 +49,15 @@ export default function llmsMarkdown(): AstroIntegration {
           },
         });
 
+        // Wrap [data-cli-omit] content with text markers the CLI strips from its output
+        turndown.addRule('cli-omit', {
+          filter: (node) => node.nodeType === 1 && (node as Element).getAttribute('data-cli-omit') !== null,
+          replacement: (content, node) => {
+            const id = (node as Element).getAttribute('data-cli-omit');
+            return `\n<!-- cli:omit ${id} -->\n${content}\n<!-- /cli:omit ${id} -->\n`;
+          },
+        });
+
         // Track all docs and blog pages for llms.txt index
         const docsPages: PageEntry[] = [];
         const blogPages: PageEntry[] = [];

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -32,9 +32,9 @@ Video.js is an **HTML video player built on custom elements** &mdash; lightweigh
 </FrameworkCase>
 
 <LLMCase>
-<div data-cli-replace="installation">
+<div data-cli-omit="installation">
 
-Run `npx @videojs/cli docs how-to/installation` interactively, or pass all flags:
+The code examples in this guide can be tailored to your use case. Run `npx @videojs/cli docs how-to/installation` interactively, or pass all flags:
 
 ```bash
 npx @videojs/cli docs how-to/installation \
@@ -45,7 +45,6 @@ npx @videojs/cli docs how-to/installation \
   --source-url <url> \
   --install-method <cdn|npm|pnpm|yarn|bun>
 ```
-
 </div>
 </LLMCase>
 
@@ -80,6 +79,10 @@ Video.js supports a wide range of file types and hosting services. It's easy to 
 <ContentWidth margins="lg">
   <RendererPicker client:idle />
 </ContentWidth>
+
+</HumanCase>
+
+<div data-cli-replace="installation" class="contents">
 
 ## Install Video.js
 
@@ -142,7 +145,7 @@ Add it to your components folder in a new file.
 </ContentWidth>
 </FrameworkCase>
 
-</HumanCase>
+</div>
 
 ## CSP
 


### PR DESCRIPTION
## Summary

Adds a `cli:omit` marker pair so doc sections aimed only at LLM readers (served via `llms.txt` / `.md` URLs) can be stripped when the same doc is printed through `@videojs/cli docs`. The installation guide uses this to keep CLI-invocation instructions in the LLM-facing markdown without re-showing them when the user is already running the CLI.

## Changes

- New `stripOmitMarkers` util in `@videojs/cli` that removes `<!-- cli:omit <id> -->...<!-- /cli:omit <id> -->` blocks from rendered docs
- `handleDocs` now strips omit markers for both the installation-replace path and regular docs
- `llms-markdown` integration emits matching `cli:omit` comments around any element with `data-cli-omit`
- Installation page switches the CLI-invocation blurb to `data-cli-omit` and moves the `data-cli-replace="installation"` wrapper around the actual install section

## Testing

Covered by new unit tests in `replace.test.ts` (four cases: basic removal, no-markers passthrough, multiple blocks, multi-line content) and extended `docs.test.ts` assertions verifying the installation render drops both the markers and the omitted copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect documentation rendering in the CLI/LLM markdown pipeline, though the new regex-based stripping could remove unintended sections if markers are misused.
> 
> **Overview**
> Adds support for `<!-- cli:omit ... -->...<!-- /cli:omit ... -->` blocks so LLM-only doc sections can be present in generated `.md` files but **automatically removed** when printing docs via `@videojs/cli docs`.
> 
> The site’s `llms-markdown` build step now emits `cli:omit` markers from `data-cli-omit`, and the installation guide restructures its content so the CLI-invocation blurb is omitted while the actual install section remains `cli:replace`-driven. Tests are updated/added to cover omit stripping and ensure CLI output no longer includes omit markers or their contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30d1e03c288fc66f9c4148a60d668df2bc1eac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->