### PR TITLE
feat(packages): add html i18n layer and shared dom locale helpers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,10 +39,10 @@
       "development": "./dist/dev/i18n.js",
       "default": "./dist/default/i18n.js"
     },
-    "./i18n/locales/en": {
-      "types": "./dist/dev/i18n/locales/en.d.ts",
-      "development": "./dist/dev/i18n/locales/en.js",
-      "default": "./dist/default/i18n/locales/en.js"
+    "./i18n/locales/*": {
+      "types": "./dist/dev/i18n/locales/*.d.ts",
+      "development": "./dist/dev/i18n/locales/*.js",
+      "default": "./dist/default/i18n/locales/*.js"
     }
   },
   "main": "dist/default/index.js",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -118,6 +118,16 @@
       "development": "./cdn/*.dev.js",
       "default": "./cdn/*.js"
     },
+    "./i18n": {
+      "types": "./dist/dev/i18n/index.d.ts",
+      "development": "./dist/dev/i18n/index.js",
+      "default": "./dist/default/i18n/index.js"
+    },
+    "./i18n/locales/*": {
+      "types": "./dist/dev/i18n/locales/*.d.ts",
+      "development": "./dist/dev/i18n/locales/*.js",
+      "default": "./dist/default/i18n/locales/*.js"
+    },
     "./*.css": "./dist/default/define/*.css",
     "./*": {
       "types": "./dist/dev/define/*.d.ts",

--- a/packages/html/src/i18n/create-i18n.ts
+++ b/packages/html/src/i18n/create-i18n.ts
@@ -1,0 +1,212 @@
+import {
+  createTranslator,
+  getI18nTranslations,
+  type Locale,
+  localeLookupChain,
+  onI18nRegistryChange,
+  type Translations,
+  type Translator,
+} from '@videojs/core/i18n';
+import type { PropertyValues, ReactiveController, ReactiveControllerHost, ReactiveElement } from '@videojs/element';
+import { type Context, ContextConsumer, ContextProvider, createContext } from '@videojs/element/context';
+import { mergeLocaleOverlays, subscribeAmbientLang } from '@videojs/utils/dom';
+import type { Constructor } from '@videojs/utils/types';
+
+import { playerContext } from '../player/context';
+import { resolveProviderLocale } from './locale';
+import { selectCaptionsByLocale } from './select-captions-by-locale';
+
+async function noopBuiltinPack(_tag: string): Promise<Partial<Translations> | undefined> {
+  return undefined;
+}
+
+/** Reflected i18n keys are untyped strings; the runtime translator accepts any key. */
+function translateReflectedKey(translator: Translator, key: string): string {
+  const translateLoose = translator as (k: string, params?: unknown) => string;
+  return translateLoose(key);
+}
+
+export interface I18nContextValue {
+  translator: Translator;
+  locale: Locale;
+}
+
+export interface CreateI18nOptions {
+  loadBuiltinLocale?: (tag: string) => Promise<Partial<Translations> | undefined>;
+}
+
+const I18N_CONTEXT_KEY = Symbol('@videojs/i18n');
+
+export type I18nLitContext = Context<typeof I18N_CONTEXT_KEY, I18nContextValue>;
+
+/**
+ * `Constructor<ReactiveElement>` does not imply static `properties`; this intersection matches how
+ * mixins spread {@link ReactiveElement.properties} from their base.
+ */
+type ReactiveElementMixinBase = Constructor<ReactiveElement> & Pick<typeof ReactiveElement, 'properties'>;
+
+export interface CreateI18nResult {
+  context: I18nLitContext;
+  I18nController: new (
+    host: ReactiveControllerHost & HTMLElement
+  ) => ReactiveController & {
+    readonly value: Translator;
+    readonly locale: Locale;
+  };
+  ProviderMixin: <Base extends ReactiveElementMixinBase>(Base: Base) => Constructor<ReactiveElement> & Base;
+  TextMixin: <Base extends ReactiveElementMixinBase>(Base: Base) => Constructor<ReactiveElement> & Base;
+}
+
+export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
+  const loadBuiltin = options?.loadBuiltinLocale ?? noopBuiltinPack;
+  const fallbackTranslator = createTranslator(getI18nTranslations('en'), 'en');
+
+  const i18nContext = createContext<I18nContextValue, typeof I18N_CONTEXT_KEY>(I18N_CONTEXT_KEY);
+
+  class I18nControllerImpl implements ReactiveController {
+    readonly #host: ReactiveControllerHost & HTMLElement;
+    readonly #consumer: ContextConsumer<I18nLitContext, ReactiveControllerHost & HTMLElement>;
+
+    constructor(host: ReactiveControllerHost & HTMLElement) {
+      this.#host = host;
+      this.#consumer = new ContextConsumer(host, {
+        context: i18nContext,
+        callback: () => this.#host.requestUpdate(),
+        subscribe: true,
+      });
+      host.addController(this);
+    }
+
+    get value(): Translator {
+      return this.#consumer.value?.translator ?? fallbackTranslator;
+    }
+
+    get locale(): Locale {
+      return this.#consumer.value?.locale ?? 'en';
+    }
+
+    hostConnected(): void {}
+
+    hostDisconnected(): void {}
+  }
+
+  const ProviderMixin = <Base extends ReactiveElementMixinBase>(Base: Base) => {
+    class I18nProviderElement extends Base {
+      static properties = {
+        ...Base.properties,
+        lang: { type: String, reflect: true },
+      };
+
+      lang = '';
+
+      readonly #i18nProvider = new ContextProvider(this, {
+        context: i18nContext,
+        initialValue: {
+          translator: fallbackTranslator,
+          locale: 'en',
+        },
+      });
+
+      #registryUnsub: (() => void) | undefined;
+      #ambientUnsub: (() => void) | undefined;
+      #lazyLayer: Partial<Translations> = {};
+      #lazySeq = 0;
+      #storeConsumer: ContextConsumer<typeof playerContext, ReactiveControllerHost & HTMLElement> | undefined;
+
+      override connectedCallback(): void {
+        super.connectedCallback();
+        this.#registryUnsub = onI18nRegistryChange(() => this.requestUpdate());
+        this.#ambientUnsub = subscribeAmbientLang(() => this.requestUpdate());
+        this.#storeConsumer = new ContextConsumer(this, {
+          context: playerContext,
+          callback: () => this.#syncCaptions(),
+          subscribe: true,
+        });
+        this.#resetLazyAndLoad();
+        this.requestUpdate();
+      }
+
+      override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.#registryUnsub?.();
+        this.#registryUnsub = undefined;
+        this.#ambientUnsub?.();
+        this.#ambientUnsub = undefined;
+        this.#lazySeq += 1;
+        this.#lazyLayer = {};
+      }
+
+      protected override willUpdate(changed: PropertyValues): void {
+        super.willUpdate(changed);
+        if (changed.has('lang') && this.hasUpdated) {
+          this.#resetLazyAndLoad();
+        }
+      }
+
+      protected override updated(changed: PropertyValues): void {
+        super.updated(changed);
+        this.#publish();
+        this.#syncCaptions();
+      }
+
+      #resetLazyAndLoad(): void {
+        this.#lazySeq += 1;
+        const seq = this.#lazySeq;
+        this.#lazyLayer = {};
+        const locale = resolveProviderLocale(this);
+        void (async () => {
+          const merged = await mergeLocaleOverlays(locale, loadBuiltin, localeLookupChain);
+          if (seq !== this.#lazySeq) return;
+          this.#lazyLayer = merged;
+          this.requestUpdate();
+        })();
+      }
+
+      #resolvedLocale(): Locale {
+        return resolveProviderLocale(this);
+      }
+
+      #publish(): void {
+        const locale = this.#resolvedLocale();
+        const registryLayer = getI18nTranslations(locale);
+        const translations: Translations = {
+          ...registryLayer,
+          ...this.#lazyLayer,
+        };
+        const translator = createTranslator(translations, locale);
+        this.#i18nProvider.setValue({ translator, locale });
+      }
+
+      #syncCaptions(): void {
+        selectCaptionsByLocale(this.#storeConsumer?.value ?? undefined, this.#resolvedLocale());
+      }
+    }
+    return I18nProviderElement;
+  };
+
+  const TextMixin = <Base extends ReactiveElementMixinBase>(Base: Base) => {
+    class MediaText extends Base {
+      static properties = {
+        ...Base.properties,
+        key: { type: String, reflect: true },
+      };
+
+      key = '';
+
+      readonly #i18n = new I18nControllerImpl(this);
+
+      protected override updated(changed: PropertyValues): void {
+        super.updated(changed);
+        this.textContent = this.key ? translateReflectedKey(this.#i18n.value, this.key) : '';
+      }
+    }
+    return MediaText;
+  };
+
+  return {
+    context: i18nContext,
+    I18nController: I18nControllerImpl,
+    ProviderMixin,
+    TextMixin,
+  };
+}

