### PR TITLE
feat(skin): add title display to minimal skin

### DIFF
--- a/apps/sandbox/app/shared/html/sandbox-state.ts
+++ b/apps/sandbox/app/shared/html/sandbox-state.ts
@@ -7,7 +7,7 @@ import {
   getInitialSource,
   type PreloadValue,
 } from '@app/shared/sandbox-listener';
-import type { SourceId } from '@app/shared/sources';
+import { SOURCES, type SourceId } from '@app/shared/sources';
 import type { Skin, Styling } from '@app/types';
 
 function getInitialStyling(): Styling {
@@ -34,6 +34,12 @@ export function createHtmlSandboxState(audioOnly?: boolean): HtmlSandboxState {
     loop: getInitialLoop(),
     preload: getInitialPreload(),
   };
+}
+
+/** Render player-level attributes (media-title) as an HTML attribute string. */
+export function renderPlayerAttrs(state: HtmlSandboxState): string {
+  const { title } = SOURCES[state.source];
+  return `media-title="${title}"`;
 }
 
 /** Render the user-controlled media attributes (autoplay/muted/loop/preload) as HTML attributes. */

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -3,36 +3,42 @@ import { getMuxAssetId } from './mux';
 export const SOURCES = {
   'hls-1': {
     label: 'HLS - Big Buck Bunny',
+    title: 'Big Buck Bunny',
     url: 'https://stream.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA.m3u8',
     type: 'hls',
     subType: 'ts',
   },
   'hls-2': {
     label: 'HLS - Elephants Dream',
+    title: 'Elephants Dream',
     url: 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8',
     type: 'hls',
     subType: 'ts',
   },
   'hls-3': {
     label: 'HLS - Dancing Dude',
+    title: 'Dancing Dude',
     url: 'https://stream.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4.m3u8',
     type: 'hls',
     subType: 'mp4',
   },
   'hls-4': {
     label: 'HLS - View From A Blue Moon Trailer',
+    title: 'View From A Blue Moon Trailer',
     url: 'https://stream.mux.com/lyrKpPcGfqyzeI00jZAfW6MvP6GNPrkML.m3u8',
     type: 'hls',
     subType: 'mp4',
   },
   'hls-5': {
     label: 'HLS - Mad Max Fury Road Trailer',
+    title: 'Mad Max Fury Road Trailer',
     url: 'https://stream.mux.com/JX01bG8eB4uaoV3OpDuK602rBfvdSgrMObjwuUOBn4JrQ.m3u8',
     type: 'hls',
     subType: 'mp4',
   },
   'hls-live': {
     label: 'HLS - Live Stream Big Buck Bunny',
+    title: 'Big Buck Bunny',
     url: 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8',
     type: 'hls',
     subType: 'mp4',
@@ -40,16 +46,19 @@ export const SOURCES = {
   },
   'mp4-1': {
     label: 'MP4 - Dancing Dude',
+    title: 'Dancing Dude',
     url: 'https://stream.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/highest.mp4',
     type: 'mp4',
   },
   'dash-1': {
     label: 'DASH - Big Buck Bunny',
+    title: 'Big Buck Bunny',
     url: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',
     type: 'dash',
   },
   'dash-2': {
     label: 'DASH - Envivio Test Stream',
+    title: 'Envivio Test Stream',
     url: 'https://dash.akamaized.net/envivio/EnvivioDash3/manifest.mpd',
     type: 'dash',
   },

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -60,6 +60,8 @@ export * from './ui/time/time-data-attrs';
 export * from './ui/time-slider/time-slider-core';
 export * from './ui/time-slider/time-slider-css-vars';
 export * from './ui/time-slider/time-slider-data-attrs';
+export * from './ui/title/title-core';
+export * from './ui/title/title-data-attrs';
 export * from './ui/tooltip/tooltip-core';
 export * from './ui/tooltip/tooltip-css-vars';
 export * from './ui/tooltip/tooltip-data-attrs';

--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -325,6 +325,18 @@ export interface MediaRemotePlaybackState {
   toggleRemotePlayback(): Promise<void>;
 }
 
+export interface MediaMetadataState {
+  /**
+   * Human-readable title for the current media. `null` if not provided.
+   *
+   * Used for: the visible title overlay, play button `aria-label`, and
+   * `navigator.mediaSession.metadata`.
+   */
+  title: string | null;
+  /** Set the media title. Pass `null` to clear. */
+  setTitle(title: string | null): void;
+}
+
 export interface MediaPictureInPictureState {
   /**
    * Whether picture-in-picture mode is currently active.

--- a/packages/core/src/core/ui/play-button/play-button-core.ts
+++ b/packages/core/src/core/ui/play-button/play-button-core.ts
@@ -3,7 +3,7 @@ import { defaults } from '@videojs/utils/object';
 import { isFunction } from '@videojs/utils/predicate';
 import type { NonNullableObject } from '@videojs/utils/types';
 
-import type { MediaPlaybackState } from '../../media/state';
+import type { MediaMetadataState, MediaPlaybackState } from '../../media/state';
 import type { ButtonState } from '../types';
 
 export interface PlayButtonProps {
@@ -30,6 +30,7 @@ export class PlayButtonCore {
 
   #props = { ...PlayButtonCore.defaultProps };
   #media: MediaPlaybackState | null = null;
+  #title: string | null = null;
 
   constructor(props?: PlayButtonProps) {
     if (props) this.setProps(props);
@@ -37,6 +38,10 @@ export class PlayButtonCore {
 
   setProps(props: PlayButtonProps): void {
     this.#props = defaults(props, PlayButtonCore.defaultProps);
+  }
+
+  setMetadata(metadata: MediaMetadataState): void {
+    this.#title = metadata.title;
   }
 
   getLabel(state: PlayButtonState): string {
@@ -49,8 +54,14 @@ export class PlayButtonCore {
       return label;
     }
 
-    if (state.ended) return 'Replay';
-    return state.paused ? 'Play' : 'Pause';
+    let base: string;
+    if (state.ended) {
+      base = 'Replay';
+    } else {
+      base = state.paused ? 'Play' : 'Pause';
+    }
+
+    return this.#title ? `${base}, ${this.#title}` : base;
   }
 
   getAttrs(state: PlayButtonState) {

--- a/packages/core/src/core/ui/title/title-core.ts
+++ b/packages/core/src/core/ui/title/title-core.ts
@@ -1,0 +1,74 @@
+import { defaults } from '@videojs/utils/object';
+import { isFunction } from '@videojs/utils/predicate';
+import type { NonNullableObject } from '@videojs/utils/types';
+
+import type { MediaMetadataState } from '../../media/state';
+
+export interface TitleProps {
+  /** Custom label for accessibility. Defaults to the title text. */
+  label?: string | ((state: TitleState) => string) | undefined;
+}
+
+export interface TitleState {
+  /** The current media title, or `null` if not set. */
+  title: string | null;
+  /** Formatted display text (title or empty string). */
+  text: string;
+  /** Whether a title is currently set. */
+  hasTitle: boolean;
+}
+
+export class TitleCore {
+  static readonly defaultProps: NonNullableObject<TitleProps> = {
+    label: '',
+  };
+
+  #props = { ...TitleCore.defaultProps };
+  #media: MediaMetadataState | null = null;
+
+  constructor(props?: TitleProps) {
+    if (props) this.setProps(props);
+  }
+
+  setProps(props: TitleProps): void {
+    this.#props = defaults(props, TitleCore.defaultProps);
+  }
+
+  setMedia(media: MediaMetadataState): void {
+    this.#media = media;
+  }
+
+  getLabel(state: TitleState): string {
+    const { label } = this.#props;
+
+    if (isFunction(label)) {
+      const customLabel = label(state);
+      if (customLabel) return customLabel;
+    } else if (label) {
+      return label;
+    }
+
+    return state.text;
+  }
+
+  getAttrs(state: TitleState) {
+    return {
+      'aria-label': this.getLabel(state) || undefined,
+      'aria-hidden': state.hasTitle ? undefined : ('true' as const),
+    };
+  }
+
+  getState(): TitleState {
+    const title = this.#media?.title ?? null;
+    return {
+      title,
+      text: title ?? '',
+      hasTitle: title !== null && title.length > 0,
+    };
+  }
+}
+
+export namespace TitleCore {
+  export type Props = TitleProps;
+  export type State = TitleState;
+}

--- a/packages/core/src/core/ui/title/title-data-attrs.ts
+++ b/packages/core/src/core/ui/title/title-data-attrs.ts
@@ -1,0 +1,6 @@
+import type { StateAttrMap } from '../types';
+import type { TitleState } from './title-core';
+
+export const TitleDataAttrs = {
+  hasTitle: 'data-has-title',
+} as const satisfies StateAttrMap<TitleState>;

--- a/packages/core/src/dom/media/types.ts
+++ b/packages/core/src/dom/media/types.ts
@@ -5,6 +5,7 @@ import type {
   MediaErrorState,
   MediaFullscreenState,
   MediaLiveState,
+  MediaMetadataState,
   MediaPictureInPictureState,
   MediaPlaybackRateState,
   MediaPlaybackState,
@@ -52,6 +53,7 @@ export type VideoFeatures = [
   PlayerFeature<MediaControlsState>,
   PlayerFeature<MediaTextTrackState>,
   PlayerFeature<MediaErrorState>,
+  PlayerFeature<MediaMetadataState>,
 ];
 
 export type AudioFeatures = [
@@ -62,6 +64,7 @@ export type AudioFeatures = [
   PlayerFeature<MediaSourceState>,
   PlayerFeature<MediaBufferState>,
   PlayerFeature<MediaErrorState>,
+  PlayerFeature<MediaMetadataState>,
 ];
 
 // TODO: Define background video features (e.g., playback, source, buffer)
@@ -86,6 +89,7 @@ export type LiveVideoFeatures = [
   PlayerFeature<MediaTextTrackState>,
   PlayerFeature<MediaErrorState>,
   PlayerFeature<MediaLiveState>,
+  PlayerFeature<MediaMetadataState>,
 ];
 
 /**
@@ -102,6 +106,7 @@ export type LiveAudioFeatures = [
   PlayerFeature<MediaBufferState>,
   PlayerFeature<MediaErrorState>,
   PlayerFeature<MediaLiveState>,
+  PlayerFeature<MediaMetadataState>,
 ];
 
 export type VideoPlayerStore = PlayerStore<VideoFeatures>;

--- a/packages/core/src/dom/store/features/index.ts
+++ b/packages/core/src/dom/store/features/index.ts
@@ -4,6 +4,7 @@ export * from './error';
 export * as features from './feature.parts';
 export * from './fullscreen';
 export * from './live';
+export * from './metadata';
 export * from './pip';
 export * from './playback';
 export * from './playback-rate';

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -1,0 +1,26 @@
+import type { MediaMetadataState } from '../../../core/media/state';
+import { definePlayerFeature } from '../../feature';
+
+export const metadataFeature = definePlayerFeature({
+  name: 'metadata',
+  state: ({ set }): MediaMetadataState => ({
+    title: null,
+    setTitle(title: string | null) {
+      set({ title });
+    },
+  }),
+
+  attach({ signal, get, store }) {
+    if (!('mediaSession' in navigator)) return;
+
+    const sync = () => {
+      const { title } = get();
+      navigator.mediaSession.metadata = title ? new MediaMetadata({ title }) : null;
+    };
+
+    const unsub = store.subscribe(sync);
+    signal.addEventListener('abort', unsub, { once: true });
+
+    sync();
+  },
+});

--- a/packages/core/src/dom/store/features/presets.ts
+++ b/packages/core/src/dom/store/features/presets.ts
@@ -10,6 +10,7 @@ import { controlsFeature } from './controls';
 import { errorFeature } from './error';
 import { fullscreenFeature } from './fullscreen';
 import { liveFeature } from './live';
+import { metadataFeature } from './metadata';
 import { pipFeature } from './pip';
 import { playbackFeature } from './playback';
 import { playbackRateFeature } from './playback-rate';
@@ -32,6 +33,7 @@ export const videoFeatures: VideoFeatures = [
   controlsFeature,
   textTrackFeature,
   errorFeature,
+  metadataFeature,
 ];
 
 export const audioFeatures: AudioFeatures = [
@@ -42,6 +44,7 @@ export const audioFeatures: AudioFeatures = [
   sourceFeature,
   bufferFeature,
   errorFeature,
+  metadataFeature,
 ];
 
 // TODO: Add background video features (e.g., playback, source, buffer)
@@ -66,6 +69,7 @@ export const liveVideoFeatures: LiveVideoFeatures = [
   textTrackFeature,
   errorFeature,
   liveFeature,
+  metadataFeature,
 ];
 
 /**
@@ -82,4 +86,5 @@ export const liveAudioFeatures: LiveAudioFeatures = [
   bufferFeature,
   errorFeature,
   liveFeature,
+  metadataFeature,
 ];

--- a/packages/core/src/dom/store/selectors.ts
+++ b/packages/core/src/dom/store/selectors.ts
@@ -5,6 +5,7 @@ import { controlsFeature } from './features/controls';
 import { errorFeature } from './features/error';
 import { fullscreenFeature } from './features/fullscreen';
 import { liveFeature } from './features/live';
+import { metadataFeature } from './features/metadata';
 import { pipFeature } from './features/pip';
 import { playbackFeature } from './features/playback';
 import { playbackRateFeature } from './features/playback-rate';
@@ -25,6 +26,8 @@ export const selectError = createSelector(errorFeature);
 export const selectFullscreen = createSelector(fullscreenFeature);
 /** Select the live state (`liveEdgeStart`, `targetLiveWindow`). */
 export const selectLive = createSelector(liveFeature);
+/** Select the metadata state (title, setTitle). */
+export const selectMetadata = createSelector(metadataFeature);
 /** Select the PiP state (picture-in-picture active, availability). */
 export const selectPiP = createSelector(pipFeature);
 /** Select the playback state (paused, ended, play, pause, toggle). */

--- a/packages/html/src/define/audio/player.ts
+++ b/packages/html/src/define/audio/player.ts
@@ -1,4 +1,5 @@
 import { audioFeatures } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { MediaContainerElement } from '../../media/container-element';
 import { createPlayer } from '../../player/create-player';
 import { MediaElement } from '../../ui/media-element';
@@ -10,6 +11,20 @@ const { ProviderMixin } = createPlayer({
 
 export class AudioPlayerElement extends ProviderMixin(MediaElement) {
   static readonly tagName = 'audio-player';
+
+  static override properties = {
+    mediaTitle: { type: String, attribute: 'media-title' },
+  } satisfies PropertyDeclarationMap;
+
+  mediaTitle: string | null = null;
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+    if (changed.has('mediaTitle')) {
+      const state = this.store.state as { setTitle?: (t: string | null) => void };
+      state.setTitle?.(this.mediaTitle);
+    }
+  }
 }
 
 // Provider must be defined before consumer for context handshake during upgrade.

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -16,7 +16,14 @@ import { SeekButtonElement } from '../../ui/seek-button/seek-button-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
 import { safeDefine } from '../safe-define';
-import { defineErrorDialog, defineMenu, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
+import {
+  defineErrorDialog,
+  defineMenu,
+  defineTime,
+  defineTimeSlider,
+  defineTitle,
+  defineVolumeSlider,
+} from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { AudioPlayerElement } from './player';
@@ -31,6 +38,7 @@ defineErrorDialog();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineTitle();
 defineMenu();
 
 // Standalone elements.

--- a/packages/html/src/define/live-audio/player.ts
+++ b/packages/html/src/define/live-audio/player.ts
@@ -1,4 +1,5 @@
 import { liveAudioFeatures } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { MediaContainerElement } from '../../media/container-element';
 import { createPlayer } from '../../player/create-player';
 import { MediaElement } from '../../ui/media-element';
@@ -10,6 +11,20 @@ const { ProviderMixin } = createPlayer({
 
 export class LiveAudioPlayerElement extends ProviderMixin(MediaElement) {
   static readonly tagName = 'live-audio-player';
+
+  static override properties = {
+    mediaTitle: { type: String, attribute: 'media-title' },
+  } satisfies PropertyDeclarationMap;
+
+  mediaTitle: string | null = null;
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+    if (changed.has('mediaTitle')) {
+      const state = this.store.state as { setTitle?: (t: string | null) => void };
+      state.setTitle?.(this.mediaTitle);
+    }
+  }
 }
 
 // Provider must be defined before consumer for context handshake during upgrade.

--- a/packages/html/src/define/live-audio/ui.ts
+++ b/packages/html/src/define/live-audio/ui.ts
@@ -11,7 +11,7 @@ import { PopoverElement } from '../../ui/popover/popover-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
 import { safeDefine } from '../safe-define';
-import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
+import { defineErrorDialog, defineTime, defineTimeSlider, defineTitle, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { LiveAudioPlayerElement } from './player';
@@ -26,6 +26,7 @@ defineErrorDialog();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineTitle();
 
 // Standalone elements.
 safeDefine(GestureElement);

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -94,6 +94,8 @@ function getTemplateHTML() {
 
       <div class="media-overlay"></div>
 
+      <media-title class="media-title"></media-title>
+
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/live-video/minimal-ui.ts
+++ b/packages/html/src/define/live-video/minimal-ui.ts
@@ -24,6 +24,7 @@ import {
   defineInputIndicators,
   defineTime,
   defineTimeSlider,
+  defineTitle,
   defineVolumeSlider,
 } from '../ui/compounds';
 
@@ -42,6 +43,7 @@ defineInputIndicators();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineTitle();
 
 // Standalone elements.
 safeDefine(BufferingIndicatorElement);

--- a/packages/html/src/define/live-video/player.ts
+++ b/packages/html/src/define/live-video/player.ts
@@ -1,4 +1,5 @@
 import { liveVideoFeatures } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { MediaContainerElement } from '../../media/container-element';
 import { createPlayer } from '../../player/create-player';
 import { MediaElement } from '../../ui/media-element';
@@ -10,6 +11,20 @@ const { ProviderMixin } = createPlayer({
 
 export class LiveVideoPlayerElement extends ProviderMixin(MediaElement) {
   static readonly tagName = 'live-video-player';
+
+  static override properties = {
+    mediaTitle: { type: String, attribute: 'media-title' },
+  } satisfies PropertyDeclarationMap;
+
+  mediaTitle: string | null = null;
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+    if (changed.has('mediaTitle')) {
+      const state = this.store.state as { setTitle?: (t: string | null) => void };
+      state.setTitle?.(this.mediaTitle);
+    }
+  }
 }
 
 // Provider must be defined before consumer for context handshake during upgrade.

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -96,6 +96,8 @@ function getTemplateHTML() {
 
       <div class="media-overlay"></div>
 
+      <media-title class="media-title"></media-title>
+
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/live-video/ui.ts
+++ b/packages/html/src/define/live-video/ui.ts
@@ -23,6 +23,7 @@ import {
   defineInputIndicators,
   defineTime,
   defineTimeSlider,
+  defineTitle,
   defineVolumeSlider,
 } from '../ui/compounds';
 
@@ -41,6 +42,7 @@ defineInputIndicators();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineTitle();
 
 // Standalone elements.
 safeDefine(BufferingIndicatorElement);

--- a/packages/html/src/define/ui/compounds.ts
+++ b/packages/html/src/define/ui/compounds.ts
@@ -32,6 +32,7 @@ import { TimeElement } from '../../ui/time/time-element';
 import { TimeGroupElement } from '../../ui/time/time-group-element';
 import { TimeSeparatorElement } from '../../ui/time/time-separator-element';
 import { TimeSliderElement } from '../../ui/time-slider/time-slider-element';
+import { TitleElement } from '../../ui/title/title-element';
 import { VolumeIndicatorElement } from '../../ui/volume-indicator/volume-indicator-element';
 import { VolumeIndicatorFillElement } from '../../ui/volume-indicator/volume-indicator-fill-element';
 import { VolumeIndicatorValueElement } from '../../ui/volume-indicator/volume-indicator-value-element';
@@ -109,4 +110,8 @@ export function defineTimeSlider(): void {
 export function defineVolumeSlider(): void {
   safeDefine(VolumeSliderElement);
   defineSliderParts();
+}
+
+export function defineTitle(): void {
+  safeDefine(TitleElement);
 }

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -146,6 +146,8 @@ function getTemplateHTML() {
 
       <div class="media-overlay"></div>
 
+      <media-title class="media-title"></media-title>
+
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/video/minimal-ui.ts
+++ b/packages/html/src/define/video/minimal-ui.ts
@@ -27,6 +27,7 @@ import {
   defineMenu,
   defineTime,
   defineTimeSlider,
+  defineTitle,
   defineVolumeSlider,
 } from '../ui/compounds';
 
@@ -45,6 +46,7 @@ defineInputIndicators();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineTitle();
 defineMenu();
 
 // Standalone elements.

--- a/packages/html/src/define/video/player.ts
+++ b/packages/html/src/define/video/player.ts
@@ -1,4 +1,5 @@
 import { videoFeatures } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { MediaContainerElement } from '../../media/container-element';
 import { createPlayer } from '../../player/create-player';
 import { MediaElement } from '../../ui/media-element';
@@ -10,6 +11,20 @@ const { ProviderMixin } = createPlayer({
 
 export class VideoPlayerElement extends ProviderMixin(MediaElement) {
   static readonly tagName = 'video-player';
+
+  static override properties = {
+    mediaTitle: { type: String, attribute: 'media-title' },
+  } satisfies PropertyDeclarationMap;
+
+  mediaTitle: string | null = null;
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+    if (changed.has('mediaTitle')) {
+      const state = this.store.state as { setTitle?: (t: string | null) => void };
+      state.setTitle?.(this.mediaTitle);
+    }
+  }
 }
 
 // Provider must be defined before consumer for context handshake during upgrade.

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -21,6 +21,7 @@ import {
   seek,
   slider,
   time,
+  title,
 } from '@videojs/skins/default/tailwind/video.tailwind';
 import { createTemplate } from '@videojs/utils/dom';
 import { cn } from '@videojs/utils/style';
@@ -160,6 +161,8 @@ function getTemplateHTML() {
       </media-controls>
 
       <div class="${overlay}"></div>
+
+      <media-title class="${title}"></media-title>
 
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -142,6 +142,8 @@ function getTemplateHTML() {
 
       <div class="media-overlay"></div>
 
+      <media-title class="media-title"></media-title>
+
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
       <media-hotkey keys="k" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/video/ui.ts
+++ b/packages/html/src/define/video/ui.ts
@@ -29,6 +29,7 @@ import {
   defineMenu,
   defineTime,
   defineTimeSlider,
+  defineTitle,
   defineVolumeSlider,
 } from '../ui/compounds';
 
@@ -47,6 +48,7 @@ defineInputIndicators();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineTitle();
 defineMenu();
 
 // Standalone elements.

--- a/packages/html/src/ui/play-button/play-button-element.ts
+++ b/packages/html/src/ui/play-button/play-button-element.ts
@@ -1,5 +1,6 @@
 import { type MediaPlaybackState, PlayButtonCore, PlayButtonDataAttrs } from '@videojs/core';
-import { selectPlayback } from '@videojs/core/dom';
+import { selectMetadata, selectPlayback } from '@videojs/core/dom';
+import type { PropertyValues } from '@videojs/element';
 
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
@@ -11,7 +12,14 @@ export class PlayButtonElement extends MediaButtonElement<PlayButtonCore> {
   protected readonly core = new PlayButtonCore();
   protected readonly stateAttrMap = PlayButtonDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectPlayback);
+  readonly #metadata = new PlayerController(this, playerContext, selectMetadata);
   protected override readonly hotkeyAction = 'togglePaused';
+
+  protected override update(changed: PropertyValues): void {
+    const metadata = this.#metadata.value;
+    if (metadata) this.core.setMetadata(metadata);
+    super.update(changed);
+  }
 
   protected activate(state: MediaPlaybackState): void {
     this.core.toggle(state);

--- a/packages/html/src/ui/title/tests/title-element.test.ts
+++ b/packages/html/src/ui/title/tests/title-element.test.ts
@@ -1,0 +1,94 @@
+import { videoFeatures } from '@videojs/core/dom';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPlayer } from '../../../player/create-player';
+import { MediaElement } from '../../media-element';
+import { TitleElement } from '../title-element';
+
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
+
+class TestPlayerElement extends ProviderMixin(MediaElement) {
+  static readonly tagName = 'test-title-player';
+}
+
+customElements.define(TestPlayerElement.tagName, TestPlayerElement);
+customElements.define(TitleElement.tagName, TitleElement);
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  let error: unknown;
+
+  for (let index = 0; index < 10; index++) {
+    try {
+      assertion();
+      return;
+    } catch (caught) {
+      error = caught;
+      await nextFrame();
+    }
+  }
+
+  throw error;
+}
+
+describe('TitleElement', () => {
+  it('has the correct tag name', () => {
+    expect(TitleElement.tagName).toBe('media-title');
+  });
+
+  it('renders empty text and is aria-hidden when no title is set', async () => {
+    const player = document.createElement(TestPlayerElement.tagName) as TestPlayerElement;
+    const title = document.createElement(TitleElement.tagName) as TitleElement;
+    player.append(title);
+    document.body.append(player);
+
+    await waitForAssertion(() => {
+      expect(title.textContent).toBe('');
+      expect(title.getAttribute('aria-hidden')).toBe('true');
+      expect(title.hasAttribute('data-has-title')).toBe(false);
+    });
+  });
+
+  it('renders title text and removes aria-hidden when title is set', async () => {
+    const player = document.createElement(TestPlayerElement.tagName) as TestPlayerElement;
+    const title = document.createElement(TitleElement.tagName) as TitleElement;
+    player.append(title);
+    document.body.append(player);
+
+    (player.store.state as { setTitle: (t: string | null) => void }).setTitle('Big Buck Bunny');
+
+    await waitForAssertion(() => {
+      expect(title.textContent).toBe('Big Buck Bunny');
+      expect(title.getAttribute('aria-hidden')).toBeNull();
+      expect(title.hasAttribute('data-has-title')).toBe(true);
+    });
+  });
+
+  it('updates text reactively when title changes', async () => {
+    const player = document.createElement(TestPlayerElement.tagName) as TestPlayerElement;
+    const title = document.createElement(TitleElement.tagName) as TitleElement;
+    player.append(title);
+    document.body.append(player);
+
+    const setTitle = (t: string | null) => (player.store.state as { setTitle: (t: string | null) => void }).setTitle(t);
+
+    setTitle('First Title');
+    await waitForAssertion(() => expect(title.textContent).toBe('First Title'));
+
+    setTitle('Updated Title');
+    await waitForAssertion(() => expect(title.textContent).toBe('Updated Title'));
+
+    setTitle(null);
+    await waitForAssertion(() => {
+      expect(title.textContent).toBe('');
+      expect(title.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+});

--- a/packages/html/src/ui/title/title-element.ts
+++ b/packages/html/src/ui/title/title-element.ts
@@ -1,0 +1,55 @@
+import { TitleCore, TitleDataAttrs } from '@videojs/core';
+import { applyElementProps, applyStateDataAttrs, logMissingFeature, selectMetadata } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
+
+import { playerContext } from '../../player/context';
+import { PlayerController } from '../../player/player-controller';
+import { MediaElement } from '../media-element';
+
+export class TitleElement extends MediaElement {
+  static readonly tagName = 'media-title';
+
+  static override properties = {
+    label: { type: String },
+  } satisfies PropertyDeclarationMap<keyof TitleCore.Props>;
+
+  label = TitleCore.defaultProps.label;
+
+  readonly #core = new TitleCore();
+  readonly #state = new PlayerController(this, playerContext, selectMetadata);
+
+  readonly #textNode = document.createTextNode('');
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    if (!this.#textNode.parentNode) {
+      this.appendChild(this.#textNode);
+    }
+
+    if (__DEV__ && !this.#state.value) {
+      logMissingFeature(this.localName, this.#state.displayName!);
+    }
+  }
+
+  protected override willUpdate(changed: PropertyValues): void {
+    super.willUpdate(changed);
+    this.#core.setProps(this);
+  }
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+
+    const media = this.#state.value;
+
+    if (!media) return;
+
+    this.#core.setMedia(media);
+    const state = this.#core.getState();
+
+    this.#textNode.textContent = state.text;
+
+    applyElementProps(this, this.#core.getAttrs(state));
+    applyStateDataAttrs(this, state, TitleDataAttrs);
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -79,6 +79,7 @@ export type { StatusIndicatorValueProps } from './ui/status-indicator/status-ind
 export { Thumbnail, type ThumbnailProps } from './ui/thumbnail/thumbnail';
 export { Time } from './ui/time';
 export { TimeSlider } from './ui/time-slider';
+export { Title } from './ui/title';
 export { Tooltip, type TooltipContextValue, useTooltipContext } from './ui/tooltip';
 export { VolumeIndicator } from './ui/volume-indicator';
 export type { VolumeIndicatorFillProps } from './ui/volume-indicator/volume-indicator-fill';

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -16,7 +16,7 @@ import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import type { FC, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 import { useDestroy } from '../utils/use-destroy';
 import { Container, PlayerContextProvider, useMedia, usePlayerContext } from './context';
@@ -28,6 +28,8 @@ export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
 
 export interface ProviderProps {
   children: ReactNode;
+  /** Human-readable title for the current media. Synced to player state and used by MediaSession. */
+  title?: string | null | undefined;
 }
 
 export interface CreatePlayerResult<Store extends PlayerStore> {
@@ -69,7 +71,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 ): CreatePlayerResult<PlayerStore<Features>>;
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
-  function Provider({ children }: ProviderProps): ReactNode {
+  function Provider({ children, title }: ProviderProps): ReactNode {
     const [store] = useState(() => createStore<PlayerTarget>()(combine(...config.features)));
     const [popupGroup] = useState(() => createPopupGroup());
     const [media, setMedia] = useState<Media | null>(null);
@@ -81,6 +83,11 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       if (!media) return;
       return store.attach({ media, container });
     }, [media, container, store]);
+
+    useLayoutEffect(() => {
+      const state = store.state as { setTitle?: (t: string | null) => void };
+      state.setTitle?.(title ?? null);
+    }, [title, store]);
 
     return (
       <PlayerContextProvider value={{ store, media, setMedia, container, setContainer, popupGroup }}>

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -13,6 +13,7 @@ import {
   poster,
   root,
   slider,
+  title,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
 import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
@@ -51,6 +52,7 @@ import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -247,6 +249,8 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
       </Controls.Root>
 
       <div className={overlay} />
+
+      <Title.Value className={title} />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -35,6 +35,7 @@ import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -201,6 +202,8 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
       </Controls.Root>
 
       <div className="media-overlay" />
+
+      <Title.Value className="media-title" />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -13,6 +13,7 @@ import {
   poster,
   root,
   slider,
+  title,
 } from '@videojs/skins/default/tailwind/video.tailwind';
 import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
@@ -51,6 +52,7 @@ import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -249,6 +251,8 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
       </Controls.Root>
 
       <div className={overlay} />
+
+      <Title.Value className={title} />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -35,6 +35,7 @@ import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -202,6 +203,8 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
       </Controls.Root>
 
       <div className="media-overlay" />
+
+      <Title.Value className="media-title" />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -20,6 +20,7 @@ import {
   seek,
   slider,
   time,
+  title,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
 import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
@@ -67,6 +68,7 @@ import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -343,6 +345,8 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
       </Controls.Root>
 
       <div className={overlay} />
+
+      <Title.Value className={title} />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -44,6 +44,7 @@ import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -276,6 +277,8 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
       </Controls.Root>
 
       <div className="media-overlay" />
+
+      <Title.Value className="media-title" />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -20,6 +20,7 @@ import {
   seek,
   slider,
   time,
+  title,
 } from '@videojs/skins/default/tailwind/video.tailwind';
 import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
@@ -67,6 +68,7 @@ import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -339,6 +341,8 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
       </Controls.Root>
 
       <div className={overlay} />
+
+      <Title.Value className={title} />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -44,6 +44,7 @@ import { StatusAnnouncer } from '@/ui/status-announcer';
 import { StatusIndicator } from '@/ui/status-indicator';
 import { Time } from '@/ui/time';
 import { TimeSlider } from '@/ui/time-slider';
+import { Title } from '@/ui/title';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
@@ -272,6 +273,8 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
       </Controls.Root>
 
       <div className="media-overlay" />
+
+      <Title.Value className="media-title" />
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/ui/play-button/play-button.tsx
+++ b/packages/react/src/ui/play-button/play-button.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import { PlayButtonCore, PlayButtonDataAttrs } from '@videojs/core';
-import { selectPlayback } from '@videojs/core/dom';
+import { logMissingFeature, selectMetadata, selectPlayback } from '@videojs/core/dom';
+import type { ForwardedRef } from 'react';
+import { forwardRef, useLayoutEffect, useState } from 'react';
 
+import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
-import { createMediaButton } from '../create-media-button';
+import { renderElement } from '../../utils/use-render';
+import { useButton } from '../hooks/use-button';
+import { useAriaKeyShortcuts } from '../hotkey/use-aria-key-shortcuts';
+import { useOptionalTooltipContext } from '../tooltip/context';
 
 export interface PlayButtonProps extends UIComponentProps<'button', PlayButtonCore.State>, PlayButtonCore.Props {}
 
@@ -24,13 +30,54 @@ export interface PlayButtonProps extends UIComponentProps<'button', PlayButtonCo
  * />
  * ```
  */
-export const PlayButton = createMediaButton<PlayButtonCore, PlayButtonProps>({
-  displayName: 'PlayButton',
-  core: PlayButtonCore,
-  stateAttrMap: PlayButtonDataAttrs,
-  selector: selectPlayback,
-  action: (core, state) => core.toggle(state),
-  hotkeyAction: 'togglePaused',
+export const PlayButton = forwardRef(function PlayButton(
+  componentProps: PlayButtonProps,
+  forwardedRef: ForwardedRef<HTMLButtonElement>
+) {
+  const { render, className, style, label, disabled, ...elementProps } = componentProps;
+
+  const tooltipCtx = useOptionalTooltipContext();
+  const playback = usePlayer(selectPlayback);
+  const metadata = usePlayer(selectMetadata);
+  const shortcuts = useAriaKeyShortcuts('togglePaused');
+
+  const [core] = useState(() => new PlayButtonCore());
+  core.setProps({ label, disabled });
+  if (metadata) core.setMetadata(metadata);
+
+  const { getButtonProps, buttonRef } = useButton({
+    displayName: 'PlayButton',
+    onActivate: () => core.toggle(playback!),
+    isDisabled: () => !!disabled || !playback,
+  });
+
+  if (playback) core.setMedia(playback);
+  const state = playback ? core.getState() : null;
+  const buttonLabel = state ? core.getLabel(state) : undefined;
+
+  useLayoutEffect(() => {
+    if (!tooltipCtx) return;
+    tooltipCtx.setContent(buttonLabel);
+    return () => tooltipCtx.setContent(undefined);
+  }, [tooltipCtx, buttonLabel]);
+
+  if (!playback || !state) {
+    if (__DEV__) logMissingFeature('PlayButton', 'playback');
+    return null;
+  }
+
+  const attrs = { ...core.getAttrs(state), 'aria-keyshortcuts': shortcuts };
+
+  return renderElement(
+    'button',
+    { render, className, style },
+    {
+      state,
+      stateAttrMap: PlayButtonDataAttrs,
+      ref: [forwardedRef, buttonRef],
+      props: [attrs, elementProps, getButtonProps()],
+    }
+  );
 });
 
 export namespace PlayButton {

--- a/packages/react/src/ui/title/index.parts.ts
+++ b/packages/react/src/ui/title/index.parts.ts
@@ -1,0 +1,1 @@
+export { Value, type ValueProps } from './title';

--- a/packages/react/src/ui/title/index.ts
+++ b/packages/react/src/ui/title/index.ts
@@ -1,0 +1,1 @@
+export * as Title from './index.parts';

--- a/packages/react/src/ui/title/tests/title.test.tsx
+++ b/packages/react/src/ui/title/tests/title.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render } from '@testing-library/react';
+import { videoFeatures } from '@videojs/core/dom';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { PlayerContextProvider, type PlayerContextValue } from '../../../player/context';
+import { createPlayer } from '../../../player/create-player';
+import { Title } from '../index';
+
+afterEach(cleanup);
+
+describe('Title.Value', () => {
+  it('returns null when no metadataFeature is present in the store', () => {
+    const { container } = render(
+      <PlayerContextProvider value={emptyPlayerContext()}>
+        <Title.Value data-testid="title" />
+      </PlayerContextProvider>
+    );
+
+    expect(container.querySelector('[data-testid="title"]')).toBeNull();
+  });
+
+  it('renders empty and aria-hidden when title is null', () => {
+    const { Provider } = createPlayer({ features: videoFeatures });
+
+    const { container } = render(
+      <Provider>
+        <Title.Value data-testid="title" />
+      </Provider>
+    );
+
+    const el = container.querySelector('[data-testid="title"]');
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe('');
+    expect(el?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders title text when title is set via Provider', () => {
+    const { Provider } = createPlayer({ features: videoFeatures });
+
+    const { container } = render(
+      <Provider title="Big Buck Bunny">
+        <Title.Value data-testid="title" />
+      </Provider>
+    );
+
+    const el = container.querySelector('[data-testid="title"]');
+    expect(el?.textContent).toBe('Big Buck Bunny');
+    expect(el?.getAttribute('aria-hidden')).toBeNull();
+    expect(el?.hasAttribute('data-has-title')).toBe(true);
+  });
+});
+
+function emptyPlayerContext(): PlayerContextValue {
+  return {
+    store: {
+      state: {},
+      subscribe: () => () => {},
+    },
+    media: null,
+    setMedia: () => {},
+    container: null,
+    setContainer: () => {},
+  } as unknown as PlayerContextValue;
+}

--- a/packages/react/src/ui/title/title.tsx
+++ b/packages/react/src/ui/title/title.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { TitleCore, TitleDataAttrs } from '@videojs/core';
+import { logMissingFeature, selectMetadata } from '@videojs/core/dom';
+import type { ForwardedRef } from 'react';
+import { forwardRef, useState } from 'react';
+
+import { usePlayer } from '../../player/context';
+import type { UIComponentProps } from '../../utils/types';
+import { renderElement } from '../../utils/use-render';
+
+export interface ValueProps extends UIComponentProps<'span', TitleCore.State>, TitleCore.Props {}
+
+/**
+ * Displays the current media title.
+ *
+ * @example
+ * ```tsx
+ * <Title.Value />
+ * ```
+ */
+export const Value = forwardRef(function Value(
+  componentProps: ValueProps,
+  forwardedRef: ForwardedRef<HTMLSpanElement>
+) {
+  const { render, className, style, label, ...elementProps } = componentProps;
+
+  const metadata = usePlayer(selectMetadata);
+
+  const [core] = useState(() => new TitleCore());
+  core.setProps({ label });
+
+  if (!metadata) {
+    if (__DEV__) logMissingFeature('Title.Value', 'metadata');
+    return null;
+  }
+
+  core.setMedia(metadata);
+  const state = core.getState();
+
+  return renderElement(
+    'span',
+    { render, className, style },
+    {
+      state,
+      stateAttrMap: TitleDataAttrs,
+      ref: [forwardedRef],
+      props: [
+        {
+          children: state.text,
+          ...core.getAttrs(state),
+        },
+        elementProps,
+      ],
+    }
+  );
+});
+
+export namespace Value {
+  export type Props = ValueProps;
+  export type State = TitleCore.State;
+}

--- a/packages/skins/src/default/css/components/overlay.css
+++ b/packages/skins/src/default/css/components/overlay.css
@@ -6,7 +6,9 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background-image: linear-gradient(to top, oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.3), oklch(0 0 0 / 0));
+  background-image:
+    linear-gradient(to bottom, oklch(0 0 0 / 0.3), oklch(0 0 0 / 0.15), oklch(0 0 0 / 0)),
+    linear-gradient(to top, oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.3), oklch(0 0 0 / 0));
   border-radius: inherit;
   opacity: 0;
   backdrop-filter: blur(0) saturate(1);

--- a/packages/skins/src/default/css/components/title.css
+++ b/packages/skins/src/default/css/components/title.css
@@ -1,0 +1,29 @@
+.media-title {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  padding: 0.75rem 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--media-color-primary, oklch(1 0 0));
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition-timing-function: ease-out;
+  transition-duration: var(--media-controls-transition-duration);
+  transition-property: opacity;
+}
+
+.media-title:not([data-has-title]) {
+  display: none;
+}
+
+.media-controls[data-visible] ~ .media-title {
+  opacity: 1;
+}
+
+.media-error[data-open] ~ .media-title {
+  display: none;
+}

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -3,6 +3,7 @@
 @import "./components/surface.css";
 @import "./components/media.css";
 @import "./components/overlay.css";
+@import "./components/title.css";
 @import "./components/buffering.css";
 @import "./components/error.css";
 @import "./components/controls.css";

--- a/packages/skins/src/default/tailwind/components/overlay.ts
+++ b/packages/skins/src/default/tailwind/components/overlay.ts
@@ -6,7 +6,7 @@ export const overlay = cn(
   'pointer-events-none rounded-[inherit]',
   // Default: hidden
   'opacity-0',
-  'bg-linear-to-t from-black/50 via-black/30 to-transparent',
+  '[background-image:linear-gradient(to_bottom,oklch(0_0_0/0.3),oklch(0_0_0/0.15),oklch(0_0_0/0)),linear-gradient(to_top,oklch(0_0_0/0.5),oklch(0_0_0/0.3),oklch(0_0_0/0))]',
   'backdrop-blur-none backdrop-saturate-100',
   // Transitions
   'transition-[opacity,backdrop-filter]',

--- a/packages/skins/src/default/tailwind/components/title.ts
+++ b/packages/skins/src/default/tailwind/components/title.ts
@@ -1,0 +1,17 @@
+import { cn } from '@videojs/utils/style';
+
+export const title = cn(
+  'absolute top-0 inset-x-0',
+  'py-3 px-4',
+  'pointer-events-none',
+  'text-base font-medium',
+  '[color:var(--media-color-primary,oklch(1_0_0))]',
+  'truncate',
+  'opacity-0',
+  'transition-opacity',
+  'duration-(--media-controls-transition-duration)',
+  'ease-out',
+  'peer-data-visible/controls:opacity-100',
+  'peer-data-open/error:hidden',
+  'not-data-has-title:hidden'
+);

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -217,3 +217,4 @@ export { overlay } from './components/overlay';
 export { playbackRate } from './components/playback-rate';
 export { poster } from './components/poster';
 export { seek } from './components/seek';
+export { title } from './components/title';

--- a/packages/skins/src/minimal/css/components/overlay.css
+++ b/packages/skins/src/minimal/css/components/overlay.css
@@ -6,15 +6,17 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background-image:
-    linear-gradient(to bottom, oklch(0 0 0 / 0.3), oklch(0 0 0 / 0.15), oklch(0 0 0 / 0)),
-    linear-gradient(to top, oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.3), oklch(0 0 0 / 0));
+  background-image: linear-gradient(to top, oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.3) 25%, oklch(0 0 0 / 0));
   border-radius: inherit;
   opacity: 0;
   backdrop-filter: blur(0) saturate(1);
   transition-timing-function: ease-out;
   transition-duration: var(--media-controls-transition-duration);
   transition-property: opacity, backdrop-filter;
+}
+
+.media-minimal-skin:has([data-has-title]) .media-overlay {
+  background-image: linear-gradient(to top, oklch(0 0 0 / 0.5), oklch(0 0 0 / 0), oklch(0 0 0 / 0.5));
 }
 
 .media-minimal-skin .media-error ~ .media-overlay {

--- a/packages/skins/src/minimal/css/components/overlay.css
+++ b/packages/skins/src/minimal/css/components/overlay.css
@@ -6,7 +6,9 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background-image: linear-gradient(to top, oklch(0 0 0 / 0.7), oklch(0 0 0 / 0.5) 7.5rem, oklch(0 0 0 / 0));
+  background-image:
+    linear-gradient(to bottom, oklch(0 0 0 / 0.3), oklch(0 0 0 / 0.15), oklch(0 0 0 / 0)),
+    linear-gradient(to top, oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.3), oklch(0 0 0 / 0));
   border-radius: inherit;
   opacity: 0;
   backdrop-filter: blur(0) saturate(1);

--- a/packages/skins/src/minimal/css/components/title.css
+++ b/packages/skins/src/minimal/css/components/title.css
@@ -1,0 +1,29 @@
+.media-minimal-skin .media-title {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  padding: 0.75rem 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--media-color-primary, oklch(1 0 0));
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition-timing-function: ease-out;
+  transition-duration: var(--media-controls-transition-duration);
+  transition-property: opacity;
+}
+
+.media-minimal-skin .media-title:not([data-has-title]) {
+  display: none;
+}
+
+.media-minimal-skin .media-controls[data-visible] ~ .media-title {
+  opacity: 1;
+}
+
+.media-minimal-skin .media-error[data-open] ~ .media-title {
+  display: none;
+}

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -2,6 +2,7 @@
 @import "./components/root.css";
 @import "./components/media.css";
 @import "./components/overlay.css";
+@import "./components/title.css";
 @import "./components/buffering.css";
 @import "./components/error.css";
 @import "./components/controls.css";

--- a/packages/skins/src/minimal/tailwind/components/overlay.ts
+++ b/packages/skins/src/minimal/tailwind/components/overlay.ts
@@ -6,7 +6,7 @@ export const overlay = cn(
   'pointer-events-none rounded-[inherit]',
   // Default: hidden
   'opacity-0',
-  'bg-linear-to-t from-black/70 via-black/50 via-[7.5rem] to-transparent',
+  '[background-image:linear-gradient(to_bottom,oklch(0_0_0/0.3),oklch(0_0_0/0.15),oklch(0_0_0/0)),linear-gradient(to_top,oklch(0_0_0/0.5),oklch(0_0_0/0.3),oklch(0_0_0/0))]',
   'backdrop-blur-none backdrop-saturate-100',
   // Transitions
   'transition-[opacity,backdrop-filter]',

--- a/packages/skins/src/minimal/tailwind/components/overlay.ts
+++ b/packages/skins/src/minimal/tailwind/components/overlay.ts
@@ -6,7 +6,9 @@ export const overlay = cn(
   'pointer-events-none rounded-[inherit]',
   // Default: hidden
   'opacity-0',
-  '[background-image:linear-gradient(to_bottom,oklch(0_0_0/0.3),oklch(0_0_0/0.15),oklch(0_0_0/0)),linear-gradient(to_top,oklch(0_0_0/0.5),oklch(0_0_0/0.3),oklch(0_0_0/0))]',
+  // Bottom darkening always; top darkening only when a title is present
+  'bg-linear-to-t from-black/50 via-black/30 via-25% to-transparent',
+  '[:has([data-has-title])_&]:[background-image:linear-gradient(to_top,oklch(0_0_0_/_0.5),oklch(0_0_0_/_0),oklch(0_0_0_/_0.5))]',
   'backdrop-blur-none backdrop-saturate-100',
   // Transitions
   'transition-[opacity,backdrop-filter]',

--- a/packages/skins/src/minimal/tailwind/components/title.ts
+++ b/packages/skins/src/minimal/tailwind/components/title.ts
@@ -1,0 +1,17 @@
+import { cn } from '@videojs/utils/style';
+
+export const title = cn(
+  'absolute top-0 inset-x-0',
+  'py-3 px-4',
+  'pointer-events-none',
+  'text-base font-medium',
+  '[color:var(--media-color-primary,oklch(1_0_0))]',
+  'truncate',
+  'opacity-0',
+  'transition-opacity',
+  'duration-(--media-controls-transition-duration)',
+  'ease-out',
+  'peer-data-visible/controls:opacity-100',
+  'peer-data-open/error:hidden',
+  'not-data-has-title:hidden'
+);

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -202,3 +202,4 @@ export { overlay } from './components/overlay';
 export { playbackRate } from './components/playback-rate';
 export { poster } from './components/poster';
 export { seek } from './components/seek';
+export { title } from './components/title';

--- a/site/src/content/docs/reference/feature-metadata.mdx
+++ b/site/src/content/docs/reference/feature-metadata.mdx
@@ -1,0 +1,48 @@
+---
+title: Metadata
+description: Media title state and actions for the player store
+---
+
+import FeatureReference from "@/components/docs/api-reference/FeatureReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+
+Provides a human-readable title for the current media. The title is used for the visible title overlay, the play button `aria-label`, and `navigator.mediaSession.metadata`.
+
+<FeatureReference feature="metadata" />
+
+### Selector
+
+<FrameworkCase frameworks={["react"]}>
+Pass `selectMetadata` to <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> to subscribe to metadata state. Returns `undefined` if the metadata feature is not configured.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Pass `selectMetadata` to <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> to subscribe to metadata state. Returns `undefined` if the metadata feature is not configured.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="TitleDisplay.tsx"
+import { selectMetadata, usePlayer } from '@videojs/react';
+
+function TitleDisplay() {
+  const metadata = usePlayer(selectMetadata);
+  if (!metadata?.title) return null;
+
+  return <span>{metadata.title}</span>;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="title-display.ts"
+import { createPlayer, MediaElement, selectMetadata } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const { PlayerController, context } = createPlayer({ features: videoFeatures });
+
+class TitleDisplay extends MediaElement {
+  readonly #metadata = new PlayerController(this, context, selectMetadata);
+}
+```
+</FrameworkCase>

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -129,6 +129,7 @@ export const sidebar: Sidebar = [
       { slug: 'reference/feature-error' },
       { slug: 'reference/feature-fullscreen' },
       { slug: 'reference/feature-live' },
+      { slug: 'reference/feature-metadata' },
       { slug: 'reference/feature-pip', sidebarLabel: 'Picture-in-picture' },
       { slug: 'reference/feature-playback' },
       { slug: 'reference/feature-playback-rate' },


### PR DESCRIPTION
> [!WARNING]
> **Blocked by #1603** — do not review or merge until `feat: add title display and media metadata state` (#1603) is merged first. The diff here includes all of PR #1603's changes; once that lands, this PR's diff will shrink to only the minimal skin files.

## Summary

- Add `<media-title>` / `Title.Value` to minimal skin templates (HTML and React, CSS and Tailwind variants)
- Create `minimal/css/components/title.css` and `minimal/tailwind/components/title.ts` with the same fade-in behavior as the default skin
- Update minimal skin overlay gradient to match the default skin: softer dual-direction scrim (`0.3/0.15` top, `0.5/0.3` bottom) replacing the original single-direction dark gradient

## Test plan

- [ ] Sandbox: switch to minimal skin → title fades in with controls on first load (no need to switch skins first)
- [ ] Verify overlay brightness matches the default skin
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm check:workspace`