### PR TITLE
feat(sandbox): add live-dvr skin examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,6 @@ bun.lockb
 AGENTS.md
 .agents
 agents
-.agents
 
 # Playwright
 test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ bun.lockb
 AGENTS.md
 .agents
 agents
+.agents
 
 # Playwright
 test-results/

--- a/apps/sandbox/app/shared/html/live-dvr/minimal-skin.tailwind.ts
+++ b/apps/sandbox/app/shared/html/live-dvr/minimal-skin.tailwind.ts
@@ -1,0 +1,209 @@
+// Importing the minimal tailwind live-video skin registers the live player,
+// container, and minimal UI custom elements (including the time slider + time
+// elements the DVR skin adds back in) and exposes the base skin element we
+// extend below.
+import { MinimalLiveVideoSkinTailwindElement } from '@videojs/html/live-video/minimal-skin.tailwind';
+import { renderIcon } from '@videojs/icons/render/minimal';
+import {
+  bufferingIndicator,
+  button,
+  buttonGroupEnd,
+  buttonGroupStart,
+  controls,
+  error,
+  icon,
+  iconState,
+  inputFeedback,
+  overlay,
+  popup,
+  poster,
+  root,
+  slider,
+  thumbnail,
+  time,
+} from '@videojs/skins/minimal/tailwind/video.tailwind';
+import { createTemplate } from '@videojs/utils/dom';
+import { cn } from '@videojs/utils/style';
+
+function getTemplateHTML() {
+  return /*html*/ `
+    <media-container class="${root(true)}">
+      <slot name="media"></slot>
+      <slot></slot>
+
+      <media-poster class="${poster(true)}">
+        <slot name="poster"></slot>
+      </media-poster>
+
+      <media-buffering-indicator class="${bufferingIndicator}">
+        ${renderIcon('spinner')}
+      </media-buffering-indicator>
+
+      <media-error-dialog class="${error.root}">
+        <div class="${error.dialog}">
+          <div class="${error.content}">
+            <media-alert-dialog-title class="${error.title}">Something went wrong.</media-alert-dialog-title>
+            <media-alert-dialog-description class="${error.description}"></media-alert-dialog-description>
+          </div>
+          <div class="${error.actions}">
+            <media-alert-dialog-close class="${cn(button.base, button.primary)}">OK</media-alert-dialog-close>
+          </div>
+        </div>
+      </media-error-dialog>
+
+      <media-controls data-controls="" class="${controls}">
+        <media-tooltip-group>
+          <div class="${buttonGroupStart}">
+              <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+                ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
+                ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
+                ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
+              </media-play-button>
+              <media-tooltip id="play-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+
+              <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
+          </div>
+
+          <div class="${time.controls}">
+            <media-time-group class="${time.group}">
+              <media-time type="current" class="${time.current}"></media-time>
+              <media-time-separator class="${time.separator}"></media-time-separator>
+              <media-time type="duration" class="${time.duration}"></media-time>
+            </media-time-group>
+
+            <media-time-slider class="${slider.root}">
+              <media-slider-track class="${slider.track}">
+                <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
+                <media-slider-buffer class="${cn(slider.fill.base, slider.fill.buffer)}"></media-slider-buffer>
+              </media-slider-track>
+              <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.interactive)}"></media-slider-thumb>
+
+              <div class="${thumbnail.root}">
+                <div class="${thumbnail.imageWrapper}">
+                  <media-slider-thumbnail class="${thumbnail.image}"></media-slider-thumbnail>
+                </div>
+                <media-slider-value type="pointer" class="${cn(time.current, thumbnail.time)}"></media-slider-value>
+                ${renderIcon('spinner', { class: cn(icon, thumbnail.spinner) })}
+              </div>
+            </media-time-slider>
+          </div>
+
+          <div class="${buttonGroupEnd}">
+            <media-mute-button commandfor="live-dvr-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+              ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
+              ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
+              ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
+            </media-mute-button>
+
+            <media-popover id="live-dvr-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="${cn(popup.volume)}">
+              <media-volume-slider class="${slider.root}" orientation="vertical" thumb-alignment="edge">
+                <media-slider-track class="${slider.track}">
+                  <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
+                </media-slider-track>
+                <media-slider-thumb class="${slider.thumb.base}"></media-slider-thumb>
+              </media-volume-slider>
+            </media-popover>
+              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+                ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
+                ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
+              </media-captions-button>
+              <media-tooltip id="captions-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+              <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
+                ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}
+                ${renderIcon('cast-exit', { class: cn(icon, iconState.cast.exit) })}
+              </media-cast-button>
+              <media-tooltip id="cast-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+              <media-airplay-button commandfor="airplay-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.airplay.button)}">
+                ${renderIcon('airplay-enter', { class: cn(icon, iconState.airplay.enter) })}
+                ${renderIcon('airplay-exit', { class: cn(icon, iconState.airplay.exit) })}
+              </media-airplay-button>
+              <media-tooltip id="airplay-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+              <media-pip-button commandfor="pip-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.pip.button)}">
+                ${renderIcon('pip-enter', { class: cn(icon, iconState.pip.off) })}
+                ${renderIcon('pip-exit', { class: cn(icon, iconState.pip.on) })}
+              </media-pip-button>
+              <media-tooltip id="pip-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+              <media-fullscreen-button commandfor="fullscreen-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.fullscreen.button)}">
+                ${renderIcon('fullscreen-enter', { class: cn(icon, iconState.fullscreen.enter) })}
+                ${renderIcon('fullscreen-exit', { class: cn(icon, iconState.fullscreen.exit) })}
+              </media-fullscreen-button>
+              <media-tooltip id="fullscreen-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+          </div>
+        </media-tooltip-group>
+      </media-controls>
+
+      <div class="${overlay}"></div>
+
+      <!-- Hotkeys -->
+      <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="k" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+      <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
+      <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
+      <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+
+      <!-- Gestures -->
+      <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
+      <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
+      <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
+
+      <!-- Input Feedback -->
+      <media-status-announcer></media-status-announcer>
+      <div class="${inputFeedback.root}">
+        <media-volume-indicator hidden class="${cn(inputFeedback.island.base, inputFeedback.island.volume, inputFeedback.island.shownVolume)}">
+          <media-volume-indicator-fill data-feedback-island-content class="${inputFeedback.island.content}">
+            ${renderIcon('volume-high', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeHigh) })}
+            ${renderIcon('volume-low', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeLow) })}
+            ${renderIcon('volume-off', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeOff) })}
+            <div aria-hidden="true" class="${inputFeedback.island.volumeProgress}"></div>
+            <media-volume-indicator-value class="${inputFeedback.island.value}"></media-volume-indicator-value>
+          </media-volume-indicator-fill>
+        </media-volume-indicator>
+        <media-status-indicator
+          hidden
+          actions="toggleSubtitles toggleFullscreen togglePictureInPicture"
+          class="${cn(inputFeedback.island.base, inputFeedback.island.shownStatus)}"
+        >
+          <div class="${inputFeedback.island.content}">
+            ${renderIcon('captions-on', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOn) })}
+            ${renderIcon('captions-off', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOff) })}
+            ${renderIcon('fullscreen-enter', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenEnter) })}
+            ${renderIcon('fullscreen-exit', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenExit) })}
+            ${renderIcon('pip-enter', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownPipEnter) })}
+            ${renderIcon('pip-exit', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownPipExit) })}
+            <media-status-indicator-value class="${inputFeedback.island.value}"></media-status-indicator-value>
+          </div>
+        </media-status-indicator>
+        <media-status-indicator hidden actions="togglePaused" class="${inputFeedback.bubble.base}">
+          ${renderIcon('play', { class: cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPlay) })}
+          ${renderIcon('pause', { class: cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPause) })}
+        </media-status-indicator>
+      </div>
+    </media-container>
+  `;
+}
+
+const TAG_NAME = 'live-dvr-minimal-skin-tailwind';
+
+/**
+ * Sandbox-only minimal tailwind live DVR skin. Extends the library
+ * `live-video-minimal-skin-tailwind` element and swaps in a template that
+ * keeps the time slider and current / duration time displays so viewers can
+ * scrub within the seekable DVR window. The skin's tailwind styles are
+ * assigned by the sandbox skin loader (see `shared/html/skins.ts`).
+ */
+export class MinimalLiveDvrSkinTailwindElement extends MinimalLiveVideoSkinTailwindElement {
+  static template = createTemplate(getTemplateHTML());
+}
+
+if (!customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, MinimalLiveDvrSkinTailwindElement);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'live-dvr-minimal-skin-tailwind': MinimalLiveDvrSkinTailwindElement;
+  }
+}

