### PR TITLE
feat(react): i18n provider layer (stacked on #1551)

### DIFF
--- a/packages/core/src/core/i18n/index.ts
+++ b/packages/core/src/core/i18n/index.ts
@@ -2,6 +2,7 @@ export { default as translations } from './locales/en';
 export {
   getI18nTranslations,
   hasRegisteredI18n,
+  localeLookupChain,
   onI18nRegistryChange,
   registerI18n,
   resetI18nRegistryForTesting,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -93,6 +93,16 @@
       "types": "./dist/dev/presets/live-audio/*.d.ts",
       "development": "./dist/dev/presets/live-audio/*.js",
       "default": "./dist/default/presets/live-audio/*.js"
+    },
+    "./i18n": {
+      "types": "./dist/dev/i18n/index.d.ts",
+      "development": "./dist/dev/i18n/index.js",
+      "default": "./dist/default/i18n/index.js"
+    },
+    "./i18n/locales/en": {
+      "types": "./dist/dev/i18n/locales/en/index.d.ts",
+      "development": "./dist/dev/i18n/locales/en/index.js",
+      "default": "./dist/default/i18n/locales/en/index.js"
     }
   },
   "scripts": {

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -198,7 +198,9 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     }, [resolvedLocale]);
 
     const [registryEpoch, invalidateRegistry] = useReducer((epoch: number) => epoch + 1, 0);
-    useEffect(() => onI18nRegistryChange(() => invalidateRegistry()), []);
+    useEffect(() => {
+      return onI18nRegistryChange(() => invalidateRegistry());
+    }, []);
 
     const [lazyLayer, setLazyLayer] = useState<Partial<Translations>>({});
 

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -243,12 +243,16 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
 
   function useTranslator(): Translator {
     const ctx = useContext(I18nContext);
-    const fallbackRef = useRef<Translator | undefined>(undefined);
-    if (!fallbackRef.current) {
-      fallbackRef.current = createTranslator(getI18nTranslations('en'), 'en');
-    }
+    const [registryEpoch, invalidateRegistry] = useReducer((epoch: number) => epoch + 1, 0);
+
+    useEffect(() => {
+      return onI18nRegistryChange(() => invalidateRegistry());
+    }, []);
+
+    const fallback = useMemo(() => createTranslator(getI18nTranslations('en'), 'en'), [registryEpoch]);
+
     if (!ctx) {
-      return fallbackRef.current;
+      return fallback;
     }
     return ctx.translator;
   }

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -171,26 +171,28 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     const onActiveLocaleChangeRef = useRef(onActiveLocaleChange);
     onActiveLocaleChangeRef.current = onActiveLocaleChange;
     const [, invalidateLangRoot] = useReducer((epoch: number) => epoch + 1, 0);