--- a/packages/html/src/i18n/define-elements.ts
+++ b/packages/html/src/i18n/define-elements.ts
@@ -1,0 +1,23 @@
+import { ReactiveElement } from '@videojs/element';
+
+import { safeDefine } from '../define/safe-define';
+import { I18nProviderMixin, I18nTextMixin } from './instance';
+
+export class MediaI18nProviderElement extends I18nProviderMixin(ReactiveElement) {
+  static readonly tagName = 'media-i18n-provider';
+}
+
+safeDefine(MediaI18nProviderElement);
+
+export class MediaTextElement extends I18nTextMixin(ReactiveElement) {
+  static readonly tagName = 'media-text';
+}
+
+safeDefine(MediaTextElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [MediaI18nProviderElement.tagName]: MediaI18nProviderElement;
+    [MediaTextElement.tagName]: MediaTextElement;
+  }
+}

--- a/packages/html/src/i18n/index.ts
+++ b/packages/html/src/i18n/index.ts
@@ -1,0 +1,29 @@
+export type {
+  Contains,
+  Locale,
+  TranslationParams,
+  Translations,
+  Translator,
+} from '@videojs/core/i18n';
+
+export {
+  createTranslator,
+  getI18nTranslations,
+  hasRegisteredI18n,
+  localeLookupChain,
+  onI18nRegistryChange,
+  registerI18n,
+} from '@videojs/core/i18n';
+export type {
+  CreateI18nOptions,
+  CreateI18nResult,
+  I18nContextValue,
+  I18nLitContext,
+} from './create-i18n';
+export { createI18n } from './create-i18n';
+export { MediaI18nProviderElement, MediaTextElement } from './define-elements';
+export { context, I18nController, I18nProviderMixin, I18nTextMixin } from './instance';
+export { localeFromDomLang, resolvePlayerLocale, resolveProviderLocale } from './locale';
+export { selectCaptionsByLocale } from './select-captions-by-locale';
+
+import './define-elements';

