### PR TITLE
feat(packages): centralize menu section labels and add SectionLabel parts

### DIFF
--- a/packages/core/src/core/ui/captions-menu/captions-menu-core.ts
+++ b/packages/core/src/core/ui/captions-menu/captions-menu-core.ts
@@ -19,6 +19,11 @@ export interface CaptionsMenuProps {
   formatTrack?: ((track: CaptionsMenuTrack) => string) | undefined;
   /** Custom label for the off option. */
   offLabel?: string | undefined;
+  /**
+   * Section title for the track list (radio group legend) and nested settings row / back button.
+   * Also prefixes the default trigger label when `label` is not set.
+   */
+  menuSectionLabel?: string | undefined;
   /** Whether captions selection is disabled. */
   disabled?: boolean | undefined;
 }
@@ -46,6 +51,7 @@ export class CaptionsMenuCore {
     label: '',
     formatTrack: formatTextTrack,
     offLabel: 'Off',
+    menuSectionLabel: 'Captions',
     disabled: false,
   };
 
@@ -80,7 +86,11 @@ export class CaptionsMenuCore {
     }
 
     const selectedTrack = this.getSelectedTrack(state);
-    return `Captions ${selectedTrack ? this.getTrackLabel(selectedTrack) : this.getOffLabel()}`;
+    return `${this.getMenuSectionLabel()} ${selectedTrack ? this.getTrackLabel(selectedTrack) : this.getOffLabel()}`;
+  }
+
+  getMenuSectionLabel(): string {
+    return this.#props.menuSectionLabel;
   }
 
   getOffLabel(): string {

--- a/packages/core/src/core/ui/captions-menu/captions-menu-core.ts
+++ b/packages/core/src/core/ui/captions-menu/captions-menu-core.ts
@@ -86,7 +86,8 @@ export class CaptionsMenuCore {
     }
 
     const selectedTrack = this.getSelectedTrack(state);
-    return `${this.getMenuSectionLabel()} ${selectedTrack ? this.getTrackLabel(selectedTrack) : this.getOffLabel()}`;
+    const value = selectedTrack ? this.getTrackLabel(selectedTrack) : this.getOffLabel();
+    return `${this.getMenuSectionLabel()}, ${value}`;
   }
 
   getMenuSectionLabel(): string {

--- a/packages/core/src/core/ui/captions-menu/tests/captions-menu-core.test.ts
+++ b/packages/core/src/core/ui/captions-menu/tests/captions-menu-core.test.ts
@@ -75,12 +75,12 @@ describe('CaptionsMenuCore', () => {
         tracks: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'showing', index: 0 }],
       });
 
-      expect(core.getLabel(state)).toBe('Captions English');
+      expect(core.getLabel(state)).toBe('Captions, English');
     });
 
     it('returns default off label when no track is selected', () => {
       const core = new CaptionsMenuCore();
-      expect(core.getLabel(createState())).toBe('Captions Off');
+      expect(core.getLabel(createState())).toBe('Captions, Off');
     });
 
     it('returns custom string label', () => {
@@ -130,7 +130,7 @@ describe('CaptionsMenuCore', () => {
         selectedTrackIndex: 0,
         tracks: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'showing', index: 0 }],
       });
-      expect(core.getLabel(state)).toBe('Subtitles English');
+      expect(core.getLabel(state)).toBe('Subtitles, English');
     });
   });
 
