### PR TITLE
refactor(packages)!: replace button availability with disabled and hidden state

### DIFF
--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -25,7 +25,11 @@ for (const { name, path, media, skipBrowsers } of ALL_VIDEO_PAGES as readonly Pa
       await expect(player.seekBackward).toHaveAttribute(DATA_ATTRS.direction, 'backward');
       await expect(player.muteButton).toHaveAttribute(DATA_ATTRS.volumeLevel);
       await expect(player.fullscreenButton).toHaveAttribute(DATA_ATTRS.availability);
-      await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.availability);
+      // PiP is unsupported on WebKit and the button receives the `hidden` attribute.
+      // Only assert `data-availability` when the pip button is visible.
+      if (await player.pipButton.isVisible()) {
+        await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.availability);
+      }
       await expect(player.captionsButton).toHaveAttribute(DATA_ATTRS.availability);
       await expect(player.duration).not.toHaveText('');
       await player.showControls();

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -26,7 +26,12 @@ for (const { name, path, media, skipBrowsers } of ALL_VIDEO_PAGES as readonly Pa
       await expect(player.seekBackward).toHaveAttribute(DATA_ATTRS.direction, 'backward');
       await expect(player.muteButton).toHaveAttribute(DATA_ATTRS.volumeLevel);
       await expect(player.fullscreenButton).toHaveAttribute(DATA_ATTRS.availability);
-      await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.availability);
+      // PiP is unsupported on WebKit and the button receives the `hidden` attribute.
+      // Only assert `data-availability` when the pip button is visible.
+      if (await player.pipButton.isVisible()) {
+        await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.availability);
+      }
+      await expect(player.captionsButton).toHaveAttribute(DATA_ATTRS.availability);
       await expect(player.settingsButton).toBeAttached();
       await expect(player.duration).not.toHaveText('');
       await player.showControls();

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -31,7 +31,6 @@ for (const { name, path, media, skipBrowsers } of ALL_VIDEO_PAGES as readonly Pa
       if (await player.pipButton.isVisible()) {
         await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.availability);
       }
-      await expect(player.captionsButton).toHaveAttribute(DATA_ATTRS.availability);
       await expect(player.settingsButton).toBeAttached();
       await expect(player.duration).not.toHaveText('');
       await player.showControls();

