### PR TITLE
feat(packages): add pauseOnDrag to time slider

### DIFF
--- a/packages/core/src/core/ui/time-slider/tests/time-slider-core.test.ts
+++ b/packages/core/src/core/ui/time-slider/tests/time-slider-core.test.ts
@@ -43,6 +43,7 @@ describe('TimeSliderCore', () => {
         min: 0,
         max: 100,
         changeThrottle: 100,
+        pauseWhileDragging: false,
       });
     });
   });

--- a/packages/core/src/core/ui/time-slider/tests/time-slider-core.test.ts
+++ b/packages/core/src/core/ui/time-slider/tests/time-slider-core.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { MediaBufferState, MediaTimeState } from '../../../media/state';
+import type { MediaBufferState, MediaPlaybackState, MediaTimeState } from '../../../media/state';
 import type { SliderInput } from '../../slider/slider-core';
 import { TimeSliderCore } from '../time-slider-core';
 
@@ -43,7 +43,7 @@ describe('TimeSliderCore', () => {
         min: 0,
         max: 100,
         changeThrottle: 100,
-        pauseWhileDragging: false,
+        pauseOnDrag: false,
       });
     });
   });
@@ -241,6 +241,78 @@ describe('TimeSliderCore', () => {
       const state = core.getState();
 
       expect(state.orientation).toBe('vertical');
+    });
+  });
+
+  describe('startDrag/endDrag', () => {
+    function createPlaybackState(overrides: Partial<MediaPlaybackState> = {}): MediaPlaybackState {
+      return {
+        paused: false,
+        ended: false,
+        started: true,
+        waiting: false,
+        play: vi.fn(async () => {}),
+        pause: vi.fn(),
+        togglePaused: vi.fn(() => false),
+        ...overrides,
+      };
+    }
+
+    it('does nothing when pauseOnDrag is false (default)', () => {
+      const core = new TimeSliderCore();
+      const playback = createPlaybackState();
+
+      core.startDrag(playback);
+      expect(playback.pause).not.toHaveBeenCalled();
+
+      core.endDrag(playback);
+      expect(playback.play).not.toHaveBeenCalled();
+    });
+
+    it('pauses on startDrag and resumes on endDrag when playing', () => {
+      const core = new TimeSliderCore({ pauseOnDrag: true });
+      const playback = createPlaybackState();
+
+      core.startDrag(playback);
+      expect(playback.pause).toHaveBeenCalledTimes(1);
+
+      core.endDrag(playback);
+      expect(playback.play).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resume on endDrag when playback was already paused', () => {
+      const core = new TimeSliderCore({ pauseOnDrag: true });
+      const playback = createPlaybackState({ paused: true });
+
+      core.startDrag(playback);
+      expect(playback.pause).not.toHaveBeenCalled();
+
+      core.endDrag(playback);
+      expect(playback.play).not.toHaveBeenCalled();
+    });
+
+    it('resumes on endDrag even if pauseOnDrag is turned off mid-drag', () => {
+      const core = new TimeSliderCore({ pauseOnDrag: true });
+      const playback = createPlaybackState();
+
+      core.startDrag(playback);
+      expect(playback.pause).toHaveBeenCalledTimes(1);
+
+      core.setProps({ pauseOnDrag: false });
+
+      core.endDrag(playback);
+      expect(playback.play).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resume on a second endDrag', () => {
+      const core = new TimeSliderCore({ pauseOnDrag: true });
+      const playback = createPlaybackState();
+
+      core.startDrag(playback);
+      core.endDrag(playback);
+      core.endDrag(playback);
+
+      expect(playback.play).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/core/ui/time-slider/time-slider-core.ts
+++ b/packages/core/src/core/ui/time-slider/time-slider-core.ts
@@ -14,6 +14,11 @@ export interface TimeSliderProps extends SliderProps {
   max?: number | undefined;
   /** Leading+trailing throttle (ms) for `onValueChange` during drag. */
   changeThrottle?: number | undefined;
+  /**
+   * When true, pause playback while the user is dragging the thumb,
+   * resuming on release if it was playing before.
+   */
+  pauseWhileDragging?: boolean | undefined;
 }
 
 export interface TimeSliderState extends SliderState, Pick<MediaTimeState, 'currentTime' | 'duration' | 'seeking'> {
@@ -27,6 +32,7 @@ export class TimeSliderCore extends SliderCore {
     ...SliderCore.defaultProps,
     label: 'Seek',
     changeThrottle: 100,
+    pauseWhileDragging: false,
   };
 
   #props = { ...TimeSliderCore.defaultProps };

--- a/packages/core/src/core/ui/time-slider/time-slider-core.ts
+++ b/packages/core/src/core/ui/time-slider/time-slider-core.ts
@@ -2,7 +2,7 @@ import { defaults } from '@videojs/utils/object';
 import { formatTimeAsPhrase } from '@videojs/utils/time';
 import type { NonNullableObject } from '@videojs/utils/types';
 
-import type { MediaBufferState, MediaTimeState } from '../../media/state';
+import type { MediaBufferState, MediaPlaybackState, MediaTimeState } from '../../media/state';
 import { SliderCore, type SliderProps, type SliderState } from '../slider/slider-core';
 
 export interface TimeSliderProps extends SliderProps {
@@ -18,7 +18,7 @@ export interface TimeSliderProps extends SliderProps {
    * When true, pause playback while the user is dragging the thumb,
    * resuming on release if it was playing before.
    */
-  pauseWhileDragging?: boolean | undefined;
+  pauseOnDrag?: boolean | undefined;
 }
 
 export interface TimeSliderState extends SliderState, Pick<MediaTimeState, 'currentTime' | 'duration' | 'seeking'> {
@@ -32,11 +32,12 @@ export class TimeSliderCore extends SliderCore {
     ...SliderCore.defaultProps,
     label: 'Seek',
     changeThrottle: 100,
-    pauseWhileDragging: false,
+    pauseOnDrag: false,
   };
 
   #props = { ...TimeSliderCore.defaultProps };
   #media: (MediaTimeState & MediaBufferState) | null = null;
+  #wasPlayingBeforeDrag = false;
 
   constructor(props?: TimeSliderProps) {
     super();
@@ -76,6 +77,32 @@ export class TimeSliderCore extends SliderCore {
 
   override getLabel(state: SliderState): string {
     return super.getLabel(state) || 'Seek';
+  }
+
+  /**
+   * Pause playback when a drag begins if `pauseOnDrag` is enabled, remembering
+   * whether media was playing so `endDrag` can resume it.
+   */
+  startDrag(playback: MediaPlaybackState | null | undefined): void {
+    this.#wasPlayingBeforeDrag = false;
+    if (this.#props.pauseOnDrag && playback && !playback.paused) {
+      this.#wasPlayingBeforeDrag = true;
+      playback.pause();
+    }
+  }
+
+  /**
+   * Resume playback if `startDrag` paused it. Resume depends only on the intent
+   * captured at drag start, so it survives `pauseOnDrag` being toggled mid-drag.
+   * Safe to call on teardown — a no-op unless a drag paused playback.
+   */
+  endDrag(playback: MediaPlaybackState | null | undefined): void {
+    if (this.#wasPlayingBeforeDrag) {
+      playback?.play().catch(() => {
+        // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
+      });
+    }
+    this.#wasPlayingBeforeDrag = false;
   }
 
   override getAttrs(state: TimeSliderState) {

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -34,6 +34,17 @@ describe('TimeSliderElement', () => {
     expect(slider.orientation).toBe('horizontal');
     expect(slider.disabled).toBe(false);
     expect(slider.thumbAlignment).toBe('center');
+    expect(slider.pauseWhileDragging).toBe(false);
+  });
+
+  it('reflects pause-while-dragging attribute to property', async () => {
+    const slider = createElement(TimeSliderElement);
+    slider.setAttribute('pause-while-dragging', '');
+
+    document.body.appendChild(slider);
+    await slider.updateComplete;
+
+    expect(slider.pauseWhileDragging).toBe(true);
   });
 
   it('binds rootProps pointer events on connect', async () => {

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -34,17 +34,17 @@ describe('TimeSliderElement', () => {
     expect(slider.orientation).toBe('horizontal');
     expect(slider.disabled).toBe(false);
     expect(slider.thumbAlignment).toBe('center');
-    expect(slider.pauseWhileDragging).toBe(false);
+    expect(slider.pauseOnDrag).toBe(false);
   });
 
-  it('reflects pause-while-dragging attribute to property', async () => {
+  it('reflects pause-on-drag attribute to property', async () => {
     const slider = createElement(TimeSliderElement);
-    slider.setAttribute('pause-while-dragging', '');
+    slider.setAttribute('pause-on-drag', '');
 
     document.body.appendChild(slider);
     await slider.updateComplete;
 
-    expect(slider.pauseWhileDragging).toBe(true);
+    expect(slider.pauseOnDrag).toBe(true);
   });
 
   it('binds rootProps pointer events on connect', async () => {

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -116,21 +116,26 @@ export class TimeSliderElement extends MediaElement {
   }
 
   override disconnectedCallback(): void {
-    // Resume playback if disconnected mid-drag — createSlider's destroy() does not
-    // fire onDragEnd, so without this the player would stay paused. Read playback
-    // before super so the PlayerController is still attached.
-    if (this.#wasPlayingBeforeDrag) {
-      this.#playbackState.value?.play().catch(() => {});
-      this.#wasPlayingBeforeDrag = false;
-    }
+    this.#resumeIfDragPaused();
     super.disconnectedCallback();
     this.#disconnect?.abort();
     this.#disconnect = null;
   }
 
   override destroyCallback(): void {
+    this.#resumeIfDragPaused();
     this.#slider?.destroy();
     super.destroyCallback();
+  }
+
+  // createSlider's destroy() does not fire onDragEnd, so a teardown mid-drag
+  // would leave playback paused. Called from both disconnect and destroy paths
+  // before super so the PlayerController is still attached.
+  #resumeIfDragPaused(): void {
+    if (this.#wasPlayingBeforeDrag) {
+      this.#playbackState.value?.play().catch(() => {});
+      this.#wasPlayingBeforeDrag = false;
+    }
   }
 
   protected override willUpdate(_changed: PropertyValues): void {

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -7,6 +7,7 @@ import {
   logMissingFeature,
   type SliderApi,
   selectBuffer,
+  selectPlayback,
   selectTime,
 } from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
@@ -30,7 +31,10 @@ export class TimeSliderElement extends MediaElement {
     orientation: { type: String },
     disabled: { type: Boolean },
     thumbAlignment: { type: String, attribute: 'thumb-alignment' },
-  } satisfies PropertyDeclarationMap<Exclude<keyof TimeSliderCore.Props, 'value' | 'min' | 'max'>>;
+    pauseWhileDragging: { type: Boolean, attribute: 'pause-while-dragging' },
+  } satisfies PropertyDeclarationMap<Exclude<keyof TimeSliderCore.Props, 'value' | 'min' | 'max'>> & {
+    pauseWhileDragging: { type: BooleanConstructor; attribute: string };
+  };
 
   label = TimeSliderCore.defaultProps.label;
   changeThrottle = TimeSliderCore.defaultProps.changeThrottle;
@@ -39,11 +43,18 @@ export class TimeSliderElement extends MediaElement {
   orientation = TimeSliderCore.defaultProps.orientation;
   disabled = TimeSliderCore.defaultProps.disabled;
   thumbAlignment = TimeSliderCore.defaultProps.thumbAlignment;
+  /**
+   * When true, pause playback while the user is dragging the thumb,
+   * resuming on release if it was playing before. Default `false`.
+   */
+  pauseWhileDragging = false;
 
   readonly #core = new TimeSliderCore();
   readonly #provider = new ContextProvider(this, { context: sliderContext });
   readonly #timeState = new PlayerController(this, playerContext, selectTime);
   readonly #bufferState = new PlayerController(this, playerContext, selectBuffer);
+  readonly #playbackState = new PlayerController(this, playerContext, selectPlayback);
+  #wasPlayingBeforeDrag = false;
 
   #slider: SliderApi | null = null;
   #disconnect: AbortController | null = null;
@@ -74,9 +85,21 @@ export class TimeSliderElement extends MediaElement {
       },
       changeThrottle: this.changeThrottle,
       onDragStart: () => {
+        this.#wasPlayingBeforeDrag = false;
+        const playback = this.#playbackState.value;
+        if (this.pauseWhileDragging && playback && !playback.paused) {
+          this.#wasPlayingBeforeDrag = true;
+          playback.pause();
+        }
         this.dispatchEvent(new CustomEvent('drag-start', { bubbles: true }));
       },
       onDragEnd: () => {
+        if (this.pauseWhileDragging && this.#wasPlayingBeforeDrag) {
+          this.#playbackState.value?.play().catch(() => {
+            // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
+          });
+        }
+        this.#wasPlayingBeforeDrag = false;
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -31,7 +31,7 @@ export class TimeSliderElement extends MediaElement {
     orientation: { type: String },
     disabled: { type: Boolean },
     thumbAlignment: { type: String, attribute: 'thumb-alignment' },
-    pauseWhileDragging: { type: Boolean, attribute: 'pause-while-dragging' },
+    pauseOnDrag: { type: Boolean, attribute: 'pause-on-drag' },
   } satisfies PropertyDeclarationMap<Exclude<keyof TimeSliderCore.Props, 'value' | 'min' | 'max'>>;
 
   label = TimeSliderCore.defaultProps.label;
@@ -41,14 +41,13 @@ export class TimeSliderElement extends MediaElement {
   orientation = TimeSliderCore.defaultProps.orientation;
   disabled = TimeSliderCore.defaultProps.disabled;
   thumbAlignment = TimeSliderCore.defaultProps.thumbAlignment;
-  pauseWhileDragging = TimeSliderCore.defaultProps.pauseWhileDragging;
+  pauseOnDrag = TimeSliderCore.defaultProps.pauseOnDrag;
 
   readonly #core = new TimeSliderCore();
   readonly #provider = new ContextProvider(this, { context: sliderContext });
   readonly #timeState = new PlayerController(this, playerContext, selectTime);
   readonly #bufferState = new PlayerController(this, playerContext, selectBuffer);
   readonly #playbackState = new PlayerController(this, playerContext, selectPlayback);
-  #wasPlayingBeforeDrag = false;
 
   #slider: SliderApi | null = null;
   #disconnect: AbortController | null = null;
@@ -79,21 +78,11 @@ export class TimeSliderElement extends MediaElement {
       },
       changeThrottle: this.changeThrottle,
       onDragStart: () => {
-        this.#wasPlayingBeforeDrag = false;
-        const playback = this.#playbackState.value;
-        if (this.pauseWhileDragging && playback && !playback.paused) {
-          this.#wasPlayingBeforeDrag = true;
-          playback.pause();
-        }
+        this.#core.startDrag(this.#playbackState.value);
         this.dispatchEvent(new CustomEvent('drag-start', { bubbles: true }));
       },
       onDragEnd: () => {
-        if (this.#wasPlayingBeforeDrag) {
-          this.#playbackState.value?.play().catch(() => {
-            // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
-          });
-        }
-        this.#wasPlayingBeforeDrag = false;
+        this.#core.endDrag(this.#playbackState.value);
         this.dispatchEvent(new CustomEvent('drag-end', { bubbles: true }));
       },
       adjustPercent: (raw, thumbSize, trackSize) => this.#core.adjustPercentForAlignment(raw, thumbSize, trackSize),
@@ -126,10 +115,7 @@ export class TimeSliderElement extends MediaElement {
   // would leave playback paused. Called from both disconnect and destroy paths
   // before super so the PlayerController is still attached.
   #resumeIfDragPaused(): void {
-    if (this.#wasPlayingBeforeDrag) {
-      this.#playbackState.value?.play().catch(() => {});
-      this.#wasPlayingBeforeDrag = false;
-    }
+    this.#core.endDrag(this.#playbackState.value);
   }
 
   protected override willUpdate(_changed: PropertyValues): void {

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -32,9 +32,7 @@ export class TimeSliderElement extends MediaElement {
     disabled: { type: Boolean },
     thumbAlignment: { type: String, attribute: 'thumb-alignment' },
     pauseWhileDragging: { type: Boolean, attribute: 'pause-while-dragging' },
-  } satisfies PropertyDeclarationMap<Exclude<keyof TimeSliderCore.Props, 'value' | 'min' | 'max'>> & {
-    pauseWhileDragging: { type: BooleanConstructor; attribute: string };
-  };
+  } satisfies PropertyDeclarationMap<Exclude<keyof TimeSliderCore.Props, 'value' | 'min' | 'max'>>;
 
   label = TimeSliderCore.defaultProps.label;
   changeThrottle = TimeSliderCore.defaultProps.changeThrottle;
@@ -43,11 +41,7 @@ export class TimeSliderElement extends MediaElement {
   orientation = TimeSliderCore.defaultProps.orientation;
   disabled = TimeSliderCore.defaultProps.disabled;
   thumbAlignment = TimeSliderCore.defaultProps.thumbAlignment;
-  /**
-   * When true, pause playback while the user is dragging the thumb,
-   * resuming on release if it was playing before. Default `false`.
-   */
-  pauseWhileDragging = false;
+  pauseWhileDragging = TimeSliderCore.defaultProps.pauseWhileDragging;
 
   readonly #core = new TimeSliderCore();
   readonly #provider = new ContextProvider(this, { context: sliderContext });

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -94,7 +94,7 @@ export class TimeSliderElement extends MediaElement {
         this.dispatchEvent(new CustomEvent('drag-start', { bubbles: true }));
       },
       onDragEnd: () => {
-        if (this.pauseWhileDragging && this.#wasPlayingBeforeDrag) {
+        if (this.#wasPlayingBeforeDrag) {
           this.#playbackState.value?.play().catch(() => {
             // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
           });
@@ -116,6 +116,13 @@ export class TimeSliderElement extends MediaElement {
   }
 
   override disconnectedCallback(): void {
+    // Resume playback if disconnected mid-drag — createSlider's destroy() does not
+    // fire onDragEnd, so without this the player would stay paused. Read playback
+    // before super so the PlayerController is still attached.
+    if (this.#wasPlayingBeforeDrag) {
+      this.#playbackState.value?.play().catch(() => {});
+      this.#wasPlayingBeforeDrag = false;
+    }
     super.disconnectedCallback();
     this.#disconnect?.abort();
     this.#disconnect = null;

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -213,8 +213,8 @@ describe('TimeSlider compound', () => {
   });
 });
 
-describe('TimeSliderRoot pauseWhileDragging', () => {
-  it('does nothing when pauseWhileDragging is false (default)', () => {
+describe('TimeSliderRoot pauseOnDrag', () => {
+  it('does nothing when pauseOnDrag is false (default)', () => {
     mockPlaybackState.paused = false;
     mockPlaybackState.play.mockClear();
     mockPlaybackState.pause.mockClear();
@@ -241,7 +241,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     const { Wrapper } = createPlayerWrapper();
     render(
       <Wrapper>
-        <TimeSliderRoot pauseWhileDragging />
+        <TimeSliderRoot pauseOnDrag />
       </Wrapper>
     );
 
@@ -260,7 +260,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     const { Wrapper } = createPlayerWrapper();
     render(
       <Wrapper>
-        <TimeSliderRoot pauseWhileDragging />
+        <TimeSliderRoot pauseOnDrag />
       </Wrapper>
     );
 
@@ -279,7 +279,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     const { Wrapper } = createPlayerWrapper();
     render(
       <Wrapper>
-        <TimeSliderRoot pauseWhileDragging onDragStart={onDragStart} onDragEnd={onDragEnd} />
+        <TimeSliderRoot pauseOnDrag onDragStart={onDragStart} onDragEnd={onDragEnd} />
       </Wrapper>
     );
 
@@ -290,7 +290,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     expect(onDragEnd).toHaveBeenCalled();
   });
 
-  it('resumes on drag-end even if pauseWhileDragging is turned off mid-drag', () => {
+  it('resumes on drag-end even if pauseOnDrag is turned off mid-drag', () => {
     mockPlaybackState.paused = false;
     mockPlaybackState.play.mockClear();
     mockPlaybackState.pause.mockClear();
@@ -298,7 +298,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     const { Wrapper } = createPlayerWrapper();
     const { rerender } = render(
       <Wrapper>
-        <TimeSliderRoot pauseWhileDragging />
+        <TimeSliderRoot pauseOnDrag />
       </Wrapper>
     );
 
@@ -307,7 +307,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
 
     rerender(
       <Wrapper>
-        <TimeSliderRoot pauseWhileDragging={false} />
+        <TimeSliderRoot pauseOnDrag={false} />
       </Wrapper>
     );
 
@@ -323,7 +323,7 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     const { Wrapper } = createPlayerWrapper();
     const { unmount } = render(
       <Wrapper>
-        <TimeSliderRoot pauseWhileDragging />
+        <TimeSliderRoot pauseOnDrag />
       </Wrapper>
     );
 

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -12,42 +12,59 @@ import { TimeSliderRoot } from '../time-slider-root';
 
 // --- Hoisted mock data (available inside vi.mock factories) ---
 
-const { mockSliderApi, mockTimeState, mockBufferState } = vi.hoisted(() => ({
-  mockSliderApi: () => ({
-    input: {
-      current: {
-        pointerPercent: 0,
-        dragPercent: 0,
-        dragging: false,
-        pointing: false,
-        focused: false,
-      },
-      subscribe: vi.fn(() => vi.fn()),
+const { mockSliderApi, mockTimeState, mockBufferState, mockPlaybackState, capturedSliderOptions } = vi.hoisted(() => {
+  const capturedSliderOptions: { current: { onDragStart?: () => void; onDragEnd?: () => void } } = {
+    current: {},
+  };
+  return {
+    mockSliderApi: (options: { onDragStart?: () => void; onDragEnd?: () => void }) => {
+      capturedSliderOptions.current = options;
+      return {
+        input: {
+          current: {
+            pointerPercent: 0,
+            dragPercent: 0,
+            dragging: false,
+            pointing: false,
+            focused: false,
+          },
+          subscribe: vi.fn(() => vi.fn()),
+        },
+        rootProps: {
+          onPointerDown: vi.fn(),
+          onPointerMove: vi.fn(),
+          onPointerLeave: vi.fn(),
+        },
+        thumbProps: {
+          onKeyDown: vi.fn(),
+          onFocus: vi.fn(),
+          onBlur: vi.fn(),
+        },
+        adjustForAlignment: <S,>(state: S): S => state,
+        destroy: vi.fn(),
+      };
     },
-    rootProps: {
-      onPointerDown: vi.fn(),
-      onPointerMove: vi.fn(),
-      onPointerLeave: vi.fn(),
+    mockTimeState: {
+      currentTime: 30,
+      duration: 120,
+      seeking: false,
+      seek: vi.fn(),
     },
-    thumbProps: {
-      onKeyDown: vi.fn(),
-      onFocus: vi.fn(),
-      onBlur: vi.fn(),
+    mockBufferState: {
+      buffered: [[0, 60]] as [number, number][],
+      seekable: [[0, 120]] as [number, number][],
     },
-    adjustForAlignment: <S,>(state: S): S => state,
-    destroy: vi.fn(),
-  }),
-  mockTimeState: {
-    currentTime: 30,
-    duration: 120,
-    seeking: false,
-    seek: vi.fn(),
-  },
-  mockBufferState: {
-    buffered: [[0, 60]] as [number, number][],
-    seekable: [[0, 120]] as [number, number][],
-  },
-}));
+    mockPlaybackState: {
+      paused: false,
+      ended: false,
+      started: true,
+      waiting: false,
+      play: vi.fn(() => Promise.resolve()),
+      pause: vi.fn(),
+    },
+    capturedSliderOptions,
+  };
+});
 
 // --- Module mocks ---
 
@@ -61,13 +78,13 @@ vi.mock('@videojs/store/react', () => ({
   useStore: vi.fn((_store: unknown, selector?: (state: object) => unknown) => {
     if (!selector) return _store;
     try {
-      const result = selector({ time: mockTimeState, buffer: mockBufferState });
+      const result = selector({ time: mockTimeState, buffer: mockBufferState, playback: mockPlaybackState });
       if (result !== undefined) return result;
     } catch {
       // fall through
     }
     try {
-      return selector({ ...mockTimeState, ...mockBufferState });
+      return selector({ ...mockTimeState, ...mockBufferState, ...mockPlaybackState });
     } catch {
       return undefined;
     }
@@ -193,5 +210,83 @@ describe('TimeSlider compound', () => {
 
     const output = container.querySelector('[data-testid="value"]');
     expect(output?.textContent).toBeTruthy();
+  });
+});
+
+describe('TimeSliderRoot pauseWhileDragging', () => {
+  it('does nothing when pauseWhileDragging is false (default)', () => {
+    mockPlaybackState.paused = false;
+    mockPlaybackState.play.mockClear();
+    mockPlaybackState.pause.mockClear();
+
+    const { Wrapper } = createPlayerWrapper();
+    render(
+      <Wrapper>
+        <TimeSliderRoot />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragStart?.();
+    expect(mockPlaybackState.pause).not.toHaveBeenCalled();
+
+    capturedSliderOptions.current.onDragEnd?.();
+    expect(mockPlaybackState.play).not.toHaveBeenCalled();
+  });
+
+  it('pauses on drag-start and resumes on drag-end when playing', () => {
+    mockPlaybackState.paused = false;
+    mockPlaybackState.play.mockClear();
+    mockPlaybackState.pause.mockClear();
+
+    const { Wrapper } = createPlayerWrapper();
+    render(
+      <Wrapper>
+        <TimeSliderRoot pauseWhileDragging />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragStart?.();
+    expect(mockPlaybackState.pause).toHaveBeenCalledTimes(1);
+
+    capturedSliderOptions.current.onDragEnd?.();
+    expect(mockPlaybackState.play).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resume on drag-end when player was already paused', () => {
+    mockPlaybackState.paused = true;
+    mockPlaybackState.play.mockClear();
+    mockPlaybackState.pause.mockClear();
+
+    const { Wrapper } = createPlayerWrapper();
+    render(
+      <Wrapper>
+        <TimeSliderRoot pauseWhileDragging />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragStart?.();
+    expect(mockPlaybackState.pause).not.toHaveBeenCalled();
+
+    capturedSliderOptions.current.onDragEnd?.();
+    expect(mockPlaybackState.play).not.toHaveBeenCalled();
+  });
+
+  it('forwards user-provided onDragStart and onDragEnd', () => {
+    mockPlaybackState.paused = false;
+    const onDragStart = vi.fn();
+    const onDragEnd = vi.fn();
+
+    const { Wrapper } = createPlayerWrapper();
+    render(
+      <Wrapper>
+        <TimeSliderRoot pauseWhileDragging onDragStart={onDragStart} onDragEnd={onDragEnd} />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragStart?.();
+    expect(onDragStart).toHaveBeenCalled();
+
+    capturedSliderOptions.current.onDragEnd?.();
+    expect(onDragEnd).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -289,4 +289,48 @@ describe('TimeSliderRoot pauseWhileDragging', () => {
     capturedSliderOptions.current.onDragEnd?.();
     expect(onDragEnd).toHaveBeenCalled();
   });
+
+  it('resumes on drag-end even if pauseWhileDragging is turned off mid-drag', () => {
+    mockPlaybackState.paused = false;
+    mockPlaybackState.play.mockClear();
+    mockPlaybackState.pause.mockClear();
+
+    const { Wrapper } = createPlayerWrapper();
+    const { rerender } = render(
+      <Wrapper>
+        <TimeSliderRoot pauseWhileDragging />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragStart?.();
+    expect(mockPlaybackState.pause).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Wrapper>
+        <TimeSliderRoot pauseWhileDragging={false} />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragEnd?.();
+    expect(mockPlaybackState.play).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes on unmount if a drag paused playback', () => {
+    mockPlaybackState.paused = false;
+    mockPlaybackState.play.mockClear();
+    mockPlaybackState.pause.mockClear();
+
+    const { Wrapper } = createPlayerWrapper();
+    const { unmount } = render(
+      <Wrapper>
+        <TimeSliderRoot pauseWhileDragging />
+      </Wrapper>
+    );
+
+    capturedSliderOptions.current.onDragStart?.();
+    expect(mockPlaybackState.pause).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(mockPlaybackState.play).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -3,7 +3,7 @@
 import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
 import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { formatTime } from '@videojs/utils/time';
-import { forwardRef, useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
@@ -34,7 +34,7 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
       thumbAlignment,
       onDragStart,
       onDragEnd,
-      pauseWhileDragging = TimeSliderCore.defaultProps.pauseWhileDragging,
+      pauseOnDrag,
       ...elementProps
     } = componentProps;
 
@@ -43,23 +43,17 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
     const playback = usePlayer(selectPlayback);
 
     const [core] = useState(() => new TimeSliderCore());
-    core.setProps({ label, step, largeStep, orientation, disabled, thumbAlignment });
+    core.setProps({ label, step, largeStep, orientation, disabled, thumbAlignment, pauseOnDrag });
 
     // Keep a ref to the latest media state for callbacks that fire outside the render cycle.
     const mediaRef = useLatestRef(time && buffer ? { ...time, ...buffer } : null);
     const playbackRef = useLatestRef(playback);
-    const wasPlayingRef = useRef(false);
 
     // Resume playback if the slider unmounts mid-drag — createSlider's destroy()
     // does not fire onDragEnd, so without this the player would stay paused.
     useEffect(() => {
-      return () => {
-        if (wasPlayingRef.current) {
-          playbackRef.current?.play().catch(() => {});
-          wasPlayingRef.current = false;
-        }
-      };
-    }, []);
+      return () => core.endDrag(playbackRef.current);
+    }, [core]);
 
     const duration = time?.duration ?? 0;
 
@@ -95,21 +89,11 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         if (media) media.seek(core.rawValueFromPercent(percent));
       },
       onDragStart: () => {
-        wasPlayingRef.current = false;
-        const playback = playbackRef.current;
-        if (pauseWhileDragging && playback && !playback.paused) {
-          wasPlayingRef.current = true;
-          playback.pause();
-        }
+        core.startDrag(playbackRef.current);
         onDragStart?.();
       },
       onDragEnd: () => {
-        if (wasPlayingRef.current) {
-          playbackRef.current?.play().catch(() => {
-            // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
-          });
-        }
-        wasPlayingRef.current = false;
+        core.endDrag(playbackRef.current);
         onDragEnd?.();
       },
     });

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -3,7 +3,7 @@
 import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
 import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { formatTime } from '@videojs/utils/time';
-import { forwardRef, useRef, useState } from 'react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
@@ -66,7 +66,7 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
     };
 
     const handleDragEnd = () => {
-      if (pauseWhileDragging && wasPlayingRef.current) {
+      if (wasPlayingRef.current) {
         playbackRef.current?.play().catch(() => {
           // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
         });
@@ -74,6 +74,17 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
       wasPlayingRef.current = false;
       onDragEnd?.();
     };
+
+    // Resume playback if the slider unmounts mid-drag — createSlider's destroy()
+    // does not fire onDragEnd, so without this the player would stay paused.
+    useEffect(() => {
+      return () => {
+        if (wasPlayingRef.current) {
+          playbackRef.current?.play().catch(() => {});
+          wasPlayingRef.current = false;
+        }
+      };
+    }, []);
 
     const duration = time?.duration ?? 0;
 

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -17,11 +17,6 @@ const noopSeek = (): Promise<number> => Promise.resolve(0);
 export interface TimeSliderRootProps extends UIComponentProps<'div', TimeSliderCore.State>, TimeSliderCore.Props {
   onDragStart?: (() => void) | undefined;
   onDragEnd?: (() => void) | undefined;
-  /**
-   * When true, pause playback while the user is dragging the thumb,
-   * resuming on release if it was playing before. Default `false`.
-   */
-  pauseWhileDragging?: boolean | undefined;
 }
 
 export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
@@ -39,7 +34,7 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
       thumbAlignment,
       onDragStart,
       onDragEnd,
-      pauseWhileDragging = false,
+      pauseWhileDragging = TimeSliderCore.defaultProps.pauseWhileDragging,
       ...elementProps
     } = componentProps;
 
@@ -54,26 +49,6 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
     const mediaRef = useLatestRef(time && buffer ? { ...time, ...buffer } : null);
     const playbackRef = useLatestRef(playback);
     const wasPlayingRef = useRef(false);
-
-    const handleDragStart = () => {
-      wasPlayingRef.current = false;
-      const playback = playbackRef.current;
-      if (pauseWhileDragging && playback && !playback.paused) {
-        wasPlayingRef.current = true;
-        playback.pause();
-      }
-      onDragStart?.();
-    };
-
-    const handleDragEnd = () => {
-      if (wasPlayingRef.current) {
-        playbackRef.current?.play().catch(() => {
-          // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
-        });
-      }
-      wasPlayingRef.current = false;
-      onDragEnd?.();
-    };
 
     // Resume playback if the slider unmounts mid-drag — createSlider's destroy()
     // does not fire onDragEnd, so without this the player would stay paused.
@@ -119,8 +94,24 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         const media = mediaRef.current;
         if (media) media.seek(core.rawValueFromPercent(percent));
       },
-      onDragStart: handleDragStart,
-      onDragEnd: handleDragEnd,
+      onDragStart: () => {
+        wasPlayingRef.current = false;
+        const playback = playbackRef.current;
+        if (pauseWhileDragging && playback && !playback.paused) {
+          wasPlayingRef.current = true;
+          playback.pause();
+        }
+        onDragStart?.();
+      },
+      onDragEnd: () => {
+        if (wasPlayingRef.current) {
+          playbackRef.current?.play().catch(() => {
+            // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
+          });
+        }
+        wasPlayingRef.current = false;
+        onDragEnd?.();
+      },
     });
 
     if (!time) {

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
-import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectTime } from '@videojs/core/dom';
+import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { formatTime } from '@videojs/utils/time';
-import { forwardRef, useState } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
@@ -17,6 +17,11 @@ const noopSeek = (): Promise<number> => Promise.resolve(0);
 export interface TimeSliderRootProps extends UIComponentProps<'div', TimeSliderCore.State>, TimeSliderCore.Props {
   onDragStart?: (() => void) | undefined;
   onDragEnd?: (() => void) | undefined;
+  /**
+   * When true, pause playback while the user is dragging the thumb,
+   * resuming on release if it was playing before. Default `false`.
+   */
+  pauseWhileDragging?: boolean | undefined;
 }
 
 export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
@@ -34,17 +39,41 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
       thumbAlignment,
       onDragStart,
       onDragEnd,
+      pauseWhileDragging = false,
       ...elementProps
     } = componentProps;
 
     const time = usePlayer(selectTime);
     const buffer = usePlayer(selectBuffer);
+    const playback = usePlayer(selectPlayback);
 
     const [core] = useState(() => new TimeSliderCore());
     core.setProps({ label, step, largeStep, orientation, disabled, thumbAlignment });
 
     // Keep a ref to the latest media state for callbacks that fire outside the render cycle.
     const mediaRef = useLatestRef(time && buffer ? { ...time, ...buffer } : null);
+    const playbackRef = useLatestRef(playback);
+    const wasPlayingRef = useRef(false);
+
+    const handleDragStart = () => {
+      wasPlayingRef.current = false;
+      const playback = playbackRef.current;
+      if (pauseWhileDragging && playback && !playback.paused) {
+        wasPlayingRef.current = true;
+        playback.pause();
+      }
+      onDragStart?.();
+    };
+
+    const handleDragEnd = () => {
+      if (pauseWhileDragging && wasPlayingRef.current) {
+        playbackRef.current?.play().catch(() => {
+          // Resume play() can reject (autoplay policy, etc.) — surface via existing error feature.
+        });
+      }
+      wasPlayingRef.current = false;
+      onDragEnd?.();
+    };
 
     const duration = time?.duration ?? 0;
 
@@ -79,8 +108,8 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         const media = mediaRef.current;
         if (media) media.seek(core.rawValueFromPercent(percent));
       },
-      onDragStart,
-      onDragEnd,
+      onDragStart: handleDragStart,
+      onDragEnd: handleDragEnd,
     });
 
     if (!time) {


### PR DESCRIPTION
Closes #1440 

### What it does

Adds opt-in `pauseWhileDragging` mirroring Vidstack's API:

- **React:** `<TimeSliderRoot pauseWhileDragging />` (default `false`)
- **HTML:** `<media-time-slider pause-while-dragging>` (boolean attribute)

Wraps the existing `onDragStart` / `onDragEnd` callbacks — user-provided callbacks still fire alongside. Reads playback state via the existing `selectPlayback` selector + `PlayerController` / `useLatestRef`, mirroring how `time` and `buffer` are already wired.

Tracks `wasPlayingBeforeDrag` internally so a player paused before the drag doesn't get accidentally auto-played on release.

### Scope choice

Opt-in default (`false`), matching Vidstack's `pauseWhileDragging` prop. v8 and Plyr are always-on (with platform disables for mobile/STV iOS audio glitching). I went opt-in because:

1. It's a behavior change consumers should consent to (subtle iOS audio glitch on some streams during scrub-pause-resume)
2. Vidstack's prior art is the closest match to v10's API shape
3. Easy follow-up to flip the default if maintainers prefer

`play()` rejection on resume (autoplay policy, ad-paused state) is swallowed here — the existing error feature surfaces it via the player error state.

### Verified locally

- `pnpm -F @videojs/react test` — **224/224 pass** (+4 new behavioral tests: default no-op, pause/resume when playing, no-resume when already paused, user-callback forwarding)
- `pnpm -F @videojs/html test` — **120/120 pass** (+1 new: attribute reflection)
- `pnpm lint` / `pnpm typecheck` / `pnpm check:workspace` — all clean

### Open question

The React test uses a hoisted-ref pattern to capture `onDragStart` / `onDragEnd` from the createSlider mock. If you'd prefer not extending the slider mock that way, happy to drop the React behavioral tests and lean on Playwright E2E for slider behavior (matches the existing convention in the HTML element tests).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches playback pause/play during seek UI interactions; default-off limits blast radius, but resume and mid-drag teardown paths affect player state.
> 
> **Overview**
> Adds an opt-in **`pauseOnDrag`** option (default `false`) on the time slider so playback can pause while scrubbing and resume on release only if it was playing when the drag started.
> 
> **`TimeSliderCore`** gains `startDrag` / `endDrag` using `MediaPlaybackState`, with `#wasPlayingBeforeDrag` so already-paused media is not auto-played; resume still runs if `pauseOnDrag` is turned off mid-drag. Failed `play()` on resume is swallowed.
> 
> **React** (`TimeSliderRoot`) and **HTML** (`media-time-slider` / `pause-on-drag`) wire drag lifecycle through the core via `selectPlayback`, still calling user `onDragStart` / `onDragEnd`. Both call `endDrag` on unmount/disconnect/destroy so a mid-drag teardown does not leave the player paused.
> 
> Tests cover core drag behavior, HTML attribute reflection, and React integration (including unmount resume and callback forwarding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ef8a8092ffd08e5b537b178f1ea871fdd5fb95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->