--- a/apps/sandbox/app/shared/html/live-dvr/minimal-skin.ts
+++ b/apps/sandbox/app/shared/html/live-dvr/minimal-skin.ts
@@ -1,0 +1,193 @@
+// Importing the minimal live-video skin registers the live player, container,
+// and minimal UI custom elements (including the time slider + time elements the
+// DVR skin adds back in) and exposes the base skin element we extend below.
+import { MinimalLiveVideoSkinElement } from '@videojs/html/live-video/minimal-skin';
+import { renderIcon } from '@videojs/icons/render/minimal';
+import { createTemplate } from '@videojs/utils/dom';
+
+function getTemplateHTML() {
+  return /*html*/ `
+    <media-container class="media-minimal-skin media-minimal-skin--video">
+      <slot name="media"></slot>
+      <slot></slot>
+
+      <media-poster>
+        <slot name="poster"></slot>
+      </media-poster>
+
+      <media-buffering-indicator class="media-buffering-indicator">
+        ${renderIcon('spinner', { class: 'media-icon' })}
+      </media-buffering-indicator>
+
+      <media-error-dialog class="media-error">
+        <div class="media-error__dialog">
+          <div class="media-error__content">
+            <media-alert-dialog-title class="media-error__title">Something went wrong.</media-alert-dialog-title>
+            <media-alert-dialog-description class="media-error__description"></media-alert-dialog-description>
+          </div>
+          <div class="media-error__actions">
+            <media-alert-dialog-close class="media-button media-button--primary">OK</media-alert-dialog-close>
+          </div>
+        </div>
+      </media-error-dialog>
+
+      <media-controls class="media-controls">
+        <media-tooltip-group>
+          <div class="media-button-group">
+            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+            </media-play-button>
+            <media-tooltip id="play-tooltip" side="top" class="media-tooltip"></media-tooltip>
+
+            <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
+          </div>
+
+          <div class="media-time-controls">
+            <media-time-group class="media-time-group">
+              <media-time type="current" class="media-time media-time--current"></media-time>
+              <media-time-separator class="media-time-separator"></media-time-separator>
+              <media-time type="duration" class="media-time media-time--duration"></media-time>
+            </media-time-group>
+
+            <media-time-slider class="media-slider">
+              <media-slider-track class="media-slider__track">
+                <media-slider-fill class="media-slider__fill"></media-slider-fill>
+                <media-slider-buffer class="media-slider__buffer"></media-slider-buffer>
+              </media-slider-track>
+              <media-slider-thumb class="media-slider__thumb"></media-slider-thumb>
+
+              <div class="media-preview media-slider__preview">
+                <div class="media-preview__thumbnail-wrapper">
+                  <media-slider-thumbnail class="media-preview__thumbnail"></media-slider-thumbnail>
+                </div>
+                <media-slider-value type="pointer" class="media-time media-preview__time"></media-slider-value>
+                ${renderIcon('spinner', { class: 'media-preview__spinner media-icon' })}
+              </div>
+            </media-time-slider>
+          </div>
+
+          <div class="media-button-group">
+            <media-mute-button commandfor="live-dvr-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
+              ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
+              ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
+              ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
+            </media-mute-button>
+
+            <media-popover id="live-dvr-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="media-popover media-popover--volume">
+              <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
+                <media-slider-track class="media-slider__track">
+                  <media-slider-fill class="media-slider__fill"></media-slider-fill>
+                </media-slider-track>
+                <media-slider-thumb class="media-slider__thumb media-slider__thumb--persistent"></media-slider-thumb>
+              </media-volume-slider>
+            </media-popover>
+
+            <media-captions-button commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
+              ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
+              ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
+            </media-captions-button>
+            <media-tooltip id="captions-tooltip" side="top" class="media-tooltip"></media-tooltip>
+
+            <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">
+              ${renderIcon('cast-enter', { class: 'media-icon media-icon--cast-enter' })}
+              ${renderIcon('cast-exit', { class: 'media-icon media-icon--cast-exit' })}
+            </media-cast-button>
+            <media-tooltip id="cast-tooltip" side="top" class="media-tooltip"></media-tooltip>
+
+            <media-airplay-button commandfor="airplay-tooltip" class="media-button media-button--subtle media-button--icon media-button--airplay">
+              ${renderIcon('airplay-enter', { class: 'media-icon media-icon--airplay-enter' })}
+              ${renderIcon('airplay-exit', { class: 'media-icon media-icon--airplay-exit' })}
+            </media-airplay-button>
+            <media-tooltip id="airplay-tooltip" side="top" class="media-tooltip"></media-tooltip>
+
+            <media-pip-button commandfor="pip-tooltip" class="media-button media-button--subtle media-button--icon media-button--pip">
+              ${renderIcon('pip-enter', { class: 'media-icon media-icon--pip-enter' })}
+              ${renderIcon('pip-exit', { class: 'media-icon media-icon--pip-exit' })}
+            </media-pip-button>
+            <media-tooltip id="pip-tooltip" side="top" class="media-tooltip"></media-tooltip>
+
+            <media-fullscreen-button commandfor="fullscreen-tooltip" class="media-button media-button--subtle media-button--icon media-button--fullscreen">
+              ${renderIcon('fullscreen-enter', { class: 'media-icon media-icon--fullscreen-enter' })}
+              ${renderIcon('fullscreen-exit', { class: 'media-icon media-icon--fullscreen-exit' })}
+            </media-fullscreen-button>
+            <media-tooltip id="fullscreen-tooltip" side="top" class="media-tooltip"></media-tooltip>
+          </div>
+        </media-tooltip-group>
+      </media-controls>
+
+      <div class="media-overlay"></div>
+
+      <!-- Hotkeys -->
+      <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="k" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+      <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
+      <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
+      <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+
+      <!-- Gestures -->
+      <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
+      <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
+      <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
+
+      <!-- Input Feedback -->
+      <media-status-announcer></media-status-announcer>
+      <div class="media-input-feedback">
+        <media-volume-indicator hidden class="media-input-feedback-island media-input-feedback-island--volume">
+          <media-volume-indicator-fill class="media-input-feedback-island__content">
+            ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
+            ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
+            ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
+            <div class="media-input-feedback-island__progress" aria-hidden="true"></div>
+            <media-volume-indicator-value class="media-input-feedback-island__value"></media-volume-indicator-value>
+          </media-volume-indicator-fill>
+        </media-volume-indicator>
+        <media-status-indicator
+          hidden
+          actions="toggleSubtitles toggleFullscreen togglePictureInPicture"
+          class="media-input-feedback-island media-input-feedback-island--status"
+        >
+          <div class="media-input-feedback-island__content">
+            ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
+            ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
+            ${renderIcon('fullscreen-enter', { class: 'media-icon media-icon--fullscreen-enter' })}
+            ${renderIcon('fullscreen-exit', { class: 'media-icon media-icon--fullscreen-exit' })}
+            ${renderIcon('pip-enter', { class: 'media-icon media-icon--pip-enter' })}
+            ${renderIcon('pip-exit', { class: 'media-icon media-icon--pip-exit' })}
+            <media-status-indicator-value class="media-input-feedback-island__value"></media-status-indicator-value>
+          </div>
+        </media-status-indicator>
+        <media-status-indicator hidden actions="togglePaused" class="media-input-feedback-bubble">
+          ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+          ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+        </media-status-indicator>
+      </div>
+    </media-container>
+  `;
+}
+
+const TAG_NAME = 'live-dvr-minimal-skin';
+
+/**
+ * Sandbox-only minimal live DVR skin. Extends the library
+ * `live-video-minimal-skin` element (inheriting its shared/skin styles) and
+ * swaps in a template that keeps the time slider and current / duration time
+ * displays so viewers can scrub within the seekable DVR window.
+ */
+export class MinimalLiveDvrSkinElement extends MinimalLiveVideoSkinElement {
+  static template = createTemplate(getTemplateHTML());
+}
+
+if (!customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, MinimalLiveDvrSkinElement);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'live-dvr-minimal-skin': MinimalLiveDvrSkinElement;
+  }
+}

--- a/apps/sandbox/app/shared/html/live-dvr/skin.tailwind.ts
+++ b/apps/sandbox/app/shared/html/live-dvr/skin.tailwind.ts
@@ -1,0 +1,203 @@
+// Importing the tailwind live-video skin registers the live player, container,
+// and all UI custom elements (including the time slider + time elements the DVR
+// skin adds back in) and exposes the base skin element we extend below.
+import { LiveVideoSkinTailwindElement } from '@videojs/html/live-video/skin.tailwind';
+import { renderIcon } from '@videojs/icons/render';
+import {
+  bufferingIndicator,
+  button,
+  buttonGroupEnd,
+  buttonGroupStart,
+  controls,
+  error,
+  icon,
+  iconState,
+  inputFeedback,
+  overlay,
+  popup,
+  poster,
+  root,
+  slider,
+  thumbnail,
+  time,
+} from '@videojs/skins/default/tailwind/video.tailwind';
+import { createTemplate } from '@videojs/utils/dom';
+import { cn } from '@videojs/utils/style';
+
+function getTemplateHTML() {
+  return /*html*/ `
+    <media-container class="${root(true)}">
+      <slot name="media"></slot>
+      <slot></slot>
+
+      <media-poster class="${poster(true)}">
+        <slot name="poster"></slot>
+      </media-poster>
+
+      <media-buffering-indicator class="${bufferingIndicator.root}">
+        <div class="${bufferingIndicator.container}">
+          ${renderIcon('spinner')}
+        </div>
+      </media-buffering-indicator>
+
+      <media-error-dialog class="${error.root}">
+        <div class="${error.dialog}">
+          <div class="${error.content}">
+            <media-alert-dialog-title class="${error.title}">Something went wrong.</media-alert-dialog-title>
+            <media-alert-dialog-description class="${error.description}"></media-alert-dialog-description>
+          </div>
+          <div class="${error.actions}">
+            <media-alert-dialog-close class="${cn(button.base, button.primary)}">OK</media-alert-dialog-close>
+          </div>
+        </div>
+      </media-error-dialog>
+
+      <media-controls data-controls="" class="${controls}">
+        <media-tooltip-group>
+          <div class="${buttonGroupStart}">
+            <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
+              ${renderIcon('restart', { class: cn(icon, iconState.play.restart) })}
+              ${renderIcon('play', { class: cn(icon, iconState.play.play) })}
+              ${renderIcon('pause', { class: cn(icon, iconState.play.pause) })}
+            </media-play-button>
+            <media-tooltip id="play-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+
+            <media-live-button class="${cn(button.base, button.subtle, button.live)}"></media-live-button>
+          </div>
+
+          <div class="${time.group}">
+            <media-time type="current" class="${time.current}"></media-time>
+            <media-time-slider class="${slider.root}">
+              <media-slider-track class="${slider.track}">
+                <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
+                <media-slider-buffer class="${cn(slider.fill.base, slider.fill.buffer)}"></media-slider-buffer>
+              </media-slider-track>
+              <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.interactive)}"></media-slider-thumb>
+
+              <div class="${thumbnail.root}">
+                <media-slider-thumbnail class="${thumbnail.image}"></media-slider-thumbnail>
+                <media-slider-value type="pointer" class="${cn(time.current, thumbnail.time)}"></media-slider-value>
+                ${renderIcon('spinner', { class: cn(icon, thumbnail.spinner) })}
+              </div>
+            </media-time-slider>
+            <media-time type="duration" class="${time.duration}"></media-time>
+          </div>
+
+          <div class="${buttonGroupEnd}">
+            <media-mute-button commandfor="live-dvr-volume-popover" class="${cn(button.base, button.subtle, button.icon, iconState.mute.button)}">
+              ${renderIcon('volume-off', { class: cn(icon, iconState.mute.volumeOff) })}
+              ${renderIcon('volume-low', { class: cn(icon, iconState.mute.volumeLow) })}
+              ${renderIcon('volume-high', { class: cn(icon, iconState.mute.volumeHigh) })}
+            </media-mute-button>
+
+            <media-popover id="live-dvr-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="${cn(popup.popover, popup.volume)}">
+              <media-volume-slider class="${slider.root}" orientation="vertical" thumb-alignment="edge">
+                <media-slider-track class="${slider.track}">
+                  <media-slider-fill class="${cn(slider.fill.base, slider.fill.fill)}"></media-slider-fill>
+                </media-slider-track>
+                <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
+              </media-volume-slider>
+            </media-popover>
+            <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
+              ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
+            </media-captions-button>
+            <media-tooltip id="captions-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+            <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
+              ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}
+              ${renderIcon('cast-exit', { class: cn(icon, iconState.cast.exit) })}
+            </media-cast-button>
+            <media-tooltip id="cast-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+            <media-airplay-button commandfor="airplay-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.airplay.button)}">
+              ${renderIcon('airplay-enter', { class: cn(icon, iconState.airplay.enter) })}
+              ${renderIcon('airplay-exit', { class: cn(icon, iconState.airplay.exit) })}
+            </media-airplay-button>
+            <media-tooltip id="airplay-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+            <media-pip-button commandfor="pip-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.pip.button)}">
+              ${renderIcon('pip-enter', { class: cn(icon, iconState.pip.off) })}
+              ${renderIcon('pip-exit', { class: cn(icon, iconState.pip.on) })}
+            </media-pip-button>
+            <media-tooltip id="pip-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+            <media-fullscreen-button commandfor="fullscreen-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.fullscreen.button)}">
+              ${renderIcon('fullscreen-enter', { class: cn(icon, iconState.fullscreen.enter) })}
+              ${renderIcon('fullscreen-exit', { class: cn(icon, iconState.fullscreen.exit) })}
+            </media-fullscreen-button>
+            <media-tooltip id="fullscreen-tooltip" side="top" class="${cn(popup.tooltip)}"></media-tooltip>
+          </div>
+        </media-tooltip-group>
+      </media-controls>
+
+      <div class="${overlay}"></div>
+
+      <!-- Hotkeys -->
+      <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="k" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+      <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
+      <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
+      <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+
+      <!-- Gestures -->
+      <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
+      <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
+      <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
+
+      <!-- Input Feedback -->
+      <media-status-announcer></media-status-announcer>
+      <div class="${inputFeedback.root}">
+        <media-volume-indicator hidden class="${cn(inputFeedback.island.base, inputFeedback.island.volume, inputFeedback.island.shownVolume)}">
+          <media-volume-indicator-fill class="${inputFeedback.island.content}">
+            ${renderIcon('volume-high', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeHigh) })}
+            ${renderIcon('volume-low', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeLow) })}
+            ${renderIcon('volume-off', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeOff) })}
+            <media-volume-indicator-value class="${inputFeedback.island.value}"></media-volume-indicator-value>
+          </media-volume-indicator-fill>
+        </media-volume-indicator>
+        <media-status-indicator
+          hidden
+          actions="toggleSubtitles toggleFullscreen togglePictureInPicture"
+          class="${cn(inputFeedback.island.base, inputFeedback.island.shownStatus)}"
+        >
+          <div class="${inputFeedback.island.content}">
+            ${renderIcon('captions-on', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOn) })}
+            ${renderIcon('captions-off', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOff) })}
+            ${renderIcon('fullscreen-enter', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenEnter) })}
+            ${renderIcon('fullscreen-exit', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenExit) })}
+            ${renderIcon('pip-enter', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownPipEnter) })}
+            ${renderIcon('pip-exit', { class: cn(inputFeedback.island.icon, inputFeedback.island.shownPipExit) })}
+            <media-status-indicator-value class="${inputFeedback.island.value}"></media-status-indicator-value>
+          </div>
+        </media-status-indicator>
+        <media-status-indicator hidden actions="togglePaused" class="${inputFeedback.bubble.base}">
+          ${renderIcon('play', { class: cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPlay) })}
+          ${renderIcon('pause', { class: cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPause) })}
+        </media-status-indicator>
+      </div>
+    </media-container>
+  `;
+}
+
+const TAG_NAME = 'live-dvr-skin-tailwind';
+
+/**
+ * Sandbox-only tailwind live DVR skin. Extends the library
+ * `live-video-skin-tailwind` element and swaps in a template that keeps the
+ * time slider and current / duration time displays so viewers can scrub
+ * within the seekable DVR window. The skin's tailwind styles are assigned by
+ * the sandbox skin loader (see `shared/html/skins.ts`).
+ */
+export class LiveDvrSkinTailwindElement extends LiveVideoSkinTailwindElement {
+  static template = createTemplate(getTemplateHTML());
+}
+
+if (!customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, LiveDvrSkinTailwindElement);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'live-dvr-skin-tailwind': LiveDvrSkinTailwindElement;
+  }
+}

