### PR TITLE
fix(core): focus selected radio menu items

### DIFF
--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -192,7 +192,11 @@ export function createMenu(options: MenuOptions): MenuApi {
   }
 
   function getInitialHighlightItem(): HTMLElement | null {
-    return items.find((item) => item.matches('[aria-checked="true"], [aria-selected="true"]')) ?? items[0] ?? null;
+    return (
+      items.find((item) => item.matches('[role="menuitemradio"][aria-checked="true"], [aria-selected="true"]')) ??
+      items[0] ??
+      null
+    );
   }
 
   // --- Type-ahead ---

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -144,13 +144,15 @@ describe('createMenu', () => {
       vi.useRealTimers();
     });
 
-    it('highlights the checked item when opening', () => {
+    it('focuses the checked radio item when opening', () => {
       vi.useFakeTimers();
 
       const { menu } = createTestMenu();
       const a = addItem('Alpha');
       const b = addItem('Beta');
+      b.setAttribute('role', 'menuitemradio');
       b.setAttribute('aria-checked', 'true');
+      const focus = vi.spyOn(b, 'focus');
 
       menu.registerItem(a);
       menu.registerItem(b);
@@ -160,17 +162,20 @@ describe('createMenu', () => {
 
       expect(b.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
       expect(a.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(focus).toHaveBeenCalledOnce();
 
       vi.useRealTimers();
     });
 
-    it('highlights the checked item when items register after opening', () => {
+    it('focuses the checked radio item when items register after opening', () => {
       vi.useFakeTimers();
 
       const { menu } = createTestMenu();
       const a = addItem('Alpha');
       const b = addItem('Beta');
+      b.setAttribute('role', 'menuitemradio');
       b.setAttribute('aria-checked', 'true');
+      const focus = vi.spyOn(b, 'focus');
 
       menu.open();
       menu.registerItem(a);
@@ -180,6 +185,30 @@ describe('createMenu', () => {
 
       expect(b.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
       expect(a.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(focus).toHaveBeenCalledOnce();
+
+      vi.useRealTimers();
+    });
+
+    it('does not initially focus a checked checkbox item over a checked radio item', () => {
+      vi.useFakeTimers();
+
+      const { menu } = createTestMenu();
+      const checkbox = addItem('Loop');
+      const radio = addItem('Auto');
+      checkbox.setAttribute('role', 'menuitemcheckbox');
+      checkbox.setAttribute('aria-checked', 'true');
+      radio.setAttribute('role', 'menuitemradio');
+      radio.setAttribute('aria-checked', 'true');
+
+      menu.registerItem(checkbox);
+      menu.registerItem(radio);
+      menu.open();
+
+      vi.runAllTimers();
+
+      expect(radio.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+      expect(checkbox.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
 
       vi.useRealTimers();
     });


### PR DESCRIPTION
## Summary

- Focus selected radio menu items when a menu opens.
- Keep checked checkbox items from taking initial focus in select-style menus.
- Cover initial open and late item registration in core menu tests.

## Validation

- `pnpm -F @videojs/core test src/dom/ui/menu/tests/create-menu.test.ts`
- `pnpm exec biome check packages/core/src/dom/ui/menu/create-menu.ts packages/core/src/dom/ui/menu/tests/create-menu.test.ts`

Closes #1640

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow ARIA selector for initial highlight in core menu only; behavior change is intentional for keyboard/a11y in mixed radio/checkbox menus.
> 
> **Overview**
> **Initial menu focus** now targets only checked **`menuitemradio`** items (and items with **`aria-selected="true"`**), not every element with **`aria-checked="true"`**. Checked **`menuitemcheckbox`** entries no longer steal open focus in select-style menus when a checked radio is present.
> 
> Tests were tightened to use **`menuitemradio`**, assert **`focus()`** on open / late registration, and cover radio-over-checkbox priority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0af24da55f02eb6304bb0da4d5e5efdf54ebcb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->