### PR TITLE
docs(spf): describe pr skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -18,6 +18,7 @@ Specialized knowledge for AI agents working on Video.js 10.
 | Reviewing accessibility    | `aria` → `review/workflow.md`      |
 | Accessibility audit        | `aria`                             |
 | Committing / creating PRs  | `git` or `/commit-pr`              |
+| Reviewer-oriented PR descriptions (SPF) | `/spf-describe-pr`        |
 | CSS → Tailwind migration   | `css-to-tailwind`                  |
 | Reviewing Tailwind migration | `css-to-tailwind` → `review/workflow.md` |
 | Reviewing branch changes   | `/review-branch`                   |
@@ -48,6 +49,7 @@ Specialized knowledge for AI agents working on Video.js 10.
 | [review-branch](review-branch/SKILL.md) | Review branch changes and suggest improvements                         | No          |
 | [rfc](rfc/SKILL.md)                     | Write RFCs — proposals needing buy-in (public API, product, DX)        | No          |
 | [spf-create-behavior](spf-create-behavior/SKILL.md) | Create a new SPF behavior with conventions-aligned shape (stub; grows with use) | No |
+| [spf-describe-pr](spf-describe-pr/SKILL.md) | Draft/revise reviewer-oriented PR descriptions for SPF-area PRs (bucket-calibrated reading order, five-label set, smoke-test discipline) | No |
 | [spf-document-feature](spf-document-feature/SKILL.md) | Produce/update SPF feature registry docs (triangulation, cluster heuristics, cross-cutting checks, cascade) | No |
 | [spf-document-use-case](spf-document-use-case/SKILL.md) | Produce/update SPF use-case-composition registry docs (four-mechanism taxonomy, constituent-feature cascade) | No |
 | [spf-implement-feature](spf-implement-feature/SKILL.md) | Implement an SPF feature from its registry doc (disambiguation, phase scoping, chunk decomposition, downstream-skill routing, doc-as-starting-point) | No |

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -44,8 +44,6 @@ Specialized knowledge for AI agents working on Video.js 10.
 | [docs](docs/SKILL.md)                   | Write Video.js 10 documentation (concepts, how-to, READMEs)    | Yes         |
 | [gh-issue](gh-issue/SKILL.md)           | Analyze GitHub issues and create implementation plans                  | No          |
 | [git](git/SKILL.md)                     | Git workflow — commit messages, PRs, branch naming, scope inference    | No          |
-| [merge-behaviors](merge-behaviors/SKILL.md) | Merge two SPF behaviors with cleaned-shape-first discipline        | No          |
-| [refactor-behavior](refactor-behavior/SKILL.md) | Refactor an SPF behavior using purpose-first discipline       | No          |
 | [review-branch](review-branch/SKILL.md) | Review branch changes and suggest improvements                         | No          |
 | [rfc](rfc/SKILL.md)                     | Write RFCs — proposals needing buy-in (public API, product, DX)        | No          |
 | [spf-create-behavior](spf-create-behavior/SKILL.md) | Create a new SPF behavior with conventions-aligned shape (stub; grows with use) | No |
@@ -54,8 +52,10 @@ Specialized knowledge for AI agents working on Video.js 10.
 | [spf-document-use-case](spf-document-use-case/SKILL.md) | Produce/update SPF use-case-composition registry docs (four-mechanism taxonomy, constituent-feature cascade) | No |
 | [spf-implement-feature](spf-implement-feature/SKILL.md) | Implement an SPF feature from its registry doc (disambiguation, phase scoping, chunk decomposition, downstream-skill routing, doc-as-starting-point) | No |
 | [spf-implement-use-case](spf-implement-use-case/SKILL.md) | Implement an SPF use-case composition from its registry doc (disambiguation/routing, constituent-feature readiness, variant assembly, doc-as-starting-point) | No |
-| [spf-update-behavior](spf-update-behavior/SKILL.md) | Update an existing SPF behavior whose purpose is changing (stub; distinct from /refactor-behavior which preserves purpose) | No |
-| [split-behavior](split-behavior/SKILL.md) | Split one SPF behavior into N with axis-declared, constraints-audited discipline | No |
+| [spf-merge-behaviors](spf-merge-behaviors/SKILL.md) | Merge two SPF behaviors with cleaned-shape-first discipline        | No          |
+| [spf-refactor-behavior](spf-refactor-behavior/SKILL.md) | Refactor an SPF behavior using purpose-first discipline       | No          |
+| [spf-split-behavior](spf-split-behavior/SKILL.md) | Split one SPF behavior into N with axis-declared, constraints-audited discipline | No |
+| [spf-update-behavior](spf-update-behavior/SKILL.md) | Update an existing SPF behavior whose purpose is changing (stub; distinct from /spf-refactor-behavior which preserves purpose) | No |
 
 ## Review Workflows
 

--- a/.claude/skills/spf-create-behavior/SKILL.md
+++ b/.claude/skills/spf-create-behavior/SKILL.md
@@ -2,10 +2,10 @@
 name: spf-create-behavior
 description: >-
   Create a new SPF behavior with conventions-aligned shape. Walks through