--- a/apps/sandbox/app/shared/html/live-dvr/skin.ts
+++ b/apps/sandbox/app/shared/html/live-dvr/skin.ts
@@ -1,0 +1,188 @@
+// Importing the live-video skin registers the live player, container, and all
+// UI custom elements (including the time slider + time elements the DVR skin
+// adds back in) and exposes the base skin element we extend below.
+import { LiveVideoSkinElement } from '@videojs/html/live-video/skin';
+import { renderIcon } from '@videojs/icons/render';
+import { createTemplate } from '@videojs/utils/dom';
+
+function getTemplateHTML() {
+  return /*html*/ `
+    <media-container class="media-default-skin media-default-skin--video">
+      <slot name="media"></slot>
+      <slot></slot>
+
+      <media-poster>
+        <slot name="poster"></slot>
+      </media-poster>
+
+      <media-buffering-indicator class="media-buffering-indicator">
+        <div class="media-surface">
+          ${renderIcon('spinner', { class: 'media-icon' })}
+        </div>
+      </media-buffering-indicator>
+
+      <media-error-dialog class="media-error">
+        <div class="media-error__dialog media-surface">
+          <div class="media-error__content">
+            <media-alert-dialog-title class="media-error__title">Something went wrong.</media-alert-dialog-title>
+            <media-alert-dialog-description class="media-error__description"></media-alert-dialog-description>
+          </div>
+          <div class="media-error__actions">
+            <media-alert-dialog-close class="media-button media-button--primary">OK</media-alert-dialog-close>
+          </div>
+        </div>
+      </media-error-dialog>
+
+      <media-controls class="media-surface media-controls">
+        <media-tooltip-group>
+          <div class="media-button-group">
+            <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
+              ${renderIcon('restart', { class: 'media-icon media-icon--restart' })}
+              ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+              ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+            </media-play-button>
+            <media-tooltip id="play-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
+
+            <media-live-button class="media-button media-button--subtle media-button--live"></media-live-button>
+          </div>
+
+          <div class="media-time-controls">
+            <media-time type="current" class="media-time"></media-time>
+            <media-time-slider class="media-slider">
+              <media-slider-track class="media-slider__track">
+                <media-slider-fill class="media-slider__fill"></media-slider-fill>
+                <media-slider-buffer class="media-slider__buffer"></media-slider-buffer>
+              </media-slider-track>
+              <media-slider-thumb class="media-slider__thumb"></media-slider-thumb>
+
+              <div class="media-surface media-preview media-slider__preview">
+                <media-slider-thumbnail class="media-preview__thumbnail"></media-slider-thumbnail>
+                <media-slider-value type="pointer" class="media-time media-preview__time"></media-slider-value>
+                ${renderIcon('spinner', { class: 'media-preview__spinner media-icon' })}
+              </div>
+            </media-time-slider>
+            <media-time type="duration" class="media-time"></media-time>
+          </div>
+
+          <div class="media-button-group">
+            <media-mute-button commandfor="live-dvr-volume-popover" class="media-button media-button--subtle media-button--icon media-button--mute">
+              ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
+              ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
+              ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
+            </media-mute-button>
+
+            <media-popover id="live-dvr-volume-popover" open-on-hover delay="200" close-delay="100" side="top" class="media-surface media-popover media-popover--volume">
+              <media-volume-slider class="media-slider" orientation="vertical" thumb-alignment="edge">
+                <media-slider-track class="media-slider__track">
+                  <media-slider-fill class="media-slider__fill"></media-slider-fill>
+                </media-slider-track>
+                <media-slider-thumb class="media-slider__thumb media-slider__thumb--persistent"></media-slider-thumb>
+              </media-volume-slider>
+            </media-popover>
+
+            <media-captions-button commandfor="captions-tooltip" class="media-button media-button--subtle media-button--icon media-button--captions">
+              ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
+              ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
+            </media-captions-button>
+            <media-tooltip id="captions-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
+
+            <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">
+              ${renderIcon('cast-enter', { class: 'media-icon media-icon--cast-enter' })}
+              ${renderIcon('cast-exit', { class: 'media-icon media-icon--cast-exit' })}
+            </media-cast-button>
+            <media-tooltip id="cast-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
+
+            <media-airplay-button commandfor="airplay-tooltip" class="media-button media-button--subtle media-button--icon media-button--airplay">
+              ${renderIcon('airplay-enter', { class: 'media-icon media-icon--airplay-enter' })}
+              ${renderIcon('airplay-exit', { class: 'media-icon media-icon--airplay-exit' })}
+            </media-airplay-button>
+            <media-tooltip id="airplay-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
+
+            <media-pip-button commandfor="pip-tooltip" class="media-button media-button--subtle media-button--icon media-button--pip">
+              ${renderIcon('pip-enter', { class: 'media-icon media-icon--pip-enter' })}
+              ${renderIcon('pip-exit', { class: 'media-icon media-icon--pip-exit' })}
+            </media-pip-button>
+            <media-tooltip id="pip-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
+
+            <media-fullscreen-button commandfor="fullscreen-tooltip" class="media-button media-button--subtle media-button--icon media-button--fullscreen">
+              ${renderIcon('fullscreen-enter', { class: 'media-icon media-icon--fullscreen-enter' })}
+              ${renderIcon('fullscreen-exit', { class: 'media-icon media-icon--fullscreen-exit' })}
+            </media-fullscreen-button>
+            <media-tooltip id="fullscreen-tooltip" side="top" class="media-surface media-tooltip"></media-tooltip>
+          </div>
+        </media-tooltip-group>
+      </media-controls>
+
+      <div class="media-overlay"></div>
+
+      <!-- Hotkeys -->
+      <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="k" action="togglePaused"></media-hotkey>
+      <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+      <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
+      <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
+      <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
+      <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
+      <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+
+      <!-- Gestures -->
+      <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
+      <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
+      <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
+
+      <!-- Input Feedback -->
+      <media-status-announcer></media-status-announcer>
+      <div class="media-input-feedback">
+        <media-volume-indicator hidden class="media-surface media-input-feedback-island media-input-feedback-island--volume">
+          <media-volume-indicator-fill class="media-input-feedback-island__content">
+            ${renderIcon('volume-high', { class: 'media-icon media-icon--volume-high' })}
+            ${renderIcon('volume-low', { class: 'media-icon media-icon--volume-low' })}
+            ${renderIcon('volume-off', { class: 'media-icon media-icon--volume-off' })}
+            <media-volume-indicator-value class="media-input-feedback-island__value"></media-volume-indicator-value>
+          </media-volume-indicator-fill>
+        </media-volume-indicator>
+        <media-status-indicator
+          hidden
+          actions="toggleSubtitles toggleFullscreen togglePictureInPicture"
+          class="media-surface media-input-feedback-island media-input-feedback-island--status"
+        >
+          <div class="media-input-feedback-island__content">
+            ${renderIcon('captions-on', { class: 'media-icon media-icon--captions-on' })}
+            ${renderIcon('captions-off', { class: 'media-icon media-icon--captions-off' })}
+            ${renderIcon('fullscreen-enter', { class: 'media-icon media-icon--fullscreen-enter' })}
+            ${renderIcon('fullscreen-exit', { class: 'media-icon media-icon--fullscreen-exit' })}
+            ${renderIcon('pip-enter', { class: 'media-icon media-icon--pip-enter' })}
+            ${renderIcon('pip-exit', { class: 'media-icon media-icon--pip-exit' })}
+            <media-status-indicator-value class="media-input-feedback-island__value"></media-status-indicator-value>
+          </div>
+        </media-status-indicator>
+        <media-status-indicator hidden actions="togglePaused" class="media-input-feedback-bubble">
+          ${renderIcon('play', { class: 'media-icon media-icon--play' })}
+          ${renderIcon('pause', { class: 'media-icon media-icon--pause' })}
+        </media-status-indicator>
+      </div>
+    </media-container>
+  `;
+}
+
+const TAG_NAME = 'live-dvr-skin';
+
+/**
+ * Sandbox-only live DVR skin. Extends the library `live-video-skin` element
+ * (inheriting its shared/skin styles) and swaps in a template that keeps the
+ * time slider and current / duration time displays so viewers can scrub
+ * within the seekable DVR window.
+ */
+export class LiveDvrSkinElement extends LiveVideoSkinElement {
+  static template = createTemplate(getTemplateHTML());
+}
+
+if (!customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, LiveDvrSkinElement);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'live-dvr-skin': LiveDvrSkinElement;
+  }
+}

