### PR TITLE
chore(build): quiet tsdown size reports in local dev

### DIFF
--- a/build/tsdown.ts
+++ b/build/tsdown.ts
@@ -1,0 +1,43 @@
+/** `dev` and `default` outputs consumed by package `exports` conditions. */
+export type PackageBuildMode = 'dev' | 'default';
+
+export const packageBuildModes: PackageBuildMode[] = ['dev', 'default'];
+
+/** Applied to every tsdown config in the monorepo. */
+export const baseConfig = {
+  report: process.env.CI === 'true',
+} as const;
+
+/** Shared options for packages that emit `dist/dev` and `dist/default`. */
+export function packageBuildConfig(mode: PackageBuildMode, platform: 'browser' | 'neutral' = 'neutral') {
+  return {
+    ...baseConfig,
+    platform,
+    format: 'es' as const,
+    sourcemap: true,
+    clean: true,
+    hash: false,
+    unbundle: true,
+    outDir: `dist/${mode}`,
+    define: {
+      __DEV__: mode === 'dev' ? 'true' : 'false',
+    },
+    dts: mode === 'dev' ? ({ tsgo: true, tsconfig: 'tsconfig.dts.json' } as const) : (false as const),
+  };
+}
+
+export function isDevBuildMode(mode: PackageBuildMode): boolean {
+  return mode === 'dev';
+}
+
+/** Single-output packages (e.g. `@videojs/utils`) without dev/default splits. */
+export const neutralLibraryConfig = {
+  ...baseConfig,
+  platform: 'neutral' as const,
+  format: 'es' as const,
+  sourcemap: true,
+  clean: true,
+  hash: false,
+  unbundle: true,
+  dts: { tsgo: true, tsconfig: 'tsconfig.dts.json' } as const,
+};

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,11 +2,13 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsdown';
+import { baseConfig } from '../../build/tsdown.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 
 export default defineConfig({
+  ...baseConfig,
   entry: { index: './src/index.ts' },
   platform: 'node',
   format: 'es',

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,12 +1,10 @@
 import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
+import { type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 import packageJson from './package.json' with { type: 'json' };
 
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
-
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'neutral'),
   entry: {
     index: './src/core/index.ts',
     dom: './src/dom/index.ts',
@@ -17,24 +15,10 @@ const createConfig = (mode: BuildMode): UserConfig => ({
     'dom/media/native-hls/index': './src/dom/media/native-hls/index.ts',
     'dom/media/simple-hls/index': './src/dom/media/simple-hls/index.ts',
   },
-  platform: 'neutral',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
-  outDir: `dist/${mode}`,
   define: {
     __DEV__: mode === 'dev' ? 'true' : 'false',
     __PLAYER_VERSION__: JSON.stringify(packageJson.version),
   },
-  dts:
-    mode === 'dev'
-      ? {
-          tsgo: true,
-          tsconfig: 'tsconfig.dts.json',
-        }
-      : false,
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/element/tsdown.config.ts
+++ b/packages/element/tsdown.config.ts
@@ -1,26 +1,13 @@
 import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
+import { type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
-
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'browser'),
   entry: {
     index: './src/index.ts',
     context: './src/context.ts',
   },
-  platform: 'browser',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
-  outDir: `dist/${mode}`,
-  define: {
-    __DEV__: mode === 'dev' ? 'true' : 'false',
-  },
-  dts: mode === 'dev' ? { tsgo: true, tsconfig: 'tsconfig.dts.json' } : false,
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -5,6 +5,7 @@ import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
 import { inlineCssPlugin } from '../../build/plugins/inline-css-plugin.ts';
 import { inlineTemplatePlugin } from '../../build/plugins/inline-template-plugin.ts';
+import { baseConfig } from '../../build/tsdown.ts';
 
 type BuildMode = 'dev' | 'prod';
 
@@ -72,6 +73,7 @@ for (const mode of buildModes) {
   const entryMap = Object.fromEntries(entries.map(({ src, name }) => [isProd ? name : `${name}.dev`, src]));
 
   configs.push({
+    ...baseConfig,
     entry: entryMap,
     platform: 'browser',
     format: 'es',

--- a/packages/html/tsdown.config.ts
+++ b/packages/html/tsdown.config.ts
@@ -7,9 +7,7 @@ import { copyCssPlugin } from '../../build/plugins/copy-css-plugin.ts';
 import { inlineCssPlugin } from '../../build/plugins/inline-css-plugin.ts';
 import { inlineTemplatePlugin } from '../../build/plugins/inline-template-plugin.ts';
 
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
+import { isDevBuildMode, type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 
 const skinsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../skins/src');
 
@@ -36,19 +34,14 @@ const iconEntries = Object.fromEntries(
   })
 );
 
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'browser'),
   entry: {
     index: 'src/index.ts',
     ...iconEntries,
     ...defineEntries,
     ...presetEntries,
   },
-  platform: 'browser',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
   treeshake: {
     // The sideEffects field in package.json uses dist paths, but the build
     // runs against source. Ensure define/* modules (which register custom
@@ -62,16 +55,11 @@ const createConfig = (mode: BuildMode): UserConfig => ({
   alias: {
     '@': new URL('./src', import.meta.url).pathname,
   },
-  outDir: `dist/${mode}`,
-  define: {
-    __DEV__: mode === 'dev' ? 'true' : 'false',
-  },
-  dts: mode === 'dev' ? { tsgo: true, tsconfig: 'tsconfig.dts.json' } : false,
   plugins: [
     copyCssPlugin({ skinsDir, outDir: `dist/${mode}` }),
-    inlineCssPlugin({ skinsDir, minify: mode !== 'dev' }),
-    inlineTemplatePlugin({ minify: mode !== 'dev' }),
+    inlineCssPlugin({ skinsDir, minify: !isDevBuildMode(mode) }),
+    inlineTemplatePlugin({ minify: !isDevBuildMode(mode) }),
   ],
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -3,31 +3,18 @@ import { fileURLToPath } from 'node:url';
 import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
 import { copyCssPlugin } from '../../build/plugins/copy-css-plugin.ts';
-
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
+import { type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 
 const skinsDir = resolve(dirname(fileURLToPath(import.meta.url)), '../skins/src');
 
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'browser'),
   entry: 'src/**/index.{ts,tsx}',
-  platform: 'browser',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
   noExternal: [/^@videojs\/skins/],
   alias: {
     '@': new URL('./src', import.meta.url).pathname,
   },
-  outDir: `dist/${mode}`,
-  define: {
-    __DEV__: mode === 'dev' ? 'true' : 'false',
-  },
-  dts: mode === 'dev' ? { tsgo: true, tsconfig: 'tsconfig.dts.json' } : false,
   plugins: [copyCssPlugin({ skinsDir, outDir: `dist/${mode}` })],
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/skins/tsdown.config.ts
+++ b/packages/skins/tsdown.config.ts
@@ -1,10 +1,7 @@
 import { globSync } from 'node:fs';
 import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
-
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
+import { type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 
 const entries = Object.fromEntries(
   globSync('src/**/*.tailwind.ts').map((file) => {
@@ -13,19 +10,9 @@ const entries = Object.fromEntries(
   })
 );
 
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'browser'),
   entry: entries,
-  platform: 'browser',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
-  outDir: `dist/${mode}`,
-  define: {
-    __DEV__: mode === 'dev' ? 'true' : 'false',
-  },
-  dts: mode === 'dev' ? { tsgo: true, tsconfig: 'tsconfig.dts.json' } : false,
   copy: [
     {
       from: 'src/**/*.css',
@@ -46,4 +33,4 @@ const createConfig = (mode: BuildMode): UserConfig => ({
   ],
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/spf/tsdown.config.ts
+++ b/packages/spf/tsdown.config.ts
@@ -1,27 +1,14 @@
 import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
+import { type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
-
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'neutral'),
   entry: {
     index: 'src/index.ts',
     dom: 'src/dom.ts',
     hls: 'src/playback/engines/hls/index.ts',
   },
-  platform: 'neutral',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
-  outDir: `dist/${mode}`,
-  define: {
-    __DEV__: mode === 'dev' ? 'true' : 'false',
-  },
-  dts: mode === 'dev' ? { tsgo: true, tsconfig: 'tsconfig.dts.json' } : false,
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/store/tsdown.config.ts
+++ b/packages/store/tsdown.config.ts
@@ -1,27 +1,14 @@
 import type { UserConfig } from 'tsdown';
 import { defineConfig } from 'tsdown';
+import { type PackageBuildMode, packageBuildConfig, packageBuildModes } from '../../build/tsdown.ts';
 
-type BuildMode = 'dev' | 'default';
-
-const buildModes: BuildMode[] = ['dev', 'default'];
-
-const createConfig = (mode: BuildMode): UserConfig => ({
+const createConfig = (mode: PackageBuildMode): UserConfig => ({
+  ...packageBuildConfig(mode, 'neutral'),
   entry: {
     index: './src/core/index.ts',
     html: './src/html/index.ts',
     react: './src/react/index.ts',
   },
-  platform: 'neutral',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
-  outDir: `dist/${mode}`,
-  define: {
-    __DEV__: mode === 'dev' ? 'true' : 'false',
-  },
-  dts: mode === 'dev' ? { tsgo: true, tsconfig: 'tsconfig.dts.json' } : false,
 });
 
-export default defineConfig(buildModes.map((mode) => createConfig(mode)));
+export default defineConfig(packageBuildModes.map((mode) => createConfig(mode)));

--- a/packages/utils/tsdown.config.ts
+++ b/packages/utils/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'tsdown';
+import { neutralLibraryConfig } from '../../build/tsdown.ts';
 
 export default defineConfig({
+  ...neutralLibraryConfig,
   entry: {
     array: './src/array/index.ts',
     dom: './src/dom/index.ts',
@@ -14,11 +16,4 @@ export default defineConfig({
     time: './src/time/index.ts',
     types: './src/types/index.ts',
   },
-  platform: 'neutral',
-  format: 'es',
-  sourcemap: true,
-  clean: true,
-  hash: false,
-  unbundle: true,
-  dts: { tsgo: true, tsconfig: 'tsconfig.dts.json' },
 });


### PR DESCRIPTION
## Summary

Local `pnpm dev` and package builds were noisy because tsdown prints a per-file size table on every run. This gates that report behind `CI=true` so day-to-day output stays focused on errors and warnings, while CI still gets bundle size feedback.

## Changes

- Add shared `build/tsdown.ts` helpers for package build modes and base options
- Set `report: process.env.CI === 'true'` on all tsdown configs via the shared base
- Deduplicate repeated dev/default build options across package configs

## Testing

- [x] `pnpm -F @videojs/utils build` — no size table locally
- [x] `CI=true pnpm -F @videojs/utils build` — size table still prints

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-system refactor that mainly changes tsdown configuration defaults; the main risk is unintended differences in package build outputs (e.g., dts/dev-default settings) due to centralization.
> 
> **Overview**
> Adds a shared `build/tsdown.ts` module to centralize tsdown defaults and build-mode helpers, including gating `report` output behind `CI=true` to reduce local build noise.
> 
> Updates package `tsdown.config.ts` files to reuse the shared base/dev-default configs (and a neutral-library preset for `utils`), removing duplicated per-package settings while keeping package-specific entries/plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ead337844345ef1511bb456e990608c24f06c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->