### PR TITLE
chore(ci): configure noUnknownProperty to allow corner-shape

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,8 @@
   "biome.requireConfiguration": true,
   "editor.defaultFormatter": "biomejs.biome",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
+  // Built-in CSS validation overlaps Biome; disable it for CSS diagnostics only.
+  "css.validate": false,
 
   "[astro]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/biome.json
+++ b/biome.json
@@ -60,6 +60,11 @@
         "noArguments": "off"
       },
       "correctness": {
+        "noUnknownProperty": {
+          "options": {
+            "ignore": ["corner-shape"]
+          }
+        },
         "noUnusedVariables": "warn",
         "noUnusedImports": "warn",
         "noUnusedFunctionParameters": "off",

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -45,11 +45,9 @@
   }
 }
 
-/* biome-ignore lint/correctness/noUnknownProperty: corner-shape is an emerging CSS spec */
 @supports (corner-shape: squircle) {
   .media-minimal-skin .media-button {
     border-radius: 1rem;
-    /* biome-ignore lint/correctness/noUnknownProperty: corner-shape is an emerging CSS spec */
     corner-shape: squircle;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is tooling/editor configuration plus removing inline lint suppressions, with no runtime behavior changes.
> 
> **Overview**
> Updates Biome lint configuration to ignore the emerging CSS property `corner-shape`, so `noUnknownProperty` warnings are not emitted for it.
> 
> Disables VS Code’s built-in CSS validation to avoid overlapping diagnostics with Biome, and removes now-unnecessary `biome-ignore` comments around `corner-shape` usage in the minimal skin button CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1af7efaaea2c07998e8d92376df38d36646f872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->