### PR TITLE
docs(site): use togglePaused in playback feature example

### DIFF
--- a/site/src/content/docs/reference/feature-playback.mdx
+++ b/site/src/content/docs/reference/feature-playback.mdx
@@ -28,7 +28,7 @@ import { selectPlayback, usePlayer } from '@videojs/react';
 function PlayButton() {
   const playback = usePlayer(selectPlayback);
   if (!playback) return null;
-  return <button onClick={playback.toggle}>{playback.paused ? 'Play' : 'Pause'}</button>;
+  return <button onClick={playback.togglePaused}>{playback.paused ? 'Play' : 'Pause'}</button>;
 }
 ```
 </FrameworkCase>


### PR DESCRIPTION
Fixes #1520

## Summary

The React example on the playback feature reference page called `playback.toggle`, which doesn't exist. The actual API is `togglePaused()` (already listed in the auto-generated table on the same page). Anyone copy-pasting the snippet got `playback.toggle is undefined` at runtime.

## Changes

- Replace `playback.toggle` with `playback.togglePaused` in the React example.

## Testing

- Visual check on `/docs/framework/react/reference/feature-playback` — example now matches the API reference table directly above it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a React snippet to call the correct playback API, reducing copy/paste runtime errors.
> 
> **Overview**
> Updates the playback feature reference page’s React `PlayButton` example to use `playback.togglePaused` instead of the non-existent `playback.toggle`, aligning the snippet with the actual API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562e5c135d66f4fe8ab9a7c4c292f11dca46f06f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->