### PR TITLE
chore: add playwright MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,12 @@
     "astro-docs": {
       "type": "http",
       "url": "https://mcp.docs.astro.build/mcp"
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"],
+      "env": {}
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the Playwright MCP server to `.mcp.json` so Claude Code sessions can drive the browser locally — useful for verification tasks like smoke-testing sandbox demos and capturing screenshots from `/spf-describe-pr`-style review flows.

Local tooling only — `.mcp.json` is read by each developer's Claude Code session. No runtime, no CI, no production effect.

## Test plan

- [x] Verified `.mcp.json` parses (valid JSON after lint-staged formatting)
- [N/A] Runtime — none touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local MCP tooling config only; no application, security, or deployment paths are modified.
> 
> **Overview**
> Registers a **Playwright** MCP server in `.mcp.json` next to the existing **astro-docs** entry, using **stdio** via `npx @playwright/mcp@latest` so local Claude Code sessions can control a browser for checks like smoke tests or screenshots.
> 
> This is developer-session configuration only; it does not change app runtime, CI, or production behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b89ea45dc14eaf1d963e8ff6b7078449eea909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->