### PR TITLE
feat(core): add vimeo media layer and html/react components

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -12,4 +12,5 @@ export const PRESETS = [
   'dash-video',
   'audio',
   'background-video',
+  'vimeo-video',
 ] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -67,6 +67,8 @@ export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';
 
 export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4';
 
+export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return (SOURCES[id] as { live?: boolean }).live === true;

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -18,6 +18,7 @@ import { Preview } from './preview';
 function getPagePath(platform: Platform, preset: Preset): string {
   if (platform === 'cdn') return '/cdn/';
   if (preset === 'background-video') return `/${platform}-background-video/`;
+  if (preset === 'vimeo-video') return `/${platform}-vimeo-video/`;
   return `/${platform}-${preset}/`;
 }
 
@@ -113,9 +114,9 @@ export function App() {
     }
   }, [preset, source, setSource]);
 
-  // CDN and background video do not have a Tailwind skin variant.
+  // CDN, background video, and vimeo video do not have a Tailwind skin variant.
   useEffect(() => {
-    if ((platform === 'cdn' || preset === 'background-video') && styling === 'tailwind') {
+    if ((platform === 'cdn' || preset === 'background-video' || preset === 'vimeo-video') && styling === 'tailwind') {
       setStyling('css');
     }
   }, [platform, preset, styling]);
@@ -151,6 +152,7 @@ export function App() {
         isSimpleHls={preset.startsWith('simple-hls-')}
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}
+        isVimeoVideo={preset === 'vimeo-video'}
         platforms={PLATFORMS}
         stylings={STYLINGS}
         presets={PRESETS}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -28,6 +28,7 @@ type NavbarProps = {
   isSimpleHls: boolean;
   isMuxVideo: boolean;
   isMuxAudio: boolean;
+  isVimeoVideo: boolean;
   platforms: readonly Platform[];
   stylings: readonly Styling[];
   presets: readonly Preset[];
@@ -53,6 +54,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'dash-video': 'DASH Video',
   audio: 'Audio',
   'background-video': 'Background Video',
+  'vimeo-video': 'Vimeo Video',
 };
 
 export function Navbar({
@@ -79,6 +81,7 @@ export function Navbar({
   isSimpleHls,
   isMuxVideo,
   isMuxAudio,
+  isVimeoVideo,
   platforms,
   stylings,
   presets,
@@ -107,7 +110,7 @@ export function Navbar({
           options={stylings.map((s) => ({
             value: s,
             label: s === 'css' ? 'CSS' : 'Tailwind',
-            disabled: s === 'tailwind' && (isBackgroundVideo || platform === 'cdn'),
+            disabled: s === 'tailwind' && (isBackgroundVideo || isVimeoVideo || platform === 'cdn'),
           }))}
         />
 
@@ -137,7 +140,7 @@ export function Navbar({
               return true;
             })
             .map((id) => ({ value: id, label: sources[id].label }))}
-          disabled={isBackgroundVideo}
+          disabled={isBackgroundVideo || isVimeoVideo}
         />
       </div>
 

--- a/apps/sandbox/templates/html-vimeo-video/index.html
+++ b/apps/sandbox/templates/html-vimeo-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Vimeo Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans p-2">
+    <div id="root" class="flex justify-center items-center min-h-screen"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-vimeo-video/main.ts
+++ b/apps/sandbox/templates/html-vimeo-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/vimeo-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { VIMEO_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <vimeo-video class="block w-full h-full" src="${VIMEO_VIDEO_SRC}" playsinline></vimeo-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-vimeo-video/index.html
+++ b/apps/sandbox/templates/react-vimeo-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Vimeo Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans p-2">
+    <div id="root" class="flex justify-center items-center min-h-screen"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-vimeo-video/main.tsx
+++ b/apps/sandbox/templates/react-vimeo-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoProvider } from '@app/shared/react/providers';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { VIMEO_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { VimeoVideo } from '@videojs/react/media/vimeo-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoProvider>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <VimeoVideo className="block w-full h-full" src={VIMEO_VIDEO_SRC} playsInline />
+      </VideoSkinComponent>
+    </VideoProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "@videojs/spf": "workspace:*",
     "@videojs/store": "workspace:*",
     "@videojs/utils": "workspace:*",
+    "@vimeo/player": "^2.30.3",
     "dashjs": "^5.0.0",
     "hls.js": "^1.6.7",
     "mux-embed": "^5.17.10"

--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -23,7 +23,7 @@ export const VideoCSSVars = {
 export const AudioCSSVars = {} as const;
 
 /** Helper function to generate the HTML template for video elements. */
-function getVideoTemplateHTML(attrs: Record<string, string>): string {
+export function getVideoTemplateHTML(attrs: Record<string, string>): string {
   return /*html*/ `
     <style>
       :host {
@@ -95,10 +95,21 @@ type CustomMediaConstructor<T extends Constructor<MediaHost>> = Constructor<HTML
   readonly observedAttributes: string[];
 };
 
+/** Apply a property value that may have been set before custom element upgrade. */
+export function upgradeProperty(element: HTMLElement, prop: string): void {
+  const self = element as unknown as Record<string, unknown>;
+  // biome-ignore lint/suspicious/noPrototypeBuiltins: see comment above
+  if (!Object.prototype.hasOwnProperty.call(self, prop)) return;
+  const value = self[prop];
+  delete self[prop];
+  self[prop] = value;
+}
+
 export function CustomMediaElement<T extends Constructor<MediaHost>>(
   tag: string,
   MediaHost: T
 ): CustomMediaConstructor<T> {
+  const syncTargetAttributes = tag !== 'iframe';
   const mediaHostAttrToProp = new Map<string, string>();
   let isDefined = false;
 
@@ -159,11 +170,11 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
 
           if (typeof descriptor.value === 'function') {
             config.value = function (this: CustomMedia, ...args: any[]) {
-              return this.#mediaHost[prop](...args);
+              return this.#mediaHost?.[prop](...args);
             };
           } else if (descriptor.get) {
             config.get = function (this: CustomMedia) {
-              return this.#mediaHost[prop];
+              return this.#mediaHost?.[prop];
             };
 
             if (descriptor.set) {
@@ -180,7 +191,7 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
                 };
               } else {
                 config.set = function (this: CustomMedia, val: any) {
-                  this.#mediaHost[prop] = val;
+                  if (this.#mediaHost) this.#mediaHost[prop] = val;
                 };
               }
             }
@@ -211,7 +222,7 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       }
     }
 
-    #mediaHost: MediaHost;
+    #mediaHost: MediaHost | null = null;
     #bridgedEventTypes = new Set<string>();
     #childMap = new Map<HTMLTrackElement | HTMLSourceElement, HTMLTrackElement | HTMLSourceElement>();
     #childObserver?: MutationObserver;
@@ -225,15 +236,15 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
 
         const allowedKeys = getAttrsFromProps(ctor.properties);
         const disallowedKeys = [...mediaHostAttrToProp.keys()];
-        const attrs: Record<string, string> = omit(
-          pick(namedNodeMapToObject(this.attributes), allowedKeys),
-          disallowedKeys
-        );
+        const pickedAttrs = pick(namedNodeMapToObject(this.attributes), allowedKeys);
+        // Embed templates (iframe) need host-bound attrs (e.g. `src`) to build the initial URL.
+        const attrs: Record<string, string> = tag === 'iframe' ? pickedAttrs : omit(pickedAttrs, disallowedKeys);
         if (tag && !attrs.part) attrs.part = tag;
         this.shadowRoot!.innerHTML = ctor.getTemplateHTML(attrs);
       }
 
-      this.#mediaHost = new MediaHost();
+      this.#createMediaHost();
+      if (tag === 'iframe') this.#syncMediaHostFromAttributes();
       this.#attachToTarget();
 
       this.#childObserver = new MutationObserver(this.#syncMediaChildAttribute.bind(this));
@@ -245,13 +256,29 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       this.#syncMediaChildren();
     }
 
+    connectedCallback(): void {
+      this.#createMediaHost();
+      this.#hydrateIframeConfig();
+      if (tag === 'iframe') this.#syncMediaHostFromAttributes();
+      this.#attachToTarget();
+      this.#syncMediaChildren();
+    }
+
+    #createMediaHost(): void {
+      if (this.#mediaHost) return;
+      this.#mediaHost = new MediaHost();
+      for (const type of this.#bridgedEventTypes) {
+        this.#mediaHost.addEventListener(type, this.#bridgeEvent);
+      }
+    }
+
     #attachToTarget(): void {
       const target = this.target;
-      if (target === this.#mediaHost.target) return;
+      if (!this.#mediaHost || target === this.#mediaHost.target) return;
       this.#mediaHost.target = target;
     }
 
-    get target(): HTMLVideoElement | HTMLAudioElement | null {
+    get target(): HTMLElement | null {
       return (
         this.querySelector(':scope > [slot=media]') ??
         this.querySelector(tag) ??
@@ -261,8 +288,12 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
     }
 
     disconnectedCallback(): void {
-      if (!this.hasAttribute('keep-alive')) {
+      if (!this.hasAttribute('keep-alive') && this.#mediaHost) {
+        for (const type of this.#bridgedEventTypes) {
+          this.#mediaHost.removeEventListener(type, this.#bridgeEvent);
+        }
         this.#mediaHost.destroy();
+        this.#mediaHost = null;
       }
     }
 
@@ -274,7 +305,8 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       super.addEventListener(type, listener as EventListener, options);
       if (!this.#bridgedEventTypes.has(type)) {
         this.#bridgedEventTypes.add(type);
-        this.#mediaHost.addEventListener(type, this.#bridgeEvent);
+        this.#createMediaHost();
+        this.#mediaHost!.addEventListener(type, this.#bridgeEvent);
       }
     }
 
@@ -295,16 +327,9 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
     attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null): void {
       const prop = mediaHostAttrToProp.get(attrName);
       if (prop) {
+        if (!this.#mediaHost) return;
         if (oldValue !== newValue) {
-          const valueType = typeof this.#mediaHost[prop];
-          const propConfig = (this.constructor as CustomMediaConstructor<T>).properties[prop];
-          const emptyValue = propConfig && 'empty' in propConfig ? propConfig.empty : '';
-          this.#mediaHost[prop] =
-            valueType === 'boolean'
-              ? newValue !== null
-              : valueType === 'number'
-                ? Number(newValue)
-                : (newValue ?? emptyValue);
+          this.#syncMediaHostFromAttributes();
         }
         return;
       }
@@ -316,6 +341,8 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
         return;
       }
 
+      if (!syncTargetAttributes) return;
+
       if (newValue === null) {
         this.target?.removeAttribute(attrName);
       } else if (this.target?.getAttribute(attrName) !== newValue) {
@@ -323,7 +350,44 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       }
     }
 
+    #hydrateIframeConfig(): void {
+      if (tag !== 'iframe' || !this.#mediaHost) return;
+      const iframe = this.target as HTMLIFrameElement | null;
+      if (!iframe?.dataset.config) return;
+
+      const hostConfig = this.#mediaHost.config;
+      if (hostConfig && typeof hostConfig === 'object' && Object.keys(hostConfig).length > 0) return;
+      try {
+        this.#mediaHost.config = JSON.parse(iframe.dataset.config);
+      } catch {
+        // ignore — invalid JSON.
+      }
+    }
+
+    #syncMediaHostFromAttributes(): void {
+      if (!this.#mediaHost) return;
+
+      const ctor = this.constructor as typeof CustomMedia;
+      for (const attrName of ctor.observedAttributes) {
+        const prop = mediaHostAttrToProp.get(attrName);
+        if (!prop) continue;
+        const newValue = this.getAttribute(attrName);
+        const valueType = typeof this.#mediaHost[prop];
+        const propConfig = (this.constructor as CustomMediaConstructor<T>).properties[prop];
+        const emptyValue = propConfig && 'empty' in propConfig ? propConfig.empty : '';
+
+        this.#mediaHost[prop] =
+          valueType === 'boolean'
+            ? newValue !== null
+            : valueType === 'number'
+              ? Number(newValue)
+              : (newValue ?? emptyValue);
+      }
+    }
+
     #syncMediaChildren(): void {
+      if (tag === 'iframe') return;
+
       const defaultSlot = this.shadowRoot?.querySelector('slot:not([name])') as HTMLSlotElement;
       const mediaChildren = new Set(
         defaultSlot

--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -329,7 +329,7 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       if (prop) {
         if (!this.#mediaHost) return;
         if (oldValue !== newValue) {
-          this.#syncMediaHostFromAttributes();
+          this.#syncMediaHostAttribute(attrName);
         }
         return;
       }
@@ -365,24 +365,29 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
     }
 
     #syncMediaHostFromAttributes(): void {
-      if (!this.#mediaHost) return;
-
       const ctor = this.constructor as typeof CustomMedia;
       for (const attrName of ctor.observedAttributes) {
-        const prop = mediaHostAttrToProp.get(attrName);
-        if (!prop) continue;
-        const newValue = this.getAttribute(attrName);
-        const valueType = typeof this.#mediaHost[prop];
-        const propConfig = (this.constructor as CustomMediaConstructor<T>).properties[prop];
-        const emptyValue = propConfig && 'empty' in propConfig ? propConfig.empty : '';
-
-        this.#mediaHost[prop] =
-          valueType === 'boolean'
-            ? newValue !== null
-            : valueType === 'number'
-              ? Number(newValue)
-              : (newValue ?? emptyValue);
+        this.#syncMediaHostAttribute(attrName);
       }
+    }
+
+    #syncMediaHostAttribute(attrName: string): void {
+      if (!this.#mediaHost) return;
+
+      const prop = mediaHostAttrToProp.get(attrName);
+      if (!prop) return;
+
+      const newValue = this.getAttribute(attrName);
+      const valueType = typeof this.#mediaHost[prop];
+      const propConfig = (this.constructor as CustomMediaConstructor<T>).properties[prop];
+      const emptyValue = propConfig && 'empty' in propConfig ? propConfig.empty : '';
+
+      this.#mediaHost[prop] =
+        valueType === 'boolean'
+          ? newValue !== null
+          : valueType === 'number'
+            ? Number(newValue)
+            : (newValue ?? emptyValue);
     }
 
     #syncMediaChildren(): void {

--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -111,6 +111,8 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
 ): CustomMediaConstructor<T> {
   const syncTargetAttributes = tag !== 'iframe';
   const mediaHostAttrToProp = new Map<string, string>();
+  const mediaHostPropToAttr = new Map<string, string>();
+  const mediaHostPropsToUpgrade = new Set<string>();
   let isDefined = false;
 
   class CustomMedia extends (globalThis.HTMLElement ?? class {}) {
@@ -178,9 +180,12 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
             };
 
             if (descriptor.set) {
+              mediaHostPropsToUpgrade.add(prop);
+
               const attr = kebabCase(prop);
               if (ctor.observedAttributes.includes(attr)) {
                 mediaHostAttrToProp.set(attr, prop);
+                mediaHostPropToAttr.set(prop, attr);
 
                 config.set = function (this: CustomMedia, val: any) {
                   if (val === true || val === false || val == null) {
@@ -244,6 +249,7 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       }
 
       this.#createMediaHost();
+      this.#upgradeMediaHostProperties();
       if (tag === 'iframe') this.#syncMediaHostFromAttributes();
       this.#attachToTarget();
 
@@ -269,6 +275,18 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       this.#mediaHost = new MediaHost();
       for (const type of this.#bridgedEventTypes) {
         this.#mediaHost.addEventListener(type, this.#bridgeEvent);
+      }
+    }
+
+    #upgradeMediaHostProperties(): void {
+      for (const prop of mediaHostPropsToUpgrade) {
+        const hadOwnProperty = Object.hasOwn(this, prop);
+        upgradeProperty(this, prop);
+
+        if (hadOwnProperty) {
+          const attr = mediaHostPropToAttr.get(prop);
+          if (attr) this.#syncMediaHostAttribute(attr);
+        }
       }
     }
 

--- a/packages/core/src/dom/media/custom-media-element/tests/custom-media-element.test.ts
+++ b/packages/core/src/dom/media/custom-media-element/tests/custom-media-element.test.ts
@@ -726,6 +726,34 @@ describe('CustomMediaElement', () => {
       expect(el.debug).toBe(true);
       expect(el.hasAttribute('debug')).toBe(false);
     });
+
+    it('upgrades pre-defined MediaHost properties when the custom element is defined', () => {
+      const tag = `test-video-${++tagCounter}`;
+      const Ctor = CustomMediaElement('video', TestVideoHostWithObjects);
+      const config = { startLevel: 3, maxBufferLength: 60 };
+      const el = document.createElement(tag) as InstanceType<typeof Ctor> & { config: typeof config };
+
+      el.config = config;
+      document.body.appendChild(el);
+      customElements.define(tag, Ctor);
+
+      expect(el.config).toBe(config);
+      expect(Object.hasOwn(el, 'config')).toBe(false);
+    });
+
+    it('upgrades pre-defined attribute-backed MediaHost properties when the custom element is defined', () => {
+      const tag = `test-video-${++tagCounter}`;
+      const Ctor = CustomMediaElement('video', TestVideoHost);
+      const el = document.createElement(tag) as InstanceType<typeof Ctor>;
+
+      el.src = 'video.mp4';
+      document.body.appendChild(el);
+      customElements.define(tag, Ctor);
+
+      expect(el.src).toBe('video.mp4');
+      expect(el.getAttribute('src')).toBe('video.mp4');
+      expect(Object.hasOwn(el, 'src')).toBe(false);
+    });
   });
 
   describe('property setters set attribute and delegate to MediaHost', () => {

--- a/packages/core/src/dom/media/custom-media-element/tests/custom-media-element.test.ts
+++ b/packages/core/src/dom/media/custom-media-element/tests/custom-media-element.test.ts
@@ -659,18 +659,47 @@ describe('CustomMediaElement', () => {
 
   describe('disconnectedCallback', () => {
     it('calls destroy on the MediaHost when disconnected', () => {
+      const destroySpy = vi.spyOn(TestVideoHost.prototype, 'destroy');
       const el = create(defineVideoElement());
-      expect(el.destroyed).toBe(false);
 
       el.remove();
-      expect(el.destroyed).toBe(true);
+
+      expect(destroySpy).toHaveBeenCalledOnce();
+      destroySpy.mockRestore();
     });
 
     it('does not destroy when keep-alive attribute is set', () => {
+      const destroySpy = vi.spyOn(TestVideoHost.prototype, 'destroy');
       const el = create(defineVideoElement());
       el.setAttribute('keep-alive', '');
 
       el.remove();
+
+      expect(destroySpy).not.toHaveBeenCalled();
+      destroySpy.mockRestore();
+    });
+
+    it('recreates MediaHost when reconnected after disconnect', () => {
+      let hostCount = 0;
+      class ReconnectVideoHost extends TestVideoHost {
+        constructor() {
+          super();
+          hostCount++;
+        }
+      }
+
+      const tag = `test-video-${++tagCounter}`;
+      const Ctor = CustomMediaElement('video', ReconnectVideoHost);
+      customElements.define(tag, Ctor);
+
+      const el = document.createElement(tag) as InstanceType<typeof Ctor> & { destroyed: boolean };
+      document.body.appendChild(el);
+      expect(hostCount).toBe(1);
+
+      el.remove();
+
+      document.body.appendChild(el);
+      expect(hostCount).toBe(2);
       expect(el.destroyed).toBe(false);
     });
   });

--- a/packages/core/src/dom/media/media-played-ranges/index.ts
+++ b/packages/core/src/dom/media/media-played-ranges/index.ts
@@ -5,7 +5,7 @@
 // License: MIT
 
 import { isNumber } from '@videojs/utils/predicate';
-import { defineExtension } from '../../../core/media/media-extension';
+import { installExtension, type MediaExtension } from '../../../core/media/media-extension';
 import { addLayer, MediaLayer } from '../../../core/media/media-layer';
 import type { TimeRangeLike } from '../../../core/media/types';
 
@@ -31,27 +31,40 @@ export type MediaPlayedRangesMedia = MediaLayer & {
  *
  * @example mediaPlayedRanges().install(media);
  */
-export class MediaPlayedRanges {
+export class MediaPlayedRanges implements MediaExtension {
+  #destroy: (() => void) | null = null;
+
   readonly name = 'media-played-ranges';
 
-  install(media: MediaPlayedRangesMedia, { signal }: { signal: AbortSignal }) {
+  install(media: MediaPlayedRangesMedia) {
+    const uninstall = installExtension(mediaPlayedRanges, media, this);
     const layer = new MediaPlayedRangesLayer();
     const removeLayer = addLayer(media, layer);
+    const abort = new AbortController();
 
-    const options = { signal };
+    const options = { signal: abort.signal };
     media.addEventListener('play', () => layer.onPlaybackStart({ time: media.currentTime }), options);
     media.addEventListener('pause', () => layer.onPlaybackStop({ time: media.currentTime }), options);
     media.addEventListener('ended', () => layer.onPlaybackStop({ time: media.currentTime }), options);
     media.addEventListener('seeking', () => layer.onSeeking(), options);
     media.addEventListener('seeked', () => layer.onSeeked({ time: media.currentTime }), options);
 
-    return removeLayer;
+    this.#destroy = () => {
+      uninstall();
+      abort.abort();
+      removeLayer();
+    };
+  }
+
+  destroy() {
+    this.#destroy?.();
+    this.#destroy = null;
   }
 }
 
-export const mediaPlayedRanges = defineExtension<void, MediaPlayedRangesMedia, MediaPlayedRanges>(
-  () => new MediaPlayedRanges()
-);
+export function mediaPlayedRanges() {
+  return new MediaPlayedRanges();
+}
 
 class MediaPlayedRangesLayer extends MediaLayer {
   #playedRanges: PlayedRange[] = [];

--- a/packages/core/src/dom/media/media-played-ranges/index.ts
+++ b/packages/core/src/dom/media/media-played-ranges/index.ts
@@ -1,0 +1,141 @@
+// Copy of `media-played-ranges-mixin@0.1.0` from `muxinc/media-elements`,
+// ported to TypeScript and adapted to fit the v10 codebase.
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { isNumber } from '@videojs/utils/predicate';
+import { defineExtension } from '../../../core/media/media-extension';
+import { addLayer, MediaLayer } from '../../../core/media/media-layer';
+import type { TimeRangeLike } from '../../../core/media/types';
+
+export interface PlayedRange {
+  start: number;
+  end: number;
+}
+
+export interface PlaybackEventParam {
+  time?: number;
+}
+
+export type MediaPlayedRangesMedia = MediaLayer & {
+  currentTime: number;
+  paused: boolean;
+};
+
+/**
+ * Tracks played ranges for media hosts lacking a native
+ * `HTMLMediaElement.played` (e.g. iframe-based embeds like Vimeo). Listens
+ * for standard media events on the host and exposes a `TimeRanges`-like
+ * `played` getter via a {@link MediaLayer}.
+ *
+ * @example mediaPlayedRanges().install(media);
+ */
+export class MediaPlayedRanges {
+  readonly name = 'media-played-ranges';
+
+  install(media: MediaPlayedRangesMedia, { signal }: { signal: AbortSignal }) {
+    const layer = new MediaPlayedRangesLayer();
+    const removeLayer = addLayer(media, layer);
+
+    const options = { signal };
+    media.addEventListener('play', () => layer.onPlaybackStart({ time: media.currentTime }), options);
+    media.addEventListener('pause', () => layer.onPlaybackStop({ time: media.currentTime }), options);
+    media.addEventListener('ended', () => layer.onPlaybackStop({ time: media.currentTime }), options);
+    media.addEventListener('seeking', () => layer.onSeeking(), options);
+    media.addEventListener('seeked', () => layer.onSeeked({ time: media.currentTime }), options);
+
+    return removeLayer;
+  }
+}
+
+export const mediaPlayedRanges = defineExtension<void, MediaPlayedRangesMedia, MediaPlayedRanges>(
+  () => new MediaPlayedRanges()
+);
+
+class MediaPlayedRangesLayer extends MediaLayer {
+  #playedRanges: PlayedRange[] = [];
+  #currentPlayedRange: PlayedRange | null = null;
+  #rangeEpsilon = 0.5;
+
+  onPlaybackStart(param: PlaybackEventParam = {}): void {
+    const host = this.root as MediaPlayedRangesMedia;
+    const t = isNumber(param.time) ? param.time : host.currentTime;
+    if (!this.#currentPlayedRange) {
+      this.#currentPlayedRange = { start: t, end: t };
+    }
+  }
+
+  onSeeking(): void {
+    this.#commitCurrentRange();
+  }
+
+  onSeeked(param: PlaybackEventParam = {}): void {
+    const host = this.root as MediaPlayedRangesMedia;
+    const t = isNumber(param.time) ? param.time : host.currentTime;
+    this.#currentPlayedRange = { start: t, end: t };
+  }
+
+  onPlaybackStop(param: PlaybackEventParam = {}): void {
+    const host = this.root as MediaPlayedRangesMedia;
+    const t = isNumber(param.time) ? param.time : host.currentTime;
+    this.#commitCurrentRange(t);
+  }
+
+  #commitCurrentRange(time?: number): void {
+    if (!this.#currentPlayedRange) return;
+    if (isNumber(time)) {
+      this.#currentPlayedRange.end = time;
+    }
+    const { start, end } = this.#currentPlayedRange;
+    this.#currentPlayedRange = null;
+    this.#addPlayedRange(start, end);
+  }
+
+  #addPlayedRange(start: number, end: number): void {
+    if (start >= end) return;
+    const allRanges: PlayedRange[] = [...this.#playedRanges, { start, end }];
+    allRanges.sort((a, b) => a.start - b.start);
+    const merged: PlayedRange[] = [];
+    for (const range of allRanges) {
+      const last = merged.length ? merged[merged.length - 1] : null;
+      if (!last) {
+        merged.push({ ...range });
+        continue;
+      }
+      if (range.start <= last.end + this.#rangeEpsilon) {
+        last.start = Math.min(last.start, range.start);
+        last.end = Math.max(last.end, range.end);
+      } else {
+        merged.push({ ...range });
+      }
+    }
+    this.#playedRanges = merged;
+  }
+
+  get played(): TimeRangeLike {
+    const host = this.root as MediaPlayedRangesMedia;
+    const time = host.currentTime;
+    if (!host.paused && !this.#currentPlayedRange && isNumber(time)) {
+      this.#currentPlayedRange = { start: time, end: time };
+    }
+    if (this.#currentPlayedRange && isNumber(time)) {
+      if (time > this.#currentPlayedRange.end) {
+        this.#currentPlayedRange.end = time;
+      }
+      this.#addPlayedRange(this.#currentPlayedRange.start, this.#currentPlayedRange.end);
+    }
+    if (!this.#playedRanges.length) {
+      return createTimeRanges([[0, 0]]);
+    }
+    return createTimeRanges(this.#playedRanges.map((r) => [r.start, r.end]));
+  }
+}
+
+function createTimeRanges(ranges: number[][]): TimeRangeLike {
+  Object.defineProperties(ranges, {
+    start: { value: (i: number) => ranges[i]?.[0] ?? 0 },
+    end: { value: (i: number) => ranges[i]?.[1] ?? 0 },
+  });
+  return ranges as unknown as TimeRangeLike;
+}

--- a/packages/core/src/dom/media/media-played-ranges/tests/index.test.ts
+++ b/packages/core/src/dom/media/media-played-ranges/tests/index.test.ts
@@ -9,10 +9,18 @@ class FakeMedia extends MediaLayer {
   paused = true;
 
   get played(): TimeRangeLike {
-    return this.next?.played ?? EMPTY_TIME_RANGES;
+    return (this.next as { played?: TimeRangeLike } | null)?.played ?? EMPTY_TIME_RANGES;
   }
 
-  play(time: number): void {
+  async play(): Promise<void> {
+    this.simulatePlay(this.currentTime);
+  }
+
+  pause(): void {
+    this.simulatePause(this.currentTime);
+  }
+
+  simulatePlay(time: number): void {
     this.paused = false;
     this.currentTime = time;
     this.dispatchEvent(new Event('play'));
@@ -22,7 +30,7 @@ class FakeMedia extends MediaLayer {
     this.currentTime = time;
   }
 
-  pause(time: number): void {
+  simulatePause(time: number): void {
     this.currentTime = time;
     this.paused = true;
     this.dispatchEvent(new Event('pause'));
@@ -57,9 +65,9 @@ describe('mediaPlayedRanges', () => {
 
   it('tracks a contiguous play segment', () => {
     const media = createTrackedMedia();
-    media.play(0);
+    media.simulatePlay(0);
     media.tick(5);
-    media.pause(5);
+    media.simulatePause(5);
 
     const played = media.played;
     expect(played.length).toBe(1);
@@ -69,10 +77,10 @@ describe('mediaPlayedRanges', () => {
 
   it('merges adjacent ranges within the epsilon tolerance', () => {
     const media = createTrackedMedia();
-    media.play(0);
-    media.pause(5);
-    media.play(5.2);
-    media.pause(8);
+    media.simulatePlay(0);
+    media.simulatePause(5);
+    media.simulatePlay(5.2);
+    media.simulatePause(8);
 
     const played = media.played;
     expect(played.length).toBe(1);
@@ -81,11 +89,11 @@ describe('mediaPlayedRanges', () => {
 
   it('keeps non-adjacent ranges separate', () => {
     const media = createTrackedMedia();
-    media.play(0);
-    media.pause(2);
+    media.simulatePlay(0);
+    media.simulatePause(2);
     media.seek(20);
-    media.play(20);
-    media.pause(25);
+    media.simulatePlay(20);
+    media.simulatePause(25);
 
     const played = media.played;
     expect(played.length).toBe(2);
@@ -97,7 +105,7 @@ describe('mediaPlayedRanges', () => {
 
   it('commits a range on ended', () => {
     const media = createTrackedMedia();
-    media.play(0);
+    media.simulatePlay(0);
     media.tick(10);
     media.end(10);
     expect(media.played.end(0)).toBe(10);

--- a/packages/core/src/dom/media/media-played-ranges/tests/index.test.ts
+++ b/packages/core/src/dom/media/media-played-ranges/tests/index.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { MediaLayer } from '../../../../core/media/media-layer';
+import type { TimeRangeLike } from '../../../../core/media/types';
+import { EMPTY_TIME_RANGES } from '../../constants';
+import { mediaPlayedRanges } from '..';
+
+class FakeMedia extends MediaLayer {
+  currentTime = 0;
+  paused = true;
+
+  get played(): TimeRangeLike {
+    return this.next?.played ?? EMPTY_TIME_RANGES;
+  }
+
+  play(time: number): void {
+    this.paused = false;
+    this.currentTime = time;
+    this.dispatchEvent(new Event('play'));
+  }
+
+  tick(time: number): void {
+    this.currentTime = time;
+  }
+
+  pause(time: number): void {
+    this.currentTime = time;
+    this.paused = true;
+    this.dispatchEvent(new Event('pause'));
+  }
+
+  seek(target: number): void {
+    this.dispatchEvent(new Event('seeking'));
+    this.currentTime = target;
+    this.dispatchEvent(new Event('seeked'));
+  }
+
+  end(time: number): void {
+    this.currentTime = time;
+    this.paused = true;
+    this.dispatchEvent(new Event('ended'));
+  }
+}
+
+function createTrackedMedia() {
+  const media = new FakeMedia();
+  mediaPlayedRanges().install(media);
+  return media;
+}
+
+describe('mediaPlayedRanges', () => {
+  it('starts with a single empty range', () => {
+    const media = createTrackedMedia();
+    expect(media.played.length).toBe(1);
+    expect(media.played.start(0)).toBe(0);
+    expect(media.played.end(0)).toBe(0);
+  });
+
+  it('tracks a contiguous play segment', () => {
+    const media = createTrackedMedia();
+    media.play(0);
+    media.tick(5);
+    media.pause(5);
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(5);
+  });
+
+  it('merges adjacent ranges within the epsilon tolerance', () => {
+    const media = createTrackedMedia();
+    media.play(0);
+    media.pause(5);
+    media.play(5.2);
+    media.pause(8);
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.end(0)).toBe(8);
+  });
+
+  it('keeps non-adjacent ranges separate', () => {
+    const media = createTrackedMedia();
+    media.play(0);
+    media.pause(2);
+    media.seek(20);
+    media.play(20);
+    media.pause(25);
+
+    const played = media.played;
+    expect(played.length).toBe(2);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(2);
+    expect(played.start(1)).toBe(20);
+    expect(played.end(1)).toBe(25);
+  });
+
+  it('commits a range on ended', () => {
+    const media = createTrackedMedia();
+    media.play(0);
+    media.tick(10);
+    media.end(10);
+    expect(media.played.end(0)).toBe(10);
+  });
+});

--- a/packages/core/src/dom/media/vimeo/index.ts
+++ b/packages/core/src/dom/media/vimeo/index.ts
@@ -1,0 +1,830 @@
+import { isNull, isString, isUndefined } from '@videojs/utils/predicate';
+import VimeoPlayer, { type LoadVideoOptions, type VimeoEmbedParameters, type VimeoUrl } from '@vimeo/player';
+import { MediaLayer } from '../../../core/media/media-layer';
+import type { ErrorLike, TextTrackKind, TextTrackListLike, Video } from '../../../core/media/types';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../constants';
+import { type MediaPlayedRangesMedia, mediaPlayedRanges } from '../media-played-ranges';
+
+export type { default as VimeoPlayerApi } from '@vimeo/player';
+
+// ----------------------------------------------------------------------------
+// Types
+// ----------------------------------------------------------------------------
+
+export type VimeoPreload = 'none' | 'metadata' | 'auto';
+
+/** Public Vimeo embed configuration. Forwarded to `@vimeo/player`. */
+export type VimeoConfig = VimeoEmbedParameters;
+
+/** Parsed pieces of a Vimeo source URL. */
+export interface VimeoSource {
+  /** Numeric Vimeo id. */
+  id: number;
+  /** `'video'` for regular clips, `'event'` for live events. */
+  kind: 'video' | 'event';
+  /** Unlisted-video / event hash (the `h` parameter). */
+  hash: string | null;
+}
+
+export interface VimeoMediaProps {
+  /** Vimeo video id, vimeo.com URL, or player.vimeo.com embed URL. */
+  src: string;
+  autoplay: boolean;
+  /** Reflects the `muted` attribute (initial state). Use `muted` for runtime mute. */
+  defaultMuted: boolean;
+  loop: boolean;
+  controls: boolean;
+  playsInline: boolean;
+  preload: VimeoPreload;
+  poster: string;
+  /**
+   * Arbitrary extra `@vimeo/player` embed parameters merged into the iframe
+   * URL. Use this for Vimeo-specific knobs that aren't on the standard media
+   * surface — e.g. `autopause`, `byline`, `dnt`, `quality`, `texttrack`.
+   */
+  config: VimeoConfig;
+}
+
+export const vimeoMediaDefaultProps: VimeoMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  config: {},
+};
+
+/** {@link Video} surface for Vimeo — omits APIs with no meaningful embed behavior. */
+export type VimeoVideoSurface = Omit<
+  Video,
+  | 'crossOrigin'
+  | 'defaultPlaybackRate'
+  | 'addTextTrack'
+  | 'canPlayType'
+  | 'streamType'
+  | 'liveEdgeStart'
+  | 'targetLiveWindow'
+  | 'poster'
+  | 'remote'
+  | 'disableRemotePlayback'
+>;
+
+// ----------------------------------------------------------------------------
+// VimeoMedia
+// ----------------------------------------------------------------------------
+
+/**
+ * Media host for Vimeo embeds. Wraps an `<iframe>` and implements
+ * {@link VimeoVideoSurface} against the underlying `@vimeo/player` instance,
+ * with played-range tracking via {@link mediaPlayedRanges}. Embed-only props
+ * (`autoplay`, `config`, …) live on the class but outside {@link Video}.
+ *
+ * Vimeo is a leaf layer: it has no `next` and drives state via the JS Player
+ * API rather than the chain's terminal `<video>` target. The `target` here is
+ * an `<iframe>` which doesn't satisfy the `Media` contract, so the overrides
+ * below silence the variance mismatch with `MediaLayer.target`.
+ */
+export class VimeoMedia extends MediaLayer<VimeoVideoSurface> implements VimeoVideoSurface {
+  #target: HTMLIFrameElement | null = null;
+  #player: VimeoPlayer | null = null;
+  #loadComplete = createPublicPromise<void>();
+
+  #src = vimeoMediaDefaultProps.src;
+  #autoplay = vimeoMediaDefaultProps.autoplay;
+  #defaultMuted = vimeoMediaDefaultProps.defaultMuted;
+  #loop = vimeoMediaDefaultProps.loop;
+  #controls = vimeoMediaDefaultProps.controls;
+  #playsInline = vimeoMediaDefaultProps.playsInline;
+  #preload = vimeoMediaDefaultProps.preload;
+  #config = vimeoMediaDefaultProps.config;
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #volume = 1;
+  #muted = false;
+  #playbackRate = 1;
+  #progress = 0;
+  #videoWidth = Number.NaN;
+  #videoHeight = Number.NaN;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: ErrorLike | null = null;
+  #isFullscreen = false;
+  #isPictureInPicture = false;
+  #disablePictureInPicture = false;
+
+  #textTracksHost: HTMLVideoElement | null = null;
+  #textTracksDisconnect: AbortController | null = null;
+
+  static PLAYER_SOFTWARE_NAME = 'vimeo-video';
+
+  constructor() {
+    super();
+    mediaPlayedRanges().install(this as MediaPlayedRangesMedia);
+  }
+
+  // -- Engine + target --
+
+  /** Underlying `@vimeo/player` instance (null before attach). */
+  get engine() {
+    return this.#player;
+  }
+
+  /** Iframe element this media is bound to. */
+  // @ts-expect-error — see class-level note on the leaf-layer variance gap.
+  override get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /**
+   * Bind (or unbind with `null`) the iframe that hosts the Vimeo embed.
+   * Creates a `@vimeo/player` instance on bind, destroys it on unbind, and
+   * dispatches `loadstart`.
+   */
+  // @ts-expect-error — see class-level note on the leaf-layer variance gap.
+  override set target(target: HTMLIFrameElement | null) {
+    if (this.#target === target) return;
+
+    // Tear down before rebinding — `super.target = …` isn't called because
+    // Vimeo is a leaf layer and the iframe isn't a media-event source.
+    if (this.#target) {
+      this.#teardownTextTracks();
+      this.#player?.destroy().catch(() => {});
+      this.#player = null;
+      this.#target = null;
+      this.#resetState();
+    }
+
+    if (!target) return;
+
+    this.#target = target;
+
+    if (!target.src) {
+      const initialSrc = buildVimeoIframeSrc(this.#src, this.#snapshotProps());
+      if (initialSrc) target.src = initialSrc;
+    }
+
+    this.#loadComplete = createPublicPromise<void>();
+    this.#player = new VimeoPlayer(target);
+    this.#bindPlayerEvents(this.#player);
+    this.#setupTextTracks(this.#player);
+
+    this.dispatchEvent(new Event('loadstart'));
+  }
+
+  destroy() {
+    this.target = null;
+  }
+
+  // -- Source --
+
+  get src() {
+    return this.#src;
+  }
+
+  set src(value) {
+    if (this.#src === value) return;
+    this.#src = value;
+    void this.load();
+  }
+
+  get currentSrc() {
+    return this.#target?.src ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /**
+   * Force a reload of the current source. Calls Vimeo's `loadVideo` API if
+   * the player is connected; otherwise a no-op until `target` is bound.
+   */
+  async load() {
+    if (!this.#player || !this.#src) return;
+
+    this.#resetState();
+    this.#loadComplete = createPublicPromise<void>();
+    this.dispatchEvent(new Event('emptied'));
+    this.dispatchEvent(new Event('loadstart'));
+
+    const loadOptions = toLoadVideoOptions(this.#src, this.#config);
+    if (!loadOptions) return;
+
+    // Vimeo dispatches an `error` event separately on failure.
+    await this.#player.loadVideo(loadOptions).catch(() => {});
+  }
+
+  // -- Playback --
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    await this.#loadComplete;
+    await this.#player?.play();
+  }
+
+  pause() {
+    void this.#player?.pause().catch(() => {});
+  }
+
+  // -- Time --
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#currentTime = value;
+    this.#afterLoad((p) => p.setCurrentTime(value));
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  // -- Volume --
+
+  get volume() {
+    return this.#volume;
+  }
+
+  set volume(value) {
+    if (this.#volume === value) return;
+    this.#volume = value;
+    this.#afterLoad((p) => p.setVolume(value));
+  }
+
+  get muted() {
+    return this.#muted;
+  }
+
+  set muted(value) {
+    if (this.#muted === value) return;
+    this.#muted = value;
+    this.#afterLoad((p) => p.setMuted(value));
+  }
+
+  // -- Playback rate --
+
+  get playbackRate() {
+    return this.#playbackRate;
+  }
+
+  set playbackRate(value) {
+    if (this.#playbackRate === value) return;
+    this.#playbackRate = value;
+    this.#afterLoad((p) => p.setPlaybackRate(value));
+  }
+
+  // -- Playback options --
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+
+  set autoplay(value) {
+    this.#autoplay = value;
+  }
+
+  get defaultMuted() {
+    return this.#defaultMuted;
+  }
+
+  set defaultMuted(value) {
+    this.#defaultMuted = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+
+  set loop(value) {
+    this.#loop = value;
+    this.#afterLoad((p) => p.setLoop(value));
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+
+  set controls(value) {
+    this.#controls = value;
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+
+  set playsInline(value) {
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+
+  set preload(value) {
+    this.#preload = value;
+  }
+
+  get config() {
+    return this.#config as Record<string, unknown>;
+  }
+
+  set config(value) {
+    this.#config = value as VimeoConfig;
+  }
+
+  // -- Buffer --
+
+  get buffered() {
+    return this.#progress > 0 ? createTimeRanges(0, this.#progress) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRanges(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get played() {
+    return this.next?.played ?? EMPTY_TIME_RANGES;
+  }
+
+  // -- Error --
+
+  get error() {
+    return this.#error;
+  }
+
+  // -- Text tracks --
+
+  get textTracks() {
+    if (!this.#textTracksHost) {
+      this.#textTracksHost = globalThis.document?.createElement('video') ?? null;
+    }
+    return (this.#textTracksHost?.textTracks as TextTrackListLike) ?? EMPTY_TEXT_TRACKS;
+  }
+
+  // -- Dimensions --
+
+  get width() {
+    return this.#target?.clientWidth ?? 0;
+  }
+
+  set width(_value) {
+    // Layout-owned on the iframe host; no-op for embeds.
+  }
+
+  get height() {
+    return this.#target?.clientHeight ?? 0;
+  }
+
+  set height(_value) {
+    // Layout-owned on the iframe host; no-op for embeds.
+  }
+
+  get videoWidth() {
+    return this.#videoWidth;
+  }
+
+  get videoHeight() {
+    return this.#videoHeight;
+  }
+
+  // -- Fullscreen / Picture-in-Picture --
+
+  get isFullscreen() {
+    return this.#isFullscreen;
+  }
+
+  async requestFullscreen() {
+    await this.#loadComplete;
+    await this.#player?.requestFullscreen?.();
+    this.#isFullscreen = true;
+  }
+
+  async exitFullscreen() {
+    await this.#loadComplete;
+    await this.#player?.exitFullscreen?.();
+    this.#isFullscreen = false;
+  }
+
+  get isPictureInPicture() {
+    return this.#isPictureInPicture;
+  }
+
+  get disablePictureInPicture() {
+    return this.#disablePictureInPicture;
+  }
+
+  set disablePictureInPicture(value) {
+    this.#disablePictureInPicture = value;
+  }
+
+  async requestPictureInPicture() {
+    await this.#loadComplete;
+    try {
+      await this.#player?.requestPictureInPicture?.();
+      this.#isPictureInPicture = true;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async exitPictureInPicture() {
+    await this.#loadComplete;
+    try {
+      await this.#player?.exitPictureInPicture?.();
+      this.#isPictureInPicture = false;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  // -- Internals --
+
+  /** Defer a player call until `loadComplete` resolves, swallowing rejections. */
+  #afterLoad(fn: (player: VimeoPlayer) => Promise<unknown>) {
+    this.#loadComplete.then(
+      () => {
+        if (this.#player) fn(this.#player).catch(() => {});
+      },
+      () => {}
+    );
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      defaultMuted: this.#defaultMuted,
+      loop: this.#loop,
+      controls: this.#controls,
+      playsInline: this.#playsInline,
+      preload: (this.#preload || vimeoMediaDefaultProps.preload) as VimeoPreload,
+      config: this.#config,
+    };
+  }
+
+  #resetState() {
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    this.#muted = false;
+    this.#paused = !this.#autoplay;
+    this.#ended = false;
+    this.#playbackRate = 1;
+    this.#progress = 0;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#volume = 1;
+    this.#error = null;
+    this.#videoWidth = Number.NaN;
+    this.#videoHeight = Number.NaN;
+    this.#isFullscreen = false;
+    this.#isPictureInPicture = false;
+  }
+
+  async #onLoaded() {
+    this.#readyState = READY_STATE_HAVE_METADATA;
+
+    const player = this.#player;
+    if (player) {
+      // Pull initial state in parallel; each fall-back to the current value
+      // so a single failure doesn't clobber the others.
+      const [muted, volume, duration] = await Promise.all([
+        player.getMuted().catch(() => this.#muted),
+        player.getVolume().catch(() => this.#volume),
+        player.getDuration().catch(() => this.#duration),
+      ]);
+      this.#muted = muted;
+      this.#volume = volume;
+      this.#duration = duration;
+    }
+
+    this.dispatchEvent(new Event('loadedmetadata'));
+    this.dispatchEvent(new Event('durationchange'));
+    this.dispatchEvent(new Event('volumechange'));
+    this.#loadComplete.resolve();
+  }
+
+  #bindPlayerEvents(player: VimeoPlayer) {
+    player.on('loaded', () => this.#onLoaded());
+    player.on('bufferstart', () => this.dispatchEvent(new Event('waiting')));
+
+    player.on('play', () => {
+      this.#paused = false;
+      this.dispatchEvent(new Event('play'));
+    });
+
+    player.on('playing', () => {
+      this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+      this.#paused = false;
+      this.dispatchEvent(new Event('playing'));
+    });
+
+    player.on('seeking', () => {
+      this.#seeking = true;
+      this.dispatchEvent(new Event('seeking'));
+    });
+
+    player.on('seeked', () => {
+      this.#seeking = false;
+      this.dispatchEvent(new Event('seeked'));
+    });
+
+    player.on('pause', () => {
+      this.#paused = true;
+      this.dispatchEvent(new Event('pause'));
+    });
+
+    player.on('ended', () => {
+      this.#paused = true;
+      this.#ended = true;
+      this.dispatchEvent(new Event('ended'));
+    });
+
+    player.on('playbackratechange', ({ playbackRate }) => {
+      this.#playbackRate = playbackRate;
+      this.dispatchEvent(new Event('ratechange'));
+    });
+
+    player.on('volumechange', ({ volume }) => {
+      this.#volume = volume;
+      this.dispatchEvent(new Event('volumechange'));
+    });
+
+    player.on('durationchange', ({ duration }) => {
+      this.#duration = duration;
+      this.dispatchEvent(new Event('durationchange'));
+    });
+
+    player.on('timeupdate', ({ seconds, duration }) => {
+      this.#currentTime = seconds;
+      if (Number.isFinite(duration) && duration !== this.#duration) this.#duration = duration;
+      this.dispatchEvent(new Event('timeupdate'));
+    });
+
+    player.on('progress', ({ seconds }) => {
+      this.#progress = seconds;
+      this.dispatchEvent(new Event('progress'));
+    });
+
+    player.on('resize', ({ videoWidth, videoHeight }) => {
+      this.#videoWidth = videoWidth;
+      this.#videoHeight = videoHeight;
+      this.dispatchEvent(new Event('resize'));
+    });
+
+    player.on('error', () => {
+      this.#error = { code: 1, message: 'Vimeo playback error' };
+      this.dispatchEvent(new Event('error'));
+    });
+
+    player.on('fullscreenchange', ({ fullscreen }) => {
+      this.#isFullscreen = fullscreen;
+    });
+
+    player.on('enterpictureinpicture', () => {
+      this.#isPictureInPicture = true;
+      this.dispatchEvent(new Event('enterpictureinpicture'));
+    });
+
+    player.on('leavepictureinpicture', () => {
+      this.#isPictureInPicture = false;
+      this.dispatchEvent(new Event('leavepictureinpicture'));
+    });
+  }
+
+  #setupTextTracks(player: VimeoPlayer) {
+    const doc = globalThis.document;
+    if (isUndefined(doc)) return;
+
+    this.#teardownTextTracks();
+
+    const host = doc.createElement('video');
+    this.#textTracksHost = host;
+
+    player
+      .getTextTracks()
+      .then((tracks) => {
+        for (const track of tracks) {
+          if (!isString(track.kind) || isNull(track.kind)) continue;
+          try {
+            host.addTextTrack?.(track.kind as TextTrackKind, track.label ?? '', track.language ?? '');
+          } catch {
+            // jsdom or unsupported environments.
+          }
+        }
+      })
+      .catch(() => {});
+
+    this.#textTracksDisconnect = new AbortController();
+    host.textTracks?.addEventListener?.(
+      'change',
+      () => {
+        const showing = Array.from(host.textTracks).find((t) => t.mode === 'showing');
+        if (showing) player.enableTextTrack(showing.language, showing.kind).catch(() => {});
+        else player.disableTextTrack().catch(() => {});
+      },
+      { signal: this.#textTracksDisconnect.signal }
+    );
+  }
+
+  #teardownTextTracks() {
+    this.#textTracksDisconnect?.abort();
+    this.#textTracksDisconnect = null;
+    this.#textTracksHost = null;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Public utilities
+// ----------------------------------------------------------------------------
+
+/** Extract a Vimeo video id from a numeric id, vimeo.com URL, or player URL. */
+export function parseVimeoVideoId(src: string) {
+  return parseVimeoSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a Vimeo source string. Recognizes:
+ * - numeric ids (`'76979871'`),
+ * - `vimeo.com/<id>` and `vimeo.com/video/<id>` URLs,
+ * - `player.vimeo.com/video/<id>` URLs,
+ * - `vimeo.com/event/<id>` URLs (live events),
+ * - unlisted/event hash via `?h=` or `/<hash>` path segment.
+ */
+export function parseVimeoSource(src: string) {
+  if (!src) return null;
+
+  if (/^\d+$/.test(src)) {
+    return { id: Number(src), kind: 'video', hash: null };
+  }
+
+  const match = MATCH_SRC.exec(src);
+  if (!match) return null;
+
+  const kind = match[1] === 'event/' ? 'event' : 'video';
+  const id = Number(match[2]);
+  const pathHash = match[3] ?? null;
+
+  let queryHash: string | null = null;
+  try {
+    queryHash = new URL(src).searchParams.get('h');
+  } catch {
+    // src isn't a valid URL — ignore.
+  }
+
+  return { id, kind, hash: queryHash ?? pathHash };
+}
+
+/** Build the iframe `src` URL for an initial Vimeo embed from the given props. */
+export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps> = {}) {
+  const parsed = parseVimeoSource(src);
+  if (!parsed) return '';
+
+  const params: Record<string, unknown> = {
+    // Hide Vimeo chrome by default; pass nothing only when controls is explicitly true.
+    controls: props.controls === true ? null : 0,
+    autoplay: props.autoplay,
+    loop: props.loop,
+    muted: props.defaultMuted,
+    playsinline: props.playsInline ?? vimeoMediaDefaultProps.playsInline,
+    preload: props.preload ?? vimeoMediaDefaultProps.preload,
+    transparent: false,
+    h: parsed.hash,
+    // Vimeo-specific knobs (`autopause`, `byline`, `dnt`, …) flow through here.
+    ...(props.config ?? undefined),
+  };
+
+  if (parsed.kind === 'event') {
+    const hashPath = parsed.hash ? `/${parsed.hash}` : '';
+    delete params.h;
+    return `${EMBED_EVENT_BASE}/${parsed.id}/embed${hashPath}?${serialize(params)}`;
+  }
+
+  return `${EMBED_VIDEO_BASE}/${parsed.id}?${serialize(params)}`;
+}
+
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    playsInline: attrs.playsinline !== undefined,
+    preload: (attrs.preload as VimeoPreload | undefined) ?? vimeoMediaDefaultProps.preload,
+  };
+}
+
+function escapeHtml(str: string) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
+}
+
+/** Shadow DOM template for `<vimeo-video>` (iframe embed). */
+export function getVimeoIframeTemplateHTML(attrs: Record<string, string>) {
+  const initialSrc = buildVimeoIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+  const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+
+  return /*html*/ `
+<style>
+  :host {
+    display: inline-block;
+    min-width: 300px;
+    min-height: 150px;
+    position: relative;
+  }
+  iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+  :host(:not([controls])) {
+    pointer-events: none;
+  }
+</style>
+<iframe part="iframe" allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen frameborder="0" width="100%" height="100%"${srcAttr}></iframe>
+`;
+}
+
+// ----------------------------------------------------------------------------
+// Module internals
+// ----------------------------------------------------------------------------
+
+const EMBED_VIDEO_BASE = 'https://player.vimeo.com/video';
+const EMBED_EVENT_BASE = 'https://vimeo.com/event';
+const MATCH_SRC = /vimeo\.com\/(video\/|event\/)?(\d+)(?:\/([\w-]+))?/;
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_FUTURE_DATA = 3;
+
+function createTimeRanges(start: number, end: number) {
+  return {
+    length: 1,
+    start: () => start,
+    end: () => end,
+  };
+}
+
+function toLoadVideoOptions(src: string, config: VimeoConfig) {
+  const parsed = parseVimeoSource(src);
+  if (!parsed) return null;
+  const baseUrl = parsed.kind === 'event' ? EMBED_EVENT_BASE : EMBED_VIDEO_BASE;
+  const path = parsed.kind === 'event' ? `${baseUrl}/${parsed.id}/embed` : `${baseUrl}/${parsed.id}`;
+  const url = `${path}${parsed.hash ? `?h=${parsed.hash}` : ''}` as VimeoUrl;
+  return { url, ...config } as LoadVideoOptions;
+}
+
+function serialize(props: Record<string, unknown>) {
+  const params = new URLSearchParams();
+  for (const key in props) {
+    const val = props[key];
+    if (val === true || val === '') params.set(key, '1');
+    else if (val === false) params.set(key, '0');
+    else if (val != null) params.set(key, String(val));
+  }
+  return params.toString();
+}
+
+interface PublicPromise<T> extends Promise<T> {
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createPublicPromise<T>(): PublicPromise<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  }) as PublicPromise<T>;
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}

--- a/packages/core/src/dom/media/vimeo/index.ts
+++ b/packages/core/src/dom/media/vimeo/index.ts
@@ -521,6 +521,7 @@ export class VimeoMedia extends MediaLayer<VimeoVideoSurface> implements VimeoVi
     this.dispatchEvent(new Event('loadedmetadata'));
     this.dispatchEvent(new Event('durationchange'));
     this.dispatchEvent(new Event('volumechange'));
+    this.dispatchEvent(new Event('loadcomplete'));
     this.#loadComplete.resolve();
   }
 

--- a/packages/core/src/dom/media/vimeo/index.ts
+++ b/packages/core/src/dom/media/vimeo/index.ts
@@ -385,22 +385,6 @@ export class VimeoMedia extends MediaLayer<VimeoVideoSurface> implements VimeoVi
 
   // -- Dimensions --
 
-  get width() {
-    return this.#target?.clientWidth ?? 0;
-  }
-
-  set width(_value) {
-    // Layout-owned on the iframe host; no-op for embeds.
-  }
-
-  get height() {
-    return this.#target?.clientHeight ?? 0;
-  }
-
-  set height(_value) {
-    // Layout-owned on the iframe host; no-op for embeds.
-  }
-
   get videoWidth() {
     return this.#videoWidth;
   }
@@ -722,55 +706,6 @@ export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps>
   }
 
   return `${EMBED_VIDEO_BASE}/${parsed.id}?${serialize(params)}`;
-}
-
-function templateAttrsToEmbedProps(attrs: Record<string, string>) {
-  return {
-    autoplay: attrs.autoplay !== undefined,
-    defaultMuted: attrs.muted !== undefined,
-    loop: attrs.loop !== undefined,
-    controls: attrs.controls !== undefined,
-    playsInline: attrs.playsinline !== undefined,
-    preload: (attrs.preload as VimeoPreload | undefined) ?? vimeoMediaDefaultProps.preload,
-  };
-}
-
-function escapeHtml(str: string) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/`/g, '&#96;');
-}
-
-/** Shadow DOM template for `<vimeo-video>` (iframe embed). */
-export function getVimeoIframeTemplateHTML(attrs: Record<string, string>) {
-  const initialSrc = buildVimeoIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
-  const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
-
-  return /*html*/ `
-<style>
-  :host {
-    display: inline-block;
-    min-width: 300px;
-    min-height: 150px;
-    position: relative;
-  }
-  iframe {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    border: 0;
-  }
-  :host(:not([controls])) {
-    pointer-events: none;
-  }
-</style>
-<iframe part="iframe" allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen frameborder="0" width="100%" height="100%"${srcAttr}></iframe>
-`;
 }
 
 // ----------------------------------------------------------------------------

--- a/packages/core/src/dom/media/vimeo/tests/index.test.ts
+++ b/packages/core/src/dom/media/vimeo/tests/index.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildVimeoIframeSrc, parseVimeoSource, parseVimeoVideoId, VimeoMedia, vimeoMediaDefaultProps } from '..';
+
+vi.mock('@vimeo/player', () => {
+  class MockPlayer {
+    static instances: MockPlayer[] = [];
+    target: unknown;
+    handlers = new Map<string, Set<(data: unknown) => void>>();
+    destroyed = false;
+
+    play = vi.fn(async () => {});
+    pause = vi.fn(async () => {});
+    setVolume = vi.fn(async (v: number) => v);
+    setMuted = vi.fn(async (v: boolean) => v);
+    setCurrentTime = vi.fn(async (s: number) => s);
+    setPlaybackRate = vi.fn(async (r: number) => r);
+    setLoop = vi.fn(async (v: boolean) => v);
+    loadVideo = vi.fn(async () => {});
+    unload = vi.fn(async () => {});
+    requestFullscreen = vi.fn(async () => {});
+    exitFullscreen = vi.fn(async () => {});
+    requestPictureInPicture = vi.fn(async () => {});
+    exitPictureInPicture = vi.fn(async () => {});
+    enableTextTrack = vi.fn(async () => {});
+    disableTextTrack = vi.fn(async () => {});
+    getMuted = vi.fn(async () => false);
+    getVolume = vi.fn(async () => 1);
+    getDuration = vi.fn(async () => 60);
+    getCurrentTime = vi.fn(async () => 0);
+    getTextTracks = vi.fn(async () => [] as unknown[]);
+    destroy = vi.fn(async () => {
+      this.destroyed = true;
+    });
+
+    constructor(target: unknown) {
+      this.target = target;
+      MockPlayer.instances.push(this);
+    }
+
+    on(event: string, handler: (data: unknown) => void): void {
+      let set = this.handlers.get(event);
+      if (!set) {
+        set = new Set();
+        this.handlers.set(event, set);
+      }
+      set.add(handler);
+    }
+
+    off(event: string, handler?: (data: unknown) => void): void {
+      const set = this.handlers.get(event);
+      if (!set) return;
+      if (handler) set.delete(handler);
+      else set.clear();
+    }
+
+    emit(event: string, data: unknown = {}): void {
+      this.handlers.get(event)?.forEach((handler) => handler(data));
+    }
+  }
+
+  return { default: MockPlayer };
+});
+
+function createIframe(): HTMLIFrameElement {
+  return document.createElement('iframe');
+}
+
+async function waitForVimeoLoaded(media: VimeoMedia): Promise<void> {
+  if (media.readyState >= 1 && Number.isFinite(media.duration)) return;
+  await new Promise<void>((resolve) => {
+    media.addEventListener('loadcomplete', () => resolve(), { once: true });
+  });
+}
+
+async function attachAndLoad(media: VimeoMedia): Promise<{ iframe: HTMLIFrameElement; player: MockPlayerLike }> {
+  const iframe = createIframe();
+  media.target = iframe;
+  const player = media.engine as unknown as MockPlayerLike;
+  player.emit('loaded');
+  await waitForVimeoLoaded(media);
+  return { iframe, player };
+}
+
+interface MockPlayerLike {
+  emit(event: string, data?: unknown): void;
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  setVolume: ReturnType<typeof vi.fn>;
+  setMuted: ReturnType<typeof vi.fn>;
+  setCurrentTime: ReturnType<typeof vi.fn>;
+  setPlaybackRate: ReturnType<typeof vi.fn>;
+  setLoop: ReturnType<typeof vi.fn>;
+  loadVideo: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+describe('parseVimeoVideoId', () => {
+  it('extracts numeric id from numeric string', () => {
+    expect(parseVimeoVideoId('76979871')).toBe(76979871);
+  });
+
+  it('extracts id from vimeo.com URL', () => {
+    expect(parseVimeoVideoId('https://vimeo.com/76979871')).toBe(76979871);
+  });
+
+  it('extracts id from player.vimeo.com URL', () => {
+    expect(parseVimeoVideoId('https://player.vimeo.com/video/76979871')).toBe(76979871);
+  });
+
+  it('extracts id from vimeo.com/video URL', () => {
+    expect(parseVimeoVideoId('https://vimeo.com/video/76979871')).toBe(76979871);
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseVimeoVideoId('')).toBe(null);
+  });
+
+  it('returns null for non-Vimeo URLs', () => {
+    expect(parseVimeoVideoId('https://example.com/video.mp4')).toBe(null);
+  });
+});
+
+describe('parseVimeoSource', () => {
+  it('detects events', () => {
+    expect(parseVimeoSource('https://vimeo.com/event/12345')).toEqual({ id: 12345, kind: 'event', hash: null });
+  });
+
+  it('extracts h param from query string', () => {
+    expect(parseVimeoSource('https://vimeo.com/12345?h=abc')).toEqual({ id: 12345, kind: 'video', hash: 'abc' });
+  });
+
+  it('extracts hash from event path', () => {
+    expect(parseVimeoSource('https://vimeo.com/event/12345/abc')).toEqual({ id: 12345, kind: 'event', hash: 'abc' });
+  });
+});
+
+describe('buildVimeoIframeSrc', () => {
+  it('builds embed URL from id with default playsinline and hidden controls', () => {
+    const src = buildVimeoIframeSrc('76979871');
+    expect(src).toContain('https://player.vimeo.com/video/76979871');
+    expect(src).toContain('playsinline=1');
+    expect(src).toContain('preload=metadata');
+    expect(src).toContain('controls=0');
+  });
+
+  it('encodes autoplay, defaultMuted, loop', () => {
+    const src = buildVimeoIframeSrc('76979871', {
+      autoplay: true,
+      defaultMuted: true,
+      loop: true,
+    });
+    expect(src).toContain('autoplay=1');
+    expect(src).toContain('muted=1');
+    expect(src).toContain('loop=1');
+  });
+
+  it('disables controls by default and when controls=false', () => {
+    expect(buildVimeoIframeSrc('76979871', { controls: false })).toContain('controls=0');
+  });
+
+  it('shows Vimeo controls when controls=true', () => {
+    const src = buildVimeoIframeSrc('76979871', { controls: true });
+    expect(src).not.toContain('controls=0');
+  });
+
+  it('forwards preload and Vimeo-specific config knobs', () => {
+    const src = buildVimeoIframeSrc('76979871', { preload: 'auto', config: { autopause: true } });
+    expect(src).toContain('preload=auto');
+    expect(src).toContain('autopause=1');
+  });
+
+  it('embeds h hash for unlisted videos', () => {
+    expect(buildVimeoIframeSrc('https://vimeo.com/12345?h=secret')).toContain('h=secret');
+  });
+
+  it('builds event embed URL with hashPath', () => {
+    const src = buildVimeoIframeSrc('https://vimeo.com/event/123/abc');
+    expect(src).toContain('https://vimeo.com/event/123/embed/abc');
+    expect(src).not.toContain('h=');
+  });
+
+  it('merges arbitrary config into params', () => {
+    const src = buildVimeoIframeSrc('76979871', { config: { background: true, byline: false } });
+    expect(src).toContain('background=1');
+    expect(src).toContain('byline=0');
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildVimeoIframeSrc('not-a-vimeo-url')).toBe('');
+  });
+});
+
+describe('VimeoMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new VimeoMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(vimeoMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('creates a Player when attached to an iframe', () => {
+    const media = new VimeoMedia();
+    const iframe = createIframe();
+    media.target = iframe;
+
+    expect(media.target).toBe(iframe);
+    expect(media.engine).not.toBe(null);
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete after loaded', async () => {
+    const media = new VimeoMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete', 'durationchange'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    const { player } = await attachAndLoad(media);
+    expect(events).toContain('loadstart');
+    expect(events).toContain('loadedmetadata');
+    expect(events).toContain('loadcomplete');
+    expect(events).toContain('durationchange');
+    expect(media.duration).toBe(60);
+
+    // Re-emit doesn't re-fire load events:
+    events.length = 0;
+    player.emit('timeupdate', { seconds: 1, duration: 60 });
+    expect(events).toEqual([]);
+  });
+
+  it('updates state from player events', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+    player.emit('play', { seconds: 0, duration: 60, percent: 0 });
+    expect(media.paused).toBe(false);
+    expect(playSpy).toHaveBeenCalled();
+
+    player.emit('timeupdate', { seconds: 12.5, duration: 60, percent: 0.2 });
+    expect(media.currentTime).toBe(12.5);
+    expect(media.duration).toBe(60);
+
+    player.emit('progress', { seconds: 30 });
+    expect(media.buffered.length).toBe(1);
+    expect(media.buffered.end(0)).toBe(30);
+
+    player.emit('resize', { videoWidth: 1280, videoHeight: 720 });
+    expect(media.videoWidth).toBe(1280);
+    expect(media.videoHeight).toBe(720);
+
+    player.emit('volumechange', { volume: 0.25 });
+    expect(media.volume).toBe(0.25);
+
+    player.emit('pause', { seconds: 12.5, duration: 60, percent: 0.2 });
+    expect(media.paused).toBe(true);
+
+    player.emit('ended', { seconds: 60, duration: 60, percent: 1 });
+    expect(media.ended).toBe(true);
+  });
+
+  it('forwards play() and pause() to the player', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    await media.play();
+    expect(player.play).toHaveBeenCalledTimes(1);
+
+    media.pause();
+    expect(player.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards setters to the player after load', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    media.currentTime = 30;
+    media.volume = 0.5;
+    media.muted = true;
+    media.playbackRate = 1.5;
+    media.loop = true;
+
+    // setters defer via loadComplete microtask — flush.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(player.setCurrentTime).toHaveBeenCalledWith(30);
+    expect(player.setVolume).toHaveBeenCalledWith(0.5);
+    expect(player.setMuted).toHaveBeenCalledWith(true);
+    expect(player.setPlaybackRate).toHaveBeenCalledWith(1.5);
+    expect(player.setLoop).toHaveBeenCalledWith(true);
+  });
+
+  it('calls loadVideo when src changes after attach', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+    player.loadVideo.mockClear();
+
+    media.src = '76979871';
+    await Promise.resolve();
+    expect(player.loadVideo).toHaveBeenCalledWith({ url: 'https://player.vimeo.com/video/76979871' });
+  });
+
+  it('forwards fullscreen and pip requests', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    await media.requestFullscreen();
+    await media.exitFullscreen();
+    await media.requestPictureInPicture();
+    await media.exitPictureInPicture();
+
+    expect((player as unknown as { requestFullscreen: ReturnType<typeof vi.fn> }).requestFullscreen).toHaveBeenCalled();
+    expect((player as unknown as { exitFullscreen: ReturnType<typeof vi.fn> }).exitFullscreen).toHaveBeenCalled();
+    expect(
+      (player as unknown as { requestPictureInPicture: ReturnType<typeof vi.fn> }).requestPictureInPicture
+    ).toHaveBeenCalled();
+    expect(
+      (player as unknown as { exitPictureInPicture: ReturnType<typeof vi.fn> }).exitPictureInPicture
+    ).toHaveBeenCalled();
+  });
+
+  it('tracks played ranges via mediaPlayedRanges', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    player.emit('play', {});
+    player.emit('timeupdate', { seconds: 1 });
+    player.emit('timeupdate', { seconds: 2 });
+    player.emit('timeupdate', { seconds: 3 });
+    player.emit('pause', {});
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(3);
+  });
+
+  it('destroys the player on detach', () => {
+    const media = new VimeoMedia();
+    const iframe = createIframe();
+    media.target = iframe;
+    const player = media.engine as unknown as MockPlayerLike;
+
+    media.target = null;
+    expect(player.destroy).toHaveBeenCalled();
+    expect(media.target).toBe(null);
+    expect(media.engine).toBe(null);
+  });
+});

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -14,8 +14,10 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/media/custom-media-element/index': './src/dom/media/custom-media-element/index.ts',
     'dom/media/mux/index': './src/dom/media/mux/index.ts',
     'dom/media/native-hls/index': './src/dom/media/native-hls/index.ts',