--- a/apps/sandbox/app/shared/html/skin-tags.ts
+++ b/apps/sandbox/app/shared/html/skin-tags.ts
@@ -22,3 +22,14 @@ export const LIVE_VIDEO_TAILWIND_SKIN_TAGS: Record<Skin, string> = {
   default: 'live-video-skin-tailwind',
   minimal: 'live-video-minimal-skin-tailwind',
 };
+
+/** Custom element tag names for the sandbox-only live DVR skins. */
+export const LIVE_DVR_CSS_SKIN_TAGS: Record<Skin, string> = {
+  default: 'live-dvr-skin',
+  minimal: 'live-dvr-minimal-skin',
+};
+
+export const LIVE_DVR_TAILWIND_SKIN_TAGS: Record<Skin, string> = {
+  default: 'live-dvr-skin-tailwind',
+  minimal: 'live-dvr-minimal-skin-tailwind',
+};

--- a/apps/sandbox/app/shared/html/skins.ts
+++ b/apps/sandbox/app/shared/html/skins.ts
@@ -1,6 +1,8 @@
 import type { Skin, Styling } from '@app/types';
 import {
   CSS_SKIN_TAGS,
+  LIVE_DVR_CSS_SKIN_TAGS,
+  LIVE_DVR_TAILWIND_SKIN_TAGS,
   LIVE_VIDEO_CSS_SKIN_TAGS,
   LIVE_VIDEO_TAILWIND_SKIN_TAGS,
   TAILWIND_SKIN_TAGS,
@@ -91,18 +93,51 @@ async function loadLiveVideoTailwindSkin(skin: Skin): Promise<string> {
   return LIVE_VIDEO_TAILWIND_SKIN_TAGS[skin];
 }
 
-type VideoSkinOptions = { live?: boolean };
+async function loadLiveDvrCssSkin(skin: Skin): Promise<string> {
+  if (skin === 'default') {
+    await import('./live-dvr/skin');
+  } else {
+    await import('./live-dvr/minimal-skin');
+  }
+
+  loadVideoStylesheets(skin);
+
+  return LIVE_DVR_CSS_SKIN_TAGS[skin];
+}
+
+async function loadLiveDvrTailwindSkin(skin: Skin): Promise<string> {
+  if (skin === 'default') {
+    const { LiveDvrSkinTailwindElement } = await import('./live-dvr/skin.tailwind');
+    const { getTailwindStyles } = await import('./tailwind-setup');
+
+    LiveDvrSkinTailwindElement.styles = getTailwindStyles();
+  } else {
+    const { MinimalLiveDvrSkinTailwindElement } = await import('./live-dvr/minimal-skin.tailwind');
+    const { getTailwindStyles } = await import('./tailwind-setup');
+
+    MinimalLiveDvrSkinTailwindElement.styles = getTailwindStyles();
+  }
+
+  return LIVE_DVR_TAILWIND_SKIN_TAGS[skin];
+}
+
+type VideoSkinOptions = { live?: boolean; dvr?: boolean };
 
 /**
  * Loads and registers the video skin for the given skin / styling combination
- * and returns its custom element tag name. Pass `live: true` to swap in the
- * `live-video` skin variant (same feature set, trimmed time UI).
+ * and returns its custom element tag name. Pass `dvr: true` to swap in the
+ * sandbox-only live DVR skin (live skin + time slider / time display), or
+ * `live: true` for the `live-video` skin variant (trimmed time UI).
  */
 export function loadVideoSkinTag(
   skin: Skin,
   styling: Styling,
-  { live = false }: VideoSkinOptions = {}
+  { live = false, dvr = false }: VideoSkinOptions = {}
 ): Promise<string> {
+  if (dvr) {
+    return styling === 'tailwind' ? loadLiveDvrTailwindSkin(skin) : loadLiveDvrCssSkin(skin);
+  }
+
   if (live) {
     return styling === 'tailwind' ? loadLiveVideoTailwindSkin(skin) : loadLiveVideoCssSkin(skin);
   }

--- a/apps/sandbox/app/shared/react/live-dvr/index.ts
+++ b/apps/sandbox/app/shared/react/live-dvr/index.ts
@@ -1,0 +1,4 @@
+export { MinimalLiveDvrSkin, type MinimalLiveDvrSkinProps } from './minimal-skin';
+export { MinimalLiveDvrSkinTailwind } from './minimal-skin.tailwind';
+export { LiveDvrSkin, type LiveDvrSkinProps } from './skin';
+export { LiveDvrSkinTailwind } from './skin.tailwind';

--- a/apps/sandbox/app/shared/react/live-dvr/minimal-skin.tailwind.tsx
+++ b/apps/sandbox/app/shared/react/live-dvr/minimal-skin.tailwind.tsx
@@ -1,0 +1,344 @@
+import {
+  AirplayButton,
+  BufferingIndicator,
+  CaptionsButton,
+  CastButton,
+  Container,
+  Controls,
+  ErrorDialog,
+  FullscreenButton,
+  Gesture,
+  Hotkey,
+  LiveButton,
+  MuteButton,
+  PiPButton,
+  PlayButton,
+  Popover,
+  Poster,
+  Slider,
+  StatusAnnouncer,
+  StatusIndicator,
+  Time,
+  TimeSlider,
+  Tooltip,
+  usePlayer,
+  VolumeIndicator,
+  VolumeSlider,
+} from '@videojs/react';
+import {
+  AirplayEnterIcon,
+  AirplayExitIcon,
+  CaptionsOffIcon,
+  CaptionsOnIcon,
+  CastEnterIcon,
+  CastExitIcon,
+  FullscreenEnterIcon,
+  FullscreenExitIcon,
+  PauseIcon,
+  PipEnterIcon,
+  PipExitIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@videojs/react/icons/minimal';
+import {
+  bufferingIndicator,
+  button,
+  buttonGroupEnd,
+  buttonGroupStart,
+  controls,
+  error,
+  icon,
+  iconState,
+  inputFeedback,
+  overlay,
+  popup,
+  poster,
+  root,
+  slider,
+  thumbnail,
+  time,
+} from '@videojs/skins/minimal/tailwind/video.tailwind';
+import { isString } from '@videojs/utils/predicate';
+import { cn } from '@videojs/utils/style';
+import { type ComponentProps, forwardRef, type ReactNode } from 'react';
+import type { MinimalLiveDvrSkinProps } from './minimal-skin';
+
+const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
+const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
+
+const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
+  return (
+    <button ref={ref} type="button" className={cn(button.base, button.subtle, button.icon, className)} {...props} />
+  );
+});
+
+const SliderRoot = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderRoot({ className, ...props }, ref) {
+  return <div ref={ref} className={cn(slider.root, className)} {...props} />;
+});
+
+const SliderTrack = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderTrack(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={cn(slider.track, className)} {...props} />;
+});
+
+const SliderFill = forwardRef<HTMLDivElement, ComponentProps<'div'> & { type?: 'fill' | 'buffer' }>(function SliderFill(
+  { type = 'fill', className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(slider.fill.base, type === 'fill' ? slider.fill.fill : slider.fill.buffer, className)}
+      {...props}
+    />
+  );
+});
+
+const SliderBuffer = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderBuffer(props, ref) {
+  return <SliderFill type="buffer" ref={ref} {...props} />;
+});
+
+const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persistent?: boolean }>(function SliderThumb(
+  { persistent, className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(slider.thumb.base, persistent ? undefined : slider.thumb.interactive, className)}
+      {...props}
+    />
+  );
+});
+
+function VolumePopover(): ReactNode {
+  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+
+  const muteButton = (
+    <MuteButton className={iconState.mute.button} render={<Button />}>
+      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
+      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
+      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
+    </MuteButton>
+  );
+
+  if (volumeUnsupported) return muteButton;
+
+  return (
+    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+      <Popover.Trigger render={muteButton} />
+      <Popover.Popup className={cn(popup.volume)}>
+        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+          <VolumeSlider.Track render={<SliderTrack />}>
+            <VolumeSlider.Fill render={<SliderFill />} />
+          </VolumeSlider.Track>
+          <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
+        </VolumeSlider.Root>
+      </Popover.Popup>
+    </Popover.Root>
+  );
+}
+
+export function MinimalLiveDvrSkinTailwind(props: MinimalLiveDvrSkinProps): ReactNode {
+  const { children, className, poster: posterProp, ...rest } = props;
+
+  return (
+    <Container className={cn(root(false), className)} {...rest}>
+      {children}
+
+      {posterProp && <Poster src={isString(posterProp) ? posterProp : undefined} className={poster(false)} />}
+
+      <BufferingIndicator
+        render={(props) => (
+          <div {...props} className={bufferingIndicator}>
+            <SpinnerIcon className={icon} />
+          </div>
+        )}
+      />
+
+      <ErrorDialog.Root>
+        <ErrorDialog.Popup className={error.root}>
+          <div className={error.dialog}>
+            <div className={error.content}>
+              <ErrorDialog.Title className={error.title}>Something went wrong.</ErrorDialog.Title>
+              <ErrorDialog.Description className={error.description} />
+            </div>
+            <div className={error.actions}>
+              <ErrorDialog.Close className={cn(button.base, button.primary)}>OK</ErrorDialog.Close>
+            </div>
+          </div>
+        </ErrorDialog.Popup>
+      </ErrorDialog.Root>
+
+      <Controls.Root
+        data-controls="" // Used as a hook for Tailwind has-[] styles
+        className={controls}
+      >
+        <Tooltip.Provider>
+          <div className={buttonGroupStart}>
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PlayButton className={iconState.play.button} render={<Button />}>
+                    <RestartIcon className={cn(icon, iconState.play.restart)} />
+                    <PlayIcon className={cn(icon, iconState.play.play)} />
+                    <PauseIcon className={cn(icon, iconState.play.pause)} />
+                  </PlayButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <LiveButton className={cn(button.base, button.subtle, button.live)} />
+          </div>
+
+          <div className={time.controls}>
+            <Time.Group className={time.group}>
+              <Time.Value type="current" className={time.current} />
+              <Time.Separator className={time.separator} />
+              <Time.Value type="duration" className={time.duration} />
+            </Time.Group>
+
+            <TimeSlider.Root render={<SliderRoot />}>
+              <TimeSlider.Track render={<SliderTrack />}>
+                <TimeSlider.Fill render={<SliderFill />} />
+                <TimeSlider.Buffer render={<SliderBuffer />} />
+              </TimeSlider.Track>
+              <TimeSlider.Thumb render={<SliderThumb />} />
+              <div className={thumbnail.root}>
+                <div className={thumbnail.imageWrapper}>
+                  <Slider.Thumbnail className={thumbnail.image} />
+                </div>
+                <TimeSlider.Value type="pointer" className={cn(time.current, thumbnail.time)} />
+                <SpinnerIcon className={cn(icon, thumbnail.spinner)} />
+              </div>
+            </TimeSlider.Root>
+          </div>
+
+          <div className={buttonGroupEnd}>
+            <VolumePopover />
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CaptionsButton className={iconState.captions.button} render={<Button />}>
+                    <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+                    <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+                  </CaptionsButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CastButton className={iconState.cast.button} render={<Button />}>
+                    <CastEnterIcon className={cn(icon, iconState.cast.enter)} />
+                    <CastExitIcon className={cn(icon, iconState.cast.exit)} />
+                  </CastButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <AirplayButton className={iconState.airplay.button} render={<Button />}>
+                    <AirplayEnterIcon className={cn(icon, iconState.airplay.enter)} />
+                    <AirplayExitIcon className={cn(icon, iconState.airplay.exit)} />
+                  </AirplayButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)} />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PiPButton className={iconState.pip.button} render={<Button />}>
+                    <PipEnterIcon className={cn(icon, iconState.pip.off)} />
+                    <PipExitIcon className={cn(icon, iconState.pip.on)} />
+                  </PiPButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <FullscreenButton className={iconState.fullscreen.button} render={<Button />}>
+                    <FullscreenEnterIcon className={cn(icon, iconState.fullscreen.enter)} />
+                    <FullscreenExitIcon className={cn(icon, iconState.fullscreen.exit)} />
+                  </FullscreenButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+          </div>
+        </Tooltip.Provider>
+      </Controls.Root>
+
+      <div className={overlay} />
+
+      {/* Hotkeys */}
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+
+      {/* Gestures */}
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+
+      {/* Input Feedback */}
+      <StatusAnnouncer />
+      <div className={inputFeedback.root}>
+        <VolumeIndicator.Root
+          className={cn(inputFeedback.island.base, inputFeedback.island.volume, inputFeedback.island.shownVolume)}
+        >
+          <VolumeIndicator.Fill data-feedback-island-content="" className={inputFeedback.island.content}>
+            <VolumeHighIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeHigh)} />
+            <VolumeLowIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeLow)} />
+            <VolumeOffIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeOff)} />
+            <div aria-hidden="true" className={inputFeedback.island.volumeProgress} />
+            <VolumeIndicator.Value className={inputFeedback.island.value} />
+          </VolumeIndicator.Fill>
+        </VolumeIndicator.Root>
+
+        <StatusIndicator.Root
+          actions={TOP_STATUS_ACTIONS}
+          className={cn(inputFeedback.island.base, inputFeedback.island.shownStatus)}
+        >
+          <div className={inputFeedback.island.content}>
+            <CaptionsOnIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOn)} />
+            <CaptionsOffIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOff)} />
+            <FullscreenEnterIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenEnter)} />
+            <FullscreenExitIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenExit)} />
+            <PipEnterIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownPipEnter)} />
+            <PipExitIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownPipExit)} />
+            <StatusIndicator.Value className={inputFeedback.island.value} />
+          </div>
+        </StatusIndicator.Root>
+
+        <StatusIndicator.Root actions={CENTER_STATUS_ACTIONS} className={inputFeedback.bubble.base}>
+          <PlayIcon className={cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPlay)} />
+          <PauseIcon className={cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPause)} />
+        </StatusIndicator.Root>
+      </div>
+    </Container>
+  );
+}

