### PR TITLE
fix(site): cache shiki highlighters during dev HMR

### DIFF
--- a/site/src/components/Code/clientHighlighter.ts
+++ b/site/src/components/Code/clientHighlighter.ts
@@ -3,7 +3,7 @@ import css from 'shiki/langs/css.mjs';
 import html from 'shiki/langs/html.mjs';
 import javascript from 'shiki/langs/javascript.mjs';
 import tsx from 'shiki/langs/tsx.mjs';
-import createHighlighter from './createHighlighter';
+import createHighlighter, { getOrCreateCachedHighlighter } from './createHighlighter';
 
 // Eager module-level Promise — deliberately NOT a top-level `await`.
 //
@@ -15,7 +15,9 @@ import createHighlighter from './createHighlighter';
 // avoiding the bug. The Promise starts resolving at import time, giving
 // it a head start before `client:idle` hydration kicks in.
 // ClientCode.tsx consumes this via React 19's `use()` hook + Suspense.
-const highlighterPromise = createHighlighter({ langs: [bash, html, tsx, css, javascript] });
+const highlighterPromise = getOrCreateCachedHighlighter('client', () =>
+  createHighlighter({ langs: [bash, html, tsx, css, javascript] })
+);
 
 export function getClientHighlighter() {
   return highlighterPromise;

--- a/site/src/components/Code/createHighlighter.ts
+++ b/site/src/components/Code/createHighlighter.ts
@@ -1,6 +1,33 @@
-import { createHighlighter as libCreateHighlighter } from 'shiki';
+import { type Highlighter, createHighlighter as libCreateHighlighter } from 'shiki';
 import gruvboxDarkHard from 'shiki/themes/gruvbox-dark-hard.mjs';
 import gruvboxDarkSoft from 'shiki/themes/gruvbox-dark-soft.mjs';
+
+const SHIKI_CACHE_SYMBOL = Symbol.for('@videojs/site/shiki');
+
+type ShikiCacheKey = 'server' | 'client';
+
+interface ShikiGlobalCache {
+  server?: Promise<Highlighter>;
+  client?: Promise<Highlighter>;
+}
+
+function getShikiGlobalCache(): ShikiGlobalCache {
+  const global = globalThis as typeof globalThis & {
+    [SHIKI_CACHE_SYMBOL]?: ShikiGlobalCache;
+  };
+  global[SHIKI_CACHE_SYMBOL] ??= {};
+  return global[SHIKI_CACHE_SYMBOL];
+}
+
+/** Reuse one highlighter per role across HMR module re-evaluations in dev. */
+export function getOrCreateCachedHighlighter(
+  key: ShikiCacheKey,
+  factory: () => Promise<Highlighter>
+): Promise<Highlighter> {
+  const cache = getShikiGlobalCache();
+  cache[key] ??= factory();
+  return cache[key];
+}
 
 export default function createHighlighter(config: Omit<Parameters<typeof libCreateHighlighter>[0], 'themes'>) {
   return libCreateHighlighter({

--- a/site/src/components/Code/serverHighlighter.ts
+++ b/site/src/components/Code/serverHighlighter.ts
@@ -4,15 +4,17 @@ import html from 'shiki/langs/html.mjs';
 import javascript from 'shiki/langs/javascript.mjs';
 import tsx from 'shiki/langs/tsx.mjs';
 import ts from 'shiki/langs/typescript.mjs';
-import createHighlighter from './createHighlighter';
+import createHighlighter, { getOrCreateCachedHighlighter } from './createHighlighter';
 
 // The highlighter is a long-lived singleton at module scope; it is never
 // disposed, so every grammar and theme we hand it stays in memory for the
 // process lifetime. Only pre-load the languages `<ServerCode>` actually
 // renders — adding `bundledLanguages` here would drag ~300 grammars into the
 // build and dominate first-render cost on code-heavy pages.
-const serverHighlighter = await createHighlighter({
-  langs: [bash, css, html, javascript, ts, tsx],
-});
+const serverHighlighter = await getOrCreateCachedHighlighter('server', () =>
+  createHighlighter({
+    langs: [bash, css, html, javascript, ts, tsx],
+  })
+);
 
 export default serverHighlighter;


### PR DESCRIPTION
## Why

I was noticing a lot of logs in the console during dev builds such as:
```
site:dev: [Shiki] 17650 instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call `highlighter.dispose()` to release unused instances.
```

## Summary

- cache server and client Shiki highlighter instances on `globalThis` using a shared symbol key
- route `serverHighlighter` and `clientHighlighter` creation through the cache to avoid repeated instances during dev HMR
- keep existing language/theme configuration unchanged while reducing Shiki instance churn in `site:dev`

## Test plan
- [x] `pnpm lint:fix:file site/src/components/Code/createHighlighter.ts site/src/components/Code/serverHighlighter.ts site/src/components/Code/clientHighlighter.ts`
- [x] `pnpm -C site astro check`
- [ ] run `pnpm dev:site` and verify the Shiki singleton warning no longer grows during normal edits/HMR

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only singleton caching for syntax highlighting; no auth, data, or production behavior changes beyond reusing the same highlighter instances.
> 
> **Overview**
> Adds a **`globalThis`** cache (via `Symbol.for`) so server and client Shiki highlighter **Promises** are created once per role and reused when dev HMR re-runs `clientHighlighter.ts` / `serverHighlighter.ts`, instead of spinning up new Shiki instances on every hot reload.
> 
> `createHighlighter.ts` now exports **`getOrCreateCachedHighlighter`**, and both entry modules route their existing `createHighlighter` configs through **`'server'`** and **`'client'`** keys. Language lists, themes, and the client’s non–top-level-`await` Promise pattern are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1aef406de74d8193dad8e7f355918cbe9d2781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->