### PR TITLE
docs(packages): ship skin eject discoverability via JSDoc @see links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,6 +528,8 @@ Skins — preset components that compose primitives into a complete player exper
 /**
  * Default video player skin with a complete media UI.
  *
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
+ *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function VideoSkin(props: VideoSkinProps): ReactNode;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,6 +520,21 @@ export type FeatureAvailability = 'available' | 'unavailable' | 'unsupported';
 - Multi-overload functions get per-overload JSDoc with `@label` tags (not a single JSDoc block).
 - `@public` opts in exports that don't match naming conventions.
 
+### Skin JSDoc
+
+Skins — preset components that compose primitives into a complete player experience — carry an `@see` link in their JSDoc that points to the published skins guide. The URL ships discoverability into the `.d.ts` so IDE hover-docs, generated reference pages, and AI coding agents surface the guide alongside the symbol.
+
+```ts
+/**
+ * Default video player skin with a complete media UI.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
+export function VideoSkin(props: VideoSkinProps): ReactNode;
+```
+
+The `@see` target must already exist. Tailwind variants share the body of their non-Tailwind sibling and add a one-liner noting the variant.
+
 ## Design Documents
 
 | Location              | Purpose                                                    |

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -125,8 +125,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<audio-minimal-skin>` — pared-down audio player skin.
+ *
+ * Same template as `<audio-minimal-skin>` but with Tailwind utility classes instead of a bundled
+ * stylesheet. To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-time-slider>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalAudioSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'audio-minimal-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -129,8 +129,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<audio-minimal-skin>` — pared-down audio player skin.
  *
  * Same template as `<audio-minimal-skin>` but with Tailwind utility classes instead of a bundled
- * stylesheet. To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-time-slider>`.
+ * stylesheet. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -107,9 +107,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Pared-down audio player skin web component with a minimal audio UI.
+ *
+ * Smaller than `<audio-skin>` — drops menus and tooltips. To customize beyond
+ * this preset, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-time-slider>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalAudioSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'audio-minimal-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -110,9 +110,7 @@ function getTemplateHTML() {
 /**
  * Pared-down audio player skin web component with a minimal audio UI.
  *
- * Smaller than `<audio-skin>` — drops menus and tooltips. To customize beyond
- * this preset, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-time-slider>`.
+ * Smaller than `<audio-skin>` — drops menus and tooltips. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -124,8 +124,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<audio-skin>` — default audio player skin with a complete audio UI.
  *
  * Same template as `<audio-skin>` but with Tailwind utility classes instead of a bundled
- * stylesheet, so consumers can theme via Tailwind tokens. To customize, build from primitive
- * elements like `<media-controls>`, `<media-play-button>`, and `<media-time-slider>`.
+ * stylesheet, so consumers can theme via Tailwind tokens. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -120,8 +120,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<audio-skin>` — default audio player skin with a complete audio UI.
+ *
+ * Same template as `<audio-skin>` but with Tailwind utility classes instead of a bundled
+ * stylesheet, so consumers can theme via Tailwind tokens. To customize, build from primitive
+ * elements like `<media-controls>`, `<media-play-button>`, and `<media-time-slider>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class AudioSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'audio-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -119,9 +119,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Default audio player skin web component with a complete audio UI.
+ *
+ * To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-time-slider>` instead of using
+ * this preset.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class AudioSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'audio-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -122,9 +122,7 @@ function getTemplateHTML() {
 /**
  * Default audio player skin web component with a complete audio UI.
  *
- * To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-time-slider>` instead of using
- * this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/background/player.ts
+++ b/packages/html/src/define/background/player.ts
@@ -8,7 +8,9 @@ const { ProviderMixin } = createPlayer({
   features: backgroundFeatures,
 });
 
+/** Custom element shell for the `<background-video-player>` tag — provides the player context and store. */
 export class BackgroundVideoPlayerElement extends ProviderMixin(MediaElement) {
+  /** Custom element tag name. */
   static readonly tagName = 'background-video-player';
 }
 