--- a/apps/sandbox/app/shared/react/live-dvr/minimal-skin.tsx
+++ b/apps/sandbox/app/shared/react/live-dvr/minimal-skin.tsx
@@ -1,0 +1,293 @@
+import {
+  AirplayButton,
+  BufferingIndicator,
+  CaptionsButton,
+  CastButton,
+  Container,
+  Controls,
+  ErrorDialog,
+  FullscreenButton,
+  Gesture,
+  Hotkey,
+  LiveButton,
+  MuteButton,
+  PiPButton,
+  PlayButton,
+  Popover,
+  Poster,
+  Slider,
+  StatusAnnouncer,
+  StatusIndicator,
+  Time,
+  TimeSlider,
+  Tooltip,
+  usePlayer,
+  VolumeIndicator,
+  VolumeSlider,
+} from '@videojs/react';
+import {
+  AirplayEnterIcon,
+  AirplayExitIcon,
+  CaptionsOffIcon,
+  CaptionsOnIcon,
+  CastEnterIcon,
+  CastExitIcon,
+  FullscreenEnterIcon,
+  FullscreenExitIcon,
+  PauseIcon,
+  PipEnterIcon,
+  PipExitIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@videojs/react/icons/minimal';
+import type { VideoSkinProps } from '@videojs/react/video';
+import { isString } from '@videojs/utils/predicate';
+import { cn } from '@videojs/utils/style';
+import { type ComponentProps, forwardRef, type ReactNode } from 'react';
+
+const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
+const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
+
+export type MinimalLiveDvrSkinProps = VideoSkinProps;
+
+const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={cn('media-button media-button--subtle media-button--icon', className)}
+      {...props}
+    />
+  );
+});
+
+function VolumePopover(): ReactNode {
+  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+
+  const muteButton = (
+    <MuteButton className="media-button--mute" render={<Button />}>
+      <VolumeOffIcon className="media-icon media-icon--volume-off" />
+      <VolumeLowIcon className="media-icon media-icon--volume-low" />
+      <VolumeHighIcon className="media-icon media-icon--volume-high" />
+    </MuteButton>
+  );
+
+  if (volumeUnsupported) return muteButton;
+
+  return (
+    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+      <Popover.Trigger render={muteButton} />
+      <Popover.Popup className="media-popover media-popover--volume">
+        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+          <VolumeSlider.Track className="media-slider__track">
+            <VolumeSlider.Fill className="media-slider__fill" />
+          </VolumeSlider.Track>
+          <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
+        </VolumeSlider.Root>
+      </Popover.Popup>
+    </Popover.Root>
+  );
+}
+
+/**
+ * Minimal video skin configured for live DVR playback. Mirrors the minimal
+ * live video skin but keeps the time slider and the current / duration time
+ * displays so viewers can scrub within the DVR window.
+ */
+export function MinimalLiveDvrSkin(props: MinimalLiveDvrSkinProps): ReactNode {
+  const { children, className, poster, ...rest } = props;
+
+  return (
+    <Container className={cn('media-minimal-skin media-minimal-skin--video', className)} {...rest}>
+      {children}
+
+      {poster && <Poster src={isString(poster) ? poster : undefined} />}
+
+      <BufferingIndicator
+        render={(props) => (
+          <div {...props} className="media-buffering-indicator">
+            <SpinnerIcon className="media-icon" />
+          </div>
+        )}
+      />
+
+      <ErrorDialog.Root>
+        <ErrorDialog.Popup className="media-error">
+          <div className="media-error__dialog">
+            <div className="media-error__content">
+              <ErrorDialog.Title className="media-error__title">Something went wrong.</ErrorDialog.Title>
+              <ErrorDialog.Description className="media-error__description" />
+            </div>
+            <div className="media-error__actions">
+              <ErrorDialog.Close className="media-button media-button--primary">OK</ErrorDialog.Close>
+            </div>
+          </div>
+        </ErrorDialog.Popup>
+      </ErrorDialog.Root>
+
+      <Controls.Root className="media-controls">
+        <Tooltip.Provider>
+          <div className="media-button-group">
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PlayButton className="media-button--play" render={<Button />}>
+                    <RestartIcon className="media-icon media-icon--restart" />
+                    <PlayIcon className="media-icon media-icon--play" />
+                    <PauseIcon className="media-icon media-icon--pause" />
+                  </PlayButton>
+                }
+              />
+              <Tooltip.Popup className="media-tooltip" />
+            </Tooltip.Root>
+
+            <LiveButton className="media-button media-button--subtle media-button--live" />
+          </div>
+
+          <div className="media-time-controls">
+            <Time.Group className="media-time-group">
+              <Time.Value type="current" className="media-time media-time--current" />
+              <Time.Separator className="media-time-separator" />
+              <Time.Value type="duration" className="media-time media-time--duration" />
+            </Time.Group>
+
+            <TimeSlider.Root className="media-slider">
+              <TimeSlider.Track className="media-slider__track">
+                <TimeSlider.Fill className="media-slider__fill" />
+                <TimeSlider.Buffer className="media-slider__buffer" />
+              </TimeSlider.Track>
+              <TimeSlider.Thumb className="media-slider__thumb" />
+
+              <div className="media-preview media-slider__preview">
+                <div className="media-preview__thumbnail-wrapper">
+                  <Slider.Thumbnail className="media-preview__thumbnail" />
+                </div>
+                <TimeSlider.Value type="pointer" className="media-time media-preview__time" />
+                <SpinnerIcon className="media-preview__spinner media-icon" />
+              </div>
+            </TimeSlider.Root>
+          </div>
+
+          <div className="media-button-group">
+            <VolumePopover />
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CaptionsButton className="media-button--captions" render={<Button />}>
+                    <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+                    <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+                  </CaptionsButton>
+                }
+              />
+              <Tooltip.Popup className="media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CastButton className="media-button--cast" render={<Button />}>
+                    <CastEnterIcon className="media-icon media-icon--cast-enter" />
+                    <CastExitIcon className="media-icon media-icon--cast-exit" />
+                  </CastButton>
+                }
+              />
+              <Tooltip.Popup className="media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <AirplayButton className="media-button--airplay" render={<Button />}>
+                    <AirplayEnterIcon className="media-icon media-icon--airplay-enter" />
+                    <AirplayExitIcon className="media-icon media-icon--airplay-exit" />
+                  </AirplayButton>
+                }
+              />
+              <Tooltip.Popup className="media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PiPButton className="media-button--pip" render={<Button />}>
+                    <PipEnterIcon className="media-icon media-icon--pip-enter" />
+                    <PipExitIcon className="media-icon media-icon--pip-exit" />
+                  </PiPButton>
+                }
+              />
+              <Tooltip.Popup className="media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <FullscreenButton className="media-button--fullscreen" render={<Button />}>
+                    <FullscreenEnterIcon className="media-icon media-icon--fullscreen-enter" />
+                    <FullscreenExitIcon className="media-icon media-icon--fullscreen-exit" />
+                  </FullscreenButton>
+                }
+              />
+              <Tooltip.Popup className="media-tooltip" />
+            </Tooltip.Root>
+          </div>
+        </Tooltip.Provider>
+      </Controls.Root>
+
+      <div className="media-overlay" />
+
+      {/* Hotkeys */}
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+
+      {/* Gestures */}
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+
+      {/* Input Feedback */}
+      <StatusAnnouncer />
+      <div className="media-input-feedback">
+        <VolumeIndicator.Root className="media-input-feedback-island media-input-feedback-island--volume">
+          <VolumeIndicator.Fill className="media-input-feedback-island__content">
+            <VolumeHighIcon className="media-icon media-icon--volume-high" />
+            <VolumeLowIcon className="media-icon media-icon--volume-low" />
+            <VolumeOffIcon className="media-icon media-icon--volume-off" />
+            <div className="media-input-feedback-island__progress" aria-hidden="true" />
+            <VolumeIndicator.Value className="media-input-feedback-island__value" />
+          </VolumeIndicator.Fill>
+        </VolumeIndicator.Root>
+
+        <StatusIndicator.Root
+          actions={TOP_STATUS_ACTIONS}
+          className="media-input-feedback-island media-input-feedback-island--status"
+        >
+          <div className="media-input-feedback-island__content">
+            <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+            <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+            <FullscreenEnterIcon className="media-icon media-icon--fullscreen-enter" />
+            <FullscreenExitIcon className="media-icon media-icon--fullscreen-exit" />
+            <PipEnterIcon className="media-icon media-icon--pip-enter" />
+            <PipExitIcon className="media-icon media-icon--pip-exit" />
+            <StatusIndicator.Value className="media-input-feedback-island__value" />
+          </div>
+        </StatusIndicator.Root>
+
+        <StatusIndicator.Root actions={CENTER_STATUS_ACTIONS} className="media-input-feedback-bubble">
+          <PlayIcon className="media-icon media-icon--play" />
+          <PauseIcon className="media-icon media-icon--pause" />
+        </StatusIndicator.Root>
+      </div>
+    </Container>
+  );
+}