--- a/internal/design/ui/disabled-hidden.md
+++ b/internal/design/ui/disabled-hidden.md
@@ -1,0 +1,82 @@
+---
+status: decided
+date: 2026-04-27
+---
+
+# Disabled & Hidden States for Controls
+
+## Decision
+
+Use `aria-disabled` (never HTML `disabled`) for all toolbar buttons. Three visual states driven by data attributes:
+
+| State | ARIA | HTML (custom element) | React | Styling |
+|-------|------|-----------------------|-------|---------|
+| **Unsupported** | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
+| **Unavailable** (Cast only) | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Reduced opacity via `[data-disabled]` |
+| **Disabled** (prop) | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Reduced opacity via `[data-disabled]` |
+| **Available + enabled** | _(none)_ | _(none)_ | _(none)_ | Fully interactive |
+
+`data-availability` remains as a string enum (`available`, `unavailable`, `unsupported`) for consumers that need the raw value.
+
+## Context
+
+Feature buttons (Fullscreen, PiP, Cast) need to communicate three distinct states to users and assistive technology:
+
+1. **Unsupported** — the browser lacks the capability entirely (e.g., PiP on older Safari). Applies to Fullscreen, PiP, and Cast.
+2. **Unavailable** — the API exists but no target is available (e.g., no cast device found). Only applies to Cast.
+3. **Disabled** — the developer explicitly disabled the control via a prop.
+
+Unsupported features are hidden entirely. Unavailable features (Cast only — no device found) and explicitly disabled buttons remain visible but non-interactive. `disabled` in state covers both the prop and feature unavailability. We evaluated `disabled` vs `aria-disabled`, `hidden` vs `aria-hidden`, and how Radix, Base UI, and WAI-ARIA APG handle these patterns.
+
+## Alternatives Considered
+
+- **HTML `disabled` attribute** — Removes elements from the tab order entirely. This breaks the APG toolbar pattern, which requires all toolbar buttons to remain focusable via arrow keys. It also prevents tooltips and hover states from working on disabled buttons.
+
+- **Hybrid approach (like Base UI's `focusableWhenDisabled`)** — Adds a prop to toggle between `disabled` and `aria-disabled`. Unnecessary complexity for our use case since we always want buttons to remain focusable.
+
+- **CSS-only hiding (`display: none` via data attributes)** — Our prior approach used `[data-availability]:not([data-available])` to hide buttons. This works but lacks native semantics. The HTML `hidden` attribute provides the same effect with proper semantics and works without any CSS.
+
+## Rationale
+
+### Why `aria-disabled` over `disabled`
+
+The WAI-ARIA APG toolbar pattern explicitly recommends `aria-disabled` for toolbar buttons:
+
+- **Keeps buttons in tab order** — keyboard users can discover disabled controls and understand what's available.
+- **Allows tooltips** — hover events still fire on `aria-disabled` elements, so tooltips can explain why a control is disabled.
+- **Consistent across custom elements** — HTML `disabled` only has native behavior on form controls (`<button>`, `<input>`), not custom elements.
+
+This aligns with both Radix (uses `aria-disabled` for custom interactive elements, `[data-disabled]` for styling) and Base UI (uses `aria-disabled` when `focusableWhenDisabled` is true, exposes `[data-disabled]`).
+
+### Why HTML `hidden` for unsupported features
+
+When a feature is unsupported, the button should not be visible at all. The HTML `hidden` attribute:
+
+- Works without CSS — no `display: none` rule needed.
+- Has native browser semantics.
+- Is set via `getAttrs()` alongside `aria-disabled`, keeping all attribute logic in one place.
+
+On the React side, the component returns `null` instead — the idiomatic React approach for conditional rendering. The `createMediaButton` factory accepts an optional `isSupported` callback that defaults to `(state) => !state.hidden` for cast/fullscreen/PiP buttons.
+
+### Why separate `data-disabled` and `data-hidden`
+
+These serve different styling purposes:
+
+- `data-disabled` — reduced opacity, `cursor: not-allowed` (button is visible but non-interactive).
+- `data-hidden` — a styling hook for consumers; the HTML `hidden` attribute handles actual hiding.
+
+Both are driven by state fields (`disabled`, `hidden`) through the standard `applyStateDataAttrs` data attribute system.
+
+### Implementation notes
+
+- `getState()` derives `disabled = props.disabled || availability !== 'available'` and `hidden = availability === 'unsupported'`.
+- `getAttrs()` returns `aria-disabled` from `state.disabled` and the native `hidden` attribute from `state.hidden`.
+- `toggle()` short-circuits on `state.current.disabled`, then awaits the underlying media call directly. Errors propagate to the caller (`MediaButtonElement` and `createMediaButton` log them in `__DEV__` and re-throw) instead of being swallowed.
+
+## References
+
+- [WAI-ARIA APG Toolbar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) — recommends `aria-disabled` for toolbar buttons.
+- [WAI-ARIA APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) — "when the action associated with a button is unavailable, the button has `aria-disabled` set to `true`".
+- [Radix Primitives Accessibility](https://www.radix-ui.com/primitives/docs/overview/accessibility) — `aria-disabled` + `[data-disabled]` for custom elements.
+- [Base UI Accessibility](https://base-ui.com/react/handbook/styling) — `focusableWhenDisabled` prop, `[data-disabled]` attr.
+- [MDN: aria-disabled](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled).

--- a/internal/design/ui/disabled-hidden.md
+++ b/internal/design/ui/disabled-hidden.md
@@ -1,84 +1,20 @@
 ---
-status: decided
+status: implemented
 date: 2026-04-27
 ---
 
-# Disabled & Hidden States for Controls
+# Disabled and hidden controls
 
 ## Decision
 
-Use `aria-disabled` (never HTML `disabled`) for all toolbar buttons. Controls distinguish whether an action is available, should remain discoverable, or should be removed from the layout:
+Toolbar buttons use `aria-disabled`, not the HTML `disabled` attribute. This keeps visible disabled controls focusable and lets their tooltips explain why an action is unavailable.
 
-| State | Controls | ARIA | HTML (custom element) | React | Styling |
-|-------|----------|------|-----------------------|-------|---------|
-| **Unsupported** | Fullscreen, PiP, Cast, AirPlay | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
-| **Unavailable and not useful yet** | Fullscreen/PiP support unresolved; captions or AirPlay absent | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
-| **Unavailable but discoverable** | Cast API supported, no device reachable | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Default skin disabled styling |
-| **Disabled** (prop) | Available controls | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Default skin disabled styling |
-| **Available + enabled** | All controls | _(none)_ | _(none)_ | _(none)_ | Fully interactive |
+Controls that are not useful are removed instead: HTML custom elements receive the native `hidden` attribute and React components return `null`. `data-disabled` and `data-hidden` remain styling hooks, while `data-availability` exposes the raw `available`, `unavailable`, or `unsupported` state.
 
-`data-availability` remains as a string enum (`available`, `unavailable`, `unsupported`) for consumers that need the raw value.
-
-## Context
-
-Feature buttons (Fullscreen, PiP, Cast, AirPlay, Captions) need to communicate distinct states to users and assistive technology:
-
-1. **Unsupported** — the browser lacks the capability entirely (e.g., PiP on older Safari). Applies to Fullscreen, PiP, Cast, and AirPlay.
-2. **Unavailable** — the capability is not usable now. Its meaning depends on the feature: Fullscreen and PiP use it while support is unresolved, Captions uses it when no caption/subtitle tracks exist, Cast uses it when its API exists but no device is reachable, and AirPlay uses it when no target is available.
-3. **Disabled** — the developer explicitly disabled the control via a prop.
-
-Unsupported features and controls without meaningful content or resolved support are hidden entirely. Cast remains visible but non-interactive when its API is supported and no device is reachable, allowing tooltips to explain the missing target. Explicitly disabled, otherwise available buttons also remain visible and non-interactive. `disabled` in state covers both the prop and feature unavailability. We evaluated `disabled` vs `aria-disabled`, `hidden` vs `aria-hidden`, and how Radix, Base UI, and WAI-ARIA APG handle these patterns.
-
-## Alternatives Considered
-
-- **HTML `disabled` attribute** — Removes elements from the tab order entirely. This breaks the APG toolbar pattern, which requires all toolbar buttons to remain focusable via arrow keys. It also prevents tooltips and hover states from working on disabled buttons.
-
-- **Hybrid approach (like Base UI's `focusableWhenDisabled`)** — Adds a prop to toggle between `disabled` and `aria-disabled`. Unnecessary complexity for our use case since we always want buttons to remain focusable.
-
-- **CSS-only hiding (`display: none` via data attributes)** — Our prior approach used `[data-availability]:not([data-available])` to hide buttons. This works but lacks native semantics. The HTML `hidden` attribute provides the same effect with proper semantics and works without any CSS.
+Cast is the deliberate exception: an unsupported Cast button is hidden, but a supported button stays visible and disabled when no device is reachable.
 
 ## Rationale
 
-### Why `aria-disabled` over `disabled`
+The [WAI-ARIA toolbar pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) recommends `aria-disabled` so disabled controls remain discoverable during toolbar navigation. Native `hidden` provides semantic hiding without depending on a skin or consumer CSS.
 
-The WAI-ARIA APG toolbar pattern explicitly recommends `aria-disabled` for toolbar buttons:
-
-- **Keeps buttons in tab order** — keyboard users can discover disabled controls and understand what's available.
-- **Allows tooltips** — hover events still fire on `aria-disabled` elements, so tooltips can explain why a control is disabled.
-- **Consistent across custom elements** — HTML `disabled` only has native behavior on form controls (`<button>`, `<input>`), not custom elements.
-
-This aligns with both Radix (uses `aria-disabled` for custom interactive elements, `[data-disabled]` for styling) and Base UI (uses `aria-disabled` when `focusableWhenDisabled` is true, exposes `[data-disabled]`).
-
-### Why HTML `hidden` for controls that are not useful yet
-
-When a feature is unsupported, capability detection is unresolved, or a content-dependent control has no content, the button should not be visible. The HTML `hidden` attribute:
-
-- Works without CSS — no `display: none` rule needed.
-- Has native browser semantics.
-- Is set via `getAttrs()` alongside `aria-disabled`, keeping all attribute logic in one place.
-
-On the React side, the component returns `null` instead — the idiomatic React approach for conditional rendering. The `createMediaButton` factory accepts an optional `isSupported` callback; AirPlay, Cast, Captions, Fullscreen, and PiP each pass `(state) => !state.hidden`.
-
-### Why separate `data-disabled` and `data-hidden`
-
-These serve different purposes:
-
-- `data-disabled` — a hook for a non-interactive button. Default skins provide disabled styling when the button remains visible.
-- `data-hidden` — a styling hook for consumers; the HTML `hidden` attribute handles actual hiding.
-
-Both are driven by state fields (`disabled`, `hidden`) through the standard `applyStateDataAttrs` data attribute system.
-
-### Implementation notes
-
-- All affected controls derive `disabled = props.disabled || availability !== 'available'`.
-- Fullscreen, PiP, and AirPlay derive `hidden = availability !== 'available'`; Cast derives `hidden = availability === 'unsupported'`; Captions derives `hidden = availability === 'unavailable'`.
-- `getAttrs()` returns `aria-disabled` from `state.disabled` and the native `hidden` attribute from `state.hidden`.
-- `toggle()` short-circuits when the derived state is disabled, then invokes the underlying media call. Direct core callers generally receive any rejection; AirPlay continues to absorb user-cancelled request failures. `MediaButtonElement` and `createMediaButton` log rejected activations in `__DEV__` and absorb them at the UI event boundary to avoid unhandled promise rejections.
-
-## References
-
-- [WAI-ARIA APG Toolbar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) — recommends `aria-disabled` for toolbar buttons.
-- [WAI-ARIA APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) — "when the action associated with a button is unavailable, the button has `aria-disabled` set to `true`".
-- [Radix Primitives Accessibility](https://www.radix-ui.com/primitives/docs/overview/accessibility) — `aria-disabled` + `[data-disabled]` for custom elements.
-- [Base UI Accessibility](https://base-ui.com/react/handbook/styling) — `focusableWhenDisabled` prop, `[data-disabled]` attr.
-- [MDN: aria-disabled](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled).
+Implementation and tests in `packages/core/src/core/ui/*-button/` define the current per-control availability rules.

--- a/internal/design/ui/disabled-hidden.md
+++ b/internal/design/ui/disabled-hidden.md
@@ -7,26 +7,27 @@ date: 2026-04-27
 
 ## Decision
 
-Use `aria-disabled` (never HTML `disabled`) for all toolbar buttons. Three visual states driven by data attributes:
+Use `aria-disabled` (never HTML `disabled`) for all toolbar buttons. Controls distinguish whether an action is available, should remain discoverable, or should be removed from the layout:
 
-| State | ARIA | HTML (custom element) | React | Styling |
-|-------|------|-----------------------|-------|---------|
-| **Unsupported** | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
-| **Unavailable** (Cast only) | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Reduced opacity via `[data-disabled]` |
-| **Disabled** (prop) | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Reduced opacity via `[data-disabled]` |
-| **Available + enabled** | _(none)_ | _(none)_ | _(none)_ | Fully interactive |
+| State | Controls | ARIA | HTML (custom element) | React | Styling |
+|-------|----------|------|-----------------------|-------|---------|
+| **Unsupported** | Fullscreen, PiP, Cast | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
+| **Unavailable and not useful yet** | Fullscreen/PiP support unresolved; captions absent | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
+| **Unavailable but discoverable** | Cast API supported, no device reachable | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Default skin disabled styling |
+| **Disabled** (prop) | Available controls | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Default skin disabled styling |
+| **Available + enabled** | All controls | _(none)_ | _(none)_ | _(none)_ | Fully interactive |
 
 `data-availability` remains as a string enum (`available`, `unavailable`, `unsupported`) for consumers that need the raw value.
 
 ## Context
 
-Feature buttons (Fullscreen, PiP, Cast) need to communicate three distinct states to users and assistive technology:
+Feature buttons (Fullscreen, PiP, Cast, Captions) need to communicate distinct states to users and assistive technology:
 
 1. **Unsupported** — the browser lacks the capability entirely (e.g., PiP on older Safari). Applies to Fullscreen, PiP, and Cast.
-2. **Unavailable** — the API exists but no target is available (e.g., no cast device found). Only applies to Cast.
+2. **Unavailable** — the capability is not usable now. Its meaning depends on the feature: Fullscreen and PiP use it while support is unresolved, Captions uses it when no caption/subtitle tracks exist, and Cast uses it when its API exists but no device is reachable.
 3. **Disabled** — the developer explicitly disabled the control via a prop.
 
-Unsupported features are hidden entirely. Unavailable features (Cast only — no device found) and explicitly disabled buttons remain visible but non-interactive. `disabled` in state covers both the prop and feature unavailability. We evaluated `disabled` vs `aria-disabled`, `hidden` vs `aria-hidden`, and how Radix, Base UI, and WAI-ARIA APG handle these patterns.
+Unsupported features and controls without meaningful content or resolved support are hidden entirely. Cast remains visible but non-interactive when its API is supported and no device is reachable, allowing tooltips to explain the missing target. Explicitly disabled, otherwise available buttons also remain visible and non-interactive. `disabled` in state covers both the prop and feature unavailability. We evaluated `disabled` vs `aria-disabled`, `hidden` vs `aria-hidden`, and how Radix, Base UI, and WAI-ARIA APG handle these patterns.
 
 ## Alternatives Considered
 
@@ -48,30 +49,31 @@ The WAI-ARIA APG toolbar pattern explicitly recommends `aria-disabled` for toolb
 
 This aligns with both Radix (uses `aria-disabled` for custom interactive elements, `[data-disabled]` for styling) and Base UI (uses `aria-disabled` when `focusableWhenDisabled` is true, exposes `[data-disabled]`).
 
-### Why HTML `hidden` for unsupported features
+### Why HTML `hidden` for controls that are not useful yet
 
-When a feature is unsupported, the button should not be visible at all. The HTML `hidden` attribute:
+When a feature is unsupported, capability detection is unresolved, or a content-dependent control has no content, the button should not be visible. The HTML `hidden` attribute:
 
 - Works without CSS — no `display: none` rule needed.
 - Has native browser semantics.
 - Is set via `getAttrs()` alongside `aria-disabled`, keeping all attribute logic in one place.
 
-On the React side, the component returns `null` instead — the idiomatic React approach for conditional rendering. The `createMediaButton` factory accepts an optional `isSupported` callback that defaults to `(state) => !state.hidden` for cast/fullscreen/PiP buttons.
+On the React side, the component returns `null` instead — the idiomatic React approach for conditional rendering. The `createMediaButton` factory accepts an optional `isSupported` callback; Cast, Captions, Fullscreen, and PiP each pass `(state) => !state.hidden`.
 
 ### Why separate `data-disabled` and `data-hidden`
 
-These serve different styling purposes:
+These serve different purposes:
 
-- `data-disabled` — reduced opacity, `cursor: not-allowed` (button is visible but non-interactive).
+- `data-disabled` — a hook for a non-interactive button. Default skins provide disabled styling when the button remains visible.
 - `data-hidden` — a styling hook for consumers; the HTML `hidden` attribute handles actual hiding.
 
 Both are driven by state fields (`disabled`, `hidden`) through the standard `applyStateDataAttrs` data attribute system.
 
 ### Implementation notes
 
-- `getState()` derives `disabled = props.disabled || availability !== 'available'` and `hidden = availability === 'unsupported'`.
+- All affected controls derive `disabled = props.disabled || availability !== 'available'`.
+- Fullscreen and PiP derive `hidden = availability !== 'available'`; Cast derives `hidden = availability === 'unsupported'`; Captions derives `hidden = availability === 'unavailable'`.
 - `getAttrs()` returns `aria-disabled` from `state.disabled` and the native `hidden` attribute from `state.hidden`.
-- `toggle()` short-circuits on `state.current.disabled`, then awaits the underlying media call directly. Errors propagate to the caller (`MediaButtonElement` and `createMediaButton` log them in `__DEV__` and re-throw) instead of being swallowed.
+- `toggle()` short-circuits when the derived state is disabled, then invokes the underlying media call directly. Direct core callers receive any rejection. `MediaButtonElement` and `createMediaButton` log rejected activations in `__DEV__` and absorb them at the UI event boundary to avoid unhandled promise rejections.
 
 ## References
 

--- a/internal/design/ui/disabled-hidden.md
+++ b/internal/design/ui/disabled-hidden.md
@@ -11,8 +11,8 @@ Use `aria-disabled` (never HTML `disabled`) for all toolbar buttons. Controls di
 
 | State | Controls | ARIA | HTML (custom element) | React | Styling |
 |-------|----------|------|-----------------------|-------|---------|
-| **Unsupported** | Fullscreen, PiP, Cast | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
-| **Unavailable and not useful yet** | Fullscreen/PiP support unresolved; captions absent | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
+| **Unsupported** | Fullscreen, PiP, Cast, AirPlay | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
+| **Unavailable and not useful yet** | Fullscreen/PiP support unresolved; captions or AirPlay absent | `aria-disabled="true"` | `hidden` + `data-hidden` + `data-disabled` | returns `null` | Browser hides natively |
 | **Unavailable but discoverable** | Cast API supported, no device reachable | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Default skin disabled styling |
 | **Disabled** (prop) | Available controls | `aria-disabled="true"` | `data-disabled` | `data-disabled` on `<button>` | Default skin disabled styling |
 | **Available + enabled** | All controls | _(none)_ | _(none)_ | _(none)_ | Fully interactive |
@@ -21,10 +21,10 @@ Use `aria-disabled` (never HTML `disabled`) for all toolbar buttons. Controls di
 
 ## Context
 
-Feature buttons (Fullscreen, PiP, Cast, Captions) need to communicate distinct states to users and assistive technology:
+Feature buttons (Fullscreen, PiP, Cast, AirPlay, Captions) need to communicate distinct states to users and assistive technology:
 
-1. **Unsupported** — the browser lacks the capability entirely (e.g., PiP on older Safari). Applies to Fullscreen, PiP, and Cast.
-2. **Unavailable** — the capability is not usable now. Its meaning depends on the feature: Fullscreen and PiP use it while support is unresolved, Captions uses it when no caption/subtitle tracks exist, and Cast uses it when its API exists but no device is reachable.
+1. **Unsupported** — the browser lacks the capability entirely (e.g., PiP on older Safari). Applies to Fullscreen, PiP, Cast, and AirPlay.
+2. **Unavailable** — the capability is not usable now. Its meaning depends on the feature: Fullscreen and PiP use it while support is unresolved, Captions uses it when no caption/subtitle tracks exist, Cast uses it when its API exists but no device is reachable, and AirPlay uses it when no target is available.
 3. **Disabled** — the developer explicitly disabled the control via a prop.
 
 Unsupported features and controls without meaningful content or resolved support are hidden entirely. Cast remains visible but non-interactive when its API is supported and no device is reachable, allowing tooltips to explain the missing target. Explicitly disabled, otherwise available buttons also remain visible and non-interactive. `disabled` in state covers both the prop and feature unavailability. We evaluated `disabled` vs `aria-disabled`, `hidden` vs `aria-hidden`, and how Radix, Base UI, and WAI-ARIA APG handle these patterns.
@@ -57,7 +57,7 @@ When a feature is unsupported, capability detection is unresolved, or a content-
 - Has native browser semantics.
 - Is set via `getAttrs()` alongside `aria-disabled`, keeping all attribute logic in one place.
 
-On the React side, the component returns `null` instead — the idiomatic React approach for conditional rendering. The `createMediaButton` factory accepts an optional `isSupported` callback; Cast, Captions, Fullscreen, and PiP each pass `(state) => !state.hidden`.
+On the React side, the component returns `null` instead — the idiomatic React approach for conditional rendering. The `createMediaButton` factory accepts an optional `isSupported` callback; AirPlay, Cast, Captions, Fullscreen, and PiP each pass `(state) => !state.hidden`.
 
 ### Why separate `data-disabled` and `data-hidden`
 
@@ -71,9 +71,9 @@ Both are driven by state fields (`disabled`, `hidden`) through the standard `app
 ### Implementation notes
 
 - All affected controls derive `disabled = props.disabled || availability !== 'available'`.
-- Fullscreen and PiP derive `hidden = availability !== 'available'`; Cast derives `hidden = availability === 'unsupported'`; Captions derives `hidden = availability === 'unavailable'`.
+- Fullscreen, PiP, and AirPlay derive `hidden = availability !== 'available'`; Cast derives `hidden = availability === 'unsupported'`; Captions derives `hidden = availability === 'unavailable'`.
 - `getAttrs()` returns `aria-disabled` from `state.disabled` and the native `hidden` attribute from `state.hidden`.
-- `toggle()` short-circuits when the derived state is disabled, then invokes the underlying media call directly. Direct core callers receive any rejection. `MediaButtonElement` and `createMediaButton` log rejected activations in `__DEV__` and absorb them at the UI event boundary to avoid unhandled promise rejections.
+- `toggle()` short-circuits when the derived state is disabled, then invokes the underlying media call. Direct core callers generally receive any rejection; AirPlay continues to absorb user-cancelled request failures. `MediaButtonElement` and `createMediaButton` log rejected activations in `__DEV__` and absorb them at the UI event boundary to avoid unhandled promise rejections.
 
 ## References
 

--- a/packages/core/src/core/ui/airplay-button/airplay-button-core.ts
+++ b/packages/core/src/core/ui/airplay-button/airplay-button-core.ts
@@ -21,7 +21,12 @@ export interface AirPlayButtonState extends ButtonState {
   state: RemotePlaybackConnectionState;
   /** Whether AirPlay is available on the active platform and media. */
   availability: MediaFeatureAvailability;
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout until AirPlay is available. */
+  hidden: boolean;
 }
+
 export class AirPlayButtonCore {
   static readonly defaultProps: NonNullableObject<AirPlayButtonProps> = {
     label: '',
@@ -31,6 +36,8 @@ export class AirPlayButtonCore {
   readonly state = createState<AirPlayButtonState>({
     state: 'disconnected',
     availability: 'unsupported',
+    disabled: true,
+    hidden: true,
     label: '',
   });
 
@@ -57,7 +64,8 @@ export class AirPlayButtonCore {
   getAttrs(state: AirPlayButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -70,22 +78,26 @@ export class AirPlayButtonCore {
     // WebKit (Safari macOS/iOS) is the only platform that surfaces AirPlay.
     // Mirrors the Chromium gate on CastButtonCore so each button only shows
     // on its supported platform.
-    const isAirPlaySupported = supportsWebKitAirPlay();
+    const airPlaySupported = supportsWebKitAirPlay();
+    const availability = airPlaySupported ? media.remotePlaybackAvailability : 'unsupported';
 
     this.state.patch({
       state: media.remotePlaybackState,
-      availability: isAirPlaySupported ? media.remotePlaybackAvailability : 'unsupported',
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability !== 'available',
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 
     return this.state.current;
   }
 
-  async toggle(state: MediaRemotePlaybackState): Promise<void> {
-    if (this.#props.disabled) return;
+  async toggle(media: MediaRemotePlaybackState): Promise<void> {
+    this.setMedia(media);
+    if (this.getState().disabled) return;
 
     try {
-      await state.toggleRemotePlayback();
+      await media.toggleRemotePlayback();
     } catch {
       // AirPlay requests can fail (user cancelled, permissions, etc.)
     }

--- a/packages/core/src/core/ui/airplay-button/airplay-button-core.ts
+++ b/packages/core/src/core/ui/airplay-button/airplay-button-core.ts
@@ -23,7 +23,7 @@ export interface AirPlayButtonState extends ButtonState {
   availability: MediaFeatureAvailability;
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout until AirPlay is available. */
+  /** Whether the button is hidden until AirPlay is available. */
   hidden: boolean;
 }
 

--- a/packages/core/src/core/ui/airplay-button/airplay-button-data-attrs.ts
+++ b/packages/core/src/core/ui/airplay-button/airplay-button-data-attrs.ts
@@ -14,4 +14,8 @@ export const AirPlayButtonDataAttrs = {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback
    */
   availability: 'data-availability',
+  /** Present when the button is non-interactive (mirrors `aria-disabled`). */
+  disabled: 'data-disabled',
+  /** Present when the button is hidden because AirPlay is unavailable. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<AirPlayButtonState>;

--- a/packages/core/src/core/ui/airplay-button/tests/airplay-button-core.test.ts
+++ b/packages/core/src/core/ui/airplay-button/tests/airplay-button-core.test.ts
@@ -28,6 +28,8 @@ function createState(overrides: Partial<AirPlayButtonState> = {}): AirPlayButton
   return {
     state: 'disconnected',
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -46,14 +48,27 @@ describe('AirPlayButtonCore', () => {
 
       expect(result.state).toBe('connected');
       expect(result.availability).toBe('available');
+      expect(result.disabled).toBe(false);
+      expect(result.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled and hidden when unavailable', () => {
+      const core = new AirPlayButtonCore();
+      core.setMedia(createMediaState({ remotePlaybackAvailability: 'unavailable' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled and hidden when unsupported', () => {
       const core = new AirPlayButtonCore();
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
     });
 
     it('reflects connecting state', () => {
@@ -71,6 +86,17 @@ describe('AirPlayButtonCore', () => {
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set, even if available', () => {
+      const core = new AirPlayButtonCore({ disabled: true });
+      core.setMedia(createMediaState({ remotePlaybackAvailability: 'available' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -120,9 +146,15 @@ describe('AirPlayButtonCore', () => {
     });
 
     it('sets aria-disabled when disabled', () => {
-      const core = new AirPlayButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+      const core = new AirPlayButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when hidden', () => {
+      const core = new AirPlayButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
@@ -148,11 +180,18 @@ describe('AirPlayButtonCore', () => {
       expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
     });
 
-    it('toggles regardless of availability (the button is hidden when unavailable)', async () => {
+    it('does nothing when unavailable', async () => {
+      const core = new AirPlayButtonCore();
+      const media = createMediaState({ remotePlaybackAvailability: 'unavailable' });
+      await core.toggle(media);
+      expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when unsupported', async () => {
       const core = new AirPlayButtonCore();
       const media = createMediaState({ remotePlaybackAvailability: 'unsupported' });
       await core.toggle(media);
-      expect(media.toggleRemotePlayback).toHaveBeenCalled();
+      expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
     });
 
     it('catches AirPlay errors silently', async () => {

--- a/packages/core/src/core/ui/captions-button/captions-button-core.ts
+++ b/packages/core/src/core/ui/captions-button/captions-button-core.ts
@@ -14,7 +14,12 @@ export interface CaptionsButtonProps {
 }
 
 export interface CaptionsButtonState extends Pick<MediaTextTrackState, 'subtitlesShowing'>, ButtonState {
+  /** Whether caption/subtitle tracks are present. */
   availability: 'available' | 'unavailable';
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because no caption tracks are present. */
+  hidden: boolean;
 }
 
 export class CaptionsButtonCore {
@@ -26,6 +31,11 @@ export class CaptionsButtonCore {
   readonly state = createState<CaptionsButtonState>({
     subtitlesShowing: false,
     availability: 'unavailable',
+    // Hidden by default until tracks are reported; matches the derivation
+    // invariants (`disabled = props.disabled || availability !== 'available'`,
+    // `hidden = availability === 'unavailable'`).
+    disabled: true,
+    hidden: true,
     label: '',
   });
 
@@ -56,7 +66,8 @@ export class CaptionsButtonCore {
   getAttrs(state: CaptionsButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -72,14 +83,20 @@ export class CaptionsButtonCore {
       ? 'available'
       : 'unavailable';
 
-    this.state.patch({ subtitlesShowing: media.subtitlesShowing, availability });
+    this.state.patch({
+      subtitlesShowing: media.subtitlesShowing,
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unavailable',
+    });
     this.state.patch({ label: this.getLabel(this.state.current) });
 
     return this.state.current;
   }
 
   toggle(media: MediaTextTrackState): void {
-    if (this.#props.disabled) return;
+    this.setMedia(media);
+    if (this.getState().disabled) return;
     media.toggleSubtitles();
   }
 }

--- a/packages/core/src/core/ui/captions-button/captions-button-core.ts
+++ b/packages/core/src/core/ui/captions-button/captions-button-core.ts
@@ -22,7 +22,7 @@ export interface CaptionsButtonState extends Pick<MediaTextTrackState, 'subtitle
   availability: 'available' | 'unavailable';
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout because no caption tracks are present. */
+  /** Whether the button is hidden because no caption tracks are present. */
   hidden: boolean;
 }
 

--- a/packages/core/src/core/ui/captions-button/captions-button-core.ts
+++ b/packages/core/src/core/ui/captions-button/captions-button-core.ts
@@ -18,7 +18,12 @@ export interface CaptionsButtonProps {
 }
 
 export interface CaptionsButtonState extends Pick<MediaTextTrackState, 'subtitlesShowing'>, ButtonState {
+  /** Whether caption/subtitle tracks are present. */
   availability: 'available' | 'unavailable';
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because no caption tracks are present. */
+  hidden: boolean;
 }
 
 export class CaptionsButtonCore {
@@ -31,6 +36,11 @@ export class CaptionsButtonCore {
   readonly state = createState<CaptionsButtonState>({
     subtitlesShowing: false,
     availability: 'unavailable',
+    // Hidden by default until tracks are reported; matches the derivation
+    // invariants (`disabled = props.disabled || availability !== 'available'`,
+    // `hidden = availability === 'unavailable'`).
+    disabled: true,
+    hidden: true,
     label: '',
   });
 
@@ -55,7 +65,8 @@ export class CaptionsButtonCore {
   getAttrs(state: CaptionsButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -69,14 +80,20 @@ export class CaptionsButtonCore {
       ? 'available'
       : 'unavailable';
 
-    this.state.patch({ subtitlesShowing: media.subtitlesShowing, availability });
+    this.state.patch({
+      subtitlesShowing: media.subtitlesShowing,
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unavailable',
+    });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 
     return this.state.current;
   }
 
   toggle(media: MediaTextTrackState): void {
-    if (this.#props.disabled) return;
+    this.setMedia(media);
+    if (this.getState().disabled) return;
     if (this.#props.menuTrigger && getCaptionTrackCount(media) > 1) return;
     media.toggleSubtitles();
   }

--- a/packages/core/src/core/ui/captions-button/captions-button-data-attrs.ts
+++ b/packages/core/src/core/ui/captions-button/captions-button-data-attrs.ts
@@ -6,4 +6,8 @@ export const CaptionsButtonDataAttrs = {
   subtitlesShowing: 'data-active',
   /** Indicates captions availability (`available` or `unavailable`). */
   availability: 'data-availability',
+  /** Present when the button is non-interactive (mirrors `aria-disabled`). */
+  disabled: 'data-disabled',
+  /** Present when the button is hidden because no caption tracks are present. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<CaptionsButtonState>;

--- a/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
+++ b/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
@@ -20,6 +20,8 @@ function createState(overrides: Partial<CaptionsButtonState> = {}): CaptionsButt
   return {
     subtitlesShowing: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -49,17 +51,36 @@ describe('CaptionsButtonCore', () => {
           ],
         })
       );
+      const state = core.getState();
 
-      expect(core.getState().availability).toBe('available');
+      expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('returns unavailable when no subtitles', () => {
+    it('marks disabled and hidden when no caption tracks are present', () => {
       const core = new CaptionsButtonCore();
       core.setMedia(
         createMediaState({ textTrackList: [{ kind: 'metadata', label: 'thumbnails', language: '', mode: 'hidden' }] })
       );
+      const state = core.getState();
 
-      expect(core.getState().availability).toBe('unavailable');
+      expect(state.availability).toBe('unavailable');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set', () => {
+      const core = new CaptionsButtonCore({ disabled: true });
+      core.setMedia(
+        createMediaState({
+          textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+        })
+      );
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -94,24 +115,41 @@ describe('CaptionsButtonCore', () => {
       expect(attrs['aria-label']).toBe('Enable captions');
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new CaptionsButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new CaptionsButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new CaptionsButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
   describe('toggle', () => {
-    it('calls toggleSubtitles when available', () => {
+    it('calls toggleSubtitles when caption tracks are present', () => {
       const core = new CaptionsButtonCore();
-      const media = createMediaState();
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+      });
       core.toggle(media);
       expect(media.toggleSubtitles).toHaveBeenCalled();
     });
 
-    it('does nothing when disabled', () => {
-      const core = new CaptionsButtonCore({ disabled: true });
+    it('does nothing when no caption tracks are present', () => {
+      const core = new CaptionsButtonCore();
       const media = createMediaState();
+      core.toggle(media);
+      expect(media.toggleSubtitles).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the disabled prop is set', () => {
+      const core = new CaptionsButtonCore({ disabled: true });
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+      });
       core.toggle(media);
       expect(media.toggleSubtitles).not.toHaveBeenCalled();
     });

--- a/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
+++ b/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
@@ -20,6 +20,8 @@ function createState(overrides: Partial<CaptionsButtonState> = {}): CaptionsButt
   return {
     subtitlesShowing: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -49,19 +51,38 @@ describe('CaptionsButtonCore', () => {
           ],
         })
       );
+      const state = core.getState();
 
-      expect(core.getState().availability).toBe('available');
+      expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('returns unavailable when no subtitles', () => {
+    it('marks disabled and hidden when no caption tracks are present', () => {
       const core = new CaptionsButtonCore();
       core.setMedia(
         createMediaState({
           textTrackList: [{ kind: 'metadata', label: 'thumbnails', language: '', mode: 'hidden' }],
         })
       );
+      const state = core.getState();
 
-      expect(core.getState().availability).toBe('unavailable');
+      expect(state.availability).toBe('unavailable');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set', () => {
+      const core = new CaptionsButtonCore({ disabled: true });
+      core.setMedia(
+        createMediaState({
+          textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+        })
+      );
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -102,23 +123,31 @@ describe('CaptionsButtonCore', () => {
       expect(attrs['aria-label']).toMatchObject({ key: 'captions.enable', text: 'Enable captions' });
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new CaptionsButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new CaptionsButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new CaptionsButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
   describe('toggle', () => {
-    it('calls toggleSubtitles when available', () => {
+    it('calls toggleSubtitles when caption tracks are present', () => {
       const core = new CaptionsButtonCore();
-      const media = createMediaState();
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+      });
       core.toggle(media);
       expect(media.toggleSubtitles).toHaveBeenCalled();
     });
 
-    it('does nothing when disabled', () => {
-      const core = new CaptionsButtonCore({ disabled: true });
+    it('does nothing when no caption tracks are present', () => {
+      const core = new CaptionsButtonCore();
       const media = createMediaState();
       core.toggle(media);
       expect(media.toggleSubtitles).not.toHaveBeenCalled();
@@ -131,6 +160,15 @@ describe('CaptionsButtonCore', () => {
           { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' },
           { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
         ],
+      });
+      core.toggle(media);
+      expect(media.toggleSubtitles).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the disabled prop is set', () => {
+      const core = new CaptionsButtonCore({ disabled: true });
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
       });
       core.toggle(media);
       expect(media.toggleSubtitles).not.toHaveBeenCalled();

--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -34,7 +34,9 @@ export class CastButtonCore {
   readonly state = createState<CastButtonState>({
     castState: 'disconnected',
     availability: 'unavailable',
-    disabled: false,
+    // No cast device available yet — derived `disabled` matches the invariant
+    // `disabled = props.disabled || availability !== 'available'`.
+    disabled: true,
     hidden: false,
     label: '',
   });

--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -15,7 +15,9 @@ export interface CastButtonProps {
 }
 
 export interface CastButtonState extends ButtonState {
+  /** Current cast connection state (`disconnected`, `connecting`, or `connected`). */
   castState: RemotePlaybackConnectionState;
+  /** Whether casting is `available` (a device is reachable), `unavailable` (no device), or `unsupported`. */
   availability: MediaFeatureAvailability;
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;

--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -17,6 +17,10 @@ export interface CastButtonProps {
 export interface CastButtonState extends ButtonState {
   castState: RemotePlaybackConnectionState;
   availability: MediaFeatureAvailability;
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because the feature is unsupported. */
+  hidden: boolean;
 }
 
 export class CastButtonCore {
@@ -28,6 +32,8 @@ export class CastButtonCore {
   readonly state = createState<CastButtonState>({
     castState: 'disconnected',
     availability: 'unavailable',
+    disabled: false,
+    hidden: false,
     label: '',
   });
 
@@ -60,7 +66,8 @@ export class CastButtonCore {
   getAttrs(state: CastButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -70,11 +77,13 @@ export class CastButtonCore {
 
   getState(): CastButtonState {
     const media = this.#media!;
-    const castSupported = !!(globalThis as any).chrome;
+    const availability = media.remotePlaybackAvailability;
 
     this.state.patch({
       castState: media.remotePlaybackState,
-      availability: castSupported ? media.remotePlaybackAvailability : 'unsupported',
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unsupported',
     });
     this.state.patch({ label: this.getLabel(this.state.current) });
 
@@ -82,14 +91,9 @@ export class CastButtonCore {
   }
 
   async toggle(media: MediaRemotePlaybackState): Promise<void> {
-    if (this.#props.disabled) return;
-    if (media.remotePlaybackAvailability !== 'available') return;
-
-    try {
-      await media.toggleRemotePlayback();
-    } catch {
-      // Cast requests can fail (user cancelled, permissions, etc.)
-    }
+    this.setMedia(media);
+    if (this.getState().disabled) return;
+    return media.toggleRemotePlayback();
   }
 }
 

--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -21,7 +21,7 @@ export interface CastButtonState extends ButtonState {
   availability: MediaFeatureAvailability;
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout because the feature is unsupported. */
+  /** Whether the button is hidden because the feature is unsupported. */
   hidden: boolean;
 }
 

--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -17,6 +17,10 @@ export interface CastButtonProps {
 export interface CastButtonState extends ButtonState {
   castState: RemotePlaybackConnectionState;
   availability: MediaFeatureAvailability;
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because the feature is unsupported. */
+  hidden: boolean;
 }
 
 export class CastButtonCore {
@@ -28,6 +32,8 @@ export class CastButtonCore {
   readonly state = createState<CastButtonState>({
     castState: 'disconnected',
     availability: 'unsupported',
+    disabled: true,
+    hidden: true,
     label: '',
   });
 
@@ -54,7 +60,8 @@ export class CastButtonCore {
   getAttrs(state: CastButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -65,10 +72,13 @@ export class CastButtonCore {
   getState(): CastButtonState {
     const media = this.#media!;
     const castSupported = !!(globalThis as any).chrome;
+    const availability = castSupported ? media.remotePlaybackAvailability : 'unsupported';
 
     this.state.patch({
       castState: media.remotePlaybackState,
-      availability: castSupported ? media.remotePlaybackAvailability : 'unsupported',
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unsupported',
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 
@@ -76,14 +86,9 @@ export class CastButtonCore {
   }
 
   async toggle(media: MediaRemotePlaybackState): Promise<void> {
-    if (this.#props.disabled) return;
-    if (media.remotePlaybackAvailability !== 'available') return;
-
-    try {
-      await media.toggleRemotePlayback();
-    } catch {
-      // Cast requests can fail (user cancelled, permissions, etc.)
-    }
+    this.setMedia(media);
+    if (this.getState().disabled) return;
+    return media.toggleRemotePlayback();
   }
 }
 

--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -16,7 +16,7 @@ export interface CastButtonProps {
 
 export interface CastButtonState extends ButtonState {
   /** Current cast connection state (`disconnected`, `connecting`, or `connected`). */
-  castState: RemotePlaybackConnectionState;
+  connection: RemotePlaybackConnectionState;
   /** Whether casting is `available` (a device is reachable), `unavailable` (no device), or `unsupported`. */
   availability: MediaFeatureAvailability;
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
@@ -32,7 +32,7 @@ export class CastButtonCore {
   };
 
   readonly state = createState<CastButtonState>({
-    castState: 'disconnected',
+    connection: 'disconnected',
     availability: 'unsupported',
     disabled: true,
     hidden: true,
@@ -54,8 +54,8 @@ export class CastButtonCore {
     const label = resolveLabel(this.#props.label, state);
     if (label) return label;
 
-    if (state.castState === 'connected') return stopText;
-    if (state.castState === 'connecting') return connectingText;
+    if (state.connection === 'connected') return stopText;
+    if (state.connection === 'connecting') return connectingText;
     return startText;
   }
 
@@ -77,7 +77,7 @@ export class CastButtonCore {
     const availability = castSupported ? media.remotePlaybackAvailability : 'unsupported';
 
     this.state.patch({
-      castState: media.remotePlaybackState,
+      connection: media.remotePlaybackState,
       availability,
       disabled: this.#props.disabled || availability !== 'available',
       hidden: availability === 'unsupported',

--- a/packages/core/src/core/ui/cast-button/cast-button-data-attrs.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-data-attrs.ts
@@ -2,6 +2,12 @@ import type { StateAttrMap } from '../types';
 import type { CastButtonState } from './cast-button-core';
 
 export const CastButtonDataAttrs = {
+  /** Indicates the current cast connection (`disconnected`, `connecting`, `connected`). */
   castState: 'data-cast-state',
+  /** Indicates cast availability (`available`, `unavailable`, `unsupported`). */
   availability: 'data-availability',
+  /** Present when the button is non-interactive (mirrors `aria-disabled`). */
+  disabled: 'data-disabled',
+  /** Present when the button is hidden because the feature is unsupported. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<CastButtonState>;

--- a/packages/core/src/core/ui/cast-button/cast-button-data-attrs.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-data-attrs.ts
@@ -14,4 +14,8 @@ export const CastButtonDataAttrs = {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback
    */
   availability: 'data-availability',
+  /** Present when the button is non-interactive (mirrors `aria-disabled`). */
+  disabled: 'data-disabled',
+  /** Present when the button is hidden because the feature is unsupported. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<CastButtonState>;

--- a/packages/core/src/core/ui/cast-button/cast-button-data-attrs.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-data-attrs.ts
@@ -7,7 +7,7 @@ export const CastButtonDataAttrs = {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/RemotePlayback/state
    */
-  castState: 'data-cast-state',
+  connection: 'data-cast-state',
   /**
    * Whether remote playback can be requested on this platform.
    *

--- a/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
+++ b/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
@@ -1,20 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { MediaRemotePlaybackState } from '../../../media/state';
 import type { CastButtonState } from '../cast-button-core';
 import { CastButtonCore } from '../cast-button-core';
-
-// CastButtonCore reports `availability: 'unsupported'` outside Chromium
-// (detected via `globalThis.chrome`). Tests run in jsdom which lacks that
-// global, so stub it for every test and let individual tests override.
-function stubChrome(present: boolean) {
-  const key = 'chrome';
-  if (present) {
-    (globalThis as unknown as Record<string, unknown>)[key] = {};
-  } else {
-    delete (globalThis as unknown as Record<string, unknown>)[key];
-  }
-}
 
 function createMediaState(overrides: Partial<MediaRemotePlaybackState> = {}): MediaRemotePlaybackState {
   return {
@@ -29,15 +17,14 @@ function createState(overrides: Partial<CastButtonState> = {}): CastButtonState 
   return {
     castState: 'disconnected',
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
 }
 
 describe('CastButtonCore', () => {
-  beforeEach(() => stubChrome(true));
-  afterEach(() => stubChrome(false));
-
   describe('getState', () => {
     it('projects castState and availability', () => {
       const core = new CastButtonCore();
@@ -47,31 +34,36 @@ describe('CastButtonCore', () => {
 
       expect(state.castState).toBe('connected');
       expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled when no cast device is available', () => {
+      const core = new CastButtonCore();
+      core.setMedia(createMediaState({ remotePlaybackAvailability: 'unavailable' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
+    });
+
+    it('marks disabled and hidden when unsupported', () => {
       const core = new CastButtonCore();
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
     });
 
-    it('reflects connecting state', () => {
-      const core = new CastButtonCore();
-      core.setMedia(createMediaState({ remotePlaybackState: 'connecting' }));
-      const state = core.getState();
-
-      expect(state.castState).toBe('connecting');
-    });
-
-    it('reports unsupported outside Chromium', () => {
-      stubChrome(false);
-      const core = new CastButtonCore();
+    it('marks disabled when the disabled prop is set, even if available', () => {
+      const core = new CastButtonCore({ disabled: true });
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'available' }));
       const state = core.getState();
 
-      expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -111,31 +103,37 @@ describe('CastButtonCore', () => {
       expect(attrs['aria-label']).toBe('Start casting');
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new CastButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new CastButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new CastButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
   describe('toggle', () => {
-    it('calls toggleRemotePlayback when disconnected', async () => {
+    it('calls toggleRemotePlayback when available', async () => {
       const core = new CastButtonCore();
       const media = createMediaState({ remotePlaybackState: 'disconnected' });
       await core.toggle(media);
       expect(media.toggleRemotePlayback).toHaveBeenCalled();
     });
 
-    it('calls toggleRemotePlayback when connected', async () => {
-      const core = new CastButtonCore();
-      const media = createMediaState({ remotePlaybackState: 'connected' });
-      await core.toggle(media);
-      expect(media.toggleRemotePlayback).toHaveBeenCalled();
-    });
-
-    it('does nothing when disabled', async () => {
+    it('does nothing when the disabled prop is set', async () => {
       const core = new CastButtonCore({ disabled: true });
       const media = createMediaState();
+      await core.toggle(media);
+      expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no cast device is available', async () => {
+      const core = new CastButtonCore();
+      const media = createMediaState({ remotePlaybackAvailability: 'unavailable' });
       await core.toggle(media);
       expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
     });
@@ -147,14 +145,14 @@ describe('CastButtonCore', () => {
       expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
     });
 
-    it('catches cast errors silently', async () => {
+    it('propagates errors from toggleRemotePlayback', async () => {
       const core = new CastButtonCore();
       const media = createMediaState({
         toggleRemotePlayback: vi.fn(async () => {
           throw new Error('user cancelled');
         }),
       });
-      await expect(core.toggle(media)).resolves.toBeUndefined();
+      await expect(core.toggle(media)).rejects.toThrow('user cancelled');
     });
   });
 });

--- a/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
+++ b/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
@@ -1,19 +1,7 @@
 import type { MediaRemotePlaybackState } from '@videojs/media';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { CastButtonState } from '../cast-button-core';
 import { CastButtonCore } from '../cast-button-core';
-
-// CastButtonCore reports `availability: 'unsupported'` outside Chromium
-// (detected via `globalThis.chrome`). Tests run in jsdom which lacks that
-// global, so stub it for every test and let individual tests override.
-function stubChrome(present: boolean) {
-  const key = 'chrome';
-  if (present) {
-    (globalThis as unknown as Record<string, unknown>)[key] = {};
-  } else {
-    delete (globalThis as unknown as Record<string, unknown>)[key];
-  }
-}
 
 function createMediaState(overrides: Partial<MediaRemotePlaybackState> = {}): MediaRemotePlaybackState {
   return {
@@ -28,15 +16,14 @@ function createState(overrides: Partial<CastButtonState> = {}): CastButtonState 
   return {
     castState: 'disconnected',
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
 }
 
 describe('CastButtonCore', () => {
-  beforeEach(() => stubChrome(true));
-  afterEach(() => stubChrome(false));
-
   describe('getState', () => {
     it('projects castState and availability', () => {
       const core = new CastButtonCore();
@@ -46,31 +33,36 @@ describe('CastButtonCore', () => {
 
       expect(state.castState).toBe('connected');
       expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled when no cast device is available', () => {
+      const core = new CastButtonCore();
+      core.setMedia(createMediaState({ remotePlaybackAvailability: 'unavailable' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
+    });
+
+    it('marks disabled and hidden when unsupported', () => {
       const core = new CastButtonCore();
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
     });
 
-    it('reflects connecting state', () => {
-      const core = new CastButtonCore();
-      core.setMedia(createMediaState({ remotePlaybackState: 'connecting' }));
-      const state = core.getState();
-
-      expect(state.castState).toBe('connecting');
-    });
-
-    it('reports unsupported outside Chromium', () => {
-      stubChrome(false);
-      const core = new CastButtonCore();
+    it('marks disabled when the disabled prop is set, even if available', () => {
+      const core = new CastButtonCore({ disabled: true });
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'available' }));
       const state = core.getState();
 
-      expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -119,31 +111,37 @@ describe('CastButtonCore', () => {
       expect(attrs['aria-label']).toMatchObject({ key: 'cast.start', text: 'Start casting' });
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new CastButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new CastButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new CastButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
   describe('toggle', () => {
-    it('calls toggleRemotePlayback when disconnected', async () => {
+    it('calls toggleRemotePlayback when available', async () => {
       const core = new CastButtonCore();
       const media = createMediaState({ remotePlaybackState: 'disconnected' });
       await core.toggle(media);
       expect(media.toggleRemotePlayback).toHaveBeenCalled();
     });
 
-    it('calls toggleRemotePlayback when connected', async () => {
-      const core = new CastButtonCore();
-      const media = createMediaState({ remotePlaybackState: 'connected' });
-      await core.toggle(media);
-      expect(media.toggleRemotePlayback).toHaveBeenCalled();
-    });
-
-    it('does nothing when disabled', async () => {
+    it('does nothing when the disabled prop is set', async () => {
       const core = new CastButtonCore({ disabled: true });
       const media = createMediaState();
+      await core.toggle(media);
+      expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no cast device is available', async () => {
+      const core = new CastButtonCore();
+      const media = createMediaState({ remotePlaybackAvailability: 'unavailable' });
       await core.toggle(media);
       expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
     });
@@ -155,14 +153,14 @@ describe('CastButtonCore', () => {
       expect(media.toggleRemotePlayback).not.toHaveBeenCalled();
     });
 
-    it('catches cast errors silently', async () => {
+    it('propagates errors from toggleRemotePlayback', async () => {
       const core = new CastButtonCore();
       const media = createMediaState({
         toggleRemotePlayback: vi.fn(async () => {
           throw new Error('user cancelled');
         }),
       });
-      await expect(core.toggle(media)).resolves.toBeUndefined();
+      await expect(core.toggle(media)).rejects.toThrow('user cancelled');
     });
   });
 });

--- a/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
+++ b/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
@@ -1,5 +1,5 @@
 import type { MediaRemotePlaybackState } from '@videojs/media';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CastButtonState } from '../cast-button-core';
 import { CastButtonCore } from '../cast-button-core';
 
@@ -23,9 +23,18 @@ function createState(overrides: Partial<CastButtonState> = {}): CastButtonState 
   };
 }
 
+function stubCastSupport(): void {
+  vi.stubGlobal('chrome', {});
+}
+
 describe('CastButtonCore', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('getState', () => {
     it('projects castState and availability', () => {
+      stubCastSupport();
       const core = new CastButtonCore();
       const media = createMediaState({ remotePlaybackState: 'connected' });
       core.setMedia(media);
@@ -38,6 +47,7 @@ describe('CastButtonCore', () => {
     });
 
     it('marks disabled when no cast device is available', () => {
+      stubCastSupport();
       const core = new CastButtonCore();
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'unavailable' }));
       const state = core.getState();
@@ -57,6 +67,7 @@ describe('CastButtonCore', () => {
     });
 
     it('marks disabled when the disabled prop is set, even if available', () => {
+      stubCastSupport();
       const core = new CastButtonCore({ disabled: true });
       core.setMedia(createMediaState({ remotePlaybackAvailability: 'available' }));
       const state = core.getState();
@@ -126,6 +137,7 @@ describe('CastButtonCore', () => {
 
   describe('toggle', () => {
     it('calls toggleRemotePlayback when available', async () => {
+      stubCastSupport();
       const core = new CastButtonCore();
       const media = createMediaState({ remotePlaybackState: 'disconnected' });
       await core.toggle(media);
@@ -140,6 +152,7 @@ describe('CastButtonCore', () => {
     });
 
     it('does nothing when no cast device is available', async () => {
+      stubCastSupport();
       const core = new CastButtonCore();
       const media = createMediaState({ remotePlaybackAvailability: 'unavailable' });
       await core.toggle(media);
@@ -154,6 +167,7 @@ describe('CastButtonCore', () => {
     });
 
     it('propagates errors from toggleRemotePlayback', async () => {
+      stubCastSupport();
       const core = new CastButtonCore();
       const media = createMediaState({
         toggleRemotePlayback: vi.fn(async () => {

--- a/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
+++ b/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
@@ -14,7 +14,7 @@ function createMediaState(overrides: Partial<MediaRemotePlaybackState> = {}): Me
 
 function createState(overrides: Partial<CastButtonState> = {}): CastButtonState {
   return {
-    castState: 'disconnected',
+    connection: 'disconnected',
     availability: 'available',
     disabled: false,
     hidden: false,
@@ -33,14 +33,14 @@ describe('CastButtonCore', () => {
   });
 
   describe('getState', () => {
-    it('projects castState and availability', () => {
+    it('projects connection and availability', () => {
       stubCastSupport();
       const core = new CastButtonCore();
       const media = createMediaState({ remotePlaybackState: 'connected' });
       core.setMedia(media);
       const state = core.getState();
 
-      expect(state.castState).toBe('connected');
+      expect(state.connection).toBe('connected');
       expect(state.availability).toBe('available');
       expect(state.disabled).toBe(false);
       expect(state.hidden).toBe(false);
@@ -80,7 +80,7 @@ describe('CastButtonCore', () => {
   describe('getLabel', () => {
     it('returns Start casting when disconnected', () => {
       const core = new CastButtonCore();
-      expect(core.getLabel(createState({ castState: 'disconnected' }))).toMatchObject({
+      expect(core.getLabel(createState({ connection: 'disconnected' }))).toMatchObject({
         key: 'cast.start',
         text: 'Start casting',
       });
@@ -88,7 +88,7 @@ describe('CastButtonCore', () => {
 
     it('returns Stop casting when connected', () => {
       const core = new CastButtonCore();
-      expect(core.getLabel(createState({ castState: 'connected' }))).toMatchObject({
+      expect(core.getLabel(createState({ connection: 'connected' }))).toMatchObject({
         key: 'cast.stop',
         text: 'Stop casting',
       });
@@ -96,7 +96,7 @@ describe('CastButtonCore', () => {
 
     it('returns Connecting when connecting', () => {
       const core = new CastButtonCore();
-      expect(core.getLabel(createState({ castState: 'connecting' }))).toMatchObject({
+      expect(core.getLabel(createState({ connection: 'connecting' }))).toMatchObject({
         key: 'cast.connecting',
         text: 'Connecting',
       });
@@ -109,9 +109,9 @@ describe('CastButtonCore', () => {
 
     it('returns custom function label', () => {
       const core = new CastButtonCore({
-        label: (state) => (state.castState === 'connected' ? 'Disconnect' : 'Connect'),
+        label: (state) => (state.connection === 'connected' ? 'Disconnect' : 'Connect'),
       });
-      expect(core.getLabel(createState({ castState: 'connected' }))).toBe('Disconnect');
+      expect(core.getLabel(createState({ connection: 'connected' }))).toBe('Disconnect');
     });
   });
 

--- a/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
+++ b/packages/core/src/core/ui/cast-button/tests/cast-button-core.test.ts
@@ -145,6 +145,7 @@ describe('CastButtonCore', () => {
     });
 
     it('does nothing when the disabled prop is set', async () => {
+      stubCastSupport();
       const core = new CastButtonCore({ disabled: true });
       const media = createMediaState();
       await core.toggle(media);

--- a/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
+++ b/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
@@ -16,6 +16,10 @@ export interface FullscreenButtonProps {
 export interface FullscreenButtonState extends Pick<MediaFullscreenState, 'fullscreen'>, ButtonState {
   /** Whether fullscreen can be requested on this platform. */
   availability: MediaFullscreenState['fullscreenAvailability'];
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because fullscreen is unsupported. */
+  hidden: boolean;
 }
 
 export class FullscreenButtonCore {
@@ -27,6 +31,8 @@ export class FullscreenButtonCore {
   readonly state = createState<FullscreenButtonState>({
     fullscreen: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
   });
 
@@ -57,7 +63,8 @@ export class FullscreenButtonCore {
   getAttrs(state: FullscreenButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -67,25 +74,23 @@ export class FullscreenButtonCore {
 
   getState(): FullscreenButtonState {
     const media = this.#media!;
-    this.state.patch({ fullscreen: media.fullscreen, availability: media.fullscreenAvailability });
+    const availability = media.fullscreenAvailability;
+
+    this.state.patch({
+      fullscreen: media.fullscreen,
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unsupported',
+    });
     this.state.patch({ label: this.getLabel(this.state.current) });
 
     return this.state.current;
   }
 
   async toggle(media: MediaFullscreenState): Promise<void> {
-    if (this.#props.disabled) return;
-    if (media.fullscreenAvailability !== 'available') return;
-
-    try {
-      if (media.fullscreen) {
-        await media.exitFullscreen();
-      } else {
-        await media.requestFullscreen();
-      }
-    } catch {
-      // Fullscreen requests can fail (user gesture required, permissions, etc.)
-    }
+    this.setMedia(media);
+    if (this.getState().disabled) return;
+    return media.fullscreen ? media.exitFullscreen() : media.requestFullscreen();
   }
 }
 

--- a/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
+++ b/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
@@ -19,7 +19,7 @@ export interface FullscreenButtonState extends Pick<MediaFullscreenState, 'fulls
   availability: MediaFullscreenState['fullscreenAvailability'];
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout because fullscreen is unsupported. */
+  /** Removed from the layout until fullscreen is available. */
   hidden: boolean;
 }
 
@@ -31,9 +31,9 @@ export class FullscreenButtonCore {
 
   readonly state = createState<FullscreenButtonState>({
     fullscreen: false,
-    availability: 'available',
-    disabled: false,
-    hidden: false,
+    availability: 'unavailable',
+    disabled: true,
+    hidden: true,
     label: '',
   });
 
@@ -75,7 +75,7 @@ export class FullscreenButtonCore {
       fullscreen: media.fullscreen,
       availability,
       disabled: this.#props.disabled || availability !== 'available',
-      hidden: availability === 'unsupported',
+      hidden: availability !== 'available',
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 

--- a/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
+++ b/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
@@ -17,6 +17,10 @@ export interface FullscreenButtonProps {
 export interface FullscreenButtonState extends Pick<MediaFullscreenState, 'fullscreen'>, ButtonState {
   /** Whether fullscreen can be requested on this platform. */
   availability: MediaFullscreenState['fullscreenAvailability'];
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because fullscreen is unsupported. */
+  hidden: boolean;
 }
 
 export class FullscreenButtonCore {
@@ -28,6 +32,8 @@ export class FullscreenButtonCore {
   readonly state = createState<FullscreenButtonState>({
     fullscreen: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
   });
 
@@ -52,7 +58,8 @@ export class FullscreenButtonCore {
   getAttrs(state: FullscreenButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -62,25 +69,23 @@ export class FullscreenButtonCore {
 
   getState(): FullscreenButtonState {
     const media = this.#media!;
-    this.state.patch({ fullscreen: media.fullscreen, availability: media.fullscreenAvailability });
+    const availability = media.fullscreenAvailability;
+
+    this.state.patch({
+      fullscreen: media.fullscreen,
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unsupported',
+    });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 
     return this.state.current;
   }
 
   async toggle(media: MediaFullscreenState): Promise<void> {
-    if (this.#props.disabled) return;
-    if (media.fullscreenAvailability !== 'available') return;
-
-    try {
-      if (media.fullscreen) {
-        await media.exitFullscreen();
-      } else {
-        await media.requestFullscreen();
-      }
-    } catch {
-      // Fullscreen requests can fail (user gesture required, permissions, etc.)
-    }
+    this.setMedia(media);
+    if (this.getState().disabled) return;
+    return media.fullscreen ? media.exitFullscreen() : media.requestFullscreen();
   }
 }
 

--- a/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
+++ b/packages/core/src/core/ui/fullscreen-button/fullscreen-button-core.ts
@@ -19,7 +19,7 @@ export interface FullscreenButtonState extends Pick<MediaFullscreenState, 'fulls
   availability: MediaFullscreenState['fullscreenAvailability'];
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout until fullscreen is available. */
+  /** Whether the button is hidden until fullscreen is available. */
   hidden: boolean;
 }
 

--- a/packages/core/src/core/ui/fullscreen-button/fullscreen-button-data-attrs.ts
+++ b/packages/core/src/core/ui/fullscreen-button/fullscreen-button-data-attrs.ts
@@ -4,6 +4,10 @@ import type { FullscreenButtonState } from './fullscreen-button-core';
 export const FullscreenButtonDataAttrs = {
   /** Present when fullscreen mode is active. */
   fullscreen: 'data-fullscreen',
-  /** Indicates fullscreen availability (`available` or `unsupported`). */
+  /** Indicates fullscreen availability (`available`, `unavailable`, `unsupported`). */
   availability: 'data-availability',
+  /** Present when the button is non-interactive (mirrors `aria-disabled`). */
+  disabled: 'data-disabled',
+  /** Present when the button is hidden because fullscreen is unsupported. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<FullscreenButtonState>;

--- a/packages/core/src/core/ui/fullscreen-button/fullscreen-button-data-attrs.ts
+++ b/packages/core/src/core/ui/fullscreen-button/fullscreen-button-data-attrs.ts
@@ -8,6 +8,6 @@ export const FullscreenButtonDataAttrs = {
   availability: 'data-availability',
   /** Present when the button is non-interactive (mirrors `aria-disabled`). */
   disabled: 'data-disabled',
-  /** Present when the button is hidden because fullscreen is unsupported. */
+  /** Present when the button is hidden because fullscreen is not available. */
   hidden: 'data-hidden',
 } as const satisfies StateAttrMap<FullscreenButtonState>;

--- a/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
+++ b/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
@@ -19,6 +19,8 @@ function createState(overrides: Partial<FullscreenButtonState> = {}): Fullscreen
   return {
     fullscreen: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -34,14 +36,27 @@ describe('FullscreenButtonCore', () => {
 
       expect(state.fullscreen).toBe(true);
       expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled and hidden when unsupported', () => {
       const core = new FullscreenButtonCore();
       core.setMedia(createMediaState({ fullscreenAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set', () => {
+      const core = new FullscreenButtonCore({ disabled: true });
+      core.setMedia(createMediaState({ fullscreenAvailability: 'available' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -76,10 +91,16 @@ describe('FullscreenButtonCore', () => {
       expect(attrs['aria-label']).toBe('Enter fullscreen');
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new FullscreenButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new FullscreenButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new FullscreenButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
@@ -98,7 +119,7 @@ describe('FullscreenButtonCore', () => {
       expect(media.exitFullscreen).toHaveBeenCalled();
     });
 
-    it('does nothing when disabled', async () => {
+    it('does nothing when the disabled prop is set', async () => {
       const core = new FullscreenButtonCore({ disabled: true });
       const media = createMediaState();
       await core.toggle(media);
@@ -112,14 +133,14 @@ describe('FullscreenButtonCore', () => {
       expect(media.requestFullscreen).not.toHaveBeenCalled();
     });
 
-    it('catches fullscreen errors silently', async () => {
+    it('propagates errors from requestFullscreen', async () => {
       const core = new FullscreenButtonCore();
       const media = createMediaState({
         requestFullscreen: vi.fn(async () => {
           throw new Error('permission denied');
         }),
       });
-      await expect(core.toggle(media)).resolves.toBeUndefined();
+      await expect(core.toggle(media)).rejects.toThrow('permission denied');
     });
   });
 });

--- a/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
+++ b/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
@@ -26,6 +26,16 @@ function createState(overrides: Partial<FullscreenButtonState> = {}): Fullscreen
 }
 
 describe('FullscreenButtonCore', () => {
+  it('starts disabled and hidden until availability is known', () => {
+    const core = new FullscreenButtonCore();
+
+    expect(core.state.current).toMatchObject({
+      availability: 'unavailable',
+      disabled: true,
+      hidden: true,
+    });
+  });
+
   describe('getState', () => {
     it('projects fullscreen and availability', () => {
       const core = new FullscreenButtonCore();
@@ -45,6 +55,16 @@ describe('FullscreenButtonCore', () => {
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled and hidden when unavailable', () => {
+      const core = new FullscreenButtonCore();
+      core.setMedia(createMediaState({ fullscreenAvailability: 'unavailable' }));
+      const state = core.getState();
+
+      expect(state.availability).toBe('unavailable');
       expect(state.disabled).toBe(true);
       expect(state.hidden).toBe(true);
     });

--- a/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
+++ b/packages/core/src/core/ui/fullscreen-button/tests/fullscreen-button-core.test.ts
@@ -18,6 +18,8 @@ function createState(overrides: Partial<FullscreenButtonState> = {}): Fullscreen
   return {
     fullscreen: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -33,14 +35,27 @@ describe('FullscreenButtonCore', () => {
 
       expect(state.fullscreen).toBe(true);
       expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled and hidden when unsupported', () => {
       const core = new FullscreenButtonCore();
       core.setMedia(createMediaState({ fullscreenAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set', () => {
+      const core = new FullscreenButtonCore({ disabled: true });
+      core.setMedia(createMediaState({ fullscreenAvailability: 'available' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -81,10 +96,16 @@ describe('FullscreenButtonCore', () => {
       expect(attrs['aria-label']).toMatchObject({ key: 'fullscreen.enter', text: 'Enter fullscreen' });
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new FullscreenButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new FullscreenButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new FullscreenButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
@@ -103,7 +124,7 @@ describe('FullscreenButtonCore', () => {
       expect(media.exitFullscreen).toHaveBeenCalled();
     });
 
-    it('does nothing when disabled', async () => {
+    it('does nothing when the disabled prop is set', async () => {
       const core = new FullscreenButtonCore({ disabled: true });
       const media = createMediaState();
       await core.toggle(media);
@@ -117,14 +138,14 @@ describe('FullscreenButtonCore', () => {
       expect(media.requestFullscreen).not.toHaveBeenCalled();
     });
 
-    it('catches fullscreen errors silently', async () => {
+    it('propagates errors from requestFullscreen', async () => {
       const core = new FullscreenButtonCore();
       const media = createMediaState({
         requestFullscreen: vi.fn(async () => {
           throw new Error('permission denied');
         }),
       });
-      await expect(core.toggle(media)).resolves.toBeUndefined();
+      await expect(core.toggle(media)).rejects.toThrow('permission denied');
     });
   });
 });

--- a/packages/core/src/core/ui/pip-button/pip-button-core.ts
+++ b/packages/core/src/core/ui/pip-button/pip-button-core.ts
@@ -16,6 +16,10 @@ export interface PiPButtonProps {
 export interface PiPButtonState extends Pick<MediaPictureInPictureState, 'pip'>, ButtonState {
   /** Whether picture-in-picture can be requested on this platform. */
   availability: MediaPictureInPictureState['pipAvailability'];
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because picture-in-picture is unsupported. */
+  hidden: boolean;
 }
 
 export class PiPButtonCore {
@@ -27,6 +31,8 @@ export class PiPButtonCore {
   readonly state = createState<PiPButtonState>({
     pip: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
   });
 
@@ -57,7 +63,8 @@ export class PiPButtonCore {
   getAttrs(state: PiPButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -67,25 +74,23 @@ export class PiPButtonCore {
 
   getState(): PiPButtonState {
     const media = this.#media!;
-    this.state.patch({ pip: media.pip, availability: media.pipAvailability });
+    const availability = media.pipAvailability;
+
+    this.state.patch({
+      pip: media.pip,
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unsupported',
+    });
     this.state.patch({ label: this.getLabel(this.state.current) });
 
     return this.state.current;
   }
 
   async toggle(media: MediaPictureInPictureState): Promise<void> {
-    if (this.#props.disabled) return;
-    if (media.pipAvailability !== 'available') return;
-
-    try {
-      if (media.pip) {
-        await media.exitPictureInPicture();
-      } else {
-        await media.requestPictureInPicture();
-      }
-    } catch {
-      // PiP requests can fail (user gesture required, permissions, etc.)
-    }
+    this.setMedia(media);
+    if (this.getState().disabled) return;
+    return media.pip ? media.exitPictureInPicture() : media.requestPictureInPicture();
   }
 }
 

--- a/packages/core/src/core/ui/pip-button/pip-button-core.ts
+++ b/packages/core/src/core/ui/pip-button/pip-button-core.ts
@@ -19,7 +19,7 @@ export interface PiPButtonState extends Pick<MediaPictureInPictureState, 'pip'>,
   availability: MediaPictureInPictureState['pipAvailability'];
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout because picture-in-picture is unsupported. */
+  /** Removed from the layout until picture-in-picture is available. */
   hidden: boolean;
 }
 
@@ -31,9 +31,9 @@ export class PiPButtonCore {
 
   readonly state = createState<PiPButtonState>({
     pip: false,
-    availability: 'available',
-    disabled: false,
-    hidden: false,
+    availability: 'unavailable',
+    disabled: true,
+    hidden: true,
     label: '',
   });
 
@@ -75,7 +75,7 @@ export class PiPButtonCore {
       pip: media.pip,
       availability,
       disabled: this.#props.disabled || availability !== 'available',
-      hidden: availability === 'unsupported',
+      hidden: availability !== 'available',
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 

--- a/packages/core/src/core/ui/pip-button/pip-button-core.ts
+++ b/packages/core/src/core/ui/pip-button/pip-button-core.ts
@@ -17,6 +17,10 @@ export interface PiPButtonProps {
 export interface PiPButtonState extends Pick<MediaPictureInPictureState, 'pip'>, ButtonState {
   /** Whether picture-in-picture can be requested on this platform. */
   availability: MediaPictureInPictureState['pipAvailability'];
+  /** Non-interactive but still focusable (mirrors `aria-disabled`). */
+  disabled: boolean;
+  /** Removed from the layout because picture-in-picture is unsupported. */
+  hidden: boolean;
 }
 
 export class PiPButtonCore {
@@ -28,6 +32,8 @@ export class PiPButtonCore {
   readonly state = createState<PiPButtonState>({
     pip: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
   });
 
@@ -52,7 +58,8 @@ export class PiPButtonCore {
   getAttrs(state: PiPButtonState) {
     return {
       'aria-label': this.getLabel(state),
-      'aria-disabled': this.#props.disabled ? 'true' : undefined,
+      'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -62,25 +69,23 @@ export class PiPButtonCore {
 
   getState(): PiPButtonState {
     const media = this.#media!;
-    this.state.patch({ pip: media.pip, availability: media.pipAvailability });
+    const availability = media.pipAvailability;
+
+    this.state.patch({
+      pip: media.pip,
+      availability,
+      disabled: this.#props.disabled || availability !== 'available',
+      hidden: availability === 'unsupported',
+    });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 
     return this.state.current;
   }
 
   async toggle(media: MediaPictureInPictureState): Promise<void> {
-    if (this.#props.disabled) return;
-    if (media.pipAvailability !== 'available') return;
-
-    try {
-      if (media.pip) {
-        await media.exitPictureInPicture();
-      } else {
-        await media.requestPictureInPicture();
-      }
-    } catch {
-      // PiP requests can fail (user gesture required, permissions, etc.)
-    }
+    this.setMedia(media);
+    if (this.getState().disabled) return;
+    return media.pip ? media.exitPictureInPicture() : media.requestPictureInPicture();
   }
 }
 

--- a/packages/core/src/core/ui/pip-button/pip-button-core.ts
+++ b/packages/core/src/core/ui/pip-button/pip-button-core.ts
@@ -19,7 +19,7 @@ export interface PiPButtonState extends Pick<MediaPictureInPictureState, 'pip'>,
   availability: MediaPictureInPictureState['pipAvailability'];
   /** Non-interactive but still focusable (mirrors `aria-disabled`). */
   disabled: boolean;
-  /** Removed from the layout until picture-in-picture is available. */
+  /** Whether the button is hidden until picture-in-picture is available. */
   hidden: boolean;
 }
 

--- a/packages/core/src/core/ui/pip-button/pip-button-data-attrs.ts
+++ b/packages/core/src/core/ui/pip-button/pip-button-data-attrs.ts
@@ -4,6 +4,10 @@ import type { PiPButtonState } from './pip-button-core';
 export const PiPButtonDataAttrs = {
   /** Present when picture-in-picture mode is active. */
   pip: 'data-pip',
-  /** Indicates picture-in-picture availability (`available` or `unsupported`). */
+  /** Indicates picture-in-picture availability (`available`, `unavailable`, `unsupported`). */
   availability: 'data-availability',
+  /** Present when the button is non-interactive (mirrors `aria-disabled`). */
+  disabled: 'data-disabled',
+  /** Present when the button is hidden because picture-in-picture is unsupported. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<PiPButtonState>;

--- a/packages/core/src/core/ui/pip-button/pip-button-data-attrs.ts
+++ b/packages/core/src/core/ui/pip-button/pip-button-data-attrs.ts
@@ -8,6 +8,6 @@ export const PiPButtonDataAttrs = {
   availability: 'data-availability',
   /** Present when the button is non-interactive (mirrors `aria-disabled`). */
   disabled: 'data-disabled',
-  /** Present when the button is hidden because picture-in-picture is unsupported. */
+  /** Present when the button is hidden because picture-in-picture is not available. */
   hidden: 'data-hidden',
 } as const satisfies StateAttrMap<PiPButtonState>;

--- a/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
+++ b/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
@@ -19,6 +19,8 @@ function createState(overrides: Partial<PiPButtonState> = {}): PiPButtonState {
   return {
     pip: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -34,14 +36,27 @@ describe('PiPButtonCore', () => {
 
       expect(state.pip).toBe(true);
       expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled and hidden when unsupported', () => {
       const core = new PiPButtonCore();
       core.setMedia(createMediaState({ pipAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set', () => {
+      const core = new PiPButtonCore({ disabled: true });
+      core.setMedia(createMediaState({ pipAvailability: 'available' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -76,10 +91,16 @@ describe('PiPButtonCore', () => {
       expect(attrs['aria-label']).toBe('Enter picture-in-picture');
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new PiPButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new PiPButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new PiPButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
@@ -98,7 +119,7 @@ describe('PiPButtonCore', () => {
       expect(media.exitPictureInPicture).toHaveBeenCalled();
     });
 
-    it('does nothing when disabled', async () => {
+    it('does nothing when the disabled prop is set', async () => {
       const core = new PiPButtonCore({ disabled: true });
       const media = createMediaState();
       await core.toggle(media);
@@ -112,14 +133,14 @@ describe('PiPButtonCore', () => {
       expect(media.requestPictureInPicture).not.toHaveBeenCalled();
     });
 
-    it('catches PiP errors silently', async () => {
+    it('propagates errors from requestPictureInPicture', async () => {
       const core = new PiPButtonCore();
       const media = createMediaState({
         requestPictureInPicture: vi.fn(async () => {
           throw new Error('permission denied');
         }),
       });
-      await expect(core.toggle(media)).resolves.toBeUndefined();
+      await expect(core.toggle(media)).rejects.toThrow('permission denied');
     });
   });
 });

--- a/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
+++ b/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
@@ -26,6 +26,16 @@ function createState(overrides: Partial<PiPButtonState> = {}): PiPButtonState {
 }
 
 describe('PiPButtonCore', () => {
+  it('starts disabled and hidden until availability is known', () => {
+    const core = new PiPButtonCore();
+
+    expect(core.state.current).toMatchObject({
+      availability: 'unavailable',
+      disabled: true,
+      hidden: true,
+    });
+  });
+
   describe('getState', () => {
     it('projects pip and availability', () => {
       const core = new PiPButtonCore();
@@ -45,6 +55,16 @@ describe('PiPButtonCore', () => {
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled and hidden when unavailable', () => {
+      const core = new PiPButtonCore();
+      core.setMedia(createMediaState({ pipAvailability: 'unavailable' }));
+      const state = core.getState();
+
+      expect(state.availability).toBe('unavailable');
       expect(state.disabled).toBe(true);
       expect(state.hidden).toBe(true);
     });

--- a/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
+++ b/packages/core/src/core/ui/pip-button/tests/pip-button-core.test.ts
@@ -18,6 +18,8 @@ function createState(overrides: Partial<PiPButtonState> = {}): PiPButtonState {
   return {
     pip: false,
     availability: 'available',
+    disabled: false,
+    hidden: false,
     label: '',
     ...overrides,
   };
@@ -33,14 +35,27 @@ describe('PiPButtonCore', () => {
 
       expect(state.pip).toBe(true);
       expect(state.availability).toBe('available');
+      expect(state.disabled).toBe(false);
+      expect(state.hidden).toBe(false);
     });
 
-    it('reflects unsupported availability', () => {
+    it('marks disabled and hidden when unsupported', () => {
       const core = new PiPButtonCore();
       core.setMedia(createMediaState({ pipAvailability: 'unsupported' }));
       const state = core.getState();
 
       expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+    });
+
+    it('marks disabled when the disabled prop is set', () => {
+      const core = new PiPButtonCore({ disabled: true });
+      core.setMedia(createMediaState({ pipAvailability: 'available' }));
+      const state = core.getState();
+
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(false);
     });
   });
 
@@ -81,10 +96,16 @@ describe('PiPButtonCore', () => {
       expect(attrs['aria-label']).toMatchObject({ key: 'pip.enter', text: 'Enter picture-in-picture' });
     });
 
-    it('sets aria-disabled when disabled', () => {
-      const core = new PiPButtonCore({ disabled: true });
-      const attrs = core.getAttrs(createState());
+    it('sets aria-disabled when state.disabled is true', () => {
+      const core = new PiPButtonCore();
+      const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets the hidden attribute when state.hidden is true', () => {
+      const core = new PiPButtonCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 
@@ -103,7 +124,7 @@ describe('PiPButtonCore', () => {
       expect(media.exitPictureInPicture).toHaveBeenCalled();
     });
 
-    it('does nothing when disabled', async () => {
+    it('does nothing when the disabled prop is set', async () => {
       const core = new PiPButtonCore({ disabled: true });
       const media = createMediaState();
       await core.toggle(media);
@@ -117,14 +138,14 @@ describe('PiPButtonCore', () => {
       expect(media.requestPictureInPicture).not.toHaveBeenCalled();
     });
 
-    it('catches PiP errors silently', async () => {
+    it('propagates errors from requestPictureInPicture', async () => {
       const core = new PiPButtonCore();
       const media = createMediaState({
         requestPictureInPicture: vi.fn(async () => {
           throw new Error('permission denied');
         }),
       });
-      await expect(core.toggle(media)).resolves.toBeUndefined();
+      await expect(core.toggle(media)).rejects.toThrow('permission denied');
     });
   });
 });

--- a/packages/core/src/core/ui/thumbnail/thumbnail-core.ts
+++ b/packages/core/src/core/ui/thumbnail/thumbnail-core.ts
@@ -23,7 +23,7 @@ export interface ThumbnailState {
   loading: boolean;
   /** The thumbnail image failed to load. */
   error: boolean;
-  /** No thumbnail is available and not loading — the component should be hidden. */
+  /** Whether the component is hidden because no thumbnail is available and it is not loading. */
   hidden: boolean;
 }
 

--- a/packages/html/src/ui/cast-button/cast-button-element.ts
+++ b/packages/html/src/ui/cast-button/cast-button-element.ts
@@ -12,7 +12,7 @@ export class CastButtonElement extends MediaButtonElement<CastButtonCore> {
   protected readonly stateAttrMap = CastButtonDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectRemotePlayback);
 
-  protected activate(state: MediaRemotePlaybackState): void {
-    this.core.toggle(state);
+  protected activate(state: MediaRemotePlaybackState): Promise<void> {
+    return this.core.toggle(state);
   }
 }

--- a/packages/html/src/ui/cast-button/cast-button-element.ts
+++ b/packages/html/src/ui/cast-button/cast-button-element.ts
@@ -13,7 +13,7 @@ export class CastButtonElement extends MediaButtonElement<CastButtonCore> {
   protected readonly stateAttrMap = CastButtonDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectRemotePlayback);
 
-  protected activate(state: MediaRemotePlaybackState): void {
-    this.core.toggle(state);
+  protected activate(state: MediaRemotePlaybackState): Promise<void> {
+    return this.core.toggle(state);
   }
 }

--- a/packages/html/src/ui/fullscreen-button/fullscreen-button-element.ts
+++ b/packages/html/src/ui/fullscreen-button/fullscreen-button-element.ts
@@ -13,7 +13,7 @@ export class FullscreenButtonElement extends MediaButtonElement<FullscreenButton
   protected readonly mediaState = new PlayerController(this, playerContext, selectFullscreen);
   protected override readonly hotkeyAction = 'toggleFullscreen';
 
-  protected activate(state: MediaFullscreenState): void {
-    this.core.toggle(state);
+  protected activate(state: MediaFullscreenState): Promise<void> {
+    return this.core.toggle(state);
   }
 }

--- a/packages/html/src/ui/fullscreen-button/fullscreen-button-element.ts
+++ b/packages/html/src/ui/fullscreen-button/fullscreen-button-element.ts
@@ -14,7 +14,7 @@ export class FullscreenButtonElement extends MediaButtonElement<FullscreenButton
   protected readonly mediaState = new PlayerController(this, playerContext, selectFullscreen);
   protected override readonly hotkeyAction = 'toggleFullscreen';
 
-  protected activate(state: MediaFullscreenState): void {
-    this.core.toggle(state);
+  protected activate(state: MediaFullscreenState): Promise<void> {
+    return this.core.toggle(state);
   }
 }

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -27,7 +27,7 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
   protected abstract readonly stateAttrMap: StateAttrMap<InferComponentState<Core>>;
   protected abstract readonly mediaState: PlayerController<any, InferMediaState<Core> | undefined>;
 
-  protected abstract activate(state: InferMediaState<Core>): void;
+  protected abstract activate(state: InferMediaState<Core>): void | Promise<void>;
 
   /** Override to set the hotkey action name for `aria-keyshortcuts`. */
   protected readonly hotkeyAction: string | undefined = undefined;
@@ -50,7 +50,14 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
     this.#disconnect = new AbortController();
 
     const buttonProps = createButton({
-      onActivate: () => this.activate(this.mediaState.value!),
+      onActivate: async () => {
+        try {
+          await this.activate(this.mediaState.value!);
+        } catch (error) {
+          if (__DEV__) console.error(`[${this.localName}]`, error);
+          throw error;
+        }
+      },
       isDisabled: () => this.disabled || !this.mediaState.value,
     });
 

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -50,13 +50,14 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
     this.#disconnect = new AbortController();
 
     const buttonProps = createButton({
-      onActivate: async () => {
-        try {
-          await this.activate(this.mediaState.value!);
-        } catch (error) {
+      // `createButton` invokes `onActivate` synchronously from click/keyup
+      // handlers, so any rejection here would be unhandled. Log in dev for
+      // visibility but absorb the failure at this UI boundary — callers
+      // awaiting `core.toggle(...)` directly still see the rejection.
+      onActivate: () => {
+        Promise.resolve(this.activate(this.mediaState.value!)).catch((error) => {
           if (__DEV__) console.error(`[${this.localName}]`, error);
-          throw error;
-        }
+        });
       },
       isDisabled: () => this.disabled || !this.mediaState.value,
     });

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -49,14 +49,19 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
   protected abstract readonly stateAttrMap: StateAttrMap<InferComponentState<Core>>;
   protected abstract readonly mediaState: PlayerController<any, InferMediaState<Core> | undefined>;
 
-  protected abstract activate(state: InferMediaState<Core>, event?: UIEvent): void;
+  protected abstract activate(state: InferMediaState<Core>, event?: UIEvent): void | Promise<void>;
 
   protected getIsButtonDisabled(): boolean {
     return this.disabled || !this.mediaState.value;
   }
 
   protected handleActivate(event: UIEvent): void {
-    this.activate(this.mediaState.value!, event);
+    // `createButton` invokes `onActivate` synchronously from click/keyup
+    // handlers, so any rejection here would be unhandled. Log in dev for
+    // visibility but absorb the failure at this UI boundary.
+    Promise.resolve(this.activate(this.mediaState.value!, event)).catch((error) => {
+      if (__DEV__) console.error(`[${this.localName}]`, error);
+    });
   }
 
   /** Override to set the hotkey action name for `aria-keyshortcuts`. */

--- a/packages/html/src/ui/pip-button/pip-button-element.ts
+++ b/packages/html/src/ui/pip-button/pip-button-element.ts
@@ -13,7 +13,7 @@ export class PiPButtonElement extends MediaButtonElement<PiPButtonCore> {
   protected readonly mediaState = new PlayerController(this, playerContext, selectPiP);
   protected override readonly hotkeyAction = 'togglePictureInPicture';
 
-  protected activate(state: MediaPictureInPictureState): void {
-    this.core.toggle(state);
+  protected activate(state: MediaPictureInPictureState): Promise<void> {
+    return this.core.toggle(state);
   }
 }

--- a/packages/html/src/ui/pip-button/pip-button-element.ts
+++ b/packages/html/src/ui/pip-button/pip-button-element.ts
@@ -14,7 +14,7 @@ export class PiPButtonElement extends MediaButtonElement<PiPButtonCore> {
   protected readonly mediaState = new PlayerController(this, playerContext, selectPiP);
   protected override readonly hotkeyAction = 'togglePictureInPicture';
 
-  protected activate(state: MediaPictureInPictureState): void {
-    this.core.toggle(state);
+  protected activate(state: MediaPictureInPictureState): Promise<void> {
+    return this.core.toggle(state);
   }
 }

--- a/packages/react/src/ui/airplay-button/airplay-button.tsx
+++ b/packages/react/src/ui/airplay-button/airplay-button.tsx
@@ -17,6 +17,7 @@ export const AirPlayButton = createMediaButton<AirPlayButtonCore, AirPlayButtonP
   stateAttrMap: AirPlayButtonDataAttrs,
   selector: selectRemotePlayback,
   action: (core, state) => core.toggle(state),
+  isSupported: (state) => !state.hidden,
 });
 
 export namespace AirPlayButton {

--- a/packages/react/src/ui/airplay-button/tests/airplay-button.test.tsx
+++ b/packages/react/src/ui/airplay-button/tests/airplay-button.test.tsx
@@ -11,14 +11,14 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function renderAirPlayButton() {
+function renderAirPlayButton(props: AirPlayButton.Props = {}) {
   const { Wrapper } = createPlayerWrapper({
     remotePlaybackState: 'disconnected',
     remotePlaybackAvailability: 'available',
     toggleRemotePlayback: vi.fn(),
   });
 
-  render(<AirPlayButton data-testid="airplay" />, { wrapper: Wrapper });
+  render(<AirPlayButton data-testid="airplay" {...props} />, { wrapper: Wrapper });
 }
 
 describe('AirPlayButton', () => {
@@ -34,5 +34,15 @@ describe('AirPlayButton', () => {
     renderAirPlayButton();
 
     expect(screen.getByTestId('airplay')).toBeDefined();
+  });
+
+  it('lets element props override generated attributes', () => {
+    vi.stubGlobal('WebKitPlaybackTargetAvailabilityEvent', class {});
+
+    renderAirPlayButton({ hidden: true, 'aria-label': 'Custom AirPlay' });
+
+    const button = screen.getByTestId('airplay');
+    expect(button.hidden).toBe(true);
+    expect(button.getAttribute('aria-label')).toBe('Custom AirPlay');
   });
 });

--- a/packages/react/src/ui/airplay-button/tests/airplay-button.test.tsx
+++ b/packages/react/src/ui/airplay-button/tests/airplay-button.test.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { AirPlayButton } from '../airplay-button';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderAirPlayButton() {
+  const { Wrapper } = createPlayerWrapper({
+    remotePlaybackState: 'disconnected',
+    remotePlaybackAvailability: 'available',
+    toggleRemotePlayback: vi.fn(),
+  });
+
+  render(<AirPlayButton data-testid="airplay" />, { wrapper: Wrapper });
+}
+
+describe('AirPlayButton', () => {
+  it('is hidden outside WebKit', () => {
+    renderAirPlayButton();
+
+    expect(screen.queryByTestId('airplay')).toBeNull();
+  });
+
+  it('renders when AirPlay is available in WebKit', () => {
+    vi.stubGlobal('WebKitPlaybackTargetAvailabilityEvent', class {});
+
+    renderAirPlayButton();
+
+    expect(screen.getByTestId('airplay')).toBeDefined();
+  });
+});

--- a/packages/react/src/ui/captions-button/captions-button.tsx
+++ b/packages/react/src/ui/captions-button/captions-button.tsx
@@ -18,6 +18,7 @@ export const CaptionsButton = createMediaButton<CaptionsButtonCore, CaptionsButt
   selector: selectTextTrack,
   action: (core, state) => core.toggle(state),
   hotkeyAction: 'toggleSubtitles',
+  isSupported: (state) => !state.hidden,
 });
 
 export namespace CaptionsButton {

--- a/packages/react/src/ui/captions-button/tests/captions-button.test.tsx
+++ b/packages/react/src/ui/captions-button/tests/captions-button.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createPlayerWrapper } from '../../../testing/mocks';
 import { Menu } from '../../menu';
+import { Tooltip, useOptionalTooltipContext } from '../../tooltip';
 import { CaptionsButton } from '../captions-button';
 
 afterEach(cleanup);
@@ -41,6 +42,34 @@ function renderCaptionsTrigger({
 }
 
 describe('CaptionsButton', () => {
+  it('does not register tooltip content when hidden', () => {
+    const { Wrapper } = createPlayerWrapper({
+      textTrackList: [],
+      subtitlesShowing: false,
+      selectSubtitlesTrack: vi.fn(),
+      chaptersCues: [],
+      thumbnailCues: [],
+      thumbnailTrackSrc: null,
+      toggleSubtitles: vi.fn(),
+    });
+
+    function TooltipContentProbe() {
+      const tooltip = useOptionalTooltipContext();
+      return <span data-testid="tooltip-label">{tooltip?.content?.label}</span>;
+    }
+
+    render(
+      <Tooltip.Root>
+        <CaptionsButton data-testid="trigger" />
+        <TooltipContentProbe />
+      </Tooltip.Root>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryByTestId('trigger')).toBeNull();
+    expect(screen.getByTestId('tooltip-label').textContent).toBe('');
+  });
+
   it('does not toggle captions when rendered inside Menu.Trigger with multiple tracks', () => {
     const { toggleSubtitles } = renderCaptionsTrigger();
 

--- a/packages/react/src/ui/cast-button/cast-button.tsx
+++ b/packages/react/src/ui/cast-button/cast-button.tsx
@@ -15,6 +15,7 @@ export const CastButton = createMediaButton<CastButtonCore, CastButtonProps>({
   stateAttrMap: CastButtonDataAttrs,
   selector: selectRemotePlayback,
   action: (core, state) => core.toggle(state),
+  isSupported: (state) => !state.hidden,
 });
 
 export namespace CastButton {

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -18,15 +18,17 @@ interface MediaButtonConfig<Core extends Required<MediaButtonComponent>> {
   core: { new (): Core; defaultProps: Record<string, unknown> };
   stateAttrMap: StateAttrMap<InferComponentState<Core>>;
   selector: Selector<object, InferMediaState<Core> | undefined>;
-  action: (core: Core, state: InferMediaState<Core>) => void;
+  action: (core: Core, state: InferMediaState<Core>) => void | Promise<void>;
   hotkeyAction?: string;
+  /** Returns `false` to render `null` (e.g., when the underlying feature is unsupported). */
+  isSupported?: (state: InferComponentState<Core>) => boolean;
 }
 
 /** Creates a media button React component from a core class and config. */
 export function createMediaButton<Core extends Required<MediaButtonComponent>, Props extends object>(
   config: MediaButtonConfig<Core>
 ): ForwardRefExoticComponent<Props & RefAttributes<HTMLButtonElement>> {
-  const { displayName, core: CoreClass, stateAttrMap, selector, action, hotkeyAction } = config;
+  const { displayName, core: CoreClass, stateAttrMap, selector, action, hotkeyAction, isSupported } = config;
 
   // Props that exist in the core's defaultProps are routed to setProps; the rest go to the DOM element.
   const corePropKeys = new Set(Object.keys(CoreClass.defaultProps));
@@ -57,7 +59,14 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
 
     const { getButtonProps, buttonRef } = useButton({
       displayName,
-      onActivate: () => action(core, feature!),
+      onActivate: async () => {
+        try {
+          await action(core, feature!);
+        } catch (error) {
+          if (__DEV__) console.error(`[${displayName}]`, error);
+          throw error;
+        }
+      },
       isDisabled: () => !!coreProps.disabled || !feature,
     });
 
@@ -79,6 +88,8 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
       if (__DEV__) logMissingFeature(displayName, selector.displayName ?? displayName);
       return null;
     }
+
+    if (isSupported && !isSupported(state)) return null;
 
     const attrs = { ...core.getAttrs(state), 'aria-keyshortcuts': shortcuts };
 

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -59,13 +59,14 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
 
     const { getButtonProps, buttonRef } = useButton({
       displayName,
-      onActivate: async () => {
-        try {
-          await action(core, feature!);
-        } catch (error) {
+      // `useButton` invokes `onActivate` synchronously from click/keyup
+      // handlers, so any rejection here would be unhandled. Log in dev for
+      // visibility but absorb the failure at this UI boundary — callers
+      // awaiting `core.toggle(...)` directly still see the rejection.
+      onActivate: () => {
+        Promise.resolve(action(core, feature!)).catch((error) => {
           if (__DEV__) console.error(`[${displayName}]`, error);
-          throw error;
-        }
+        });
       },
       isDisabled: () => !!coreProps.disabled || !feature,
     });

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -111,8 +111,10 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
     type State = InferComponentState<Core>;
     if (feature) core.setMedia(feature);
     const state = feature ? (core.getState() as State) : null;
-    const label = state ? translateText(core.getLabel(state), translator, getLabelParams(core, state)) : undefined;
-    const tooltipText = state ? (tooltipLabel?.(core, state) ?? label) : undefined;
+    const supported = state ? (isSupported?.(state) ?? true) : false;
+    const label =
+      state && supported ? translateText(core.getLabel(state), translator, getLabelParams(core, state)) : undefined;
+    const tooltipText = state && supported ? (tooltipLabel?.(core, state) ?? label) : undefined;
 
     // Forward label to tooltip popup content when inside a Tooltip.Root.
     useLayoutEffect(() => {
@@ -126,7 +128,7 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
       return null;
     }
 
-    if (isSupported && !isSupported(state)) return null;
+    if (!supported) return null;
 
     const attrs = core.getAttrs(state) as Record<string, unknown>;
     const ariaLabel = attrs['aria-label'];

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -147,7 +147,7 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
         state,
         stateAttrMap,
         ref: [forwardedRef, buttonRef],
-        props: [getButtonProps(), elementProps, resolvedAttrs],
+        props: [getButtonProps(), resolvedAttrs, elementProps],
       }
     );
   });

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -22,10 +22,12 @@ interface MediaButtonConfig<Core extends Required<MediaButtonComponent>> {
   core: { new (): Core; defaultProps: Record<string, unknown> };
   stateAttrMap: StateAttrMap<InferComponentState<Core>>;
   selector: Selector<object, InferMediaState<Core> | undefined>;
-  action: (core: Core, state: InferMediaState<Core>) => void;
+  action: (core: Core, state: InferMediaState<Core>) => void | Promise<void>;
   hotkeyAction?: string;
   hotkeyValue?: (props: Record<string, unknown>) => number | undefined;
   tooltipLabel?: (core: Core, state: InferComponentState<Core>) => string | undefined;
+  /** Returns `false` to render `null` (e.g., when the underlying feature is unsupported). */
+  isSupported?: (state: InferComponentState<Core>) => boolean;
 }
 
 type LabelParams = Record<string, string | number>;
@@ -53,6 +55,7 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
     hotkeyAction,
     hotkeyValue,
     tooltipLabel,
+    isSupported,
   } = config;
 
   // Props that exist in the core's defaultProps are routed to setProps; the rest go to the DOM element.
@@ -92,7 +95,14 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
 
     const { getButtonProps, buttonRef } = useButton({
       displayName,
-      onActivate: () => action(core, feature!),
+      // `useButton` invokes `onActivate` synchronously from click/keyup
+      // handlers, so any rejection here would be unhandled. Log in dev for
+      // visibility but absorb the failure at this UI boundary.
+      onActivate: () => {
+        Promise.resolve(action(core, feature!)).catch((error) => {
+          if (__DEV__) console.error(`[${displayName}]`, error);
+        });
+      },
       isDisabled: () => !!coreProps.disabled || !feature,
     });
 
@@ -115,6 +125,8 @@ export function createMediaButton<Core extends Required<MediaButtonComponent>, P
       if (__DEV__) logMissingFeature(displayName, selector.displayName ?? displayName);
       return null;
     }
+
+    if (isSupported && !isSupported(state)) return null;
 
     const attrs = core.getAttrs(state) as Record<string, unknown>;
     const ariaLabel = attrs['aria-label'];

--- a/packages/react/src/ui/fullscreen-button/fullscreen-button.tsx
+++ b/packages/react/src/ui/fullscreen-button/fullscreen-button.tsx
@@ -18,6 +18,7 @@ export const FullscreenButton = createMediaButton<FullscreenButtonCore, Fullscre
   selector: selectFullscreen,
   action: (core, state) => core.toggle(state),
   hotkeyAction: 'toggleFullscreen',
+  isSupported: (state) => !state.hidden,
 });
 
 export namespace FullscreenButton {

--- a/packages/react/src/ui/pip-button/pip-button.tsx
+++ b/packages/react/src/ui/pip-button/pip-button.tsx
@@ -16,6 +16,7 @@ export const PiPButton = createMediaButton<PiPButtonCore, PiPButtonProps>({
   selector: selectPiP,
   action: (core, state) => core.toggle(state),
   hotkeyAction: 'togglePictureInPicture',
+  isSupported: (state) => !state.hidden,
 });
 
 export namespace PiPButton {

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -32,15 +32,11 @@
     scale: 0.98;
   }
 
-  &[disabled] {
+  &[disabled],
+  &[data-disabled] {
     opacity: 0.5;
     filter: grayscale(1);
     cursor: not-allowed;
-  }
-
-  &[data-availability="unavailable"],
-  &[data-availability="unsupported"] {
-    display: none;
   }
 }
 

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -28,7 +28,7 @@
     outline-offset: 2px;
   }
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.98;
   }
 
@@ -69,7 +69,7 @@
   padding: 0;
   aspect-ratio: 1;
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.9;
   }
 

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -38,6 +38,11 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
+
+  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
+  &[hidden] {
+    display: none;
+  }
 }
 
 /* Primary button variant */

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -38,11 +38,6 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
-
-  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
-  &[hidden] {
-    display: none;
-  }
 }
 
 /* Primary button variant */

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -34,15 +34,11 @@
     scale: 0.98;
   }
 
-  &[disabled] {
-    cursor: not-allowed;
+  &[disabled],
+  &[data-disabled] {
     opacity: 0.5;
     filter: grayscale(1);
-  }
-
-  &[data-availability="unavailable"],
-  &[data-availability="unsupported"] {
-    display: none;
+    cursor: not-allowed;
   }
 }
 

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -40,11 +40,6 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
-
-  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
-  &[hidden] {
-    display: none;
-  }
 }
 
 /* Primary button variant */

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -30,15 +30,14 @@
     outline-offset: 2px;
   }
 
-  &:active:not([disabled]):not([data-disabled]) {
+  &:active:not([aria-disabled="true"]) {
     scale: 0.98;
   }
 
-  &[disabled],
-  &[data-disabled] {
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
     opacity: 0.5;
     filter: grayscale(1);
-    cursor: not-allowed;
   }
 }
 
@@ -70,7 +69,7 @@
   aspect-ratio: 1;
   padding: 0;
 
-  &:active:not([disabled]):not([data-disabled]) {
+  &:active:not([aria-disabled="true"]) {
     scale: 0.9;
   }
 

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -30,7 +30,7 @@
     outline-offset: 2px;
   }
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.98;
   }
 
@@ -70,7 +70,7 @@
   aspect-ratio: 1;
   padding: 0;
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.9;
   }
 

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -40,6 +40,11 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
+
+  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
+  &[hidden] {
+    display: none;
+  }
 }
 
 /* Primary button variant */

--- a/packages/skins/src/default/css/components/reset.css
+++ b/packages/skins/src/default/css/components/reset.css
@@ -16,6 +16,10 @@
 .media-default-skin button {
   font: inherit;
 }
+.media-default-skin [hidden][hidden] {
+  /* Keep authored templates hidden even when component classes set display. */
+  display: none;
+}
 @media (prefers-reduced-motion: no-preference) {
   .media-default-skin {
     interpolate-size: allow-keywords;

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -8,9 +8,8 @@ export const button = {
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
-    'focus-visible:outline-current focus-visible:outline-offset-2',
-    'data-[availability=unavailable]:hidden',
-    'data-[availability=unsupported]:hidden'
+    'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',
   subtle: cn(

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -6,7 +6,7 @@ export const button = {
     'py-2 px-4 rounded-full',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
-    'active:scale-[0.98]',
+    'not-disabled:not-data-disabled:active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
     'focus-visible:outline-current focus-visible:outline-offset-2'
@@ -18,5 +18,5 @@ export const button = {
     'focus-visible:bg-current/10',
     'aria-expanded:bg-current/10'
   ),
-  icon: cn('grid w-9 aspect-square p-0', 'active:scale-90'),
+  icon: cn('grid w-9 aspect-square p-0', 'not-disabled:not-data-disabled:active:scale-90'),
 };

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -9,6 +9,8 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    // Override `flex` so the native `hidden` attribute hides the button.
+    '[&[hidden]]:hidden',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -9,8 +9,6 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
-    // Override `flex` so the native `hidden` attribute hides the button.
-    '[&[hidden]]:hidden',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -11,6 +11,8 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    // Override `flex` so the native `hidden` attribute hides the button.
+    '[&[hidden]]:hidden',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -10,9 +10,8 @@ export const button = {
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
-    'focus-visible:outline-current focus-visible:outline-offset-2',
-    'data-[availability=unavailable]:hidden',
-    'data-[availability=unsupported]:hidden'
+    'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',
   subtle: cn(

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -11,8 +11,6 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
-    // Override `flex` so the native `hidden` attribute hides the button.
-    '[&[hidden]]:hidden',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -8,9 +8,8 @@ export const button = {
     'py-2 px-4 rounded-full',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
-    'not-disabled:not-data-disabled:active:scale-[0.98]',
-    'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
-    'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    'not-aria-disabled:active:scale-[0.98]',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:grayscale',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',
@@ -20,7 +19,7 @@ export const button = {
     'focus-visible:bg-current/10',
     'aria-expanded:bg-current/10'
   ),
-  icon: cn('grid aspect-square p-0!', 'not-disabled:not-data-disabled:active:scale-90'),
+  icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-90'),
   seek: hideAtSmall,
   /**
    * Live variant: wide pill button with a status dot rendered via `::before`

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -8,7 +8,7 @@ export const button = {
     'py-2 px-4 rounded-full',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
-    'active:scale-[0.98]',
+    'not-disabled:not-data-disabled:active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
     'focus-visible:outline-current focus-visible:outline-offset-2'
@@ -20,7 +20,7 @@ export const button = {
     'focus-visible:bg-current/10',
     'aria-expanded:bg-current/10'
   ),
-  icon: cn('grid aspect-square p-0!', 'active:scale-90'),
+  icon: cn('grid aspect-square p-0!', 'not-disabled:not-data-disabled:active:scale-90'),
   seek: hideAtSmall,
   /**
    * Live variant: wide pill button with a status dot rendered via `::before`

--- a/packages/skins/src/default/tailwind/components/root.ts
+++ b/packages/skins/src/default/tailwind/components/root.ts
@@ -10,5 +10,7 @@ export const root = cn(
   // Resets
   '**:box-border',
   '[&_button]:font-[inherit]',
+  // Keep authored templates hidden even when component classes set `display`.
+  '[&_[hidden][hidden]]:hidden',
   'motion-safe:[interpolate-size:allow-keywords]'
 );

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -32,15 +32,11 @@
     scale: 0.98;
   }
 
-  &[disabled] {
+  &[disabled],
+  &[data-disabled] {
     opacity: 0.5;
     filter: grayscale(1);
     cursor: not-allowed;
-  }
-
-  &[data-availability="unavailable"],
-  &[data-availability="unsupported"] {
-    display: none;
   }
 }
 

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -38,11 +38,6 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
-
-  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
-  &[hidden] {
-    display: none;
-  }
 }
 
 /* biome-ignore lint/correctness/noUnknownProperty: corner-shape is an emerging CSS spec */

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -28,7 +28,7 @@
     outline-offset: 2px;
   }
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.98;
   }
 
@@ -77,7 +77,7 @@
   padding: 0;
   aspect-ratio: 1;
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.9;
   }
 

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -38,6 +38,11 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
+
+  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
+  &[hidden] {
+    display: none;
+  }
 }
 
 /* biome-ignore lint/correctness/noUnknownProperty: corner-shape is an emerging CSS spec */

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -30,15 +30,14 @@
     outline-offset: 2px;
   }
 
-  &:active:not([disabled]):not([data-disabled]) {
+  &:active:not([aria-disabled="true"]) {
     scale: 0.98;
   }
 
-  &[disabled],
-  &[data-disabled] {
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
     opacity: 0.5;
     filter: grayscale(1);
-    cursor: not-allowed;
   }
 }
 
@@ -76,7 +75,7 @@
   aspect-ratio: 1;
   padding: 0;
 
-  &:active:not([disabled]):not([data-disabled]) {
+  &:active:not([aria-disabled="true"]) {
     scale: 0.9;
   }
 

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -40,11 +40,6 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
-
-  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
-  &[hidden] {
-    display: none;
-  }
 }
 
 @supports (corner-shape: squircle) {

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -34,15 +34,11 @@
     scale: 0.98;
   }
 
-  &[disabled] {
-    cursor: not-allowed;
+  &[disabled],
+  &[data-disabled] {
     opacity: 0.5;
     filter: grayscale(1);
-  }
-
-  &[data-availability="unavailable"],
-  &[data-availability="unsupported"] {
-    display: none;
+    cursor: not-allowed;
   }
 }
 

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -30,7 +30,7 @@
     outline-offset: 2px;
   }
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.98;
   }
 
@@ -76,7 +76,7 @@
   aspect-ratio: 1;
   padding: 0;
 
-  &:active {
+  &:active:not([disabled]):not([data-disabled]) {
     scale: 0.9;
   }
 

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -40,6 +40,11 @@
     filter: grayscale(1);
     cursor: not-allowed;
   }
+
+  /* Override the skin's `display: flex/grid` so the native `hidden` attribute hides the button. */
+  &[hidden] {
+    display: none;
+  }
 }
 
 @supports (corner-shape: squircle) {

--- a/packages/skins/src/minimal/css/components/reset.css
+++ b/packages/skins/src/minimal/css/components/reset.css
@@ -16,6 +16,10 @@
 .media-minimal-skin button {
   font: inherit;
 }
+.media-minimal-skin [hidden][hidden] {
+  /* Keep authored templates hidden even when component classes set display. */
+  display: none;
+}
 @media (prefers-reduced-motion: no-preference) {
   .media-minimal-skin {
     interpolate-size: allow-keywords;

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -7,7 +7,7 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-current focus-visible:outline-offset-2',
-    'active:scale-[0.98]',
+    'not-disabled:not-data-disabled:active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
     'supports-[corner-shape:squircle]:rounded-[1rem]',
@@ -20,5 +20,5 @@ export const button = {
     'focus-visible:bg-current/10',
     'aria-expanded:bg-current/10'
   ),
-  icon: cn('grid w-[2.375rem] aspect-square p-0', 'active:scale-90'),
+  icon: cn('grid w-[2.375rem] aspect-square p-0', 'not-disabled:not-data-disabled:active:scale-90'),
 };

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -10,8 +10,6 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
-    // Override `flex` so the native `hidden` attribute hides the button.
-    '[&[hidden]]:hidden',
     'supports-[corner-shape:squircle]:rounded-[1rem]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -10,6 +10,8 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    // Override `flex` so the native `hidden` attribute hides the button.
+    '[&[hidden]]:hidden',
     'supports-[corner-shape:squircle]:rounded-[1rem]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -9,10 +9,9 @@ export const button = {
     'focus-visible:outline-current focus-visible:outline-offset-2',
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
+    'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
     'supports-[corner-shape:squircle]:rounded-[1rem]',
-    'supports-[corner-shape:squircle]:[corner-shape:squircle]',
-    'data-[availability=unavailable]:hidden',
-    'data-[availability=unsupported]:hidden'
+    'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',
   subtle: cn(

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -12,6 +12,8 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    // Override `flex` so the native `hidden` attribute hides the button.
+    '[&[hidden]]:hidden',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -11,10 +11,9 @@ export const button = {
     'focus-visible:outline-current focus-visible:outline-offset-2',
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
+    'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
-    'supports-[corner-shape:squircle]:[corner-shape:squircle]',
-    'data-[availability=unavailable]:hidden',
-    'data-[availability=unsupported]:hidden'
+    'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',
   subtle: cn(

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -9,9 +9,8 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-current focus-visible:outline-offset-2',
-    'not-disabled:not-data-disabled:active:scale-[0.98]',
-    'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
-    'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
+    'not-aria-disabled:active:scale-[0.98]',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:grayscale',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),
@@ -22,7 +21,7 @@ export const button = {
     'focus-visible:bg-current/10',
     'aria-expanded:bg-current/10'
   ),
-  icon: cn('grid aspect-square p-0!', 'not-disabled:not-data-disabled:active:scale-90'),
+  icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-90'),
   seek: hideAtSmall,
   cast: hideAtSmall,
   airplay: hideAtSmall,

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -12,8 +12,6 @@ export const button = {
     'active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
-    // Override `flex` so the native `hidden` attribute hides the button.
-    '[&[hidden]]:hidden',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -9,7 +9,7 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-current focus-visible:outline-offset-2',
-    'active:scale-[0.98]',
+    'not-disabled:not-data-disabled:active:scale-[0.98]',
     'disabled:cursor-not-allowed disabled:opacity-50 disabled:grayscale',
     'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[disabled]:grayscale',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
@@ -22,7 +22,7 @@ export const button = {
     'focus-visible:bg-current/10',
     'aria-expanded:bg-current/10'
   ),
-  icon: cn('grid aspect-square p-0!', 'active:scale-90'),
+  icon: cn('grid aspect-square p-0!', 'not-disabled:not-data-disabled:active:scale-90'),
   seek: hideAtSmall,
   cast: hideAtSmall,
   airplay: hideAtSmall,

--- a/packages/skins/src/minimal/tailwind/components/root.ts
+++ b/packages/skins/src/minimal/tailwind/components/root.ts
@@ -10,5 +10,7 @@ export const root = cn(
   // Resets
   '**:box-border',
   '[&_button]:font-[inherit]',
+  // Keep authored templates hidden even when component classes set `display`.
+  '[&_[hidden][hidden]]:hidden',
   'motion-safe:[interpolate-size:allow-keywords]'
 );

--- a/site/src/components/docs/demos/airplay-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/airplay-button/html/css/BasicUsage.css
@@ -22,9 +22,7 @@
 }
 
 .media-airplay-button .connected,
-.media-airplay-button .not-connected,
-.media-airplay-button .no-devices,
-.media-airplay-button .unsupported {
+.media-airplay-button .not-connected {
   display: none;
 }
 
@@ -33,24 +31,13 @@
   display: inline;
 }
 
-/* Available, not connected: ready to AirPlay */
-.media-airplay-button:not([data-airplay-state="connected"])[data-availability="available"] .not-connected {
+/* Not connected: ready to AirPlay */
+.media-airplay-button:not([data-airplay-state="connected"]) .not-connected {
   display: inline;
 }
 
-/* Platform supports AirPlay but no receivers are visible. */
-.media-airplay-button[data-availability="unavailable"] .no-devices {
-  display: inline;
-}
-
-/* AirPlay not supported on this platform. */
-.media-airplay-button[data-availability="unsupported"] .unsupported {
-  display: inline;
-}
-
-/* Inactive states: the toggle is a no-op unless availability is "available". */
-.media-airplay-button[data-availability="unavailable"],
-.media-airplay-button[data-availability="unsupported"] {
+/* Explicitly disabled while AirPlay is available. */
+.media-airplay-button[data-disabled] {
   cursor: not-allowed;
   opacity: 0.5;
   filter: grayscale(1);

--- a/site/src/components/docs/demos/airplay-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/airplay-button/html/css/BasicUsage.html
@@ -5,8 +5,6 @@
         <media-airplay-button class="media-airplay-button">
             <span class="connected">Stop AirPlay</span>
             <span class="not-connected">Start AirPlay</span>
-            <span class="no-devices">No AirPlay devices found</span>
-            <span class="unsupported">AirPlay not supported</span>
         </media-airplay-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.css
@@ -20,9 +20,8 @@
   backdrop-filter: blur(10px);
 }
 
-/* Inactive states: the toggle is a no-op unless availability is "available". */
-.media-airplay-button[data-availability="unavailable"],
-.media-airplay-button[data-availability="unsupported"] {
+/* Explicitly disabled while AirPlay is available. */
+.media-airplay-button[data-disabled] {
   cursor: not-allowed;
   opacity: 0.5;
   filter: grayscale(1);

--- a/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.tsx
@@ -10,17 +10,9 @@ export default function BasicUsage() {
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <AirPlayButton
           className="media-airplay-button"
-          render={(props, state) => {
-            const label =
-              state.availability === 'unsupported'
-                ? 'AirPlay not supported'
-                : state.state === 'connected'
-                  ? 'Stop AirPlay'
-                  : state.availability === 'unavailable'
-                    ? 'No AirPlay devices found'
-                    : 'Start AirPlay';
-            return <button {...props}>{label}</button>;
-          }}
+          render={(props, state) => (
+            <button {...props}>{state.state === 'connected' ? 'Stop AirPlay' : 'Start AirPlay'}</button>
+          )}
         />
       </Player.Container>
     </Player.Provider>

--- a/site/src/components/docs/demos/cast-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/cast-button/html/css/BasicUsage.css
@@ -21,8 +21,10 @@
   backdrop-filter: blur(10px);
 }
 
-.media-cast-button[data-availability="unsupported"] {
-  display: none;
+.media-cast-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+  filter: grayscale(1);
 }
 
 .media-cast-button .connected {

--- a/site/src/components/docs/demos/cast-button/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/cast-button/react/css/BasicUsage.css
@@ -20,6 +20,8 @@
   backdrop-filter: blur(10px);
 }
 
-.media-cast-button[data-availability="unsupported"] {
-  display: none;
+.media-cast-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+  filter: grayscale(1);
 }

--- a/site/src/components/docs/demos/cast-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/cast-button/react/css/BasicUsage.tsx
@@ -12,7 +12,7 @@ export default function BasicUsage() {
         <CastButton
           className="media-cast-button"
           render={(props, state) => (
-            <button {...props}>{state.castState === 'connected' ? 'Stop casting' : 'Start casting'}</button>
+            <button {...props}>{state.connection === 'connected' ? 'Stop casting' : 'Start casting'}</button>
           )}
         />
       </Player.Container>

--- a/site/src/content/docs/concepts/cast.mdx
+++ b/site/src/content/docs/concepts/cast.mdx
@@ -225,12 +225,18 @@ class CastStatus extends HTMLElement {
 
 ## Browser availability
 
-The Remote Playback feature reports availability as `'available'` (a device is on the network), `'unavailable'` (no device found), or `'unsupported'` (the browser can't cast). The `CastButton` reflects it as a `data-availability` attribute. Use it to hide the button where casting never works:
+The Remote Playback feature reports availability as `'available'` (a device is on the network), `'unavailable'` (no device found), or `'unsupported'` (the browser can't cast). The `CastButton` keeps this raw value in `data-availability`, but handles presentation for you:
+
+- When Cast is unsupported, the HTML custom element receives the native `hidden` attribute and the React component returns `null`.
+- When Cast is supported but no device is reachable, the button remains visible with `aria-disabled="true"` and `data-disabled`.
+
+Use `data-disabled` to style the visible, non-interactive state:
 
 <FrameworkCase frameworks={["html"]}>
 ```css
-media-cast-button[data-availability="unsupported"] {
-  display: none;
+media-cast-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
 </FrameworkCase>
@@ -243,11 +249,14 @@ media-cast-button[data-availability="unsupported"] {
 ```
 
 ```css
-.cast-button[data-availability="unsupported"] {
-  display: none;
+.cast-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
 </FrameworkCase>
+
+Unsupported buttons hide automatically, so no availability selector or extra hiding CSS is required.
 
 ## See also
 

--- a/site/src/content/docs/concepts/features.mdx
+++ b/site/src/content/docs/concepts/features.mdx
@@ -160,19 +160,27 @@ Volume, fullscreen, and picture-in-picture expose an `*Availability` property be
 | `'unavailable'` | Could work, not ready yet |
 | `'unsupported'` | Platform can never do this |
 
-Components that depend on availability (like <DocsLink slug="reference/pip-button">`PiPButton`</DocsLink> and <DocsLink slug="reference/fullscreen-button">`FullscreenButton`</DocsLink>) expose a `data-availability` attribute, so you can hide unsupported controls with CSS:
+Components that depend on availability (like <DocsLink slug="reference/pip-button">`PiPButton`</DocsLink> and <DocsLink slug="reference/fullscreen-button">`FullscreenButton`</DocsLink>) handle the three states for you:
+
+- **`unsupported`** — the HTML custom element receives the native `hidden` attribute (and `data-hidden`); React buttons return `null`. No CSS needed.
+- **`unavailable`** or the `disabled` prop — the button stays visible and focusable with `aria-disabled="true"` plus `data-disabled` for styling.
+- **`available`** — fully interactive.
+
+Use `data-disabled` to style the non-interactive state:
 
 <FrameworkCase frameworks={["html"]}>
 ```css
-media-pip-button[data-availability="unsupported"] {
-  display: none;
+media-pip-button[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["react"]}>
 ```css
-.pip-button[data-availability="unsupported"] {
-  display: none;
+.pip-button[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/concepts/features.mdx
+++ b/site/src/content/docs/concepts/features.mdx
@@ -163,7 +163,8 @@ Volume, fullscreen, and picture-in-picture expose an `*Availability` property be
 Components that depend on availability (like <DocsLink slug="reference/pip-button">`PiPButton`</DocsLink> and <DocsLink slug="reference/fullscreen-button">`FullscreenButton`</DocsLink>) handle the three states for you:
 
 - **`unsupported`** — the HTML custom element receives the native `hidden` attribute (and `data-hidden`); React buttons return `null`. No CSS needed.
-- **`unavailable`** or the `disabled` prop — the button stays visible and focusable with `aria-disabled="true"` plus `data-disabled` for styling.
+- **`unavailable`** — the presentation controls stay hidden while capability detection is unresolved. Cast remains visible but disabled when its API is supported and no device is reachable.
+- **`disabled` prop** — an available button stays visible and focusable with `aria-disabled="true"` plus `data-disabled` for styling.
 - **`available`** — fully interactive.
 
 Use `data-disabled` to style the non-interactive state:
@@ -192,7 +193,7 @@ You can also check availability in JS:
 function PiPControl() {
   const availability = usePlayer((s) => s.pipAvailability);
 
-  if (availability === 'unsupported') return null;
+  if (availability !== 'available') return null;
 
   return <PiPButton />;
 }
@@ -202,7 +203,7 @@ function PiPControl() {
 ```ts
 const media = this.#pip.value;
 
-if (media?.availability === 'unsupported') {
+if (media?.pipAvailability !== 'available') {
   this.hidden = true;
 }
 ```

--- a/site/src/content/docs/reference/airplay-button.mdx
+++ b/site/src/content/docs/reference/airplay-button.mdx
@@ -40,7 +40,7 @@ import basicUsageHtmlTs from "@/components/docs/demos/airplay-button/html/css/Ba
 
 Opens the WebKit AirPlay playback target picker and reflects session state. AirPlay is a WebKit-only feature, so the button reports `availability: "unsupported"` outside Safari (macOS and iOS). On supported platforms availability flips to `"available"` once Safari discovers at least one AirPlay receiver on the local network, and `"unavailable"` otherwise.
 
-The toggle is a no-op unless `availability` is `"available"` — clicking the button while `"unsupported"` or `"unavailable"` will not open the picker. Style the button accordingly (see [Styling](#styling) below) so its appearance matches its actual behavior.
+The button is hidden until `availability` is `"available"`: the HTML custom element receives the native `hidden` attribute, and the React component returns `null`. An explicitly disabled, otherwise available button stays visible and focusable with `aria-disabled="true"` and `data-disabled`, but does not open the picker.
 
 The component consumes the unified <DocsLink slug="reference/feature-remote-playback">`remotePlayback`</DocsLink> store feature alongside `CastButton`: both buttons drive their state from the same feature, but each only surfaces on its supported platform (WebKit for AirPlay, Chromium for Cast).
 
@@ -52,6 +52,8 @@ WebKit does not expose a `"connecting"` intermediate state — the `state` slice
 |-----------|--------|-------------|
 | `data-airplay-state` | `"disconnected"` \| `"connecting"` \| `"connected"` | Current AirPlay session state |
 | `data-availability` | `"available"` \| `"unavailable"` \| `"unsupported"` | Whether AirPlay is reachable on the current platform |
+| `data-disabled` | Present / absent | Present when the button is non-interactive |
+| `data-hidden` | Present / absent | Present on the HTML element while AirPlay is unavailable or unsupported |
 
 Use `data-airplay-state` to swap icons or labels based on the session state:
 
@@ -75,23 +77,27 @@ React renders a `<button>` element. Add a `className` and use it as the selector
 ```
 </FrameworkCase>
 
-Consider hiding the button on platforms where AirPlay isn't supported:
+Use `data-disabled` to style an explicitly disabled, available button:
 
 <FrameworkCase frameworks={["html"]}>
 ```css
-media-airplay-button[data-availability="unsupported"] {
-  display: none;
+media-airplay-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
 ```css
-.airplay-button[data-availability="unsupported"] {
-  display: none;
+.airplay-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
 </FrameworkCase>
+
+Unavailable and unsupported buttons are hidden automatically. No availability selector or extra hiding CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/captions-button.mdx
+++ b/site/src/content/docs/reference/captions-button.mdx
@@ -37,9 +37,9 @@ import basicUsageHtmlTs from "@/components/docs/demos/captions-button/html/css/B
 
 ## Behavior
 
-Toggles captions and subtitles on and off. The button checks the media's text track list for tracks with `kind="captions"` or `kind="subtitles"` and reflects availability via `data-availability`.
+Toggles captions and subtitles on and off. The button checks the media's text track list for tracks with `kind="captions"` or `kind="subtitles"`. When none are present, the HTML custom element receives the native `hidden` attribute and the React component returns `null`. The raw state remains available as `data-availability`.
 
-When no caption or subtitle tracks are present, `data-availability="unavailable"` is set. Use this to hide the button when there are no tracks to toggle.
+An explicitly disabled button with caption tracks stays visible and focusable with `aria-disabled="true"` and `data-disabled`, but does not toggle captions.
 
 When `menuTrigger` is enabled and multiple caption or subtitle tracks are available, activation opens the linked captions menu instead of toggling captions directly. React enables `menuTrigger` automatically when a `CaptionsButton` is rendered inside `Menu.Trigger`.
 
@@ -52,13 +52,16 @@ media-captions-button[data-active] .icon-on { display: inline; }
 media-captions-button:not([data-active]) .icon-off { display: inline; }
 ```
 
-Hide when no caption tracks are available:
+Style an explicitly disabled, available button:
 
 ```css
-media-captions-button[data-availability="unavailable"] {
-  display: none;
+media-captions-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
+
+The button hides automatically when no caption tracks are available. No availability selector or extra hiding CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/cast-button.mdx
+++ b/site/src/content/docs/reference/cast-button.mdx
@@ -40,13 +40,17 @@ import basicUsageHtmlTs from "@/components/docs/demos/cast-button/html/css/Basic
 
 Toggles a Google Cast session. Clicking the button while `disconnected` opens the Cast device picker; clicking while `connected` ends the session.
 
-The button does nothing when `availability` is not `'available'` — for example, when no Chromecast is on the network, or on browsers that don't support Cast.
+The button derives its presentation from `availability`:
+
+- **`"unsupported"`** — the HTML custom element receives the native `hidden` attribute; the React component returns `null`.
+- **`"unavailable"`** — the button remains visible and focusable with `aria-disabled="true"` and `data-disabled`, but does not open the picker. This lets a tooltip explain that no Cast device is reachable.
+- **`"available"`** — the button is fully interactive unless the `disabled` prop is set.
 
 Cast sessions come from the <DocsLink slug="concepts/cast">Google Cast</DocsLink> component. Add it to the player next to your media element; without it the button drives the browser's native Remote Playback API instead, which offers no receiver or load-request configuration.
 
 ## Styling
 
-Style based on cast state and availability:
+Style based on cast and disabled state:
 
 <FrameworkCase frameworks={["html"]}>
 ```css
@@ -55,9 +59,10 @@ media-cast-button[data-cast-state="connected"] {
   color: blue;
 }
 
-/* Hide when Cast is unsupported (non-Chromium browsers) */
-media-cast-button[data-availability="unsupported"] {
-  display: none;
+/* Cast is supported, but no device is reachable */
+media-cast-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
 </FrameworkCase>
@@ -71,12 +76,15 @@ React renders a `<button>` element. Add a `className` to style it:
   color: blue;
 }
 
-/* Hide when Cast is unsupported (non-Chromium browsers) */
-.cast-button[data-availability="unsupported"] {
-  display: none;
+/* Cast is supported, but no device is reachable */
+.cast-button[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 ```
 </FrameworkCase>
+
+Unsupported buttons are hidden automatically. No availability selector or extra hiding CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/fullscreen-button.mdx
+++ b/site/src/content/docs/reference/fullscreen-button.mdx
@@ -37,7 +37,10 @@ import basicUsageHtmlTs from "@/components/docs/demos/fullscreen-button/html/css
 
 ## Behavior
 
-Toggles fullscreen mode. Detects platform support through `availability` — when fullscreen is `"unsupported"`, the toggle does nothing.
+Toggles fullscreen mode. The button derives two state hooks from `availability`:
+
+- **`disabled`** (`true` when the API is available but not currently usable, or when the `disabled` prop is set) — sets `aria-disabled="true"` and `data-disabled` so the button stays focusable but does not activate.
+- **`hidden`** (`true` when fullscreen is `"unsupported"`) — applies the native HTML `hidden` attribute on the custom element; the React component returns `null`.
 
 ## Styling
 
@@ -48,6 +51,12 @@ You can style the button based on fullscreen state:
 /* In fullscreen */
 media-fullscreen-button[data-fullscreen] {
   background: red;
+}
+
+/* Non-interactive (disabled prop or temporarily unavailable) */
+media-fullscreen-button[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 ```
 </FrameworkCase>
@@ -60,26 +69,16 @@ React renders a `<button>` element. Add a `className` to style it:
 .fullscreen-button[data-fullscreen] {
   background: red;
 }
-```
-</FrameworkCase>
 
-Consider hiding the button when unsupported:
-
-<FrameworkCase frameworks={["html"]}>
-```css
-media-fullscreen-button[data-availability="unsupported"] {
-  display: none;
+/* Non-interactive (disabled prop or temporarily unavailable) */
+.fullscreen-button[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 ```
 </FrameworkCase>
 
-<FrameworkCase frameworks={["react"]}>
-```css
-.fullscreen-button[data-availability="unsupported"] {
-  display: none;
-}
-```
-</FrameworkCase>
+Unsupported environments hide the button automatically — the HTML element receives the native `hidden` attribute, and the React component returns `null`. No extra CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/fullscreen-button.mdx
+++ b/site/src/content/docs/reference/fullscreen-button.mdx
@@ -39,8 +39,8 @@ import basicUsageHtmlTs from "@/components/docs/demos/fullscreen-button/html/css
 
 Toggles fullscreen mode. The button derives two state hooks from `availability`:
 
-- **`disabled`** (`true` when the API is available but not currently usable, or when the `disabled` prop is set) — sets `aria-disabled="true"` and `data-disabled` so the button stays focusable but does not activate.
-- **`hidden`** (`true` when fullscreen is `"unsupported"`) — applies the native HTML `hidden` attribute on the custom element; the React component returns `null`.
+- **`disabled`** (`true` until fullscreen is available, or when the `disabled` prop is set) — sets `aria-disabled="true"` and `data-disabled`. A prop-disabled, available button stays focusable but does not activate.
+- **`hidden`** (`true` while fullscreen is `"unavailable"` or `"unsupported"`) — applies the native HTML `hidden` attribute on the custom element; the React component returns `null`.
 
 ## Styling
 
@@ -53,7 +53,7 @@ media-fullscreen-button[data-fullscreen] {
   background: red;
 }
 
-/* Non-interactive (disabled prop or temporarily unavailable) */
+/* Non-interactive (disabled prop) */
 media-fullscreen-button[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
@@ -70,7 +70,7 @@ React renders a `<button>` element. Add a `className` to style it:
   background: red;
 }
 
-/* Non-interactive (disabled prop or temporarily unavailable) */
+/* Non-interactive (disabled prop) */
 .fullscreen-button[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
@@ -78,7 +78,7 @@ React renders a `<button>` element. Add a `className` to style it:
 ```
 </FrameworkCase>
 
-Unsupported environments hide the button automatically — the HTML element receives the native `hidden` attribute, and the React component returns `null`. No extra CSS is required.
+The button remains hidden until fullscreen is available. The HTML element receives the native `hidden` attribute, and the React component returns `null`. No extra CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/pip-button.mdx
+++ b/site/src/content/docs/reference/pip-button.mdx
@@ -37,7 +37,10 @@ import basicUsageHtmlTs from "@/components/docs/demos/pip-button/html/css/BasicU
 
 ## Behavior
 
-Toggles picture-in-picture (PiP) mode. Detects platform support through `availability` — when PiP is `"unsupported"`, the toggle does nothing.
+Toggles picture-in-picture (PiP) mode. The button derives two state hooks from `availability`:
+
+- **`disabled`** (`true` when the API is available but not currently usable, or when the `disabled` prop is set) — sets `aria-disabled="true"` and `data-disabled` so the button stays focusable but does not activate.
+- **`hidden`** (`true` when PiP is `"unsupported"`) — applies the native HTML `hidden` attribute on the custom element; the React component returns `null`.
 
 ## Styling
 
@@ -48,6 +51,12 @@ You can style the button based on PiP state:
 /* In PiP mode */
 media-pip-button[data-pip] {
   background: red;
+}
+
+/* Non-interactive (disabled prop or temporarily unavailable) */
+media-pip-button[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 ```
 </FrameworkCase>
@@ -60,26 +69,16 @@ React renders a `<button>` element. Add a `className` to style it:
 .pip-button[data-pip] {
   background: red;
 }
-```
-</FrameworkCase>
 
-Consider hiding the button when unsupported:
-
-<FrameworkCase frameworks={["html"]}>
-```css
-media-pip-button[data-availability="unsupported"] {
-  display: none;
+/* Non-interactive (disabled prop or temporarily unavailable) */
+.pip-button[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 ```
 </FrameworkCase>
 
-<FrameworkCase frameworks={["react"]}>
-```css
-.pip-button[data-availability="unsupported"] {
-  display: none;
-}
-```
-</FrameworkCase>
+Unsupported environments hide the button automatically — the HTML element receives the native `hidden` attribute, and the React component returns `null`. No extra CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/pip-button.mdx
+++ b/site/src/content/docs/reference/pip-button.mdx
@@ -39,8 +39,8 @@ import basicUsageHtmlTs from "@/components/docs/demos/pip-button/html/css/BasicU
 
 Toggles picture-in-picture (PiP) mode. The button derives two state hooks from `availability`:
 
-- **`disabled`** (`true` when the API is available but not currently usable, or when the `disabled` prop is set) — sets `aria-disabled="true"` and `data-disabled` so the button stays focusable but does not activate.
-- **`hidden`** (`true` when PiP is `"unsupported"`) — applies the native HTML `hidden` attribute on the custom element; the React component returns `null`.
+- **`disabled`** (`true` until PiP is available, or when the `disabled` prop is set) — sets `aria-disabled="true"` and `data-disabled`. A prop-disabled, available button stays focusable but does not activate.
+- **`hidden`** (`true` while PiP is `"unavailable"` or `"unsupported"`) — applies the native HTML `hidden` attribute on the custom element; the React component returns `null`.
 
 ## Styling
 
@@ -53,7 +53,7 @@ media-pip-button[data-pip] {
   background: red;
 }
 
-/* Non-interactive (disabled prop or temporarily unavailable) */
+/* Non-interactive (disabled prop) */
 media-pip-button[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
@@ -70,7 +70,7 @@ React renders a `<button>` element. Add a `className` to style it:
   background: red;
 }
 
-/* Non-interactive (disabled prop or temporarily unavailable) */
+/* Non-interactive (disabled prop) */
 .pip-button[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
@@ -78,7 +78,7 @@ React renders a `<button>` element. Add a `className` to style it:
 ```
 </FrameworkCase>
 
-Unsupported environments hide the button automatically — the HTML element receives the native `hidden` attribute, and the React component returns `null`. No extra CSS is required.
+The button remains hidden until picture-in-picture is available. The HTML element receives the native `hidden` attribute, and the React component returns `null`. No extra CSS is required.
 
 ## Accessibility
 


### PR DESCRIPTION
Closes #2082

Replace the `available` boolean on buttons with `disabled` and `hidden` states that follow standard ARIA patterns — `aria-disabled` for non-interactive controls and HTML `hidden` for unsupported features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wide breaking API and UX change across core, HTML, React, and skins (including Cast state rename and when controls appear), affecting accessibility, toolbars, and integrators who styled `data-availability`.
> 
> **Overview**
> **Breaking change:** toolbar media buttons now expose derived **`disabled`** and **`hidden`** state (plus `data-disabled` / `data-hidden`) instead of relying on skins or consumer CSS to hide controls via `data-availability`.
> 
> Non-interactive controls use **`aria-disabled`** from core state (including when a feature isn’t ready), while useless controls are removed with the native **`hidden`** attribute on HTML custom elements and **`null`** in React via a new **`isSupported`** hook on `createMediaButton`. Raw **`data-availability`** is still exposed for styling and debugging.
> 
> **Per-control rules differ:** PiP, fullscreen, AirPlay, and captions hide until **`available`**; **Cast** hides only when **`unsupported`** but stays visible and **`aria-disabled`** when supported with no device. **`CastButton`** state renames **`castState`** → **`connection`**. **`toggle`** paths recompute disabled state before acting; Cast/fullscreen/PiP can **propagate** media API errors while HTML/React UI layers **catch** async rejections in dev.
> 
> Skins drop availability-based `display: none` and **`[disabled]`** styling in favor of **`aria-disabled`**. Docs, demos, e2e (e.g. PiP on WebKit), and an internal **disabled/hidden** design note are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa204b09aaad0f9a01f2dc0fca2fb20d1276b9be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->