+    'dom/media/media-played-ranges/index': './src/dom/media/media-played-ranges/index.ts',
     'dom/media/simple-hls-audio-only/index': './src/dom/media/simple-hls-audio-only/index.ts',
     'dom/media/simple-hls/index': './src/dom/media/simple-hls/index.ts',
+    'dom/media/vimeo/index': './src/dom/media/vimeo/index.ts',
   },
   define: {
     __DEV__: mode === 'dev' ? 'true' : 'false',

--- a/packages/html/src/define/media/vimeo-video.ts
+++ b/packages/html/src/define/media/vimeo-video.ts
@@ -1,0 +1,14 @@
+import { VimeoVideo } from '../../media/vimeo-video';
+import { safeDefine } from '../safe-define';
+
+export class VimeoVideoElement extends VimeoVideo {
+  static readonly tagName = 'vimeo-video';
+}
+
+safeDefine(VimeoVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [VimeoVideoElement.tagName]: VimeoVideoElement;
+  }
+}

--- a/packages/html/src/media/vimeo-video/index.ts
+++ b/packages/html/src/media/vimeo-video/index.ts
@@ -5,6 +5,7 @@ import {
   type VimeoPreload,
   vimeoMediaDefaultProps,
 } from '@videojs/core/dom/media/vimeo';
