### PR TITLE
fix(core): resolve cast button ssr hydration mismatch

### DIFF
--- a/packages/core/src/core/ui/cast-button/cast-button-core.ts
+++ b/packages/core/src/core/ui/cast-button/cast-button-core.ts
@@ -27,7 +27,7 @@ export class CastButtonCore {
 
   readonly state = createState<CastButtonState>({
     castState: 'disconnected',
-    availability: 'unavailable',
+    availability: 'unsupported',
     label: '',
   });
 

--- a/packages/core/src/dom/store/features/remote-playback.ts
+++ b/packages/core/src/dom/store/features/remote-playback.ts
@@ -10,7 +10,7 @@ export const remotePlaybackFeature = definePlayerFeature({
   name: 'remotePlayback',
   state: ({ target }): MediaRemotePlaybackState => ({
     remotePlaybackState: 'disconnected',
-    remotePlaybackAvailability: 'unavailable',
+    remotePlaybackAvailability: 'unsupported',
 
     async toggleRemotePlayback() {
       const { media, container } = target();


### PR DESCRIPTION
Closes #1517

## Summary

The cast button produced different markup server-side vs. first client render in Chrome, causing a React SSR hydration mismatch.

## Changes

- Initialise `remotePlaybackAvailability` to `'unsupported'` in the remote-playback feature so first client render matches the server. The real value is set once `watchAvailability` resolves post-hydration.
- Match the initial `availability` default in `CastButtonCore.state`.

## Testing

- `pnpm -F @videojs/core test src/core/ui/cast-button` (16 tests pass)
- `pnpm typecheck`
- Manual: render the React player in an SSR app and confirm no hydration warning around the cast button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes initial remote playback/cast availability defaults to align server and first client render, with actual availability still resolved asynchronously via `watchAvailability`.
> 
> **Overview**
> Fixes an SSR hydration mismatch for the cast button by changing the initial availability defaults from `'unavailable'` to `'unsupported'` in both `CastButtonCore` state and the `remotePlaybackFeature` state.
> 
> Runtime availability continues to be updated after hydration when `watchAvailability` resolves, but the first render now matches server-side markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e756dee5369e9e402b9915a66e3ca83652c79c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->