### PR TITLE
chore(root): rename agents alias to .agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,7 +154,7 @@ bun.lockb
 .claude/worktrees/
 .opencode
 AGENTS.md
-agents
+.agents
 
 # Playwright
 test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ bun.lockb
 .opencode
 AGENTS.md
 .agents
+agents
 
 # Playwright
 test-results/

--- a/build/scripts/link-aliases.mjs
+++ b/build/scripts/link-aliases.mjs
@@ -4,7 +4,7 @@
  *
  * Aliases created:
  *   .opencode  → .claude       (directory)
- *   agents     → .claude       (directory)
+ *   .agents    → .claude       (directory)
  *   AGENTS.md  → CLAUDE.md     (file)
  *
  * Cross-platform notes:
@@ -21,7 +21,7 @@ const root = resolve(import.meta.dirname, '../..');
 
 const aliases = [
   { target: '.claude', path: '.opencode', type: 'junction' },
-  { target: '.claude', path: 'agents', type: 'junction' },
+  { target: '.claude', path: '.agents', type: 'junction' },
   { target: 'CLAUDE.md', path: 'AGENTS.md', type: 'file' },
 ];
 


### PR DESCRIPTION
## Summary

Rename the generated agent-config alias from `agents` to `.agents` so it sits alongside the other dotfile aliases (`.opencode`) and stays hidden by default. The alias is produced by `link-aliases.mjs` on install and points to `.claude`, matching how `.opencode` already works.

## Changes

- `link-aliases.mjs` now creates `.agents -> .claude` (was `agents`)
- Update the gitignore entry to `.agents`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-time symlink naming and gitignore only; no runtime or application logic changes.
> 
> **Overview**
> The install-time alias that points non–Claude Code tools at `.claude` is renamed from `agents` to **`.agents`**, matching the hidden **`.opencode`** pattern.
> 
> `build/scripts/link-aliases.mjs` (run on `postinstall`) now creates `.agents → .claude` instead of `agents → .claude`, and **`.gitignore`** ignores the new **`.agents`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e6a994934c286de10b9c60feefbc96b1b04e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->