### PR TITLE
fix(spf): refactor track switching to rules

### DIFF
--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -44,6 +44,12 @@ export const SOURCES = {
     subType: 'mp4',
     live: true,
   },
+  'hls-audio-only-cmaf': {
+    label: 'HLS - Audio only (CMAF/fmp4)',
+    url: 'https://stream.mux.com/2NEjLyf6ETnskbfAtbM00Vdzb97B00OKUUQcRD6LZpBRw.m3u8',
+    type: 'hls',
+    subType: 'mp4',
+  },
   'mp4-1': {
     label: 'MP4 - Dancing Dude',
     url: 'https://stream.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/highest.mp4',

--- a/packages/spf/src/all.ts
+++ b/packages/spf/src/all.ts
@@ -101,5 +101,5 @@ export { syncPreload } from './playback/behaviors/sync-preload';
 // Features — Track Switching (video ABR + audio language selection)
 // =============================================================================
 
-export type { TrackSwitchingConfig, TrackSwitchingState } from './playback/behaviors/track-switching';
+export type { SwitchVideoTrackConfig, TrackSwitchingState } from './playback/behaviors/track-switching';
 export { DEFAULT_INITIAL_BANDWIDTH, switchAudioTrack, switchVideoTrack } from './playback/behaviors/track-switching';

--- a/packages/spf/src/core/composition/share-signals.ts
+++ b/packages/spf/src/core/composition/share-signals.ts
@@ -26,24 +26,25 @@ export interface ShareSignalsConfig<S extends object, C extends object> {
  * intent can be expressed by typing captured refs as `Signal<T>` or
  * `ReadonlySignal<T>` at the call site).
  *
- * Declares no keys of its own (`stateKeys: []`, `contextKeys: []`); the
- * composition's state/context maps come from other behaviors' key
- * declarations. This behavior just observes/forwards whatever signals
- * the composition built.
+ * By default declares no keys; the composition's state/context maps come from
+ * other behaviors. Pass `inputStateKeys` / `inputContextKeys` to *materialize*
+ * consumer-input slots that no other behavior produces — a slot the consumer
+ * writes (e.g. `userAudioTrackSelection`) but only a rule reads. shareSignals
+ * is the consumer boundary, so it's the natural place to bring those slots into
+ * existence; readers then treat them as optional.
  *
- * Uses a `Behavior<>` literal (not `defineBehavior`) so the empty key
- * arrays don't trip the exhaustiveness check — the setup-param state/
- * context shapes here describe what the consumer's callback receives,
- * not keys this behavior needs created.
+ * Uses a `Behavior<>` literal (not `defineBehavior`) so its (possibly empty,
+ * possibly partial) key arrays don't trip the exhaustiveness check — the
+ * setup-param state/context shapes describe what the callback receives (the
+ * full `S` / `C`), not the subset this behavior materializes.
  */
-export function makeShareSignals<S extends object, C extends object>(): Behavior<
-  StateSignals<S>,
-  ContextSignals<C>,
-  ShareSignalsConfig<S, C>
-> {
+export function makeShareSignals<S extends object, C extends object>(
+  inputStateKeys: readonly (keyof S)[] = [],
+  inputContextKeys: readonly (keyof C)[] = []
+): Behavior<StateSignals<S>, ContextSignals<C>, ShareSignalsConfig<S, C>> {
   return {
-    stateKeys: [],
-    contextKeys: [],
+    stateKeys: inputStateKeys,
+    contextKeys: inputContextKeys,
     setup: ({ state, context, config }) => {
       config.onSignalsReady?.({ state, context });
     },

--- a/packages/spf/src/media/abr/quality-selection.ts
+++ b/packages/spf/src/media/abr/quality-selection.ts
@@ -154,6 +154,15 @@ export function selectLowestQuality<T extends { bandwidth: number }>(tracks: rea
 }
 
 /**
+ * Resolution as a total pixel count (`width × height`), the basis for
+ * comparing two tracks at the same bitrate. Missing dimensions count as 0, so
+ * tracks without resolution metadata (e.g. audio) area-compare equal.
+ */
+export function resolutionArea(track: { width?: number; height?: number }): number {
+  return (track.width ?? 0) * (track.height ?? 0);
+}
+
+/**
  * Check if track A has higher resolution than track B.
  * Compares by total pixel count (width × height).
  *
@@ -165,7 +174,5 @@ function hasHigherResolution(
   trackA: PartiallyResolvedVideoTrack | VideoTrack,
   trackB: PartiallyResolvedVideoTrack | VideoTrack
 ): boolean {
-  const pixelsA = (trackA.width ?? 0) * (trackA.height ?? 0);
-  const pixelsB = (trackB.width ?? 0) * (trackB.height ?? 0);
-  return pixelsA > pixelsB;
+  return resolutionArea(trackA) > resolutionArea(trackB);
 }

--- a/packages/spf/src/media/abr/quality-selection.ts
+++ b/packages/spf/src/media/abr/quality-selection.ts
@@ -154,24 +154,6 @@ export function selectLowestQuality<T extends { bandwidth: number }>(tracks: rea
 }
 
 /**
- * Lowest-quality fallback tolerant of tracks whose `bandwidth` is optional
- * (audio candidates). Falls back to the first track when no candidate carries
- * bandwidth info.
- *
- * @param tracks - Candidate tracks (bandwidth optional)
- * @returns The lowest-bandwidth track, the first track when none carry
- *   bandwidth, or `undefined` if `tracks` is empty
- */
-export function selectLowestQualityWithBandwidth<T extends { bandwidth?: number }>(
-  tracks: readonly T[]
-): T | undefined {
-  if (tracks.length === 0) return undefined;
-  const withBandwidth = tracks.filter((t): t is T & { bandwidth: number } => typeof t.bandwidth === 'number');
-  if (withBandwidth.length === 0) return tracks[0];
-  return selectLowestQuality(withBandwidth);
-}
-
-/**
  * Check if track A has higher resolution than track B.
  * Compares by total pixel count (width × height).
  *

--- a/packages/spf/src/media/abr/quality-selection.ts
+++ b/packages/spf/src/media/abr/quality-selection.ts
@@ -154,6 +154,24 @@ export function selectLowestQuality<T extends { bandwidth: number }>(tracks: rea
 }
 
 /**
+ * Lowest-quality fallback tolerant of tracks whose `bandwidth` is optional
+ * (audio candidates). Falls back to the first track when no candidate carries
+ * bandwidth info.
+ *
+ * @param tracks - Candidate tracks (bandwidth optional)
+ * @returns The lowest-bandwidth track, the first track when none carry
+ *   bandwidth, or `undefined` if `tracks` is empty
+ */
+export function selectLowestQualityWithBandwidth<T extends { bandwidth?: number }>(
+  tracks: readonly T[]
+): T | undefined {
+  if (tracks.length === 0) return undefined;
+  const withBandwidth = tracks.filter((t): t is T & { bandwidth: number } => typeof t.bandwidth === 'number');
+  if (withBandwidth.length === 0) return tracks[0];
+  return selectLowestQuality(withBandwidth);
+}
+
+/**
  * Check if track A has higher resolution than track B.
  * Compares by total pixel count (width × height).
  *

--- a/packages/spf/src/media/abr/tests/quality-selection.test.ts
+++ b/packages/spf/src/media/abr/tests/quality-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { PartiallyResolvedVideoTrack } from '../../types';
-import { DEFAULT_QUALITY_CONFIG, selectLowestQuality, selectQuality } from '../quality-selection';
+import { DEFAULT_QUALITY_CONFIG, resolutionArea, selectLowestQuality, selectQuality } from '../quality-selection';
 
 // Helper to create test tracks
 const createTrack = (id: string, bandwidth: number, width = 1920, height = 1080): PartiallyResolvedVideoTrack => ({
@@ -306,5 +306,17 @@ describe('selectLowestQuality', () => {
     ];
 
     expect(selectLowestQuality(tracks)?.id).toBe('low');
+  });
+});
+
+describe('resolutionArea', () => {
+  it('returns the pixel count (width × height)', () => {
+    expect(resolutionArea({ width: 1920, height: 1080 })).toBe(2_073_600);
+  });
+
+  it('treats a missing dimension as 0', () => {
+    expect(resolutionArea({ width: 1920 })).toBe(0);
+    expect(resolutionArea({ height: 1080 })).toBe(0);
+    expect(resolutionArea({})).toBe(0);
   });
 });

--- a/packages/spf/src/media/primitives/select-tracks.ts
+++ b/packages/spf/src/media/primitives/select-tracks.ts
@@ -113,6 +113,24 @@ export type TrackPicker<Config = unknown> = (
 ) => string | undefined;
 
 /**
+ * Test whether a track matches a partial-track description: every present,
+ * defined field of `filter` equals the track's. Absent or `undefined` filter
+ * fields don't constrain. Used to narrow candidates by a user selection
+ * (`{ id }`, `{ language }`, `{ height }`, …).
+ *
+ * @param track - The track to test
+ * @param filter - Partial-track description; only present, defined fields constrain
+ * @returns `true` when the track matches every constraining field
+ */
+export function matchesPartialTrack<T>(track: T, filter: Partial<T>): boolean {
+  for (const key in filter) {
+    const filterValue = filter[key as keyof T];
+    if (filterValue !== undefined && track[key as keyof T] !== filterValue) return false;
+  }
+  return true;
+}
+
+/**
  * Pick the first track of the given type from a presentation.
  *
  * Returns the first track in the first switching set of the matching

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -680,16 +680,18 @@ describe('applyRules', () => {
   const track = (id: string) => ({ id });
   const all = [track('a'), track('b'), track('c')];
 
+  const noDeps = { state: {}, context: {}, config: {} };
+
   it('applies rules in order; the pick is the first survivor', () => {
     const dropA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'a');
     const reverse: SelectionRule<{ id: string }> = (tracks) => [...tracks].reverse();
-    const result = applyRules([dropA, reverse], all, {}, {});
+    const result = applyRules([dropA, reverse], all, noDeps);
     expect(result.map((t) => t.id)).toEqual(['c', 'b']);
   });
 
   it('skips a rule that returns nothing (fall-through), keeping the prior set', () => {
     const matchNone: SelectionRule<{ id: string }> = () => [];
-    const result = applyRules([matchNone], all, {}, {});
+    const result = applyRules([matchNone], all, noDeps);
     expect(result.map((t) => t.id)).toEqual(['a', 'b', 'c']);
   });
 
@@ -700,20 +702,22 @@ describe('applyRules', () => {
       laterCalled = true;
       return tracks;
     };
-    const result = applyRules([toA, later], all, {}, {});
+    const result = applyRules([toA, later], all, noDeps);
     expect(result.map((t) => t.id)).toEqual(['a']);
     expect(laterCalled).toBe(false);
   });
 
-  it('passes the candidate list, state, and context through to each rule', () => {
-    const state = { marker: 1 };
-    const context = { other: 2 };
+  it('passes the candidate list and deps (state, context, config) through to each rule', () => {
+    const deps = { state: { marker: 1 }, context: { other: 2 }, config: { tuning: 3 } };
     let received: unknown[] = [];
-    const rule: SelectionRule<{ id: string }, typeof state, typeof context> = (tracks, s, c) => {
-      received = [tracks, s, c];
+    const rule: SelectionRule<{ id: string }, typeof deps.state, typeof deps.context, typeof deps.config> = (
+      tracks,
+      ruleDeps
+    ) => {
+      received = [tracks, ruleDeps];
       return tracks;
     };
-    applyRules([rule], all, state, context);
-    expect(received).toEqual([all, state, context]);
+    applyRules([rule], all, deps);
+    expect(received).toEqual([all, deps]);
   });
 });

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -378,6 +378,52 @@ describe('switchVideoTrack', () => {
     });
   });
 
+  describe('equal-bitrate resolution tie-break', () => {
+    const withResolution = (track: PartiallyResolvedVideoTrack, width: number, height: number) => ({
+      ...track,
+      width,
+      height,
+    });
+
+    it('prefers the higher-resolution rendition when bitrates are equal', async () => {
+      // Same bitrate, but the lower-resolution variant is listed first — a
+      // bitrate-only ranker would pick it by manifest order.
+      const equalBitrate = [
+        withResolution(createVideoTrack('sd', 3_000_000), 640, 360),
+        withResolution(createVideoTrack('hd', 3_000_000), 1920, 1080),
+      ];
+      const state = makeState({
+        presentation: createPresentation(equalBitrate),
+        bandwidthState: createBandwidthState(6_000_000),
+      });
+
+      const reactor = switchVideoTrack.setup({ state });
+      await flush();
+      expect(state.selectedVideoTrackId.get()).toBe('hd');
+
+      reactor.destroy();
+    });
+
+    it('breaks ties by resolution among the smallest over-throughput renditions', async () => {
+      // Both exceed the throughput threshold (equal, lowest bitrate) — the
+      // fallback pick should still favor the higher-resolution variant.
+      const overThreshold = [
+        withResolution(createVideoTrack('sd', 8_000_000), 640, 360),
+        withResolution(createVideoTrack('hd', 8_000_000), 1920, 1080),
+      ];
+      const state = makeState({
+        presentation: createPresentation(overThreshold),
+        bandwidthState: createBandwidthState(1_000_000),
+      });
+
+      const reactor = switchVideoTrack.setup({ state });
+      await flush();
+      expect(state.selectedVideoTrackId.get()).toBe('hd');
+
+      reactor.destroy();
+    });
+  });
+
   describe('configuration', () => {
     it('uses custom safetyMargin', async () => {
       const state = makeState({

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -12,6 +12,8 @@ import type {
 } from '../../../media/types';
 import type { BandwidthState } from '../../../network/bandwidth-estimator';
 import {
+  applyRules,
+  type SelectionRule,
   switchAudioTrack,
   switchVideoTrack,
   type TrackSwitchingConfig,
@@ -667,5 +669,51 @@ describe('switchAudioTrack — userAudioTrackSelection filter', () => {
     expect(state.selectedAudioTrackId.get()).toBe('audio-en');
 
     reactor.destroy();
+  });
+});
+
+// ============================================================================
+// applyRules — the rule-chain composer (pure; no signals)
+// ============================================================================
+
+describe('applyRules', () => {
+  const track = (id: string) => ({ id });
+  const all = [track('a'), track('b'), track('c')];
+
+  it('applies rules in order; the pick is the first survivor', () => {
+    const dropA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'a');
+    const reverse: SelectionRule<{ id: string }> = (tracks) => [...tracks].reverse();
+    const result = applyRules([dropA, reverse], all, {}, {});
+    expect(result.map((t) => t.id)).toEqual(['c', 'b']);
+  });
+
+  it('skips a rule that returns nothing (fall-through), keeping the prior set', () => {
+    const matchNone: SelectionRule<{ id: string }> = () => [];
+    const result = applyRules([matchNone], all, {}, {});
+    expect(result.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('stops at one survivor and does not run later rules (early-bail)', () => {
+    const toA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id === 'a');
+    let laterCalled = false;
+    const later: SelectionRule<{ id: string }> = (tracks) => {
+      laterCalled = true;
+      return tracks;
+    };
+    const result = applyRules([toA, later], all, {}, {});
+    expect(result.map((t) => t.id)).toEqual(['a']);
+    expect(laterCalled).toBe(false);
+  });
+
+  it('passes the candidate list, state, and context through to each rule', () => {
+    const state = { marker: 1 };
+    const context = { other: 2 };
+    let received: unknown[] = [];
+    const rule: SelectionRule<{ id: string }, typeof state, typeof context> = (tracks, s, c) => {
+      received = [tracks, s, c];
+      return tracks;
+    };
+    applyRules([rule], all, state, context);
+    expect(received).toEqual([all, state, context]);
   });
 });

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -14,9 +14,9 @@ import type { BandwidthState } from '../../../network/bandwidth-estimator';
 import {
   applyRules,
   type SelectionRule,
+  type SwitchVideoTrackConfig,
   switchAudioTrack,
   switchVideoTrack,
-  type TrackSwitchingConfig,
   type TrackSwitchingState,
 } from '../track-switching';
 
@@ -365,7 +365,7 @@ describe('switchVideoTrack', () => {
         selectedVideoTrackId: '360p',
       });
 
-      const config: TrackSwitchingConfig = { quality: { safetyMargin: 1.0 } };
+      const config: SwitchVideoTrackConfig = { quality: { safetyMargin: 1.0 } };
       const reactor = switchVideoTrack.setup({ state, config });
       await flush();
       expect(state.selectedVideoTrackId.get()).toBe('720p');
@@ -380,7 +380,7 @@ describe('switchVideoTrack', () => {
         selectedVideoTrackId: 'low',
       });
 
-      const config: TrackSwitchingConfig = { quality: { upgradeMargin: 1.05 } };
+      const config: SwitchVideoTrackConfig = { quality: { upgradeMargin: 1.05 } };
       const reactor = switchVideoTrack.setup({ state, config });
       await flush();
       expect(state.selectedVideoTrackId.get()).toBe('high');
@@ -403,7 +403,7 @@ describe('switchVideoTrack', () => {
         selectedVideoTrackId: '360p',
       });
 
-      const config: TrackSwitchingConfig = { initialBandwidth: 5_000_000 };
+      const config: SwitchVideoTrackConfig = { initialBandwidth: 5_000_000 };
       const reactor = switchVideoTrack.setup({ state, config });
       await flush();
       expect(state.selectedVideoTrackId.get()).toBe('720p');
@@ -428,7 +428,7 @@ describe('switchVideoTrack', () => {
         selectedVideoTrackId: '720p',
       });
 
-      const config: TrackSwitchingConfig = {
+      const config: SwitchVideoTrackConfig = {
         bandwidth: { minTotalBytes: 40_000 },
         initialBandwidth: 5_000_000,
       };

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -17,7 +17,6 @@ import {
   type SwitchVideoTrackConfig,
   switchAudioTrack,
   switchVideoTrack,
-  type TrackSwitchingState,
 } from '../track-switching';
 
 // ============================================================================
@@ -31,7 +30,7 @@ interface SwitchVideoTrackState {
   userVideoTrackSelection?: Partial<VideoTrack>;
 }
 
-function makeState(initial: Partial<TrackSwitchingState> = {}): StateSignals<SwitchVideoTrackState> {
+function makeState(initial: Partial<SwitchVideoTrackState> = {}): StateSignals<SwitchVideoTrackState> {
   return {
     presentation: signal<MaybeResolvedPresentation | undefined>(initial.presentation),
     bandwidthState: signal<BandwidthState | undefined>(initial.bandwidthState),

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -410,45 +410,6 @@ describe('switchVideoTrack', () => {
       reactor.destroy();
     });
 
-    it('uses custom picker for initial pick; ABR adjusts from there', async () => {
-      // Picker pins the initial pick to 360p (lowest, regardless of bandwidth).
-      // At 6 Mbps, ABR would default-pick 1080p; the picker overrides for
-      // the initial pick. Subsequent ABR upgrade applies normally.
-      const state = makeState({
-        presentation: createPresentation(tracks),
-        bandwidthState: createBandwidthState(6_000_000),
-      });
-
-      const config: TrackSwitchingConfig = { picker: () => '360p' };
-      const reactor = switchVideoTrack.setup({ state, config });
-      await flush();
-      // Picker drives the initial selection.
-      expect(state.selectedVideoTrackId.get()).toBe('360p');
-
-      // Bumping bandwidth re-fires the effect; the slot is no longer empty,
-      // so ABR runs and upgrades to 1080p (at 6 Mbps with default margins).
-      state.bandwidthState.set(createBandwidthState(6_000_001));
-      await flush();
-      expect(state.selectedVideoTrackId.get()).toBe('1080p');
-
-      reactor.destroy();
-    });
-
-    it('picker returning undefined falls back to bandwidth-aware default', async () => {
-      const state = makeState({
-        presentation: createPresentation(tracks),
-        bandwidthState: createBandwidthState(3_000_000),
-      });
-
-      const config: TrackSwitchingConfig = { picker: () => undefined };
-      const reactor = switchVideoTrack.setup({ state, config });
-      await flush();
-      // 3 Mbps with default safetyMargin 0.85 → 720p (1080p needs 5.65 Mbps).
-      expect(state.selectedVideoTrackId.get()).toBe('720p');
-
-      reactor.destroy();
-    });
-
     it('uses custom minTotalBytes threshold to trust the measured estimate sooner', async () => {
       // 800 kbps measured, only 50 KB sampled — below the default 128 KB
       // threshold (would fall back to initialBandwidth) but above our
@@ -486,11 +447,12 @@ describe('switchVideoTrack', () => {
 // switchAudioTrack
 //
 // The audio variant shares `setupTrackSwitching` with `switchVideoTrack` —
-// these tests cover the audio-specific surface: default picker, language
-// pinning, filter reactivity, single-candidate short-circuit. The
-// bandwidth-driven re-evaluation tests live above under `switchVideoTrack`
-// and don't need duplicating; audio's `selectAudioCurrent` pins to the
-// current track and is exercised here by the steady-state assertions.
+// these tests cover the audio-specific surface: default pick (first track),
+// language pinning via the user-selection filter, filter reactivity, and the
+// single-candidate early-bail. The bandwidth-driven re-evaluation tests live
+// above under `switchVideoTrack` and don't need duplicating; audio's
+// `selectAudioCurrent` pins to the current track and is exercised here by the
+// steady-state assertions.
 // ============================================================================
 
 interface SwitchAudioTrackState {
@@ -568,22 +530,6 @@ describe('switchAudioTrack', () => {
     reactor.destroy();
   });
 
-  it('picks track matching preferredAudioLanguage when supplied', async () => {
-    const state = makeAudioState({
-      presentation: createAudioPresentation([
-        makeAudioTrack('audio-en', { language: 'en' }),
-        makeAudioTrack('audio-es', { language: 'es' }),
-      ]),
-    });
-
-    const reactor = switchAudioTrack.setup({ state, config: { preferredAudioLanguage: 'es' } });
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(state.selectedAudioTrackId.get()).toBe('audio-es');
-
-    reactor.destroy();
-  });
-
   it('clears selectedAudioTrackId on src unload', async () => {
     const state = makeAudioState({
       presentation: createAudioPresentation([makeAudioTrack('audio-en', { language: 'en' })]),
@@ -642,7 +588,7 @@ describe('switchAudioTrack — userAudioTrackSelection filter', () => {
     reactor.destroy();
   });
 
-  it('filter narrowing to a single track short-circuits the picker', async () => {
+  it('filter narrowing to a single track early-bails to that track', async () => {
     const state = makeAudioState({
       presentation: createAudioPresentation([
         makeAudioTrack('audio-en', { language: 'en' }),

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -150,6 +150,28 @@ describe('switchVideoTrack', () => {
 
       reactor.destroy();
     });
+
+    it('re-picks when the candidate set changes while staying resolved (constraint-readiness seam)', async () => {
+      // The playable candidate set is derived in a `computed` the effect reads
+      // reactively, so the pick updates whenever that set changes — not only on
+      // an unresolved→resolved gate transition. This is what readies the
+      // behavior for dynamic constraints (e.g. CDN failover) that re-prune the
+      // set while a presentation stays resolved.
+      const state = makeState({ presentation: createPresentation(tracks) });
+
+      const reactor = switchVideoTrack.setup({ state });
+      await flush();
+      expect(state.selectedVideoTrackId.get()).toBe('720p');
+
+      // Swap directly to a different resolved presentation (no undefined gap, so
+      // the gate state stays 'presentation-resolved' and never re-enters).
+      const narrowed = [createVideoTrack('480p', 1_200_000), createVideoTrack('540p', 1_500_000)];
+      state.presentation.set({ ...createPresentation(narrowed), id: 'pres-2' });
+      await flush();
+      expect(state.selectedVideoTrackId.get()).toBe('540p');
+
+      reactor.destroy();
+    });
   });
 
   describe('default-pick (no bandwidthState yet)', () => {

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -88,7 +88,7 @@ export interface TrackSwitchingState {
 
 /**
  * Config for `switchVideoTrack` — the ABR tuning read by its ranker rule
- * (`rankByQuality`). `quality.safetyMargin` is the bandwidth-headroom
+ * (`rankByBandwidth`). `quality.safetyMargin` is the bandwidth-headroom
  * multiplier; `quality.upgradeMargin` the hysteresis ratio gating upgrades;
  * `bandwidth` tunes the estimator; `initialBandwidth` is the pre-sample
  * fallback. Defaults: `DEFAULT_QUALITY_CONFIG` (0.85 / 1.15),
@@ -201,9 +201,14 @@ type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
 // it in detaches the user-selection mapped value from `P` and TS collapses
 // the intersection. T flows through `TrackSwitchingSetupConfig` instead;
 // the user-filter access casts at the read site (see below).
+//
+// `bandwidthState` is intentionally absent: only the bandwidth ranker rule
+// reads it, not the behavior's lifecycle. A rule needing a signal the behavior
+// doesn't use declares it *optional* on its own deps and reads it defensively
+// (see `BandwidthRankerStateMap`), so the behavior never assumes a rule-only
+// signal exists.
 type TrackSwitchingStateMap<S extends SelectionKey, U extends UserSelectionKey> = {
   presentation: ReadonlySignal<TrackSwitchingState['presentation']>;
-  bandwidthState: ReadonlySignal<TrackSwitchingState['bandwidthState']>;
 } & { [P in S]: Signal<TrackSwitchingState[P]> } & { [P in U]: ReadonlySignal<TrackSwitchingState[P]> };
 
 /**
@@ -233,6 +238,18 @@ type TrackSwitchingRuleDeps<
   U extends UserSelectionKey,
   T extends SwitchableTrack,
 > = SelectionRuleDeps<TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>;
+
+/**
+ * State a bandwidth ranker reads: the behavior's lifecycle map plus an
+ * *optional* `bandwidthState`. The signal exists only when the composition
+ * includes a bandwidth sampler; the ranker reads it defensively and falls back
+ * to `initialBandwidth` (with a debug note) when it's absent. A behavior state
+ * map without `bandwidthState` is assignable here (the slot is optional), so a
+ * ranker drops into a chain whose behavior never declared the signal.
+ */
+type BandwidthRankerStateMap<S extends SelectionKey, U extends UserSelectionKey> = TrackSwitchingStateMap<S, U> & {
+  bandwidthState?: ReadonlySignal<TrackSwitchingState['bandwidthState']>;
+};
 
 type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
 type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
@@ -276,13 +293,18 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
  */
 function rankByBandwidth<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
-  { state, config }: TrackSwitchingRuleDeps<S, U, T>
+  { state, config }: SelectionRuleDeps<BandwidthRankerStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
 ): readonly T[] {
   const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
   const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
   const initialBandwidth = config.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
   const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...config.bandwidth };
-  const threshold = getBandwidthEstimate(state.bandwidthState.get(), initialBandwidth, bandwidthConfig) * safetyMargin;
+  if (!state.bandwidthState) {
+    console.debug(
+      '[track-switching] rankByBandwidth: no bandwidthState signal in composition; ranking on initialBandwidth'
+    );
+  }
+  const threshold = getBandwidthEstimate(state.bandwidthState?.get(), initialBandwidth, bandwidthConfig) * safetyMargin;
   const currentId = state[config.selectionKey].get();
   const bitrate = (track: T) => track.bandwidth ?? 0;
   // Boost the current track's sort weight by upgradeMargin (fitting set only) so
@@ -368,7 +390,7 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
  * const reactor = switchVideoTrack.setup({ state });
  */
 export const switchVideoTrack = defineBehavior({
-  stateKeys: ['presentation', 'bandwidthState', 'selectedVideoTrackId', 'userVideoTrackSelection'],
+  stateKeys: ['presentation', 'selectedVideoTrackId', 'userVideoTrackSelection'],
   contextKeys: [],
   setup: ({
     state,
@@ -409,7 +431,7 @@ export const switchVideoTrack = defineBehavior({
  * const reactor = switchAudioTrack.setup({ state });
  */
 export const switchAudioTrack = defineBehavior({
-  stateKeys: ['presentation', 'bandwidthState', 'selectedAudioTrackId', 'userAudioTrackSelection'],
+  stateKeys: ['presentation', 'selectedAudioTrackId', 'userAudioTrackSelection'],
   contextKeys: [],
   setup: ({
     state,

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -11,9 +11,9 @@
  *
  *   1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
  *      partial-track match; an empty match falls through to the full set.
- *   2. **ranking** — the terminal sort: the per-variant `selectOptimal` over
- *      the bandwidth estimate (video ABR with hysteresis — downgrades immediate,
- *      upgrades gated by `upgradeMargin`; audio pin-to-current).
+ *   2. **ranking** — the terminal sort: a per-variant ranker rule (video
+ *      `rankByQuality` — ABR with hysteresis, downgrades immediate, upgrades
+ *      gated by `upgradeMargin`; audio `pinToCurrentTrack`).
  *
  * The composer's early-bail (one survivor → stop) is load-bearing: a user
  * selection that narrows to a single track is the pick without the ranker
@@ -24,11 +24,11 @@
  * resolved state owns the signal; its entry-returned cleanup clears it on exit
  * (canonical cleanup-binds-to-setup per `reactors.md`).
  *
- * The pick is the head of the chain's result (`applyRules(...)[0]`). Variants:
- * `switchVideoTrack` (bandwidth-driven ranker), `switchAudioTrack` (pin-to-
- * current ranker, ABR-ready for when audio-ABR lands); both share
- * `setupTrackSwitching`, with the candidate type and `selectOptimal` as the
- * variation points.
+ * The pick is the head of the chain's result (`applyRules(...)[0]`). Each
+ * variant supplies its **rule chain** via config; `setupTrackSwitching` owns
+ * only the lifecycle and runs whatever chain it's given. Variants:
+ * `switchVideoTrack` (bandwidth-driven ranker, ABR tuning config),
+ * `switchAudioTrack` (pin-to-current ranker, no config yet).
  *
  * Deferred (not yet in the chain): a hard-constraints pre-pass (capability
  * probing, CDN failover) gating the candidate set, and audio's preferred-
@@ -90,37 +90,18 @@ export interface TrackSwitchingState {
   userAudioTrackSelection?: Partial<AudioTrack>;
 }
 
-export interface TrackSwitchingConfig {
-  /**
-   * Quality-selection tuning consumed by bandwidth-driven `selectOptimal`
-   * variants (today: `switchVideoTrack`'s `selectQuality`). `safetyMargin`
-   * is the bandwidth-headroom multiplier; `upgradeMargin` is the
-   * hysteresis ratio gating upgrades. Defaults: `DEFAULT_QUALITY_CONFIG`
-   * (0.85 / 1.15). Ignored by pin-to-current variants
-   * (today: `switchAudioTrack`).
-   */
+/**
+ * Config for `switchVideoTrack` — the ABR tuning read by its ranker rule
+ * (`rankByQuality`). `quality.safetyMargin` is the bandwidth-headroom
+ * multiplier; `quality.upgradeMargin` the hysteresis ratio gating upgrades;
+ * `bandwidth` tunes the estimator; `initialBandwidth` is the pre-sample
+ * fallback. Defaults: `DEFAULT_QUALITY_CONFIG` (0.85 / 1.15),
+ * `DEFAULT_BANDWIDTH_CONFIG`, `DEFAULT_INITIAL_BANDWIDTH` (5 Mbps).
+ */
+export interface SwitchVideoTrackConfig {
   quality?: Partial<QualityConfig>;
-
-  /**
-   * Bandwidth-estimator tuning passed through to `getBandwidthEstimate`.
-   * Merged over `DEFAULT_BANDWIDTH_CONFIG`. Consumed only by bandwidth-
-   * driven variants.
-   */
   bandwidth?: Partial<BandwidthConfig>;
-
-  /**
-   * Bandwidth estimate in bps to use before enough samples have been
-   * collected. Default: 5_000_000 (5 Mbps).
-   */
   initialBandwidth?: number;
-
-  /**
-   * Audio-variant config — preferred audio language. Currently **unconsumed**:
-   * its previous consumer (the default audio picker) was removed when the
-   * initial pick became the rule chain's head; it returns when preferred-
-   * language lands as a standing soft-filter rule. Engines still surface it.
-   */
-  preferredAudioLanguage?: string;
 }
 
 /** Default initial-bandwidth value before bandwidth measurements arrive. */
@@ -187,7 +168,7 @@ export function applyRules<T, State, Context, Config>(
 // `setupTrackSwitching` has the same shape as a Behavior `setup` function:
 // `({ state, config }) => Reactor`. Each `switchXTrack` export below calls
 // it from inside its own `defineBehavior` setup, passing the per-type slot
-// keys, track type, and selection algorithm via three generic parameters —
+// keys, candidate track type, and rule chain via three generic parameters —
 // `S` (selection slot key), `U` (user-selection slot key), `T` (candidate
 // track type).
 //
@@ -228,28 +209,20 @@ type TrackSwitchingStateMap<S extends SelectionKey, U extends UserSelectionKey> 
 } & { [P in S]: Signal<TrackSwitchingState[P]> } & { [P in U]: ReadonlySignal<TrackSwitchingState[P]> };
 
 /**
- * Selection context passed to `selectOptimal`. Built once per effect run.
- * Bandwidth-aware variants (video ABR, future audio ABR) read all fields;
- * pin-to-current variants (audio today) ignore the bandwidth-shaped fields.
- *
- * The context is built *inside* the effect, so bandwidth-aware variants
- * subscribe to `bandwidthState` automatically; pin-to-current variants
- * receive the same context but never re-fire on bandwidth changes because
- * the single-candidate short-circuit (above) bypasses the bandwidth read.
+ * Config `setupTrackSwitching` receives — the per-variant wiring: which slots
+ * to read/write (`selectionKey` / `userSelectionKey`), how to enumerate the
+ * candidate tracks (`getTracks`), and the **rule chain** to run. ABR tuning is
+ * optional and read only by the video ranker rule (`rankByQuality`); audio
+ * leaves it unset.
  */
-export interface SelectionCtx<T extends SwitchableTrack> {
-  bandwidth: number;
-  safetyMargin: number;
-  upgradeMargin: number;
-  currentTrack?: T;
-}
-
-interface TrackSwitchingSetupConfig<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>
-  extends TrackSwitchingConfig {
+interface TrackSwitchingSetupConfig<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack> {
   selectionKey: S;
   userSelectionKey: U;
   getTracks: (presentation: MaybeResolvedPresentation) => readonly T[];
-  selectOptimal: (tracks: readonly T[], ctx: SelectionCtx<T>) => T | undefined;
+  rules: readonly SelectionRule<T, TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>[];
+  quality?: Partial<QualityConfig>;
+  bandwidth?: Partial<BandwidthConfig>;
+  initialBandwidth?: number;
 }
 
 /**
@@ -262,6 +235,9 @@ type TrackSwitchingRuleDeps<
   U extends UserSelectionKey,
   T extends SwitchableTrack,
 > = SelectionRuleDeps<TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>;
+
+type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
+type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
 
 // ----------------------------------------------------------------------------
 // Rules — defined outside the behavior closure, parameterized only by their
@@ -284,16 +260,16 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
 }
 
 /**
- * Ranking — the terminal sort. Reads the bandwidth estimate, runs the
- * per-variant `selectOptimal` (video ABR with hysteresis; audio pin-to-
- * current), and returns the list with the pick at the head. Early-bail skips
- * this rule when a prior one narrowed to a single track, so the bandwidth
- * estimate is neither read nor subscribed while that choice holds.
+ * Video ranking — the terminal sort. Reads the bandwidth estimate + ABR tuning
+ * from config, runs `selectQuality` (hysteresis: downgrades immediate, upgrades
+ * gated by `upgradeMargin`), and returns the list with the pick at the head.
+ * Early-bail skips this rule when a prior one narrowed to a single track, so the
+ * bandwidth estimate is neither read nor subscribed while that choice holds.
  */
-function rankByOptimal<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
-  tracks: readonly T[],
-  { state, config }: TrackSwitchingRuleDeps<S, U, T>
-): readonly T[] {
+function rankByQuality<S extends SelectionKey, U extends UserSelectionKey>(
+  tracks: readonly VideoTrackCandidate[],
+  { state, config }: TrackSwitchingRuleDeps<S, U, VideoTrackCandidate>
+): readonly VideoTrackCandidate[] {
   const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
   const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
   const initialBandwidth = config.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
@@ -301,9 +277,23 @@ function rankByOptimal<S extends SelectionKey, U extends UserSelectionKey, T ext
   const bandwidth = getBandwidthEstimate(state.bandwidthState.get(), initialBandwidth, bandwidthConfig);
   const currentTrack = tracks.find((track) => track.id === state[config.selectionKey].get());
   const optimal =
-    config.selectOptimal(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
+    selectQuality(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
     selectLowestQualityWithBandwidth(tracks);
   return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
+}
+
+/**
+ * Pin-to-current ranking — keeps the currently-selected track if it's still a
+ * candidate, otherwise takes the first. The non-ABR ranker (audio today); reads
+ * no bandwidth, so it never subscribes the effect to bandwidth changes.
+ */
+function pinToCurrentTrack<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
+  tracks: readonly T[],
+  { state, config }: TrackSwitchingRuleDeps<S, U, T>
+): readonly T[] {
+  const currentTrack = tracks.find((track) => track.id === state[config.selectionKey].get());
+  const pick = currentTrack ?? tracks[0];
+  return pick ? [pick, ...tracks.filter((track) => track !== pick)] : tracks;
 }
 
 // `context` is the composition's context map, threaded in by each variant's
@@ -321,15 +311,7 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
   context?: AnySlotMap;
   config: TrackSwitchingSetupConfig<S, U, T>;
 }) {
-  const { selectionKey, getTracks } = config;
-
-  // Selection chain, most authoritative first. The rules live at module scope
-  // (closure-free — they read only their deps); the variant's concrete keys
-  // instantiate them here.
-  const rules: SelectionRule<T, TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>[] = [
-    filterByUserSelection,
-    rankByOptimal,
-  ];
+  const { selectionKey, getTracks, rules } = config;
 
   const derivedStateSignal = computed(() =>
     isResolvedPresentation(state.presentation.get())
@@ -343,10 +325,9 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
     states: {
       'presentation-unresolved': {},
       'presentation-resolved': {
-        // Canonical cleanup-binds-to-setup: the selection slot's valid
-        // lifespan is exactly 'presentation-resolved'. Clear fires on
-        // 'presentation-resolved' exit, covering both src unload and
-        // behavior destroy.
+        // Canonical cleanup-binds-to-setup: the selection signal's valid
+        // lifespan is exactly 'presentation-resolved'. Clear fires on exit,
+        // covering both src unload and behavior destroy.
         entry: () => () => state[selectionKey].set(undefined),
         effects: [
           () => {
@@ -356,10 +337,9 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             const allTracks = getTracks(presentation);
             if (!allTracks.length) return;
 
-            // state, context, and config all flow to every rule. context comes
-            // from the composition (threaded in by the variant's rest-spread);
-            // today's rules don't consult it, but it's in place for one that
-            // will (e.g. a CDN-pathway rule reading context).
+            // state + config come from the behavior's deps; context arrives from
+            // the composition (threaded in by the variant's rest-spread). Each is
+            // passed to every rule in the variant-supplied chain.
             const candidates = applyRules(rules, allTracks, { state, context, config });
 
             // applyRules early-bails to a single survivor and never narrows to
@@ -384,8 +364,6 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
 // Variant: switchVideoTrack — bandwidth-driven ABR
 // ============================================================================
 
-type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
-
 /**
  * Manage `selectedVideoTrackId`: pick a default on src load, dynamically
  * adjust based on bandwidth, clear on src unload. Honors
@@ -404,7 +382,7 @@ export const switchVideoTrack = defineBehavior({
     ...otherProps
   }: {
     state: TrackSwitchingStateMap<'selectedVideoTrackId', 'userVideoTrackSelection'>;
-    config?: TrackSwitchingConfig;
+    config?: SwitchVideoTrackConfig;
   }) =>
     setupTrackSwitching<'selectedVideoTrackId', 'userVideoTrackSelection', VideoTrackCandidate>({
       ...otherProps,
@@ -414,7 +392,7 @@ export const switchVideoTrack = defineBehavior({
         selectionKey: 'selectedVideoTrackId',
         userSelectionKey: 'userVideoTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'video') as readonly VideoTrackCandidate[],
-        selectOptimal: selectQuality,
+        rules: [filterByUserSelection, rankByQuality],
       },
     }),
 });
@@ -422,20 +400,6 @@ export const switchVideoTrack = defineBehavior({
 // ============================================================================
 // Variant: switchAudioTrack — pin-to-current (ABR-ready shape)
 // ============================================================================
-
-type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
-
-/**
- * Audio's `selectOptimal` — pin-to-current variant. Returns the current
- * track if it's in the candidate set; otherwise the first candidate. No
- * bandwidth-driven re-evaluation today (audio is not ABR-driven yet); the
- * `ctx` shape carries bandwidth so audio-ABR can swap this for a
- * bandwidth-aware variant without touching the helper.
- */
-const selectAudioCurrent = (
-  tracks: readonly AudioTrackCandidate[],
-  { currentTrack }: SelectionCtx<AudioTrackCandidate>
-): AudioTrackCandidate | undefined => currentTrack ?? tracks[0];
 
 /**
  * Manage `selectedAudioTrackId`: pick a default on src load, narrow by
@@ -455,21 +419,18 @@ export const switchAudioTrack = defineBehavior({
   contextKeys: [],
   setup: ({
     state,
-    config,
     ...otherProps
   }: {
     state: TrackSwitchingStateMap<'selectedAudioTrackId', 'userAudioTrackSelection'>;
-    config?: TrackSwitchingConfig;
   }) =>
     setupTrackSwitching<'selectedAudioTrackId', 'userAudioTrackSelection', AudioTrackCandidate>({
       ...otherProps,
       state,
       config: {
-        ...config,
         selectionKey: 'selectedAudioTrackId',
         userSelectionKey: 'userAudioTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'audio') as readonly AudioTrackCandidate[],
-        selectOptimal: selectAudioCurrent,
+        rules: [filterByUserSelection, pinToCurrentTrack],
       },
     }),
 });

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -35,7 +35,7 @@
  * preferred-language / default-track logic to standing soft-filter rules.
  */
 
-import { defineBehavior } from '../../core/composition/create-composition';
+import { type AnySlotMap, defineBehavior } from '../../core/composition/create-composition';
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
 import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
 import {
@@ -262,45 +262,77 @@ interface TrackSwitchingSetupConfig<S extends SelectionKey, U extends UserSelect
   selectOptimal: (tracks: readonly T[], ctx: SelectionCtx<T>) => T | undefined;
 }
 
+/**
+ * Deps shape every track-switching rule consumes. Context conforms to the
+ * generic slot-map shape (`AnySlotMap`) — threaded through but with no keys
+ * read today, ready for a rule that consults context (e.g. CDN pathway).
+ */
+type TrackSwitchingRuleDeps<
+  S extends SelectionKey,
+  U extends UserSelectionKey,
+  T extends SwitchableTrack,
+> = SelectionRuleDeps<TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>;
+
+// ----------------------------------------------------------------------------
+// Rules — defined outside the behavior closure, parameterized only by their
+// deps. Each is generic over the slot keys + track type; the variant's
+// concrete keys instantiate it where the chain is assembled.
+// ----------------------------------------------------------------------------
+
+/**
+ * User intent — a soft filter. Narrows to tracks matching the partial-track
+ * selection in `user*TrackSelection`; an empty match falls through (the
+ * composer skips it) to the unfiltered set — e.g. a stale id from a previous
+ * source.
+ */
+function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
+  tracks: readonly T[],
+  { state, config }: TrackSwitchingRuleDeps<S, U, T>
+): readonly T[] {
+  const filter = state[config.userSelectionKey].get() as Partial<T> | undefined;
+  return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
+}
+
+/**
+ * Ranking — the terminal sort. Reads the bandwidth estimate, runs the
+ * per-variant `selectOptimal` (video ABR with hysteresis; audio pin-to-
+ * current), and returns the list with the pick at the head. Early-bail skips
+ * this rule when a prior one narrowed to a single track, so the bandwidth
+ * estimate is neither read nor subscribed while that choice holds.
+ */
+function rankByOptimal<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
+  tracks: readonly T[],
+  { state, config }: TrackSwitchingRuleDeps<S, U, T>
+): readonly T[] {
+  const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
+  const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
+  const initialBandwidth = config.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
+  const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...config.bandwidth };
+  const bandwidth = getBandwidthEstimate(state.bandwidthState.get(), initialBandwidth, bandwidthConfig);
+  const currentTrack = tracks.find((track) => track.id === state[config.selectionKey].get());
+  const optimal =
+    config.selectOptimal(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
+    selectLowestQualityWithBandwidth(tracks);
+  return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
+}
+
 function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>({
   state,
+  context = {},
   config,
 }: {
   state: TrackSwitchingStateMap<S, U>;
+  context?: AnySlotMap;
   config: TrackSwitchingSetupConfig<S, U, T>;
 }) {
   const { selectionKey, getTracks } = config;
 
-  // The selection chain, most authoritative first. Each rule reads the state
-  // signals and config values it needs from the deps passed at apply time —
-  // nothing grabbed from this closure — so the effect subscribes to exactly
-  // what the applied rules consult and a rule stays relocatable.
-  type RuleConfig = TrackSwitchingSetupConfig<S, U, T>;
-  const rules: SelectionRule<T, TrackSwitchingStateMap<S, U>, Record<never, never>, RuleConfig>[] = [
-    // User intent — a soft filter. Narrows to tracks matching the partial-track
-    // selection; an empty match falls through (the composer skips it) to the
-    // unfiltered set — e.g. a stale id from a previous source.
-    (tracks, { state: ruleState, config: ruleConfig }) => {
-      const filter = ruleState[ruleConfig.userSelectionKey].get() as Partial<T> | undefined;
-      return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
-    },
-    // Ranking — the terminal sort. Reads the bandwidth estimate, runs the
-    // per-variant `selectOptimal` (video ABR with hysteresis; audio
-    // pin-to-current), and returns the list with the pick at the head. Early-
-    // bail skips this rule when a prior one narrowed to a single track, so the
-    // bandwidth estimate is neither read nor subscribed while that choice holds.
-    (tracks, { state: ruleState, config: ruleConfig }) => {
-      const safetyMargin = ruleConfig.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
-      const upgradeMargin = ruleConfig.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
-      const initialBandwidth = ruleConfig.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
-      const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...ruleConfig.bandwidth };
-      const bandwidth = getBandwidthEstimate(ruleState.bandwidthState.get(), initialBandwidth, bandwidthConfig);
-      const currentTrack = tracks.find((track) => track.id === ruleState[ruleConfig.selectionKey].get());
-      const optimal =
-        ruleConfig.selectOptimal(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
-        selectLowestQualityWithBandwidth(tracks);
-      return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
-    },
+  // Selection chain, most authoritative first. The rules live at module scope
+  // (closure-free — they read only their deps); the variant's concrete keys
+  // instantiate them here.
+  const rules: SelectionRule<T, TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>[] = [
+    filterByUserSelection,
+    rankByOptimal,
   ];
 
   const derivedStateSignal = computed(() =>
@@ -328,10 +360,11 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             const allTracks = getTracks(presentation);
             if (!allTracks.length) return;
 
-            // Rules read only state signals today; context and config thread
-            // through unused for rules that will need them (a CDN-pathway rule
-            // reading context, a rule reading engine config).
-            const candidates = applyRules(rules, allTracks, { state, context: {}, config });
+            // state + config come from the behavior's deps; context is typed as
+            // the generic slot-map shape and passed to every rule, but sourced
+            // empty for now — wiring it from composition waits until a rule (and
+            // the behavior's contextKeys) declares real context keys.
+            const candidates = applyRules(rules, allTracks, { state, context, config });
             const selectedId = state[selectionKey].get();
 
             // A single survivor — an early-bail from the chain, or a single-

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -113,11 +113,13 @@ export const DEFAULT_INITIAL_BANDWIDTH = 5_000_000;
 
 /**
  * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
- * deps so a rule reads from the same surfaces a behavior does.
+ * deps so a rule reads from the same surfaces a behavior does. `context` is
+ * optional — it's threaded through but absent on direct setup calls (and
+ * unread by today's rules), so the whole deps object can pass straight through.
  */
 export interface SelectionRuleDeps<State = unknown, Context = unknown, Config = unknown> {
   state: State;
-  context: Context;
+  context?: Context;
   config: Config;
 }
 
@@ -300,17 +302,14 @@ function pinToCurrentTrack<S extends SelectionKey, U extends UserSelectionKey, T
 // rest-spread and typed as the generic slot-map shape (`AnySlotMap`). It can't
 // be a typed param on the `defineBehavior` setup without widening `ContextMap`
 // to its constraint and forcing the slot required, so the variants forward it
-// untyped via the rest and it lands here; the `{}` default covers direct setup
-// calls (tests) that omit it.
-function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>({
-  state,
-  context = {},
-  config,
-}: {
+// untyped via the rest and it lands here — absent on direct setup calls, and
+// passed straight through to the rules (which don't read it yet).
+function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(deps: {
   state: TrackSwitchingStateMap<S, U>;
   context?: AnySlotMap;
   config: TrackSwitchingSetupConfig<S, U, T>;
 }) {
+  const { state, config } = deps;
   const { selectionKey, getTracks, rules } = config;
 
   const derivedStateSignal = computed(() =>
@@ -337,10 +336,10 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             const allTracks = getTracks(presentation);
             if (!allTracks.length) return;
 
-            // state + config come from the behavior's deps; context arrives from
-            // the composition (threaded in by the variant's rest-spread). Each is
-            // passed to every rule in the variant-supplied chain.
-            const candidates = applyRules(rules, allTracks, { state, context, config });
+            // The whole deps object passes straight through to every rule in the
+            // variant-supplied chain (state + config from the behavior; context
+            // threaded in by the variant's rest-spread).
+            const candidates = applyRules(rules, allTracks, deps);
 
             // applyRules early-bails to a single survivor and never narrows to
             // nothing (a soft filter that would empty the set falls through), so

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -58,32 +58,18 @@ import { DEFAULT_BANDWIDTH_CONFIG, getBandwidthEstimate } from '../../network/ba
 // State + Config
 // ============================================================================
 
+/**
+ * The slots `setupTrackSwitching` itself owns: the `presentation` gate it reads
+ * and the per-type `selected*TrackId` it writes. Rule-only inputs are
+ * deliberately absent — `user*TrackSelection` and `bandwidthState` belong to
+ * whoever materializes them (the embedder via `shareSignals`, the buffer-actor
+ * sampler), and each rule declares the signal it consults as an optional slot
+ * on its own deps map, so the behavior never assumes a rule's signal exists.
+ */
 export interface TrackSwitchingState {
   presentation?: MaybeResolvedPresentation;
-  bandwidthState?: BandwidthState;
   selectedVideoTrackId?: string;
   selectedAudioTrackId?: string;
-  /**
-   * Partial-track description expressing user intent for video. When set,
-   * narrows candidates to tracks matching every present field. Common case
-   * is `{ id: 'specific-track-id' }` for "manual quality"; other shapes
-   * work (e.g., `{ height: 720 }` constrains to 720p tracks — ABR
-   * continues to pick among them).
-   *
-   * When narrowed candidates contain exactly one track, ABR is
-   * short-circuited entirely (no bandwidth read, no effect re-fire).
-   *
-   * Falls back to the unfiltered set when the filter matches no tracks
-   * (e.g., user-picked id from a previous source doesn't exist here).
-   */
-  userVideoTrackSelection?: Partial<VideoTrack>;
-  /**
-   * Partial-track description expressing user intent for audio. Common
-   * case is `{ language: 'es' }` for language-pinning, `{ id: 'X' }` for
-   * absolute pinning. Same narrowing + short-circuit + fallback semantics
-   * as `userVideoTrackSelection`.
-   */
-  userAudioTrackSelection?: Partial<AudioTrack>;
 }
 
 /**
@@ -176,8 +162,8 @@ export function applyRules<T, State, Context, Config>(
 // What blocks it: indexing a mapped-type intersection by a generic key.
 // When `S extends keyof TrackSwitchingState` (or `string`), TS conservatively
 // treats `state[selectionKey]` as the union of every possible match across
-// the intersected mapped portions — including the fixed-key signals
-// (`presentation`, `bandwidthState`) — and widens to their value-type union.
+// the intersected mapped portions — including the fixed-key signal
+// (`presentation`) — and widens to their value-type union.
 // The sibling pattern hits the same constraint and answers it the same way:
 // `SelectedTrackKey` in `select-tracks.ts` is a hardcoded narrow union for
 // the same reason.
@@ -229,12 +215,18 @@ interface TrackSwitchingSetupConfig<S extends SelectionKey, U extends UserSelect
 
 /**
  * State the user-selection filter reads: the lifecycle map plus an *optional*
- * user-selection slot (keyed by `U`). The slot exists only when the composition
- * provides it (materialized by `shareSignals`); the filter reads it defensively
- * and no-ops when it's absent (no user override).
+ * user-selection slot (keyed by `U`), holding a partial-track description to
+ * match against the candidates (`Partial<T>` — `{ id }`, `{ language }`,
+ * `{ height }`, …). The slot exists only when the composition provides it
+ * (materialized by `shareSignals`); the filter reads it defensively and no-ops
+ * when it's absent (no user override).
  */
-type UserSelectionStateMap<S extends SelectionKey, U extends UserSelectionKey> = TrackSwitchingStateMap<S> & {
-  [P in U]?: ReadonlySignal<TrackSwitchingState[P]>;
+type UserSelectionStateMap<
+  S extends SelectionKey,
+  U extends UserSelectionKey,
+  T extends SwitchableTrack,
+> = TrackSwitchingStateMap<S> & {
+  [P in U]?: ReadonlySignal<Partial<T> | undefined>;
 };
 
 /**
@@ -244,7 +236,7 @@ type UserSelectionStateMap<S extends SelectionKey, U extends UserSelectionKey> =
  * `initialBandwidth` (with a debug note) when it's absent.
  */
 type BandwidthRankerStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
-  bandwidthState?: ReadonlySignal<TrackSwitchingState['bandwidthState']>;
+  bandwidthState?: ReadonlySignal<BandwidthState | undefined>;
 };
 
 type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
@@ -264,9 +256,9 @@ type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
  */
 function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
-  { state, config }: SelectionRuleDeps<UserSelectionStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
+  { state, config }: SelectionRuleDeps<UserSelectionStateMap<S, U, T>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
 ): readonly T[] {
-  const filter = state[config.userSelectionKey]?.get() as Partial<T> | undefined;
+  const filter = state[config.userSelectionKey]?.get();
   return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
 }
 

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -269,21 +269,19 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
   state: TrackSwitchingStateMap<S, U>;
   config: TrackSwitchingSetupConfig<S, U, T>;
 }) {
-  const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
-  const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
-  const initialBandwidth = config.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
-  const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...config.bandwidth };
-  const { selectionKey, userSelectionKey, getTracks, selectOptimal } = config;
+  const { selectionKey, getTracks } = config;
 
-  // The selection chain, most authoritative first. Each rule reads the signals
-  // it needs from the state passed at apply time, so the effect subscribes to
-  // exactly what the applied rules consult.
-  const rules: SelectionRule<T, TrackSwitchingStateMap<S, U>>[] = [
+  // The selection chain, most authoritative first. Each rule reads the state
+  // signals and config values it needs from the deps passed at apply time —
+  // nothing grabbed from this closure — so the effect subscribes to exactly
+  // what the applied rules consult and a rule stays relocatable.
+  type RuleConfig = TrackSwitchingSetupConfig<S, U, T>;
+  const rules: SelectionRule<T, TrackSwitchingStateMap<S, U>, Record<never, never>, RuleConfig>[] = [
     // User intent — a soft filter. Narrows to tracks matching the partial-track
     // selection; an empty match falls through (the composer skips it) to the
     // unfiltered set — e.g. a stale id from a previous source.
-    (tracks, { state: ruleState }) => {
-      const filter = ruleState[userSelectionKey].get() as Partial<T> | undefined;
+    (tracks, { state: ruleState, config: ruleConfig }) => {
+      const filter = ruleState[ruleConfig.userSelectionKey].get() as Partial<T> | undefined;
       return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
     },
     // Ranking — the terminal sort. Reads the bandwidth estimate, runs the
@@ -291,11 +289,15 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
     // pin-to-current), and returns the list with the pick at the head. Early-
     // bail skips this rule when a prior one narrowed to a single track, so the
     // bandwidth estimate is neither read nor subscribed while that choice holds.
-    (tracks, { state: ruleState }) => {
+    (tracks, { state: ruleState, config: ruleConfig }) => {
+      const safetyMargin = ruleConfig.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
+      const upgradeMargin = ruleConfig.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
+      const initialBandwidth = ruleConfig.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
+      const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...ruleConfig.bandwidth };
       const bandwidth = getBandwidthEstimate(ruleState.bandwidthState.get(), initialBandwidth, bandwidthConfig);
-      const currentTrack = tracks.find((track) => track.id === ruleState[selectionKey].get());
+      const currentTrack = tracks.find((track) => track.id === ruleState[ruleConfig.selectionKey].get());
       const optimal =
-        selectOptimal(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
+        ruleConfig.selectOptimal(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
         selectLowestQualityWithBandwidth(tracks);
       return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
     },

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -151,10 +151,12 @@ export function applyRules<T, State, Context, Config>(
 //
 // `setupTrackSwitching` has the same shape as a Behavior `setup` function:
 // `({ state, config }) => Reactor`. Each `switchXTrack` export below calls
-// it from inside its own `defineBehavior` setup, passing the per-type slot
-// keys, candidate track type, and rule chain via three generic parameters —
-// `S` (selection slot key), `U` (user-selection slot key), `T` (candidate
-// track type).
+// it from inside its own `defineBehavior` setup. Its generics — `S` (selection
+// slot key), `T` (candidate track type), `C` (the concrete config the variant
+// builds) — all infer from the passed `state` + `config`, so the variants need
+// no explicit type arguments. `C extends TrackSwitchingConfig<S, T>` lets the
+// variant's richer config (rule-specific fields included) flow through the
+// helper untouched; the rules read those fields off their own config views.
 //
 // -- Design note: why narrow `SelectionKey` / `UserSelectionKey` unions ----
 // Goal we did not reach: have callers "fully pass in" the slot keys, with
@@ -183,7 +185,7 @@ type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
 
 // Each mapped value references `P` so TS keeps the per-key dependency and
 // resolves `state[selectionKey]` to the right arm. `T` (track type) stays out
-// of the state map (it flows through `TrackSwitchingSetupConfig` instead).
+// of the state map (it flows through `TrackSwitchingConfig` instead).
 //
 // Only the behavior's own lifecycle signals are required here: the presentation
 // gate and the selection slot it writes. Signals a *rule* reads but the
@@ -198,19 +200,19 @@ type TrackSwitchingStateMap<S extends SelectionKey> = {
 } & { [P in S]: Signal<TrackSwitchingState[P]> };
 
 /**
- * Config `setupTrackSwitching` receives — the per-variant wiring: which slots
- * to read/write (`selectionKey` / `userSelectionKey`), how to enumerate the
- * candidate tracks (`getTracks`), and the **rule chain** to run. ABR tuning is
- * optional and read only by the bandwidth ranker rule (`rankByBandwidth`).
+ * Config `setupTrackSwitching` itself reads — its own wiring: which selection
+ * slot to write and clear (`selectionKey`), how to enumerate candidate tracks
+ * (`getTracks`), and the **rule chain** to run (`rules`). Rule-specific config
+ * is deliberately absent — each rule declares the fields it reads as *optional*
+ * on its own config view (`UserSelectionConfig`, `BandwidthRankerConfig`), so
+ * the behavior never enumerates a rule's config. The variant builds the
+ * concrete config as this base plus whatever its chain's rules consult; it
+ * flows through untouched as the `C` type param on `setupTrackSwitching`.
  */
-interface TrackSwitchingSetupConfig<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack> {
+interface TrackSwitchingConfig<S extends SelectionKey, T extends SwitchableTrack> {
   selectionKey: S;
-  userSelectionKey: U;
   getTracks: (presentation: MaybeResolvedPresentation) => readonly T[];
-  rules: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>[];
-  quality?: Partial<QualityConfig>;
-  bandwidth?: Partial<BandwidthConfig>;
-  initialBandwidth?: number;
+  rules: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>[];
 }
 
 /**
@@ -230,6 +232,18 @@ type UserSelectionStateMap<
 };
 
 /**
+ * Config the user-selection filter reads: `userSelectionKey` names the state
+ * slot holding the user's selection. *Optional* on the rule's view — the base
+ * config doesn't carry it, so an unwired key means "no user selection" and the
+ * filter passes through. The variants always supply it.
+ */
+type UserSelectionConfig<
+  S extends SelectionKey,
+  U extends UserSelectionKey,
+  T extends SwitchableTrack,
+> = TrackSwitchingConfig<S, T> & { userSelectionKey?: U };
+
+/**
  * State the bandwidth ranker reads: the lifecycle map plus an *optional*
  * `bandwidthState`. The signal exists only when the composition includes a
  * bandwidth sampler; the ranker reads it defensively and falls back to
@@ -238,6 +252,13 @@ type UserSelectionStateMap<
 type BandwidthRankerStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
   bandwidthState?: ReadonlySignal<BandwidthState | undefined>;
 };
+
+/**
+ * Config the bandwidth ranker reads: the ABR tuning in `SwitchVideoTrackConfig`
+ * (`quality` / `bandwidth` / `initialBandwidth`), all optional with defaults.
+ */
+type BandwidthRankerConfig<S extends SelectionKey, T extends SwitchableTrack> = TrackSwitchingConfig<S, T> &
+  SwitchVideoTrackConfig;
 
 type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
 type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
@@ -256,9 +277,11 @@ type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
  */
 function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
-  { state, config }: SelectionRuleDeps<UserSelectionStateMap<S, U, T>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
+  { state, config }: SelectionRuleDeps<UserSelectionStateMap<S, U, T>, AnySlotMap, UserSelectionConfig<S, U, T>>
 ): readonly T[] {
-  const filter = state[config.userSelectionKey]?.get();
+  const key = config.userSelectionKey;
+  if (!key) return tracks;
+  const filter = state[key]?.get();
   return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
 }
 
@@ -279,9 +302,9 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
  * rule when a prior one narrowed to a single track, so the estimate is neither
  * read nor subscribed while that holds.
  */
-function rankByBandwidth<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
+function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
-  { state, config }: SelectionRuleDeps<BandwidthRankerStateMap<S>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
+  { state, config }: SelectionRuleDeps<BandwidthRankerStateMap<S>, AnySlotMap, BandwidthRankerConfig<S, T>>
 ): readonly T[] {
   const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
   const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
@@ -309,11 +332,11 @@ function rankByBandwidth<S extends SelectionKey, U extends UserSelectionKey, T e
 // to its constraint and forcing the slot required, so the variants forward it
 // untyped via the rest and it lands here — absent on direct setup calls, and
 // passed straight through to the rules (which don't read it yet).
-function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(deps: {
-  state: TrackSwitchingStateMap<S>;
-  context?: AnySlotMap;
-  config: TrackSwitchingSetupConfig<S, U, T>;
-}) {
+function setupTrackSwitching<
+  S extends SelectionKey,
+  T extends SwitchableTrack,
+  C extends TrackSwitchingConfig<S, T>,
+>(deps: { state: TrackSwitchingStateMap<S>; context?: AnySlotMap; config: C }) {
   const { state, config } = deps;
   const { selectionKey, getTracks, rules } = config;
 
@@ -343,8 +366,14 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
 
             // The whole deps object passes straight through to every rule in the
             // variant-supplied chain (state + config from the behavior; context
-            // threaded in by the variant's rest-spread).
-            const candidates = applyRules(rules, allTracks, deps);
+            // threaded in by the variant's rest-spread). Typed against the base
+            // config — each rule re-declares the extra fields it reads as
+            // optional, and the concrete `C` is assignable to the base.
+            const candidates = applyRules<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>(
+              rules,
+              allTracks,
+              deps
+            );
 
             // applyRules early-bails to a single survivor and never narrows to
             // nothing (a soft filter that would empty the set falls through), so
@@ -388,7 +417,7 @@ export const switchVideoTrack = defineBehavior({
     state: TrackSwitchingStateMap<'selectedVideoTrackId'>;
     config?: SwitchVideoTrackConfig;
   }) =>
-    setupTrackSwitching<'selectedVideoTrackId', 'userVideoTrackSelection', VideoTrackCandidate>({
+    setupTrackSwitching({
       ...otherProps,
       state,
       config: {
@@ -422,7 +451,7 @@ export const switchAudioTrack = defineBehavior({
   stateKeys: ['presentation', 'selectedAudioTrackId'],
   contextKeys: [],
   setup: ({ state, ...otherProps }: { state: TrackSwitchingStateMap<'selectedAudioTrackId'> }) =>
-    setupTrackSwitching<'selectedAudioTrackId', 'userAudioTrackSelection', AudioTrackCandidate>({
+    setupTrackSwitching({
       ...otherProps,
       state,
       config: {

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -316,6 +316,12 @@ function rankByOptimal<S extends SelectionKey, U extends UserSelectionKey, T ext
   return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
 }
 
+// `context` is the composition's context map, threaded in by each variant's
+// rest-spread and typed as the generic slot-map shape (`AnySlotMap`). It can't
+// be a typed param on the `defineBehavior` setup without widening `ContextMap`
+// to its constraint and forcing the slot required, so the variants forward it
+// untyped via the rest and it lands here; the `{}` default covers direct setup
+// calls (tests) that omit it.
 function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>({
   state,
   context = {},
@@ -360,10 +366,10 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             const allTracks = getTracks(presentation);
             if (!allTracks.length) return;
 
-            // state + config come from the behavior's deps; context is typed as
-            // the generic slot-map shape and passed to every rule, but sourced
-            // empty for now — wiring it from composition waits until a rule (and
-            // the behavior's contextKeys) declares real context keys.
+            // state, context, and config all flow to every rule. context comes
+            // from the composition (threaded in by the variant's rest-spread);
+            // today's rules don't consult it, but it's in place for one that
+            // will (e.g. a CDN-pathway rule reading context).
             const candidates = applyRules(rules, allTracks, { state, context, config });
             const selectedId = state[selectionKey].get();
 
@@ -410,11 +416,13 @@ export const switchVideoTrack = defineBehavior({
   setup: ({
     state,
     config,
+    ...otherProps
   }: {
     state: TrackSwitchingStateMap<'selectedVideoTrackId', 'userVideoTrackSelection'>;
     config?: TrackSwitchingConfig;
   }) =>
     setupTrackSwitching<'selectedVideoTrackId', 'userVideoTrackSelection', VideoTrackCandidate>({
+      ...otherProps,
       state,
       config: {
         ...config,
@@ -463,11 +471,13 @@ export const switchAudioTrack = defineBehavior({
   setup: ({
     state,
     config,
+    ...otherProps
   }: {
     state: TrackSwitchingStateMap<'selectedAudioTrackId', 'userAudioTrackSelection'>;
     config?: TrackSwitchingConfig;
   }) =>
     setupTrackSwitching<'selectedAudioTrackId', 'userAudioTrackSelection', AudioTrackCandidate>({
+      ...otherProps,
       state,
       config: {
         ...config,

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -40,7 +40,7 @@
 import { type AnySlotMap, defineBehavior } from '../../core/composition/create-composition';
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
 import { computed, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
-import { DEFAULT_QUALITY_CONFIG, type QualityConfig } from '../../media/abr/quality-selection';
+import { DEFAULT_QUALITY_CONFIG, type QualityConfig, resolutionArea } from '../../media/abr/quality-selection';
 import { matchesPartialTrack } from '../../media/primitives/select-tracks';
 import {
   type AudioTrack,
@@ -177,8 +177,12 @@ export function applyRules<T, State, Context, Config>(
 // --------------------------------------------------------------------------
 // ============================================================================
 
-/** Minimum candidate-track shape consumed by the helper. */
-type SwitchableTrack = { id: string; bandwidth?: number };
+/**
+ * Minimum candidate-track shape consumed by the helper. `bandwidth` feeds the
+ * ranker's throughput sort; `width`/`height` are the equal-bitrate tie-break
+ * (absent on audio, so audio candidates area-compare equal).
+ */
+type SwitchableTrack = { id: string; bandwidth?: number; width?: number; height?: number };
 
 type SelectionKey = 'selectedVideoTrackId' | 'selectedAudioTrackId';
 type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
@@ -297,10 +301,13 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
  * outranks it once it clears `current.bitrate * upgradeMargin` (no flapping on
  * marginal bandwidth gains). Downgrades fall out for free — a current track
  * over the threshold isn't in the fitting set to be boosted, so the best fit (a
- * downgrade) wins immediately. A stable sort, so equal-bitrate tracks (e.g.
- * same-bitrate language variants) keep candidate order. Early-bail skips this
- * rule when a prior one narrowed to a single track, so the estimate is neither
- * read nor subscribed while that holds.
+ * downgrade) wins immediately. Equal-bitrate tracks break by resolution (higher
+ * `width × height` first), so an equal-bitrate ladder never picks a lower-
+ * quality rendition by manifest order; audio tracks carry no dimensions, so
+ * they area-compare equal and a stable sort keeps their candidate order (e.g.
+ * same-bitrate language variants). Early-bail skips this rule when a prior one
+ * narrowed to a single track, so the estimate is neither read nor subscribed
+ * while that holds.
  */
 function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
@@ -321,8 +328,16 @@ function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
   // Boost the current track's sort weight by upgradeMargin (fitting set only) so
   // an upgrade must clear current.bitrate * upgradeMargin to outrank it.
   const rank = (track: T) => (track.id === currentId ? bitrate(track) * upgradeMargin : bitrate(track));
-  const fitting = tracks.filter((track) => bitrate(track) <= threshold).sort((a, b) => rank(b) - rank(a));
-  const over = tracks.filter((track) => bitrate(track) > threshold).sort((a, b) => bitrate(a) - bitrate(b));
+  // Equal bitrate → prefer higher resolution (width × height), so an
+  // equal-bitrate ladder doesn't pick a lower-quality rendition by manifest
+  // order. Audio tracks carry no dimensions, so they area-compare equal and
+  // keep candidate order (stable sort).
+  const fitting = tracks
+    .filter((track) => bitrate(track) <= threshold)
+    .sort((a, b) => rank(b) - rank(a) || resolutionArea(b) - resolutionArea(a));
+  const over = tracks
+    .filter((track) => bitrate(track) > threshold)
+    .sort((a, b) => bitrate(a) - bitrate(b) || resolutionArea(b) - resolutionArea(a));
   return [...fitting, ...over];
 }
 

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -11,9 +11,10 @@
  *
  *   1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
  *      partial-track match; an empty match falls through to the full set.
- *   2. **ranking** — the terminal sort: a per-variant ranker rule (video
- *      `rankByQuality` — ABR with hysteresis, downgrades immediate, upgrades
- *      gated by `upgradeMargin`; audio `pinToCurrentTrack`).
+ *   2. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and
+ *      audio. Fitting tracks (within the throughput threshold) first, highest
+ *      bitrate first; over-throughput tracks after, least-over first. Hysteresis
+ *      via boosting the current track's sort weight by `upgradeMargin`.
  *
  * The composer's early-bail (one survivor → stop) is load-bearing: a user
  * selection that narrows to a single track is the pick without the ranker
@@ -26,9 +27,9 @@
  *
  * The pick is the head of the chain's result (`applyRules(...)[0]`). Each
  * variant supplies its **rule chain** via config; `setupTrackSwitching` owns
- * only the lifecycle and runs whatever chain it's given. Variants:
- * `switchVideoTrack` (bandwidth-driven ranker, ABR tuning config),
- * `switchAudioTrack` (pin-to-current ranker, no config yet).
+ * only the lifecycle and runs whatever chain it's given. Both variants today run
+ * `[filterByUserSelection, rankByBandwidth]`; `switchVideoTrack` also accepts ABR
+ * tuning config, `switchAudioTrack` takes none.
  *
  * Deferred (not yet in the chain): a hard-constraints pre-pass (capability
  * probing, CDN failover) gating the candidate set, and audio's preferred-
@@ -39,12 +40,7 @@
 import { type AnySlotMap, defineBehavior } from '../../core/composition/create-composition';
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
 import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
-import {
-  DEFAULT_QUALITY_CONFIG,
-  type QualityConfig,
-  selectLowestQualityWithBandwidth,
-  selectQuality,
-} from '../../media/abr/quality-selection';
+import { DEFAULT_QUALITY_CONFIG, type QualityConfig } from '../../media/abr/quality-selection';
 import { matchesPartialTrack } from '../../media/primitives/select-tracks';
 import {
   type AudioTrack,
@@ -262,40 +258,39 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
 }
 
 /**
- * Video ranking — the terminal sort. Reads the bandwidth estimate + ABR tuning
- * from config, runs `selectQuality` (hysteresis: downgrades immediate, upgrades
- * gated by `upgradeMargin`), and returns the list with the pick at the head.
- * Early-bail skips this rule when a prior one narrowed to a single track, so the
- * bandwidth estimate is neither read nor subscribed while that choice holds.
+ * Bandwidth ranking — the terminal sort, shared by video and audio. Orders by
+ * the throughput estimate: tracks within the bandwidth threshold first
+ * (fitting), highest bitrate first; then over-threshold tracks, least-over
+ * first. The head is the best-quality track that fits, falling back to the
+ * smallest over-throughput track when nothing fits.
+ *
+ * Hysteresis without temporal state: the current track's effective bitrate is
+ * boosted by `upgradeMargin` in the fitting sort, so a higher track only
+ * outranks it once it clears `current.bitrate * upgradeMargin` (no flapping on
+ * marginal bandwidth gains). Downgrades fall out for free — a current track
+ * over the threshold isn't in the fitting set to be boosted, so the best fit (a
+ * downgrade) wins immediately. A stable sort, so equal-bitrate tracks (e.g.
+ * same-bitrate language variants) keep candidate order. Early-bail skips this
+ * rule when a prior one narrowed to a single track, so the estimate is neither
+ * read nor subscribed while that holds.
  */
-function rankByQuality<S extends SelectionKey, U extends UserSelectionKey>(
-  tracks: readonly VideoTrackCandidate[],
-  { state, config }: TrackSwitchingRuleDeps<S, U, VideoTrackCandidate>
-): readonly VideoTrackCandidate[] {
+function rankByBandwidth<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
+  tracks: readonly T[],
+  { state, config }: TrackSwitchingRuleDeps<S, U, T>
+): readonly T[] {
   const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
   const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
   const initialBandwidth = config.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
   const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...config.bandwidth };
-  const bandwidth = getBandwidthEstimate(state.bandwidthState.get(), initialBandwidth, bandwidthConfig);
-  const currentTrack = tracks.find((track) => track.id === state[config.selectionKey].get());
-  const optimal =
-    selectQuality(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
-    selectLowestQualityWithBandwidth(tracks);
-  return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
-}
-
-/**
- * Pin-to-current ranking — keeps the currently-selected track if it's still a
- * candidate, otherwise takes the first. The non-ABR ranker (audio today); reads
- * no bandwidth, so it never subscribes the effect to bandwidth changes.
- */
-function pinToCurrentTrack<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
-  tracks: readonly T[],
-  { state, config }: TrackSwitchingRuleDeps<S, U, T>
-): readonly T[] {
-  const currentTrack = tracks.find((track) => track.id === state[config.selectionKey].get());
-  const pick = currentTrack ?? tracks[0];
-  return pick ? [pick, ...tracks.filter((track) => track !== pick)] : tracks;
+  const threshold = getBandwidthEstimate(state.bandwidthState.get(), initialBandwidth, bandwidthConfig) * safetyMargin;
+  const currentId = state[config.selectionKey].get();
+  const bitrate = (track: T) => track.bandwidth ?? 0;
+  // Boost the current track's sort weight by upgradeMargin (fitting set only) so
+  // an upgrade must clear current.bitrate * upgradeMargin to outrank it.
+  const rank = (track: T) => (track.id === currentId ? bitrate(track) * upgradeMargin : bitrate(track));
+  const fitting = tracks.filter((track) => bitrate(track) <= threshold).sort((a, b) => rank(b) - rank(a));
+  const over = tracks.filter((track) => bitrate(track) > threshold).sort((a, b) => bitrate(a) - bitrate(b));
+  return [...fitting, ...over];
 }
 
 // `context` is the composition's context map, threaded in by each variant's
@@ -391,13 +386,13 @@ export const switchVideoTrack = defineBehavior({
         selectionKey: 'selectedVideoTrackId',
         userSelectionKey: 'userVideoTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'video') as readonly VideoTrackCandidate[],
-        rules: [filterByUserSelection, rankByQuality],
+        rules: [filterByUserSelection, rankByBandwidth],
       },
     }),
 });
 
 // ============================================================================
-// Variant: switchAudioTrack — pin-to-current (ABR-ready shape)
+// Variant: switchAudioTrack — bandwidth-ranked (shared ranker)
 // ============================================================================
 
 /**
@@ -429,7 +424,7 @@ export const switchAudioTrack = defineBehavior({
         selectionKey: 'selectedAudioTrackId',
         userSelectionKey: 'userAudioTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'audio') as readonly AudioTrackCandidate[],
-        rules: [filterByUserSelection, pinToCurrentTrack],
+        rules: [filterByUserSelection, rankByBandwidth],
       },
     }),
 });

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -141,17 +141,26 @@ export const DEFAULT_INITIAL_BANDWIDTH = 5_000_000;
 // ============================================================================
 
 /**
- * A selection rule narrows or reorders the candidate list. It reads the state
- * and context signals it needs at apply time (tightly-coupled reads), so a
+ * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
+ * deps so a rule reads from the same surfaces a behavior does.
+ */
+export interface SelectionRuleDeps<State = unknown, Context = unknown, Config = unknown> {
+  state: State;
+  context: Context;
+  config: Config;
+}
+
+/**
+ * A selection rule narrows or reorders the candidate list. It reads the state,
+ * context, and config it needs at apply time (tightly-coupled reads), so a
  * rule's `.get()`s subscribe the running effect to exactly what it consulted.
  * Returning an empty list means "no match" — the composer skips it, so a soft
  * filter never narrows the set to nothing. A ranker returns the list with its
  * pick at the head.
  */
-export type SelectionRule<T, State = unknown, Context = unknown> = (
+export type SelectionRule<T, State = unknown, Context = unknown, Config = unknown> = (
   tracks: readonly T[],
-  state: State,
-  context: Context
+  deps: SelectionRuleDeps<State, Context, Config>
 ) => readonly T[];
 
 /**
@@ -164,19 +173,17 @@ export type SelectionRule<T, State = unknown, Context = unknown> = (
  *
  * @param rules - Rules to apply, most authoritative first
  * @param tracks - Candidate tracks
- * @param state - The behavior's state signal map, passed through to each rule
- * @param context - The behavior's context signal map, passed through to each rule
+ * @param deps - The behavior's `{ state, context, config }`, passed through to each rule
  * @returns The surviving candidates, pick first
  */
-export function applyRules<T, State, Context>(
-  rules: readonly SelectionRule<T, State, Context>[],
+export function applyRules<T, State, Context, Config>(
+  rules: readonly SelectionRule<T, State, Context, Config>[],
   tracks: readonly T[],
-  state: State,
-  context: Context
+  deps: SelectionRuleDeps<State, Context, Config>
 ): readonly T[] {
   let current = tracks;
   for (const rule of rules) {
-    const remaining = rule(current, state, context);
+    const remaining = rule(current, deps);
     if (remaining.length === 0) continue;
     current = remaining;
     if (current.length === 1) break;
@@ -275,7 +282,7 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
     // User intent — a soft filter. Narrows to tracks matching the partial-track
     // selection; an empty match falls through (the composer skips it) to the
     // unfiltered set — e.g. a stale id from a previous source.
-    (tracks, ruleState) => {
+    (tracks, { state: ruleState }) => {
       const filter = ruleState[userSelectionKey].get() as Partial<T> | undefined;
       return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
     },
@@ -284,7 +291,7 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
     // pin-to-current), and returns the list with the pick at the head. Early-
     // bail skips this rule when a prior one narrowed to a single track, so the
     // bandwidth estimate is neither read nor subscribed while that choice holds.
-    (tracks, ruleState) => {
+    (tracks, { state: ruleState }) => {
       const bandwidth = getBandwidthEstimate(ruleState.bandwidthState.get(), initialBandwidth, bandwidthConfig);
       const currentTrack = tracks.find((track) => track.id === ruleState[selectionKey].get());
       const optimal =
@@ -319,10 +326,10 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             const allTracks = getTracks(presentation);
             if (!allTracks.length) return;
 
-            // Context is unused by today's rules; the chain reads only state
-            // signals. Real engine context threads here when a context-reading
-            // rule lands (e.g. CDN pathway).
-            const candidates = applyRules(rules, allTracks, state, {});
+            // Rules read only state signals today; context and config thread
+            // through unused for rules that will need them (a CDN-pathway rule
+            // reading context, a rule reading engine config).
+            const candidates = applyRules(rules, allTracks, { state, context: {}, config });
             const selectedId = state[selectionKey].get();
 
             // A single survivor — an early-bail from the chain, or a single-

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -196,58 +196,54 @@ type SelectionKey = 'selectedVideoTrackId' | 'selectedAudioTrackId';
 type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
 
 // Each mapped value references `P` so TS keeps the per-key dependency and
-// resolves `state[selectionKey]` / `state[userSelectionKey]` to the right
-// arm. `T` (track type) deliberately stays out of the state map — pulling
-// it in detaches the user-selection mapped value from `P` and TS collapses
-// the intersection. T flows through `TrackSwitchingSetupConfig` instead;
-// the user-filter access casts at the read site (see below).
+// resolves `state[selectionKey]` to the right arm. `T` (track type) stays out
+// of the state map (it flows through `TrackSwitchingSetupConfig` instead).
 //
-// `bandwidthState` is intentionally absent: only the bandwidth ranker rule
-// reads it, not the behavior's lifecycle. A rule needing a signal the behavior
-// doesn't use declares it *optional* on its own deps and reads it defensively
-// (see `BandwidthRankerStateMap`), so the behavior never assumes a rule-only
-// signal exists.
-type TrackSwitchingStateMap<S extends SelectionKey, U extends UserSelectionKey> = {
+// Only the behavior's own lifecycle signals are required here: the presentation
+// gate and the selection slot it writes. Signals a *rule* reads but the
+// behavior doesn't — `user*TrackSelection` (the user-selection filter) and
+// `bandwidthState` (the bandwidth ranker) — are NOT here; each rule declares
+// the signal it needs as *optional* on its own deps and reads it defensively,
+// so the behavior never assumes a rule-only signal exists. Those slots are
+// materialized by whoever owns them: `shareSignals` for the consumer-input
+// `user*TrackSelection`, the buffer-actor sampler for `bandwidthState`.
+type TrackSwitchingStateMap<S extends SelectionKey> = {
   presentation: ReadonlySignal<TrackSwitchingState['presentation']>;
-} & { [P in S]: Signal<TrackSwitchingState[P]> } & { [P in U]: ReadonlySignal<TrackSwitchingState[P]> };
+} & { [P in S]: Signal<TrackSwitchingState[P]> };
 
 /**
  * Config `setupTrackSwitching` receives — the per-variant wiring: which slots
  * to read/write (`selectionKey` / `userSelectionKey`), how to enumerate the
  * candidate tracks (`getTracks`), and the **rule chain** to run. ABR tuning is
- * optional and read only by the video ranker rule (`rankByQuality`); audio
- * leaves it unset.
+ * optional and read only by the bandwidth ranker rule (`rankByBandwidth`).
  */
 interface TrackSwitchingSetupConfig<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack> {
   selectionKey: S;
   userSelectionKey: U;
   getTracks: (presentation: MaybeResolvedPresentation) => readonly T[];
-  rules: readonly SelectionRule<T, TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>[];
+  rules: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>[];
   quality?: Partial<QualityConfig>;
   bandwidth?: Partial<BandwidthConfig>;
   initialBandwidth?: number;
 }
 
 /**
- * Deps shape every track-switching rule consumes. Context conforms to the
- * generic slot-map shape (`AnySlotMap`) — threaded through but with no keys
- * read today, ready for a rule that consults context (e.g. CDN pathway).
+ * State the user-selection filter reads: the lifecycle map plus an *optional*
+ * user-selection slot (keyed by `U`). The slot exists only when the composition
+ * provides it (materialized by `shareSignals`); the filter reads it defensively
+ * and no-ops when it's absent (no user override).
  */
-type TrackSwitchingRuleDeps<
-  S extends SelectionKey,
-  U extends UserSelectionKey,
-  T extends SwitchableTrack,
-> = SelectionRuleDeps<TrackSwitchingStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>;
+type UserSelectionStateMap<S extends SelectionKey, U extends UserSelectionKey> = TrackSwitchingStateMap<S> & {
+  [P in U]?: ReadonlySignal<TrackSwitchingState[P]>;
+};
 
 /**
- * State a bandwidth ranker reads: the behavior's lifecycle map plus an
- * *optional* `bandwidthState`. The signal exists only when the composition
- * includes a bandwidth sampler; the ranker reads it defensively and falls back
- * to `initialBandwidth` (with a debug note) when it's absent. A behavior state
- * map without `bandwidthState` is assignable here (the slot is optional), so a
- * ranker drops into a chain whose behavior never declared the signal.
+ * State the bandwidth ranker reads: the lifecycle map plus an *optional*
+ * `bandwidthState`. The signal exists only when the composition includes a
+ * bandwidth sampler; the ranker reads it defensively and falls back to
+ * `initialBandwidth` (with a debug note) when it's absent.
  */
-type BandwidthRankerStateMap<S extends SelectionKey, U extends UserSelectionKey> = TrackSwitchingStateMap<S, U> & {
+type BandwidthRankerStateMap<S extends SelectionKey> = TrackSwitchingStateMap<S> & {
   bandwidthState?: ReadonlySignal<TrackSwitchingState['bandwidthState']>;
 };
 
@@ -268,9 +264,9 @@ type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
  */
 function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
-  { state, config }: TrackSwitchingRuleDeps<S, U, T>
+  { state, config }: SelectionRuleDeps<UserSelectionStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
 ): readonly T[] {
-  const filter = state[config.userSelectionKey].get() as Partial<T> | undefined;
+  const filter = state[config.userSelectionKey]?.get() as Partial<T> | undefined;
   return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
 }
 
@@ -293,7 +289,7 @@ function filterByUserSelection<S extends SelectionKey, U extends UserSelectionKe
  */
 function rankByBandwidth<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(
   tracks: readonly T[],
-  { state, config }: SelectionRuleDeps<BandwidthRankerStateMap<S, U>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
+  { state, config }: SelectionRuleDeps<BandwidthRankerStateMap<S>, AnySlotMap, TrackSwitchingSetupConfig<S, U, T>>
 ): readonly T[] {
   const safetyMargin = config.quality?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
   const upgradeMargin = config.quality?.upgradeMargin ?? DEFAULT_QUALITY_CONFIG.upgradeMargin;
@@ -322,7 +318,7 @@ function rankByBandwidth<S extends SelectionKey, U extends UserSelectionKey, T e
 // untyped via the rest and it lands here — absent on direct setup calls, and
 // passed straight through to the rules (which don't read it yet).
 function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey, T extends SwitchableTrack>(deps: {
-  state: TrackSwitchingStateMap<S, U>;
+  state: TrackSwitchingStateMap<S>;
   context?: AnySlotMap;
   config: TrackSwitchingSetupConfig<S, U, T>;
 }) {
@@ -390,14 +386,14 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
  * const reactor = switchVideoTrack.setup({ state });
  */
 export const switchVideoTrack = defineBehavior({
-  stateKeys: ['presentation', 'selectedVideoTrackId', 'userVideoTrackSelection'],
+  stateKeys: ['presentation', 'selectedVideoTrackId'],
   contextKeys: [],
   setup: ({
     state,
     config,
     ...otherProps
   }: {
-    state: TrackSwitchingStateMap<'selectedVideoTrackId', 'userVideoTrackSelection'>;
+    state: TrackSwitchingStateMap<'selectedVideoTrackId'>;
     config?: SwitchVideoTrackConfig;
   }) =>
     setupTrackSwitching<'selectedVideoTrackId', 'userVideoTrackSelection', VideoTrackCandidate>({
@@ -431,14 +427,9 @@ export const switchVideoTrack = defineBehavior({
  * const reactor = switchAudioTrack.setup({ state });
  */
 export const switchAudioTrack = defineBehavior({
-  stateKeys: ['presentation', 'selectedAudioTrackId', 'userAudioTrackSelection'],
+  stateKeys: ['presentation', 'selectedAudioTrackId'],
   contextKeys: [],
-  setup: ({
-    state,
-    ...otherProps
-  }: {
-    state: TrackSwitchingStateMap<'selectedAudioTrackId', 'userAudioTrackSelection'>;
-  }) =>
+  setup: ({ state, ...otherProps }: { state: TrackSwitchingStateMap<'selectedAudioTrackId'> }) =>
     setupTrackSwitching<'selectedAudioTrackId', 'userAudioTrackSelection', AudioTrackCandidate>({
       ...otherProps,
       state,

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -1,37 +1,38 @@
 /**
- * **Per-type track-selection slot management with optional ABR.** While a
- * presentation is resolved, owns the selection slot's lifecycle: pick a
- * default, react to user intent (partial-track filter), re-evaluate
- * algorithmically (today: bandwidth via `selectQuality` for video; pin-to-
- * current for audio), and clear on src unload.
+ * **Per-type track selection as a rule chain.** While a presentation is
+ * resolved, owns that type's `selected{Video,Audio}TrackId` signal: pick a
+ * default, react to user intent and algorithmic ranking, and clear it on src
+ * unload.
  *
- * User intent is expressed as a partial-track description in a sibling slot
- * (e.g. `userVideoTrackSelection`, `userAudioTrackSelection`) which
- * constrains the candidate set for selection — when the constraint narrows
- * candidates to exactly one, the choice is fully determined and the
- * selection algorithm is short-circuited (no bandwidth read, no effect
- * re-fire on bandwidth changes).
+ * Selection runs a small ordered chain of rules over the candidate tracks
+ * (`applyRules`). Each rule narrows or reorders the list and reads the signals
+ * it needs at apply time, so the effect subscribes to exactly what the applied
+ * rules consult. Today the chain is two rules, most authoritative first:
+ *
+ *   1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
+ *      partial-track match; an empty match falls through to the full set.
+ *   2. **ranking** — the terminal sort: the per-variant `selectOptimal` over
+ *      the bandwidth estimate (video ABR with hysteresis — downgrades immediate,
+ *      upgrades gated by `upgradeMargin`; audio pin-to-current).
+ *
+ * The composer's early-bail (one survivor → stop) is load-bearing: a user
+ * selection that narrows to a single track is the pick without the ranker
+ * running, so the bandwidth estimate is never read and the effect doesn't
+ * re-fire on bandwidth while that choice holds.
  *
  * Lifecycle: `'presentation-unresolved'` ↔ `'presentation-resolved'`. The
- * `'presentation-resolved'` state owns the selection slot; its
- * entry-returned cleanup clears the slot on exit (canonical
- * cleanup-binds-to-setup per `reactors.md`).
+ * resolved state owns the signal; its entry-returned cleanup clears it on exit
+ * (canonical cleanup-binds-to-setup per `reactors.md`).
  *
- * Hysteresis (video ABR today, audio ABR when added): downgrades apply
- * immediately; upgrades require the optimal track's bandwidth to exceed
- * the current track's by `upgradeMargin`. No temporal state — short-term
- * smoothing is the bandwidth estimator's job.
+ * `config.picker` provides the empty-slot initial default (e.g. audio's
+ * language-aware pick) ahead of the ranker's head. Variants: `switchVideoTrack`
+ * (bandwidth-driven ranker), `switchAudioTrack` (pin-to-current ranker,
+ * ABR-ready for when audio-ABR lands); both share `setupTrackSwitching`, with
+ * the candidate type and `selectOptimal` as the variation points.
  *
- * Initial pick is configurable via `config.picker` — pass any `TrackPicker`
- * to override the default-pick for the empty-slot case. Algorithmic
- * re-evaluation (`selectOptimal`) is unaffected.
- *
- * Variants: `switchVideoTrack` (bandwidth-driven `selectOptimal`),
- * `switchAudioTrack` (pin-to-current `selectOptimal`, ABR-ready shape for
- * a future bandwidth-driven variant once audio-ABR lands). Both variants
- * share this helper; the only point of variation is the per-variant
- * `selectOptimal` and the candidate-track type. Future track-switching
- * axes (text tracks, etc.) plug in the same way.
+ * Deferred (not yet in the chain): a hard-constraints pre-pass (capability
+ * probing, CDN failover) gating the candidate set, and promoting the picker's
+ * preferred-language / default-track logic to standing soft-filter rules.
  */
 
 import { defineBehavior } from '../../core/composition/create-composition';
@@ -40,10 +41,10 @@ import { computed, peek, type ReadonlySignal, type Signal } from '../../core/sig
 import {
   DEFAULT_QUALITY_CONFIG,
   type QualityConfig,
-  selectLowestQuality,
+  selectLowestQualityWithBandwidth,
   selectQuality,
 } from '../../media/abr/quality-selection';
-import { pickAudioTrack, type TrackPicker } from '../../media/primitives/select-tracks';
+import { matchesPartialTrack, pickAudioTrack, type TrackPicker } from '../../media/primitives/select-tracks';
 import {
   type AudioTrack,
   isResolvedPresentation,
@@ -136,6 +137,54 @@ export interface TrackSwitchingConfig {
 export const DEFAULT_INITIAL_BANDWIDTH = 5_000_000;
 
 // ============================================================================
+// Rule chain
+// ============================================================================
+
+/**
+ * A selection rule narrows or reorders the candidate list. It reads the state
+ * and context signals it needs at apply time (tightly-coupled reads), so a
+ * rule's `.get()`s subscribe the running effect to exactly what it consulted.
+ * Returning an empty list means "no match" — the composer skips it, so a soft
+ * filter never narrows the set to nothing. A ranker returns the list with its
+ * pick at the head.
+ */
+export type SelectionRule<T, State = unknown, Context = unknown> = (
+  tracks: readonly T[],
+  state: State,
+  context: Context
+) => readonly T[];
+
+/**
+ * Apply rules to a candidate list in order; the pick is the first survivor.
+ * Two responsibilities the rules don't carry: a rule that returns nothing is
+ * skipped (fall-through — a preference never empties the set), and once one
+ * survivor remains the chain stops (early-bail — later rules, including the
+ * bandwidth ranker, never run, so the effect doesn't subscribe to their
+ * signals while the choice is fixed).
+ *
+ * @param rules - Rules to apply, most authoritative first
+ * @param tracks - Candidate tracks
+ * @param state - The behavior's state signal map, passed through to each rule
+ * @param context - The behavior's context signal map, passed through to each rule
+ * @returns The surviving candidates, pick first
+ */
+export function applyRules<T, State, Context>(
+  rules: readonly SelectionRule<T, State, Context>[],
+  tracks: readonly T[],
+  state: State,
+  context: Context
+): readonly T[] {
+  let current = tracks;
+  for (const rule of rules) {
+    const remaining = rule(current, state, context);
+    if (remaining.length === 0) continue;
+    current = remaining;
+    if (current.length === 1) break;
+  }
+  return current;
+}
+
+// ============================================================================
 // Specialization helper
 //
 // `setupTrackSwitching` has the same shape as a Behavior `setup` function:
@@ -219,6 +268,32 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
   const bandwidthConfig: BandwidthConfig = { ...DEFAULT_BANDWIDTH_CONFIG, ...config.bandwidth };
   const { selectionKey, userSelectionKey, getTracks, selectOptimal } = config;
 
+  // The selection chain, most authoritative first. Each rule reads the signals
+  // it needs from the state passed at apply time, so the effect subscribes to
+  // exactly what the applied rules consult.
+  const rules: SelectionRule<T, TrackSwitchingStateMap<S, U>>[] = [
+    // User intent — a soft filter. Narrows to tracks matching the partial-track
+    // selection; an empty match falls through (the composer skips it) to the
+    // unfiltered set — e.g. a stale id from a previous source.
+    (tracks, ruleState) => {
+      const filter = ruleState[userSelectionKey].get() as Partial<T> | undefined;
+      return filter ? tracks.filter((track) => matchesPartialTrack(track, filter)) : tracks;
+    },
+    // Ranking — the terminal sort. Reads the bandwidth estimate, runs the
+    // per-variant `selectOptimal` (video ABR with hysteresis; audio
+    // pin-to-current), and returns the list with the pick at the head. Early-
+    // bail skips this rule when a prior one narrowed to a single track, so the
+    // bandwidth estimate is neither read nor subscribed while that choice holds.
+    (tracks, ruleState) => {
+      const bandwidth = getBandwidthEstimate(ruleState.bandwidthState.get(), initialBandwidth, bandwidthConfig);
+      const currentTrack = tracks.find((track) => track.id === ruleState[selectionKey].get());
+      const optimal =
+        selectOptimal(tracks, { bandwidth, safetyMargin, upgradeMargin, currentTrack }) ??
+        selectLowestQualityWithBandwidth(tracks);
+      return optimal ? [optimal, ...tracks.filter((track) => track !== optimal)] : tracks;
+    },
+  ];
+
   const derivedStateSignal = computed(() =>
     isResolvedPresentation(state.presentation.get())
       ? ('presentation-resolved' as const)
@@ -242,108 +317,34 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             if (!presentation) return;
 
             const allTracks = getTracks(presentation);
-            const [firstAllTrack] = allTracks;
-            if (!firstAllTrack) return;
+            if (!allTracks.length) return;
 
-            // State stores the filter as `Partial<XTrack>` (user-facing
-            // shape — includes per-type fields like `height` or
-            // `language`); the helper works against `Partial<T>` so
-            // filter and track access share one index type. Filter keys
-            // absent on a partially-resolved track read as `undefined`
-            // and just exclude that track.
-            const userFilter = state[userSelectionKey].get() as Partial<T> | undefined;
-            const matching = userFilter
-              ? allTracks.filter((track) => {
-                  for (const key in userFilter) {
-                    const filterValue = userFilter[key as keyof T];
-                    if (filterValue !== undefined && track[key as keyof T] !== filterValue) return false;
-                  }
-                  return true;
-                })
-              : allTracks;
-            // Fall back to all tracks when the filter excludes everything
-            // (e.g., user-picked id doesn't exist in the current source).
-            const candidates = matching.length > 0 ? matching : allTracks;
-            if (!candidates.length) return;
-
+            // Context is unused by today's rules; the chain reads only state
+            // signals. Real engine context threads here when a context-reading
+            // rule lands (e.g. CDN pathway).
+            const candidates = applyRules(rules, allTracks, state, {});
             const selectedId = state[selectionKey].get();
 
-            // Common case: user has fully constrained the choice (e.g.,
-            // `{ id: 'specific-720p' }` or `{ language: 'es' }` when only
-            // one Spanish track exists). Skip the algorithm path — and
-            // crucially, don't read `bandwidthState` so the effect
-            // doesn't re-fire on bandwidth changes while the user's
-            // selection holds.
-            if (candidates.length === 1) {
-              if (candidates[0]!.id !== selectedId) state[selectionKey].set(candidates[0]!.id);
-              return;
-            }
+            // A single survivor — an early-bail from the chain, or a single-
+            // track source — is the pick outright, decided before the picker
+            // (matching the prior short-circuit, including never reading
+            // bandwidth). Otherwise an empty slot defers to the optional
+            // initial-pick picker (e.g. audio's language-aware default),
+            // falling back to the ranker's head; a populated slot takes the
+            // ranker's head.
+            const pickId =
+              candidates.length === 1
+                ? candidates[0]!.id
+                : !selectedId && config.picker
+                  ? (config.picker(presentation, config) ?? candidates[0]?.id)
+                  : candidates[0]?.id;
 
-            // Read bandwidth up front to establish the signal subscription —
-            // future bandwidth changes must re-fire this effect even when
-            // the picker branch below takes the early-return path. (If the
-            // picker bails out without ever touching `bandwidthState`,
-            // bandwidth-driven `selectOptimal` would otherwise be deaf to
-            // subsequent bandwidth changes.) Pin-to-current variants read
-            // the field but ignore it — the subscription cost is fixed
-            // per effect run regardless.
-            //
-            // Single path for pre-trust and post-trust: `getBandwidthEstimate`
-            // returns `initialBandwidth` when state is undefined or bytes
-            // sampled hasn't crossed `minTotalBytes`, so the initial pick
-            // and early-ABR window run the same `selectOptimal` path as a
-            // fully-trusted measurement.
-            const bandwidth = getBandwidthEstimate(state.bandwidthState.get(), initialBandwidth, bandwidthConfig);
-
-            // Picker-driven initial pick: when the slot is empty and the
-            // caller supplied a `picker`, defer to it instead of the
-            // algorithmic default. The picker sees the full presentation
-            // (not narrowed by the user-selection filter) — honoring the
-            // filter is the picker's responsibility when overridden.
-            // Returning `undefined` falls through to the algorithmic
-            // default pick (graceful fallback).
-            //
-            // Algorithmic re-evaluation runs as usual on subsequent
-            // effect re-runs once the slot is set.
-            if (!selectedId && config.picker) {
-              const id = config.picker(presentation, config);
-              if (id) {
-                state[selectionKey].set(id);
-                return;
-              }
-            }
-            // `selectOptimal` decides the track to apply now given current
-            // selection + context. Returns:
-            //   - the optimal when no current track or on a downgrade
-            //   - the optimal when an upgrade clears `upgradeMargin`
-            //   - the current track itself when an upgrade doesn't clear
-            //     margin (caller's id-compare below no-ops in that case)
-            // Outer `?? selectLowestQuality` is defensive — `selectQuality`
-            // falls back to lowest internally; pin-to-current variants
-            // return `currentTrack ?? tracks[0]` so they never produce
-            // `undefined` for a non-empty `candidates`. The fallback
-            // catches future variants that don't return a definitive pick.
-            const currentTrack = candidates.find((t) => t.id === selectedId);
-            const ctx: SelectionCtx<T> = { bandwidth, safetyMargin, upgradeMargin, currentTrack };
-            const optimal = selectOptimal(candidates, ctx) ?? selectLowestQualityWithBandwidth(candidates);
-            if (optimal && optimal.id !== selectedId) state[selectionKey].set(optimal.id);
+            if (pickId && pickId !== selectedId) state[selectionKey].set(pickId);
           },
         ],
       },
     },
   });
-}
-
-/**
- * Adapter for `selectLowestQuality` that tolerates tracks whose `bandwidth`
- * field is optional (audio's candidate shape). Falls back to the first
- * candidate when no bandwidth info is available.
- */
-function selectLowestQualityWithBandwidth<T extends SwitchableTrack>(tracks: readonly T[]): T | undefined {
-  if (tracks.length === 0) return undefined;
-  const withBandwidth = tracks.filter((t): t is T & { bandwidth: number } => typeof t.bandwidth === 'number');
-  if (withBandwidth.length === 0) return tracks[0];
-  return selectLowestQuality(withBandwidth);
 }
 
 // ============================================================================

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -24,15 +24,16 @@
  * resolved state owns the signal; its entry-returned cleanup clears it on exit
  * (canonical cleanup-binds-to-setup per `reactors.md`).
  *
- * `config.picker` provides the empty-slot initial default (e.g. audio's
- * language-aware pick) ahead of the ranker's head. Variants: `switchVideoTrack`
- * (bandwidth-driven ranker), `switchAudioTrack` (pin-to-current ranker,
- * ABR-ready for when audio-ABR lands); both share `setupTrackSwitching`, with
- * the candidate type and `selectOptimal` as the variation points.
+ * The pick is the head of the chain's result (`applyRules(...)[0]`). Variants:
+ * `switchVideoTrack` (bandwidth-driven ranker), `switchAudioTrack` (pin-to-
+ * current ranker, ABR-ready for when audio-ABR lands); both share
+ * `setupTrackSwitching`, with the candidate type and `selectOptimal` as the
+ * variation points.
  *
  * Deferred (not yet in the chain): a hard-constraints pre-pass (capability
- * probing, CDN failover) gating the candidate set, and promoting the picker's
- * preferred-language / default-track logic to standing soft-filter rules.
+ * probing, CDN failover) gating the candidate set, and audio's preferred-
+ * language / default-track selection as standing soft-filter rules — previously
+ * the empty-slot picker, dropped in the move to the rule chain.
  */
 
 import { type AnySlotMap, defineBehavior } from '../../core/composition/create-composition';
@@ -44,7 +45,7 @@ import {
   selectLowestQualityWithBandwidth,
   selectQuality,
 } from '../../media/abr/quality-selection';
-import { matchesPartialTrack, pickAudioTrack, type TrackPicker } from '../../media/primitives/select-tracks';
+import { matchesPartialTrack } from '../../media/primitives/select-tracks';
 import {
   type AudioTrack,
   isResolvedPresentation,
@@ -114,21 +115,10 @@ export interface TrackSwitchingConfig {
   initialBandwidth?: number;
 
   /**
-   * Override the initial-pick algorithm. When set, the picker is called
-   * the first time the slot is empty in the `'presentation-resolved'`
-   * state; its returned id is set verbatim (no algorithmic logic).
-   * Subsequent re-evaluation via the variant's `selectOptimal` is
-   * unaffected.
-   *
-   * Honors of the user-selection filter are the picker's responsibility
-   * when overridden. If the picker returns `undefined`, the variant's
-   * default initial pick fires (graceful fallback).
-   */
-  picker?: TrackPicker<TrackSwitchingConfig>;
-
-  /**
-   * Audio-variant config — preferred language consumed by the default
-   * audio picker (`pickAudioTrack`). Ignored by other variants.
+   * Audio-variant config — preferred audio language. Currently **unconsumed**:
+   * its previous consumer (the default audio picker) was removed when the
+   * initial pick became the rule chain's head; it returns when preferred-
+   * language lands as a standing soft-filter rule. Engines still surface it.
    */
   preferredAudioLanguage?: string;
 }
@@ -371,23 +361,18 @@ function setupTrackSwitching<S extends SelectionKey, U extends UserSelectionKey,
             // today's rules don't consult it, but it's in place for one that
             // will (e.g. a CDN-pathway rule reading context).
             const candidates = applyRules(rules, allTracks, { state, context, config });
-            const selectedId = state[selectionKey].get();
 
-            // A single survivor — an early-bail from the chain, or a single-
-            // track source — is the pick outright, decided before the picker
-            // (matching the prior short-circuit, including never reading
-            // bandwidth). Otherwise an empty slot defers to the optional
-            // initial-pick picker (e.g. audio's language-aware default),
-            // falling back to the ranker's head; a populated slot takes the
-            // ranker's head.
-            const pickId =
-              candidates.length === 1
-                ? candidates[0]!.id
-                : !selectedId && config.picker
-                  ? (config.picker(presentation, config) ?? candidates[0]?.id)
-                  : candidates[0]?.id;
-
-            if (pickId && pickId !== selectedId) state[selectionKey].set(pickId);
+            // applyRules early-bails to a single survivor and never narrows to
+            // nothing (a soft filter that would empty the set falls through), so
+            // the pick is just the head. An empty result means a rule misbehaved
+            // — applyRules is supposed to account for those cases, so surface it.
+            if (!candidates.length) {
+              console.error('[track-switching] applyRules returned no candidates');
+              return;
+            }
+            // No change-guard needed: the slot uses default (Object.is) equality,
+            // so re-setting the same id is a no-op (no notify, no re-fire).
+            state[selectionKey].set(candidates[0]!.id);
           },
         ],
       },
@@ -485,7 +470,6 @@ export const switchAudioTrack = defineBehavior({
         userSelectionKey: 'userAudioTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'audio') as readonly AudioTrackCandidate[],
         selectOptimal: selectAudioCurrent,
-        picker: config?.picker ?? pickAudioTrack,
       },
     }),
 });

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -39,7 +39,7 @@
 
 import { type AnySlotMap, defineBehavior } from '../../core/composition/create-composition';
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
-import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
+import { computed, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
 import { DEFAULT_QUALITY_CONFIG, type QualityConfig } from '../../media/abr/quality-selection';
 import { matchesPartialTrack } from '../../media/primitives/select-tracks';
 import {
@@ -346,6 +346,32 @@ function setupTrackSwitching<
       : ('presentation-unresolved' as const)
   );
 
+  // The playable candidate set — the tracks the rule chain gets to pick from,
+  // derived *outside* the reaction. This is the seam a future hard-constraints
+  // pre-pass (capability probing, CDN failover) occupies: it would narrow these
+  // tracks before the chain runs —
+  //   isResolvedPresentation(p) ? applyConstraints(constraints, getTracks(p), deps) : []
+  // — and because it's a `computed`, the constraints' own signal reads are
+  // tracked here. The effect reads it with `.get()`, so when the playable set
+  // changes — a new source, or a *dynamic* constraint like a CDN entering
+  // cooldown — the effect re-picks. Today it's just the type's tracks while a
+  // presentation is resolved.
+  //
+  // The `equals` gates notification on the *set of track ids*, not array
+  // identity: a live playlist refresh swaps in a new presentation object with
+  // the same variant tracks, and a constraint's inputs can churn without
+  // changing which tracks survive. In both cases the playable set is unchanged,
+  // so the reaction must not re-fire (the rule chain still re-runs on its own
+  // inputs — bandwidth, user selection). Same intent as `equalsById`, for the
+  // track list.
+  const candidateSet = computed<readonly T[]>(
+    () => {
+      const presentation = state.presentation.get();
+      return isResolvedPresentation(presentation) ? getTracks(presentation) : [];
+    },
+    { equals: (a, b) => a.length === b.length && a.every((track) => b.some((other) => other.id === track.id)) }
+  );
+
   return createMachineReactor({
     initial: 'presentation-unresolved',
     monitor: () => derivedStateSignal.get(),
@@ -358,11 +384,15 @@ function setupTrackSwitching<
         entry: () => () => state[selectionKey].set(undefined),
         effects: [
           () => {
-            const presentation = peek(state.presentation);
-            if (!presentation) return;
-
-            const allTracks = getTracks(presentation);
-            if (!allTracks.length) return;
+            // Reactive read: subscribes the reaction to the candidate set, so a
+            // new presentation — or a future constraint pruning it — re-fires
+            // this and re-picks.
+            const tracks = candidateSet.get();
+            // No playable tracks: no tracks of this type, or (once constraints
+            // exist) everything pruned. Nothing to pick. Surfacing "nothing
+            // playable" as a distinct not-ready state is left to the constraints
+            // work; for now it's a silent no-op, leaving any prior pick in place.
+            if (!tracks.length) return;
 
             // The whole deps object passes straight through to every rule in the
             // variant-supplied chain (state + config from the behavior; context
@@ -371,7 +401,7 @@ function setupTrackSwitching<
             // optional, and the concrete `C` is assignable to the base.
             const candidates = applyRules<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>(
               rules,
-              allTracks,
+              tracks,
               deps
             );
 

--- a/packages/spf/src/playback/engines/hls/engine-audio-only.ts
+++ b/packages/spf/src/playback/engines/hls/engine-audio-only.ts
@@ -92,7 +92,11 @@ export interface SimpleHlsAudioOnlyEngineConfig
 // Audio-Only HLS Playback Engine
 // ============================================================================
 
-const shareSignals = makeShareSignals<SimpleHlsAudioOnlyEngineState, SimpleHlsAudioOnlyEngineContext>();
+// Materializes the consumer-input slot `userAudioTrackSelection` (only read by
+// switchAudioTrack, produced by no behavior) in addition to forwarding refs.
+const shareSignals = makeShareSignals<SimpleHlsAudioOnlyEngineState, SimpleHlsAudioOnlyEngineContext>([
+  'userAudioTrackSelection',
+]);
 
 /**
  * Create an audio-only HLS playback engine.

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -194,9 +194,14 @@ export interface SimpleHlsEngineConfig extends ShareSignalsConfig<SimpleHlsEngin
 /**
  * Generic `shareSignals` instantiated against the HLS engine's full state
  * and context — captures composition signal refs into the consumer's
- * `onSignalsReady` callback at setup time.
+ * `onSignalsReady` callback at setup time, and materializes the consumer-input
+ * slots (`user*TrackSelection`) that no behavior produces: the track-switching
+ * behaviors only *read* them, so shareSignals owns bringing them into existence.
  */
-const shareSignals = makeShareSignals<SimpleHlsEngineState, SimpleHlsEngineContext>();
+const shareSignals = makeShareSignals<SimpleHlsEngineState, SimpleHlsEngineContext>([
+  'userVideoTrackSelection',
+  'userAudioTrackSelection',
+]);
 
 /**
  * Create an HLS playback engine.


### PR DESCRIPTION
## TL;DR

Refactors `setupTrackSwitching` into a **rule-chain model**: track selection runs an ordered chain of rules (soft filters + one ranker) through an `applyRules` composer, instead of a hardcoded filter-then-rank. Along the way it unwinds the type coupling between the behavior and its rules — the behavior now declares only the signals/config it owns, and each rule re-declares what it reads as optional on its own view — and lifts the candidate-track derivation into a reactive seam ready for a future hard-constraints pre-pass. Video ABR (bandwidth-driven adaptive bitrate) is at parity; the one deliberate behavior change is that audio default-language selection is dropped (see *Breaking changes*). Internal SPF only (alpha) — no external consumers.

## For reviewers — how to read this PR

Effectively a single-file change: `track-switching.ts` is the PR; the other seven files are wiring, tests, and one sandbox preset.

**Read fully:** `track-switching.ts` (608) — four things to evaluate as shapes: (1) the rule contract + `applyRules` composer — fall-through (a rule that empties the set is skipped) + early-bail (stop at one survivor, so the ranker never reads bandwidth while a single-track selection holds); (2) the behavior↔rules decoupling — the behavior's state map + config carry only `presentation` / `selected*TrackId` / lifecycle config, while each rule's signals and config live on its own optional view (`UserSelection*` / `BandwidthRanker*`); (3) `rankByBandwidth` — one threshold-sort shared by video and audio, hysteresis preserved by boosting the current track's sort weight (no temporal state); (4) `candidateSet` — the playable-set computed read reactively, the seam a constraints pre-pass will occupy.

**Targeted careful read:** `share-signals.ts` (+16/−15) — `makeShareSignals` now materializes consumer-input slots (`user*TrackSelection`) via new `inputStateKeys`/`inputContextKeys`; verify it declares those as its `stateKeys`/`contextKeys` and that the consumer-boundary rationale holds (these slots are written by the embedder, read only by the filter rule).

**Skim file:** `track-switching.test.ts` (+87/−68) — assertion shape across the rule chain; the new resolved→resolved candidate-set reactivity test; removed picker / preferred-language tests.

**Skim structure only:** `engine.ts` (materializes both `user*TrackSelection` keys), `engine-audio-only.ts` (materializes `userAudioTrackSelection`), `select-tracks.ts` (new `matchesPartialTrack` helper, single caller), `all.ts` (`TrackSwitchingConfig` → `SwitchVideoTrackConfig` re-export rename), `sources.ts` (sandbox: one audio-only preset for the smoke test).

## Smoke test

Load locally (`pnpm dev:sandbox` → paste the path into the running Vite server) or via the PR's deploy preview. Use the **`spf-segment-loading`** harness — the default player skins don't surface rendition/audio-track controls, but this harness exposes rendition buttons, audio-track buttons, live throughput, and now-playing quality (exactly the track-switching surface this PR changes).

**1. Renditions + multi-language audio + ABR** — `/spf-segment-loading/?src=https://stream.mux.com/s41JYeqIpBMBzE4OzxDyGR2yrp2hD1CQ6gJN9SlVGDQ.m3u8`

- Press **Play** (the harness video is `preload="none"`).
- **Observe:**
  - The presentation resolves: the rendition list fills (640×286 → 3840×1714) and the audio-track list shows all languages (und/fr/es/de/it/pt/hi).
  - ABR (bandwidth-driven) selects a rendition for the measured throughput (marked `⟳`); throttle in Chrome DevTools → Network ("Slow 4G") and the selection steps **down**; clear the throttle and it steps back **up** (watch now-playing-quality + throughput).
  - Click a rendition → it locks (`🔒`, ABR disabled); "Re-enable ABR" returns to `⟳`.
  - Click an audio language → it switches **mid-stream with no stall or audio gap** (the track shows `🔒`; "Clear filter" returns to the default).
  - On first load the audio sits on `und · Default` — the bandwidth-ranked default, **not** an auto-picked preferred language (the intended change; see *Breaking changes*).

**2. Audio-only engine** — `/html-simple-hls-audio-only/?source=hls-audio-only-cmaf`

- Press play.
- **Observe:** the CMAF/fmp4 audio-only asset plays through cleanly (the audio-only composition omits the video behaviors).

## What changed — by surface

**Rule-chain model.** `setupTrackSwitching` no longer hardcodes a filter-then-rank pair. Selection is an ordered chain of rules run by `applyRules` (fall-through + early-bail); each variant supplies its chain via config and the helper just runs it and takes the head as the pick. Today both variants run `[filterByUserSelection, rankByBandwidth]`.

**Behavior↔rules decoupling (state + config).** The behavior previously declared every signal and config field any rule might read (`bandwidthState`, `user*TrackSelection`, ABR tuning). It now declares only what it owns — `presentation`, `selected*TrackId`, and its lifecycle config. Each rule re-declares the signal/config it reads as optional on its own view and reads it defensively. The consumer-input `user*TrackSelection` slots are materialized at the consumer boundary by `shareSignals`; `bandwidthState` comes from the buffer-actor sampler — `createComposition` hands full state to every behavior, so a composition without a sampler (audio-only) simply ranks on `initialBandwidth`.

**Shared bandwidth ranker.** One `rankByBandwidth` rule replaces the video ABR wrapper and the audio pin-to-current: fitting tracks (within the throughput threshold) highest-bitrate-first, over-throughput tracks least-over-first; the head is the pick. Hysteresis is kept without temporal state by boosting the current track's effective bitrate by `upgradeMargin` in the fitting sort.

**Constraints-readiness seam.** The candidate-track derivation moves out of the selection effect into a `candidateSet` computed, read reactively. A future hard-constraints pre-pass (capability probing, multi-CDN failover) narrows the set there; the effect re-picks when the playable set actually changes. No constraint code yet — just the reactive shape.

## Notable design decisions

- **Dropped the empty-slot audio picker now rather than carrying it alongside the chain.** The old `pickAudioTrack` set a preferred-language / default audio track on load; it's removed and `preferredAudioLanguage` is inert until it returns as a standing soft-filter rule. Alternative considered: keep the picker until its replacement rule lands so nothing regresses. Rejected because the picker and the chain both write `selectedAudioTrackId` — running them together reintroduces the multi-writer coupling the refactor removes. The regression is internal/alpha (flagged in callouts).
- **Tightly-coupled reads as the rule↔signal contract.** A rule names the state/context/config it needs on its own deps view and reads it at apply time. Alternative considered: a rule declares its dependencies as metadata the behavior aggregates up (keeping `stateKeys` exhaustive), or the behavior hands rules a prebuilt context. Rejected for now because metadata-aggregation collides with early-bail (you'd subscribe to every rule's signals up front, defeating the lazy chain), and this is the design's still-open contract question — tightly-coupled reads are the documented starting point.
- **`candidateSet` is read reactively (`.get()`), not peeked.** Alternative considered: keep the prior `peek(state.presentation)` (no subscription to the track set). Rejected because a future dynamic constraint (CDN failover) must re-pick when the playable set changes while a presentation stays resolved — `peek` can't see that. A track-id **set** equality on the computed keeps it from re-firing on presentation churn that leaves the set intact (a live playlist refresh swaps the presentation object but not the tracks).

## Reviewer callouts — known limitations

- **[Author] `preferredAudioLanguage` is inert.** Audio default-language / default-track selection on load is gone until it returns as a standing soft-filter rule — the most user-visible change on the branch. Good enough for alpha; follow-up will reintroduce it as a rule.
- **[Author] `defineBehavior` context is threaded via a rest-spread stopgap.** A typed `context` param on the variant setup would widen `ContextMap` to its `AnySlotMap` bound (contravariant inference) and force the slot required, breaking direct `.setup({ state })` calls. The variants forward context untyped through `{ config, ...otherProps }`; it rides through at runtime. Proper fix = a typed pass-through-context affordance on `defineBehavior` (deferred).
- **[Author] The constraints seam is shape-only.** No `applyConstraints` / `constraints` config yet, and an empty playable set is a silent early-return, not a modeled "nothing playable" not-ready state — left to the constraints work.
- **[Deferred] Feature docs not yet updated.** `multi-language-audio.md` (dropped default selection), `audio-abr.md` (now the shared ranker), `video-abr.md` (impl surface), `audio-playback.md` (default-selection note re-opens) are owed a combined pass at merge — deferred because they track `main` and the recommendation doc is still draft.

## Breaking changes

Internal SPF only (alpha; no external consumers). Audio track selection drops its default-language / default-track pick on load (`preferredAudioLanguage` now unconsumed) and moves from pin-to-current to bandwidth ranking — audio with differing per-rendition bitrates now selects by bandwidth. The `TrackSwitchingConfig` → `SwitchVideoTrackConfig` export rename is internal SPF as well.

## Test plan

- [x] Full SPF suite green (`pnpm -F @videojs/spf test` — 925 passed / 13 skipped), including a new resolved→resolved candidate-set reactivity test and the `applyRules` composer unit tests.
- [x] Smoke-checked in the `spf-segment-loading` harness via automated browser: 7 renditions + 7 audio languages enumerate, manual rendition lock disables ABR, audio language switch is mid-stream with no stall, and the audio-only CMAF asset plays. ABR-under-throttle left as a reviewer hands-on check (see *Smoke test*).
- [ ] Feature-doc cascade — deferred to merge (see callouts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core playback selection (video ABR + audio defaults) and removes preferred-language on load; scope is internal alpha but affects mid-stream track behavior and embedder signal wiring.
> 
> **Overview**
> Refactors SPF **track switching** from a hardcoded filter-then-`selectQuality` path into an ordered **rule chain** (`filterByUserSelection` → `rankByBandwidth`) composed by **`applyRules`** (soft-filter fall-through + early-bail when one candidate remains so bandwidth isn’t subscribed under a locked user pick).
> 
> The behavior now owns only **`presentation`** and **`selected*TrackId`**; rules read **`user*TrackSelection`** and **`bandwidthState`** via optional deps. **`makeShareSignals`** can **materialize** embedder-written `user*TrackSelection` slots; HLS engines wire those keys. Playable candidates move to a reactive **`candidateSet`** computed (id-set equality) so picks update when the track set changes while still resolved.
> 
> Video ABR stays at parity via **`rankByBandwidth`** (hysteresis + **`resolutionArea`** tie-break). **Audio** drops empty-slot **`pickAudioTrack`** / **`preferredAudioLanguage`** and shares the bandwidth ranker (manifest-order default when bitrates tie). Public rename: **`TrackSwitchingConfig` → `SwitchVideoTrackConfig`**. Sandbox adds an **audio-only CMAF** source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c111e316d356158f7c4237c235a45519cc6514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->