+import { escapeHtml } from '@videojs/utils/string';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
 class VimeoCustomMediaElement extends CustomMediaElement('iframe', VimeoMedia) {
@@ -44,16 +45,6 @@ function templateAttrsToEmbedProps(attrs: Record<string, string>) {
     playsInline: attrs.playsinline !== undefined,
     preload: (attrs.preload as VimeoPreload | undefined) ?? vimeoMediaDefaultProps.preload,
   };
-}
-
-function escapeHtml(str: string) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/`/g, '&#96;');
 }
 
 /**

--- a/packages/html/src/media/vimeo-video/index.ts
+++ b/packages/html/src/media/vimeo-video/index.ts
@@ -1,10 +1,5 @@
 import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
-import {
-  buildVimeoIframeSrc,
-  VimeoMedia,
-  type VimeoPreload,
-  vimeoMediaDefaultProps,
-} from '@videojs/core/dom/media/vimeo';
+import { buildVimeoIframeSrc, VimeoMedia } from '@videojs/core/dom/media/vimeo';
 import { escapeHtml } from '@videojs/utils/string';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
@@ -43,7 +38,7 @@ function templateAttrsToEmbedProps(attrs: Record<string, string>) {
     loop: attrs.loop !== undefined,
     controls: attrs.controls !== undefined,
     playsInline: attrs.playsinline !== undefined,
-    preload: (attrs.preload as VimeoPreload | undefined) ?? vimeoMediaDefaultProps.preload,
+    preload: (attrs.preload as 'none' | 'metadata' | 'auto' | undefined) ?? 'metadata',
   };
 }
 

--- a/packages/html/src/media/vimeo-video/index.ts
+++ b/packages/html/src/media/vimeo-video/index.ts
@@ -1,0 +1,21 @@
+import { CustomMediaElement, upgradeProperty } from '@videojs/core/dom/media/custom-media-element';
+import { getVimeoIframeTemplateHTML, VimeoMedia } from '@videojs/core/dom/media/vimeo';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class VimeoCustomMediaElement extends CustomMediaElement('iframe', VimeoMedia) {
+  static override getTemplateHTML = getVimeoIframeTemplateHTML;
+
+  constructor() {
+    super();
+    upgradeProperty(this, 'config');
+  }
+}
+
+/**
+ * Web component that embeds a Vimeo video via `@vimeo/player` and exposes an
+ * `HTMLMediaElement`-like API. Mirrors the public surface of `media-elements`'
+ * `vimeo-video-element`, including support for unlisted videos, live events,
+ * picture-in-picture, fullscreen, and arbitrary embed `config` (use this for
+ * Vimeo-specific knobs like `autopause`, `byline`, `dnt`).
+ */
+export class VimeoVideo extends MediaAttachMixin(VimeoCustomMediaElement) {}

--- a/packages/html/src/media/vimeo-video/index.ts
+++ b/packages/html/src/media/vimeo-video/index.ts
@@ -1,14 +1,59 @@
-import { CustomMediaElement, upgradeProperty } from '@videojs/core/dom/media/custom-media-element';
-import { getVimeoIframeTemplateHTML, VimeoMedia } from '@videojs/core/dom/media/vimeo';
+import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
+import {
+  buildVimeoIframeSrc,
+  VimeoMedia,
+  type VimeoPreload,
+  vimeoMediaDefaultProps,
+} from '@videojs/core/dom/media/vimeo';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
 class VimeoCustomMediaElement extends CustomMediaElement('iframe', VimeoMedia) {
-  static override getTemplateHTML = getVimeoIframeTemplateHTML;
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildVimeoIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: inline-block;
+          min-width: 300px;
+          min-height: 150px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        :host(:not([controls])) {
+          pointer-events: none;
+        }
+      </style>
+      <iframe part="iframe" allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen frameborder="0" width="100%" height="100%"${srcAttr}></iframe>
+    `;
+  };
+}
 