--- a/packages/html/src/i18n/instance.ts
+++ b/packages/html/src/i18n/instance.ts
@@ -1,0 +1,8 @@
+import { createI18n } from './create-i18n';
+
+const built = createI18n();
+
+export const context = built.context;
+export const I18nController = built.I18nController;
+export const I18nProviderMixin = built.ProviderMixin;
+export const I18nTextMixin = built.TextMixin;

--- a/packages/html/src/i18n/locale.ts
+++ b/packages/html/src/i18n/locale.ts
@@ -1,0 +1,34 @@
+import type { Locale } from '@videojs/core/i18n';
+import { nearestLang } from '@videojs/utils/dom';
+import { isUndefined } from '@videojs/utils/predicate';
+
+/** DOM `lang` values are untyped strings; align with core {@link Locale} at the boundary. */
+export function localeFromDomLang(raw: string | undefined): Locale | undefined {
+  if (isUndefined(raw) || raw.trim() === '') {
+    return undefined;
+  }
+  return raw as Locale;
+}
+
+/**
+ * Same precedence as `effectiveLocale` from `@videojs/utils/dom`; typed so the result is
+ * {@link Locale} without widening from `string`.
+ */
+export function resolvePlayerLocale(explicit: Locale | undefined, inherited: Locale | undefined): Locale {
+  if (!isUndefined(explicit) && String(explicit).trim() !== '') {
+    return explicit;
+  }
+  if (!isUndefined(inherited) && inherited.trim() !== '') {
+    return inherited;
+  }
+  return 'en';
+}
+
+/** Effective locale for an i18n provider element (explicit `lang` → ancestor `lang` chain → `en`). */
+export function resolveProviderLocale(host: HTMLElement & { lang?: string }): Locale {
+  const trimmed = host.lang?.trim();
+  const explicit = trimmed ? (trimmed as Locale) : undefined;
+  const root = host.parentElement ?? (typeof document !== 'undefined' ? document.documentElement : null);
+  const inherited = localeFromDomLang(nearestLang(root));
+  return resolvePlayerLocale(explicit, inherited);
+}

--- a/packages/html/src/i18n/locales/en/index.ts
+++ b/packages/html/src/i18n/locales/en/index.ts
@@ -1,0 +1,1 @@
+export { englishTranslations } from '@videojs/core/i18n/locales/en';

