### PR TITLE
fix(build): resolve link-aliases root from repo root

### DIFF
--- a/build/scripts/link-aliases.mjs
+++ b/build/scripts/link-aliases.mjs
@@ -17,7 +17,7 @@
 import { existsSync, symlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const root = resolve(import.meta.dirname, '..');
+const root = resolve(import.meta.dirname, '../..');
 
 const aliases = [
   { target: '.claude', path: '.opencode', type: 'junction' },


### PR DESCRIPTION
## Summary
- The `postinstall` script in `build/scripts/link-aliases.mjs` resolved its root path one level too shallow, so the `AGENTS.md` / `.opencode` / `agents` aliases were created inside `build/` instead of the repo root.
- AI tools that look for these aliases at the repo root (OpenCode, Cursor, etc.) couldn't discover project instructions.
- Fix: resolve from `import.meta.dirname` two levels up (`../..`) instead of one.

Closes #1498

## Test plan
- [x] Removed misplaced `build/.opencode`, `build/agents`, `build/AGENTS.md`
- [x] Re-ran `node build/scripts/link-aliases.mjs` — symlinks now appear at the repo root
- [x] `pnpm lint:fix:file build/scripts/link-aliases.mjs`
- [x] `pnpm typecheck`
- [x] `pnpm check:workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line path resolution fix in a postinstall helper script; main risk is creating symlinks in an unexpected location if `import.meta.dirname` assumptions differ across environments.
> 
> **Overview**
> Fixes `build/scripts/link-aliases.mjs` to resolve its `root` directory from two levels up (`../..`) so the `.opencode`, `agents`, and `AGENTS.md` symlink aliases are created at the repository root instead of under `build/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5c47ec3be32a7282aeb929e4469415fc1da878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->