### PR TITLE
feat(core): add media track extension support

### DIFF
--- a/packages/core/src/core/media/media-tracks/audio-rendition-list.ts
+++ b/packages/core/src/core/media/media-tracks/audio-rendition-list.ts
@@ -1,0 +1,141 @@
+import type { AudioRendition } from './audio-rendition';
+import type { AudioTrack } from './audio-track';
+import { RenditionEvent } from './rendition-event';
+import { getPrivate } from './utils';
+
+export function addRendition(track: AudioTrack, rendition: AudioRendition) {
+  const renditionList = getPrivate(track).media?.deref()?.audioRenditions as AudioRenditionList | undefined;
+
+  getPrivate(rendition).media = getPrivate(track).media;
+  getPrivate(rendition).track = track;
+
+  const renditionSet = getPrivate(track).renditionSet as Set<AudioRendition>;
+  renditionSet.add(rendition);
+  const index = renditionSet.size - 1;
+
+  if (!(index in AudioRenditionList.prototype)) {
+    Object.defineProperty(AudioRenditionList.prototype, index, {
+      get() {
+        return getCurrentRenditions(this)[index];
+      },
+    });
+  }
+
+  queueMicrotask(() => {
+    if (!renditionList || !track.enabled) return;
+
+    renditionList.dispatchEvent(new RenditionEvent('addrendition', { rendition }));
+  });
+}
+
+export function removeRendition(rendition: AudioRendition) {
+  const renditionList = getPrivate(rendition).media?.deref()?.audioRenditions as AudioRenditionList | undefined;
+  const track = getPrivate(rendition).track as AudioTrack;
+  const renditionSet = getPrivate(track).renditionSet as Set<AudioRendition>;
+  renditionSet.delete(rendition);
+
+  queueMicrotask(() => {
+    if (!renditionList || !track.enabled) return;
+
+    renditionList.dispatchEvent(new RenditionEvent('removerendition', { rendition }));
+  });
+}
+
+export function selectedChanged(rendition: AudioRendition) {
+  const renditionList = getPrivate(rendition).media?.deref()?.audioRenditions as AudioRenditionList | undefined;
+
+  // Prevent firing a rendition list `change` event multiple times per tick.
+  if (!renditionList || getPrivate(renditionList).changeRequested) return;
+  getPrivate(renditionList).changeRequested = true;
+
+  queueMicrotask(() => {
+    delete getPrivate(renditionList).changeRequested;
+
+    const track = getPrivate(rendition).track as AudioTrack;
+    if (!track.enabled) return;
+
+    renditionList.dispatchEvent(new Event('change'));
+  });
+}
+
+function getCurrentRenditions(renditionList: AudioRenditionList): AudioRendition[] {
+  const media = getPrivate(renditionList).media?.deref() as HTMLMediaElement | undefined;
+  if (!media) return [];
+  return [...media.audioTracks]
+    .filter((track) => track.enabled)
+    .flatMap((track) => [...(getPrivate(track).renditionSet as Set<AudioRendition>)]);
+}
+
+export class AudioRenditionList extends EventTarget {
+  [index: number]: AudioRendition;
+  #addRenditionCallback: (() => void) | undefined;
+  #removeRenditionCallback: (() => void) | undefined;
+  #changeCallback: (() => void) | undefined;
+
+  [Symbol.iterator]() {
+    return getCurrentRenditions(this).values();
+  }
+
+  get length() {
+    return getCurrentRenditions(this).length;
+  }
+
+  getRenditionById(id: string): AudioRendition | null {
+    return getCurrentRenditions(this).find((rendition) => `${rendition.id}` === `${id}`) ?? null;
+  }
+
+  get selectedIndex() {
+    return getCurrentRenditions(this).findIndex((rendition) => rendition.selected);
+  }
+
+  set selectedIndex(index) {
+    for (const [i, rendition] of getCurrentRenditions(this).entries()) {
+      rendition.selected = i === index;
+    }
+  }
+
+  get onaddrendition() {
+    return this.#addRenditionCallback;
+  }
+
+  set onaddrendition(callback: ((event?: { rendition: AudioRendition }) => void) | undefined) {
+    if (this.#addRenditionCallback) {
+      this.removeEventListener('addrendition', this.#addRenditionCallback);
+      this.#addRenditionCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#addRenditionCallback = callback;
+      this.addEventListener('addrendition', callback as unknown as EventListener);
+    }
+  }
+
+  get onremoverendition() {
+    return this.#removeRenditionCallback;
+  }
+
+  set onremoverendition(callback: ((event?: { rendition: AudioRendition }) => void) | undefined) {
+    if (this.#removeRenditionCallback) {
+      this.removeEventListener('removerendition', this.#removeRenditionCallback);
+      this.#removeRenditionCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#removeRenditionCallback = callback;
+      this.addEventListener('removerendition', callback as unknown as EventListener);
+    }
+  }
+
+  get onchange() {
+    return this.#changeCallback;
+  }
+
+  set onchange(callback) {
+    if (this.#changeCallback) {
+      this.removeEventListener('change', this.#changeCallback);
+      this.#changeCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#changeCallback = callback;
+      this.addEventListener('change', callback);
+    }
+  }
+}

--- a/packages/core/src/core/media/media-tracks/audio-rendition.ts
+++ b/packages/core/src/core/media/media-tracks/audio-rendition.ts
@@ -1,0 +1,24 @@
+import { selectedChanged } from './audio-rendition-list';
+
+/**
+ * The consumer should use the `selected` setter to select one or multiple
+ * renditions that the engine is allowed to play.
+ */
+export class AudioRendition {
+  src: string | undefined;
+  id: string | undefined;
+  bitrate: number | undefined;
+  codec: string | undefined;
+  #selected = false;
+
+  get selected(): boolean {
+    return this.#selected;
+  }
+
+  set selected(value: boolean) {
+    if (this.#selected === value) return;
+    this.#selected = value;
+
+    selectedChanged(this);
+  }
+}

--- a/packages/core/src/core/media/media-tracks/audio-track-list.ts
+++ b/packages/core/src/core/media/media-tracks/audio-track-list.ts
@@ -1,0 +1,127 @@
+import type { AudioTrack } from './audio-track';
+import { TrackEvent } from './change-event';
+import { getPrivate } from './utils';
+
+export function addAudioTrack(media: HTMLMediaElement, track: AudioTrack) {
+  const trackList = media.audioTracks;
+  getPrivate(track).media = new WeakRef(media);
+
+  if (!getPrivate(track).renditionSet) {
+    getPrivate(track).renditionSet = new Set();
+  }
+
+  const trackSet = getPrivate(trackList).trackSet as Set<AudioTrack>;
+  trackSet.add(track);
+  const index = trackSet.size - 1;
+
+  if (!(index in AudioTrackList.prototype)) {
+    Object.defineProperty(AudioTrackList.prototype, index, {
+      get() {
+        return [...(getPrivate(this).trackSet as Set<AudioTrack>)][index];
+      },
+    });
+  }
+
+  // The event is queued to align with native `addtrack` behavior.
+  queueMicrotask(() => {
+    trackList.dispatchEvent(new TrackEvent('addtrack', { track }));
+  });
+}
+
+export function removeAudioTrack(track: AudioTrack) {
+  const trackList = getPrivate(track).media?.deref()?.audioTracks as AudioTrackList | undefined;
+  if (!trackList) return;
+
+  const trackSet = getPrivate(trackList).trackSet as Set<AudioTrack>;
+  trackSet.delete(track);
+
+  queueMicrotask(() => {
+    trackList.dispatchEvent(new TrackEvent('removetrack', { track }));
+  });
+}
+
+export function enabledChanged(track: AudioTrack) {
+  const trackList = getPrivate(track).media?.deref()?.audioTracks as AudioTrackList | undefined;
+
+  // Prevent firing a track list `change` event multiple times per tick.
+  if (!trackList || getPrivate(trackList).changeRequested) return;
+  getPrivate(trackList).changeRequested = true;
+
+  queueMicrotask(() => {
+    delete getPrivate(trackList).changeRequested;
+    trackList.dispatchEvent(new Event('change'));
+  });
+}
+
+export class AudioTrackList extends EventTarget {
+  [index: number]: AudioTrack;
+  #addTrackCallback: (() => void) | undefined;
+  #removeTrackCallback: (() => void) | undefined;
+  #changeCallback: (() => void) | undefined;
+
+  constructor() {
+    super();
+    getPrivate(this).trackSet = new Set();
+  }
+
+  get #tracks() {
+    return getPrivate(this).trackSet as Set<AudioTrack>;
+  }
+
+  [Symbol.iterator]() {
+    return this.#tracks.values();
+  }
+
+  get length() {
+    return this.#tracks.size;
+  }
+
+  getTrackById(id: string): AudioTrack | null {
+    return [...this.#tracks].find((track) => track.id === id) ?? null;
+  }
+
+  get onaddtrack() {
+    return this.#addTrackCallback;
+  }
+
+  set onaddtrack(callback: ((event?: { track: AudioTrack }) => void) | undefined) {
+    if (this.#addTrackCallback) {
+      this.removeEventListener('addtrack', this.#addTrackCallback);
+      this.#addTrackCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#addTrackCallback = callback;
+      this.addEventListener('addtrack', callback as unknown as EventListener);
+    }
+  }
+
+  get onremovetrack() {
+    return this.#removeTrackCallback;
+  }
+
+  set onremovetrack(callback: ((event?: { track: AudioTrack }) => void) | undefined) {
+    if (this.#removeTrackCallback) {
+      this.removeEventListener('removetrack', this.#removeTrackCallback);
+      this.#removeTrackCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#removeTrackCallback = callback;
+      this.addEventListener('removetrack', callback as unknown as EventListener);
+    }
+  }
+
+  get onchange() {
+    return this.#changeCallback;
+  }
+
+  set onchange(callback) {
+    if (this.#changeCallback) {
+      this.removeEventListener('change', this.#changeCallback);
+      this.#changeCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#changeCallback = callback;
+      this.addEventListener('change', callback);
+    }
+  }
+}

--- a/packages/core/src/core/media/media-tracks/audio-track.ts
+++ b/packages/core/src/core/media/media-tracks/audio-track.ts
@@ -1,0 +1,45 @@
+import { AudioRendition } from './audio-rendition';
+import { addRendition, removeRendition } from './audio-rendition-list';
+import { enabledChanged } from './audio-track-list';
+
+export const AudioTrackKind = {
+  alternative: 'alternative',
+  descriptions: 'descriptions',
+  main: 'main',
+  'main-desc': 'main-desc',
+  translation: 'translation',
+  commentary: 'commentary',
+};
+
+export class AudioTrack {
+  id: string | undefined;
+  kind: string | undefined;
+  label = '';
+  language = '';
+  sourceBuffer: unknown;
+  #enabled = false;
+
+  addRendition(src: string, codec?: string, bitrate?: number) {
+    const rendition = new AudioRendition();
+    rendition.src = src;
+    rendition.codec = codec;
+    rendition.bitrate = bitrate;
+    addRendition(this, rendition);
+    return rendition;
+  }
+
+  removeRendition(rendition: AudioRendition) {
+    removeRendition(rendition);
+  }
+
+  get enabled(): boolean {
+    return this.#enabled;
+  }
+
+  set enabled(value: boolean) {
+    if (this.#enabled === value) return;
+    this.#enabled = value;
+
+    enabledChanged(this);
+  }
+}

--- a/packages/core/src/core/media/media-tracks/change-event.ts
+++ b/packages/core/src/core/media/media-tracks/change-event.ts
@@ -1,0 +1,11 @@
+import type { AudioTrack } from './audio-track';
+import type { VideoTrack } from './video-track';
+
+export class TrackEvent extends Event {
+  track: AudioTrack | VideoTrack;
+
+  constructor(type: string, init: { track: AudioTrack | VideoTrack }) {
+    super(type);
+    this.track = init.track;
+  }
+}

--- a/packages/core/src/core/media/media-tracks/global.ts
+++ b/packages/core/src/core/media/media-tracks/global.ts
@@ -1,0 +1,19 @@
+import type { AudioRenditionList } from './audio-rendition-list';
+import type { AudioTrack } from './audio-track';
+import type { AudioTrackList } from './audio-track-list';
+import type { VideoRenditionList } from './video-rendition-list';
+import type { VideoTrack } from './video-track';
+import type { VideoTrackList } from './video-track-list';
+
+declare global {
+  interface HTMLMediaElement {
+    videoTracks: VideoTrackList;
+    audioTracks: AudioTrackList;
+    addVideoTrack(kind: string, label?: string, language?: string): VideoTrack;
+    addAudioTrack(kind: string, label?: string, language?: string): AudioTrack;
+    removeVideoTrack(track: VideoTrack): void;
+    removeAudioTrack(track: AudioTrack): void;
+    videoRenditions: VideoRenditionList;
+    audioRenditions: AudioRenditionList;
+  }
+}

--- a/packages/core/src/core/media/media-tracks/index.ts
+++ b/packages/core/src/core/media/media-tracks/index.ts
@@ -1,0 +1,11 @@
+export { AudioRendition } from './audio-rendition';
+export { AudioRenditionList } from './audio-rendition-list';
+export { AudioTrack, AudioTrackKind } from './audio-track';
+export { AudioTrackList } from './audio-track-list';
+export { TrackEvent } from './change-event';
+export * from './mixin';
+export { RenditionEvent } from './rendition-event';
+export { VideoRendition } from './video-rendition';
+export { VideoRenditionList } from './video-rendition-list';
+export { VideoTrack, VideoTrackKind } from './video-track';
+export { VideoTrackList } from './video-track-list';

--- a/packages/core/src/core/media/media-tracks/mixin.ts
+++ b/packages/core/src/core/media/media-tracks/mixin.ts
@@ -1,3 +1,4 @@
+import type { AnyConstructor, MixinReturn } from '@videojs/utils/types';
 import { AudioRenditionList } from './audio-rendition-list';
 import { AudioTrack } from './audio-track';
 import { AudioTrackList, addAudioTrack, removeAudioTrack } from './audio-track-list';
@@ -18,21 +19,16 @@ interface MediaTracks {
   audioRenditions: AudioRenditionList;
 }
 
-type Constructor<Instance = object> = {
-  new (...args: any[]): Instance;
-  prototype: Instance;
-};
+export type WithMediaTracks<Base extends AnyConstructor<any>> = MixinReturn<Base, MediaTracks>;
 
-export type WithMediaTracks<Base extends Constructor> = Base & Constructor<InstanceType<Base> & MediaTracks>;
-
-const HTMLMediaElementConstructor = (globalThis as { HTMLMediaElement?: Constructor<HTMLMediaElement> })
+const HTMLMediaElementConstructor = (globalThis as { HTMLMediaElement?: AnyConstructor<HTMLMediaElement> })
   .HTMLMediaElement;
 const nativeVideoTracksFn = getBaseMediaTracksFn(HTMLMediaElementConstructor, 'video');
 const nativeAudioTracksFn = getBaseMediaTracksFn(HTMLMediaElementConstructor, 'audio');
 
 // Safari supports native media tracks, but native implementations cannot
 // reliably represent manifest-derived MSE tracks or manually-added tracks.
-export function MediaTracksMixin<Base extends Constructor>(MediaElementClass: Base): WithMediaTracks<Base> {
+export function MediaTracksMixin<Base extends AnyConstructor<any>>(MediaElementClass: Base): WithMediaTracks<Base> {
   if (!MediaElementClass?.prototype) return MediaElementClass as WithMediaTracks<Base>;
 
   const prototype = MediaElementClass.prototype as Record<string, any>;

--- a/packages/core/src/core/media/media-tracks/mixin.ts
+++ b/packages/core/src/core/media/media-tracks/mixin.ts
@@ -1,0 +1,223 @@
+import { AudioRenditionList } from './audio-rendition-list';
+import { AudioTrack } from './audio-track';
+import { AudioTrackList, addAudioTrack, removeAudioTrack } from './audio-track-list';
+import type { TrackEvent } from './change-event';
+import { getPrivate } from './utils';
+import { VideoRenditionList } from './video-rendition-list';
+import { VideoTrack } from './video-track';
+import { addVideoTrack, removeVideoTrack, VideoTrackList } from './video-track-list';
+
+interface MediaTracks {
+  videoTracks: VideoTrackList;
+  audioTracks: AudioTrackList;
+  addVideoTrack(kind: string, label?: string, language?: string): VideoTrack;
+  addAudioTrack(kind: string, label?: string, language?: string): AudioTrack;
+  removeVideoTrack(track: VideoTrack): void;
+  removeAudioTrack(track: AudioTrack): void;
+  videoRenditions: VideoRenditionList;
+  audioRenditions: AudioRenditionList;
+}
+
+type Constructor<Instance = object> = {
+  new (...args: any[]): Instance;
+  prototype: Instance;
+};
+
+export type WithMediaTracks<Base extends Constructor> = Base & Constructor<InstanceType<Base> & MediaTracks>;
+
+const HTMLMediaElementConstructor = (globalThis as { HTMLMediaElement?: Constructor<HTMLMediaElement> })
+  .HTMLMediaElement;
+const nativeVideoTracksFn = getBaseMediaTracksFn(HTMLMediaElementConstructor, 'video');
+const nativeAudioTracksFn = getBaseMediaTracksFn(HTMLMediaElementConstructor, 'audio');
+
+// Safari supports native media tracks, but native implementations cannot
+// reliably represent manifest-derived MSE tracks or manually-added tracks.
+export function MediaTracksMixin<Base extends Constructor>(MediaElementClass: Base): WithMediaTracks<Base> {
+  if (!MediaElementClass?.prototype) return MediaElementClass as WithMediaTracks<Base>;
+
+  const prototype = MediaElementClass.prototype as Record<string, any>;
+  const videoTracksFn = getBaseMediaTracksFn(MediaElementClass, 'video');
+
+  if (!videoTracksFn || `${videoTracksFn}`.includes('[native code]')) {
+    Object.defineProperty(prototype, 'videoTracks', {
+      get() {
+        return getVideoTracks(this);
+      },
+    });
+  }
+
+  const audioTracksFn = getBaseMediaTracksFn(MediaElementClass, 'audio');
+
+  if (!audioTracksFn || `${audioTracksFn}`.includes('[native code]')) {
+    Object.defineProperty(prototype, 'audioTracks', {
+      get() {
+        return getAudioTracks(this);
+      },
+    });
+  }
+
+  if (!hasOwn(prototype, 'addVideoTrack')) {
+    prototype.addVideoTrack = function (this: HTMLMediaElement, kind: string, label = '', language = '') {
+      const track = new VideoTrack();
+      track.kind = kind;
+      track.label = label;
+      track.language = language;
+      addVideoTrack(this, track);
+      return track;
+    };
+  }
+
+  if (!hasOwn(prototype, 'removeVideoTrack')) {
+    prototype.removeVideoTrack = removeVideoTrack;
+  }
+
+  if (!hasOwn(prototype, 'addAudioTrack')) {
+    prototype.addAudioTrack = function (this: HTMLMediaElement, kind: string, label = '', language = '') {
+      const track = new AudioTrack();
+      track.kind = kind;
+      track.label = label;
+      track.language = language;
+      addAudioTrack(this, track);
+      return track;
+    };
+  }
+
+  if (!hasOwn(prototype, 'removeAudioTrack')) {
+    prototype.removeAudioTrack = removeAudioTrack;
+  }
+
+  if (!hasOwn(prototype, 'videoRenditions')) {
+    Object.defineProperty(prototype, 'videoRenditions', {
+      get() {
+        return initVideoRenditions(this);
+      },
+    });
+  }
+
+  if (!hasOwn(prototype, 'audioRenditions')) {
+    Object.defineProperty(prototype, 'audioRenditions', {
+      get() {
+        return initAudioRenditions(this);
+      },
+    });
+  }
+
+  return MediaElementClass as WithMediaTracks<Base>;
+}
+
+function hasOwn(value: object, key: PropertyKey) {
+  return Object.hasOwn(value, key);
+}
+
+function initVideoRenditions(media: HTMLMediaElement) {
+  let renditions = getPrivate(media).videoRenditions as VideoRenditionList | undefined;
+  if (!renditions) {
+    renditions = new VideoRenditionList();
+    getPrivate(renditions).media = new WeakRef(media);
+    getPrivate(media).videoRenditions = renditions;
+  }
+  return renditions;
+}
+
+function initAudioRenditions(media: HTMLMediaElement) {
+  let renditions = getPrivate(media).audioRenditions as AudioRenditionList | undefined;
+  if (!renditions) {
+    renditions = new AudioRenditionList();
+    getPrivate(renditions).media = new WeakRef(media);
+    getPrivate(media).audioRenditions = renditions;
+  }
+  return renditions;
+}
+
+function getBaseMediaTracksFn(MediaElementClass: any, type: string): (() => any) | undefined {
+  if (MediaElementClass?.prototype) {
+    return Object.getOwnPropertyDescriptor(MediaElementClass.prototype, `${type}Tracks`)?.get;
+  }
+  return undefined;
+}
+
+function getVideoTracks(media: any) {
+  let tracks = getPrivate(media).videoTracks as VideoTrackList | undefined;
+  if (!tracks) {
+    tracks = new VideoTrackList();
+    getPrivate(media).videoTracks = tracks;
+
+    const nativeEl = media.nativeEl ?? media.target;
+
+    if (nativeVideoTracksFn && nativeEl) {
+      const currentTracks = tracks;
+      const nativeTracks = nativeVideoTracksFn.call(nativeEl);
+
+      for (const nativeTrack of nativeTracks) {
+        addVideoTrack(media, nativeTrack);
+      }
+
+      const onChange = () => {
+        currentTracks.dispatchEvent(new Event('change'));
+      };
+
+      const onAddTrack = (event: TrackEvent) => {
+        if ([...currentTracks].some((track) => track instanceof VideoTrack)) {
+          for (const nativeTrack of nativeTracks) {
+            removeVideoTrack(nativeTrack as VideoTrack);
+          }
+          return;
+        }
+
+        addVideoTrack(media, event.track as VideoTrack);
+      };
+
+      const onRemoveTrack = (event: TrackEvent) => {
+        removeVideoTrack(event.track as VideoTrack);
+      };
+
+      nativeTracks.addEventListener('change', onChange);
+      nativeTracks.addEventListener('addtrack', onAddTrack);
+      nativeTracks.addEventListener('removetrack', onRemoveTrack);
+    }
+  }
+  return tracks;
+}
+
+function getAudioTracks(media: any) {
+  let tracks = getPrivate(media).audioTracks as AudioTrackList | undefined;
+  if (!tracks) {
+    tracks = new AudioTrackList();
+    getPrivate(media).audioTracks = tracks;
+
+    const nativeEl = media.nativeEl ?? media.target;
+
+    if (nativeAudioTracksFn && nativeEl) {
+      const currentTracks = tracks;
+      const nativeTracks = nativeAudioTracksFn.call(nativeEl);
+
+      for (const nativeTrack of nativeTracks) {
+        addAudioTrack(media, nativeTrack);
+      }
+
+      const onChange = () => {
+        currentTracks.dispatchEvent(new Event('change'));
+      };
+
+      const onAddTrack = (event: TrackEvent) => {
+        if ([...currentTracks].some((track) => track instanceof AudioTrack)) {
+          for (const nativeTrack of nativeTracks) {
+            removeAudioTrack(nativeTrack as AudioTrack);
+          }
+          return;
+        }
+
+        addAudioTrack(media, event.track as AudioTrack);
+      };
+
+      const onRemoveTrack = (event: TrackEvent) => {
+        removeAudioTrack(event.track as AudioTrack);
+      };
+
+      nativeTracks.addEventListener('change', onChange);
+      nativeTracks.addEventListener('addtrack', onAddTrack);
+      nativeTracks.addEventListener('removetrack', onRemoveTrack);
+    }
+  }
+  return tracks;
+}

--- a/packages/core/src/core/media/media-tracks/polyfill.ts
+++ b/packages/core/src/core/media/media-tracks/polyfill.ts
@@ -1,0 +1,3 @@
+import { MediaTracksMixin } from './mixin';
+
+MediaTracksMixin((globalThis as any).HTMLMediaElement);

--- a/packages/core/src/core/media/media-tracks/rendition-event.ts
+++ b/packages/core/src/core/media/media-tracks/rendition-event.ts
@@ -1,0 +1,11 @@
+import type { AudioRendition } from './audio-rendition';
+import type { VideoRendition } from './video-rendition';
+
+export class RenditionEvent extends Event {
+  rendition: AudioRendition | VideoRendition;
+
+  constructor(type: string, init: { rendition: AudioRendition | VideoRendition }) {
+    super(type);
+    this.rendition = init.rendition;
+  }
+}

--- a/packages/core/src/core/media/media-tracks/utils.ts
+++ b/packages/core/src/core/media/media-tracks/utils.ts
@@ -1,0 +1,12 @@
+const privateProps = new WeakMap<object, Record<string, any>>();
+
+export function getPrivate(instance: object) {
+  return privateProps.get(instance) ?? setPrivate(instance, {});
+}
+
+export function setPrivate(instance: object, props: Record<string, any>) {
+  let saved = privateProps.get(instance);
+  if (!saved) privateProps.set(instance, (saved = {}));
+
+  return Object.assign(saved, props);
+}

--- a/packages/core/src/core/media/media-tracks/video-rendition-list.ts
+++ b/packages/core/src/core/media/media-tracks/video-rendition-list.ts
@@ -1,0 +1,141 @@
+import { RenditionEvent } from './rendition-event';
+import { getPrivate } from './utils';
+import type { VideoRendition } from './video-rendition';
+import type { VideoTrack } from './video-track';
+
+export function addRendition(track: VideoTrack, rendition: VideoRendition) {
+  const renditionList = getPrivate(track).media?.deref()?.videoRenditions as VideoRenditionList | undefined;
+
+  getPrivate(rendition).media = getPrivate(track).media;
+  getPrivate(rendition).track = track;
+
+  const renditionSet = getPrivate(track).renditionSet as Set<VideoRendition>;
+  renditionSet.add(rendition);
+  const index = renditionSet.size - 1;
+
+  if (!(index in VideoRenditionList.prototype)) {
+    Object.defineProperty(VideoRenditionList.prototype, index, {
+      get() {
+        return getCurrentRenditions(this)[index];
+      },
+    });
+  }
+
+  queueMicrotask(() => {
+    if (!renditionList || !track.selected) return;
+
+    renditionList.dispatchEvent(new RenditionEvent('addrendition', { rendition }));
+  });
+}
+
+export function removeRendition(rendition: VideoRendition) {
+  const renditionList = getPrivate(rendition).media?.deref()?.videoRenditions as VideoRenditionList | undefined;
+  const track = getPrivate(rendition).track as VideoTrack;
+  const renditionSet = getPrivate(track).renditionSet as Set<VideoRendition>;
+  renditionSet.delete(rendition);
+
+  queueMicrotask(() => {
+    if (!renditionList || !track.selected) return;
+
+    renditionList.dispatchEvent(new RenditionEvent('removerendition', { rendition }));
+  });
+}
+
+export function selectedChanged(rendition: VideoRendition) {
+  const renditionList = getPrivate(rendition).media?.deref()?.videoRenditions as VideoRenditionList | undefined;
+
+  // Prevent firing a rendition list `change` event multiple times per tick.
+  if (!renditionList || getPrivate(renditionList).changeRequested) return;
+  getPrivate(renditionList).changeRequested = true;
+
+  queueMicrotask(() => {
+    delete getPrivate(renditionList).changeRequested;
+
+    const track = getPrivate(rendition).track as VideoTrack;
+    if (!track.selected) return;
+
+    renditionList.dispatchEvent(new Event('change'));
+  });
+}
+
+function getCurrentRenditions(renditionList: VideoRenditionList): VideoRendition[] {
+  const media = getPrivate(renditionList).media?.deref() as HTMLMediaElement | undefined;
+  if (!media) return [];
+  return [...media.videoTracks]
+    .filter((track) => track.selected)
+    .flatMap((track) => [...(getPrivate(track).renditionSet as Set<VideoRendition>)]);
+}
+
+export class VideoRenditionList extends EventTarget {
+  [index: number]: VideoRendition;
+  #addRenditionCallback: (() => void) | undefined;
+  #removeRenditionCallback: (() => void) | undefined;
+  #changeCallback: (() => void) | undefined;
+
+  [Symbol.iterator]() {
+    return getCurrentRenditions(this).values();
+  }
+
+  get length() {
+    return getCurrentRenditions(this).length;
+  }
+
+  getRenditionById(id: string): VideoRendition | null {
+    return getCurrentRenditions(this).find((rendition) => `${rendition.id}` === `${id}`) ?? null;
+  }
+
+  get selectedIndex() {
+    return getCurrentRenditions(this).findIndex((rendition) => rendition.selected);
+  }
+
+  set selectedIndex(index) {
+    for (const [i, rendition] of getCurrentRenditions(this).entries()) {
+      rendition.selected = i === index;
+    }
+  }
+
+  get onaddrendition() {
+    return this.#addRenditionCallback;
+  }
+
+  set onaddrendition(callback: ((event?: { rendition: VideoRendition }) => void) | undefined) {
+    if (this.#addRenditionCallback) {
+      this.removeEventListener('addrendition', this.#addRenditionCallback);
+      this.#addRenditionCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#addRenditionCallback = callback;
+      this.addEventListener('addrendition', callback as unknown as EventListener);
+    }
+  }
+
+  get onremoverendition() {
+    return this.#removeRenditionCallback;
+  }
+
+  set onremoverendition(callback: ((event?: { rendition: VideoRendition }) => void) | undefined) {
+    if (this.#removeRenditionCallback) {
+      this.removeEventListener('removerendition', this.#removeRenditionCallback);
+      this.#removeRenditionCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#removeRenditionCallback = callback;
+      this.addEventListener('removerendition', callback as unknown as EventListener);
+    }
+  }
+
+  get onchange() {
+    return this.#changeCallback;
+  }
+
+  set onchange(callback) {
+    if (this.#changeCallback) {
+      this.removeEventListener('change', this.#changeCallback);
+      this.#changeCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#changeCallback = callback;
+      this.addEventListener('change', callback);
+    }
+  }
+}

--- a/packages/core/src/core/media/media-tracks/video-rendition.ts
+++ b/packages/core/src/core/media/media-tracks/video-rendition.ts
@@ -1,0 +1,27 @@
+import { selectedChanged } from './video-rendition-list';
+
+/**
+ * The consumer should use the `selected` setter to select one or multiple
+ * renditions that the engine is allowed to play.
+ */
+export class VideoRendition {
+  src: string | undefined;
+  id: string | undefined;
+  width: number | undefined;
+  height: number | undefined;
+  bitrate: number | undefined;
+  frameRate: number | undefined;
+  codec: string | undefined;
+  #selected = false;
+
+  get selected(): boolean {
+    return this.#selected;
+  }
+
+  set selected(value: boolean) {
+    if (this.#selected === value) return;
+    this.#selected = value;
+
+    selectedChanged(this);
+  }
+}

--- a/packages/core/src/core/media/media-tracks/video-track-list.ts
+++ b/packages/core/src/core/media/media-tracks/video-track-list.ts
@@ -1,0 +1,140 @@
+import { TrackEvent } from './change-event';
+import { getPrivate } from './utils';
+import type { VideoTrack } from './video-track';
+
+export function addVideoTrack(media: HTMLMediaElement, track: VideoTrack) {
+  const trackList = media.videoTracks;
+  getPrivate(track).media = new WeakRef(media);
+
+  if (!getPrivate(track).renditionSet) {
+    getPrivate(track).renditionSet = new Set();
+  }
+
+  const trackSet = getPrivate(trackList).trackSet as Set<VideoTrack>;
+  trackSet.add(track);
+  const index = trackSet.size - 1;
+
+  if (!(index in VideoTrackList.prototype)) {
+    Object.defineProperty(VideoTrackList.prototype, index, {
+      get() {
+        return [...(getPrivate(this).trackSet as Set<VideoTrack>)][index];
+      },
+    });
+  }
+
+  // The event is queued to align with native `addtrack` behavior.
+  queueMicrotask(() => {
+    trackList.dispatchEvent(new TrackEvent('addtrack', { track }));
+  });
+}
+
+export function removeVideoTrack(track: VideoTrack) {
+  const trackList = getPrivate(track).media?.deref()?.videoTracks as VideoTrackList | undefined;
+  if (!trackList) return;
+
+  const trackSet = getPrivate(trackList).trackSet as Set<VideoTrack>;
+  trackSet.delete(track);
+
+  queueMicrotask(() => {
+    trackList.dispatchEvent(new TrackEvent('removetrack', { track }));
+  });
+}
+
+export function selectedChanged(selected: VideoTrack) {
+  const trackList = (getPrivate(selected).media?.deref()?.videoTracks ?? []) as VideoTrackList | VideoTrack[];
+  let hasUnselected = false;
+
+  for (const track of trackList) {
+    if (track === selected) continue;
+    track.selected = false;
+    hasUnselected = true;
+  }
+
+  if (!hasUnselected) return;
+
+  // Prevent firing a track list `change` event multiple times per tick.
+  if (getPrivate(trackList).changeRequested) return;
+  getPrivate(trackList).changeRequested = true;
+
+  queueMicrotask(() => {
+    delete getPrivate(trackList).changeRequested;
+    (trackList as VideoTrackList).dispatchEvent(new Event('change'));
+  });
+}
+
+export class VideoTrackList extends EventTarget {
+  [index: number]: VideoTrack;
+  #addTrackCallback: (() => void) | undefined;
+  #removeTrackCallback: (() => void) | undefined;
+  #changeCallback: (() => void) | undefined;
+
+  constructor() {
+    super();
+    getPrivate(this).trackSet = new Set();
+  }
+
+  get #tracks() {
+    return getPrivate(this).trackSet as Set<VideoTrack>;
+  }
+
+  [Symbol.iterator]() {
+    return this.#tracks.values();
+  }
+
+  get length() {
+    return this.#tracks.size;
+  }
+
+  getTrackById(id: string): VideoTrack | null {
+    return [...this.#tracks].find((track) => track.id === id) ?? null;
+  }
+
+  get selectedIndex() {
+    return [...this.#tracks].findIndex((track) => track.selected);
+  }
+
+  get onaddtrack() {
+    return this.#addTrackCallback;
+  }
+
+  set onaddtrack(callback: ((event?: { track: VideoTrack }) => void) | undefined) {
+    if (this.#addTrackCallback) {
+      this.removeEventListener('addtrack', this.#addTrackCallback);
+      this.#addTrackCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#addTrackCallback = callback;
+      this.addEventListener('addtrack', callback as unknown as EventListener);
+    }
+  }
+
+  get onremovetrack() {
+    return this.#removeTrackCallback;
+  }
+
+  set onremovetrack(callback: ((event?: { track: VideoTrack }) => void) | undefined) {
+    if (this.#removeTrackCallback) {
+      this.removeEventListener('removetrack', this.#removeTrackCallback);
+      this.#removeTrackCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#removeTrackCallback = callback;
+      this.addEventListener('removetrack', callback as unknown as EventListener);
+    }
+  }
+
+  get onchange() {
+    return this.#changeCallback;
+  }
+
+  set onchange(callback) {
+    if (this.#changeCallback) {
+      this.removeEventListener('change', this.#changeCallback);
+      this.#changeCallback = undefined;
+    }
+    if (typeof callback === 'function') {
+      this.#changeCallback = callback;
+      this.addEventListener('change', callback);
+    }
+  }
+}

--- a/packages/core/src/core/media/media-tracks/video-track.ts
+++ b/packages/core/src/core/media/media-tracks/video-track.ts
@@ -1,0 +1,50 @@
+import { VideoRendition } from './video-rendition';
+import { addRendition, removeRendition } from './video-rendition-list';
+import { selectedChanged } from './video-track-list';
+
+export const VideoTrackKind = {
+  alternative: 'alternative',
+  captions: 'captions',
+  main: 'main',
+  sign: 'sign',
+  subtitles: 'subtitles',
+  commentary: 'commentary',
+};
+
+export class VideoTrack {
+  id: string | undefined;
+  kind: string | undefined;
+  label = '';
+  language = '';
+  sourceBuffer: unknown;
+  #selected = false;
+
+  addRendition(src: string, width?: number, height?: number, codec?: string, bitrate?: number, frameRate?: number) {
+    const rendition = new VideoRendition();
+    rendition.src = src;
+    rendition.width = width;
+    rendition.height = height;
+    rendition.frameRate = frameRate;
+    rendition.bitrate = bitrate;
+    rendition.codec = codec;
+    addRendition(this, rendition);
+    return rendition;
+  }
+
+  removeRendition(rendition: VideoRendition) {
+    removeRendition(rendition);
+  }
+
+  get selected(): boolean {
+    return this.#selected;
+  }
+
+  set selected(value: boolean) {
+    if (this.#selected === value) return;
+    this.#selected = value;
+
+    if (value !== true) return;
+
+    selectedChanged(this);
+  }
+}

--- a/packages/core/src/core/media/types.ts
+++ b/packages/core/src/core/media/types.ts
@@ -239,6 +239,119 @@ export interface MediaTextTrackCapability {
 }
 
 // ----------------------------------------
+// Media tracks
+// ----------------------------------------
+
+interface TrackEventLike<Track> extends EventLike {
+  readonly track: Track;
+}
+
+interface RenditionEventLike<Rendition> extends EventLike {
+  readonly rendition: Rendition;
+}
+
+interface TrackListEvents<Track> {
+  addtrack: TrackEventLike<Track>;
+  removetrack: TrackEventLike<Track>;
+  change: EventLike;
+}
+
+interface RenditionListEvents<Rendition> {
+  addrendition: RenditionEventLike<Rendition>;
+  removerendition: RenditionEventLike<Rendition>;
+  change: EventLike;
+}
+
+export interface AudioTrackLike {
+  id: string | undefined;
+  readonly kind: string | undefined;
+  readonly label: string;
+  readonly language: string;
+  enabled: boolean;
+  addRendition(src: string, codec?: string | undefined, bitrate?: number | undefined): AudioRenditionLike;
+  removeRendition(rendition: AudioRenditionLike): void;
+}
+
+export interface AudioTrackListLike extends EventTargetLike<TrackListEvents<AudioTrackLike>> {
+  readonly length: number;
+  readonly [index: number]: AudioTrackLike;
+  [Symbol.iterator](): Iterator<AudioTrackLike>;
+  getTrackById(id: string): AudioTrackLike | null;
+}
+
+export interface AudioRenditionLike {
+  id: string | undefined;
+  readonly bitrate: number | undefined;
+  readonly codec: string | undefined;
+  selected: boolean;
+}
+
+export interface AudioRenditionListLike extends EventTargetLike<RenditionListEvents<AudioRenditionLike>> {
+  readonly length: number;
+  readonly [index: number]: AudioRenditionLike;
+  [Symbol.iterator](): Iterator<AudioRenditionLike>;
+  getRenditionById(id: string): AudioRenditionLike | null;
+  selectedIndex: number;
+}
+
+export interface VideoTrackLike {
+  id: string | undefined;
+  readonly kind: string | undefined;
+  readonly label: string;
+  readonly language: string;
+  selected: boolean;
+  addRendition(
+    src: string,
+    width?: number | undefined,
+    height?: number | undefined,
+    codec?: string | undefined,
+    bitrate?: number | undefined,
+    frameRate?: number | undefined
+  ): VideoRenditionLike;
+  removeRendition(rendition: VideoRenditionLike): void;
+}
+
+export interface VideoTrackListLike extends EventTargetLike<TrackListEvents<VideoTrackLike>> {
+  readonly length: number;
+  readonly [index: number]: VideoTrackLike;
+  [Symbol.iterator](): Iterator<VideoTrackLike>;
+  getTrackById(id: string): VideoTrackLike | null;
+  readonly selectedIndex: number;
+}
+
+export interface VideoRenditionLike {
+  id: string | undefined;
+  readonly width: number | undefined;
+  readonly height: number | undefined;
+  readonly bitrate: number | undefined;
+  readonly frameRate: number | undefined;
+  readonly codec: string | undefined;
+  selected: boolean;
+}
+
+export interface VideoRenditionListLike extends EventTargetLike<RenditionListEvents<VideoRenditionLike>> {
+  readonly length: number;
+  readonly [index: number]: VideoRenditionLike;
+  [Symbol.iterator](): Iterator<VideoRenditionLike>;
+  getRenditionById(id: string): VideoRenditionLike | null;
+  selectedIndex: number;
+}
+
+export interface MediaAudioTrackCapability {
+  readonly audioTracks: AudioTrackListLike;
+  readonly audioRenditions: AudioRenditionListLike;
+  addAudioTrack(kind: string, label?: string, language?: string): AudioTrackLike;
+  removeAudioTrack(track: AudioTrackLike): void;
+}
+
+export interface MediaVideoTrackCapability {
+  readonly videoTracks: VideoTrackListLike;
+  readonly videoRenditions: VideoRenditionListLike;
+  addVideoTrack(kind: string, label?: string, language?: string): VideoTrackLike;
+  removeVideoTrack(track: VideoTrackLike): void;
+}
+
+// ----------------------------------------
 // Fullscreen
 // ----------------------------------------
 
@@ -398,8 +511,8 @@ export interface Media<Engine = unknown, Events extends { [K in keyof Events]: E
     EventTargetLike<Events> {
   readonly engine?: Engine | null;
   readonly target?: unknown;
-  readonly next?: Media | null;
-  readonly root?: Media | null;
+  readonly next?: Media<Engine, any> | null;
+  readonly root?: Media<Engine, any> | null;
   destroy?(): Promise<void> | void;
 }
 
@@ -431,6 +544,8 @@ export interface MediaFull<Engine = unknown, Events extends { [K in keyof Events
     MediaPlayedCapability,
     MediaErrorCapability,
     MediaTextTrackCapability,
+    MediaAudioTrackCapability,
+    MediaVideoTrackCapability,
     MediaStreamTypeCapability,
     MediaLiveCapability,
     MediaRemotePlaybackCapability,

--- a/packages/core/src/dom/media/constants.ts
+++ b/packages/core/src/dom/media/constants.ts
@@ -1,11 +1,13 @@
-import type { RemotePlaybackLike, TextTrackListLike, TimeRangeLike } from '../../core/media/types';
+import type { RemotePlaybackLike, TimeRangeLike } from '../../core/media/types';
 
 export const EMPTY_TIME_RANGES: TimeRangeLike = Object.freeze({ length: 0, start: () => 0, end: () => 0 });
-
-export const EMPTY_TEXT_TRACKS: TextTrackListLike = Object.assign(new EventTarget(), {
-  length: 0,
-}) as unknown as TextTrackListLike;
 
 export const EMPTY_REMOTE = new EventTarget() as unknown as RemotePlaybackLike;
 
 export const EMPTY_CONFIG: Record<string, unknown> = Object.freeze({});
+
+const EMPTY_MEDIA_LIST_PROPS = Object.freeze({
+  length: 0,
+});
+
+export const EMPTY_MEDIA_LIST = Object.assign(new EventTarget(), EMPTY_MEDIA_LIST_PROPS);

--- a/packages/core/src/dom/media/dash/index.ts
+++ b/packages/core/src/dom/media/dash/index.ts
@@ -9,7 +9,7 @@ export const dashMediaDefaultProps: DashMediaProps = {
   src: '',
 };
 
-export class DashMedia extends HTMLVideoElementHost<dashjs.MediaPlayerClass> implements DashMediaProps {
+export class DashMedia extends HTMLVideoElementHost implements DashMediaProps {
   #engine: dashjs.MediaPlayerClass;
   #src = dashMediaDefaultProps.src;
   #pendingLoad: Promise<void> | null = null;

--- a/packages/core/src/dom/media/google-cast/google-cast-layer.ts
+++ b/packages/core/src/dom/media/google-cast/google-cast-layer.ts
@@ -1,4 +1,5 @@
 import { isCaptionOrSubtitleTrack } from '@videojs/utils/dom';
+import type { TextTrackLike } from '../../../core/media/types';
 import type { HTMLAudioElementHost } from '../html-audio-element-host';
 import type { HTMLVideoElementHost } from '../html-video-element-host';
 import { HTMLVideoElementLayer } from '../html-video-element-layer';
@@ -514,7 +515,7 @@ export class GoogleCastLayer extends HTMLVideoElementLayer {
   async #updateRemoteTextTrack() {
     if (!this.#isCasting || !this.target) return;
 
-    const localSubs = [...this.textTracks].filter(isCaptionOrSubtitleTrack);
+    const localSubs = [...this.textTracks].filter((track): track is TextTrackLike => isCaptionOrSubtitleTrack(track));
 
     const matched = (this.#remotePlayer.mediaInfo?.tracks ?? [])
       .filter(({ type }) => type === chrome.cast.media.TrackType.TEXT)

--- a/packages/core/src/dom/media/hls-js/index.ts
+++ b/packages/core/src/dom/media/hls-js/index.ts
@@ -1,6 +1,7 @@
 import HlsJs, { type HlsConfig as HlsJsConfig } from 'hls.js';
-import { MediaTracksMixin } from '../../../core/media/media-tracks';
+import { addLayer } from '../../../core/media/media-layer';
 import { HTMLVideoElementHost } from '../html-video-element-host';
+import { MediaTracksLayer } from '../media-tracks-layer';
 import { hlsJsErrors } from './errors';
 import { hlsJsLive } from './live';
 import { hlsJsMediaTracks } from './media-tracks';
@@ -25,13 +26,14 @@ export interface HlsJsMediaParams {
   config?: Partial<HlsJsConfig>;
 }
 
-const HlsJsMediaBase = MediaTracksMixin(HTMLVideoElementHost<HlsJs>);
-export class HlsJsMedia extends HlsJsMediaBase {
+export class HlsJsMedia extends HTMLVideoElementHost<HlsJs> {
   #engine: HlsJs | null;
 
   constructor(params: HlsJsMediaParams = {}) {
     super();
     this.#engine = new HlsJs({ ...defaultHlsJsConfig, ...params.config });
+
+    addLayer(this, new MediaTracksLayer());
 
     hlsJsErrors().install(this);
     hlsJsStreamType().install(this);

--- a/packages/core/src/dom/media/hls-js/index.ts
+++ b/packages/core/src/dom/media/hls-js/index.ts
@@ -1,7 +1,9 @@
 import HlsJs, { type HlsConfig as HlsJsConfig } from 'hls.js';
+import { MediaTracksMixin } from '../../../core/media/media-tracks';
 import { HTMLVideoElementHost } from '../html-video-element-host';
 import { hlsJsErrors } from './errors';
 import { hlsJsLive } from './live';
+import { hlsJsMediaTracks } from './media-tracks';
 import { hlsJsMetadataTracks } from './metadata-tracks';
 import { hlsJsPreload } from './preload';
 import { hlsJsStreamType } from './stream-type';
@@ -23,7 +25,8 @@ export interface HlsJsMediaParams {
   config?: Partial<HlsJsConfig>;
 }
 
-export class HlsJsMedia extends HTMLVideoElementHost<HlsJs> {
+const HlsJsMediaBase = MediaTracksMixin(HTMLVideoElementHost<HlsJs>);
+export class HlsJsMedia extends HlsJsMediaBase {
   #engine: HlsJs | null;
 
   constructor(params: HlsJsMediaParams = {}) {
@@ -36,6 +39,7 @@ export class HlsJsMedia extends HTMLVideoElementHost<HlsJs> {
     hlsJsPreload().install(this);
     hlsJsMetadataTracks().install(this);
     hlsJsTextTracks().install(this);
+    hlsJsMediaTracks().install(this);
   }
 
   override get engine(): HlsJs | null {

--- a/packages/core/src/dom/media/hls-js/media-tracks.ts
+++ b/packages/core/src/dom/media/hls-js/media-tracks.ts
@@ -1,0 +1,143 @@
+import HlsJs from 'hls.js';
+import { installExtension, type MediaExtension } from '../../../core/media/media-extension';
+import type { VideoTrackLike } from '../../../core/media/types';
+import type { HTMLVideoElementHost } from '../html-video-element-host';
+
+type HlsJsMediaTrackLevel = {
+  url: string[];
+  width?: number | undefined;
+  height?: number | undefined;
+  videoCodec?: string | undefined;
+  bitrate?: number | undefined;
+};
+
+type HlsJsMediaAudioTrack = {
+  id: number;
+  default?: boolean | undefined;
+  name?: string | undefined;
+  lang?: string | undefined;
+};
+
+export class HlsJsMediaTracks implements MediaExtension {
+  #destroy: (() => void) | null = null;
+  readonly name = 'hls-js-media-tracks';
+
+  install(media: HTMLVideoElementHost<HlsJs>) {
+    const { engine } = media;
+    if (!engine) return;
+
+    const uninstall = installExtension(hlsJsMediaTracks, media, this);
+
+    const levelIdMap = new WeakMap<HlsJsMediaTrackLevel, string>();
+    let currentVideoTrack: VideoTrackLike | null = null;
+
+    const onManifestParsed = (_event: string, data: { levels: HlsJsMediaTrackLevel[] }) => {
+      removeAllMediaTracks(media);
+
+      const videoTrack = media.addVideoTrack('main');
+      currentVideoTrack = videoTrack;
+      videoTrack.selected = true;
+
+      for (const [id, level] of data.levels.entries()) {
+        const rendition = videoTrack.addRendition(
+          level.url[0] ?? '',
+          level.width,
+          level.height,
+          level.videoCodec,
+          level.bitrate
+        );
+
+        levelIdMap.set(level, `${id}`);
+        rendition.id = `${id}`;
+      }
+    };
+
+    const onAudioTracksUpdated = (_event: string, data: { audioTracks: HlsJsMediaAudioTrack[] }) => {
+      removeAudioTracks(media);
+
+      for (const hlsAudioTrack of data.audioTracks) {
+        const kind = hlsAudioTrack.default ? 'main' : 'alternative';
+        const audioTrack = media.addAudioTrack(kind, hlsAudioTrack.name, hlsAudioTrack.lang);
+        audioTrack.id = `${hlsAudioTrack.id}`;
+        audioTrack.enabled = Boolean(hlsAudioTrack.default);
+      }
+    };
+
+    const switchAudioTrack = () => {
+      const selectedTrackId = [...media.audioTracks].find((track) => track.enabled)?.id;
+      if (!selectedTrackId) return;
+
+      const audioTrackId = Number(selectedTrackId);
+      const availableIds = engine.audioTracks.map((track) => track.id);
+
+      if (audioTrackId !== engine.audioTrack && availableIds.includes(audioTrackId)) {
+        engine.audioTrack = audioTrackId;
+      }
+    };
+
+    const onLevelsUpdated = (_event: string, data: { levels: HlsJsMediaTrackLevel[] }) => {
+      if (!currentVideoTrack) return;
+
+      const levelIds = data.levels.map((level) => levelIdMap.get(level));
+
+      for (const rendition of media.videoRenditions) {
+        if (rendition.id && !levelIds.includes(rendition.id)) {
+          currentVideoTrack.removeRendition(rendition);
+        }
+      }
+    };
+
+    const switchRendition = () => {
+      const level = media.videoRenditions.selectedIndex;
+      if (level !== engine.nextLevel) engine.nextLevel = level;
+    };
+
+    const onDestroying = () => {
+      removeAllMediaTracks(media);
+      media.audioTracks.removeEventListener('change', switchAudioTrack);
+      media.videoRenditions.removeEventListener('change', switchRendition);
+    };
+
+    engine.on(HlsJs.Events.MANIFEST_PARSED, onManifestParsed);
+    engine.on(HlsJs.Events.AUDIO_TRACKS_UPDATED, onAudioTracksUpdated);
+    engine.on(HlsJs.Events.LEVELS_UPDATED, onLevelsUpdated);
+    engine.once(HlsJs.Events.DESTROYING, onDestroying);
+    media.audioTracks.addEventListener('change', switchAudioTrack);
+    media.videoRenditions.addEventListener('change', switchRendition);
+
+    this.#destroy = () => {
+      uninstall();
+      onDestroying();
+      engine.off(HlsJs.Events.MANIFEST_PARSED, onManifestParsed);
+      engine.off(HlsJs.Events.AUDIO_TRACKS_UPDATED, onAudioTracksUpdated);
+      engine.off(HlsJs.Events.LEVELS_UPDATED, onLevelsUpdated);
+      engine.off(HlsJs.Events.DESTROYING, onDestroying);
+    };
+  }
+
+  destroy() {
+    this.#destroy?.();
+    this.#destroy = null;
+  }
+}
+
+export function hlsJsMediaTracks() {
+  return new HlsJsMediaTracks();
+}
+
+function removeAllMediaTracks(media: HTMLVideoElementHost<HlsJs>) {
+  removeVideoTracks(media);
+  removeAudioTracks(media);
+}
+
+function removeVideoTracks(media: HTMLVideoElementHost<HlsJs>) {
+  for (const videoTrack of media.videoTracks) {
+    media.removeVideoTrack(videoTrack);
+  }
+}
+
+function removeAudioTracks(media: HTMLVideoElementHost<HlsJs>) {
+  for (const audioTrack of media.audioTracks) {
+    media.removeAudioTrack(audioTrack);
+  }
+}

--- a/packages/core/src/dom/media/hls-js/tests/errors.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/errors.test.ts
@@ -24,7 +24,7 @@ function createEngine(): HlsJs {
   } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost {
+class HlsHost extends HTMLVideoElementHost<HlsJs> {
   #engine: HlsJs;
   constructor(engine: HlsJs) {
     super();

--- a/packages/core/src/dom/media/hls-js/tests/errors.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/errors.test.ts
@@ -24,7 +24,7 @@ function createEngine(): HlsJs {
   } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost<HlsJs> {
+class HlsHost extends HTMLVideoElementHost {
   #engine: HlsJs;
   constructor(engine: HlsJs) {
     super();

--- a/packages/core/src/dom/media/hls-js/tests/errors.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/errors.test.ts
@@ -1,4 +1,4 @@
-import Hls from 'hls.js';
+import HlsJs from 'hls.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MediaError } from '../../../../core/media/media-error';
 import { HTMLVideoElementHost } from '../../html-video-element-host';
@@ -8,7 +8,7 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-function createEngine(): Hls {
+function createEngine(): HlsJs {
   const listeners = new Map<string, Set<(...args: any[]) => void>>();
   return {
     on(event: string, fn: (...args: any[]) => void) {
@@ -21,12 +21,12 @@ function createEngine(): Hls {
     emit(event: string, ...args: any[]) {
       for (const fn of listeners.get(event) ?? []) fn(event, ...args);
     },
-  } as unknown as Hls;
+  } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost<Hls> {
-  #engine: Hls;
-  constructor(engine: Hls) {
+class HlsHost extends HTMLVideoElementHost<HlsJs> {
+  #engine: HlsJs;
+  constructor(engine: HlsJs) {
     super();
     this.#engine = engine;
   }
@@ -43,7 +43,7 @@ function setup() {
   host.target = video;
   const extension = hlsJsErrors();
   extension.install(host);
-  (engine as any).emit(Hls.Events.MEDIA_ATTACHED);
+  (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
   return { engine, host, video, extension };
 }
 
@@ -53,9 +53,9 @@ describe('hlsJsErrors', () => {
     const handler = vi.fn();
     host.addEventListener('error', handler);
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.NETWORK_ERROR,
-      details: Hls.ErrorDetails.MANIFEST_LOAD_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.NETWORK_ERROR,
+      details: HlsJs.ErrorDetails.MANIFEST_LOAD_ERROR,
       fatal: true,
       error: new Error('network failure'),
     });
@@ -66,7 +66,7 @@ describe('hlsJsErrors', () => {
     expect(event.error).toBeInstanceOf(MediaError);
     expect(event.error.code).toBe(MediaError.MEDIA_ERR_NETWORK);
     expect(event.error.fatal).toBe(true);
-    expect(event.error.context).toBe(Hls.ErrorDetails.MANIFEST_LOAD_ERROR);
+    expect(event.error.context).toBe(HlsJs.ErrorDetails.MANIFEST_LOAD_ERROR);
     expect(event.error.data).toBeDefined();
   });
 
@@ -75,9 +75,9 @@ describe('hlsJsErrors', () => {
 
     expect(host.error).toBeNull();
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.NETWORK_ERROR,
-      details: Hls.ErrorDetails.MANIFEST_LOAD_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.NETWORK_ERROR,
+      details: HlsJs.ErrorDetails.MANIFEST_LOAD_ERROR,
       fatal: true,
       error: new Error('network failure'),
     });
@@ -91,9 +91,9 @@ describe('hlsJsErrors', () => {
     const handler = vi.fn();
     host.addEventListener('error', handler);
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.NETWORK_ERROR,
-      details: Hls.ErrorDetails.FRAG_LOAD_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.NETWORK_ERROR,
+      details: HlsJs.ErrorDetails.FRAG_LOAD_ERROR,
       fatal: false,
       error: new Error('transient'),
     });
@@ -107,9 +107,9 @@ describe('hlsJsErrors', () => {
     const handler = vi.fn();
     host.addEventListener('error', handler);
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.MEDIA_ERROR,
-      details: Hls.ErrorDetails.BUFFER_APPEND_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.MEDIA_ERROR,
+      details: HlsJs.ErrorDetails.BUFFER_APPEND_ERROR,
       fatal: true,
       error: new Error('decode'),
     });
@@ -123,9 +123,9 @@ describe('hlsJsErrors', () => {
     const handler = vi.fn();
     host.addEventListener('error', handler);
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.KEY_SYSTEM_ERROR,
-      details: Hls.ErrorDetails.KEY_SYSTEM_NO_KEYS,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.KEY_SYSTEM_ERROR,
+      details: HlsJs.ErrorDetails.KEY_SYSTEM_NO_KEYS,
       fatal: true,
       error: new Error('drm'),
     });
@@ -139,11 +139,11 @@ describe('hlsJsErrors', () => {
     const handler = vi.fn();
     host.addEventListener('error', handler);
 
-    (engine as any).emit(Hls.Events.MEDIA_DETACHED);
+    (engine as any).emit(HlsJs.Events.MEDIA_DETACHED);
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.NETWORK_ERROR,
-      details: Hls.ErrorDetails.MANIFEST_LOAD_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.NETWORK_ERROR,
+      details: HlsJs.ErrorDetails.MANIFEST_LOAD_ERROR,
       fatal: true,
       error: new Error('after detach'),
     });
@@ -154,16 +154,16 @@ describe('hlsJsErrors', () => {
   it('resets error after MEDIA_DETACHED', () => {
     const { engine, host } = setup();
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.NETWORK_ERROR,
-      details: Hls.ErrorDetails.MANIFEST_LOAD_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.NETWORK_ERROR,
+      details: HlsJs.ErrorDetails.MANIFEST_LOAD_ERROR,
       fatal: true,
       error: new Error('failure'),
     });
 
     expect(host.error).not.toBeNull();
 
-    (engine as any).emit(Hls.Events.MEDIA_DETACHED);
+    (engine as any).emit(HlsJs.Events.MEDIA_DETACHED);
 
     expect(host.error).toBeNull();
   });
@@ -173,9 +173,9 @@ describe('hlsJsErrors', () => {
     const handler = vi.fn();
     host.addEventListener('error', handler);
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.OTHER_ERROR,
-      details: Hls.ErrorDetails.INTERNAL_EXCEPTION,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.OTHER_ERROR,
+      details: HlsJs.ErrorDetails.INTERNAL_EXCEPTION,
       fatal: true,
       error: new Error('something broke'),
     });
@@ -192,9 +192,9 @@ describe('hlsJsErrors', () => {
 
     extension.destroy();
 
-    (engine as any).emit(Hls.Events.ERROR, {
-      type: Hls.ErrorTypes.NETWORK_ERROR,
-      details: Hls.ErrorDetails.MANIFEST_LOAD_ERROR,
+    (engine as any).emit(HlsJs.Events.ERROR, {
+      type: HlsJs.ErrorTypes.NETWORK_ERROR,
+      details: HlsJs.ErrorDetails.MANIFEST_LOAD_ERROR,
       fatal: true,
       error: new Error('post-destroy'),
     });

--- a/packages/core/src/dom/media/hls-js/tests/live.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/live.test.ts
@@ -444,13 +444,14 @@ describe('hlsJsLive', () => {
     it('removes engine listeners and the layer when destroyed', () => {
       const engine = createEngine();
       const host = new FakeHlsJsMedia(engine);
-      const destroy = hlsJsLive().install(host);
+      const extension = hlsJsLive();
+      extension.install(host);
       setTarget(host, [[0, 60]]);
 
       emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
       expect(host.targetLiveWindow).toBe(0);
 
-      destroy();
+      extension.destroy();
 
       emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 36 }));
       // After destroy, the layer is gone, so the host's chain falls through

--- a/packages/core/src/dom/media/hls-js/tests/live.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/live.test.ts
@@ -1,0 +1,461 @@
+import HlsJs from 'hls.js';
+import { describe, expect, it, vi } from 'vitest';
+import { HTMLVideoElementHost } from '../../html-video-element-host';
+import { hlsJsLive } from '../live';
+
+function createEngine(userConfig: Record<string, unknown> = {}): HlsJs {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  return {
+    config: { ...userConfig },
+    userConfig: { ...userConfig },
+    on(event: string, fn: (...args: any[]) => void) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(fn);
+    },
+    off(event: string, fn: (...args: any[]) => void) {
+      listeners.get(event)?.delete(fn);
+    },
+    emit(event: string, ...args: any[]) {
+      for (const fn of listeners.get(event) ?? []) fn(event, ...args);
+    },
+  } as unknown as HlsJs;
+}
+
+class FakeHlsJsMedia extends HTMLVideoElementHost<HlsJs> {
+  #engine: HlsJs;
+  constructor(engine: HlsJs) {
+    super();
+    this.#engine = engine;
+  }
+  override get engine(): HlsJs | null {
+    return this.#engine;
+  }
+}
+
+// Minimal LevelDetails shape — only the fields the extension reads.
+function levelDetails(overrides: Record<string, unknown>) {
+  return {
+    live: false,
+    type: null,
+    partList: null,
+    partHoldBack: 0,
+    partTarget: 0,
+    holdBack: 0,
+    targetduration: 6,
+    totalduration: 0,
+    ...overrides,
+  } as any;
+}
+
+function emitLevelLoaded(engine: HlsJs, details: unknown) {
+  (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details });
+}
+
+function setTarget(host: FakeHlsJsMedia, ranges: [number, number][]) {
+  const video = document.createElement('video');
+  Object.defineProperty(video, 'seekable', {
+    configurable: true,
+    get() {
+      return {
+        length: ranges.length,
+        start: (i: number) => ranges[i]?.[0] ?? 0,
+        end: (i: number) => ranges[i]?.[1] ?? 0,
+      } as TimeRanges;
+    },
+  });
+  host.target = video;
+  return video;
+}
+
+describe('hlsJsLive', () => {
+  describe('defaults', () => {
+    it('starts with `NaN` for both values and no event', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+
+      expect(host.targetLiveWindow).toBeNaN();
+      expect(host.liveEdgeStart).toBeNaN();
+    });
+  });
+
+  describe('targetLiveWindow derivation', () => {
+    it('is `0` for standard live', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+
+      const handler = vi.fn();
+      host.addEventListener('targetlivewindowchange', handler);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, type: null, holdBack: 18 }));
+
+      expect(host.targetLiveWindow).toBe(0);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('is `Infinity` for an `EVENT` playlist (DVR)', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, type: 'EVENT', holdBack: 18 }));
+
+      expect(host.targetLiveWindow).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it('is `NaN` for non-live playlists', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+
+      emitLevelLoaded(engine, levelDetails({ live: false, type: 'VOD' }));
+
+      expect(host.targetLiveWindow).toBeNaN();
+    });
+
+    it('dedupes `targetlivewindowchange` when the value does not change', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+
+      const handler = vi.fn();
+      host.addEventListener('targetlivewindowchange', handler);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('liveEdgeStart derivation', () => {
+    it('uses `holdBack` for standard live (`seekable.end - holdBack`)', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18, targetduration: 6 }));
+
+      expect(host.liveEdgeStart).toBe(42);
+    });
+
+    it('falls back to `targetduration * 3` when `holdBack` is absent', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 0, targetduration: 6 }));
+
+      expect(host.liveEdgeStart).toBe(42);
+    });
+
+    it('uses `partHoldBack` for low-latency live', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, partList: [{}], partHoldBack: 2, partTarget: 0.5 }));
+
+      expect(host.liveEdgeStart).toBe(58);
+    });
+
+    it('falls back to `partTarget * 2` when `partHoldBack` is absent', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, partList: [{}], partHoldBack: 0, partTarget: 0.5 }));
+
+      expect(host.liveEdgeStart).toBe(59);
+    });
+
+    it('is `NaN` when no seekable range is available', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, []);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      expect(host.liveEdgeStart).toBeNaN();
+    });
+
+    it('is `NaN` when the stream is not live', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: false, type: 'VOD' }));
+
+      expect(host.liveEdgeStart).toBeNaN();
+    });
+
+    it('reflects the current `seekable` on every read', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+
+      let end = 60;
+      const video = document.createElement('video');
+      Object.defineProperty(video, 'seekable', {
+        configurable: true,
+        get() {
+          return {
+            length: 1,
+            start: () => 0,
+            end: () => end,
+          } as TimeRanges;
+        },
+      });
+      host.target = video;
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      expect(host.liveEdgeStart).toBe(42);
+
+      end = 120;
+      expect(host.liveEdgeStart).toBe(102);
+    });
+  });
+
+  describe('seek-to-live on first play', () => {
+    function emitManifestLoading(engine: HlsJs) {
+      (engine as any).emit(HlsJs.Events.MANIFEST_LOADING);
+    }
+
+    it('seeks to `liveEdgeStart` on the first `play` event', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18, targetduration: 6 }));
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(video.currentTime).toBe(42);
+    });
+
+    it('does not seek when `autoplay` is set', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+      video.autoplay = true;
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(video.currentTime).toBe(0);
+    });
+
+    it('only seeks on the first play (subsequent plays are ignored)', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      video.dispatchEvent(new Event('play'));
+      expect(video.currentTime).toBe(42);
+
+      video.currentTime = 30;
+      video.dispatchEvent(new Event('play'));
+      expect(video.currentTime).toBe(30);
+    });
+
+    it('does not seek backwards when already at or past the live edge', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      video.currentTime = 50;
+      video.dispatchEvent(new Event('play'));
+
+      expect(video.currentTime).toBe(50);
+    });
+
+    it('does not seek when stream is on-demand', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: false, type: 'VOD' }));
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(video.currentTime).toBe(0);
+    });
+
+    it('defers the seek until `liveEdgeStart` becomes finite (preload="none")', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      // Manifest is requested at startup but `LEVEL_LOADED` only arrives after `play`.
+      emitManifestLoading(engine);
+      video.dispatchEvent(new Event('play'));
+      expect(video.currentTime).toBe(0);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      expect(video.currentTime).toBe(42);
+    });
+
+    it('re-arms on a subsequent source load', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+      video.dispatchEvent(new Event('play'));
+      expect(video.currentTime).toBe(42);
+
+      video.currentTime = 0;
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+      video.dispatchEvent(new Event('play'));
+
+      expect(video.currentTime).toBe(42);
+    });
+
+    it('disarms on `DESTROYING`', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      const video = setTarget(host, [[0, 60]]);
+
+      emitManifestLoading(engine);
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      (engine as any).emit(HlsJs.Events.DESTROYING);
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(video.currentTime).toBe(0);
+    });
+  });
+
+  describe('hls.js config updates', () => {
+    it('applies low-latency defaults when partList is present', () => {
+      const engine = createEngine({ abrBandWidthFactor: 0.95 });
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, partList: [{}], partHoldBack: 2, partTarget: 0.5 }));
+
+      expect((engine as any).config.backBufferLength).toBe(4);
+      expect((engine as any).config.maxFragLookUpTolerance).toBe(0.001);
+      expect((engine as any).config.abrBandWidthUpFactor).toBe(0.95);
+    });
+
+    it('applies standard live defaults when partList is absent', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      expect((engine as any).config.backBufferLength).toBe(8);
+    });
+
+    it('respects user-supplied overrides', () => {
+      const engine = createEngine({ backBufferLength: 30 });
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+
+      expect((engine as any).config.backBufferLength).toBe(30);
+    });
+
+    it('does not touch config for non-live streams', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: false, type: 'VOD' }));
+
+      expect((engine as any).config.backBufferLength).toBeUndefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('resets on `MANIFEST_LOADING`', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+      expect(host.targetLiveWindow).toBe(0);
+
+      const handler = vi.fn();
+      host.addEventListener('targetlivewindowchange', handler);
+
+      (engine as any).emit(HlsJs.Events.MANIFEST_LOADING);
+
+      expect(host.targetLiveWindow).toBeNaN();
+      expect(host.liveEdgeStart).toBeNaN();
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('resets on `DESTROYING`', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+      expect(host.targetLiveWindow).toBe(0);
+
+      (engine as any).emit(HlsJs.Events.DESTROYING);
+
+      expect(host.targetLiveWindow).toBeNaN();
+      expect(host.liveEdgeStart).toBeNaN();
+    });
+  });
+
+  describe('uninstall', () => {
+    it('removes engine listeners and the layer when destroyed', () => {
+      const engine = createEngine();
+      const host = new FakeHlsJsMedia(engine);
+      const destroy = hlsJsLive().install(host);
+      setTarget(host, [[0, 60]]);
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 18 }));
+      expect(host.targetLiveWindow).toBe(0);
+
+      destroy();
+
+      emitLevelLoaded(engine, levelDetails({ live: true, holdBack: 36 }));
+      // After destroy, the layer is gone, so the host's chain falls through
+      // to the underlying video (which has no live properties → NaN).
+      expect(host.targetLiveWindow).toBeNaN();
+    });
+  });
+});