--- a/packages/html/src/i18n/select-captions-by-locale.ts
+++ b/packages/html/src/i18n/select-captions-by-locale.ts
@@ -1,0 +1,35 @@
+import type { AnyPlayerStore } from '@videojs/core/dom';
+import type { Locale } from '@videojs/core/i18n';
+import { localeLookupChain } from '@videojs/core/i18n';
+
+function normalizeLangTag(tag: string): string {
+  return tag.trim().replace(/_/g, '-').toLowerCase();
+}
+
+/**
+ * Picks caption/subtitle tracks matching {@link localeLookupChain} and shows the best match.
+ * Other subtitle/caption tracks are disabled. No-op when there is no match (preserves user state).
+ */
+export function selectCaptionsByLocale(store: AnyPlayerStore | undefined, locale: Locale): void {
+  const media = store?.target?.media;
+  if (!media || !('textTracks' in media)) return;
+
+  const el = media as HTMLMediaElement;
+  const candidates = [...el.textTracks].filter((t) => t.kind === 'captions' || t.kind === 'subtitles');
+  if (!candidates.length) return;
+
+  const chain = localeLookupChain(locale).map(normalizeLangTag);
+  let picked: TextTrack | undefined;
+  for (const tag of chain) {
+    picked = candidates.find((t) => {
+      const lang = normalizeLangTag(t.language ?? '');
+      return lang === tag || lang.startsWith(`${tag}-`) || tag.startsWith(`${lang}-`);
+    });
+    if (picked) break;
+  }
+  if (!picked) return;
+
+  for (const t of candidates) {
+    t.mode = t === picked ? 'showing' : 'disabled';
+  }
+}

--- a/packages/html/src/i18n/tests/create-i18n-html.test.ts
+++ b/packages/html/src/i18n/tests/create-i18n-html.test.ts
@@ -1,0 +1,97 @@
+import type { AnyPlayerStore } from '@videojs/core/dom';
+import { registerI18n, resetI18nRegistryForTesting } from '@videojs/core/i18n';
+import { ReactiveElement } from '@videojs/element';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createI18n } from '../../i18n/create-i18n';
+import { MediaI18nProviderElement, MediaTextElement } from '../../i18n/index';
+import { selectCaptionsByLocale } from '../select-captions-by-locale';
+
+describe('createI18n (HTML)', () => {
+  afterEach(() => {
+    resetI18nRegistryForTesting();
+    document.documentElement.removeAttribute('lang');
+  });
+
+  it('media-i18n-provider uses explicit lang for registry copy', async () => {
+    registerI18n('fr', { play: 'Lire' });
+    const provider = new MediaI18nProviderElement();
+    provider.setAttribute('lang', 'fr');
+    document.body.appendChild(provider);
+    await Promise.resolve();
+    expect(provider.getAttribute('lang')).toBe('fr');
+  });
+
+  it('media-text shows translation key inside provider', async () => {
+    registerI18n('de', { play: 'Los' });
+    const provider = new MediaI18nProviderElement();
+    provider.setAttribute('lang', 'de');
+    const text = new MediaTextElement();
+    text.setAttribute('key', 'play');
+    provider.appendChild(text);
+    document.body.appendChild(provider);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(text.textContent).toBe('Los');
+  });
+
+  it('inherits ambient html lang when provider has no lang', async () => {
+    registerI18n('es', { play: 'Ir' });
+    document.documentElement.lang = 'es';
+    const provider = new MediaI18nProviderElement();
+    const text = new MediaTextElement();
+    text.setAttribute('key', 'play');
+    provider.appendChild(text);
+    document.body.appendChild(provider);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(text.textContent).toBe('Ir');
+  });
+
+  it('updates media-text when html lang changes', async () => {
+    registerI18n('de', { play: 'Los' });
+    registerI18n('fr', { play: 'Lire' });
+    document.documentElement.lang = 'de';
+    const provider = new MediaI18nProviderElement();
+    const text = new MediaTextElement();
+    text.setAttribute('key', 'play');
+    provider.appendChild(text);
+    document.body.appendChild(provider);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(text.textContent).toBe('Los');
+    document.documentElement.lang = 'fr';
+    await vi.waitFor(() => {
+      expect(text.textContent).toBe('Lire');
+    });
+  });
+
+  it('I18nController falls back to English without provider', async () => {
+    const { I18nController: Ctor } = createI18n();
+    class Probe extends ReactiveElement {
+      readonly #i18n = new Ctor(this);
+      override connectedCallback(): void {
+        super.connectedCallback();
+        this.textContent = this.#i18n.value('play');
+      }
+    }
+    customElements.define('i18n-probe-fallback', Probe);
+    const el = new Probe();
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(el.textContent).toBe('Play');
+  });
+
+  it('selectCaptionsByLocale activates a matching text track', () => {
+    const video = document.createElement('video');
+    video.addTextTrack('subtitles', 'DE', 'de');
+    video.addTextTrack('subtitles', 'FR', 'fr');
+
+    document.body.appendChild(video);
+
+    selectCaptionsByLocale({ target: { media: video, container: null } } as AnyPlayerStore, 'fr');
+
+    const frTrack = [...video.textTracks].find((t) => t.language === 'fr');
+    expect(frTrack?.mode).toBe('showing');
+  });
+});

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -14,6 +14,37 @@ export { DestroyMixin, ReactiveElement } from '@videojs/element';
 // Store
 export type { Comparator, Selector } from '@videojs/store';
 export { createSelector, shallowEqual } from '@videojs/store';
