### PR TITLE
chore(build): enforce JSDoc presence on public-API exports in check:workspace

### DIFF
--- a/build/scripts/check-workspace.mjs
+++ b/build/scripts/check-workspace.mjs
@@ -11,7 +11,10 @@
  * 4. Package metadata — non-private packages have required fields
  * 5. Release-please config — every versioned package is registered
  * 6. Define imports — no bare side-effect imports from relative paths
+ * 7. Bundled docs publishing — html/react ship per-framework docs
+ * 8. JSDoc presence — every public-API export carries a JSDoc summary
  */
+import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -324,6 +327,38 @@ function checkDefineImports() {
   return { ok: warnings.length === 0, warnings };
 }
 
+// ── Check 8: JSDoc presence on public exports ────────────────────────────────
+
+/**
+ * Every public-API export in @videojs/react, @videojs/html, and @videojs/core
+ * must carry a JSDoc summary. The checker parses source with the TypeScript
+ * Compiler API and lives under site/ (the only workspace with a usable
+ * `typescript` + tsx). See site/scripts/jsdoc-presence/.
+ */
+function checkJsdocPresence() {
+  const cli = join(ROOT, 'site/scripts/jsdoc-presence/cli.ts');
+  try {
+    execFileSync('node', ['--import', 'tsx', cli], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, warnings: [] };
+  } catch (error) {
+    const stdout = String(error.stdout ?? '');
+    // Exit 1 = violations on stdout; anything else = the checker failed to run.
+    if (error.status === 1) {
+      const warnings = stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+      return { ok: warnings.length === 0, warnings };
+    }
+    const stderr = String(error.stderr ?? '');
+    return { ok: false, warnings: [`JSDoc presence check failed to run: ${stderr.trim() || error.message}`] };
+  }
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 
 const checks = [
@@ -334,6 +369,7 @@ const checks = [
   { name: 'Release-please config', fn: checkReleasePleaseConfig },
   { name: 'Bundled docs publishing', fn: checkBundledDocs },
   { name: 'Define imports', fn: checkDefineImports },
+  { name: 'JSDoc presence', fn: checkJsdocPresence },
 ];
 
 let failed = 0;

--- a/site/scripts/jsdoc-presence/README.md
+++ b/site/scripts/jsdoc-presence/README.md
@@ -1,0 +1,92 @@
+# JSDoc Presence Check
+
+Fails CI when any top-level public-API export in a published package lacks a JSDoc summary.
+Wired into `pnpm check:workspace` as the "JSDoc presence" check. Enforces the
+[JSDoc on Published Exports](../../../CLAUDE.md) rule so the documentation sweep can't silently regress.
+
+## Architecture
+
+```
+package tsdown.config.ts  (entry: map | glob | array)
+         ↓  resolveEntryFiles  (check.ts)
+public-API entry source files
+         ↓  collectPackageViolations  (check.ts, TypeScript Compiler API)
+each module's exports → resolve alias → in-package? → carve-out? → has JSDoc summary?
+         ↓  cli.ts
+violations on stdout, exit 1
+         ↓  build/scripts/check-workspace.mjs
+"✗ JSDoc presence" with the failing exports
+```
+
+## How it works
+
+For each package in the list (`cli.ts`):
+
+1. **Resolve entries** (`resolveEntryFiles` in `check.ts`) — imports the package's `tsdown.config.ts`
+   and reads its `entry` field, which is the authoritative set of public build outputs. It normalizes
+   the three shapes tsdown allows (object map, glob string, array) into a flat list of source files
+   via `fs.globSync`. To switch the check to parse built `.d.ts` instead, you'd rewrite this function
+   (read `package.json` `exports`, glob `dist/`) and leave the engine untouched.
+
+2. **Check exports** (`collectPackageViolations` in `check.ts`) — builds one `ts.Program` per package
+   rooted at those entry files and walks each entry module's exports via the TypeScript `TypeChecker`:
+   - **Resolve alias** — barrels are pure re-exports (`export { X } from './x'`), so each export is
+     followed to its real declaration.
+   - **In-package gate** — only symbols declared inside this package's `src/` are checked. Cross-package
+     re-exports (e.g. `@videojs/core/dom` re-exported by `@videojs/react`) are skipped here and checked
+     when their owning package runs.
+   - **Namespace descent** — `export * as Ns from './mod'` (compound components like `AlertDialog`) is
+     descended into, so its members (`AlertDialog.Root`, …) are checked where their JSDoc lives.
+   - **Carve-outs** — leaf wrappers (`interface Foo extends Bar {}`, `type Foo = Bar`) and `@internal`
+     exports are exempt, matching the documented rule.
+   - **Presence test** — `symbol.getDocumentationComment(checker)` must produce non-empty prose.
+     Tag-only JSDoc (`/** @deprecated */`) yields an empty summary and is flagged.
+
+The check parses **source**, so it needs no build step — consistent with the other `check:workspace`
+checks. On a branch without the JSDoc sweep merged it reports many gaps; that's expected.
+
+## Usage
+
+```bash
+# Full workspace suite (this check is one of several)
+pnpm check:workspace
+
+# Just this check (prints each undocumented export, exit 1 if any)
+node --import tsx site/scripts/jsdoc-presence/cli.ts
+```
+
+## Adding a package
+
+Add one entry to `PACKAGES` in [`cli.ts`](cli.ts):
+
+```ts
+const PACKAGES: PackageRef[] = [
+  { name: '@videojs/react', dir: 'packages/react' },
+  // ...
+  { name: '@videojs/store', dir: 'packages/store' }, // new
+];
+```
+
+The package needs a `tsdown.config.ts` with an `entry` field (all published packages have one) and a
+`tsconfig.json`. No other change is required.
+
+## File structure
+
+```
+site/scripts/jsdoc-presence/
+├── README.md   # This file
+├── check.ts    # Entry resolution + engine (Program + export walk + alias/gate/carve-out/presence)
+└── cli.ts      # Entry point: runs the package list, prints violations, sets exit code
+
+site/scripts/tests/
+├── jsdoc-presence.test.ts         # Unit tests for the engine
+└── fixtures/jsdoc-presence/       # Mock monorepo exercising each rule
+```
+
+## Dependencies
+
+- `typescript`: Compiler API for parsing and export resolution
+- `tsx`: TypeScript execution
+
+Both are in `site/package.json` devDependencies — which is why this checker lives under `site/` rather
+than next to `check-workspace.mjs` (the repo root has no usable `typescript`).

--- a/site/scripts/jsdoc-presence/check.ts
+++ b/site/scripts/jsdoc-presence/check.ts
@@ -1,0 +1,196 @@
+import { globSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as ts from 'typescript';
+
+export interface Violation {
+  package: string;
+  symbol: string;
+  file: string;
+}
+
+export interface PackageRef {
+  /** Published name, e.g. `@videojs/core`. */
+  name: string;
+  /** Directory relative to the monorepo root, e.g. `packages/core`. */
+  dir: string;
+}
+
+/** Resolves each package's public entries and checks every top-level export for a JSDoc summary. */
+export async function checkJsDocPresence(
+  monorepoRoot: string,
+  packages: PackageRef[]
+): Promise<{ violations: Violation[] }> {
+  const violations: Violation[] = [];
+  for (const pkg of packages) {
+    const packageRoot = path.resolve(monorepoRoot, pkg.dir);
+    const entryFiles = await resolveEntryFiles(packageRoot);
+    violations.push(
+      ...collectPackageViolations({
+        packageName: pkg.name,
+        packageRoot,
+        entryFiles,
+        tsconfigPath: path.join(packageRoot, 'tsconfig.json'),
+      })
+    );
+  }
+  return { violations };
+}
+
+export interface PackageCheckOptions {
+  packageName: string;
+  /** Absolute path to the package directory. */
+  packageRoot: string;
+  /** Absolute paths to the package's public entry source files. */
+  entryFiles: string[];
+  /** Absolute path to the package's tsconfig.json (for `@/` paths, jsx, lib). */
+  tsconfigPath: string;
+}
+
+/** The check engine: enumerates module exports and flags those without a JSDoc summary. */
+export function collectPackageViolations(opts: PackageCheckOptions): Violation[] {
+  const { packageName, packageRoot, entryFiles, tsconfigPath } = opts;
+  const program = ts.createProgram(entryFiles, loadCompilerOptions(tsconfigPath));
+  const checker = program.getTypeChecker();
+  const srcDir = path.join(packageRoot, 'src');
+
+  const violations: Violation[] = [];
+  const seen = new Set<string>();
+  const visitedModules = new Set<ts.Symbol>();
+
+  const checkSymbol = (exported: ts.Symbol): void => {
+    const target = resolveAlias(exported, checker);
+    const declarations = target.getDeclarations() ?? [];
+
+    // Namespace re-export (`export * as Ns from './mod'`, used by compound
+    // components): descend into its members, which are the real public surface
+    // (e.g. AlertDialog.Root) and where the JSDoc lives.
+    if (declarations.some(ts.isSourceFile)) {
+      if (visitedModules.has(target)) return;
+      visitedModules.add(target);
+      for (const member of checker.getExportsOfModule(target)) checkSymbol(member);
+      return;
+    }
+
+    // Only flag symbols declared in this package's own src; cross-package
+    // re-exports (e.g. `@videojs/core/dom`) are checked in their owning package.
+    const inPackage = declarations.filter((d) => isUnder(d.getSourceFile().fileName, srcDir));
+    if (inPackage.length === 0) return;
+    if (inPackage.every(isLeafWrapper)) return;
+    if (inPackage.some(hasInternalTag)) return;
+
+    const summary = target
+      .getDocumentationComment(checker)
+      .map((part) => part.text)
+      .join('')
+      .trim();
+    if (summary !== '') return;
+
+    const declFile = inPackage[0].getSourceFile().fileName;
+    const key = `${declFile}#${target.getName()}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    violations.push({
+      package: packageName,
+      symbol: target.getName(),
+      file: path.relative(packageRoot, declFile),
+    });
+  };
+
+  for (const entryFile of entryFiles) {
+    const sourceFile = program.getSourceFile(entryFile);
+    if (!sourceFile) continue;
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+    if (!moduleSymbol) continue;
+    for (const exported of checker.getExportsOfModule(moduleSymbol)) checkSymbol(exported);
+  }
+
+  return violations;
+}
+
+/** Resolves a package's public-API entry source files from its tsdown config. */
+export async function resolveEntryFiles(packageDir: string): Promise<string[]> {
+  const configPath = path.join(packageDir, 'tsdown.config.ts');
+  let mod: { default?: unknown };
+  try {
+    mod = await import(pathToFileURL(configPath).href);
+  } catch (cause) {
+    throw new Error(`Failed to load tsdown config at ${configPath}: ${(cause as Error).message}`, { cause });
+  }
+
+  // tsdown's `defineConfig` returns the user config (or an array, one per build mode).
+  const value = mod.default;
+  const config = Array.isArray(value) ? value[0] : value;
+  if (typeof config !== 'object' || config === null) {
+    throw new Error(`Unexpected tsdown config default export shape in ${configPath}`);
+  }
+
+  const entry = (config as { entry?: unknown }).entry;
+  const patterns = entryToPatterns(entry, configPath);
+
+  const files = new Set<string>();
+  for (const pattern of patterns) {
+    // globSync handles literal paths and globs uniformly.
+    for (const rel of globSync(pattern, { cwd: packageDir })) {
+      const abs = path.resolve(packageDir, rel);
+      if (/\.(test|spec)\.[cm]?tsx?$/.test(abs) || abs.endsWith('.d.ts')) continue;
+      files.add(abs);
+    }
+  }
+  return [...files];
+}
+
+function entryToPatterns(entry: unknown, configPath: string): string[] {
+  if (typeof entry === 'string') return [entry];
+  if (Array.isArray(entry)) return entry.filter((e): e is string => typeof e === 'string');
+  if (typeof entry === 'object' && entry !== null) {
+    return Object.values(entry).filter((e): e is string => typeof e === 'string');
+  }
+  throw new Error(`Unsupported tsdown "entry" shape in ${configPath}`);
+}
+
+function resolveAlias(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
+  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+}
+
+function isUnder(file: string, dir: string): boolean {
+  const rel = path.relative(dir, file);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
+ * Leaf wrappers add nothing beyond the base, so they're exempt from the summary
+ * rule: empty-body `interface Foo extends Bar {}` and pure-alias `type Foo = Bar`.
+ */
+function isLeafWrapper(decl: ts.Declaration): boolean {
+  if (ts.isInterfaceDeclaration(decl)) {
+    return decl.members.length === 0 && (decl.heritageClauses?.length ?? 0) > 0;
+  }
+  if (ts.isTypeAliasDeclaration(decl)) {
+    return ts.isTypeReferenceNode(decl.type) && !decl.type.typeArguments;
+  }
+  return false;
+}
+
+function hasInternalTag(decl: ts.Declaration): boolean {
+  return ts.getJSDocTags(decl).some((tag) => tag.tagName.text === 'internal');
+}
+
+function loadCompilerOptions(tsconfigPath: string): ts.CompilerOptions {
+  const host: ts.ParseConfigFileHost = {
+    ...ts.sys,
+    onUnRecoverableConfigFileDiagnostic: (diagnostic) => {
+      throw new Error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'));
+    },
+  };
+  const parsed = ts.getParsedCommandLineOfConfigFile(tsconfigPath, {}, host);
+  if (!parsed) throw new Error(`Failed to parse tsconfig at ${tsconfigPath}`);
+  return {
+    ...parsed.options,
+    noEmit: true,
+    skipLibCheck: true,
+    composite: false,
+    types: [],
+  };
+}

--- a/site/scripts/jsdoc-presence/cli.ts
+++ b/site/scripts/jsdoc-presence/cli.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { checkJsDocPresence, type PackageRef } from './check.js';
+
+/** Published packages whose public-API exports must carry a JSDoc summary. */
+const PACKAGES: PackageRef[] = [
+  { name: '@videojs/react', dir: 'packages/react' },
+  { name: '@videojs/html', dir: 'packages/html' },
+  { name: '@videojs/core', dir: 'packages/core' },
+];
+
+const monorepoRoot = path.resolve(import.meta.dirname, '../../../');
+
+try {
+  const { violations } = await checkJsDocPresence(monorepoRoot, PACKAGES);
+
+  // stdout = one violation per line (consumed by check-workspace.mjs); stderr = summary.
+  for (const v of violations) {
+    process.stdout.write(`${v.package}: ${v.symbol} (${v.file})\n`);
+  }
+  process.stderr.write(`\n${violations.length} public export(s) missing a JSDoc summary\n`);
+
+  // Exit codes: 0 = clean, 1 = violations (on stdout), 2 = crash. Setting exitCode
+  // (instead of calling process.exit) lets Node flush stdout naturally — important
+  // because writes to a piped stdout are buffered and process.exit can cut them off.
+  process.exitCode = violations.length > 0 ? 1 : 0;
+} catch (error) {
+  process.stderr.write(`jsdoc-presence check crashed: ${(error as Error)?.stack ?? error}\n`);
+  process.exitCode = 2;
+}

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/cases.ts
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/cases.ts
@@ -1,0 +1,24 @@
+// One file per rule so a failing assertion points at the rule directly.
+
+/** A documented function. */
+export function Documented(): void {}
+
+export function Undocumented(): void {}
+
+export interface WithMembers {
+  x: number;
+}
+
+/** @internal */
+export function Internal(): void {}
+
+/** @deprecated use the new one */
+export function TagsOnly(): void {}
+
+interface Base {
+  y: number;
+}
+
+// Leaf wrappers (carve-out): empty-body extends interface + pure-alias type.
+export interface LeafWrapper extends Base {}
+export type PureAlias = Base;

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/cases.ts
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/cases.ts
@@ -1,4 +1,7 @@
-// One file per rule so a failing assertion points at the rule directly.
+// Test fixtures for the JSDoc-presence check — one representative export per rule
+// so a failing assertion points straight at the rule it covers.
+
+// ─── Basic presence ────────────────────────────────────────────────
 
 /** A documented function. */
 export function Documented(): void {}
@@ -9,16 +12,61 @@ export interface WithMembers {
   x: number;
 }
 
-/** @internal */
-export function Internal(): void {}
+// ─── JSDoc shape (a summary is required; tags alone don't count) ───
 
 /** @deprecated use the new one */
 export function TagsOnly(): void {}
+
+/** @see https://example.com */
+export function TagOnlySee(): void {}
+
+/** Toggles playback. @deprecated tag is metadata; the summary carries the meaning. */
+export function SummaryWithTags(): void {}
+
+// ─── @internal carve-out (exempt regardless of summary) ────────────
+
+/** @internal */
+export function Internal(): void {}
+
+/** Helper utility. @internal */
+export function InternalWithSummary(): void {}
+
+// ─── Leaf-wrapper carve-out (adds nothing beyond the base) ─────────
 
 interface Base {
   y: number;
 }
 
-// Leaf wrappers (carve-out): empty-body extends interface + pure-alias type.
+namespace Inner {
+  export interface InnerType {
+    q: number;
+  }
+}
+
 export interface LeafWrapper extends Base {}
 export type PureAlias = Base;
+export type QualifiedAlias = Inner.InnerType;
+
+// ─── NOT leaf wrappers — these all add shape, so they need a summary ───
+
+export interface ExtendsAddsMembers extends Base {
+  z: number;
+}
+
+export type GenericAlias = Array<Base>;
+
+export type UnionAlias = 'a' | 'b';
+
+export type ObjectLiteralAlias = { z: number };
+
+// ─── Class members (Ring 2, NOT checked) ───────────────────────────
+
+/** A documented class. Its undocumented members are not checked. */
+export class DocumentedClass {
+  method(): void {}
+  field = 1;
+}
+
+export class UndocumentedClass {
+  method(): void {}
+}

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/group.parts.ts
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/group.parts.ts
@@ -1,0 +1,4 @@
+/** A documented group member. */
+export function GroupMemberDocumented(): void {}
+
+export function GroupMemberUndocumented(): void {}

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/index.ts
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/index.ts
@@ -1,3 +1,21 @@
 export { External } from '../../pkg-b/src/external.js';
-export { Documented, Internal, LeafWrapper, PureAlias, TagsOnly, Undocumented, WithMembers } from './cases.js';
+export {
+  Documented,
+  DocumentedClass,
+  ExtendsAddsMembers,
+  GenericAlias,
+  Internal,
+  InternalWithSummary,
+  LeafWrapper,
+  ObjectLiteralAlias,
+  PureAlias,
+  QualifiedAlias,
+  SummaryWithTags,
+  TagOnlySee,
+  TagsOnly,
+  Undocumented,
+  UndocumentedClass,
+  UnionAlias,
+  WithMembers,
+} from './cases.js';
 export * as Group from './group.parts.js';

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/index.ts
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/src/index.ts
@@ -1,0 +1,3 @@
+export { External } from '../../pkg-b/src/external.js';
+export { Documented, Internal, LeafWrapper, PureAlias, TagsOnly, Undocumented, WithMembers } from './cases.js';
+export * as Group from './group.parts.js';

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/tsconfig.json
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-a/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-b/src/external.ts
+++ b/site/scripts/tests/fixtures/jsdoc-presence/monorepo/packages/pkg-b/src/external.ts
@@ -1,0 +1,1 @@
+export function External(): void {}

--- a/site/scripts/tests/jsdoc-presence.test.ts
+++ b/site/scripts/tests/jsdoc-presence.test.ts
@@ -15,28 +15,93 @@ function flaggedSymbols(): string[] {
 
 describe('collectPackageViolations', () => {
   it('flags exactly the undocumented public exports', () => {
-    expect(flaggedSymbols().sort()).toEqual(['GroupMemberUndocumented', 'TagsOnly', 'Undocumented', 'WithMembers']);
+    expect(flaggedSymbols().sort()).toEqual([
+      'ExtendsAddsMembers',
+      'GenericAlias',
+      'GroupMemberUndocumented',
+      'ObjectLiteralAlias',
+      'TagOnlySee',
+      'TagsOnly',
+      'Undocumented',
+      'UndocumentedClass',
+      'UnionAlias',
+      'WithMembers',
+    ]);
   });
 
-  it('passes documented exports and documented re-exports', () => {
-    const names = flaggedSymbols();
-    expect(names).not.toContain('Documented');
-    expect(names).not.toContain('GroupMemberDocumented');
+  // ─── Passing cases ──────────────────────────────────────────────
+
+  it('passes a documented function with a plain summary', () => {
+    expect(flaggedSymbols()).not.toContain('Documented');
   });
 
-  it('skips leaf-wrapper interfaces and pure type aliases', () => {
-    const names = flaggedSymbols();
-    expect(names).not.toContain('LeafWrapper');
-    expect(names).not.toContain('PureAlias');
+  it('passes a documented class — undocumented members are NOT checked (Ring 1 only)', () => {
+    expect(flaggedSymbols()).not.toContain('DocumentedClass');
   });
 
-  it('skips @internal exports', () => {
+  it('passes a JSDoc summary that also carries tags', () => {
+    expect(flaggedSymbols()).not.toContain('SummaryWithTags');
+  });
+
+  it('passes a documented re-export resolved through a namespace', () => {
+    expect(flaggedSymbols()).not.toContain('GroupMemberDocumented');
+  });
+
+  // ─── JSDoc shape: tags without prose count as missing ───────────
+
+  it('flags tag-only JSDoc with @deprecated', () => {
+    expect(flaggedSymbols()).toContain('TagsOnly');
+  });
+
+  it('flags tag-only JSDoc with @see', () => {
+    expect(flaggedSymbols()).toContain('TagOnlySee');
+  });
+
+  // ─── Leaf-wrapper carve-out ─────────────────────────────────────
+
+  it('skips empty-body extends interface', () => {
+    expect(flaggedSymbols()).not.toContain('LeafWrapper');
+  });
+
+  it('skips pure type alias (bare reference: type X = Bar)', () => {
+    expect(flaggedSymbols()).not.toContain('PureAlias');
+  });
+
+  it('skips pure type alias to a qualified name (type X = A.B)', () => {
+    expect(flaggedSymbols()).not.toContain('QualifiedAlias');
+  });
+
+  it('does NOT skip type alias with type arguments (type X = Bar<Foo>)', () => {
+    expect(flaggedSymbols()).toContain('GenericAlias');
+  });
+
+  it('does NOT skip union type alias', () => {
+    expect(flaggedSymbols()).toContain('UnionAlias');
+  });
+
+  it('does NOT skip object-literal type alias', () => {
+    expect(flaggedSymbols()).toContain('ObjectLiteralAlias');
+  });
+
+  it('does NOT skip interface that extends and adds members', () => {
+    expect(flaggedSymbols()).toContain('ExtendsAddsMembers');
+  });
+
+  it('flags an undocumented class itself', () => {
+    expect(flaggedSymbols()).toContain('UndocumentedClass');
+  });
+
+  // ─── @internal carve-out ────────────────────────────────────────
+
+  it('skips @internal-tagged exports', () => {
     expect(flaggedSymbols()).not.toContain('Internal');
   });
 
-  it('flags JSDoc that has only tags (no prose summary)', () => {
-    expect(flaggedSymbols()).toContain('TagsOnly');
+  it('skips @internal even when the export also has a summary', () => {
+    expect(flaggedSymbols()).not.toContain('InternalWithSummary');
   });
+
+  // ─── Cross-package gate ─────────────────────────────────────────
 
   it('skips cross-package re-exports declared outside the package src', () => {
     expect(flaggedSymbols()).not.toContain('External');

--- a/site/scripts/tests/jsdoc-presence.test.ts
+++ b/site/scripts/tests/jsdoc-presence.test.ts
@@ -1,0 +1,44 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { collectPackageViolations } from '../jsdoc-presence/check.js';
+
+const pkgA = path.resolve(import.meta.dirname, 'fixtures/jsdoc-presence/monorepo/packages/pkg-a');
+
+function flaggedSymbols(): string[] {
+  return collectPackageViolations({
+    packageName: 'pkg-a',
+    packageRoot: pkgA,
+    entryFiles: [path.join(pkgA, 'src/index.ts')],
+    tsconfigPath: path.join(pkgA, 'tsconfig.json'),
+  }).map((v) => v.symbol);
+}
+
+describe('collectPackageViolations', () => {
+  it('flags exactly the undocumented public exports', () => {
+    expect(flaggedSymbols().sort()).toEqual(['GroupMemberUndocumented', 'TagsOnly', 'Undocumented', 'WithMembers']);
+  });
+
+  it('passes documented exports and documented re-exports', () => {
+    const names = flaggedSymbols();
+    expect(names).not.toContain('Documented');
+    expect(names).not.toContain('GroupMemberDocumented');
+  });
+
+  it('skips leaf-wrapper interfaces and pure type aliases', () => {
+    const names = flaggedSymbols();
+    expect(names).not.toContain('LeafWrapper');
+    expect(names).not.toContain('PureAlias');
+  });
+
+  it('skips @internal exports', () => {
+    expect(flaggedSymbols()).not.toContain('Internal');
+  });
+
+  it('flags JSDoc that has only tags (no prose summary)', () => {
+    expect(flaggedSymbols()).toContain('TagsOnly');
+  });
+
+  it('skips cross-package re-exports declared outside the package src', () => {
+    expect(flaggedSymbols()).not.toContain('External');
+  });
+});

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -11,7 +11,13 @@ export default getViteConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      include: ['src/utils/**', 'src/components/**', 'src/types/**', 'scripts/api-docs-builder/src/**'],
+      include: [
+        'src/utils/**',
+        'src/components/**',
+        'src/types/**',
+        'scripts/api-docs-builder/src/**',
+        'scripts/jsdoc-presence/**',
+      ],
       exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx', '**/test/**'],
     },
   },


### PR DESCRIPTION
# PR Description

## Why

Resolves #1571.

We agreed to require JSDoc for all public API exports back in #1558 and #1570, but up until now, it was just a review-time guideline. This meant reviewers had to catch missing docs manually, and some gaps inevitably slipped through. 

This PR automates that process by adding an automated check to `pnpm check:workspace`. Now, if any public export in a published package is missing a JSDoc summary, the CI build will fail.

The check inspects the source code directly, meaning it runs quickly and doesn't require a full build step to test locally or in CI.

> **Note:** This is blocked by #1570. That PR contains the actual documentation updates. Until #1570 lands, this check will fail on several files in `@videojs/react`, `@videojs/html`, and `@videojs/core`. Recommended merge order: #1570 → this PR.

---

## What's in this PR

We added a **JSDoc presence check** to our workspace tools. It scans public exports for the following initial packages:
- `@videojs/react`
- `@videojs/html`
- `@videojs/core`

It ensures each public export has an actual descriptive summary.

### How it works (High Level)
1. **Finds Entry Points:** It reads `tsdown.config.ts` for each package to find the official public entry files.
2. **Scans Exports:** It uses the TypeScript Compiler API to track down the actual source declarations.
3. **Smart Exclusions:** - It skips exports marked as `@internal`.
   - It skips empty interfaces that just extend another interface.
   - It handles complex re-exports correctly so each component/function is only checked once.

### Why is this located under `site/`?
The script relies on the TypeScript Compiler API and `tsx` to run. Instead of adding these heavy development dependencies to the repository root, we placed the script inside `site/scripts/jsdoc-presence/` because the documentation builder there already uses them.

### How to add more packages later
When we are ready to expand coverage, you just need to add the package name to the `PACKAGES` list inside `site/scripts/jsdoc-presence/cli.ts`.

---

## Test Plan

- [x] **Integration Test:** Verified that running `pnpm check:workspace` on the current `main` branch correctly flags the existing missing JSDocs with clear error messages.
- [x] **Unit Tests:** Added 18 unit tests in `site/scripts/tests/jsdoc-presence.test.ts` to cover edge cases like internal tags, re-exports, and empty extensions.
- [x] **Manual Verification:** Temporarily added documentation to a flagged file and confirmed the checker turned green, then went back to red when removed.
- [x] **Lint & Typechecks:** Ensured `pnpm lint` and `pnpm astro check` pass successfully with the new files.