-    const attachedLangRootRef = useRef<Element | null>(null);
+    const langRootElementRef = useRef<Element | null>(null);
 
     useLayoutEffect(() => {
       if (!langRootRef) {
-        attachedLangRootRef.current = null;
+        if (langRootElementRef.current !== null) {
+          langRootElementRef.current = null;
+          invalidateLangRoot();
+        }
         return;
       }
       const node = langRootRef.current;
-      if (node === attachedLangRootRef.current) return;
-      attachedLangRootRef.current = node;
-      if (node) {
-        invalidateLangRoot();
-      }
+      if (node === langRootElementRef.current) return;
+      langRootElementRef.current = node;
+      invalidateLangRoot();
     });
 
     const ambientLang = useSyncExternalStore(
       subscribeAmbientLang,
       () => {
         if (langRootRef) {
-          return nearestLang(langRootRef.current);
+          const root = langRootElementRef.current ?? langRootRef.current;
+          return nearestLang(root);
         }
         const root = typeof document !== 'undefined' ? document.documentElement : null;
         return nearestLang(root);

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import {
+  createTranslator,
+  getI18nTranslations,
+  type Locale,
+  localeLookupChain,
+  onI18nRegistryChange,
+  type Translations,
+  type Translator,
+} from '@videojs/core/i18n';
+import { isUndefined } from '@videojs/utils/predicate';
+import {
+  type Context,
+  createContext,
+  type ReactNode,
+  type RefObject,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+/** Built-ins omit English; defaults already live in the core registry via {@link getI18nTranslations}. */
+async function noopBuiltinPack(tag: string): Promise<Partial<Translations> | undefined> {
+  void tag;
+  return undefined;
+}
+
+async function mergeBuiltinOverlays(
+  locale: string,
+  load: (tag: string) => Promise<Partial<Translations> | undefined>
+): Promise<Partial<Translations>> {
+  const chain = localeLookupChain(locale);
+  const layers = await Promise.all(chain.map((tag) => load(tag)));
+  const merged: Partial<Translations> = {};
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const layer = layers[i];
+    if (layer) {
+      Object.assign(merged, layer);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Subscribes to DOM updates that can change {@link nearestLang}: any `lang` attribute edit,
+ * or subtree structural changes under `<html>` (which can move nodes between labeled ancestors).
+ */
+function subscribeAmbientLang(onStoreChange: () => void): () => void {
+  if (typeof document === 'undefined') {
+    return () => {};
+  }
+  let disconnected = false;
+  let queued = false;
+  const flush = (): void => {
+    queued = false;
+    if (disconnected) {
+      return;
+    }
+    onStoreChange();
+  };
+  const schedule = (): void => {
+    if (!queued) {
+      queued = true;
+      queueMicrotask(flush);
+    }
+  };
+  const root = document.documentElement;
+  const observer = new MutationObserver(schedule);
+  observer.observe(root, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['lang'],
+    childList: true,
+  });
+  return () => {
+    disconnected = true;
+    observer.disconnect();
+    queued = false;
+  };
+}
+
+/** First non-empty `lang` on `start` or an ancestor (HTML language inheritance). */
+function nearestLang(start: Element | null): string | undefined {
+  if (!start || typeof document === 'undefined') {
+    return undefined;
+  }
+  let node: Element | null = start;
+  while (node) {
+    const trimmed = node.getAttribute('lang')?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+    node = node.parentElement;
+  }
+  return undefined;
+}
+
+function ambientLangServerSnapshot(): string | undefined {
+  return undefined;
+}
+
+function effectiveLocale(localeProp: Locale | undefined, ambientLang: string | undefined): Locale {
+  if (!isUndefined(localeProp) && String(localeProp).trim() !== '') {
+    return localeProp;
+  }
+  if (!isUndefined(ambientLang) && ambientLang.trim() !== '') {
+    return ambientLang;
+  }
+  return 'en';
+}
+
+export interface CreateI18nOptions {
+  /** Override built-in locale loading (tests or custom packs). */
+  loadBuiltinLocale?: (tag: string) => Promise<Partial<Translations> | undefined>;
+}
+
+export interface I18nProviderProps {
+  /**
+   * Forces the active locale. Omit to inherit the nearest non-empty `lang` by walking DOM
+   * ancestors from {@link langRootRef} when set, otherwise from `document.documentElement`
+   * (typically `<html lang>`). Updates when any `lang` attribute changes anywhere under `<html>`,
+   * or when subtree moves alter which ancestor supplies `lang`. For SSR, pass `locale` explicitly.
+   */
+  locale?: Locale;
+  /**
+   * Element whose ancestor chain is searched for a non-empty `lang` when {@link locale} is
+   * omitted—for example a ref to your player shell `HTMLElement`.
+   */
+  langRootRef?: RefObject<Element | null>;
+  translations?: Partial<Translations>;
+  children: ReactNode;
+  /** Fires when the resolved locale changes (caption selection hooks may use this later). */
+  onActiveLocaleChange?: (locale: Locale) => void;
+}
+
+export interface I18nContextValue {
+  translator: Translator;
+  locale: Locale;
+}
+
+export interface CreateI18nResult {
+  I18nContext: Context<I18nContextValue | null>;
+  I18nProvider: (props: I18nProviderProps) => ReactNode;
+  useTranslator: () => Translator;
+  useLocale: () => Locale;
+}
+
+/**
+ * Creates an isolated i18n context stack (`I18nProvider`, hooks) mirroring {@link createPlayer}.
+ *
+ * @param options - Optional hooks such as custom built-in locale loading.
+ */
+export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
+  const loadBuiltin = options?.loadBuiltinLocale ?? noopBuiltinPack;
+
+  const I18nContext = createContext<I18nContextValue | null>(null);
+
+  function I18nProvider({
+    locale: localeProp,
+    langRootRef,
+    translations: translationsProp,
+    children,
+    onActiveLocaleChange,
+  }: I18nProviderProps): ReactNode {
+    const [, invalidateLangRoot] = useReducer((epoch: number) => epoch + 1, 0);
+
+    useLayoutEffect(() => {
+      if (langRootRef) {
+        invalidateLangRoot();
+      }
+    }, [langRootRef]);
+
+    const ambientLang = useSyncExternalStore(
+      subscribeAmbientLang,
+      () => {
+        const langRoot = langRootRef?.current ?? (typeof document !== 'undefined' ? document.documentElement : null);
+        return nearestLang(langRoot);
+      },
+      ambientLangServerSnapshot
+    );
+
+    const resolvedLocale = useMemo(() => effectiveLocale(localeProp, ambientLang), [localeProp, ambientLang]);
+
+    useEffect(() => {
+      onActiveLocaleChange?.(resolvedLocale);
+    }, [resolvedLocale, onActiveLocaleChange]);
+
+    const [registryEpoch, invalidateRegistry] = useReducer((epoch: number) => epoch + 1, 0);
+    useEffect(() => onI18nRegistryChange(() => invalidateRegistry()), []);
+
+    const [lazyLayer, setLazyLayer] = useState<Partial<Translations>>({});
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: rerun when `resolvedLocale` changes even though the reset callback does not reference it.
+    useLayoutEffect(() => {
+      setLazyLayer({});
+    }, [resolvedLocale]);
+
+    useEffect(() => {
+      let cancelled = false;
+      void (async () => {
+        const mergedLazy = await mergeBuiltinOverlays(resolvedLocale, loadBuiltin);
+        if (!cancelled) {
+          setLazyLayer(mergedLazy);
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [resolvedLocale]);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: `registryEpoch` bumps on registry mutations; `getI18nTranslations` reads mutable registry state.
+    const translations = useMemo(() => {
+      const registryLayer = getI18nTranslations(resolvedLocale);
+      return {
+        ...registryLayer,
+        ...lazyLayer,
+        ...translationsProp,
+      } as Translations;
+    }, [resolvedLocale, lazyLayer, translationsProp, registryEpoch]);
+
+    const translator = useMemo(() => createTranslator(translations, resolvedLocale), [translations, resolvedLocale]);
+
+    const value = useMemo<I18nContextValue>(
+      () => ({ translator, locale: resolvedLocale }),
+      [translator, resolvedLocale]
+    );
+
+    return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+  }
+
+  function useTranslator(): Translator {
+    const ctx = useContext(I18nContext);
+    const fallbackRef = useRef<Translator | undefined>(undefined);
+    if (!fallbackRef.current) {
+      fallbackRef.current = createTranslator(getI18nTranslations('en'), 'en');
+    }
+    if (!ctx) {
+      return fallbackRef.current;
+    }
+    return ctx.translator;
+  }
+
+  function useLocale(): Locale {
+    const ctx = useContext(I18nContext);
+    return ctx?.locale ?? 'en';
+  }
+
+  return { I18nContext, I18nProvider, useTranslator, useLocale };
+}

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -203,23 +203,22 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     }, []);
 
     const [lazyLayer, setLazyLayer] = useState<Partial<Translations>>({});
+    const lazySeqRef = useRef(0);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: rerun when `resolvedLocale` changes even though the reset callback does not reference it.
     useLayoutEffect(() => {
+      lazySeqRef.current += 1;
       setLazyLayer({});
     }, [resolvedLocale]);
 
     useEffect(() => {
-      let cancelled = false;
+      const seq = lazySeqRef.current;
+      const locale = resolvedLocale;
       void (async () => {
-        const mergedLazy = await mergeBuiltinOverlays(resolvedLocale, loadBuiltin);
-        if (!cancelled) {
-          setLazyLayer(mergedLazy);
-        }
+        const mergedLazy = await mergeBuiltinOverlays(locale, loadBuiltin);
+        if (seq !== lazySeqRef.current) return;
+        setLazyLayer(mergedLazy);
       })();
-      return () => {
-        cancelled = true;
-      };
     }, [resolvedLocale]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: `registryEpoch` bumps on registry mutations; `getI18nTranslations` reads mutable registry state.

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -174,10 +174,9 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     onActiveLocaleChangeRef.current = onActiveLocaleChange;
 
     useLayoutEffect(() => {
-      if (langRootRef) {
-        invalidateLangRoot();
-      }
-    }, [langRootRef, langRootElement]);
+      if (!langRootRef) return;
+      invalidateLangRoot();
+    }, [langRootElement]);
 
     const ambientLang = useSyncExternalStore(
       subscribeAmbientLang,
@@ -215,9 +214,13 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
       const seq = lazySeqRef.current;
       const locale = resolvedLocale;
       void (async () => {
-        const mergedLazy = await mergeBuiltinOverlays(locale, loadBuiltin);
-        if (seq !== lazySeqRef.current) return;
-        setLazyLayer(mergedLazy);
+        try {
+          const mergedLazy = await mergeBuiltinOverlays(locale, loadBuiltin);
+          if (seq !== lazySeqRef.current) return;
+          setLazyLayer(mergedLazy);
+        } catch {
+          // Ignore rejected built-in locale loads; registry/prop layers still apply.
+        }
       })();
     }, [resolvedLocale]);
 

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -169,18 +169,24 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     onActiveLocaleChange,
   }: I18nProviderProps): ReactNode {
     const [, invalidateLangRoot] = useReducer((epoch: number) => epoch + 1, 0);
+    const langRootElement = langRootRef?.current ?? null;
+    const onActiveLocaleChangeRef = useRef(onActiveLocaleChange);
+    onActiveLocaleChangeRef.current = onActiveLocaleChange;
 
     useLayoutEffect(() => {
       if (langRootRef) {
         invalidateLangRoot();
       }
-    }, [langRootRef]);
+    }, [langRootRef, langRootElement]);
 
     const ambientLang = useSyncExternalStore(
       subscribeAmbientLang,
       () => {
-        const langRoot = langRootRef?.current ?? (typeof document !== 'undefined' ? document.documentElement : null);
-        return nearestLang(langRoot);
+        if (langRootRef) {
+          return nearestLang(langRootRef.current);
+        }
+        const root = typeof document !== 'undefined' ? document.documentElement : null;
+        return nearestLang(root);
       },
       ambientLangServerSnapshot
     );
