### PR TITLE
docs(site): warn that bundled HTML installs need type="module"

### DIFF
--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -127,6 +127,16 @@ Video.js supports a wide range of file types and hosting services. It's easy to 
 <ContentWidth>
   <HTMLUsageCodeBlock client:idle />
 </ContentWidth>
+
+<Aside type="caution" title="Load your script as a module">
+When using a bundler (npm, pnpm, yarn, bun), load the resulting bundle with `type="module"`:
+
+```html
+<script type="module" src="/dist/player.js"></script>
+```
+
+Some bundlers default to an IIFE output format. Loading that bundle without `type="module"` will cause a `StoreError: NO_TARGET` error when interacting with the player. The CDN install path already uses `type="module"` — bundled installs need the same.
+</Aside>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>


### PR DESCRIPTION
## Summary

- Add a caution Aside to the HTML installation guide explaining that bundled JavaScript must be loaded with `type="module"`.
- The CDN install path already uses `type="module"` in its generated `<script>` tags. Bundler-based installs (npm/pnpm/yarn/bun) were missing this guidance, causing users to encounter `StoreError: NO_TARGET` when clicking any control.
- The `@videojs/html` package ships ESM-only (`"type": "module"` in its `package.json`). Some bundlers (e.g. esbuild) default to IIFE output; loading that bundle without `type="module"` breaks custom element registration timing.

Closes #1493

## Validation

- `pnpm dev:site` → navigate to `/docs/framework/html/how-to/installation/` with a non-CDN install method selected → confirm the caution aside appears under "Use your player".
- Switch to the React framework view → confirm the aside does not appear (it is inside `<FrameworkCase frameworks={["html"]}>`).
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or build logic is modified.
> 
> **Overview**
> Adds a **caution note** to the HTML installation guide warning that bundler-produced player scripts must be loaded with `type="module"`, including an example `<script>` tag.
> 
> Calls out that non-module (e.g., IIFE) bundles can trigger `StoreError: NO_TARGET` when interacting with the player, and clarifies that the CDN path already uses module scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df0359e6fa0223048503aad1289d8a7258e6c2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->