### PR TITLE
docs(site): add 'use client' to homepage React snippet

### DIFF
--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -20,7 +20,9 @@ export function generateReactCode(skin: Skin): string {
   const skinComponent = skin === 'default' ? 'VideoSkin' : 'MinimalVideoSkin';
   const skinCss = skin === 'default' ? 'skin' : 'minimal-skin';
 
-  return `import { createPlayer } from '@videojs/react';
+  return `'use client';
+
+import { createPlayer } from '@videojs/react';
 import { ${skinComponent}, Video, videoFeatures } from '@videojs/react/video';
 import '@videojs/react/video/${skinCss}.css';
 


### PR DESCRIPTION
## Summary

- Add `'use client'` directive to the homepage React code snippet generated by `generateReactCode()` in `site/src/components/home/Demo/baseCode.ts`.
- This makes the "Assemble your player" homepage demo consistent with the installation guide's `MyPlayer.tsx` template (which already includes `'use client'`), and the ejected-skin examples (also already correct since #1488).

Closes #1384

## Validation

- `pnpm dev:site` and verify "Assemble your player" → React tab shows `'use client';` as the first line of the code snippet.
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a displayed code snippet string; no runtime logic or data/auth paths are changed.
> 
> **Overview**
> Adds the `'use client';` directive to the React/TSX code snippet generated by `generateReactCode()` for the homepage “Assemble your player” demo.
> 
> This makes the snippet compatible with Next.js/React Server Components expectations and consistent with other documented examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7fff3249c14f0195fbec81fd36018cb1bff5cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->