### PR TITLE
fix(skin): fix minimal tailwind root sizing

### DIFF
--- a/packages/skins/src/minimal/tailwind/components/root.ts
+++ b/packages/skins/src/minimal/tailwind/components/root.ts
@@ -2,7 +2,7 @@ import { cn } from '@videojs/utils/style';
 
 export const root = cn(
   // Layout & containment
-  'block relative isolate @container/media-root',
+  'block relative isolate h-full w-full @container/media-root',
   // Appearance
   'rounded-(--media-border-radius,0.75rem)',
   'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] leading-normal subpixel-antialiased',


### PR DESCRIPTION
Closes #1539

## Summary

The minimal Tailwind skin root collapses to 0×0 when its parent is a flex container without `align-items: stretch`, even when sized via `aspect-ratio` on the root. Reproduces on the `react-simple-hls-video` sandbox template with `?skin=minimal&styling=tailwind` — nothing renders.

`@container/media-root` compiles to `container-type: inline-size`, which applies inline-size containment. With `display: block` and no explicit width, the root has no way to derive its inline size — descendants can't contribute (containment), and the flex parent doesn't stretch the cross axis. Width resolves to 0, then `aspect-ratio` resolves height to 0.

The default Tailwind root hit the same problem and was fixed in #881 by adding `h-full w-full`. The minimal root was missed. This applies the same fix.

## Test plan

- [ ] `pnpm -F sandbox dev`, open `react-simple-hls-video/?skin=minimal&styling=tailwind`, verify the player renders
- [ ] Same check for `react-video`, `react-hls-video`, `react-live-video` with `skin=minimal&styling=tailwind`
- [ ] Default skin (`skin=default&styling=tailwind`) and CSS styling unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adds explicit `h-full w-full` sizing to the minimal Tailwind skin root; potential impact is limited to layout in edge containers.
> 
> **Overview**
> Fixes a rendering/layout issue in the minimal Tailwind skin by adding explicit `h-full w-full` sizing to the root (`@container/media-root`) element so it doesn’t collapse to 0×0 in non-stretch flex parents (matching the default skin behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a304daecce90941dc46113cfc21acd264b9e9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->