+export type {
+  Contains,
+  CreateI18nOptions,
+  CreateI18nResult,
+  I18nContextValue,
+  I18nLitContext,
+  Locale,
+  TranslationParams,
+  Translations,
+  Translator,
+} from './i18n';
+// i18n — subpath `@videojs/html/i18n` registers `<media-i18n-provider>` / `<media-text>`.
+export {
+  context as i18nContext,
+  createI18n,
+  createTranslator,
+  getI18nTranslations,
+  hasRegisteredI18n,
+  I18nController,
+  I18nProviderMixin,
+  I18nTextMixin,
+  localeFromDomLang,
+  localeLookupChain,
+  MediaI18nProviderElement,
+  MediaTextElement,
+  onI18nRegistryChange,
+  registerI18n,
+  resolvePlayerLocale,
+  resolveProviderLocale,
+  selectCaptionsByLocale,
+} from './i18n';
 // Media
 export { MediaContainerElement } from './media/container-element';
 // Player

--- a/packages/html/tsdown.config.ts
+++ b/packages/html/tsdown.config.ts
@@ -39,6 +39,8 @@ const iconEntries = Object.fromEntries(
 const createConfig = (mode: BuildMode): UserConfig => ({
   entry: {
     index: 'src/index.ts',
+    'i18n/index': 'src/i18n/index.ts',
+    'i18n/locales/en': 'src/i18n/locales/en/index.ts',
     ...iconEntries,
     ...defineEntries,
     ...presetEntries,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -98,10 +98,10 @@
       "development": "./dist/dev/i18n/index.js",
       "default": "./dist/default/i18n/index.js"
     },
-    "./i18n/locales/en": {
-      "types": "./dist/dev/i18n/locales/en/index.d.ts",
-      "development": "./dist/dev/i18n/locales/en/index.js",
-      "default": "./dist/default/i18n/locales/en/index.js"
+    "./i18n/locales/*": {
+      "types": "./dist/dev/i18n/locales/*/index.d.ts",
+      "development": "./dist/dev/i18n/locales/*/index.js",
+      "default": "./dist/default/i18n/locales/*/index.js"
     }
   },
   "scripts": {

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -9,6 +9,7 @@ import {
   type Translations,
   type Translator,
 } from '@videojs/core/i18n';
+import { mergeLocaleOverlays, nearestLang, subscribeAmbientLang } from '@videojs/utils/dom';
 import { isUndefined } from '@videojs/utils/predicate';
 import {
   type Context,
@@ -31,86 +32,25 @@ async function noopBuiltinPack(tag: string): Promise<Partial<Translations> | und
   return undefined;
 }
 
-async function mergeBuiltinOverlays(
-  locale: string,
-  load: (tag: string) => Promise<Partial<Translations> | undefined>
-): Promise<Partial<Translations>> {
-  const chain = localeLookupChain(locale);
-  const layers = await Promise.all(chain.map((tag) => load(tag)));
-  const merged: Partial<Translations> = {};
-  for (let i = chain.length - 1; i >= 0; i--) {
-    const layer = layers[i];
-    if (layer) {
-      Object.assign(merged, layer);
-    }
-  }
-  return merged;
+function ambientLangServerSnapshot(): Locale | undefined {
+  return undefined;
 }
 
-/**
- * Subscribes to DOM updates that can change {@link nearestLang}: any `lang` attribute edit,
- * or subtree structural changes under `<html>` (which can move nodes between labeled ancestors).
- */
-function subscribeAmbientLang(onStoreChange: () => void): () => void {
-  if (typeof document === 'undefined') {
-    return () => {};
-  }
-  let disconnected = false;
-  let queued = false;
-  const flush = (): void => {
-    queued = false;
-    if (disconnected) {
-      return;
-    }
-    onStoreChange();
-  };
-  const schedule = (): void => {
-    if (!queued) {
-      queued = true;
-      queueMicrotask(flush);
-    }
-  };
-  const root = document.documentElement;
-  const observer = new MutationObserver(schedule);
-  observer.observe(root, {
-    subtree: true,
-    attributes: true,
-    attributeFilter: ['lang'],
-    childList: true,
-  });
-  return () => {
-    disconnected = true;
-    observer.disconnect();
-    queued = false;
-  };
-}
-
-/** First non-empty `lang` on `start` or an ancestor (HTML language inheritance). */
-function nearestLang(start: Element | null): string | undefined {
-  if (!start || typeof document === 'undefined') {
+/** DOM `lang` values are untyped strings; align with core {@link Locale} at the boundary. */
+function localeFromDomLang(raw: string | undefined): Locale | undefined {
+  if (isUndefined(raw) || raw.trim() === '') {
     return undefined;
   }
-  let node: Element | null = start;
-  while (node) {
-    const trimmed = node.getAttribute('lang')?.trim();
-    if (trimmed) {
-      return trimmed;
-    }
-    node = node.parentElement;
-  }
-  return undefined;
+  return raw as Locale;
 }
 
-function ambientLangServerSnapshot(): string | undefined {
-  return undefined;
-}
-
-function effectiveLocale(localeProp: Locale | undefined, ambientLang: string | undefined): Locale {
-  if (!isUndefined(localeProp) && String(localeProp).trim() !== '') {
-    return localeProp;
+/** Matches `effectiveLocale` from `@videojs/utils/dom`; duplicated here so the result types as `Locale` without a cast. */
+function resolvePlayerLocale(explicit: Locale | undefined, inherited: Locale | undefined): Locale {
+  if (!isUndefined(explicit) && String(explicit).trim() !== '') {
+    return explicit;
   }
-  if (!isUndefined(ambientLang) && ambientLang.trim() !== '') {
-    return ambientLang;
+  if (!isUndefined(inherited) && inherited.trim() !== '') {
+    return inherited;
   }
   return 'en';
 }
@@ -180,12 +120,12 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
       subscribeAmbientLang,
       () => {
         const langRoot = langRootRef?.current ?? (typeof document !== 'undefined' ? document.documentElement : null);
-        return nearestLang(langRoot);
+        return localeFromDomLang(nearestLang(langRoot));
       },
       ambientLangServerSnapshot
     );
 
-    const resolvedLocale = useMemo(() => effectiveLocale(localeProp, ambientLang), [localeProp, ambientLang]);
+    const resolvedLocale = useMemo(() => resolvePlayerLocale(localeProp, ambientLang), [localeProp, ambientLang]);
 
     useEffect(() => {
       onActiveLocaleChange?.(resolvedLocale);
@@ -204,7 +144,7 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     useEffect(() => {
       let cancelled = false;
       void (async () => {
-        const mergedLazy = await mergeBuiltinOverlays(resolvedLocale, loadBuiltin);
+        const mergedLazy = await mergeLocaleOverlays(resolvedLocale, loadBuiltin, localeLookupChain);
         if (!cancelled) {
           setLazyLayer(mergedLazy);
         }

--- a/packages/utils/src/dom/effective-locale.ts
+++ b/packages/utils/src/dom/effective-locale.ts
@@ -1,0 +1,16 @@
+import { isUndefined } from '../predicate';
+
+/** Resolves locale: explicit non-empty value → ambient `lang` → {@link fallback}. */
+export function effectiveLocale(
+  explicitLocale: string | undefined,
+  ambientLang: string | undefined,
+  fallback = 'en'
+): string {
+  if (!isUndefined(explicitLocale) && String(explicitLocale).trim() !== '') {
+    return explicitLocale;
+  }
+  if (!isUndefined(ambientLang) && ambientLang.trim() !== '') {
+    return ambientLang;
+  }
+  return fallback;
+}

--- a/packages/utils/src/dom/index.ts
+++ b/packages/utils/src/dom/index.ts
@@ -1,6 +1,7 @@
 export { animationFrame } from './animation-frame';
 export { namedNodeMapToObject, serializeAttributes } from './attributes';
 export { isRTL } from './direction';
+export { effectiveLocale } from './effective-locale';
 export { type OnEventOptions, onEvent, resolveEventTarget } from './event';
 export { idleCallback } from './idle-callback';
 export {
@@ -12,6 +13,8 @@ export {
   isInteractiveTarget,
 } from './interactive';
 export { listen } from './listen';
+export { mergeLocaleOverlays } from './merge-locale-overlays';
+export { nearestLang } from './nearest-lang';
 export { isMacOS } from './platform';
 export { tryHidePopover, tryShowPopover } from './popover';
 export { isHTMLAudioElement, isHTMLMediaElement, isHTMLVideoElement } from './predicates';
@@ -24,6 +27,7 @@ export {
 } from './shadow-styles';
 export { getSlottedElement, querySlot } from './slotted';
 export { applyStyles, resolveCSSLength } from './style';
+export { subscribeAmbientLang } from './subscribe-ambient-lang';
 export { supportsAnchorPositioning, supportsAnimationFrame, supportsIdleCallback } from './supports';
 export { createTemplate, renderTemplate } from './template';
 export { findTrackElement, getTextTrackList } from './text-track';

--- a/packages/utils/src/dom/merge-locale-overlays.ts
+++ b/packages/utils/src/dom/merge-locale-overlays.ts
@@ -1,0 +1,20 @@
+/**
+ * Loads overlay layers for each tag in {@link localeLookupChain}, least-specific first, then merges
+ * most-specific-last (same semantics as the core i18n registry).
+ */
+export async function mergeLocaleOverlays<Overlay extends object>(
+  locale: string,
+  load: (tag: string) => Promise<Partial<Overlay> | undefined>,
+  localeLookupChain: (locale: string) => string[]
+): Promise<Partial<Overlay>> {
+  const chain = localeLookupChain(locale);
+  const layers = await Promise.all(chain.map((tag) => load(tag)));
+  const merged: Partial<Overlay> = {};
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const layer = layers[i];
+    if (layer) {
+      Object.assign(merged, layer);
+    }
+  }
+  return merged;
+}

--- a/packages/utils/src/dom/nearest-lang.ts
+++ b/packages/utils/src/dom/nearest-lang.ts
@@ -1,0 +1,15 @@
+/** First non-empty `lang` on `start` or an ancestor (HTML language inheritance). */
+export function nearestLang(start: Element | null): string | undefined {
+  if (!start || typeof document === 'undefined') {
+    return undefined;
+  }
+  let node: Element | null = start;
+  while (node) {
+    const trimmed = node.getAttribute('lang')?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+    node = node.parentElement;
+  }
+  return undefined;
+}

--- a/packages/utils/src/dom/subscribe-ambient-lang.ts
+++ b/packages/utils/src/dom/subscribe-ambient-lang.ts
@@ -1,0 +1,37 @@
+/**
+ * Subscribes to DOM updates that can change inherited `lang`: any `lang` attribute edit,
+ * or subtree structural changes under `<html>` (which can move nodes between labeled ancestors).
+ */
+export function subscribeAmbientLang(onStoreChange: () => void): () => void {
+  if (typeof document === 'undefined') {
+    return () => {};
+  }
+  let disconnected = false;
+  let queued = false;
+  const flush = (): void => {
+    queued = false;
+    if (disconnected) {
+      return;
+    }
+    onStoreChange();
+  };
+  const schedule = (): void => {
+    if (!queued) {
+      queued = true;
+      queueMicrotask(flush);
+    }
+  };
+  const root = document.documentElement;
+  const observer = new MutationObserver(schedule);
+  observer.observe(root, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['lang'],
+    childList: true,
+  });
+  return () => {
+    disconnected = true;
+    observer.disconnect();
+    queued = false;
+  };
+}

--- a/packages/utils/src/dom/tests/effective-locale.test.ts
+++ b/packages/utils/src/dom/tests/effective-locale.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { effectiveLocale } from '../effective-locale';
+
+describe('effectiveLocale', () => {
+  it('prefers explicit locale over ambient', () => {
+    expect(effectiveLocale('fr', 'de')).toBe('fr');
+  });
+
+  it('uses ambient when explicit is undefined', () => {
+    expect(effectiveLocale(undefined, 'es-MX')).toBe('es-MX');
+  });
+
+  it('falls back to en when both missing or blank', () => {
+    expect(effectiveLocale(undefined, undefined)).toBe('en');
+    expect(effectiveLocale('  ', undefined)).toBe('en');
+    expect(effectiveLocale(undefined, '  ')).toBe('en');
+  });
+
+  it('respects custom fallback', () => {
+    expect(effectiveLocale(undefined, undefined, 'xx')).toBe('xx');
+  });
+});

--- a/packages/utils/src/dom/tests/merge-locale-overlays.test.ts
+++ b/packages/utils/src/dom/tests/merge-locale-overlays.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeLocaleOverlays } from '../merge-locale-overlays';
+
+describe('mergeLocaleOverlays', () => {
+  it('merges layers least-specific to most-specific', async () => {
+    const chain = (_locale: string) => ['es', 'en'];
+    const load = async (tag: string): Promise<Partial<Record<'a' | 'b' | 'c', string>> | undefined> =>
+      tag === 'en' ? { a: 'en-a', b: 'en-b' } : tag === 'es' ? { b: 'es-b', c: 'es-c' } : undefined;
+
+    const merged = await mergeLocaleOverlays('es', load, chain);
+    expect(merged).toEqual({ a: 'en-a', b: 'es-b', c: 'es-c' });
+  });
+
+  it('skips undefined layers', async () => {
+    const chain = () => ['en', 'xx'];
+    const load = async (tag: string) => (tag === 'en' ? { k: 'v' } : undefined);
+    expect(await mergeLocaleOverlays('xx', load, chain)).toEqual({ k: 'v' });
+  });
+});

--- a/packages/utils/src/dom/tests/nearest-lang.test.ts
+++ b/packages/utils/src/dom/tests/nearest-lang.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { nearestLang } from '../nearest-lang';
+
+describe('nearestLang', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.removeAttribute('lang');
+  });
+
+  it('returns undefined for null start', () => {
+    expect(nearestLang(null)).toBeUndefined();
+  });
+
+  it('reads lang on the start element', () => {
+    const el = document.createElement('div');
+    el.setAttribute('lang', 'fr');
+    document.body.appendChild(el);
+    expect(nearestLang(el)).toBe('fr');
+  });
+
+  it('walks ancestors and prefers closest lang', () => {
+    const outer = document.createElement('section');
+    outer.setAttribute('lang', 'de');
+    const inner = document.createElement('div');
+    inner.setAttribute('lang', 'fr');
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+    expect(nearestLang(inner)).toBe('fr');
+  });
+
+  it('inherits from an ancestor when start has no lang', () => {
+    const outer = document.createElement('section');
+    outer.setAttribute('lang', 'de');
+    const inner = document.createElement('div');
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+    expect(nearestLang(inner)).toBe('de');
+  });
+
+  it('ignores empty lang and continues walking', () => {
+    const outer = document.createElement('section');
+    outer.setAttribute('lang', 'de');
+    const inner = document.createElement('div');
+    inner.setAttribute('lang', '  ');
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+    expect(nearestLang(inner)).toBe('de');
+  });
+});

--- a/packages/utils/src/dom/tests/subscribe-ambient-lang.test.ts
+++ b/packages/utils/src/dom/tests/subscribe-ambient-lang.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { subscribeAmbientLang } from '../subscribe-ambient-lang';
+
+describe('subscribeAmbientLang', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('lang');
+    vi.restoreAllMocks();
+  });
+
+  it('invokes callback when html lang changes', async () => {
+    const spy = vi.fn();
+    const off = subscribeAmbientLang(spy);
+    document.documentElement.setAttribute('lang', 'de');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalled();
+    off();
+  });
+
+  it('unsubscribe stops notifications', async () => {
+    const spy = vi.fn();
+    const off = subscribeAmbientLang(spy);
+    off();
+    spy.mockClear();
+    document.documentElement.setAttribute('lang', 'fr');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Lit/Web Components i18n stack on `@videojs/html` (`createI18n`, provider/text mixins, elements, caption selection helper) with `./i18n` and `./i18n/locales/*` package exports.
- Moves `nearestLang`, `subscribeAmbientLang`, `mergeLocaleOverlays`, and `effectiveLocale` into `@videojs/utils/dom` with tests, and switches React `createI18n` to use those helpers.
- Switches `@videojs/core` and `@videojs/react` locale subpath exports to `./i18n/locales/*` so additional locale bundles do not need new export lines.

**Stack:** targets `feat/i18n-react-layer` (React `createI18n` / ambient locale). Merge that PR before this one.

## Test plan
- [ ] `pnpm -F @videojs/utils test src/dom/tests`
- [ ] `pnpm -F @videojs/html test src/i18n/tests/create-i18n-html.test.ts`
- [ ] `pnpm -F @videojs/react test` (or targeted i18n tests if present)
- [ ] `pnpm typecheck`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new i18n provider/controller layer for web components (including automatic caption track selection) and changes public package exports for locale bundles, which could affect downstream bundling and runtime behavior. React i18n locale resolution is refactored to shared DOM helpers, so regressions would show up as incorrect locale/translation updates on `lang` changes.
> 
> **Overview**
> Adds a new `@videojs/html/i18n` entrypoint that registers `<media-i18n-provider>` and `<media-text>`, plus `createI18n` mixins/controllers that resolve locale from explicit `lang` or ambient DOM language and can auto-select caption/subtitle tracks via `selectCaptionsByLocale`.
> 
> Moves DOM locale helpers into `@videojs/utils/dom` (`nearestLang`, `subscribeAmbientLang`, `mergeLocaleOverlays`, `effectiveLocale`) with new unit tests, and refactors React `createI18n` to consume these shared helpers.
> 
> Updates package export maps so `@videojs/core` and `@videojs/react` expose `./i18n/locales/*` via wildcard (and `@videojs/html` adds `./i18n` + `./i18n/locales/*`), reducing per-locale export maintenance and adding new build entries for the HTML i18n subpaths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36676d0e0032176938c4a07a4310e6a46b193871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->