### PR TITLE
fix(skin): improve buffering, overlays, and input feedback

### DIFF
--- a/packages/core/src/dom/ui/tests/transition.test.ts
+++ b/packages/core/src/dom/ui/tests/transition.test.ts
@@ -29,6 +29,28 @@ describe('createTransition', () => {
       await promise;
       expect(handler.state.current).toEqual({ active: true, status: 'idle' });
     });
+
+    it('cancels active animations and flushes styles when restarting an active transition', async () => {
+      const handler = createTransition();
+      const el = document.createElement('div');
+      const getOffsetHeight = vi.spyOn(el, 'offsetHeight', 'get');
+      const cancel = vi.fn();
+      Object.defineProperty(el, 'getAnimations', {
+        value: vi.fn(() => [{ cancel }]),
+      });
+
+      await handler.open();
+      await vi.waitFor(() => {
+        expect(handler.state.current.status).toBe('idle');
+      });
+
+      handler.open(el);
+
+      await vi.waitFor(() => {
+        expect(cancel).toHaveBeenCalled();
+      });
+      expect(getOffsetHeight).toHaveBeenCalled();
+    });
   });
 
   describe('close', () => {

--- a/packages/core/src/dom/ui/transition.ts
+++ b/packages/core/src/dom/ui/transition.ts
@@ -4,7 +4,7 @@ import type { TransitionState } from '../../core/ui/transition';
 
 export interface TransitionApi {
   state: State<TransitionState>;
-  open(): Promise<void>;
+  open(el?: HTMLElement | null): Promise<void>;
   close(el: HTMLElement | null): Promise<void>;
   cancel(): void;
   destroy(): void;
@@ -15,7 +15,8 @@ export interface TransitionApi {
  *
  * **Open:** patches `{ active: true, status: 'starting' }`, then after a
  * double-RAF patches `{ status: 'idle' }` so the browser paints the
- * initial ("from") state before transitioning.
+ * initial ("from") state before transitioning. Reopening an active transition
+ * flushes styles first so CSS transitions can restart.
  *
  * **Close:** patches `{ status: 'ending' }` (keeping `active: true` so the
  * element stays mounted), then after a double-RAF waits for
@@ -28,17 +29,27 @@ export function createTransition(): TransitionApi {
   let rafId1 = 0;
   let rafId2 = 0;
 
-  function open(): Promise<void> {
+  function open(el: HTMLElement | null = null): Promise<void> {
     cancelAnimationFrame(rafId1);
     cancelAnimationFrame(rafId2);
     rafId1 = 0;
     rafId2 = 0;
+
+    const restarting = state.current.active;
+
+    if (restarting) {
+      state.patch({ status: 'idle' });
+    }
 
     state.patch({ active: true, status: 'starting' });
 
     return new Promise<void>((resolve) => {
       rafId1 = requestAnimationFrame(() => {
         rafId1 = 0;
+        if (restarting) {
+          cancelAnimations(el);
+          flushStyles(el);
+        }
         rafId2 = requestAnimationFrame(() => {
           rafId2 = 0;
           if (destroyed || !state.current.active) return resolve();
@@ -94,6 +105,19 @@ export function createTransition(): TransitionApi {
       cancel();
     },
   };
+}
+
+function flushStyles(el: HTMLElement | null): void {
+  if (!el) return;
+  void el.offsetHeight;
+}
+
+function cancelAnimations(el: HTMLElement | null): void {
+  const animations = el?.getAnimations?.({ subtree: true }) ?? [];
+
+  for (const animation of animations) {
+    animation.cancel();
+  }
 }
 
 function waitForAnimations(el: HTMLElement | null): Promise<void> {

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -9,6 +9,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -48,15 +49,20 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
-            </media-tooltip>
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -9,6 +9,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -48,12 +49,17 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}"></media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -31,15 +31,20 @@ function getTemplateHTML() {
       <div class="media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
-            </media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip">
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -31,12 +31,17 @@ function getTemplateHTML() {
       <div class="media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip"></media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip"></media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -2,6 +2,7 @@
 // used by the minimal skin without creating a skin element. Use this entry
 // when building an ejected (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
 import { PlayButtonElement } from '../../ui/play-button/play-button-element';
@@ -32,6 +33,7 @@ defineTime();
 defineMenu();
 
 // Standalone elements.
+safeDefine(BufferingIndicatorElement);
 safeDefine(HotkeyElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -2,6 +2,7 @@
 // used by the minimal skin without creating a skin element. Use this entry
 // when building an ejected (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
 import { PlayButtonElement } from '../../ui/play-button/play-button-element';
 import { PlaybackRateMenuElement } from '../../ui/playback-rate-menu/playback-rate-menu-element';
@@ -30,6 +31,7 @@ defineTime();
 defineMenu();
 
 // Standalone elements.
+safeDefine(BufferingIndicatorElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);
 safeDefine(PlaybackRateOptionsElement);

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -9,6 +9,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -48,15 +49,20 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
-            </media-tooltip>
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -9,6 +9,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -48,12 +49,17 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}"></media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="${cn(button.base, button.subtle, button.icon)}">
               <span class="${iconContainer}">

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -31,15 +31,20 @@ function getTemplateHTML() {
       <div class="media-surface media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
-            </media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip">
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -31,12 +31,17 @@ function getTemplateHTML() {
       <div class="media-surface media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip"></media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip"></media-tooltip>
+            </span>
 
             <media-seek-button commandfor="seek-backward-tooltip" seconds="${-SEEK_TIME}" class="media-button media-button--subtle media-button--icon media-button--seek">
               <span class="media-icon__container">

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -2,6 +2,7 @@
 // without creating a skin element. Use this entry when building an ejected
 // (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
 import { LiveButtonElement } from '../../ui/live-button/live-button-element';
@@ -35,6 +36,7 @@ defineMenu();
 // Standalone elements.
 safeDefine(GestureElement);
 safeDefine(HotkeyElement);
+safeDefine(BufferingIndicatorElement);
 safeDefine(LiveButtonElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -2,6 +2,7 @@
 // without creating a skin element. Use this entry when building an ejected
 // (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
 import { LiveButtonElement } from '../../ui/live-button/live-button-element';
@@ -36,6 +37,7 @@ defineMenu();
 // Standalone elements.
 safeDefine(GestureElement);
 safeDefine(HotkeyElement);
+safeDefine(BufferingIndicatorElement);
 safeDefine(LiveButtonElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -6,6 +6,7 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
@@ -40,7 +41,11 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
@@ -49,6 +54,7 @@ function getTemplateHTML() {
                 <media-tooltip-label></media-tooltip-label>
                 <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
               </media-tooltip>
+            </span>
 
               <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -6,6 +6,7 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
@@ -40,12 +41,17 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}"></media-tooltip>
+            </span>
 
               <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -29,15 +29,20 @@ function getTemplateHTML() {
       <div class="media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
-            </media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip">
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
             <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -29,12 +29,17 @@ function getTemplateHTML() {
       <div class="media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip"></media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-tooltip"></media-tooltip>
+            </span>
 
             <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/minimal-ui.ts
+++ b/packages/html/src/define/live-audio/minimal-ui.ts
@@ -3,6 +3,7 @@
 // this entry when building an ejected (light DOM) player layout for live
 // HLS / DASH streams.
 import { MediaContainerElement } from '../../media/container-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { LiveButtonElement } from '../../ui/live-button/live-button-element';
 import { MuteButtonElement } from '../../ui/mute-button/mute-button-element';
 import { PlayButtonElement } from '../../ui/play-button/play-button-element';
@@ -27,6 +28,7 @@ defineVolumeSlider();
 defineTime();
 
 // Standalone elements.
+safeDefine(BufferingIndicatorElement);
 safeDefine(LiveButtonElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -6,6 +6,7 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
@@ -40,15 +41,20 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
-            </media-tooltip>
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
               <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -6,6 +6,7 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
@@ -40,12 +41,17 @@ function getTemplateHTML() {
       <div class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
-              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+            <span class="${playButton.wrapper}">
+              <media-buffering-indicator class="${playButton.bufferingRoot}">
+                ${renderIcon('spinner', { class: icon })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button, playButton.control)}">
                 ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
                 ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
                 ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
               </media-play-button>
               <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="${cn(popup.tooltip)}"></media-tooltip>
+            </span>
 
               <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/skin.ts
+++ b/packages/html/src/define/live-audio/skin.ts
@@ -29,15 +29,20 @@ function getTemplateHTML() {
       <div class="media-surface media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip">
-              <media-tooltip-label></media-tooltip-label>
-              <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
-            </media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip">
+                <media-tooltip-label></media-tooltip-label>
+                <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
+              </media-tooltip>
+            </span>
 
             <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/skin.ts
+++ b/packages/html/src/define/live-audio/skin.ts
@@ -29,12 +29,17 @@ function getTemplateHTML() {
       <div class="media-surface media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
-            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
-              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
-              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
-              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
-            </media-play-button>
-            <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip"></media-tooltip>
+            <span class="media-button--play__wrapper">
+              <media-buffering-indicator class="media-buffering-indicator">
+                ${renderIcon('spinner', { class: 'media-icon' })}
+              </media-buffering-indicator>
+              <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+                ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+                ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+                ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" boundary="viewport" class="media-surface media-tooltip"></media-tooltip>
+            </span>
 
             <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
           </div>

--- a/packages/html/src/define/live-audio/ui.ts
+++ b/packages/html/src/define/live-audio/ui.ts
@@ -2,6 +2,7 @@
 // elements without creating a skin element. Use this entry when building an
 // ejected (light DOM) player layout for live HLS / DASH streams.
 import { MediaContainerElement } from '../../media/container-element';
+import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
 import { LiveButtonElement } from '../../ui/live-button/live-button-element';
@@ -30,6 +31,7 @@ defineTime();
 // Standalone elements.
 safeDefine(GestureElement);
 safeDefine(HotkeyElement);
+safeDefine(BufferingIndicatorElement);
 safeDefine(LiveButtonElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -36,9 +36,7 @@ function getTemplateHTML() {
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator.root}">
-        <div class="${bufferingIndicator.container}">
-          ${renderIcon('spinner')}
-        </div>
+        ${renderIcon('spinner', { class: icon })}
       </media-buffering-indicator>
 
       <media-error-dialog class="${error.root}">

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -35,9 +35,7 @@ function getTemplateHTML() {
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator.root}">
-        <div class="${bufferingIndicator.container}">
-          ${renderIcon('spinner')}
-        </div>
+        ${renderIcon('spinner', { class: icon })}
       </media-buffering-indicator>
 
       <media-error-dialog class="${error.root}">

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -19,9 +19,7 @@ function getTemplateHTML() {
       </media-poster>
 
       <media-buffering-indicator class="media-buffering-indicator">
-        <div class="media-surface">
-          ${renderIcon('spinner', { class: 'media-icon' })}
-        </div>
+        ${renderIcon('spinner', { class: 'media-icon' })}
       </media-buffering-indicator>
 
       <media-error-dialog class="media-error">

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -44,9 +44,7 @@ function getTemplateHTML() {
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator.root}">
-        <div class="${bufferingIndicator.container}">
-          ${renderIcon('spinner')}
-        </div>
+        ${renderIcon('spinner', { class: icon })}
       </media-buffering-indicator>
 
       <media-error-dialog class="${error.root}">

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -21,9 +21,7 @@ function getTemplateHTML() {
       </media-poster>
 
       <media-buffering-indicator class="media-buffering-indicator">
-        <div class="media-surface">
-          ${renderIcon('spinner', { class: 'media-icon' })}
-        </div>
+        ${renderIcon('spinner', { class: 'media-icon' })}
       </media-buffering-indicator>
 
       <media-error-dialog class="media-error">

--- a/packages/html/src/ui/input-indicators/input-indicator-element.ts
+++ b/packages/html/src/ui/input-indicators/input-indicator-element.ts
@@ -29,10 +29,17 @@ export interface InputIndicatorCoreApi<IndicatorState extends IndicatorLifecycle
   processEvent(event: InputActionEvent, snapshot: MediaSnapshot): boolean;
 }
 
+export interface InputIndicatorOptions {
+  replayOnUpdate?: boolean | undefined;
+}
+
 export abstract class InputIndicatorElement<IndicatorState extends IndicatorLifecycleState> extends MediaElement {
   protected abstract get core(): InputIndicatorCoreApi<IndicatorState>;
   protected abstract get transition(): TransitionApi;
   protected abstract get liveIndicator(): LiveIndicator<IndicatorState>;
+  protected get options(): InputIndicatorOptions {
+    return {};
+  }
 
   protected abstract syncCoreProps(): void;
 
@@ -119,7 +126,12 @@ export abstract class InputIndicatorElement<IndicatorState extends IndicatorLife
       this.#snapshot = currentState;
       if (this.#lastGeneration !== currentState.generation) {
         this.#lastGeneration = currentState.generation;
-        void this.transition.open();
+        const transitionState = this.transition.state.current;
+        if (!transitionState.active || this.options.replayOnUpdate !== false) {
+          void this.transition.open(this.liveIndicator.element);
+        } else if (transitionState.status === 'ending') {
+          this.transition.cancel();
+        }
       }
       return;
     }

--- a/packages/html/src/ui/volume-indicator/volume-indicator-element.ts
+++ b/packages/html/src/ui/volume-indicator/volume-indicator-element.ts
@@ -7,7 +7,7 @@ import {
 import { createTransition } from '@videojs/core/dom';
 import type { PropertyDeclarationMap } from '@videojs/element';
 
-import { InputIndicatorElement } from '../input-indicators/input-indicator-element';
+import { InputIndicatorElement, type InputIndicatorOptions } from '../input-indicators/input-indicator-element';
 import { LiveIndicator } from '../input-indicators/live-indicator';
 
 export class VolumeIndicatorElement extends InputIndicatorElement<VolumeIndicatorCore.State> {
@@ -26,6 +26,7 @@ export class VolumeIndicatorElement extends InputIndicatorElement<VolumeIndicato
     dataAttrs: VolumeIndicatorDataAttrs,
     render: renderVolumeIndicator,
   });
+  readonly #options = { replayOnUpdate: false } satisfies InputIndicatorOptions;
 
   protected get core() {
     return this.#core;
@@ -37,6 +38,10 @@ export class VolumeIndicatorElement extends InputIndicatorElement<VolumeIndicato
 
   protected get liveIndicator() {
     return this.#liveIndicator;
+  }
+
+  protected override get options() {
+    return this.#options;
   }
 
   protected override syncCoreProps(): void {

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -8,6 +8,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -23,11 +24,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
@@ -179,21 +182,30 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}>
-                <Tooltip.Label />
-                <Tooltip.Shortcut className={popup.tooltipShortcut} />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}>
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className={popup.tooltipShortcut} />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -8,6 +8,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -23,11 +24,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
@@ -163,18 +166,27 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -6,11 +6,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -126,21 +128,30 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
       <div className="media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-tooltip">
-                <Tooltip.Label />
-                <Tooltip.Shortcut className="media-tooltip__kbd" />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-tooltip">
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className="media-tooltip__kbd" />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -6,11 +6,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -110,18 +112,27 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
       <div className="media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-tooltip" />
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-tooltip" />
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -8,6 +8,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -23,11 +24,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -181,21 +184,30 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}>
-                <Tooltip.Label />
-                <Tooltip.Shortcut className={popup.tooltipShortcut} />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}>
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className={popup.tooltipShortcut} />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -8,6 +8,7 @@ import {
   iconFlipped,
   iconState,
   menu,
+  playButton,
   playbackRate,
   popup,
   root,
@@ -23,11 +24,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -165,18 +168,27 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -6,11 +6,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -126,21 +128,30 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
       <div className="media-surface media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-surface media-tooltip">
-                <Tooltip.Label />
-                <Tooltip.Shortcut className="media-tooltip__kbd" />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-surface media-tooltip">
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className="media-tooltip__kbd" />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -6,11 +6,13 @@ import {
   PlayIcon,
   RestartIcon,
   SeekIcon,
+  SpinnerIcon,
   VolumeHighIcon,
   VolumeLowIcon,
   VolumeOffIcon,
 } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -110,18 +112,27 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
       <div className="media-surface media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-surface media-tooltip" />
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-surface media-tooltip" />
+              </Tooltip.Root>
+            </span>
 
             <Tooltip.Root side="top" boundary="viewport">
               <Tooltip.Trigger

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -5,14 +5,24 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
 } from '@videojs/skins/minimal/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons/minimal';
+import {
+  PauseIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -119,21 +129,30 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}>
-                <Tooltip.Label />
-                <Tooltip.Shortcut className={popup.tooltipShortcut} />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}>
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className={popup.tooltipShortcut} />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className={cn(button.base, button.subtle, button.live)} />
           </div>

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -5,14 +5,24 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
 } from '@videojs/skins/minimal/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons/minimal';
+import {
+  PauseIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -119,18 +129,27 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className={cn(button.base, button.subtle, button.live)} />
           </div>

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -1,7 +1,16 @@
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons/minimal';
+import {
+  PauseIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -85,21 +94,30 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
       <div className="media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-tooltip">
-                <Tooltip.Label />
-                <Tooltip.Shortcut className="media-tooltip__kbd" />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-tooltip">
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className="media-tooltip__kbd" />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className="media-button media-button--subtle media-button--live" />
           </div>

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -1,7 +1,16 @@
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons/minimal';
+import {
+  PauseIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -85,18 +94,27 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
       <div className="media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-tooltip" />
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-tooltip" />
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className="media-button media-button--subtle media-button--live" />
           </div>

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -5,14 +5,16 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
 } from '@videojs/skins/default/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
+import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -119,21 +121,30 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}>
-                <Tooltip.Label />
-                <Tooltip.Shortcut className={popup.tooltipShortcut} />
-              </Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}>
+                  <Tooltip.Label />
+                  <Tooltip.Shortcut className={popup.tooltipShortcut} />
+                </Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className={cn(button.base, button.subtle, button.live)} />
           </div>

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -5,14 +5,16 @@ import {
   error,
   icon,
   iconState,
+  playButton,
   popup,
   root,
   slider,
 } from '@videojs/skins/default/tailwind/audio.tailwind';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
+import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -119,18 +121,27 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
       <div className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className={iconState.play.button} render={<Button />}>
-                    <RestartIcon className={cn(icon, iconState.play.restart)} />
-                    <PlayIcon className={cn(icon, iconState.play.play)} />
-                    <PauseIcon className={cn(icon, iconState.play.pause)} />
-                  </PlayButton>
-                }
+            <span className={playButton.wrapper}>
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className={cn(playButton.bufferingRoot, props.className)}>
+                    <SpinnerIcon className={icon} />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className={cn(iconState.play.button, playButton.control)} render={<Button />}>
+                      <RestartIcon className={cn(icon, iconState.play.restart)} />
+                      <PlayIcon className={cn(icon, iconState.play.play)} />
+                      <PauseIcon className={cn(icon, iconState.play.pause)} />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className={cn(button.base, button.subtle, button.live)} />
           </div>

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -1,7 +1,8 @@
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
+import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -93,18 +94,27 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
       <div className="media-surface media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <TooltipPopup />
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <TooltipPopup />
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className="media-button media-button--subtle media-button--live" />
           </div>

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -1,7 +1,8 @@
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
-import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
+import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -84,18 +85,27 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
       <div className="media-surface media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
-            <Tooltip.Root side="top" boundary="viewport">
-              <Tooltip.Trigger
-                render={
-                  <PlayButton className="media-button--play" render={<Button />}>
-                    <RestartIcon className="media-icon media-icon--restart" />
-                    <PlayIcon className="media-icon media-icon--play" />
-                    <PauseIcon className="media-icon media-icon--pause" />
-                  </PlayButton>
-                }
+            <span className="media-button--play__wrapper">
+              <BufferingIndicator
+                render={(props) => (
+                  <div {...props} className="media-buffering-indicator">
+                    <SpinnerIcon className="media-icon" />
+                  </div>
+                )}
               />
-              <Tooltip.Popup className="media-surface media-tooltip" />
-            </Tooltip.Root>
+              <Tooltip.Root side="top" boundary="viewport">
+                <Tooltip.Trigger
+                  render={
+                    <PlayButton className="media-button--play" render={<Button />}>
+                      <RestartIcon className="media-icon media-icon--restart" />
+                      <PlayIcon className="media-icon media-icon--play" />
+                      <PauseIcon className="media-icon media-icon--pause" />
+                    </PlayButton>
+                  }
+                />
+                <Tooltip.Popup className="media-surface media-tooltip" />
+              </Tooltip.Root>
+            </span>
 
             <LiveButton className="media-button media-button--subtle media-button--live" />
           </div>

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -149,9 +149,7 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className={bufferingIndicator.root}>
-            <div className={bufferingIndicator.container}>
-              <SpinnerIcon className={icon} />
-            </div>
+            <SpinnerIcon className={icon} />
           </div>
         )}
       />

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -213,9 +213,7 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className={bufferingIndicator.root}>
-            <div className={bufferingIndicator.container}>
-              <SpinnerIcon className={icon} />
-            </div>
+            <SpinnerIcon className={icon} />
           </div>
         )}
       />

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -105,9 +105,7 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className="media-buffering-indicator">
-            <div className="media-surface">
-              <SpinnerIcon className="media-icon" />
-            </div>
+            <SpinnerIcon className="media-icon" />
           </div>
         )}
       />

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -170,9 +170,7 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className="media-buffering-indicator">
-            <div className="media-surface">
-              <SpinnerIcon className="media-icon" />
-            </div>
+            <SpinnerIcon className="media-icon" />
           </div>
         )}
       />

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -191,9 +191,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className={bufferingIndicator.root}>
-            <div className={bufferingIndicator.container}>
-              <SpinnerIcon className={icon} />
-            </div>
+            <SpinnerIcon className={icon} />
           </div>
         )}
       />

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -363,9 +363,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className={bufferingIndicator.root}>
-            <div className={bufferingIndicator.container}>
-              <SpinnerIcon className={icon} />
-            </div>
+            <SpinnerIcon className={icon} />
           </div>
         )}
       />

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -296,9 +296,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className="media-buffering-indicator">
-            <div className="media-surface">
-              <SpinnerIcon className="media-icon" />
-            </div>
+            <SpinnerIcon className="media-icon" />
           </div>
         )}
       />

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -126,9 +126,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       <BufferingIndicator
         render={(props) => (
           <div {...props} className="media-buffering-indicator">
-            <div className="media-surface">
-              <SpinnerIcon className="media-icon" />
-            </div>
+            <SpinnerIcon className="media-icon" />
           </div>
         )}
       />

--- a/packages/react/src/ui/input-indicators/tests/use-rendered-indicator-state.test.tsx
+++ b/packages/react/src/ui/input-indicators/tests/use-rendered-indicator-state.test.tsx
@@ -1,0 +1,99 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { IndicatorLifecycleState, TransitionState } from '@videojs/core';
+import { createState } from '@videojs/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transitionMock = vi.hoisted(() => ({
+  createTransition: vi.fn(),
+}));
+
+vi.mock('@videojs/core/dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@videojs/core/dom')>()),
+  createTransition: transitionMock.createTransition,
+}));
+
+import { useRenderedIndicatorState } from '../use-rendered-indicator-state';
+
+interface TestIndicatorState extends IndicatorLifecycleState {
+  value: string;
+}
+
+function makeState(generation: number): TestIndicatorState {
+  return {
+    open: true,
+    generation,
+    value: String(generation),
+    transitionStarting: false,
+    transitionEnding: false,
+  };
+}
+
+function mockTransition() {
+  const state = createState<TransitionState>({ active: false, status: 'idle' });
+  const open = vi.fn(() => {
+    state.patch({ active: true, status: 'starting' });
+    return Promise.resolve();
+  });
+  const close = vi.fn(() => Promise.resolve());
+  const cancel = vi.fn();
+  const destroy = vi.fn();
+
+  transitionMock.createTransition.mockReturnValue({ state, open, close, cancel, destroy });
+
+  return { state, open, close, cancel, destroy };
+}
+
+beforeEach(() => {
+  transitionMock.createTransition.mockReset();
+});
+
+describe('useRenderedIndicatorState', () => {
+  it('replays the open transition on updates by default', async () => {
+    const transition = mockTransition();
+    const { rerender } = renderHook(({ current }) => useRenderedIndicatorState(current), {
+      initialProps: { current: makeState(1) },
+    });
+
+    await waitFor(() => {
+      expect(transition.open).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ current: makeState(2) });
+
+    await waitFor(() => {
+      expect(transition.open).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('skips replaying the open transition on updates when disabled', async () => {
+    const transition = mockTransition();
+    const { rerender } = renderHook(({ current }) => useRenderedIndicatorState(current, { replayOnUpdate: false }), {
+      initialProps: { current: makeState(1) },
+    });
+
+    await waitFor(() => {
+      expect(transition.open).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ current: makeState(2) });
+
+    expect(transition.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels an ending transition when replay is disabled and an update arrives', async () => {
+    const transition = mockTransition();
+    const { rerender } = renderHook(({ current }) => useRenderedIndicatorState(current, { replayOnUpdate: false }), {
+      initialProps: { current: makeState(1) },
+    });
+
+    await waitFor(() => {
+      expect(transition.open).toHaveBeenCalledTimes(1);
+    });
+
+    transition.state.patch({ active: true, status: 'ending' });
+    rerender({ current: makeState(2) });
+
+    expect(transition.open).toHaveBeenCalledTimes(1);
+    expect(transition.cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/ui/input-indicators/use-input-indicator-root.ts
+++ b/packages/react/src/ui/input-indicators/use-input-indicator-root.ts
@@ -7,7 +7,7 @@ import { useState, useSyncExternalStore } from 'react';
 import { useDestroy } from '../../utils/use-destroy';
 import { useIndicatorVisibility } from './use-indicator-visibility';
 import { useInputActionSubscription } from './use-input-action-subscription';
-import { useRenderedIndicatorState } from './use-rendered-indicator-state';
+import { type RenderedIndicatorOptions, useRenderedIndicatorState } from './use-rendered-indicator-state';
 
 interface InputIndicatorRootCore<IndicatorState extends IndicatorLifecycleState, Props> {
   readonly state: StoreState<IndicatorState>;
@@ -19,7 +19,8 @@ interface InputIndicatorRootCore<IndicatorState extends IndicatorLifecycleState,
 
 export function useInputIndicatorRoot<IndicatorState extends IndicatorLifecycleState, Props>(
   createCore: () => InputIndicatorRootCore<IndicatorState, Props>,
-  props: Props
+  props: Props,
+  options?: RenderedIndicatorOptions
 ) {
   const [core] = useState(createCore);
   useDestroy(core);
@@ -36,5 +37,5 @@ export function useInputIndicatorRoot<IndicatorState extends IndicatorLifecycleS
     () => core.state.current
   );
 
-  return useRenderedIndicatorState(currentState);
+  return useRenderedIndicatorState(currentState, options);
 }

--- a/packages/react/src/ui/input-indicators/use-rendered-indicator-state.ts
+++ b/packages/react/src/ui/input-indicators/use-rendered-indicator-state.ts
@@ -2,11 +2,18 @@
 
 import { getRenderedIndicatorState, type IndicatorLifecycleState, isIndicatorPresent } from '@videojs/core';
 import { createTransition } from '@videojs/core/dom';
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
 
 import { useDestroy } from '../../utils/use-destroy';
 
-export function useRenderedIndicatorState<State extends IndicatorLifecycleState>(currentState: State) {
+export interface RenderedIndicatorOptions {
+  replayOnUpdate?: boolean | undefined;
+}
+
+export function useRenderedIndicatorState<State extends IndicatorLifecycleState>(
+  currentState: State,
+  options: RenderedIndicatorOptions = {}
+) {
   const elementRef = useRef<HTMLElement>(null);
   const currentStateRef = useRef(currentState);
   const snapshotRef = useRef(currentState);
@@ -22,13 +29,18 @@ export function useRenderedIndicatorState<State extends IndicatorLifecycleState>
 
   const { generation, open } = currentState;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (open) {
       const nextState = currentStateRef.current;
       if (nextState.generation !== generation) return;
 
       snapshotRef.current = nextState;
-      void transition.open();
+      const transitionState = transition.state.current;
+      if (!transitionState.active || options.replayOnUpdate !== false) {
+        void transition.open(elementRef.current);
+      } else if (transitionState.status === 'ending') {
+        transition.cancel();
+      }
       return;
     }
 
@@ -36,7 +48,7 @@ export function useRenderedIndicatorState<State extends IndicatorLifecycleState>
     if (active && status !== 'ending') {
       void transition.close(elementRef.current);
     }
-  }, [generation, open, transition]);
+  }, [generation, open, options.replayOnUpdate, transition]);
 
   return {
     elementRef,

--- a/packages/react/src/ui/volume-indicator/volume-indicator-root.tsx
+++ b/packages/react/src/ui/volume-indicator/volume-indicator-root.tsx
@@ -18,7 +18,11 @@ export const VolumeIndicatorRoot = forwardRef(function VolumeIndicatorRoot(
   forwardedRef: ForwardedRef<HTMLDivElement>
 ) {
   const { render, className, style, closeDelay, ...elementProps } = componentProps;
-  const { elementRef, present, state } = useInputIndicatorRoot(() => new VolumeIndicatorCore(), { closeDelay });
+  const { elementRef, present, state } = useInputIndicatorRoot(
+    () => new VolumeIndicatorCore(),
+    { closeDelay },
+    { replayOnUpdate: false }
+  );
 
   if (!present) return null;
 

--- a/packages/skins/src/default/css/audio.css
+++ b/packages/skins/src/default/css/audio.css
@@ -104,6 +104,26 @@
 }
 
 /* ==========================================================================
+   Buffering (spinner over play button — overlay only, no layout change)
+   ========================================================================== */
+
+.media-default-skin--audio .media-button--play__wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.media-default-skin--audio .media-button--play__wrapper .media-buffering-indicator {
+  color: inherit;
+}
+
+.media-default-skin--audio
+  .media-button--play__wrapper:has(.media-buffering-indicator[data-visible])
+  .media-button--play
+  .media-icon {
+  opacity: 0;
+}
+
+/* ==========================================================================
    Sliders
    ========================================================================== */
 

--- a/packages/skins/src/default/css/audio.css
+++ b/packages/skins/src/default/css/audio.css
@@ -103,6 +103,26 @@
 }
 
 /* ==========================================================================
+   Buffering (spinner over play button — overlay only, no layout change)
+   ========================================================================== */
+
+.media-default-skin--audio .media-button--play__wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.media-default-skin--audio .media-button--play__wrapper .media-buffering-indicator {
+  color: inherit;
+}
+
+.media-default-skin--audio
+  .media-button--play__wrapper:has(.media-buffering-indicator[data-visible])
+  .media-button--play
+  .media-icon {
+  opacity: 0;
+}
+
+/* ==========================================================================
    Sliders
    ========================================================================== */
 

--- a/packages/skins/src/default/css/components/buffering.css
+++ b/packages/skins/src/default/css/components/buffering.css
@@ -5,9 +5,9 @@
 .media-default-skin .media-buffering-indicator {
   position: absolute;
   inset: 0;
+  z-index: 10;
   display: none;
-  align-items: center;
-  justify-content: center;
+  place-content: center;
   color: oklch(1 0 0);
   pointer-events: none;
 
@@ -16,11 +16,6 @@
   }
 
   &[data-visible] {
-    display: flex;
-  }
-
-  .media-surface {
-    padding: 0.25rem;
-    border-radius: 100%;
+    display: grid;
   }
 }

--- a/packages/skins/src/default/css/components/input-feedback.css
+++ b/packages/skins/src/default/css/components/input-feedback.css
@@ -105,29 +105,29 @@
     border-radius: inherit;
     transition: --media-progress-fill 200ms linear;
   }
+
+  &[data-level="high"] .media-icon--volume-high,
+  &[data-level="low"] .media-icon--volume-low,
+  &[data-level="off"] .media-icon--volume-off {
+    display: block;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    &[data-min],
+    &[data-max] {
+      animation: media-shake 300ms ease-in-out;
+    }
+  }
 }
 
-.media-default-skin .media-input-feedback-island--volume[data-level="high"] .media-icon--volume-high,
-.media-default-skin .media-input-feedback-island--volume[data-level="low"] .media-icon--volume-low,
-.media-default-skin .media-input-feedback-island--volume[data-level="off"] .media-icon--volume-off {
-  display: block;
-}
-
-.media-default-skin .media-input-feedback-island--status[data-status="captions-on"] .media-icon--captions-on,
-.media-default-skin .media-input-feedback-island--status[data-status="captions-off"] .media-icon--captions-off,
-.media-default-skin .media-input-feedback-island--status[data-status="fullscreen"] .media-icon--fullscreen-enter,
-.media-default-skin .media-input-feedback-island--status[data-status="exit-fullscreen"] .media-icon--fullscreen-exit,
-.media-default-skin .media-input-feedback-island--status[data-status="pip"] .media-icon--pip-enter,
-.media-default-skin .media-input-feedback-island--status[data-status="exit-pip"] .media-icon--pip-exit {
-  display: block;
-}
-
-/* --- Boundary shake ------------------------------------------------------- */
-
-@media (prefers-reduced-motion: no-preference) {
-  .media-default-skin .media-input-feedback-island--volume[data-min],
-  .media-default-skin .media-input-feedback-island--volume[data-max] {
-    animation: media-shake 300ms ease-in-out;
+.media-default-skin .media-input-feedback-island--status {
+  &[data-status="captions-on"] .media-icon--captions-on,
+  &[data-status="captions-off"] .media-icon--captions-off,
+  &[data-status="fullscreen"] .media-icon--fullscreen-enter,
+  &[data-status="exit-fullscreen"] .media-icon--fullscreen-exit,
+  &[data-status="pip"] .media-icon--pip-enter,
+  &[data-status="exit-pip"] .media-icon--pip-exit {
+    display: block;
   }
 }
 
@@ -136,103 +136,94 @@
 .media-default-skin .media-input-feedback-bubble {
   display: grid;
   grid-row: 1;
-  grid-column: 2; /* default to center for status bubbles and undirected seeks */
+  grid-column: 2;
   place-content: center;
   padding: 1rem;
   text-align: center;
-  transition: opacity 250ms ease-out;
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    transition-timing-function: ease-in;
+  /* Central bubble (play, pause) */
+  &:not([data-direction]) {
+    background: oklch(0 0 0 / 0.35);
+    border-radius: 100%;
+    backdrop-filter: blur(8px);
+    transition-timing-function: ease-out;
     transition-duration: 200ms;
-  }
-}
+    transition-property: opacity, scale;
 
-/* Direction placement — seek bubbles move to the side implied by their direction. */
-.media-default-skin .media-input-feedback-bubble[data-direction="backward"] {
-  grid-column: 1;
-  justify-self: left;
-}
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+      scale: 0.85;
+    }
 
-.media-default-skin .media-input-feedback-bubble[data-direction] {
-  gap: 0.25rem;
+    &[data-ending-style] {
+      transition-timing-function: ease-in;
+      transition-duration: 100ms;
+    }
 
-  @container media-root (width > 24rem) {
-    padding: 1.5rem;
-  }
-}
-
-.media-default-skin .media-input-feedback-bubble:not([data-direction]) {
-  grid-column: 2;
-  background: oklch(0 0 0 / 0.35);
-  border-radius: 100%;
-  backdrop-filter: blur(8px);
-  transition-timing-function:
-    ease-out, linear(0, 0.12 1.5%, 1.35 9.7%, 2.2 13.9%, 3 19.9%, 2.7 21.8%, 0.62 37.5%, 0.96 50.9%, 1);
-  transition-duration: 600ms;
-  transition-property: opacity, scale;
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: opacity 100ms ease-out;
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 50ms;
+      transition-property: opacity;
+    }
   }
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    scale: 0.8;
-    transition-timing-function: ease-in;
-    transition-duration: 200ms;
+  /* Directional bubbles (seek) */
+  &[data-direction] {
+    gap: 0.25rem;
+
+    @container media-root (width > 24rem) {
+      padding: 1.5rem;
+    }
   }
-}
 
-.media-default-skin .media-input-feedback-bubble[data-direction="forward"] {
-  grid-column: 3;
-  justify-self: right;
-}
-
-/* --- Bubble icons ---------------------------------------------------------- */
-
-.media-default-skin .media-input-feedback-bubble .media-icon {
-  display: none;
-  width: calc(var(--media-icon-size) * 1.5);
-  height: calc(var(--media-icon-size) * 1.5);
-
-  &.media-icon--play {
-    translate: 1px 0;
+  &[data-direction="backward"] {
+    grid-column: 1;
+    justify-self: left;
   }
-}
 
-/* seek: seek icon, flipped for backward */
-.media-default-skin .media-input-feedback-bubble[data-direction] .media-icon--seek {
-  display: block;
-}
+  &[data-direction="forward"] {
+    grid-column: 3;
+    justify-self: right;
+  }
 
-.media-default-skin .media-input-feedback-bubble[data-direction="backward"] .media-icon--seek {
-  transform: scaleX(-1);
-}
+  /* Icons */
+  .media-icon {
+    display: none;
+    width: calc(var(--media-icon-size) * 1.5);
+    height: calc(var(--media-icon-size) * 1.5);
 
-@media (prefers-reduced-motion: no-preference) {
-  .media-default-skin
-    .media-input-feedback-bubble[data-direction="forward"]:not([data-starting-style])
+    &.media-icon--play {
+      translate: 1px 0;
+    }
+  }
+
+  &[data-direction] .media-icon--seek,
+  &[data-status="pause"] .media-icon--pause,
+  &[data-status="play"] .media-icon--play {
+    display: block;
+  }
+
+  &[data-direction="backward"] .media-icon--seek {
+    scale: -1 1;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
     .media-icon--seek {
-    animation: media-slide-in-forward 300ms ease-in-out;
-  }
+      transition-timing-function: ease-in-out;
+      transition-duration: 200ms;
+      transition-property: translate, opacity;
+    }
 
-  .media-default-skin
-    .media-input-feedback-bubble[data-direction="backward"]:not([data-starting-style])
-    .media-icon--seek {
-    animation: media-slide-in-backward 300ms ease-in-out;
-  }
+    &[data-starting-style] .media-icon--seek,
+    &[data-ending-style] .media-icon--seek {
+      opacity: 0;
+    }
 
-  .media-default-skin .media-input-feedback-island--status[data-status]:not([data-starting-style]) .media-icon,
-  .media-default-skin .media-input-feedback-bubble[data-status]:not([data-starting-style]) .media-icon {
-    animation: media-pop-in 250ms ease-out;
+    &[data-direction="forward"][data-starting-style] .media-icon--seek {
+      translate: -60% 0;
+    }
+    &[data-direction="backward"][data-starting-style] .media-icon--seek {
+      translate: 60% 0;
+    }
   }
-}
-
-.media-default-skin .media-input-feedback-bubble[data-status="pause"] .media-icon--pause,
-.media-default-skin .media-input-feedback-bubble[data-status="play"] .media-icon--play {
-  display: block;
 }

--- a/packages/skins/src/default/css/components/input-feedback.css
+++ b/packages/skins/src/default/css/components/input-feedback.css
@@ -134,18 +134,13 @@
 /* --- Bubble ---------------------------------------------------------------- */
 
 .media-default-skin .media-input-feedback-bubble {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   grid-row: 1;
   grid-column: 2; /* default to center for status bubbles and undirected seeks */
-  align-items: center;
-  justify-content: center;
+  place-content: center;
   padding: 1rem;
+  text-align: center;
   transition: opacity 250ms ease-out;
-
-  @container media-root (width > 24rem) {
-    padding: 2rem;
-  }
 
   &[data-starting-style],
   &[data-ending-style] {
@@ -161,8 +156,19 @@
   justify-self: left;
 }
 
+.media-default-skin .media-input-feedback-bubble[data-direction] {
+  gap: 0.25rem;
+
+  @container media-root (width > 24rem) {
+    padding: 1.5rem;
+  }
+}
+
 .media-default-skin .media-input-feedback-bubble:not([data-direction]) {
   grid-column: 2;
+  background: oklch(0 0 0 / 0.35);
+  border-radius: 100%;
+  backdrop-filter: blur(8px);
   transition-timing-function:
     ease-out, linear(0, 0.12 1.5%, 1.35 9.7%, 2.2 13.9%, 3 19.9%, 2.7 21.8%, 0.62 37.5%, 0.96 50.9%, 1);
   transition-duration: 600ms;
@@ -190,8 +196,12 @@
 
 .media-default-skin .media-input-feedback-bubble .media-icon {
   display: none;
-  width: 36px;
-  height: 36px;
+  width: calc(var(--media-icon-size) * 1.5);
+  height: calc(var(--media-icon-size) * 1.5);
+
+  &.media-icon--play {
+    translate: 1px 0;
+  }
 }
 
 /* seek: seek icon, flipped for backward */

--- a/packages/skins/src/default/css/components/overlay.css
+++ b/packages/skins/src/default/css/components/overlay.css
@@ -25,6 +25,12 @@
   opacity: 1;
 }
 
+.media-default-skin .media-buffering-indicator[data-visible] ~ .media-overlay {
+  background: oklch(0 0 0 / 0.35);
+  opacity: 1;
+  backdrop-filter: blur(8px);
+}
+
 .media-default-skin .media-error[data-open] ~ .media-overlay {
   backdrop-filter: blur(16px) saturate(1.5);
 }

--- a/packages/skins/src/default/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/default/tailwind/audio.tailwind.ts
@@ -1,5 +1,4 @@
 import { cn } from '@videojs/utils/style';
-import { bufferingIndicator as baseBufferingIndicator } from './components/buffering';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
 import { popup as basePopup } from './components/popup';
@@ -50,6 +49,18 @@ export const root = cn(
 
 export const controls = cn(baseControls, surface, 'text-(--media-text-color)', 'peer-data-open/error:**:invisible');
 
+export const playButton = {
+  wrapper: 'group/play inline-flex relative',
+  /** `peer/play-buffering` on `bufferingRoot`; merge onto the play trigger after the peer in DOM. */
+  control: 'peer-data-visible/play-buffering:[&>svg]:opacity-0',
+  bufferingRoot: cn(
+    'peer/play-buffering',
+    'absolute inset-0 z-10 hidden place-content-center pointer-events-none text-inherit',
+    'not-data-visible:[--media-spinner-animation:none]',
+    'data-visible:grid'
+  ),
+};
+
 /* ==========================================================================
    Sliders
    ========================================================================== */
@@ -67,15 +78,6 @@ export const popup = {
   ...basePopup,
   popover: cn(surface, basePopup.popover),
   tooltip: cn(surface, basePopup.tooltip),
-};
-
-/* ==========================================================================
-   Buffering (with audio surface)
-   ========================================================================== */
-
-export const bufferingIndicator = {
-  ...baseBufferingIndicator,
-  container: cn(baseBufferingIndicator.container, surface),
 };
 
 /* ==========================================================================
@@ -104,6 +106,7 @@ export const error = {
 
 export { iconState } from '../../shared/tailwind/icon-state';
 export { badge } from './components/badge';
+export { bufferingIndicator } from './components/buffering';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';

--- a/packages/skins/src/default/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/default/tailwind/audio.tailwind.ts
@@ -1,5 +1,4 @@
 import { cn } from '@videojs/utils/style';
-import { bufferingIndicator as baseBufferingIndicator } from './components/buffering';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
 import { popup as basePopup } from './components/popup';
@@ -50,6 +49,18 @@ export const root = cn(
 
 export const controls = cn(baseControls, surface, 'text-(--media-text-color)', 'peer-data-open/error:**:invisible');
 
+export const playButton = {
+  wrapper: 'group/play inline-flex relative',
+  /** `peer/play-buffering` on `bufferingRoot`; merge onto the play trigger after the peer in DOM. */
+  control: 'peer-data-visible/play-buffering:[&>svg]:opacity-0',
+  bufferingRoot: cn(
+    'peer/play-buffering',
+    'absolute inset-0 z-10 hidden place-content-center pointer-events-none text-inherit',
+    'not-data-visible:[--media-spinner-animation:none]',
+    'data-visible:grid'
+  ),
+};
+
 /* ==========================================================================
    Sliders
    ========================================================================== */
@@ -67,15 +78,6 @@ export const popup = {
   ...basePopup,
   popover: cn(surface, basePopup.popover),
   tooltip: cn(surface, basePopup.tooltip),
-};
-
-/* ==========================================================================
-   Buffering (with audio surface)
-   ========================================================================== */
-
-export const bufferingIndicator = {
-  ...baseBufferingIndicator,
-  container: cn(baseBufferingIndicator.container, surface),
 };
 
 /* ==========================================================================
@@ -103,6 +105,7 @@ export const error = {
    ========================================================================== */
 
 export { iconState } from '../../shared/tailwind/icon-state';
+export { bufferingIndicator } from './components/buffering';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';

--- a/packages/skins/src/default/tailwind/components/buffering.ts
+++ b/packages/skins/src/default/tailwind/components/buffering.ts
@@ -1,4 +1,3 @@
 export const bufferingIndicator = {
   root: 'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:grid',
-  container: '',
 };

--- a/packages/skins/src/default/tailwind/components/buffering.ts
+++ b/packages/skins/src/default/tailwind/components/buffering.ts
@@ -1,4 +1,4 @@
 export const bufferingIndicator = {
-  root: 'absolute inset-0 hidden items-center justify-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:flex',
-  container: 'p-1 rounded-full',
+  root: 'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:grid',
+  container: '',
 };

--- a/packages/skins/src/default/tailwind/components/input-feedback.ts
+++ b/packages/skins/src/default/tailwind/components/input-feedback.ts
@@ -101,7 +101,9 @@ export const inputFeedback = {
       'group/input-indicator',
       // Default placement — center column for status bubbles and undirected seeks
       'col-start-2 row-start-1',
-      'flex flex-col items-center justify-center p-4',
+      'grid place-content-center text-center p-4',
+      'data-direction:gap-1',
+      '@2xl/media-root:data-direction:p-6',
       'transition-opacity duration-250 ease-out',
       'data-starting-style:opacity-0',
       'data-ending-style:opacity-0',
@@ -109,7 +111,7 @@ export const inputFeedback = {
       'data-starting-style:ease-in',
       'data-ending-style:duration-200',
       'data-ending-style:ease-in',
-      '@2xl/media-root:p-8',
+      'not-data-direction:bg-black/35 not-data-direction:rounded-full not-data-direction:backdrop-blur-sm',
       'not-data-direction:[transition-property:opacity,scale]',
       'not-data-direction:duration-600',
       'not-data-direction:[transition-timing-function:ease-out,linear(0,0.12_1.5%,1.35_9.7%,2.2_13.9%,3_19.9%,2.7_21.8%,0.62_37.5%,0.96_50.9%,1)]',
@@ -127,7 +129,7 @@ export const inputFeedback = {
       'data-[direction=forward]:col-start-3 data-[direction=forward]:justify-self-end'
     ),
     // Icons in the bubble
-    icon: 'hidden w-9 h-9',
+    icon: 'hidden size-[calc(var(--media-icon-size)*1.5)]',
     // seek icon: shown for seekStep + seekToPercent; flipped for backward; slides in on active
     shownSeek: cn(
       'group-data-direction/input-indicator:block',
@@ -144,6 +146,7 @@ export const inputFeedback = {
     ),
     shownPlay: cn(
       'group-data-[status=play]/input-indicator:block',
+      'group-data-[status=play]/input-indicator:translate-x-px',
       'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=play]/input-indicator:animate-media-pop-in'
     ),
     time: 'tabular-nums',

--- a/packages/skins/src/default/tailwind/components/input-feedback.ts
+++ b/packages/skins/src/default/tailwind/components/input-feedback.ts
@@ -77,52 +77,32 @@ export const inputFeedback = {
     // Captions state → which icon shows
     shownCaptionsOn: 'group-data-[status=captions-on]/input-indicator:block',
     shownCaptionsOff: 'group-data-[status=captions-off]/input-indicator:block',
-    shownFullscreenEnter: cn(
-      'group-data-[status=fullscreen]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=fullscreen]/input-indicator:animate-media-pop-in'
-    ),
-    shownFullscreenExit: cn(
-      'group-data-[status=exit-fullscreen]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=exit-fullscreen]/input-indicator:animate-media-pop-in'
-    ),
-    shownPipEnter: cn(
-      'group-data-[status=pip]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=pip]/input-indicator:animate-media-pop-in'
-    ),
-    shownPipExit: cn(
-      'group-data-[status=exit-pip]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=exit-pip]/input-indicator:animate-media-pop-in'
-    ),
+    shownFullscreenEnter: 'group-data-[status=fullscreen]/input-indicator:block',
+    shownFullscreenExit: 'group-data-[status=exit-fullscreen]/input-indicator:block',
+    shownPipEnter: 'group-data-[status=pip]/input-indicator:block',
+    shownPipExit: 'group-data-[status=exit-pip]/input-indicator:block',
     value: 'ml-auto',
   },
 
   bubble: {
     base: cn(
       'group/input-indicator',
-      // Default placement — center column for status bubbles and undirected seeks
+      // Default placement
       'col-start-2 row-start-1',
       'grid place-content-center text-center p-4',
       'data-direction:gap-1',
       '@2xl/media-root:data-direction:p-6',
-      'transition-opacity duration-250 ease-out',
-      'data-starting-style:opacity-0',
-      'data-ending-style:opacity-0',
-      'data-starting-style:duration-200',
-      'data-starting-style:ease-in',
-      'data-ending-style:duration-200',
-      'data-ending-style:ease-in',
+      // Central bubble (play, pause)
       'not-data-direction:bg-black/35 not-data-direction:rounded-full not-data-direction:backdrop-blur-sm',
       'not-data-direction:[transition-property:opacity,scale]',
-      'not-data-direction:duration-600',
-      'not-data-direction:[transition-timing-function:ease-out,linear(0,0.12_1.5%,1.35_9.7%,2.2_13.9%,3_19.9%,2.7_21.8%,0.62_37.5%,0.96_50.9%,1)]',
+      'not-data-direction:duration-200 not-data-direction:ease-out',
       'motion-reduce:not-data-direction:transition-opacity',
-      'motion-reduce:not-data-direction:duration-100',
-      'motion-reduce:not-data-direction:ease-out',
-      'not-data-direction:data-starting-style:scale-80',
-      'not-data-direction:data-ending-style:scale-80',
-      'not-data-direction:data-starting-style:duration-200',
-      'not-data-direction:data-starting-style:ease-in',
-      'not-data-direction:data-ending-style:duration-200',
+      'motion-reduce:not-data-direction:duration-50',
+      'not-data-direction:data-starting-style:opacity-0',
+      'not-data-direction:data-ending-style:opacity-0',
+      'not-data-direction:data-starting-style:scale-[0.85]',
+      'not-data-direction:data-ending-style:scale-[0.85]',
+      'not-data-direction:data-ending-style:duration-100',
       'not-data-direction:data-ending-style:ease-in',
       // Direction placement
       'data-[direction=backward]:col-start-1 data-[direction=backward]:justify-self-start',
@@ -130,24 +110,21 @@ export const inputFeedback = {
     ),
     // Icons in the bubble
     icon: 'hidden size-[calc(var(--media-icon-size)*1.5)]',
-    // seek icon: shown for seekStep + seekToPercent; flipped for backward; slides in on active
+    // Seek icon: shown for seekStep + seekToPercent; flipped for backward.
     shownSeek: cn(
       'group-data-direction/input-indicator:block',
-      'group-data-[direction=backward]/input-indicator:-scale-x-100',
-      // Slide animation (keyframes registered in companion CSS)
-      'group-not-data-starting-style/input-indicator:group-data-[direction=forward]/input-indicator:animate-media-slide-in-forward',
-      'group-not-data-starting-style/input-indicator:group-data-[direction=backward]/input-indicator:animate-media-slide-in-backward',
-      'motion-reduce:group-data-direction/input-indicator:animate-none'
+      'group-data-[direction=backward]/input-indicator:[scale:-1_1]',
+      'motion-safe:transition-[translate,opacity] motion-safe:duration-200 motion-safe:ease-in-out',
+      'motion-safe:group-data-starting-style/input-indicator:opacity-0',
+      'motion-safe:group-data-ending-style/input-indicator:opacity-0',
+      'motion-safe:group-data-[direction=forward]/input-indicator:group-data-starting-style/input-indicator:[translate:-60%_0]',
+      'motion-safe:group-data-[direction=backward]/input-indicator:group-data-starting-style/input-indicator:[translate:60%_0]'
     ),
     // togglePaused: pause icon when paused, play icon when playing
-    shownPause: cn(
-      'group-data-[status=pause]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=pause]/input-indicator:animate-media-pop-in'
-    ),
+    shownPause: 'group-data-[status=pause]/input-indicator:block',
     shownPlay: cn(
       'group-data-[status=play]/input-indicator:block',
-      'group-data-[status=play]/input-indicator:translate-x-px',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=play]/input-indicator:animate-media-pop-in'
+      'group-data-[status=play]/input-indicator:translate-x-px'
     ),
     time: 'tabular-nums',
   },

--- a/packages/skins/src/default/tailwind/components/overlay.ts
+++ b/packages/skins/src/default/tailwind/components/overlay.ts
@@ -14,6 +14,10 @@ export const overlay = cn(
   'ease-out',
   // Shown when controls visible
   'peer-data-visible/controls:opacity-100',
+  // Shown when buffering visible
+  'peer-data-visible/buffering:bg-black/35',
+  'peer-data-visible/buffering:opacity-100',
+  'peer-data-visible/buffering:backdrop-blur-sm',
   // Shown when error visible (+ blur)
   // Light DOM: peer/error is a direct sibling (React)
   'peer-data-open/error:opacity-100',

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -1,5 +1,4 @@
 import { cn } from '@videojs/utils/style';
-import { bufferingIndicator as baseBufferingIndicator } from './components/buffering';
 import { buttonGroup as baseButtonGroup } from './components/button-group';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
@@ -173,15 +172,6 @@ export const popup = {
 };
 
 /* ==========================================================================
-   Buffering (with video surface)
-   ========================================================================== */
-
-export const bufferingIndicator = {
-  ...baseBufferingIndicator,
-  container: cn(baseBufferingIndicator.container, surface),
-};
-
-/* ==========================================================================
    Error (with video surface)
    ========================================================================== */
 
@@ -209,6 +199,7 @@ export const inputFeedback = {
    ========================================================================== */
 
 export { iconState } from '../../shared/tailwind/icon-state';
+export { bufferingIndicator } from './components/buffering';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -186,13 +186,10 @@ export const menu = {
 };
 
 /* ==========================================================================
-   Buffering (with video surface)
+   Buffering
    ========================================================================== */
 
-export const bufferingIndicator = {
-  ...baseBufferingIndicator,
-  container: cn(baseBufferingIndicator.container, surface),
-};
+export const bufferingIndicator = baseBufferingIndicator;
 
 /* ==========================================================================
    Error (with video surface)

--- a/packages/skins/src/minimal/css/audio.css
+++ b/packages/skins/src/minimal/css/audio.css
@@ -109,6 +109,26 @@
 }
 
 /* ==========================================================================
+   Buffering (spinner over play button — overlay only, no layout change)
+   ========================================================================== */
+
+.media-minimal-skin--audio .media-button--play__wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.media-minimal-skin--audio .media-button--play__wrapper .media-buffering-indicator {
+  color: inherit;
+}
+
+.media-minimal-skin--audio
+  .media-button--play__wrapper:has(.media-buffering-indicator[data-visible])
+  .media-button--play
+  .media-icon {
+  opacity: 0;
+}
+
+/* ==========================================================================
    Popups & Animations
    ========================================================================== */
 

--- a/packages/skins/src/minimal/css/audio.css
+++ b/packages/skins/src/minimal/css/audio.css
@@ -105,6 +105,26 @@
 }
 
 /* ==========================================================================
+   Buffering (spinner over play button — overlay only, no layout change)
+   ========================================================================== */
+
+.media-minimal-skin--audio .media-button--play__wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.media-minimal-skin--audio .media-button--play__wrapper .media-buffering-indicator {
+  color: inherit;
+}
+
+.media-minimal-skin--audio
+  .media-button--play__wrapper:has(.media-buffering-indicator[data-visible])
+  .media-button--play
+  .media-icon {
+  opacity: 0;
+}
+
+/* ==========================================================================
    Popups & Animations
    ========================================================================== */
 

--- a/packages/skins/src/minimal/css/components/buffering.css
+++ b/packages/skins/src/minimal/css/components/buffering.css
@@ -5,9 +5,9 @@
 .media-minimal-skin .media-buffering-indicator {
   position: absolute;
   inset: 0;
+  z-index: 10;
   display: none;
-  align-items: center;
-  justify-content: center;
+  place-content: center;
   color: oklch(1 0 0);
   pointer-events: none;
 
@@ -16,6 +16,6 @@
   }
 
   &[data-visible] {
-    display: flex;
+    display: grid;
   }
 }

--- a/packages/skins/src/minimal/css/components/input-feedback.css
+++ b/packages/skins/src/minimal/css/components/input-feedback.css
@@ -1,6 +1,6 @@
 /* ==========================================================================
-  Input Feedback
-  ========================================================================== */
+   Input Feedback
+   ========================================================================== */
 
 .media-minimal-skin .media-input-feedback {
   position: absolute;
@@ -116,29 +116,29 @@
     border-radius: calc(Infinity * 1px);
     box-shadow: 0 1px 0 var(--media-current-shadow-color-subtle);
   }
+
+  &[data-level="high"] .media-icon--volume-high,
+  &[data-level="low"] .media-icon--volume-low,
+  &[data-level="off"] .media-icon--volume-off {
+    display: block;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    &[data-min] .media-input-feedback-island__content,
+    &[data-max] .media-input-feedback-island__content {
+      animation: media-shake 300ms ease-in-out;
+    }
+  }
 }
 
-.media-minimal-skin .media-input-feedback-island--volume[data-level="high"] .media-icon--volume-high,
-.media-minimal-skin .media-input-feedback-island--volume[data-level="low"] .media-icon--volume-low,
-.media-minimal-skin .media-input-feedback-island--volume[data-level="off"] .media-icon--volume-off {
-  display: block;
-}
-
-.media-minimal-skin .media-input-feedback-island--status[data-status="captions-on"] .media-icon--captions-on,
-.media-minimal-skin .media-input-feedback-island--status[data-status="captions-off"] .media-icon--captions-off,
-.media-minimal-skin .media-input-feedback-island--status[data-status="fullscreen"] .media-icon--fullscreen-enter,
-.media-minimal-skin .media-input-feedback-island--status[data-status="exit-fullscreen"] .media-icon--fullscreen-exit,
-.media-minimal-skin .media-input-feedback-island--status[data-status="pip"] .media-icon--pip-enter,
-.media-minimal-skin .media-input-feedback-island--status[data-status="exit-pip"] .media-icon--pip-exit {
-  display: block;
-}
-
-/* --- Boundary shake ------------------------------------------------------- */
-
-@media (prefers-reduced-motion: no-preference) {
-  .media-minimal-skin .media-input-feedback-island--volume[data-min] .media-input-feedback-island__content,
-  .media-minimal-skin .media-input-feedback-island--volume[data-max] .media-input-feedback-island__content {
-    animation: media-shake 300ms ease-in-out;
+.media-minimal-skin .media-input-feedback-island--status {
+  &[data-status="captions-on"] .media-icon--captions-on,
+  &[data-status="captions-off"] .media-icon--captions-off,
+  &[data-status="fullscreen"] .media-icon--fullscreen-enter,
+  &[data-status="exit-fullscreen"] .media-icon--fullscreen-exit,
+  &[data-status="pip"] .media-icon--pip-enter,
+  &[data-status="exit-pip"] .media-icon--pip-exit {
+    display: block;
   }
 }
 
@@ -147,97 +147,92 @@
 .media-minimal-skin .media-input-feedback-bubble {
   display: grid;
   grid-row: 1;
-  grid-column: 2; /* default to center for status bubbles and undirected seeks */
+  grid-column: 2;
   place-content: center;
   padding: 1rem;
   text-align: center;
-  transition: opacity 250ms ease-out;
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    transition-timing-function: ease-in;
+  /* Central bubble (play, pause) */
+  &:not([data-direction]) {
+    transition-timing-function: ease-out;
     transition-duration: 200ms;
-  }
-}
-/* Direction placement — seek bubbles move to the side implied by their direction. */
-.media-minimal-skin .media-input-feedback-bubble[data-direction="backward"] {
-  grid-column: 1;
-  justify-self: left;
-}
+    transition-property: opacity, scale;
 
-.media-minimal-skin .media-input-feedback-bubble[data-direction] {
-  gap: 0.25rem;
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+      scale: 0.85;
+    }
 
-  @container media-root (width > 24rem) {
-    padding: 1.5rem;
-  }
-}
+    &[data-ending-style] {
+      transition-timing-function: ease-in;
+      transition-duration: 100ms;
+    }
 
-.media-minimal-skin .media-input-feedback-bubble:not([data-direction]) {
-  grid-column: 2;
-  transition-timing-function:
-    ease-out, linear(0, 0.12 1.5%, 1.35 9.7%, 2.2 13.9%, 3 19.9%, 2.7 21.8%, 0.62 37.5%, 0.96 50.9%, 1);
-  transition-duration: 600ms;
-  transition-property: opacity, scale;
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: opacity 100ms ease-out;
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 50ms;
+      transition-property: opacity;
+    }
   }
 
-  &[data-starting-style],
-  &[data-ending-style] {
-    opacity: 0;
-    scale: 0.8;
-    transition-timing-function: ease-in;
-    transition-duration: 200ms;
+  /* Directional bubbles (seek) */
+  &[data-direction] {
+    gap: 0.25rem;
+
+    @container media-root (width > 24rem) {
+      padding: 1.5rem;
+    }
   }
-}
 
-.media-minimal-skin .media-input-feedback-bubble[data-direction="forward"] {
-  grid-column: 3;
-  justify-self: right;
-}
+  &[data-direction="backward"] {
+    grid-column: 1;
+    justify-self: left;
+  }
 
-/* --- Bubble icons ---------------------------------------------------------- */
+  &[data-direction="forward"] {
+    grid-column: 3;
+    justify-self: right;
+  }
 
-.media-minimal-skin .media-input-feedback-bubble .media-icon {
-  display: none;
-  width: calc(var(--media-icon-size) * 2);
-  height: calc(var(--media-icon-size) * 2);
-}
+  /* Icons */
+  .media-icon {
+    display: none;
+    width: calc(var(--media-icon-size) * 2);
+    height: calc(var(--media-icon-size) * 2);
+  }
 
-/* seek: seek icon, flipped for backward */
-.media-minimal-skin .media-input-feedback-bubble[data-direction] .media-icon--seek {
-  display: block;
-  width: calc(var(--media-icon-size) * 1.5);
-  height: calc(var(--media-icon-size) * 1.5);
-}
+  .media-icon--seek {
+    width: calc(var(--media-icon-size) * 1.5);
+    height: calc(var(--media-icon-size) * 1.5);
+  }
 
-.media-minimal-skin .media-input-feedback-bubble[data-direction="backward"] .media-icon--seek {
-  transform: scaleX(-1);
-}
+  &[data-direction] .media-icon--seek,
+  &[data-status="pause"] .media-icon--pause,
+  &[data-status="play"] .media-icon--play {
+    display: block;
+  }
 
-@media (prefers-reduced-motion: no-preference) {
-  .media-minimal-skin
-    .media-input-feedback-bubble[data-direction="forward"]:not([data-starting-style])
+  &[data-direction="backward"] .media-icon--seek {
+    scale: -1 1;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
     .media-icon--seek {
-    animation: media-slide-in-forward 300ms ease-in-out;
-  }
+      transition-timing-function: ease-in-out;
+      transition-duration: 200ms;
+      transition-property: translate, opacity;
+    }
 
-  .media-minimal-skin
-    .media-input-feedback-bubble[data-direction="backward"]:not([data-starting-style])
-    .media-icon--seek {
-    animation: media-slide-in-backward 300ms ease-in-out;
-  }
+    &[data-starting-style] .media-icon--seek,
+    &[data-ending-style] .media-icon--seek {
+      opacity: 0;
+    }
 
-  .media-minimal-skin .media-input-feedback-island--status[data-status]:not([data-starting-style]) .media-icon,
-  .media-minimal-skin .media-input-feedback-bubble[data-status]:not([data-starting-style]) .media-icon {
-    animation: media-pop-in 250ms ease-out;
+    &[data-direction="forward"][data-starting-style] .media-icon--seek {
+      translate: -60% 0;
+    }
+    &[data-direction="backward"][data-starting-style] .media-icon--seek {
+      translate: 60% 0;
+    }
   }
-}
-
-.media-minimal-skin .media-input-feedback-bubble[data-status="pause"] .media-icon--pause,
-.media-minimal-skin .media-input-feedback-bubble[data-status="play"] .media-icon--play {
-  display: block;
 }

--- a/packages/skins/src/minimal/css/components/input-feedback.css
+++ b/packages/skins/src/minimal/css/components/input-feedback.css
@@ -145,18 +145,13 @@
 /* --- Bubble ---------------------------------------------------------------- */
 
 .media-minimal-skin .media-input-feedback-bubble {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   grid-row: 1;
   grid-column: 2; /* default to center for status bubbles and undirected seeks */
-  align-items: center;
-  justify-content: center;
+  place-content: center;
   padding: 1rem;
+  text-align: center;
   transition: opacity 250ms ease-out;
-
-  @container media-root (width > 24rem) {
-    padding: 2rem;
-  }
 
   &[data-starting-style],
   &[data-ending-style] {
@@ -169,6 +164,14 @@
 .media-minimal-skin .media-input-feedback-bubble[data-direction="backward"] {
   grid-column: 1;
   justify-self: left;
+}
+
+.media-minimal-skin .media-input-feedback-bubble[data-direction] {
+  gap: 0.25rem;
+
+  @container media-root (width > 24rem) {
+    padding: 1.5rem;
+  }
 }
 
 .media-minimal-skin .media-input-feedback-bubble:not([data-direction]) {
@@ -200,13 +203,15 @@
 
 .media-minimal-skin .media-input-feedback-bubble .media-icon {
   display: none;
-  width: 36px;
-  height: 36px;
+  width: calc(var(--media-icon-size) * 2);
+  height: calc(var(--media-icon-size) * 2);
 }
 
 /* seek: seek icon, flipped for backward */
 .media-minimal-skin .media-input-feedback-bubble[data-direction] .media-icon--seek {
   display: block;
+  width: calc(var(--media-icon-size) * 1.5);
+  height: calc(var(--media-icon-size) * 1.5);
 }
 
 .media-minimal-skin .media-input-feedback-bubble[data-direction="backward"] .media-icon--seek {

--- a/packages/skins/src/minimal/css/components/overlay.css
+++ b/packages/skins/src/minimal/css/components/overlay.css
@@ -25,6 +25,12 @@
   opacity: 1;
 }
 
+.media-minimal-skin .media-buffering-indicator[data-visible] ~ .media-overlay {
+  background: oklch(0 0 0 / 0.35);
+  opacity: 1;
+  backdrop-filter: blur(8px);
+}
+
 .media-minimal-skin .media-error[data-open] ~ .media-overlay {
   backdrop-filter: blur(16px) saturate(1.2);
 }

--- a/packages/skins/src/minimal/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/audio.tailwind.ts
@@ -58,6 +58,18 @@ export const controls = cn(
   'ring-1 ring-(color:--media-controls-border-color)'
 );
 
+export const playButton = {
+  wrapper: 'group/play inline-flex relative',
+  /** `peer/play-buffering` on `bufferingRoot`; merge onto the play trigger after the peer in DOM. */
+  control: 'peer-data-visible/play-buffering:[&>svg]:opacity-0',
+  bufferingRoot: cn(
+    'peer/play-buffering',
+    'absolute inset-0 z-10 hidden place-content-center pointer-events-none text-inherit',
+    'not-data-visible:[--media-spinner-animation:none]',
+    'data-visible:grid'
+  ),
+};
+
 /* ==========================================================================
    Popup
    ========================================================================== */

--- a/packages/skins/src/minimal/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/audio.tailwind.ts
@@ -54,6 +54,18 @@ export const controls = cn(
   'ring-1 ring-(color:--media-controls-border-color)'
 );
 
+export const playButton = {
+  wrapper: 'group/play inline-flex relative',
+  /** `peer/play-buffering` on `bufferingRoot`; merge onto the play trigger after the peer in DOM. */
+  control: 'peer-data-visible/play-buffering:[&>svg]:opacity-0',
+  bufferingRoot: cn(
+    'peer/play-buffering',
+    'absolute inset-0 z-10 hidden place-content-center pointer-events-none text-inherit',
+    'not-data-visible:[--media-spinner-animation:none]',
+    'data-visible:grid'
+  ),
+};
+
 /* ==========================================================================
    Popup
    ========================================================================== */

--- a/packages/skins/src/minimal/tailwind/components/buffering.ts
+++ b/packages/skins/src/minimal/tailwind/components/buffering.ts
@@ -1,2 +1,2 @@
 export const bufferingIndicator =
-  'absolute inset-0 hidden items-center justify-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:flex';
+  'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:grid';

--- a/packages/skins/src/minimal/tailwind/components/input-feedback.ts
+++ b/packages/skins/src/minimal/tailwind/components/input-feedback.ts
@@ -135,7 +135,8 @@ export const inputFeedback = {
     ),
     icon: 'hidden size-[calc(var(--media-icon-size)*2)]',
     shownSeek: cn(
-      'size-[calc(var(--media-icon-size)*1.5)]',
+      // Avoid two arbitrary `size-*` utilities on one element (order-dependent); mirror CSS `[data-direction] .media-icon--seek` specificity.
+      'group-data-direction/input-indicator:size-[calc(var(--media-icon-size)*1.5)]',
       'group-data-direction/input-indicator:block',
       'group-data-[direction=backward]/input-indicator:-scale-x-100',
       // Slide animation (keyframes registered in companion CSS)

--- a/packages/skins/src/minimal/tailwind/components/input-feedback.ts
+++ b/packages/skins/src/minimal/tailwind/components/input-feedback.ts
@@ -83,51 +83,31 @@ export const inputFeedback = {
     shownVolumeOff: 'group-data-[level=off]/input-indicator:block',
     shownCaptionsOn: 'group-data-[status=captions-on]/input-indicator:block',
     shownCaptionsOff: 'group-data-[status=captions-off]/input-indicator:block',
-    shownFullscreenEnter: cn(
-      'group-data-[status=fullscreen]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=fullscreen]/input-indicator:animate-media-pop-in'
-    ),
-    shownFullscreenExit: cn(
-      'group-data-[status=exit-fullscreen]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=exit-fullscreen]/input-indicator:animate-media-pop-in'
-    ),
-    shownPipEnter: cn(
-      'group-data-[status=pip]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=pip]/input-indicator:animate-media-pop-in'
-    ),
-    shownPipExit: cn(
-      'group-data-[status=exit-pip]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=exit-pip]/input-indicator:animate-media-pop-in'
-    ),
+    shownFullscreenEnter: 'group-data-[status=fullscreen]/input-indicator:block',
+    shownFullscreenExit: 'group-data-[status=exit-fullscreen]/input-indicator:block',
+    shownPipEnter: 'group-data-[status=pip]/input-indicator:block',
+    shownPipExit: 'group-data-[status=exit-pip]/input-indicator:block',
     value: 'ml-auto',
   },
 
   bubble: {
     base: cn(
       'group/input-indicator',
-      // Default placement — center column for status bubbles and undirected seeks
+      // Default placement
       'col-start-2 row-start-1',
       'grid place-content-center text-center p-4',
       'data-direction:gap-1',
       '@2xl/media-root:data-direction:p-6',
-      'transition-opacity duration-250 ease-out',
-      'data-starting-style:opacity-0',
-      'data-ending-style:opacity-0',
-      'data-starting-style:duration-200',
-      'data-starting-style:ease-in',
-      'data-ending-style:duration-200',
-      'data-ending-style:ease-in',
+      // Central bubble (play, pause)
       'not-data-direction:[transition-property:opacity,scale]',
-      'not-data-direction:duration-600',
-      'not-data-direction:[transition-timing-function:ease-out,linear(0,0.12_1.5%,1.35_9.7%,2.2_13.9%,3_19.9%,2.7_21.8%,0.62_37.5%,0.96_50.9%,1)]',
+      'not-data-direction:duration-200 not-data-direction:ease-out',
       'motion-reduce:not-data-direction:transition-opacity',
-      'motion-reduce:not-data-direction:duration-100',
-      'motion-reduce:not-data-direction:ease-out',
-      'not-data-direction:data-starting-style:scale-80',
-      'not-data-direction:data-ending-style:scale-80',
-      'not-data-direction:data-starting-style:duration-200',
-      'not-data-direction:data-starting-style:ease-in',
-      'not-data-direction:data-ending-style:duration-200',
+      'motion-reduce:not-data-direction:duration-50',
+      'not-data-direction:data-starting-style:opacity-0',
+      'not-data-direction:data-ending-style:opacity-0',
+      'not-data-direction:data-starting-style:scale-[0.85]',
+      'not-data-direction:data-ending-style:scale-[0.85]',
+      'not-data-direction:data-ending-style:duration-100',
       'not-data-direction:data-ending-style:ease-in',
       // Direction placement
       'data-[direction=backward]:col-start-1 data-[direction=backward]:justify-self-start',
@@ -135,22 +115,18 @@ export const inputFeedback = {
     ),
     icon: 'hidden size-[calc(var(--media-icon-size)*2)]',
     shownSeek: cn(
-      'size-[calc(var(--media-icon-size)*1.5)]',
+      // Avoid two arbitrary `size-*` utilities on one element (order-dependent); mirror CSS `[data-direction] .media-icon--seek` specificity.
+      'group-data-direction/input-indicator:size-[calc(var(--media-icon-size)*1.5)]',
       'group-data-direction/input-indicator:block',
-      'group-data-[direction=backward]/input-indicator:-scale-x-100',
-      // Slide animation (keyframes registered in companion CSS)
-      'group-not-data-starting-style/input-indicator:group-data-[direction=forward]/input-indicator:animate-media-slide-in-forward',
-      'group-not-data-starting-style/input-indicator:group-data-[direction=backward]/input-indicator:animate-media-slide-in-backward',
-      'motion-reduce:group-data-direction/input-indicator:animate-none'
+      'group-data-[direction=backward]/input-indicator:[scale:-1_1]',
+      'motion-safe:transition-[translate,opacity] motion-safe:duration-200 motion-safe:ease-in-out',
+      'motion-safe:group-data-starting-style/input-indicator:opacity-0',
+      'motion-safe:group-data-ending-style/input-indicator:opacity-0',
+      'motion-safe:group-data-[direction=forward]/input-indicator:group-data-starting-style/input-indicator:[translate:-60%_0]',
+      'motion-safe:group-data-[direction=backward]/input-indicator:group-data-starting-style/input-indicator:[translate:60%_0]'
     ),
-    shownPause: cn(
-      'group-data-[status=pause]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=pause]/input-indicator:animate-media-pop-in'
-    ),
-    shownPlay: cn(
-      'group-data-[status=play]/input-indicator:block',
-      'motion-safe:group-not-data-starting-style/input-indicator:group-data-[status=play]/input-indicator:animate-media-pop-in'
-    ),
+    shownPause: 'group-data-[status=pause]/input-indicator:block',
+    shownPlay: 'group-data-[status=play]/input-indicator:block',
     time: 'tabular-nums',
   },
 };

--- a/packages/skins/src/minimal/tailwind/components/input-feedback.ts
+++ b/packages/skins/src/minimal/tailwind/components/input-feedback.ts
@@ -107,7 +107,9 @@ export const inputFeedback = {
       'group/input-indicator',
       // Default placement — center column for status bubbles and undirected seeks
       'col-start-2 row-start-1',
-      'flex flex-col items-center justify-center p-4',
+      'grid place-content-center text-center p-4',
+      'data-direction:gap-1',
+      '@2xl/media-root:data-direction:p-6',
       'transition-opacity duration-250 ease-out',
       'data-starting-style:opacity-0',
       'data-ending-style:opacity-0',
@@ -115,7 +117,6 @@ export const inputFeedback = {
       'data-starting-style:ease-in',
       'data-ending-style:duration-200',
       'data-ending-style:ease-in',
-      '@2xl/media-root:p-8',
       'not-data-direction:[transition-property:opacity,scale]',
       'not-data-direction:duration-600',
       'not-data-direction:[transition-timing-function:ease-out,linear(0,0.12_1.5%,1.35_9.7%,2.2_13.9%,3_19.9%,2.7_21.8%,0.62_37.5%,0.96_50.9%,1)]',
@@ -132,8 +133,9 @@ export const inputFeedback = {
       'data-[direction=backward]:col-start-1 data-[direction=backward]:justify-self-start',
       'data-[direction=forward]:col-start-3 data-[direction=forward]:justify-self-end'
     ),
-    icon: 'hidden w-9 h-9',
+    icon: 'hidden size-[calc(var(--media-icon-size)*2)]',
     shownSeek: cn(
+      'size-[calc(var(--media-icon-size)*1.5)]',
       'group-data-direction/input-indicator:block',
       'group-data-[direction=backward]/input-indicator:-scale-x-100',
       // Slide animation (keyframes registered in companion CSS)

--- a/packages/skins/src/minimal/tailwind/components/overlay.ts
+++ b/packages/skins/src/minimal/tailwind/components/overlay.ts
@@ -14,6 +14,10 @@ export const overlay = cn(
   'ease-out',
   // Shown when controls visible
   'peer-data-visible/controls:opacity-100',
+  // Shown when buffering visible
+  'peer-data-visible/buffering:bg-black/35',
+  'peer-data-visible/buffering:opacity-100',
+  'peer-data-visible/buffering:backdrop-blur-sm',
   // Shown when error visible (+ blur)
   // Light DOM: peer/error is a direct sibling (React)
   'peer-data-open/error:opacity-100',

--- a/packages/skins/src/shared/global/video/keyframes.css
+++ b/packages/skins/src/shared/global/video/keyframes.css
@@ -20,24 +20,3 @@
     translate: 1px 0;
   }
 }
-
-@keyframes media-slide-in-forward {
-  from {
-    translate: -60% 0;
-    opacity: 0;
-  }
-}
-
-@keyframes media-slide-in-backward {
-  from {
-    translate: 60% 0;
-    opacity: 0;
-  }
-}
-
-@keyframes media-pop-in {
-  from {
-    scale: 0.8;
-    opacity: 0;
-  }
-}

--- a/packages/skins/src/shared/tailwind.css
+++ b/packages/skins/src/shared/tailwind.css
@@ -7,7 +7,4 @@
 
 @theme {
   --animate-media-shake: media-shake 300ms ease-in-out;
-  --animate-media-slide-in-forward: media-slide-in-forward 300ms ease-in-out;
-  --animate-media-slide-in-backward: media-slide-in-backward 300ms ease-in-out;
-  --animate-media-pop-in: media-pop-in 250ms ease-out;
 }


### PR DESCRIPTION
## Summary

This tightens the default and minimal skin feedback paths across HTML and React.

- Improves video/live-video buffering treatment with centered full-frame indicators and a clearer buffering scrim.
- Shows audio/live-audio buffering in the play-control slot and registers `BufferingIndicator` for ejected audio skins.
- Cleans up input feedback styling in vanilla CSS and Tailwind so seek/play feedback share the same layout, contrast, and transition hooks.
- Updates input indicator transitions so repeated actions can replay the entry transition by reapplying `data-starting-style`; volume feedback opts out so repeated volume keypresses do not disappear and reappear.

## Validation

- `pnpm -F @videojs/core test src/dom/ui/tests/transition.test.ts`
- `pnpm -F @videojs/react test src/ui/input-indicators/tests/use-rendered-indicator-state.test.tsx`
- `pnpm -F @videojs/skins build`
- `pnpm exec biome check ...`
- `pnpm exec tsgo --build packages/core/tsconfig.json packages/html/tsconfig.json packages/react/tsconfig.json`

Closes #1509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared transition lifecycle and broad skin markup/CSS across HTML/React; behavior changes for buffering UI and input-indicator animations, though covered by new/updated unit tests.
> 
> **Overview**
> Improves **buffering** and **overlay** presentation across default/minimal skins (HTML + React): video/live-video use a simpler full-frame spinner (no extra surface wrapper), overlays react when buffering is visible, and **audio/live-audio** show buffering as a spinner over the play control via a new `playButton` wrapper pattern. Ejected audio UI entries now register `BufferingIndicator`.
> 
> **`createTransition().open`** accepts an optional element and, when reopening an already-active transition, cancels subtree animations and flushes layout so CSS entry transitions can replay; input indicators pass the live DOM node and gain **`replayOnUpdate`** (default on). **Volume** feedback sets `replayOnUpdate: false` so rapid volume changes don’t flash off/on.
> 
> **Input feedback** styling is aligned in CSS/Tailwind: shared bubble/island layout, shorter central play/pause transitions (replacing pop/slide keyframes), and seek icons animate via translate/opacity instead of dedicated keyframe animations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5e1e73fff5beb2144d5720ef707163c25f1760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->