### PR TITLE
feat(core,html,react): add YouTube provider, refactor IframeMediaHost and fix stale TextTrackList for iframe providers

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -10,6 +10,7 @@ export const PRESETS = [
   'simple-hls-video',
   'dash-video',
   'vimeo-video',
+  'youtube-video',
   'audio',
   'background-video',
 ] as const;

--- a/apps/sandbox/app/shared/html/sandbox-state.ts
+++ b/apps/sandbox/app/shared/html/sandbox-state.ts
@@ -24,10 +24,14 @@ export type HtmlSandboxState = {
   preload: PreloadValue;
 };
 
-export function createHtmlSandboxState(audioOnly?: boolean, vimeoOnly?: boolean): HtmlSandboxState {
+export function createHtmlSandboxState(
+  audioOnly?: boolean,
+  vimeoOnly?: boolean,
+  youtubeOnly?: boolean
+): HtmlSandboxState {
   return {
     skin: getInitialSkin(),
-    source: getInitialSource(audioOnly, vimeoOnly),
+    source: getInitialSource(audioOnly, vimeoOnly, youtubeOnly),
     styling: getInitialStyling(),
     autoplay: getInitialAutoplay(),
     muted: getInitialMuted(),

--- a/apps/sandbox/app/shared/react/use-source.ts
+++ b/apps/sandbox/app/shared/react/use-source.ts
@@ -2,8 +2,8 @@ import { getInitialSource, onSourceChange } from '@app/shared/sandbox-listener';
 import type { SourceId } from '@app/shared/sources';
 import { useEffect, useState } from 'react';
 
-export function useSource(audioOnly?: boolean, vimeoOnly?: boolean): SourceId {
-  const [source, setSource] = useState(() => getInitialSource(audioOnly, vimeoOnly));
+export function useSource(audioOnly?: boolean, vimeoOnly?: boolean, youtubeOnly?: boolean): SourceId {
+  const [source, setSource] = useState(() => getInitialSource(audioOnly, vimeoOnly, youtubeOnly));
   useEffect(() => onSourceChange(setSource), []);
   return source;
 }

--- a/apps/sandbox/app/shared/sandbox-listener.ts
+++ b/apps/sandbox/app/shared/sandbox-listener.ts
@@ -1,6 +1,6 @@
 import { SKINS } from '@app/constants';
 import type { Skin } from '@app/types';
-import { DEFAULT_AUDIO_SOURCE, DEFAULT_VIMEO_SOURCE, SOURCES, type SourceId } from './sources';
+import { DEFAULT_AUDIO_SOURCE, DEFAULT_VIMEO_SOURCE, DEFAULT_YOUTUBE_SOURCE, SOURCES, type SourceId } from './sources';
 
 export const PRELOAD_VALUES = ['none', 'metadata', 'auto'] as const;
 export type PreloadValue = (typeof PRELOAD_VALUES)[number];
@@ -55,7 +55,7 @@ export function onSkinChange(callback: (skin: Skin) => void): () => void {
   };
 }
 
-export function getInitialSource(audioOnly?: boolean, vimeoOnly?: boolean): SourceId {
+export function getInitialSource(audioOnly?: boolean, vimeoOnly?: boolean, youtubeOnly?: boolean): SourceId {
   const stored = currentSource;
 
   if (audioOnly && SOURCES[stored].type !== 'mp4') {
@@ -64,6 +64,10 @@ export function getInitialSource(audioOnly?: boolean, vimeoOnly?: boolean): Sour
 
   if (vimeoOnly && SOURCES[stored].type !== 'vimeo') {
     return DEFAULT_VIMEO_SOURCE;
+  }
+
+  if (youtubeOnly && SOURCES[stored].type !== 'youtube') {
+    return DEFAULT_YOUTUBE_SOURCE;
   }
 
   return stored;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -63,18 +63,30 @@ export const SOURCES = {
     url: 'https://vimeo.com/638371504',
     type: 'vimeo',
   },
+  'youtube-1': {
+    label: 'Big Buck Bunny',
+    url: 'https://www.youtube.com/watch?v=YE7VzlLtp-4',
+    type: 'youtube',
+  },
+  'youtube-2': {
+    label: 'Tears of Steel',
+    url: 'https://www.youtube.com/watch?v=eRsGyueVLvQ',
+    type: 'youtube',
+  },
 } as const;
 
 export type SourceId = keyof typeof SOURCES;
 
 export const SOURCE_IDS = Object.keys(SOURCES) as SourceId[];
 export const NON_DASH_SOURCE_IDS = SOURCE_IDS.filter(
-  (id) => SOURCES[id].type !== 'dash' && SOURCES[id].type !== 'vimeo'
+  (id) => SOURCES[id].type !== 'dash' && SOURCES[id].type !== 'vimeo' && SOURCES[id].type !== 'youtube'
 );
 export const MP4_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'mp4');
 export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'dash');
 export const VIMEO_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'vimeo');
+export const YOUTUBE_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'youtube');
 export const DEFAULT_VIMEO_SOURCE: SourceId = 'vimeo-1';
+export const DEFAULT_YOUTUBE_SOURCE: SourceId = 'youtube-1';
 export const DEFAULT_SOURCE: SourceId = 'hls-1';
 export const DEFAULT_AUDIO_SOURCE: SourceId = 'mp4-1';
 export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -7,10 +7,12 @@ import {
   DEFAULT_DASH_SOURCE,
   DEFAULT_SOURCE,
   DEFAULT_VIMEO_SOURCE,
+  DEFAULT_YOUTUBE_SOURCE,
   MP4_SOURCE_IDS,
   NON_DASH_SOURCE_IDS,
   SOURCES,
   VIMEO_SOURCE_IDS,
+  YOUTUBE_SOURCE_IDS,
 } from '@app/shared/sources';
 import type { Platform, Preset, Styling } from '@app/types';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -115,12 +117,22 @@ export function App() {
     }
   }, [preset, source, setSource]);
 
-  // Constrain source away from DASH and Vimeo for non-matching presets
+  // Constrain source to YouTube when switching to youtube-video
+  useEffect(() => {
+    if (preset === 'youtube-video' && SOURCES[source].type !== 'youtube') {
+      setSource(DEFAULT_YOUTUBE_SOURCE);
+    }
+  }, [preset, source, setSource]);
+
+  // Constrain source away from DASH, Vimeo, and YouTube for non-matching presets
   useEffect(() => {
     if (preset !== 'dash-video' && SOURCES[source].type === 'dash') {
       setSource(DEFAULT_SOURCE);
     }
     if (preset !== 'vimeo-video' && SOURCES[source].type === 'vimeo') {
+      setSource(DEFAULT_SOURCE);
+    }
+    if (preset !== 'youtube-video' && SOURCES[source].type === 'youtube') {
       setSource(DEFAULT_SOURCE);
     }
   }, [preset, source, setSource]);
