### PR TITLE
perf(utils): rewrite defaults using spread for stable object shape

### DIFF
--- a/packages/utils/src/object/defaults.ts
+++ b/packages/utils/src/object/defaults.ts
@@ -14,13 +14,6 @@ type PartialWithUndefined<T> = { [K in keyof T]?: T[K] | undefined };
  * ```
  */
 export function defaults<T extends object>(object: PartialWithUndefined<T>, defaultValues: T): T {
-  const result = { ...defaultValues };
-
-  for (const key in object) {
-    if (!isUndefined(object[key])) {
-      result[key as keyof T] = object[key] as T[keyof T];
-    }
-  }
-
-  return result;
+  const defined = Object.fromEntries(Object.entries(object).filter(([, value]) => !isUndefined(value)));
+  return { ...defaultValues, ...defined } as T;
 }


### PR DESCRIPTION
Refs #1335

## Summary

`defaults()` is called once per `setProps()` call, which runs on every Lit update cycle for every component. During multi-player init it accumulates into hundreds of calls. The previous imperative for-in loop with dynamic property assignment (`result[key as keyof T] = ...`) produced result objects with unstable hidden classes in V8, slowing both the function itself and every downstream read of the resulting `#props` object. Switching to a spread-based functional pipeline preserves the documented contract (undefined values still filtered) while landing on V8's optimized spread fast path.

## Changes

- `defaults()` rewritten as `Object.fromEntries(...filter(...))` + spread merge
- Behavior unchanged: undefined values still skipped, defaults still fill in
- Existing 11-test suite passes without modification — the contract is identical, only the implementation strategy changed

<details>
<summary>Why this is faster</summary>

Two V8 mechanisms compound:

1. **Hidden class stability** — V8 compiles `obj.label` to a direct memory offset when the object's shape is predictable. Dynamic property assignment with a computed key (`result[key] = value`) forces shape transitions and pushes property reads into a slower polymorphic path. Object spread has a heavily optimized fast clone that produces a stable shape.
2. **for-in prototype-chain check** — `for (const key in object)` traverses the prototype chain by default. V8 has a fast path for plain objects but still verifies enumerability on every call. `Object.entries` only walks own enumerable keys.

The result objects from `defaults()` are read repeatedly afterwards (`this.#props.label`, `this.#props.disabled`, …), so the hidden-class effect compounds across every property access during init.

</details>

## Impact

Measured on a 6 player multi-player sandbox html:

Before the changes:
<img width="1568" height="940" alt="Performance-tab-original" src="https://github.com/user-attachments/assets/65b7a5e7-320f-4275-b10f-e940b900574c" />
After the changes - different scale, same task goes from ~110ms to ~30ms:
<img width="1556" height="929" alt="image" src="https://github.com/user-attachments/assets/744070c7-af93-4bb5-a73c-089e4c77b1e9" />


- LCP halves further
- One Long Task during init eliminated (no >50ms main-thread blocking task remains)

A Long Task disappearing means the engine got a yield point during init that previously didn't exist — paint can land at that yield, which is consistent with the additional LCP improvement.

## Testing

`pnpm -F @videojs/utils test src/object/tests/defaults.test.ts` — existing tests pass without modification, including the cases that exercise the undefined-filtering contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in a small utility that should preserve behavior; main risk is subtle differences in key enumeration/typing due to switching from `for...in` assignment to `Object.entries` + spread.
> 
> **Overview**
> Refactors `defaults()` to build a `defined` object via `Object.entries(...).filter(!isUndefined)` and then return `{ ...defaultValues, ...defined }` instead of imperatively copying and conditionally assigning properties.
> 
> The intent is to keep the same contract (*ignore `undefined` inputs; preserve defined values*) while producing a more stable object shape for performance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775941d7e053ab8df47593435f6f75d03b6e9ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->