### PR TITLE
docs(react): clarify usePlayer typed vs untyped store access

### DIFF
--- a/packages/react/src/player/context.tsx
+++ b/packages/react/src/player/context.tsx
@@ -45,11 +45,19 @@ export function usePlayerContext(): PlayerContextValue {
 /**
  * Access the player store from within a Player Provider.
  *
+ * This standalone hook has no knowledge of your configured features, so it
+ * returns an untyped `UnknownStore` whose state properties are typed as
+ * `unknown`. For typed access, use the `usePlayer` returned by `createPlayer()`,
+ * or pass a premade selector to recover the type from its return value.
+ *
  * @label Without Selector
  */
 export function usePlayer(): UnknownStore;
 /**
  * Select a value from the player store. Re-renders when the selected value changes.
+ *
+ * The selector receives `UnknownState`, so an inline selector returns `unknown`.
+ * Pass a premade selector (e.g. `selectPlayback`) to get a typed result.
  *
  * @label With Selector
  * @param selector - Derives a value from the player store state.

--- a/site/src/content/docs/reference/use-player.mdx
+++ b/site/src/content/docs/reference/use-player.mdx
@@ -4,6 +4,7 @@ description: Hook to access the player store from within a Player.Provider
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
+import Aside from "@/components/Aside.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
@@ -16,6 +17,18 @@ import selectorReactTsx from "@/components/docs/demos/use-player/react/css/Selec
 import selectorReactCss from "@/components/docs/demos/use-player/react/css/Selector.css?raw";
 
 `Player.usePlayer` gives you access to the player store from any component within a `Player.Provider`. It has two overloads — without arguments for direct store access, or with a selector for reactive state subscriptions. `Player.usePlayer` is typed to the features you passed to <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>. It's also available as a standalone import (`import { usePlayer } from '@videojs/react'`), but the standalone version returns an untyped store.
+
+<Aside type="note" title="Typed vs. untyped access">
+`Player.usePlayer` (from <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>) is typed to your features and needs no selector. The standalone `import { usePlayer } from '@videojs/react'` returns an untyped `UnknownStore` — pass a premade selector to recover typing.
+</Aside>
+
+```tsx
+import { usePlayer } from '@videojs/react';
+import { selectPlayback } from '@videojs/core/dom';
+
+usePlayer();               // UnknownStore (state: unknown)
+usePlayer(selectPlayback); // PlaybackState | undefined
+```
 
 ## Examples
 

--- a/site/src/content/docs/reference/use-player.mdx
+++ b/site/src/content/docs/reference/use-player.mdx
@@ -4,7 +4,6 @@ description: Hook to access the player store from within a Player.Provider
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
-import Aside from "@/components/Aside.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
@@ -16,15 +15,12 @@ import SelectorDemoReact from "@/components/docs/demos/use-player/react/css/Sele
 import selectorReactTsx from "@/components/docs/demos/use-player/react/css/Selector.tsx?raw";
 import selectorReactCss from "@/components/docs/demos/use-player/react/css/Selector.css?raw";
 
-`Player.usePlayer` gives you access to the player store from any component within a `Player.Provider`. It has two overloads — without arguments for direct store access, or with a selector for reactive state subscriptions. `Player.usePlayer` is typed to the features you passed to <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>. It's also available as a standalone import (`import { usePlayer } from '@videojs/react'`), but the standalone version returns an untyped store.
+`Player.usePlayer` (from <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>) gives you access to the player store from any component within a `Player.Provider`. It's typed to the features you passed to `createPlayer`, and has two overloads — without arguments for direct store access, or with a selector for reactive state subscriptions.
 
-<Aside type="note" title="Typed vs. untyped access">
-`Player.usePlayer` (from <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>) is typed to your features and needs no selector. The standalone `import { usePlayer } from '@videojs/react'` returns an untyped `UnknownStore` — pass a premade selector to recover typing.
-</Aside>
+`usePlayer` is also available as a standalone import (`import { usePlayer } from '@videojs/react'`), but the standalone version returns an untyped `UnknownStore`. Pass a premade selector to recover typing:
 
 ```tsx
-import { usePlayer } from '@videojs/react';
-import { selectPlayback } from '@videojs/core/dom';
+import { usePlayer, selectPlayback } from '@videojs/react';
 
 usePlayer();               // UnknownStore (state: unknown)
 usePlayer(selectPlayback); // PlaybackState | undefined


### PR DESCRIPTION
Closes #1483

## Summary

The `use-player` reference page mentioned the typed-vs-untyped distinction only in a single easy-to-miss sentence, so users assumed the standalone `usePlayer()` is supposed to return `unknown`. This makes the distinction prominent on the page and corrects the standalone hook's generated reference.

## Changes

- Add a note callout to the `use-player` reference page: `Player.usePlayer` (from `createPlayer`) is typed to the configured features and needs no selector, while the standalone `import { usePlayer }` returns an untyped `UnknownStore` and needs a premade selector to recover typing.
- Enrich the standalone `usePlayer` JSDoc so the generated reference explains the `UnknownStore` return — and that inline selectors stay `unknown` while premade selectors (e.g. `selectPlayback`) carry their type.

## Testing

- `pnpm -F site api-docs` — regenerates the util reference; confirmed `use-player.json` now includes the new JSDoc paragraphs.
- `pnpm build:site` — site builds and the page renders.

> Related: #1111 (premade selectors incompatible with `createPlayer().PlayerController` types) is a separate types bug and is **not** addressed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no runtime or type behavior changes.
> 
> **Overview**
> Improves discoverability of **typed vs. untyped** `usePlayer` behavior so users don’t treat standalone `unknown` returns as a bug.
> 
> The **`use-player` reference** adds a note callout and a short example: `Player.usePlayer` from `createPlayer()` is feature-typed without a selector; standalone `import { usePlayer } from '@videojs/react'` yields an **`UnknownStore`**, with typing recoverable via premade selectors like `selectPlayback`.
> 
> **JSDoc** on the standalone `usePlayer` overloads now states the same — no feature knowledge, `UnknownStore` / `UnknownState`, inline selectors stay `unknown`, premade selectors carry their return type — so generated API reference matches the docs page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c447e2e5a6d4874cbc8a671b2ded1131ca6e03d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->