### PR TITLE
fix(skin): prevent initial audio pause icon flash

### DIFF
--- a/packages/skins/src/shared/css/audio/icon-state.css
+++ b/packages/skins/src/shared/css/audio/icon-state.css
@@ -22,10 +22,11 @@
 
 /* Play: ended → restart */
 .media-button--play[data-ended] .media-icon--restart,
-/* Play: paused (not ended) → play */
+/* Play: paused or not yet started (not ended) → play */
 .media-button--play:not([data-ended])[data-paused] .media-icon--play,
-/* Play: playing (not paused, not ended) → pause */
-.media-button--play:not([data-paused]):not([data-ended]) .media-icon--pause,
+.media-button--play:not([data-ended]):not([data-started]) .media-icon--play,
+/* Play: started and not paused/ended → pause */
+.media-button--play[data-started]:not([data-paused]):not([data-ended]) .media-icon--pause,
 /* Mute: muted → volume off */
 .media-button--mute[data-muted] .media-icon--volume-off,
 /* Mute: volume low (not muted) → volume low */

--- a/packages/skins/src/shared/tailwind/icon-state.ts
+++ b/packages/skins/src/shared/tailwind/icon-state.ts
@@ -6,9 +6,15 @@ export const iconState = {
   play: {
     button: 'group',
     restart: 'hidden opacity-0 group-data-ended:block group-data-ended:opacity-100',
-    play: 'hidden opacity-0 group-not-data-ended:group-data-paused:block group-not-data-ended:group-data-paused:opacity-100',
+    play: [
+      'hidden opacity-0',
+      'group-not-data-ended:group-data-paused:block',
+      'group-not-data-ended:group-data-paused:opacity-100',
+      'group-not-data-ended:group-not-data-started:block',
+      'group-not-data-ended:group-not-data-started:opacity-100',
+    ].join(' '),
     pause:
-      'hidden opacity-0 group-not-data-paused:group-not-data-ended:block group-not-data-paused:group-not-data-ended:opacity-100',
+      'hidden opacity-0 group-data-started:group-not-data-paused:group-not-data-ended:block group-data-started:group-not-data-paused:group-not-data-ended:opacity-100',
   },
   mute: {
     button: 'group',


### PR DESCRIPTION
## Summary

Fixes an issue where the pause icon would flash up for the first paint before showing the play icon. Most noticeable in the audio skins. 

- Update shared audio icon-state CSS so play icon is the default before playback has started
- Require `data-started` before showing the pause icon to avoid initial startup flicker
- Mirror the same startup-state logic in shared Tailwind icon-state classes

## Test plan
- [x] Verify in browser that audio skin no longer flashes pause icon on initial render

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 295d889d24a0d764dcea61760d248a455ee1ba9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->