@@ -188,8 +194,8 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     const resolvedLocale = useMemo(() => effectiveLocale(localeProp, ambientLang), [localeProp, ambientLang]);
 
     useEffect(() => {
-      onActiveLocaleChange?.(resolvedLocale);
-    }, [resolvedLocale, onActiveLocaleChange]);
+      onActiveLocaleChangeRef.current?.(resolvedLocale);
+    }, [resolvedLocale]);
 
     const [registryEpoch, invalidateRegistry] = useReducer((epoch: number) => epoch + 1, 0);
     useEffect(() => onI18nRegistryChange(() => invalidateRegistry()), []);

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -168,15 +168,23 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     children,
     onActiveLocaleChange,
   }: I18nProviderProps): ReactNode {
-    const [, invalidateLangRoot] = useReducer((epoch: number) => epoch + 1, 0);
-    const langRootElement = langRootRef?.current ?? null;
     const onActiveLocaleChangeRef = useRef(onActiveLocaleChange);
     onActiveLocaleChangeRef.current = onActiveLocaleChange;
+    const [, invalidateLangRoot] = useReducer((epoch: number) => epoch + 1, 0);
+    const attachedLangRootRef = useRef<Element | null>(null);
 
     useLayoutEffect(() => {
-      if (!langRootRef) return;
-      invalidateLangRoot();
-    }, [langRootElement]);
+      if (!langRootRef) {
+        attachedLangRootRef.current = null;
+        return;
+      }
+      const node = langRootRef.current;
+      if (node === attachedLangRootRef.current) return;
+      attachedLangRootRef.current = node;
+      if (node) {
+        invalidateLangRoot();
+      }
+    });
 
     const ambientLang = useSyncExternalStore(
       subscribeAmbientLang,

--- a/packages/react/src/i18n/index.ts
+++ b/packages/react/src/i18n/index.ts
@@ -1,0 +1,31 @@
+'use client';
+
+export type {
+  Contains,
+  Locale,
+  TranslationParams,
+  Translations,
+  Translator,
+} from '@videojs/core/i18n';
+
+export {
+  createTranslator,
+  getI18nTranslations,
+  hasRegisteredI18n,
+  localeLookupChain,
+  onI18nRegistryChange,
+  registerI18n,
+} from '@videojs/core/i18n';
+
+export type {
+  CreateI18nOptions,
+  CreateI18nResult,
+  I18nContextValue,
+  I18nProviderProps,
+} from './create-i18n';
+
+export { createI18n } from './create-i18n';
+
+import { createI18n as createDefaultI18n } from './create-i18n';
+
+export const { I18nContext, I18nProvider, useLocale, useTranslator } = createDefaultI18n();

--- a/packages/react/src/i18n/locales/en/index.ts
+++ b/packages/react/src/i18n/locales/en/index.ts
@@ -1,0 +1,1 @@
+export { default } from '@videojs/core/i18n/locales/en';

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -1,0 +1,345 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { registerI18n, resetI18nRegistryForTesting } from '@videojs/core/i18n';
+import { createRef, type ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createI18n } from '../create-i18n';
+
+describe('createI18n', () => {
+  afterEach(() => {
+    cleanup();
+    resetI18nRegistryForTesting();
+    document.documentElement.removeAttribute('lang');
+  });
+
+  it('uses explicit locale for translations', async () => {
+    registerI18n('fr', { play: 'Lire' });
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <I18nProvider locale="fr">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lire')).not.toBeNull();
+    });
+  });
+
+  it('merges translations prop above registry and lazy built-ins', async () => {
+    registerI18n('en', { play: 'Registry', pause: 'RegistryPause' });
+    const { I18nProvider, useTranslator } = createI18n({
+      loadBuiltinLocale: async (tag) =>
+        tag === 'en'
+          ? {
+              play: 'Lazy',
+              replay: 'LazyReplay',
+            }
+          : undefined,
+    });
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return (
+        <span>
+          {t('play')}:{t('pause')}:{t('replay')}
+        </span>
+      );
+    }
+
+    render(
+      <I18nProvider locale="en" translations={{ play: 'Prop' }}>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Prop:RegistryPause:LazyReplay')).not.toBeNull();
+    });
+  });
+
+  it('inherits nearest ancestor lang (including html)', async () => {
+    registerI18n('de', { play: 'Los' });
+    document.documentElement.lang = 'de';
+
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Los')).not.toBeNull();
+    });
+  });
+
+  it('updates ambient locale when subtree moves change which ancestor supplies lang', async () => {
+    registerI18n('de', { play: 'Los' });
+    registerI18n('fr', { play: 'Lire' });
+    document.documentElement.setAttribute('lang', 'fr');
+
+    const rootRef = createRef<HTMLDivElement>();
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    const { rerender } = render(
+      <div ref={rootRef}>
+        <I18nProvider langRootRef={rootRef}>
+          <Probe />
+        </I18nProvider>
+      </div>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lire')).not.toBeNull();
+    });
+
+    rerender(
+      <section lang="de">
+        <div ref={rootRef}>
+          <I18nProvider langRootRef={rootRef}>
+            <Probe />
+          </I18nProvider>
+        </div>
+      </section>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Los')).not.toBeNull();
+    });
+  });
+
+  it('prefers the closest lang attribute over html lang', async () => {
+    registerI18n('de', { play: 'Los' });
+    registerI18n('fr', { play: 'Lire' });
+    document.documentElement.setAttribute('lang', 'de');
+
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    const sectionRef = createRef<HTMLElement>();
+
+    render(
+      <section ref={sectionRef} lang="fr">
+        <I18nProvider langRootRef={sectionRef}>
+          <Probe />
+        </I18nProvider>
+      </section>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lire')).not.toBeNull();
+    });
+  });
+
+  it('updates when html lang changes', async () => {
+    registerI18n('de', { play: 'Los' });
+    registerI18n('fr', { play: 'Lire' });
+    document.documentElement.lang = 'de';
+
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Los')).not.toBeNull();
+    });
+
+    document.documentElement.setAttribute('lang', 'fr');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lire')).not.toBeNull();
+    });
+  });
+
+  it('refreshes merged translations when the registry updates after mount', async () => {
+    registerI18n('en', { play: 'First' });
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <I18nProvider locale="en">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('First')).not.toBeNull();
+    });
+
+    registerI18n('en', { play: 'Second' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Second')).not.toBeNull();
+    });
+  });
+
+  it('drops lazy builtin overlay from the prior locale while the next locale is loading', async () => {
+    registerI18n('en', { play: 'EnReg' });
+    registerI18n('fr', { play: 'FrReg' });
+
+    let unblockFr!: () => void;
+    const frBlocked = new Promise<void>((resolve) => {
+      unblockFr = resolve;
+    });
+
+    const { I18nProvider, useTranslator } = createI18n({
+      loadBuiltinLocale: async (tag) => {
+        if (tag === 'en') {
+          return { play: 'EnLazy' };
+        }
+        if (tag === 'fr') {
+          await frBlocked;
+          return { play: 'FrLazy' };
+        }
+        return undefined;
+      },
+    });
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    const { rerender } = render(
+      <I18nProvider locale="en">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('EnLazy')).not.toBeNull();
+    });
+
+    rerender(
+      <I18nProvider locale="fr">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('FrReg')).not.toBeNull();
+    });
+    expect(screen.queryByText('EnLazy')).toBeNull();
+
+    unblockFr();
+
+    await waitFor(() => {
+      expect(screen.queryByText('FrLazy')).not.toBeNull();
+    });
+  });
+
+  it('loads built-ins for unregistered locales via lazy loader', async () => {
+    const { I18nProvider, useTranslator } = createI18n({
+      loadBuiltinLocale: async (tag) => (tag === 'xx' ? { play: 'BuiltinXX' } : undefined),
+    });
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <I18nProvider locale="xx">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('BuiltinXX')).not.toBeNull();
+    });
+  });
+
+  it('useLocale reflects resolved locale', async () => {
+    const { I18nProvider, useLocale } = createI18n();
+    document.documentElement.lang = 'es-MX';
+
+    function Probe(): ReactElement {
+      return <span>{useLocale()}</span>;
+    }
+
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('es-MX')).not.toBeNull();
+    });
+  });
+
+  it('notifies onActiveLocaleChange when resolved locale changes', async () => {
+    const onActiveLocaleChange = vi.fn();
+    registerI18n('de', { play: 'Los' });
+    document.documentElement.lang = 'de';
+
+    const { I18nProvider } = createI18n();
+
+    function Probe(): ReactElement {
+      return <span>x</span>;
+    }
+
+    render(
+      <I18nProvider onActiveLocaleChange={onActiveLocaleChange}>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(onActiveLocaleChange.mock.calls.some((c) => c[0] === 'de')).toBe(true);
+    });
+
+    document.documentElement.setAttribute('lang', 'fr');
+
+    await waitFor(() => {
+      expect(onActiveLocaleChange.mock.calls.some((c) => c[0] === 'fr')).toBe(true);
+    });
+  });
+
+  it('useTranslator falls back to English outside a provider', () => {
+    const { useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(<Probe />);
+    expect(screen.queryByText('Play')).not.toBeNull();
+  });
+});

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -126,6 +126,35 @@ describe('createI18n', () => {
     });
   });
 
