### PR TITLE
feat(core): delegate remaining media element props through layers

### DIFF
--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -7,6 +7,7 @@ export * from './hotkey/actions';
 export * from './hotkey/aria';
 export * from './hotkey/coordinator';
 export * from './hotkey/hotkey';
+export * from './media/predicate';
 export * from './media/types';
 export * from './store/features';
 export * from './store/selectors';

--- a/packages/core/src/dom/media/html-media-element-layer.ts
+++ b/packages/core/src/dom/media/html-media-element-layer.ts
@@ -8,7 +8,7 @@ import type {
   VideoEvents,
 } from '../../core/media/types';
 import { MediaStreamTypes } from '../../core/media/types';
-import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants';
+import { EMPTY_CONFIG, EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants';
 
 export abstract class HTMLMediaElementLayer<
   Target extends HTMLMediaElement = HTMLMediaElement,
@@ -132,6 +132,14 @@ export abstract class HTMLMediaElementLayer<
     if (this.next) this.next.preload = value;
   }
 
+  get crossOrigin() {
+    return this.next?.crossOrigin ?? null;
+  }
+
+  set crossOrigin(value) {
+    if (this.next) this.next.crossOrigin = value;
+  }
+
   load() {
     return this.next?.load();
   }
@@ -168,6 +176,14 @@ export abstract class HTMLMediaElementLayer<
     if (this.next) this.next.playbackRate = value;
   }
 
+  get defaultPlaybackRate() {
+    return this.next?.defaultPlaybackRate ?? 1;
+  }
+
+  set defaultPlaybackRate(value) {
+    if (this.next) this.next.defaultPlaybackRate = value;
+  }
+
   // -- Buffer --
 
   get buffered() {
@@ -176,6 +192,12 @@ export abstract class HTMLMediaElementLayer<
 
   get seekable() {
     return this.next?.seekable ?? EMPTY_TIME_RANGES;
+  }
+
+  // -- Played --
+
+  get played() {
+    return this.next?.played ?? EMPTY_TIME_RANGES;
   }
 
   // -- Error --
@@ -206,5 +228,41 @@ export abstract class HTMLMediaElementLayer<
 
   set disableRemotePlayback(value) {
     if (this.next) this.next.disableRemotePlayback = value;
+  }
+
+  // -- Playback options --
+
+  get autoplay() {
+    return this.next?.autoplay ?? false;
+  }
+
+  set autoplay(value) {
+    if (this.next) this.next.autoplay = value;
+  }
+
+  get defaultMuted() {
+    return this.next?.defaultMuted ?? false;
+  }
+
+  set defaultMuted(value) {
+    if (this.next) this.next.defaultMuted = value;
+  }
+
+  get controls() {
+    return this.next?.controls ?? false;
+  }
+
+  set controls(value) {
+    if (this.next) this.next.controls = value;
+  }
+
+  // -- Config --
+
+  get config() {
+    return this.next?.config ?? EMPTY_CONFIG;
+  }
+
+  set config(value) {
+    if (this.next) this.next.config = value;
   }
 }

--- a/packages/core/src/dom/media/html-video-element-layer.ts
+++ b/packages/core/src/dom/media/html-video-element-layer.ts
@@ -19,6 +19,22 @@ export abstract class HTMLVideoElementLayer<
     if (this.next) this.next.poster = value;
   }
 
+  get playsInline() {
+    return this.next?.playsInline ?? false;
+  }
+
+  set playsInline(value: boolean) {
+    if (this.next) this.next.playsInline = value;
+  }
+
+  get videoWidth() {
+    return this.next?.videoWidth ?? 0;
+  }
+
+  get videoHeight() {
+    return this.next?.videoHeight ?? 0;
+  }
+
   get webkitPresentationMode() {
     return (this.next as WebKitVideoElement | null)?.webkitPresentationMode;
   }
