### PR TITLE
fix(react): replace any with unknown in isRenderProp type guard

### DIFF
--- a/packages/react/src/utils/use-render.tsx
+++ b/packages/react/src/utils/use-render.tsx
@@ -9,7 +9,7 @@ import type { HTMLProps, RenderProp } from './types';
 import { composeRefs } from './use-composed-refs';
 
 /** Check if a value is a render prop (function or React element). */
-export function isRenderProp(value: unknown): value is RenderProp<any> {
+export function isRenderProp(value: unknown): value is RenderProp<unknown> {
   return isFunction(value) || isValidElement(value);
 }
 

--- a/site/scripts/build-ejected-skins.ts
+++ b/site/scripts/build-ejected-skins.ts
@@ -1133,7 +1133,7 @@ function inlinePrivatePackages(source: string): { source: string; utilities: str
     }
 
     utilities.push(
-      "function isRenderProp(value: unknown): value is RenderProp<any> {\n  return typeof value === 'function' || isValidElement(value);\n}"
+      "function isRenderProp(value: unknown): value is RenderProp<unknown> {\n  return typeof value === 'function' || isValidElement(value);\n}"
     );
   }
 


### PR DESCRIPTION
## Summary

- Replaces `RenderProp<any>` with `RenderProp<unknown>` in `isRenderProp` to avoid `@typescript-eslint/no-explicit-any` violations
- Mirrors the same fix in `build-ejected-skins.ts` so the ejected skin output stays consistent with the source

Closes [1485](https://github.com/videojs/v10/issues/1485)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change to a React utility type guard and its codegen mirror; no runtime behavior changes expected beyond TypeScript narrowing differences.
> 
> **Overview**
> Updates the `isRenderProp` type guard to narrow to `RenderProp<unknown>` instead of `RenderProp<any>` to avoid explicit-`any` usage.
> 
> Mirrors the same type change in `build-ejected-skins.ts` so generated/ejected skin utilities stay consistent with the source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23270f44af4de1ec9b70c9387ed9a27eba5cd842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->