+  it('does not inherit html lang before langRootRef attaches', async () => {
+    registerI18n('de', { play: 'Los' });
+    registerI18n('fr', { play: 'Lire' });
+    document.documentElement.setAttribute('lang', 'de');
+
+    const rootRef = createRef<HTMLDivElement>();
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <section lang="fr">
+        <I18nProvider langRootRef={rootRef}>
+          <div ref={rootRef}>
+            <Probe />
+          </div>
+        </I18nProvider>
+      </section>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lire')).not.toBeNull();
+    });
+    expect(screen.queryByText('Los')).toBeNull();
+  });
+
   it('prefers the closest lang attribute over html lang', async () => {
     registerI18n('de', { play: 'Los' });
     registerI18n('fr', { play: 'Lire' });
@@ -301,6 +330,38 @@ describe('createI18n', () => {
     await waitFor(() => {
       expect(screen.queryByText('es-MX')).not.toBeNull();
     });
+  });
+
+  it('does not re-notify onActiveLocaleChange when the handler identity changes', async () => {
+    registerI18n('de', { play: 'Los' });
+    document.documentElement.lang = 'de';
+
+    const onActiveLocaleChange = vi.fn();
+    const { I18nProvider } = createI18n();
+
+    function Probe(): ReactElement {
+      return <span>x</span>;
+    }
+
+    const { rerender } = render(
+      <I18nProvider onActiveLocaleChange={onActiveLocaleChange}>
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(onActiveLocaleChange).toHaveBeenCalledWith('de');
+    });
+
+    const callCountAfterMount = onActiveLocaleChange.mock.calls.length;
+
+    rerender(
+      <I18nProvider onActiveLocaleChange={() => {}}>
+        <Probe />
+      </I18nProvider>
+    );
+
+    expect(onActiveLocaleChange.mock.calls.length).toBe(callCountAfterMount);
   });
 
   it('notifies onActiveLocaleChange when resolved locale changes', async () => {

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -332,6 +332,53 @@ describe('createI18n', () => {
     });
   });
 
+  it('does not apply stale lazy locale overlays after locale switch', async () => {
+    let resolveDe: ((value: Partial<Translations>) => void) | undefined;
+    const deLoad = new Promise<Partial<Translations>>((resolve) => {
+      resolveDe = resolve;
+    });
+
+    const { I18nProvider, useTranslator } = createI18n({
+      loadBuiltinLocale: async (tag) => {
+        if (tag === 'de') {
+          return deLoad;
+        }
+        if (tag === 'fr') {
+          return { play: 'Lecture' };
+        }
+        return undefined;
+      },
+    });
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    const { rerender } = render(
+      <I18nProvider locale="de">
+        <Probe />
+      </I18nProvider>
+    );
+
+    rerender(
+      <I18nProvider locale="fr">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lecture')).not.toBeNull();
+    });
+
+    resolveDe?.({ play: 'Abspielen' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Abspielen')).toBeNull();
+      expect(screen.queryByText('Lecture')).not.toBeNull();
+    });
+  });
+
   it('does not re-notify onActiveLocaleChange when the handler identity changes', async () => {
     registerI18n('de', { play: 'Los' });
     document.documentElement.lang = 'de';

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -495,11 +495,9 @@ describe('createI18n', () => {
 
   it('does not loop when langRootRef identity changes each render', async () => {
     registerI18n('fr', { play: 'Lire' });
-    const renderSpy = vi.fn();
     const { I18nProvider, useTranslator } = createI18n();
 
     function Probe(): ReactElement {
-      renderSpy();
       const t = useTranslator();
       return <span>{t('play')}</span>;
     }
@@ -523,11 +521,10 @@ describe('createI18n', () => {
       expect(screen.queryByText('Lire')).not.toBeNull();
     });
 
-    const rendersAfterMount = renderSpy.mock.calls.length;
+    for (let i = 0; i < 20; i++) {
+      rerender(<Shell />);
+    }
 
-    rerender(<Shell />);
-    rerender(<Shell />);
-
-    expect(renderSpy.mock.calls.length - rendersAfterMount).toBeLessThanOrEqual(2);
+    expect(screen.queryByText('Lire')).not.toBeNull();
   });
 });

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { registerI18n, resetI18nRegistryForTesting } from '@videojs/core/i18n';
+import { registerI18n, resetI18nRegistryForTesting, type Translations } from '@videojs/core/i18n';
 import { createRef, type ReactElement } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -468,4 +468,66 @@ describe('createI18n', () => {
       expect(screen.queryByText('RegistryPlay')).not.toBeNull();
     });
   });
