### PR TITLE
chore(ci): scope triage label to external authors

### DIFF
--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -11,8 +11,20 @@ jobs:
     permissions:
       issues: write
     steps:
-      - run: gh issue edit "$NUMBER" --add-label triage
+      - name: Add triage label for external authors
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          internal=(decepulis mihar-22 luwes sampotts cjpillsbury heff esbie r-delfino95 ronald-urbina ronalduqualabs jerricho93 spuppo-mux)
+          author_lc="${AUTHOR,,}"
+          for handle in "${internal[@]}"; do
+            if [[ "$author_lc" == "$handle" ]]; then
+              echo "Author $AUTHOR is internal; skipping triage label."
+              exit 0
+            fi
+          done
+          echo "Author $AUTHOR is external; adding triage label."
+          gh issue edit "$NUMBER" --add-label triage

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -60,17 +60,18 @@ jobs:
             - Review labels used on related/cross-referenced issues before deciding.
             - Add missing useful labels and remove clearly incorrect labels.
             - Do not create new labels; only use existing labels.
-            - Never apply these labels — they are managed manually:
+            - Never apply these labels — they are managed manually or by other automation:
               - `epic` (epic linkage is curated by maintainers)
               - Priority labels (`P0`, `P1`, `P2`)
+              - `triage` (applied by automation only for external authors)
               Surface these as recommendations in step 8 instead.
             3. Detect probable duplicates:
             - Search for existing issues with the same bug/request symptoms, stack traces, repro steps, or scope.
             - If a likely duplicate is found, leave one concise comment linking the likely canonical issue and why it appears duplicated.
-            - If confidence is not high, do not mark as duplicate; instead add `triage` label for human review.
+            - If confidence is not high, do not mark as duplicate; instead leave a concise comment flagging the uncertainty for human review.
             - Do not auto-close duplicates unless there is very high confidence and no meaningful unique information.
             4. Escalate uncertainty:
-            - Add `triage` label when classification is ambiguous, conflicting, or needs human judgment.
+            - When classification is ambiguous, conflicting, or needs human judgment, leave a concise comment flagging the uncertainty rather than applying labels.
             5. Suggest docs/resources when helpful:
             - Use https://videojs.org/llms.txt as the primary source to discover relevant docs links.
             - If likely already documented, suggest 1-3 relevant docs links with a short reason.
@@ -81,7 +82,7 @@ jobs:
             - If the issue suggests the user is struggling to achieve something with the library, provide practical guidance.
             - Suggest the most relevant documented approach with 1-3 links (from https://videojs.org/llms.txt discovery).
             - Include concise next steps or a minimal example/snippet when it materially helps.
-            - If docs appear incomplete or unclear, call that out and add `triage` for human follow-up.
+            - If docs appear incomplete or unclear, call that out in a comment for human follow-up.
             8. Planning recommendations (comment-only):
             - Review roadmap context at https://github.com/orgs/videojs/projects/7 and current repository milestones.
             - Identify likely related epics/issues and related open PRs.


### PR DESCRIPTION
## Summary

The `triage` label is meant to flag issues that need human attention. Two changes to keep it useful:

- The auto-label workflow now skips internal team members, so issues we open ourselves don't get queued for triage.
- The triage bot no longer applies `triage` itself. When it's uncertain it leaves a comment instead, which keeps the label's signal clean (one source of truth: the auto-label workflow).

<details>
<summary>Internal author list</summary>

Hardcoded in `issue-label.yml`:
`decepulis, mihar-22, luwes, sampotts, cjpillsbury, heff, esbie, r-delfino95, ronald-urbina, ronalduqualabs, jerricho93, spuppo-mux`

If the team changes, update the list there.
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow/prompt-only changes; main risk is misclassifying an internal username and skipping/adding `triage` unexpectedly on new issues.
> 
> **Overview**
> Updates issue automation so the `triage` label is only applied when a newly opened issue is authored by someone *not* in a hardcoded internal-handle allowlist.
> 
> Adjusts the Claude issue-triage prompt to treat `triage` as automation-managed and to stop using it to express uncertainty, replacing prior “add `triage`” instructions with leaving a concise comment instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271cfeca57465b526f5843c98c5ce4c92484005e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->