--- a/apps/sandbox/app/shared/react/live-dvr/skin.tailwind.tsx
+++ b/apps/sandbox/app/shared/react/live-dvr/skin.tailwind.tsx
@@ -1,0 +1,339 @@
+import {
+  AirplayButton,
+  BufferingIndicator,
+  CaptionsButton,
+  CastButton,
+  Container,
+  Controls,
+  ErrorDialog,
+  FullscreenButton,
+  Gesture,
+  Hotkey,
+  LiveButton,
+  MuteButton,
+  PiPButton,
+  PlayButton,
+  Popover,
+  Poster,
+  Slider,
+  StatusAnnouncer,
+  StatusIndicator,
+  Time,
+  TimeSlider,
+  Tooltip,
+  usePlayer,
+  VolumeIndicator,
+  VolumeSlider,
+} from '@videojs/react';
+import {
+  AirplayEnterIcon,
+  AirplayExitIcon,
+  CaptionsOffIcon,
+  CaptionsOnIcon,
+  CastEnterIcon,
+  CastExitIcon,
+  FullscreenEnterIcon,
+  FullscreenExitIcon,
+  PauseIcon,
+  PipEnterIcon,
+  PipExitIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@videojs/react/icons';
+import {
+  bufferingIndicator,
+  button,
+  buttonGroupEnd,
+  buttonGroupStart,
+  controls,
+  error,
+  icon,
+  iconState,
+  inputFeedback,
+  overlay,
+  popup,
+  poster,
+  root,
+  slider,
+  thumbnail,
+  time,
+} from '@videojs/skins/default/tailwind/video.tailwind';
+import { isString } from '@videojs/utils/predicate';
+import { cn } from '@videojs/utils/style';
+import { type ComponentProps, forwardRef, type ReactNode } from 'react';
+import type { LiveDvrSkinProps } from './skin';
+
+const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
+const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
+
+const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
+  return (
+    <button ref={ref} type="button" className={cn(button.base, button.subtle, button.icon, className)} {...props} />
+  );
+});
+
+const SliderRoot = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderRoot({ className, ...props }, ref) {
+  return <div ref={ref} className={cn(slider.root, className)} {...props} />;
+});
+
+const SliderTrack = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderTrack(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={cn(slider.track, className)} {...props} />;
+});
+
+const SliderFill = forwardRef<HTMLDivElement, ComponentProps<'div'> & { type?: 'fill' | 'buffer' }>(function SliderFill(
+  { type = 'fill', className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(slider.fill.base, type === 'fill' ? slider.fill.fill : slider.fill.buffer, className)}
+      {...props}
+    />
+  );
+});
+
+const SliderBuffer = forwardRef<HTMLDivElement, ComponentProps<'div'>>(function SliderBuffer(props, ref) {
+  return <SliderFill type="buffer" ref={ref} {...props} />;
+});
+
+const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persistent?: boolean }>(function SliderThumb(
+  { persistent, className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cn(slider.thumb.base, persistent ? slider.thumb.persistent : slider.thumb.interactive, className)}
+      {...props}
+    />
+  );
+});
+
+function VolumePopover(): ReactNode {
+  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+
+  const muteButton = (
+    <MuteButton className={iconState.mute.button} render={<Button />}>
+      <VolumeOffIcon className={cn(icon, iconState.mute.volumeOff)} />
+      <VolumeLowIcon className={cn(icon, iconState.mute.volumeLow)} />
+      <VolumeHighIcon className={cn(icon, iconState.mute.volumeHigh)} />
+    </MuteButton>
+  );
+
+  if (volumeUnsupported) return muteButton;
+
+  return (
+    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+      <Popover.Trigger render={muteButton} />
+      <Popover.Popup className={cn(popup.popover, popup.volume)}>
+        <VolumeSlider.Root orientation="vertical" thumbAlignment="edge" render={<SliderRoot />}>
+          <VolumeSlider.Track render={<SliderTrack />}>
+            <VolumeSlider.Fill render={<SliderFill />} />
+          </VolumeSlider.Track>
+          <VolumeSlider.Thumb render={(props) => <SliderThumb persistent {...props} />} />
+        </VolumeSlider.Root>
+      </Popover.Popup>
+    </Popover.Root>
+  );
+}
+
+export function LiveDvrSkinTailwind(props: LiveDvrSkinProps): ReactNode {
+  const { children, className, poster: posterProp, ...rest } = props;
+
+  return (
+    <Container className={cn(root(false), className)} {...rest}>
+      {children}
+
+      {posterProp && <Poster src={isString(posterProp) ? posterProp : undefined} className={poster(false)} />}
+
+      <BufferingIndicator
+        render={(props) => (
+          <div {...props} className={bufferingIndicator.root}>
+            <div className={bufferingIndicator.container}>
+              <SpinnerIcon className={icon} />
+            </div>
+          </div>
+        )}
+      />
+
+      <ErrorDialog.Root>
+        <ErrorDialog.Popup className={error.root}>
+          <div className={error.dialog}>
+            <div className={error.content}>
+              <ErrorDialog.Title className={error.title}>Something went wrong.</ErrorDialog.Title>
+              <ErrorDialog.Description className={error.description} />
+            </div>
+            <div className={error.actions}>
+              <ErrorDialog.Close className={cn(button.base, button.primary)}>OK</ErrorDialog.Close>
+            </div>
+          </div>
+        </ErrorDialog.Popup>
+      </ErrorDialog.Root>
+
+      <Controls.Root
+        data-controls="" // Used as a hook for Tailwind has-[] styles
+        className={controls}
+      >
+        <Tooltip.Provider>
+          <div className={buttonGroupStart}>
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PlayButton className={iconState.play.button} render={<Button />}>
+                    <RestartIcon className={cn(icon, iconState.play.restart)} />
+                    <PlayIcon className={cn(icon, iconState.play.play)} />
+                    <PauseIcon className={cn(icon, iconState.play.pause)} />
+                  </PlayButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <LiveButton className={cn(button.base, button.subtle, button.live)} />
+          </div>
+
+          <div className={time.group}>
+            <Time.Value type="current" className={time.current} />
+            <TimeSlider.Root render={<SliderRoot />}>
+              <TimeSlider.Track render={<SliderTrack />}>
+                <TimeSlider.Fill render={<SliderFill />} />
+                <TimeSlider.Buffer render={<SliderBuffer />} />
+              </TimeSlider.Track>
+              <TimeSlider.Thumb render={<SliderThumb />} />
+              <div className={thumbnail.root}>
+                <Slider.Thumbnail className={thumbnail.image} />
+                <TimeSlider.Value type="pointer" className={cn(time.current, thumbnail.time)} />
+                <SpinnerIcon className={cn(icon, thumbnail.spinner)} />
+              </div>
+            </TimeSlider.Root>
+            <Time.Value type="duration" className={time.duration} />
+          </div>
+
+          <div className={buttonGroupEnd}>
+            <VolumePopover />
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CaptionsButton className={iconState.captions.button} render={<Button />}>
+                    <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
+                    <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
+                  </CaptionsButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CastButton className={iconState.cast.button} render={<Button />}>
+                    <CastEnterIcon className={cn(icon, iconState.cast.enter)} />
+                    <CastExitIcon className={cn(icon, iconState.cast.exit)} />
+                  </CastButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <AirplayButton className={iconState.airplay.button} render={<Button />}>
+                    <AirplayEnterIcon className={cn(icon, iconState.airplay.enter)} />
+                    <AirplayExitIcon className={cn(icon, iconState.airplay.exit)} />
+                  </AirplayButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)} />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PiPButton className={iconState.pip.button} render={<Button />}>
+                    <PipEnterIcon className={cn(icon, iconState.pip.off)} />
+                    <PipExitIcon className={cn(icon, iconState.pip.on)} />
+                  </PiPButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <FullscreenButton className={iconState.fullscreen.button} render={<Button />}>
+                    <FullscreenEnterIcon className={cn(icon, iconState.fullscreen.enter)} />
+                    <FullscreenExitIcon className={cn(icon, iconState.fullscreen.exit)} />
+                  </FullscreenButton>
+                }
+              />
+              <Tooltip.Popup className={cn(popup.tooltip)}></Tooltip.Popup>
+            </Tooltip.Root>
+          </div>
+        </Tooltip.Provider>
+      </Controls.Root>
+
+      <div className={overlay} />
+
+      {/* Hotkeys */}
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+
+      {/* Gestures */}
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+
+      {/* Input Feedback */}
+      <StatusAnnouncer />
+      <div className={inputFeedback.root}>
+        <VolumeIndicator.Root
+          className={cn(inputFeedback.island.base, inputFeedback.island.volume, inputFeedback.island.shownVolume)}
+        >
+          <VolumeIndicator.Fill className={inputFeedback.island.content}>
+            <VolumeHighIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeHigh)} />
+            <VolumeLowIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeLow)} />
+            <VolumeOffIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownVolumeOff)} />
+            <VolumeIndicator.Value className={inputFeedback.island.value} />
+          </VolumeIndicator.Fill>
+        </VolumeIndicator.Root>
+
+        <StatusIndicator.Root
+          actions={TOP_STATUS_ACTIONS}
+          className={cn(inputFeedback.island.base, inputFeedback.island.shownStatus)}
+        >
+          <div className={inputFeedback.island.content}>
+            <CaptionsOnIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOn)} />
+            <CaptionsOffIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownCaptionsOff)} />
+            <FullscreenEnterIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenEnter)} />
+            <FullscreenExitIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownFullscreenExit)} />
+            <PipEnterIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownPipEnter)} />
+            <PipExitIcon className={cn(inputFeedback.island.icon, inputFeedback.island.shownPipExit)} />
+            <StatusIndicator.Value className={inputFeedback.island.value} />
+          </div>
+        </StatusIndicator.Root>
+
+        <StatusIndicator.Root actions={CENTER_STATUS_ACTIONS} className={inputFeedback.bubble.base}>
+          <PlayIcon className={cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPlay)} />
+          <PauseIcon className={cn(inputFeedback.bubble.icon, inputFeedback.bubble.shownPause)} />
+        </StatusIndicator.Root>
+      </div>
+    </Container>
+  );
+}

