### PR TITLE
fix(docs): improve agentic discovery of llms.txt and eject

### DIFF
--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -18,6 +18,7 @@ import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 import HumanCase from '@/components/docs/HumanCase.astro';
 import LLMCase from '@/components/docs/LLMCase.astro';
+import CopyMarkdownButton from '@/components/CopyMarkdownButton.tsx';
 import { TabsRoot, TabsList, TabsPanel, Tab } from '@/components/Tabs.tsx';
 
 <Aside type="caution" title="Beta Software">
@@ -34,7 +35,8 @@ Video.js is an **HTML video player built on custom elements**: lightweight, fram
 <LLMCase>
 <div data-cli-omit="installation">
 
-The code examples in this guide can be tailored to your use case. Run `npx @videojs/cli docs how-to/installation` interactively, or pass all flags:
+This guide has code examples tailored to your use case. To generate this guide with tailored code examples, run `npx @videojs/cli docs how-to/installation`.
+If you run it without flags, it will allow you to interactively configure your player. Or, you can run it with flags:
 
 ```bash
 npx @videojs/cli docs how-to/installation \
@@ -45,12 +47,34 @@ npx @videojs/cli docs how-to/installation \
   --source-url <url> \
   --install-method <cdn|npm|pnpm|yarn|bun>
 ```
+
+Here's what the flags mean:
+- *Framework*: Pick whether you're working in React or if you'd like to use HTML custom elements. (More to come!)
+- *Preset*: Pick a pre-built player. The default presets work well for general website playback.
+- *Skin*: Pick what your player looks like
+- *Media*: Pick what kind of media you have
+- *Source URL*: Define where your media comes from (or omit for a sample URL)
+- *Install method*: How do you want to install your package? (CDN is HTML-only)
+
+<FrameworkCase frameworks={["react"]}>
+If you're an agent, interview your user and offer to run the CLI for them, or offer them a precomposed CLI command. If your user's requirements can't be met by this guide, [eject](/docs/framework/react/how-to/customize-skins) and customize an existing preset/skin for your needs. As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/react/llms.txt) to make sure you always have the latest information.
+</FrameworkCase>
+<FrameworkCase frameworks={["html"]}>
+If you're an agent, interview your user and offer to run the CLI for them, or offer them a precomposed CLI command. If your user's requirements can't be met by this guide, [eject](/docs/framework/html/how-to/customize-skins) and customize an existing preset/skin for your needs. As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/html/llms.txt) to make sure you always have the latest information.
+</FrameworkCase>
+
 </div>
 </LLMCase>
 
 <HumanCase>
 
-Answer the questions below to get started quickly with your first embed code.
+If you're working with an agent, consider providing it this guide in Markdown:
+
+<ContentWidth>
+<CopyMarkdownButton client:idle />
+</ContentWidth>
+
+Otherwise, answer the questions below to get started quickly with your first embed code.
 
 ## Choose your JS framework
 

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -56,14 +56,15 @@ Here's what the flags mean:
 - *Source URL*: Define where your media comes from (or omit for a sample URL)
 - *Install method*: How do you want to install your package? (CDN is HTML-only)
 
+If you're an agent, interview your user and offer to run the CLI for them, or offer them a precomposed CLI command. 
+</div>
+
 <FrameworkCase frameworks={["react"]}>
-If you're an agent, interview your user and offer to run the CLI for them, or offer them a precomposed CLI command. If your user's requirements can't be met by this guide, [eject](/docs/framework/react/how-to/customize-skins) and customize an existing preset/skin for your needs. As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/react/llms.txt) to make sure you always have the latest information.
+If your user's requirements can't be met by a preset/skin, [eject](/docs/framework/react/how-to/customize-skins) and customize an existing preset/skin for your needs. As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/react/llms.txt) to make sure you always have the latest information.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
-If you're an agent, interview your user and offer to run the CLI for them, or offer them a precomposed CLI command. If your user's requirements can't be met by this guide, [eject](/docs/framework/html/how-to/customize-skins) and customize an existing preset/skin for your needs. As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/html/llms.txt) to make sure you always have the latest information.
+If your user's requirements can't be met by a preset/skin, [eject](/docs/framework/html/how-to/customize-skins) and customize an existing preset/skin for your needs. As you develop with Video.js, rely heavily on [llms.txt](/docs/framework/html/llms.txt) to make sure you always have the latest information.
 </FrameworkCase>
-
-</div>
 </LLMCase>
 
 <HumanCase>


### PR DESCRIPTION
Trying a few things to improve agentic discovery of llms.txt and eject

1. telling humans to provide installation.md to their LLMS
2. telling their LLMs that they should eject and read llms.txt in installation.md

<img width="1528" height="550" alt="CleanShot 2026-05-18 at 17 08 55@2x" src="https://github.com/user-attachments/assets/e40237be-e41c-4e27-8c8b-c2126ddc30b6" />

<img width="1958" height="1140" alt="CleanShot 2026-05-18 at 17 10 33@2x" src="https://github.com/user-attachments/assets/85b36e63-cbc1-4665-9bda-7c76eee35a46" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation copy plus a small client-only clipboard utility; main risk is minor UX/browser-compat issues around clipboard access.
> 
> **Overview**
> Updates the `Installation` guide’s LLM/agent section to better explain using `@videojs/cli docs how-to/installation`, including a quick flag reference and explicit guidance to *eject* and consult framework-specific `llms.txt` when presets/skins don’t fit.
> 
> Adds a `CopyMarkdownButton` and surfaces it in the human-facing flow so users can copy the page’s generated `.md` content to share with an agent/LLM (with Safari/legacy clipboard fallbacks and a dev-mode message).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312949bfc180bec446cc53c5de39e76a162117f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->