@@ -139,7 +151,9 @@ export function App() {
         ? DASH_SOURCE_IDS
         : preset === 'vimeo-video'
           ? VIMEO_SOURCE_IDS
-          : NON_DASH_SOURCE_IDS;
+          : preset === 'youtube-video'
+            ? YOUTUBE_SOURCE_IDS
+            : NON_DASH_SOURCE_IDS;
 
   const handleSourceChange = useCallback((value: string) => setSource(value as SourceId), [setSource]);
 
@@ -170,6 +184,7 @@ export function App() {
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}
         isVimeoVideo={preset === 'vimeo-video'}
+        isYoutubeVideo={preset === 'youtube-video'}
         platforms={PLATFORMS}
         stylings={STYLINGS}
         presets={PRESETS}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -29,6 +29,7 @@ type NavbarProps = {
   isMuxVideo: boolean;
   isMuxAudio: boolean;
   isVimeoVideo: boolean;
+  isYoutubeVideo: boolean;
   platforms: readonly Platform[];
   stylings: readonly Styling[];
   presets: readonly Preset[];
@@ -82,6 +83,7 @@ export function Navbar({
   isMuxVideo,
   isMuxAudio,
   isVimeoVideo,
+  isYoutubeVideo,
   platforms,
   stylings,
   presets,

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -52,6 +52,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'simple-hls-video': 'Simple HLS Video',
   'dash-video': 'DASH Video',
   'vimeo-video': 'Vimeo Video',
+  'youtube-video': 'Youtube Video',
   audio: 'Audio',
   'background-video': 'Background Video',
 };

--- a/apps/sandbox/templates/html-youtube-video/index.html
+++ b/apps/sandbox/templates/html-youtube-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML YouTube Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans p-2">
+    <div id="root" class="flex justify-center items-center min-h-screen"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-youtube-video/main.ts
+++ b/apps/sandbox/templates/html-youtube-video/main.ts
@@ -1,5 +1,5 @@
 import '@videojs/html/video/player';
-import '@videojs/html/media/vimeo-video';
+import '@videojs/html/media/youtube-video';
 import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
 import { loadVideoSkinTag } from '@app/shared/html/skins';
 import {
@@ -13,7 +13,7 @@ import { SOURCES } from '@app/shared/sources';
 
 const html = String.raw;
 
-const state = createHtmlSandboxState(false, true);
+const state = createHtmlSandboxState(false, false, true);
 const loadLatest = createLatestLoader();
 
 async function render() {
@@ -27,12 +27,12 @@ async function render() {
   document.getElementById('root')!.innerHTML = html`
     <video-player>
       <${tag} class="aspect-video max-w-4xl mx-auto">
-        <vimeo-video
+        <youtube-video
           src="${SOURCES[state.source].url}"
           ${autoplay}
           ${muted}
           ${loop}
-        ></vimeo-video>
+        ></youtube-video>
       </${tag}>
     </video-player>
   `;

--- a/apps/sandbox/templates/react-youtube-video/index.html
+++ b/apps/sandbox/templates/react-youtube-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React YouTube Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans p-2">
+    <div id="root" class="flex justify-center items-center min-h-screen"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-youtube-video/main.tsx
+++ b/apps/sandbox/templates/react-youtube-video/main.tsx
@@ -1,0 +1,35 @@
+import { VideoProvider } from '@app/shared/react/providers';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useAutoplay } from '@app/shared/react/use-autoplay';
+import { useLoop } from '@app/shared/react/use-loop';
+import { useMuted } from '@app/shared/react/use-muted';
+import { useSkin } from '@app/shared/react/use-skin';
+import { useSource } from '@app/shared/react/use-source';
+import { SOURCES } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { YouTubeVideo } from '@videojs/react/media/youtube-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const source = useSource(false, false, true);
+  const styling = useMemo(readStyling, []);
+  const autoplay = useAutoplay();
+  const muted = useMuted();
+  const loop = useLoop();
+
+  return (
+    <VideoProvider>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <YouTubeVideo src={SOURCES[source].url} autoplay={autoplay} muted={muted} loop={loop} controls={false} />
+      </VideoSkinComponent>
+    </VideoProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/core/src/dom/media/iframe-host.ts
+++ b/packages/core/src/dom/media/iframe-host.ts
@@ -1,0 +1,329 @@
+import type {
+  MediaEngineHost,
+  MediaPictureInPictureCapability,
+  MediaTextTrackCapability,
+  TimeRangeLike,
+  VideoEvents,
+} from '../../core/media/types';
+import { TypedEventTarget } from '../../core/media/types';
+
+export interface PlaybackStateCache {
+  paused: boolean;
+  ended: boolean;
+  duration: number;
+  currentTime: number;
+  /** Seconds buffered — converted to a `TimeRangeLike` by `get buffered()`. */
+  buffered: number;
+  readyState: number;
+  volume: number;
+  muted: boolean;
+  playbackRate: number;
+  seeking: boolean;
+  pip: boolean;
+  error: { code: number; message: string } | null;
+}
+
+const EMPTY_TIME_RANGES: Readonly<TimeRangeLike> = Object.freeze({
+  length: 0,
+  start() {
+    return 0;
+  },
+  end() {
+    return 0;
+  },
+});
+
+export abstract class IframeMediaHost<Engine>
+  extends TypedEventTarget<VideoEvents>()
+  implements MediaEngineHost<Engine, HTMLElement>, MediaPictureInPictureCapability, MediaTextTrackCapability
+{
+  #engine: Engine | null = null;
+  #container: HTMLElement | null = null;
+  #overlay: HTMLDivElement | null = null;
+  #activationCleanup: (() => void) | null = null;
+  #destroyed = false;
+  #textTracksVideo: HTMLVideoElement | null = null;
+  #mountedTracks: TextTrack[] = [];
+  #textTracksAbort: AbortController | null = null;
+
+  // Cached playback state — kept in sync via provider SDK events so sync
+  // getters always return a meaningful value without extra async round-trips.
+  #paused = true;
+  #ended = false;
+  #duration = NaN;
+  #currentTime = 0;
+  #buffered = 0;
+  #readyState = 0;
+  #volume = 1;
+  // `#muted` serves both as the initial embed prop and the cached live value.
+  // The setter updates it (for pre-mount config) and the provider's volumechange
+  // handler keeps it current after the player is running.
+  #muted = false;
+  #playbackRate = 1;
+  #seeking = false;
+  #pip = false;
+  #error: { code: number; message: string } | null = null;
+
+  // PiP only works on Safari via webkit's cross-origin iframe mechanism.
+  readonly isPipCapable =
+    typeof navigator !== 'undefined' &&
+    /Version\/.*Safari\//.test(navigator.userAgent) &&
+    !/Chrome|Chromium/.test(navigator.userAgent);
+
+  get engine() {
+    return this.#engine;
+  }
+
+  get target() {
+    return this.#container;
+  }
+
+  attach(container: HTMLElement) {
+    this.#container = container;
+    container.style.position = 'relative';
+
+    // Overlay: sits above the iframe so pointer events reach <media-container>
+    // for controlsFeature (hover-to-show, idle timer, etc.).
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:absolute;inset:0;z-index:1;';
+    container.appendChild(overlay);
+    this.#overlay = overlay;
+
+    // PiP requires the iframe's browsing context to have user activation.
+    // Since the overlay intercepts clicks, the iframe never gets direct
+    // interaction. Work around this by focusing the iframe on every user click
+    // anywhere in the document — iframe.focus() during a user gesture gives
+    // the iframe activation via Chrome's focus-delegation mechanism.
+    const focusIframe = () => {
+      const iframe = this.#container?.querySelector<HTMLIFrameElement>('iframe');
+      iframe?.focus();
+    };
+    globalThis.document?.addEventListener('click', focusIframe, { capture: true });
+    this.#activationCleanup = () => globalThis.document?.removeEventListener('click', focusIframe, { capture: true });
+
+    if (this.src) this.mount(container);
+  }
+
+  detach() {
+    this.#overlay?.remove();
+    this.#overlay = null;
+    this.#activationCleanup?.();
+    this.#activationCleanup = null;
+    this.unmount();
+    this.#container = null;
+  }
+
+  destroy() {
+    if (this.#destroyed) return;
+    this.#destroyed = true;
+    this.detach();
+  }
+
+  load() {
+    if (this.#container && this.src) this.mount(this.#container);
+  }
+
+  // -- Playback state --
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  // -- Volume --
+
+  get volume() {
+    return this.#volume;
+  }
+
+  set volume(value: number) {
+    this.updateState({ volume: value });
+    this.onSetVolume(value);
+  }
+
+  get muted() {
+    return this.#muted;
+  }
+
+  set muted(value: boolean) {
+    this.updateState({ muted: value });
+    this.onSetMuted(value);
+  }
+
+  // -- Playback rate --
+
+  get playbackRate() {
+    return this.#playbackRate;
+  }
+
+  set playbackRate(value: number) {
+    this.updateState({ playbackRate: value });
+    this.onSetPlaybackRate(value);
+  }
+
+  // -- Buffer --
+
+  get buffered(): TimeRangeLike {
+    if (this.#buffered > 0) {
+      const end = this.#buffered;
+      return Object.freeze({ length: 1, start: () => 0, end: () => end });
+    }
+    return EMPTY_TIME_RANGES;
+  }
+
+  get seekable(): TimeRangeLike {
+    return EMPTY_TIME_RANGES;
+  }
+
+  // -- Picture-in-picture --
+
+  get isPictureInPicture() {
+    return this.#pip;
+  }
+
+  requestPictureInPicture() {
+    if (this.isPipCapable) this.#postIframeMethod('requestPictureInPicture');
+    return Promise.resolve();
+  }
+
+  exitPictureInPicture() {
+    if (this.isPipCapable) this.#postIframeMethod('exitPictureInPicture');
+    return Promise.resolve();
+  }
+
+  // -- Text tracks --
+
+  get textTracks(): TextTrackList {
+    return this.syntheticTextTracksVideo.textTracks;
+  }
+
+  // -- Abstract interface --
+
+  protected abstract get src(): string | null;
+  protected abstract mount(container: HTMLElement): void;
+  protected abstract unmount(): void;
+  abstract play(): Promise<void>;
+  abstract pause(): Promise<void>;
+
+  protected abstract onSetVolume(value: number): void;
+  protected abstract onSetMuted(value: boolean): void;
+  protected abstract onSetPlaybackRate(value: number): void;
+
+  // -- Protected helpers --
+
+  protected updateEngine(engine: Engine | null): void {
+    this.#engine = engine;
+  }
+
+  protected updateState({
+    paused,
+    ended,
+    duration,
+    currentTime,
+    buffered,
+    readyState,
+    volume,
+    muted,
+    playbackRate,
+    seeking,
+    pip,
+    error,
+  }: Partial<PlaybackStateCache>): void {
+    if (paused !== undefined) this.#paused = paused;
+    if (ended !== undefined) this.#ended = ended;
+    if (duration !== undefined) this.#duration = duration;
+    if (currentTime !== undefined) this.#currentTime = currentTime;
+    if (buffered !== undefined) this.#buffered = buffered;
+    if (readyState !== undefined) this.#readyState = readyState;
+    if (volume !== undefined) this.#volume = volume;
+    if (muted !== undefined) this.#muted = muted;
+    if (playbackRate !== undefined) this.#playbackRate = playbackRate;
+    if (seeking !== undefined) this.#seeking = seeking;
+    if (pip !== undefined) this.#pip = pip;
+    if (error !== undefined) this.#error = error;
+  }
+
+  protected get syntheticTextTracksVideo(): HTMLVideoElement {
+    if (!this.#textTracksVideo) {
+      this.#textTracksVideo = document.createElement('video');
+    }
+    return this.#textTracksVideo;
+  }
+
+  protected addMountedTrack(track: TextTrack): void {
+    this.#mountedTracks.push(track);
+  }
+
+  protected isMountedTrack(track: TextTrack): boolean {
+    return this.#mountedTracks.includes(track);
+  }
+
+  protected resetTextTracks(): void {
+    this.#textTracksAbort?.abort();
+    this.#textTracksAbort = null;
+    for (const track of this.#mountedTracks) {
+      track.mode = 'disabled';
+    }
+    this.#mountedTracks = [];
+  }
+
+  protected startTextTrackAbort(): AbortController {
+    this.#textTracksAbort?.abort();
+    this.#textTracksAbort = new AbortController();
+    return this.#textTracksAbort;
+  }
+
+  protected resetState(): void {
+    this.updateState({
+      paused: true,
+      ended: false,
+      duration: NaN,
+      currentTime: 0,
+      buffered: 0,
+      readyState: 0,
+      volume: 1,
+      playbackRate: 1,
+      seeking: false,
+      pip: false,
+      error: null,
+      // muted intentionally not reset — it's both prop config and cached state
+    });
+    this.dispatchEvent(new Event('emptied'));
+  }
+
+  // -- Private --
+
+  #postIframeMethod(method: string) {
+    const iframe = this.#container?.querySelector<HTMLIFrameElement>('iframe');
+    if (!iframe?.contentWindow || !iframe.src) return;
+    try {
+      const origin = new URL(iframe.src).origin;
+      iframe.contentWindow.postMessage({ method }, origin);
+    } catch {
+      // Ignore cross-origin or URL parse errors.
+    }
+  }
+}

--- a/packages/core/src/dom/media/iframe-host.ts
+++ b/packages/core/src/dom/media/iframe-host.ts
@@ -288,6 +288,10 @@ export abstract class IframeMediaHost<Engine>
       track.mode = 'disabled';
     }
     this.#mountedTracks = [];
+    // Replace the synthetic video element so old tracks don't persist into the
+    // next load. HTMLVideoElement.textTracks has no removeTrack() API, so the
+    // only way to clear the list is to start with a fresh element.
+    this.#textTracksVideo = null;
   }
 
   protected startTextTrackAbort(): AbortController {

--- a/packages/core/src/dom/media/tests/iframe-host.test.ts
+++ b/packages/core/src/dom/media/tests/iframe-host.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IframeMediaHost } from '../iframe-host';
+
+// Minimal concrete subclass used across all tests.
+class TestHost extends IframeMediaHost<{ destroy: () => void }> {
+  mountCalls: HTMLElement[] = [];
+  unmountCalls = 0;
+
+  #src: string | null = null;
+
+  protected get src() {
+    return this.#src;
+  }
+
+  setSrc(value: string | null) {
+    this.#src = value;
+  }
+
+  protected mount(container: HTMLElement) {
+    this.mountCalls.push(container);
+  }
+
+  protected unmount() {
+    this.unmountCalls++;
+  }
+
+  play() {
+    return Promise.resolve();
+  }
+
+  pause() {
+    return Promise.resolve();
+  }
+
+  get currentTime() {
+    return super.currentTime;
+  }
+
+  set currentTime(_value: number) {}
+
+  protected onSetVolume(_value: number) {}
+  protected onSetMuted(_value: boolean) {}
+  protected onSetPlaybackRate(_value: number) {}
+
+  // Expose protected API for testing.
+  callUpdateEngine(engine: { destroy: () => void } | null) {
+    this.updateEngine(engine);
+  }
+
+  callUpdateState(patch: Parameters<typeof this.updateState>[0]) {
+    this.updateState(patch);
+  }
+
+  callResetState() {
+    this.resetState();
+  }
+
+  callResetTextTracks() {
+    this.resetTextTracks();
+  }
+
+  callAddMountedTrack(track: TextTrack) {
+    this.addMountedTrack(track);
+  }
+
+  callIsMountedTrack(track: TextTrack) {
+    return this.isMountedTrack(track);
+  }
+
+  callStartTextTrackAbort() {
+    return this.startTextTrackAbort();
+  }
+
+  get exposedSyntheticVideo() {
+    return this.syntheticTextTracksVideo;
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('IframeMediaHost', () => {
+  describe('attach / detach lifecycle', () => {
+    it('attach sets target to the provided container', () => {
+      const host = new TestHost();
+      const container = document.createElement('div');
+      host.attach(container);
+      expect(host.target).toBe(container);
+    });
+
+    it('attach calls mount when src is set', () => {
+      const host = new TestHost();
+      host.setSrc('https://example.com/video');
+      const container = document.createElement('div');
+      host.attach(container);
+      expect(host.mountCalls).toHaveLength(1);
+      expect(host.mountCalls[0]).toBe(container);
+    });
+
+    it('attach does not call mount when src is null', () => {
+      const host = new TestHost();
+      const container = document.createElement('div');
+      host.attach(container);
+      expect(host.mountCalls).toHaveLength(0);
+    });
+
+    it('attach creates an overlay div inside the container', () => {
+      const host = new TestHost();
+      const container = document.createElement('div');
+      host.attach(container);
+      const overlay = container.querySelector('div');
+      expect(overlay).not.toBeNull();
+      expect(overlay!.style.position).toBe('absolute');
+    });
+
+    it('detach calls unmount', () => {
+      const host = new TestHost();
+      host.setSrc('src');
+      host.attach(document.createElement('div'));
+      host.detach();
+      expect(host.unmountCalls).toBe(1);
+    });
+
+    it('detach clears target', () => {
+      const host = new TestHost();
+      host.attach(document.createElement('div'));
+      host.detach();
+      expect(host.target).toBeNull();
+    });
+
+    it('detach removes the overlay', () => {
+      const host = new TestHost();
+      const container = document.createElement('div');
+      host.attach(container);
+      host.detach();
+      expect(container.querySelector('div')).toBeNull();
+    });
+  });
+
+  describe('destroy', () => {
+    it('calls detach once', () => {
+      const host = new TestHost();
+      host.attach(document.createElement('div'));
+      host.destroy();
+      expect(host.unmountCalls).toBe(1);
+    });
+
+    it('is idempotent — second call is a no-op', () => {
+      const host = new TestHost();
+      host.setSrc('src');
+      host.attach(document.createElement('div'));
+      host.destroy();
+      host.destroy();
+      expect(host.unmountCalls).toBe(1);
+    });
+  });
+
+  describe('load', () => {
+    it('calls mount when container and src are set', () => {
+      const host = new TestHost();
+      host.setSrc('src');
+      const container = document.createElement('div');
+      host.attach(container);
+      host.mountCalls.length = 0;
+      host.load();
+      expect(host.mountCalls).toHaveLength(1);
+    });
+
+    it('is a no-op when src is null', () => {
+      const host = new TestHost();
+      host.attach(document.createElement('div'));
+      host.load();
+      expect(host.mountCalls).toHaveLength(0);
+    });
+
+    it('is a no-op when not attached', () => {
+      const host = new TestHost();
+      host.setSrc('src');
+      host.load();
+      expect(host.mountCalls).toHaveLength(0);
+    });
+  });
+
+  describe('updateEngine', () => {
+    it('exposes engine via getter', () => {
+      const host = new TestHost();
+      const engine = { destroy: vi.fn() };
+      host.callUpdateEngine(engine);
+      expect(host.engine).toBe(engine);
+    });
+
+    it('accepts null to clear the engine', () => {
+      const host = new TestHost();
+      host.callUpdateEngine({ destroy: vi.fn() });
+      host.callUpdateEngine(null);
+      expect(host.engine).toBeNull();
+    });
+  });
+
+  describe('updateState', () => {
+    it('updates only supplied fields', () => {
+      const host = new TestHost();
+      host.callUpdateState({ paused: false, readyState: 4 });
+      expect(host.paused).toBe(false);
+      expect(host.readyState).toBe(4);
+      expect(host.ended).toBe(false); // default unchanged
+    });
+
+    it('updates volume', () => {
+      const host = new TestHost();
+      host.callUpdateState({ volume: 0.5 });
+      expect(host.volume).toBe(0.5);
+    });
+
+    it('updates muted', () => {
+      const host = new TestHost();
+      host.callUpdateState({ muted: true });
+      expect(host.muted).toBe(true);
+    });
+
+    it('clears error when set to null', () => {
+      const host = new TestHost();
+      host.callUpdateState({ error: { code: 4, message: 'oops' } });
+      expect(host.error).toEqual({ code: 4, message: 'oops' });
+      host.callUpdateState({ error: null });
+      expect(host.error).toBeNull();
+    });
+
+    it('does not touch muted when key is absent from patch', () => {
+      const host = new TestHost();
+      host.callUpdateState({ muted: true });
+      host.callUpdateState({ volume: 0.8 }); // no muted key
+      expect(host.muted).toBe(true);
+    });
+  });
+
+  describe('resetState', () => {
+    it('resets playback state to initial values', () => {
+      const host = new TestHost();
+      host.callUpdateState({ paused: false, ended: true, readyState: 4, seeking: true });
+      host.callResetState();
+      expect(host.paused).toBe(true);
+      expect(host.ended).toBe(false);
+      expect(host.readyState).toBe(0);
+      expect(host.seeking).toBe(false);
+    });
+
+    it('preserves muted across reset', () => {
+      const host = new TestHost();
+      host.callUpdateState({ muted: true });
+      host.callResetState();
+      expect(host.muted).toBe(true);
+    });
+
+    it('dispatches emptied event', () => {
+      const host = new TestHost();
+      const handler = vi.fn();
+      host.addEventListener('emptied', handler);
+      host.callResetState();
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('volume / muted / playbackRate setters', () => {
+    it('set volume updates cache and calls onSetVolume', () => {
+      const host = new TestHost();
+      const spy = vi.spyOn(host as TestHost & { onSetVolume: (v: number) => void }, 'onSetVolume');
+      host.volume = 0.3;
+      expect(host.volume).toBe(0.3);
+      expect(spy).toHaveBeenCalledWith(0.3);
+    });
+
+    it('set muted updates cache and calls onSetMuted', () => {
+      const host = new TestHost();
+      const spy = vi.spyOn(host as TestHost & { onSetMuted: (v: boolean) => void }, 'onSetMuted');
+      host.muted = true;
+      expect(host.muted).toBe(true);
+      expect(spy).toHaveBeenCalledWith(true);
+    });
+
+    it('set playbackRate updates cache and calls onSetPlaybackRate', () => {
+      const host = new TestHost();
+      const spy = vi.spyOn(host as TestHost & { onSetPlaybackRate: (v: number) => void }, 'onSetPlaybackRate');
+      host.playbackRate = 2;
+      expect(host.playbackRate).toBe(2);
+      expect(spy).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe('buffered / seekable', () => {
+    it('buffered returns empty ranges when buffered seconds is 0', () => {
+      const host = new TestHost();
+      expect(host.buffered.length).toBe(0);
+    });
+
+    it('buffered returns a single range when buffered seconds > 0', () => {
+      const host = new TestHost();
+      host.callUpdateState({ buffered: 30 });
+      expect(host.buffered.length).toBe(1);
+      expect(host.buffered.start(0)).toBe(0);
+      expect(host.buffered.end(0)).toBe(30);
+    });
+
+    it('seekable always returns empty ranges', () => {
+      const host = new TestHost();
+      expect(host.seekable.length).toBe(0);
+    });
+  });
+
+  describe('picture-in-picture', () => {
+    it('isPictureInPicture starts false', () => {
+      const host = new TestHost();
+      expect(host.isPictureInPicture).toBe(false);
+    });
+
+    it('updateState({ pip: true }) reflects in isPictureInPicture', () => {
+      const host = new TestHost();
+      host.callUpdateState({ pip: true });
+      expect(host.isPictureInPicture).toBe(true);
+    });
+
+    it('requestPictureInPicture does not post message when isPipCapable is false', () => {
+      const host = new TestHost();
+      const container = document.createElement('div');
+      host.attach(container);
+      const iframe = document.createElement('iframe');
+      const postMessage = vi.fn();
+      Object.defineProperty(iframe, 'src', { value: 'https://example.com', writable: false });
+      Object.defineProperty(iframe, 'contentWindow', { value: { postMessage }, writable: false });
+      container.appendChild(iframe);
+
+      host.requestPictureInPicture();
+
+      expect(postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('textTracks / syntheticTextTracksVideo', () => {
+    it('textTracks returns the synthetic video textTracks', () => {
+      const host = new TestHost();
+      expect(host.textTracks).toBe(host.exposedSyntheticVideo.textTracks);
+    });
+
+    it('syntheticTextTracksVideo always returns the same element', () => {
+      const host = new TestHost();
+      expect(host.exposedSyntheticVideo).toBe(host.exposedSyntheticVideo);
+    });
+  });
+
+  describe('text track helpers', () => {
+    it('addMountedTrack / isMountedTrack round-trips', () => {
+      const host = new TestHost();
+      const track = {} as TextTrack;
+      expect(host.callIsMountedTrack(track)).toBe(false);
+      host.callAddMountedTrack(track);
+      expect(host.callIsMountedTrack(track)).toBe(true);
+    });
+
+    it('resetTextTracks disables all mounted tracks and clears the list', () => {
+      const host = new TestHost();
+      const track = { mode: 'showing' as TextTrackMode } as TextTrack;
+      host.callAddMountedTrack(track);
+      host.callResetTextTracks();
+      expect(track.mode).toBe('disabled');
+      expect(host.callIsMountedTrack(track)).toBe(false);
+    });
+
+    it('startTextTrackAbort returns an AbortController and aborts previous one', () => {
+      const host = new TestHost();
+      const first = host.callStartTextTrackAbort();
+      const second = host.callStartTextTrackAbort();
+      expect(first.signal.aborted).toBe(true);
+      expect(second.signal.aborted).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/dom/media/tests/iframe-host.test.ts
+++ b/packages/core/src/dom/media/tests/iframe-host.test.ts
@@ -366,6 +366,13 @@ describe('IframeMediaHost', () => {
       expect(host.callIsMountedTrack(track)).toBe(false);
     });
 
+    it('resetTextTracks replaces the synthetic video so old tracks do not persist into the next load', () => {
+      const host = new TestHost();
+      const videoBefore = host.exposedSyntheticVideo;
+      host.callResetTextTracks();
+      expect(host.exposedSyntheticVideo).not.toBe(videoBefore);
+    });
+
     it('startTextTrackAbort returns an AbortController and aborts previous one', () => {
       const host = new TestHost();
       const first = host.callStartTextTrackAbort();

--- a/packages/core/src/dom/media/vimeo/index.ts
+++ b/packages/core/src/dom/media/vimeo/index.ts
@@ -1,13 +1,6 @@
 import type { VimeoEmbedParameters, VimeoUrl } from '@vimeo/player';
 import Player from '@vimeo/player';
-import type {
-  MediaEngineHost,
-  MediaPictureInPictureCapability,
-  MediaTextTrackCapability,
-  TimeRangeLike,
-  VideoEvents,
-} from '../../../core/media/types';
-import { TypedEventTarget } from '../../../core/media/types';
+import { IframeMediaHost } from '../iframe-host';
 
 export interface VimeoMediaProps {
   /** Vimeo video URL or numeric video ID as a string. */
@@ -57,56 +50,9 @@ export const vimeoMediaDefaultProps: VimeoMediaProps = {
   transparent: true,
 };
 
-const EMPTY_TIME_RANGES: Readonly<TimeRangeLike> = Object.freeze({
-  length: 0,
-  start() {
-    return 0;
-  },
-  end() {
-    return 0;
-  },
-});
-
-export class VimeoMedia
-  extends TypedEventTarget<VideoEvents>()
-  implements
-    MediaEngineHost<Player, HTMLElement>,
-    VimeoMediaProps,
-    MediaPictureInPictureCapability,
-    MediaTextTrackCapability
-{
+export class VimeoMedia extends IframeMediaHost<Player> implements VimeoMediaProps {
+  // Local typed reference — kept in sync with base `engine` via `updateEngine`.
   #player: Player | null = null;
-  #container: HTMLElement | null = null;
-  #overlay: HTMLDivElement | null = null;
-  #activationCleanup: (() => void) | null = null;
-  #destroyed = false;
-
-  // PiP only works on Safari via webkit's cross-origin iframe mechanism.
-  readonly isPipCapable =
-    typeof navigator !== 'undefined' &&
-    /Version\/.*Safari\//.test(navigator.userAgent) &&
-    !/Chrome|Chromium/.test(navigator.userAgent);
-
-  // Cached playback state — kept in sync via Vimeo SDK events so sync
-  // getters always return a meaningful value without extra async round-trips.
-  #paused = true;
-  #ended = false;
-  #duration = NaN;
-  #currentTime = 0;
-  #buffered = 0;
-  #readyState = 0;
-  #volume = 1;
-  // `#muted` serves both as the initial embed prop and the cached live value.
-  // The setter updates it (for pre-mount config) and the volumechange handler
-  // keeps it current after the player is running.
-  #muted = vimeoMediaDefaultProps.muted;
-  #playbackRate = 1;
-  #seeking = false;
-  #pip = false;
-  #error: { code: number; message: string } | null = null;
-  #textTracksVideo: HTMLVideoElement | null = null;
-  #mountedTracks: TextTrack[] = [];
-  #textTracksAbort: AbortController | null = null;
 
   // Embed props
   #src = vimeoMediaDefaultProps.src;
@@ -127,79 +73,25 @@ export class VimeoMedia
   #title = vimeoMediaDefaultProps.title;
   #transparent = vimeoMediaDefaultProps.transparent;
 
-  get engine() {
-    return this.#player;
-  }
-
-  get target() {
-    return this.#container;
-  }
-
-  attach(container: HTMLElement) {
-    this.#container = container;
-    container.style.position = 'relative';
-
-    // Overlay: sits above the iframe so pointer events reach <media-container>
-    // for controlsFeature (hover-to-show, idle timer, etc.).
-    const overlay = document.createElement('div');
-    overlay.style.cssText = 'position:absolute;inset:0;z-index:1;';
-    container.appendChild(overlay);
-    this.#overlay = overlay;
-
-    // PiP requires the iframe's browsing context to have user activation.
-    // Since the overlay intercepts clicks, the iframe never gets direct
-    // interaction. Work around this by focusing the iframe on every user click
-    // anywhere in the document — iframe.focus() during a user gesture gives
-    // the iframe activation via Chrome's focus-delegation mechanism.
-    const focusIframe = () => {
-      const iframe = this.#container?.querySelector<HTMLIFrameElement>('iframe');
-      iframe?.focus();
-    };
-    globalThis.document?.addEventListener('click', focusIframe, { capture: true });
-    this.#activationCleanup = () => globalThis.document?.removeEventListener('click', focusIframe, { capture: true });
-
-    if (this.#src) this.#mount();
-  }
-
-  detach() {
-    this.#overlay?.remove();
-    this.#overlay = null;
-    this.#activationCleanup?.();
-    this.#activationCleanup = null;
-    this.#unmount();
-    this.#container = null;
-  }
-
-  destroy() {
-    if (this.#destroyed) return;
-    this.#destroyed = true;
-    this.detach();
-  }
-
   // -- Source --
 
-  get src() {
+  // Overrides `protected abstract get src()` with public access — satisfies both
+  // the base class contract and VimeoMediaProps.
+  get src(): string {
     return this.#src;
   }
 
   set src(value: string) {
     if (this.#src === value) return;
     this.#src = value;
-    if (!this.#container) return;
-    if (value) this.#mount();
-    else this.#unmount();
+    const container = this.target;
+    if (!container) return;
+    if (value) this.mount(container);
+    else this.unmount();
   }
 
   get currentSrc() {
     return this.#src;
-  }
-
-  get readyState() {
-    return this.#readyState;
-  }
-
-  load() {
-    if (this.#container && this.#src) this.#mount();
   }
 
   // -- Playback --
@@ -209,144 +101,52 @@ export class VimeoMedia
   }
 
   pause() {
-    this.#player?.pause();
-  }
-
-  get paused() {
-    return this.#paused;
-  }
-
-  get ended() {
-    return this.#ended;
+    return this.#player?.pause() ?? Promise.resolve();
   }
 
   // -- Seek --
 
   get currentTime() {
-    return this.#currentTime;
+    return super.currentTime;
   }
 
   set currentTime(value: number) {
     if (!this.#player) return;
-    if (!this.#paused) {
+    if (!this.paused) {
       this.#player.setCurrentTime(value);
       return;
     }
     const seekingPlayer = this.#player;
-    const previousTime = this.#currentTime;
-    this.#currentTime = value;
-    this.#seeking = true;
+    const previousTime = this.currentTime;
+    this.updateState({ currentTime: value, seeking: true });
     this.dispatchEvent(new Event('seeking'));
     this.#player.setCurrentTime(value).then(
       (time) => {
         if (this.#player !== seekingPlayer) return;
-        this.#currentTime = time;
-        this.#seeking = false;
+        this.updateState({ currentTime: time, seeking: false });
         this.dispatchEvent(new Event('timeupdate'));
         this.dispatchEvent(new Event('seeked'));
       },
       () => {
-        if (this.#player !== seekingPlayer || !this.#seeking) return;
-        this.#currentTime = previousTime;
-        this.#seeking = false;
+        if (this.#player !== seekingPlayer || !this.seeking) return;
+        this.updateState({ currentTime: previousTime, seeking: false });
         this.dispatchEvent(new Event('seeked'));
       }
     );
   }
 
-  get duration() {
-    return this.#duration;
-  }
+  // -- Volume / playback rate delegates --
 
-  get seeking() {
-    return this.#seeking;
-  }
-
-  // -- Volume --
-
-  get volume() {
-    return this.#volume;
-  }
-
-  set volume(value: number) {
+  protected onSetVolume(value: number) {
     this.#player?.setVolume(value);
   }
 
-  get muted() {
-    return this.#muted;
-  }
-
-  set muted(value: boolean) {
-    this.#muted = value;
+  protected onSetMuted(value: boolean) {
     this.#player?.setMuted(value);
   }
 
-  // -- Playback rate --
-
-  get playbackRate() {
-    return this.#playbackRate;
-  }
-
-  set playbackRate(value: number) {
+  protected onSetPlaybackRate(value: number) {
     this.#player?.setPlaybackRate(value);
-  }
-
-  // -- Buffer --
-
-  get buffered(): TimeRangeLike {
-    if (this.#buffered > 0) {
-      const end = this.#buffered;
-      return Object.freeze({ length: 1, start: () => 0, end: () => end });
-    }
-    return EMPTY_TIME_RANGES;
-  }
-
-  get seekable(): TimeRangeLike {
-    return EMPTY_TIME_RANGES;
-  }
-
-  // -- Picture-in-picture --
-
-  get isPictureInPicture() {
-    return this.#pip;
-  }
-
-  requestPictureInPicture() {
-    // Only attempt PiP on Safari — webkit's cross-origin iframe mechanism works
-    // without requiring user activation in the iframe's browsing context.
-    if (this.isPipCapable) this.#postVimeoMethod('requestPictureInPicture');
-    return Promise.resolve();
-  }
-
-  exitPictureInPicture() {
-    if (this.isPipCapable) this.#postVimeoMethod('exitPictureInPicture');
-    return Promise.resolve();
-  }
-
-  #postVimeoMethod(method: string) {
-    const iframe = this.#container?.querySelector<HTMLIFrameElement>('iframe');
-    if (!iframe?.contentWindow || !iframe.src) return;
-    try {
-      const origin = new URL(iframe.src).origin;
-      iframe.contentWindow.postMessage({ method }, origin);
-    } catch {
-      // Ignore cross-origin or URL parse errors.
-    }
-  }
-
-  // -- Error --
-
-  get error() {
-    return this.#error;
-  }
-
-  // -- Text tracks --
-
-  get textTracks(): TextTrackList {
-    if (!this.#textTracksVideo) {
-      this.#textTracksVideo = document.createElement('video');
-    }
-    return this.#textTracksVideo.textTracks;
   }
 
   // -- Embed params --
@@ -358,7 +158,7 @@ export class VimeoMedia
   set dnt(value: boolean) {
     if (this.#dnt === value) return;
     this.#dnt = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get autoplay() {
@@ -385,7 +185,7 @@ export class VimeoMedia
   set background(value: boolean) {
     if (this.#background === value) return;
     this.#background = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get byline() {
@@ -395,7 +195,7 @@ export class VimeoMedia
   set byline(value: boolean) {
     if (this.#byline === value) return;
     this.#byline = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get color() {
@@ -414,7 +214,7 @@ export class VimeoMedia
   set controls(value: boolean) {
     if (this.#controls === value) return;
     this.#controls = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get loop() {
@@ -433,7 +233,7 @@ export class VimeoMedia
   set playsinline(value: boolean) {
     if (this.#playsinline === value) return;
     this.#playsinline = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get portrait() {
@@ -443,7 +243,7 @@ export class VimeoMedia
   set portrait(value: boolean) {
     if (this.#portrait === value) return;
     this.#portrait = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get quality() {
@@ -471,7 +271,7 @@ export class VimeoMedia
   set speed(value: boolean) {
     if (this.#speed === value) return;
     this.#speed = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get texttrack() {
@@ -493,7 +293,7 @@ export class VimeoMedia
   set title(value: boolean) {
     if (this.#title === value) return;
     this.#title = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
   get transparent() {
@@ -503,14 +303,14 @@ export class VimeoMedia
   set transparent(value: boolean) {
     if (this.#transparent === value) return;
     this.#transparent = value;
-    if (this.#player) this.#mount();
+    if (this.#player) this.mount(this.target!);
   }
 
-  // -- Private --
+  // -- Protected lifecycle --
 
-  #mount() {
-    this.#unmount();
-    if (!this.#container || !this.#src) return;
+  protected mount(container: HTMLElement) {
+    this.unmount();
+    if (!this.#src) return;
 
     const options: VimeoEmbedParameters = {
       dnt: this.#dnt,
@@ -520,7 +320,7 @@ export class VimeoMedia
       byline: this.#byline,
       controls: this.#controls,
       loop: this.#loop,
-      muted: this.#muted,
+      muted: this.muted,
       playsinline: this.#playsinline,
       portrait: this.#portrait,
       quality: this.#quality,
@@ -541,10 +341,11 @@ export class VimeoMedia
       options.url = src as VimeoUrl;
     }
 
-    this.#player = new Player(this.#container, options);
+    this.#player = new Player(container, options);
+    this.updateEngine(this.#player);
 
     // Make the iframe fill its container completely in both HTML and React contexts.
-    const iframe = this.#container.querySelector('iframe');
+    const iframe = container.querySelector('iframe');
     if (iframe) {
       iframe.style.width = '100%';
       iframe.style.height = '100%';
@@ -561,108 +362,98 @@ export class VimeoMedia
     mountedPlayer.ready().then(
       () => {
         if (this.#player !== mountedPlayer) return;
-        const iframe = this.#container?.querySelector<HTMLIFrameElement>('iframe');
+        const iframe = container.querySelector<HTMLIFrameElement>('iframe');
         if (iframe) {
           iframe.style.width = '100%';
           iframe.style.height = '100%';
         }
       },
       (err: Error) => {
-        if (this.#player !== mountedPlayer || this.#error) return;
-        this.#error = { code: 4, message: err?.message ?? 'Failed to load Vimeo video' };
+        if (this.#player !== mountedPlayer || this.error) return;
+        this.updateState({ error: { code: 4, message: err?.message ?? 'Failed to load Vimeo video' } });
         this.dispatchEvent(new Event('error'));
       }
     );
   }
 
-  #unmount() {
+  protected unmount() {
     if (!this.#player) return;
-    this.#textTracksAbort?.abort();
-    this.#textTracksAbort = null;
-    for (const track of this.#mountedTracks) {
-      track.mode = 'disabled';
-    }
-    this.#mountedTracks = [];
+    this.resetTextTracks();
     this.#player.destroy();
     this.#player = null;
-    this.#resetState();
+    this.updateEngine(null);
+    this.resetState();
   }
+
+  // -- Private --
 
   #subscribe(player: Player) {
     player.on('play', () => {
-      this.#paused = false;
-      this.#ended = false;
-      // Vimeo only fires 'play' when the video is actually ready to play,
-      // so readyState must be HAVE_ENOUGH_DATA before syncing the store.
-      this.#readyState = 4;
+      this.updateState({ paused: false, ended: false, readyState: 4 });
       this.dispatchEvent(new Event('play'));
       this.dispatchEvent(new Event('playing'));
     });
 
     player.on('pause', () => {
-      this.#paused = true;
+      this.updateState({ paused: true });
       this.dispatchEvent(new Event('pause'));
     });
 
     player.on('ended', () => {
-      this.#paused = true;
-      this.#ended = true;
+      this.updateState({ paused: true, ended: true });
       this.dispatchEvent(new Event('ended'));
       this.dispatchEvent(new Event('pause'));
     });
 
     player.on('timeupdate', ({ seconds }) => {
-      this.#currentTime = seconds;
+      this.updateState({ currentTime: seconds });
       this.dispatchEvent(new Event('timeupdate'));
     });
 
     player.on('durationchange', ({ duration }) => {
-      this.#duration = duration;
+      this.updateState({ duration });
       this.dispatchEvent(new Event('durationchange'));
     });
 
     player.on('volumechange', ({ volume, muted }) => {
-      this.#volume = volume;
       // The Vimeo SDK historically emits only { volume } — `muted` was added
       // later and may be absent. Fall back to cached value to avoid corruption.
-      this.#muted = muted ?? this.#muted;
+      this.updateState({ volume, muted: muted ?? this.muted });
       this.dispatchEvent(new Event('volumechange'));
     });
 
     player.on('playbackratechange', ({ playbackRate }) => {
-      this.#playbackRate = playbackRate;
+      this.updateState({ playbackRate });
       this.dispatchEvent(new Event('ratechange'));
     });
 
     player.on('seeking', () => {
       // Seeking means the current position's data is no longer available.
-      this.#readyState = 2;
-      this.#seeking = true;
+      this.updateState({ readyState: 2, seeking: true });
       this.dispatchEvent(new Event('seeking'));
     });
 
     player.on('seeked', () => {
-      this.#readyState = 4;
-      this.#seeking = false;
+      this.updateState({ readyState: 4, seeking: false });
       this.dispatchEvent(new Event('seeked'));
     });
 
     player.on('bufferstart', () => {
       // Rebuffering — data at current position only.
-      this.#readyState = 2;
+      this.updateState({ readyState: 2 });
       this.dispatchEvent(new Event('waiting'));
     });
 
     player.on('bufferend', () => {
-      this.#readyState = 4;
+      this.updateState({ readyState: 4 });
       this.dispatchEvent(new Event('canplay'));
       // Dispatch 'playing' so playbackFeature re-syncs waiting → false.
-      if (!this.#paused) this.dispatchEvent(new Event('playing'));
+      if (!this.paused) this.dispatchEvent(new Event('playing'));
     });
 
     player.on('loaded', () => {
       // 'loaded' fires when the video is ready to play — treat as HAVE_ENOUGH_DATA.
-      this.#readyState = 4;
+      this.updateState({ readyState: 4 });
       this.dispatchEvent(new Event('loadstart'));
       this.dispatchEvent(new Event('loadedmetadata'));
       this.dispatchEvent(new Event('loadeddata'));
@@ -676,22 +467,22 @@ export class VimeoMedia
       // not playback errors and should not trigger the error dialog.
       if (name === 'NotAllowedError') return;
       // Map Vimeo error names to MediaError codes (3 = MEDIA_ERR_DECODE, 4 = MEDIA_ERR_SRC_NOT_SUPPORTED)
-      this.#error = { code: name === 'NotFoundError' ? 4 : 3, message };
+      this.updateState({ error: { code: name === 'NotFoundError' ? 4 : 3, message } });
       this.dispatchEvent(new Event('error'));
     });
 
     player.on('enterpictureinpicture', () => {
-      this.#pip = true;
+      this.updateState({ pip: true });
       this.dispatchEvent(new Event('enterpictureinpicture'));
     });
 
     player.on('leavepictureinpicture', () => {
-      this.#pip = false;
+      this.updateState({ pip: false });
       this.dispatchEvent(new Event('leavepictureinpicture'));
     });
 
     player.on('progress', ({ seconds }) => {
-      this.#buffered = seconds;
+      this.updateState({ buffered: seconds });
       this.dispatchEvent(new Event('progress'));
     });
 
@@ -708,13 +499,9 @@ export class VimeoMedia
       player.getDuration(),
       player.getPlaybackRate(),
     ])
-      .then(([volume, muted, paused, duration, rate]) => {
+      .then(([volume, muted, paused, duration, playbackRate]) => {
         if (this.#player !== seededPlayer) return;
-        this.#volume = volume;
-        this.#muted = muted;
-        this.#paused = paused;
-        this.#duration = duration;
-        this.#playbackRate = rate;
+        this.updateState({ volume, muted, paused, duration, playbackRate });
         // Notify the store of the actual initial state — the feature's sync()
         // ran before these promises resolved, so the store needs a nudge.
         this.dispatchEvent(new Event('volumechange'));
@@ -724,10 +511,7 @@ export class VimeoMedia
       .catch(() => {});
 
     // Populate the synthetic TextTrackList from the Vimeo API.
-    if (!this.#textTracksVideo) {
-      this.#textTracksVideo = document.createElement('video');
-    }
-    const textTracksVideo = this.#textTracksVideo;
+    const textTracksVideo = this.syntheticTextTracksVideo;
     const mountedPlayer = player;
 
     player
@@ -737,19 +521,18 @@ export class VimeoMedia
         for (const t of vimeoTracks) {
           const track = textTracksVideo.addTextTrack(t.kind as TextTrackKind, t.label, t.language);
           track.mode = t.mode === 'showing' ? 'showing' : 'disabled';
-          this.#mountedTracks.push(track);
+          this.addMountedTrack(track);
         }
       })
       .catch(() => {});
 
     // Forward track-mode changes made by the UI back to the Vimeo iframe.
-    this.#textTracksAbort?.abort();
-    this.#textTracksAbort = new AbortController();
+    const abort = this.startTextTrackAbort();
     textTracksVideo.textTracks.addEventListener(
       'change',
       () => {
         const active = Array.from(textTracksVideo.textTracks).find(
-          (t) => t.mode === 'showing' && this.#mountedTracks.includes(t as TextTrack)
+          (t) => t.mode === 'showing' && this.isMountedTrack(t as TextTrack)
         );
         if (active) {
           player.enableTextTrack(active.language, active.kind);
@@ -757,23 +540,7 @@ export class VimeoMedia
           player.disableTextTrack();
         }
       },
-      { signal: this.#textTracksAbort.signal }
+      { signal: abort.signal }
     );
-  }
-
-  #resetState() {
-    this.#paused = true;
-    this.#ended = false;
-    this.#duration = NaN;
-    this.#currentTime = 0;
-    this.#buffered = 0;
-    this.#readyState = 0;
-    this.#volume = 1;
-    this.#playbackRate = 1;
-    this.#seeking = false;
-    this.#pip = false;
-    this.#error = null;
-    // #muted is intentionally preserved — it's both prop config and cached state.
-    this.dispatchEvent(new Event('emptied'));
   }
 }

--- a/packages/core/src/dom/media/vimeo/tests/vimeo-media.test.ts
+++ b/packages/core/src/dom/media/vimeo/tests/vimeo-media.test.ts
@@ -1,3 +1,4 @@
+import type { VimeoTextTrack } from '@vimeo/player';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Captured Player constructor call args and instance per test.
@@ -26,7 +27,7 @@ function makeMockPlayer() {
     setQuality: vi.fn(() => Promise.resolve(null)),
     requestPictureInPicture: vi.fn(() => Promise.resolve()),
     exitPictureInPicture: vi.fn(() => Promise.resolve()),
-    getTextTracks: vi.fn(() => Promise.resolve([])),
+    getTextTracks: vi.fn((): Promise<VimeoTextTrack[]> => Promise.resolve([])),
     enableTextTrack: vi.fn(() => Promise.resolve({})),
     disableTextTrack: vi.fn(() => Promise.resolve({})),
     getVolume: vi.fn(() => Promise.resolve(1)),
@@ -752,6 +753,26 @@ describe('VimeoMedia', () => {
       media.attach(container);
 
       expect((capturedOptions as { muted: boolean }).muted).toBe(true);
+    });
+  });
+
+  describe('text tracks', () => {
+    it('textTracks is a fresh list after src change so old tracks do not persist', async () => {
+      mockPlayerInstance.getTextTracks.mockResolvedValueOnce([
+        { kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' },
+      ]);
+      const { media } = setup('111');
+
+      // Let getTextTracks resolve and add the track to the synthetic video.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const firstTrackList = media.textTracks;
+
+      // Changing src must reset the synthetic video element via resetTextTracks().
+      media.src = '222';
+
+      // textTracks now points to a fresh element — the old list is gone.
+      expect(media.textTracks).not.toBe(firstTrackList);
     });
   });
 

--- a/packages/core/src/dom/media/youtube/api.ts
+++ b/packages/core/src/dom/media/youtube/api.ts
@@ -1,0 +1,91 @@
+// Minimal YouTube IFrame Player API types (runtime-loaded global — no npm package).
+
+export interface YTCaptionTrack {
+  languageCode: string;
+  displayName: string;
+}
+
+export interface YTPlayerEvent {
+  data: number;
+  target: YTPlayer;
+}
+
+export interface YTPlayer {
+  playVideo(): void;
+  pauseVideo(): void;
+  seekTo(seconds: number, allowSeekAhead: boolean): void;
+  setVolume(volume: number): void;
+  mute(): void;
+  unMute(): void;
+  isMuted(): boolean;
+  getVolume(): number;
+  setPlaybackRate(rate: number): void;
+  getPlaybackRate(): number;
+  getPlayerState(): number;
+  getDuration(): number;
+  getCurrentTime(): number;
+  getVideoLoadedFraction(): number;
+  setOption(module: string, option: string, value: unknown): void;
+  getOption(module: string, option: string): unknown;
+  addEventListener(event: string, listener: (e: YTPlayerEvent) => void): void;
+  destroy(): void;
+}
+
+export interface YTPlayerConfig {
+  events?: {
+    onReady?: (e: YTPlayerEvent) => void;
+    onError?: (e: YTPlayerEvent) => void;
+  };
+}
+
+export interface YTNamespace {
+  Player: new (element: HTMLIFrameElement, config: YTPlayerConfig) => YTPlayer;
+  PlayerState: {
+    readonly UNSTARTED: -1;
+    readonly ENDED: 0;
+    readonly PLAYING: 1;
+    readonly PAUSED: 2;
+    readonly BUFFERING: 3;
+    readonly CUED: 5;
+  };
+}
+
+const API_URL = 'https://www.youtube.com/iframe_api';
+const API_GLOBAL = 'YT';
+const API_GLOBAL_READY = 'onYouTubeIframeAPIReady';
+
+// Module-level cache — one script load per page lifetime.
+let apiPromise: Promise<YTNamespace> | null = null;
+
+export function loadYouTubeApi(): Promise<YTNamespace> {
+  const win = globalThis as unknown as Record<string, unknown>;
+
+  if (win[API_GLOBAL]) {
+    return (apiPromise ??= Promise.resolve(win[API_GLOBAL] as YTNamespace));
+  }
+
+  if (apiPromise) return apiPromise;
+
+  apiPromise = new Promise<YTNamespace>((resolve, reject) => {
+    // Chain onto any existing ready callback (e.g. another player on the page).
+    const prev = win[API_GLOBAL_READY] as (() => void) | undefined;
+    win[API_GLOBAL_READY] = () => {
+      prev?.();
+      resolve(win[API_GLOBAL] as YTNamespace);
+    };
+    const script = document.createElement('script');
+    script.src = API_URL;
+    script.onerror = () => {
+      apiPromise = null;
+      reject(new Error('Failed to load YouTube IFrame API'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return apiPromise;
+}
+
+/** Reset the cached API promise — for use in tests only. */
+export function resetYouTubeApiCache(): void {
+  apiPromise = null;
+}

--- a/packages/core/src/dom/media/youtube/index.ts
+++ b/packages/core/src/dom/media/youtube/index.ts
@@ -1,0 +1,590 @@
+import { IframeMediaHost } from '../iframe-host';
+import { loadYouTubeApi, type YTCaptionTrack, type YTNamespace, type YTPlayer } from './api';
+
+// -- Embed URL helpers --
+
+const EMBED_BASE = 'https://www.youtube.com/embed';
+const EMBED_BASE_NOCOOKIE = 'https://www.youtube-nocookie.com/embed';
+
+const VIDEO_RE =
+  /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((\w|-){11})/;
+const PLAYLIST_RE = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/.*?[?&]list=)([\w_-]+)/;
+
+// YouTube player state values (mirrors YT.PlayerState).
+const YTState = {
+  UNSTARTED: -1,
+  ENDED: 0,
+  PLAYING: 1,
+  PAUSED: 2,
+  BUFFERING: 3,
+  CUED: 5,
+} as const;
+
+function parseStartTime(src: string): number | undefined {
+  const match = src.match(/[?&]t=([\dms]+)/i);
+  if (!match?.[1]) return undefined;
+  const val = match[1].toLowerCase();
+  let total = 0;
+  let found = false;
+  const m = val.match(/(\d+)m/);
+  if (m?.[1]) {
+    total += parseInt(m[1], 10) * 60;
+    found = true;
+  }
+  const s = val.match(/(\d+)s?$/);
+  if (s?.[1]) {
+    total += parseInt(s[1], 10);
+    found = true;
+  }
+  return found ? total : undefined;
+}
+
+interface EmbedOptions {
+  autoplay: boolean;
+  controls: boolean;
+  loop: boolean;
+  muted: boolean;
+  playsinline: boolean;
+  start: number;
+}
+
+function buildEmbedUrl(src: string, nocookie: boolean, opts: EmbedOptions): string {
+  const base = nocookie ? EMBED_BASE_NOCOOKIE : EMBED_BASE;
+  const startTime = parseStartTime(src) ?? (opts.start > 0 ? opts.start : undefined);
+
+  const params: Record<string, number | string | undefined> = {
+    enablejsapi: 1,
+    rel: 0,
+    iv_load_policy: 3,
+    controls: opts.controls ? 1 : 0,
+    playsinline: opts.playsinline ? 1 : 0,
+    autoplay: opts.autoplay ? 1 : undefined,
+    loop: opts.loop ? 1 : undefined,
+    mute: opts.muted ? 1 : undefined,
+    start: startTime,
+  };
+
+  const videoMatch = src.match(VIDEO_RE);
+  if (videoMatch) {
+    const videoId = videoMatch[1];
+    // YouTube requires playlist=VIDEO_ID alongside loop=1 for single videos.
+    if (opts.loop) params.playlist = videoId;
+    return `${base}/${videoId}?${serializeParams(params)}`;
+  }
+
+  const listMatch = src.match(PLAYLIST_RE);
+  if (listMatch) {
+    params.listType = 'playlist';
+    params.list = listMatch[1];
+    return `${base}?${serializeParams(params)}`;
+  }
+
+  // Fallback: treat src as a raw video ID or embed path.
+  return `${base}/${src}?${serializeParams(params)}`;
+}
+
+function serializeParams(params: Record<string, number | string | undefined>): string {
+  return Object.entries(params)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+    .join('&');
+}
+
+function youTubeErrorMessage(code: number): string {
+  switch (code) {
+    case 2:
+      return 'Invalid parameter value';
+    case 5:
+      return 'HTML5 player error';
+    case 100:
+      return 'Video not found (private or deleted)';
+    case 101:
+    case 150:
+      return 'Embedding not allowed by video owner';
+    default:
+      return 'Unknown error';
+  }
+}
+
+// -- YouTubeMedia --
+
+export interface YouTubeMediaProps {
+  /** YouTube video URL, video ID, playlist URL, shorts URL, or live URL. */
+  src: string;
+  autoplay: boolean;
+  /** Show the YouTube native controls. Defaults to `false` (use Video.js controls). */
+  controls: boolean;
+  loop: boolean;
+  muted: boolean;
+  playsinline: boolean;
+  /**
+   * Use `youtube-nocookie.com` for the embed domain to reduce tracking cookies.
+   * Defaults to `false` (opt-in).
+   */
+  nocookie: boolean;
+  /** Start playback at this offset in seconds. Overridden by a `t=` parameter in the URL. */
+  start: number;
+}
+
+export const youTubeMediaDefaultProps: YouTubeMediaProps = {
+  src: '',
+  autoplay: false,
+  controls: false,
+  loop: false,
+  muted: false,
+  playsinline: true,
+  nocookie: false,
+  start: 0,
+};
+
+export class YouTubeMedia extends IframeMediaHost<YTPlayer> implements YouTubeMediaProps {
+  // Local typed reference — kept in sync with base `engine` via `updateEngine`.
+  #player: YTPlayer | null = null;
+  #iframe: HTMLIFrameElement | null = null;
+  // Aborts the in-progress async mount when unmount/remount is triggered.
+  #mountAbort: AbortController | null = null;
+  // Polls currentTime and buffered while playing (YouTube has no native timeupdate event).
+  #timeupdateInterval: ReturnType<typeof setInterval> | null = null;
+  // Seek synthesis state.
+  #seekPending = false;
+  #seekTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  // Tracks whether play() has been dispatched for the current play session.
+  #playFired = false;
+
+  // Embed props
+  #src = youTubeMediaDefaultProps.src;
+  #autoplay = youTubeMediaDefaultProps.autoplay;
+  #controls = youTubeMediaDefaultProps.controls;
+  #loop = youTubeMediaDefaultProps.loop;
+  #playsinline = youTubeMediaDefaultProps.playsinline;
+  #nocookie = youTubeMediaDefaultProps.nocookie;
+  #start = youTubeMediaDefaultProps.start;
+
+  // -- Source --
+
+  // Overrides `protected abstract get src()` with public access, satisfying
+  // both the base class contract and YouTubeMediaProps.
+  get src(): string {
+    return this.#src;
+  }
+
+  set src(value: string) {
+    if (this.#src === value) return;
+    this.#src = value;
+    const container = this.target;
+    if (!container) return;
+    if (value) this.mount(container);
+    else this.unmount();
+  }
+
+  get currentSrc() {
+    return this.#src;
+  }
+
+  // -- Playback --
+
+  play() {
+    this.#player?.playVideo();
+    return Promise.resolve();
+  }
+
+  pause() {
+    this.#player?.pauseVideo();
+    return Promise.resolve();
+  }
+
+  // -- Seek --
+
+  get currentTime() {
+    return super.currentTime;
+  }
+
+  set currentTime(value: number) {
+    if (!this.#player) return;
+    // Cancel any pending seek timeout before starting a new one.
+    if (this.#seekTimeoutId !== null) {
+      clearTimeout(this.#seekTimeoutId);
+      this.#seekTimeoutId = null;
+    }
+    this.#seekPending = true;
+    this.updateState({ currentTime: value, seeking: true });
+    this.dispatchEvent(new Event('seeking'));
+    this.#player.seekTo(value, true);
+    // Fallback: if no state change fires within 600 ms (e.g. seek to already-buffered
+    // position while paused), dispatch seeked to avoid the consumer hanging.
+    const player = this.#player;
+    this.#seekTimeoutId = setTimeout(() => {
+      this.#seekTimeoutId = null;
+      if (!this.#seekPending || this.#player !== player) return;
+      this.#resolveSeeked();
+    }, 600);
+  }
+
+  // -- Volume / playback rate delegates --
+
+  protected onSetVolume(value: number) {
+    // YouTube volume is 0–100; our API is 0–1.
+    this.#player?.setVolume(value * 100);
+  }
+
+  protected onSetMuted(value: boolean) {
+    if (value) this.#player?.mute();
+    else this.#player?.unMute();
+  }
+
+  protected onSetPlaybackRate(value: number) {
+    this.#player?.setPlaybackRate(value);
+  }
+
+  // -- Embed props --
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+  set autoplay(value: boolean) {
+    if (this.#autoplay === value) return;
+    this.#autoplay = value;
+    if (this.#player) this.mount(this.target!);
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+  set controls(value: boolean) {
+    if (this.#controls === value) return;
+    this.#controls = value;
+    if (this.#player) this.mount(this.target!);
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+  set loop(value: boolean) {
+    if (this.#loop === value) return;
+    this.#loop = value;
+    if (this.#player) this.mount(this.target!);
+  }
+
+  get playsinline() {
+    return this.#playsinline;
+  }
+  set playsinline(value: boolean) {
+    if (this.#playsinline === value) return;
+    this.#playsinline = value;
+    if (this.#player) this.mount(this.target!);
+  }
+
+  get nocookie() {
+    return this.#nocookie;
+  }
+  set nocookie(value: boolean) {
+    if (this.#nocookie === value) return;
+    this.#nocookie = value;
+    if (this.#player) this.mount(this.target!);
+  }
+
+  get start() {
+    return this.#start;
+  }
+  set start(value: number) {
+    this.#start = value;
+    // start is embed-only; no runtime API to update without remounting.
+  }
+
+  // -- Protected lifecycle --
+
+  protected mount(container: HTMLElement) {
+    this.unmount();
+    if (!this.#src) return;
+
+    const abort = new AbortController();
+    this.#mountAbort = abort;
+
+    // Create the iframe immediately so the browser begins fetching the embed
+    // before the YT IFrame API script finishes loading.
+    const iframe = document.createElement('iframe');
+    iframe.src = buildEmbedUrl(this.#src, this.#nocookie, {
+      autoplay: this.#autoplay,
+      controls: this.#controls,
+      loop: this.#loop,
+      muted: this.muted,
+      playsinline: this.#playsinline,
+      start: this.#start,
+    });
+    iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+    iframe.setAttribute('allowfullscreen', '');
+    iframe.style.border = 'none';
+
+    if (!this.#controls) {
+      // CSS crop trick — hides the YouTube title bar (top) and branding bar (bottom)
+      // that appear even without native controls. Extend the iframe 60 px beyond each
+      // edge and clip it with overflow:hidden so the visible area stays 16:9.
+      container.style.overflow = 'hidden';
+      iframe.style.position = 'absolute';
+      iframe.style.top = '-60px';
+      iframe.style.left = '0';
+      iframe.style.width = '100%';
+      iframe.style.height = 'calc(100% + 120px)';
+    } else {
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+      iframe.style.display = 'block';
+    }
+
+    container.appendChild(iframe);
+    this.#iframe = iframe;
+
+    this.#mountAsync(iframe, abort.signal).catch(() => {});
+  }
+
+  protected unmount() {
+    this.#mountAbort?.abort();
+    this.#mountAbort = null;
+
+    // Reset crop styles applied in mount() so a remount with controls=true works cleanly.
+    const container = this.target;
+    if (container) container.style.overflow = '';
+
+    this.#stopTimeupdateInterval();
+    this.#cancelSeek();
+
+    this.#playFired = false;
+
+    if (this.#player) {
+      this.resetTextTracks();
+      this.#player.destroy();
+      this.#player = null;
+      this.updateEngine(null);
+    }
+
+    this.#iframe?.remove();
+    this.#iframe = null;
+
+    this.resetState();
+  }
+
+  // -- Private --
+
+  async #mountAsync(iframe: HTMLIFrameElement, signal: AbortSignal): Promise<void> {
+    let yt: YTNamespace;
+    try {
+      yt = await loadYouTubeApi();
+    } catch {
+      if (signal.aborted) return;
+      this.updateState({
+        error: { code: 4, message: 'Failed to load YouTube IFrame API' },
+      });
+      this.dispatchEvent(new Event('error'));
+      return;
+    }
+
+    if (signal.aborted) return;
+
+    this.#player = new yt.Player(iframe, {
+      events: {
+        onReady: () => {
+          const p = this.#player;
+          if (signal.aborted || !p) return;
+          this.#onPlayerReady(p);
+        },
+        onError: (e) => {
+          if (signal.aborted || !this.#player) return;
+          this.#onPlayerError(e.data);
+        },
+      },
+    });
+
+    const mountedPlayer = this.#player;
+    this.updateEngine(mountedPlayer);
+    this.#subscribePlayer(mountedPlayer, yt, signal);
+
+    // Dispatch loadstart now that the iframe is in the DOM and the player is wired up.
+    this.dispatchEvent(new Event('loadstart'));
+  }
+
+  #onPlayerReady(player: YTPlayer) {
+    const volume = player.getVolume() / 100;
+    const muted = player.isMuted();
+    const duration = player.getDuration();
+    const playbackRate = player.getPlaybackRate();
+
+    this.updateState({ volume, muted, duration, playbackRate, readyState: 1 });
+    this.dispatchEvent(new Event('loadedmetadata'));
+    this.dispatchEvent(new Event('durationchange'));
+    this.dispatchEvent(new Event('volumechange'));
+
+    // Re-apply volume if the caller set it before the player was ready.
+    if (this.volume !== volume) player.setVolume(this.volume * 100);
+
+    this.#refreshCaptionTracks(player);
+    this.#setupTextTrackListener(player);
+  }
+
+  #onPlayerError(code: number) {
+    // Map YouTube error codes to MediaError codes.
+    // 2 (invalid param), 5 (HTML5 error) → MEDIA_ERR_DECODE = 3
+    // 100 (not found), 101/150 (embed disallowed) → MEDIA_ERR_SRC_NOT_SUPPORTED = 4
+    const mediaCode = code === 2 || code === 5 ? 3 : 4;
+    this.updateState({
+      error: {
+        code: mediaCode,
+        message: `YouTube error ${code}: ${youTubeErrorMessage(code)}`,
+      },
+    });
+    this.dispatchEvent(new Event('error'));
+  }
+
+  #subscribePlayer(player: YTPlayer, yt: YTNamespace, signal: AbortSignal) {
+    player.addEventListener('onStateChange', (e) => {
+      if (signal.aborted || this.#player !== player) return;
+      this.#onStateChange(e.data, player, yt);
+    });
+
+    player.addEventListener('onPlaybackRateChange', () => {
+      if (signal.aborted || this.#player !== player) return;
+      this.updateState({ playbackRate: player.getPlaybackRate() });
+      this.dispatchEvent(new Event('ratechange'));
+    });
+
+    // onVolumeChange is widely supported but undocumented in the official API.
+    player.addEventListener('onVolumeChange', () => {
+      if (signal.aborted || this.#player !== player) return;
+      this.updateState({ volume: player.getVolume() / 100, muted: player.isMuted() });
+      this.dispatchEvent(new Event('volumechange'));
+    });
+  }
+
+  #onStateChange(state: number, player: YTPlayer, yt: YTNamespace) {
+    // Capture before the combined play/buffer check mutates #playFired so the
+    // BUFFERING branch can distinguish "first buffer" from "rebuffering".
+    const wasAlreadyPlaying = this.#playFired;
+
+    if (state === YTState.PLAYING || state === yt.PlayerState.BUFFERING) {
+      if (!this.#playFired && !this.#seekPending) {
+        this.#playFired = true;
+        this.updateState({ paused: false, ended: false });
+        this.dispatchEvent(new Event('play'));
+      }
+    }
+
+    if (state === YTState.PLAYING) {
+      this.#refreshCaptionTracks(player);
+
+      if (this.#seekPending) {
+        this.updateState({
+          currentTime: player.getCurrentTime(),
+          readyState: 4,
+        });
+        this.#resolveSeeked();
+        this.dispatchEvent(new Event('timeupdate'));
+        if (!this.paused) this.dispatchEvent(new Event('playing'));
+      } else {
+        this.updateState({ readyState: 4 });
+        this.dispatchEvent(new Event('playing'));
+      }
+      this.#startTimeupdateInterval(player);
+    } else if (state === YTState.BUFFERING) {
+      if (!this.#seekPending) {
+        this.updateState({ readyState: 2 });
+        if (wasAlreadyPlaying) this.dispatchEvent(new Event('waiting'));
+      }
+    } else if (state === YTState.PAUSED) {
+      this.#stopTimeupdateInterval();
+      this.updateState({ currentTime: player.getCurrentTime() });
+      this.dispatchEvent(new Event('timeupdate'));
+
+      if (this.#seekPending) {
+        this.#resolveSeeked();
+      }
+
+      this.#playFired = false;
+      this.updateState({ paused: true });
+      this.dispatchEvent(new Event('pause'));
+    } else if (state === YTState.ENDED) {
+      this.#stopTimeupdateInterval();
+      if (this.#seekPending) this.#resolveSeeked();
+      this.#playFired = false;
+      this.updateState({ paused: true, ended: true, readyState: 4, seeking: false });
+      this.dispatchEvent(new Event('pause'));
+      this.dispatchEvent(new Event('ended'));
+    } else if (state === YTState.CUED) {
+      this.updateState({ readyState: 1 });
+    }
+  }
+
+  #resolveSeeked() {
+    if (this.#seekTimeoutId !== null) {
+      clearTimeout(this.#seekTimeoutId);
+      this.#seekTimeoutId = null;
+    }
+    this.#seekPending = false;
+    this.updateState({ seeking: false });
+    this.dispatchEvent(new Event('seeked'));
+  }
+
+  #cancelSeek() {
+    if (this.#seekTimeoutId !== null) {
+      clearTimeout(this.#seekTimeoutId);
+      this.#seekTimeoutId = null;
+    }
+    this.#seekPending = false;
+  }
+
+  #refreshCaptionTracks(player: YTPlayer) {
+    const tracklist = player.getOption('captions', 'tracklist') as YTCaptionTrack[] | null;
+    if (!tracklist?.length) return;
+    const video = this.syntheticTextTracksVideo;
+    for (const t of tracklist) {
+      const exists = Array.from(video.textTracks).some((tt) => tt.language === t.languageCode);
+      if (!exists) {
+        const track = video.addTextTrack('subtitles', t.displayName, t.languageCode);
+        this.addMountedTrack(track);
+      }
+    }
+  }
+
+  #setupTextTrackListener(player: YTPlayer) {
+    const abort = this.startTextTrackAbort();
+    this.syntheticTextTracksVideo.textTracks.addEventListener(
+      'change',
+      () => {
+        const active = Array.from(this.syntheticTextTracksVideo.textTracks).find(
+          (t) => t.mode === 'showing' && this.isMountedTrack(t as TextTrack)
+        );
+        player.setOption('captions', 'track', active ? { languageCode: active.language } : {});
+      },
+      { signal: abort.signal }
+    );
+  }
+
+  #startTimeupdateInterval(player: YTPlayer) {
+    this.#stopTimeupdateInterval();
+    let lastBuffered = -1;
+    this.#timeupdateInterval = setInterval(() => {
+      if (!this.#player || this.#player !== player) {
+        this.#stopTimeupdateInterval();
+        return;
+      }
+      const currentTime = player.getCurrentTime();
+      const duration = player.getDuration();
+      this.updateState({ currentTime, duration });
+      this.dispatchEvent(new Event('timeupdate'));
+
+      if (duration > 0) {
+        const buffered = player.getVideoLoadedFraction() * duration;
+        this.updateState({ buffered });
+        if (Math.abs(buffered - lastBuffered) > 0.1) {
+          lastBuffered = buffered;
+          this.dispatchEvent(new Event('progress'));
+        }
+      }
+    }, 250);
+  }
+
+  #stopTimeupdateInterval() {
+    if (this.#timeupdateInterval !== null) {
+      clearInterval(this.#timeupdateInterval);
+      this.#timeupdateInterval = null;
+    }
+  }
+}

--- a/packages/core/src/dom/media/youtube/tests/youtube-media.test.ts
+++ b/packages/core/src/dom/media/youtube/tests/youtube-media.test.ts
@@ -1,0 +1,688 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { YTCaptionTrack, YTNamespace, YTPlayer, YTPlayerConfig } from '../api';
+
+// -- Mock YT player factory --
+
+let mockPlayerInstance: ReturnType<typeof makeMockPlayer>;
+let capturedConfig: YTPlayerConfig;
+
+function makeMockPlayer() {
+  const handlers: Record<string, (e: { data: number; target: unknown }) => void> = {};
+  const player = {
+    playVideo: vi.fn(),
+    pauseVideo: vi.fn(),
+    seekTo: vi.fn(),
+    setVolume: vi.fn(),
+    mute: vi.fn(),
+    unMute: vi.fn(),
+    isMuted: vi.fn(() => false),
+    getVolume: vi.fn(() => 100),
+    setPlaybackRate: vi.fn(),
+    getPlaybackRate: vi.fn(() => 1),
+    getPlayerState: vi.fn(() => -1),
+    getDuration: vi.fn(() => NaN),
+    getCurrentTime: vi.fn(() => 0),
+    getVideoLoadedFraction: vi.fn(() => 0),
+    setOption: vi.fn(),
+    getOption: vi.fn((_mod: string, opt: string) => {
+      if (opt === 'tracklist') return [] as YTCaptionTrack[];
+      return null;
+    }),
+    addEventListener: vi.fn((event: string, handler: (e: { data: number; target: unknown }) => void) => {
+      handlers[event] = handler;
+    }),
+    destroy: vi.fn(),
+    _emit(event: string, data = 0) {
+      handlers[event]?.({ data, target: player });
+    },
+  };
+  return player;
+}
+
+const mockYT: YTNamespace = {
+  // biome-ignore lint/complexity/useArrowFunction: must be a regular function so `new YT.Player()` works
+  Player: vi.fn(function (_iframe: unknown, config: YTPlayerConfig) {
+    capturedConfig = config;
+    mockPlayerInstance = makeMockPlayer();
+    return mockPlayerInstance;
+  }) as unknown as YTNamespace['Player'],
+  PlayerState: { UNSTARTED: -1, ENDED: 0, PLAYING: 1, PAUSED: 2, BUFFERING: 3, CUED: 5 },
+};
+
+// Mock loadYouTubeApi so tests never hit the network.
+vi.mock('../api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api')>();
+  return {
+    ...original,
+    loadYouTubeApi: vi.fn(() => Promise.resolve(mockYT)),
+  };
+});
+
+// jsdom video element lacks a real TextTrackList; provide a minimal mock.
+const _origCreate = document.createElement.bind(document);
+vi.spyOn(document, 'createElement').mockImplementation((tag, ...args) => {
+  if (tag !== 'video') return _origCreate(tag, ...args);
+  const textTracks = Object.assign(new EventTarget(), {
+    length: 0,
+    [Symbol.iterator]: function* () {},
+  }) as unknown as TextTrackList;
+  return {
+    textTracks,
+    addTextTrack: vi.fn(
+      (kind: TextTrackKind, label = '', language = '') =>
+        ({ kind, label, language, mode: 'disabled' as TextTrackMode }) as TextTrack
+    ),
+  } as unknown as HTMLVideoElement;
+});
+
+import { YouTubeMedia, youTubeMediaDefaultProps } from '../index';
+
+// Fire the onReady callback for the most-recently created player.
+// Pass `beforeReady` to configure mocks after the player is constructed
+// but before onReady fires (useful for seeding getDuration, getVolume, etc.).
+async function fireReady(beforeReady?: () => void) {
+  await Promise.resolve(); // allow #mountAsync to construct the YT.Player
+  beforeReady?.();
+  capturedConfig.events?.onReady?.({ data: 1, target: mockPlayerInstance as unknown as YTPlayer });
+}
+
+function makeContainer() {
+  return document.createElement('div');
+}
+
+function setup(src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ') {
+  const media = new YouTubeMedia();
+  media.src = src;
+  const container = makeContainer();
+  media.attach(container);
+  return { media, container };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  capturedConfig = undefined as unknown as YTPlayerConfig;
+});
+
+describe('YouTubeMedia', () => {
+  describe('defaults', () => {
+    it('starts paused', () => {
+      const { media } = setup();
+      expect(media.paused).toBe(true);
+    });
+
+    it('starts with NaN duration', () => {
+      const { media } = setup();
+      expect(media.duration).toBeNaN();
+    });
+
+    it('starts with readyState 0', () => {
+      const { media } = setup();
+      expect(media.readyState).toBe(0);
+    });
+
+    it('nocookie is false by default', () => {
+      expect(youTubeMediaDefaultProps.nocookie).toBe(false);
+    });
+  });
+
+  describe('attach', () => {
+    it('creates an iframe in the container', () => {
+      const { container } = setup();
+      const iframe = container.querySelector('iframe');
+      expect(iframe).not.toBeNull();
+    });
+
+    it('embed URL contains enablejsapi=1', () => {
+      const { container } = setup();
+      const iframe = container.querySelector('iframe')!;
+      expect(iframe.src).toContain('enablejsapi=1');
+    });
+
+    it('embed URL parses video ID from watch URL', () => {
+      const { container } = setup('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      const iframe = container.querySelector('iframe')!;
+      expect(iframe.src).toContain('/dQw4w9WgXcQ?');
+    });
+
+    it('embed URL parses video ID from youtu.be short URL', () => {
+      const { container } = setup('https://youtu.be/dQw4w9WgXcQ');
+      const iframe = container.querySelector('iframe')!;
+      expect(iframe.src).toContain('/dQw4w9WgXcQ?');
+    });
+
+    it('embed URL uses nocookie domain when nocookie=true', () => {
+      const media = new YouTubeMedia();
+      media.nocookie = true;
+      media.src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+      const container = makeContainer();
+      media.attach(container);
+      expect(container.querySelector('iframe')!.src).toContain('youtube-nocookie.com');
+    });
+
+    it('does not create a player when src is empty', async () => {
+      const MockPlayer = vi.mocked(mockYT.Player);
+      MockPlayer.mockClear();
+      const media = new YouTubeMedia();
+      media.attach(makeContainer());
+      await Promise.resolve();
+      expect(MockPlayer).not.toHaveBeenCalled();
+    });
+
+    it('exposes the player via engine after onReady', async () => {
+      const { media } = setup();
+      await fireReady();
+      expect(media.engine).toBe(mockPlayerInstance);
+    });
+
+    it('exposes the container via target', () => {
+      const { media, container } = setup();
+      expect(media.target).toBe(container);
+    });
+
+    it('dispatches loadstart after player is wired', async () => {
+      const media = new YouTubeMedia();
+      media.src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+      const container = makeContainer();
+      const handler = vi.fn();
+      media.addEventListener('loadstart', handler);
+      media.attach(container);
+      await Promise.resolve(); // allow #mountAsync
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('onReady', () => {
+    it('updates readyState to 1 and dispatches loadedmetadata/durationchange/volumechange', async () => {
+      const { media } = setup();
+
+      const dispatched: string[] = [];
+      for (const type of ['loadedmetadata', 'durationchange', 'volumechange'] as const) {
+        media.addEventListener(type, () => dispatched.push(type));
+      }
+
+      // Configure mocks inside beforeReady so they apply to the newly constructed player.
+      await fireReady(() => {
+        mockPlayerInstance.getDuration.mockReturnValue(120);
+        mockPlayerInstance.getVolume.mockReturnValue(80);
+      });
+
+      expect(media.readyState).toBe(1);
+      expect(media.duration).toBe(120);
+      expect(media.volume).toBeCloseTo(0.8);
+      expect(dispatched).toContain('loadedmetadata');
+      expect(dispatched).toContain('durationchange');
+      expect(dispatched).toContain('volumechange');
+    });
+  });
+
+  describe('detach', () => {
+    it('destroys the player', async () => {
+      const { media } = setup();
+      await fireReady();
+      const player = mockPlayerInstance;
+      media.detach();
+      expect(player.destroy).toHaveBeenCalledOnce();
+    });
+
+    it('removes the iframe from the container', async () => {
+      const { media, container } = setup();
+      await fireReady();
+      media.detach();
+      expect(container.querySelector('iframe')).toBeNull();
+    });
+
+    it('nullifies engine and target', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.detach();
+      expect(media.engine).toBeNull();
+      expect(media.target).toBeNull();
+    });
+
+    it('dispatches emptied', async () => {
+      const { media } = setup();
+      const handler = vi.fn();
+      media.addEventListener('emptied', handler);
+      media.detach();
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('destroy', () => {
+    it('is idempotent', async () => {
+      const { media } = setup();
+      await fireReady();
+      const player = mockPlayerInstance;
+      media.destroy();
+      media.destroy();
+      expect(player.destroy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('src setter', () => {
+    it('remounts with the new URL', async () => {
+      const { media } = setup('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      await fireReady();
+      const MockPlayer = vi.mocked(mockYT.Player);
+      const callsBefore = MockPlayer.mock.calls.length;
+
+      media.src = 'https://www.youtube.com/watch?v=9bZkp7q19f0';
+      await Promise.resolve();
+
+      expect(MockPlayer.mock.calls.length).toBe(callsBefore + 1);
+    });
+
+    it('destroys the previous player on src change', async () => {
+      const { media } = setup();
+      await fireReady();
+      const first = mockPlayerInstance;
+      media.src = 'https://www.youtube.com/watch?v=9bZkp7q19f0';
+      expect(first.destroy).toHaveBeenCalledOnce();
+    });
+
+    it('unmounts without remounting when src set to empty', async () => {
+      const { media } = setup();
+      await fireReady();
+      const first = mockPlayerInstance;
+      const MockPlayer = vi.mocked(mockYT.Player);
+      MockPlayer.mockClear();
+
+      media.src = '';
+
+      expect(first.destroy).toHaveBeenCalledOnce();
+      await Promise.resolve();
+      expect(MockPlayer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('state changes — onStateChange', () => {
+    it('PLAYING fires play + playing, sets paused=false', async () => {
+      const { media } = setup();
+      await fireReady();
+      const play = vi.fn();
+      const playing = vi.fn();
+      media.addEventListener('play', play);
+      media.addEventListener('playing', playing);
+
+      mockPlayerInstance._emit('onStateChange', 1); // PLAYING
+
+      expect(play).toHaveBeenCalledOnce();
+      expect(playing).toHaveBeenCalledOnce();
+      expect(media.paused).toBe(false);
+    });
+
+    it('BUFFERING fires play before PLAYING (first buffer), then waiting on rebuffer', async () => {
+      const { media } = setup();
+      await fireReady();
+      const play = vi.fn();
+      const waiting = vi.fn();
+      media.addEventListener('play', play);
+      media.addEventListener('waiting', waiting);
+
+      // First time: BUFFERING should fire play (not yet playing).
+      mockPlayerInstance._emit('onStateChange', 3); // BUFFERING
+      expect(play).toHaveBeenCalledOnce();
+      expect(waiting).not.toHaveBeenCalled();
+
+      // Then PLAYING fires playing and starts interval.
+      mockPlayerInstance._emit('onStateChange', 1); // PLAYING
+
+      // Rebuffer: BUFFERING again should fire waiting.
+      mockPlayerInstance._emit('onStateChange', 3); // BUFFERING
+      expect(waiting).toHaveBeenCalledOnce();
+    });
+
+    it('PAUSED fires pause, sets paused=true, resets playFired', async () => {
+      const { media } = setup();
+      await fireReady();
+      const handler = vi.fn();
+      media.addEventListener('pause', handler);
+
+      mockPlayerInstance._emit('onStateChange', 1); // PLAYING
+      mockPlayerInstance._emit('onStateChange', 2); // PAUSED
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(media.paused).toBe(true);
+    });
+
+    it('ENDED fires pause + ended, sets ended=true', async () => {
+      const { media } = setup();
+      await fireReady();
+      const pause = vi.fn();
+      const ended = vi.fn();
+      media.addEventListener('pause', pause);
+      media.addEventListener('ended', ended);
+
+      mockPlayerInstance._emit('onStateChange', 0); // ENDED
+
+      expect(pause).toHaveBeenCalledOnce();
+      expect(ended).toHaveBeenCalledOnce();
+      expect(media.ended).toBe(true);
+    });
+
+    it('CUED sets readyState to 1', async () => {
+      const { media } = setup();
+      await fireReady();
+      mockPlayerInstance._emit('onStateChange', 5); // CUED
+      expect(media.readyState).toBe(1);
+    });
+
+    it('play event fires only once across BUFFERING → PLAYING', async () => {
+      const { media } = setup();
+      await fireReady();
+      const play = vi.fn();
+      media.addEventListener('play', play);
+
+      mockPlayerInstance._emit('onStateChange', 3); // BUFFERING
+      mockPlayerInstance._emit('onStateChange', 1); // PLAYING
+
+      expect(play).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('playback controls', () => {
+    it('play() calls player.playVideo()', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.play();
+      expect(mockPlayerInstance.playVideo).toHaveBeenCalledOnce();
+    });
+
+    it('pause() calls player.pauseVideo()', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.pause();
+      expect(mockPlayerInstance.pauseVideo).toHaveBeenCalledOnce();
+    });
+
+    it('currentTime setter calls player.seekTo()', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.currentTime = 42;
+      expect(mockPlayerInstance.seekTo).toHaveBeenCalledWith(42, true);
+    });
+
+    it('currentTime setter dispatches seeking', async () => {
+      const { media } = setup();
+      await fireReady();
+      const handler = vi.fn();
+      media.addEventListener('seeking', handler);
+      media.currentTime = 10;
+      expect(handler).toHaveBeenCalledOnce();
+      expect(media.seeking).toBe(true);
+    });
+
+    it('seeking resolves to seeked on PAUSED state change', async () => {
+      const { media } = setup();
+      await fireReady();
+      const seeked = vi.fn();
+      media.addEventListener('seeked', seeked);
+
+      media.currentTime = 30;
+      expect(media.seeking).toBe(true);
+
+      mockPlayerInstance._emit('onStateChange', 2); // PAUSED
+
+      expect(seeked).toHaveBeenCalledOnce();
+      expect(media.seeking).toBe(false);
+    });
+
+    it('seeking resolves to seeked on PLAYING state change', async () => {
+      const { media } = setup();
+      await fireReady();
+      mockPlayerInstance._emit('onStateChange', 1); // first PLAYING → not seeking
+      const seeked = vi.fn();
+      media.addEventListener('seeked', seeked);
+
+      media.currentTime = 30;
+      mockPlayerInstance._emit('onStateChange', 1); // PLAYING after seek
+
+      expect(seeked).toHaveBeenCalledOnce();
+    });
+
+    it('seeking resolves via timeout fallback', async () => {
+      vi.useFakeTimers();
+      const { media } = setup();
+      await fireReady();
+      const seeked = vi.fn();
+      media.addEventListener('seeked', seeked);
+
+      media.currentTime = 30;
+      expect(seeked).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(600);
+      expect(seeked).toHaveBeenCalledOnce();
+      expect(media.seeking).toBe(false);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('volume / muted / playbackRate', () => {
+    it('volume setter calls player.setVolume() with 0–100 scale', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.volume = 0.5;
+      expect(mockPlayerInstance.setVolume).toHaveBeenCalledWith(50);
+    });
+
+    it('muted=true calls player.mute()', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.muted = true;
+      expect(mockPlayerInstance.mute).toHaveBeenCalledOnce();
+    });
+
+    it('muted=false calls player.unMute()', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.muted = false;
+      expect(mockPlayerInstance.unMute).toHaveBeenCalledOnce();
+    });
+
+    it('playbackRate setter calls player.setPlaybackRate()', async () => {
+      const { media } = setup();
+      await fireReady();
+      media.playbackRate = 1.5;
+      expect(mockPlayerInstance.setPlaybackRate).toHaveBeenCalledWith(1.5);
+    });
+
+    it('muted=true before attach is passed via embed URL mute param', () => {
+      const media = new YouTubeMedia();
+      media.muted = true;
+      media.src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+      const container = makeContainer();
+      media.attach(container);
+      expect(container.querySelector('iframe')!.src).toContain('mute=1');
+    });
+
+    it('onVolumeChange event updates cached volume', async () => {
+      const { media } = setup();
+      await fireReady();
+      mockPlayerInstance.getVolume.mockReturnValue(60);
+      mockPlayerInstance.isMuted.mockReturnValue(true);
+
+      const handler = vi.fn();
+      media.addEventListener('volumechange', handler);
+      mockPlayerInstance._emit('onVolumeChange', 0);
+
+      expect(media.volume).toBeCloseTo(0.6);
+      expect(media.muted).toBe(true);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('playback rate event', () => {
+    it('onPlaybackRateChange updates cached playbackRate and dispatches ratechange', async () => {
+      const { media } = setup();
+      await fireReady();
+      mockPlayerInstance.getPlaybackRate.mockReturnValue(2);
+      const handler = vi.fn();
+      media.addEventListener('ratechange', handler);
+
+      mockPlayerInstance._emit('onPlaybackRateChange', 0);
+
+      expect(media.playbackRate).toBe(2);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('error handling', () => {
+    it('onError with code 100 sets error code 4 and dispatches error', async () => {
+      const { media } = setup();
+      await fireReady();
+      const handler = vi.fn();
+      media.addEventListener('error', handler);
+
+      capturedConfig.events?.onError?.({ data: 100, target: mockPlayerInstance as unknown as YTPlayer });
+
+      expect(media.error?.code).toBe(4);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('onError with code 5 sets error code 3', async () => {
+      const { media } = setup();
+      await fireReady();
+      capturedConfig.events?.onError?.({ data: 5, target: mockPlayerInstance as unknown as YTPlayer });
+      expect(media.error?.code).toBe(3);
+    });
+
+    it('API load failure sets error and dispatches error event', async () => {
+      const { loadYouTubeApi } = await import('../api');
+      vi.mocked(loadYouTubeApi).mockRejectedValueOnce(new Error('network'));
+
+      const media = new YouTubeMedia();
+      const handler = vi.fn();
+      media.addEventListener('error', handler);
+      media.src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+      media.attach(makeContainer());
+
+      await new Promise<void>((r) => setTimeout(r, 0));
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(media.error?.code).toBe(4);
+    });
+  });
+
+  describe('embed props that trigger remount', () => {
+    it.each([
+      ['controls', true],
+      ['loop', true],
+      ['playsinline', false],
+      ['nocookie', true],
+      ['autoplay', true],
+    ] as const)('%s setter remounts the player', async (prop, newValue) => {
+      const { media } = setup();
+      await fireReady();
+      const MockPlayer = vi.mocked(mockYT.Player);
+      const callsBefore = MockPlayer.mock.calls.length;
+
+      (media as unknown as Record<string, unknown>)[prop] = newValue;
+      await Promise.resolve();
+
+      expect(MockPlayer.mock.calls.length).toBe(callsBefore + 1);
+    });
+
+    it('setting a prop to its current value does not remount', async () => {
+      const { media } = setup();
+      await fireReady();
+      const MockPlayer = vi.mocked(mockYT.Player);
+      const callsBefore = MockPlayer.mock.calls.length;
+
+      media.controls = youTubeMediaDefaultProps.controls;
+
+      expect(MockPlayer.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
+  describe('embed URL building', () => {
+    it('includes exactly the required params (no deprecated ones)', () => {
+      const { container } = setup();
+      const src = container.querySelector('iframe')!.src;
+      expect(src).toContain('enablejsapi=1');
+      expect(src).toContain('rel=0');
+      expect(src).toContain('iv_load_policy=3');
+      expect(src).toContain('controls=0');
+      expect(src).toContain('playsinline=1');
+      // Deprecated params must be absent.
+      expect(src).not.toContain('modestbranding');
+      expect(src).not.toContain('showinfo');
+      expect(src).not.toContain('cc_load_policy');
+    });
+
+    it('loop=true adds playlist=VIDEO_ID for single-video loop', () => {
+      const media = new YouTubeMedia();
+      media.loop = true;
+      media.src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+      media.attach(makeContainer());
+      const iframe = media.target!.querySelector('iframe')!;
+      expect(iframe.src).toContain('loop=1');
+      expect(iframe.src).toContain('playlist=dQw4w9WgXcQ');
+    });
+
+    it('controls=false adds controls=0', () => {
+      const { container } = setup();
+      expect(container.querySelector('iframe')!.src).toContain('controls=0');
+    });
+
+    it('extracts start time from t= param in URL', () => {
+      const { container } = setup('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=2m51s');
+      expect(container.querySelector('iframe')!.src).toContain('start=171');
+    });
+
+    it('playlist URL uses listType=playlist', () => {
+      // A URL with only list= (no v=) hits the playlist branch.
+      const { container } = setup('https://www.youtube.com/playlist?list=PLtest123');
+      const iframeSrc = container.querySelector('iframe')!.src;
+      expect(iframeSrc).toContain('listType=playlist');
+      expect(iframeSrc).toContain('list=PLtest123');
+    });
+  });
+
+  describe('CSS crop trick', () => {
+    it('applies crop styles to iframe and overflow:hidden to container when controls=false', () => {
+      const { container } = setup();
+      const iframe = container.querySelector('iframe')!;
+      expect(container.style.overflow).toBe('hidden');
+      expect(iframe.style.position).toBe('absolute');
+      expect(iframe.style.top).toBe('-60px');
+      expect(iframe.style.left).toBe('0px');
+      expect(iframe.style.width).toBe('100%');
+      expect(iframe.style.height).toBe('calc(100% + 120px)');
+    });
+
+    it('does not crop and does not set overflow:hidden when controls=true', () => {
+      const media = new YouTubeMedia();
+      media.controls = true;
+      media.src = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+      const container = makeContainer();
+      media.attach(container);
+      const iframe = container.querySelector('iframe')!;
+      expect(container.style.overflow).not.toBe('hidden');
+      expect(iframe.style.position).not.toBe('absolute');
+      expect(iframe.style.top).not.toBe('-60px');
+    });
+
+    it('resets overflow when detaching', () => {
+      const { media, container } = setup();
+      expect(container.style.overflow).toBe('hidden');
+      media.detach();
+      expect(container.style.overflow).toBe('');
+    });
+
+    it('resets and reapplies overflow on remount', () => {
+      const { media, container } = setup();
+      expect(container.style.overflow).toBe('hidden');
+      media.src = 'https://www.youtube.com/watch?v=9bZkp7q19f0';
+      // After remount with controls still false, overflow is hidden again.
+      expect(container.style.overflow).toBe('hidden');
+    });
+  });
+
+  describe('picture-in-picture', () => {
+    it('starts with isPictureInPicture=false', () => {
+      const { media } = setup();
+      expect(media.isPictureInPicture).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -40,6 +40,7 @@ export const textTrackFeature = definePlayerFeature({
     if (!isMediaTextTrackCapable(media)) return;
 
     let trackCleanup: AbortController | null = null;
+    let trackListCleanup: AbortController | null = null;
 
     const sync = () => {
       trackCleanup?.abort();
@@ -97,16 +98,41 @@ export const textTrackFeature = definePlayerFeature({
       set({ chaptersCues, thumbnailCues, thumbnailTrackSrc, textTrackList, subtitlesShowing });
     };
 
+    // Subscribe to addtrack / removetrack / change on the current textTracks
+    // object. Called once at attach and again on each loadstart because iframe
+    // providers (Vimeo, YouTube) replace the underlying TextTrackList when the
+    // src changes — the previous reference becomes stale.
+    const subscribeTrackList = () => {
+      trackListCleanup?.abort();
+      trackListCleanup = new AbortController();
+      const textTracks = media.textTracks;
+      if (textTracks instanceof EventTarget) {
+        listen(textTracks, 'addtrack', sync, { signal: trackListCleanup.signal });
+        listen(textTracks, 'removetrack', sync, { signal: trackListCleanup.signal });
+        listen(textTracks, 'change', sync, { signal: trackListCleanup.signal });
+      }
+    };
+
     sync();
+    subscribeTrackList();
 
-    const textTracks = media.textTracks;
-    if (textTracks instanceof EventTarget) {
-      listen(textTracks, 'addtrack', sync, { signal });
-      listen(textTracks, 'removetrack', sync, { signal });
-      listen(textTracks, 'change', sync, { signal });
-    }
-    listen(media, 'loadstart', sync, { signal });
+    listen(
+      media,
+      'loadstart',
+      () => {
+        subscribeTrackList();
+        sync();
+      },
+      { signal }
+    );
 
-    signal.addEventListener('abort', () => trackCleanup?.abort(), { once: true });
+    signal.addEventListener(
+      'abort',
+      () => {
+        trackListCleanup?.abort();
+        trackCleanup?.abort();
+      },
+      { once: true }
+    );
   },
 });

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -17,6 +17,7 @@ const createConfig = (mode: BuildMode): UserConfig => ({
     'dom/media/native-hls/index': './src/dom/media/native-hls/index.ts',
     'dom/media/simple-hls/index': './src/dom/media/simple-hls/index.ts',
     'dom/media/vimeo/index': './src/dom/media/vimeo/index.ts',
+    'dom/media/youtube/index': './src/dom/media/youtube/index.ts',
   },
   platform: 'neutral',
   format: 'es',

--- a/packages/html/src/define/media/youtube-video.ts
+++ b/packages/html/src/define/media/youtube-video.ts
@@ -1,0 +1,14 @@
+import { YouTubeVideo } from '../../media/youtube-video';
+import { safeDefine } from '../safe-define';
+
+export class YouTubeVideoElement extends YouTubeVideo {
+  static readonly tagName = 'youtube-video';
+}
+
+safeDefine(YouTubeVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [YouTubeVideoElement.tagName]: YouTubeVideoElement;
+  }
+}

--- a/packages/html/src/media/youtube-video/index.ts
+++ b/packages/html/src/media/youtube-video/index.ts
@@ -1,0 +1,93 @@
+import type { Media } from '@videojs/core/dom';
+import { YouTubeMedia, youTubeMediaDefaultProps } from '@videojs/core/dom/media/youtube';
+import { isUndefined } from '@videojs/utils/predicate';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+const OBSERVED_ATTRIBUTES = [
+  'src',
+  'autoplay',
+  'controls',
+  'loop',
+  'muted',
+  'playsinline',
+  'nocookie',
+  'start',
+] as const;
+
+type ObservedAttribute = (typeof OBSERVED_ATTRIBUTES)[number];
+
+const ATTR_TO_PROP: Record<ObservedAttribute, string> = {
+  src: 'src',
+  autoplay: 'autoplay',
+  controls: 'controls',
+  loop: 'loop',
+  muted: 'muted',
+  playsinline: 'playsinline',
+  nocookie: 'nocookie',
+  start: 'start',
+};
+
+function parseAttrValue(attr: ObservedAttribute, value: string | null): unknown {
+  const defaultValue = (youTubeMediaDefaultProps as unknown as Record<string, unknown>)[attr];
+  if (isUndefined(value) || value === null) return defaultValue;
+  if (typeof defaultValue === 'boolean') return value !== 'false';
+  if (typeof defaultValue === 'number') return Number(value) || defaultValue;
+  return value;
+}
+
+export class YouTubeVideo extends MediaAttachMixin(HTMLElement) {
+  static get observedAttributes(): string[] {
+    return [...OBSERVED_ATTRIBUTES];
+  }
+
+  #media = new YouTubeMedia();
+  #container: HTMLDivElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        :host { display: block; height: 100%; overflow: hidden; border-radius: inherit; }
+        div { width: 100%; height: 100%; position: relative; }
+        div > iframe { width: 100%; height: 100%; border: none; display: block; }
+      </style>
+      <div></div>
+    `;
+    this.#container = shadow.querySelector('div')!;
+  }
+
+  // Register YouTubeMedia (not `this`) with the player store.
+  getMediaTarget(): Media | null {
+    return this.#media as unknown as Media;
+  }
+
+  connectedCallback() {
+    // The mixin adds connectedCallback to the runtime prototype; call it to
+    // register YouTubeMedia with the store context.
+    // @ts-expect-error -- connectedCallback is on the mixin prototype, not HTMLElement's TS type
+    super.connectedCallback?.();
+    this.#media.attach(this.#container);
+    // Sync any attributes that were set before connection.
+    for (const attr of OBSERVED_ATTRIBUTES) {
+      const value = this.getAttribute(attr);
+      if (value !== null) this.#syncAttr(attr, value);
+    }
+  }
+
+  disconnectedCallback() {
+    // @ts-expect-error -- disconnectedCallback is on the mixin prototype, not HTMLElement's TS type
+    super.disconnectedCallback?.();
+    this.#media.detach();
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, next: string | null) {
+    this.#syncAttr(name as ObservedAttribute, next);
+  }
+
+  #syncAttr(attr: ObservedAttribute, value: string | null) {
+    const prop = ATTR_TO_PROP[attr];
+    if (!prop) return;
+    (this.#media as unknown as Record<string, unknown>)[prop] = parseAttrValue(attr, value);
+  }
+}

--- a/packages/react/src/media/youtube-video/index.tsx
+++ b/packages/react/src/media/youtube-video/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { YouTubeMediaProps } from '@videojs/core/dom/media/youtube';
+import { YouTubeMedia, youTubeMediaDefaultProps } from '@videojs/core/dom/media/youtube';
+import { cn } from '@videojs/utils/style';
+import type { HTMLAttributes, ReactNode, RefCallback } from 'react';
+import { forwardRef, useCallback } from 'react';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface YouTubeVideoProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, keyof YouTubeMediaProps>,
+    Partial<YouTubeMediaProps> {
+  children?: ReactNode;
+}
+
+export const YouTubeVideo = forwardRef<HTMLDivElement, YouTubeVideoProps>(function YouTubeVideo(
+  { children, ...props },
+  ref
+) {
+  const media = useMediaInstance(YouTubeMedia);
+
+  // YouTubeMedia targets an HTMLElement container (not HTMLMediaElement), so we
+  // inline the attach callback instead of using useAttachMedia.
+  const attachRef: RefCallback<HTMLDivElement> = useCallback(
+    (element) => {
+      if (element) media.attach(element);
+      else media.detach();
+      return () => media.detach();
+    },
+    [media]
+  );
+
+  const composedRef = useComposedRefs(attachRef, ref);
+  const htmlProps = useSyncProps(media, props, youTubeMediaDefaultProps);
+
+  return (
+    <div ref={composedRef} {...htmlProps} className={cn('media-youtube', htmlProps.className)}>
+      {children}
+    </div>
+  );
+});
+
+export namespace YouTubeVideo {
+  export type Props = YouTubeVideoProps;
+}

--- a/packages/skins/src/default/css/components/media.css
+++ b/packages/skins/src/default/css/components/media.css
@@ -4,6 +4,7 @@
 
 .media-default-skin ::slotted(video),
 .media-default-skin ::slotted(vimeo-video),
+.media-default-skin ::slotted(youtube-video),
 .media-default-skin video,
 .media-default-skin .media-vimeo,
 .media-default-skin .media-youtube {
@@ -15,6 +16,7 @@
 }
 .media-default-skin ::slotted(video),
 .media-default-skin ::slotted(vimeo-video),
+.media-default-skin ::slotted(youtube-video),
 .media-default-skin .media-vimeo,
 .media-default-skin .media-youtube {
   overflow: hidden;
@@ -26,6 +28,7 @@
 
 .media-default-skin:fullscreen ::slotted(video),
 .media-default-skin:fullscreen ::slotted(vimeo-video),
+.media-default-skin:fullscreen ::slotted(youtube-video),
 .media-default-skin:fullscreen video,
 .media-default-skin:fullscreen .media-vimeo,
 .media-default-skin:fullscreen .media-youtube {

--- a/packages/skins/src/default/css/components/media.css
+++ b/packages/skins/src/default/css/components/media.css
@@ -5,7 +5,8 @@
 .media-default-skin ::slotted(video),
 .media-default-skin ::slotted(vimeo-video),
 .media-default-skin video,
-.media-default-skin .media-vimeo {
+.media-default-skin .media-vimeo,
+.media-default-skin .media-youtube {
   display: block;
   width: 100%;
   height: 100%;
@@ -14,7 +15,8 @@
 }
 .media-default-skin ::slotted(video),
 .media-default-skin ::slotted(vimeo-video),
-.media-default-skin .media-vimeo {
+.media-default-skin .media-vimeo,
+.media-default-skin .media-youtube {
   overflow: hidden;
   border-radius: var(--media-video-border-radius);
 }
@@ -25,6 +27,7 @@
 .media-default-skin:fullscreen ::slotted(video),
 .media-default-skin:fullscreen ::slotted(vimeo-video),
 .media-default-skin:fullscreen video,
-.media-default-skin:fullscreen .media-vimeo {
+.media-default-skin:fullscreen .media-vimeo,
+.media-default-skin:fullscreen .media-youtube {
   object-fit: contain;
 }

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -36,6 +36,11 @@ export const root = (isShadowDOM: boolean) =>
       '[&_.media-vimeo]:block [&_.media-vimeo]:w-full [&_.media-vimeo]:h-full [&_.media-vimeo]:overflow-hidden [&_.media-vimeo]:rounded-(--media-video-border-radius)':
         !isShadowDOM,
     },
+    // YouTube embed element
+    {
+      '[&_.media-youtube]:block [&_.media-youtube]:w-full [&_.media-youtube]:h-full [&_.media-youtube]:overflow-hidden [&_.media-youtube]:rounded-(--media-video-border-radius)':
+        !isShadowDOM,
+    },
     '[--media-spring-timing-function:linear(0,0.034_1.5%,0.763_9.7%,1.066_13.9%,1.198_19.9%,1.184_21.8%,0.963_37.5%,0.997_50.9%,1)]',
     '[--media-video-border-radius:var(--media-border-radius,2rem)]',
     '[--media-controls-transition-duration:100ms]',

--- a/packages/skins/src/minimal/css/components/media.css
+++ b/packages/skins/src/minimal/css/components/media.css
@@ -4,6 +4,7 @@
 
 .media-minimal-skin ::slotted(video),
 .media-minimal-skin ::slotted(vimeo-video),
+.media-minimal-skin ::slotted(youtube-video),
 .media-minimal-skin video,
 .media-minimal-skin .media-vimeo,
 .media-minimal-skin .media-youtube {
@@ -15,6 +16,7 @@
 }
 .media-minimal-skin ::slotted(video),
 .media-minimal-skin ::slotted(vimeo-video),
+.media-minimal-skin ::slotted(youtube-video),
 .media-minimal-skin .media-vimeo,
 .media-minimal-skin .media-youtube {
   overflow: hidden;
@@ -26,6 +28,7 @@
 
 .media-minimal-skin:fullscreen ::slotted(video),
 .media-minimal-skin:fullscreen ::slotted(vimeo-video),
+.media-minimal-skin:fullscreen ::slotted(youtube-video),
 .media-minimal-skin:fullscreen video,
 .media-minimal-skin:fullscreen .media-vimeo,
 .media-minimal-skin:fullscreen .media-youtube {

--- a/packages/skins/src/minimal/css/components/media.css
+++ b/packages/skins/src/minimal/css/components/media.css
@@ -5,7 +5,8 @@
 .media-minimal-skin ::slotted(video),
 .media-minimal-skin ::slotted(vimeo-video),
 .media-minimal-skin video,
-.media-minimal-skin .media-vimeo {
+.media-minimal-skin .media-vimeo,
+.media-minimal-skin .media-youtube {
   display: block;
   width: 100%;
   height: 100%;
@@ -14,7 +15,8 @@
 }
 .media-minimal-skin ::slotted(video),
 .media-minimal-skin ::slotted(vimeo-video),
-.media-minimal-skin .media-vimeo {
+.media-minimal-skin .media-vimeo,
+.media-minimal-skin .media-youtube {
   overflow: hidden;
   border-radius: var(--media-video-border-radius);
 }
@@ -25,6 +27,7 @@
 .media-minimal-skin:fullscreen ::slotted(video),
 .media-minimal-skin:fullscreen ::slotted(vimeo-video),
 .media-minimal-skin:fullscreen video,
-.media-minimal-skin:fullscreen .media-vimeo {
+.media-minimal-skin:fullscreen .media-vimeo,
+.media-minimal-skin:fullscreen .media-youtube {
   object-fit: contain;
 }

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -33,6 +33,11 @@ export const root = (isShadowDOM: boolean) =>
       '[&_.media-vimeo]:block [&_.media-vimeo]:w-full [&_.media-vimeo]:h-full [&_.media-vimeo]:overflow-hidden [&_.media-vimeo]:rounded-(--media-video-border-radius)':
         !isShadowDOM,
     },
+    // YouTube embed element
+    {
+      '[&_.media-youtube]:block [&_.media-youtube]:w-full [&_.media-youtube]:h-full [&_.media-youtube]:overflow-hidden [&_.media-youtube]:rounded-(--media-video-border-radius)':
+        !isShadowDOM,
+    },
     '[--media-video-border-radius:var(--media-border-radius,0.75rem)]',
     '[--media-controls-background-color:transparent]',
     '[--media-controls-transition-duration:100ms]',


### PR DESCRIPTION
### Summary

Adds a full YouTube embed provider — `YouTubeMedia` (core), `YouTubeVideo` custom element (html), and `YoutubeVideo` React component (react) — and extracts a shared `IframeMediaHost` base class that both YouTube and Vimeo now extend.

Also fixes a bug where iframe providers created a new `TextTrackList` on every `src` change, leaving stale listeners on the old list.

---

### What's included

#### New: YouTube provider
- **`packages/core/src/dom/media/youtube/index.ts`** — `YouTubeMedia`: full `MediaEngineHost` implementation over the YouTube IFrame Player API
  - Parses video IDs, watch URLs, Shorts URLs, playlist URLs, and live stream URLs
  - CSS crop trick to hide YouTube title/branding bars when native controls are disabled
  - Polling-based `timeupdate` (250 ms) — the YouTube SDK doesn't emit these natively
  - Seek synthesis with 600 ms fallback for buffered positions
  - Synthetic caption tracks via `getOption('captions', 'tracklist')`
  - YouTube error code → `MediaError` mapping
  - Supported props: `src`, `autoplay`, `controls`, `loop`, `muted`, `playsinline`, `nocookie`, `start`
- **`packages/core/src/dom/media/youtube/api.ts`** — lightweight IFrame API loader with module-level caching and multi-player callback chaining
- **`packages/html/src/media/youtube-video/`** — `YouTubeVideo` custom element (Shadow DOM, observed attributes)
- **`packages/react/src/media/youtube-video/`** — `YoutubeVideo` React component (`useMediaInstance`, `useSyncProps`, `useComposedRefs`)
- **`packages/core/src/dom/media/youtube/tests/youtube-media.test.ts`** — ~690-line test suite

#### Refactor: shared `IframeMediaHost`
- **`packages/core/src/dom/media/iframe-host.ts`** — abstract base class extracted from the Vimeo provider
  - Manages playback state cache (paused, ended, duration, currentTime, buffered, readyState, volume, muted, playbackRate, seeking, pip, error)
  - Overlay div pattern to prevent iframe pointer events from blocking controls
  - PiP support via `requestPictureInPicture` postMessage for Safari
  - Synthetic `TextTrackList` management
  - Lifecycle: `attach` / `detach` / `destroy`
- **`packages/core/src/dom/media/vimeo/index.ts`** — simplified ~320 lines by extending `IframeMediaHost`
- **`packages/html/src/media/vimeo-video/`** — new HTML custom element for Vimeo (parallel to YouTube)

#### Bug fix: stale `TextTrackList` for iframe providers
- **`packages/core/src/dom/store/features/text-track.ts`** — re-subscribes to track list events (`addtrack`, `removetrack`, `change`) on every `loadstart`, using an `AbortController` to clean up the previous subscription before attaching to the new list

#### Sandbox / demos
- `html-youtube-video` and `react-youtube-video` sandbox templates
- `html-vimeo-video` and `react-vimeo-video` sandbox templates (Vimeo was missing React)
- Navbar and source picker updated to include YouTube entries

---

### Architecture notes

- **Embed-only props** (`autoplay`, `controls`, `loop`, `nocookie`, `start`) require an iframe remount on change; runtime props (`muted`, `volume`, `playbackRate`) delegate to the SDK directly
- YouTube's `loop` param requires `playlist` to be set to the same video ID — handled automatically
- `nocookie` defaults to `false` (opt-in) so URLs stay consistent with what users provide
- The CSS crop technique offsets and clips the iframe to hide YouTube's title bar and bottom branding without stretching