@@ -138,7 +138,7 @@ describe('CaptionsMenuCore', () => {
     it('returns aria-label', () => {
       const core = new CaptionsMenuCore();
       const attrs = core.getAttrs(createState());
-      expect(attrs['aria-label']).toBe('Captions Off');
+      expect(attrs['aria-label']).toBe('Captions, Off');
     });
 
     it('sets aria-disabled when disabled', () => {

--- a/packages/core/src/core/ui/captions-menu/tests/captions-menu-core.test.ts
+++ b/packages/core/src/core/ui/captions-menu/tests/captions-menu-core.test.ts
@@ -115,6 +115,25 @@ describe('CaptionsMenuCore', () => {
     });
   });
 
+  describe('getMenuSectionLabel', () => {
+    it('returns the default section label', () => {
+      expect(new CaptionsMenuCore().getMenuSectionLabel()).toBe('Captions');
+    });
+
+    it('returns a custom section label', () => {
+      expect(new CaptionsMenuCore({ menuSectionLabel: 'Subtitles' }).getMenuSectionLabel()).toBe('Subtitles');
+    });
+
+    it('prefixes the default trigger label using the section label', () => {
+      const core = new CaptionsMenuCore({ menuSectionLabel: 'Subtitles' });
+      const state = createState({
+        selectedTrackIndex: 0,
+        tracks: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'showing', index: 0 }],
+      });
+      expect(core.getLabel(state)).toBe('Subtitles English');
+    });
+  });
+
   describe('getAttrs', () => {
     it('returns aria-label', () => {
       const core = new CaptionsMenuCore();

--- a/packages/core/src/core/ui/playback-rate-menu/playback-rate-menu-core.ts
+++ b/packages/core/src/core/ui/playback-rate-menu/playback-rate-menu-core.ts
@@ -70,7 +70,7 @@ export class PlaybackRateMenuCore {
       return label;
     }
 
-    return `${this.getRadioGroupLabel()} ${state.rate}`;
+    return `${this.getRadioGroupLabel()}, ${this.getRateLabel(state.rate)}`;
   }
 
   getMenuSectionLabel(): string {

--- a/packages/core/src/core/ui/playback-rate-menu/playback-rate-menu-core.ts
+++ b/packages/core/src/core/ui/playback-rate-menu/playback-rate-menu-core.ts
@@ -11,6 +11,14 @@ export interface PlaybackRateMenuProps {
   label?: string | ((state: PlaybackRateMenuState) => string) | undefined;
   /** Custom formatter for visible playback rate labels. */
   formatRate?: ((rate: number) => string) | undefined;
+  /**
+   * Section title for the nested speed row (and back button) when playback rate is in a submenu.
+   */
+  menuSectionLabel?: string | undefined;
+  /**
+   * Accessible label for the rate radio group and default trigger text prefix before the numeric rate.
+   */
+  radioGroupLabel?: string | undefined;
   /** Whether playback rate selection is disabled. */
   disabled?: boolean | undefined;
 }
@@ -29,6 +37,8 @@ export class PlaybackRateMenuCore {
   static readonly defaultProps: NonNullableObject<PlaybackRateMenuProps> = {
     label: '',
     formatRate: formatPlaybackRate,
+    menuSectionLabel: 'Speed',
+    radioGroupLabel: 'Playback rate',
     disabled: false,
   };
 
@@ -60,7 +70,15 @@ export class PlaybackRateMenuCore {
       return label;
     }
 
-    return `Playback rate ${state.rate}`;
+    return `${this.getRadioGroupLabel()} ${state.rate}`;
+  }
+
+  getMenuSectionLabel(): string {
+    return this.#props.menuSectionLabel;
+  }
+
+  getRadioGroupLabel(): string {
+    return this.#props.radioGroupLabel;
   }
 
   getRateLabel(rate: number): string {

--- a/packages/core/src/core/ui/playback-rate-menu/tests/playback-rate-menu-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-menu/tests/playback-rate-menu-core.test.ts
@@ -47,7 +47,7 @@ describe('PlaybackRateMenuCore', () => {
   describe('getLabel', () => {
     it('returns default label with rate', () => {
       const core = new PlaybackRateMenuCore();
-      expect(core.getLabel(createState({ rate: 1.5 }))).toBe('Playback rate 1.5');
+      expect(core.getLabel(createState({ rate: 1.5 }))).toBe('Playback rate, 1.5×');
     });
 
     it('returns custom string label', () => {
@@ -86,7 +86,7 @@ describe('PlaybackRateMenuCore', () => {
 
     it('prefixes the default trigger label with the radio group label', () => {
       const core = new PlaybackRateMenuCore({ radioGroupLabel: 'Rate' });
-      expect(core.getLabel(createState({ rate: 2 }))).toBe('Rate 2');
+      expect(core.getLabel(createState({ rate: 2 }))).toBe('Rate, 2×');
     });
   });
 
@@ -109,7 +109,7 @@ describe('PlaybackRateMenuCore', () => {
     it('returns aria-label', () => {
       const core = new PlaybackRateMenuCore();
       const attrs = core.getAttrs(createState({ rate: 1.5 }));
-      expect(attrs['aria-label']).toBe('Playback rate 1.5');
+      expect(attrs['aria-label']).toBe('Playback rate, 1.5×');
     });
 
     it('sets aria-disabled when disabled', () => {

--- a/packages/core/src/core/ui/playback-rate-menu/tests/playback-rate-menu-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-menu/tests/playback-rate-menu-core.test.ts
@@ -63,6 +63,33 @@ describe('PlaybackRateMenuCore', () => {
     });
   });
 
+  describe('getMenuSectionLabel', () => {
+    it('returns the default section label', () => {
+      expect(new PlaybackRateMenuCore().getMenuSectionLabel()).toBe('Speed');
+    });
+
+    it('returns a custom section label', () => {
+      expect(new PlaybackRateMenuCore({ menuSectionLabel: 'Playback speed' }).getMenuSectionLabel()).toBe(
+        'Playback speed'
+      );
+    });
+  });
+
+  describe('getRadioGroupLabel', () => {
+    it('returns the default radio group label', () => {
+      expect(new PlaybackRateMenuCore().getRadioGroupLabel()).toBe('Playback rate');
+    });
+
+    it('returns a custom radio group label', () => {
+      expect(new PlaybackRateMenuCore({ radioGroupLabel: 'Rate' }).getRadioGroupLabel()).toBe('Rate');
+    });
+
+    it('prefixes the default trigger label with the radio group label', () => {
+      const core = new PlaybackRateMenuCore({ radioGroupLabel: 'Rate' });
+      expect(core.getLabel(createState({ rate: 2 }))).toBe('Rate 2');
+    });
+  });
+
   describe('getRateLabel', () => {
     it('formats rate labels by default', () => {
       const core = new PlaybackRateMenuCore();

--- a/packages/html/src/media/background-video/index.ts
+++ b/packages/html/src/media/background-video/index.ts
@@ -68,8 +68,10 @@ export class BackgroundVideo extends MediaAttachMixin(HTMLElement) {
   }
 
   get target(): HTMLVideoElement | null {
+    const slotted = this.querySelector(':scope > [slot=media]');
+
     return (
-      this.querySelector(':scope > [slot=media]') ??
+      (slotted instanceof HTMLVideoElement ? slotted : null) ??
       this.querySelector('video') ??
       this.shadowRoot?.querySelector('video') ??
       null

--- a/packages/html/src/ui/captions-menu/captions-menu-element.ts
+++ b/packages/html/src/ui/captions-menu/captions-menu-element.ts
@@ -5,6 +5,7 @@ import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MenuElement } from '../menu/menu-element';
+import { syncSectionLabelParts } from '../menu/sync-section-label-parts';
 
 export class CaptionsMenuElement extends MenuElement {
   static override readonly tagName = 'media-captions-menu';
@@ -13,6 +14,7 @@ export class CaptionsMenuElement extends MenuElement {
     ...MenuElement.properties,
     label: { type: String },
     offLabel: { type: String, attribute: 'off-label' },
+    menuSectionLabel: { type: String, attribute: 'menu-section-label' },
     disabled: { type: Boolean },
   } satisfies PropertyDeclarationMap<
     | 'open'
@@ -24,11 +26,13 @@ export class CaptionsMenuElement extends MenuElement {
     | 'boundary'
     | 'label'
     | 'offLabel'
+    | 'menuSectionLabel'
     | 'disabled'
   >;
 
   label = '';
   offLabel = CaptionsMenuCore.defaultProps.offLabel;
+  menuSectionLabel = CaptionsMenuCore.defaultProps.menuSectionLabel;
   disabled = false;
   override align: MenuElement['align'] = 'center';
   formatTrack = CaptionsMenuCore.defaultProps.formatTrack;
@@ -57,6 +61,7 @@ export class CaptionsMenuElement extends MenuElement {
 
     applyElementProps(this, this.#core.getAttrs(state));
     applyStateDataAttrs(this, state, CaptionsMenuDataAttrs);
+    syncSectionLabelParts(this, this.#core.getMenuSectionLabel());
   }
 }
 

--- a/packages/html/src/ui/captions-menu/captions-menu-trigger-element.ts
+++ b/packages/html/src/ui/captions-menu/captions-menu-trigger-element.ts
@@ -5,6 +5,7 @@ import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaElement } from '../media-element';
+import { syncSectionLabelParts } from '../menu/sync-section-label-parts';
 
 export class CaptionsMenuTriggerElement extends MediaElement {
   static readonly tagName = 'media-captions-menu-trigger';
@@ -12,12 +13,14 @@ export class CaptionsMenuTriggerElement extends MediaElement {
   static override properties = {
     label: { type: String },
     offLabel: { type: String, attribute: 'off-label' },
+    menuSectionLabel: { type: String, attribute: 'menu-section-label' },
     disabled: { type: Boolean },
     commandfor: { type: String },
-  } satisfies PropertyDeclarationMap<'label' | 'offLabel' | 'disabled' | 'commandfor'>;
+  } satisfies PropertyDeclarationMap<'label' | 'offLabel' | 'menuSectionLabel' | 'disabled' | 'commandfor'>;
 
   label = '';
   offLabel = CaptionsMenuCore.defaultProps.offLabel;
+  menuSectionLabel = CaptionsMenuCore.defaultProps.menuSectionLabel;
   disabled = false;
   commandfor: string | undefined = undefined;
   formatTrack = CaptionsMenuCore.defaultProps.formatTrack;
@@ -72,6 +75,7 @@ export class CaptionsMenuTriggerElement extends MediaElement {
       tabIndex: 0,
       ...this.#core.getAttrs(state),
     });
+    syncSectionLabelParts(this, this.#core.getMenuSectionLabel());
     applyStateDataAttrs(this, state, CaptionsMenuDataAttrs);
   }
 

--- a/packages/html/src/ui/captions-menu/captions-options-element.ts
+++ b/packages/html/src/ui/captions-menu/captions-options-element.ts
@@ -55,7 +55,7 @@ export class CaptionsOptionsElement extends MenuRadioGroupElement {
       state = this.#core.getState();
 
       this.value = this.#core.getTrackValue(state.selectedTrackIndex);
-      this.label = this.label || 'Captions';
+      this.label = this.label || this.#core.getMenuSectionLabel();
       this.#syncContent(state);
     }
 

--- a/packages/html/src/ui/captions-menu/tests/captions-menu-element.test.ts
+++ b/packages/html/src/ui/captions-menu/tests/captions-menu-element.test.ts
@@ -1,14 +1,16 @@
 import type { MediaTextTrackState } from '@videojs/core';
 import type { AnyPlayerStore } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
-import { createStore } from '@videojs/store';
+import { createStore, type WritableState } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
 import { MediaElement } from '../../media-element';
+import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
 import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
+import { MenuViewElement } from '../../menu/menu-view-element';
 import { CaptionsMenuElement } from '../captions-menu-element';
 import { CaptionsMenuTriggerElement } from '../captions-menu-trigger-element';
 import { CaptionsOptionsElement } from '../captions-options-element';
@@ -135,6 +137,30 @@ function setup({
   return { menu, options, provider, store, trigger };
 }
 
+function setupSettingsSubmenu({ textTrackList }: { textTrackList?: MediaTextTrackState['textTrackList'] | undefined }) {
+  const store = createTextTrackStore({ textTrackList, subtitlesShowing: false });
+  const provider = document.createElement('test-captions-menu-player') as TestPlayerProviderElement;
+  const root = createElement(MenuElement);
+  const rootView = createElement(MenuViewElement);
+  const trigger = createElement(CaptionsMenuTriggerElement);
+  const menu = createElement(CaptionsMenuElement);
+  const options = createElement(CaptionsOptionsElement);
+
+  provider.setStore(store);
+  root.open = true;
+  trigger.id = 'captions-trigger';
+  trigger.commandfor = 'captions-menu';
+  menu.id = 'captions-menu';
+
+  menu.append(options);
+  rootView.append(trigger);
+  root.append(rootView, menu);
+  provider.append(root);
+  document.body.append(provider);
+
+  return { menu, options, provider, root, rootView, store, trigger };
+}
+
 async function waitForMenu(
   menu: CaptionsMenuElement,
   trigger?: CaptionsMenuTriggerElement,
@@ -173,6 +199,29 @@ describe('CaptionsMenuElement', () => {
     expect(menu.getAttribute('aria-label')).toBe('Captions CC');
     expect(menu.getAttribute('data-active')).toBe('');
     expect(menu.getAttribute('data-availability')).toBe('available');
+  });
+
+  it('syncs descendant section label parts', async () => {
+    const { menu, trigger } = setup();
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    menu.insertBefore(section, menu.firstChild);
+
+    await waitForMenu(menu, trigger);
+
+    expect(section.textContent).toBe('Captions');
+  });
+
+  it('respects menu-section-label on the menu element for section label parts', async () => {
+    const { menu, trigger } = setup();
+    menu.setAttribute('menu-section-label', 'Subtitles');
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    menu.insertBefore(section, menu.firstChild);
+
+    await waitForMenu(menu, trigger);
+
+    expect(section.textContent).toBe('Subtitles');
   });
 
   it('renders radio items from a template', async () => {
@@ -220,6 +269,39 @@ describe('CaptionsMenuElement', () => {
 
     expect(selectTextTrack).toHaveBeenCalledWith(null);
   });
+
+  it('hides a settings submenu trigger when no captions are available', async () => {
+    const { menu, options, trigger } = setupSettingsSubmenu({
+      textTrackList: [{ kind: 'metadata', label: 'thumbnails', language: '', mode: 'hidden' }],
+    });
+
+    await waitForMenu(menu, trigger, options);
+
+    expect(trigger.hidden).toBe(true);
+    expect(trigger.hasAttribute('data-item')).toBe(false);
+    expect([...options.querySelectorAll(MenuRadioItemElement.tagName)]).toHaveLength(0);
+  });
+
+  it('updates settings submenu items when captions become available', async () => {
+    const { menu, options, store, trigger } = setupSettingsSubmenu({ textTrackList: [] });
+
+    await waitForMenu(menu, trigger, options);
+
+    expect(trigger.hidden).toBe(true);
+    expect([...options.querySelectorAll(MenuRadioItemElement.tagName)]).toHaveLength(0);
+
+    (store.$state as WritableState<MediaTextTrackState>).patch({
+      textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+    });
+
+    await waitForMenu(menu, trigger, options);
+
+    const items = [...options.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
+
+    expect(trigger.hidden).toBe(false);
+    expect(trigger.hasAttribute('data-item')).toBe(true);
+    expect(items.map((item) => item.textContent)).toEqual(['Off', 'English']);
+  });
 });
 
 describe('CaptionsMenuTriggerElement', () => {
@@ -232,6 +314,29 @@ describe('CaptionsMenuTriggerElement', () => {
     expect(trigger.getAttribute('aria-label')).toBe('Captions CC');
     expect(trigger.getAttribute('data-active')).toBe('');
     expect(trigger.getAttribute('data-availability')).toBe('available');
+  });
+
+  it('syncs section label part in the trigger', async () => {
+    const { trigger } = setup();
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    trigger.append(section);
+
+    await trigger.updateComplete;
+
+    expect(section.textContent).toBe('Captions');
+  });
+
+  it('respects menu-section-label on the trigger', async () => {
+    const { trigger } = setup();
+    trigger.setAttribute('menu-section-label', 'Subtitles');
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    trigger.append(section);
+
+    await trigger.updateComplete;
+
+    expect(section.textContent).toBe('Subtitles');
   });
 
   it('prevents activation when no captions are available', async () => {
@@ -250,5 +355,44 @@ describe('CaptionsMenuTriggerElement', () => {
     expect(trigger.getAttribute('data-availability')).toBe('unavailable');
     expect(trigger.hasAttribute('data-disabled')).toBe(true);
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not open a submenu from a secondary pointer button', async () => {
+    const provider = document.createElement('test-captions-menu-player') as TestPlayerProviderElement;
+    const root = createElement(MenuElement);
+    const rootView = createElement(MenuViewElement);
+    const trigger = createElement(CaptionsMenuTriggerElement);
+    const menu = createElement(CaptionsMenuElement);
+    const options = createElement(CaptionsOptionsElement);
+
+    provider.setStore(createTextTrackStore());
+    root.open = true;
+    trigger.id = 'captions-trigger';
+    trigger.commandfor = 'captions-menu';
+    menu.id = 'captions-menu';
+
+    menu.append(options);
+    rootView.append(trigger);
+    root.append(rootView, menu);
+    provider.append(root);
+    document.body.append(provider);
+
+    await root.updateComplete;
+    await rootView.updateComplete;
+    await trigger.updateComplete;
+    await menu.updateComplete;
+    await options.updateComplete;
+
+    const handled = trigger.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2 })
+    );
+
+    await root.updateComplete;
+    await trigger.updateComplete;
+    await menu.updateComplete;
+
+    expect(handled).toBe(true);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(menu.hasAttribute('data-open')).toBe(false);
   });
 });

--- a/packages/html/src/ui/captions-menu/tests/captions-menu-element.test.ts
+++ b/packages/html/src/ui/captions-menu/tests/captions-menu-element.test.ts
@@ -1,16 +1,14 @@
 import type { MediaTextTrackState } from '@videojs/core';
 import type { AnyPlayerStore } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
-import { createStore, type WritableState } from '@videojs/store';
+import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
 import { MediaElement } from '../../media-element';
-import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
 import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
-import { MenuViewElement } from '../../menu/menu-view-element';
 import { CaptionsMenuElement } from '../captions-menu-element';
 import { CaptionsMenuTriggerElement } from '../captions-menu-trigger-element';
 import { CaptionsOptionsElement } from '../captions-options-element';
@@ -137,30 +135,6 @@ function setup({
   return { menu, options, provider, store, trigger };
 }
 
-function setupSettingsSubmenu({ textTrackList }: { textTrackList?: MediaTextTrackState['textTrackList'] | undefined }) {
-  const store = createTextTrackStore({ textTrackList, subtitlesShowing: false });
-  const provider = document.createElement('test-captions-menu-player') as TestPlayerProviderElement;
-  const root = createElement(MenuElement);
-  const rootView = createElement(MenuViewElement);
-  const trigger = createElement(CaptionsMenuTriggerElement);
-  const menu = createElement(CaptionsMenuElement);
-  const options = createElement(CaptionsOptionsElement);
-
-  provider.setStore(store);
-  root.open = true;
-  trigger.id = 'captions-trigger';
-  trigger.commandfor = 'captions-menu';
-  menu.id = 'captions-menu';
-
-  menu.append(options);
-  rootView.append(trigger);
-  root.append(rootView, menu);
-  provider.append(root);
-  document.body.append(provider);
-
-  return { menu, options, provider, root, rootView, store, trigger };
-}
-
 async function waitForMenu(
   menu: CaptionsMenuElement,
   trigger?: CaptionsMenuTriggerElement,
@@ -269,39 +243,6 @@ describe('CaptionsMenuElement', () => {
 
     expect(selectTextTrack).toHaveBeenCalledWith(null);
   });
-
-  it('hides a settings submenu trigger when no captions are available', async () => {
-    const { menu, options, trigger } = setupSettingsSubmenu({
-      textTrackList: [{ kind: 'metadata', label: 'thumbnails', language: '', mode: 'hidden' }],
-    });
-
-    await waitForMenu(menu, trigger, options);
-
-    expect(trigger.hidden).toBe(true);
-    expect(trigger.hasAttribute('data-item')).toBe(false);
-    expect([...options.querySelectorAll(MenuRadioItemElement.tagName)]).toHaveLength(0);
-  });
-
-  it('updates settings submenu items when captions become available', async () => {
-    const { menu, options, store, trigger } = setupSettingsSubmenu({ textTrackList: [] });
-
-    await waitForMenu(menu, trigger, options);
-
-    expect(trigger.hidden).toBe(true);
-    expect([...options.querySelectorAll(MenuRadioItemElement.tagName)]).toHaveLength(0);
-
-    (store.$state as WritableState<MediaTextTrackState>).patch({
-      textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
-    });
-
-    await waitForMenu(menu, trigger, options);
-
-    const items = [...options.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
-
-    expect(trigger.hidden).toBe(false);
-    expect(trigger.hasAttribute('data-item')).toBe(true);
-    expect(items.map((item) => item.textContent)).toEqual(['Off', 'English']);
-  });
 });
 
 describe('CaptionsMenuTriggerElement', () => {
@@ -314,29 +255,6 @@ describe('CaptionsMenuTriggerElement', () => {
     expect(trigger.getAttribute('aria-label')).toBe('Captions CC');
     expect(trigger.getAttribute('data-active')).toBe('');
     expect(trigger.getAttribute('data-availability')).toBe('available');
-  });
-
-  it('syncs section label part in the trigger', async () => {
-    const { trigger } = setup();
-    const section = document.createElement('span');
-    section.setAttribute('data-part', 'section-label');
-    trigger.append(section);
-
-    await trigger.updateComplete;
-
-    expect(section.textContent).toBe('Captions');
-  });
-
-  it('respects menu-section-label on the trigger', async () => {
-    const { trigger } = setup();
-    trigger.setAttribute('menu-section-label', 'Subtitles');
-    const section = document.createElement('span');
-    section.setAttribute('data-part', 'section-label');
-    trigger.append(section);
-
-    await trigger.updateComplete;
-
-    expect(section.textContent).toBe('Subtitles');
   });
 
   it('prevents activation when no captions are available', async () => {
@@ -355,44 +273,5 @@ describe('CaptionsMenuTriggerElement', () => {
     expect(trigger.getAttribute('data-availability')).toBe('unavailable');
     expect(trigger.hasAttribute('data-disabled')).toBe(true);
     expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it('does not open a submenu from a secondary pointer button', async () => {
-    const provider = document.createElement('test-captions-menu-player') as TestPlayerProviderElement;
-    const root = createElement(MenuElement);
-    const rootView = createElement(MenuViewElement);
-    const trigger = createElement(CaptionsMenuTriggerElement);
-    const menu = createElement(CaptionsMenuElement);
-    const options = createElement(CaptionsOptionsElement);
-
-    provider.setStore(createTextTrackStore());
-    root.open = true;
-    trigger.id = 'captions-trigger';
-    trigger.commandfor = 'captions-menu';
-    menu.id = 'captions-menu';
-
-    menu.append(options);
-    rootView.append(trigger);
-    root.append(rootView, menu);
-    provider.append(root);
-    document.body.append(provider);
-
-    await root.updateComplete;
-    await rootView.updateComplete;
-    await trigger.updateComplete;
-    await menu.updateComplete;
-    await options.updateComplete;
-
-    const handled = trigger.dispatchEvent(
-      new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2 })
-    );
-
-    await root.updateComplete;
-    await trigger.updateComplete;
-    await menu.updateComplete;
-
-    expect(handled).toBe(true);
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
-    expect(menu.hasAttribute('data-open')).toBe(false);
   });
 });

--- a/packages/html/src/ui/captions-menu/tests/captions-menu-element.test.ts
+++ b/packages/html/src/ui/captions-menu/tests/captions-menu-element.test.ts
@@ -170,7 +170,7 @@ describe('CaptionsMenuElement', () => {
     await waitForAssertion(() => {
       expect(items.map((item) => item.getAttribute('aria-checked'))).toEqual(['false', 'false', 'true']);
     });
-    expect(menu.getAttribute('aria-label')).toBe('Captions CC');
+    expect(menu.getAttribute('aria-label')).toBe('Captions, CC');
     expect(menu.getAttribute('data-active')).toBe('');
     expect(menu.getAttribute('data-availability')).toBe('available');
   });
@@ -252,7 +252,7 @@ describe('CaptionsMenuTriggerElement', () => {
     await trigger.updateComplete;
 
     expect(trigger.getAttribute('role')).toBe('button');
-    expect(trigger.getAttribute('aria-label')).toBe('Captions CC');
+    expect(trigger.getAttribute('aria-label')).toBe('Captions, CC');
     expect(trigger.getAttribute('data-active')).toBe('');
     expect(trigger.getAttribute('data-availability')).toBe('available');
   });

--- a/packages/html/src/ui/menu/sync-section-label-parts.ts
+++ b/packages/html/src/ui/menu/sync-section-label-parts.ts
@@ -1,0 +1,6 @@
+/** Sets text on `[data-part~="section-label"]` for menu section titles (settings row / back heading). */
+export function syncSectionLabelParts(root: HTMLElement | ShadowRoot, text: string): void {
+  for (const el of root.querySelectorAll<HTMLElement>('[data-part~="section-label"]')) {
+    el.textContent = text;
+  }
+}

--- a/packages/html/src/ui/playback-rate-menu/playback-rate-menu-element.ts
+++ b/packages/html/src/ui/playback-rate-menu/playback-rate-menu-element.ts
@@ -5,6 +5,7 @@ import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MenuElement } from '../menu/menu-element';
+import { syncSectionLabelParts } from '../menu/sync-section-label-parts';
 
 export class PlaybackRateMenuElement extends MenuElement {
   static override readonly tagName = 'media-playback-rate-menu';
@@ -12,6 +13,7 @@ export class PlaybackRateMenuElement extends MenuElement {
   static override properties = {
     ...MenuElement.properties,
     label: { type: String },
+    menuSectionLabel: { type: String, attribute: 'menu-section-label' },
     disabled: { type: Boolean },
   } satisfies PropertyDeclarationMap<
     | 'open'
@@ -22,10 +24,12 @@ export class PlaybackRateMenuElement extends MenuElement {
     | 'closeOnOutsideClick'
     | 'boundary'
     | 'label'
+    | 'menuSectionLabel'
     | 'disabled'
   >;
 
   label = '';
+  menuSectionLabel = PlaybackRateMenuCore.defaultProps.menuSectionLabel;
   disabled = false;
   override align: MenuElement['align'] = 'center';
   formatRate = PlaybackRateMenuCore.defaultProps.formatRate;
@@ -54,6 +58,7 @@ export class PlaybackRateMenuElement extends MenuElement {
 
     applyElementProps(this, this.#core.getAttrs(state));
     applyStateDataAttrs(this, state, PlaybackRateMenuDataAttrs);
+    syncSectionLabelParts(this, this.#core.getMenuSectionLabel());
   }
 }
 

--- a/packages/html/src/ui/playback-rate-menu/playback-rate-menu-trigger-element.ts
+++ b/packages/html/src/ui/playback-rate-menu/playback-rate-menu-trigger-element.ts
@@ -5,17 +5,20 @@ import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaElement } from '../media-element';
+import { syncSectionLabelParts } from '../menu/sync-section-label-parts';
 
 export class PlaybackRateMenuTriggerElement extends MediaElement {
   static readonly tagName = 'media-playback-rate-menu-trigger';
 
   static override properties = {
     label: { type: String },
+    menuSectionLabel: { type: String, attribute: 'menu-section-label' },
     disabled: { type: Boolean },
     commandfor: { type: String },
-  } satisfies PropertyDeclarationMap<'label' | 'disabled' | 'commandfor'>;
+  } satisfies PropertyDeclarationMap<'label' | 'menuSectionLabel' | 'disabled' | 'commandfor'>;
 
   label = '';
+  menuSectionLabel = PlaybackRateMenuCore.defaultProps.menuSectionLabel;
   disabled = false;
   commandfor: string | undefined = undefined;
   formatRate = PlaybackRateMenuCore.defaultProps.formatRate;
@@ -70,6 +73,7 @@ export class PlaybackRateMenuTriggerElement extends MediaElement {
       tabIndex: 0,
       ...this.#core.getAttrs(state),
     });
+    syncSectionLabelParts(this, this.#core.getMenuSectionLabel());
     applyStateDataAttrs(this, state, PlaybackRateMenuDataAttrs);
   }
 

--- a/packages/html/src/ui/playback-rate-menu/playback-rate-options-element.ts
+++ b/packages/html/src/ui/playback-rate-menu/playback-rate-options-element.ts
@@ -53,7 +53,7 @@ export class PlaybackRateOptionsElement extends MenuRadioGroupElement {
       state = this.#core.getState();
 
       this.value = this.#core.getRateValue(state.rate);
-      this.label = this.label || 'Playback rate';
+      this.label = this.label || this.#core.getRadioGroupLabel();
       this.#syncContent(state);
     }
 

--- a/packages/html/src/ui/playback-rate-menu/tests/playback-rate-menu-element.test.ts
+++ b/packages/html/src/ui/playback-rate-menu/tests/playback-rate-menu-element.test.ts
@@ -163,7 +163,7 @@ describe('PlaybackRateMenuElement', () => {
     await waitForAssertion(() => {
       expect(items.map((item) => item.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false']);
     });
-    expect(menu.getAttribute('aria-label')).toBe('Playback rate 1.25');
+    expect(menu.getAttribute('aria-label')).toBe('Playback rate, 1.25×');
     expect(menu.getAttribute('data-rate')).toBe('1.25');
   });
 
@@ -238,7 +238,7 @@ describe('PlaybackRateMenuTriggerElement', () => {
     await trigger.updateComplete;
 
     expect(trigger.getAttribute('role')).toBe('button');
-    expect(trigger.getAttribute('aria-label')).toBe('Playback rate 2');
+    expect(trigger.getAttribute('aria-label')).toBe('Playback rate, 2×');
     expect(trigger.getAttribute('data-rate')).toBe('2');
   });
 

--- a/packages/html/src/ui/playback-rate-menu/tests/playback-rate-menu-element.test.ts
+++ b/packages/html/src/ui/playback-rate-menu/tests/playback-rate-menu-element.test.ts
@@ -6,9 +6,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
 import { MediaElement } from '../../media-element';
+import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
 import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
+import { MenuViewElement } from '../../menu/menu-view-element';
 import { PlaybackRateMenuElement } from '../playback-rate-menu-element';
 import { PlaybackRateMenuTriggerElement } from '../playback-rate-menu-trigger-element';
 import { PlaybackRateOptionsElement } from '../playback-rate-options-element';
@@ -167,6 +169,29 @@ describe('PlaybackRateMenuElement', () => {
     expect(menu.getAttribute('data-rate')).toBe('1.25');
   });
 
+  it('syncs descendant section label parts', async () => {
+    const { menu, trigger } = setup();
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    menu.insertBefore(section, menu.firstChild);
+
+    await waitForMenu(menu, trigger);
+
+    expect(section.textContent).toBe('Speed');
+  });
+
+  it('respects menu-section-label on the menu element for section label parts', async () => {
+    const { menu, trigger } = setup();
+    menu.setAttribute('menu-section-label', 'Tempo');
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    menu.insertBefore(section, menu.firstChild);
+
+    await waitForMenu(menu, trigger);
+
+    expect(section.textContent).toBe('Tempo');
+  });
+
   it('renders radio items from a template', async () => {
     const { menu, options, trigger } = setup({
       template:
@@ -219,6 +244,29 @@ describe('PlaybackRateMenuTriggerElement', () => {
     expect(trigger.getAttribute('data-rate')).toBe('2');
   });
 
+  it('syncs section label part in the trigger', async () => {
+    const { trigger } = setup({ playbackRate: 2 });
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    trigger.append(section);
+
+    await trigger.updateComplete;
+
+    expect(section.textContent).toBe('Speed');
+  });
+
+  it('respects menu-section-label on the trigger', async () => {
+    const { trigger } = setup({ playbackRate: 2 });
+    trigger.setAttribute('menu-section-label', 'Tempo');
+    const section = document.createElement('span');
+    section.setAttribute('data-part', 'section-label');
+    trigger.append(section);
+
+    await trigger.updateComplete;
+
+    expect(section.textContent).toBe('Tempo');
+  });
+
   it('prevents activation when there are no playback rates', async () => {
     const { trigger } = setup({ playbackRates: [] });
 
@@ -231,5 +279,44 @@ describe('PlaybackRateMenuTriggerElement', () => {
     expect(trigger.getAttribute('aria-disabled')).toBe('true');
     expect(trigger.hasAttribute('data-disabled')).toBe(true);
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not open a submenu from a secondary pointer button', async () => {
+    const provider = document.createElement('test-playback-rate-player') as TestPlayerProviderElement;
+    const root = createElement(MenuElement);
+    const rootView = createElement(MenuViewElement);
+    const trigger = createElement(PlaybackRateMenuTriggerElement);
+    const menu = createElement(PlaybackRateMenuElement);
+    const options = createElement(PlaybackRateOptionsElement);
+
+    provider.setStore(createPlaybackRateStore());
+    root.open = true;
+    trigger.id = 'playback-rate-trigger';
+    trigger.commandfor = 'playback-rate-menu';
+    menu.id = 'playback-rate-menu';
+
+    menu.append(options);
+    rootView.append(trigger);
+    root.append(rootView, menu);
+    provider.append(root);
+    document.body.append(provider);
+
+    await root.updateComplete;
+    await rootView.updateComplete;
+    await trigger.updateComplete;
+    await menu.updateComplete;
+    await options.updateComplete;
+
+    const handled = trigger.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2 })
+    );
+
+    await root.updateComplete;
+    await trigger.updateComplete;
+    await menu.updateComplete;
+
+    expect(handled).toBe(true);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(menu.hasAttribute('data-open')).toBe(false);
   });
 });

--- a/packages/html/src/ui/playback-rate-menu/tests/playback-rate-menu-element.test.ts
+++ b/packages/html/src/ui/playback-rate-menu/tests/playback-rate-menu-element.test.ts
@@ -6,11 +6,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
 import { MediaElement } from '../../media-element';
-import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
 import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
-import { MenuViewElement } from '../../menu/menu-view-element';
 import { PlaybackRateMenuElement } from '../playback-rate-menu-element';
 import { PlaybackRateMenuTriggerElement } from '../playback-rate-menu-trigger-element';
 import { PlaybackRateOptionsElement } from '../playback-rate-options-element';
@@ -170,7 +168,7 @@ describe('PlaybackRateMenuElement', () => {
   });
 
   it('syncs descendant section label parts', async () => {
-    const { menu, trigger } = setup();
+    const { menu, trigger } = setup({ playbackRates: [1, 1.25], playbackRate: 1 });
     const section = document.createElement('span');
     section.setAttribute('data-part', 'section-label');
     menu.insertBefore(section, menu.firstChild);
@@ -181,15 +179,15 @@ describe('PlaybackRateMenuElement', () => {
   });
 
   it('respects menu-section-label on the menu element for section label parts', async () => {
-    const { menu, trigger } = setup();
-    menu.setAttribute('menu-section-label', 'Tempo');
+    const { menu, trigger } = setup({ playbackRates: [1, 1.25], playbackRate: 1 });
+    menu.setAttribute('menu-section-label', 'Playback speed');
     const section = document.createElement('span');
     section.setAttribute('data-part', 'section-label');
     menu.insertBefore(section, menu.firstChild);
 
     await waitForMenu(menu, trigger);
 
-    expect(section.textContent).toBe('Tempo');
+    expect(section.textContent).toBe('Playback speed');
   });
 
   it('renders radio items from a template', async () => {
@@ -244,29 +242,6 @@ describe('PlaybackRateMenuTriggerElement', () => {
     expect(trigger.getAttribute('data-rate')).toBe('2');
   });
 
-  it('syncs section label part in the trigger', async () => {
-    const { trigger } = setup({ playbackRate: 2 });
-    const section = document.createElement('span');
-    section.setAttribute('data-part', 'section-label');
-    trigger.append(section);
-
-    await trigger.updateComplete;
-
-    expect(section.textContent).toBe('Speed');
-  });
-
-  it('respects menu-section-label on the trigger', async () => {
-    const { trigger } = setup({ playbackRate: 2 });
-    trigger.setAttribute('menu-section-label', 'Tempo');
-    const section = document.createElement('span');
-    section.setAttribute('data-part', 'section-label');
-    trigger.append(section);
-
-    await trigger.updateComplete;
-
-    expect(section.textContent).toBe('Tempo');
-  });
-
   it('prevents activation when there are no playback rates', async () => {
     const { trigger } = setup({ playbackRates: [] });
 
@@ -279,44 +254,5 @@ describe('PlaybackRateMenuTriggerElement', () => {
     expect(trigger.getAttribute('aria-disabled')).toBe('true');
     expect(trigger.hasAttribute('data-disabled')).toBe(true);
     expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it('does not open a submenu from a secondary pointer button', async () => {
-    const provider = document.createElement('test-playback-rate-player') as TestPlayerProviderElement;
-    const root = createElement(MenuElement);
-    const rootView = createElement(MenuViewElement);
-    const trigger = createElement(PlaybackRateMenuTriggerElement);
-    const menu = createElement(PlaybackRateMenuElement);
-    const options = createElement(PlaybackRateOptionsElement);
-
-    provider.setStore(createPlaybackRateStore());
-    root.open = true;
-    trigger.id = 'playback-rate-trigger';
-    trigger.commandfor = 'playback-rate-menu';
-    menu.id = 'playback-rate-menu';
-
-    menu.append(options);
-    rootView.append(trigger);
-    root.append(rootView, menu);
-    provider.append(root);
-    document.body.append(provider);
-
-    await root.updateComplete;
-    await rootView.updateComplete;
-    await trigger.updateComplete;
-    await menu.updateComplete;
-    await options.updateComplete;
-
-    const handled = trigger.dispatchEvent(
-      new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2 })
-    );
-
-    await root.updateComplete;
-    await trigger.updateComplete;
-    await menu.updateComplete;
-
-    expect(handled).toBe(true);
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
-    expect(menu.hasAttribute('data-open')).toBe(false);
   });
 });

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -121,10 +121,10 @@ function VolumePopover(): ReactNode {
 }
 
 function PlaybackRateMenuItems(): ReactNode {
-  const { options, setValue, value } = usePlaybackRateMenu();
+  const { options, setValue, value, radioGroupLabel } = usePlaybackRateMenu();
 
   return (
-    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Playback rate">
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label={radioGroupLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -70,10 +70,10 @@ function VolumePopover(): ReactNode {
 }
 
 function PlaybackRateMenuItems(): ReactNode {
-  const { options, setValue, value } = usePlaybackRateMenu();
+  const { options, setValue, value, radioGroupLabel } = usePlaybackRateMenu();
 
   return (
-    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Playback rate">
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label={radioGroupLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -123,10 +123,10 @@ function VolumePopover(): ReactNode {
 }
 
 function PlaybackRateMenuItems(): ReactNode {
-  const { options, setValue, value } = usePlaybackRateMenu();
+  const { options, setValue, value, radioGroupLabel } = usePlaybackRateMenu();
 
   return (
-    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Playback rate">
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label={radioGroupLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -70,10 +70,10 @@ function VolumePopover(): ReactNode {
 }
 
 function PlaybackRateMenuItems(): ReactNode {
-  const { options, setValue, value } = usePlaybackRateMenu();
+  const { options, setValue, value, radioGroupLabel } = usePlaybackRateMenu();
 
   return (
-    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Playback rate">
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label={radioGroupLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -135,10 +135,10 @@ function VolumePopover(): ReactNode {
 }
 
 function CaptionsMenuItems(): ReactNode {
-  const { options, setValue, value } = useCaptionsMenu();
+  const { options, setValue, value, menuSectionLabel } = useCaptionsMenu();
 
   return (
-    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Captions">
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label={menuSectionLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -88,10 +88,10 @@ function VolumePopover(): ReactNode {
 }
 
 function CaptionsMenuItems(): ReactNode {
-  const { options, setValue, value } = useCaptionsMenu();
+  const { options, setValue, value, menuSectionLabel } = useCaptionsMenu();
 
   return (
-    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Captions">
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label={menuSectionLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -135,10 +135,10 @@ function VolumePopover(): ReactNode {
 }
 
 function CaptionsMenuItems(): ReactNode {
-  const { options, setValue, value } = useCaptionsMenu();
+  const { options, setValue, value, menuSectionLabel } = useCaptionsMenu();
 
   return (
-    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Captions">
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label={menuSectionLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -88,10 +88,10 @@ function VolumePopover(): ReactNode {
 }
 
 function CaptionsMenuItems(): ReactNode {
-  const { options, setValue, value } = useCaptionsMenu();
+  const { options, setValue, value, menuSectionLabel } = useCaptionsMenu();
 
   return (
-    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Captions">
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label={menuSectionLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
           <span>{option.label}</span>

--- a/packages/react/src/ui/captions-menu/captions-menu-root.tsx
+++ b/packages/react/src/ui/captions-menu/captions-menu-root.tsx
@@ -17,6 +17,7 @@ export function CaptionsMenuRoot({
   label,
   formatTrack,
   offLabel,
+  menuSectionLabel,
   disabled,
   align = 'center',
   children,
@@ -25,7 +26,7 @@ export function CaptionsMenuRoot({
   const textTrack = usePlayer(selectTextTrack);
   const [core] = useState(() => new CaptionsMenuCore());
 
-  core.setProps({ label, formatTrack, offLabel, disabled });
+  core.setProps({ label, formatTrack, offLabel, menuSectionLabel, disabled });
 
   if (!textTrack) {
     if (__DEV__) logMissingFeature('CaptionsMenu', selectTextTrack.displayName ?? 'textTrack');

--- a/packages/react/src/ui/captions-menu/captions-menu-section-label.tsx
+++ b/packages/react/src/ui/captions-menu/captions-menu-section-label.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { CaptionsMenuCore } from '@videojs/core';
+import { forwardRef } from 'react';
+
+import type { UIComponentProps } from '../../utils/types';
+import { renderElement } from '../../utils/use-render';
+import { useCaptionsMenuContext } from './context';
+
+export interface CaptionsMenuSectionLabelProps extends UIComponentProps<'span', CaptionsMenuCore.State> {}
+
+export const CaptionsMenuSectionLabel = forwardRef<HTMLSpanElement, CaptionsMenuSectionLabelProps>(
+  function CaptionsMenuSectionLabel({ render, className, style, children, ...elementProps }, forwardedRef) {
+    const { core, state } = useCaptionsMenuContext();
+    const content = children ?? core.getMenuSectionLabel();
+
+    return renderElement(
+      'span',
+      { render, className, style },
+      {
+        state,
+        ref: [forwardedRef],
+        props: [{ ...elementProps, 'data-part': 'section-label', children: content }],
+      }
+    );
+  }
+);
+
+export namespace CaptionsMenuSectionLabel {
+  export type Props = CaptionsMenuSectionLabelProps;
+  export type State = CaptionsMenuCore.State;
+}

--- a/packages/react/src/ui/captions-menu/index.parts.ts
+++ b/packages/react/src/ui/captions-menu/index.parts.ts
@@ -6,6 +6,10 @@ export {
 } from './captions-menu-content';
 export { CaptionsMenuRoot as Root, type CaptionsMenuRootProps as RootProps } from './captions-menu-root';
 export {
+  CaptionsMenuSectionLabel as SectionLabel,
+  type CaptionsMenuSectionLabelProps as SectionLabelProps,
+} from './captions-menu-section-label';
+export {
   CaptionsMenuTrigger as Trigger,
   type CaptionsMenuTriggerProps as TriggerProps,
 } from './captions-menu-trigger';

--- a/packages/react/src/ui/captions-menu/tests/captions-menu.test.tsx
+++ b/packages/react/src/ui/captions-menu/tests/captions-menu.test.tsx
@@ -61,10 +61,10 @@ function renderCaptionsMenu({
 }
 
 function CaptionsMenuItems(): ReactNode {
-  const { menuSectionLabel, options, setValue, value } = useCaptionsMenu();
+  const { options, setValue, value } = useCaptionsMenu();
 
   return (
-    <Menu.RadioGroup value={value} onValueChange={setValue} label={menuSectionLabel}>
+    <Menu.RadioGroup value={value} onValueChange={setValue} label="Captions">
       {options.map((option) => (
         <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
           {option.label}
@@ -138,38 +138,6 @@ describe('CaptionsMenu', () => {
 
     expect(screen.getByTestId('trigger').textContent).toBe('Captions EN captions');
     expect(screen.getByRole('menuitemradio', { name: 'EN captions' }).getAttribute('aria-checked')).toBe('true');
-  });
-
-  it('renders SectionLabel with default menu section copy', () => {
-    const { Wrapper } = createPlayerWrapper(createTextTrackState() as unknown as Record<string, unknown>);
-
-    render(
-      <CaptionsMenu.Root defaultOpen>
-        <CaptionsMenu.Content>
-          <CaptionsMenu.SectionLabel data-testid="section-label" />
-        </CaptionsMenu.Content>
-      </CaptionsMenu.Root>,
-      { wrapper: Wrapper }
-    );
-
-    const section = screen.getByTestId('section-label');
-    expect(section.textContent).toBe('Captions');
-    expect(section.getAttribute('data-part')).toBe('section-label');
-  });
-
-  it('renders SectionLabel from menuSectionLabel on Root', () => {
-    const { Wrapper } = createPlayerWrapper(createTextTrackState() as unknown as Record<string, unknown>);
-
-    render(
-      <CaptionsMenu.Root defaultOpen menuSectionLabel="Subtitles">
-        <CaptionsMenu.Content>
-          <CaptionsMenu.SectionLabel data-testid="section-label" />
-        </CaptionsMenu.Content>
-      </CaptionsMenu.Root>,
-      { wrapper: Wrapper }
-    );
-
-    expect(screen.getByTestId('section-label').textContent).toBe('Subtitles');
   });
 
   it('disables the trigger when no captions are available', () => {

--- a/packages/react/src/ui/captions-menu/tests/captions-menu.test.tsx
+++ b/packages/react/src/ui/captions-menu/tests/captions-menu.test.tsx
@@ -80,8 +80,8 @@ describe('CaptionsMenu', () => {
 
     const trigger = screen.getByTestId('trigger');
 
-    expect(trigger.textContent).toBe('Captions CC');
-    expect(trigger.getAttribute('aria-label')).toBe('Captions CC');
+    expect(trigger.textContent).toBe('Captions, CC');
+    expect(trigger.getAttribute('aria-label')).toBe('Captions, CC');
     expect(trigger.getAttribute('data-active')).toBe('');
     expect(trigger.getAttribute('data-availability')).toBe('available');
   });
@@ -136,7 +136,7 @@ describe('CaptionsMenu', () => {
       formatTrack: (track) => `${track.language.toUpperCase()} ${track.kind}`,
     });
 
-    expect(screen.getByTestId('trigger').textContent).toBe('Captions EN captions');
+    expect(screen.getByTestId('trigger').textContent).toBe('Captions, EN captions');
     expect(screen.getByRole('menuitemradio', { name: 'EN captions' }).getAttribute('aria-checked')).toBe('true');
   });
 

--- a/packages/react/src/ui/captions-menu/tests/captions-menu.test.tsx
+++ b/packages/react/src/ui/captions-menu/tests/captions-menu.test.tsx
@@ -61,10 +61,10 @@ function renderCaptionsMenu({
 }
 
 function CaptionsMenuItems(): ReactNode {
-  const { options, setValue, value } = useCaptionsMenu();
+  const { menuSectionLabel, options, setValue, value } = useCaptionsMenu();
 
   return (
-    <Menu.RadioGroup value={value} onValueChange={setValue} label="Captions">
+    <Menu.RadioGroup value={value} onValueChange={setValue} label={menuSectionLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
           {option.label}
@@ -138,6 +138,38 @@ describe('CaptionsMenu', () => {
 
     expect(screen.getByTestId('trigger').textContent).toBe('Captions EN captions');
     expect(screen.getByRole('menuitemradio', { name: 'EN captions' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders SectionLabel with default menu section copy', () => {
+    const { Wrapper } = createPlayerWrapper(createTextTrackState() as unknown as Record<string, unknown>);
+
+    render(
+      <CaptionsMenu.Root defaultOpen>
+        <CaptionsMenu.Content>
+          <CaptionsMenu.SectionLabel data-testid="section-label" />
+        </CaptionsMenu.Content>
+      </CaptionsMenu.Root>,
+      { wrapper: Wrapper }
+    );
+
+    const section = screen.getByTestId('section-label');
+    expect(section.textContent).toBe('Captions');
+    expect(section.getAttribute('data-part')).toBe('section-label');
+  });
+
+  it('renders SectionLabel from menuSectionLabel on Root', () => {
+    const { Wrapper } = createPlayerWrapper(createTextTrackState() as unknown as Record<string, unknown>);
+
+    render(
+      <CaptionsMenu.Root defaultOpen menuSectionLabel="Subtitles">
+        <CaptionsMenu.Content>
+          <CaptionsMenu.SectionLabel data-testid="section-label" />
+        </CaptionsMenu.Content>
+      </CaptionsMenu.Root>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByTestId('section-label').textContent).toBe('Subtitles');
   });
 
   it('disables the trigger when no captions are available', () => {

--- a/packages/react/src/ui/captions-menu/use-captions-menu.ts
+++ b/packages/react/src/ui/captions-menu/use-captions-menu.ts
@@ -18,6 +18,7 @@ export interface CaptionsMenuResult {
   selectedTrackIndex: number | null;
   value: string;
   options: CaptionsMenuOption[];
+  menuSectionLabel: string;
   availability: CaptionsMenuCore.State['availability'];
   disabled: boolean;
   setTrack: (trackIndex: number | null) => void;
@@ -54,6 +55,7 @@ export function useCaptionsMenu(): CaptionsMenuResult {
           ]
         : [],
     availability: state.availability,
+    menuSectionLabel: core.getMenuSectionLabel(),
     disabled: state.disabled,
     setTrack,
     setValue,

--- a/packages/react/src/ui/playback-rate-menu/index.parts.ts
+++ b/packages/react/src/ui/playback-rate-menu/index.parts.ts
@@ -6,6 +6,10 @@ export {
 } from './playback-rate-menu-content';
 export { PlaybackRateMenuRoot as Root, type PlaybackRateMenuRootProps as RootProps } from './playback-rate-menu-root';
 export {
+  PlaybackRateMenuSectionLabel as SectionLabel,
+  type PlaybackRateMenuSectionLabelProps as SectionLabelProps,
+} from './playback-rate-menu-section-label';
+export {
   PlaybackRateMenuTrigger as Trigger,
   type PlaybackRateMenuTriggerProps as TriggerProps,
 } from './playback-rate-menu-trigger';

--- a/packages/react/src/ui/playback-rate-menu/playback-rate-menu-root.tsx
+++ b/packages/react/src/ui/playback-rate-menu/playback-rate-menu-root.tsx
@@ -16,6 +16,8 @@ export interface PlaybackRateMenuRootProps extends Omit<MenuRootProps, 'children
 export function PlaybackRateMenuRoot({
   label,
   formatRate,
+  menuSectionLabel,
+  radioGroupLabel,
   disabled,
   align = 'center',
   children,
@@ -24,7 +26,7 @@ export function PlaybackRateMenuRoot({
   const playbackRate = usePlayer(selectPlaybackRate);
   const [core] = useState(() => new PlaybackRateMenuCore());
 
-  core.setProps({ label, formatRate, disabled });
+  core.setProps({ label, formatRate, menuSectionLabel, radioGroupLabel, disabled });
 
   if (!playbackRate) {
     if (__DEV__) logMissingFeature('PlaybackRateMenu', selectPlaybackRate.displayName ?? 'playbackRate');

--- a/packages/react/src/ui/playback-rate-menu/playback-rate-menu-section-label.tsx
+++ b/packages/react/src/ui/playback-rate-menu/playback-rate-menu-section-label.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { PlaybackRateMenuCore } from '@videojs/core';
+import { forwardRef } from 'react';
+
+import type { UIComponentProps } from '../../utils/types';
+import { renderElement } from '../../utils/use-render';
+import { usePlaybackRateMenuContext } from './context';
+
+export interface PlaybackRateMenuSectionLabelProps extends UIComponentProps<'span', PlaybackRateMenuCore.State> {}
+
+export const PlaybackRateMenuSectionLabel = forwardRef<HTMLSpanElement, PlaybackRateMenuSectionLabelProps>(
+  function PlaybackRateMenuSectionLabel({ render, className, style, children, ...elementProps }, forwardedRef) {
+    const { core, state } = usePlaybackRateMenuContext();
+    const content = children ?? core.getMenuSectionLabel();
+
+    return renderElement(
+      'span',
+      { render, className, style },
+      {
+        state,
+        ref: [forwardedRef],
+        props: [{ ...elementProps, 'data-part': 'section-label', children: content }],
+      }
+    );
+  }
+);
+
+export namespace PlaybackRateMenuSectionLabel {
+  export type Props = PlaybackRateMenuSectionLabelProps;
+  export type State = PlaybackRateMenuCore.State;
+}

--- a/packages/react/src/ui/playback-rate-menu/tests/playback-rate-menu.test.tsx
+++ b/packages/react/src/ui/playback-rate-menu/tests/playback-rate-menu.test.tsx
@@ -55,7 +55,7 @@ describe('PlaybackRateMenu', () => {
     const trigger = screen.getByTestId('trigger');
 
     expect(trigger.textContent).toBe('1.5×');
-    expect(trigger.getAttribute('aria-label')).toBe('Playback rate 1.5');
+    expect(trigger.getAttribute('aria-label')).toBe('Playback rate, 1.5×');
     expect(trigger.getAttribute('data-rate')).toBe('1.5');
     expect(trigger.hasAttribute('data-inline-rate-label')).toBe(true);
   });

--- a/packages/react/src/ui/playback-rate-menu/tests/playback-rate-menu.test.tsx
+++ b/packages/react/src/ui/playback-rate-menu/tests/playback-rate-menu.test.tsx
@@ -35,10 +35,10 @@ function renderPlaybackRateMenu({
 }
 
 function PlaybackRateMenuItems(): ReactNode {
-  const { options, setValue, value, radioGroupLabel } = usePlaybackRateMenu();
+  const { options, setValue, value } = usePlaybackRateMenu();
 
   return (
-    <Menu.RadioGroup value={value} onValueChange={setValue} label={radioGroupLabel}>
+    <Menu.RadioGroup value={value} onValueChange={setValue} label="Playback rate">
       {options.map((option) => (
         <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
           {option.label}
@@ -117,38 +117,6 @@ describe('PlaybackRateMenu', () => {
 
     expect(screen.getByTestId('trigger').textContent).toBe('Normal');
     expect(screen.getByRole('menuitemradio', { name: 'Normal' }).getAttribute('aria-checked')).toBe('true');
-  });
-
-  it('renders SectionLabel with default menu section copy', () => {
-    const { Wrapper } = createPlayerWrapper({ playbackRates: [1, 1.5], playbackRate: 1 });
-
-    render(
-      <PlaybackRateMenu.Root defaultOpen>
-        <PlaybackRateMenu.Content>
-          <PlaybackRateMenu.SectionLabel data-testid="section-label" />
-        </PlaybackRateMenu.Content>
-      </PlaybackRateMenu.Root>,
-      { wrapper: Wrapper }
-    );
-
-    const section = screen.getByTestId('section-label');
-    expect(section.textContent).toBe('Speed');
-    expect(section.getAttribute('data-part')).toBe('section-label');
-  });
-
-  it('renders SectionLabel from menuSectionLabel on Root', () => {
-    const { Wrapper } = createPlayerWrapper({ playbackRates: [1, 1.5], playbackRate: 1 });
-
-    render(
-      <PlaybackRateMenu.Root defaultOpen menuSectionLabel="Tempo">
-        <PlaybackRateMenu.Content>
-          <PlaybackRateMenu.SectionLabel data-testid="section-label" />
-        </PlaybackRateMenu.Content>
-      </PlaybackRateMenu.Root>,
-      { wrapper: Wrapper }
-    );
-
-    expect(screen.getByTestId('section-label').textContent).toBe('Tempo');
   });
 
   it('disables the trigger when there are no rates', () => {

--- a/packages/react/src/ui/playback-rate-menu/tests/playback-rate-menu.test.tsx
+++ b/packages/react/src/ui/playback-rate-menu/tests/playback-rate-menu.test.tsx
@@ -35,10 +35,10 @@ function renderPlaybackRateMenu({
 }
 
 function PlaybackRateMenuItems(): ReactNode {
-  const { options, setValue, value } = usePlaybackRateMenu();
+  const { options, setValue, value, radioGroupLabel } = usePlaybackRateMenu();
 
   return (
-    <Menu.RadioGroup value={value} onValueChange={setValue} label="Playback rate">
+    <Menu.RadioGroup value={value} onValueChange={setValue} label={radioGroupLabel}>
       {options.map((option) => (
         <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
           {option.label}
@@ -117,6 +117,38 @@ describe('PlaybackRateMenu', () => {
 
     expect(screen.getByTestId('trigger').textContent).toBe('Normal');
     expect(screen.getByRole('menuitemradio', { name: 'Normal' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('renders SectionLabel with default menu section copy', () => {
+    const { Wrapper } = createPlayerWrapper({ playbackRates: [1, 1.5], playbackRate: 1 });
+
+    render(
+      <PlaybackRateMenu.Root defaultOpen>
+        <PlaybackRateMenu.Content>
+          <PlaybackRateMenu.SectionLabel data-testid="section-label" />
+        </PlaybackRateMenu.Content>
+      </PlaybackRateMenu.Root>,
+      { wrapper: Wrapper }
+    );
+
+    const section = screen.getByTestId('section-label');
+    expect(section.textContent).toBe('Speed');
+    expect(section.getAttribute('data-part')).toBe('section-label');
+  });
+
+  it('renders SectionLabel from menuSectionLabel on Root', () => {
+    const { Wrapper } = createPlayerWrapper({ playbackRates: [1, 1.5], playbackRate: 1 });
+
+    render(
+      <PlaybackRateMenu.Root defaultOpen menuSectionLabel="Tempo">
+        <PlaybackRateMenu.Content>
+          <PlaybackRateMenu.SectionLabel data-testid="section-label" />
+        </PlaybackRateMenu.Content>
+      </PlaybackRateMenu.Root>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByTestId('section-label').textContent).toBe('Tempo');
   });
 
   it('disables the trigger when there are no rates', () => {

--- a/packages/react/src/ui/playback-rate-menu/use-playback-rate-menu.ts
+++ b/packages/react/src/ui/playback-rate-menu/use-playback-rate-menu.ts
@@ -17,6 +17,8 @@ export interface PlaybackRateMenuResult {
   rate: number;
   value: string;
   options: PlaybackRateMenuOption[];
+  menuSectionLabel: string;
+  radioGroupLabel: string;
   disabled: boolean;
   setRate: (rate: number) => void;
   setValue: (value: string) => void;
@@ -38,6 +40,8 @@ export function usePlaybackRateMenu(): PlaybackRateMenuResult {
       label: core.getRateLabel(rate),
       disabled: state.disabled,
     })),
+    menuSectionLabel: core.getMenuSectionLabel(),
+    radioGroupLabel: core.getRadioGroupLabel(),
     disabled: state.disabled,
     setRate,
     setValue,


### PR DESCRIPTION
Refs #1533

## Summary

Centralize captions and playback rate menu section label strings in core and add declarative SectionLabel parts for HTML and React bindings.

## Changes

- Add default menu section labels to captions and playback rate menu core modules
- Add SectionLabel parts and sync helpers for HTML and React
- Update audio and live-video presets to use centralized labels
- Compose default menu trigger labels as `"<prefix>, <value>"` (e.g. `Captions, English`, `Playback rate, 1.25×`)

## Label props

These menus expose three related but distinct label props in core:

| Prop | Purpose |
| --- | --- |
| `label` | Full **trigger** label (`aria-label`). Override when you want complete custom text; when unset, core composes a default from the props below. |
| `menuSectionLabel` | Settings UI copy: submenu row title, back button, and `SectionLabel` part (e.g. `"Captions"`, `"Speed"`). |
| `radioGroupLabel` | Playback rate only: `Menu.RadioGroup` `aria-label` and the default trigger prefix (e.g. `"Playback rate"`). |

They are not collapsed into a single `label` prop because the strings serve different surfaces and can intentionally differ. Captions uses `menuSectionLabel` everywhere—the same word labels the section heading and prefixes the trigger. Playback rate splits them: `menuSectionLabel: "Speed"` for the nested settings row, and `radioGroupLabel: "Playback rate"` for the radio group’s accessible name and trigger prefix. `label` remains the escape hatch when consumers need fully custom trigger text.

## Testing

- `pnpm -F @videojs/core test src/core/ui/captions-menu src/core/ui/playback-rate-menu`
- `pnpm -F @videojs/html test src/ui/captions-menu/tests/captions-menu-element.test.ts`
- `pnpm -F @videojs/react test src/ui/captions-menu/tests/captions-menu.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes default `aria-label`/trigger label strings and introduces new label props that could affect consumer expectations and snapshot tests, but it does not touch playback logic or data handling.
> 
> **Overview**
> Centralizes captions and playback-rate menu copy in core by adding `menuSectionLabel` (and `radioGroupLabel` for playback rate) and updating default trigger/`aria-label` text composition to `"<prefix>, <value>"`.
> 
> Adds a new `SectionLabel` part for both HTML and React bindings: HTML elements now accept `menu-section-label` and sync text into descendants tagged with `[data-part~="section-label"]`, while React exports `CaptionsMenu.SectionLabel`/`PlaybackRateMenu.SectionLabel` and exposes the labels via `useCaptionsMenu`/`usePlaybackRateMenu`.
> 
> Updates HTML/React option group labels and preset skins to use the centralized labels, and tightens `BackgroundVideo.target` to only treat a slotted `[slot=media]` as the target when it is an `HTMLVideoElement`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19166d50d6834db78070860846749384c776675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->