### PR TITLE
fix(react): recover from StoreError: DESTROYED on React <Activity> hide/reveal

### DIFF
--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -70,7 +70,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
   function Provider({ children }: ProviderProps): ReactNode {
-    const [store] = useState(() => createStore<PlayerTarget>()(combine(...config.features)));
+    const [store, setStore] = useState(() => createStore<PlayerTarget>()(combine(...config.features)));
     const [popupGroup] = useState(() => createPopupGroup());
     const [media, setMedia] = useState<Media | null>(null);
     const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -79,6 +79,16 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
     useEffect(() => {
       if (!media) return;
+
+      // The store may have been destroyed during an asynchronous gap between React
+      // effect cleanup and re-setup (e.g., React <Activity> hide → reveal). The
+      // useState initializer does not re-run in this case, so we recreate and swap
+      // the store instance to unblock the next render cycle.
+      if (store.destroyed) {
+        setStore(createStore<PlayerTarget>()(combine(...config.features)));
+        return;
+      }
+
       return store.attach({ media, container });
     }, [media, container, store]);
 

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -82,8 +82,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
       // The store may have been destroyed during an asynchronous gap between React
       // effect cleanup and re-setup (e.g., React <Activity> hide → reveal). The
-      // useState initializer does not re-run in this case, so we recreate and swap
-      // the store instance to unblock the next render cycle.
+      // useState initializer does not re-run in this case.
       if (store.destroyed) {
         setStore(createStore<PlayerTarget>()(combine(...config.features)));
         return;

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -96,17 +96,13 @@ describe('createPlayer', () => {
       originalStore.destroy();
       expect(originalStore.destroyed).toBe(true);
 
-      // Trigger the attach effect to re-run by changing the `media` dep — this
-      // mirrors what happens in the real app where Activity reveals the subtree
-      // with an already-attached media element. Without the fix this throws
-      // StoreError('DESTROYED').
+      // Mirrors the real app: Activity reveals the subtree with an already-attached media element.
       expect(() => {
         act(() => {
           setMediaFn(document.createElement('video'));
         });
       }).not.toThrow();
 
-      // Provider should have swapped in a fresh store so the player is operational.
       expect(store).toBeDefined();
       expect(store.destroyed).toBe(false);
       expect(store).not.toBe(originalStore);
@@ -167,7 +163,6 @@ describe('createPlayer', () => {
       // The Activity guard must not have fired: one store instance, not two.
       // (setStore would have been called and produced a second instance.)
       expect(seenStores.size).toBe(1);
-      // Deferred destroy was cancelled — store is alive after all timers flush.
       expect(currentStore.destroyed).toBe(false);
 
       vi.useRealTimers();

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -1,9 +1,10 @@
-import { render, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import type { PlayerStore } from '@videojs/core/dom';
 import { defineSlice } from '@videojs/store';
 import type { ReactNode } from 'react';
 import { StrictMode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { usePlayerContext } from '../context';
 import { createPlayer } from '../create-player';
 
 describe('createPlayer', () => {
@@ -66,6 +67,51 @@ describe('createPlayer', () => {
       vi.useRealTimers();
     });
 
+    it('recovers after Activity-style async destroy (React <Activity>)', () => {
+      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+
+      let store!: PlayerStore;
+      // Captured inside TestComponent so we can trigger a media-dep change
+      // from the test body, simulating Activity reveal re-running the attach effect.
+      let setMediaFn!: (media: HTMLMediaElement | null) => void;
+
+      function TestComponent() {
+        store = usePlayer();
+        const { setMedia } = usePlayerContext();
+        setMediaFn = setMedia;
+        return null;
+      }
+
+      render(
+        <Provider>
+          <TestComponent />
+        </Provider>
+      );
+
+      const originalStore = store;
+      expect(originalStore.destroyed).toBe(false);
+
+      // Simulate the Activity gap: the deferred timeout fires before React gets
+      // a chance to re-run effects, leaving the store destroyed.
+      originalStore.destroy();
+      expect(originalStore.destroyed).toBe(true);
+
+      // Trigger the attach effect to re-run by changing the `media` dep — this
+      // mirrors what happens in the real app where Activity reveals the subtree
+      // with an already-attached media element. Without the fix this throws
+      // StoreError('DESTROYED').
+      expect(() => {
+        act(() => {
+          setMediaFn(document.createElement('video'));
+        });
+      }).not.toThrow();
+
+      // Provider should have swapped in a fresh store so the player is operational.
+      expect(store).toBeDefined();
+      expect(store.destroyed).toBe(false);
+      expect(store).not.toBe(originalStore);
+    });
+
     it('survives React StrictMode without StoreError', () => {
       const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
 
@@ -88,6 +134,43 @@ describe('createPlayer', () => {
 
       expect(store).toBeDefined();
       expect(store.destroyed).toBe(false);
+    });
+
+    it('StrictMode: preserves the same store instance and cancels the pending destroy', () => {
+      vi.useFakeTimers();
+
+      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+
+      // Track every store instance the component sees across all renders.
+      const seenStores = new Set<PlayerStore>();
+      let currentStore!: PlayerStore;
+
+      function TestComponent() {
+        currentStore = usePlayer();
+        seenStores.add(currentStore);
+        return null;
+      }
+
+      render(
+        <StrictMode>
+          <Provider>
+            <TestComponent />
+          </Provider>
+        </StrictMode>
+      );
+
+      // Flush timers — the deferred destroy was scheduled during StrictMode's
+      // simulated cleanup. If it was NOT cancelled by the re-mount effect, the
+      // store would be destroyed here.
+      vi.runAllTimers();
+
+      // The Activity guard must not have fired: one store instance, not two.
+      // (setStore would have been called and produced a second instance.)
+      expect(seenStores.size).toBe(1);
+      // Deferred destroy was cancelled — store is alive after all timers flush.
+      expect(currentStore.destroyed).toBe(false);
+
+      vi.useRealTimers();
     });
 
     it('uses displayName when provided', () => {


### PR DESCRIPTION
resolves [#1583](https://github.com/videojs/v10/issues/1583)

Problem
When Player.Provider is used inside a React <Activity> subtree (e.g. Next.js cacheComponents), navigating away and back throws StoreError: DESTROYED.

Why it happens:
useDestroy defers store.destroy() to a setTimeout(0) so React StrictMode's synchronous cleanup+remount can cancel it. That works because StrictMode's cycle is synchronous. With <Activity>, the gap between cleanup and reveal is asynchronous — the timeout fires before React gets a chance to re-run effects, leaving the store destroyed. When Activity reveals the subtree, useState returns the same (now-destroyed) store reference and store.attach() throws.

Fix
Added a destroyed-store guard in the attach effect in [create-player.tsx](vscode-webview://10fsht0qpfv7t7er069rre02ntjk5c10op1j16nlq9vlur2k2i4l/packages/react/src/player/create-player.tsx). If store.destroyed is true when the effect runs, a fresh store is created via setStore and the effect returns early. The resulting re-render re-runs the effect with a live store and attaches normally.


if (store.destroyed) {
  setStore(createStore<PlayerTarget>()(combine(...config.features)));
  return;
}
StrictMode is unaffected — the timeout is cancelled before it fires, so store.destroyed is always false during StrictMode's re-mount.

Tests
Two tests added to the Provider describe block:

Activity recovery — destroys the store mid-flight, triggers the attach effect via setMedia, asserts no throw and a fresh store instance
StrictMode invariant — flushes fake timers after a StrictMode render, asserts the same store instance and that the deferred destroy was cancelled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core player lifecycle and store recreation on attach; behavior is narrow (destroyed-store guard) but wrong timing could leak stores or double-attach in edge cases.
> 
> **Overview**
> Fixes **`StoreError: DESTROYED`** when `Player.Provider` is hidden and shown again via React **`<Activity>`** (e.g. Next.js cache components). Deferred `useDestroy` cleanup can run in the async gap before effects re-run, so the same `useState` store is still destroyed when `store.attach()` runs.
> 
> The attach **`useEffect`** now checks **`store.destroyed`** when `media` is present: it **`setStore`**s a new combined store and bails once so the next run attaches with a live instance. **StrictMode** behavior is unchanged because the pending destroy is still cancelled on the synchronous remount.
> 
> Adds Provider tests for Activity-style destroy + **`setMedia`** recovery (new store, no throw) and for StrictMode (single store after flushing timers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4351b369e04d7bb7dce645b23a05059d03a96f5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->