### PR TITLE
docs(site): fix feature export names in why-videojs guide

### DIFF
--- a/site/src/content/docs/concepts/why-videojs.mdx
+++ b/site/src/content/docs/concepts/why-videojs.mdx
@@ -84,19 +84,19 @@ Most player libraries ship every feature in one bundle, so you carry code you do
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-import { createPlayer, playback, time } from '@videojs/react';
+import { createPlayer, playbackFeature, timeFeature } from '@videojs/react';
 
 const Player = createPlayer({
-  features: [playback, time], // [!code focus]
+  features: [playbackFeature, timeFeature], // [!code focus]
 });
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 ```ts
-import { createPlayer, playback, time } from '@videojs/html';
+import { createPlayer, playbackFeature, timeFeature } from '@videojs/html';
 
 const { ProviderMixin, PlayerController, context } = createPlayer({
-  features: [playback, time], // [!code focus]
+  features: [playbackFeature, timeFeature], // [!code focus]
 });
 ```
 </FrameworkCase>


### PR DESCRIPTION
Follow-up to #1513, addressing @decepulis's review comment about the newly added "Why Video.js?" concept guide using the same outdated bare feature exports.

Renames `playback` → `playbackFeature` and `time` → `timeFeature` in both the React and HTML snippets in `site/src/content/docs/concepts/why-videojs.mdx`, so the imports match what's actually exported from `@videojs/react` / `@videojs/html`.

No `controlsFeature` is added here because the example does not render any UI — it's purely demonstrating feature composition for `createPlayer`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5RKb3oazPmgXvTfuapnie)_