### PR TITLE
fix(site): exclude clientcode suspense fallback from llms and search

### DIFF
--- a/site/src/components/Code/ClientCode.tsx
+++ b/site/src/components/Code/ClientCode.tsx
@@ -34,7 +34,7 @@ export default function ClientCode({ code, lang }: ClientCodeProps) {
   return (
     <Suspense
       fallback={
-        <pre className={shared.pre}>
+        <pre className={shared.pre} data-llms-ignore="true" data-search-ignore="true">
           <code className={shared.codeBlock}>{code}</code>
         </pre>
       }


### PR DESCRIPTION
## Summary

The `<Suspense>` fallback in `ClientCode` renders an unhighlighted `<pre>` as a hydration-gap safety net, but it was being picked up by the LLM markdown integration and DocSearch crawler. That can duplicate code blocks (fallback + real, highlighted version) in the LLM output and search index.

## Changes

- Add `data-llms-ignore="true"` and `data-search-ignore="true"` to the Suspense fallback `<pre>` so LLM markdown extraction and Algolia crawling skip it.

## Testing

Covered by existing behavior — attributes are standard exclusion hooks already honored by the LLM markdown integration (`integrations/llms-markdown.ts`) and the DocSearch crawler.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds ignore attributes to markup only, affecting LLM markdown extraction and search indexing but not runtime highlighting logic.
> 
> **Overview**
> Prevents the unhighlighted `ClientCode` `<Suspense>` fallback code block from being indexed/duplicated in downstream consumers.
> 
> Adds `data-llms-ignore="true"` and `data-search-ignore="true"` to the fallback `<pre>` so the LLM markdown integration and DocSearch crawler skip it while the highlighted version remains indexable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a04a3602d9b3708de514326933ce94c45365581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->