--- a/packages/html/src/define/background/skin.ts
+++ b/packages/html/src/define/background/skin.ts
@@ -15,9 +15,20 @@ function getTemplateHTML(_attrs: Record<string, string>) {
   `;
 }
 
+/**
+ * Background video skin web component — a minimal container with no user-facing UI.
+ *
+ * Used to render ambient/looping video. To customize, place a `<background-video>` (or any
+ * `Media` element) inside `<background-video-player>` directly instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class BackgroundVideoSkinElement extends ReactiveElement {
+  /** Custom element tag name. */
   static readonly tagName = 'background-video-skin';
+  /** Shadow DOM options applied during construction. */
   static shadowRootOptions = { mode: 'open' as ShadowRootMode };
+  /** Builds the shadow DOM HTML from the host's attributes. */
   static getTemplateHTML = getTemplateHTML;
 
   constructor() {

--- a/packages/html/src/define/background/skin.ts
+++ b/packages/html/src/define/background/skin.ts
@@ -18,8 +18,7 @@ function getTemplateHTML(_attrs: Record<string, string>) {
 /**
  * Background video skin web component — a minimal container with no user-facing UI.
  *
- * Used to render ambient/looping video. To customize, place a `<background-video>` (or any
- * `Media` element) inside `<background-video-player>` directly instead of using this preset.
+ * Used to render ambient/looping video. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -74,8 +74,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<live-audio-minimal-skin>` — pared-down live audio player skin.
+ *
+ * Same template as `<live-audio-minimal-skin>` but with Tailwind utility classes instead of a
+ * bundled stylesheet. To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-live-button>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalLiveAudioSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-audio-minimal-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -78,8 +78,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<live-audio-minimal-skin>` — pared-down live audio player skin.
  *
  * Same template as `<live-audio-minimal-skin>` but with Tailwind utility classes instead of a
- * bundled stylesheet. To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-live-button>`.
+ * bundled stylesheet. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -63,9 +63,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Pared-down live audio player skin web component with a minimal audio UI and a Live button.
+ *
+ * Smaller than `<live-audio-skin>` — drops menus and tooltips. To customize beyond this preset,
+ * build from primitive elements like `<media-controls>`, `<media-play-button>`, and
+ * `<media-live-button>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalLiveAudioSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-audio-minimal-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -66,9 +66,7 @@ function getTemplateHTML() {
 /**
  * Pared-down live audio player skin web component with a minimal audio UI and a Live button.
  *
- * Smaller than `<live-audio-skin>` — drops menus and tooltips. To customize beyond this preset,
- * build from primitive elements like `<media-controls>`, `<media-play-button>`, and
- * `<media-live-button>`.
+ * Smaller than `<live-audio-skin>` — drops menus and tooltips. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -74,8 +74,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<live-audio-skin>` — default live audio player skin with a Live button.
+ *
+ * Same template as `<live-audio-skin>` but with Tailwind utility classes instead of a bundled
+ * stylesheet. To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-live-button>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class LiveAudioSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-audio-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -78,8 +78,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<live-audio-skin>` — default live audio player skin with a Live button.
  *
  * Same template as `<live-audio-skin>` but with Tailwind utility classes instead of a bundled
- * stylesheet. To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-live-button>`.
+ * stylesheet. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-audio/skin.ts
+++ b/packages/html/src/define/live-audio/skin.ts
@@ -70,9 +70,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Default live audio player skin web component with a complete audio UI and a Live button.
+ *
+ * To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-live-button>` instead of using
+ * this preset.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class LiveAudioSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-audio-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-audio/skin.ts
+++ b/packages/html/src/define/live-audio/skin.ts
@@ -73,9 +73,7 @@ function getTemplateHTML() {
 /**
  * Default live audio player skin web component with a complete audio UI and a Live button.
  *
- * To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-live-button>` instead of using
- * this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -161,8 +161,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<live-video-minimal-skin>` — pared-down live video player skin.
  *
  * Same template as `<live-video-minimal-skin>` but with Tailwind utility classes instead of a
- * bundled stylesheet. To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-live-button>`.
+ * bundled stylesheet. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -157,8 +157,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<live-video-minimal-skin>` — pared-down live video player skin.
+ *
+ * Same template as `<live-video-minimal-skin>` but with Tailwind utility classes instead of a
+ * bundled stylesheet. To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-live-button>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalLiveVideoSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-video-minimal-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -148,9 +148,7 @@ function getTemplateHTML() {
 /**
  * Pared-down live video player skin web component with a minimal media UI and a Live button.
  *
- * Smaller than `<live-video-skin>` — drops menus and tooltips. To customize beyond this preset,
- * build from primitive elements like `<media-controls>`, `<media-play-button>`, and
- * `<media-live-button>`.
+ * Smaller than `<live-video-skin>` — drops menus and tooltips. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -145,9 +145,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Pared-down live video player skin web component with a minimal media UI and a Live button.
+ *
+ * Smaller than `<live-video-skin>` — drops menus and tooltips. To customize beyond this preset,
+ * build from primitive elements like `<media-controls>`, `<media-play-button>`, and
+ * `<media-live-button>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalLiveVideoSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-video-minimal-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -158,8 +158,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<live-video-skin>` — default live video player skin with a Live button.
+ *
+ * Same template as `<live-video-skin>` but with Tailwind utility classes instead of a bundled
+ * stylesheet. To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-live-button>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class LiveVideoSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-video-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -162,8 +162,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<live-video-skin>` — default live video player skin with a Live button.
  *
  * Same template as `<live-video-skin>` but with Tailwind utility classes instead of a bundled
- * stylesheet. To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-live-button>`.
+ * stylesheet. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -149,9 +149,7 @@ function getTemplateHTML() {
 /**
  * Default live video player skin web component with a complete media UI and a Live button.
  *
- * To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-live-button>` instead of using
- * this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -146,9 +146,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Default live video player skin web component with a complete media UI and a Live button.
+ *
+ * To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-live-button>` instead of using
+ * this preset.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class LiveVideoSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'live-video-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/media/background-video.ts
+++ b/packages/html/src/define/media/background-video.ts
@@ -1,7 +1,9 @@
 import { BackgroundVideo } from '../../media/background-video';
 import { safeDefine } from '../safe-define';
 
+/** Custom element shell for the `<background-video>` tag — muted, looping, autoplaying ambient video. */
 export class BackgroundVideoElement extends BackgroundVideo {
+  /** Custom element tag name. */
   static readonly tagName = 'background-video';
 }
 

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -234,8 +234,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<video-minimal-skin>` — pared-down video player skin.
+ *
+ * Same template as `<video-minimal-skin>` but with Tailwind utility classes instead of a bundled
+ * stylesheet. To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-time-slider>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalVideoSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'video-minimal-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -238,8 +238,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<video-minimal-skin>` — pared-down video player skin.
  *
  * Same template as `<video-minimal-skin>` but with Tailwind utility classes instead of a bundled
- * stylesheet. To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-time-slider>`.
+ * stylesheet. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -214,9 +214,7 @@ function getTemplateHTML() {
 /**
  * Pared-down video player skin web component with a minimal media UI.
  *
- * Smaller than `<video-skin>` — drops menus, tooltips, and the volume popover.
- * To customize beyond this preset, build from primitive elements like
- * `<media-controls>`, `<media-play-button>`, and `<media-time-slider>`.
+ * Smaller than `<video-skin>` — drops menus, tooltips, and the volume popover. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -211,9 +211,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Pared-down video player skin web component with a minimal media UI.
+ *
+ * Smaller than `<video-skin>` — drops menus, tooltips, and the volume popover.
+ * To customize beyond this preset, build from primitive elements like
+ * `<media-controls>`, `<media-play-button>`, and `<media-time-slider>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class MinimalVideoSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'video-minimal-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -228,8 +228,19 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Tailwind-styled variant of `<video-skin>` — default video player skin with a complete media UI.
+ *
+ * Same template as `<video-skin>` but with Tailwind utility classes instead of a bundled
+ * stylesheet, so consumers can theme via Tailwind tokens. To customize, build from primitive
+ * elements like `<media-controls>`, `<media-play-button>`, and `<media-time-slider>`.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class VideoSkinTailwindElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'video-skin-tailwind';
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -232,8 +232,7 @@ function getTemplateHTML() {
  * Tailwind-styled variant of `<video-skin>` — default video player skin with a complete media UI.
  *
  * Same template as `<video-skin>` but with Tailwind utility classes instead of a bundled
- * stylesheet, so consumers can theme via Tailwind tokens. To customize, build from primitive
- * elements like `<media-controls>`, `<media-play-button>`, and `<media-time-slider>`.
+ * stylesheet, so consumers can theme via Tailwind tokens. To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -207,9 +207,21 @@ function getTemplateHTML() {
   `;
 }
 
+/**
+ * Default video player skin web component with a complete media UI.
+ *
+ * To customize, build from primitive elements like `<media-controls>`,
+ * `<media-play-button>`, and `<media-time-slider>` instead of using
+ * this preset.
+ *
+ * @see https://videojs.org/docs/framework/html/concepts/skins
+ */
 export class VideoSkinElement extends SkinElement {
+  /** Custom element tag name. */
   static readonly tagName = 'video-skin';
+  /** Shadow DOM stylesheet shared across all instances. */
   static styles = createShadowStyle(styles);
+  /** Shadow DOM template cloned into each instance. */
   static template = createTemplate(getTemplateHTML());
 }
 

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -210,9 +210,7 @@ function getTemplateHTML() {
 /**
  * Default video player skin web component with a complete media UI.
  *
- * To customize, build from primitive elements like `<media-controls>`,
- * `<media-play-button>`, and `<media-time-slider>` instead of using
- * this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/html/concepts/skins
  */

--- a/packages/react/src/media/background-video/index.tsx
+++ b/packages/react/src/media/background-video/index.tsx
@@ -8,6 +8,7 @@ import { useComposedRefs } from '../../utils/use-composed-refs';
 
 export interface BackgroundVideoProps extends VideoHTMLAttributes<HTMLVideoElement> {}
 
+/** Renders a muted, autoplaying, looping `<video>` element for ambient background use. */
 export const BackgroundVideo = forwardRef<HTMLVideoElement, BackgroundVideoProps>(function BackgroundVideo(
   { children, ...props },
   ref

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -142,8 +142,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Minimal audio player skin (Tailwind-styled variant of `<MinimalAudioSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -139,6 +139,14 @@ function PlaybackRateMenuItems(): ReactNode {
 
 /* ------------------------------------------ Skin ------------------------------------------- */
 
+/**
+ * Minimal audio player skin (Tailwind-styled variant of `<MinimalAudioSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
 

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -89,8 +89,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Minimal audio player skin with a stripped-back media UI.
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -86,6 +86,14 @@ function PlaybackRateMenuItems(): ReactNode {
   );
 }
 
+/**
+ * Minimal audio player skin with a stripped-back media UI.
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
 

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -141,6 +141,14 @@ function PlaybackRateMenuItems(): ReactNode {
 
 /* ------------------------------------------ Skin ------------------------------------------- */
 
+/**
+ * Default audio player skin (Tailwind-styled variant of `<AudioSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
 

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -144,8 +144,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Default audio player skin (Tailwind-styled variant of `<AudioSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -89,8 +89,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Default audio player skin with a complete media UI.
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -86,6 +86,14 @@ function PlaybackRateMenuItems(): ReactNode {
   );
 }
 
+/**
+ * Default audio player skin with a complete media UI.
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function AudioSkin(props: AudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
 

--- a/packages/react/src/presets/background/skin.tsx
+++ b/packages/react/src/presets/background/skin.tsx
@@ -3,6 +3,14 @@ import type { BaseSkinProps } from '../types';
 
 export type BackgroundVideoSkinProps = BaseSkinProps;
 
+/**
+ * Ambient background video skin with no user controls.
+ *
+ * To customize, render `<BackgroundVideo>` directly inside your own wrapper
+ * instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function BackgroundVideoSkin(props: BackgroundVideoSkinProps) {
   const { children, className, ...rest } = props;
   return (

--- a/packages/react/src/presets/background/skin.tsx
+++ b/packages/react/src/presets/background/skin.tsx
@@ -6,8 +6,7 @@ export type BackgroundVideoSkinProps = BaseSkinProps;
 /**
  * Ambient background video skin with no user controls.
  *
- * To customize, render `<BackgroundVideo>` directly inside your own wrapper
- * instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -98,8 +98,7 @@ function VolumePopover(): ReactNode {
 /**
  * Minimal live audio player skin (Tailwind-styled variant of `<MinimalLiveAudioSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<LiveButton>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -95,6 +95,14 @@ function VolumePopover(): ReactNode {
   );
 }
 
+/**
+ * Minimal live audio player skin (Tailwind-styled variant of `<MinimalLiveAudioSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<LiveButton>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
 

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -60,6 +60,8 @@ function VolumePopover(): ReactNode {
  * duration / remaining time displays. A flexible spacer stretches between
  * the play and volume controls so they sit at opposite edges of the
  * control bar.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -61,6 +61,8 @@ function VolumePopover(): ReactNode {
  * the play and volume controls so they sit at opposite edges of the
  * control bar.
  *
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
+ *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNode {

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -95,6 +95,14 @@ function VolumePopover(): ReactNode {
   );
 }
 
+/**
+ * Default live audio player skin (Tailwind-styled variant of `<LiveAudioSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<LiveButton>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;
 

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -98,8 +98,7 @@ function VolumePopover(): ReactNode {
 /**
  * Default live audio player skin (Tailwind-styled variant of `<LiveAudioSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<LiveButton>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -59,6 +59,8 @@ function VolumePopover(): ReactNode {
  * but omits the time slider and the current / duration time displays. A
  * flexible spacer stretches between the play and volume controls so they
  * sit at opposite edges of the control bar.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
   const { children, className, ...rest } = props;

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -60,6 +60,8 @@ function VolumePopover(): ReactNode {
  * flexible spacer stretches between the play and volume controls so they
  * sit at opposite edges of the control bar.
  *
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
+ *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -134,8 +134,7 @@ function VolumePopover(): ReactNode {
 /**
  * Minimal live video player skin (Tailwind-styled variant of `<MinimalLiveVideoSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<LiveButton>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -131,6 +131,14 @@ function VolumePopover(): ReactNode {
   );
 }
 
+/**
+ * Minimal live video player skin (Tailwind-styled variant of `<MinimalLiveVideoSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<LiveButton>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): ReactNode {
   const { children, className, poster: posterProp, ...rest } = props;
 

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -92,6 +92,8 @@ function VolumePopover(): ReactNode {
  * the start and end button groups so they sit at opposite edges of the
  * control bar.
  *
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
+ *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNode {

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -91,6 +91,8 @@ function VolumePopover(): ReactNode {
  * duration / remaining time displays. A flexible spacer stretches between
  * the start and end button groups so they sit at opposite edges of the
  * control bar.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNode {
   const { children, className, poster, ...rest } = props;

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -134,8 +134,7 @@ function VolumePopover(): ReactNode {
 /**
  * Default live video player skin (Tailwind-styled variant of `<LiveVideoSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<LiveButton>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -131,6 +131,14 @@ function VolumePopover(): ReactNode {
   );
 }
 
+/**
+ * Default live video player skin (Tailwind-styled variant of `<LiveVideoSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<LiveButton>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
   const { children, className, poster: posterProp, ...rest } = props;
 

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -91,6 +91,8 @@ function VolumePopover(): ReactNode {
  * flexible spacer stretches between the start and end button groups so they
  * sit at opposite edges of the control bar.
  *
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
+ *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -90,6 +90,8 @@ function VolumePopover(): ReactNode {
  * but omits the time slider and the duration / current-time displays. A
  * flexible spacer stretches between the start and end button groups so they
  * sit at opposite edges of the control bar.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
  */
 export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
   const { children, className, poster, ...rest } = props;

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -173,6 +173,14 @@ function PlaybackRateMenuItems(): ReactNode {
 
 /* ------------------------------------------ Skin ------------------------------------------- */
 
+/**
+ * Minimal video player skin (Tailwind-styled variant of `<MinimalVideoSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNode {
   const { children, className, poster: posterProp, ...rest } = props;
 

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -176,8 +176,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Minimal video player skin (Tailwind-styled variant of `<MinimalVideoSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -115,8 +115,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Minimal video player skin with a stripped-back media UI.
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -112,6 +112,14 @@ function PlaybackRateMenuItems(): ReactNode {
   );
 }
 
+/**
+ * Minimal video player skin with a stripped-back media UI.
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
   const { children, className, poster, ...rest } = props;
 

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -176,8 +176,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Default video player skin (Tailwind-styled variant of `<VideoSkin>`).
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -173,6 +173,14 @@ function PlaybackRateMenuItems(): ReactNode {
 
 /* ------------------------------------------ Skin ------------------------------------------- */
 
+/**
+ * Default video player skin (Tailwind-styled variant of `<VideoSkin>`).
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
   const { children, className, poster: posterProp, ...rest } = props;
 

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -112,6 +112,14 @@ function PlaybackRateMenuItems(): ReactNode {
   );
 }
 
+/**
+ * Default video player skin with a complete media UI.
+ *
+ * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
+ * and `<TimeSlider>` instead of using this preset.
+ *
+ * @see https://videojs.org/docs/framework/react/concepts/skins
+ */
 export function VideoSkin(props: VideoSkinProps): ReactNode {
   const { children, className, poster, ...rest } = props;
 

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -115,8 +115,7 @@ function PlaybackRateMenuItems(): ReactNode {
 /**
  * Default video player skin with a complete media UI.
  *
- * To customize, build from primitives like `<Controls.Root>`, `<PlayButton>`,
- * and `<TimeSlider>` instead of using this preset.
+ * To customize, eject this skin and build from primitives. Read more about eject in the docs.
  *
  * @see https://videojs.org/docs/framework/react/concepts/skins
  */


### PR DESCRIPTION
## Summary

Adds an `@see` link to every skin's JSDoc pointing to the published `concepts/skins` guide. Ships skin eject discoverability into the `.d.ts` files that AI coding agents read directly.

## Background

[#1558](https://github.com/videojs/v10/issues/1558) surfaced that AI coding agents Read 15–27 distinct `.d.ts` files per Video.js install — they have the type signature in context but not the docs page that explains how to use it. The eject pattern — copy a packaged skin into your project and customize it — was invisible to agents because the skin's `.d.ts` didn't link to the guide. Agents could see `VideoSkin` but not know "eject" was an option.

## What changed

- Every skin variant in `@videojs/react` and `@videojs/html` (including Tailwind siblings) gets `@see https://videojs.org/docs/framework/{react|html}/concepts/skins`.
- Background-video plumbing (`define/background/{skin,player}.ts`, `define/media/background-video.ts`, `react/src/media/background-video/index.tsx`) gets matching JSDoc since it ships as part of the background preset.
- `CLAUDE.md` gets a small **Skin JSDoc** section codifying the convention.

Pure additions — 38 files, +327 / -0.

## Test plan

- [ ] `pnpm -F @videojs/react build && pnpm -F @videojs/html build` — confirm `@see` survives into emitted `.d.ts`
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] CI green

## Relationship to #1570

This is the first slice of [#1570](https://github.com/videojs/v10/pull/1570) — the eject-discoverability portion that fixes the immediate problem from [#1558](https://github.com/videojs/v10/issues/1558) with low review burden. The broader sweep (JSDoc on every public API export across react / html / core, plus the CLAUDE.md rule that justifies it) stays in #1570 for team discussion.

https://claude.ai/code/session_01YDMP31nT51YrdWKSqvkT98

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDMP31nT51YrdWKSqvkT98)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only JSDoc additions that should not affect runtime behavior, with the main risk being accidental TypeScript declaration/doc-generation formatting issues.
> 
> **Overview**
> Adds a new **Skin JSDoc** convention to `CLAUDE.md`, requiring skins to include an `@see` link to the published skins guide so the link is carried into generated `.d.ts` hover/docs.
> 
> Applies that convention across `@videojs/html` and `@videojs/react` by adding JSDoc blocks (including `@see https://videojs.org/docs/framework/{html|react}/concepts/skins`) to all skin exports/variants and to the background-video preset elements (`BackgroundVideo*` web components and the React `BackgroundVideo` component).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3196b0484142d363fe6ea0f4254bacf499e439f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->