+
+  it('ignores rejected built-in locale loads', async () => {
+    registerI18n('de', { play: 'RegistryPlay' });
+    const { I18nProvider, useTranslator } = createI18n({
+      loadBuiltinLocale: async () => {
+        throw new Error('load failed');
+      },
+    });
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(
+      <I18nProvider locale="de">
+        <Probe />
+      </I18nProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('RegistryPlay')).not.toBeNull();
+    });
+  });
+
+  it('does not loop when langRootRef identity changes each render', async () => {
+    registerI18n('fr', { play: 'Lire' });
+    const renderSpy = vi.fn();
+    const { I18nProvider, useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      renderSpy();
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    function Shell(): ReactElement {
+      const rootRef = createRef<HTMLDivElement>();
+      return (
+        <section lang="fr">
+          <I18nProvider langRootRef={rootRef}>
+            <div ref={rootRef}>
+              <Probe />
+            </div>
+          </I18nProvider>
+        </section>
+      );
+    }
+
+    const { rerender } = render(<Shell />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Lire')).not.toBeNull();
+    });
+
+    const rendersAfterMount = renderSpy.mock.calls.length;
+
+    rerender(<Shell />);
+    rerender(<Shell />);
+
+    expect(renderSpy.mock.calls.length - rendersAfterMount).toBeLessThanOrEqual(2);
+  });
 });

