### PR TITLE
fix(react): memoize Provider context value

### DIFF
--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -16,7 +16,7 @@ import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import type { FC, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useDestroy } from '../utils/use-destroy';
 import { Container, PlayerContextProvider, useMedia, usePlayerContext } from './context';
@@ -82,11 +82,21 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       return store.attach({ media, container });
     }, [media, container, store]);
 
-    return (
-      <PlayerContextProvider value={{ store, media, setMedia, container, setContainer, popupGroup }}>
-        {children}
-      </PlayerContextProvider>
+    // Memoize the context value so its identity only changes when one of its
+    // members actually changes. Without this, every render of a component
+    // above the Provider rebuilds the value object, which forces every
+    // `useContext(PlayerContext)` consumer to re-render even when nothing
+    // it depends on changed. `setMedia` and `setContainer` are `useState`
+    // setters and are identity-stable; `store` and `popupGroup` are also
+    // initialized once via `useState(() => ...)` and never change for the
+    // lifetime of the Provider. They're listed in the dep array to satisfy
+    // `useExhaustiveDependencies`. See #1296.
+    const value = useMemo(
+      () => ({ store, media, setMedia, container, setContainer, popupGroup }),
+      [store, media, container, popupGroup]
     );
+
+    return <PlayerContextProvider value={value}>{children}</PlayerContextProvider>;
   }
 
   if (__DEV__ && config.displayName) {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -1,9 +1,10 @@
-import { render, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import type { PlayerStore } from '@videojs/core/dom';
 import { defineSlice } from '@videojs/store';
 import type { ReactNode } from 'react';
-import { StrictMode } from 'react';
+import { StrictMode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { usePlayerContext } from '../context';
 import { createPlayer } from '../create-player';
 
 describe('createPlayer', () => {
@@ -109,6 +110,46 @@ describe('createPlayer', () => {
       );
 
       expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
+    });
+
+    it('provides a stable context value across parent re-renders (fix for #1296)', () => {
+      // Without memoization, the Provider rebuilds its context value on every
+      // render. Every `useContext(PlayerContext)` consumer then re-renders on
+      // any parent re-render, which (combined with callback-ref usage in
+      // media components) detaches and re-attaches the underlying media on
+      // every parent state change. At end-of-stream this rewinds the video.
+      const { Provider } = createPlayer({ features: [mockSlice] });
+
+      const receivedValues: unknown[] = [];
+
+      function ContextConsumer() {
+        const ctx = usePlayerContext();
+        receivedValues.push(ctx);
+        return null;
+      }
+
+      let forceParentRerender!: () => void;
+      function Parent() {
+        const [, setTick] = useState(0);
+        forceParentRerender = () => setTick((t) => t + 1);
+        return (
+          <Provider>
+            <ContextConsumer />
+          </Provider>
+        );
+      }
+
+      render(<Parent />);
+
+      const valueAfterMount = receivedValues[receivedValues.length - 1];
+
+      act(() => forceParentRerender());
+      act(() => forceParentRerender());
+      act(() => forceParentRerender());
+
+      const valueAfterRerenders = receivedValues[receivedValues.length - 1];
+
+      expect(valueAfterRerenders).toBe(valueAfterMount);
     });
   });
 


### PR DESCRIPTION
Related to #1296
 
## What changed
 
**Diff:** 2 files changed, 58 insertions(+), 7 deletions(-).

- **`packages/react/src/player/create-player.tsx`** — Provider context value wrapped in `useMemo` keyed on `[store, media, container, popupGroup]`. `setMedia` and `setContainer` are omitted (identity-stable `useState` setters). `popupGroup` (added on `main` since the original PR was opened) is included in both the value and the dep array.

- **`packages/react/src/player/tests/create-player.test.tsx`** — one regression test added: mounts a `usePlayerContext()` consumer, forces parent re-renders three times, asserts context value identity is preserved (`toBe`).

**Test results in `packages/react`:**

| Step | Result |
|---|---|
| Baseline (untouched `main`) | 17 files, **237 passing** |
| With fix applied | 17 files, **238 passing** (+1 new) |
| Source reverted, new test kept | 1 new test **fails** (fail-before/pass-after contract) |
| Source re-applied | **238/238 passing** |
| `pnpm typecheck` (root) | Clean |
| `pnpm lint` on the 2 changed files | Clean |

The `attachMediaElement` `WeakMap` fix has been fully discarded. Worth noting that #1376 has since landed on `main`, which introduced `useAttachMedia` (a `useCallback`-based hook keyed on `[media]`), so the ref-identity stability that fix #2 was guarding against is now handled at the hook level — fix #2 isn't just unwanted, it's obsolete against current `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to React context value memoization and adds a regression test; behavior should be unchanged except fewer unnecessary re-renders and attach/detach churn.
> 
> **Overview**
> Fixes `createPlayer().Provider` to **memoize the `PlayerContext` value** via `useMemo`, so consumers don’t re-render (and trigger media detach/reattach) on unrelated parent renders (regression #1296).
> 
> Adds a test asserting the context value identity remains stable across repeated parent re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e2915791e2c4684ca0c5299de58bb903be8f678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->