### PR TITLE
feat(core): track animation settle with data-transitioning lifecycle

### DIFF
--- a/packages/core/src/core/ui/alert-dialog/alert-dialog-core.ts
+++ b/packages/core/src/core/ui/alert-dialog/alert-dialog-core.ts
@@ -55,7 +55,7 @@ export class AlertDialogCore {
       status: input.status,
       titleId: this.#titleId,
       descriptionId: this.#descriptionId,
-      ...getTransitionFlags(input.status),
+      ...getTransitionFlags(input.status, input.transitioning),
     };
   }
 

--- a/packages/core/src/core/ui/alert-dialog/tests/alert-dialog-core.test.ts
+++ b/packages/core/src/core/ui/alert-dialog/tests/alert-dialog-core.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { AlertDialogCore, type AlertDialogInput } from '../alert-dialog-core';
 
-const CLOSED: AlertDialogInput = { active: false, status: 'idle' };
-const OPEN: AlertDialogInput = { active: true, status: 'idle' };
-const STARTING: AlertDialogInput = { active: true, status: 'starting' };
-const ENDING: AlertDialogInput = { active: true, status: 'ending' };
+const CLOSED: AlertDialogInput = { active: false, status: 'idle', transitioning: false };
+const OPEN: AlertDialogInput = { active: true, status: 'idle', transitioning: false };
+const STARTING: AlertDialogInput = { active: true, status: 'starting', transitioning: true };
+const ENDING: AlertDialogInput = { active: true, status: 'ending', transitioning: true };
 
 describe('AlertDialogCore', () => {
   it('uses default props', () => {

--- a/packages/core/src/core/ui/input-feedback/indicator-lifecycle.ts
+++ b/packages/core/src/core/ui/input-feedback/indicator-lifecycle.ts
@@ -88,6 +88,6 @@ export function getRenderedIndicatorState<State extends IndicatorLifecycleState>
     ...payload,
     open: current.open && transition.active,
     generation: current.open ? current.generation : payload.generation,
-    ...getTransitionFlags(transition.status),
+    ...getTransitionFlags(transition.status, transition.transitioning),
   };
 }

--- a/packages/core/src/core/ui/input-feedback/seek-indicator-core.ts
+++ b/packages/core/src/core/ui/input-feedback/seek-indicator-core.ts
@@ -29,6 +29,7 @@ const INITIAL_STATE: SeekIndicatorState = {
   seekTotal: 0,
   value: null,
   currentTime: '0:00',
+  transitioning: false,
   transitionStarting: false,
   transitionEnding: false,
 };

--- a/packages/core/src/core/ui/input-feedback/status-indicator-core.ts
+++ b/packages/core/src/core/ui/input-feedback/status-indicator-core.ts
@@ -33,6 +33,7 @@ const INITIAL_STATE: StatusIndicatorState = {
   status: null,
   label: null,
   value: null,
+  transitioning: false,
   transitionStarting: false,
   transitionEnding: false,
 };

--- a/packages/core/src/core/ui/input-feedback/tests/indicator-lifecycle.test.ts
+++ b/packages/core/src/core/ui/input-feedback/tests/indicator-lifecycle.test.ts
@@ -15,6 +15,7 @@ const IDLE_STATE: TestState = {
   open: false,
   generation: 0,
   value: null,
+  transitioning: false,
   transitionStarting: false,
   transitionEnding: false,
 };
@@ -31,6 +32,7 @@ describe('indicator-lifecycle', () => {
     const rendered = getRenderedIndicatorState(IDLE_STATE, snapshot, {
       active: true,
       status: 'ending',
+      transitioning: true,
     });
 
     expect(rendered.open).toBe(false);

--- a/packages/core/src/core/ui/input-feedback/volume-indicator-core.ts
+++ b/packages/core/src/core/ui/input-feedback/volume-indicator-core.ts
@@ -32,6 +32,7 @@ const INITIAL_STATE: VolumeIndicatorState = {
   fill: null,
   min: false,
   max: false,
+  transitioning: false,
   transitionStarting: false,
   transitionEnding: false,
 };

--- a/packages/core/src/core/ui/menu/menu-core.ts
+++ b/packages/core/src/core/ui/menu/menu-core.ts
@@ -76,7 +76,7 @@ export class MenuCore {
       side: isSubmenu ? undefined : this.#props.side,
       align: isSubmenu ? undefined : this.#props.align,
       isSubmenu,
-      ...getTransitionFlags(input.status),
+      ...getTransitionFlags(input.status, input.transitioning),
     };
   }
 

--- a/packages/core/src/core/ui/menu/tests/menu-core.test.ts
+++ b/packages/core/src/core/ui/menu/tests/menu-core.test.ts
@@ -6,6 +6,7 @@ function createInput(overrides: Partial<MenuInput> = {}): MenuInput {
   return {
     active: false,
     status: 'idle',
+    transitioning: false,
     ...overrides,
   };
 }
@@ -192,7 +193,7 @@ describe('MenuCore', () => {
     it('exports Props, State, Input types via namespace', () => {
       // Compile-time check: ensure namespace types are accessible.
       const _props: MenuCore.Props = {};
-      const _input: MenuCore.Input = { active: false, status: 'idle' };
+      const _input: MenuCore.Input = { active: false, status: 'idle', transitioning: false };
       expect(_props).toBeDefined();
       expect(_input).toBeDefined();
     });

--- a/packages/core/src/core/ui/popover/popover-core.ts
+++ b/packages/core/src/core/ui/popover/popover-core.ts
@@ -88,7 +88,7 @@ export class PopoverCore {
       side: this.#props.side,
       align: this.#props.align,
       modal: this.#props.modal,
-      ...getTransitionFlags(input.status),
+      ...getTransitionFlags(input.status, input.transitioning),
     };
   }
 

--- a/packages/core/src/core/ui/popover/tests/popover-core.test.ts
+++ b/packages/core/src/core/ui/popover/tests/popover-core.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { PopoverCore, type PopoverInput } from '../popover-core';
 
-const CLOSED: PopoverInput = { active: false, status: 'idle' };
-const OPEN: PopoverInput = { active: true, status: 'idle' };
+const CLOSED: PopoverInput = { active: false, status: 'idle', transitioning: false };
+const OPEN: PopoverInput = { active: true, status: 'idle', transitioning: false };
 
 describe('PopoverCore', () => {
   it('uses default props', () => {
@@ -138,7 +138,7 @@ describe('PopoverCore', () => {
   describe('transition flags', () => {
     it('sets transitionStarting when status is starting', () => {
       const core = new PopoverCore();
-      core.setInput({ active: true, status: 'starting' });
+      core.setInput({ active: true, status: 'starting', transitioning: true });
       const state = core.getState();
 
       expect(state.transitionStarting).toBe(true);
@@ -147,7 +147,7 @@ describe('PopoverCore', () => {
 
     it('sets transitionEnding when status is ending', () => {
       const core = new PopoverCore();
-      core.setInput({ active: true, status: 'ending' });
+      core.setInput({ active: true, status: 'ending', transitioning: true });
       const state = core.getState();
 
       expect(state.transitionStarting).toBe(false);

--- a/packages/core/src/core/ui/tooltip/tests/tooltip-core.test.ts
+++ b/packages/core/src/core/ui/tooltip/tests/tooltip-core.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { TooltipCore, type TooltipInput } from '../tooltip-core';
 
-const CLOSED: TooltipInput = { active: false, status: 'idle' };
-const OPEN: TooltipInput = { active: true, status: 'idle' };
+const CLOSED: TooltipInput = { active: false, status: 'idle', transitioning: false };
+const OPEN: TooltipInput = { active: true, status: 'idle', transitioning: false };
 
 describe('TooltipCore', () => {
   it('uses default props', () => {
@@ -65,7 +65,7 @@ describe('TooltipCore', () => {
   describe('transition flags', () => {
     it('sets transitionStarting when status is starting', () => {
       const core = new TooltipCore();
-      core.setInput({ active: true, status: 'starting' });
+      core.setInput({ active: true, status: 'starting', transitioning: true });
       const state = core.getState();
 
       expect(state.transitionStarting).toBe(true);
@@ -74,7 +74,7 @@ describe('TooltipCore', () => {
 
     it('sets transitionEnding when status is ending', () => {
       const core = new TooltipCore();
-      core.setInput({ active: true, status: 'ending' });
+      core.setInput({ active: true, status: 'ending', transitioning: true });
       const state = core.getState();
 
       expect(state.transitionStarting).toBe(false);

--- a/packages/core/src/core/ui/tooltip/tooltip-core.ts
+++ b/packages/core/src/core/ui/tooltip/tooltip-core.ts
@@ -72,7 +72,7 @@ export class TooltipCore {
       status: input.status,
       side: this.#props.side,
       align: this.#props.align,
-      ...getTransitionFlags(input.status),
+      ...getTransitionFlags(input.status, input.transitioning),
     };
   }
 

--- a/packages/core/src/core/ui/transition.ts
+++ b/packages/core/src/core/ui/transition.ts
@@ -7,9 +7,13 @@ export interface TransitionState {
   active: boolean;
   /** Current phase of the transition lifecycle. */
   status: TransitionStatus;
+  /** Whether an open or close animation is currently running. */
+  transitioning: boolean;
 }
 
 export interface TransitionFlags {
+  /** Whether an open or close animation is currently running. */
+  transitioning: boolean;
   /** Whether the open transition is in progress. */
   transitionStarting: boolean;
   /** Whether the close transition is in progress. */
@@ -17,30 +21,40 @@ export interface TransitionFlags {
 }
 
 export interface TransitionStyleAttrs {
+  'data-transitioning'?: '' | undefined;
   'data-starting-style'?: '' | undefined;
   'data-ending-style'?: '' | undefined;
 }
 
+export type TransitionStyleFlags = Omit<TransitionFlags, 'transitioning'> & {
+  transitioning?: boolean | undefined;
+};
+
 /** Shared data attributes for open/close transition state. Spread into component data-attrs objects. */
 export const TransitionDataAttrs = {
+  /** Present while an open or close animation is running. */
+  transitioning: 'data-transitioning',
   /** Present during the open transition. */
   transitionStarting: 'data-starting-style',
   /** Present during the close transition. */
   transitionEnding: 'data-ending-style',
 } as const satisfies StateAttrMap<TransitionFlags>;
 
-export function getTransitionFlags(status: TransitionStatus): TransitionFlags {
+export function getTransitionFlags(status: TransitionStatus, transitioning = status !== 'idle'): TransitionFlags {
   return {
+    transitioning,
     transitionStarting: status === 'starting',
     transitionEnding: status === 'ending',
   };
 }
 
 export function getTransitionStyleAttrs({
+  transitioning = false,
   transitionStarting,
   transitionEnding,
-}: TransitionFlags): TransitionStyleAttrs {
+}: TransitionStyleFlags): TransitionStyleAttrs {
   return {
+    [TransitionDataAttrs.transitioning]: transitioning ? '' : undefined,
     [TransitionDataAttrs.transitionStarting]: transitionStarting ? '' : undefined,
     [TransitionDataAttrs.transitionEnding]: transitionEnding ? '' : undefined,
   };

--- a/packages/core/src/dom/ui/dismiss-layer.ts
+++ b/packages/core/src/dom/ui/dismiss-layer.ts
@@ -19,7 +19,7 @@ export interface DismissLayerApi {
   /** Reactive transition state for platforms to subscribe to. */
   input: State<TransitionState>;
   /** Start the open transition. Returns animation promise, or `null` if already open or destroyed. */
-  open(): Promise<void> | null;
+  open(element?: HTMLElement | null): Promise<void> | null;
   /** Start the close transition. Returns animation promise, or `null` if already closed or destroyed. */
   close(element: HTMLElement | null): Promise<void> | null;
   /** Lifecycle signal. Aborted on destroy. */
@@ -37,7 +37,7 @@ export function createDismissLayer(options: DismissLayerOptions): DismissLayerAp
 
   // --- Open/Close ---
 
-  function open(): Promise<void> | null {
+  function open(element?: HTMLElement | null): Promise<void> | null {
     if (abort.signal.aborted) return null;
 
     const { active, status } = state.current;
@@ -48,7 +48,7 @@ export function createDismissLayer(options: DismissLayerOptions): DismissLayerAp
       transition.cancel();
     }
 
-    return transition.open();
+    return transition.open(element);
   }
 
   function close(element: HTMLElement | null): Promise<void> | null {

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -57,7 +57,7 @@ describe('createMenu', () => {
 
   it('starts closed', () => {
     const { menu } = createTestMenu();
-    expect(menu.input.current).toEqual({ active: false, status: 'idle' });
+    expect(menu.input.current).toEqual({ active: false, status: 'idle', transitioning: false });
   });
 
   // -------------------------------------------------------------------------
@@ -79,7 +79,7 @@ describe('createMenu', () => {
 
       menu.open();
 
-      expect(menu.input.current).toEqual({ active: true, status: 'starting' });
+      expect(menu.input.current).toEqual({ active: true, status: 'starting', transitioning: true });
     });
 
     it('closes and calls onOpenChange', () => {

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -72,6 +72,10 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   const capturedPointers = new Set<number>();
   let skipBlurCloseAfterInsidePointer = false;
   let skipBlurCloseTimeout: ReturnType<typeof setTimeout> | null = null;
+  /** Settled when the current close animation finishes (see `applyClose`). */
+  let closeAnimationPromise: Promise<void> | null = null;
+  /** True while a trigger click during `ending` has scheduled `applyOpen` after close settles. */
+  let reopenAfterClosePending = false;
 
   const layer = createDismissLayer({
     transition: options.transition,
@@ -81,7 +85,10 @@ export function createPopover(options: PopoverOptions): PopoverApi {
       applyClose('escape', event);
     },
     onDocumentActive(signal) {
-      listen(document, 'pointerdown', handleDocumentPointerdown, { capture: true, signal });
+      listen(document, 'pointerdown', handleDocumentPointerdown, {
+        capture: true,
+        signal,
+      });
     },
   });
 
@@ -124,6 +131,9 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   }
 
   function skipNextBlurCloseAfterInsidePointer(): void {
+    // Some browsers retarget focus to the shadow host/body between pointerdown
+    // and click. Keep this armed through the gesture so inside menu actions can
+    // decide whether the popup closes.
     skipBlurCloseAfterInsidePointer = true;
     if (skipBlurCloseTimeout !== null) clearTimeout(skipBlurCloseTimeout);
     skipBlurCloseTimeout = setTimeout(clearInsidePointerBlurCloseGuard, 500);
@@ -141,20 +151,20 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   /**
    * The transition handler manages animation lifecycle via `createState`:
    *
-   * **Open:** `transition.open()` patches `{ active: true, status: 'starting' }`.
-   * After one RAF it patches `{ status: 'idle' }` and the promise resolves.
+   * **Open:** `transition.open()` patches `{ active: true, status: 'starting', transitioning: true }`.
+   * After one RAF it patches `{ status: 'idle' }`; the promise resolves when animations settle.
    * Frameworks render `data-starting-style` / `data-ending-style` via
    * `getPopupAttrs(state)` — no imperative DOM mutation needed.
    *
-   * **Close:** `transition.close(el)` patches `{ status: 'ending' }` (keeping
+   * **Close:** `transition.close(el)` patches `{ status: 'ending', transitioning: true }` (keeping
    * `active: true` so the element stays mounted). After a double-RAF it waits
-   * for `getAnimations()` to settle, then patches `{ active: false, status: 'idle' }`.
+   * for `getAnimations({ subtree: true })` to settle, then patches `{ active: false, status: 'idle' }`.
    *
    * `onOpenChange` fires immediately (before animations).
    * `onOpenChangeComplete` fires after animations finish.
    */
   function applyOpen(reason: PopoverOpenChangeReason, event?: Event): void {
-    const opening = layer.open();
+    const opening = layer.open(popupEl);
     if (!opening) return;
 
     options.group?.()?.open(groupMember);
@@ -171,6 +181,10 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   function applyClose(reason: PopoverOpenChangeReason, event?: Event): void {
     const closing = layer.close(popupEl);
     if (!closing) return;
+
+    closeAnimationPromise = closing.finally(() => {
+      closeAnimationPromise = null;
+    });
 
     options.group?.()?.close(groupMember);
 
@@ -237,13 +251,38 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     onClick(event) {
       if (!canToggleOnClick()) return;
 
-      // During a close animation (open=true, status=ending), treat
-      // the click as a re-open rather than a second close attempt.
-      if (state.current.active && state.current.status !== 'ending') {
-        applyClose('click', event);
-      } else {
+      event.preventDefault();
+
+      const { active, status } = state.current;
+
+      if (!active) {
         applyOpen('click', event);
+        return;
       }
+
+      // During the close animation `layer.close()` is a no-op. Canceling the close via
+      // `transition.cancel()` + immediate `open()` leaves transitions half-applied (Safari)
+      // and conflicts with menu triggers that share this handler. Defer reopen until the
+      // in-flight close settles so rapid double-clicks still toggle reliably.
+      if (status === 'ending') {
+        const pending = closeAnimationPromise;
+        if (!pending || reopenAfterClosePending) return;
+
+        reopenAfterClosePending = true;
+        pending
+          .then(() => {
+            if (layer.signal.aborted) return;
+            if (!state.current.active) {
+              applyOpen('click', event);
+            }
+          })
+          .finally(() => {
+            reopenAfterClosePending = false;
+          });
+        return;
+      }
+
+      applyClose('click', event);
     },
 
     onPointerEnter(_event) {
@@ -330,13 +369,36 @@ export function createPopover(options: PopoverOptions): PopoverApi {
         return;
       }
 
-      if (relatedTarget instanceof HTMLElement && options.group?.()?.isPeerTrigger(relatedTarget, triggerEl)) {
+      if (relatedTarget instanceof HTMLElement && options.group?.()?.isPeerTrigger?.(relatedTarget, triggerEl)) {
         return;
       }
 
       if (shouldSkipBlurCloseAfterInsidePointer()) return;
 
-      applyClose('blur');
+      if (relatedTarget !== null) {
+        if (!state.current.active || state.current.status === 'ending') return;
+        applyClose('blur');
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (!state.current.active || state.current.status === 'ending' || state.current.status === 'starting') {
+            return;
+          }
+
+          const active = typeof document !== 'undefined' ? document.activeElement : null;
+          if (active && (triggerEl?.contains(active) || popupEl?.contains(active))) {
+            return;
+          }
+
+          if (active instanceof HTMLElement && options.group?.()?.isPeerTrigger?.(active, triggerEl)) {
+            return;
+          }
+
+          applyClose('blur');
+        });
+      });
     },
   };
 
@@ -360,9 +422,10 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     }
 
     popupEl = el;
+    options.transition.setElement(el);
 
     if (el) {
-      // If the popover is already open (e.g., React mount after state
+      // If the popover is already open (e.g. React mount after state
       // change), show the popover now. In `applyOpen` the element may not
       // have been in the DOM yet, so the earlier `tryShowPopover` was a no-op.
       if (state.current.active) {
@@ -382,6 +445,8 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     setPopupElement,
     open,
     close,
-    destroy: layer.destroy,
+    destroy() {
+      layer.destroy();
+    },
   };
 }

--- a/packages/core/src/dom/ui/popover/tests/popover.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { createPopupGroup } from '../popup-group';
 import { createTestPopover } from './popover-helpers';
 
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
 describe('createPopover', () => {
   it('starts closed', () => {
     const { popover } = createTestPopover();
-    expect(popover.input.current).toEqual({ active: false, status: 'idle' });
+    expect(popover.input.current).toEqual({ active: false, status: 'idle', transitioning: false });
   });
 
   describe('open/close', () => {
@@ -24,7 +28,7 @@ describe('createPopover', () => {
 
       popover.open();
 
-      expect(popover.input.current).toEqual({ active: true, status: 'starting' });
+      expect(popover.input.current).toEqual({ active: true, status: 'starting', transitioning: true });
     });
 
     it('calls onOpenChange when closing', () => {
@@ -46,7 +50,7 @@ describe('createPopover', () => {
       popover.open();
       popover.close();
 
-      expect(popover.input.current).toEqual({ active: true, status: 'ending' });
+      expect(popover.input.current).toEqual({ active: true, status: 'ending', transitioning: true });
     });
 
     it('does not call onOpenChange if already open', () => {
@@ -93,6 +97,20 @@ describe('createPopover', () => {
       popover.close('imperative-action');
 
       expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-close the first popover when another opens without a shared group', () => {
+      const first = createTestPopover();
+      const second = createTestPopover();
+
+      first.popover.open();
+      first.onOpenChange.mockClear();
+
+      second.popover.open();
+
+      expect(first.onOpenChange).not.toHaveBeenCalled();
+      expect(first.popover.input.current.active).toBe(true);
+      expect(second.popover.input.current.active).toBe(true);
     });
 
     it('closes the previously open grouped popover when another opens', () => {
@@ -158,36 +176,47 @@ describe('createPopover', () => {
 
       popover.triggerProps.onClick(event);
 
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(popover.input.current.active).toBe(true);
       expect(onOpenChange).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'click' }));
     });
 
     it('closes on click when open', () => {
       const { popover, onOpenChange } = createTestPopover();
+      const event = { preventDefault: vi.fn() } as unknown as UIEvent;
 
       popover.open();
       onOpenChange.mockClear();
 
-      popover.triggerProps.onClick({ preventDefault: vi.fn() } as unknown as UIEvent);
+      popover.triggerProps.onClick(event);
 
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
       // active stays true until close animation completes
       expect(popover.input.current.active).toBe(true);
       expect(onOpenChange).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'click' }));
     });
 
-    it('re-opens on click during close animation', () => {
+    it('defers reopen until close settles when clicked during close animation', async () => {
       const { popover, onOpenChange } = createTestPopover();
+      const event = { preventDefault: vi.fn() } as unknown as UIEvent;
 
       popover.open();
       popover.close();
       onOpenChange.mockClear();
 
-      // Click during close animation should re-open
-      popover.triggerProps.onClick({ preventDefault: vi.fn() } as unknown as UIEvent);
+      popover.triggerProps.onClick(event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(popover.input.current.active).toBe(true);
+      expect(popover.input.current.status).toBe('ending');
+      expect(onOpenChange).not.toHaveBeenCalled();
+
+      await vi.waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'click' }));
+      });
 
       expect(popover.input.current.active).toBe(true);
       expect(popover.input.current.status).not.toBe('ending');
-      expect(onOpenChange).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'click' }));
     });
 
     it('does not open on click on touch devices when openOnHover is enabled', () => {
@@ -199,9 +228,11 @@ describe('createPopover', () => {
       const { popover, onOpenChange } = createTestPopover({
         openOnHover: () => true,
       });
+      const event = { preventDefault: vi.fn() } as unknown as UIEvent;
 
-      popover.triggerProps.onClick({ preventDefault: vi.fn() } as unknown as UIEvent);
+      popover.triggerProps.onClick(event);
 
+      expect(event.preventDefault).not.toHaveBeenCalled();
       expect(onOpenChange).not.toHaveBeenCalled();
       expect(popover.input.current.active).toBe(false);
 
@@ -299,6 +330,193 @@ describe('createPopover', () => {
 
       popover.destroy();
       popup.remove();
+    });
+
+    it('does not blur-close during a pointer interaction that started inside the popup', () => {
+      const { popover, onOpenChange } = createTestPopover();
+      const popup = document.createElement('div');
+      const child = document.createElement('button');
+      const outside = document.createElement('button');
+      popup.appendChild(child);
+      document.body.append(popup, outside);
+
+      popover.setPopupElement(popup);
+      popover.open();
+      flush();
+      onOpenChange.mockClear();
+
+      child.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+      popover.popupProps.onFocusOut({
+        relatedTarget: outside,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+
+      expect(onOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+
+      popover.destroy();
+      popup.remove();
+      outside.remove();
+    });
+
+    it('does not blur-close after an inside pointer interaction spans a frame', async () => {
+      const { popover, onOpenChange } = createTestPopover();
+      const popup = document.createElement('div');
+      const child = document.createElement('button');
+      const outside = document.createElement('button');
+      popup.appendChild(child);
+      document.body.append(popup, outside);
+
+      popover.setPopupElement(popup);
+      popover.open();
+      flush();
+      onOpenChange.mockClear();
+
+      child.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+      await nextFrame();
+      popover.popupProps.onFocusOut({
+        relatedTarget: outside,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+
+      expect(onOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+
+      popover.destroy();
+      popup.remove();
+      outside.remove();
+    });
+
+    it('blur-closes when focus leaves the popup without an inside pointer interaction', async () => {
+      const { popover, onOpenChange } = createTestPopover();
+      const popup = document.createElement('div');
+      const outside = document.createElement('button');
+      document.body.append(popup, outside);
+
+      popover.setPopupElement(popup);
+      popover.open();
+      flush();
+      await nextFrame();
+      await nextFrame();
+      onOpenChange.mockClear();
+
+      popover.popupProps.onFocusOut({
+        relatedTarget: outside,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+
+      expect(onOpenChange).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'blur' }));
+
+      popover.destroy();
+      popup.remove();
+      outside.remove();
+    });
+
+    it('closes on peer trigger pointerdown without a shared PopupGroup (lost-click-prone path)', () => {
+      const first = createTestPopover();
+      const second = createTestPopover();
+      const t1 = document.createElement('button');
+      const t2 = document.createElement('button');
+      const p1 = document.createElement('div');
+      document.body.appendChild(t1);
+      document.body.appendChild(t2);
+      document.body.appendChild(p1);
+
+      first.popover.setTriggerElement(t1);
+      first.popover.setPopupElement(p1);
+      second.popover.setTriggerElement(t2);
+
+      first.popover.open();
+      flush();
+      first.onOpenChange.mockClear();
+      second.onOpenChange.mockClear();
+
+      t2.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+
+      expect(first.onOpenChange).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'outside-click' }));
+
+      const click = { preventDefault: vi.fn() } as unknown as UIEvent;
+      second.popover.triggerProps.onClick(click);
+
+      expect(second.onOpenChange).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'click' }));
+
+      first.popover.destroy();
+      second.popover.destroy();
+      t1.remove();
+      t2.remove();
+      p1.remove();
+    });
+
+    it('skips outside-dismiss on peer trigger pointerdown when sharing a PopupGroup', () => {
+      const group = createPopupGroup();
+      const first = createTestPopover({ group: () => group });
+      const second = createTestPopover({ group: () => group });
+      const t1 = document.createElement('button');
+      const t2 = document.createElement('button');
+      const p1 = document.createElement('div');
+      document.body.appendChild(t1);
+      document.body.appendChild(t2);
+      document.body.appendChild(p1);
+
+      first.popover.setTriggerElement(t1);
+      first.popover.setPopupElement(p1);
+      second.popover.setTriggerElement(t2);
+
+      first.popover.open();
+      flush();
+      first.onOpenChange.mockClear();
+      second.onOpenChange.mockClear();
+
+      t2.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+
+      expect(first.onOpenChange).not.toHaveBeenCalled();
+
+      const click = { preventDefault: vi.fn() } as unknown as UIEvent;
+      second.popover.triggerProps.onClick(click);
+
+      expect(first.onOpenChange).toHaveBeenCalledWith(false, { reason: 'group-open' });
+      expect(second.onOpenChange).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'click' }));
+
+      first.popover.destroy();
+      second.popover.destroy();
+      t1.remove();
+      t2.remove();
+      p1.remove();
+    });
+
+    it('does not blur-close when focus moves to another registered group trigger', () => {
+      const group = createPopupGroup();
+      const first = createTestPopover({ group: () => group });
+      const second = createTestPopover({ group: () => group });
+      const t1 = document.createElement('button');
+      const t2 = document.createElement('button');
+      const p2 = document.createElement('div');
+      document.body.appendChild(t1);
+      document.body.appendChild(t2);
+      document.body.appendChild(p2);
+
+      first.popover.setTriggerElement(t1);
+      second.popover.setTriggerElement(t2);
+      second.popover.setPopupElement(p2);
+
+      second.popover.open();
+      flush();
+      second.onOpenChange.mockClear();
+
+      second.popover.popupProps.onFocusOut({
+        relatedTarget: t1,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      });
+
+      expect(second.onOpenChange).not.toHaveBeenCalledWith(false, expect.anything());
+
+      first.popover.destroy();
+      second.popover.destroy();
+      t1.remove();
+      t2.remove();
+      p2.remove();
     });
 
     it('closes when clicking outside the popup', () => {

--- a/packages/core/src/dom/ui/tests/alert-dialog.test.ts
+++ b/packages/core/src/dom/ui/tests/alert-dialog.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 describe('createAlertDialog', () => {
   it('starts closed', () => {
     const { alertDialog } = createTestAlertDialog();
-    expect(alertDialog.input.current).toEqual({ active: false, status: 'idle' });
+    expect(alertDialog.input.current).toEqual({ active: false, status: 'idle', transitioning: false });
   });
 
   describe('open/close', () => {
@@ -39,7 +39,7 @@ describe('createAlertDialog', () => {
 
       alertDialog.open();
 
-      expect(alertDialog.input.current).toEqual({ active: true, status: 'starting' });
+      expect(alertDialog.input.current).toEqual({ active: true, status: 'starting', transitioning: true });
     });
 
     it('calls onOpenChange when closing', () => {
@@ -61,7 +61,7 @@ describe('createAlertDialog', () => {
       alertDialog.open();
       alertDialog.close();
 
-      expect(alertDialog.input.current).toEqual({ active: true, status: 'ending' });
+      expect(alertDialog.input.current).toEqual({ active: true, status: 'ending', transitioning: true });
     });
 
     it('does not call onOpenChange if already open', () => {

--- a/packages/core/src/dom/ui/tests/dismiss-layer.test.ts
+++ b/packages/core/src/dom/ui/tests/dismiss-layer.test.ts
@@ -17,7 +17,7 @@ function createTestLayer(overrides?: Partial<Parameters<typeof createDismissLaye
 describe('createDismissLayer', () => {
   it('starts closed', () => {
     const { layer } = createTestLayer();
-    expect(layer.input.current).toEqual({ active: false, status: 'idle' });
+    expect(layer.input.current).toEqual({ active: false, status: 'idle', transitioning: false });
   });
 
   describe('open', () => {
@@ -27,7 +27,7 @@ describe('createDismissLayer', () => {
       const result = layer.open();
 
       expect(result).toBeInstanceOf(Promise);
-      expect(layer.input.current).toEqual({ active: true, status: 'starting' });
+      expect(layer.input.current).toEqual({ active: true, status: 'starting', transitioning: true });
     });
 
     it('returns null if already open', () => {
@@ -71,7 +71,7 @@ describe('createDismissLayer', () => {
       const result = layer.close(null);
 
       expect(result).toBeInstanceOf(Promise);
-      expect(layer.input.current).toEqual({ active: true, status: 'ending' });
+      expect(layer.input.current).toEqual({ active: true, status: 'ending', transitioning: true });
     });
 
     it('returns null if already closed', () => {

--- a/packages/core/src/dom/ui/tests/transition.test.ts
+++ b/packages/core/src/dom/ui/tests/transition.test.ts
@@ -53,6 +53,31 @@ describe('createTransition', () => {
 
       expect(handler.state.current.transitioning).toBe(false);
     });
+
+    it('waits for animations on an element registered after open', async () => {
+      const handler = createTransition();
+      let resolveAnimation!: () => void;
+      const animation = new Promise<void>((resolve) => {
+        resolveAnimation = resolve;
+      });
+
+      const promise = handler.open();
+
+      const el = document.createElement('div');
+      el.getAnimations = vi.fn(() => [{ finished: animation } as unknown as Animation]);
+      handler.setElement(el);
+
+      await vi.waitFor(() => {
+        expect(handler.state.current.status).toBe('idle');
+      });
+
+      expect(handler.state.current.transitioning).toBe(true);
+
+      resolveAnimation();
+      await promise;
+
+      expect(handler.state.current.transitioning).toBe(false);
+    });
   });
 
   describe('close', () => {

--- a/packages/core/src/dom/ui/tests/transition.test.ts
+++ b/packages/core/src/dom/ui/tests/transition.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createTransition } from '../transition';
+import { createTransition, waitForAnimations } from '../transition';
 
 describe('createTransition', () => {
   it('starts with idle state', () => {
     const handler = createTransition();
-    expect(handler.state.current).toEqual({ active: false, status: 'idle' });
+    expect(handler.state.current).toEqual({ active: false, status: 'idle', transitioning: false });
   });
 
   describe('open', () => {
@@ -13,7 +13,7 @@ describe('createTransition', () => {
 
       handler.open();
 
-      expect(handler.state.current).toEqual({ active: true, status: 'starting' });
+      expect(handler.state.current).toEqual({ active: true, status: 'starting', transitioning: true });
     });
 
     it('transitions to idle after a double-RAF', async () => {
@@ -27,7 +27,31 @@ describe('createTransition', () => {
       });
 
       await promise;
-      expect(handler.state.current).toEqual({ active: true, status: 'idle' });
+      expect(handler.state.current).toEqual({ active: true, status: 'idle', transitioning: false });
+    });
+
+    it('keeps transitioning true until open animations settle', async () => {
+      const handler = createTransition();
+      const el = document.createElement('div');
+      let resolveAnimation!: () => void;
+      const animation = new Promise<void>((resolve) => {
+        resolveAnimation = resolve;
+      });
+
+      el.getAnimations = vi.fn(() => [{ finished: animation } as unknown as Animation]);
+
+      const promise = handler.open(el);
+
+      await vi.waitFor(() => {
+        expect(handler.state.current.status).toBe('idle');
+      });
+
+      expect(handler.state.current.transitioning).toBe(true);
+
+      resolveAnimation();
+      await promise;
+
+      expect(handler.state.current.transitioning).toBe(false);
     });
   });
 
@@ -41,7 +65,7 @@ describe('createTransition', () => {
 
       handler.close(el);
 
-      expect(handler.state.current).toEqual({ active: true, status: 'ending' });
+      expect(handler.state.current).toEqual({ active: true, status: 'ending', transitioning: true });
     });
 
     it('keeps open true during close animation', () => {
@@ -68,7 +92,36 @@ describe('createTransition', () => {
       });
 
       await promise;
-      expect(handler.state.current).toEqual({ active: false, status: 'idle' });
+      expect(handler.state.current).toEqual({ active: false, status: 'idle', transitioning: false });
+    });
+
+    it('waits for descendant animations via getAnimations({ subtree: true })', async () => {
+      const handler = createTransition();
+      const el = document.createElement('div');
+      let resolveAnimation!: () => void;
+      const animation = new Promise<void>((resolve) => {
+        resolveAnimation = resolve;
+      });
+      const pending = { finished: animation } as unknown as Animation;
+
+      el.getAnimations = vi.fn((options?: { subtree?: boolean }) =>
+        options?.subtree ? [pending] : []
+      ) as HTMLElement['getAnimations'];
+
+      handler.open(el);
+      await vi.waitFor(() => {
+        expect(handler.state.current.status).toBe('idle');
+      });
+
+      const closePromise = handler.close(el);
+      expect(handler.state.current.status).toBe('ending');
+      expect(handler.state.current.transitioning).toBe(true);
+      expect(el.getAnimations).toHaveBeenCalledWith({ subtree: true });
+
+      resolveAnimation();
+      await closePromise;
+
+      expect(handler.state.current).toEqual({ active: false, status: 'idle', transitioning: false });
     });
   });
 
@@ -81,6 +134,7 @@ describe('createTransition', () => {
 
       handler.cancel();
       expect(handler.state.current.status).toBe('idle');
+      expect(handler.state.current.transitioning).toBe(false);
     });
 
     it('preserves open state', () => {
@@ -123,5 +177,37 @@ describe('createTransition', () => {
       handler.destroy();
       handler.destroy(); // should not throw
     });
+  });
+});
+
+describe('waitForAnimations', () => {
+  it('waits for the CSS transition fallback when a Web Animation is canceled', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const el = document.createElement('div');
+      const canceledAnimation = Promise.reject(new Error('canceled'));
+      let settled = false;
+
+      el.style.transitionDuration = '100ms';
+      el.getAnimations = vi.fn(() => [{ finished: canceledAnimation } as unknown as Animation]);
+
+      const promise = waitForAnimations(el, { includeCSSTransitions: true }).then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await promise;
+
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
+++ b/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
@@ -6,7 +6,7 @@ import { createTestTooltip } from './tooltip-helpers';
 describe('createTooltip', () => {
   it('starts closed', () => {
     const { tooltip } = createTestTooltip();
-    expect(tooltip.input.current).toEqual({ active: false, status: 'idle' });
+    expect(tooltip.input.current).toEqual({ active: false, status: 'idle', transitioning: false });
   });
 
   describe('open/close', () => {
@@ -24,7 +24,7 @@ describe('createTooltip', () => {
 
       tooltip.open();
 
-      expect(tooltip.input.current).toEqual({ active: true, status: 'starting' });
+      expect(tooltip.input.current).toEqual({ active: true, status: 'starting', transitioning: true });
     });
 
     it('calls onOpenChange when closing', () => {

--- a/packages/core/src/dom/ui/transition.ts
+++ b/packages/core/src/dom/ui/transition.ts
@@ -41,7 +41,7 @@ export function scheduleTransitionSettle(
 
   function pollVisualComplete(): void {
     pollRaf = 0;
-    if (!isCurrent()) return;
+    if (settled || !isCurrent()) return;
 
     if (options.isVisuallyComplete?.(element)) {
       settle();

--- a/packages/core/src/dom/ui/transition.ts
+++ b/packages/core/src/dom/ui/transition.ts
@@ -1,71 +1,155 @@
 import { createState, type State } from '@videojs/store';
+import { afterDoubleAnimationFrame, getMaxCSSTransitionTime } from '@videojs/utils/dom';
 import { noop } from '@videojs/utils/function';
 import type { TransitionState } from '../../core/ui/transition';
 
 export interface TransitionApi {
   state: State<TransitionState>;
-  open(): Promise<void>;
+  setElement(el: HTMLElement | null): void;
+  open(el?: HTMLElement | null): Promise<void>;
   close(el: HTMLElement | null): Promise<void>;
   cancel(): void;
   destroy(): void;
 }
 
+export interface WaitForAnimationsOptions {
+  includeCSSTransitions?: boolean;
+}
+
+export interface ScheduleTransitionSettleOptions {
+  includeCSSTransitions?: boolean;
+  isVisuallyComplete?: (element: HTMLElement) => boolean;
+}
+
+/** After double-RAF, optionally poll visual completion, then wait for animations to settle. */
+export function scheduleTransitionSettle(
+  element: HTMLElement,
+  isCurrent: () => boolean,
+  onSettled: () => void,
+  options: ScheduleTransitionSettleOptions = {}
+): () => void {
+  let pollRaf = 0;
+  let settled = false;
+
+  function settle(): void {
+    if (settled || !isCurrent()) return;
+    settled = true;
+    cancelAnimationFrame(pollRaf);
+    pollRaf = 0;
+    onSettled();
+  }
+
+  function pollVisualComplete(): void {
+    pollRaf = 0;
+    if (!isCurrent()) return;
+
+    if (options.isVisuallyComplete?.(element)) {
+      settle();
+      return;
+    }
+
+    pollRaf = requestAnimationFrame(pollVisualComplete);
+  }
+
+  afterDoubleAnimationFrame(isCurrent, () => {
+    pollVisualComplete();
+
+    waitForAnimations(element, {
+      includeCSSTransitions: options.includeCSSTransitions ?? false,
+    }).then(() => {
+      settle();
+    });
+  });
+
+  return () => {
+    settled = true;
+    cancelAnimationFrame(pollRaf);
+  };
+}
+
 /**
  * Manages open/close transition lifecycle via `createState`.
  *
- * **Open:** patches `{ active: true, status: 'starting' }`, then after a
- * double-RAF patches `{ status: 'idle' }` so the browser paints the
- * initial ("from") state before transitioning.
+ * **Open:** patches `{ active: true, status: 'starting', transitioning: true }`, then
+ * after a double-RAF patches `{ status: 'idle' }` so the browser paints the
+ * initial ("from") state before transitioning. `transitioning` stays true
+ * until the element's animations settle.
  *
- * **Close:** patches `{ status: 'ending' }` (keeping `active: true` so the
- * element stays mounted), then after a double-RAF waits for
- * `getAnimations()` to settle before patching `{ active: false, status: 'idle' }`.
+ * **Close:** patches `{ status: 'ending', transitioning: true }` (keeping
+ * `active: true` so the element stays mounted), then after a double-RAF waits
+ * for `getAnimations({ subtree: true })` to settle before patching
+ * `{ active: false, status: 'idle' }`.
  */
 export function createTransition(): TransitionApi {
-  const state = createState<TransitionState>({ active: false, status: 'idle' });
+  const state = createState<TransitionState>({ active: false, status: 'idle', transitioning: false });
 
   let destroyed = false;
+  let element: HTMLElement | null = null;
+  let transitionId = 0;
   let rafId1 = 0;
   let rafId2 = 0;
 
-  function open(): Promise<void> {
+  function setElement(el: HTMLElement | null): void {
+    element = el;
+  }
+
+  function cancelFrames(): void {
     cancelAnimationFrame(rafId1);
     cancelAnimationFrame(rafId2);
     rafId1 = 0;
     rafId2 = 0;
+  }
 
-    state.patch({ active: true, status: 'starting' });
+  function open(el?: HTMLElement | null): Promise<void> {
+    transitionId++;
+    const currentTransitionId = transitionId;
+    cancelFrames();
+
+    if (el !== undefined) {
+      element = el;
+    }
+
+    const animationTarget = element;
+
+    state.patch({ active: true, status: 'starting', transitioning: true });
 
     return new Promise<void>((resolve) => {
       rafId1 = requestAnimationFrame(() => {
         rafId1 = 0;
         rafId2 = requestAnimationFrame(() => {
           rafId2 = 0;
-          if (destroyed || !state.current.active) return resolve();
+          if (destroyed || currentTransitionId !== transitionId || !state.current.active) return resolve();
           state.patch({ status: 'idle' });
-          resolve();
+          waitForAnimations(animationTarget).finally(() => {
+            if (destroyed || currentTransitionId !== transitionId || !state.current.active) return resolve();
+            state.patch({ transitioning: false });
+            resolve();
+          });
         });
       });
     });
   }
 
   function close(el: HTMLElement | null): Promise<void> {
-    cancelAnimationFrame(rafId1);
-    cancelAnimationFrame(rafId2);
-    rafId1 = 0;
-    rafId2 = 0;
+    transitionId++;
+    const currentTransitionId = transitionId;
+    cancelFrames();
 
-    state.patch({ status: 'ending' });
+    element = el;
+
+    state.patch({ status: 'ending', transitioning: true });
 
     return new Promise<void>((resolve) => {
       rafId1 = requestAnimationFrame(() => {
         rafId1 = 0;
         rafId2 = requestAnimationFrame(() => {
           rafId2 = 0;
-          if (destroyed) return resolve();
+          if (destroyed || currentTransitionId !== transitionId) return resolve();
           waitForAnimations(el).finally(() => {
-            if (destroyed || state.current.status !== 'ending') return resolve();
-            state.patch({ active: false, status: 'idle' });
+            if (destroyed || currentTransitionId !== transitionId || state.current.status !== 'ending') {
+              return resolve();
+            }
+            state.patch({ active: false, status: 'idle', transitioning: false });
             resolve();
           });
         });
@@ -74,17 +158,16 @@ export function createTransition(): TransitionApi {
   }
 
   function cancel(): void {
-    cancelAnimationFrame(rafId1);
-    cancelAnimationFrame(rafId2);
-    rafId1 = 0;
-    rafId2 = 0;
-    if (state.current.status !== 'idle') {
-      state.patch({ status: 'idle' });
+    transitionId++;
+    cancelFrames();
+    if (state.current.status !== 'idle' || state.current.transitioning) {
+      state.patch({ status: 'idle', transitioning: false });
     }
   }
 
   return {
     state,
+    setElement,
     open,
     close,
     cancel,
@@ -96,12 +179,28 @@ export function createTransition(): TransitionApi {
   };
 }
 
-function waitForAnimations(el: HTMLElement | null): Promise<void> {
+export function waitForAnimations(
+  el: HTMLElement | null,
+  { includeCSSTransitions = false }: WaitForAnimationsOptions = {}
+): Promise<void> {
   if (!el) return Promise.resolve();
 
-  const animations = el.getAnimations?.() ?? [];
+  // Include descendant animations so nested menu views (submenus) keep the root
+  // layer in `ending` until their CSS animations finish.
+  const animations = el.getAnimations?.({ subtree: true }) ?? [];
+  const transitionTime = includeCSSTransitions ? getMaxCSSTransitionTime(el) : 0;
+  const transitionPromise =
+    transitionTime > 0
+      ? new Promise<void>((resolve) => {
+          setTimeout(resolve, transitionTime);
+        })
+      : Promise.resolve();
 
-  if (animations.length === 0) return Promise.resolve();
+  if (animations.length === 0) return transitionPromise;
 
-  return Promise.all(animations.map((a) => a.finished)).then(noop, noop);
+  // Canceled animations reject `finished`; handle each one so a single
+  // cancellation does not short-circuit the CSS transition fallback.
+  const animationPromises = animations.map((animation) => animation.finished.catch(noop));
+
+  return Promise.all([transitionPromise, ...animationPromises]).then(noop);
 }

--- a/packages/core/src/dom/ui/transition.ts
+++ b/packages/core/src/dom/ui/transition.ts
@@ -1,5 +1,5 @@
 import { createState, type State } from '@videojs/store';
-import { afterDoubleAnimationFrame, getMaxCSSTransitionTime } from '@videojs/utils/dom';
+import { getMaxCSSTransitionTime } from '@videojs/utils/dom';
 import { noop } from '@videojs/utils/function';
 import type { TransitionState } from '../../core/ui/transition';
 
@@ -14,57 +14,6 @@ export interface TransitionApi {
 
 export interface WaitForAnimationsOptions {
   includeCSSTransitions?: boolean;
-}
-
-export interface ScheduleTransitionSettleOptions {
-  includeCSSTransitions?: boolean;
-  isVisuallyComplete?: (element: HTMLElement) => boolean;
-}
-
-/** After double-RAF, optionally poll visual completion, then wait for animations to settle. */
-export function scheduleTransitionSettle(
-  element: HTMLElement,
-  isCurrent: () => boolean,
-  onSettled: () => void,
-  options: ScheduleTransitionSettleOptions = {}
-): () => void {
-  let pollRaf = 0;
-  let settled = false;
-
-  function settle(): void {
-    if (settled || !isCurrent()) return;
-    settled = true;
-    cancelAnimationFrame(pollRaf);
-    pollRaf = 0;
-    onSettled();
-  }
-
-  function pollVisualComplete(): void {
-    pollRaf = 0;
-    if (settled || !isCurrent()) return;
-
-    if (options.isVisuallyComplete?.(element)) {
-      settle();
-      return;
-    }
-
-    pollRaf = requestAnimationFrame(pollVisualComplete);
-  }
-
-  afterDoubleAnimationFrame(isCurrent, () => {
-    pollVisualComplete();
-
-    waitForAnimations(element, {
-      includeCSSTransitions: options.includeCSSTransitions ?? false,
-    }).then(() => {
-      settle();
-    });
-  });
-
-  return () => {
-    settled = true;
-    cancelAnimationFrame(pollRaf);
-  };
 }
 
 /**
@@ -109,8 +58,6 @@ export function createTransition(): TransitionApi {
       element = el;
     }
 
-    const animationTarget = element;
-
     state.patch({ active: true, status: 'starting', transitioning: true });
 
     return new Promise<void>((resolve) => {
@@ -120,7 +67,7 @@ export function createTransition(): TransitionApi {
           rafId2 = 0;
           if (destroyed || currentTransitionId !== transitionId || !state.current.active) return resolve();
           state.patch({ status: 'idle' });
-          waitForAnimations(animationTarget).finally(() => {
+          waitForAnimations(element).finally(() => {
             if (destroyed || currentTransitionId !== transitionId || !state.current.active) return resolve();
             state.patch({ transitioning: false });
             resolve();

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -91,7 +91,7 @@ function getTemplateHTML() {
           <div class="${buttonGroup}">
             <media-playback-rate-menu-trigger commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}">
             </media-playback-rate-menu-trigger>
-            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${cn(popup.popover, menu.root)}">
+            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${menu.root}">
               <media-playback-rate-options class="${menu.group}">
                 <template>
                   <media-menu-radio-item class="${menu.item}">

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -86,7 +86,7 @@ function getTemplateHTML() {
 
           <div class="${buttonGroup}">
             <media-playback-rate-menu-trigger commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}"></media-playback-rate-menu-trigger>
-            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${cn(popup.popover, menu.root)}">
+            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" boundary="viewport" class="${menu.root}">
               <media-playback-rate-options class="${menu.group}">
                 <template>
                   <media-menu-radio-item class="${menu.item}">

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -85,7 +85,7 @@ function getTemplateHTML() {
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-menu-trigger>
-              <media-captions-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root)}">
+              <media-captions-menu id="captions-menu" side="top" align="center" class="${menu.root}">
                 <media-captions-options class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -87,7 +87,7 @@ function getTemplateHTML() {
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-menu-trigger>
-              <media-captions-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root)}">
+              <media-captions-menu id="captions-menu" side="top" align="center" class="${menu.root}">
                 <media-captions-options class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -113,7 +113,7 @@ function getTemplateHTML() {
           <div class="${buttonGroupEnd}">
             <media-playback-rate-menu-trigger commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}">
             </media-playback-rate-menu-trigger>
-            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" class="${cn(popup.popover, menu.root)}">
+            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" class="${menu.root}">
               <media-playback-rate-options class="${menu.group}">
                 <template>
                   <media-menu-radio-item class="${menu.item}">
@@ -144,7 +144,7 @@ function getTemplateHTML() {
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-menu-trigger>
-              <media-captions-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root)}">
+              <media-captions-menu id="captions-menu" side="top" align="center" class="${menu.root}">
                 <media-captions-options class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -108,7 +108,7 @@ function getTemplateHTML() {
 
           <div class="${buttonGroupEnd}">
             <media-playback-rate-menu-trigger commandfor="playback-rate-menu" class="${cn(button.base, button.subtle, button.icon, playbackRate.button)}"></media-playback-rate-menu-trigger>
-            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" class="${cn(popup.popover, menu.root)}">
+            <media-playback-rate-menu id="playback-rate-menu" side="top" align="center" class="${menu.root}">
               <media-playback-rate-options class="${menu.group}">
                 <template>
                   <media-menu-radio-item class="${menu.item}">
@@ -139,7 +139,7 @@ function getTemplateHTML() {
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-menu-trigger>
-              <media-captions-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root)}">
+              <media-captions-menu id="captions-menu" side="top" align="center" class="${menu.root}">
                 <media-captions-options class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">

--- a/packages/html/src/ui/input-indicators/tests/input-indicators.test.ts
+++ b/packages/html/src/ui/input-indicators/tests/input-indicators.test.ts
@@ -64,6 +64,7 @@ describe('input indicators', () => {
       max: false,
       transitionStarting: true,
       transitionEnding: false,
+      transitioning: true,
     });
 
     expect(liveElement).toBe(host);

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -224,7 +224,7 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
           <div className={buttonGroup}>
             <PlaybackRateMenu.Root side="top" align="center" boundary="viewport">
               <PlaybackRateMenu.Trigger className={playbackRate.button} render={<Button />} />
-              <PlaybackRateMenu.Content className={cn(popup.popover, menu.root)}>
+              <PlaybackRateMenu.Content className={menu.root}>
                 <PlaybackRateMenuItems />
               </PlaybackRateMenu.Content>
             </PlaybackRateMenu.Root>

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -222,7 +222,7 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
           <div className={buttonGroup}>
             <PlaybackRateMenu.Root side="top" align="center" boundary="viewport">
               <PlaybackRateMenu.Trigger className={playbackRate.button} render={<Button />} />
-              <PlaybackRateMenu.Content className={cn(popup.popover, menu.root)}>
+              <PlaybackRateMenu.Content className={menu.root}>
                 <PlaybackRateMenuItems />
               </PlaybackRateMenu.Content>
             </PlaybackRateMenu.Root>

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -220,7 +220,7 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
                 <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
                 <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
               </CaptionsMenu.Trigger>
-              <CaptionsMenu.Content className={cn(popup.popover, menu.root)}>
+              <CaptionsMenu.Content className={menu.root}>
                 <CaptionsMenuItems />
               </CaptionsMenu.Content>
             </CaptionsMenu.Root>

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -222,7 +222,7 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
                 <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
                 <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
               </CaptionsMenu.Trigger>
-              <CaptionsMenu.Content className={cn(popup.popover, menu.root)}>
+              <CaptionsMenu.Content className={menu.root}>
                 <CaptionsMenuItems />
               </CaptionsMenu.Content>
             </CaptionsMenu.Root>

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -301,7 +301,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
           <div className={buttonGroupEnd}>
             <PlaybackRateMenu.Root side="top" align="center">
               <PlaybackRateMenu.Trigger className={playbackRate.button} render={<Button />} />
-              <PlaybackRateMenu.Content className={cn(popup.popover, menu.root)}>
+              <PlaybackRateMenu.Content className={menu.root}>
                 <PlaybackRateMenuItems />
               </PlaybackRateMenu.Content>
             </PlaybackRateMenu.Root>
@@ -313,7 +313,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
                 <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
                 <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
               </CaptionsMenu.Trigger>
-              <CaptionsMenu.Content className={cn(popup.popover, menu.root)}>
+              <CaptionsMenu.Content className={menu.root}>
                 <CaptionsMenuItems />
               </CaptionsMenu.Content>
             </CaptionsMenu.Root>

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -297,7 +297,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
           <div className={buttonGroupEnd}>
             <PlaybackRateMenu.Root side="top" align="center">
               <PlaybackRateMenu.Trigger className={playbackRate.button} render={<Button />} />
-              <PlaybackRateMenu.Content className={cn(popup.popover, menu.root)}>
+              <PlaybackRateMenu.Content className={menu.root}>
                 <PlaybackRateMenuItems />
               </PlaybackRateMenu.Content>
             </PlaybackRateMenu.Root>
@@ -309,7 +309,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
                 <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
                 <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
               </CaptionsMenu.Trigger>
-              <CaptionsMenu.Content className={cn(popup.popover, menu.root)}>
+              <CaptionsMenu.Content className={menu.root}>
                 <CaptionsMenuItems />
               </CaptionsMenu.Content>
             </CaptionsMenu.Root>

--- a/packages/react/src/ui/input-indicators/tests/input-indicators.test.tsx
+++ b/packages/react/src/ui/input-indicators/tests/input-indicators.test.tsx
@@ -25,6 +25,7 @@ describe('input indicators', () => {
       value: null,
       transitionStarting: false,
       transitionEnding: false,
+      transitioning: false,
     };
 
     const { getByTestId } = render(
@@ -54,6 +55,7 @@ describe('input indicators', () => {
       max: false,
       transitionStarting: false,
       transitionEnding: false,
+      transitioning: false,
     };
 
     const { getByTestId } = render(
@@ -82,6 +84,7 @@ describe('input indicators', () => {
       currentTime: '0:30',
       transitionStarting: false,
       transitionEnding: false,
+      transitioning: false,
     };
 
     const { getByTestId } = render(

--- a/packages/skins/src/default/css/components/menus.css
+++ b/packages/skins/src/default/css/components/menus.css
@@ -16,6 +16,10 @@
   &::before {
     display: none;
   }
+
+  &[data-transitioning] {
+    overflow: hidden;
+  }
 }
 
 .media-default-skin .media-popover.media-menu .media-menu__group {

--- a/packages/skins/src/default/css/components/popup.css
+++ b/packages/skins/src/default/css/components/popup.css
@@ -20,6 +20,10 @@
     scale: 0.85;
   }
 
+  &[data-transitioning] {
+    overflow: hidden;
+  }
+
   &[data-instant] {
     transition-duration: 0ms;
   }

--- a/packages/skins/src/default/tailwind/audio.tailwind.ts
+++ b/packages/skins/src/default/tailwind/audio.tailwind.ts
@@ -2,6 +2,7 @@ import { cn } from '@videojs/utils/style';
 import { bufferingIndicator as baseBufferingIndicator } from './components/buffering';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
+import { menu as baseMenu } from './components/menu';
 import { popup as basePopup } from './components/popup';
 import { root as baseRoot } from './components/root';
 import { slider as baseSlider } from './components/slider';
@@ -106,7 +107,10 @@ export { iconState } from '../../shared/tailwind/icon-state';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';
-export { menu } from './components/menu';
+export const menu = {
+  ...baseMenu,
+  root: cn(surface, baseMenu.root),
+};
 export { playbackRate } from './components/playback-rate';
 export { seek } from './components/seek';
 export { time } from './components/time';

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -5,6 +5,7 @@ export const menu = {
     'box-border min-w-[min(6rem,var(--media-popover-available-width,6rem))]',
     'max-w-(--media-popover-available-width) max-h-(--media-popover-available-height)',
     'p-1.5 !overflow-auto overscroll-none rounded-[1.25rem]',
+    'data-transitioning:overflow-hidden',
     'before:hidden'
   ),
   group: cn(

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -5,7 +5,7 @@ export const menu = {
     'box-border min-w-[min(6rem,var(--media-popover-available-width,6rem))]',
     'max-w-(--media-popover-available-width) max-h-(--media-popover-available-height)',
     'p-1.5 !overflow-auto overscroll-none rounded-[1.25rem]',
-    'data-transitioning:overflow-hidden',
+    'data-transitioning:!overflow-hidden',
     'before:hidden'
   ),
   group: cn(

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -1,11 +1,23 @@
 import { cn } from '@videojs/utils/style';
 
+import { popoverShell, popoverSideOffsetSize } from './popup';
+
+const menuHostShell = cn(
+  popoverShell,
+  popoverSideOffsetSize,
+  'transition-[transform,scale,opacity,filter]',
+  'duration-(--media-popup-transition-duration)',
+  'ease-(--media-popup-transition-timing-function)',
+  'box-border rounded-[1.25rem] p-1.5 overscroll-none'
+);
+
 export const menu = {
+  /** Standalone menu popover host (captions, playback rate). */
   root: cn(
-    'box-border min-w-[min(6rem,var(--media-popover-available-width,6rem))]',
+    menuHostShell,
+    'min-w-[min(6rem,var(--media-popover-available-width,6rem))]',
     'max-w-(--media-popover-available-width) max-h-(--media-popover-available-height)',
-    'p-1.5 !overflow-auto overscroll-none rounded-[1.25rem]',
-    'data-transitioning:!overflow-hidden',
+    'overflow-auto data-transitioning:overflow-hidden',
     'before:hidden'
   ),
   group: cn(

--- a/packages/skins/src/default/tailwind/components/popup.ts
+++ b/packages/skins/src/default/tailwind/components/popup.ts
@@ -9,6 +9,7 @@ const base = cn(
   'ease-(--media-popup-transition-timing-function)',
   'data-starting-style:opacity-0 data-starting-style:scale-50 data-starting-style:blur-sm',
   'data-ending-style:opacity-0 data-ending-style:scale-50 data-ending-style:blur-sm',
+  'data-transitioning:overflow-hidden',
   'data-instant:duration-0',
   // Ensure we animate from the correct origin based on the side the popover is on
   'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left',

--- a/packages/skins/src/default/tailwind/components/popup.ts
+++ b/packages/skins/src/default/tailwind/components/popup.ts
@@ -1,19 +1,18 @@
 import { cn } from '@videojs/utils/style';
 
-const base = cn(
-  // Reset default popover styles
-  'm-0 border-0 text-inherit overflow-visible',
-  // Animation
-  'transition-[transform,scale,opacity,filter]',
-  'duration-(--media-popup-transition-duration)',
-  'ease-(--media-popup-transition-timing-function)',
+export const popupReset = 'm-0 border-0 text-inherit';
+
+export const popupSideOrigins = cn(
+  'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left'
+);
+
+export const popupOpenCloseStyles = cn(
   'data-starting-style:opacity-0 data-starting-style:scale-50 data-starting-style:blur-sm',
   'data-ending-style:opacity-0 data-ending-style:scale-50 data-ending-style:blur-sm',
-  'data-transitioning:overflow-hidden',
-  'data-instant:duration-0',
-  // Ensure we animate from the correct origin based on the side the popover is on
-  'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left',
-  // Safe area between trigger and popup
+  'data-instant:duration-0'
+);
+
+export const popupSideOffsetBefore = cn(
   'before:absolute before:pointer-events-[inherit]',
   'data-[side=top]:before:left-0 data-[side=top]:before:right-0 data-[side=top]:before:top-full',
   'data-[side=bottom]:before:left-0 data-[side=bottom]:before:right-0 data-[side=bottom]:before:bottom-full',
@@ -21,17 +20,40 @@ const base = cn(
   'data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:right-full'
 );
 
+export const popoverSideOffsetSize = cn(
+  'data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)',
+  'data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)'
+);
+
+export const tooltipSideOffsetSize = cn(
+  'data-[side=top]:before:h-(--media-tooltip-side-offset) data-[side=bottom]:before:h-(--media-tooltip-side-offset)',
+  'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'
+);
+
+/** Popover positioning shell shared by popups and menus (no overflow or transition timing). */
+export const popoverShell = cn(popupReset, popupSideOffsetBefore, popupSideOrigins, popupOpenCloseStyles);
+
+const popoverAnimation = cn(
+  'transition-[transform,scale,opacity,filter]',
+  'duration-(--media-popup-transition-duration)',
+  'ease-(--media-popup-transition-timing-function)'
+);
+
 export const popup = {
   popover: cn(
-    base,
-    'data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)',
-    'data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)'
+    popoverShell,
+    popoverSideOffsetSize,
+    popoverAnimation,
+    'overflow-visible',
+    'data-transitioning:overflow-hidden'
   ),
   tooltip: cn(
-    base,
+    popoverShell,
+    tooltipSideOffsetSize,
+    popoverAnimation,
     'py-1 px-2.5 rounded-full text-[0.75rem] whitespace-nowrap',
-    'data-[side=top]:before:h-(--media-tooltip-side-offset) data-[side=bottom]:before:h-(--media-tooltip-side-offset)',
-    'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'
+    'overflow-visible',
+    'data-transitioning:overflow-hidden'
   ),
   volume: 'py-3 px-0 rounded-full',
 };

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -4,6 +4,7 @@ import { buttonGroup as baseButtonGroup } from './components/button-group';
 import { controls as baseControls } from './components/controls';
 import { error as baseError } from './components/error';
 import { inputFeedback as baseInputFeedback } from './components/input-feedback';
+import { menu as baseMenu } from './components/menu';
 import { popup as basePopup } from './components/popup';
 import { preview as basePreview } from './components/preview';
 import { root as baseRoot } from './components/root';
@@ -212,7 +213,10 @@ export { iconState } from '../../shared/tailwind/icon-state';
 export { button } from './components/button';
 export { buttonGroup } from './components/button-group';
 export { icon, iconContainer, iconFlipped, iconHidden } from './components/icon';
-export { menu } from './components/menu';
+export const menu = {
+  ...baseMenu,
+  root: cn(surface, baseMenu.root),
+};
 export { overlay } from './components/overlay';
 export { playbackRate } from './components/playback-rate';
 export { poster } from './components/poster';

--- a/packages/skins/src/minimal/css/components/menus.css
+++ b/packages/skins/src/minimal/css/components/menus.css
@@ -22,6 +22,10 @@
   &::before {
     display: none;
   }
+
+  &[data-transitioning] {
+    overflow: hidden;
+  }
 }
 
 .media-minimal-skin .media-popover.media-menu .media-menu__group {

--- a/packages/skins/src/minimal/css/components/popup.css
+++ b/packages/skins/src/minimal/css/components/popup.css
@@ -19,6 +19,10 @@
     scale: 0.5;
   }
 
+  &[data-transitioning] {
+    overflow: hidden;
+  }
+
   &[data-instant] {
     transition-duration: 0ms;
   }

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -1,13 +1,29 @@
 import { cn } from '@videojs/utils/style';
 
+import { popoverShell, popoverSideOffsetSize } from './popup';
+
+const menuSurface = cn(
+  'bg-(--media-tooltip-background-color) [backdrop-filter:var(--media-tooltip-backdrop-filter)]',
+  'ring-1 ring-(color:--media-tooltip-border-color) shadow-md shadow-black/10'
+);
+
+const menuHostShell = cn(
+  popoverShell,
+  popoverSideOffsetSize,
+  menuSurface,
+  'transition-[transform,scale,opacity,filter]',
+  'duration-(--media-popup-transition-duration)',
+  'ease-(--media-popup-transition-timing-function)',
+  'box-border rounded-xl p-1 overscroll-none'
+);
+
 export const menu = {
+  /** Standalone menu popover host (captions, playback rate). */
   root: cn(
-    'box-border min-w-[min(6rem,var(--media-popover-available-width,6rem))]',
+    menuHostShell,
+    'min-w-[min(6rem,var(--media-popover-available-width,6rem))]',
     'max-w-(--media-popover-available-width) max-h-(--media-popover-available-height)',
-    'bg-(--media-tooltip-background-color) p-1 !overflow-auto overscroll-none rounded-xl',
-    '[backdrop-filter:var(--media-tooltip-backdrop-filter)]',
-    'ring-1 ring-(color:--media-tooltip-border-color) shadow-md shadow-black/10',
-    'data-transitioning:!overflow-hidden',
+    'overflow-auto data-transitioning:overflow-hidden',
     'before:hidden'
   ),
   group: 'flex flex-col gap-0.5',

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -7,6 +7,7 @@ export const menu = {
     'bg-(--media-tooltip-background-color) p-1 !overflow-auto overscroll-none rounded-xl',
     '[backdrop-filter:var(--media-tooltip-backdrop-filter)]',
     'ring-1 ring-(color:--media-tooltip-border-color) shadow-md shadow-black/10',
+    'data-transitioning:overflow-hidden',
     'before:hidden'
   ),
   group: 'flex flex-col gap-0.5',

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -7,7 +7,7 @@ export const menu = {
     'bg-(--media-tooltip-background-color) p-1 !overflow-auto overscroll-none rounded-xl',
     '[backdrop-filter:var(--media-tooltip-backdrop-filter)]',
     'ring-1 ring-(color:--media-tooltip-border-color) shadow-md shadow-black/10',
-    'data-transitioning:overflow-hidden',
+    'data-transitioning:!overflow-hidden',
     'before:hidden'
   ),
   group: 'flex flex-col gap-0.5',

--- a/packages/skins/src/minimal/tailwind/components/popup.ts
+++ b/packages/skins/src/minimal/tailwind/components/popup.ts
@@ -1,19 +1,18 @@
 import { cn } from '@videojs/utils/style';
 
-const base = cn(
-  // Reset default popover styles
-  'm-0 border-0 text-inherit overflow-visible',
-  // Animation
-  'transition-[transform,scale,opacity,filter]',
-  'duration-(--media-popup-transition-duration)',
-  'ease-(--media-popup-transition-timing-function)',
+export const popupReset = 'm-0 border-0 text-inherit';
+
+export const popupSideOrigins = cn(
+  'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left'
+);
+
+export const popupOpenCloseStyles = cn(
   'data-starting-style:opacity-0 data-starting-style:scale-50 data-starting-style:blur-sm',
   'data-ending-style:opacity-0 data-ending-style:scale-50 data-ending-style:blur-sm',
-  'data-transitioning:overflow-hidden',
-  'data-instant:duration-0',
-  // Ensure we animate from the correct origin based on the side the popover is on
-  'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left',
-  // Safe area between trigger and popup
+  'data-instant:duration-0'
+);
+
+export const popupSideOffsetBefore = cn(
   'before:absolute before:pointer-events-[inherit]',
   'data-[side=top]:before:left-0 data-[side=top]:before:right-0 data-[side=top]:before:top-full',
   'data-[side=bottom]:before:left-0 data-[side=bottom]:before:right-0 data-[side=bottom]:before:bottom-full',
@@ -21,20 +20,43 @@ const base = cn(
   'data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:right-full'
 );
 
+export const popoverSideOffsetSize = cn(
+  'data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)',
+  'data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)'
+);
+
+export const tooltipSideOffsetSize = cn(
+  'data-[side=top]:before:h-(--media-tooltip-side-offset) data-[side=bottom]:before:h-(--media-tooltip-side-offset)',
+  'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'
+);
+
+/** Popover positioning shell shared by popups and menus (no overflow or transition timing). */
+export const popoverShell = cn(popupReset, popupSideOffsetBefore, popupSideOrigins, popupOpenCloseStyles);
+
+const popoverAnimation = cn(
+  'transition-[transform,scale,opacity,filter]',
+  'duration-(--media-popup-transition-duration)',
+  'ease-(--media-popup-transition-timing-function)'
+);
+
 export const popup = {
-  base,
+  base: popoverShell,
   popover: cn(
-    base,
-    'data-[side=top]:before:h-(--media-popover-side-offset) data-[side=bottom]:before:h-(--media-popover-side-offset)',
-    'data-[side=left]:before:w-(--media-popover-side-offset) data-[side=right]:before:w-(--media-popover-side-offset)'
+    popoverShell,
+    popoverSideOffsetSize,
+    popoverAnimation,
+    'overflow-visible',
+    'data-transitioning:overflow-hidden'
   ),
   tooltip: cn(
-    base,
+    popoverShell,
+    tooltipSideOffsetSize,
+    popoverAnimation,
     'px-2 py-1 rounded-lg text-[0.75rem] whitespace-nowrap',
     'bg-(--media-tooltip-background-color) [backdrop-filter:var(--media-tooltip-backdrop-filter)]',
     'ring-1 ring-(color:--media-tooltip-border-color) shadow-md shadow-black/10',
     'text-(--media-tooltip-text-color)',
-    'data-[side=top]:before:h-(--media-tooltip-side-offset) data-[side=bottom]:before:h-(--media-tooltip-side-offset)',
-    'data-[side=left]:before:w-(--media-tooltip-side-offset) data-[side=right]:before:w-(--media-tooltip-side-offset)'
+    'overflow-visible',
+    'data-transitioning:overflow-hidden'
   ),
 };

--- a/packages/skins/src/minimal/tailwind/components/popup.ts
+++ b/packages/skins/src/minimal/tailwind/components/popup.ts
@@ -9,6 +9,7 @@ const base = cn(
   'ease-(--media-popup-transition-timing-function)',
   'data-starting-style:opacity-0 data-starting-style:scale-50 data-starting-style:blur-sm',
   'data-ending-style:opacity-0 data-ending-style:scale-50 data-ending-style:blur-sm',
+  'data-transitioning:overflow-hidden',
   'data-instant:duration-0',
   // Ensure we animate from the correct origin based on the side the popover is on
   'data-[side=top]:origin-bottom data-[side=bottom]:origin-top data-[side=left]:origin-right data-[side=right]:origin-left',


### PR DESCRIPTION
## Summary
- Adds a `transitioning` flag to `createTransition` that stays true until open/close animations settle, and exposes it as `data-transitioning` through popover/menu/tooltip/alert-dialog cores.
- Restores popover close-animation coordination (`setElement`, deferred reopen during `ending`) on top of the transition API changes.
- Adds generic `data-transitioning:overflow-hidden` skin hooks for popups and menus (submenu-view selectors remain in the viewport/settings stack).

## Transitioning vs `status`

`createTransition` state has both `status` (`idle` | `starting` | `ending`) and a separate `transitioning` boolean. They are not folded into one field because they answer different questions:

| Field | Question it answers | Drives |
| --- | --- | --- |
| `status` | Which **CSS style-hook phase** are we in? | `data-starting-style`, `data-ending-style` |
| `transitioning` | Is **motion still in progress** (Web Animations / CSS settle)? | `data-transitioning` |

On **open**, `status` becomes `idle` after a double-RAF so the browser can paint the “from” state and drop `data-starting-style` before the enter animation runs—but the popup may still be animating. `transitioning` stays `true` until `getAnimations({ subtree: true })` settles. That gap (`status: idle`, `transitioning: true`) is intentional: style hooks and layout/interaction guards need different lifetimes.

On **close**, both overlap more (`status: ending`, `transitioning: true`), but `status` still tracks the ending-style hook while `transitioning` covers the full settle window—including descendant animations and CSS transition fallbacks.

Consumers use `data-transitioning` for concerns that should span the whole animation (overflow clipping, deferring trigger re-open until close finishes) without overloading `status` or keeping `data-starting-style` / `data-ending-style` active longer than the CSS hooks require.

## Stack position
`feat/captions-menu` → `feat/menu-popup-group` (#1577) → **this PR** → `feat/menu-viewport` (#1579) → …

## Test plan
- [x] `pnpm build:packages && pnpm typecheck`
- [x] `pnpm -F @videojs/core test src/dom/ui/tests/transition.test.ts src/dom/ui/popover`
- [ ] Manual: open/close a captions menu and confirm `data-transitioning` is present during the animation window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core open/close transition plumbing and popover interaction timing (click/blur/outside-dismiss), which can regress UI dismissal/animation behavior across platforms; changes are well-covered by updated and expanded tests.
> 
> **Overview**
> **Adds a first-class `transitioning` lifecycle for UI transitions.** `TransitionState` now includes `transitioning`, `getTransitionFlags`/`getTransitionStyleAttrs` expose it as `data-transitioning`, and core UI states (`PopoverCore`, `MenuCore`, `TooltipCore`, `AlertDialogCore`, input indicators) propagate the flag.
> 
> **Updates DOM transition + popover behavior to respect animation settling.** `createTransition` now tracks a registered element via `setElement`, waits for `getAnimations({ subtree: true })` (plus optional CSS-transition fallback), and keeps `transitioning` true until settle; `createDismissLayer.open()` can receive an element. `createPopover` is adjusted to pass the popup element into open, defer re-open clicks during `ending` until close completes, and harden blur/outside-dismiss edge cases (incl. group peer-trigger checks).
> 
> **Skins/presets adopt the new attribute hook.** Default/minimal CSS and Tailwind utilities add `data-transitioning:overflow-hidden`, and React/HTML presets stop composing `popup.popover` into menu content classes in favor of the menu root styling shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b4a5bec29ba8545949ef28689a4128be8aa192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->