### PR TITLE
feat(html): re-export reactive primitives from @videojs/element

### DIFF
--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,5 +1,15 @@
 // Core
 export * from '@videojs/core/dom';
+export type {
+  Destroyable,
+  PropertyDeclaration,
+  PropertyDeclarationMap,
+  PropertyValues,
+  ReactiveController,
+  ReactiveControllerHost,
+} from '@videojs/element';
+// Element — reactive primitives for users extending MediaElement
+export { DestroyMixin, ReactiveElement } from '@videojs/element';
 
 // Store
 export type { Comparator, Selector } from '@videojs/store';


### PR DESCRIPTION
## Summary

Re-exports the reactive primitives from `@videojs/element` so users extending `MediaElement` to build custom UI components don't need to install and import from `@videojs/element` directly:

- `ReactiveElement`, `DestroyMixin` (runtime values)
- `Destroyable`, `PropertyDeclaration`, `PropertyDeclarationMap`, `PropertyValues`, `ReactiveController`, `ReactiveControllerHost` (types)

The motivating case is overriding `update(changed: PropertyValues)` — users need `PropertyValues` to type the override parameter, but it lives in `@videojs/element`. They're already pulling `MediaElement` from `@videojs/html`, so this puts the types in the same package.

Purely additive — no name conflicts, no breaking change. `@videojs/element` is already a workspace dep of `@videojs/html`, and the runtime values (`ReactiveElement`, `DestroyMixin`) are already pulled in transitively via `MediaElement`, so no bundle size cost.

## Context

Suggested by @mihar-22 reviewing #1008 ([this comment](https://github.com/videojs/v10/pull/1008#discussion_r2957420807)). The "Build your own component" guide hits the same friction repeatedly.

## Test plan

- [x] `pnpm -F @videojs/html build` — types regenerated, all re-exports present in `dist/dev/index.d.ts`
- [x] `pnpm -F @videojs/html test` — 101 tests pass
- [x] `pnpm check:workspace` — 6/6 checks pass
- [x] `pnpm typecheck` — same baseline as origin/main (330 pre-existing errors, none introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a purely additive public API change that only re-exports existing runtime values and TypeScript types, with no behavioral changes.
> 
> **Overview**
> `@videojs/html` now re-exports reactive primitives from `@videojs/element`, exposing `ReactiveElement`/`DestroyMixin` plus related controller/property types (e.g., `PropertyValues`).
> 
> This lets consumers extending `MediaElement` import the reactive building blocks from `@videojs/html` directly without adding a separate dependency/import path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75335c73b1480d958f0ea61203af3ef2f5f7bfb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->