### PR TITLE
fix(skin): prevent initial pause icon flash

### DIFF
--- a/packages/skins/src/shared/css/audio/icon-state.css
+++ b/packages/skins/src/shared/css/audio/icon-state.css
@@ -22,10 +22,11 @@
 
 /* Play: ended → restart */
 .media-button--play[data-ended] .media-icon--restart,
-/* Play: paused (not ended) → play */
+/* Play: paused or not yet started (not ended) → play */
 .media-button--play:not([data-ended])[data-paused] .media-icon--play,
-/* Play: playing (not paused, not ended) → pause */
-.media-button--play:not([data-paused]):not([data-ended]) .media-icon--pause,
+.media-button--play:not([data-ended]):not([data-started]) .media-icon--play,
+/* Play: started and not paused/ended → pause */
+.media-button--play[data-started]:not([data-paused]):not([data-ended]) .media-icon--pause,
 /* Mute: muted → volume off */
 .media-button--mute[data-muted] .media-icon--volume-off,
 /* Mute: volume low (not muted) → volume low */

--- a/packages/skins/src/shared/css/video/icon-state.css
+++ b/packages/skins/src/shared/css/video/icon-state.css
@@ -32,10 +32,11 @@
 
 /* Play: ended → restart */
 .media-button--play[data-ended] .media-icon--restart,
-/* Play: paused (not ended) → play */
+/* Play: paused or not yet started (not ended) → play */
 .media-button--play:not([data-ended])[data-paused] .media-icon--play,
-/* Play: playing (not paused, not ended) → pause */
-.media-button--play:not([data-paused]):not([data-ended]) .media-icon--pause,
+.media-button--play:not([data-ended]):not([data-started]) .media-icon--play,
+/* Play: started and not paused/ended → pause */
+.media-button--play[data-started]:not([data-paused]):not([data-ended]) .media-icon--pause,
 /* Mute: muted → volume off */
 .media-button--mute[data-muted] .media-icon--volume-off,
 /* Mute: volume low (not muted) → volume low */

--- a/packages/skins/src/shared/tailwind/icon-state.ts
+++ b/packages/skins/src/shared/tailwind/icon-state.ts
@@ -6,9 +6,15 @@ export const iconState = {
   play: {
     button: 'group',
     restart: 'hidden opacity-0 group-data-ended:block group-data-ended:opacity-100',
-    play: 'hidden opacity-0 group-not-data-ended:group-data-paused:block group-not-data-ended:group-data-paused:opacity-100',
+    play: [
+      'hidden opacity-0',
+      'group-not-data-ended:group-data-paused:block',
+      'group-not-data-ended:group-data-paused:opacity-100',
+      'group-not-data-ended:group-not-data-started:block',
+      'group-not-data-ended:group-not-data-started:opacity-100',
+    ].join(' '),
     pause:
-      'hidden opacity-0 group-not-data-paused:group-not-data-ended:block group-not-data-paused:group-not-data-ended:opacity-100',
+      'hidden opacity-0 group-data-started:group-not-data-paused:group-not-data-ended:block group-data-started:group-not-data-paused:group-not-data-ended:opacity-100',
   },
   mute: {
     button: 'group',


### PR DESCRIPTION
## Summary

Fixes an issue where the pause icon would flash up for the first paint before showing the play icon. Most noticeable in the audio skins. 

- Update shared audio and video icon-state CSS so play icon is the default before playback has started
- Require `data-started` before showing the pause icon to avoid initial startup flicker
- Mirror the same startup-state logic in shared Tailwind icon-state classes

## Test plan
- [x] Verify in browser that skins no longer flash the pause icon on initial render

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/Tailwind visibility rules only; no auth, data, or playback control logic changed.
> 
> **Overview**
> Fixes a first-paint flicker where the **pause** icon appeared before playback had begun (especially on audio skins).
> 
> Shared **play** icon visibility in audio/video `icon-state.css` and Tailwind `iconState` now treats **not started** like paused for showing the **play** icon (`:not([data-started])`), and only shows **pause** when `data-started` is set and the media is playing (not paused/ended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c45bf6f80b8cfc208e9e2371068b13f6cce82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->