### PR TITLE
fix(skin): fix safari button alignment issue when zoomed

### DIFF
--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -8,6 +8,7 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
+  min-height: 0;
   padding: 0.5rem 1rem;
   text-align: center;
   touch-action: manipulation;

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const button = {
   base: cn(
-    'flex items-center justify-center shrink-0 border-none cursor-pointer select-none text-center touch-manipulation',
+    'flex items-center justify-center shrink-0 border-none cursor-pointer select-none text-center touch-manipulation min-h-0',
     'py-2 px-4 rounded-full',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -8,6 +8,7 @@
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
+  min-height: 0;
   padding: 0.5rem 1rem;
   text-align: center;
   touch-action: manipulation;

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const button = {
   base: cn(
-    'flex items-center justify-center shrink-0 border-none cursor-pointer select-none text-center touch-manipulation',
+    'flex items-center justify-center shrink-0 border-none cursor-pointer select-none text-center touch-manipulation min-h-0',
     'py-2 px-4 rounded-lg',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',


### PR DESCRIPTION
Buttons in desktop Safari 26.4 were misaligned when zoomed in at ~200% or so. This is the fix.

Closes #1491 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS/Tailwind tweak limited to button layout (`min-height: 0`) in two skins; low chance of regressions outside of sizing/overflow behavior.
> 
> **Overview**
> Fixes Safari desktop zoom alignment issues by explicitly setting `min-height: 0` on the base `.media-button` styles.
> 
> Applies the same change in both the `default` and `minimal` skins, in both the raw CSS and Tailwind component definitions, to keep the two styling pipelines consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5042047b2704457fe93dc56e0987fcb38a02ccaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->