### PR TITLE
fix(skin): restore overflow on audio skins

### DIFF
--- a/packages/skins/src/default/css/components/root.css
+++ b/packages/skins/src/default/css/components/root.css
@@ -11,7 +11,6 @@
   width: 100%;
   height: 100%;
   container: media-root / inline-size;
-  overflow: clip;
   font-family:
     Inter Variable,
     Inter,

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -55,6 +55,7 @@
   --media-tooltip-boundary-offset: 0.5rem;
   --media-popover-side-offset: 0.5rem;
   --media-popover-boundary-offset: 0.5rem;
+  overflow: clip;
   background: oklch(0 0 0);
 
   @media (prefers-reduced-motion: reduce) {

--- a/packages/skins/src/default/tailwind/components/root.ts
+++ b/packages/skins/src/default/tailwind/components/root.ts
@@ -6,7 +6,6 @@ export const root = cn(
   // Layout & containment
   'block relative isolate h-full w-full @container/media-root',
   // Appearance
-  'overflow-clip',
   'rounded-(--media-border-radius,2rem)',
   'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-[0.8125rem] leading-normal subpixel-antialiased',
   // Focus ring

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -18,7 +18,7 @@ import { time as baseTime } from './components/time';
 export const root = (isShadowDOM: boolean) =>
   cn(
     baseRoot,
-    'bg-black',
+    'bg-black overflow-clip',
     // Inner border ring
     'after:absolute after:pointer-events-none after:rounded-[inherit] after:z-10',
     'after:inset-0 after:ring-1 after:ring-inset after:ring-black/10 dark:after:ring-white/15',

--- a/packages/skins/src/minimal/css/components/root.css
+++ b/packages/skins/src/minimal/css/components/root.css
@@ -11,7 +11,6 @@
   width: 100%;
   height: 100%;
   container: media-root / inline-size;
-  overflow: clip;
   font-family:
     Inter Variable,
     Inter,

--- a/packages/skins/src/minimal/tailwind/components/root.ts
+++ b/packages/skins/src/minimal/tailwind/components/root.ts
@@ -6,7 +6,6 @@ export const root = cn(
   // Layout & containment
   'block relative isolate h-full w-full @container/media-root',
   // Appearance
-  'overflow-clip',
   'rounded-(--media-border-radius,0.75rem)',
   'font-[Inter_Variable,Inter,ui-sans-serif,system-ui,sans-serif] text-[0.8125rem] leading-normal subpixel-antialiased',
   // Focus ring


### PR DESCRIPTION
A previous PR to add AirPlay added `overflow: clip` to all skins which caused the border/ring and shadow to be clipped. This moves the `overflow: clip` to the video skins only. The minimal skin seemed to already apply `overflow: clip` in the video skins. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout/containment tweak with a clear split between audio and video roots; low blast radius.
> 
> **Overview**
> Moves **`overflow: clip`** off the shared **default** and **minimal** root styles (CSS and Tailwind) so it no longer applies to **audio** players, where it was clipping borders, rings, and shadows.
> 
> **Video** skins keep clipping: **default** adds `overflow: clip` on the video skin (`video.css` and `video.tailwind.ts` via `overflow-clip` on the video root). **Minimal** video already had `overflow: clip` in its video CSS; only the shared root lost it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c0774e76e03308bc6efa1c94e2b28e457cac16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->