--- a/apps/sandbox/app/shared/react/live-dvr/skin.tsx
+++ b/apps/sandbox/app/shared/react/live-dvr/skin.tsx
@@ -1,0 +1,288 @@
+import {
+  AirplayButton,
+  BufferingIndicator,
+  CaptionsButton,
+  CastButton,
+  Container,
+  Controls,
+  ErrorDialog,
+  FullscreenButton,
+  Gesture,
+  Hotkey,
+  LiveButton,
+  MuteButton,
+  PiPButton,
+  PlayButton,
+  Popover,
+  Poster,
+  Slider,
+  StatusAnnouncer,
+  StatusIndicator,
+  Time,
+  TimeSlider,
+  Tooltip,
+  usePlayer,
+  VolumeIndicator,
+  VolumeSlider,
+} from '@videojs/react';
+import {
+  AirplayEnterIcon,
+  AirplayExitIcon,
+  CaptionsOffIcon,
+  CaptionsOnIcon,
+  CastEnterIcon,
+  CastExitIcon,
+  FullscreenEnterIcon,
+  FullscreenExitIcon,
+  PauseIcon,
+  PipEnterIcon,
+  PipExitIcon,
+  PlayIcon,
+  RestartIcon,
+  SpinnerIcon,
+  VolumeHighIcon,
+  VolumeLowIcon,
+  VolumeOffIcon,
+} from '@videojs/react/icons';
+import type { VideoSkinProps } from '@videojs/react/video';
+import { isString } from '@videojs/utils/predicate';
+import { cn } from '@videojs/utils/style';
+import { type ComponentProps, forwardRef, type ReactNode } from 'react';
+
+const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
+const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
+
+export type LiveDvrSkinProps = VideoSkinProps;
+
+const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={cn('media-button media-button--subtle media-button--icon', className)}
+      {...props}
+    />
+  );
+});
+
+function VolumePopover(): ReactNode {
+  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+
+  const muteButton = (
+    <MuteButton className="media-button--mute" render={<Button />}>
+      <VolumeOffIcon className="media-icon media-icon--volume-off" />
+      <VolumeLowIcon className="media-icon media-icon--volume-low" />
+      <VolumeHighIcon className="media-icon media-icon--volume-high" />
+    </MuteButton>
+  );
+
+  if (volumeUnsupported) return muteButton;
+
+  return (
+    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+      <Popover.Trigger render={muteButton} />
+      <Popover.Popup className="media-surface media-popover media-popover--volume">
+        <VolumeSlider.Root className="media-slider" orientation="vertical" thumbAlignment="edge">
+          <VolumeSlider.Track className="media-slider__track">
+            <VolumeSlider.Fill className="media-slider__fill" />
+          </VolumeSlider.Track>
+          <VolumeSlider.Thumb className="media-slider__thumb media-slider__thumb--persistent" />
+        </VolumeSlider.Root>
+      </Popover.Popup>
+    </Popover.Root>
+  );
+}
+
+/**
+ * Default video skin configured for live DVR playback. Mirrors the live
+ * video skin but keeps the time slider and the current / duration time
+ * displays so viewers can scrub within the DVR window.
+ */
+export function LiveDvrSkin(props: LiveDvrSkinProps): ReactNode {
+  const { children, className, poster, ...rest } = props;
+
+  return (
+    <Container className={cn('media-default-skin media-default-skin--video', className)} {...rest}>
+      {children}
+
+      {poster && <Poster src={isString(poster) ? poster : undefined} />}
+
+      <BufferingIndicator
+        render={(props) => (
+          <div {...props} className="media-buffering-indicator">
+            <div className="media-surface">
+              <SpinnerIcon className="media-icon" />
+            </div>
+          </div>
+        )}
+      />
+
+      <ErrorDialog.Root>
+        <ErrorDialog.Popup className="media-error">
+          <div className="media-error__dialog media-surface">
+            <div className="media-error__content">
+              <ErrorDialog.Title className="media-error__title">Something went wrong.</ErrorDialog.Title>
+              <ErrorDialog.Description className="media-error__description" />
+            </div>
+            <div className="media-error__actions">
+              <ErrorDialog.Close className="media-button media-button--primary">OK</ErrorDialog.Close>
+            </div>
+          </div>
+        </ErrorDialog.Popup>
+      </ErrorDialog.Root>
+
+      <Controls.Root className="media-surface media-controls">
+        <Tooltip.Provider>
+          <div className="media-button-group">
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PlayButton className="media-button--play" render={<Button />}>
+                    <RestartIcon className="media-icon media-icon--restart" />
+                    <PlayIcon className="media-icon media-icon--play" />
+                    <PauseIcon className="media-icon media-icon--pause" />
+                  </PlayButton>
+                }
+              />
+              <Tooltip.Popup className="media-surface media-tooltip" />
+            </Tooltip.Root>
+
+            <LiveButton className="media-button media-button--subtle media-button--live" />
+          </div>
+
+          <div className="media-time-controls">
+            <Time.Value type="current" className="media-time" />
+            <TimeSlider.Root className="media-slider">
+              <TimeSlider.Track className="media-slider__track">
+                <TimeSlider.Fill className="media-slider__fill" />
+                <TimeSlider.Buffer className="media-slider__buffer" />
+              </TimeSlider.Track>
+              <TimeSlider.Thumb className="media-slider__thumb" />
+
+              <div className="media-surface media-preview media-slider__preview">
+                <Slider.Thumbnail className="media-preview__thumbnail" />
+                <TimeSlider.Value type="pointer" className="media-time media-preview__time" />
+                <SpinnerIcon className="media-preview__spinner media-icon" />
+              </div>
+            </TimeSlider.Root>
+            <Time.Value type="duration" className="media-time" />
+          </div>
+
+          <div className="media-button-group">
+            <VolumePopover />
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CaptionsButton className="media-button--captions" render={<Button />}>
+                    <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+                    <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+                  </CaptionsButton>
+                }
+              />
+              <Tooltip.Popup className="media-surface media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <CastButton className="media-button--cast" render={<Button />}>
+                    <CastEnterIcon className="media-icon media-icon--cast-enter" />
+                    <CastExitIcon className="media-icon media-icon--cast-exit" />
+                  </CastButton>
+                }
+              />
+              <Tooltip.Popup className="media-surface media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <AirplayButton className="media-button--airplay" render={<Button />}>
+                    <AirplayEnterIcon className="media-icon media-icon--airplay-enter" />
+                    <AirplayExitIcon className="media-icon media-icon--airplay-exit" />
+                  </AirplayButton>
+                }
+              />
+              <Tooltip.Popup className="media-surface media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <PiPButton className="media-button--pip" render={<Button />}>
+                    <PipEnterIcon className="media-icon media-icon--pip-enter" />
+                    <PipExitIcon className="media-icon media-icon--pip-exit" />
+                  </PiPButton>
+                }
+              />
+              <Tooltip.Popup className="media-surface media-tooltip" />
+            </Tooltip.Root>
+
+            <Tooltip.Root side="top">
+              <Tooltip.Trigger
+                render={
+                  <FullscreenButton className="media-button--fullscreen" render={<Button />}>
+                    <FullscreenEnterIcon className="media-icon media-icon--fullscreen-enter" />
+                    <FullscreenExitIcon className="media-icon media-icon--fullscreen-exit" />
+                  </FullscreenButton>
+                }
+              />
+              <Tooltip.Popup className="media-surface media-tooltip" />
+            </Tooltip.Root>
+          </div>
+        </Tooltip.Provider>
+      </Controls.Root>
+
+      <div className="media-overlay" />
+
+      {/* Hotkeys */}
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+
+      {/* Gestures */}
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+
+      {/* Input Feedback */}
+      <StatusAnnouncer />
+      <div className="media-input-feedback">
+        <VolumeIndicator.Root className="media-surface media-input-feedback-island media-input-feedback-island--volume">
+          <VolumeIndicator.Fill className="media-input-feedback-island__content">
+            <VolumeHighIcon className="media-icon media-icon--volume-high" />
+            <VolumeLowIcon className="media-icon media-icon--volume-low" />
+            <VolumeOffIcon className="media-icon media-icon--volume-off" />
+            <VolumeIndicator.Value className="media-input-feedback-island__value" />
+          </VolumeIndicator.Fill>
+        </VolumeIndicator.Root>
+
+        <StatusIndicator.Root
+          actions={TOP_STATUS_ACTIONS}
+          className="media-surface media-input-feedback-island media-input-feedback-island--status"
+        >
+          <div className="media-input-feedback-island__content">
+            <CaptionsOnIcon className="media-icon media-icon--captions-on" />
+            <CaptionsOffIcon className="media-icon media-icon--captions-off" />
+            <FullscreenEnterIcon className="media-icon media-icon--fullscreen-enter" />
+            <FullscreenExitIcon className="media-icon media-icon--fullscreen-exit" />
+            <PipEnterIcon className="media-icon media-icon--pip-enter" />
+            <PipExitIcon className="media-icon media-icon--pip-exit" />
+            <StatusIndicator.Value className="media-input-feedback-island__value" />
+          </div>
+        </StatusIndicator.Root>
+
+        <StatusIndicator.Root actions={CENTER_STATUS_ACTIONS} className="media-input-feedback-bubble">
+          <PlayIcon className="media-icon media-icon--play" />
+          <PauseIcon className="media-icon media-icon--pause" />
+        </StatusIndicator.Root>
+      </div>
+    </Container>
+  );
+}