-  constructor() {
-    super();
-    upgradeProperty(this, 'config');
-  }
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    playsInline: attrs.playsinline !== undefined,
+    preload: (attrs.preload as VimeoPreload | undefined) ?? vimeoMediaDefaultProps.preload,
+  };
+}
+
+function escapeHtml(str: string) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
 }
 
 /**

--- a/packages/react/src/media/vimeo-video/index.tsx
+++ b/packages/react/src/media/vimeo-video/index.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import type { VimeoConfig, VimeoMediaProps } from '@videojs/core/dom/media/vimeo';
+import { buildVimeoIframeSrc, VimeoMedia, vimeoMediaDefaultProps } from '@videojs/core/dom/media/vimeo';
+import type { IframeHTMLAttributes, ReactNode, RefCallback } from 'react';
+import { forwardRef, useCallback, useState } from 'react';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface VimeoVideoProps
+  extends Omit<IframeHTMLAttributes<HTMLIFrameElement>, keyof VimeoMediaProps | 'muted'>,
+    Partial<VimeoMediaProps> {
+  /** Alias for `defaultMuted` — mirrors the HTML `<video muted>` attribute. */
+  muted?: boolean;
+  children?: ReactNode;
+}
+
+/**
+ * React component that embeds a Vimeo video via `@vimeo/player`. Renders an
+ * `<iframe>` whose `src` is built from the supplied props and attaches a
+ * `VimeoMedia` instance to the surrounding player. Supports unlisted videos,
+ * live events (`vimeo.com/event/<id>`), `preload`, and `poster`,
+ * and arbitrary extra Vimeo `config` (use this for Vimeo-specific knobs like
+ * `autopause`, `byline`, `dnt`).
+ */
+export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(function VimeoVideo(
+  { children, muted, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(VimeoMedia);
+
+  const props: Partial<VimeoMediaProps> & Record<string, unknown> = { ...rawProps };
+  const resolvedDefaultMuted = rawProps.defaultMuted ?? muted;
+  if (resolvedDefaultMuted !== undefined) props.defaultMuted = resolvedDefaultMuted;
+
+  const attachRef = useCallback<RefCallback<HTMLIFrameElement>>(
+    (element) => {
+      media.target = element;
+      return () => {
+        media.target = null;
+      };
+    },
+    [media]
+  );
+
+  const composedRef = useComposedRefs(attachRef, ref);
+
+  // Compute the iframe src once on mount; subsequent prop changes are
+  // forwarded to VimeoMedia (which calls Player.loadVideo) so the iframe
+  // element itself isn't replaced on every render.
+  const [initialSrc] = useState(() => buildVimeoIframeSrc(props.src ?? '', { ...vimeoMediaDefaultProps, ...props }));
+
+  type VimeoSyncedProps = Pick<
+    VimeoMediaProps,
+    'src' | 'autoplay' | 'defaultMuted' | 'loop' | 'controls' | 'preload' | 'config'
+  >;
+
+  const iframeProps = useSyncProps<VimeoSyncedProps, Record<string, unknown>>(
+    media as VimeoMedia & VimeoSyncedProps,
+    props,
+    vimeoMediaDefaultProps
+  );
+  const config = props.config as VimeoConfig | null | undefined;
+  const dataConfig = config ? JSON.stringify(config) : undefined;
+  const referrerPolicy = (config as { referrerpolicy?: string } | null | undefined)?.referrerpolicy;
+
+  return (
+    <iframe
+      title="Vimeo video player"
+      allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      data-config={dataConfig}
+      referrerPolicy={referrerPolicy as IframeHTMLAttributes<HTMLIFrameElement>['referrerPolicy']}
+      {...iframeProps}
+      ref={composedRef}
+      src={initialSrc}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace VimeoVideo {
+  export type Props = VimeoVideoProps;
+}

--- a/packages/utils/src/string/escape-html.ts
+++ b/packages/utils/src/string/escape-html.ts
@@ -1,0 +1,9 @@
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
+}

--- a/packages/utils/src/string/index.ts
+++ b/packages/utils/src/string/index.ts
@@ -1,2 +1,3 @@
 export * from './casing';
+export * from './escape-html';
 export * from './generate-id';

--- a/packages/utils/src/string/tests/escape-html.test.ts
+++ b/packages/utils/src/string/tests/escape-html.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from '../escape-html';
+
+describe('escapeHtml', () => {
+  it('escapes HTML special characters', () => {
+    expect(escapeHtml('&<>"\'`')).toBe('&amp;&lt;&gt;&quot;&#39;&#96;');
+  });
+
+  it('preserves strings without HTML special characters', () => {
+    expect(escapeHtml('https://player.vimeo.com/video/123?autoplay=1')).toBe(
+      'https://player.vimeo.com/video/123?autoplay=1'
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@videojs/utils':
         specifier: workspace:*
         version: link:../utils
+      '@vimeo/player':
+        specifier: ^2.30.3
+        version: 2.30.3
       dashjs:
         specifier: ^5.0.0
         version: 5.1.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)
@@ -3583,6 +3586,9 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  '@vimeo/player@2.30.3':
+    resolution: {integrity: sha512-3skwNetfstLG/KvbfrwhUDms3Cd68LfqbN2DNYijcMV+oPGf5GzekVBxNCrxbeLXyVZMNZCXWV0DQQAwcQJ/iA==}
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6241,6 +6247,9 @@ packages:
     resolution: {integrity: sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  native-promise-only@0.8.1:
+    resolution: {integrity: sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -7998,6 +8007,10 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  weakmap-polyfill@2.0.4:
+    resolution: {integrity: sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==}
+    engines: {node: '>=8.10.0'}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -11386,6 +11399,11 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vimeo/player@2.30.3':
+    dependencies:
+      native-promise-only: 0.8.1
+      weakmap-polyfill: 2.0.4
+
   '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
@@ -14745,6 +14763,8 @@ snapshots:
 
   nanostores@1.1.1: {}
 
+  native-promise-only@0.8.1: {}
+
   neotraverse@0.6.18: {}
 
   netlify-redirector@0.5.0: {}
@@ -16660,6 +16680,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  weakmap-polyfill@2.0.4: {}
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
Fix #1435
Related https://github.com/videojs/v10/pull/1538

## Summary

Adds Vimeo playback on the media-layer architecture: a `VimeoMedia` host in core, HTML and React `VimeoVideo` components, shared `mediaPlayedRanges` for buffered/played ranges on custom media, and sandbox demos.

## Changes

- `VimeoMedia` wraps `@vimeo/player` with an `HTMLMediaElement`-like surface (src parsing, load, PiP, fullscreen, embed `config`)
- `mediaPlayedRanges` helper for custom elements that lack native `TimeRanges`
- `CustomMediaElement` gains iframe template support for Vimeo embeds
- `VimeoVideo` web component and React wrapper with sandbox HTML/React templates

## Testing

- `pnpm -F @videojs/core test src/dom/media/vimeo`
- `pnpm -F @videojs/core test src/dom/media/media-played-ranges`
- Sandbox: open HTML and React Vimeo video demos

Made with [Cursor](https://cursor.com)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared CustomMediaElement lifecycle (reconnect, iframe path) used by other custom media; new third-party @vimeo/player dependency and large embed surface area, mitigated by unit tests.
> 
> **Overview**
> Adds **Vimeo** as a first-class media source on the v10 media-layer stack, with sandbox demos and shared infrastructure for iframe embeds.
> 
> **Core:** New `VimeoMedia` host wraps `@vimeo/player`, maps Vimeo events to standard media APIs (play/pause, time, volume, PiP, fullscreen, text tracks), parses ids/URLs (including live events and unlisted `h` hashes), and builds embed URLs via `buildVimeoIframeSrc`. Adds `mediaPlayedRanges` so iframe hosts expose a `played` `TimeRanges`-like surface. `CustomMediaElement` is extended for **iframe** embeds: lazy/recreatable media host, property upgrade before define, iframe `config` hydration from `data-config`, and no track/source sync on iframe.
> 
> **Packages:** HTML `vimeo-video` web component and React `VimeoVideo` attach `VimeoMedia` to an iframe; `escapeHtml` secures iframe `src` in templates. `@vimeo/player` is a new `@videojs/core` dependency; build entries include vimeo and media-played-ranges.
> 
> **Sandbox:** New `vimeo-video` preset with fixed `VIMEO_VIDEO_SRC`, HTML/React templates, routing, and UI rules (no Tailwind skin, source picker disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ceb05d24050bf9971c26c58cc4a1f054e11670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->