### PR TITLE
feat(core): lock fullscreen orientation

### DIFF
--- a/apps/sandbox/app/shared/react/providers.ts
+++ b/apps/sandbox/app/shared/react/providers.ts
@@ -1,4 +1,4 @@
-import { createPlayer } from '@videojs/react';
+import { createPlayer, features } from '@videojs/react';
 import { audioFeatures } from '@videojs/react/audio';
 import { backgroundFeatures } from '@videojs/react/background';
 import { liveAudioFeatures } from '@videojs/react/live-audio';
@@ -6,7 +6,7 @@ import { liveVideoFeatures } from '@videojs/react/live-video';
 import { videoFeatures } from '@videojs/react/video';
 
 export const { Provider: VideoProvider } = createPlayer({
-  features: videoFeatures,
+  features: [...videoFeatures, features.orientationLock],
 });
 
 export const { Provider: AudioProvider } = createPlayer({

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -1,5 +1,49 @@
-import { defineSlice } from '@videojs/store';
+import { type AttachContext, defineSlice, type SliceConfig, type StateContext } from '@videojs/store';
+import { isUndefined } from '@videojs/utils/predicate';
 
-import type { PlayerTarget } from './media/types';
+import type { PlayerFeature, PlayerTarget } from './media/types';
 
-export const definePlayerFeature = defineSlice<PlayerTarget>();
+export interface ConfigurablePlayerFeature<Config, State> extends PlayerFeature<State> {
+  (config?: Config): PlayerFeature<State>;
+}
+
+export interface ConfigurablePlayerFeatureConfig<Config, State>
+  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'state'> {
+  state: (ctx: StateContext<PlayerTarget>, config: Config) => State;
+  attach?: (ctx: AttachContext<PlayerTarget, State>, config: Config) => void;
+}
+
+const definePlayerSlice = defineSlice<PlayerTarget>();
+
+export function definePlayerFeature<State>(config: SliceConfig<PlayerTarget, State>): PlayerFeature<State>;
+export function definePlayerFeature<Config, State>(
+  config: ConfigurablePlayerFeatureConfig<Config, State>,
+  defaultConfig: Config
+): ConfigurablePlayerFeature<Config, State>;
+export function definePlayerFeature<Config, State>(
+  config: SliceConfig<PlayerTarget, State> | ConfigurablePlayerFeatureConfig<Config, State>,
+  defaultConfig?: Config
+): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> {
+  if (arguments.length === 1) {
+    return definePlayerSlice(config as SliceConfig<PlayerTarget, State>);
+  }
+
+  const { name, state, attach } = config as ConfigurablePlayerFeatureConfig<Config, State>;
+
+  const forConfig = (featureConfig: Config): PlayerFeature<State> =>
+    definePlayerSlice({
+      ...(isUndefined(name) ? {} : { name }),
+      state: (ctx) => state(ctx, featureConfig),
+      ...(attach ? { attach: (ctx) => attach(ctx, featureConfig) } : {}),
+    });
+
+  const defaultFeature = forConfig(defaultConfig as Config);
+  const feature = ((featureConfig?: Config) =>
+    isUndefined(featureConfig) ? defaultFeature : forConfig(featureConfig)) as ConfigurablePlayerFeature<Config, State>;
+
+  feature.state = defaultFeature.state;
+  if (defaultFeature.attach) feature.attach = defaultFeature.attach;
+  if (!isUndefined(name)) Object.defineProperty(feature, 'name', { value: name });
+
+  return feature;
+}

--- a/packages/core/src/dom/presentation/orientation.ts
+++ b/packages/core/src/dom/presentation/orientation.ts
@@ -13,15 +13,14 @@ export type ScreenOrientationLockType =
   | 'natural'
   | 'portrait'
   | 'portrait-primary'
-  | 'portrait-secondary'
-  | false;
+  | 'portrait-secondary';
 
 export interface ScreenOrientationLockConfig {
   type?: ScreenOrientationLockType | undefined;
 }
 
 interface ScreenOrientation {
-  lock?: ((type: Exclude<ScreenOrientationLockType, false>) => Promise<void>) | undefined;
+  lock?: ((type: ScreenOrientationLockType) => Promise<void>) | undefined;
   unlock?: (() => void) | undefined;
 }
 
@@ -44,7 +43,7 @@ export function createScreenOrientationLock({
 
   return {
     async lock() {
-      if (!type || locked) return;
+      if (locked) return;
 
       const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
       const lock = orientation?.lock;

--- a/packages/core/src/dom/presentation/orientation.ts
+++ b/packages/core/src/dom/presentation/orientation.ts
@@ -28,7 +28,7 @@ export function createScreenOrientationLock({
   type = 'landscape',
 }: ScreenOrientationLockConfig = {}): ScreenOrientationLock {
   let locked = false;
-  let generation = 0;
+  let desired = false;
 
   const releaseOrientation = () => {
     const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
@@ -44,13 +44,12 @@ export function createScreenOrientationLock({
   return {
     async lock() {
       if (locked) return;
+      desired = true;
 
       const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
       const lock = orientation?.lock;
 
       if (!isFunction(lock)) return;
-
-      const lockGeneration = ++generation;
 
       try {
         await lock.call(orientation, type);
@@ -58,7 +57,7 @@ export function createScreenOrientationLock({
         return;
       }
 
-      if (lockGeneration === generation) {
+      if (desired) {
         locked = true;
       } else {
         releaseOrientation();
@@ -66,7 +65,7 @@ export function createScreenOrientationLock({
     },
 
     unlock() {
-      generation += 1;
+      desired = false;
 
       if (!locked) return;
 

--- a/packages/core/src/dom/presentation/orientation.ts
+++ b/packages/core/src/dom/presentation/orientation.ts
@@ -1,0 +1,78 @@
+import { isFunction } from '@videojs/utils/predicate';
+
+export interface ScreenOrientationLock {
+  lock(): Promise<void>;
+  unlock(): void;
+}
+
+export type ScreenOrientationLockType =
+  | 'any'
+  | 'landscape'
+  | 'landscape-primary'
+  | 'landscape-secondary'
+  | 'natural'
+  | 'portrait'
+  | 'portrait-primary'
+  | 'portrait-secondary'
+  | false;
+
+export interface ScreenOrientationLockConfig {
+  type?: ScreenOrientationLockType | undefined;
+}
+
+interface ScreenOrientation {
+  lock?: ((type: Exclude<ScreenOrientationLockType, false>) => Promise<void>) | undefined;
+  unlock?: (() => void) | undefined;
+}
+
+export function createScreenOrientationLock({
+  type = 'landscape',
+}: ScreenOrientationLockConfig = {}): ScreenOrientationLock {
+  let locked = false;
+  let generation = 0;
+
+  const releaseOrientation = () => {
+    const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
+    const unlock = orientation?.unlock;
+
+    if (!isFunction(unlock)) return;
+
+    try {
+      unlock.call(orientation);
+    } catch {}
+  };
+
+  return {
+    async lock() {
+      if (!type || locked) return;
+
+      const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
+      const lock = orientation?.lock;
+
+      if (!isFunction(lock)) return;
+
+      const lockGeneration = ++generation;
+
+      try {
+        await lock.call(orientation, type);
+      } catch {
+        return;
+      }
+
+      if (lockGeneration === generation) {
+        locked = true;
+      } else {
+        releaseOrientation();
+      }
+    },
+
+    unlock() {
+      generation += 1;
+
+      if (!locked) return;
+
+      locked = false;
+      releaseOrientation();
+    },
+  };
+}

--- a/packages/core/src/dom/presentation/tests/orientation.test.ts
+++ b/packages/core/src/dom/presentation/tests/orientation.test.ts
@@ -38,22 +38,6 @@ describe('createScreenOrientationLock', () => {
     expect(orientation.lock).toHaveBeenCalledWith('portrait');
   });
 
-  it('does nothing when disabled', async () => {
-    const orientation = {
-      lock: vi.fn(async () => {}),
-      unlock: vi.fn(),
-    };
-    stubOrientation(orientation);
-
-    const screenLock = createScreenOrientationLock({ type: false });
-
-    await screenLock.lock();
-    screenLock.unlock();
-
-    expect(orientation.lock).not.toHaveBeenCalled();
-    expect(orientation.unlock).not.toHaveBeenCalled();
-  });
-
   it('unlocks only after a successful lock', async () => {
     const orientation = {
       lock: vi.fn(async () => {}),

--- a/packages/core/src/dom/presentation/tests/orientation.test.ts
+++ b/packages/core/src/dom/presentation/tests/orientation.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createScreenOrientationLock } from '../orientation';
+
+function stubOrientation(orientation: Partial<ScreenOrientation>) {
+  vi.stubGlobal('screen', { orientation });
+}
+
+describe('createScreenOrientationLock', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('locks landscape by default', async () => {
+    const orientation = {
+      lock: vi.fn(async () => {}),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock();
+
+    await screenLock.lock();
+
+    expect(orientation.lock).toHaveBeenCalledWith('landscape');
+  });
+
+  it('locks the configured orientation type', async () => {
+    const orientation = {
+      lock: vi.fn(async () => {}),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock({ type: 'portrait' });
+
+    await screenLock.lock();
+
+    expect(orientation.lock).toHaveBeenCalledWith('portrait');
+  });
+
+  it('does nothing when disabled', async () => {
+    const orientation = {
+      lock: vi.fn(async () => {}),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock({ type: false });
+
+    await screenLock.lock();
+    screenLock.unlock();
+
+    expect(orientation.lock).not.toHaveBeenCalled();
+    expect(orientation.unlock).not.toHaveBeenCalled();
+  });
+
+  it('unlocks only after a successful lock', async () => {
+    const orientation = {
+      lock: vi.fn(async () => {}),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock();
+
+    screenLock.unlock();
+    await screenLock.lock();
+    await screenLock.lock();
+    screenLock.unlock();
+    screenLock.unlock();
+
+    expect(orientation.lock).toHaveBeenCalledTimes(1);
+    expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores missing browser APIs', async () => {
+    stubOrientation({});
+
+    const screenLock = createScreenOrientationLock();
+
+    await expect(screenLock.lock()).resolves.toBeUndefined();
+    expect(() => screenLock.unlock()).not.toThrow();
+  });
+
+  it('releases orientation when unlock runs before lock settles', async () => {
+    let resolveLock!: () => void;
+    const lockPromise = new Promise<void>((resolve) => {
+      resolveLock = resolve;
+    });
+
+    const orientation = {
+      lock: vi.fn(() => lockPromise),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock();
+    const lockTask = screenLock.lock();
+
+    screenLock.unlock();
+    resolveLock();
+    await lockTask;
+
+    expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores rejected locks and thrown unlocks', async () => {
+    const orientation = {
+      lock: vi.fn<ScreenOrientation['lock']>().mockRejectedValue(new Error('NotAllowedError')),
+      unlock: vi.fn(() => {
+        throw new Error('InvalidStateError');
+      }),
+    };
+    stubOrientation(orientation);
+
+    const rejectedLock = createScreenOrientationLock();
+
+    await expect(rejectedLock.lock()).resolves.toBeUndefined();
+    rejectedLock.unlock();
+
+    expect(orientation.unlock).not.toHaveBeenCalled();
+
+    const acceptedLock = createScreenOrientationLock();
+    orientation.lock.mockResolvedValue(undefined);
+
+    await acceptedLock.lock();
+
+    expect(() => acceptedLock.unlock()).not.toThrow();
+  });
+});

--- a/packages/core/src/dom/presentation/tests/orientation.test.ts
+++ b/packages/core/src/dom/presentation/tests/orientation.test.ts
@@ -88,6 +88,42 @@ describe('createScreenOrientationLock', () => {
     expect(orientation.unlock).toHaveBeenCalledTimes(1);
   });
 
+  it('does not release a newer active lock when an older lock settles', async () => {
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+
+    const firstLock = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondLock = new Promise<void>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    const orientation = {
+      lock: vi.fn<ScreenOrientation['lock']>().mockReturnValueOnce(firstLock).mockReturnValueOnce(secondLock),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock();
+    const firstTask = screenLock.lock();
+
+    screenLock.unlock();
+    const secondTask = screenLock.lock();
+
+    resolveSecond();
+    await secondTask;
+
+    resolveFirst();
+    await firstTask;
+
+    expect(orientation.unlock).not.toHaveBeenCalled();
+
+    screenLock.unlock();
+
+    expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores rejected locks and thrown unlocks', async () => {
     const orientation = {
       lock: vi.fn<ScreenOrientation['lock']>().mockRejectedValue(new Error('NotAllowedError')),

--- a/packages/core/src/dom/store/features/feature.parts.ts
+++ b/packages/core/src/dom/store/features/feature.parts.ts
@@ -2,6 +2,7 @@ import { bufferFeature } from './buffer';
 import { controlsFeature } from './controls';
 import { fullscreenFeature } from './fullscreen';
 import { liveFeature } from './live';
+import { orientationLockFeature } from './orientation-lock';
 import { pipFeature } from './pip';
 import { playbackFeature } from './playback';
 import { playbackRateFeature } from './playback-rate';
@@ -20,6 +21,7 @@ export {
   controlsFeature as controls,
   fullscreenFeature as fullscreen,
   liveFeature as live,
+  orientationLockFeature as orientationLock,
   pipFeature as pip,
   playbackFeature as playback,
   playbackRateFeature as playbackRate,

--- a/packages/core/src/dom/store/features/fullscreen.ts
+++ b/packages/core/src/dom/store/features/fullscreen.ts
@@ -1,69 +1,122 @@
 import { listen } from '@videojs/utils/dom';
 
 import type { MediaFullscreenState } from '../../../core/media/state';
-import { definePlayerFeature } from '../../feature';
+import { type ConfigurablePlayerFeature, definePlayerFeature } from '../../feature';
 import { exitFullscreen, isFullscreen, isFullscreenEnabled, requestFullscreen } from '../../presentation/fullscreen';
+import {
+  createScreenOrientationLock,
+  type ScreenOrientationLock,
+  type ScreenOrientationLockType,
+} from '../../presentation/orientation';
 import { exitPictureInPicture, isPictureInPicture } from '../../presentation/pip';
 import type { WebKitVideoElement } from '../../presentation/types';
 
-export const fullscreenFeature = definePlayerFeature({
-  name: 'fullscreen',
-  state: ({ target }): MediaFullscreenState => ({
-    fullscreen: false,
-    fullscreenAvailability: 'unavailable',
+const ORIENTATION_LOCK_SYMBOL = Symbol('@videojs/fullscreen-orientation-lock');
 
-    async requestFullscreen() {
-      const { media, container } = target();
+type FullscreenState = MediaFullscreenState & {
+  [ORIENTATION_LOCK_SYMBOL]: ScreenOrientationLock;
+};
 
-      // Exit PiP first if active (browser behavior is inconsistent)
-      if (isPictureInPicture(media)) {
-        await exitPictureInPicture(media);
-      }
+export type FullscreenOrientationLock = ScreenOrientationLockType;
 
-      return requestFullscreen(container, media);
+export interface FullscreenFeatureConfig {
+  /** Lock the screen orientation while fullscreen is active. Pass `false` to disable. */
+  orientationLock?: FullscreenOrientationLock | undefined;
+}
+
+export type ConfigurableFullscreenFeature = ConfigurablePlayerFeature<FullscreenFeatureConfig, MediaFullscreenState>;
+
+function getOrientationLock(state: Readonly<MediaFullscreenState>) {
+  return (state as Readonly<Partial<FullscreenState>>)[ORIENTATION_LOCK_SYMBOL];
+}
+
+export const fullscreenFeature: ConfigurableFullscreenFeature = definePlayerFeature(
+  {
+    name: 'fullscreen',
+    state: ({ target }, config: FullscreenFeatureConfig): MediaFullscreenState => {
+      const orientationLock = createScreenOrientationLock({ type: config.orientationLock });
+
+      const enterFullscreen = async () => {
+        const { media, container } = target();
+
+        // Exit PiP first if active (browser behavior is inconsistent)
+        if (isPictureInPicture(media)) {
+          await exitPictureInPicture(media);
+        }
+
+        await requestFullscreen(container, media);
+        await orientationLock.lock();
+      };
+
+      const leaveFullscreen = async () => {
+        const { media } = target();
+
+        try {
+          return await exitFullscreen(media);
+        } finally {
+          orientationLock.unlock();
+        }
+      };
+
+      const state: FullscreenState = {
+        [ORIENTATION_LOCK_SYMBOL]: orientationLock,
+        fullscreen: false,
+        fullscreenAvailability: 'unavailable',
+        requestFullscreen: enterFullscreen,
+        exitFullscreen: leaveFullscreen,
+
+        async toggleFullscreen() {
+          const { media, container } = target();
+
+          if (isFullscreen(container, media)) {
+            return leaveFullscreen();
+          }
+
+          return enterFullscreen();
+        },
+      };
+
+      return state;
     },
 
-    async exitFullscreen() {
-      const { media } = target();
-      return exitFullscreen(media);
-    },
+    attach({ target, signal, set, get }) {
+      const { media, container } = target;
 
-    async toggleFullscreen() {
-      const { media, container } = target();
-
-      if (isFullscreen(container, media)) {
-        return exitFullscreen(media);
-      }
-
-      if (isPictureInPicture(media)) {
-        await exitPictureInPicture(media);
-      }
-
-      return requestFullscreen(container, media);
-    },
-  }),
-
-  attach({ target, signal, set }) {
-    const { media, container } = target;
-
-    set({
-      fullscreenAvailability: isFullscreenEnabled() ? 'available' : 'unsupported',
-    });
-
-    const sync = () =>
       set({
-        fullscreen: isFullscreen(container, media),
+        fullscreenAvailability: isFullscreenEnabled() ? 'available' : 'unsupported',
       });
 
-    sync();
+      let wasFullscreen = false;
+      const sync = () => {
+        const fullscreen = isFullscreen(container, media);
 
-    listen(document, 'fullscreenchange', sync, { signal });
-    listen(document, 'webkitfullscreenchange', sync, { signal });
+        if (wasFullscreen && !fullscreen) {
+          getOrientationLock(get())?.unlock();
+        }
 
-    // iOS Safari presentation mode change (covers fullscreen)
-    const video = media as WebKitVideoElement;
-    if ('webkitPresentationMode' in video) {
-      listen(media, 'webkitpresentationmodechanged', sync, { signal });
-    }
+        wasFullscreen = fullscreen;
+        set({ fullscreen });
+      };
+
+      sync();
+
+      listen(document, 'fullscreenchange', sync, { signal });
+      listen(document, 'webkitfullscreenchange', sync, { signal });
+
+      // iOS Safari presentation mode change (covers fullscreen)
+      const video = media as WebKitVideoElement;
+      if ('webkitPresentationMode' in video) {
+        listen(media, 'webkitpresentationmodechanged', sync, { signal });
+      }
+
+      signal.addEventListener(
+        'abort',
+        () => {
+          getOrientationLock(get())?.unlock();
+        },
+        { once: true }
+      );
+    },
   },
-});
+  {}
+);

--- a/packages/core/src/dom/store/features/fullscreen.ts
+++ b/packages/core/src/dom/store/features/fullscreen.ts
@@ -1,122 +1,69 @@
 import { listen } from '@videojs/utils/dom';
 
 import type { MediaFullscreenState } from '../../../core/media/state';
-import { type ConfigurablePlayerFeature, definePlayerFeature } from '../../feature';
+import { definePlayerFeature } from '../../feature';
 import { exitFullscreen, isFullscreen, isFullscreenEnabled, requestFullscreen } from '../../presentation/fullscreen';
-import {
-  createScreenOrientationLock,
-  type ScreenOrientationLock,
-  type ScreenOrientationLockType,
-} from '../../presentation/orientation';
 import { exitPictureInPicture, isPictureInPicture } from '../../presentation/pip';
 import type { WebKitVideoElement } from '../../presentation/types';
 
-const ORIENTATION_LOCK_SYMBOL = Symbol('@videojs/fullscreen-orientation-lock');
+export const fullscreenFeature = definePlayerFeature({
+  name: 'fullscreen',
+  state: ({ target }): MediaFullscreenState => ({
+    fullscreen: false,
+    fullscreenAvailability: 'unavailable',
 
-type FullscreenState = MediaFullscreenState & {
-  [ORIENTATION_LOCK_SYMBOL]: ScreenOrientationLock;
-};
+    async requestFullscreen() {
+      const { media, container } = target();
 
-export type FullscreenOrientationLock = ScreenOrientationLockType;
-
-export interface FullscreenFeatureConfig {
-  /** Lock the screen orientation while fullscreen is active. Pass `false` to disable. */
-  orientationLock?: FullscreenOrientationLock | undefined;
-}
-
-export type ConfigurableFullscreenFeature = ConfigurablePlayerFeature<FullscreenFeatureConfig, MediaFullscreenState>;
-
-function getOrientationLock(state: Readonly<MediaFullscreenState>) {
-  return (state as Readonly<Partial<FullscreenState>>)[ORIENTATION_LOCK_SYMBOL];
-}
-
-export const fullscreenFeature: ConfigurableFullscreenFeature = definePlayerFeature(
-  {
-    name: 'fullscreen',
-    state: ({ target }, config: FullscreenFeatureConfig): MediaFullscreenState => {
-      const orientationLock = createScreenOrientationLock({ type: config.orientationLock });
-
-      const enterFullscreen = async () => {
-        const { media, container } = target();
-
-        // Exit PiP first if active (browser behavior is inconsistent)
-        if (isPictureInPicture(media)) {
-          await exitPictureInPicture(media);
-        }
-
-        await requestFullscreen(container, media);
-        await orientationLock.lock();
-      };
-
-      const leaveFullscreen = async () => {
-        const { media } = target();
-
-        try {
-          return await exitFullscreen(media);
-        } finally {
-          orientationLock.unlock();
-        }
-      };
-
-      const state: FullscreenState = {
-        [ORIENTATION_LOCK_SYMBOL]: orientationLock,
-        fullscreen: false,
-        fullscreenAvailability: 'unavailable',
-        requestFullscreen: enterFullscreen,
-        exitFullscreen: leaveFullscreen,
-
-        async toggleFullscreen() {
-          const { media, container } = target();
-
-          if (isFullscreen(container, media)) {
-            return leaveFullscreen();
-          }
-
-          return enterFullscreen();
-        },
-      };
-
-      return state;
-    },
-
-    attach({ target, signal, set, get }) {
-      const { media, container } = target;
-
-      set({
-        fullscreenAvailability: isFullscreenEnabled() ? 'available' : 'unsupported',
-      });
-
-      let wasFullscreen = false;
-      const sync = () => {
-        const fullscreen = isFullscreen(container, media);
-
-        if (wasFullscreen && !fullscreen) {
-          getOrientationLock(get())?.unlock();
-        }
-
-        wasFullscreen = fullscreen;
-        set({ fullscreen });
-      };
-
-      sync();
-
-      listen(document, 'fullscreenchange', sync, { signal });
-      listen(document, 'webkitfullscreenchange', sync, { signal });
-
-      // iOS Safari presentation mode change (covers fullscreen)
-      const video = media as WebKitVideoElement;
-      if ('webkitPresentationMode' in video) {
-        listen(media, 'webkitpresentationmodechanged', sync, { signal });
+      // Exit PiP first if active (browser behavior is inconsistent)
+      if (isPictureInPicture(media)) {
+        await exitPictureInPicture(media);
       }
 
-      signal.addEventListener(
-        'abort',
-        () => {
-          getOrientationLock(get())?.unlock();
-        },
-        { once: true }
-      );
+      return requestFullscreen(container, media);
     },
+
+    async exitFullscreen() {
+      const { media } = target();
+      return exitFullscreen(media);
+    },
+
+    async toggleFullscreen() {
+      const { media, container } = target();
+
+      if (isFullscreen(container, media)) {
+        return exitFullscreen(media);
+      }
+
+      if (isPictureInPicture(media)) {
+        await exitPictureInPicture(media);
+      }
+
+      return requestFullscreen(container, media);
+    },
+  }),
+
+  attach({ target, signal, set }) {
+    const { media, container } = target;
+
+    set({
+      fullscreenAvailability: isFullscreenEnabled() ? 'available' : 'unsupported',
+    });
+
+    const sync = () =>
+      set({
+        fullscreen: isFullscreen(container, media),
+      });
+
+    sync();
+
+    listen(document, 'fullscreenchange', sync, { signal });
+    listen(document, 'webkitfullscreenchange', sync, { signal });
+
+    // iOS Safari presentation mode change (covers fullscreen)
+    const video = media as WebKitVideoElement;
+    if ('webkitPresentationMode' in video) {
+      listen(media, 'webkitpresentationmodechanged', sync, { signal });
+    }
   },
-  {}
-);
+});

--- a/packages/core/src/dom/store/features/index.ts
+++ b/packages/core/src/dom/store/features/index.ts
@@ -4,6 +4,7 @@ export * from './error';
 export * as features from './feature.parts';
 export * from './fullscreen';
 export * from './live';
+export * from './orientation-lock';
 export * from './pip';
 export * from './playback';
 export * from './playback-rate';

--- a/packages/core/src/dom/store/features/orientation-lock.ts
+++ b/packages/core/src/dom/store/features/orientation-lock.ts
@@ -3,11 +3,14 @@ import { listen } from '@videojs/utils/dom';
 import { definePlayerFeature } from '../../feature';
 import { isFullscreen } from '../../presentation/fullscreen';
 import { createScreenOrientationLock, type ScreenOrientationLockType } from '../../presentation/orientation';
-import type { WebKitVideoElement } from '../../presentation/types';
 
 export interface OrientationLockFeatureConfig {
   /** Screen orientation type to lock while fullscreen is active. */
   type?: ScreenOrientationLockType | undefined;
+}
+
+interface WebKitPresentationMedia extends HTMLMediaElement {
+  webkitPresentationMode?: string;
 }
 
 export const orientationLockFeature = definePlayerFeature(
@@ -37,7 +40,7 @@ export const orientationLockFeature = definePlayerFeature(
       listen(document, 'fullscreenchange', sync, { signal });
       listen(document, 'webkitfullscreenchange', sync, { signal });
 
-      const video = media as WebKitVideoElement;
+      const video = media as WebKitPresentationMedia;
       if ('webkitPresentationMode' in video) {
         listen(media, 'webkitpresentationmodechanged', sync, { signal });
       }

--- a/packages/core/src/dom/store/features/orientation-lock.ts
+++ b/packages/core/src/dom/store/features/orientation-lock.ts
@@ -1,0 +1,49 @@
+import { listen } from '@videojs/utils/dom';
+
+import { definePlayerFeature } from '../../feature';
+import { isFullscreen } from '../../presentation/fullscreen';
+import { createScreenOrientationLock, type ScreenOrientationLockType } from '../../presentation/orientation';
+import type { WebKitVideoElement } from '../../presentation/types';
+
+export interface OrientationLockFeatureConfig {
+  /** Screen orientation type to lock while fullscreen is active. */
+  type?: ScreenOrientationLockType | undefined;
+}
+
+export const orientationLockFeature = definePlayerFeature(
+  {
+    name: 'orientationLock',
+    state: () => ({}),
+
+    attach({ target, signal }, config: OrientationLockFeatureConfig) {
+      const { media, container } = target;
+      const orientationLock = createScreenOrientationLock({ type: config.type });
+
+      let wasFullscreen = false;
+      const sync = () => {
+        const fullscreen = isFullscreen(container, media);
+
+        if (!wasFullscreen && fullscreen) {
+          void orientationLock.lock();
+        } else if (wasFullscreen && !fullscreen) {
+          orientationLock.unlock();
+        }
+
+        wasFullscreen = fullscreen;
+      };
+
+      sync();
+
+      listen(document, 'fullscreenchange', sync, { signal });
+      listen(document, 'webkitfullscreenchange', sync, { signal });
+
+      const video = media as WebKitVideoElement;
+      if ('webkitPresentationMode' in video) {
+        listen(media, 'webkitpresentationmodechanged', sync, { signal });
+      }
+
+      signal.addEventListener('abort', () => orientationLock.unlock(), { once: true });
+    },
+  },
+  { type: 'landscape' } satisfies OrientationLockFeatureConfig
+);

--- a/packages/core/src/dom/store/features/tests/fullscreen.test.ts
+++ b/packages/core/src/dom/store/features/tests/fullscreen.test.ts
@@ -7,15 +7,6 @@ import { createMockVideo } from '../../../tests/test-helpers';
 import { selectFullscreen } from '../../selectors';
 import { fullscreenFeature } from '../fullscreen';
 
-function stubOrientation() {
-  const orientation = {
-    lock: vi.fn(async () => {}),
-    unlock: vi.fn(),
-  };
-  vi.stubGlobal('screen', { orientation });
-  return orientation;
-}
-
 describe('fullscreenFeature', () => {
   let originalFullscreenEnabled: boolean | undefined;
 
@@ -43,11 +34,11 @@ describe('fullscreenFeature', () => {
       expect(selectFullscreen.displayName).toBe('fullscreen');
     });
 
-    it('selects configured fullscreen state', () => {
+    it('selects fullscreen state', () => {
       const video = createMockVideo();
       const container = document.createElement('div');
 
-      const store = createStore<PlayerTarget>()(fullscreenFeature({ orientationLock: false }));
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
       store.attach({ media: video, container });
 
       expect(selectFullscreen(store.state)?.fullscreen).toBe(false);
@@ -300,46 +291,6 @@ describe('fullscreenFeature', () => {
       expect(container.requestFullscreen).toHaveBeenCalled();
     });
 
-    it('requestFullscreen() locks orientation to landscape by default', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-
-      expect(orientation.lock).toHaveBeenCalledWith('landscape');
-    });
-
-    it('requestFullscreen() skips orientation lock when disabled', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature({ orientationLock: false }));
-      store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-
-      expect(orientation.lock).not.toHaveBeenCalled();
-    });
-
     it('requestFullscreen() falls back to media when no container', async () => {
       const video = createMockVideo();
       video.requestFullscreen = vi.fn().mockResolvedValue(undefined);
@@ -364,32 +315,6 @@ describe('fullscreenFeature', () => {
       await store.exitFullscreen();
 
       expect(document.exitFullscreen).toHaveBeenCalled();
-
-      document.exitFullscreen = originalExit;
-    });
-
-    it('exitFullscreen() unlocks orientation after a successful lock', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const originalExit = document.exitFullscreen;
-      document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-      await store.exitFullscreen();
-
-      expect(orientation.unlock).toHaveBeenCalledTimes(1);
 
       document.exitFullscreen = originalExit;
     });
@@ -434,42 +359,6 @@ describe('fullscreenFeature', () => {
   });
 
   describe('transitions', () => {
-    it('toggleFullscreen() locks on enter and unlocks on exit', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const originalExit = document.exitFullscreen;
-      document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      await store.toggleFullscreen();
-
-      expect(orientation.lock).toHaveBeenCalledWith('landscape');
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: container,
-        writable: true,
-        configurable: true,
-      });
-
-      await store.toggleFullscreen();
-
-      expect(document.exitFullscreen).toHaveBeenCalled();
-      expect(orientation.unlock).toHaveBeenCalledTimes(1);
-
-      document.exitFullscreen = originalExit;
-    });
-
     it('toggleFullscreen() exits PiP first when entering fullscreen', async () => {
       Object.defineProperty(document, 'fullscreenEnabled', {
         value: true,
@@ -504,151 +393,6 @@ describe('fullscreenFeature', () => {
         writable: true,
         configurable: true,
       });
-    });
-
-    it('unlocks orientation when fullscreen exits outside store actions', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: container,
-        writable: true,
-        configurable: true,
-      });
-      document.dispatchEvent(new Event('fullscreenchange'));
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: null,
-        writable: true,
-        configurable: true,
-      });
-      document.dispatchEvent(new Event('fullscreenchange'));
-
-      expect(orientation.unlock).toHaveBeenCalledTimes(1);
-    });
-
-    it('unlocks orientation when fullscreen exits before lock settles', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      let resolveLock!: () => void;
-      const lockPromise = new Promise<void>((resolve) => {
-        resolveLock = resolve;
-      });
-
-      const orientation = {
-        lock: vi.fn(() => lockPromise),
-        unlock: vi.fn(),
-      };
-      vi.stubGlobal('screen', { orientation });
-
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      const enterTask = store.requestFullscreen();
-
-      await vi.waitFor(() => {
-        expect(orientation.lock).toHaveBeenCalled();
-      });
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: container,
-        writable: true,
-        configurable: true,
-      });
-      document.dispatchEvent(new Event('fullscreenchange'));
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: null,
-        writable: true,
-        configurable: true,
-      });
-      document.dispatchEvent(new Event('fullscreenchange'));
-
-      resolveLock();
-      await enterTask;
-
-      expect(orientation.unlock).toHaveBeenCalledTimes(1);
-    });
-
-    it('unlocks orientation on detach while still fullscreen', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      const detach = store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: container,
-        writable: true,
-        configurable: true,
-      });
-      document.dispatchEvent(new Event('fullscreenchange'));
-
-      orientation.unlock.mockClear();
-      detach();
-
-      expect(orientation.unlock).toHaveBeenCalledTimes(1);
-    });
-
-    it('unlocks orientation on destroy while still fullscreen', async () => {
-      Object.defineProperty(document, 'fullscreenEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
-
-      const orientation = stubOrientation();
-      const video = createMockVideo();
-      const container = document.createElement('div');
-      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
-
-      const store = createStore<PlayerTarget>()(fullscreenFeature);
-      store.attach({ media: video, container });
-
-      await store.requestFullscreen();
-
-      Object.defineProperty(document, 'fullscreenElement', {
-        value: container,
-        writable: true,
-        configurable: true,
-      });
-      document.dispatchEvent(new Event('fullscreenchange'));
-
-      orientation.unlock.mockClear();
-      store.destroy();
-
-      expect(orientation.unlock).toHaveBeenCalledTimes(1);
     });
 
     it('requestFullscreen() exits PiP first if active', async () => {

--- a/packages/core/src/dom/store/features/tests/fullscreen.test.ts
+++ b/packages/core/src/dom/store/features/tests/fullscreen.test.ts
@@ -4,7 +4,17 @@ import type { PlayerTarget } from '../../../media/types';
 import { HTMLVideoElementHost } from '../../../media/video-host';
 import type { WebKitVideoElement } from '../../../presentation/types';
 import { createMockVideo } from '../../../tests/test-helpers';
+import { selectFullscreen } from '../../selectors';
 import { fullscreenFeature } from '../fullscreen';
+
+function stubOrientation() {
+  const orientation = {
+    lock: vi.fn(async () => {}),
+    unlock: vi.fn(),
+  };
+  vi.stubGlobal('screen', { orientation });
+  return orientation;
+}
 
 describe('fullscreenFeature', () => {
   let originalFullscreenEnabled: boolean | undefined;
@@ -24,9 +34,25 @@ describe('fullscreenFeature', () => {
       writable: true,
       configurable: true,
     });
+    vi.unstubAllGlobals();
   });
 
   describe('attach', () => {
+    it('exposes the fullscreen slice name for selectors', () => {
+      expect(fullscreenFeature.name).toBe('fullscreen');
+      expect(selectFullscreen.displayName).toBe('fullscreen');
+    });
+
+    it('selects configured fullscreen state', () => {
+      const video = createMockVideo();
+      const container = document.createElement('div');
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature({ orientationLock: false }));
+      store.attach({ media: video, container });
+
+      expect(selectFullscreen(store.state)?.fullscreen).toBe(false);
+    });
+
     it('syncs initial state on attach', () => {
       const video = createMockVideo();
       const container = document.createElement('div');
@@ -274,6 +300,46 @@ describe('fullscreenFeature', () => {
       expect(container.requestFullscreen).toHaveBeenCalled();
     });
 
+    it('requestFullscreen() locks orientation to landscape by default', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      await store.requestFullscreen();
+
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    });
+
+    it('requestFullscreen() skips orientation lock when disabled', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature({ orientationLock: false }));
+      store.attach({ media: video, container });
+
+      await store.requestFullscreen();
+
+      expect(orientation.lock).not.toHaveBeenCalled();
+    });
+
     it('requestFullscreen() falls back to media when no container', async () => {
       const video = createMockVideo();
       video.requestFullscreen = vi.fn().mockResolvedValue(undefined);
@@ -298,6 +364,32 @@ describe('fullscreenFeature', () => {
       await store.exitFullscreen();
 
       expect(document.exitFullscreen).toHaveBeenCalled();
+
+      document.exitFullscreen = originalExit;
+    });
+
+    it('exitFullscreen() unlocks orientation after a successful lock', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const originalExit = document.exitFullscreen;
+      document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      await store.requestFullscreen();
+      await store.exitFullscreen();
+
+      expect(orientation.unlock).toHaveBeenCalledTimes(1);
 
       document.exitFullscreen = originalExit;
     });
@@ -342,6 +434,223 @@ describe('fullscreenFeature', () => {
   });
 
   describe('transitions', () => {
+    it('toggleFullscreen() locks on enter and unlocks on exit', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const originalExit = document.exitFullscreen;
+      document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      await store.toggleFullscreen();
+
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: container,
+        writable: true,
+        configurable: true,
+      });
+
+      await store.toggleFullscreen();
+
+      expect(document.exitFullscreen).toHaveBeenCalled();
+      expect(orientation.unlock).toHaveBeenCalledTimes(1);
+
+      document.exitFullscreen = originalExit;
+    });
+
+    it('toggleFullscreen() exits PiP first when entering fullscreen', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const originalExit = document.exitPictureInPicture;
+      document.exitPictureInPicture = vi.fn().mockResolvedValue(undefined);
+
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      Object.defineProperty(document, 'pictureInPictureElement', {
+        value: video,
+        writable: true,
+        configurable: true,
+      });
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      await store.toggleFullscreen();
+
+      expect(document.exitPictureInPicture).toHaveBeenCalled();
+      expect(container.requestFullscreen).toHaveBeenCalled();
+
+      document.exitPictureInPicture = originalExit;
+      Object.defineProperty(document, 'pictureInPictureElement', {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('unlocks orientation when fullscreen exits outside store actions', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      await store.requestFullscreen();
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: container,
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      expect(orientation.unlock).toHaveBeenCalledTimes(1);
+    });
+
+    it('unlocks orientation when fullscreen exits before lock settles', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      let resolveLock!: () => void;
+      const lockPromise = new Promise<void>((resolve) => {
+        resolveLock = resolve;
+      });
+
+      const orientation = {
+        lock: vi.fn(() => lockPromise),
+        unlock: vi.fn(),
+      };
+      vi.stubGlobal('screen', { orientation });
+
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      const enterTask = store.requestFullscreen();
+
+      await vi.waitFor(() => {
+        expect(orientation.lock).toHaveBeenCalled();
+      });
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: container,
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      resolveLock();
+      await enterTask;
+
+      expect(orientation.unlock).toHaveBeenCalledTimes(1);
+    });
+
+    it('unlocks orientation on detach while still fullscreen', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      const detach = store.attach({ media: video, container });
+
+      await store.requestFullscreen();
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: container,
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      orientation.unlock.mockClear();
+      detach();
+
+      expect(orientation.unlock).toHaveBeenCalledTimes(1);
+    });
+
+    it('unlocks orientation on destroy while still fullscreen', async () => {
+      Object.defineProperty(document, 'fullscreenEnabled', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      const orientation = stubOrientation();
+      const video = createMockVideo();
+      const container = document.createElement('div');
+      container.requestFullscreen = vi.fn().mockResolvedValue(undefined);
+
+      const store = createStore<PlayerTarget>()(fullscreenFeature);
+      store.attach({ media: video, container });
+
+      await store.requestFullscreen();
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: container,
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      orientation.unlock.mockClear();
+      store.destroy();
+
+      expect(orientation.unlock).toHaveBeenCalledTimes(1);
+    });
+
     it('requestFullscreen() exits PiP first if active', async () => {
       Object.defineProperty(document, 'fullscreenEnabled', {
         value: true,
@@ -419,6 +728,7 @@ describe('fullscreenFeature with HTMLVideoElementHost', () => {
       writable: true,
       configurable: true,
     });
+    vi.unstubAllGlobals();
   });
 
   describe('attach', () => {

--- a/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
+++ b/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
@@ -1,0 +1,184 @@
+import { createStore } from '@videojs/store';
+import type { Mock } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { PlayerTarget } from '../../../media/types';
+import type { WebKitVideoElement } from '../../../presentation/types';
+import { createMockVideo } from '../../../tests/test-helpers';
+import { orientationLockFeature } from '../orientation-lock';
+
+type OrientationMock = {
+  lock: Mock<ScreenOrientation['lock']>;
+  unlock: Mock<ScreenOrientation['unlock']>;
+};
+
+function stubOrientation(): OrientationMock;
+function stubOrientation<Orientation extends Partial<ScreenOrientation>>(orientation: Orientation): Orientation;
+function stubOrientation<Orientation extends Partial<ScreenOrientation>>(orientation?: Orientation) {
+  const stub =
+    orientation ??
+    ({
+      lock: vi.fn<ScreenOrientation['lock']>(async () => {}),
+      unlock: vi.fn<ScreenOrientation['unlock']>(),
+    } satisfies OrientationMock);
+
+  vi.stubGlobal('screen', { orientation: stub });
+  return stub;
+}
+
+function setFullscreenElement(value: Element | null) {
+  Object.defineProperty(document, 'fullscreenElement', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('orientationLockFeature', () => {
+  afterEach(() => {
+    setFullscreenElement(null);
+    vi.unstubAllGlobals();
+  });
+
+  it('locks landscape by default when fullscreen starts', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    });
+  });
+
+  it('locks the configured orientation type when fullscreen starts', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature({ type: 'portrait' }));
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('portrait');
+    });
+  });
+
+  it('unlocks when fullscreen exits', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalled();
+    });
+
+    await Promise.resolve();
+    orientation.unlock.mockClear();
+
+    setFullscreenElement(null);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('unlocks on destroy while fullscreen is active', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalled();
+    });
+
+    await Promise.resolve();
+    orientation.unlock.mockClear();
+    store.destroy();
+
+    expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles webkit presentation mode changes', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+    video.webkitPresentationMode = 'inline';
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    video.webkitPresentationMode = 'fullscreen';
+    video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    });
+
+    await Promise.resolve();
+    orientation.unlock.mockClear();
+
+    video.webkitPresentationMode = 'inline';
+    video.dispatchEvent(new Event('webkitpresentationmodechanged'));
+
+    expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when screen orientation APIs are unsupported', () => {
+    const orientation = stubOrientation({});
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+    setFullscreenElement(null);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    expect(orientation).toEqual({});
+  });
+
+  it('does not unlock when the lock request rejects', async () => {
+    const orientation = stubOrientation({
+      lock: vi.fn().mockRejectedValue(new Error('NotAllowedError')),
+      unlock: vi.fn(),
+    });
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalled();
+    });
+
+    setFullscreenElement(null);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    expect(orientation.unlock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
+++ b/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
@@ -2,7 +2,6 @@ import { createStore } from '@videojs/store';
 import type { Mock } from 'vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../media/types';
-import type { WebKitVideoElement } from '../../../presentation/types';
 import { createMockVideo } from '../../../tests/test-helpers';
 import { orientationLockFeature } from '../orientation-lock';
 
@@ -10,6 +9,10 @@ type OrientationMock = {
   lock: Mock<ScreenOrientation['lock']>;
   unlock: Mock<ScreenOrientation['unlock']>;
 };
+
+interface WebKitPresentationVideo extends HTMLVideoElement {
+  webkitPresentationMode?: string;
+}
 
 function stubOrientation(): OrientationMock;
 function stubOrientation<Orientation extends Partial<ScreenOrientation>>(orientation: Orientation): Orientation;
@@ -119,7 +122,7 @@ describe('orientationLockFeature', () => {
 
   it('handles webkit presentation mode changes', async () => {
     const orientation = stubOrientation();
-    const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
+    const video = createMockVideo() as WebKitPresentationVideo;
     video.webkitPresentationMode = 'inline';
     const container = document.createElement('div');
 

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -1,0 +1,41 @@
+import { createSelector, type StateContext } from '@videojs/store';
+import { describe, expect, it } from 'vitest';
+import { definePlayerFeature } from '../feature';
+import type { PlayerTarget } from '../media/types';
+
+const stateContext = {
+  target: () => {
+    throw new Error('Target is not available in this test.');
+  },
+  signals: undefined as unknown as StateContext<PlayerTarget>['signals'],
+  get: () => ({}),
+  set: () => {},
+} satisfies StateContext<PlayerTarget>;
+
+describe('definePlayerFeature', () => {
+  it('defines a plain player feature', () => {
+    const feature = definePlayerFeature({
+      name: 'plain',
+      state: () => ({ enabled: true }),
+    });
+
+    expect(feature.name).toBe('plain');
+    expect(feature.state(stateContext).enabled).toBe(true);
+  });
+
+  it('defines a configurable player feature', () => {
+    const feature = definePlayerFeature(
+      {
+        name: 'configurable',
+        state: (_ctx, config: { enabled: boolean }) => ({ enabled: config.enabled }),
+      },
+      { enabled: true }
+    );
+
+    expect(feature.name).toBe('configurable');
+    expect(feature.state(stateContext).enabled).toBe(true);
+    expect(feature().state(stateContext).enabled).toBe(true);
+    expect(feature({ enabled: false }).state(stateContext).enabled).toBe(false);
+    expect(createSelector(feature).displayName).toBe('configurable');
+  });
+});

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -1,5 +1,5 @@
 import type { AudioPlayerStore, PlayerStore, PlayerTarget, VideoPlayerStore } from '@videojs/core/dom';
-import { audioFeatures, backgroundFeatures, definePlayerFeature, videoFeatures } from '@videojs/core/dom';
+import { audioFeatures, backgroundFeatures, definePlayerFeature, features, videoFeatures } from '@videojs/core/dom';
 import type { Slice } from '@videojs/store';
 import { assertType, describe, it } from 'vitest';
 
@@ -42,6 +42,16 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: [customFeature] });
 
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
+  });
+
+  it('accepts the fullscreen feature alias with and without config', () => {
+    const configuredFullscreen = features.fullscreen({ orientationLock: false });
+
+    const defaultResult = createPlayer({ features: [features.fullscreen] });
+    const configuredResult = createPlayer({ features: [configuredFullscreen] });
+
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.fullscreen]>>>(defaultResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof configuredFullscreen]>>>(configuredResult);
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -44,14 +44,14 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('accepts the fullscreen feature alias with and without config', () => {
-    const configuredFullscreen = features.fullscreen({ orientationLock: false });
+  it('accepts the orientation lock feature alias with and without config', () => {
+    const configuredOrientationLock = features.orientationLock({ type: 'portrait' });
 
-    const defaultResult = createPlayer({ features: [features.fullscreen] });
-    const configuredResult = createPlayer({ features: [configuredFullscreen] });
+    const defaultResult = createPlayer({ features: [features.orientationLock] });
+    const configuredResult = createPlayer({ features: [configuredOrientationLock] });
 
-    assertType<CreatePlayerResult<PlayerStore<[typeof features.fullscreen]>>>(defaultResult);
-    assertType<CreatePlayerResult<PlayerStore<[typeof configuredFullscreen]>>>(configuredResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -1,5 +1,5 @@
 import type { AudioPlayerStore, PlayerStore, PlayerTarget, VideoPlayerStore } from '@videojs/core/dom';
-import { audioFeatures, definePlayerFeature, videoFeatures } from '@videojs/core/dom';
+import { audioFeatures, definePlayerFeature, features, videoFeatures } from '@videojs/core/dom';
 import type { Slice } from '@videojs/store';
 import { assertType, describe, it } from 'vitest';
 
@@ -36,6 +36,16 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: [customFeature] });
 
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
+  });
+
+  it('accepts the fullscreen feature alias with and without config', () => {
+    const configuredFullscreen = features.fullscreen({ orientationLock: false });
+
+    const defaultResult = createPlayer({ features: [features.fullscreen] });
+    const configuredResult = createPlayer({ features: [configuredFullscreen] });
+
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.fullscreen]>>>(defaultResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof configuredFullscreen]>>>(configuredResult);
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -38,14 +38,14 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('accepts the fullscreen feature alias with and without config', () => {
-    const configuredFullscreen = features.fullscreen({ orientationLock: false });
+  it('accepts the orientation lock feature alias with and without config', () => {
+    const configuredOrientationLock = features.orientationLock({ type: 'portrait' });
 
-    const defaultResult = createPlayer({ features: [features.fullscreen] });
-    const configuredResult = createPlayer({ features: [configuredFullscreen] });
+    const defaultResult = createPlayer({ features: [features.orientationLock] });
+    const configuredResult = createPlayer({ features: [configuredOrientationLock] });
 
-    assertType<CreatePlayerResult<PlayerStore<[typeof features.fullscreen]>>>(defaultResult);
-    assertType<CreatePlayerResult<PlayerStore<[typeof configuredFullscreen]>>>(configuredResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -88,8 +88,18 @@ function isEmptyState(node: ts.Expression): boolean {
   if (!ts.isArrowFunction(node) && !ts.isFunctionExpression(node)) return false;
   if (ts.isBlock(node.body)) return false;
 
-  const body = ts.skipParentheses(node.body);
+  const body = unwrapParentheses(node.body);
   return ts.isObjectLiteralExpression(body) && body.properties.length === 0;
+}
+
+function unwrapParentheses(node: ts.Expression): ts.Expression {
+  let expression = node;
+
+  while (ts.isParenthesizedExpression(expression)) {
+    expression = expression.expression;
+  }
+
+  return expression;
 }
 
 // ─── Type Formatting ──────────────────────────────────────────────

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -12,6 +12,7 @@
  *   - Feature files: *.ts in the features directory (excluding index, presets, feature.parts)
  *   - Feature exports: const matching *Feature (singular, not *Features)
  *   - State type: explicit return type annotation on the state() arrow function
+ *   - Silent features: state() returns an empty object
  *   - State interfaces: exported from packages/core/src/core/media/state.ts
  */
 import * as fs from 'node:fs';
@@ -25,7 +26,7 @@ const SKIP_FILES = new Set(['index.ts', 'presets.ts', 'feature.parts.ts']);
 interface FeatureSource {
   filePath: string;
   name: string;
-  stateTypeName: string;
+  stateTypeName?: string;
 }
 
 // ─── Discovery ────────────────────────────────────────────────────
@@ -54,6 +55,7 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
 
         let name: string | undefined;
         let stateTypeName: string | undefined;
+        let silent = false;
 
         for (const prop of arg.properties) {
           if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
@@ -66,11 +68,13 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
             const fn = prop.initializer;
             if ((ts.isArrowFunction(fn) || ts.isFunctionExpression(fn)) && fn.type && ts.isTypeReferenceNode(fn.type)) {
               stateTypeName = fn.type.typeName.getText(sourceFile);
+            } else if (isEmptyState(fn)) {
+              silent = true;
             }
           }
         }
 
-        if (name && stateTypeName) {
+        if (name && (stateTypeName || silent)) {
           sources.push({ filePath, name, stateTypeName });
         }
       }
@@ -78,6 +82,14 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
   }
 
   return sources;
+}
+
+function isEmptyState(node: ts.Expression): boolean {
+  if (!ts.isArrowFunction(node) && !ts.isFunctionExpression(node)) return false;
+  if (ts.isBlock(node.body)) return false;
+
+  const body = ts.skipParentheses(node.body);
+  return ts.isObjectLiteralExpression(body) && body.properties.length === 0;
 }
 
 // ─── Type Formatting ──────────────────────────────────────────────
@@ -194,6 +206,18 @@ export function generateFeatureReferences(monorepoRoot: string): FeatureResult[]
 
   const results: FeatureResult[] = [];
   for (const source of sources) {
+    if (!source.stateTypeName) {
+      const ref: FeatureReference = {
+        name: source.name,
+        slug: source.name,
+        state: {},
+        actions: {},
+      };
+
+      results.push({ name: source.name, slug: source.name, reference: ref });
+      continue;
+    }
+
     const interfaceDecl = interfaces.get(source.stateTypeName);
     if (!interfaceDecl) continue;
 

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -713,6 +713,7 @@ describe('Feature pipeline (end-to-end)', () => {
   describe('Discovery', () => {
     it('discovers features from the features index', () => {
       const names = results.map((r) => r.name);
+      expect(names).toContain('orientationLock');
       expect(names).toContain('playback');
       expect(names).toContain('volume');
     });
@@ -729,7 +730,16 @@ describe('Feature pipeline (end-to-end)', () => {
     });
 
     it('produces one result per feature', () => {
-      expect(results.length).toBe(2);
+      expect(results.length).toBe(3);
+    });
+  });
+
+  describe('orientationLock (silent feature)', () => {
+    it('generates an empty reference for empty state', () => {
+      const ref = findFeature('orientationLock')!.reference;
+
+      expect(ref.state).toEqual({});
+      expect(ref.actions).toEqual({});
     });
   });
 

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/feature.parts.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/feature.parts.ts
@@ -4,5 +4,7 @@
  * Exercises: namespace re-export filtering — `export * as features from './feature.parts'`
  * in the index should NOT produce a feature entry named "features".
  */
+
+export { orientationLockFeature as orientationLock } from './orientation-lock';
 export { playbackFeature as playback } from './playback';
 export { volumeFeature as volume } from './volume';

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/index.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * as features from './feature.parts';
+export * from './orientation-lock';
 export * from './playback';
 export * from './presets';
 export * from './volume';

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/orientation-lock.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/orientation-lock.ts
@@ -1,0 +1,6 @@
+import { definePlayerFeature } from '../../feature';
+
+export const orientationLockFeature = definePlayerFeature({
+  name: 'orientationLock',
+  state: () => ({}),
+});

--- a/site/src/content/docs/reference/feature-fullscreen.mdx
+++ b/site/src/content/docs/reference/feature-fullscreen.mdx
@@ -7,7 +7,7 @@ import FeatureReference from "@/components/docs/api-reference/FeatureReference.a
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 
-Controls fullscreen mode. Tries the container element first, falls back to the media element.
+Controls fullscreen mode. Tries the container element first, falls back to the media element. Video players lock screen orientation to landscape while fullscreen is active when the browser supports the Screen Orientation API.
 
 <FeatureReference feature="fullscreen" />
 
@@ -27,11 +27,11 @@ import { selectFullscreen, usePlayer } from '@videojs/react';
 
 function FullscreenButton() {
   const fs = usePlayer(selectFullscreen);
-  if (!fs || fs.availability !== 'available') return null;
+  if (!fs || fs.fullscreenAvailability !== 'available') return null;
 
   return (
-    <button onClick={fs.toggle}>
-      {fs.active ? 'Exit fullscreen' : 'Fullscreen'}
+    <button onClick={fs.toggleFullscreen}>
+      {fs.fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
     </button>
   );
 }
@@ -50,3 +50,17 @@ class FullscreenButton extends MediaElement {
 }
 ```
 </FrameworkCase>
+
+### Screen orientation
+
+When fullscreen is entered, `features.fullscreen` tries `screen.orientation.lock('landscape')`. When fullscreen exits, it unlocks orientation if the feature successfully locked it. Unsupported browsers and rejected lock requests are ignored, so iOS Safari continues to use its normal fullscreen behavior.
+
+Disable orientation locking by replacing the default fullscreen feature in a custom feature bundle:
+
+```ts
+import { createPlayer, features } from '@videojs/react';
+
+const Player = createPlayer({
+  features: [features.playback, features.time, features.fullscreen({ orientationLock: false })],
+});
+```

--- a/site/src/content/docs/reference/feature-fullscreen.mdx
+++ b/site/src/content/docs/reference/feature-fullscreen.mdx
@@ -7,7 +7,7 @@ import FeatureReference from "@/components/docs/api-reference/FeatureReference.a
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 
-Controls fullscreen mode. Tries the container element first, falls back to the media element. Video players lock screen orientation to landscape while fullscreen is active when the browser supports the Screen Orientation API.
+Controls fullscreen mode. Tries the container element first, falls back to the media element.
 
 <FeatureReference feature="fullscreen" />
 
@@ -53,14 +53,15 @@ class FullscreenButton extends MediaElement {
 
 ### Screen orientation
 
-When fullscreen is entered, `features.fullscreen` tries `screen.orientation.lock('landscape')`. When fullscreen exits, it unlocks orientation if the feature successfully locked it. Unsupported browsers and rejected lock requests are ignored, so iOS Safari continues to use its normal fullscreen behavior.
+Add <DocsLink slug="reference/feature-orientation-lock">`features.orientationLock`</DocsLink> to lock screen orientation while fullscreen is active. Unsupported browsers and rejected lock requests are ignored, so iOS Safari continues to use its normal fullscreen behavior.
 
-Disable orientation locking by replacing the default fullscreen feature in a custom feature bundle:
+By default, the feature locks to `landscape`. Pass a Screen Orientation API type to customize it:
 
 ```ts
 import { createPlayer, features } from '@videojs/react';
+import { videoFeatures } from '@videojs/react/video';
 
 const Player = createPlayer({
-  features: [features.playback, features.time, features.fullscreen({ orientationLock: false })],
+  features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
 });
 ```

--- a/site/src/content/docs/reference/feature-orientation-lock.mdx
+++ b/site/src/content/docs/reference/feature-orientation-lock.mdx
@@ -1,0 +1,61 @@
+---
+title: Orientation lock
+description: Screen orientation locking while fullscreen is active
+---
+
+import FeatureReference from "@/components/docs/api-reference/FeatureReference.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+
+Locks screen orientation while fullscreen is active. Add it explicitly to a feature list; it is not included in the default video presets.
+
+<FeatureReference feature="orientationLock" />
+
+### Usage
+
+By default, the feature locks to `landscape`. Pass a Screen Orientation API type to customize it.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="player.tsx"
+import { createPlayer, features } from '@videojs/react';
+import { videoFeatures } from '@videojs/react/video';
+
+export const Player = createPlayer({
+  features: [...videoFeatures, features.orientationLock],
+});
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="player.ts"
+import { createPlayer, features } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const player = createPlayer({
+  features: [...videoFeatures, features.orientationLock],
+});
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="portrait-player.tsx"
+import { createPlayer, features } from '@videojs/react';
+import { videoFeatures } from '@videojs/react/video';
+
+export const Player = createPlayer({
+  features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
+});
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="portrait-player.ts"
+import { createPlayer, features } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const player = createPlayer({
+  features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
+});
+```
+</FrameworkCase>
+
+Unsupported browsers and rejected lock requests are ignored.

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -130,6 +130,7 @@ export const sidebar: Sidebar = [
       { slug: 'reference/feature-error' },
       { slug: 'reference/feature-fullscreen' },
       { slug: 'reference/feature-live' },
+      { slug: 'reference/feature-orientation-lock' },
       { slug: 'reference/feature-pip', sidebarLabel: 'Picture-in-picture' },
       { slug: 'reference/feature-playback' },
       { slug: 'reference/feature-playback-rate' },


### PR DESCRIPTION
## Summary

- Add `features.orientationLock` as an opt-in silent feature that locks screen orientation while fullscreen is active.
- Default the lock type to `landscape`, with configurable Screen Orientation API types via `features.orientationLock({ type })`.
- Keep `features.fullscreen` focused on fullscreen state/actions, with no orientation config or lock side effects.
- Extend configurable feature support in `definePlayerFeature` for opt-in feature configuration.
- Add docs, type tests, and unit coverage for orientation locking without adding it to default presets.

## Validation

- `pnpm -F @videojs/core test src/dom/store/features/tests/fullscreen.test.ts src/dom/store/features/tests/orientation-lock.test.ts src/dom/presentation/tests/orientation.test.ts`
- `pnpm exec tsgo --noEmit -p packages/core/tsconfig.json`
- `pnpm -F @videojs/core build`
- `pnpm -F @videojs/html build`
- `pnpm -F @videojs/react build`
- `pnpm -F site test scripts/api-docs-builder/src/tests/e2e.test.ts`
- `pnpm -F site api-docs`
- `pnpm exec biome check ...`
- `git diff --check`

Note: `pnpm -F site build` renders the new orientation-lock reference routes, then fails on the existing `AirplayEnterIcon is not defined` site build issue.

Closes #1429

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes presentation behavior when consumers opt in (Screen Orientation API is browser-dependent and permission-sensitive), but fullscreen logic is isolated in a new feature and defaults are unchanged.
> 
> **Overview**
> Adds an **opt-in** `features.orientationLock` silent feature that locks screen orientation (default **`landscape`**, configurable via `features.orientationLock({ type })`) while fullscreen is active, using a new `createScreenOrientationLock` helper that tolerates missing APIs, rejected locks, and async races.
> 
> **`definePlayerFeature`** gains a second overload for **configurable** features (default config + callable factory). Fullscreen stays orientation-free; orientation is wired only through the new feature listening to fullscreen / WebKit presentation events.
> 
> Exports **`features.orientationLock`**, sandbox video provider opt-in, docs (new reference page + fullscreen orientation section), API-docs **silent feature** discovery, and broad unit/type tests. Not added to default `videoFeatures` presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ebfb5c60fed179ec7dc4bbec020f20190f33ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->