--- a/packages/react/src/i18n/tests/create-i18n.test.tsx
+++ b/packages/react/src/i18n/tests/create-i18n.test.tsx
@@ -450,4 +450,22 @@ describe('createI18n', () => {
     render(<Probe />);
     expect(screen.queryByText('Play')).not.toBeNull();
   });
+
+  it('refreshes fallback translator when the registry updates outside a provider', async () => {
+    const { useTranslator } = createI18n();
+
+    function Probe(): ReactElement {
+      const t = useTranslator();
+      return <span>{t('play')}</span>;
+    }
+
+    render(<Probe />);
+    expect(screen.queryByText('Play')).not.toBeNull();
+
+    registerI18n('en', { play: 'RegistryPlay' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('RegistryPlay')).not.toBeNull();
+    });
+  });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,29 @@ export * from '@videojs/core/dom';
 export type { Comparator, Selector } from '@videojs/store';
 export { createSelector, shallowEqual } from '@videojs/store';
 export { useSelector, useStore } from '@videojs/store/react';
+// Media utilities
+export {
+  type Contains,
+  type CreateI18nOptions,
+  type CreateI18nResult,
+  createI18n,
+  createTranslator,
+  getI18nTranslations,
+  hasRegisteredI18n,
+  I18nContext,
+  type I18nContextValue,
+  I18nProvider,
+  type I18nProviderProps,
+  type Locale,
+  localeLookupChain,
+  onI18nRegistryChange,
+  registerI18n,
+  type TranslationParams,
+  type Translations,
+  type Translator,
+  useLocale,
+  useTranslator,
+} from './i18n';
 // Media primitives
 export {
   Container,
@@ -88,7 +111,6 @@ export { VolumeSlider } from './ui/volume-slider';
 // Utilities
 export { mergeProps } from './utils/merge-props';
 export type { HTMLProps, RenderFunction, RenderProp, UIComponentProps } from './utils/types';
-// Media utilities
 export { useAttachMedia } from './utils/use-attach-media';
 export { composeRefs, useComposedRefs } from './utils/use-composed-refs';
 export { useDestroy } from './utils/use-destroy';


### PR DESCRIPTION
Stacked PR: **base branch `feat/i18n-core`** — review and merge **#1551** first. After #1551 lands on `main`, retarget this PR to `main` or rebase as usual.

## What this PR adds on top of #1551

- **Core:** export `localeLookupChain`; add `@videojs/core/i18n/locales/en` conditional export and tsdown entry for explicit English strings.
- **React:** `createI18n()` with `I18nProvider`, `useTranslator`, and `useLocale`; translation merge order registry → lazy builtin overlays (locale lookup chain) → `translations` prop; optional `locale` override; otherwise inherited DOM `lang` from `langRootRef` or `<html>`, with live updates (`MutationObserver` + subtree moves).
- **Packaging:** `@videojs/react` `./i18n` and `./i18n/locales/en` exports; re-exports from the package root `index`.

Ref https://github.com/videojs/v10/issues/1364

## Test plan

- [ ] `pnpm -F @videojs/core test src/core/i18n`
- [ ] `pnpm -F @videojs/react test src/i18n/tests/create-i18n.test.tsx`
- [ ] `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new React i18n context/provider with async locale overlay loading and live DOM `lang` tracking via `MutationObserver`, which could affect rendering/update behavior across apps. Also expands public package exports, so API surface/packaging regressions are the main risk.
> 
> **Overview**
> Adds a new React i18n layer (`createI18n`, `I18nProvider`, `useTranslator`, `useLocale`) that resolves the active locale from an explicit `locale` prop or by inheriting the nearest DOM `lang` (optionally rooted at `langRootRef`) and reacting to `lang`/subtree changes.
> 
> Translations are now composed in React as **registry → lazily loaded built-in overlays (using `localeLookupChain`) → `translations` prop**, with safeguards against stale async loads and updates when the core i18n registry changes; comprehensive tests cover locale inheritance, live updates, merge precedence, and race cases.
> 
> Exposes the new functionality publicly by exporting `localeLookupChain` from `@videojs/core/i18n`, adding `@videojs/react` export paths for `./i18n` and `./i18n/locales/en`, and re-exporting i18n utilities/hooks from the React package root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ec45f1a61f8fa67f783ae42bf818b9044ec55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->