@@ -26,6 +42,14 @@ export abstract class HTMLVideoElementLayer<
   get webkitSetPresentationMode(): ((mode: WebKitPresentationMode) => void) | undefined {
     const fn = (this.next as WebKitVideoElement | null)?.webkitSetPresentationMode;
     return isFunction(fn) ? fn.bind(this.next) : undefined;
+  }
+
+  get disablePictureInPicture() {
+    return this.next?.disablePictureInPicture ?? false;
+  }
+
+  set disablePictureInPicture(value: boolean) {
+    if (this.next) this.next.disablePictureInPicture = value;
   }
 
   get isPictureInPicture(): boolean {

--- a/packages/core/src/dom/media/predicate.ts
+++ b/packages/core/src/dom/media/predicate.ts
@@ -11,6 +11,7 @@ import type {
   MediaSourceCapability,
   MediaStreamTypeCapability,
   MediaTextTrackCapability,
+  MediaVideoDimensionsCapability,
   MediaVolumeCapability,
 } from '../../core/media/types';
 
@@ -40,6 +41,10 @@ export function isMediaSourceCapable(value: unknown): value is MediaSourceCapabi
 
 export function isMediaVolumeCapable(value: unknown): value is MediaVolumeCapability {
   return isObject(value) && 'volume' in value && 'muted' in value;
+}
+
+export function isMediaVideoDimensionsCapable(value: unknown): value is MediaVideoDimensionsCapability {
+  return isObject(value) && 'videoWidth' in value && 'videoHeight' in value;
 }
 
 export function isMediaPlaybackRateCapable(value: unknown): value is MediaPlaybackRateCapability {

--- a/packages/core/src/dom/media/tests/video-host.test.ts
+++ b/packages/core/src/dom/media/tests/video-host.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type { WebKitDocument, WebKitVideoElement } from '../../presentation/types';
+import { EMPTY_CONFIG, EMPTY_TIME_RANGES } from '../constants';
 import { HTMLVideoElementHost } from '../html-video-element-host';
 
 afterEach(() => {
@@ -22,6 +23,66 @@ afterEach(() => {
 });
 
 describe('HTMLVideoElementHost', () => {
+  describe('delegating props', () => {
+    it('returns defaults when no target is attached', () => {
+      const host = new HTMLVideoElementHost();
+
+      expect(host.crossOrigin).toBeNull();
+      expect(host.defaultPlaybackRate).toBe(1);
+      expect(host.played).toBe(EMPTY_TIME_RANGES);
+      expect(host.autoplay).toBe(false);
+      expect(host.defaultMuted).toBe(false);
+      expect(host.controls).toBe(false);
+      expect(host.config).toBe(EMPTY_CONFIG);
+      expect(host.playsInline).toBe(false);
+      expect(host.disablePictureInPicture).toBe(false);
+      expect(host.videoWidth).toBe(0);
+      expect(host.videoHeight).toBe(0);
+    });
+
+    it('delegates reads to the attached target', () => {
+      const video = document.createElement('video');
+      video.crossOrigin = 'anonymous';
+      video.defaultPlaybackRate = 2;
+      video.autoplay = true;
+      video.defaultMuted = true;
+      video.controls = true;
+      video.playsInline = true;
+      video.disablePictureInPicture = true;
+
+      const host = new HTMLVideoElementHost();
+      host.target = video;
+
+      expect(host.crossOrigin).toBe('anonymous');
+      expect(host.defaultPlaybackRate).toBe(2);
+      expect(host.autoplay).toBe(true);
+      expect(host.defaultMuted).toBe(true);
+      expect(host.controls).toBe(true);
+      expect(host.playsInline).toBe(true);
+      expect(host.disablePictureInPicture).toBe(true);
+    });
+
+    it('delegates writes to the attached target', () => {
+      const video = document.createElement('video');
+      const host = new HTMLVideoElementHost();
+      host.target = video;
+
+      host.crossOrigin = 'use-credentials';
+      host.defaultPlaybackRate = 1.5;
+      host.autoplay = true;
+      host.controls = true;
+      host.playsInline = true;
+      host.disablePictureInPicture = true;
+
+      expect(video.crossOrigin).toBe('use-credentials');
+      expect(video.defaultPlaybackRate).toBe(1.5);
+      expect(video.autoplay).toBe(true);
+      expect(video.controls).toBe(true);
+      expect(video.playsInline).toBe(true);
+      expect(video.disablePictureInPicture).toBe(true);
+    });
+  });
+
   describe('isPictureInPicture', () => {
     it('returns false when no target is attached', () => {
       const host = new HTMLVideoElementHost();


### PR DESCRIPTION
## Summary

Fills in the remaining media element properties that the layer chain did not yet forward, so wrapping layers transparently expose the full media element surface.

## Changes

- `HTMLMediaElementLayer`: delegate `crossOrigin`, `defaultPlaybackRate`, `played`, `autoplay`, `defaultMuted`, `controls`, and `config`
- `HTMLVideoElementLayer`: delegate `playsInline`, `videoWidth`, `videoHeight`, and `disablePictureInPicture`
- Getters fall back to sensible defaults (e.g. `EMPTY_CONFIG`, `EMPTY_TIME_RANGES`) when no target is attached

## Testing

Covered by new `delegating props` tests in `video-host.test.ts` verifying default, read, and write delegation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive property delegation and tests on the media layer proxy; no auth, security, or data-path changes.
> 
> **Overview**
> **Completes transparent forwarding** of the remaining HTML media/video element surface through the core DOM layer chain, so hosts and wrappers behave like a real `<video>` / `<audio>` element when no underlying target is wired yet.
> 
> `HTMLMediaElementLayer` now delegates **`crossOrigin`**, **`defaultPlaybackRate`**, **`played`**, playback flags (**`autoplay`**, **`defaultMuted`**, **`controls`**), and **`config`**, using shared empty defaults (`EMPTY_TIME_RANGES`, `EMPTY_CONFIG`) when `next` is missing. **`HTMLVideoElementLayer`** adds **`playsInline`**, read-only **`videoWidth` / `videoHeight`**, and **`disablePictureInPicture`**.
> 
> The public DOM package re-exports **`media/predicate`**, including a new **`isMediaVideoDimensionsCapable`** guard. **`video-host.test.ts`** adds **delegating props** coverage for default values, reads, and writes through `HTMLVideoElementHost`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af31d2ecba4d3a05f66df355033222fb6be6f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->