### PR TITLE
fix(test): update slider thumbnail selector

### DIFF
--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -61,7 +61,7 @@ export const SELECTORS = {
   duration: 'media-time[type="duration"], [data-type="duration"].media-time',
   poster: 'media-poster, img[data-visible]',
   bufferingIndicator: 'media-buffering-indicator, .media-buffering-indicator',
-  thumbnail: 'media-slider-thumbnail, .media-preview__thumbnail',
+  thumbnail: 'media-slider-thumbnail, .media-thumbnail__image',
 
   // Popover & tooltip
   tooltip: 'media-tooltip, .media-tooltip',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only selector change with no production or runtime behavior impact.
> 
> **Overview**
> Updates the shared e2e **`SELECTORS.thumbnail`** so the React branch targets **`.media-thumbnail__image`** instead of **`.media-preview__thumbnail`**, while still matching **`media-slider-thumbnail`** for the HTML/Web Components renderer.
> 
> This keeps storyboard-on-hover checks (e.g. visual tests that wait for the thumbnail to attach and finish loading) aligned with the current React DOM for the time-slider preview image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96bb2f54e6f015b9ce772506ef2b8f9f1fb3fa6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->