### PR TITLE
refactor(packages)!: normalize fullscreen and picture-in-picture host APIs

### DIFF
--- a/packages/core/src/core/media/types.ts
+++ b/packages/core/src/core/media/types.ts
@@ -174,11 +174,15 @@ export interface MediaTextTrackCapability {
 }
 
 export interface MediaFullscreenCapability {
+  readonly isFullscreen: boolean;
   requestFullscreen(): Promise<void>;
+  exitFullscreen(): Promise<void>;
 }
 
 export interface MediaPictureInPictureCapability {
+  readonly isPictureInPicture: boolean;
   requestPictureInPicture(): Promise<unknown>;
+  exitPictureInPicture(): Promise<void>;
 }
 
 export interface MediaRemotePlaybackCapability {

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -7,6 +7,7 @@ export * from './hotkey/actions';
 export * from './hotkey/aria';
 export * from './hotkey/coordinator';
 export * from './hotkey/hotkey';
+export * from './media/to-media-host';
 export * from './media/types';
 export * from './store/features';
 export * from './store/selectors';

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -7,7 +7,6 @@ export * from './hotkey/actions';
 export * from './hotkey/aria';
 export * from './hotkey/coordinator';
 export * from './hotkey/hotkey';
-export * from './media/to-media-host';
 export * from './media/types';
 export * from './store/features';
 export * from './store/selectors';

--- a/packages/core/src/dom/media/dash/index.ts
+++ b/packages/core/src/dom/media/dash/index.ts
@@ -1,6 +1,6 @@
 import * as dashjs from 'dashjs';
 import type { MediaEngineHost } from '../../../core/media/types';
-import { HTMLVideoElementHost } from '../video-host';
+import { HTMLVideoElementHost } from '../host';
 
 export interface DashMediaProps {
   src: string;

--- a/packages/core/src/dom/media/hls/hlsjs.ts
+++ b/packages/core/src/dom/media/hls/hlsjs.ts
@@ -1,6 +1,6 @@
 import Hls, { type HlsConfig } from 'hls.js';
 import type { MediaEngineHost } from '../../../core/media/types';
-import { HTMLVideoElementHost } from '../video-host';
+import { HTMLVideoElementHost } from '../host';
 import { HlsJsMediaErrorsMixin } from './errors';
 import { HlsJsMediaMetadataTracksMixin } from './metadata-tracks';
 import { HlsJsMediaPreloadMixin } from './preload';

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -2,8 +2,8 @@ import { shallowEqual } from '@videojs/utils/object';
 import Hls from 'hls.js';
 import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { bridgeEvents } from '../../../core/utils/bridge-events';
+import { HTMLVideoElementHost } from '../host';
 import { NativeHlsMedia } from '../native-hls';
-import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsMedia } from './hlsjs';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';

--- a/packages/core/src/dom/media/host/index.ts
+++ b/packages/core/src/dom/media/host/index.ts
@@ -1,6 +1,10 @@
-import type { Audio, Media, Video } from '../../core/media/types';
-import { HTMLAudioElementHost } from './audio-host';
-import { HTMLVideoElementHost } from './video-host';
+import type { Audio, Media, Video } from '../../../core/media/types';
+import { HTMLAudioElementHost } from '../audio-host';
+import { HTMLVideoElementHost } from '../video-host';
+
+export { HTMLAudioElementHost } from '../audio-host';
+export { HTMLMediaElementHost } from '../media-host';
+export { HTMLVideoElementHost } from '../video-host';
 
 export interface ToMediaHostResult<M> {
   /**
@@ -23,6 +27,10 @@ export interface ToMediaHostResult<M> {
  * If the input is already a host or any non-element value, it is returned
  * unchanged. The caller owns the lifecycle of any host created here — call
  * `release()` to detach it.
+ *
+ * Lives under `@videojs/core/dom/media/host` (not the main `dom` barrel)
+ * so consumers that don't need to wrap raw elements don't pay the cost of
+ * shipping the host classes.
  *
  * @label Video
  * @param media - A native `HTMLVideoElement` to wrap.

--- a/packages/core/src/dom/media/host/tests/index.test.ts
+++ b/packages/core/src/dom/media/host/tests/index.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { HTMLAudioElementHost } from '../audio-host';
-import { toMediaHost } from '../to-media-host';
-import { HTMLVideoElementHost } from '../video-host';
+import { HTMLAudioElementHost, HTMLVideoElementHost, toMediaHost } from '..';
 
 describe('toMediaHost', () => {
   it('wraps a raw HTMLVideoElement in an HTMLVideoElementHost attached to it', () => {

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -1,5 +1,5 @@
 import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
-import { HTMLVideoElementHost } from '../video-host';
+import { HTMLVideoElementHost } from '../host';
 import { NativeHlsMediaErrorsMixin } from './errors';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 

--- a/packages/core/src/dom/media/predicate.ts
+++ b/packages/core/src/dom/media/predicate.ts
@@ -4,6 +4,7 @@ import type {
   MediaBufferCapability,
   MediaErrorCapability,
   MediaPauseCapability,
+  MediaPictureInPictureCapability,
   MediaPlaybackRateCapability,
   MediaRemotePlaybackCapability,
   MediaSeekCapability,
@@ -59,6 +60,10 @@ export function isMediaTextTrackCapable(value: unknown): value is MediaTextTrack
 
 export function isMediaRemotePlaybackCapable(value: unknown): value is MediaRemotePlaybackCapability {
   return isObject(value) && 'remote' in value && isObject((value as Record<string, unknown>).remote);
+}
+
+export function isMediaPictureInPictureCapable(value: unknown): value is MediaPictureInPictureCapability {
+  return isObject(value) && 'isPictureInPicture' in value;
 }
 
 export function isMediaStreamTypeCapable(value: unknown): value is MediaStreamTypeCapability {

--- a/packages/core/src/dom/media/simple-hls/index.ts
+++ b/packages/core/src/dom/media/simple-hls/index.ts
@@ -1,4 +1,4 @@
 import { SpfMediaMixin } from '@videojs/spf/dom';
-import { HTMLVideoElementHost } from '../video-host';
+import { HTMLVideoElementHost } from '../host';
 
 export class SimpleHlsMedia extends SpfMediaMixin(HTMLVideoElementHost) {}

--- a/packages/core/src/dom/media/tests/to-media-host.test.ts
+++ b/packages/core/src/dom/media/tests/to-media-host.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { HTMLAudioElementHost } from '../audio-host';
+import { toMediaHost } from '../to-media-host';
+import { HTMLVideoElementHost } from '../video-host';
+
+describe('toMediaHost', () => {
+  it('wraps a raw HTMLVideoElement in an HTMLVideoElementHost attached to it', () => {
+    const video = document.createElement('video');
+
+    const result = toMediaHost(video);
+
+    expect(result.media).toBeInstanceOf(HTMLVideoElementHost);
+    expect((result.media as HTMLVideoElementHost).target).toBe(video);
+  });
+
+  it('wraps a raw HTMLAudioElement in an HTMLAudioElementHost attached to it', () => {
+    const audio = document.createElement('audio');
+
+    const result = toMediaHost(audio);
+
+    expect(result.media).toBeInstanceOf(HTMLAudioElementHost);
+    expect((result.media as HTMLAudioElementHost).target).toBe(audio);
+  });
+
+  it('exposes the wrapped host API on the result media (e.g. requestFullscreen)', () => {
+    const video = document.createElement('video');
+
+    const { media } = toMediaHost(video);
+
+    expect(typeof media.isFullscreen).toBe('boolean');
+    expect(typeof media.requestFullscreen).toBe('function');
+    expect(typeof media.exitFullscreen).toBe('function');
+    expect(typeof media.isPictureInPicture).toBe('boolean');
+    expect(typeof media.requestPictureInPicture).toBe('function');
+    expect(typeof media.exitPictureInPicture).toBe('function');
+  });
+
+  it('release() detaches the auto-created host from the underlying element', () => {
+    const video = document.createElement('video');
+    const result = toMediaHost(video);
+
+    expect((result.media as HTMLVideoElementHost).target).toBe(video);
+
+    result.release();
+
+    expect((result.media as HTMLVideoElementHost).target).toBeNull();
+  });
+
+  it('returns existing hosts unchanged with a no-op release', () => {
+    const video = document.createElement('video');
+    const host = new HTMLVideoElementHost();
+    host.attach(video);
+
+    const result = toMediaHost(host);
+
+    expect(result.media).toBe(host);
+    result.release();
+    // Host stays attached — release is a no-op for inputs we did not create.
+    expect(host.target).toBe(video);
+  });
+
+  it('returns non-element values unchanged with a no-op release', () => {
+    const fake = { play: () => Promise.resolve() } as unknown as HTMLVideoElement;
+
+    const result = toMediaHost(fake);
+
+    expect(result.media).toBe(fake);
+    expect(() => result.release()).not.toThrow();
+  });
+});

--- a/packages/core/src/dom/media/tests/video-host.test.ts
+++ b/packages/core/src/dom/media/tests/video-host.test.ts
@@ -1,0 +1,521 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WebKitVideoElement } from '../../presentation/types';
+import { createMockVideo } from '../../tests/test-helpers';
+import { HTMLVideoElementHost } from '../video-host';
+
+describe('HTMLVideoElementHost', () => {
+  afterEach(() => {
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, 'pictureInPictureElement', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('fullscreen', () => {
+    describe('requestFullscreen()', () => {
+      it('calls native requestFullscreen on the target', async () => {
+        const video = createMockVideo();
+        video.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.requestFullscreen();
+
+        expect(video.requestFullscreen).toHaveBeenCalled();
+      });
+
+      it('prefers webkitEnterFullscreen when available (iOS Safari)', async () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+        video.webkitEnterFullscreen = vi.fn();
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.requestFullscreen();
+
+        expect(video.webkitEnterFullscreen).toHaveBeenCalled();
+        expect(video.requestFullscreen).not.toHaveBeenCalled();
+      });
+
+      it('rejects with NotSupportedError when no target is attached', async () => {
+        const host = new HTMLVideoElementHost();
+
+        await expect(host.requestFullscreen()).rejects.toThrow('Fullscreen not supported');
+      });
+
+      it('rejects with NotSupportedError when neither API is available', async () => {
+        const video = createMockVideo();
+        (video as unknown as { requestFullscreen: undefined }).requestFullscreen = undefined;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await expect(host.requestFullscreen()).rejects.toThrow('Fullscreen not supported');
+      });
+    });
+
+    describe('exitFullscreen()', () => {
+      it('calls document.exitFullscreen by default', async () => {
+        const originalExit = document.exitFullscreen;
+        document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
+
+        const video = createMockVideo();
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.exitFullscreen();
+
+        expect(document.exitFullscreen).toHaveBeenCalled();
+
+        document.exitFullscreen = originalExit;
+      });
+
+      it('calls webkitExitFullscreen when video is in WebKit fullscreen', async () => {
+        const originalExit = document.exitFullscreen;
+        document.exitFullscreen = vi.fn();
+
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitExitFullscreen = vi.fn();
+        video.webkitDisplayingFullscreen = true;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.exitFullscreen();
+
+        expect(video.webkitExitFullscreen).toHaveBeenCalled();
+        expect(document.exitFullscreen).not.toHaveBeenCalled();
+
+        document.exitFullscreen = originalExit;
+      });
+    });
+
+    describe('isFullscreen', () => {
+      it('returns false when no target is attached', () => {
+        const host = new HTMLVideoElementHost();
+        expect(host.isFullscreen).toBe(false);
+      });
+
+      it('returns true when document.fullscreenElement matches target', () => {
+        const video = createMockVideo();
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        Object.defineProperty(document, 'fullscreenElement', {
+          value: video,
+          writable: true,
+          configurable: true,
+        });
+
+        expect(host.isFullscreen).toBe(true);
+      });
+
+      it('returns true for WebKit fullscreen (iOS Safari)', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitDisplayingFullscreen = true;
+        video.webkitPresentationMode = 'fullscreen';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        expect(host.isFullscreen).toBe(true);
+      });
+
+      it('returns false when fullscreenElement does not match', () => {
+        const video = createMockVideo();
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        Object.defineProperty(document, 'fullscreenElement', {
+          value: document.createElement('div'),
+          writable: true,
+          configurable: true,
+        });
+
+        expect(host.isFullscreen).toBe(false);
+      });
+    });
+  });
+
+  describe('picture-in-picture', () => {
+    describe('requestPictureInPicture()', () => {
+      it('calls native requestPictureInPicture on the target', async () => {
+        const video = createMockVideo();
+        video.requestPictureInPicture = vi.fn().mockResolvedValue({});
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.requestPictureInPicture();
+
+        expect(video.requestPictureInPicture).toHaveBeenCalled();
+      });
+
+      it('prefers webkitSetPresentationMode when available (iOS Safari)', async () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.requestPictureInPicture = vi.fn().mockResolvedValue({});
+        video.webkitSetPresentationMode = vi.fn((mode) => {
+          video.webkitPresentationMode = mode;
+          video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+        });
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.requestPictureInPicture();
+
+        expect(video.webkitSetPresentationMode).toHaveBeenCalledWith('picture-in-picture');
+        expect(video.requestPictureInPicture).not.toHaveBeenCalled();
+      });
+
+      it('resolves only after the enterpictureinpicture event fires (WebKit)', async () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitSetPresentationMode = vi.fn();
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const promise = host.requestPictureInPicture();
+        const settled = vi.fn();
+        promise.then(settled);
+
+        // Defer microtask drain — the promise must not resolve before the event.
+        await Promise.resolve();
+        expect(settled).not.toHaveBeenCalled();
+
+        video.webkitPresentationMode = 'picture-in-picture';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        await promise;
+        expect(settled).toHaveBeenCalled();
+      });
+
+      it('resolves immediately when already in picture-in-picture', async () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'picture-in-picture';
+        video.webkitSetPresentationMode = vi.fn();
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.requestPictureInPicture();
+
+        expect(video.webkitSetPresentationMode).not.toHaveBeenCalled();
+      });
+
+      it('rejects with NotSupportedError when no target is attached', async () => {
+        const host = new HTMLVideoElementHost();
+
+        await expect(host.requestPictureInPicture()).rejects.toThrow('Picture-in-Picture not supported');
+      });
+
+      it('rejects with NotSupportedError when neither API is available', async () => {
+        const video = createMockVideo();
+        (video as unknown as { requestPictureInPicture: undefined }).requestPictureInPicture = undefined;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await expect(host.requestPictureInPicture()).rejects.toThrow('Picture-in-Picture not supported');
+      });
+    });
+
+    describe('exitPictureInPicture()', () => {
+      it('calls document.exitPictureInPicture when in standard PiP', async () => {
+        const originalExit = document.exitPictureInPicture;
+        const originalElement = Object.getOwnPropertyDescriptor(Document.prototype, 'pictureInPictureElement');
+        document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
+
+        const video = createMockVideo();
+        Object.defineProperty(document, 'pictureInPictureElement', {
+          value: video,
+          writable: true,
+          configurable: true,
+        });
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.exitPictureInPicture();
+
+        expect(document.exitPictureInPicture).toHaveBeenCalled();
+
+        document.exitPictureInPicture = originalExit;
+        if (originalElement) {
+          Object.defineProperty(document, 'pictureInPictureElement', originalElement);
+        }
+      });
+
+      it('uses webkitSetPresentationMode("inline") when in WebKit PiP', async () => {
+        const originalExit = document.exitPictureInPicture;
+        document.exitPictureInPicture = vi.fn();
+
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'picture-in-picture';
+        video.webkitSetPresentationMode = vi.fn((mode) => {
+          video.webkitPresentationMode = mode;
+          video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+        });
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.exitPictureInPicture();
+
+        expect(video.webkitSetPresentationMode).toHaveBeenCalledWith('inline');
+        expect(document.exitPictureInPicture).not.toHaveBeenCalled();
+
+        document.exitPictureInPicture = originalExit;
+      });
+
+      it('resolves only after the leavepictureinpicture event fires (WebKit)', async () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'picture-in-picture';
+        video.webkitSetPresentationMode = vi.fn();
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const promise = host.exitPictureInPicture();
+        const settled = vi.fn();
+        promise.then(settled);
+
+        await Promise.resolve();
+        expect(settled).not.toHaveBeenCalled();
+
+        video.webkitPresentationMode = 'inline';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        await promise;
+        expect(settled).toHaveBeenCalled();
+      });
+
+      it('resolves immediately when not in picture-in-picture', async () => {
+        const originalExit = document.exitPictureInPicture;
+        document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
+
+        const video = createMockVideo();
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        await host.exitPictureInPicture();
+
+        expect(document.exitPictureInPicture).not.toHaveBeenCalled();
+
+        document.exitPictureInPicture = originalExit;
+      });
+    });
+
+    describe('webkit event normalization', () => {
+      it('synthesized fullscreenchange bubbles (matching the native event)', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'inline';
+        video.webkitDisplayingFullscreen = false;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const fullscreenListener = vi.fn<(e: Event) => void>();
+        host.addEventListener('fullscreenchange', fullscreenListener);
+
+        video.webkitPresentationMode = 'fullscreen';
+        video.webkitDisplayingFullscreen = true;
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(fullscreenListener.mock.calls[0]?.[0].bubbles).toBe(true);
+      });
+
+      it('dispatches fullscreenchange when webkitfullscreenchange fires on the target', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitDisplayingFullscreen = false;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const fullscreenListener = vi.fn();
+        host.addEventListener('fullscreenchange', fullscreenListener);
+
+        video.webkitDisplayingFullscreen = true;
+        video.webkitPresentationMode = 'fullscreen';
+        video.dispatchEvent(new Event('webkitfullscreenchange'));
+
+        expect(fullscreenListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('dispatches fullscreenchange when entering WebKit fullscreen', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'inline';
+        video.webkitDisplayingFullscreen = false;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const fullscreenListener = vi.fn();
+        host.addEventListener('fullscreenchange', fullscreenListener);
+
+        video.webkitPresentationMode = 'fullscreen';
+        video.webkitDisplayingFullscreen = true;
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(fullscreenListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('dispatches fullscreenchange when exiting WebKit fullscreen', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'fullscreen';
+        video.webkitDisplayingFullscreen = true;
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const fullscreenListener = vi.fn();
+        host.addEventListener('fullscreenchange', fullscreenListener);
+
+        video.webkitPresentationMode = 'inline';
+        video.webkitDisplayingFullscreen = false;
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(fullscreenListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not dispatch fullscreenchange when only the PiP state changes', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'picture-in-picture';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const fullscreenListener = vi.fn();
+        host.addEventListener('fullscreenchange', fullscreenListener);
+
+        video.webkitPresentationMode = 'inline';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(fullscreenListener).not.toHaveBeenCalled();
+      });
+
+      it('dispatches enterpictureinpicture when entering WebKit PiP', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'inline';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const enterListener = vi.fn();
+        const leaveListener = vi.fn();
+        host.addEventListener('enterpictureinpicture', enterListener);
+        host.addEventListener('leavepictureinpicture', leaveListener);
+
+        video.webkitPresentationMode = 'picture-in-picture';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(enterListener).toHaveBeenCalledTimes(1);
+        expect(leaveListener).not.toHaveBeenCalled();
+      });
+
+      it('dispatches leavepictureinpicture when exiting WebKit PiP', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'picture-in-picture';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const enterListener = vi.fn();
+        const leaveListener = vi.fn();
+        host.addEventListener('enterpictureinpicture', enterListener);
+        host.addEventListener('leavepictureinpicture', leaveListener);
+
+        video.webkitPresentationMode = 'inline';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(leaveListener).toHaveBeenCalledTimes(1);
+        expect(enterListener).not.toHaveBeenCalled();
+      });
+
+      it('does not dispatch when the PiP state does not change (e.g. fullscreen transition)', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'inline';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const enterListener = vi.fn();
+        const leaveListener = vi.fn();
+        host.addEventListener('enterpictureinpicture', enterListener);
+        host.addEventListener('leavepictureinpicture', leaveListener);
+
+        video.webkitPresentationMode = 'fullscreen';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(enterListener).not.toHaveBeenCalled();
+        expect(leaveListener).not.toHaveBeenCalled();
+      });
+
+      it('stops forwarding after detach', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'inline';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        const enterListener = vi.fn();
+        host.addEventListener('enterpictureinpicture', enterListener);
+
+        host.detach();
+
+        video.webkitPresentationMode = 'picture-in-picture';
+        video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+        expect(enterListener).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('isPictureInPicture', () => {
+      it('returns false when no target is attached', () => {
+        const host = new HTMLVideoElementHost();
+        expect(host.isPictureInPicture).toBe(false);
+      });
+
+      it('returns true when document.pictureInPictureElement matches target', () => {
+        const video = createMockVideo();
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        Object.defineProperty(document, 'pictureInPictureElement', {
+          value: video,
+          writable: true,
+          configurable: true,
+        });
+
+        expect(host.isPictureInPicture).toBe(true);
+      });
+
+      it('returns true for WebKit PiP presentation mode (iOS Safari)', () => {
+        const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+        video.webkitPresentationMode = 'picture-in-picture';
+
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        expect(host.isPictureInPicture).toBe(true);
+      });
+
+      it('returns false when not in PiP', () => {
+        const video = createMockVideo();
+        const host = new HTMLVideoElementHost();
+        host.attach(video);
+
+        expect(host.isPictureInPicture).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/core/src/dom/media/to-media-host.ts
+++ b/packages/core/src/dom/media/to-media-host.ts
@@ -1,0 +1,62 @@
+import type { Audio, Media, Video } from '../../core/media/types';
+import { HTMLAudioElementHost } from './audio-host';
+import { HTMLVideoElementHost } from './video-host';
+
+export interface ToMediaHostResult<M> {
+  /**
+   * The resolved media value. If the input was a raw `<video>` / `<audio>`
+   * element, this is a host wrapping it; otherwise it's the input unchanged.
+   */
+  media: M;
+  /**
+   * Detach any host created by `toMediaHost`. No-op when the input was
+   * already a host (or any non-element value).
+   */
+  release(): void;
+}
+
+/**
+ * Wrap a raw `<video>` / `<audio>` element in its corresponding media host
+ * so it exposes the full {@link Video} / {@link Audio} API expected by the
+ * player features (e.g. `isFullscreen`, `exitPictureInPicture`).
+ *
+ * If the input is already a host or any non-element value, it is returned
+ * unchanged. The caller owns the lifecycle of any host created here — call
+ * `release()` to detach it.
+ *
+ * @label Video
+ * @param media - A native `HTMLVideoElement` to wrap.
+ */
+export function toMediaHost(media: HTMLVideoElement): ToMediaHostResult<Video>;
+/**
+ * @label Audio
+ * @param media - A native `HTMLAudioElement` to wrap.
+ */
+export function toMediaHost(media: HTMLAudioElement): ToMediaHostResult<Audio>;
+/**
+ * @label Media
+ * @param media - A {@link Media}-shaped value (e.g. an existing host); returned unchanged.
+ */
+export function toMediaHost(media: Media): ToMediaHostResult<Video>;
+/**
+ * @label Generic
+ * @param media - A media value that is already a host or any non-element value.
+ */
+export function toMediaHost<M>(media: M): ToMediaHostResult<M>;
+export function toMediaHost(media: unknown): ToMediaHostResult<unknown> {
+  if (media instanceof HTMLVideoElement) {
+    const host = new HTMLVideoElementHost();
+    host.attach(media);
+    return { media: host, release: () => host.detach() };
+  }
+
+  if (media instanceof HTMLAudioElement) {
+    const host = new HTMLAudioElementHost();
+    host.attach(media);
+    return { media: host, release: () => host.detach() };
+  }
+
+  return { media, release: noop };
+}
+
+function noop(): void {}

--- a/packages/core/src/dom/media/types.ts
+++ b/packages/core/src/dom/media/types.ts
@@ -13,14 +13,14 @@ import type {
   MediaTimeState,
   MediaVolumeState,
 } from '../../core/media/state';
-import type { Media } from '../../core/media/types';
+import type { Media, Video } from '../../core/media/types';
 
-export type { Media };
+export type { Media, Video };
 
 export interface MediaContainer extends HTMLElement {}
 
 export interface PlayerTarget {
-  media: Media;
+  media: Video;
   container: MediaContainer | null;
 }
 

--- a/packages/core/src/dom/media/video-host.ts
+++ b/packages/core/src/dom/media/video-host.ts
@@ -1,8 +1,13 @@
+import { onEvent } from '@videojs/utils/dom';
+import { isFunction } from '@videojs/utils/predicate';
 import type { Video, VideoEvents } from '../../core/media/types';
-import type { WebKitPresentationMode, WebKitVideoElement } from '../presentation/types';
+import type { WebKitDocument, WebKitVideoElement } from '../presentation/types';
 import { HTMLMediaElementHost } from './media-host';
 
 export class HTMLVideoElementHost extends HTMLMediaElementHost<HTMLVideoElement, VideoEvents> implements Video {
+  #wasFullscreen = false;
+  #wasPictureInPicture = false;
+
   get poster() {
     return this.target?.poster ?? '';
   }
@@ -11,31 +16,142 @@ export class HTMLVideoElementHost extends HTMLMediaElementHost<HTMLVideoElement,
     if (this.target) this.target.poster = value;
   }
 
-  get webkitDisplayingFullscreen() {
-    return (this.target as unknown as WebKitVideoElement | null)?.webkitDisplayingFullscreen ?? false;
+  override attach(target: HTMLVideoElement) {
+    super.attach(target);
+    this.#wasFullscreen = this.isFullscreen;
+    this.#wasPictureInPicture = this.isPictureInPicture;
+    // Normalize WebKit-only events on the target into their standard
+    // counterparts so consumers can listen to a single set of events:
+    // - webkitpresentationmodechanged → fullscreenchange / enter|leavepictureinpicture
+    // - webkitfullscreenchange → fullscreenchange
+    target.addEventListener('webkitpresentationmodechanged', this.#handlePresentationChange);
+    target.addEventListener('webkitfullscreenchange', this.#handlePresentationChange);
   }
 
-  get webkitPresentationMode() {
-    return (this.target as unknown as WebKitVideoElement | null)?.webkitPresentationMode ?? 'inline';
+  override detach() {
+    this.target?.removeEventListener('webkitpresentationmodechanged', this.#handlePresentationChange);
+    this.target?.removeEventListener('webkitfullscreenchange', this.#handlePresentationChange);
+    super.detach();
   }
 
-  requestPictureInPicture() {
-    return this.target?.requestPictureInPicture() ?? Promise.reject();
+  #handlePresentationChange = () => {
+    const isFullscreen = this.isFullscreen;
+    if (isFullscreen !== this.#wasFullscreen) {
+      this.#wasFullscreen = isFullscreen;
+      // Match the native fullscreenchange event, which bubbles.
+      this.dispatchEvent(new Event('fullscreenchange', { bubbles: true }));
+    }
+
+    const isPip = this.isPictureInPicture;
+    if (isPip !== this.#wasPictureInPicture) {
+      this.#wasPictureInPicture = isPip;
+      this.dispatchEvent(new Event(isPip ? 'enterpictureinpicture' : 'leavepictureinpicture'));
+    }
+  };
+
+  // -- Fullscreen --
+
+  get isFullscreen() {
+    const video = this.target as (HTMLVideoElement & WebKitVideoElement) | null;
+    if (!video) return false;
+
+    if (video.webkitDisplayingFullscreen && video.webkitPresentationMode === 'fullscreen') {
+      return true;
+    }
+
+    const doc = document as WebKitDocument;
+    const el = doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
+    return el === video;
   }
 
   requestFullscreen() {
-    return this.target?.requestFullscreen() ?? Promise.reject();
+    const video = this.target as (HTMLVideoElement & WebKitVideoElement) | null;
+    if (!video) return Promise.reject(new DOMException('Fullscreen not supported', 'NotSupportedError'));
+
+    if (isFunction(video.webkitEnterFullscreen)) {
+      video.webkitEnterFullscreen();
+      return Promise.resolve();
+    }
+
+    if (isFunction(video.requestFullscreen)) {
+      return video.requestFullscreen();
+    }
+
+    return Promise.reject(new DOMException('Fullscreen not supported', 'NotSupportedError'));
   }
 
-  webkitEnterFullscreen() {
-    return (this.target as unknown as WebKitVideoElement | null)?.webkitEnterFullscreen?.();
+  exitFullscreen() {
+    const video = this.target as (HTMLVideoElement & WebKitVideoElement) | null;
+
+    if (video?.webkitDisplayingFullscreen && isFunction(video.webkitExitFullscreen)) {
+      video.webkitExitFullscreen();
+      return Promise.resolve();
+    }
+
+    const doc = document as WebKitDocument;
+    if (isFunction(doc.exitFullscreen)) {
+      return doc.exitFullscreen();
+    }
+
+    if (isFunction(doc.webkitExitFullscreen)) {
+      return doc.webkitExitFullscreen();
+    }
+
+    return Promise.resolve();
   }
 
-  webkitExitFullscreen() {
-    return (this.target as unknown as WebKitVideoElement | null)?.webkitExitFullscreen?.();
+  // -- Picture-in-Picture --
+
+  get isPictureInPicture() {
+    const video = this.target as (HTMLVideoElement & WebKitVideoElement) | null;
+    if (!video) return false;
+
+    if (document.pictureInPictureElement === video) {
+      return true;
+    }
+
+    return video.webkitPresentationMode === 'picture-in-picture';
   }
 
-  webkitSetPresentationMode(mode: WebKitPresentationMode) {
-    return (this.target as unknown as WebKitVideoElement | null)?.webkitSetPresentationMode?.(mode);
+  async requestPictureInPicture() {
+    const video = this.target as (HTMLVideoElement & WebKitVideoElement) | null;
+
+    if (video && this.isPictureInPicture) return;
+
+    // WebKit's setPresentationMode is fire-and-forget — the transition is
+    // async and signaled via webkitpresentationmodechanged (normalized to
+    // enterpictureinpicture in #handlePresentationChange).
+    if (video && isFunction(video.webkitSetPresentationMode)) {
+      const event = onEvent(this, 'enterpictureinpicture');
+      video.webkitSetPresentationMode('picture-in-picture');
+      await event;
+      return;
+    }
+
+    // Standard requestPictureInPicture resolves *after* the
+    // enterpictureinpicture event has fired (per spec).
+    if (video && isFunction(video.requestPictureInPicture)) {
+      await video.requestPictureInPicture();
+      return;
+    }
+
+    throw new DOMException('Picture-in-Picture not supported', 'NotSupportedError');
+  }
+
+  async exitPictureInPicture() {
+    const video = this.target as (HTMLVideoElement & WebKitVideoElement) | null;
+
+    if (!this.isPictureInPicture) return;
+
+    if (video?.webkitPresentationMode === 'picture-in-picture' && isFunction(video.webkitSetPresentationMode)) {
+      const event = onEvent(this, 'leavepictureinpicture');
+      video.webkitSetPresentationMode('inline');
+      await event;
+      return;
+    }
+
+    if (isFunction(document.exitPictureInPicture)) {
+      await document.exitPictureInPicture();
+    }
   }
 }

--- a/packages/core/src/dom/presentation/fullscreen.ts
+++ b/packages/core/src/dom/presentation/fullscreen.ts
@@ -1,5 +1,6 @@
 import { isFunction } from '@videojs/utils/predicate';
 
+import type { MediaFullscreenCapability } from '../../core/media/types';
 import type { WebKitDocument, WebKitFullscreenElement, WebKitVideoElement } from './types';
 
 export function isFullscreenEnabled(): boolean {
@@ -18,21 +19,14 @@ export function getFullscreenElement(): Element | null {
   return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
 }
 
-export function isFullscreenElement(container: HTMLElement | null, media: EventTarget): boolean {
-  if (media instanceof HTMLMediaElement) {
-    const video = media as WebKitVideoElement;
-    if (video.webkitDisplayingFullscreen && video.webkitPresentationMode === 'fullscreen') {
-      return true;
-    }
-  }
+export function isFullscreenElement(container: HTMLElement | null, media: MediaFullscreenCapability) {
+  if (media.isFullscreen) return true;
 
-  const target = container ?? media;
+  if (container && getFullscreenElement() === container) return true;
 
-  if (getFullscreenElement() === target) return true;
-
-  if (target instanceof Element) {
+  if (container) {
     try {
-      return target.matches(':fullscreen');
+      return container.matches(':fullscreen');
     } catch {
       return false;
     }
@@ -41,7 +35,7 @@ export function isFullscreenElement(container: HTMLElement | null, media: EventT
   return false;
 }
 
-export async function requestFullscreen(container: HTMLElement | null, media: EventTarget): Promise<void> {
+export async function requestFullscreen(container: HTMLElement | null, media: MediaFullscreenCapability) {
   const doc = document as WebKitDocument;
 
   if (container && (doc.fullscreenEnabled || doc.webkitFullscreenEnabled)) {
@@ -56,32 +50,18 @@ export async function requestFullscreen(container: HTMLElement | null, media: Ev
     }
   }
 
-  if (media instanceof HTMLMediaElement) {
-    const video = media as WebKitVideoElement;
-    if (isFunction(video.webkitEnterFullscreen)) {
-      video.webkitEnterFullscreen();
-      return;
-    }
-
-    if (isFunction(media.requestFullscreen)) {
-      return media.requestFullscreen();
-    }
-  }
-
-  throw new DOMException('Fullscreen not supported', 'NotSupportedError');
+  return media.requestFullscreen();
 }
 
-export async function exitFullscreen(media?: EventTarget): Promise<void> {
-  const doc = document as WebKitDocument;
-
-  if (media instanceof HTMLMediaElement) {
-    const video = media as WebKitVideoElement;
-    if (isFunction(video.webkitExitFullscreen) && video.webkitDisplayingFullscreen) {
-      video.webkitExitFullscreen();
-      return;
-    }
+export async function exitFullscreen(media?: MediaFullscreenCapability) {
+  // If the media element is in fullscreen (including WebKit element-level
+  // fullscreen on iOS Safari), delegate to the media.
+  if (media?.isFullscreen) {
+    return media.exitFullscreen();
   }
 
+  // Otherwise, exit whatever is currently fullscreen at the document level.
+  const doc = document as WebKitDocument;
   if (isFunction(doc.exitFullscreen)) {
     return doc.exitFullscreen();
   }

--- a/packages/core/src/dom/presentation/pip.ts
+++ b/packages/core/src/dom/presentation/pip.ts
@@ -1,73 +1,12 @@
 import { isFunction } from '@videojs/utils/predicate';
-
 import type { WebKitVideoElement } from './types';
-
-function resolveMediaTarget(media: EventTarget): EventTarget {
-  const target = (media as EventTarget & { target?: unknown }).target;
-  return target instanceof HTMLMediaElement ? target : media;
-}
 
 export function isPictureInPictureEnabled(): boolean {
   if (document.pictureInPictureEnabled) {
     const isSafari = /.*Version\/.*Safari\/.*/.test(navigator.userAgent);
-    const isPWA = typeof matchMedia === 'function' && matchMedia('(display-mode: standalone)').matches;
-    return !isSafari || !isPWA;
+    if (!isSafari) return true;
   }
 
   const video = document.createElement('video') as WebKitVideoElement;
   return isFunction(video.webkitSetPresentationMode);
-}
-
-export function isPictureInPictureElement(media: EventTarget): boolean {
-  const target = resolveMediaTarget(media);
-
-  if (document.pictureInPictureElement === target) {
-    return true;
-  }
-
-  if (target instanceof HTMLVideoElement) {
-    const video = target as WebKitVideoElement;
-    return video.webkitPresentationMode === 'picture-in-picture';
-  }
-
-  return false;
-}
-
-export async function requestPictureInPicture(media: EventTarget): Promise<void> {
-  const target = resolveMediaTarget(media);
-
-  if (!(target instanceof HTMLVideoElement)) {
-    throw new DOMException('Picture-in-Picture not supported', 'NotSupportedError');
-  }
-
-  const video = target as HTMLVideoElement & WebKitVideoElement;
-
-  if (isFunction(video.webkitSetPresentationMode)) {
-    video.webkitSetPresentationMode('picture-in-picture');
-    return;
-  }
-
-  if (isFunction(video.requestPictureInPicture)) {
-    await video.requestPictureInPicture();
-    return;
-  }
-
-  throw new DOMException('Picture-in-Picture not supported', 'NotSupportedError');
-}
-
-export async function exitPictureInPicture(media?: EventTarget): Promise<void> {
-  if (media) {
-    const target = resolveMediaTarget(media);
-    if (target instanceof HTMLVideoElement) {
-      const video = target as WebKitVideoElement;
-      if (isFunction(video.webkitSetPresentationMode) && video.webkitPresentationMode === 'picture-in-picture') {
-        video.webkitSetPresentationMode('inline');
-        return;
-      }
-    }
-  }
-
-  if (isFunction(document.exitPictureInPicture)) {
-    return document.exitPictureInPicture();
-  }
 }

--- a/packages/core/src/dom/store/features/controls.ts
+++ b/packages/core/src/dom/store/features/controls.ts
@@ -4,7 +4,11 @@ import { isNull } from '@videojs/utils/predicate';
 import type { MediaControlsState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
 import { findGestureCoordinator } from '../../gesture/coordinator';
-import { isMediaPauseCapable, isMediaRemotePlaybackCapable } from '../../media/predicate';
+import {
+  isMediaPauseCapable,
+  isMediaPictureInPictureCapable,
+  isMediaRemotePlaybackCapable,
+} from '../../media/predicate';
 import { isRemotePlaybackConnected, isRemotePlaybackConnecting } from '../../presentation/remote-playback';
 
 const IDLE_DELAY = 2000;
@@ -34,7 +38,13 @@ export const controlsFeature = definePlayerFeature({
     }
 
     const computeVisible = (userActive: boolean): boolean => {
-      return userActive || media.paused || isRemotePlaybackConnected(media) || isRemotePlaybackConnecting(media);
+      return (
+        userActive ||
+        media.paused ||
+        isRemotePlaybackConnected(media) ||
+        isRemotePlaybackConnecting(media) ||
+        (isMediaPictureInPictureCapable(media) && media.isPictureInPicture)
+      );
     };
 
     // Idle timer
@@ -131,6 +141,17 @@ export const controlsFeature = definePlayerFeature({
     listen(media, 'play', onPlaybackChange, { signal });
     listen(media, 'pause', onPlaybackChange, { signal });
     listen(media, 'ended', onPlaybackChange, { signal });
+
+    // Recompute visibility when picture-in-picture state changes.
+    if (isMediaPictureInPictureCapable(media)) {
+      const onPipChange = () => {
+        const { userActive } = get();
+        set({ controlsVisible: computeVisible(userActive) });
+      };
+
+      listen(media, 'enterpictureinpicture', onPipChange, { signal });
+      listen(media, 'leavepictureinpicture', onPipChange, { signal });
+    }
 
     // Recompute visibility when cast state changes.
     if (isMediaRemotePlaybackCapable(media)) {

--- a/packages/core/src/dom/store/features/fullscreen.ts
+++ b/packages/core/src/dom/store/features/fullscreen.ts
@@ -1,5 +1,4 @@
 import { listen } from '@videojs/utils/dom';
-
 import type { MediaFullscreenState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
 import {
@@ -8,8 +7,6 @@ import {
   isFullscreenEnabled,
   requestFullscreen,
 } from '../../presentation/fullscreen';
-import { exitPictureInPicture, isPictureInPictureElement } from '../../presentation/pip';
-import type { WebKitVideoElement } from '../../presentation/types';
 
 export const fullscreenFeature = definePlayerFeature({
   name: 'fullscreen',
@@ -21,8 +18,8 @@ export const fullscreenFeature = definePlayerFeature({
       const { media, container } = target();
 
       // Exit PiP first if active (browser behavior is inconsistent)
-      if (isPictureInPictureElement(media)) {
-        await exitPictureInPicture(media);
+      if (media.isPictureInPicture) {
+        await media.exitPictureInPicture();
       }
 
       return requestFullscreen(container, media);
@@ -40,8 +37,8 @@ export const fullscreenFeature = definePlayerFeature({
         return exitFullscreen(media);
       }
 
-      if (isPictureInPictureElement(media)) {
-        await exitPictureInPicture(media);
+      if (media.isPictureInPicture) {
+        await media.exitPictureInPicture();
       }
 
       return requestFullscreen(container, media);
@@ -65,10 +62,9 @@ export const fullscreenFeature = definePlayerFeature({
     listen(document, 'fullscreenchange', sync, { signal });
     listen(document, 'webkitfullscreenchange', sync, { signal });
 
-    // iOS Safari presentation mode change (covers fullscreen)
-    const video = media as WebKitVideoElement;
-    if ('webkitPresentationMode' in video) {
-      listen(media, 'webkitpresentationmodechanged', sync, { signal });
-    }
+    // The video host normalizes WebKit-only element-level events
+    // (webkitpresentationmodechanged, webkitfullscreenchange) into a
+    // bubbling fullscreenchange event on itself.
+    listen(media, 'fullscreenchange', sync, { signal });
   },
 });

--- a/packages/core/src/dom/store/features/pip.ts
+++ b/packages/core/src/dom/store/features/pip.ts
@@ -1,15 +1,8 @@
 import { listen } from '@videojs/utils/dom';
-
 import type { MediaPictureInPictureState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
 import { exitFullscreen, isFullscreenElement } from '../../presentation/fullscreen';
-import {
-  exitPictureInPicture,
-  isPictureInPictureElement,
-  isPictureInPictureEnabled,
-  requestPictureInPicture,
-} from '../../presentation/pip';
-import type { WebKitVideoElement } from '../../presentation/types';
+import { isPictureInPictureEnabled } from '../../presentation/pip';
 
 export const pipFeature = definePlayerFeature({
   name: 'pip',
@@ -22,29 +15,29 @@ export const pipFeature = definePlayerFeature({
 
       // Exit fullscreen first if active
       if (isFullscreenElement(container, media)) {
-        await exitFullscreen();
+        await exitFullscreen(media);
       }
 
-      return requestPictureInPicture(media);
+      await media.requestPictureInPicture();
     },
 
     async exitPictureInPicture() {
       const { media } = target();
-      return exitPictureInPicture(media);
+      return media.exitPictureInPicture();
     },
 
     async togglePictureInPicture() {
       const { media, container } = target();
 
-      if (isPictureInPictureElement(media)) {
-        return exitPictureInPicture(media);
+      if (media.isPictureInPicture) {
+        return media.exitPictureInPicture();
       }
 
       if (isFullscreenElement(container, media)) {
-        await exitFullscreen();
+        await exitFullscreen(media);
       }
 
-      return requestPictureInPicture(media);
+      await media.requestPictureInPicture();
     },
   }),
 
@@ -57,18 +50,12 @@ export const pipFeature = definePlayerFeature({
 
     const sync = () =>
       set({
-        pip: isPictureInPictureElement(media),
+        pip: media.isPictureInPicture,
       });
 
     sync();
 
     listen(media, 'enterpictureinpicture', sync, { signal });
     listen(media, 'leavepictureinpicture', sync, { signal });
-
-    // iOS Safari presentation mode change (covers PiP)
-    const video = media as WebKitVideoElement;
-    if ('webkitPresentationMode' in video) {
-      listen(media, 'webkitpresentationmodechanged', sync, { signal });
-    }
   },
 });

--- a/packages/core/src/dom/store/features/remote-playback.ts
+++ b/packages/core/src/dom/store/features/remote-playback.ts
@@ -20,7 +20,7 @@ export const remotePlaybackFeature = definePlayerFeature({
       }
 
       if (isFullscreenElement(container, media)) {
-        await exitFullscreen();
+        await exitFullscreen(media);
       }
 
       return requestRemotePlayback(media);

--- a/packages/core/src/dom/store/features/tests/buffer.test.ts
+++ b/packages/core/src/dom/store/features/tests/buffer.test.ts
@@ -1,26 +1,26 @@
 import { createStore } from '@videojs/store';
 import { describe, expect, it } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo, createTimeRanges } from '../../../tests/test-helpers';
+import { createMockVideoHost, createTimeRanges } from '../../../tests/test-helpers';
 import { bufferFeature } from '../buffer';
 
 describe('bufferFeature', () => {
   describe('attach', () => {
     it('syncs buffered and seekable ranges on attach', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         buffered: createTimeRanges([[0, 60]]),
         seekable: createTimeRanges([[0, 120]]),
       });
 
       const store = createStore<PlayerTarget>()(bufferFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.buffered).toEqual([[0, 60]]);
       expect(store.state.seekable).toEqual([[0, 120]]);
     });
 
     it('handles multiple ranges', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         buffered: createTimeRanges([
           [0, 30],
           [60, 90],
@@ -29,7 +29,7 @@ describe('bufferFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(bufferFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.buffered).toEqual([
         [0, 30],
@@ -38,13 +38,13 @@ describe('bufferFeature', () => {
     });
 
     it('updates on progress event', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         buffered: createTimeRanges([[0, 50]]),
         seekable: createTimeRanges([[0, 100]]),
       });
 
       const store = createStore<PlayerTarget>()(bufferFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Update the mock video's buffered range
       Object.defineProperty(video, 'buffered', {
@@ -59,13 +59,13 @@ describe('bufferFeature', () => {
     });
 
     it('updates on emptied event', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         buffered: createTimeRanges([[0, 50]]),
         seekable: createTimeRanges([[0, 100]]),
       });
 
       const store = createStore<PlayerTarget>()(bufferFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Update the mock video to have no buffered content
       Object.defineProperty(video, 'buffered', {

--- a/packages/core/src/dom/store/features/tests/controls.test.ts
+++ b/packages/core/src/dom/store/features/tests/controls.test.ts
@@ -1,6 +1,7 @@
 import { createStore, flush } from '@videojs/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
+import { HTMLVideoElementHost } from '../../../media/video-host';
 import { createMockVideo } from '../../../tests/test-helpers';
 import { controlsFeature } from '../controls';
 
@@ -406,6 +407,54 @@ describe('controlsFeature', () => {
     });
   });
 
+  describe('picture-in-picture interaction', () => {
+    it('keeps controlsVisible true when in picture-in-picture and user goes inactive', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      enterPictureInPicture(video);
+      flush();
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(true);
+    });
+
+    it('hides controls after leaving picture-in-picture and user is inactive', () => {
+      const video = createMockVideo({ paused: false });
+      const { store } = createPlayerStore(video);
+
+      enterPictureInPicture(video);
+      flush();
+
+      vi.advanceTimersByTime(IDLE_DELAY);
+      flush();
+
+      expect(store.state.controlsVisible).toBe(true);
+
+      leavePictureInPicture(video);
+      flush();
+
+      expect(store.state.controlsVisible).toBe(false);
+    });
+
+    it('keeps controlsVisible true on mouseleave while in picture-in-picture', () => {
+      const video = createMockVideo({ paused: false });
+      const { store, container } = createPlayerStore(video);
+
+      enterPictureInPicture(video);
+      flush();
+
+      container!.dispatchEvent(new Event('mouseleave'));
+      flush();
+
+      expect(store.state.userActive).toBe(false);
+      expect(store.state.controlsVisible).toBe(true);
+    });
+  });
+
   describe('null container', () => {
     it('does not track activity without container', () => {
       const video = createMockVideo({ paused: false });
@@ -434,10 +483,12 @@ describe('controlsFeature', () => {
 
     it('clears idle timer on detach', () => {
       const video = createMockVideo({ paused: false });
+      const host = new HTMLVideoElementHost();
+      host.attach(video);
       const store = createStore<PlayerTarget>()(controlsFeature);
 
       const container = createContainer();
-      const detach = store.attach({ media: video, container });
+      const detach = store.attach({ media: host, container });
       flush();
 
       detach();
@@ -452,10 +503,12 @@ describe('controlsFeature', () => {
 
     it('does not react to media events after detach', () => {
       const video = createMockVideo({ paused: false });
+      const host = new HTMLVideoElementHost();
+      host.attach(video);
       const store = createStore<PlayerTarget>()(controlsFeature);
 
       const container = createContainer();
-      const detach = store.attach({ media: video, container });
+      const detach = store.attach({ media: host, container });
       flush();
 
       vi.advanceTimersByTime(IDLE_DELAY);
@@ -499,6 +552,24 @@ function createMockRemote(): EventTarget & { state: string; prompt: () => Promis
   return target;
 }
 
+function enterPictureInPicture(video: HTMLVideoElement): void {
+  Object.defineProperty(document, 'pictureInPictureElement', {
+    value: video,
+    configurable: true,
+    writable: true,
+  });
+  video.dispatchEvent(new Event('enterpictureinpicture'));
+}
+
+function leavePictureInPicture(video: HTMLVideoElement): void {
+  Object.defineProperty(document, 'pictureInPictureElement', {
+    value: null,
+    configurable: true,
+    writable: true,
+  });
+  video.dispatchEvent(new Event('leavepictureinpicture'));
+}
+
 function createGoogleCastVideo(overrides: Parameters<typeof createMockVideo>[0] = {}) {
   const video = createMockVideo(overrides);
   const remote = createMockRemote();
@@ -509,11 +580,13 @@ function createGoogleCastVideo(overrides: Parameters<typeof createMockVideo>[0] 
 function createPlayerStore(video?: HTMLVideoElement, container?: HTMLElement | null) {
   const store = createStore<PlayerTarget>()(controlsFeature);
 
-  const media = video ?? createMockVideo({ paused: true });
+  const vid = video ?? createMockVideo({ paused: true });
+  const host = new HTMLVideoElementHost();
+  host.attach(vid);
   const cont = container === undefined ? createContainer() : container;
 
-  store.attach({ media, container: cont });
+  store.attach({ media: host, container: cont });
   flush();
 
-  return { store, media, container: cont };
+  return { store, media: host, container: cont };
 }

--- a/packages/core/src/dom/store/features/tests/fullscreen.test.ts
+++ b/packages/core/src/dom/store/features/tests/fullscreen.test.ts
@@ -2,7 +2,7 @@ import { createStore } from '@videojs/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import type { WebKitVideoElement } from '../../../presentation/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { createMockVideoHost } from '../../../tests/test-helpers';
 import { fullscreenFeature } from '../fullscreen';
 
 describe('fullscreenFeature', () => {
@@ -27,11 +27,11 @@ describe('fullscreenFeature', () => {
 
   describe('attach', () => {
     it('syncs initial state on attach', () => {
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const container = document.createElement('div');
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       expect(store.state.fullscreen).toBe(false);
     });
@@ -43,9 +43,9 @@ describe('fullscreenFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.fullscreenAvailability).toBe('available');
     });
@@ -57,9 +57,9 @@ describe('fullscreenFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.fullscreenAvailability).toBe('unsupported');
     });
@@ -76,9 +76,9 @@ describe('fullscreenFeature', () => {
       const original = proto.webkitEnterFullscreen;
       proto.webkitEnterFullscreen = () => {};
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.fullscreenAvailability).toBe('available');
 
@@ -96,26 +96,27 @@ describe('fullscreenFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
-      video.webkitPresentationMode = 'inline';
-      video.webkitDisplayingFullscreen = false;
+      const { host, video } = createMockVideoHost();
+      const wkVideo = video as HTMLVideoElement & WebKitVideoElement;
+      wkVideo.webkitPresentationMode = 'inline';
+      wkVideo.webkitDisplayingFullscreen = false;
 
       const container = document.createElement('div');
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       expect(store.state.fullscreen).toBe(false);
 
       // Simulate entering fullscreen via WebKit presentation mode
-      video.webkitPresentationMode = 'fullscreen';
-      video.webkitDisplayingFullscreen = true;
+      wkVideo.webkitPresentationMode = 'fullscreen';
+      wkVideo.webkitDisplayingFullscreen = true;
       video.dispatchEvent(new Event('webkitpresentationmodechanged'));
 
       expect(store.state.fullscreen).toBe(true);
 
       // Simulate exiting
-      video.webkitPresentationMode = 'inline';
-      video.webkitDisplayingFullscreen = false;
+      wkVideo.webkitPresentationMode = 'inline';
+      wkVideo.webkitDisplayingFullscreen = false;
       video.dispatchEvent(new Event('webkitpresentationmodechanged'));
 
       expect(store.state.fullscreen).toBe(false);
@@ -128,11 +129,11 @@ describe('fullscreenFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const container = document.createElement('div');
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       expect(store.state.fullscreen).toBe(false);
 
@@ -164,11 +165,11 @@ describe('fullscreenFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const container = document.createElement('div');
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       store.destroy();
 
@@ -193,12 +194,12 @@ describe('fullscreenFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const container = document.createElement('div');
       container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       await store.requestFullscreen();
 
@@ -206,11 +207,11 @@ describe('fullscreenFeature', () => {
     });
 
     it('requestFullscreen() falls back to media when no container', async () => {
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
       video.requestFullscreen = vi.fn().mockResolvedValue(undefined);
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.requestFullscreen();
 
@@ -221,52 +222,14 @@ describe('fullscreenFeature', () => {
       const originalExit = document.exitFullscreen;
       document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.exitFullscreen();
 
       expect(document.exitFullscreen).toHaveBeenCalled();
-
-      document.exitFullscreen = originalExit;
-    });
-
-    it('requestFullscreen() uses webkitEnterFullscreen when element fullscreen is unsupported (iOS Safari)', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: false,
-        writable: true,
-        configurable: true,
-      });
-
-      const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
-      video.webkitEnterFullscreen = vi.fn();
-      const container = document.createElement('div');
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-
-      expect(video.webkitEnterFullscreen).toHaveBeenCalled();
-    });
-
-    it('exitFullscreen() uses webkitExitFullscreen first when video is in WebKit fullscreen (iOS Safari)', async () => {
-      const originalExit = document.exitFullscreen;
-      document.exitFullscreen = vi.fn();
-
-      const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
-      video.webkitExitFullscreen = vi.fn();
-      video.webkitDisplayingFullscreen = true;
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container: null });
-
-      await store.exitFullscreen();
-
-      expect(video.webkitExitFullscreen).toHaveBeenCalled();
-      expect(document.exitFullscreen).not.toHaveBeenCalled();
 
       document.exitFullscreen = originalExit;
     });
@@ -283,7 +246,7 @@ describe('fullscreenFeature', () => {
       const originalExit = document.exitPictureInPicture;
       document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
       const container = document.createElement('div');
       container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
 
@@ -295,7 +258,7 @@ describe('fullscreenFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       await store.requestFullscreen();
 
@@ -315,12 +278,12 @@ describe('fullscreenFeature', () => {
       const originalExit = document.exitPictureInPicture;
       document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const container = document.createElement('div');
       container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
 
       const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       await store.requestFullscreen();
 

--- a/packages/core/src/dom/store/features/tests/pip.test.ts
+++ b/packages/core/src/dom/store/features/tests/pip.test.ts
@@ -2,7 +2,7 @@ import { createStore } from '@videojs/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
 import type { WebKitVideoElement } from '../../../presentation/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { createMockVideoHost } from '../../../tests/test-helpers';
 import { pipFeature } from '../pip';
 
 describe('pipFeature', () => {
@@ -27,10 +27,10 @@ describe('pipFeature', () => {
 
   describe('attach', () => {
     it('syncs initial state on attach', () => {
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.pip).toBe(false);
     });
@@ -42,9 +42,9 @@ describe('pipFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.pipAvailability).toBe('available');
     });
@@ -56,10 +56,10 @@ describe('pipFeature', () => {
         configurable: true,
       });
 
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.pip).toBe(false);
 
@@ -85,93 +85,47 @@ describe('pipFeature', () => {
     });
 
     it('syncs pip on webkitpresentationmodechanged event (iOS Safari)', () => {
-      const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
-      video.webkitPresentationMode = 'inline';
+      const { host, video } = createMockVideoHost();
+      const wkVideo = video as HTMLVideoElement & WebKitVideoElement;
+      wkVideo.webkitPresentationMode = 'inline';
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.pip).toBe(false);
 
       // Simulate entering PiP via WebKit presentation mode
-      video.webkitPresentationMode = 'picture-in-picture';
+      wkVideo.webkitPresentationMode = 'picture-in-picture';
       video.dispatchEvent(new Event('webkitpresentationmodechanged'));
 
       expect(store.state.pip).toBe(true);
 
       // Simulate exiting
-      video.webkitPresentationMode = 'inline';
+      wkVideo.webkitPresentationMode = 'inline';
       video.dispatchEvent(new Event('webkitpresentationmodechanged'));
 
       expect(store.state.pip).toBe(false);
-    });
-
-    it('syncs pip when media element proxies to an internal target video', () => {
-      Object.defineProperty(document, 'pictureInPictureEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const targetVideo = createMockVideo();
-      const mediaHost = document.createElement('div') as unknown as HTMLVideoElement & {
-        target: HTMLVideoElement;
-      };
-
-      Object.defineProperty(mediaHost, 'target', {
-        value: targetVideo,
-        writable: true,
-        configurable: true,
-      });
-
-      const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: mediaHost, container: null });
-
-      expect(store.state.pip).toBe(false);
-
-      Object.defineProperty(document, 'pictureInPictureElement', {
-        value: targetVideo,
-        writable: true,
-        configurable: true,
-      });
-      mediaHost.dispatchEvent(new Event('enterpictureinpicture'));
-
-      expect(store.state.pip).toBe(true);
     });
   });
 
   describe('actions', () => {
     it('requestPictureInPicture() calls requestPictureInPicture on video', async () => {
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
       video.requestPictureInPicture = vi.fn().mockResolvedValue({});
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.requestPictureInPicture();
 
       expect(video.requestPictureInPicture).toHaveBeenCalled();
     });
 
-    it('requestPictureInPicture() uses webkitSetPresentationMode first when available (iOS Safari)', async () => {
-      const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
-      video.requestPictureInPicture = vi.fn().mockResolvedValue({});
-      video.webkitSetPresentationMode = vi.fn();
-
-      const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
-
-      await store.requestPictureInPicture();
-
-      expect(video.webkitSetPresentationMode).toHaveBeenCalledWith('picture-in-picture');
-      expect(video.requestPictureInPicture).not.toHaveBeenCalled();
-    });
-
     it('exitPictureInPicture() calls document.exitPictureInPicture', async () => {
       const originalExit = document.exitPictureInPicture;
       document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
 
       // Set the video as the current PiP element
       Object.defineProperty(document, 'pictureInPictureElement', {
@@ -181,7 +135,7 @@ describe('pipFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.exitPictureInPicture();
 
@@ -190,11 +144,11 @@ describe('pipFeature', () => {
       document.exitPictureInPicture = originalExit;
     });
 
-    it('exitPictureInPicture() calls document.exitPictureInPicture even without pictureInPictureElement', async () => {
+    it('exitPictureInPicture() is a no-op when not in picture-in-picture', async () => {
       const originalExit = document.exitPictureInPicture;
       document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host } = createMockVideoHost();
 
       Object.defineProperty(document, 'pictureInPictureElement', {
         value: null,
@@ -203,11 +157,11 @@ describe('pipFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.exitPictureInPicture();
 
-      expect(document.exitPictureInPicture).toHaveBeenCalled();
+      expect(document.exitPictureInPicture).not.toHaveBeenCalled();
 
       document.exitPictureInPicture = originalExit;
     });
@@ -218,7 +172,7 @@ describe('pipFeature', () => {
       const originalExit = document.exitFullscreen;
       document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
       video.requestPictureInPicture = vi.fn().mockResolvedValue({});
       const container = document.createElement('div');
 
@@ -230,7 +184,7 @@ describe('pipFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container });
+      store.attach({ media: host, container });
 
       await store.requestPictureInPicture();
 
@@ -244,11 +198,11 @@ describe('pipFeature', () => {
       const originalExit = document.exitFullscreen;
       document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
 
-      const video = createMockVideo();
+      const { host, video } = createMockVideoHost();
       video.requestPictureInPicture = vi.fn().mockResolvedValue({});
 
       const store = createStore<PlayerTarget>()(pipFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.requestPictureInPicture();
 

--- a/packages/core/src/dom/store/features/tests/playback.test.ts
+++ b/packages/core/src/dom/store/features/tests/playback.test.ts
@@ -1,13 +1,13 @@
 import { createStore } from '@videojs/store';
 import { describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { createMockVideoHost } from '../../../tests/test-helpers';
 import { playbackFeature } from '../playback';
 
 describe('playbackFeature', () => {
   describe('attach', () => {
     it('syncs playback state on attach', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         paused: false,
         ended: false,
         currentTime: 30,
@@ -15,7 +15,7 @@ describe('playbackFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.paused).toBe(false);
       expect(store.state.ended).toBe(false);
@@ -24,46 +24,46 @@ describe('playbackFeature', () => {
     });
 
     it('detects waiting state when buffering', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         paused: false,
         readyState: HTMLMediaElement.HAVE_CURRENT_DATA,
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.waiting).toBe(true);
     });
 
     it('detects started from currentTime', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         paused: true,
         currentTime: 5,
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.started).toBe(true);
     });
 
     it('detects started from playing state', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         paused: false,
         currentTime: 0,
       });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.started).toBe(true);
     });
 
     it('updates on play event', () => {
-      const video = createMockVideo({ paused: true });
+      const { host, video } = createMockVideoHost({ paused: true });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.paused).toBe(true);
 
@@ -75,10 +75,10 @@ describe('playbackFeature', () => {
     });
 
     it('updates on pause event', () => {
-      const video = createMockVideo({ paused: false });
+      const { host, video } = createMockVideoHost({ paused: false });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.paused).toBe(false);
 
@@ -90,10 +90,10 @@ describe('playbackFeature', () => {
     });
 
     it('updates on ended event', () => {
-      const video = createMockVideo({ ended: false });
+      const { host, video } = createMockVideoHost({ ended: false });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.ended).toBe(false);
 
@@ -105,10 +105,10 @@ describe('playbackFeature', () => {
     });
 
     it('clears ended state on seeked event', () => {
-      const video = createMockVideo({ ended: true });
+      const { host, video } = createMockVideoHost({ ended: true });
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.ended).toBe(true);
 
@@ -120,10 +120,10 @@ describe('playbackFeature', () => {
     });
 
     it('stops listening when store is destroyed', () => {
-      const video = createMockVideo({});
+      const { host, video } = createMockVideoHost({});
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       store.destroy();
 
@@ -138,11 +138,11 @@ describe('playbackFeature', () => {
 
   describe('actions', () => {
     it('play() calls play on target', async () => {
-      const video = createMockVideo({});
+      const { host, video } = createMockVideoHost({});
       video.play = vi.fn().mockResolvedValue(undefined);
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       await store.play();
 
@@ -150,11 +150,11 @@ describe('playbackFeature', () => {
     });
 
     it('pause() calls pause on target', () => {
-      const video = createMockVideo({});
+      const { host, video } = createMockVideoHost({});
       video.pause = vi.fn();
 
       const store = createStore<PlayerTarget>()(playbackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       store.pause();
 

--- a/packages/core/src/dom/store/features/tests/source.test.ts
+++ b/packages/core/src/dom/store/features/tests/source.test.ts
@@ -1,21 +1,22 @@
 import { combine, createStore } from '@videojs/store';
 import { describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { HTMLVideoElementHost } from '../../../media/video-host';
+import { createMockVideoHost } from '../../../tests/test-helpers';
 import { sourceFeature } from '../source';
 import { timeFeature } from '../time';
 
 describe('sourceFeature', () => {
   describe('attach', () => {
     it('syncs source state on attach', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         currentSrc: 'https://example.com/video.mp4',
         src: 'https://example.com/video.mp4',
         readyState: HTMLMediaElement.HAVE_ENOUGH_DATA,
       });
 
       const store = createStore<PlayerTarget>()(sourceFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.source).toBe('https://example.com/video.mp4');
       expect(store.state.canPlay).toBe(true);
@@ -27,21 +28,24 @@ describe('sourceFeature', () => {
       Object.defineProperty(video, 'currentSrc', { value: '', writable: false });
       Object.defineProperty(video, 'readyState', { value: HTMLMediaElement.HAVE_NOTHING, writable: false });
 
+      const host = new HTMLVideoElementHost();
+      host.attach(video);
+
       const store = createStore<PlayerTarget>()(sourceFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.source).toBe(null);
       expect(store.state.canPlay).toBe(false);
     });
 
     it('updates on canplay event', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         currentSrc: '',
         readyState: HTMLMediaElement.HAVE_NOTHING,
       });
 
       const store = createStore<PlayerTarget>()(sourceFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.canPlay).toBe(false);
 
@@ -57,12 +61,12 @@ describe('sourceFeature', () => {
     });
 
     it('updates on loadstart event', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         currentSrc: 'https://example.com/video.mp4',
       });
 
       const store = createStore<PlayerTarget>()(sourceFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.source).toBe('https://example.com/video.mp4');
 
@@ -78,13 +82,13 @@ describe('sourceFeature', () => {
     });
 
     it('updates on emptied event', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         currentSrc: 'https://example.com/video.mp4',
         readyState: HTMLMediaElement.HAVE_ENOUGH_DATA,
       });
 
       const store = createStore<PlayerTarget>()(sourceFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.canPlay).toBe(true);
 
@@ -105,11 +109,11 @@ describe('sourceFeature', () => {
   describe('actions', () => {
     describe('loadSource', () => {
       it('sets src on target and calls load', async () => {
-        const video = createMockVideo({});
+        const { host, video } = createMockVideoHost({});
         video.load = vi.fn();
 
         const store = createStore<PlayerTarget>()(sourceFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const result = await store.loadSource('https://example.com/new.mp4');
 
@@ -119,13 +123,13 @@ describe('sourceFeature', () => {
       });
 
       it('aborts pending operations when loading new source', async () => {
-        const video = createMockVideo({
+        const { host, video } = createMockVideoHost({
           readyState: HTMLMediaElement.HAVE_METADATA,
         });
         video.load = vi.fn();
 
         const store = createStore<PlayerTarget>()(combine(sourceFeature, timeFeature));
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         // Start a seek that will wait for seeked event
         const seekPromise = store.seek(30);

--- a/packages/core/src/dom/store/features/tests/stream-type.test.ts
+++ b/packages/core/src/dom/store/features/tests/stream-type.test.ts
@@ -2,43 +2,43 @@ import { createStore } from '@videojs/store';
 import { describe, expect, it } from 'vitest';
 import { type MediaStreamType, MediaStreamTypes } from '../../../../core/media/types';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { createMockVideoHost } from '../../../tests/test-helpers';
 import { streamTypeFeature } from '../stream-type';
 
 describe('streamTypeFeature', () => {
   describe('fallback (no `streamType` property on media)', () => {
     it('defaults to `unknown` when duration is not known', () => {
-      const video = createMockVideo({ duration: Number.NaN });
+      const { host } = createMockVideoHost({ duration: Number.NaN });
 
       const store = createStore<PlayerTarget>()(streamTypeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.streamType).toBe(MediaStreamTypes.UNKNOWN);
     });
 
     it('detects `live` from infinite duration', () => {
-      const video = createMockVideo({ duration: Number.POSITIVE_INFINITY });
+      const { host } = createMockVideoHost({ duration: Number.POSITIVE_INFINITY });
 
       const store = createStore<PlayerTarget>()(streamTypeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.streamType).toBe(MediaStreamTypes.LIVE);
     });
 
     it('detects `on-demand` from a finite duration', () => {
-      const video = createMockVideo({ duration: 120 });
+      const { host } = createMockVideoHost({ duration: 120 });
 
       const store = createStore<PlayerTarget>()(streamTypeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.streamType).toBe(MediaStreamTypes.ON_DEMAND);
     });
 
     it('updates on `durationchange`', () => {
-      const video = createMockVideo({ duration: Number.NaN });
+      const { host, video } = createMockVideoHost({ duration: Number.NaN });
 
       const store = createStore<PlayerTarget>()(streamTypeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.streamType).toBe(MediaStreamTypes.UNKNOWN);
 
@@ -49,10 +49,10 @@ describe('streamTypeFeature', () => {
     });
 
     it('resets to `unknown` on `emptied`', () => {
-      const video = createMockVideo({ duration: 120 });
+      const { host, video } = createMockVideoHost({ duration: 120 });
 
       const store = createStore<PlayerTarget>()(streamTypeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.streamType).toBe(MediaStreamTypes.ON_DEMAND);
 

--- a/packages/core/src/dom/store/features/tests/text-track.test.ts
+++ b/packages/core/src/dom/store/features/tests/text-track.test.ts
@@ -1,7 +1,7 @@
 import { createStore } from '@videojs/store';
 import { describe, expect, it } from 'vitest';
-
 import type { PlayerTarget } from '../../../media/types';
+import { HTMLVideoElementHost } from '../../../media/video-host';
 import { textTrackFeature } from '../text-track';
 
 /**
@@ -12,8 +12,11 @@ import { textTrackFeature } from '../text-track';
  * and `loadstart` resync (dispatched on media, which works).
  */
 
-function createVideo(): HTMLVideoElement {
-  return document.createElement('video');
+function createVideo(): { host: HTMLVideoElementHost; video: HTMLVideoElement } {
+  const video = document.createElement('video');
+  const host = new HTMLVideoElementHost();
+  host.attach(video);
+  return { host, video };
 }
 
 function mockTextTracks(video: HTMLVideoElement, tracks: TextTrack[]): void {
@@ -36,9 +39,9 @@ function createMockTrack(kind: TextTrackKind, mode: TextTrackMode = 'disabled'):
 describe('textTrackFeature', () => {
   describe('initial state', () => {
     it('has empty initial state', () => {
-      const video = createVideo();
+      const { host } = createVideo();
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.chaptersCues).toEqual([]);
       expect(store.state.thumbnailCues).toEqual([]);
@@ -50,22 +53,22 @@ describe('textTrackFeature', () => {
 
   describe('attach', () => {
     it('detects chapters track via addTextTrack', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       video.addTextTrack('chapters', 'Chapters', 'en');
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Track detected, but no cues in jsdom
       expect(store.state.chaptersCues).toEqual([]);
     });
 
     it('detects thumbnail track by kind and label', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       video.addTextTrack('metadata', 'thumbnails', 'en');
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Track detected, but no cues or <track> element for src
       expect(store.state.thumbnailCues).toEqual([]);
@@ -73,25 +76,25 @@ describe('textTrackFeature', () => {
     });
 
     it('ignores metadata tracks without thumbnails label', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       video.addTextTrack('metadata', 'ad-cues', 'en');
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.thumbnailCues).toEqual([]);
       expect(store.state.thumbnailTrackSrc).toBeNull();
     });
 
     it('prefers first matching track when multiple exist', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       video.addTextTrack('chapters', 'Ch1', 'en');
       video.addTextTrack('chapters', 'Ch2', 'fr');
       video.addTextTrack('metadata', 'thumbnails', 'en');
       video.addTextTrack('metadata', 'thumbnails', 'fr');
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Should not error with multiple matching tracks
       expect(store.state.chaptersCues).toEqual([]);
@@ -99,10 +102,10 @@ describe('textTrackFeature', () => {
     });
 
     it('resyncs on loadstart event', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Add a track programmatically (won't trigger textTracks event in jsdom)
       video.addTextTrack('metadata', 'thumbnails', 'en');
@@ -116,7 +119,7 @@ describe('textTrackFeature', () => {
     });
 
     it('resolves thumbnailTrackSrc from track element', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       const trackEl = document.createElement('track');
       trackEl.kind = 'metadata';
       trackEl.label = 'thumbnails';
@@ -127,7 +130,7 @@ describe('textTrackFeature', () => {
       // In jsdom, appending <track> to <video> adds to textTracks.
       // The track.track property links the element to its TextTrack.
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // findTrackElement maps TextTrack → <track> element → src
       // jsdom's TextTrack from <track> may or may not match addTextTrack
@@ -140,24 +143,24 @@ describe('textTrackFeature', () => {
     });
 
     it('sets subtitlesShowing when a subtitles track is showing', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       mockTextTracks(video, [createMockTrack('subtitles', 'showing')]);
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.subtitlesShowing).toBe(true);
     });
 
     it('exposes textTrackList for all track kinds', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       const subtitlesTrack = { kind: 'subtitles', mode: 'showing', label: 'English', language: 'en' } as TextTrack;
       const captionsTrack = { kind: 'captions', mode: 'disabled', label: 'CC', language: 'en' } as TextTrack;
       const metadataTrack = createMockTrack('metadata', 'showing');
       mockTextTracks(video, [subtitlesTrack, captionsTrack, metadataTrack]);
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.textTrackList).toEqual([
         { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' },
@@ -167,13 +170,13 @@ describe('textTrackFeature', () => {
     });
 
     it('toggleSubtitles() enables and disables caption/subtitle tracks', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       const subtitlesTrack = createMockTrack('subtitles');
       const captionsTrack = createMockTrack('captions');
       mockTextTracks(video, [subtitlesTrack, captionsTrack]);
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       const enabled = store.state.toggleSubtitles();
       expect(enabled).toBe(true);
@@ -187,20 +190,20 @@ describe('textTrackFeature', () => {
     });
 
     it('toggleSubtitles() returns false when no subtitle tracks exist', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       const metadataTrack = createMockTrack('metadata', 'showing');
       mockTextTracks(video, [metadataTrack]);
 
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.toggleSubtitles()).toBe(false);
     });
 
     it('stops updating after destroy', () => {
-      const video = createVideo();
+      const { host, video } = createVideo();
       const store = createStore<PlayerTarget>()(textTrackFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       store.destroy();
 

--- a/packages/core/src/dom/store/features/tests/time.test.ts
+++ b/packages/core/src/dom/store/features/tests/time.test.ts
@@ -1,41 +1,41 @@
 import { createStore } from '@videojs/store';
 import { describe, expect, it } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo, createTimeRanges } from '../../../tests/test-helpers';
+import { createMockVideoHost, createTimeRanges } from '../../../tests/test-helpers';
 import { timeFeature } from '../time';
 
 describe('timeFeature', () => {
   describe('attach', () => {
     it('syncs time state on attach', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         currentTime: 30,
         duration: 120,
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.currentTime).toBe(30);
       expect(store.state.duration).toBe(120);
     });
 
     it('handles NaN duration', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         currentTime: 0,
         duration: Number.NaN,
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.duration).toBe(0);
     });
 
     it('updates on timeupdate event', () => {
-      const video = createMockVideo({ currentTime: 0 });
+      const { host, video } = createMockVideoHost({ currentTime: 0 });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.currentTime).toBe(0);
 
@@ -47,10 +47,10 @@ describe('timeFeature', () => {
     });
 
     it('updates on durationchange event', () => {
-      const video = createMockVideo({ duration: 0 });
+      const { host, video } = createMockVideoHost({ duration: 0 });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.duration).toBe(0);
 
@@ -62,10 +62,10 @@ describe('timeFeature', () => {
     });
 
     it('updates on seeked event', () => {
-      const video = createMockVideo({ currentTime: 0 });
+      const { host, video } = createMockVideoHost({ currentTime: 0 });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Update mock currentTime
       video.currentTime = 50;
@@ -75,38 +75,38 @@ describe('timeFeature', () => {
     });
 
     it('uses seekable end as duration for live streams (Infinity)', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         currentTime: 0,
         duration: Number.POSITIVE_INFINITY,
         seekable: createTimeRanges([[0, 300]]),
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.duration).toBe(300);
     });
 
     it('returns 0 duration for live streams with no seekable range', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         duration: Number.POSITIVE_INFINITY,
         seekable: createTimeRanges([]),
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.duration).toBe(0);
     });
 
     it('updates live duration as seekable range grows on progress', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         duration: Number.POSITIVE_INFINITY,
         seekable: createTimeRanges([[0, 300]]),
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.duration).toBe(300);
 
@@ -120,7 +120,7 @@ describe('timeFeature', () => {
     });
 
     it('uses end of last seekable range when multiple ranges exist', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         duration: Number.POSITIVE_INFINITY,
         seekable: createTimeRanges([
           [0, 100],
@@ -129,19 +129,19 @@ describe('timeFeature', () => {
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.duration).toBe(300);
     });
 
     it('updates on emptied event', () => {
-      const video = createMockVideo({
+      const { host, video } = createMockVideoHost({
         currentTime: 30,
         duration: 120,
       });
 
       const store = createStore<PlayerTarget>()(timeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Update mock to empty state
       video.currentTime = 0;
@@ -156,9 +156,9 @@ describe('timeFeature', () => {
   describe('actions', () => {
     describe('seek', () => {
       it('sets currentTime on target and waits for seeked event', async () => {
-        const video = createMockVideo({ readyState: HTMLMediaElement.HAVE_METADATA });
+        const { host, video } = createMockVideoHost({ readyState: HTMLMediaElement.HAVE_METADATA });
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const resultPromise = store.seek(45);
 
@@ -172,9 +172,9 @@ describe('timeFeature', () => {
       });
 
       it('aborts pending seek on detach', async () => {
-        const video = createMockVideo({ readyState: HTMLMediaElement.HAVE_METADATA });
+        const { host, video } = createMockVideoHost({ readyState: HTMLMediaElement.HAVE_METADATA });
         const store = createStore<PlayerTarget>()(timeFeature);
-        const detach = store.attach({ media: video, container: null });
+        const detach = store.attach({ media: host, container: null });
 
         const resultPromise = store.seek(45);
 
@@ -189,9 +189,9 @@ describe('timeFeature', () => {
       });
 
       it('supersedes previous seek when new seek starts', async () => {
-        const video = createMockVideo({ readyState: HTMLMediaElement.HAVE_METADATA });
+        const { host, video } = createMockVideoHost({ readyState: HTMLMediaElement.HAVE_METADATA });
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         // Start first seek
         const seek1Promise = store.seek(10);
@@ -213,9 +213,9 @@ describe('timeFeature', () => {
       });
 
       it('optimistically updates currentTime before seeked event fires', () => {
-        const video = createMockVideo({ readyState: HTMLMediaElement.HAVE_METADATA });
+        const { host } = createMockVideoHost({ readyState: HTMLMediaElement.HAVE_METADATA });
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         expect(store.state.currentTime).toBe(0);
 
@@ -227,9 +227,9 @@ describe('timeFeature', () => {
       });
 
       it('optimistically sets seeking to true before seeking event fires', () => {
-        const video = createMockVideo({ readyState: HTMLMediaElement.HAVE_METADATA });
+        const { host } = createMockVideoHost({ readyState: HTMLMediaElement.HAVE_METADATA });
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         expect(store.state.seeking).toBe(false);
 
@@ -239,9 +239,9 @@ describe('timeFeature', () => {
       });
 
       it('optimistic seeking is corrected by seeked event', async () => {
-        const video = createMockVideo({ readyState: HTMLMediaElement.HAVE_METADATA });
+        const { host, video } = createMockVideoHost({ readyState: HTMLMediaElement.HAVE_METADATA });
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const resultPromise = store.seek(45);
 
@@ -258,14 +258,14 @@ describe('timeFeature', () => {
       });
 
       it('timeupdate during seek does not overwrite optimistic currentTime', () => {
-        const video = createMockVideo({
+        const { host, video } = createMockVideoHost({
           currentTime: 10,
           duration: 120,
           readyState: HTMLMediaElement.HAVE_METADATA,
         });
 
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         expect(store.state.currentTime).toBe(10);
 
@@ -284,14 +284,14 @@ describe('timeFeature', () => {
       });
 
       it('progress during seek does not overwrite optimistic currentTime', () => {
-        const video = createMockVideo({
+        const { host, video } = createMockVideoHost({
           currentTime: 10,
           duration: 120,
           readyState: HTMLMediaElement.HAVE_METADATA,
         });
 
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         store.seek(60);
         expect(store.state.currentTime).toBe(60);
@@ -307,14 +307,14 @@ describe('timeFeature', () => {
       });
 
       it('timeupdate resumes syncing after seeked', async () => {
-        const video = createMockVideo({
+        const { host, video } = createMockVideoHost({
           currentTime: 10,
           duration: 120,
           readyState: HTMLMediaElement.HAVE_METADATA,
         });
 
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const resultPromise = store.seek(60);
 
@@ -336,14 +336,14 @@ describe('timeFeature', () => {
       });
 
       it('rapid seeks during drag preserve latest optimistic value', () => {
-        const video = createMockVideo({
+        const { host, video } = createMockVideoHost({
           currentTime: 10,
           duration: 120,
           readyState: HTMLMediaElement.HAVE_METADATA,
         });
 
         const store = createStore<PlayerTarget>()(timeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         // Simulate rapid drag: multiple seeks without waiting for seeked.
         store.seek(30);

--- a/packages/core/src/dom/store/features/tests/volume.test.ts
+++ b/packages/core/src/dom/store/features/tests/volume.test.ts
@@ -1,38 +1,38 @@
 import { createStore } from '@videojs/store';
 import { describe, expect, it } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import { createMockVideo } from '../../../tests/test-helpers';
+import { createMockVideoHost } from '../../../tests/test-helpers';
 import { volumeFeature } from '../volume';
 
 describe('volumeFeature', () => {
   describe('attach', () => {
     it('syncs volume state on attach', () => {
-      const video = createMockVideo({
+      const { host } = createMockVideoHost({
         volume: 0.8,
         muted: false,
       });
 
       const store = createStore<PlayerTarget>()(volumeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.volume).toBe(0.8);
       expect(store.state.muted).toBe(false);
     });
 
     it('sets volumeAvailability on attach', () => {
-      const video = createMockVideo({});
+      const { host } = createMockVideoHost({});
       const store = createStore<PlayerTarget>()(volumeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       // Should be 'available' or 'unsupported' based on browser capability
       expect(['available', 'unsupported']).toContain(store.state.volumeAvailability);
     });
 
     it('updates on volumechange event', () => {
-      const video = createMockVideo({ volume: 1, muted: false });
+      const { host, video } = createMockVideoHost({ volume: 1, muted: false });
 
       const store = createStore<PlayerTarget>()(volumeFeature);
-      store.attach({ media: video, container: null });
+      store.attach({ media: host, container: null });
 
       expect(store.state.volume).toBe(1);
 
@@ -49,9 +49,9 @@ describe('volumeFeature', () => {
   describe('actions', () => {
     describe('setVolume', () => {
       it('sets volume on target', async () => {
-        const video = createMockVideo({});
+        const { host, video } = createMockVideoHost({});
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const result = await store.setVolume(0.7);
 
@@ -60,9 +60,9 @@ describe('volumeFeature', () => {
       });
 
       it('clamps volume to min 0', async () => {
-        const video = createMockVideo({});
+        const { host, video } = createMockVideoHost({});
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         await store.setVolume(-0.5);
 
@@ -70,9 +70,9 @@ describe('volumeFeature', () => {
       });
 
       it('clamps volume to max 1', async () => {
-        const video = createMockVideo({});
+        const { host, video } = createMockVideoHost({});
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         await store.setVolume(1.5);
 
@@ -80,9 +80,9 @@ describe('volumeFeature', () => {
       });
 
       it('unmutes when setting volume above 0 while muted', async () => {
-        const video = createMockVideo({ muted: true, volume: 0.5 });
+        const { host, video } = createMockVideoHost({ muted: true, volume: 0.5 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         await store.setVolume(0.7);
 
@@ -91,9 +91,9 @@ describe('volumeFeature', () => {
       });
 
       it('does not unmute when setting volume to 0', async () => {
-        const video = createMockVideo({ muted: true, volume: 0.5 });
+        const { host, video } = createMockVideoHost({ muted: true, volume: 0.5 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         await store.setVolume(0);
 
@@ -102,9 +102,9 @@ describe('volumeFeature', () => {
       });
 
       it('does not change muted when already unmuted', async () => {
-        const video = createMockVideo({ muted: false, volume: 0.5 });
+        const { host, video } = createMockVideoHost({ muted: false, volume: 0.5 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         await store.setVolume(0.8);
 
@@ -115,9 +115,9 @@ describe('volumeFeature', () => {
 
     describe('toggleMuted', () => {
       it('mutes when unmuted with volume > 0', async () => {
-        const video = createMockVideo({ muted: false, volume: 0.8 });
+        const { host, video } = createMockVideoHost({ muted: false, volume: 0.8 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const result = await store.toggleMuted();
 
@@ -127,9 +127,9 @@ describe('volumeFeature', () => {
       });
 
       it('unmutes when muted with volume > 0', async () => {
-        const video = createMockVideo({ muted: true, volume: 0.6 });
+        const { host, video } = createMockVideoHost({ muted: true, volume: 0.6 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const result = await store.toggleMuted();
 
@@ -139,9 +139,9 @@ describe('volumeFeature', () => {
       });
 
       it('restores volume to 0.25 when unmuting at volume 0', async () => {
-        const video = createMockVideo({ muted: true, volume: 0 });
+        const { host, video } = createMockVideoHost({ muted: true, volume: 0 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         await store.toggleMuted();
 
@@ -150,9 +150,9 @@ describe('volumeFeature', () => {
       });
 
       it('unmutes and restores volume when volume is 0 and not muted', async () => {
-        const video = createMockVideo({ muted: false, volume: 0 });
+        const { host, video } = createMockVideoHost({ muted: false, volume: 0 });
         const store = createStore<PlayerTarget>()(volumeFeature);
-        store.attach({ media: video, container: null });
+        store.attach({ media: host, container: null });
 
         const result = await store.toggleMuted();
 

--- a/packages/core/src/dom/tests/test-helpers.ts
+++ b/packages/core/src/dom/tests/test-helpers.ts
@@ -1,5 +1,6 @@
 import type { SliderState } from '../../core/ui/slider/slider-core';
 import type { TimeSliderState } from '../../core/ui/time-slider/time-slider-core';
+import { HTMLVideoElementHost } from '../media/video-host';
 
 // ---------------------------------------------------------------------------
 // Mock Video
@@ -51,6 +52,22 @@ export function createMockVideo(overrides: MockVideoOverrides = {}): HTMLVideoEl
   if (overrides.src !== undefined) video.src = overrides.src;
 
   return video;
+}
+
+/**
+ * Create an `HTMLVideoElementHost` attached to a `createMockVideo()` element.
+ *
+ * Returns both the host and the underlying video so tests can stub WebKit
+ * properties on the video while exercising the generic host API.
+ */
+export function createMockVideoHost(overrides: MockVideoOverrides = {}): {
+  host: HTMLVideoElementHost;
+  video: HTMLVideoElement;
+} {
+  const video = createMockVideo(overrides);
+  const host = new HTMLVideoElementHost();
+  host.attach(video);
+  return { host, video };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -12,6 +12,7 @@ const createConfig = (mode: BuildMode): UserConfig => ({
     dom: './src/dom/index.ts',
     'dom/media/dash/index': './src/dom/media/dash/index.ts',
     'dom/media/hls/index': './src/dom/media/hls/index.ts',
+    'dom/media/host/index': './src/dom/media/host/index.ts',
     'dom/media/custom-media-element/index': './src/dom/media/custom-media-element/index.ts',
     'dom/media/mux/index': './src/dom/media/mux/index.ts',
     'dom/media/native-hls/index': './src/dom/media/native-hls/index.ts',

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -1,4 +1,5 @@
-import type { Media, MediaContainer, PlayerStore, PlayerTarget } from '@videojs/core/dom';
+import type { Media, MediaContainer, PlayerStore, PlayerTarget, Video } from '@videojs/core/dom';
+import { toMediaHost } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import { isNull } from '@videojs/utils/predicate';
 import type { MediaElementConstructor } from '@/ui/media-element';
@@ -36,6 +37,8 @@ export function createProviderMixin<Store extends PlayerStore>(
     class PlayerProviderElement extends BaseClass implements PlayerProvider<Store> {
       #store: Store | null = config.factory();
       #detach: (() => void) | null = null;
+      #releaseMedia: (() => void) | null = null;
+      #wrappedMedia: Video | null = null;
       #media: Media | null = null;
       #container: MediaContainer | null = null;
       #fallbackQueued = false;
@@ -43,6 +46,8 @@ export function createProviderMixin<Store extends PlayerStore>(
       #setMedia = (media: Media | null): void => {
         if (this.#media === media) return;
         this.#media = media;
+        // Drop any previous auto-host so the next #tryAttach re-wraps.
+        this.#releaseAutoHost();
         this.#mediaProvider.setValue({ media, setMedia: this.#setMedia });
         this.#tryAttach();
       };
@@ -107,8 +112,16 @@ export function createProviderMixin<Store extends PlayerStore>(
           return;
         }
 
+        // Wrap raw <video>/<audio> elements so features see the full host API.
+        // The wrapper is reused until #media changes (see #setMedia).
+        if (!this.#wrappedMedia) {
+          const { media, release } = toMediaHost(this.#media);
+          this.#wrappedMedia = media;
+          this.#releaseMedia = release;
+        }
+
         const target: PlayerTarget = {
-          media: this.#media,
+          media: this.#wrappedMedia,
           container: this.#container,
         };
 
@@ -116,7 +129,7 @@ export function createProviderMixin<Store extends PlayerStore>(
         const hasContainerChanged = store.target?.container !== target.container;
 
         if (hasMediaChanged || hasContainerChanged) {
-          this.#detachStore();
+          this.#detach?.();
           this.#detach = store.attach(target);
         }
       }
@@ -124,6 +137,13 @@ export function createProviderMixin<Store extends PlayerStore>(
       #detachStore(): void {
         this.#detach?.();
         this.#detach = null;
+        this.#releaseAutoHost();
+      }
+
+      #releaseAutoHost(): void {
+        this.#releaseMedia?.();
+        this.#releaseMedia = null;
+        this.#wrappedMedia = null;
       }
 
       #queueFallbackDiscovery(): void {

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -1,5 +1,5 @@
 import type { Media, MediaContainer, PlayerStore, PlayerTarget, Video } from '@videojs/core/dom';
-import { toMediaHost } from '@videojs/core/dom';
+import { toMediaHost } from '@videojs/core/dom/media/host';
 import { ContextProvider } from '@videojs/element/context';
 import { isNull } from '@videojs/utils/predicate';
 import type { MediaElementConstructor } from '@/ui/media-element';

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -11,7 +11,7 @@ import type {
   VideoFeatures,
   VideoPlayerStore,
 } from '@videojs/core/dom';
-import { toMediaHost } from '@videojs/core/dom';
+import { toMediaHost } from '@videojs/core/dom/media/host';
 import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -11,6 +11,7 @@ import type {
   VideoFeatures,
   VideoPlayerStore,
 } from '@videojs/core/dom';
+import { toMediaHost } from '@videojs/core/dom';
 import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
@@ -77,7 +78,13 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
     useEffect(() => {
       if (!media) return;
-      return store.attach({ media, container });
+      // Wrap raw <video>/<audio> so features see the full host API.
+      const wrapped = toMediaHost(media);
+      const detach = store.attach({ media: wrapped.media, container });
+      return () => {
+        detach();
+        wrapped.release();
+      };
     }, [media, container, store]);
 
     return (


### PR DESCRIPTION
## Summary

Normalize the video host's fullscreen and picture-in-picture APIs around
standard methods (`requestFullscreen`, `exitFullscreen`,
`requestPictureInPicture`, `exitPictureInPicture`) plus `isFullscreen` and
`isPictureInPicture` getters. WebKit-specific quirks (`webkit*` events and
methods) are now centralized in `HTMLVideoElementHost` so features and
presentation helpers can stay platform-agnostic.

## Changes

- **Host API** — Generic methods/getters on `HTMLVideoElementHost`. WebKit
  events (`webkitpresentationmodechanged`, `webkitfullscreenchange`) are
  normalized into bubbling `fullscreenchange` and
  `enter`/`leavepictureinpicture` events.
- **Promise correctness** — `requestPictureInPicture` and
  `exitPictureInPicture` now resolve only after the corresponding event
  fires (WebKit's `setPresentationMode` is fire-and-forget).
- **iOS regression fix** — Restored preference for `webkitEnterFullscreen`
  over the standard API on `<video>`, where the latter silently fails
  (originally fixed in a05e8f20).
- **`toMediaHost` helper** — New helper that wraps raw `HTMLVideoElement` /
  `HTMLAudioElement` instances into their host classes. Lives at
  `@videojs/core/dom/media/host` (a dedicated subpath) so the host classes
  stay out of the main `@videojs/core/dom` barrel — only `@videojs/html`
  and `@videojs/react` import from it.
- **Controls visibility** — Controls stay visible while in
  picture-in-picture, mirroring the existing paused / remote-playback
  behavior.

<details>
<summary>Breaking changes</summary>

- `PlayerTarget.media` is now typed as `Video` instead of `Media`.
- `presentation/fullscreen.ts` and `presentation/pip.ts` no longer accept
  WebKit-specific overloads — call `media.requestFullscreen()` etc.
  directly.
- `exitFullscreen` no longer takes a `container` argument; it picks the
  correct exit path from `media.isFullscreen`.

</details>

## Testing

- `pnpm typecheck`
- `pnpm -F @videojs/core test` — 1066 tests
- `pnpm -F @videojs/html test` — 101 tests
- `pnpm -F @videojs/react test` — 200 tests
- New tests cover `toMediaHost`, host PiP/fullscreen behavior, WebKit event
  normalization, and PiP-aware controls visibility.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to breaking type/API changes around `PlayerTarget.media` and fullscreen/PiP handling, plus new wrapping lifecycle that could affect attach/detach behavior across consumers and platforms (notably iOS WebKit).
> 
> **Overview**
> **Normalizes fullscreen and picture-in-picture APIs** across the DOM player stack by extending media capability types with `isFullscreen`/`exitFullscreen` and `isPictureInPicture`/`exitPictureInPicture`, and moving WebKit-specific behavior into `HTMLVideoElementHost` (including event normalization and promise timing).
> 
> **Introduces `toMediaHost`** under `@videojs/core/dom/media/host` to wrap raw `<video>/<audio>` elements into host classes and provide a `release()` hook; `@videojs/html` and `@videojs/react` now wrap media before `store.attach()` and clean up the wrapper on detach.
> 
> **Updates player features to rely on host capabilities** (fullscreen/PiP/controls visibility) and trims presentation helpers (`pip.ts` now only exposes enablement; `fullscreen.ts` delegates exit to media when element-level fullscreen is active). Extensive tests are added/updated to use host-based media and to cover WebKit fullscreen/PiP edge cases and controls staying visible during PiP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3601734c308f90667cd69f0b46b31ebf6d05a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->