### PR TITLE
feat(packages): add captions menu using menu primitives

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -6,6 +6,8 @@ export * from './ui/buffering-indicator/buffering-indicator-core';
 export * from './ui/buffering-indicator/buffering-indicator-data-attrs';
 export * from './ui/captions-button/captions-button-core';
 export * from './ui/captions-button/captions-button-data-attrs';
+export * from './ui/captions-radio-group/captions-radio-group-core';
+export * from './ui/captions-radio-group/captions-radio-group-data-attrs';
 export * from './ui/cast-button/cast-button-core';
 export * from './ui/cast-button/cast-button-data-attrs';
 export * from './ui/controls/controls-core';

--- a/packages/core/src/core/media/state.ts
+++ b/packages/core/src/core/media/state.ts
@@ -278,6 +278,8 @@ export interface MediaTextTrackState {
   subtitlesShowing: boolean;
   /** Toggle captions/subtitles visibility. Returns the new enabled value. */
   toggleSubtitles(forceShow?: boolean): boolean;
+  /** Select a captions/subtitles track by menu value, or disable with `"off"`. */
+  selectSubtitlesTrack(value: string): void;
 }
 
 export interface MediaError {

--- a/packages/core/src/core/ui/captions-button/captions-button-core.ts
+++ b/packages/core/src/core/ui/captions-button/captions-button-core.ts
@@ -12,6 +12,8 @@ export interface CaptionsButtonProps {
   label?: string | ((state: CaptionsButtonState) => string) | undefined;
   /** Whether the button is disabled. */
   disabled?: boolean | undefined;
+  /** When true with multiple tracks, pointer activation opens a menu instead of toggling. React sets this automatically inside `Menu.Trigger`. */
+  menuTrigger?: boolean | undefined;
 }
 
 export interface CaptionsButtonState extends Pick<MediaTextTrackState, 'subtitlesShowing'>, ButtonState {
@@ -22,6 +24,7 @@ export class CaptionsButtonCore {
   static readonly defaultProps: NonNullableObject<CaptionsButtonProps> = {
     label: '',
     disabled: false,
+    menuTrigger: false,
   };
 
   readonly state = createState<CaptionsButtonState>({
@@ -79,8 +82,13 @@ export class CaptionsButtonCore {
 
   toggle(media: MediaTextTrackState): void {
     if (this.#props.disabled) return;
+    if (this.#props.menuTrigger && getCaptionTrackCount(media) > 1) return;
     media.toggleSubtitles();
   }
+}
+
+function getCaptionTrackCount(media: MediaTextTrackState): number {
+  return media.textTrackList.filter(isCaptionOrSubtitleTrack).length;
 }
 
 export namespace CaptionsButtonCore {

--- a/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
+++ b/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
@@ -116,5 +116,26 @@ describe('CaptionsButtonCore', () => {
       core.toggle(media);
       expect(media.toggleSubtitles).not.toHaveBeenCalled();
     });
+
+    it('does not toggle when acting as a menu trigger with multiple tracks', () => {
+      const core = new CaptionsButtonCore({ menuTrigger: true });
+      const media = createMediaState({
+        textTrackList: [
+          { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' },
+          { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+        ],
+      });
+      core.toggle(media);
+      expect(media.toggleSubtitles).not.toHaveBeenCalled();
+    });
+
+    it('still toggles as a menu trigger with a single track', () => {
+      const core = new CaptionsButtonCore({ menuTrigger: true });
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' }],
+      });
+      core.toggle(media);
+      expect(media.toggleSubtitles).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
+++ b/packages/core/src/core/ui/captions-button/tests/captions-button-core.test.ts
@@ -12,6 +12,7 @@ function createMediaState(overrides: Partial<MediaTextTrackState> = {}): MediaTe
     textTrackList: [],
     subtitlesShowing: false,
     toggleSubtitles: vi.fn(() => true),
+    selectSubtitlesTrack: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
+++ b/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
@@ -1,0 +1,145 @@
+import { createState } from '@videojs/store';
+import { isCaptionOrSubtitleTrack } from '@videojs/utils/dom';
+import { defaults } from '@videojs/utils/object';
+import { isFunction } from '@videojs/utils/predicate';
+import type { NonNullableObject } from '@videojs/utils/types';
+
+import type { MediaTextTrack, MediaTextTrackState } from '../../media/state';
+import type { ButtonState } from '../types';
+
+export interface CaptionsRadioGroupProps {
+  /** Custom label for the menu trigger. */
+  label?: string | ((state: CaptionsRadioGroupState) => string) | undefined;
+  /** Custom formatter for visible track labels. */
+  formatTrack?: ((track: MediaTextTrack) => string) | undefined;
+  /** Whether track selection is disabled. */
+  disabled?: boolean | undefined;
+}
+
+export interface CaptionsRadioGroupTrack {
+  value: string;
+  label: string;
+}
+
+export interface CaptionsRadioGroupState extends Pick<MediaTextTrackState, 'subtitlesShowing'>, ButtonState {
+  tracks: readonly CaptionsRadioGroupTrack[];
+  value: string;
+  disabled: boolean;
+}
+
+export const CAPTIONS_OFF_VALUE = 'off';
+
+function formatTrackLabel(track: MediaTextTrack): string {
+  if (track.label) return track.label;
+  if (track.language) return track.language;
+  return track.kind === 'captions' ? 'Captions' : 'Subtitles';
+}
+
+function getCaptionTracks(textTrackList: readonly MediaTextTrack[]): MediaTextTrack[] {
+  return textTrackList.filter(isCaptionOrSubtitleTrack);
+}
+
+export class CaptionsRadioGroupCore {
+  static readonly defaultProps: NonNullableObject<CaptionsRadioGroupProps> = {
+    label: '',
+    formatTrack: formatTrackLabel,
+    disabled: false,
+  };
+
+  readonly state = createState<CaptionsRadioGroupState>({
+    tracks: [],
+    value: CAPTIONS_OFF_VALUE,
+    subtitlesShowing: false,
+    disabled: false,
+    label: '',
+  });
+
+  #props = { ...CaptionsRadioGroupCore.defaultProps };
+  #media: MediaTextTrackState | null = null;
+
+  constructor(props?: CaptionsRadioGroupProps) {
+    if (props) this.setProps(props);
+  }
+
+  setProps(props: CaptionsRadioGroupProps): void {
+    this.#props = defaults(props, CaptionsRadioGroupCore.defaultProps);
+  }
+
+  getLabel(state: CaptionsRadioGroupState): string {
+    const { label } = this.#props;
+
+    if (isFunction(label)) {
+      const customLabel = label(state);
+      if (customLabel) return customLabel;
+    } else if (label) {
+      return label;
+    }
+
+    return state.subtitlesShowing ? 'Disable captions' : 'Enable captions';
+  }
+
+  getTrackLabel(track: MediaTextTrack): string {
+    return this.#props.formatTrack(track);
+  }
+
+  getTrackValue(index: number): string {
+    return String(index);
+  }
+
+  getAttrs(state: CaptionsRadioGroupState) {
+    return {
+      'aria-label': this.getLabel(state),
+      'aria-disabled': state.disabled ? 'true' : undefined,
+    };
+  }
+
+  setMedia(media: MediaTextTrackState): void {
+    this.#media = media;
+  }
+
+  getState(): CaptionsRadioGroupState {
+    const media = this.#media!;
+    const captionTracks = getCaptionTracks(media.textTrackList);
+    const showingIndex = captionTracks.findIndex((track) => track.mode === 'showing');
+    const tracks = captionTracks.map((track, index) => ({
+      value: this.getTrackValue(index),
+      label: this.getTrackLabel(track),
+    }));
+
+    this.state.patch({
+      tracks,
+      value: showingIndex === -1 ? CAPTIONS_OFF_VALUE : this.getTrackValue(showingIndex),
+      subtitlesShowing: media.subtitlesShowing,
+      disabled: this.#props.disabled || captionTracks.length === 0,
+    });
+    this.state.patch({ label: this.getLabel(this.state.current) });
+
+    return this.state.current;
+  }
+
+  select(media: MediaTextTrackState, value: string): void {
+    if (this.#props.disabled) return;
+
+    const captionTracks = getCaptionTracks(media.textTrackList);
+    if (!captionTracks.length) return;
+
+    if (value === CAPTIONS_OFF_VALUE) {
+      media.selectSubtitlesTrack(CAPTIONS_OFF_VALUE);
+      return;
+    }
+
+    const index = captionTracks.findIndex((_track, candidateIndex) => this.getTrackValue(candidateIndex) === value);
+    if (index === -1) return;
+
+    media.selectSubtitlesTrack(value);
+  }
+
+  selectValue(media: MediaTextTrackState, value: string): void {
+    this.select(media, value);
+  }
+}
+
+export namespace CaptionsRadioGroupCore {
+  export type Props = CaptionsRadioGroupProps;
+  export type State = CaptionsRadioGroupState;
+}

--- a/packages/core/src/core/ui/captions-radio-group/captions-radio-group-data-attrs.ts
+++ b/packages/core/src/core/ui/captions-radio-group/captions-radio-group-data-attrs.ts
@@ -1,0 +1,9 @@
+import type { StateAttrMap } from '../types';
+import type { CaptionsRadioGroupState } from './captions-radio-group-core';
+
+export const CaptionsRadioGroupDataAttrs = {
+  /** Present when captions are enabled. */
+  subtitlesShowing: 'data-active',
+  /** Present when track selection is disabled. */
+  disabled: 'data-disabled',
+} as const satisfies StateAttrMap<CaptionsRadioGroupState>;

--- a/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MediaTextTrackState } from '../../../media/state';
+import { CAPTIONS_OFF_VALUE, CaptionsRadioGroupCore, type CaptionsRadioGroupState } from '../captions-radio-group-core';
+
+function createMediaState(overrides: Partial<MediaTextTrackState> = {}): MediaTextTrackState {
+  return {
+    chaptersCues: [],
+    thumbnailCues: [],
+    thumbnailTrackSrc: null,
+    textTrackList: [],
+    subtitlesShowing: false,
+    toggleSubtitles: vi.fn(() => true),
+    selectSubtitlesTrack: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createState(overrides: Partial<CaptionsRadioGroupState> = {}): CaptionsRadioGroupState {
+  return {
+    tracks: [],
+    value: CAPTIONS_OFF_VALUE,
+    subtitlesShowing: false,
+    disabled: false,
+    label: '',
+    ...overrides,
+  };
+}
+
+describe('CaptionsRadioGroupCore', () => {
+  describe('getState', () => {
+    it('projects caption tracks and the active value', () => {
+      const core = new CaptionsRadioGroupCore();
+      const media = createMediaState({
+        subtitlesShowing: true,
+        textTrackList: [
+          { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' },
+          { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+        ],
+      });
+      core.setMedia(media);
+      const state = core.getState();
+
+      expect(state.tracks).toEqual([
+        { value: '0', label: 'English' },
+        { value: '1', label: 'Spanish' },
+      ]);
+      expect(state.value).toBe('0');
+      expect(state.subtitlesShowing).toBe(true);
+    });
+
+    it('marks state disabled when no caption tracks are available', () => {
+      const core = new CaptionsRadioGroupCore();
+      const media = createMediaState({
+        textTrackList: [{ kind: 'metadata', label: 'thumbnails', language: '', mode: 'hidden' }],
+      });
+      core.setMedia(media);
+
+      expect(core.getState().disabled).toBe(true);
+    });
+
+    it('uses off when no track is showing', () => {
+      const core = new CaptionsRadioGroupCore();
+      const media = createMediaState({
+        textTrackList: [
+          { kind: 'captions', label: 'English', language: 'en', mode: 'disabled' },
+          { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+        ],
+      });
+      core.setMedia(media);
+
+      expect(core.getState().value).toBe(CAPTIONS_OFF_VALUE);
+    });
+  });
+
+  describe('getLabel', () => {
+    it('returns default labels based on showing state', () => {
+      const core = new CaptionsRadioGroupCore();
+      expect(core.getLabel(createState({ subtitlesShowing: false }))).toBe('Enable captions');
+      expect(core.getLabel(createState({ subtitlesShowing: true }))).toBe('Disable captions');
+    });
+
+    it('returns custom string label', () => {
+      const core = new CaptionsRadioGroupCore({ label: 'Captions' });
+      expect(core.getLabel(createState())).toBe('Captions');
+    });
+
+    it('returns custom function label', () => {
+      const core = new CaptionsRadioGroupCore({
+        label: (state) => (state.subtitlesShowing ? 'Hide subtitles' : 'Show subtitles'),
+      });
+      expect(core.getLabel(createState({ subtitlesShowing: true }))).toBe('Hide subtitles');
+    });
+  });
+
+  describe('getTrackLabel', () => {
+    it('formats track labels by default', () => {
+      const core = new CaptionsRadioGroupCore();
+      expect(core.getTrackLabel({ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' })).toBe(
+        'English'
+      );
+      expect(core.getTrackLabel({ kind: 'subtitles', label: '', language: 'es', mode: 'disabled' })).toBe('es');
+      expect(core.getTrackLabel({ kind: 'captions', label: '', language: '', mode: 'disabled' })).toBe('Captions');
+    });
+
+    it('uses a custom formatter', () => {
+      const core = new CaptionsRadioGroupCore({
+        formatTrack: (track) => `${track.language.toUpperCase()} subtitles`,
+      });
+
+      expect(core.getTrackLabel({ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' })).toBe(
+        'EN subtitles'
+      );
+    });
+  });
+
+  describe('select', () => {
+    it('selects a track from the available list', () => {
+      const core = new CaptionsRadioGroupCore();
+      const media = createMediaState({
+        textTrackList: [
+          { kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' },
+          { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+        ],
+      });
+      core.select(media, '1');
+      expect(media.selectSubtitlesTrack).toHaveBeenCalledWith('1');
+    });
+
+    it('turns captions off', () => {
+      const core = new CaptionsRadioGroupCore();
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' }],
+      });
+      core.select(media, CAPTIONS_OFF_VALUE);
+      expect(media.selectSubtitlesTrack).toHaveBeenCalledWith(CAPTIONS_OFF_VALUE);
+    });
+
+    it('does nothing when disabled', () => {
+      const core = new CaptionsRadioGroupCore({ disabled: true });
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+      });
+      core.select(media, '0');
+      expect(media.selectSubtitlesTrack).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for unavailable tracks', () => {
+      const core = new CaptionsRadioGroupCore();
+      const media = createMediaState({
+        textTrackList: [{ kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' }],
+      });
+      core.select(media, '2');
+      expect(media.selectSubtitlesTrack).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/dom/store/features/tests/text-track.test.ts
+++ b/packages/core/src/dom/store/features/tests/text-track.test.ts
@@ -197,6 +197,38 @@ describe('textTrackFeature', () => {
       expect(store.state.toggleSubtitles()).toBe(false);
     });
 
+    it('selectSubtitlesTrack() enables one track and disables the others', () => {
+      const video = createVideo();
+      const englishTrack = createMockTrack('subtitles', 'disabled');
+      englishTrack.label = 'English';
+      const spanishTrack = createMockTrack('subtitles', 'disabled');
+      spanishTrack.label = 'Spanish';
+      mockTextTracks(video, [englishTrack, spanishTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      store.state.selectSubtitlesTrack('1');
+
+      expect(englishTrack.mode).toBe('disabled');
+      expect(spanishTrack.mode).toBe('showing');
+    });
+
+    it('selectSubtitlesTrack("off") disables all caption tracks', () => {
+      const video = createVideo();
+      const englishTrack = createMockTrack('subtitles', 'showing');
+      const spanishTrack = createMockTrack('subtitles', 'disabled');
+      mockTextTracks(video, [englishTrack, spanishTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      store.state.selectSubtitlesTrack('off');
+
+      expect(englishTrack.mode).toBe('disabled');
+      expect(spanishTrack.mode).toBe('disabled');
+    });
+
     it('stops updating after destroy', () => {
       const video = createVideo();
       const store = createStore<PlayerTarget>()(textTrackFeature);

--- a/packages/core/src/dom/store/features/tests/text-track.test.ts
+++ b/packages/core/src/dom/store/features/tests/text-track.test.ts
@@ -29,8 +29,17 @@ function mockTextTracks(video: HTMLVideoElement, tracks: TextTrack[]): void {
   });
 }
 
-function createMockTrack(kind: TextTrackKind, mode: TextTrackMode = 'disabled'): TextTrack {
-  return { kind, mode, label: '', language: '' } as TextTrack;
+function createMockTrack(
+  kind: TextTrackKind,
+  mode: TextTrackMode = 'disabled',
+  options: { label?: string; language?: string } = {}
+): TextTrack {
+  return {
+    kind,
+    mode,
+    label: options.label ?? '',
+    language: options.language ?? '',
+  } as TextTrack;
 }
 
 describe('textTrackFeature', () => {
@@ -199,10 +208,8 @@ describe('textTrackFeature', () => {
 
     it('selectSubtitlesTrack() enables one track and disables the others', () => {
       const video = createVideo();
-      const englishTrack = createMockTrack('subtitles', 'disabled');
-      englishTrack.label = 'English';
-      const spanishTrack = createMockTrack('subtitles', 'disabled');
-      spanishTrack.label = 'Spanish';
+      const englishTrack = createMockTrack('subtitles', 'disabled', { label: 'English' });
+      const spanishTrack = createMockTrack('subtitles', 'disabled', { label: 'Spanish' });
       mockTextTracks(video, [englishTrack, spanishTrack]);
 
       const store = createStore<PlayerTarget>()(textTrackFeature);

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -29,6 +29,28 @@ export const textTrackFeature = definePlayerFeature({
 
       return nextShowing;
     },
+    selectSubtitlesTrack(value: string) {
+      const { media } = target();
+      if (!isMediaTextTrackCapable(media)) return;
+
+      const subtitlesTracks = getTextTrackList(media, isCaptionOrSubtitleTrack);
+      if (!subtitlesTracks.length) return;
+
+      if (value === 'off') {
+        for (const track of subtitlesTracks) {
+          track.mode = 'disabled';
+        }
+        return;
+      }
+
+      const index = Number.parseInt(value, 10);
+      const track = subtitlesTracks[index];
+      if (!track) return;
+
+      for (const candidate of subtitlesTracks) {
+        candidate.mode = candidate === track ? 'showing' : 'disabled';
+      }
+    },
   }),
 
   attach({ target, signal, set }) {

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -9,6 +9,7 @@ import {
   icon,
   iconState,
   inputFeedback,
+  menu,
   overlay,
   popup,
   poster,
@@ -80,10 +81,22 @@ function getTemplateHTML() {
                 <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
-              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-button>
+              <media-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root, 'media-menu--captions')}">
+                <media-captions-radio-group class="${menu.group}">
+                  <template>
+                    <media-menu-radio-item class="${menu.item}">
+                      <span data-part="label"></span>
+                      <media-menu-item-indicator force-mount class="${menu.indicator}">
+                        ${renderIcon('check', { class: icon })}
+                      </media-menu-item-indicator>
+                    </media-menu-radio-item>
+                  </template>
+                </media-captions-radio-group>
+              </media-menu>
               <media-tooltip id="captions-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
               <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
                 ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -65,10 +65,22 @@ function getTemplateHTML() {
               </media-volume-slider>
             </media-popover>
 
-            <media-captions-button commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
+            <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
               ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
               ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
             </media-captions-button>
+            <media-menu id="captions-menu" side="top" align="center" class="media-popover media-menu media-menu--captions">
+              <media-captions-radio-group class="media-menu__group">
+                <template>
+                  <media-menu-radio-item class="media-menu__item">
+                    <span data-part="label"></span>
+                    <media-menu-item-indicator force-mount class="media-menu__indicator">
+                      ${renderIcon('check', { class: 'media-icon' })}
+                    </media-menu-item-indicator>
+                  </media-menu-radio-item>
+                </template>
+              </media-captions-radio-group>
+            </media-menu>
             <media-tooltip id="captions-tooltip" side="top" class="media-tooltip"></media-tooltip>
 
             <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">

--- a/packages/html/src/define/live-video/minimal-ui.ts
+++ b/packages/html/src/define/live-video/minimal-ui.ts
@@ -5,6 +5,7 @@
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
+import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { CastButtonElement } from '../../ui/cast-button/cast-button-element';
 import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
@@ -22,6 +23,7 @@ import {
   defineControls,
   defineErrorDialog,
   defineInputIndicators,
+  defineMenu,
   defineTime,
   defineTimeSlider,
   defineVolumeSlider,
@@ -42,10 +44,12 @@ defineInputIndicators();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineMenu();
 
 // Standalone elements.
 safeDefine(BufferingIndicatorElement);
 safeDefine(CaptionsButtonElement);
+safeDefine(CaptionsRadioGroupElement);
 safeDefine(CastButtonElement);
 safeDefine(FullscreenButtonElement);
 safeDefine(GestureElement);

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -9,6 +9,7 @@ import {
   icon,
   iconState,
   inputFeedback,
+  menu,
   overlay,
   popup,
   poster,
@@ -82,10 +83,22 @@ function getTemplateHTML() {
                 <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
-              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-button>
+              <media-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root, 'media-menu--captions')}">
+                <media-captions-radio-group class="${menu.group}">
+                  <template>
+                    <media-menu-radio-item class="${menu.item}">
+                      <span data-part="label"></span>
+                      <media-menu-item-indicator force-mount class="${menu.indicator}">
+                        ${renderIcon('check', { class: icon })}
+                      </media-menu-item-indicator>
+                    </media-menu-radio-item>
+                  </template>
+                </media-captions-radio-group>
+              </media-menu>
               <media-tooltip id="captions-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
               <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
                 ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -67,10 +67,22 @@ function getTemplateHTML() {
               </media-volume-slider>
             </media-popover>
 
-            <media-captions-button commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
+            <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
               ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
               ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
             </media-captions-button>
+            <media-menu id="captions-menu" side="top" align="center" class="media-surface media-popover media-menu media-menu--captions">
+              <media-captions-radio-group class="media-menu__group">
+                <template>
+                  <media-menu-radio-item class="media-menu__item">
+                    <span data-part="label"></span>
+                    <media-menu-item-indicator force-mount class="media-menu__indicator">
+                      ${renderIcon('check', { class: 'media-icon' })}
+                    </media-menu-item-indicator>
+                  </media-menu-radio-item>
+                </template>
+              </media-captions-radio-group>
+            </media-menu>
             <media-tooltip id="captions-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
 
             <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">

--- a/packages/html/src/define/live-video/ui.ts
+++ b/packages/html/src/define/live-video/ui.ts
@@ -4,6 +4,7 @@
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
+import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { CastButtonElement } from '../../ui/cast-button/cast-button-element';
 import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
@@ -21,6 +22,7 @@ import {
   defineControls,
   defineErrorDialog,
   defineInputIndicators,
+  defineMenu,
   defineTime,
   defineTimeSlider,
   defineVolumeSlider,
@@ -41,10 +43,12 @@ defineInputIndicators();
 defineTimeSlider();
 defineVolumeSlider();
 defineTime();
+defineMenu();
 
 // Standalone elements.
 safeDefine(BufferingIndicatorElement);
 safeDefine(CaptionsButtonElement);
+safeDefine(CaptionsRadioGroupElement);
 safeDefine(CastButtonElement);
 safeDefine(FullscreenButtonElement);
 safeDefine(GestureElement);

--- a/packages/html/src/define/ui/captions-radio-group.ts
+++ b/packages/html/src/define/ui/captions-radio-group.ts
@@ -1,0 +1,12 @@
+import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
+import { safeDefine } from '../safe-define';
+import { defineMenu } from './compounds';
+
+defineMenu();
+safeDefine(CaptionsRadioGroupElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [CaptionsRadioGroupElement.tagName]: CaptionsRadioGroupElement;
+  }
+}

--- a/packages/html/src/define/ui/captions-radio-group.ts
+++ b/packages/html/src/define/ui/captions-radio-group.ts
@@ -1,8 +1,6 @@
 import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { safeDefine } from '../safe-define';
-import { defineMenu } from './compounds';
 
-defineMenu();
 safeDefine(CaptionsRadioGroupElement);
 
 declare global {

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -140,10 +140,22 @@ function getTemplateHTML() {
                 <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
-              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-button>
+              <media-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root, 'media-menu--captions')}">
+                <media-captions-radio-group class="${menu.group}">
+                  <template>
+                    <media-menu-radio-item class="${menu.item}">
+                      <span data-part="label"></span>
+                      <media-menu-item-indicator force-mount class="${menu.indicator}">
+                        ${renderIcon('check', { class: icon })}
+                      </media-menu-item-indicator>
+                    </media-menu-radio-item>
+                  </template>
+                </media-captions-radio-group>
+              </media-menu>
               <media-tooltip id="captions-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
               <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
                 ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -117,10 +117,22 @@ function getTemplateHTML() {
               </media-volume-slider>
             </media-popover>
 
-            <media-captions-button commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
+            <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
               ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
               ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
             </media-captions-button>
+            <media-menu id="captions-menu" side="top" align="center" class="media-popover media-menu media-menu--captions">
+              <media-captions-radio-group class="media-menu__group">
+                <template>
+                  <media-menu-radio-item class="media-menu__item">
+                    <span data-part="label"></span>
+                    <media-menu-item-indicator force-mount class="media-menu__indicator">
+                      ${renderIcon('check', { class: 'media-icon' })}
+                    </media-menu-item-indicator>
+                  </media-menu-radio-item>
+                </template>
+              </media-captions-radio-group>
+            </media-menu>
             <media-tooltip id="captions-tooltip" side="top" class="media-tooltip"></media-tooltip>
 
             <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">

--- a/packages/html/src/define/video/minimal-ui.ts
+++ b/packages/html/src/define/video/minimal-ui.ts
@@ -4,6 +4,7 @@
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
+import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { CastButtonElement } from '../../ui/cast-button/cast-button-element';
 import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
@@ -58,6 +59,7 @@ safeDefine(PiPButtonElement);
 safeDefine(PlayButtonElement);
 safeDefine(PlaybackRateButtonElement);
 safeDefine(PlaybackRateRadioGroupElement);
+safeDefine(CaptionsRadioGroupElement);
 safeDefine(PopoverElement);
 safeDefine(PosterElement);
 safeDefine(SeekButtonElement);

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -135,10 +135,22 @@ function getTemplateHTML() {
                 <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
               </media-volume-slider>
             </media-popover>
-              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-button>
+              <media-menu id="captions-menu" side="top" align="center" class="${cn(popup.popover, menu.root, 'media-menu--captions')}">
+                <media-captions-radio-group class="${menu.group}">
+                  <template>
+                    <media-menu-radio-item class="${menu.item}">
+                      <span data-part="label"></span>
+                      <media-menu-item-indicator force-mount class="${menu.indicator}">
+                        ${renderIcon('check', { class: icon })}
+                      </media-menu-item-indicator>
+                    </media-menu-radio-item>
+                  </template>
+                </media-captions-radio-group>
+              </media-menu>
               <media-tooltip id="captions-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
               <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
                 ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -113,10 +113,22 @@ function getTemplateHTML() {
               </media-volume-slider>
             </media-popover>
 
-            <media-captions-button commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
+            <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
               ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
               ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
             </media-captions-button>
+            <media-menu id="captions-menu" side="top" align="center" class="media-surface media-popover media-menu media-menu--captions">
+              <media-captions-radio-group class="media-menu__group">
+                <template>
+                  <media-menu-radio-item class="media-menu__item">
+                    <span data-part="label"></span>
+                    <media-menu-item-indicator force-mount class="media-menu__indicator">
+                      ${renderIcon('check', { class: 'media-icon' })}
+                    </media-menu-item-indicator>
+                  </media-menu-radio-item>
+                </template>
+              </media-captions-radio-group>
+            </media-menu>
             <media-tooltip id="captions-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
 
             <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">

--- a/packages/html/src/define/video/ui.ts
+++ b/packages/html/src/define/video/ui.ts
@@ -4,6 +4,7 @@
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
+import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { CastButtonElement } from '../../ui/cast-button/cast-button-element';
 import { FullscreenButtonElement } from '../../ui/fullscreen-button/fullscreen-button-element';
 import { GestureElement } from '../../ui/gesture/gesture-element';
@@ -60,6 +61,7 @@ safeDefine(PiPButtonElement);
 safeDefine(PlayButtonElement);
 safeDefine(PlaybackRateButtonElement);
 safeDefine(PlaybackRateRadioGroupElement);
+safeDefine(CaptionsRadioGroupElement);
 safeDefine(PopoverElement);
 safeDefine(PosterElement);
 safeDefine(SeekButtonElement);

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -32,6 +32,7 @@ export { AlertDialogTitleElement } from './ui/alert-dialog/alert-dialog-title-el
 export { type AlertDialogContextValue, alertDialogContext } from './ui/alert-dialog/context';
 export { BufferingIndicatorElement } from './ui/buffering-indicator/buffering-indicator-element';
 export { CaptionsButtonElement } from './ui/captions-button/captions-button-element';
+export { CaptionsRadioGroupElement } from './ui/captions-radio-group/captions-radio-group-element';
 export { CastButtonElement } from './ui/cast-button/cast-button-element';
 export { ContextPartElement, type PartContextValue } from './ui/context-part-element';
 export { ControlsElement } from './ui/controls/controls-element';

--- a/packages/html/src/media/background-video/index.ts
+++ b/packages/html/src/media/background-video/index.ts
@@ -68,12 +68,10 @@ export class BackgroundVideo extends MediaAttachMixin(HTMLElement) {
   }
 
   get target(): HTMLVideoElement | null {
-    return (
-      this.querySelector(':scope > [slot=media]') ??
-      this.querySelector('video') ??
-      this.shadowRoot?.querySelector('video') ??
-      null
-    );
+    const slotted = this.querySelector(':scope > [slot=media]');
+    if (slotted instanceof HTMLVideoElement) return slotted;
+
+    return this.querySelector('video') ?? this.shadowRoot?.querySelector('video') ?? null;
   }
 }
 

--- a/packages/html/src/ui/captions-button/captions-button-element.ts
+++ b/packages/html/src/ui/captions-button/captions-button-element.ts
@@ -1,19 +1,88 @@
 import { CaptionsButtonCore, CaptionsButtonDataAttrs, type MediaTextTrackState } from '@videojs/core';
-import { selectTextTrack } from '@videojs/core/dom';
+import { applyElementProps, selectTextTrack, type UIEvent } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
+import { isCaptionOrSubtitleTrack } from '@videojs/utils/dom';
 
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
+import { toggleCommandTarget } from '../command-for';
 import { MediaButtonElement } from '../media-button-element';
+
+function getCaptionTrackCount(state: MediaTextTrackState): number {
+  return state.textTrackList.filter(isCaptionOrSubtitleTrack).length;
+}
 
 export class CaptionsButtonElement extends MediaButtonElement<CaptionsButtonCore> {
   static readonly tagName = 'media-captions-button';
+
+  static override properties = {
+    label: { type: String },
+    disabled: { type: Boolean },
+    commandfor: { type: String },
+    menuFor: { type: String },
+  } satisfies PropertyDeclarationMap<'label' | 'disabled' | 'commandfor' | 'menuFor'>;
+
+  commandfor: string | undefined = undefined;
+  menuFor: string | undefined = undefined;
 
   protected readonly core = new CaptionsButtonCore();
   protected readonly stateAttrMap = CaptionsButtonDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectTextTrack);
   protected override readonly hotkeyAction = 'toggleSubtitles';
 
-  protected activate(state: MediaTextTrackState): void {
+  protected activate(state: MediaTextTrackState, event?: UIEvent): void {
+    if (this.menuFor && getCaptionTrackCount(state) > 1) {
+      if (event instanceof KeyboardEvent) {
+        toggleCommandTarget(this, this.menuFor);
+      }
+      return;
+    }
+
     this.core.toggle(state);
   }
+
+  protected override getIsButtonDisabled(): boolean {
+    const media = this.mediaState.value;
+    if (super.getIsButtonDisabled()) return true;
+    if (media && getCaptionTrackCount(media) === 0) return true;
+    return false;
+  }
+
+  protected override willUpdate(changed: PropertyValues): void {
+    super.willUpdate(changed);
+
+    if (changed.has('commandfor') || changed.has('menuFor')) {
+      this.#syncCommandFor();
+    }
+  }
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+
+    const media = this.mediaState.value;
+    if (!media) return;
+
+    this.#syncCommandFor(media);
+
+    if (this.menuFor && getCaptionTrackCount(media) > 1) {
+      applyElementProps(this, {
+        'aria-disabled': this.getIsButtonDisabled() ? 'true' : undefined,
+      });
+    }
+  }
+
+  #syncCommandFor(media?: MediaTextTrackState): void {
+    const state = media ?? this.mediaState.value;
+    const target = state && this.menuFor && getCaptionTrackCount(state) > 1 ? this.menuFor : this.commandfor;
+
+    if (target) {
+      this.setAttribute('commandfor', target);
+    } else {
+      this.removeAttribute('commandfor');
+    }
+  }
+}
+
+export namespace CaptionsButtonElement {
+  export type State = CaptionsButtonCore.State;
 }

--- a/packages/html/src/ui/captions-radio-group/captions-radio-group-element.ts
+++ b/packages/html/src/ui/captions-radio-group/captions-radio-group-element.ts
@@ -1,0 +1,146 @@
+import { CAPTIONS_OFF_VALUE, CaptionsRadioGroupCore, CaptionsRadioGroupDataAttrs } from '@videojs/core';
+import { applyStateDataAttrs, logMissingFeature, selectTextTrack } from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
+
+import { playerContext } from '../../player/context';
+import { PlayerController } from '../../player/player-controller';
+import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
+import { MenuRadioGroupElement } from '../menu/menu-radio-group-element';
+import { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+
+export class CaptionsRadioGroupElement extends MenuRadioGroupElement {
+  static override readonly tagName = 'media-captions-radio-group';
+
+  static override properties = {
+    ...MenuRadioGroupElement.properties,
+    disabled: { type: Boolean },
+  } satisfies PropertyDeclarationMap<'value' | 'label' | 'disabled'>;
+
+  disabled = false;
+
+  readonly #core = new CaptionsRadioGroupCore();
+  readonly #mediaState = new PlayerController(this, playerContext, selectTextTrack);
+
+  #tracksKey = '';
+  #disconnect: AbortController | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (this.destroyed) return;
+
+    this.#disconnect = new AbortController();
+    this.addEventListener('value-change', this.#handleValueChange, { signal: this.#disconnect.signal });
+
+    if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
+      logMissingFeature(this.localName, this.#mediaState.displayName);
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+
+  protected override update(changed: PropertyValues): void {
+    const media = this.#mediaState.value;
+    let state: CaptionsRadioGroupCore.State | null = null;
+
+    if (media) {
+      this.#core.setProps({ disabled: this.disabled });
+      this.#core.setMedia(media);
+      state = this.#core.getState();
+
+      this.value = state.value;
+      this.label = this.label || 'Captions';
+      this.#syncContent(state);
+    }
+
+    super.update(changed);
+
+    if (state) applyStateDataAttrs(this, state, CaptionsRadioGroupDataAttrs);
+  }
+
+  #syncContent(state: CaptionsRadioGroupCore.State): void {
+    const template = this.#getTemplate();
+    const templateKey = template?.innerHTML ?? '';
+    const tracksKey = `${state.tracks.map((track) => track.value).join('|')}::${templateKey}`;
+
+    if (tracksKey !== this.#tracksKey) {
+      this.#tracksKey = tracksKey;
+
+      for (const child of [...this.children]) {
+        if (child instanceof HTMLTemplateElement) continue;
+        child.remove();
+      }
+
+      this.append(this.#createItem(CAPTIONS_OFF_VALUE, 'Off', template));
+      this.append(...state.tracks.map((track) => this.#createItem(track.value, track.label, template)));
+    }
+
+    for (const item of this.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)) {
+      const checked = item.value === this.value;
+
+      item.disabled = state.disabled;
+
+      for (const indicator of item.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)) {
+        indicator.checked = checked;
+      }
+    }
+  }
+
+  #createItem(value: string, label: string, template: HTMLTemplateElement | null): MenuRadioItemElement {
+    const item = this.#createItemFromTemplate(template);
+
+    item.value = value;
+    item.setAttribute('data-track', value);
+    this.#setLabel(item, label);
+
+    return item;
+  }
+
+  #createItemFromTemplate(template: HTMLTemplateElement | null): MenuRadioItemElement {
+    if (!template) return document.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement;
+
+    const fragment = template.content.cloneNode(true) as DocumentFragment;
+    const root = fragment.firstElementChild;
+
+    if (!root || root.localName !== MenuRadioItemElement.tagName || root.nextElementSibling) {
+      return document.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement;
+    }
+
+    return root as MenuRadioItemElement;
+  }
+
+  #setLabel(item: MenuRadioItemElement, label: string): void {
+    const labelPart = item.querySelector<HTMLElement>('[data-part~="label"]');
+
+    if (labelPart) {
+      labelPart.textContent = label;
+    } else {
+      item.textContent = label;
+    }
+  }
+
+  #getTemplate(): HTMLTemplateElement | null {
+    for (const child of this.children) {
+      if (child instanceof HTMLTemplateElement) return child;
+    }
+
+    return null;
+  }
+
+  #handleValueChange = (event: Event): void => {
+    if (event.target !== this) return;
+
+    const media = this.#mediaState.value;
+    if (!media) return;
+
+    const { value } = (event as CustomEvent<{ value: string }>).detail;
+    this.#core.selectValue(media, value);
+  };
+}
+
+export namespace CaptionsRadioGroupElement {
+  export type State = CaptionsRadioGroupCore.State;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,6 +32,12 @@ export {
 export { AlertDialog, type AlertDialogContextValue, useAlertDialogContext } from './ui/alert-dialog';
 export { BufferingIndicator, type BufferingIndicatorProps } from './ui/buffering-indicator/buffering-indicator';
 export { CaptionsButton, type CaptionsButtonProps } from './ui/captions-button/captions-button';
+export {
+  type CaptionsOption,
+  type CaptionsOptionsProps,
+  type CaptionsOptionsResult,
+  useCaptionsOptions,
+} from './ui/captions-radio-group';
 export { CastButton, type CastButtonProps } from './ui/cast-button/cast-button';
 export { Controls } from './ui/controls';
 export type { ControlsGroupProps } from './ui/controls/controls-group';

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -159,7 +159,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -182,16 +182,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className={iconState.captions.button}
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className={iconState.captions.button} render={<Button />}>
             <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
             <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className={cn(popup.popover, menu.root)}>

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -8,6 +8,7 @@ import {
   icon,
   iconState,
   inputFeedback,
+  menu,
   overlay,
   popup,
   poster,
@@ -22,6 +23,7 @@ import {
   CaptionsOnIcon,
   CastEnterIcon,
   CastExitIcon,
+  CheckIcon,
   FullscreenEnterIcon,
   FullscreenExitIcon,
   PauseIcon,
@@ -37,6 +39,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -44,6 +47,7 @@ import { FullscreenButton } from '@/ui/fullscreen-button';
 import { Gesture } from '@/ui/gesture';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
+import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
@@ -131,6 +135,72 @@ function VolumePopover(): ReactNode {
   );
 }
 
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className={menu.indicator}>
+            <CheckIcon className={icon} />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className={iconState.captions.button} render={<Button />}>
+              <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+              <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className={cn(popup.tooltip)} />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className={iconState.captions.button}
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+            <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+          </Button>
+        }
+      />
+      <Menu.Content className={cn(popup.popover, menu.root)}>
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
 export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): ReactNode {
   const { children, className, poster: posterProp, ...rest } = props;
 
@@ -195,17 +265,7 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
           <div className={buttonGroupEnd}>
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className={iconState.captions.button} render={<Button />}>
-                    <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
-                    <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -119,7 +119,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -142,16 +142,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className="media-button--captions"
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className="media-button--captions" render={<Button />}>
             <CaptionsOffIcon className="media-icon media-icon--captions-off" />
             <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className="media-popover media-menu media-menu--captions">

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -6,6 +6,7 @@ import {
   CaptionsOnIcon,
   CastEnterIcon,
   CastExitIcon,
+  CheckIcon,
   FullscreenEnterIcon,
   FullscreenExitIcon,
   PauseIcon,
@@ -21,6 +22,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -28,6 +30,7 @@ import { FullscreenButton } from '@/ui/fullscreen-button';
 import { Gesture } from '@/ui/gesture';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
+import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
@@ -92,6 +95,72 @@ function VolumePopover(): ReactNode {
  * the start and end button groups so they sit at opposite edges of the
  * control bar.
  */
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
+            <CheckIcon className="media-icon" />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className="media-button--captions" render={<Button />}>
+              <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+              <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className="media-tooltip" />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className="media-button--captions"
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+            <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+          </Button>
+        }
+      />
+      <Menu.Content className="media-popover media-menu media-menu--captions">
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
 export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNode {
   const { children, className, poster, ...rest } = props;
 
@@ -149,17 +218,7 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
           <div className="media-button-group">
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className="media-button--captions" render={<Button />}>
-                    <CaptionsOffIcon className="media-icon media-icon--captions-off" />
-                    <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className="media-tooltip" />
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -8,6 +8,7 @@ import {
   icon,
   iconState,
   inputFeedback,
+  menu,
   overlay,
   popup,
   poster,
@@ -22,6 +23,7 @@ import {
   CaptionsOnIcon,
   CastEnterIcon,
   CastExitIcon,
+  CheckIcon,
   FullscreenEnterIcon,
   FullscreenExitIcon,
   PauseIcon,
@@ -37,6 +39,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -44,6 +47,7 @@ import { FullscreenButton } from '@/ui/fullscreen-button';
 import { Gesture } from '@/ui/gesture';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
+import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
@@ -131,6 +135,72 @@ function VolumePopover(): ReactNode {
   );
 }
 
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className={menu.indicator}>
+            <CheckIcon className={icon} />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className={iconState.captions.button} render={<Button />}>
+              <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+              <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className={cn(popup.tooltip)} />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className={iconState.captions.button}
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+            <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+          </Button>
+        }
+      />
+      <Menu.Content className={cn(popup.popover, menu.root)}>
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
 export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
   const { children, className, poster: posterProp, ...rest } = props;
 
@@ -197,17 +267,7 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
           <div className={buttonGroupEnd}>
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className={iconState.captions.button} render={<Button />}>
-                    <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
-                    <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -159,7 +159,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -182,16 +182,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className={iconState.captions.button}
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className={iconState.captions.button} render={<Button />}>
             <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
             <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className={cn(popup.popover, menu.root)}>

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -6,6 +6,7 @@ import {
   CaptionsOnIcon,
   CastEnterIcon,
   CastExitIcon,
+  CheckIcon,
   FullscreenEnterIcon,
   FullscreenExitIcon,
   PauseIcon,
@@ -21,6 +22,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -28,6 +30,7 @@ import { FullscreenButton } from '@/ui/fullscreen-button';
 import { Gesture } from '@/ui/gesture';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
+import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
@@ -91,6 +94,72 @@ function VolumePopover(): ReactNode {
  * flexible spacer stretches between the start and end button groups so they
  * sit at opposite edges of the control bar.
  */
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
+            <CheckIcon className="media-icon" />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className="media-button--captions" render={<Button />}>
+              <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+              <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className="media-surface media-tooltip" />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className="media-button--captions"
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+            <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+          </Button>
+        }
+      />
+      <Menu.Content className="media-surface media-popover media-menu media-menu--captions">
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
 export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
   const { children, className, poster, ...rest } = props;
 
@@ -150,17 +219,7 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
           <div className="media-button-group">
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className="media-button--captions" render={<Button />}>
-                    <CaptionsOffIcon className="media-icon media-icon--captions-off" />
-                    <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className="media-surface media-tooltip" />
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -118,7 +118,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -141,16 +141,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className="media-button--captions"
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className="media-button--captions" render={<Button />}>
             <CaptionsOffIcon className="media-icon media-icon--captions-off" />
             <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className="media-surface media-popover media-menu media-menu--captions">

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -47,6 +47,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -187,6 +188,72 @@ function PlaybackRateTrigger(): ReactNode {
   );
 }
 
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className={menu.indicator}>
+            <CheckIcon className={icon} />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className={iconState.captions.button} render={<Button />}>
+              <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+              <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className={cn(popup.tooltip)} />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className={iconState.captions.button}
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+            <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+          </Button>
+        }
+      />
+      <Menu.Content className={cn(popup.popover, menu.root)}>
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNode {
@@ -307,17 +374,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
 
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className={iconState.captions.button} render={<Button />}>
-                    <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
-                    <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -212,7 +212,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -235,16 +235,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className={iconState.captions.button}
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className={iconState.captions.button} render={<Button />}>
             <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
             <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className={cn(popup.popover, menu.root)}>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -153,7 +153,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -176,16 +176,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className="media-button--captions"
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className="media-button--captions" render={<Button />}>
             <CaptionsOffIcon className="media-icon media-icon--captions-off" />
             <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className="media-popover media-menu media-menu--captions">

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -24,6 +24,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -125,6 +126,72 @@ function PlaybackRateTrigger(): ReactNode {
       disabled={playbackRate.disabled}
       render={<PlaybackRateButton className="media-button--playback-rate" render={<Button />} />}
     />
+  );
+}
+
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
+            <CheckIcon className="media-icon" />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className="media-button--captions" render={<Button />}>
+              <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+              <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className="media-tooltip" />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className="media-button--captions"
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+            <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+          </Button>
+        }
+      />
+      <Menu.Content className="media-popover media-menu media-menu--captions">
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
   );
 }
 
@@ -240,17 +307,7 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
 
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className="media-button--captions" render={<Button />}>
-                    <CaptionsOffIcon className="media-icon media-icon--captions-off" />
-                    <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className="media-tooltip" />
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -212,7 +212,7 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
-  const { disabled, state } = captions;
+  const { disabled } = captions;
 
   if (!captions.showMenu) {
     return (
@@ -235,16 +235,10 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <Button
-            className={iconState.captions.button}
-            disabled={disabled}
-            data-active={state.subtitlesShowing ? '' : undefined}
-            data-availability="available"
-            aria-label={state.label}
-          >
+          <CaptionsButton className={iconState.captions.button} render={<Button />}>
             <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
             <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-          </Button>
+          </CaptionsButton>
         }
       />
       <Menu.Content className={cn(popup.popover, menu.root)}>

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -47,6 +47,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -187,6 +188,72 @@ function PlaybackRateTrigger(): ReactNode {
   );
 }
 
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className={menu.indicator}>
+            <CheckIcon className={icon} />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  const { disabled, state } = captions;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className={iconState.captions.button} render={<Button />}>
+              <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+              <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className={cn(popup.tooltip)} />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        disabled={disabled}
+        render={
+          <Button
+            className={iconState.captions.button}
+            disabled={disabled}
+            data-active={state.subtitlesShowing ? '' : undefined}
+            data-availability="available"
+            aria-label={state.label}
+          >
+            <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+            <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+          </Button>
+        }
+      />
+      <Menu.Content className={cn(popup.popover, menu.root)}>
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
@@ -303,17 +370,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
 
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className={iconState.captions.button} render={<Button />}>
-                    <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
-                    <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -153,6 +153,8 @@ function CaptionsTrigger(): ReactNode {
   const captions = useCaptionsOptions();
   if (!captions) return null;
 
+  const { disabled } = captions;
+
   if (!captions.showMenu) {
     return (
       <Tooltip.Root side="top">
@@ -172,6 +174,7 @@ function CaptionsTrigger(): ReactNode {
   return (
     <Menu.Root side="top" align="center">
       <Menu.Trigger
+        disabled={disabled}
         render={
           <CaptionsButton className="media-button--captions" render={<Button />}>
             <CaptionsOffIcon className="media-icon media-icon--captions-off" />

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -24,6 +24,7 @@ import {
 import { Container, usePlayer } from '@/player/context';
 import { BufferingIndicator } from '@/ui/buffering-indicator';
 import { CaptionsButton } from '@/ui/captions-button';
+import { useCaptionsOptions } from '@/ui/captions-radio-group';
 import { CastButton } from '@/ui/cast-button';
 import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
@@ -125,6 +126,63 @@ function PlaybackRateTrigger(): ReactNode {
       disabled={playbackRate.disabled}
       render={<PlaybackRateButton className="media-button--playback-rate" render={<Button />} />}
     />
+  );
+}
+
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup className="media-menu__group" value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
+          <span>{option.label}</span>
+          <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
+            <CheckIcon className="media-icon" />
+          </Menu.ItemIndicator>
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+function CaptionsTrigger(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions) return null;
+
+  if (!captions.showMenu) {
+    return (
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <CaptionsButton className="media-button--captions" render={<Button />}>
+              <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+              <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+            </CaptionsButton>
+          }
+        />
+        <Tooltip.Popup className="media-surface media-tooltip" />
+      </Tooltip.Root>
+    );
+  }
+
+  return (
+    <Menu.Root side="top" align="center">
+      <Menu.Trigger
+        render={
+          <CaptionsButton className="media-button--captions" render={<Button />}>
+            <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+            <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+          </CaptionsButton>
+        }
+      />
+      <Menu.Content className="media-surface media-popover media-menu media-menu--captions">
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>
   );
 }
 
@@ -236,17 +294,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
 
             <VolumePopover />
 
-            <Tooltip.Root side="top">
-              <Tooltip.Trigger
-                render={
-                  <CaptionsButton className="media-button--captions" render={<Button />}>
-                    <CaptionsOffIcon className="media-icon media-icon--captions-off" />
-                    <CaptionsOnIcon className="media-icon media-icon--captions-on" />
-                  </CaptionsButton>
-                }
-              />
-              <Tooltip.Popup className="media-surface media-tooltip" />
-            </Tooltip.Root>
+            <CaptionsTrigger />
 
             <Tooltip.Root side="top">
               <Tooltip.Trigger

--- a/packages/react/src/ui/captions-button/tests/captions-button.test.tsx
+++ b/packages/react/src/ui/captions-button/tests/captions-button.test.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Menu } from '../../menu';
+import { CaptionsButton } from '../captions-button';
+
+afterEach(cleanup);
+
+function renderCaptionsTrigger({
+  textTrackList = [
+    { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' },
+    { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+  ] as const,
+  toggleSubtitles = vi.fn(() => true),
+}: {
+  textTrackList?: readonly { kind: string; label: string; language: string; mode: string }[];
+  toggleSubtitles?: () => boolean;
+} = {}) {
+  const { Wrapper } = createPlayerWrapper({
+    textTrackList,
+    subtitlesShowing: true,
+    selectSubtitlesTrack: vi.fn(),
+    chaptersCues: [],
+    thumbnailCues: [],
+    thumbnailTrackSrc: null,
+    toggleSubtitles,
+  });
+
+  render(
+    <Menu.Root>
+      <Menu.Trigger render={<CaptionsButton data-testid="trigger" />} />
+      <Menu.Content>Captions</Menu.Content>
+    </Menu.Root>,
+    { wrapper: Wrapper }
+  );
+
+  return { toggleSubtitles };
+}
+
+describe('CaptionsButton', () => {
+  it('does not toggle captions when rendered inside Menu.Trigger with multiple tracks', () => {
+    const { toggleSubtitles } = renderCaptionsTrigger();
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(toggleSubtitles).not.toHaveBeenCalled();
+  });
+
+  it('still toggles captions outside Menu.Trigger', () => {
+    const toggleSubtitles = vi.fn(() => true);
+    const { Wrapper } = createPlayerWrapper({
+      textTrackList: [
+        { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' },
+        { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+      ],
+      subtitlesShowing: true,
+      selectSubtitlesTrack: vi.fn(),
+      chaptersCues: [],
+      thumbnailCues: [],
+      thumbnailTrackSrc: null,
+      toggleSubtitles,
+    });
+
+    render(<CaptionsButton data-testid="trigger" />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(toggleSubtitles).toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/ui/captions-radio-group/index.ts
+++ b/packages/react/src/ui/captions-radio-group/index.ts
@@ -1,0 +1,6 @@
+export {
+  type CaptionsOption,
+  type CaptionsOptionsProps,
+  type CaptionsOptionsResult,
+  useCaptionsOptions,
+} from './use-captions-options';

--- a/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { CAPTIONS_OFF_VALUE } from '@videojs/core';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Menu } from '../../menu';
+import { useCaptionsOptions } from '../use-captions-options';
+
+afterEach(cleanup);
+
+function renderCaptionsMenu({
+  textTrackList = [
+    { kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' },
+    { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'showing' },
+  ] as const,
+  subtitlesShowing = true,
+  selectSubtitlesTrack = vi.fn(),
+}: {
+  textTrackList?: readonly { kind: string; label: string; language: string; mode: string }[];
+  subtitlesShowing?: boolean;
+  selectSubtitlesTrack?: (value: string) => void;
+} = {}) {
+  const { Wrapper } = createPlayerWrapper({
+    textTrackList,
+    subtitlesShowing,
+    selectSubtitlesTrack,
+    chaptersCues: [],
+    thumbnailCues: [],
+    thumbnailTrackSrc: null,
+    toggleSubtitles: vi.fn(),
+  });
+
+  render(
+    <Menu.Root defaultOpen align="center">
+      <Menu.Content data-testid="content">
+        <CaptionsRadioGroup />
+      </Menu.Content>
+    </Menu.Root>,
+    { wrapper: Wrapper }
+  );
+
+  return { selectSubtitlesTrack };
+}
+
+function CaptionsRadioGroup(): ReactNode {
+  const captions = useCaptionsOptions();
+  if (!captions?.showMenu) return null;
+
+  const { options, setValue, value } = captions;
+
+  return (
+    <Menu.RadioGroup value={value} onValueChange={setValue} label="Captions">
+      {options.map((option) => (
+        <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
+          {option.label}
+        </Menu.RadioItem>
+      ))}
+    </Menu.RadioGroup>
+  );
+}
+
+describe('useCaptionsOptions', () => {
+  it('renders radio items for off and available tracks', () => {
+    renderCaptionsMenu();
+
+    expect(screen.getByRole('menuitemradio', { name: 'Off' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('menuitemradio', { name: 'English' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('menuitemradio', { name: 'Spanish' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('center aligns the popup by default', () => {
+    renderCaptionsMenu();
+
+    expect(screen.getByTestId('content').getAttribute('data-align')).toBe('center');
+  });
+
+  it('selects a captions track', () => {
+    const selectSubtitlesTrack = vi.fn();
+    renderCaptionsMenu({ selectSubtitlesTrack });
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'English' }));
+
+    expect(selectSubtitlesTrack).toHaveBeenCalledWith('0');
+  });
+
+  it('turns captions off', () => {
+    const selectSubtitlesTrack = vi.fn();
+    renderCaptionsMenu({ selectSubtitlesTrack });
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Off' }));
+
+    expect(selectSubtitlesTrack).toHaveBeenCalledWith(CAPTIONS_OFF_VALUE);
+  });
+});

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  CAPTIONS_OFF_VALUE,
+  type CaptionsRadioGroupCore,
+  CaptionsRadioGroupCore as CaptionsRadioGroupCoreClass,
+} from '@videojs/core';
+import { logMissingFeature, selectTextTrack } from '@videojs/core/dom';
+import { useCallback, useState } from 'react';
+
+import { usePlayer } from '../../player/context';
+
+export interface CaptionsOptionsProps extends CaptionsRadioGroupCore.Props {}
+
+export interface CaptionsOption {
+  value: string;
+  label: string;
+  disabled: boolean;
+}
+
+export interface CaptionsOptionsResult {
+  state: CaptionsRadioGroupCore.State;
+  value: string;
+  options: CaptionsOption[];
+  disabled: boolean;
+  showMenu: boolean;
+  setValue: (value: string) => void;
+}
+
+export function useCaptionsOptions(props?: CaptionsOptionsProps): CaptionsOptionsResult | null {
+  const media = usePlayer(selectTextTrack);
+  const [core] = useState(() => new CaptionsRadioGroupCoreClass());
+
+  core.setProps(props ?? {});
+
+  const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
+
+  if (!media) {
+    if (__DEV__) logMissingFeature('useCaptionsOptions', selectTextTrack.displayName ?? 'textTrack');
+    return null;
+  }
+
+  core.setMedia(media);
+  const state = core.getState();
+  const showMenu = state.tracks.length > 1;
+
+  return {
+    state,
+    value: state.value,
+    options: [
+      { value: CAPTIONS_OFF_VALUE, label: 'Off', disabled: state.disabled },
+      ...state.tracks.map((track) => ({
+        value: track.value,
+        label: track.label,
+        disabled: state.disabled,
+      })),
+    ],
+    disabled: state.disabled,
+    showMenu,
+    setValue,
+  };
+}
+
+export namespace useCaptionsOptions {
+  export type Props = CaptionsOptionsProps;
+  export type Result = CaptionsOptionsResult;
+  export type Option = CaptionsOption;
+}


### PR DESCRIPTION
## Summary

- Adds a captions track menu for multi-track sources: `CaptionsRadioGroupCore`, `useCaptionsOptions`, and `<media-captions-radio-group>` composed in skins alongside existing `Menu` primitives
- Single-track sources keep toggle behavior via `CaptionsButton`; multi-track sources open a radio menu without toggling on trigger click (`menuTrigger` auto-detected from `Menu.Trigger`)
- Includes playback rate menu primitive work this branch stacks on: `PlaybackRateOptionsCore`, `usePlaybackRateOptions`, `PlaybackRateButton` menu trigger mode, and generic `Menu.Trigger` disabled forwarding

## Test plan

- [ ] Open a multi-track video in the sandbox — captions button opens a menu with Off + track options; current track is selected
- [ ] Select a different track — captions switch without closing incorrectly
- [ ] Single-track source — captions button toggles on/off with tooltip (no menu)
- [ ] Verify playback rate menu still works in the same skins
- [ ] `pnpm -F @videojs/core test src/core/ui/captions-radio-group`
- [ ] `pnpm -F @videojs/react test src/ui/captions-radio-group`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches text-track selection and public exports across core, HTML, and React with removal of playback-rate menu elements; behavior is well-tested but integrators using old element/hook names must migrate.
> 
> **Overview**
> Adds **multi-track captions selection** via shared menu primitives: `selectSubtitlesTrack` on media state, `CaptionsRadioGroupCore` / `useCaptionsOptions` / `<media-captions-radio-group>`, and skins that wire `menu-for` on `<media-captions-button>` when more than one caption/subtitle track exists (single track still toggles).
> 
> **Refactors playback rate** the same way: `PlaybackRateMenu*` becomes `PlaybackRateOptions*` plus generic `<media-menu>`; `<media-playback-rate-button commandfor="…">` opens the menu instead of cycling when linked. Captions and playback-rate buttons gain **`menuTrigger`** so they skip toggle/cycle when used as menu triggers (React sets this inside `Menu.Trigger`).
> 
> HTML/React presets and e2e selectors are updated accordingly; dedicated playback-rate menu custom elements are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0008e14e7bd593db3b511697442c6713b24c2759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->