### PR TITLE
fix(site): add 'use client' to ejected skin Next.js output

### DIFF
--- a/site/scripts/build-ejected-skins.ts
+++ b/site/scripts/build-ejected-skins.ts
@@ -1387,7 +1387,7 @@ function reorganizeReactOutput(source: string, extraUtilities: string[], extraIc
     parts.push(declarations.join('\n\n'));
   }
 
-  return `${parts.join('\n\n')}\n`;
+  return `'use client';\n\n${parts.join('\n\n')}\n`;
 }
 
 /**


### PR DESCRIPTION
The build-ejected-skins script was missing the `'use client'` directive
in the React output, causing hydration errors when developers copy the
ejected skin example from the Next.js tab on the skins docs page.

Prepends `'use client';` to the reorganized React output so it matches
the packaged skin sample.

Closes [1486](https://github.com/videojs/v10/issues/1486)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small string prefix change in the site build script that only affects generated ejected-skin snippets, with no runtime logic changes beyond Next.js hydration behavior for copied examples.
> 
> **Overview**
> Fixes the React ejected-skin snippet generation for Next.js by prepending the `'use client';` directive to the output of `reorganizeReactOutput` in `build-ejected-skins.ts`.
> 
> This ensures the copy-paste React skin examples are treated as client components and avoids hydration issues when used in Next.js apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c2fa4bd4decb4cc8de69e2dce469b5c15a1193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->