--- a/apps/sandbox/app/shared/react/providers.ts
+++ b/apps/sandbox/app/shared/react/providers.ts
@@ -23,6 +23,13 @@ export const { Provider: LiveVideoProvider } = createPlayer({
   features: liveVideoFeatures,
 });
 
+// Live DVR reuses the live feature set — `liveVideoFeatures` already includes
+// `timeFeature` and `bufferFeature`, which the DVR skin's time slider and time
+// displays read to scrub within the seekable DVR window.
+export const { Provider: LiveDvrVideoProvider } = createPlayer({
+  features: liveVideoFeatures,
+});
+
 export const { Provider: LiveAudioProvider } = createPlayer({
   features: liveAudioFeatures,
 });

--- a/apps/sandbox/app/shared/react/skins.tsx
+++ b/apps/sandbox/app/shared/react/skins.tsx
@@ -36,6 +36,24 @@ async function loadLiveVideoSkinComponent(skin: Skin, styling: Styling): Promise
   return module.MinimalLiveVideoSkin;
 }
 
+async function loadLiveDvrSkinComponent(skin: Skin, styling: Styling): Promise<ComponentType<VideoSkinProps>> {
+  const module = await import('./live-dvr');
+
+  if (styling === 'tailwind') {
+    return skin === 'default' ? module.LiveDvrSkinTailwind : module.MinimalLiveDvrSkinTailwind;
+  }
+
+  // The DVR skin reuses the shared live-video skin stylesheet — it includes the
+  // time slider / time display styles the variant adds back in.
+  if (skin === 'default') {
+    await import('@videojs/react/live-video/skin.css');
+    return module.LiveDvrSkin;
+  }
+
+  await import('@videojs/react/live-video/minimal-skin.css');
+  return module.MinimalLiveDvrSkin;
+}
+
 async function loadAudioSkinComponent(skin: Skin, styling: Styling): Promise<ComponentType<AudioSkinProps>> {
   const module = await import('@videojs/react/audio');
 
@@ -82,17 +100,18 @@ function useLoadedComponent<Props>(
   return component;
 }
 
-type VideoSkinComponentProps = { skin: Skin; styling: Styling; live?: boolean } & VideoSkinProps;
+type VideoSkinComponentProps = { skin: Skin; styling: Styling; live?: boolean; dvr?: boolean } & VideoSkinProps;
 
 /**
- * Loads the video skin for the given skin/styling. When `live` is true,
- * the `live-video` skin variant is used instead.
+ * Loads the video skin for the given skin/styling. When `dvr` is true, the
+ * sandbox-only live DVR skin variant is used; otherwise when `live` is true,
+ * the `live-video` skin variant is used.
  */
-export function VideoSkinComponent({ skin, styling, live = false, ...props }: VideoSkinComponentProps) {
-  const Component = useLoadedComponent(
-    () => (live ? loadLiveVideoSkinComponent(skin, styling) : loadVideoSkinComponent(skin, styling)),
-    [skin, styling, live]
-  );
+export function VideoSkinComponent({ skin, styling, live = false, dvr = false, ...props }: VideoSkinComponentProps) {
+  const Component = useLoadedComponent(() => {
+    if (dvr) return loadLiveDvrSkinComponent(skin, styling);
+    return live ? loadLiveVideoSkinComponent(skin, styling) : loadVideoSkinComponent(skin, styling);
+  }, [skin, styling, live, dvr]);
 
   if (!Component) return null;
 

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -38,6 +38,14 @@ export const SOURCES = {
     subType: 'mp4',
     live: true,
   },
+  'hls-dvr': {
+    label: 'HLS - Live DVR Big Buck Bunny',
+    url: 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8',
+    type: 'hls',
+    subType: 'mp4',
+    live: true,
+    dvr: true,
+  },
   'mp4-1': {
     label: 'MP4 - Dancing Dude',
     url: 'https://stream.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/highest.mp4',
@@ -70,6 +78,14 @@ export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02n
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return (SOURCES[id] as { live?: boolean }).live === true;
+}
+
+/**
+ * Returns true when the given source represents a live DVR stream and should
+ * use the sandbox-only live DVR skin (live skin + time slider / time display).
+ */
+export function isDvrSource(id: SourceId): boolean {
+  return (SOURCES[id] as { dvr?: boolean }).dvr === true;
 }
 
 export function getPosterSrc(source: SourceId): string | undefined {

--- a/apps/sandbox/templates/html-hls-video/main.ts
+++ b/apps/sandbox/templates/html-hls-video/main.ts
@@ -12,7 +12,7 @@ import {
   onSkinChange,
   onSourceChange,
 } from '@app/shared/sandbox-listener';
-import { getPosterSrc, getStoryboardSrc, isLiveSource, SOURCES } from '@app/shared/sources';
+import { getPosterSrc, getStoryboardSrc, isDvrSource, isLiveSource, SOURCES } from '@app/shared/sources';
 
 const html = String.raw;
 
@@ -20,8 +20,9 @@ const state = createHtmlSandboxState();
 const loadLatest = createLatestLoader();
 
 async function render() {
+  const dvr = isDvrSource(state.source);
   const live = isLiveSource(state.source);
-  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling, { live }));
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling, { live, dvr }));
   if (!tag) return;
 
   const storyboard = getStoryboardSrc(state.source);

--- a/apps/sandbox/templates/react-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-hls-video/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
+import { LiveDvrVideoProvider, LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { Storyboard } from '@app/shared/react/storyboard';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -10,7 +10,7 @@ import { usePreload } from '@app/shared/react/use-preload';
 import { useSkin } from '@app/shared/react/use-skin';
 import { useSource } from '@app/shared/react/use-source';
 import { useStoryboard } from '@app/shared/react/use-storyboard';
-import { isLiveSource, SOURCES } from '@app/shared/sources';
+import { isDvrSource, isLiveSource, SOURCES } from '@app/shared/sources';
 import type { Styling } from '@app/types';
 import { HlsVideo } from '@videojs/react/media/hls-video';
 import { useMemo } from 'react';
@@ -26,12 +26,13 @@ function App() {
   const styling = useMemo(readStyling, []);
   const poster = usePoster();
   const storyboard = useStoryboard();
+  const dvr = isDvrSource(source);
   const live = isLiveSource(source);
   const autoplay = useAutoplay();
   const muted = useMuted();
   const loop = useLoop();
   const preload = usePreload();
-  const Provider = live ? LiveVideoProvider : VideoProvider;
+  const Provider = dvr ? LiveDvrVideoProvider : live ? LiveVideoProvider : VideoProvider;
 
   return (
     <Provider>
@@ -40,6 +41,7 @@ function App() {
         skin={skin}
         styling={styling}
         live={live}
+        dvr={dvr}
         className="aspect-video max-w-4xl mx-auto"
       >
         <HlsVideo


### PR DESCRIPTION
Refs #1427

## Summary

Add sandbox demos for the DVR / live-rewind UX so the live-DVR skins can be exercised against a real live-DVR stream while the feature lands.

## Changes

- Live-DVR skins for both players (HTML + React), in standard and minimal variants, with CSS and Tailwind versions of each
- New `hls-dvr` source (live stream with a DVR window) plus an `isDvrSource` helper to route DVR sources to the DVR skin
- Wire the new skins into the sandbox skin registries and HLS templates

## Testing

`pnpm dev` and select the `hls-dvr` source — verify the live-DVR skin renders with a scrubbable time slider and time display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the sandbox app (demo skins and routing); no production player or auth paths are modified.
> 
> **Overview**
> Adds **sandbox-only live DVR player skins** (default + minimal, CSS + Tailwind, HTML custom elements + React) that extend the existing live-video skins but **restore the time slider, current/duration labels, and scrub preview** so viewers can rewind within the seekable DVR window while keeping the live button and rest of the live chrome.
> 
> Wires them through the sandbox: new `LIVE_DVR_*` skin tags, `loadVideoSkinTag` / `VideoSkinComponent` **`dvr` option** (takes precedence over `live`), `LiveDvrVideoProvider`, an **`hls-dvr`** source plus **`isDvrSource`**, and updates to the HTML and React HLS video demos to pick the DVR skin when that source is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543d7e57c2f7f6129d36e78273be2ce4e019d002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->