-  purpose articulation (carries /refactor-behavior's purpose-first discipline),
+  purpose articulation (carries /spf-refactor-behavior's purpose-first discipline),
   signal type choice, slot map design, composition placement, cleanup pattern
   selection, test placement, and engine wiring. Distinct from
-  /refactor-behavior (which modifies an existing behavior preserving its
+  /spf-refactor-behavior (which modifies an existing behavior preserving its
   purpose) and /spf-update-behavior (which modifies an existing behavior whose
   purpose is changing). Triggers: "create behavior", "new behavior", "create
   SPF behavior", "add behavior", "scaffold behavior", "new SPF behavior".
@@ -58,7 +58,7 @@ Required reading before drafting:
 
 ## Failure-mode catalog (seeded; grows with use)
 
-- **Purpose-articulation skipped.** Same failure mode as `/refactor-behavior`:
+- **Purpose-articulation skipped.** Same failure mode as `/spf-refactor-behavior`:
   jumping from "we need a behavior" to `defineBehavior` without naming what
   the behavior *does* in business terms. Carries the purpose-first
   discipline. The articulation should answer: what business rule does this
@@ -94,7 +94,7 @@ Required reading before drafting:
 
 ### Step 1 — Articulate purpose
 
-Carry `/refactor-behavior`'s purpose-first discipline forward to new
+Carry `/spf-refactor-behavior`'s purpose-first discipline forward to new
 behaviors. Before any code:
 
 - **What business rule does this behavior implement?** Name it in plain
@@ -170,10 +170,10 @@ Audit checklist:
 
 ## When this is the wrong skill
 
-- **Refactoring an existing behavior, purpose preserved** → `/refactor-behavior`
+- **Refactoring an existing behavior, purpose preserved** → `/spf-refactor-behavior`
 - **Updating an existing behavior, purpose changing** → `/spf-update-behavior`
-- **Splitting / merging existing behaviors** → `/split-behavior` /
-  `/merge-behaviors` (often routed through `/refactor-behavior`)
+- **Splitting / merging existing behaviors** → `/spf-split-behavior` /
+  `/spf-merge-behaviors` (often routed through `/spf-refactor-behavior`)
 - **Creating a media-layer or network-layer helper (not a behavior)** →
   manual for now; future media-layer / network-layer skills will own this
 

--- a/.claude/skills/spf-describe-pr/SKILL.md
+++ b/.claude/skills/spf-describe-pr/SKILL.md
@@ -83,10 +83,15 @@ depth label. The target shape is "Bucket 1 fits in one viewport" —
 prioritize line count over word count. See *Compression discipline*
 below for the line-saving moves.
 
-Open with one short line on the diff shape — `#<num>: X files / +Y / −Z`
-— and note any line-count weirdness only if material (e.g., "~3500 of
-4593 added lines are agent skills with no runtime impact"). Skip the
-intro entirely if the diff shape is unremarkable.
+**Skip a diff-stat opener by default.** GitHub already shows
+`X files / +Y / −Z` prominently above the PR body, and restating it
+adds no signal. Include a diff-shape line only when it carries
+*characterization* GitHub can't show — typically a weight imbalance
+reviewers should know about (e.g., "~3500 of 4593 added lines are
+agent skills with no runtime impact"; "29 files but the bulk of the
+diff is a mass rename"). When you include it, the *characterization*
+is the load-bearing part — the numbers are optional context, not the
+point. Bare numerical recitation always gets cut.
 
 Per-bucket shape:
 
@@ -833,6 +838,10 @@ When revising an existing description, walk this checklist:
 - [ ] **No implementation-history paragraphs** ("commit order on the
       branch is preserved…") or restated scope rationale across
       sections.
+- [ ] **No bare diff-stat opener** ("`#<num>: X files / +Y / −Z`"
+      without characterization) — GitHub already shows the numbers.
+      Include only when paired with a weight-imbalance call-out that
+      GitHub can't show.
 - [ ] **Reviewer callouts have scope-narrowing** when the limitation
       doesn't apply PR-wide.
 - [ ] **No relative file-path links** anywhere in the body.

--- a/.claude/skills/spf-describe-pr/SKILL.md
+++ b/.claude/skills/spf-describe-pr/SKILL.md
@@ -238,10 +238,28 @@ nuance lives that the depth label alone can't carry.
   terse-but-obscure prose; that's worse than wordy-but-clear.** A
   reviewer who isn't deep in SPF should still be able to act on each
   item.
-- **Name what's verifiable, not what the file does.** "Only the one
-  internal caller updated" is verifiable; "manages quality selection"
-  is descriptive. *What changed — by surface* carries file-purpose
-  narrative; the Look-for clause carries verification targets.
+- **Name concerns and what's verifiable, not implementation details
+  or file purpose.** "Single-writer invariant on `selectedAudioTrackId`;
+  verify the new caller path doesn't violate it" gives a reviewer a
+  hypothesis to test against the diff. "`selectQuality(tracks, ctx)`
+  packs bandwidth, safetyMargin, upgradeMargin, currentTrack" is a
+  `git diff` summary — it restates the diff instead of naming what
+  makes the change *correct*. Concern-naming serves the human
+  reviewer's comparative advantage (comprehension, architectural fit);
+  impl-naming duplicates the per-line review that Cursor/Bugbot/etc.
+  handle better. File-purpose narrative belongs in *What changed — by
+  surface*, not in *Look for:* prose.
+- **Don't carry over meta-discourse jargon from internal docs.** Labels
+  like "Tier 1", "Phase 2", "Stage A/B", or feature/use-case codenames
+  come from feature-doc phasing taxonomies. Reviewers arriving cold
+  don't share that context. Translate to substance ("Tier 1 + Tier 2"
+  → "default selection + programmatic selection + same-codec
+  mid-stream switching") rather than inline-defining the label.
+  Inline definitions teach the reader a taxonomy they don't need; the
+  gloss table is for *durable code terms* (`ABR`,
+  `single-writer invariant`) that recur across PRs, not for
+  meta-discourse labels that don't survive past the feature doc's
+  current phasing.
 
 **Good shapes:**
 
@@ -372,6 +390,14 @@ of the registry. Examples of good theme labels:
 If a theme's narrative wants to grow beyond 5 sentences, factor a
 *Notable design decisions* bullet out of it.
 
+**Contract to fewer themes when the diff is cohesive.** If the PR is
+one focused change, one paragraph here is enough — don't manufacture
+themes by listing every supporting refactor. *Less is more*: the goal
+is comprehension, not coverage. The point of the section isn't to
+enumerate what changed (the diff and the *Files changed* tab do that);
+it's to give the reviewer the *narrative spine* of the change so the
+diff makes sense.
+
 ### 5. Notable design decisions
 
 Bulleted list. Each item: **choice / alternative / why**. Lead with
@@ -383,9 +409,13 @@ then the rejection rationale. Format:
   <the road not taken>. Rejected because <why>.
 ```
 
-Use this section for decisions a reviewer might reasonably push back
-on. Don't use it for routine implementation details (those belong in
-*What changed* or commit messages).
+**Only for genuine push-back-able forks.** Routine implementation
+choices (renaming a private function for symmetry, packing a context
+object, signature tweaks for ergonomics) don't qualify. The test: can
+you articulate the alternative as a *real road-not-taken* and the
+rejection rationale as *non-obvious*? If not, the decision wasn't a
+fork — drop the bullet. The section can be entirely empty (omit it
+from the body) for many PRs.
 
 End an item with a reviewer-facing question when one exists. Example:
 *"Reviewers: is the filter too broad?"*
@@ -407,15 +437,23 @@ doesn't affect runtime code. The heading should say so:
 ```
 
 For each callout, frame as **<source-tag>** (e.g., `[Cursor Bugbot]`,
-`[Author]`, `[Deferred from Tier 2]`) + the limitation + the
-disposition ("good enough for now," "follow-up issue welcome," "blocker
-if reviewer disagrees").
+`[Author]`, `[Deferred]`) + the limitation + the disposition ("good
+enough for now," "follow-up issue welcome," "blocker if reviewer
+disagrees").
+
+**Omit the section entirely if there are no callouts.** Don't write an
+"None" heading — empty section = noise. Absence of the section IS the
+signal that nothing was flagged.
 
 ### 7. Breaking changes
 
-Single paragraph. If none, say so explicitly with the alpha caveat if
-SPF: *"None. SPF stays alpha; `<config>` surface unchanged. Deleted
-docs are internal-only, not exported API."*
+Single paragraph naming the break and its scope. **Omit the section
+entirely if there's genuinely no break** — "None" boilerplate adds
+nothing. Exception: keep the section when reviewers might *expect* a
+break (rename PR, signature-change PR, deprecation PR) and you want
+to explicitly characterize the non-break. Example:
+*"`switchVideoQuality` → `switchVideoTrack` rename is internal SPF
+only; no external consumers."*
 
 ### 8. Test plan
 
@@ -426,9 +464,27 @@ verification surface lives in *Smoke test* (section 3) — don't duplicate
 it here. Include any manual verification the author did beyond the
 smoke-test (deeper sweeps, environment-specific checks).
 
+**Omit perfunctory entries.** `pnpm typecheck — clean`, `pnpm test —
+pass`, `pnpm check:workspace — clean` are baseline expectations every
+PR runs; enumerating them adds zero signal and signals AI-checklist-
+performance theater. Include only what's *distinctive*: deferred E2E
+sweeps, environment-specific verification, sibling-PR-dependent items,
+manual sandbox runs beyond the smoke-test. If after this filter the
+section would be empty, omit the whole section.
+
 ## Disciplines
 
 ### Compression discipline
+
+**Less is more.** When an AI assistant drafts a PR description, it
+pattern-matches on "be thorough" and enumerates every change it made.
+That's the wrong target. Reviewer time is the budget, and description
+quality is `line-count × signal-density`, not line-count alone.
+**Description should serve what human reviewers do *better* than an
+LLM-driven reviewer — comprehension of the codebase, cross-cutting
+concerns, architectural fit — and skip what an LLM-driven reviewer
+already does line-by-line.** The discipline below is about *cutting*,
+not adding.
 
 The *For reviewers — how to read this PR* section is what reviewers
 will actually use to pace themselves. The target is **"Bucket 1 fits
@@ -471,6 +527,25 @@ more than word count.
   SPF won't be taught by one sentence; one who does is wasting their
   time on it.
 - **The *Look for:* label.** Em-dash is enough.
+- **Function-signature recitation in *Look for:* prose.** `fn(x, y)`
+  signatures, ctx field lists, packed-object enumerations — these are
+  `git diff` summaries, not verification targets. Name the *concern*
+  (single-writer invariant, ordering, contract match), not the
+  signature.
+- **Implementation-history paragraphs.** "The implementation order on
+  the branch (X → Y → Z) is preserved in commit history; the final
+  shape is what's being shipped." That's what every well-managed PR
+  does — saying it adds no signal. Drop unless reviewers asked about
+  a specific non-obvious rebase decision.
+- **Restated scope rationale across sections.** "Internal-only" + "SPF
+  stays alpha" belongs in *one* place (TL;DR). Repeating it in
+  *Breaking changes*, *Reviewer callouts*, *and* *What changed* is
+  over-insurance.
+- **Perfunctory test-plan checklists.** `pnpm typecheck — clean` etc.
+  are baseline expectations. See Section 8.
+- **Performed-but-empty sections.** *Reviewer callouts: None.*
+  *Breaking: None.* *Test plan:* (only baseline commands). Empty
+  sections are noise — omit them entirely (see Sections 6 / 7 / 8).
 
 **What to keep:**
 
@@ -741,8 +816,23 @@ When revising an existing description, walk this checklist:
       the URL + observables before push.
 - [ ] **Every entry has verification content** with contrast pairs or
       glosses for technical terms.
+- [ ] **No meta-discourse jargon** (Tier N, Phase N, Stage A/B,
+      codenames) carried from feature docs without translation to
+      substance.
+- [ ] **No function-signature recitation** in *Look for:* prose;
+      verification names the *concern* (invariant, ordering, contract),
+      not the impl.
 - [ ] **Notable design decisions follow choice/alternative/why** for
-      every bullet.
+      every bullet — *and* only genuine push-back-able forks remain.
+      Section omitted if no real forks exist for this PR.
+- [ ] **Sections 4–8 contracted to what's load-bearing.** Empty
+      *Reviewer callouts* / *Breaking changes* / *Test plan* sections
+      omitted entirely rather than performed as "None" boilerplate.
+      Perfunctory test-plan entries (`pnpm typecheck — clean` etc.)
+      cut.
+- [ ] **No implementation-history paragraphs** ("commit order on the
+      branch is preserved…") or restated scope rationale across
+      sections.
 - [ ] **Reviewer callouts have scope-narrowing** when the limitation
       doesn't apply PR-wide.
 - [ ] **No relative file-path links** anywhere in the body.
@@ -797,3 +887,27 @@ When revising an existing description, walk this checklist:
 - **Skipping the user confirmation on smoke-test values.** The skill
   can't reliably guess the source URL or the observables. Always
   propose + confirm before writing the section.
+- **AI-enthusiasm verbose mode.** When an AI assistant drafts the
+  description, it pattern-matches on "be thorough" and enumerates
+  every change it made. Reviewer time is the budget; description
+  quality is `line-count × signal-density`, not line-count alone. Cut
+  anything the diff already says — the *Files changed* tab is one
+  click away. The description's job is to give the reviewer the
+  *spine* and the *concerns*, not to re-narrate the diff.
+- **Inheriting feature-doc jargon.** Labels like "Tier 1", "Phase 2",
+  "Stage A/B" come from feature-doc phasing taxonomies and don't
+  travel — reviewers don't share that context. Translate to substance
+  ("Tier 1 + Tier 2" → "default selection + mid-stream switching")
+  rather than inline-defining the label. If the label *itself* matters
+  to the reviewer's understanding (rare), give a one-clause gloss; if
+  not (usual case), drop the label entirely.
+- **Performing empty sections.** "Breaking: None." "Reviewer callouts:
+  None." `pnpm typecheck — clean` as the only test-plan entry. These
+  perform-the-checklist rituals add nothing — the *absence* of the
+  section IS the signal. Omit entirely.
+- **Notable design decisions for routine impl choices.** "Renamed
+  `switchVideoQuality` to `switchVideoTrack`" is a rename, not a fork.
+  The section is for decisions a reviewer might push back on, not for
+  documenting every signature change. If the alternative isn't a real
+  road-not-taken with a non-obvious rejection rationale, drop the
+  bullet.

--- a/.claude/skills/spf-describe-pr/SKILL.md
+++ b/.claude/skills/spf-describe-pr/SKILL.md
@@ -146,6 +146,16 @@ and avoid framings that claim risk profile ("Where regression bugs
 live") — both overclaim and waste vertical space. The per-file depth
 labels carry per-file risk; the heading carries category.
 
+**When a bucket is empty.** Docs-only or skill-only PRs have no Bucket
+1 — omit the heading entirely rather than naming an empty bucket. With
+only 1–2 buckets populated, drop bucket numbering in favor of
+descriptive headings ("Design doc cascade", "Agent skills"); the
+numbering matters only when all three are present. The PR's load-
+bearing artifact gets `[Skim file]` regardless of which bucket it sits
+in — a precedent-setting skill in an otherwise-cascade PR is
+`[Skim file]`, not the default `[Skim or skip]`. Worked example:
+#1624 (this skill's own PR).
+
 #### The five-label set
 
 A 2D grid: scope of attention × intensity of attention.
@@ -323,10 +333,20 @@ No reviewer-actionable smoke test for this PR — the change is
 runtime surface. Verification lives in *Test plan*.
 ```
 
-The explicit note is preferable when the PR is large, touches runtime
-code paths, but the *user-visible* effect is null (e.g., a refactor that
-preserves behavior). Skipping the section silently makes reviewers
-wonder whether you forgot or whether none exists.
+The explicit note is preferable when one of:
+
+- The PR has runtime impact but the user-visible effect is null (e.g.,
+  a refactor that preserves behavior).
+- The PR is large enough (~10+ files or ~500+ lines) that reviewers may
+  scan for a smoke-test before reading the description top-to-bottom,
+  regardless of whether runtime is touched.
+
+Omit the section entirely for small docs-only / skill-only PRs (< 10
+files, < 500 lines) — the docs-only nature speaks for itself.
+
+Skipping the section silently on a large PR makes reviewers wonder
+whether you forgot or whether none exists; the explicit note resolves
+that ambiguity.
 
 **Human-in-the-loop.** The skill can detect candidates from the diff
 (sandbox templates touched, new behaviors with observable output, demo
@@ -631,6 +651,15 @@ family. Specific items to carry forward:
 If you propose a structural change on one PR (e.g., dropping a section,
 narrowing a callout scope), check whether the same change applies to
 the sibling.
+
+**When the sibling has already shipped (merged or closed).** Don't
+retroactively edit a closed PR's description to backfill a new
+discipline that landed after it shipped. Instead, log the gap as a
+Reviewer callout in the *current* PR (`[Deferred] <discipline> not
+applied to #<n>; backfill if reviewing that PR's history`) and let
+the new discipline land on the next SPF PR description. Retroactive
+edits churn merged context for marginal value; the canonical
+worked-example library lives in *open* PR descriptions.
 
 ## Workflow
 

--- a/.claude/skills/spf-describe-pr/SKILL.md
+++ b/.claude/skills/spf-describe-pr/SKILL.md
@@ -1,0 +1,770 @@
+---
+name: spf-describe-pr
+description: >-
+  Draft or revise a PR description for SPF-area PRs using a reviewer-orientation
+  discipline. Produces a body structured around how to read the PR — bucket-
+  calibrated reading order, per-file [depth] + Look-for tags drawn from a
+  five-label set, design-decisions framed as choice/alternative/why, scope-
+  narrowed reviewer callouts, and link discipline that survives merge.
+  Distinct from /commit-pr (which produces the title + a baseline body)
+  and /review-branch (which audits the diff). Triggers: "describe PR",
+  "rewrite PR description", "PR description", "draft PR body", "improve
+  PR description", "SPF PR description".
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Write, Edit, AskUserQuestion
+---
+
+# Describe an SPF PR
+
+Draft or revise the body of a PR that touches SPF-area code (and adjacent
+design docs / agent skills). Produces a body that lets reviewers pace
+themselves: what to read fully, what to skim, what to skip — and *what
+kind of issue* lives in each file. Distinct from /commit-pr (which writes
+a baseline body matching project conventions) and /review-branch (which
+audits the diff itself).
+
+The default failure mode without this discipline is a description that
+enumerates *what changed* file-by-file like an extended changelog —
+useful for someone who already knows the codebase, useless to a reviewer
+arriving cold who needs to figure out where to focus. This skill
+reorganizes the body around *how to review*.
+
+## Usage
+
+```
+/spf-describe-pr [<pr-number-or-url>]
+```
+
+- `<pr-number-or-url>` (optional): the PR to describe. If omitted, infer
+  from the current branch via `gh pr view`.
+
+## Reference: when to use this skill
+
+**Use when:**
+
+- A PR is non-trivial (~10+ files or any file with substantial design impact).
+- The PR touches multiple areas (runtime + docs, runtime + skills, etc.).
+- The author wants reviewer guidance, not just a changelog.
+- Cursor Bugbot or similar tooling has produced inline findings worth
+  promoting into the description.
+- An existing PR description is doing the changelog thing and a rewrite
+  would meaningfully change reviewer experience.
+
+**Don't use when:**
+
+- The PR is a trivial fix (1–3 files, mechanical).
+- The author wants only a commit-message-style body (use /commit-pr).
+- The PR has no reviewers and won't get any (just write a TL;DR).
+
+## Output
+
+The final PR body, written to `/tmp/pr-<num>-body.md` and pushed via
+`gh pr edit <num> --body-file /tmp/pr-<num>-body.md`. Always check in
+with the user before pushing — see the *Workflow* section.
+
+## Structure (eight sections, in order)
+
+The order matters: framing → reviewer guidance → smoke test → narrative →
+decisions → callouts → breaking → tests. Reviewers who stop reading at
+any cut-point get useful information at that depth. Smoke test sits high
+in the order because a reviewer who can confirm the change works in 30
+seconds will read the rest with different eyes than one who can't.
+
+### 1. TL;DR
+
+2–4 sentences. What this PR establishes + what validates it (if non-obvious)
++ scope rationale if the PR is internal-only or alpha. Pull the "why
+this scope" justification up here if reviewers might push back on scope
+(e.g., "why is X inline rather than a follow-up PR").
+
+### 2. For reviewers — how to read this PR
+
+The load-bearing section. Three buckets, each with files grouped by
+depth label. The target shape is "Bucket 1 fits in one viewport" —
+prioritize line count over word count. See *Compression discipline*
+below for the line-saving moves.
+
+Open with one short line on the diff shape — `#<num>: X files / +Y / −Z`
+— and note any line-count weirdness only if material (e.g., "~3500 of
+4593 added lines are agent skills with no runtime impact"). Skip the
+intro entirely if the diff shape is unremarkable.
+
+Per-bucket shape:
+
+- **Heading** carries everything load-bearing about the bucket: what's
+  in it, the recommended depth (e.g., "focus here" / "skim" / "skim or
+  skip"), and any deferrability rationale (e.g., "no runtime impact").
+  No framing sentence below the heading.
+- **Files grouped by depth label**, not by original ordering. The
+  reviewer scans for `[Read fully]` and `[Targeted careful read]`
+  first; the `[Skim ...]` groups can be glanced.
+- **Single-file depth groups: inline.** One line: `**Read fully:**
+  path — verification targets`.
+- **Multi-file depth groups: block.** Depth heading on its own line,
+  then bulleted list. Each bullet: `path (Δ) — verification targets`.
+- **No "*Look for:*" label.** Verification content is the body of each
+  entry; the em-dash after the path or depth label introduces it
+  directly.
+
+#### Bucket calibration
+
+The three buckets are scoped by *artifact type*. Per-file depth labels
+within each bucket carry the risk signal — don't put risk claims in
+the bucket framing.
+
+- **Bucket 1 — Runtime surface (focus here).** SPF behaviors, actors,
+  engines, adapters, primitives, and their tests. The code surface
+  this PR touches. Spans the full label range (`[Read fully]` → `[Skim
+  structure only]`).
+- **Bucket 2 — Design docs / infrastructure-as-doc (skim).** Internal
+  design registry, conventions, use-case docs, feature-doc cascades.
+  Not user-facing; not runtime. Caps at `[Skim file]` for the
+  precedent-setting doc; everything else is `[Skim structure only]`
+  or `[Skim or skip]`.
+- **Bucket 3 — Agent skills (skim or skip).** `.claude/skills/*` files.
+  LLM-consumed; no runtime impact. Drift can be corrected in any
+  future PR — explicitly say so in the bucket framing. Every file
+  here is `[Skim or skip]`.
+
+A file's bucket is determined by *what kind of artifact it is*, not by
+its directory. A test file for a runtime behavior goes in Bucket 1. A
+sandbox demo goes in Bucket 1 (it's runtime-adjacent even though not
+shipped). A feature-doc cascade goes in Bucket 2.
+
+**Drop framing sentences below bucket headings.** The heading does the
+work — there's no need for a one-line intro elaborating it. If the
+bucket has rationale worth surfacing (typically Bucket 3's "why is
+skipping OK?" answer), fold a 2–4-word qualifier into the heading
+itself rather than write a sentence:
+
+```
+### Bucket 3 — Agent skills, no runtime impact (skim or skip)
+```
+
+Avoid framing sentences that restate the heading ("SPF runtime:
+behaviors, actors, segment-loading. The code surface this PR touches.")
+and avoid framings that claim risk profile ("Where regression bugs
+live") — both overclaim and waste vertical space. The per-file depth
+labels carry per-file risk; the heading carries category.
+
+#### The five-label set
+
+A 2D grid: scope of attention × intensity of attention.
+
+|                | Whole file       | Targeted              |
+| -------------- | ---------------- | --------------------- |
+| **High attention** | `[Read fully]`         | `[Targeted careful read]` |
+| **Low attention**  | `[Skim file]`          | `[Skim structure only]`   |
+
+Plus a fifth tier below the grid: `[Skim or skip]` — deferrable
+entirely; reviewer can pass.
+
+**Label-to-file mapping rules:**
+
+- **`[Read fully]`** — new files, especially precedent-setters. Reviewer
+  reads every line and asks *"is this the right shape?"* Example:
+  `engine-audio-only.ts` (first concrete variant engine, +168 lines new).
+- **`[Targeted careful read]`** — diffs into existing files where the
+  *Look for:* prose names what to focus on. Reviewer doesn't re-read
+  the whole file; they zoom in on named areas at high attention. Used
+  for risk-surface files too (the qualifier lives in prose, not the
+  label). Example: `segment-loader.ts` (+90 into a much larger
+  pre-existing file; "*Look for: staleRange anchor correctness…*").
+  Also use for files where the *Look for:* names multiple specific
+  things to verify (single-writer invariants, ordering, predicate
+  edge cases) — fold "Spot-check + verify X, Y, Z" up into this label.
+- **`[Skim file]`** — whole file at low attention. Pass through; come
+  away with a working mental model. Used for prose-heavy files where
+  substance matters but reviewer doesn't need to memorize details.
+  Example: `multi-language-audio.md` (+178; "*Look for: Tier 1/2
+  status reflects what shipped…*"). Also for *test* files where the
+  test suite is heavy and reviewer trusts the suite but verifies
+  assertion shape.
+- **`[Skim structure only]`** — targeted at low attention. Don't read
+  prose; confirm specific structural properties (does it mirror its
+  sibling? is the frontmatter intact? was the single caller updated?).
+  Used for mechanical files and trust-internals-verify-wiring cases.
+  Example: `setup-buffer-actors.ts` (small lifecycle-only revert; "*Look
+  for: no stray flush logic left behind*"). Also for `[Trust + verify
+  single caller]`-shaped asks where the file internals are trusted
+  and only one consequence needs verification — fold those into this
+  label.
+- **`[Skim or skip]`** — genuinely deferrable. Reviewer can pass
+  entirely without the PR being meaningfully under-reviewed. Used for
+  Bucket 3 (agent skills) and for tertiary Bucket 2 files (coarser
+  siblings, secondary use-case docs). The bucket-level framing should
+  explain *why* skipping is acceptable (e.g., "drift can be corrected
+  in any future PR — no coupling to runtime review").
+
+**Avoid the medium-tier trap.** Earlier iterations of this discipline
+used labels like `[Spot-check]`, `[Trust + verify single caller]`,
+`[Skim + verify the spy filter]` for files that didn't quite fit the
+four-cell grid. These collapse into the four cells cleanly:
+
+- Logic-y verification (a small change with named things to verify) →
+  `[Targeted careful read]`.
+- Mechanical or single-consequence verification (file internals trusted,
+  one wiring point to confirm) → `[Skim structure only]`.
+
+The specific ask lives in the *Look for:* prose. The label carries
+*how much / how carefully*, not *what to verify*.
+
+#### Verification content (the "Look for:" content, no label)
+
+Every file entry names specific things to verify after the depth
+label. The verification content is the body of the entry — no explicit
+"*Look for:*" label needed; the em-dash after the depth label or
+file path introduces it directly. This is where the mode-of-attention
+nuance lives that the depth label alone can't carry.
+
+**Rules:**
+
+- **Noun phrases or short clauses, not full sentences.** Multiple items
+  separated by semicolons. Target 5–10 words per item.
+- **Every technical term needs a contrast or a gloss.** Either pair an
+  abbreviated term with the alternative it's contrasted against
+  (`switchVideoTrack` (bandwidth-driven ABR) vs. `switchAudioTrack`
+  (pin-to-current)), or provide a parenthetical (`ABR (bandwidth-
+  driven)`). **Compressing past the reader's prior knowledge produces
+  terse-but-obscure prose; that's worse than wordy-but-clear.** A
+  reviewer who isn't deep in SPF should still be able to act on each
+  item.
+- **Name what's verifiable, not what the file does.** "Only the one
+  internal caller updated" is verifiable; "manages quality selection"
+  is descriptive. *What changed — by surface* carries file-purpose
+  narrative; the Look-for clause carries verification targets.
+
+**Good shapes:**
+
+- *Names a precedent.* "First concrete subtractive-composition engine
+  variant (engine omits the default's video + text behaviors); the
+  shape sets precedent for future variants."
+- *Names a risk pattern.* "Just absorbed the stall-bug fix in
+  `cb6cd8b2` — same class of bug can re-emerge if `planTasks` ordering
+  changes."
+- *Names invariants.* "Filter doesn't violate the single-writer
+  invariant on `selectedAudioTrackId` (path must stay clear for
+  `switchAudioQuality`)."
+- *Names what's mechanically verifiable.* "Only the one internal caller
+  in `media/primitives/select-tracks.ts` updated; no shim debt."
+
+**Gloss table for common SPF terms** (use gloss on first mention; drop
+on subsequent uses within the same description):
+
+| Term | Suggested first-use gloss |
+|---|---|
+| `ABR` | `(bandwidth-driven)` or `(adaptive bitrate)` |
+| `cross-rendition switch` | `(language or codec change, not bitrate)` |
+| `per-rendition switch` | `(same program, different bitrate)` — i.e., ABR |
+| `variant engine` | `(composition variant of the default engine)` |
+| `subtractive composition` | `(engine variant omitting some default behaviors)` |
+| `defensive-read pattern` | `(behavior reads cross-track slots as optional)` |
+| `staleRanges` / `stale-range` | `(buffered content that will be overwritten on next append)` |
+| `single-writer invariant` | `(only one behavior may write a given state slot)` |
+| `slot owner` | `(behavior that writes a specific state slot)` |
+| `DWIM` | `(do-what-I-mean — sensible default for under-specified cases)` |
+
+Bad *Look for:* prose restates what the bullet's intro already said,
+uses bare technical terms without contrast or gloss, or describes file
+purpose rather than verification targets.
+
+### 3. Smoke test
+
+A reviewer-actionable verification block: a URL the reviewer can paste
+into a running sandbox (or a deploy-preview link), plus 2–5 concrete
+things to observe that confirm the change. Distinct from *Test plan*
+(section 8), which is the author's record of what was already run. This
+section is for the reviewer's hands.
+
+**Shape (when smoke-test applies):**
+
+```markdown
+## Smoke test
+
+**Sandbox:** `/<template>/?<params>&src=<source-url>`
+
+- Load locally (`pnpm dev:sandbox` → paste path into the running
+  Vite server) or via the PR's deploy preview (if one is configured).
+- **Observe:**
+  - <Observable 1 — concrete, user-visible>
+  - <Observable 2>
+  - ...
+```
+
+**Rules:**
+
+- **URL is path-only**, not host-qualified. Reviewers append the path
+  to whichever host they're using (local Vite, deploy preview). One
+  artifact, two consumption modes.
+- **Template path comes from `apps/sandbox/src/<template>/`.** The
+  directory name is the URL path. Pick the template that exercises the
+  surface this PR changes — usually the sandbox demo the PR also
+  updates.
+- **Source URLs must be publicly accessible.** Mux test streams, public
+  HLS samples — not LOCAL or auth-gated assets. The reviewer should
+  be able to load the URL without any setup beyond pulling the branch.
+- **Observables are user-visible, not internal-state.** "Audio language
+  switches mid-stream without a stall" is observable. "`planTasks`
+  emits the expected stale range" is not — that's a test, not a smoke
+  test.
+- **2–5 observables.** Fewer = the section isn't carrying its weight.
+  More = reviewer fatigue; pick the most distinguishing ones and
+  defer the rest to the test plan.
+
+**When smoke-test doesn't apply.** Some PRs have no observable surface
+(internal refactor, docs-only, skill-only, types-only). Don't fabricate
+a smoke test. Either omit the section or, if reviewers might expect one
+and look for it, keep the heading with an explicit note:
+
+```markdown
+## Smoke test
+
+No reviewer-actionable smoke test for this PR — the change is
+<internal refactor / docs-only / skill-only / types-only> with no
+runtime surface. Verification lives in *Test plan*.
+```
+
+The explicit note is preferable when the PR is large, touches runtime
+code paths, but the *user-visible* effect is null (e.g., a refactor that
+preserves behavior). Skipping the section silently makes reviewers
+wonder whether you forgot or whether none exists.
+
+**Human-in-the-loop.** The skill can detect candidates from the diff
+(sandbox templates touched, new behaviors with observable output, demo
+preset changes) but cannot reliably synthesize the *meaningful* part —
+which source URL exercises the new behavior, which query params are
+needed, what specifically to look for. Propose a draft to the user and
+ask them to confirm the URL, source, and observables before writing.
+See *Smoke-test discipline* under *Disciplines* for the proposal
+pattern.
+
+### 4. What changed — by surface
+
+Theme-grouped narrative, 3–5 themes. Each theme = 1 short paragraph
+(3–5 sentences). Themes are by *surface*, not by file or by section
+of the registry. Examples of good theme labels:
+
+- "Multi-language audio Tier 1 + Tier 2 (programmatic + mid-stream)."
+- "Track-switching unification."
+- "Cross-rendition switch via MSE overwrite-on-append."
+- "Stall-bug fix."
+- "SPF doc registry — new use-case-composition tier."
+
+If a theme's narrative wants to grow beyond 5 sentences, factor a
+*Notable design decisions* bullet out of it.
+
+### 5. Notable design decisions
+
+Bulleted list. Each item: **choice / alternative / why**. Lead with
+the choice in bold, then a sentence on the alternative considered,
+then the rejection rationale. Format:
+
+```
+- **<Choice>.** <One-sentence elaboration.> Alternative considered:
+  <the road not taken>. Rejected because <why>.
+```
+
+Use this section for decisions a reviewer might reasonably push back
+on. Don't use it for routine implementation details (those belong in
+*What changed* or commit messages).
+
+End an item with a reviewer-facing question when one exists. Example:
+*"Reviewers: is the filter too broad?"*
+
+### 6. Reviewer callouts — known limitations
+
+Bulleted list of explicit known-gaps + deferred-work flags + Cursor
+Bugbot findings worth promoting from inline threads.
+
+**Scope-narrow the section heading if it doesn't apply PR-wide.** A
+common case: a known limitation lives entirely in `apps/sandbox` and
+doesn't affect runtime code. The heading should say so:
+
+```markdown
+## Reviewer callouts — known limitations (sandbox app only)
+
+> Scope: this section is **only about `apps/sandbox`** (the dev/test
+> harness). No runtime/library code is affected.
+```
+
+For each callout, frame as **<source-tag>** (e.g., `[Cursor Bugbot]`,
+`[Author]`, `[Deferred from Tier 2]`) + the limitation + the
+disposition ("good enough for now," "follow-up issue welcome," "blocker
+if reviewer disagrees").
+
+### 7. Breaking changes
+
+Single paragraph. If none, say so explicitly with the alpha caveat if
+SPF: *"None. SPF stays alpha; `<config>` surface unchanged. Deleted
+docs are internal-only, not exported API."*
+
+### 8. Test plan
+
+Markdown checklist. `[x]` for completed items, `[ ]` for pending. Each
+item: command + result. **Author-facing**: what was actually run, what's
+deferred, what depends on a sibling PR landing. The reviewer-actionable
+verification surface lives in *Smoke test* (section 3) — don't duplicate
+it here. Include any manual verification the author did beyond the
+smoke-test (deeper sweeps, environment-specific checks).
+
+## Disciplines
+
+### Compression discipline
+
+The *For reviewers — how to read this PR* section is what reviewers
+will actually use to pace themselves. The target is **"Bucket 1 fits
+in one viewport"** (~25 lines at typical zoom). Line count matters
+more than word count.
+
+**Line-saving moves (apply in order):**
+
+1. **Drop bucket framing lines.** Heading does the work. If a
+   rationale needs to be visible, fold a 2–4-word qualifier into the
+   heading itself (e.g., `Bucket 3 — Agent skills, no runtime impact`).
+2. **Group files by depth label.** Reviewers scan for priority; depth
+   grouping makes it visible at a glance.
+3. **Inline single-file depth groups.** One line:
+   `**Read fully:** path — verification targets`. Multi-file groups
+   keep the block shape.
+4. **Combine multiple low-priority files into one line.** Three
+   `[Skim structure only]` files can share a line as
+   `path1 (note1), path2 (note2), path3 (note3)`.
+5. **Drop the *Look for:* label.** Em-dash introduces verification
+   content directly.
+
+**Per-entry budget:**
+
+- **One line is default.** ~80–120 characters including depth label
+  and verification content.
+- **Spill to a second line only when content genuinely earns it.**
+  Examples that earn the spill: a recent bug-fix regression risk (the
+  `cb6cd8b2` callout on `segment-loader.ts` in #1605); a new-file
+  precedent that future PRs will copy (`engine-audio-only.ts` in
+  #1584).
+
+**What to cut:**
+
+- **"What this file is" narrative per entry.** Themes live in *What
+  changed — by surface*. Entries carry path + (Δ) + depth + verification.
+- **Multi-sentence verification items.** Noun phrases / short clauses,
+  semicolon-separated. See *Verification content*.
+- **Teaching prose in bucket framings.** A reviewer who doesn't know
+  SPF won't be taught by one sentence; one who does is wasting their
+  time on it.
+- **The *Look for:* label.** Em-dash is enough.
+
+**What to keep:**
+
+- **Glosses on first use of technical terms.** Terseness is not the
+  same as obscurity. See *Verification content* for the gloss rule
+  and table.
+- **Commit links inside verification prose** when they anchor a risk
+  pattern.
+- **Contrast pairs** that establish meaning for compressed terms
+  (`X (does this) vs. Y (does that)`).
+
+**Target shape** (Bucket 1 example):
+
+```
+### Bucket 1 — Runtime (focus here)
+
+**Read fully:** `track-switching.ts` (new) — no video-ABR vs.
+audio-pin bias; conventions; `switchAudioQuality` slots in
+
+**Targeted careful read:**
+- `segment-loader.ts` (+90) — `staleRange` at playhead (not next-
+  boundary); `isCrossRenditionSwitch` edges; bandwidth-aware dedup
+  keeps new-track segments. Stall-bug fix [`<sha>`](url) — same
+  class can re-emerge if `planTasks` ordering changes
+- `source-buffer.ts` (+22) — `initTrackLanguage` captured before
+  append
+- `select-tracks.ts` — single-writer invariant on selected-slot;
+  3-tier picker default; short-circuit when filter narrows to one
+
+**Skim structure only:** `quality-selection.ts` (single caller, no
+shim), `setup-buffer-actors.ts` (lifecycle revert), sandbox demo
+(mirrors siblings)
+
+**Skim file:** Tests (4 files, +628 total) — assertion shape across
+cross-rendition, stall regression, picker tiebreaks
+```
+
+~11 lines for an 8-file bucket. The whole *How to read* section
+should fit in ~25 lines for typical PRs.
+
+### Smoke-test discipline
+
+The skill cannot reliably synthesize a meaningful smoke-test URL from
+the diff alone. The diff names what changed; it does not name what
+source URL exercises the change, which query params trigger the right
+codepath, or what the reviewer should *see* if it works. Those are
+author-knowledge choices that the skill should propose and the author
+should confirm.
+
+**The proposal pattern:**
+
+1. **Scan the diff for smoke-test signals.** Worth proposing a smoke
+   test when any of these are present:
+   - A sandbox template (`apps/sandbox/src/<template>/`) is touched.
+   - A sandbox demo preset is added or modified (e.g., a new HLS
+     source preset, a new picker UI).
+   - A new public behavior shows up with observable output (default
+     selection, mid-stream switching, error UX, accessibility surface).
+   - A bug fix where the regression has a user-visible signature
+     (stall, broken control, wrong default).
+2. **Draft a proposal.** Pick the most likely template + a placeholder
+   source URL + 2–5 observables drawn from the *What changed* themes.
+   Be explicit that values are guesses:
+
+   ```
+   Proposed smoke test (please confirm or correct):
+
+   **Sandbox:** `/<template>/?<params>&src=<your source URL>`
+   - <Observable 1, inferred from theme A>
+   - <Observable 2, inferred from theme B>
+   ```
+
+3. **Ask the user to confirm three things.** The URL path + params, the
+   source URL, and the observables. Use one `AskUserQuestion` block;
+   each is a separate question. If the user provides a full URL in the
+   conversation (e.g., pasted directly), skip the URL questions and
+   only confirm observables.
+4. **Write the section once confirmed.** Don't write the smoke test
+   to the body until the user signs off — a wrong URL or a wrong
+   observable burns reviewer time.
+
+**When no smoke test applies.** Internal refactors, docs-only PRs,
+skill-only PRs, types-only PRs. Don't propose a fabricated smoke test.
+Either omit the section entirely or, if the PR is large enough that
+reviewers might expect one, write the explicit *"No reviewer-actionable
+smoke test"* note (see section 3 shape). Confirm with the user which.
+
+**Don't try to infer the deploy-preview URL.** Vercel / Netlify /
+similar preview-URL conventions vary per project and per PR; the skill
+should not hard-code a hostname. Path-only smoke-test URLs let
+reviewers append to whichever host they use; the author can paste a
+preview link in a PR comment if helpful, but the description stays
+host-agnostic.
+
+**Observable phrasing.** Same rules as *Verification content* in
+section 2 — noun phrases or short clauses, technical terms paired with
+a contrast or gloss. Observables are *user-visible*, not internal:
+
+- Good: "Audio language switches mid-stream without a visible stall."
+- Good: "Default selection picks `en` (preferred) over `fr` on first
+  load."
+- Bad: "`planTasks` emits a `staleRange` for the cross-rendition
+  switch." (Internal state — that's a test, not a smoke test.)
+- Bad: "Multi-language audio works." (Not distinguishing — what
+  specifically would tell the reviewer the change is broken?)
+
+### Link discipline
+
+**File-path links in PR descriptions are fragile. The default is no link.**
+
+- Relative paths (`packages/.../file.ts`) resolve against the repo's
+  *default branch* (main), not the PR's head. Always wrong for new
+  files; misleading for modified files.
+- Absolute branch-ref URLs
+  (`https://github.com/<owner>/<repo>/blob/<head-branch>/path`) work
+  during the PR's open period but rot after merge (branch is usually
+  deleted). They also encode the head-branch name, which makes the
+  body harder to reuse.
+- Commit-SHA URLs are stable but require knowing the SHA at draft
+  time and don't update with subsequent pushes.
+
+**Default: keep file paths as plain backticked code spans** (`` `path/to/file.ts` ``).
+Reviewers can navigate via the *Files changed* tab. The path-as-text
+survives all merge / rebase / branch-deletion events.
+
+**Exception: commit links.** Absolute commit URLs (`pull/<num>/commits/<sha>`)
+are stable forever. Use these when referencing a specific commit's
+context (e.g., a postmortem in the commit message that you're pointing
+reviewers at).
+
+### Cursor Bugbot integration
+
+When Bugbot has produced inline findings, decide per finding:
+
+- **Promote to *Reviewer callouts***: a real finding that the PR isn't
+  addressing (or is addressing partially). Frame as `[Cursor Bugbot]`
+  + description + disposition ("good enough for now," "follow-up issue
+  welcome").
+- **Address in code**: a real finding the PR should fix. Don't put in
+  the description; just fix it.
+- **Dismiss inline**: a false positive. Reply in the inline thread; no
+  description treatment needed.
+
+Don't bury Bugbot findings in the narrative body. They belong as
+explicit callouts so reviewers can engage with them.
+
+### Stacked-PR awareness
+
+If the PR is stacked on another open PR (e.g., #1605 stacked on #1584),
+GitHub's *Files changed* tab is anchored at the merge-base on main,
+not at the parent PR's tip. Until the parent PR squash-merges and the
+stacked PR rebases, the diff display will include the parent's
+content.
+
+**Default: don't mention stacking in the PR description.** It adds
+noise for reviewers who don't need to know about the branch topology.
+The description should describe what *this PR contributes* on top of
+its base — the diff-display weirdness is a workflow concern, not a
+review-content concern.
+
+**Exception:** if the PR is open for review *before* the parent lands
+and the diff display will materially confuse reviewers, add a brief
+stacking note in the *How to read* section. Remove the note before
+final merge.
+
+### Carry-forward discipline
+
+When you draft a description for one PR and a related PR (stacked,
+sibling, follow-up) exists, propagate the structure + label set to
+the related PR. Reviewers benefit from consistent shape across a PR
+family. Specific items to carry forward:
+
+- The five-label set + 2D grid (don't re-derive).
+- The seven-section structure (don't reorder).
+- Discoveries that apply to both PRs (a link-discipline rule learned
+  on PR A applies to PR B).
+
+If you propose a structural change on one PR (e.g., dropping a section,
+narrowing a callout scope), check whether the same change applies to
+the sibling.
+
+## Workflow
+
+1. **Gather context.**
+   - `gh pr view <num>` for current title, body, base/head branches.
+   - `gh pr view <num> --json files | …` for the file list with line
+     counts (sort by `additions + deletions` descending).
+   - `git log <base>..<head>` for the commit history — commit messages
+     often carry the design rationale you'll cite in *Notable design
+     decisions*.
+   - `gh pr view <num> --json reviews,comments` + the inline-comments
+     endpoint for Cursor Bugbot findings.
+   - The current description (if any) — read it before drafting; some
+     content may be reusable.
+
+2. **Route files to buckets.** Walk the file list and assign each file
+   (or file group) to Bucket 1 / 2 / 3 by risk concentration (see
+   *Bucket calibration*). Group mechanical files into single bullets
+   (e.g., "Player cascade (core / html / react / sandbox) + sandbox
+   preset wiring").
+
+3. **Assign labels.** For each Bucket 1 file, apply the five-label
+   set. For Bucket 2, default to `[Skim file]` for the precedent-setting
+   doc and `[Skim structure only]` or `[Skim or skip]` for the rest.
+   For Bucket 3, every file is `[Skim or skip]`.
+
+4. **Write *Look for:* prose.** For each labeled file, name the
+   specific things the reviewer should check. See *"Look for:" prose*
+   above for what makes good prose.
+
+5. **Propose the smoke test (or confirm none applies).** Scan the
+   diff for smoke-test signals (see *Smoke-test discipline*). If
+   any are present, draft a `<template>` + source-URL + observables
+   proposal and ask the user to confirm. If none are present — or
+   if the PR is internal-only — confirm with the user whether to
+   omit the section or include the explicit no-smoke-test note.
+
+6. **Draft the body.** Write to `/tmp/pr-<num>-body.md`. Preserve any
+   `<!-- CURSOR_SUMMARY -->` block from the current description intact
+   at the bottom.
+
+7. **Propose to the user.** Always check in before pushing. Show the
+   structure and key choices; ask whether to push as-is or revise.
+   Specific things worth flagging:
+   - Trim level (aggressive vs. preserve-detail).
+   - Bugbot finding framing (callout / address / dismiss).
+   - Authorship note (omit by default).
+   - Scope justification (in TL;DR or omit).
+   - Sandbox-only scope on Reviewer callouts (when applicable).
+   - Smoke-test inclusion + observables (re-confirm if values
+     changed since the proposal in step 5).
+
+8. **Push via `gh pr edit <num> --body-file /tmp/pr-<num>-body.md`.**
+   Verify the live state matches the file with a quick
+   `gh pr view <num> --json body --jq .body | diff -`.
+
+9. **If a sibling PR exists, offer to carry forward.** See *Carry-
+   forward discipline*.
+
+## Audit pattern
+
+When revising an existing description, walk this checklist:
+
+- [ ] **TL;DR carries the "why this scope" rationale** if reviewers
+      might push back on scope.
+- [ ] **How-to-read uses the five-label set** with no medium-tier
+      labels (`[Spot-check]`, `[Trust + verify…]`) lingering.
+- [ ] **Files grouped by depth label**, not by original ordering.
+- [ ] **No bucket framing sentences** below headings. Deferrability
+      rationale folded into heading itself (e.g., "no runtime impact").
+- [ ] **No *Look for:* label** on entries; em-dash introduces
+      verification content.
+- [ ] **Single-file depth groups inline**; multi-file groups in block.
+- [ ] **How-to-read section fits in ~25 lines** for a typical PR
+      (Bucket 1 in one viewport).
+- [ ] **Smoke test section present** with path-only URL + 2–5 observable
+      checks, OR the explicit no-smoke-test note, OR justifiably absent
+      (purely internal change with no runtime surface). User confirmed
+      the URL + observables before push.
+- [ ] **Every entry has verification content** with contrast pairs or
+      glosses for technical terms.
+- [ ] **Notable design decisions follow choice/alternative/why** for
+      every bullet.
+- [ ] **Reviewer callouts have scope-narrowing** when the limitation
+      doesn't apply PR-wide.
+- [ ] **No relative file-path links** anywhere in the body.
+- [ ] **No stacking note** (unless the parent PR hasn't landed and
+      the stacking materially confuses the diff display).
+- [ ] **Cursor summary block preserved** if present in the original.
+
+## Common pitfalls
+
+- **Treating the description as a changelog.** File-by-file
+  enumeration is what *Files changed* is for. The description should
+  tell a reviewer *how to read* and *what's at stake*.
+- **Stacking medium-tier labels.** `[Spot-check]` and friends
+  proliferate when you try to express *mode of attention* (precedent-
+  check vs. risk-hunt vs. consistency-check) through the label. The
+  label carries scope × intensity only; the prose carries mode.
+- **Adding file-path links because they look professional.** They
+  almost always break. Either commit to working absolute URLs and
+  verify them with `curl`, or use plain code spans. Don't ship
+  relative paths.
+- **Burying Bugbot findings in the body.** A finding the PR isn't
+  addressing belongs in *Reviewer callouts* with explicit disposition.
+- **Skipping the user check-in.** Always propose before pushing. PR
+  descriptions are author-facing artifacts; the author has context
+  the skill doesn't.
+- **Over-compressing past reader knowledge.** Terse-but-obscure is
+  worse than wordy-but-clear. "No video-ABR bias in the variant-
+  agnostic body" fails because *variant-agnostic body* and *video-
+  ABR* are both jargon with no anchor for someone who isn't deep in
+  SPF. Pair every technical term with a contrast or gloss; the
+  reviewer should be able to act on each *Look for:* item without
+  spelunking the code first.
+- **Claiming risk in bucket framings.** "Where regression bugs live"
+  overclaims (implies bugs exist) and isn't categorically true
+  (additive opt-in changes have minimal regression surface). Name
+  what's in the bucket and characterize *code shape*; let the per-
+  file labels carry per-file risk.
+- **Fabricating a smoke test when none applies.** Internal refactors,
+  docs-only PRs, skill-only PRs have no observable runtime surface.
+  Don't manufacture observables to pad the section. Either omit it or
+  write the explicit no-smoke-test note (see section 3 shape).
+- **Burying the smoke test in Test plan.** The author-facing checklist
+  (section 8) is for "what I ran"; the reviewer-actionable URL +
+  observables belongs in section 3 where reviewers can find it without
+  reading to the bottom. If both feel like they're saying the same
+  thing, the *Test plan* item is over-detailed — trim it to the
+  command + result.
+- **Hard-coding a deploy-preview hostname.** Vercel / Netlify /
+  similar conventions vary per project, per PR, per fork. The smoke-
+  test URL is path-only; reviewers append it to whichever host they
+  use. Hosts in the description rot when redeploys happen.
+- **Skipping the user confirmation on smoke-test values.** The skill
+  can't reliably guess the source URL or the observables. Always
+  propose + confirm before writing the section.

--- a/.claude/skills/spf-document-feature/SKILL.md
+++ b/.claude/skills/spf-document-feature/SKILL.md
@@ -224,7 +224,7 @@ This is the load-bearing step. Getting it wrong (misreading historical
 context as current scope, missing a sister feature, conflating with
 another feature, inflating an API primitive into a standalone feature)
 invalidates everything downstream — same failure shape as
-`refactor-behavior`'s Step 1 misdiagnosis.
+`spf-refactor-behavior`'s Step 1 misdiagnosis.
 
 ### Step 2 — Discuss to resolve ambiguities
 
@@ -562,11 +562,11 @@ by Step 1's gathering.
 
 ## When this is the wrong skill
 
-- **You want to refactor an existing behavior** → `/refactor-behavior`.
-- **You want to split a per-type behavior** → `/refactor-behavior`'s
-  Step 6a may route you to `/split-behavior`.
-- **You want to merge two behaviors** → `/refactor-behavior`'s Step 3
-  routes to `/merge-behaviors`.
+- **You want to refactor an existing behavior** → `/spf-refactor-behavior`.
+- **You want to split a per-type behavior** → `/spf-refactor-behavior`'s
+  Step 6a may route you to `/spf-split-behavior`.
+- **You want to merge two behaviors** → `/spf-refactor-behavior`'s Step 3
+  routes to `/spf-merge-behaviors`.
 - **You want to write a design doc for an architecture concern (not a
   feature)** → `design` skill. Architectural concerns live in
   `internal/design/spf/` directly, not under `features/`.

--- a/.claude/skills/spf-document-use-case/SKILL.md
+++ b/.claude/skills/spf-document-use-case/SKILL.md
@@ -254,7 +254,7 @@ having to surface it themselves.
 
 This is the load-bearing step. Getting it wrong invalidates everything
 downstream — same failure shape as `/spf-document-feature`'s Step 1
-misdiagnosis and `/refactor-behavior`'s Step 1 purpose-articulation.
+misdiagnosis and `/spf-refactor-behavior`'s Step 1 purpose-articulation.
 
 ### Step 2 — Discuss to resolve ambiguities
 
@@ -605,10 +605,10 @@ ambiguities are genuinely resolved by Step 1's gathering.
 - **Your candidate's implementation shape is middle-pattern, not
   composition** → `/spf-document-feature`. Per `clusters.md`: most
   candidates fail this check.
-- **You want to refactor an existing behavior** → `/refactor-behavior`.
-- **You want to split or merge behaviors** → `/refactor-behavior`'s
-  Step 3 / Step 6a may route you to `/split-behavior` or
-  `/merge-behaviors`.
+- **You want to refactor an existing behavior** → `/spf-refactor-behavior`.
+- **You want to split or merge behaviors** → `/spf-refactor-behavior`'s
+  Step 3 / Step 6a may route you to `/spf-split-behavior` or
+  `/spf-merge-behaviors`.
 - **You want to write an architectural design doc** → `design` skill.
   Architectural concerns live in `internal/design/spf/` directly, not
   under `use-cases/`.

--- a/.claude/skills/spf-implement-feature/SKILL.md
+++ b/.claude/skills/spf-implement-feature/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   /spf-document-feature (which produces the doc; this consumes it). Walks
   through resolving the doc's open questions before coding, maps phases to
   discrete chunks, applies the SPF conventions catalog, routes to downstream
-  skills (/spf-create-behavior, /spf-update-behavior, /refactor-behavior) per
+  skills (/spf-create-behavior, /spf-update-behavior, /spf-refactor-behavior) per
   chunk shape, and updates the feature doc's Status / Implementation surface
   / Verification sections as code lands. Triggers: "implement feature",
   "implement SPF feature", "build feature", "code feature", "scope feature
@@ -105,9 +105,9 @@ Downstream skills routed-to:
 - `.claude/skills/spf-create-behavior/SKILL.md` — new behaviors.
 - `.claude/skills/spf-update-behavior/SKILL.md` — existing behaviors whose
   purpose is changing.
-- `.claude/skills/refactor-behavior/SKILL.md` — existing behaviors whose
+- `.claude/skills/spf-refactor-behavior/SKILL.md` — existing behaviors whose
   purpose is preserved but implementation improves.
-- `.claude/skills/split-behavior/SKILL.md`, `.claude/skills/merge-behaviors/SKILL.md`
+- `.claude/skills/spf-split-behavior/SKILL.md`, `.claude/skills/spf-merge-behaviors/SKILL.md`
   — structural changes.
 - *(future)* media-layer / network-layer skills for `packages/spf/src/media/`
   and `packages/spf/src/network/` changes.
@@ -293,7 +293,7 @@ Step 1's report:
   code), (ii) config-driven (existing behavior gains a knob), (iii)
   new behavior (route to `/spf-create-behavior`), (iv) behavior update
   with purpose change (route to `/spf-update-behavior`), (v) behavior
-  refactor with preserved purpose (route to `/refactor-behavior`), (vi)
+  refactor with preserved purpose (route to `/spf-refactor-behavior`), (vi)
   media-layer / network-layer change (handle inline or defer per the
   downstream-skill-missing branch).
 - **Resolve open questions the implementation needs.** Per the
@@ -372,8 +372,8 @@ Iterate per chunk:
    - **Config-driven** — handle inline.
    - **New behavior** — route to `/spf-create-behavior` for this chunk.
    - **Behavior update (purpose changing)** — route to `/spf-update-behavior`.
-   - **Behavior refactor (purpose preserved)** — route to `/refactor-behavior`.
-   - **Structural (split/merge)** — route via `/refactor-behavior`'s
+   - **Behavior refactor (purpose preserved)** — route to `/spf-refactor-behavior`.
+   - **Structural (split/merge)** — route via `/spf-refactor-behavior`'s
      decomposition check.
    - **Media-layer / network-layer** — handle inline for now; future
      skills will own these.
@@ -532,8 +532,8 @@ in the open, with the user making the call.
   *(future)* `/spf-implement-use-case`. For now, this skill can be invoked
   per-constituent-feature of a use case.
 - **You want to refactor an existing behavior without feature scope** →
-  `/refactor-behavior`.
-- **You want to split or merge behaviors** → `/refactor-behavior`'s
+  `/spf-refactor-behavior`.
+- **You want to split or merge behaviors** → `/spf-refactor-behavior`'s
   decomposition check.
 - **You want to write an architectural design doc** → `design` skill.
 - **You want to write an RFC** → `rfc` skill.

--- a/.claude/skills/spf-implement-use-case/SKILL.md
+++ b/.claude/skills/spf-implement-use-case/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   status), resolves the doc's open questions with the user, maps phases to
   chunks, routes to downstream skills (/spf-implement-feature for
   unimplemented constituents, /spf-create-behavior, /spf-update-behavior,
-  /refactor-behavior), and updates both the use-case doc and constituent
+  /spf-refactor-behavior), and updates both the use-case doc and constituent
   feature docs as code lands. Treats the use-case doc as a starting point for
   planning, not a hardened specification. Triggers: "implement use case",
   "implement SPF use case", "implement use-case composition", "build use
@@ -86,7 +86,7 @@ Downstream skills routed-to:
   discipline).
 - `.claude/skills/spf-update-behavior/SKILL.md` — existing behaviors whose
   purpose changes for the variant.
-- `.claude/skills/refactor-behavior/SKILL.md` — existing behaviors with
+- `.claude/skills/spf-refactor-behavior/SKILL.md` — existing behaviors with
   preserved purpose, improved implementation.
 - `.claude/skills/spf-document-use-case/SKILL.md` — invoked when Step 1
   routing concludes the candidate isn't yet documented as a use case.
@@ -429,7 +429,7 @@ typical for use-case implementations:
 - **Use-case-specific behavior creation** (if any) — route to
   `/spf-create-behavior`.
 - **Existing behavior updates** (if any) — route to
-  `/spf-update-behavior` or `/refactor-behavior`.
+  `/spf-update-behavior` or `/spf-refactor-behavior`.
 - **Engine-level test scaffolding** — engine integration tests for
   the variant; per-behavior tests for any new use-case-specific
   behaviors.
@@ -522,10 +522,10 @@ Iterate per chunk:
    - **Behavior update (purpose changing)** → route to
      `/spf-update-behavior`.
    - **Behavior refactor (purpose preserved)** → route to
-     `/refactor-behavior`.
+     `/spf-refactor-behavior`.
    - **Unimplemented constituent feature** → route to
      `/spf-implement-feature` (per Step 2's readiness strategy).
-   - **Structural (split/merge)** → route via `/refactor-behavior`.
+   - **Structural (split/merge)** → route via `/spf-refactor-behavior`.
    - **Media-layer / network-layer** — handle inline for now; future
      skills will own these.
 3. **Run the test passing.**
@@ -734,8 +734,8 @@ isn't; building a factory twice; silent doc drift).
   `/spf-document-use-case`. Implementation requires a starting-point
   doc.
 - **You want to refactor an existing behavior without feature/use-case
-  scope** → `/refactor-behavior`.
-- **You want to split or merge behaviors** → `/refactor-behavior`'s
+  scope** → `/spf-refactor-behavior`.
+- **You want to split or merge behaviors** → `/spf-refactor-behavior`'s
   decomposition check.
 - **You want to write an architectural design doc** → `design` skill.
 - **You want to write an RFC** → `rfc` skill.

--- a/.claude/skills/spf-merge-behaviors/SKILL.md
+++ b/.claude/skills/spf-merge-behaviors/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: merge-behaviors
+name: spf-merge-behaviors
 description: >-
   Merge two SPF behaviors into one with cleaned-shape-first discipline.
   Forces per-side standalone analysis and an explicit complexity-driven
   direction declaration before any combining happens — avoids the
   "relocated mess" failure mode where the merge anchors on the current
   merged-file shape rather than the cleaned per-side shapes. Use after
-  /refactor-behavior's decomposition check has concluded "merge," or to
+  /spf-refactor-behavior's decomposition check has concluded "merge," or to
   redo a merge that landed without the discipline. Triggers: "merge
   behaviors", "merge these behaviors", "combine behaviors", "redo merge",
   "merge X into Y".
@@ -26,13 +26,13 @@ direction declared from a complexity inventory, then combine.
 ## Usage
 
 ```
-/merge-behaviors <file-a> <file-b>
+/spf-merge-behaviors <file-a> <file-b>
 ```
 
 Or for a redo case (a merge that already landed without this discipline):
 
 ```
-/merge-behaviors <merged-file>
+/spf-merge-behaviors <merged-file>
 ```
 
 For the redo case, identify the pre-merge inputs from git history (the
@@ -58,17 +58,17 @@ The canonical references — read them first:
   conditional branches around optional state-scoped work).
 - [`internal/design/spf/conventions/signals.md`](../../../internal/design/spf/conventions/signals.md)
   — multi-writer slots, decomposition check.
-- [`.claude/skills/refactor-behavior/SKILL.md`](../refactor-behavior/SKILL.md)
+- [`.claude/skills/spf-refactor-behavior/SKILL.md`](../spf-refactor-behavior/SKILL.md)
   — the per-side analysis (Steps 1–4) is borrowed from here.
 
-## When to use this skill vs. /refactor-behavior
+## When to use this skill vs. /spf-refactor-behavior
 
 | Situation | Skill |
 | --- | --- |
-| Cleaning up a single behavior file | `/refactor-behavior` |
-| Decomposition check (Step 6 of `/refactor-behavior`) concludes "this should merge with X" | `/merge-behaviors` |
-| A merge already landed without per-side analysis (suspected "relocated mess") | `/merge-behaviors` |
-| Splitting one behavior into two | `/refactor-behavior` (or open a design discussion first) |
+| Cleaning up a single behavior file | `/spf-refactor-behavior` |
+| Decomposition check (Step 6 of `/spf-refactor-behavior`) concludes "this should merge with X" | `/spf-merge-behaviors` |
+| A merge already landed without per-side analysis (suspected "relocated mess") | `/spf-merge-behaviors` |
+| Splitting one behavior into two | `/spf-refactor-behavior` (or open a design discussion first) |
 
 ## Steps (do these in order; do not skip)
 
@@ -82,7 +82,7 @@ Confirm with the user before proceeding if the inputs aren't obvious.
 
 ### Step 2 — Per-side standalone analysis
 
-For **each side independently**, run Steps 1–4 of `/refactor-behavior`:
+For **each side independently**, run Steps 1–4 of `/spf-refactor-behavior`:
 
 1. Articulate the purpose (1 sentence). Apply the **purpose-verb
    diagnostic** from `behaviors.md` Step 1 — note whether the verbs are
@@ -92,7 +92,7 @@ For **each side independently**, run Steps 1–4 of `/refactor-behavior`:
    exist).
 4. Pattern selection.
 
-The per-side analysis is exactly what `/refactor-behavior` does up to
+The per-side analysis is exactly what `/spf-refactor-behavior` does up to
 Step 4; you're running it twice in parallel.
 
 **Don't refactor pre-emptively.** If a side's gap analysis is empty or
@@ -100,7 +100,7 @@ trivial — the current code already conforms to current conventions —
 record that finding and move on. The next step (cleaned-shape sketch)
 takes the current shape, not a projected cleaner one. Only when the
 gap analysis turned up real issues do you project a cleaned shape; in
-that case, recommend (don't perform) `/refactor-behavior` on that side
+that case, recommend (don't perform) `/spf-refactor-behavior` on that side
 as an optional standalone exercise the user may opt into.
 
 ### Step 3 — Cleaned-shape sketch per side
@@ -123,7 +123,7 @@ comparable.
 If a side already conforms (Step 2 found no issues), the sketch
 describes the current shape. If the side needed projecting, the sketch
 is the projected post-refactor shape — and the proposal should note
-that landing the standalone refactor first (via `/refactor-behavior`)
+that landing the standalone refactor first (via `/spf-refactor-behavior`)
 is an option the user can choose.
 
 ### Step 4 — Complexity inventory + direction declaration
@@ -163,7 +163,7 @@ in which fields are populated.
 
 ### Step 6 — Convention checks + decomposition note
 
-Same as `/refactor-behavior` Steps 5–6:
+Same as `/spf-refactor-behavior` Steps 5–6:
 
 - Setup-shape helper signature (`({ state, config }) => cleanup`)?
   Helpers parameterized by what *varies between variants* (per-type

--- a/.claude/skills/spf-refactor-behavior/SKILL.md
+++ b/.claude/skills/spf-refactor-behavior/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: refactor-behavior
+name: spf-refactor-behavior
 description: >-
   Refactor an existing SPF behavior using purpose-first discipline. Forces
   articulation of the behavior's purpose and business rules before code
@@ -22,7 +22,7 @@ refactors. Steps 3–6 only make sense once the purpose is named.
 ## Usage
 
 ```
-/refactor-behavior <path>
+/spf-refactor-behavior <path>
 ```
 
 `path` (required): the behavior file to refactor, e.g.
@@ -134,11 +134,11 @@ Three categories:
   conditional branches around optional state-scoped work.
 
 **If this refactor is a merge of two behaviors, stop and use
-`/merge-behaviors` instead.** A merge is two analyses combined, not
+`/spf-merge-behaviors` instead.** A merge is two analyses combined, not
 one — the per-side cleaned-shape sketch + complexity-driven direction
 declaration that merges need don't fit cleanly inside the
 single-behavior workflow. See `behaviors.md` "Merging two behaviors —
-extra discipline" and `.claude/skills/merge-behaviors/SKILL.md`.
+extra discipline" and `.claude/skills/spf-merge-behaviors/SKILL.md`.
 
 ### Step 4 — Pattern selection
 
@@ -292,7 +292,7 @@ Before writing the refactor:
     "Inverse: behaviors that operate uniformly across tracks."
   - **Downstream consumers operate per-type** → this isn't an
     in-place fix; this is a **split candidate**. Defer the resolution
-    to Step 6a — recommend `/split-behavior` rather than rewriting
+    to Step 6a — recommend `/spf-split-behavior` rather than rewriting
     the slot map here.
 
   Diagnostic: would an audio-only or video-only engine be able to
@@ -355,7 +355,7 @@ not split). The distinguishing signals below pull split apart from
 uniform-aggregate.
 
 **Diagnostic — three split-candidate triggers. Any one firing is enough
-to recommend `/split-behavior` as the follow-up.**
+to recommend `/spf-split-behavior` as the follow-up.**
 
 - **Explicit per-type axis declared inline.** A `type FooType =
   'video' | 'audio'`, a `KeyByType` map, a `for (const type of types)`
@@ -363,7 +363,7 @@ to recommend `/split-behavior` as the follow-up.**
   per-type specialization was already in mind when the merged form was
   written — the merged form usually exists because of a *perceived
   cross-type constraint*. Don't pre-decide the constraint here; surface
-  it as the invariant `/split-behavior`'s cross-boundary audit will
+  it as the invariant `/spf-split-behavior`'s cross-boundary audit will
   evaluate.
 - **Sibling precedents at the same engine layer.** If per-type-
   specialized siblings already exist (`resolveVideoTrack`/`Audio`/
@@ -383,7 +383,7 @@ to recommend `/split-behavior` as the follow-up.**
   iterate `mediaSource.sourceBuffers` or similar aggregates, not when
   consumers consume per-type slots.
 
-**If any trigger fires**: recommend `/split-behavior` as the follow-up
+**If any trigger fires**: recommend `/spf-split-behavior` as the follow-up
 (don't perform the split inline, and don't pre-decide the cross-
 boundary constraint — that's the skill's audit step). Per `behaviors.md`
 "Per-type specialization" (destination shape for per-type splits) and
@@ -420,12 +420,12 @@ often slots cleanly into the larger refactor of the *other* writer
 rather than landing as a standalone change.
 
 **If merge is the answer**: don't perform the merge inline. Recommend
-`/merge-behaviors` as the follow-up — it operationalizes the per-side
+`/spf-merge-behaviors` as the follow-up — it operationalizes the per-side
 cleaned-shape sketch + complexity-inventory + direction-declaration
 discipline that merges need. Per `behaviors.md` "Merging two behaviors
 — extra discipline."
 
-(The split path is handled in 6a above. Recommend `/split-behavior` if
+(The split path is handled in 6a above. Recommend `/spf-split-behavior` if
 any of the three triggers fire there.)
 
 ### Step 7 — Final-shape audit (after writing the change)

--- a/.claude/skills/spf-split-behavior/SKILL.md
+++ b/.claude/skills/spf-split-behavior/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: split-behavior
+name: spf-split-behavior
 description: >-
   Split one SPF behavior into N with axis-declared, constraints-audited
   discipline. Forces explicit axis declaration (per-type horizontal vs.
@@ -7,7 +7,7 @@ description: >-
   the split lands — avoids the failure mode where an apparent
   per-type-friendly behavior ships a split that quietly drops a
   cross-type ordering invariant the merged code was enforcing. Use after
-  /refactor-behavior's decomposition check has concluded "split," or
+  /spf-refactor-behavior's decomposition check has concluded "split," or
   when you've already noticed a behavior wants splitting. Triggers:
   "split this behavior", "split into per-type", "extract per-type
   behaviors", "convert to per-type variants", "split behavior".
@@ -32,7 +32,7 @@ shape is right) and a cross-boundary constraint audit *before* code
 ## Usage
 
 ```
-/split-behavior <file>
+/spf-split-behavior <file>
 ```
 
 Where `<file>` is the single behavior file you're splitting. The skill
@@ -60,18 +60,18 @@ The canonical references — read them first:
   with conditional branches around optional state-scoped work — the
   setup-shape helper for a per-type split must not carry per-variant
   conditionals).
-- [`.claude/skills/refactor-behavior/SKILL.md`](../refactor-behavior/SKILL.md)
+- [`.claude/skills/spf-refactor-behavior/SKILL.md`](../spf-refactor-behavior/SKILL.md)
   — the per-side analysis (Steps 1–4) is borrowed from here.
 
-## When to use this skill vs. /refactor-behavior, /merge-behaviors
+## When to use this skill vs. /spf-refactor-behavior, /spf-merge-behaviors
 
 | Situation | Skill |
 | --- | --- |
-| Cleaning up a single behavior file (same shape, same boundaries) | `/refactor-behavior` |
-| `/refactor-behavior`'s decomposition check concludes "this should split" | `/split-behavior` |
-| Splitting one behavior into per-type variants (video/audio/text) | `/split-behavior` (per-type axis) |
-| Splitting one behavior into per-concern behaviors (two disjoint slot clusters) | `/split-behavior` (per-concern axis) |
-| Merging two behaviors into one | `/merge-behaviors` |
+| Cleaning up a single behavior file (same shape, same boundaries) | `/spf-refactor-behavior` |
+| `/spf-refactor-behavior`'s decomposition check concludes "this should split" | `/spf-split-behavior` |
+| Splitting one behavior into per-type variants (video/audio/text) | `/spf-split-behavior` (per-type axis) |
+| Splitting one behavior into per-concern behaviors (two disjoint slot clusters) | `/spf-split-behavior` (per-concern axis) |
+| Merging two behaviors into one | `/spf-merge-behaviors` |
 
 ## Steps (do these in order; do not skip)
 
@@ -83,12 +83,12 @@ Confirm with the user if it's not obvious.
 ### Step 2 — Articulate the current behavior's purpose
 
 In one sentence: what is this behavior **for**? Same as
-[`refactor-behavior`](../refactor-behavior/SKILL.md) Step 1.
+[`spf-refactor-behavior`](../spf-refactor-behavior/SKILL.md) Step 1.
 
 The purpose establishes the basis for evaluating the split. If the
 purpose is one coherent thing that doesn't decompose into a per-type
 or per-concern shape, that's a finding ("the split doesn't earn its
-keep — keep as-is or apply `/refactor-behavior` instead").
+keep — keep as-is or apply `/spf-refactor-behavior` instead").
 
 Pull from the file-level JSDoc if present; if not, that's a doc gap
 to flag.
@@ -153,12 +153,12 @@ may be wrong.
 post-split unit *would* look like extracted from the current code, not
 a projected refactored version. If a unit's sketch reveals real issues
 (closure-mutable state, fight-the-shape sniffs), note them as
-follow-up `/refactor-behavior` candidates *for that variant after the
+follow-up `/spf-refactor-behavior` candidates *for that variant after the
 split lands* — don't bundle the refactor into the split.
 
 ### Step 5 — Cross-boundary constraint audit (load-bearing)
 
-This is the discipline that distinguishes `/split-behavior` from the
+This is the discipline that distinguishes `/spf-split-behavior` from the
 pre-existing decomposition guidance. Skipping it is how splits ship
 latent races.
 
@@ -238,7 +238,7 @@ Based on the axis:
 
 ### Step 7 — Convention checks
 
-Same as `/refactor-behavior` Step 5 applied to each post-split unit
+Same as `/spf-refactor-behavior` Step 5 applied to each post-split unit
 independently:
 
 - File placement (DOM-free vs. DOM-bound) per unit.
@@ -308,4 +308,4 @@ Three failure modes the order prevents:
 
 A side benefit: the per-side sketches double as the design for each
 post-split unit's standalone refactor (if the user later opts to land
-the split as separate `/refactor-behavior` runs on each variant).
+the split as separate `/spf-refactor-behavior` runs on each variant).

--- a/.claude/skills/spf-update-behavior/SKILL.md
+++ b/.claude/skills/spf-update-behavior/SKILL.md
@@ -2,10 +2,10 @@
 name: spf-update-behavior
 description: >-
   Update an existing SPF behavior whose purpose is changing or expanding.
-  Distinct from /refactor-behavior, which preserves purpose — this skill
+  Distinct from /spf-refactor-behavior, which preserves purpose — this skill
   handles cases where the behavior gains new responsibility (new state slot
   to react to, new lifecycle phase, new constraint, new code path). Carries
-  /refactor-behavior's purpose-first discipline applied to the *purpose
+  /spf-refactor-behavior's purpose-first discipline applied to the *purpose
   change*. Triggers: "update behavior", "extend behavior", "modify behavior",
   "change behavior purpose", "expand behavior responsibility".
 ---
@@ -14,7 +14,7 @@ description: >-
 
 Modify an existing SPF behavior whose purpose is **changing or expanding**.
 The canonical failure mode without this discipline is treating
-purpose-changes as refactors — applying `/refactor-behavior`'s
+purpose-changes as refactors — applying `/spf-refactor-behavior`'s
 preserve-purpose lens to a change that's actually adding responsibility. The
 discipline distinction matters because:
 
@@ -44,7 +44,7 @@ directly when the user has identified the behavior to update.
   update must continue to satisfy
 - `internal/design/spf/conventions/signals.md` — multi-writer characterization
   when adding writers to a slot another behavior writes
-- `.claude/skills/refactor-behavior/SKILL.md` — the purpose-first discipline
+- `.claude/skills/spf-refactor-behavior/SKILL.md` — the purpose-first discipline
   shape this skill mirrors (applied to *purpose change* instead of
   *preserved purpose*)
 - The feature doc driving the update (if invoked from
@@ -74,9 +74,9 @@ directly when the user has identified the behavior to update.
   canonical leak shape; reorganizing cleanup without preserving order is
   the canonical lifecycle bug.
 
-- **Conflating with refactor-behavior territory.** If the purpose isn't
+- **Conflating with spf-refactor-behavior territory.** If the purpose isn't
   actually changing — the behavior's contract stays the same, just the
-  implementation improves — route to `/refactor-behavior`. The discipline
+  implementation improves — route to `/spf-refactor-behavior`. The discipline
   for purpose-preservation vs purpose-evolution differs; using the wrong
   skill produces drift in either direction (refactor-as-update bloats the
   behavior; update-as-refactor silently changes contracts).
@@ -97,7 +97,7 @@ The load-bearing setup step. Before any code:
   observable interface.
 - **Why is this an *update*, not a *refactor*?** If the answer is "the
   behavior does the same thing, just differently," **stop and route to
-  `/refactor-behavior`**.
+  `/spf-refactor-behavior`**.
 
 **Stop and report to user** with the purpose-change articulation. The user
 confirms before proceeding.
@@ -159,10 +159,10 @@ Audit checklist:
 
 ## When this is the wrong skill
 
-- **Behavior's purpose stays the same, just code improves** → `/refactor-behavior`
+- **Behavior's purpose stays the same, just code improves** → `/spf-refactor-behavior`
 - **Creating a new behavior** → `/spf-create-behavior`
-- **Major restructuring (split or merge)** → `/refactor-behavior` (which
-  may route to `/split-behavior` or `/merge-behaviors`)
+- **Major restructuring (split or merge)** → `/spf-refactor-behavior` (which
+  may route to `/spf-split-behavior` or `/spf-merge-behaviors`)
 - **Pure config-driven change with no behavior code change** → handle in
   the feature implementation directly; no behavior-update needed
 
@@ -175,14 +175,14 @@ it.
 
 ## Open framing question
 
-The boundary between `/spf-update-behavior` and `/refactor-behavior`-with-
+The boundary between `/spf-update-behavior` and `/spf-refactor-behavior`-with-
 extension is genuinely open. Per `project_spf_implementation_skills_next`
 memory: *"`spf-update-behavior` OR non-trivial updates to `spf-refactor-
 behavior` — when an existing behavior needs a feature-implementation change
-that isn't a pure refactor. Open which framing — extend refactor-behavior
+that isn't a pure refactor. Open which framing — extend spf-refactor-behavior
 or add a new skill."*
 
-This skill ships as a separate skill (rather than a refactor-behavior
+This skill ships as a separate skill (rather than a spf-refactor-behavior
 extension) because the **purposes differ** — refactor preserves; update
 changes. If usage reveals the discipline is mostly shared, the skills may
 later merge. For now, the separation is intentional: route by

--- a/internal/design/spf/conventions/behaviors.md
+++ b/internal/design/spf/conventions/behaviors.md
@@ -58,7 +58,7 @@ The decomposition question. The default leans toward **split until merging is re
 - Two concerns happen to be wired together but don't share state — one reads a slot, another writes a different slot, and the only connection is "we set them up at the same time."
 - The body has multiple lifecycle phases with different cleanup timing.
 - Some keys in `stateKeys` / `contextKeys` are read only by some code paths in the body, never together.
-- **Explicit per-type axis declared inline.** A `type FooType = 'video' | 'audio'`, a `KeyByType` map, a `for (const type of types)` loop that writes per-type slots. The axis being declared inline is itself a sniff: per-type specialization was already in mind when the merged form was written, and the merged form usually exists because of a perceived cross-type constraint (atomicity, ordering, shared lifecycle). Surface the constraint as the invariant `/split-behavior`'s cross-boundary audit will evaluate, rather than treating it as foreclosing the split. The audit's possible outcomes include "split is fine, the invariant survives in registration order" and "keep merged, the invariant doesn't survive cleanly" — pre-deciding short-circuits both. Distinguishing this from the [uniform-across-tracks foil](#inverse-behaviors-that-operate-uniformly-across-tracks) is the *downstream consumer interface*: if consumers consume per-type, the per-type interface is the destination shape; if consumers iterate the aggregating resource, the aggregate is the destination shape.
+- **Explicit per-type axis declared inline.** A `type FooType = 'video' | 'audio'`, a `KeyByType` map, a `for (const type of types)` loop that writes per-type slots. The axis being declared inline is itself a sniff: per-type specialization was already in mind when the merged form was written, and the merged form usually exists because of a perceived cross-type constraint (atomicity, ordering, shared lifecycle). Surface the constraint as the invariant `/spf-split-behavior`'s cross-boundary audit will evaluate, rather than treating it as foreclosing the split. The audit's possible outcomes include "split is fine, the invariant survives in registration order" and "keep merged, the invariant doesn't survive cleanly" — pre-deciding short-circuits both. Distinguishing this from the [uniform-across-tracks foil](#inverse-behaviors-that-operate-uniformly-across-tracks) is the *downstream consumer interface*: if consumers consume per-type, the per-type interface is the destination shape; if consumers iterate the aggregating resource, the aggregate is the destination shape.
 
 ### Sniffs that say "merge"
 
@@ -186,7 +186,7 @@ This matters for single refactors (a "continuously … gated by … resetting on
 | "Atomically X all Y" / "X every Z" / "X all needed Y" | Atomic-aggregate framing. Often hides a per-type axis under a cross-cutting constraint. |
 | "Per available track type, X the Y for that type" / "For each type, X" | Explicit per-type structure. Each type is a unit; cross-type concerns are constraints linking the units, not the headline operation. |
 
-If the file declares an inline per-type axis (`type FooType = 'video' | 'audio'`, a `KeyByType` map, a `for (const type of types)` loop), the purpose statement should match. Atomic-aggregate framing on per-type-structured work hides the axis and propagates the miss through downstream steps — `/refactor-behavior`'s split-candidate check (Step 6a) is unlikely to recover the axis from body-iteration sniffs alone if Step 1's framing already collapsed it. The per-type axis is a Step-1 concern, not a Step-6 discovery.
+If the file declares an inline per-type axis (`type FooType = 'video' | 'audio'`, a `KeyByType` map, a `for (const type of types)` loop), the purpose statement should match. Atomic-aggregate framing on per-type-structured work hides the axis and propagates the miss through downstream steps — `/spf-refactor-behavior`'s split-candidate check (Step 6a) is unlikely to recover the axis from body-iteration sniffs alone if Step 1's framing already collapsed it. The per-type axis is a Step-1 concern, not a Step-6 discovery.
 
 Cross-type constraints (atomicity, ordering, shared-lifecycle) are *secondary* to the per-type axis in the purpose statement — they describe how the per-type units interact, not what the behavior does. Demoting atomicity from headline verb ("atomically X") to constraint clause ("…in one synchronous block") is what surfaces the per-type axis as primary.
 
@@ -305,7 +305,7 @@ A sketch is not a refactor commitment. If a side already conforms to current con
 
 ### Merging two behaviors — extra discipline
 
-> This section is the canonical reference for the merge workflow. The [`merge-behaviors`](../../../.claude/skills/merge-behaviors/SKILL.md) skill operationalizes it; either reach for that skill or follow the steps below directly.
+> This section is the canonical reference for the merge workflow. The [`spf-merge-behaviors`](../../../.claude/skills/spf-merge-behaviors/SKILL.md) skill operationalizes it; either reach for that skill or follow the steps below directly.
 
 When the decomposition check says merge, the refactor is **two separate analyses combined**, not one:
 
@@ -504,7 +504,7 @@ Why: each `listen` / `subscribe` call already returns its own removal function �
 
 ## Per-type specialization
 
-> This section codifies the *destination shape* for per-type behaviors. The [`split-behavior`](../../../.claude/skills/split-behavior/SKILL.md) skill operationalizes the *refactor moment* — converting a single behavior into per-type variants — with an explicit axis declaration + cross-boundary constraint audit so implicit ordering invariants in the merged code aren't silently dropped.
+> This section codifies the *destination shape* for per-type behaviors. The [`spf-split-behavior`](../../../.claude/skills/spf-split-behavior/SKILL.md) skill operationalizes the *refactor moment* — converting a single behavior into per-type variants — with an explicit axis declaration + cross-boundary constraint audit so implicit ordering invariants in the merged code aren't silently dropped.
 
 When a behavior's logic varies by media type (video / audio / text), prefer **separate exports per type** over a single behavior with a `config.type` discriminant.
 
@@ -526,9 +526,9 @@ Per-type specialization addresses behaviors whose *logic varies* by type. The du
 > **Disambiguator — body-shape isn't enough; the downstream consumer interface is.** A body that iterates a per-type pair via `KeyByType[type]` looks identical between "uniform-across-tracks → aggregate" and "per-type-split candidate." The distinguishing question is *what shape downstream consumers consume*:
 >
 > - **Consumers operate uniformly** (e.g., `endOfStream` calls `endOfStream` on every actor; a hypothetical `updateMediaSourceDuration` iterates `mediaSource.sourceBuffers`) → this section's prescription: compose against the aggregating resource.
-> - **Consumers operate per-type** (e.g., `loadVideoSegments` reads `videoBufferActor`, `loadAudioSegments` reads `audioBufferActor`) → the per-type interface is the destination shape; the writer should split per type with a shared setup-shape helper. See [Per-type specialization](#per-type-specialization) and `/split-behavior` for the audit workflow (atomicity / ordering / shared-lifecycle constraints are exactly what the cross-boundary audit evaluates).
+> - **Consumers operate per-type** (e.g., `loadVideoSegments` reads `videoBufferActor`, `loadAudioSegments` reads `audioBufferActor`) → the per-type interface is the destination shape; the writer should split per type with a shared setup-shape helper. See [Per-type specialization](#per-type-specialization) and `/spf-split-behavior` for the audit workflow (atomicity / ordering / shared-lifecycle constraints are exactly what the cross-boundary audit evaluates).
 >
-> A behavior whose body iterates a per-type pair *and whose downstream consumers split per-type* is a `/split-behavior` candidate, not a `/refactor-behavior` in-place fix. `setup-sourcebuffer.ts` is the worked example: explicit `MediaTrackType` axis, per-type write loop, per-type consumers (`loadVideoSegments` / `loadAudioSegments`) — per-type split with a shared `setupSourceBuffer` helper is the destination shape, with the Firefox `mozHasAudio` atomicity invariant as the cross-boundary audit's headline item.
+> A behavior whose body iterates a per-type pair *and whose downstream consumers split per-type* is a `/spf-split-behavior` candidate, not a `/spf-refactor-behavior` in-place fix. `setup-sourcebuffer.ts` is the worked example: explicit `MediaTrackType` axis, per-type write loop, per-type consumers (`loadVideoSegments` / `loadAudioSegments`) — per-type split with a shared `setupSourceBuffer` helper is the destination shape, with the Firefox `mozHasAudio` atomicity invariant as the cross-boundary audit's headline item.
 
 **Sniff** (for the aggregate-composition path, given the disambiguator above): `contextKeys` (or `stateKeys`) enumerates a per-type slot pair (`videoBuffer` + `audioBuffer`, `videoSegmentLoaderActor` + `audioSegmentLoaderActor`, etc.) and the behavior's body treats them interchangeably — filtering both into a single collection, iterating both with identical logic, or referencing them only to forward into helpers that operate uniformly — **and** the downstream consumers also operate uniformly.
 

--- a/internal/design/spf/features/clusters.md
+++ b/internal/design/spf/features/clusters.md
@@ -310,7 +310,7 @@ Parallel behaviors for video / audio / text with a shared `setup*` helper or `ma
 
 **Where it shows up.** `resolveVideoTrack` / `resolveAudioTrack` / `resolveTextTrack` (shared `setupTrackResolution`). `loadVideoSegments` / `loadAudioSegments` / `loadTextTrackSegments`. `setupVideoBufferActors` / `setupAudioBufferActors`.
 
-**Skill action when this pattern is suspected.** When adding a new per-track-type capability, default to the per-type-split shape with a shared `setup*` helper unless a cross-type constraint forbids it. The split-vs-merge decision belongs in `/refactor-behavior` → `/split-behavior` if the feature surfaces during refactor work; for new features, follow precedent. See `conventions/behaviors.md` "Per-type specialization."
+**Skill action when this pattern is suspected.** When adding a new per-track-type capability, default to the per-type-split shape with a shared `setup*` helper unless a cross-type constraint forbids it. The split-vs-merge decision belongs in `/spf-refactor-behavior` → `/spf-split-behavior` if the feature surfaces during refactor work; for new features, follow precedent. See `conventions/behaviors.md` "Per-type specialization."
 
 ---
 


### PR DESCRIPTION
## TL;DR

Adds **`/spf-describe-pr`** — a new agent skill that drafts reviewer-oriented PR descriptions for SPF-area PRs. Eight-section structure (TL;DR → How to read → Smoke test → What changed → Decisions → Callouts → Breaking → Tests), five-label depth grid (scope × intensity), smoke-test section with a human-in-the-loop proposal pattern, link discipline that survives merge. Methodology validated by applying the skill manually to rewrite #1584 and #1605 descriptions before shipping.

Also "smuggles in" a long-pending rename: the SPF-specific behavior-workflow skills get a consistent `spf-` prefix (`refactor-behavior` → `spf-refactor-behavior`, `merge-behaviors` → `spf-merge-behaviors`, `split-behavior` → `spf-split-behavior`), with cross-reference propagation across 6 sibling skills, the README, and 2 design docs.

No runtime impact. Documentation + Claude Code skills only.

## For reviewers — how to read this PR

No runtime; the substantive new content is one new skill file. Everything else is the rename cascade.

### Design doc cross-ref cascade (skim or skip)

`internal/design/spf/conventions/behaviors.md` (+6/−6), `internal/design/spf/features/clusters.md` (+1/−1) — token swap propagating the skill rename; no semantic change.

### Agent skills (focus on the new skill)

**Skim file:** `.claude/skills/spf-describe-pr/SKILL.md` (+770, new) — the PR's load-bearing artifact. Read prose for: eight-section structure, five-label depth grid (`[Read fully]` / `[Targeted careful read]` / `[Skim file]` / `[Skim structure only]` / `[Skim or skip]`), Smoke-test discipline (proposal pattern, no fabrication, no hard-coded hostname), Compression / Link / Cursor-Bugbot / Stacked-PR / Carry-forward disciplines, Audit-pattern checklist, Common-pitfalls list.

**Skim or skip:**
- 3 renamed skills (`spf-refactor-behavior`, `spf-merge-behaviors`, `spf-split-behavior`) — directory + frontmatter `name:` + body token swap; no semantic change
- 6 sibling skills with cross-reference updates (`spf-create-behavior`, `spf-document-feature`, `spf-document-use-case`, `spf-implement-feature`, `spf-implement-use-case`, `spf-update-behavior`) — token swap only
- `.claude/skills/README.md` (+6/−4) — quick-reference row + skills-table entries

## Smoke test

No reviewer-actionable smoke test for this PR — skill-only / docs-only changes with no runtime surface. The skill's *methodology* was validated by applying it manually to the descriptions of #1584 and #1605 before this PR shipped; reviewers wanting to test-drive can run `/spf-describe-pr <pr-num>` against any open SPF-area PR.

## What changed — by surface

**`/spf-describe-pr` skill — eight-section structure.** TL;DR → For reviewers (how to read) → Smoke test → What changed → Notable design decisions → Reviewer callouts → Breaking → Test plan. Smoke test sits at section 3 (high in the order) so a reviewer who can confirm the change works in 30 seconds reads the rest with different eyes than one who can't. Each section has explicit rules for shape, scope-narrowing, and what to cut.

**Five-label depth grid.** Per-file labels in *How to read* live on a 2D grid: scope of attention × intensity of attention. `[Read fully]` / `[Targeted careful read]` / `[Skim file]` / `[Skim structure only]` plus a fifth tier `[Skim or skip]`. Explicit rule against medium-tier labels like `[Spot-check]` — they collapse into the four cells, and the per-file *Look for* prose carries mode-of-attention nuance.

**Smoke-test discipline with human-in-the-loop.** The skill scans the diff for smoke-test signals (sandbox templates touched, demo presets changed, new observable behaviors, bug fixes with user-visible signatures) but cannot reliably synthesize meaningful URLs + observables. Mandates an `AskUserQuestion`-based proposal pattern where the author confirms URL + source + observables before the section is written. Explicit guidance against fabricating smoke tests when none applies (skill-only / docs-only / internal refactors) — use the explicit "no smoke-test applicable" note when reviewers might expect one and look for it.

**Bucket-3-friendly framing for docs/skill-only PRs.** The bucket calibration (Runtime / Design docs / Agent skills) anticipates PRs that mix categories; for an all-Bucket-3 PR like this one, the audit-pattern checklist and bucket-framing rules still apply but Bucket 1 is omitted entirely. This PR is itself the first worked example.

**SPF-prefix rename.** `merge-behaviors → spf-merge-behaviors`, `refactor-behavior → spf-refactor-behavior`, `split-behavior → spf-split-behavior` brings the behavior-workflow skills into line with the existing SPF-namespace convention (`spf-create-behavior`, `spf-document-feature`, etc.). Token swap with no semantic change; propagates frontmatter `name:`, cross-references in 6 sibling skills, the README skills table, and 2 design docs in `internal/design/spf/`.

## Notable design decisions

- **Smoke test as section 3, not a subsection of Test plan.** Reviewers can confirm "does this work in my hands?" before reading 800 lines of design narrative; that confirmation changes how they read the rest. Alternative considered: Smoke test as a subsection of *Test plan* (section 8). Rejected because reviewers naturally read top-down — burying the smoke-test at the bottom defeats its purpose. Authors writing only a Test-plan checklist line ("Manual sandbox verification") give reviewers a description rather than a runnable URL.

- **Smoke test is human-in-the-loop, not skill-synthesized.** The skill scans the diff for candidates but explicitly asks the user to confirm URL + source + observables via `AskUserQuestion` before writing the section. Alternative considered: the skill picks defaults (closest-matching sandbox template + first manifest in some source registry). Rejected because the wrong URL or observable burns reviewer time worse than a missing section, and the author always has context the skill doesn't.

- **Path-only smoke-test URLs, no hostname.** Reviewers append the path to whichever host they use — local Vite, Vercel preview, Netlify preview, etc. Alternative considered: hard-code the Vercel preview-URL convention. Rejected because deploy-preview conventions vary per project and per PR, and committed URLs rot when redeploys happen.

- **Rename SPF-specific skills to `spf-` prefix.** Brings `merge-behaviors`, `refactor-behavior`, `split-behavior` into line with `spf-create-behavior`, `spf-document-feature`, etc. Alternative considered: leave them as-is. Rejected because the naming inconsistency obscures the SPF-namespace boundary — a reader scanning `.claude/skills/` should be able to identify which skills are SPF-specific vs. cross-cutting (`docs`, `git`, `commit-pr`) from the file names alone.

- **Bundle the rename with the new skill in one PR (not split).** The rename ("smuggled in") rides on the same branch as the new skill. Alternative considered: two PRs (skill first, rename second). Rejected because both are documentation-only with zero merge-conflict risk, and a single squash-commit on main keeps history compact.

## Reviewer callouts — known limitations

- **[Author] Skill is 770 lines.** Reflects three iterations of methodology validation (#1584, #1605, and post-smoke-test refinements). Some sections may consolidate over future PRs as the worked-example library matures. Not a structural concern; flag if the prescription density feels excessive.
- **[Author] Smoke-test discipline is new; one worked example in production (#1605).** The proposal pattern + observable rules will firm up as the skill is applied to more PRs. Reviewers: flag if the pattern feels over-prescriptive for simpler PRs.
- **[Deferred] Carry-forward to #1605 not yet done.** The smoke-test additions on the skill landed *after* #1605's description was finalized, so #1605's smoke-test section pre-dates the "observable phrasing" + "no fabrication" rules now codified. Will be addressed via direct edits to #1605 or in the next SPF PR description.

## Breaking changes

The three skill renames (`/refactor-behavior` → `/spf-refactor-behavior`, etc.) don't break any committed code but may break user muscle memory or saved local Claude Code commands. The old names are gone — no aliasing shim. SPF stays alpha; no public-API surface affected.

## Test plan

- [x] `pnpm typecheck` — clean (no code changes)
- [x] `pnpm check:workspace` — clean
- [x] Repo-wide grep for stale references (`refactor-behavior`, `merge-behaviors`, `split-behavior` without `spf-` prefix) — zero hits
- [x] Methodology validation — applied the skill manually to #1584 and #1605 PR descriptions; both live and verified
- [N/A] Runtime tests — no runtime code changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill changes only; slash-command renames may break saved workflows but do not affect shipped product code.
> 
> **Overview**
> Adds **`/spf-describe-pr`**, a large new Claude skill that tells agents how to draft **reviewer-oriented** SPF PR bodies (eight sections, runtime/design/skills buckets, five depth labels, smoke-test + link/compression rules, user check-in before `gh pr edit`).
> 
> Renames the behavior workflow skills to the shared **`spf-`** namespace (`refactor-behavior` → `spf-refactor-behavior`, `merge-behaviors` → `spf-merge-behaviors`, `split-behavior` → `spf-split-behavior`) and propagates those command names through sibling skills, `.claude/skills/README.md`, and `internal/design/spf/conventions/behaviors.md` / `features/clusters.md`.
> 
> **No runtime or library code** — agent skills and internal design doc cross-refs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c434682e8d59a907f5542b01cb34c9c9c708751a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


