### PR TITLE
fix(html): set min dimensions on background-video host

### DIFF
--- a/packages/html/src/define/background/skin.css
+++ b/packages/html/src/define/background/skin.css
@@ -7,7 +7,9 @@ background-video-skin {
   position: relative;
   display: block;
   width: 100%;
+  min-width: 300px;
   height: 100%;
+  min-height: 150px;
   object-fit: var(--media-object-fit);
 }
 

--- a/packages/html/src/media/background-video/index.ts
+++ b/packages/html/src/media/background-video/index.ts
@@ -7,8 +7,6 @@ function getTemplateHTML(attrs: Record<string, string>) {
     <style>
       :host {
         position: relative;
-        min-width: 300px;
-        min-height: 150px;
       }
 
       video {

--- a/packages/html/src/media/background-video/index.ts
+++ b/packages/html/src/media/background-video/index.ts
@@ -7,6 +7,8 @@ function getTemplateHTML(attrs: Record<string, string>) {
     <style>
       :host {
         position: relative;
+        min-width: 300px;
+        min-height: 150px;
       }
 
       video {


### PR DESCRIPTION
Refs #1497

## Summary

Give `background-video-skin` a default `min-width: 300px` / `min-height: 150px` so the installation snippet renders visibly when copy-pasted into an empty page. Mirrors the CSS spec's intrinsic 300×150 default for replaced elements with no natural dimensions.

## Changes

- Add `min-width: 300px; min-height: 150px` to `background-video-skin` in `packages/html/src/define/background/skin.css`. The skin is the in-flow element (`display: block; width: 100%; height: 100%`), so the floor reserves layout space when the parent is unsized.
- The previous iteration of this PR put the floor on `:host` of `<background-video>`, but the skin absolutely-positions that element (`position: absolute; inset: 0`), so the min-* did not reserve space and could leave the parent collapsed while the video overflowed. Moving it onto the in-flow skin element addresses that review comment.

## Testing

No existing snapshot covers `background-video-skin`. Manual: pasting the generated install snippet into a fresh page now renders the player at 300×150 instead of collapsing to 0×0. Adding a `background-skin.spec.ts` visual test is a reasonable follow-up — happy to fold one into this PR if preferred.

## Risk

Low. CSS-only; existing consumers can override with `min-width: 0; min-height: 0` or by setting explicit `width` / `height` / `aspect-ratio` on a parent. The behavior change is limited to cases that previously rendered as 0×0.