--- a/packages/core/src/dom/media/hls-js/tests/preload.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/preload.test.ts
@@ -30,7 +30,7 @@ function createEngine(): HlsJs {
   } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost<HlsJs> {
+class HlsHost extends HTMLVideoElementHost {
   #engine: HlsJs | null;
   constructor(engine: HlsJs | null) {
     super();

--- a/packages/core/src/dom/media/hls-js/tests/preload.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/preload.test.ts
@@ -1,0 +1,159 @@
+import HlsJs from 'hls.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HTMLVideoElementHost } from '../../html-video-element-host';
+import { hlsJsPreload } from '../preload';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function createEngine(): HlsJs {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  return {
+    config: {
+      maxBufferLength: 30,
+      maxBufferSize: 60_000_000,
+    },
+    on(event: string, fn: (...args: any[]) => void) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(fn);
+    },
+    off(event: string, fn: (...args: any[]) => void) {
+      listeners.get(event)?.delete(fn);
+    },
+    emit(event: string, ...args: any[]) {
+      for (const fn of listeners.get(event) ?? []) fn(event, ...args);
+    },
+    startLoad: vi.fn(),
+    loadingEnabled: false,
+    media: null,
+  } as unknown as HlsJs;
+}
+
+class HlsHost extends HTMLVideoElementHost<HlsJs> {
+  #engine: HlsJs | null;
+  constructor(engine: HlsJs | null) {
+    super();
+    this.#engine = engine;
+  }
+  override get engine() {
+    return this.#engine;
+  }
+}
+
+function setup(engine: HlsJs = createEngine()) {
+  const host = new HlsHost(engine);
+  const destroy = hlsJsPreload().install(host);
+  const video = document.createElement('video');
+  document.body.appendChild(video);
+  return { engine, host, video, destroy };
+}
+
+describe('hlsJsPreload', () => {
+  it('defaults preload to metadata', () => {
+    const { host } = setup();
+    expect(host.preload).toBe('metadata');
+  });
+
+  it('stores preload value even when target is null', () => {
+    const { host } = setup();
+    host.preload = 'none';
+    expect(host.preload).toBe('none');
+    expect(host.target).toBeNull();
+  });
+
+  it('syncs stored preload to native element on MEDIA_ATTACHED', () => {
+    const { engine, host, video } = setup();
+    host.preload = 'none';
+    expect(host.target).toBeNull();
+
+    host.target = video;
+    (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
+
+    expect(video.preload).toBe('none');
+  });
+
+  it('applies preload set before attach when MEDIA_ATTACHED fires', () => {
+    const { engine, host, video } = setup();
+    host.preload = 'auto';
+
+    host.target = video;
+    (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
+
+    expect(engine.startLoad).toHaveBeenCalled();
+    expect(video.preload).toBe('auto');
+  });
+
+  it('uses stored preload (not native default) for loading strategy on MEDIA_ATTACHED', () => {
+    const { engine, host, video } = setup();
+    host.preload = 'none';
+
+    host.target = video;
+    (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
+
+    expect(engine.startLoad).not.toHaveBeenCalled();
+  });
+
+  it('starts metadata-level load for preload=metadata', () => {
+    const { engine, host, video } = setup();
+    host.preload = 'metadata';
+
+    host.target = video;
+    (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
+
+    expect(engine.startLoad).toHaveBeenCalled();
+    expect(engine.config.maxBufferLength).toBe(1);
+    expect(engine.config.maxBufferSize).toBe(1);
+  });
+
+  it('defers full load to play event when preload=metadata', () => {
+    const { engine, host, video } = setup();
+    host.preload = 'metadata';
+
+    host.target = video;
+    (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
+
+    (engine.startLoad as ReturnType<typeof vi.fn>).mockClear();
+
+    video.dispatchEvent(new Event('play'));
+
+    expect(engine.startLoad).toHaveBeenCalled();
+    expect(engine.config.maxBufferLength).toBe(30);
+    expect(engine.config.maxBufferSize).toBe(60_000_000);
+  });
+
+  it('applies preload to native element immediately when target exists', () => {
+    const { host, video } = setup();
+    host.target = video;
+    host.preload = 'auto';
+
+    expect(video.preload).toBe('auto');
+  });
+
+  it('cleans up on MEDIA_DETACHED', () => {
+    const { engine, host, video } = setup();
+    host.preload = 'metadata';
+
+    host.target = video;
+    (engine as any).emit(HlsJs.Events.MEDIA_ATTACHED);
+
+    (engine.startLoad as ReturnType<typeof vi.fn>).mockClear();
+
+    (engine as any).emit(HlsJs.Events.MEDIA_DETACHED);
+
+    video.dispatchEvent(new Event('play'));
+    expect(engine.startLoad).not.toHaveBeenCalled();
+  });
+
+  it('removes the preload layer on destroy', () => {
+    const { host, video, destroy } = setup();
+    host.target = video;
+    host.preload = 'auto';
+    expect(host.preload).toBe('auto');
+
+    destroy();
+
+    // After destroy, host.preload falls through to native element default
+    expect(host.preload).toBe(video.preload);
+  });
+});

--- a/packages/core/src/dom/media/hls-js/tests/preload.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/preload.test.ts
@@ -43,10 +43,11 @@ class HlsHost extends HTMLVideoElementHost<HlsJs> {
 
 function setup(engine: HlsJs = createEngine()) {
   const host = new HlsHost(engine);
-  const destroy = hlsJsPreload().install(host);
+  const extension = hlsJsPreload();
+  extension.install(host);
   const video = document.createElement('video');
   document.body.appendChild(video);
-  return { engine, host, video, destroy };
+  return { engine, host, video, extension };
 }
 
 describe('hlsJsPreload', () => {
@@ -146,12 +147,12 @@ describe('hlsJsPreload', () => {
   });
 
   it('removes the preload layer on destroy', () => {
-    const { host, video, destroy } = setup();
+    const { host, video, extension } = setup();
     host.target = video;
     host.preload = 'auto';
     expect(host.preload).toBe('auto');
 
-    destroy();
+    extension.destroy();
 
     // After destroy, host.preload falls through to native element default
     expect(host.preload).toBe(video.preload);

--- a/packages/core/src/dom/media/hls-js/tests/preload.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/preload.test.ts
@@ -30,7 +30,7 @@ function createEngine(): HlsJs {
   } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost {
+class HlsHost extends HTMLVideoElementHost<HlsJs> {
   #engine: HlsJs | null;
   constructor(engine: HlsJs | null) {
     super();

--- a/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
@@ -24,7 +24,7 @@ function createEngine(): HlsJs {
   } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost {
+class HlsHost extends HTMLVideoElementHost<HlsJs> {
   #engine: HlsJs;
   constructor(engine: HlsJs) {
     super();

--- a/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
@@ -24,7 +24,7 @@ function createEngine(): HlsJs {
   } as unknown as HlsJs;
 }
 
-class HlsHost extends HTMLVideoElementHost<HlsJs> {
+class HlsHost extends HTMLVideoElementHost {
   #engine: HlsJs;
   constructor(engine: HlsJs) {
     super();

--- a/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
@@ -1,0 +1,139 @@
+import HlsJs from 'hls.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MediaStreamTypes } from '../../../../core/media/types';
+import { HTMLVideoElementHost } from '../../html-video-element-host';
+import { hlsJsStreamType } from '../stream-type';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function createEngine(): HlsJs {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  return {
+    on(event: string, fn: (...args: any[]) => void) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(fn);
+    },
+    off(event: string, fn: (...args: any[]) => void) {
+      listeners.get(event)?.delete(fn);
+    },
+    emit(event: string, ...args: any[]) {
+      for (const fn of listeners.get(event) ?? []) fn(event, ...args);
+    },
+  } as unknown as HlsJs;
+}
+
+class HlsHost extends HTMLVideoElementHost<HlsJs> {
+  #engine: HlsJs;
+  constructor(engine: HlsJs) {
+    super();
+    this.#engine = engine;
+  }
+  override get engine() {
+    return this.#engine;
+  }
+}
+
+function setup() {
+  const engine = createEngine();
+  const host = new HlsHost(engine);
+  const destroy = hlsJsStreamType().install(host);
+  return { engine, host, destroy };
+}
+
+describe('hlsJsStreamType', () => {
+  it('starts as unknown', () => {
+    const { host } = setup();
+    expect(host.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+
+  it('detects live from a LEVEL_LOADED event with live details', () => {
+    const { engine, host } = setup();
+    const handler = vi.fn();
+    host.addEventListener('streamtypechange', handler);
+
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: true } });
+
+    expect(host.streamType).toBe(MediaStreamTypes.LIVE);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('detects on-demand from a LEVEL_LOADED event without live details', () => {
+    const { engine, host } = setup();
+    const handler = vi.fn();
+    host.addEventListener('streamtypechange', handler);
+
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: false } });
+
+    expect(host.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('dedupes streamtypechange when the detected value does not change', () => {
+    const { engine, host } = setup();
+    const handler = vi.fn();
+    host.addEventListener('streamtypechange', handler);
+
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: true } });
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: true } });
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('resets to unknown on MANIFEST_LOADING', () => {
+    const { engine, host } = setup();
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: true } });
+    expect(host.streamType).toBe(MediaStreamTypes.LIVE);
+
+    (engine as any).emit(HlsJs.Events.MANIFEST_LOADING);
+    expect(host.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+
+  it('resets to unknown on DESTROYING', () => {
+    const { engine, host } = setup();
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: false } });
+    expect(host.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+
+    (engine as any).emit(HlsJs.Events.DESTROYING);
+    expect(host.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+
+  it('lets user-set values win over auto-detection', () => {
+    const { engine, host } = setup();
+    const handler = vi.fn();
+    host.addEventListener('streamtypechange', handler);
+
+    host.streamType = MediaStreamTypes.LIVE;
+    expect(host.streamType).toBe(MediaStreamTypes.LIVE);
+    expect(handler).toHaveBeenCalledOnce();
+
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: false } });
+    expect(host.streamType).toBe(MediaStreamTypes.LIVE);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('clears the user override when set back to unknown', () => {
+    const { engine, host } = setup();
+    host.streamType = MediaStreamTypes.LIVE;
+
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: false } });
+    expect(host.streamType).toBe(MediaStreamTypes.LIVE);
+
+    host.streamType = MediaStreamTypes.UNKNOWN;
+    expect(host.streamType).toBe(MediaStreamTypes.UNKNOWN);
+
+    (engine as any).emit(HlsJs.Events.LEVEL_LOADED, { details: { live: false } });
+    expect(host.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+  });
+
+  it('removes the layer on destroy', () => {
+    const { host, destroy } = setup();
+    host.streamType = MediaStreamTypes.LIVE;
+    expect(host.streamType).toBe(MediaStreamTypes.LIVE);
+
+    destroy();
+
+    expect(host.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+});

--- a/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
+++ b/packages/core/src/dom/media/hls-js/tests/stream-type.test.ts
@@ -38,8 +38,9 @@ class HlsHost extends HTMLVideoElementHost<HlsJs> {
 function setup() {
   const engine = createEngine();
   const host = new HlsHost(engine);
-  const destroy = hlsJsStreamType().install(host);
-  return { engine, host, destroy };
+  const extension = hlsJsStreamType();
+  extension.install(host);
+  return { engine, host, extension };
 }
 
 describe('hlsJsStreamType', () => {
@@ -128,11 +129,11 @@ describe('hlsJsStreamType', () => {
   });
 
   it('removes the layer on destroy', () => {
-    const { host, destroy } = setup();
+    const { host, extension } = setup();
     host.streamType = MediaStreamTypes.LIVE;
     expect(host.streamType).toBe(MediaStreamTypes.LIVE);
 
-    destroy();
+    extension.destroy();
 
     expect(host.streamType).toBe(MediaStreamTypes.UNKNOWN);
   });

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -34,7 +34,7 @@ export const hlsMediaDefaultProps: HlsMediaProps = {
 const M3U8_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 const MP4_CONTENT_TYPE = 'video/mp4';
 
-export class HlsMedia extends HTMLVideoElementHost<HlsJs> implements HlsMediaProps {
+export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #delegate: HlsJsMedia | NativeHlsMedia | null = null;
   #pendingLoad: Promise<void> | null = null;
   #prevEngineKey: EngineKey | null = null;

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -1,14 +1,16 @@
 import { shallowEqual } from '@videojs/utils/object';
 import HlsJs from 'hls.js';
+import { MediaTracksMixin } from '../../../core/media/media-tracks';
 import { type MediaPreloadType, type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { bridgeEvents } from '../../../core/utils/bridge-events';
 import { type HlsJsConfig, HlsJsMedia } from '../hls-js';
 import { HTMLVideoElementHost } from '../html-video-element-host';
 import { NativeHlsMedia } from '../native-hls';
 
-interface EngineKey {
-  engine: 'mse' | 'native';
-  hlsJs: Partial<HlsJsConfig> | undefined;
+export interface HlsMediaProps {
+  src: string;
+  preload: MediaPreloadType;
+  config: HlsMediaConfig;
 }
 
 export interface HlsMediaConfig {
@@ -19,10 +21,9 @@ export interface HlsMediaConfig {
   [key: string]: unknown;
 }
 
-export interface HlsMediaProps {
-  src: string;
-  preload: MediaPreloadType;
-  config: HlsMediaConfig;
+interface EngineKey {
+  engine: 'mse' | 'native';
+  hlsJs: Partial<HlsJsConfig> | undefined;
 }
 
 export const hlsMediaDefaultProps: HlsMediaProps = {
@@ -34,7 +35,8 @@ export const hlsMediaDefaultProps: HlsMediaProps = {
 const M3U8_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 const MP4_CONTENT_TYPE = 'video/mp4';
 
-export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
+const HlsMediaBase = MediaTracksMixin(HTMLVideoElementHost<HlsJs>);
+export class HlsMedia extends HlsMediaBase implements HlsMediaProps {
   #delegate: HlsJsMedia | NativeHlsMedia | null = null;
   #pendingLoad: Promise<void> | null = null;
   #prevEngineKey: EngineKey | null = null;
@@ -55,7 +57,7 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   override get engine() {
-    return this.#delegate?.engine ?? null;
+    return this.#delegate instanceof HlsJsMedia ? this.#delegate.engine : null;
   }
 
   get config() {
@@ -111,6 +113,22 @@ export class HlsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   override get error() {
     return this.#delegate?.error ?? null;
+  }
+
+  override get videoTracks() {
+    return this.#delegate?.videoTracks ?? super.videoTracks;
+  }
+
+  override get audioTracks() {
+    return this.#delegate?.audioTracks ?? super.audioTracks;
+  }
+
+  override get videoRenditions() {
+    return this.#delegate?.videoRenditions ?? super.videoRenditions;
+  }
+
+  override get audioRenditions() {
+    return this.#delegate?.audioRenditions ?? super.audioRenditions;
   }
 
   load() {

--- a/packages/core/src/dom/media/hls/index.ts
+++ b/packages/core/src/dom/media/hls/index.ts
@@ -1,6 +1,5 @@
 import { shallowEqual } from '@videojs/utils/object';
 import HlsJs from 'hls.js';
-import { MediaTracksMixin } from '../../../core/media/media-tracks';
 import { type MediaPreloadType, type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { bridgeEvents } from '../../../core/utils/bridge-events';
 import { type HlsJsConfig, HlsJsMedia } from '../hls-js';
@@ -35,8 +34,7 @@ export const hlsMediaDefaultProps: HlsMediaProps = {
 const M3U8_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 const MP4_CONTENT_TYPE = 'video/mp4';
 
-const HlsMediaBase = MediaTracksMixin(HTMLVideoElementHost<HlsJs>);
-export class HlsMedia extends HlsMediaBase implements HlsMediaProps {
+export class HlsMedia extends HTMLVideoElementHost<HlsJs> implements HlsMediaProps {
   #delegate: HlsJsMedia | NativeHlsMedia | null = null;
   #pendingLoad: Promise<void> | null = null;
   #prevEngineKey: EngineKey | null = null;

--- a/packages/core/src/dom/media/html-media-element-layer.ts
+++ b/packages/core/src/dom/media/html-media-element-layer.ts
@@ -22,9 +22,7 @@ export abstract class HTMLMediaElementLayer<
   Engine = unknown,
   Events extends { [K in keyof Events]: EventLike } = VideoEvents,
   Next extends Video<Engine> = Video<Engine>,
-> extends MediaLayer<Next, Events>
-  implements Video<Engine>
-{
+> extends MediaLayer<Next, Events> {
   querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
   querySelector<E extends Element = Element>(selectors: string): E | null;
   querySelector(selectors: string): Element | null {

--- a/packages/core/src/dom/media/html-media-element-layer.ts
+++ b/packages/core/src/dom/media/html-media-element-layer.ts
@@ -21,8 +21,10 @@ export abstract class HTMLMediaElementLayer<
   Target extends HTMLMediaElement = HTMLMediaElement,
   Engine = unknown,
   Events extends { [K in keyof Events]: EventLike } = VideoEvents,
-  Next extends Video = Video,
-> extends MediaLayer<Next, Events> {
+  Next extends Video<Engine> = Video<Engine>,
+> extends MediaLayer<Next, Events>
+  implements Video<Engine>
+{
   querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
   querySelector<E extends Element = Element>(selectors: string): E | null;
   querySelector(selectors: string): Element | null {

--- a/packages/core/src/dom/media/html-media-element-layer.ts
+++ b/packages/core/src/dom/media/html-media-element-layer.ts
@@ -1,14 +1,20 @@
 import { MediaLayer } from '../../core/media/media-layer';
 import type {
+  AudioRenditionListLike,
+  AudioTrackLike,
+  AudioTrackListLike,
   CanPlayTypeResult,
   EventLike,
   TextTrackKind,
   TextTrackLike,
   Video,
   VideoEvents,
+  VideoRenditionListLike,
+  VideoTrackLike,
+  VideoTrackListLike,
 } from '../../core/media/types';
 import { MediaStreamTypes } from '../../core/media/types';
-import { EMPTY_CONFIG, EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants';
+import { EMPTY_CONFIG, EMPTY_MEDIA_LIST, EMPTY_REMOTE, EMPTY_TIME_RANGES } from './constants';
 
 export abstract class HTMLMediaElementLayer<
   Target extends HTMLMediaElement = HTMLMediaElement,
@@ -60,6 +66,40 @@ export abstract class HTMLMediaElementLayer<
 
   get targetLiveWindow() {
     return this.next?.targetLiveWindow ?? Number.NaN;
+  }
+
+  get videoTracks() {
+    return this.next?.videoTracks ?? (EMPTY_MEDIA_LIST as unknown as VideoTrackListLike);
+  }
+
+  get audioTracks() {
+    return this.next?.audioTracks ?? (EMPTY_MEDIA_LIST as unknown as AudioTrackListLike);
+  }
+
+  get videoRenditions() {
+    return this.next?.videoRenditions ?? (EMPTY_MEDIA_LIST as unknown as VideoRenditionListLike);
+  }
+
+  get audioRenditions() {
+    return this.next?.audioRenditions ?? (EMPTY_MEDIA_LIST as unknown as AudioRenditionListLike);
+  }
+
+  addVideoTrack(kind: string, label?: string, language?: string) {
+    if (!this.next) throw new Error('[vjs] Cannot add video track without a media target.');
+    return this.next.addVideoTrack(kind, label, language);
+  }
+
+  removeVideoTrack(track: VideoTrackLike) {
+    this.next?.removeVideoTrack(track);
+  }
+
+  addAudioTrack(kind: string, label?: string, language?: string) {
+    if (!this.next) throw new Error('[vjs] Cannot add audio track without a media target.');
+    return this.next.addAudioTrack(kind, label, language);
+  }
+
+  removeAudioTrack(track: AudioTrackLike) {
+    this.next?.removeAudioTrack(track);
   }
 
   // -- Playback --
@@ -209,7 +249,7 @@ export abstract class HTMLMediaElementLayer<
   // -- Text tracks --
 
   get textTracks() {
-    return this.next?.textTracks ?? EMPTY_TEXT_TRACKS;
+    return this.next?.textTracks ?? (EMPTY_MEDIA_LIST as unknown as TextTrackListLike);
   }
 
   addTextTrack(kind: TextTrackKind, label?: string, language?: string) {

--- a/packages/core/src/dom/media/html-media-element-layer.ts
+++ b/packages/core/src/dom/media/html-media-element-layer.ts
@@ -7,6 +7,7 @@ import type {
   EventLike,
   TextTrackKind,
   TextTrackLike,
+  TextTrackListLike,
   Video,
   VideoEvents,
   VideoRenditionListLike,

--- a/packages/core/src/dom/media/html-video-element-layer.ts
+++ b/packages/core/src/dom/media/html-video-element-layer.ts
@@ -7,7 +7,7 @@ export abstract class HTMLVideoElementLayer<
   Target extends HTMLVideoElement = HTMLVideoElement,
   Engine = unknown,
   Events extends { [K in keyof Events]: EventLike } = VideoEvents,
-  Next extends Video = Video,
+  Next extends Video<Engine> = Video<Engine>,
 > extends HTMLMediaElementLayer<Target, Engine, Events, Next> {
   // -- Video --
 

--- a/packages/core/src/dom/media/media-tracks-layer.ts
+++ b/packages/core/src/dom/media/media-tracks-layer.ts
@@ -1,0 +1,16 @@
+import { MediaTracksMixin } from '../../core/media/media-tracks';
+import { HTMLMediaElementLayer } from './html-media-element-layer';
+
+// Empty subclass so the mixin has a fresh prototype to install onto —
+// applying the mixin directly to `HTMLMediaElementLayer` no-ops because
+// its prototype already owns `addAudioTrack`/`videoTracks`/etc.
+class MediaTracksLayerBase extends HTMLMediaElementLayer {}
+
+/**
+ * `HTMLMediaElementLayer` with the media-tracks mixin pre-applied. Push into
+ * a media chain via `addLayer(host, new MediaTracksLayer())` so the layer
+ * owns the `audioTracks`, `videoTracks`, and rendition lists the host's
+ * delegating getters then walk into.
+ */
+export const MediaTracksLayer = MediaTracksMixin(MediaTracksLayerBase);
+export type MediaTracksLayer = InstanceType<typeof MediaTracksLayer>;

--- a/packages/core/src/dom/media/mux/mux-data.ts
+++ b/packages/core/src/dom/media/mux/mux-data.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../node_modules/mux-embed/dist/types/mux-embed.d.ts" preserve="true" />
 
-import Hls from 'hls.js';
+import HlsJs from 'hls.js';
 import Mux, { type Options as MuxDataOptions, type Mux as MuxDataSdk } from 'mux-embed';
 import { installExtension, type MediaExtension } from '../../../core/media/media-extension';
 import { addLayer } from '../../../core/media/media-layer';
@@ -99,7 +99,7 @@ class MuxData implements MuxDataProps, MediaExtension {
       ...(this.beaconCollectionDomain ? { beaconCollectionDomain: this.beaconCollectionDomain } : {}),
       ...(this.disableCookies ? { disableCookies: this.disableCookies } : {}),
       ...(hlsjs ? { hlsjs } : {}),
-      Hls,
+      Hls: HlsJs,
       data: {
         ...(this.envKey ? { env_key: this.envKey } : {}),
         // Some Mux Data integrations key off `player_software_name` and others off `player_software`;

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -1,6 +1,7 @@
-import { MediaTracksMixin } from '../../../core/media/media-tracks';
+import { addLayer } from '../../../core/media/media-layer';
 import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { HTMLVideoElementHost } from '../html-video-element-host';
+import { MediaTracksLayer } from '../media-tracks-layer';
 import { nativeHlsErrors } from './errors';
 import { nativeHlsLive } from './live';
 import { nativeHlsStreamType } from './stream-type';
@@ -22,13 +23,14 @@ export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {
   streamType: MediaStreamTypes.UNKNOWN,
 };
 
-const NativeHlsMediaBase = MediaTracksMixin(HTMLVideoElementHost);
-export class NativeHlsMedia extends NativeHlsMediaBase implements NativeHlsMediaProps {
+export class NativeHlsMedia extends HTMLVideoElementHost implements NativeHlsMediaProps {
   #src = nativeHlsMediaDefaultProps.src;
   #preload = nativeHlsMediaDefaultProps.preload;
 
   constructor() {
     super();
+    addLayer(this, new MediaTracksLayer());
+
     nativeHlsErrors().install(this);
     nativeHlsStreamType().install(this);
     nativeHlsLive().install(this);

--- a/packages/core/src/dom/media/native-hls/index.ts
+++ b/packages/core/src/dom/media/native-hls/index.ts
@@ -1,3 +1,4 @@
+import { MediaTracksMixin } from '../../../core/media/media-tracks';
 import { type MediaStreamType, MediaStreamTypes } from '../../../core/media/types';
 import { HTMLVideoElementHost } from '../html-video-element-host';
 import { nativeHlsErrors } from './errors';
@@ -21,7 +22,8 @@ export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {
   streamType: MediaStreamTypes.UNKNOWN,
 };
 
-export class NativeHlsMedia extends HTMLVideoElementHost implements NativeHlsMediaProps {
+const NativeHlsMediaBase = MediaTracksMixin(HTMLVideoElementHost);
+export class NativeHlsMedia extends NativeHlsMediaBase implements NativeHlsMediaProps {
   #src = nativeHlsMediaDefaultProps.src;
   #preload = nativeHlsMediaDefaultProps.preload;
 

--- a/packages/core/src/dom/media/tests/media-tracks-layer.test.ts
+++ b/packages/core/src/dom/media/tests/media-tracks-layer.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { addLayer } from '../../../core/media/media-layer';
+import { HTMLVideoElementHost } from '../html-video-element-host';
+import { MediaTracksLayer } from '../media-tracks-layer';
+
+describe('MediaTracksLayer', () => {
+  it('routes host track authoring through the installed layer', () => {
+    const host = new HTMLVideoElementHost();
+    addLayer(host, new MediaTracksLayer());
+
+    const track = host.addAudioTrack('main', 'English', 'en');
+
+    expect(host.audioTracks.length).toBe(1);
+    expect(host.audioTracks[0]).toBe(track);
+    expect([...host.audioTracks]).toEqual([track]);
+  });
+});

--- a/packages/core/src/dom/media/tests/media-tracks-mixin.test.ts
+++ b/packages/core/src/dom/media/tests/media-tracks-mixin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { MediaTracksMixin } from '../../../core/media/media-tracks';
+import { HTMLVideoElementHost } from '../html-video-element-host';
+
+describe('MediaTracksMixin', () => {
+  it('overrides inherited layer authoring methods with track-list backed methods', () => {
+    const MixedHost = MediaTracksMixin(HTMLVideoElementHost);
+    const media = new MixedHost();
+
+    const track = media.addAudioTrack('main', 'English', 'en');
+
+    expect(media.audioTracks.length).toBe(1);
+    expect(media.audioTracks[0]).toBe(track);
+    expect([...media.audioTracks]).toEqual([track]);
+  });
+});


### PR DESCRIPTION
Fix #1261
Fix #1262
Fix #1563

## Summary

Add core media track and rendition primitives so media extensions can expose audio/video track state through the media layer. This keeps HLS.js track integration typed against core contracts and lets HLS, native HLS, DASH, Cast, and Mux data hosts share the updated media host generics.

## Changes

- Add core media track/rendition list implementations and media-facing capability types.
- Add an HLS.js media track extension that populates audio/video tracks and renditions from engine events.
- Thread engine generics through HTML media hosts/layers and clean up extension media aliases so event maps no longer need explicit `any`.

## Testing

- `pnpm typecheck`

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches playback quality selection (ABR levels and alternate audio) and a large new event-driven API on the media chain; risk is mitigated by tests but behavior changes affect all HLS/MSE paths.
> 
> **Overview**
> Introduces **audio/video track and rendition** APIs on the core media model (track lists, rendition lists, `addtrack`/`change` events, and a `MediaTracksMixin` that can replace or bridge native `HTMLMediaElement` track getters for MSE/manifest-driven use cases).
> 
> **HLS.js** gains a `hlsJsMediaTracks` extension that mirrors manifest levels and alternate audio into `videoRenditions` / `audioTracks`, and wires user selection back to `engine.nextLevel` and `engine.audioTrack`. **Hls** and **native HLS** hosts install a `MediaTracksLayer` and delegate track/rendition getters to the active engine delegate.
> 
> `MediaFull` / HTML media layers are extended so hosts and layers expose the same track surface; empty lists use a shared `EMPTY_MEDIA_LIST` stub. Adds unit tests for the mixin, layer routing, and several HLS.js extensions (including large live/preload/stream-type suites). Minor typing cleanups (engine generics on layers, Cast subtitle filter, Mux `HlsJs` export).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57cf7714deb4c9b1dd86187f8a711d8cdd86d79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->