### PR TITLE
feat(core): add vimeo media host and html/react components

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -12,4 +12,5 @@ export const PRESETS = [
   'dash-video',
   'audio',
   'background-video',
+  'vimeo-video',
 ] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -79,6 +79,8 @@ export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';
 
 export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4';
 
+export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return (SOURCES[id] as { live?: boolean }).live === true;

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -18,6 +18,7 @@ import { Preview } from './preview';
 function getPagePath(platform: Platform, preset: Preset): string {
   if (platform === 'cdn') return '/cdn/';
   if (preset === 'background-video') return `/${platform}-background-video/`;
+  if (preset === 'vimeo-video') return `/${platform}-vimeo-video/`;
   return `/${platform}-${preset}/`;
 }
 
@@ -113,9 +114,9 @@ export function App() {
     }
   }, [preset, source, setSource]);
 
-  // CDN and background video do not have a Tailwind skin variant.
+  // CDN, background video, and vimeo video do not have a Tailwind skin variant.
   useEffect(() => {
-    if ((platform === 'cdn' || preset === 'background-video') && styling === 'tailwind') {
+    if ((platform === 'cdn' || preset === 'background-video' || preset === 'vimeo-video') && styling === 'tailwind') {
       setStyling('css');
     }
   }, [platform, preset, styling]);
@@ -151,6 +152,7 @@ export function App() {
         isSimpleHls={preset.startsWith('simple-hls-')}
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}
+        isVimeoVideo={preset === 'vimeo-video'}
         platforms={PLATFORMS}
         stylings={STYLINGS}
         presets={PRESETS}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -28,6 +28,7 @@ type NavbarProps = {
   isSimpleHls: boolean;
   isMuxVideo: boolean;
   isMuxAudio: boolean;
+  isVimeoVideo: boolean;
   platforms: readonly Platform[];
   stylings: readonly Styling[];
   presets: readonly Preset[];
@@ -53,6 +54,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'dash-video': 'DASH Video',
   audio: 'Audio',
   'background-video': 'Background Video',
+  'vimeo-video': 'Vimeo Video',
 };
 
 export function Navbar({
@@ -79,6 +81,7 @@ export function Navbar({
   isSimpleHls,
   isMuxVideo,
   isMuxAudio,
+  isVimeoVideo,
   platforms,
   stylings,
   presets,
@@ -107,7 +110,7 @@ export function Navbar({
           options={stylings.map((s) => ({
             value: s,
             label: s === 'css' ? 'CSS' : 'Tailwind',
-            disabled: s === 'tailwind' && (isBackgroundVideo || platform === 'cdn'),
+            disabled: s === 'tailwind' && (isBackgroundVideo || isVimeoVideo || platform === 'cdn'),
           }))}
         />
 
@@ -137,7 +140,7 @@ export function Navbar({
               return true;
             })
             .map((id) => ({ value: id, label: sources[id].label }))}
-          disabled={isBackgroundVideo}
+          disabled={isBackgroundVideo || isVimeoVideo}
         />
       </div>
 

--- a/apps/sandbox/templates/html-vimeo-video/index.html
+++ b/apps/sandbox/templates/html-vimeo-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Vimeo Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans p-2">
+    <div id="root" class="flex justify-center items-center min-h-screen"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-vimeo-video/main.ts
+++ b/apps/sandbox/templates/html-vimeo-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/vimeo-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { VIMEO_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <vimeo-video class="block w-full h-full" src="${VIMEO_VIDEO_SRC}" playsinline></vimeo-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-vimeo-video/index.html
+++ b/apps/sandbox/templates/react-vimeo-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Vimeo Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans p-2">
+    <div id="root" class="flex justify-center items-center min-h-screen"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-vimeo-video/main.tsx
+++ b/apps/sandbox/templates/react-vimeo-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoProvider } from '@app/shared/react/providers';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { VIMEO_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { VimeoVideo } from '@videojs/react/media/vimeo-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoProvider>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <VimeoVideo className="block w-full h-full" src={VIMEO_VIDEO_SRC} playsInline />
+      </VideoSkinComponent>
+    </VideoProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "@videojs/spf": "workspace:*",
     "@videojs/store": "workspace:*",
     "@videojs/utils": "workspace:*",
+    "@vimeo/player": "^2.30.3",
     "dashjs": "^5.0.0",
     "hls.js": "^1.6.7",
     "mux-embed": "^5.17.10"

--- a/packages/core/src/dom/media/constants.ts
+++ b/packages/core/src/dom/media/constants.ts
@@ -1,11 +1,13 @@
 import type { RemotePlaybackLike, TextTrackListLike, TimeRangeLike } from '../../core/media/types';
 
+/** A frozen, empty `TimeRanges`-like value for hosts with no ranges. */
 export const EMPTY_TIME_RANGES: TimeRangeLike = Object.freeze({
   length: 0,
   start: () => 0,
   end: () => 0,
 });
 
+/** A frozen, empty `TextTrackList`-like value for hosts with no text tracks. */
 export const EMPTY_TEXT_TRACKS: TextTrackListLike = Object.assign(new EventTarget(), {
   length: 0,
   *[Symbol.iterator]() {},

--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -272,7 +272,15 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       );
     }
 
-    disconnectedCallback(): void {
+    connectedCallback() {
+      if (tag !== 'iframe') return;
+      // Add data attribute for styling and avoiding cross-origin issues. e.g. backdrop-filter
+      if (!this.hasAttribute('data-cross-origin-frame')) {
+        this.setAttribute('data-cross-origin-frame', '');
+      }
+    }
+
+    disconnectedCallback() {
       if (this.hasAttribute('keep-alive')) return;
       // Defer so a synchronous reparent (remove + insert) doesn't tear down
       // the host and its registered components.

--- a/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/packages/core/src/dom/media/custom-media-element/index.ts
@@ -102,6 +102,10 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
   tag: string,
   MediaHost: T
 ): CustomMediaConstructor<T> {
+  // Embed hosts (iframe) drive an external player rather than a native media
+  // element, so attribute changes are not mirrored onto the iframe target and
+  // there is no `<track>` / `<source>` syncing.
+  const syncTargetAttributes = tag !== 'iframe';
   const mediaHostAttrToProp = new Map<string, string>();
   let isDefined = false;
 
@@ -229,10 +233,9 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
 
         const allowedKeys = getAttrsFromProps(ctor.properties);
         const disallowedKeys = [...mediaHostAttrToProp.keys()];
-        const attrs: Record<string, string> = omit(
-          pick(namedNodeMapToObject(this.attributes), allowedKeys),
-          disallowedKeys
-        );
+        const pickedAttrs = pick(namedNodeMapToObject(this.attributes), allowedKeys);
+        // Embed templates (iframe) need host-bound attrs (e.g. `src`) to build the initial URL.
+        const attrs: Record<string, string> = syncTargetAttributes ? omit(pickedAttrs, disallowedKeys) : pickedAttrs;
         if (tag && !attrs.part) attrs.part = tag;
         this.shadowRoot!.innerHTML = ctor.getTemplateHTML(attrs);
       }
@@ -260,7 +263,7 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       return this.#mediaHost;
     }
 
-    get target(): HTMLVideoElement | HTMLAudioElement | null {
+    get target(): HTMLElement | null {
       return (
         this.querySelector(':scope > [slot=media]') ??
         this.querySelector(tag) ??
@@ -328,6 +331,8 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
         return;
       }
 
+      if (!syncTargetAttributes) return;
+
       if (newValue === null) {
         this.target?.removeAttribute(attrName);
       } else if (this.target?.getAttribute(attrName) !== newValue) {
@@ -336,6 +341,8 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
     }
 
     #syncMediaChildren(): void {
+      if (tag === 'iframe') return;
+
       const defaultSlot = this.shadowRoot?.querySelector('slot:not([name])') as HTMLSlotElement;
       const mediaChildren = new Set(
         defaultSlot

--- a/packages/core/src/dom/media/custom-media-element/tests/custom-media-element.test.ts
+++ b/packages/core/src/dom/media/custom-media-element/tests/custom-media-element.test.ts
@@ -73,6 +73,17 @@ class TestAudioHost extends HTMLAudioElementHost {
   destroy() {}
 }
 
+class TestIframeHost extends EventTarget {
+  target: EventTarget | null = null;
+  attach(target: EventTarget | null) {
+    this.target = target;
+  }
+  detach() {
+    this.target = null;
+  }
+  destroy() {}
+}
+
 let tagCounter = 0;
 
 function defineVideoElement() {
@@ -92,6 +103,13 @@ function defineVideoElementWithObjects() {
 function defineAudioElement() {
   const tag = `test-audio-${++tagCounter}`;
   const Ctor = CustomMediaElement('audio', TestAudioHost);
+  customElements.define(tag, Ctor);
+  return { Ctor, tag };
+}
+
+function defineIframeElement() {
+  const tag = `test-iframe-${++tagCounter}`;
+  const Ctor = CustomMediaElement('iframe', TestIframeHost as never);
   customElements.define(tag, Ctor);
   return { Ctor, tag };
 }
@@ -678,6 +696,18 @@ describe('CustomMediaElement', () => {
       el.target!.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
 
       expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('connectedCallback', () => {
+    it('marks iframe embeds with data-cross-origin-frame for cross-origin-safe styling', () => {
+      const el = create(defineIframeElement());
+      expect(el.hasAttribute('data-cross-origin-frame')).toBe(true);
+    });
+
+    it('does not add data-cross-origin-frame to native media elements', () => {
+      const el = create(defineVideoElement());
+      expect(el.hasAttribute('data-cross-origin-frame')).toBe(false);
     });
   });
 

--- a/packages/core/src/dom/media/media-played-ranges/index.ts
+++ b/packages/core/src/dom/media/media-played-ranges/index.ts
@@ -1,0 +1,150 @@
+// Adapted from `media-played-ranges-mixin@0.1.0` from `muxinc/media-elements`,
+// ported to TypeScript and reshaped as a class mixin to fit the v10 media-host
+// architecture.
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { isNumber } from '@videojs/utils/predicate';
+import type { Constructor, MixinReturn } from '@videojs/utils/types';
+import type { TimeRangeLike } from '../../../core/media/types';
+
+export interface PlayedRange {
+  start: number;
+  end: number;
+}
+
+/** Surface a media host must expose for played-range tracking. */
+export interface MediaPlayedRangesHost extends EventTarget {
+  currentTime: number;
+  paused: boolean;
+}
+
+/** Public surface contributed by {@link MediaPlayedRangesMixin}. */
+export interface MediaPlayedRangesAPI {
+  /** `TimeRanges`-like view of the ranges the user has actually played. */
+  readonly played: TimeRangeLike;
+  destroy(): void;
+}
+
+/**
+ * Mixin that tracks played ranges for media hosts lacking a native
+ * `HTMLMediaElement.played` (e.g. iframe-based embeds like Vimeo).
+ *
+ * Listens for standard media events the host dispatches on itself
+ * (`play`, `pause`, `ended`, `seeking`, `seeked`) and derives a
+ * `TimeRanges`-like `played` value from the host's `currentTime` / `paused`.
+ *
+ * @example
+ * class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) { ... }
+ */
+export function MediaPlayedRangesMixin<Base extends Constructor<EventTarget & { destroy?(): void }>>(
+  BaseClass: Base
+): MixinReturn<Base, MediaPlayedRangesAPI> {
+  class MediaPlayedRanges extends BaseClass {
+    #playedRanges: PlayedRange[] = [];
+    #currentPlayedRange: PlayedRange | null = null;
+    #rangeEpsilon = 0.5;
+    #disconnect = new AbortController();
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const options = { signal: this.#disconnect.signal };
+      this.addEventListener('play', () => this.#onPlaybackStart(this.#currentTime), options);
+      this.addEventListener('pause', () => this.#onPlaybackStop(this.#currentTime), options);
+      this.addEventListener('ended', () => this.#onPlaybackStop(this.#currentTime), options);
+      this.addEventListener('seeking', () => this.#commitCurrentRange(), options);
+      this.addEventListener('seeked', () => this.#onSeeked(this.#currentTime), options);
+    }
+
+    /** The host (subclass) supplies `currentTime` / `paused`. */
+    get #host(): MediaPlayedRangesHost {
+      return this as unknown as MediaPlayedRangesHost;
+    }
+
+    get #currentTime(): number {
+      return this.#host.currentTime;
+    }
+
+    get played(): TimeRangeLike {
+      const time = this.#currentTime;
+      if (!this.#host.paused && !this.#currentPlayedRange && isNumber(time)) {
+        this.#currentPlayedRange = { start: time, end: time };
+      }
+      if (this.#currentPlayedRange && isNumber(time)) {
+        if (time > this.#currentPlayedRange.end) {
+          this.#currentPlayedRange.end = time;
+        }
+        this.#addPlayedRange(this.#currentPlayedRange.start, this.#currentPlayedRange.end);
+      }
+      if (!this.#playedRanges.length) {
+        return createTimeRanges([[0, 0]]);
+      }
+      return createTimeRanges(this.#playedRanges.map((r) => [r.start, r.end]));
+    }
+
+    destroy(): void {
+      this.#disconnect.abort();
+      super.destroy?.();
+    }
+
+    #onPlaybackStart(time: number): void {
+      const t = isNumber(time) ? time : this.#currentTime;
+      if (!this.#currentPlayedRange) {
+        this.#currentPlayedRange = { start: t, end: t };
+      }
+    }
+
+    #onSeeked(time: number): void {
+      const t = isNumber(time) ? time : this.#currentTime;
+      this.#currentPlayedRange = { start: t, end: t };
+    }
+
+    #onPlaybackStop(time: number): void {
+      const t = isNumber(time) ? time : this.#currentTime;
+      this.#commitCurrentRange(t);
+    }
+
+    #commitCurrentRange(time?: number): void {
+      if (!this.#currentPlayedRange) return;
+      if (isNumber(time)) {
+        this.#currentPlayedRange.end = time;
+      }
+      const { start, end } = this.#currentPlayedRange;
+      this.#currentPlayedRange = null;
+      this.#addPlayedRange(start, end);
+    }
+
+    #addPlayedRange(start: number, end: number): void {
+      if (start >= end) return;
+      const allRanges: PlayedRange[] = [...this.#playedRanges, { start, end }];
+      allRanges.sort((a, b) => a.start - b.start);
+      const merged: PlayedRange[] = [];
+      for (const range of allRanges) {
+        const last = merged.length ? merged[merged.length - 1] : null;
+        if (!last) {
+          merged.push({ ...range });
+          continue;
+        }
+        if (range.start <= last.end + this.#rangeEpsilon) {
+          last.start = Math.min(last.start, range.start);
+          last.end = Math.max(last.end, range.end);
+        } else {
+          merged.push({ ...range });
+        }
+      }
+      this.#playedRanges = merged;
+    }
+  }
+
+  return MediaPlayedRanges as unknown as MixinReturn<Base, MediaPlayedRangesAPI>;
+}
+
+function createTimeRanges(ranges: number[][]): TimeRangeLike {
+  Object.defineProperties(ranges, {
+    start: { value: (i: number) => ranges[i]?.[0] ?? 0 },
+    end: { value: (i: number) => ranges[i]?.[1] ?? 0 },
+  });
+  return ranges as unknown as TimeRangeLike;
+}

--- a/packages/core/src/dom/media/media-played-ranges/tests/index.test.ts
+++ b/packages/core/src/dom/media/media-played-ranges/tests/index.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { MediaPlayedRangesMixin } from '..';
+
+class FakeMedia extends MediaPlayedRangesMixin(EventTarget) {
+  currentTime = 0;
+  paused = true;
+
+  simulatePlay(time: number): void {
+    this.paused = false;
+    this.currentTime = time;
+    this.dispatchEvent(new Event('play'));
+  }
+
+  tick(time: number): void {
+    this.currentTime = time;
+  }
+
+  simulatePause(time: number): void {
+    this.currentTime = time;
+    this.paused = true;
+    this.dispatchEvent(new Event('pause'));
+  }
+
+  seek(target: number): void {
+    this.dispatchEvent(new Event('seeking'));
+    this.currentTime = target;
+    this.dispatchEvent(new Event('seeked'));
+  }
+
+  end(time: number): void {
+    this.currentTime = time;
+    this.paused = true;
+    this.dispatchEvent(new Event('ended'));
+  }
+}
+
+describe('MediaPlayedRangesMixin', () => {
+  it('starts with a single empty range', () => {
+    const media = new FakeMedia();
+    expect(media.played.length).toBe(1);
+    expect(media.played.start(0)).toBe(0);
+    expect(media.played.end(0)).toBe(0);
+  });
+
+  it('tracks a contiguous play segment', () => {
+    const media = new FakeMedia();
+    media.simulatePlay(0);
+    media.tick(5);
+    media.simulatePause(5);
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(5);
+  });
+
+  it('merges adjacent ranges within the epsilon tolerance', () => {
+    const media = new FakeMedia();
+    media.simulatePlay(0);
+    media.simulatePause(5);
+    media.simulatePlay(5.2);
+    media.simulatePause(8);
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.end(0)).toBe(8);
+  });
+
+  it('keeps non-adjacent ranges separate', () => {
+    const media = new FakeMedia();
+    media.simulatePlay(0);
+    media.simulatePause(2);
+    media.seek(20);
+    media.simulatePlay(20);
+    media.simulatePause(25);
+
+    const played = media.played;
+    expect(played.length).toBe(2);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(2);
+    expect(played.start(1)).toBe(20);
+    expect(played.end(1)).toBe(25);
+  });
+
+  it('commits a range on ended', () => {
+    const media = new FakeMedia();
+    media.simulatePlay(0);
+    media.tick(10);
+    media.end(10);
+    expect(media.played.end(0)).toBe(10);
+  });
+
+  it('stops tracking after destroy', () => {
+    const media = new FakeMedia();
+    media.destroy();
+    media.simulatePlay(0);
+    media.tick(5);
+    media.simulatePause(5);
+    // Listeners were removed on destroy, so no range was recorded.
+    expect(media.played.length).toBe(1);
+    expect(media.played.end(0)).toBe(0);
+  });
+});

--- a/packages/core/src/dom/media/vimeo/index.ts
+++ b/packages/core/src/dom/media/vimeo/index.ts
@@ -1,0 +1,748 @@
+import { isNull, isString, isUndefined } from '@videojs/utils/predicate';
+import VimeoPlayer, { type LoadVideoOptions, type VimeoEmbedParameters, type VimeoUrl } from '@vimeo/player';
+import type { ErrorLike, TextTrackListLike, Video } from '../../../core/media/types';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../constants';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+
+export type { default as VimeoPlayerApi } from '@vimeo/player';
+
+// ----------------------------------------------------------------------------
+// Types
+// ----------------------------------------------------------------------------
+
+export type VimeoPreload = 'none' | 'metadata' | 'auto';
+
+/** Public Vimeo embed configuration. Forwarded to `@vimeo/player`. */
+export type VimeoConfig = VimeoEmbedParameters;
+
+/** Parsed pieces of a Vimeo source URL. */
+export interface VimeoSource {
+  /** Numeric Vimeo id. */
+  id: number;
+  /** `'video'` for regular clips, `'event'` for live events. */
+  kind: 'video' | 'event';
+  /** Unlisted-video / event hash (the `h` parameter). */
+  hash: string | null;
+}
+
+export interface VimeoMediaProps {
+  /** Vimeo video id, vimeo.com URL, or player.vimeo.com embed URL. */
+  src: string;
+  autoplay: boolean;
+  /** Reflects the `muted` attribute (initial state). Use `muted` for runtime mute. */
+  defaultMuted: boolean;
+  loop: boolean;
+  controls: boolean;
+  playsInline: boolean;
+  preload: VimeoPreload;
+  poster: string;
+  /**
+   * Arbitrary extra `@vimeo/player` embed parameters merged into the iframe
+   * URL. Use this for Vimeo-specific knobs that aren't on the standard media
+   * surface — e.g. `autopause`, `byline`, `dnt`, `quality`, `texttrack`.
+   */
+  config: VimeoConfig;
+}
+
+export const vimeoMediaDefaultProps: VimeoMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  config: {},
+};
+
+// ----------------------------------------------------------------------------
+// VimeoMedia
+// ----------------------------------------------------------------------------
+
+/**
+ * Media host for Vimeo embeds. Wraps an `<iframe>` and implements the
+ * {@link Video} surface against the underlying `@vimeo/player` instance, with
+ * played-range tracking via {@link MediaPlayedRangesMixin}. Embed-only props
+ * (`autoplay`, `config`, …) live on the class but outside {@link Video}.
+ *
+ * Vimeo drives state via the JS Player API rather than a native `<video>`
+ * target — the `target` here is the `<iframe>` the player is bound to.
+ */
+export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements Video {
+  #target: HTMLIFrameElement | null = null;
+  #player: VimeoPlayer | null = null;
+  #loadComplete = createPublicPromise<void>();
+
+  #src = vimeoMediaDefaultProps.src;
+  #autoplay = vimeoMediaDefaultProps.autoplay;
+  #defaultMuted = vimeoMediaDefaultProps.defaultMuted;
+  #loop = vimeoMediaDefaultProps.loop;
+  #controls = vimeoMediaDefaultProps.controls;
+  #playsInline = vimeoMediaDefaultProps.playsInline;
+  #preload = vimeoMediaDefaultProps.preload;
+  #poster = vimeoMediaDefaultProps.poster;
+  #config = vimeoMediaDefaultProps.config;
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #volume = 1;
+  #muted = false;
+  #playbackRate = 1;
+  #progress = 0;
+  #videoWidth = Number.NaN;
+  #videoHeight = Number.NaN;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: ErrorLike | null = null;
+  #isFullscreen = false;
+  #isPictureInPicture = false;
+  #disablePictureInPicture = false;
+
+  #textTracksHost: HTMLVideoElement | null = null;
+  #textTracksDisconnect: AbortController | null = null;
+
+  static PLAYER_SOFTWARE_NAME = 'vimeo-video';
+
+  // -- Engine + target --
+
+  /** Underlying `@vimeo/player` instance (null before attach). */
+  get engine() {
+    return this.#player;
+  }
+
+  /** Iframe element this media is bound to. */
+  get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /**
+   * Bind the iframe that hosts the Vimeo embed. Creates a `@vimeo/player`
+   * instance and dispatches `loadstart`.
+   */
+  attach(target: HTMLIFrameElement | null): void {
+    if (!target || this.#target === target) return;
+    if (this.#target) this.detach();
+
+    this.#target = target;
+
+    if (!target.src) {
+      const initialSrc = buildVimeoIframeSrc(this.#src, this.#snapshotProps());
+      if (initialSrc) target.src = initialSrc;
+    }
+
+    this.#loadComplete = createPublicPromise<void>();
+    this.#player = new VimeoPlayer(target);
+    this.#bindPlayerEvents(this.#player);
+    this.#setupTextTracks(this.#player);
+
+    this.dispatchEvent(new Event('loadstart'));
+  }
+
+  /** Unbind the iframe, destroying the underlying `@vimeo/player` instance. */
+  detach(): void {
+    if (!this.#target) return;
+    this.#teardownTextTracks();
+    this.#player?.destroy().catch(() => {});
+    this.#player = null;
+    this.#target = null;
+    this.#resetState();
+  }
+
+  override destroy() {
+    this.detach();
+    super.destroy();
+  }
+
+  // -- Source --
+
+  get src() {
+    return this.#src;
+  }
+
+  set src(value) {
+    if (this.#src === value) return;
+    this.#src = value;
+    void this.load();
+  }
+
+  get currentSrc() {
+    return this.#target?.src ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /**
+   * Force a reload of the current source. Calls Vimeo's `loadVideo` API if
+   * the player is connected; otherwise a no-op until `attach()` is called.
+   */
+  async load() {
+    if (!this.#player || !this.#src) return;
+
+    this.#resetState();
+    this.#loadComplete = createPublicPromise<void>();
+    this.dispatchEvent(new Event('emptied'));
+    this.dispatchEvent(new Event('loadstart'));
+
+    const loadOptions = toLoadVideoOptions(this.#src, this.#config);
+    if (!loadOptions) return;
+
+    // Vimeo dispatches an `error` event separately on failure.
+    await this.#player.loadVideo(loadOptions).catch(() => {});
+  }
+
+  // -- Playback --
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    await this.#loadComplete;
+    await this.#player?.play();
+  }
+
+  pause() {
+    void this.#player?.pause().catch(() => {});
+  }
+
+  // -- Time --
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#currentTime = value;
+    this.#afterLoad((p) => p.setCurrentTime(value));
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  // -- Volume --
+
+  get volume() {
+    return this.#volume;
+  }
+
+  set volume(value) {
+    if (this.#volume === value) return;
+    this.#volume = value;
+    this.#afterLoad((p) => p.setVolume(value));
+  }
+
+  get muted() {
+    return this.#muted;
+  }
+
+  set muted(value) {
+    if (this.#muted === value) return;
+    this.#muted = value;
+    this.#afterLoad((p) => p.setMuted(value));
+  }
+
+  // -- Playback rate --
+
+  get playbackRate() {
+    return this.#playbackRate;
+  }
+
+  set playbackRate(value) {
+    if (this.#playbackRate === value) return;
+    this.#playbackRate = value;
+    this.#afterLoad((p) => p.setPlaybackRate(value));
+  }
+
+  // -- Playback options --
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+
+  set autoplay(value) {
+    this.#autoplay = value;
+  }
+
+  get defaultMuted() {
+    return this.#defaultMuted;
+  }
+
+  set defaultMuted(value) {
+    this.#defaultMuted = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+
+  set loop(value) {
+    this.#loop = value;
+    this.#afterLoad((p) => p.setLoop(value));
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+
+  set controls(value) {
+    this.#controls = value;
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+
+  set playsInline(value) {
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+
+  set preload(value) {
+    this.#preload = value;
+  }
+
+  get poster() {
+    return this.#poster;
+  }
+
+  set poster(value) {
+    this.#poster = value;
+  }
+
+  get config() {
+    return this.#config as Record<string, unknown>;
+  }
+
+  set config(value) {
+    this.#config = value as VimeoConfig;
+  }
+
+  // -- Buffer --
+
+  get buffered() {
+    return this.#progress > 0 ? createTimeRanges(0, this.#progress) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRanges(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  // -- Error --
+
+  get error() {
+    return this.#error;
+  }
+
+  // -- Text tracks --
+
+  get textTracks() {
+    if (!this.#textTracksHost) {
+      this.#textTracksHost = globalThis.document?.createElement('video') ?? null;
+    }
+    return (this.#textTracksHost?.textTracks as TextTrackListLike) ?? EMPTY_TEXT_TRACKS;
+  }
+
+  // -- Dimensions --
+
+  get videoWidth() {
+    return this.#videoWidth;
+  }
+
+  get videoHeight() {
+    return this.#videoHeight;
+  }
+
+  // -- Fullscreen / Picture-in-Picture --
+
+  get isFullscreen() {
+    return this.#isFullscreen;
+  }
+
+  async requestFullscreen() {
+    await this.#loadComplete;
+    await this.#player?.requestFullscreen?.();
+    this.#isFullscreen = true;
+  }
+
+  async exitFullscreen() {
+    await this.#loadComplete;
+    await this.#player?.exitFullscreen?.();
+    this.#isFullscreen = false;
+  }
+
+  get isPictureInPicture() {
+    return this.#isPictureInPicture;
+  }
+
+  get disablePictureInPicture() {
+    return this.#disablePictureInPicture;
+  }
+
+  set disablePictureInPicture(value) {
+    this.#disablePictureInPicture = value;
+  }
+
+  async requestPictureInPicture() {
+    await this.#loadComplete;
+    try {
+      await this.#player?.requestPictureInPicture?.();
+      this.#isPictureInPicture = true;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async exitPictureInPicture() {
+    await this.#loadComplete;
+    try {
+      await this.#player?.exitPictureInPicture?.();
+      this.#isPictureInPicture = false;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  // -- Internals --
+
+  /** Defer a player call until `loadComplete` resolves, swallowing rejections. */
+  #afterLoad(fn: (player: VimeoPlayer) => Promise<unknown>) {
+    this.#loadComplete.then(
+      () => {
+        if (this.#player) fn(this.#player).catch(() => {});
+      },
+      () => {}
+    );
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      defaultMuted: this.#defaultMuted,
+      loop: this.#loop,
+      controls: this.#controls,
+      playsInline: this.#playsInline,
+      preload: (this.#preload || vimeoMediaDefaultProps.preload) as VimeoPreload,
+      config: this.#config,
+    };
+  }
+
+  #resetState() {
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    this.#muted = false;
+    this.#paused = !this.#autoplay;
+    this.#ended = false;
+    this.#playbackRate = 1;
+    this.#progress = 0;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#volume = 1;
+    this.#error = null;
+    this.#videoWidth = Number.NaN;
+    this.#videoHeight = Number.NaN;
+    this.#isFullscreen = false;
+    this.#isPictureInPicture = false;
+  }
+
+  async #onLoaded() {
+    this.#readyState = READY_STATE_HAVE_METADATA;
+
+    const player = this.#player;
+    if (player) {
+      // Pull initial state in parallel; each falls back to the current value
+      // so a single failure doesn't clobber the others.
+      const [muted, volume, duration] = await Promise.all([
+        player.getMuted().catch(() => this.#muted),
+        player.getVolume().catch(() => this.#volume),
+        player.getDuration().catch(() => this.#duration),
+      ]);
+      this.#muted = muted;
+      this.#volume = volume;
+      this.#duration = duration;
+    }
+
+    this.dispatchEvent(new Event('loadedmetadata'));
+    this.dispatchEvent(new Event('durationchange'));
+    this.dispatchEvent(new Event('volumechange'));
+    this.dispatchEvent(new Event('loadcomplete'));
+    this.#loadComplete.resolve();
+  }
+
+  #bindPlayerEvents(player: VimeoPlayer) {
+    player.on('loaded', () => this.#onLoaded());
+    player.on('bufferstart', () => this.dispatchEvent(new Event('waiting')));
+
+    player.on('play', () => {
+      this.#paused = false;
+      this.dispatchEvent(new Event('play'));
+    });
+
+    player.on('playing', () => {
+      this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+      this.#paused = false;
+      this.dispatchEvent(new Event('playing'));
+    });
+
+    player.on('seeking', () => {
+      this.#seeking = true;
+      this.dispatchEvent(new Event('seeking'));
+    });
+
+    player.on('seeked', () => {
+      this.#seeking = false;
+      this.dispatchEvent(new Event('seeked'));
+    });
+
+    player.on('pause', () => {
+      this.#paused = true;
+      this.dispatchEvent(new Event('pause'));
+    });
+
+    player.on('ended', () => {
+      this.#paused = true;
+      this.#ended = true;
+      this.dispatchEvent(new Event('ended'));
+    });
+
+    player.on('playbackratechange', ({ playbackRate }) => {
+      this.#playbackRate = playbackRate;
+      this.dispatchEvent(new Event('ratechange'));
+    });
+
+    player.on('volumechange', ({ volume }) => {
+      this.#volume = volume;
+      this.dispatchEvent(new Event('volumechange'));
+    });
+
+    player.on('durationchange', ({ duration }) => {
+      this.#duration = duration;
+      this.dispatchEvent(new Event('durationchange'));
+    });
+
+    player.on('timeupdate', ({ seconds, duration }) => {
+      this.#currentTime = seconds;
+      if (Number.isFinite(duration) && duration !== this.#duration) this.#duration = duration;
+      this.dispatchEvent(new Event('timeupdate'));
+    });
+
+    player.on('progress', ({ seconds }) => {
+      this.#progress = seconds;
+      this.dispatchEvent(new Event('progress'));
+    });
+
+    player.on('resize', ({ videoWidth, videoHeight }) => {
+      this.#videoWidth = videoWidth;
+      this.#videoHeight = videoHeight;
+      this.dispatchEvent(new Event('resize'));
+    });
+
+    player.on('error', () => {
+      this.#error = { code: 1, message: 'Vimeo playback error' };
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen/PiP don't hang.
+      this.#loadComplete.resolve();
+    });
+
+    player.on('fullscreenchange', ({ fullscreen }) => {
+      this.#isFullscreen = fullscreen;
+      this.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    player.on('enterpictureinpicture', () => {
+      this.#isPictureInPicture = true;
+      this.dispatchEvent(new Event('enterpictureinpicture'));
+    });
+
+    player.on('leavepictureinpicture', () => {
+      this.#isPictureInPicture = false;
+      this.dispatchEvent(new Event('leavepictureinpicture'));
+    });
+  }
+
+  #setupTextTracks(player: VimeoPlayer) {
+    const doc = globalThis.document;
+    if (isUndefined(doc)) return;
+
+    this.#teardownTextTracks();
+
+    const host = doc.createElement('video');
+    this.#textTracksHost = host;
+
+    player
+      .getTextTracks()
+      .then((tracks) => {
+        for (const track of tracks) {
+          if (!isString(track.kind) || isNull(track.kind)) continue;
+          try {
+            host.addTextTrack?.(track.kind as TextTrackKind, track.label ?? '', track.language ?? '');
+          } catch {
+            // jsdom or unsupported environments.
+          }
+        }
+      })
+      .catch(() => {});
+
+    this.#textTracksDisconnect = new AbortController();
+    host.textTracks?.addEventListener?.(
+      'change',
+      () => {
+        const showing = Array.from(host.textTracks).find((t) => t.mode === 'showing');
+        if (showing) player.enableTextTrack(showing.language, showing.kind).catch(() => {});
+        else player.disableTextTrack().catch(() => {});
+      },
+      { signal: this.#textTracksDisconnect.signal }
+    );
+  }
+
+  #teardownTextTracks() {
+    this.#textTracksDisconnect?.abort();
+    this.#textTracksDisconnect = null;
+    this.#textTracksHost = null;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Public utilities
+// ----------------------------------------------------------------------------
+
+/** Extract a Vimeo video id from a numeric id, vimeo.com URL, or player URL. */
+export function parseVimeoVideoId(src: string) {
+  return parseVimeoSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a Vimeo source string. Recognizes:
+ * - numeric ids (`'76979871'`),
+ * - `vimeo.com/<id>` and `vimeo.com/video/<id>` URLs,
+ * - `player.vimeo.com/video/<id>` URLs,
+ * - `vimeo.com/event/<id>` URLs (live events),
+ * - unlisted/event hash via `?h=` or `/<hash>` path segment.
+ */
+export function parseVimeoSource(src: string): VimeoSource | null {
+  if (!src) return null;
+
+  if (/^\d+$/.test(src)) {
+    return { id: Number(src), kind: 'video', hash: null };
+  }
+
+  const match = MATCH_SRC.exec(src);
+  if (!match) return null;
+
+  const kind = match[1] === 'event/' ? 'event' : 'video';
+  const id = Number(match[2]);
+  const pathHash = match[3] ?? null;
+
+  let queryHash: string | null = null;
+  try {
+    queryHash = new URL(src).searchParams.get('h');
+  } catch {
+    // src isn't a valid URL — ignore.
+  }
+
+  return { id, kind, hash: queryHash ?? pathHash };
+}
+
+/** Build the iframe `src` URL for an initial Vimeo embed from the given props. */
+export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps> = {}) {
+  const parsed = parseVimeoSource(src);
+  if (!parsed) return '';
+
+  const params: Record<string, unknown> = {
+    // Hide Vimeo chrome by default; pass nothing only when controls is explicitly true.
+    controls: props.controls === true ? null : 0,
+    autoplay: props.autoplay,
+    loop: props.loop,
+    muted: props.defaultMuted,
+    playsinline: props.playsInline ?? vimeoMediaDefaultProps.playsInline,
+    preload: props.preload ?? vimeoMediaDefaultProps.preload,
+    transparent: false,
+    h: parsed.hash,
+    // Vimeo-specific knobs (`autopause`, `byline`, `dnt`, …) flow through here.
+    ...(props.config ?? undefined),
+  };
+
+  if (parsed.kind === 'event') {
+    const hashPath = parsed.hash ? `/${parsed.hash}` : '';
+    delete params.h;
+    return `${EMBED_EVENT_BASE}/${parsed.id}/embed${hashPath}?${serialize(params)}`;
+  }
+
+  return `${EMBED_VIDEO_BASE}/${parsed.id}?${serialize(params)}`;
+}
+
+// ----------------------------------------------------------------------------
+// Module internals
+// ----------------------------------------------------------------------------
+
+const EMBED_VIDEO_BASE = 'https://player.vimeo.com/video';
+const EMBED_EVENT_BASE = 'https://vimeo.com/event';
+const MATCH_SRC = /vimeo\.com\/(video\/|event\/)?(\d+)(?:\/([\w-]+))?/;
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_FUTURE_DATA = 3;
+
+function createTimeRanges(start: number, end: number) {
+  return {
+    length: 1,
+    start: () => start,
+    end: () => end,
+  };
+}
+
+function toLoadVideoOptions(src: string, config: VimeoConfig) {
+  const parsed = parseVimeoSource(src);
+  if (!parsed) return null;
+  const baseUrl = parsed.kind === 'event' ? EMBED_EVENT_BASE : EMBED_VIDEO_BASE;
+  const path = parsed.kind === 'event' ? `${baseUrl}/${parsed.id}/embed` : `${baseUrl}/${parsed.id}`;
+  const url = `${path}${parsed.hash ? `?h=${parsed.hash}` : ''}` as VimeoUrl;
+  return { url, ...config } as LoadVideoOptions;
+}
+
+function serialize(props: Record<string, unknown>) {
+  const params = new URLSearchParams();
+  for (const key in props) {
+    const val = props[key];
+    if (val === true || val === '') params.set(key, '1');
+    else if (val === false) params.set(key, '0');
+    else if (val != null) params.set(key, String(val));
+  }
+  return params.toString();
+}
+
+interface PublicPromise<T> extends Promise<T> {
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createPublicPromise<T>(): PublicPromise<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  }) as PublicPromise<T>;
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}

--- a/packages/core/src/dom/media/vimeo/index.ts
+++ b/packages/core/src/dom/media/vimeo/index.ts
@@ -1,23 +1,18 @@
 import { isNull, isString, isUndefined } from '@videojs/utils/predicate';
 import VimeoPlayer, { type LoadVideoOptions, type VimeoEmbedParameters, type VimeoUrl } from '@vimeo/player';
-import type { ErrorLike, TextTrackListLike, Video } from '../../../core/media/types';
+import type { ErrorLike, MediaPreloadType, TextTrackListLike, Video } from '../../../core/media/types';
 import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../constants';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
 
 export type { default as VimeoPlayerApi } from '@vimeo/player';
 
-// ----------------------------------------------------------------------------
-// Types
-// ----------------------------------------------------------------------------
-
-export type VimeoPreload = 'none' | 'metadata' | 'auto';
-
 /** Public Vimeo embed configuration. Forwarded to `@vimeo/player`. */
-export type VimeoConfig = VimeoEmbedParameters;
+export interface VimeoConfig extends VimeoEmbedParameters {
+  referrerPolicy?: ReferrerPolicy;
+}
 
 /** Parsed pieces of a Vimeo source URL. */
 export interface VimeoSource {
-  /** Numeric Vimeo id. */
   id: number;
   /** `'video'` for regular clips, `'event'` for live events. */
   kind: 'video' | 'event';
@@ -26,21 +21,15 @@ export interface VimeoSource {
 }
 
 export interface VimeoMediaProps {
-  /** Vimeo video id, vimeo.com URL, or player.vimeo.com embed URL. */
   src: string;
   autoplay: boolean;
-  /** Reflects the `muted` attribute (initial state). Use `muted` for runtime mute. */
   defaultMuted: boolean;
+  muted: boolean;
   loop: boolean;
   controls: boolean;
   playsInline: boolean;
-  preload: VimeoPreload;
+  preload: MediaPreloadType;
   poster: string;
-  /**
-   * Arbitrary extra `@vimeo/player` embed parameters merged into the iframe
-   * URL. Use this for Vimeo-specific knobs that aren't on the standard media
-   * surface — e.g. `autopause`, `byline`, `dnt`, `quality`, `texttrack`.
-   */
   config: VimeoConfig;
 }
 
@@ -48,6 +37,7 @@ export const vimeoMediaDefaultProps: VimeoMediaProps = {
   src: '',
   autoplay: false,
   defaultMuted: false,
+  muted: false,
   loop: false,
   controls: false,
   playsInline: true,
@@ -56,20 +46,7 @@ export const vimeoMediaDefaultProps: VimeoMediaProps = {
   config: {},
 };
 
-// ----------------------------------------------------------------------------
-// VimeoMedia
-// ----------------------------------------------------------------------------
-
-/**
- * Media host for Vimeo embeds. Wraps an `<iframe>` and implements the
- * {@link Video} surface against the underlying `@vimeo/player` instance, with
- * played-range tracking via {@link MediaPlayedRangesMixin}. Embed-only props
- * (`autoplay`, `config`, …) live on the class but outside {@link Video}.
- *
- * Vimeo drives state via the JS Player API rather than a native `<video>`
- * target — the `target` here is the `<iframe>` the player is bound to.
- */
-export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements Video {
+export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;
   #player: VimeoPlayer | null = null;
   #loadComplete = createPublicPromise<void>();
@@ -100,48 +77,36 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   #isFullscreen = false;
   #isPictureInPicture = false;
   #disablePictureInPicture = false;
-
   #textTracksHost: HTMLVideoElement | null = null;
   #textTracksDisconnect: AbortController | null = null;
 
   static PLAYER_SOFTWARE_NAME = 'vimeo-video';
-
-  // -- Engine + target --
 
   /** Underlying `@vimeo/player` instance (null before attach). */
   get engine() {
     return this.#player;
   }
 
-  /** Iframe element this media is bound to. */
   get target(): HTMLIFrameElement | null {
     return this.#target;
   }
 
-  /**
-   * Bind the iframe that hosts the Vimeo embed. Creates a `@vimeo/player`
-   * instance and dispatches `loadstart`.
-   */
+  /** Bind the iframe hosting the embed, creating a `@vimeo/player` instance. */
   attach(target: HTMLIFrameElement | null): void {
     if (!target || this.#target === target) return;
     if (this.#target) this.detach();
-
     this.#target = target;
-
     if (!target.src) {
       const initialSrc = buildVimeoIframeSrc(this.#src, this.#snapshotProps());
       if (initialSrc) target.src = initialSrc;
     }
-
     this.#loadComplete = createPublicPromise<void>();
     this.#player = new VimeoPlayer(target);
     this.#bindPlayerEvents(this.#player);
     this.#setupTextTracks(this.#player);
-
     this.dispatchEvent(new Event('loadstart'));
   }
 
-  /** Unbind the iframe, destroying the underlying `@vimeo/player` instance. */
   detach(): void {
     if (!this.#target) return;
     this.#teardownTextTracks();
@@ -156,12 +121,9 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
     super.destroy();
   }
 
-  // -- Source --
-
   get src() {
     return this.#src;
   }
-
   set src(value) {
     if (this.#src === value) return;
     this.#src = value;
@@ -176,26 +138,18 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
     return this.#readyState;
   }
 
-  /**
-   * Force a reload of the current source. Calls Vimeo's `loadVideo` API if
-   * the player is connected; otherwise a no-op until `attach()` is called.
-   */
+  /** Reload the current source via Vimeo's `loadVideo`; no-op until `attach()`. */
   async load() {
     if (!this.#player || !this.#src) return;
-
     this.#resetState();
     this.#loadComplete = createPublicPromise<void>();
     this.dispatchEvent(new Event('emptied'));
     this.dispatchEvent(new Event('loadstart'));
-
     const loadOptions = toLoadVideoOptions(this.#src, this.#config);
     if (!loadOptions) return;
-
     // Vimeo dispatches an `error` event separately on failure.
     await this.#player.loadVideo(loadOptions).catch(() => {});
   }
-
-  // -- Playback --
 
   get paused() {
     return this.#paused;
@@ -218,12 +172,9 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
     void this.#player?.pause().catch(() => {});
   }
 
-  // -- Time --
-
   get currentTime() {
     return this.#currentTime;
   }
-
   set currentTime(value) {
     if (this.#currentTime === value) return;
     this.#currentTime = value;
@@ -234,12 +185,9 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
     return this.#duration;
   }
 
-  // -- Volume --
-
   get volume() {
     return this.#volume;
   }
-
   set volume(value) {
     if (this.#volume === value) return;
     this.#volume = value;
@@ -249,31 +197,24 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get muted() {
     return this.#muted;
   }
-
   set muted(value) {
     if (this.#muted === value) return;
     this.#muted = value;
     this.#afterLoad((p) => p.setMuted(value));
   }
 
-  // -- Playback rate --
-
   get playbackRate() {
     return this.#playbackRate;
   }
-
   set playbackRate(value) {
     if (this.#playbackRate === value) return;
     this.#playbackRate = value;
     this.#afterLoad((p) => p.setPlaybackRate(value));
   }
 
-  // -- Playback options --
-
   get autoplay() {
     return this.#autoplay;
   }
-
   set autoplay(value) {
     this.#autoplay = value;
   }
@@ -281,7 +222,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get defaultMuted() {
     return this.#defaultMuted;
   }
-
   set defaultMuted(value) {
     this.#defaultMuted = value;
   }
@@ -289,7 +229,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get loop() {
     return this.#loop;
   }
-
   set loop(value) {
     this.#loop = value;
     this.#afterLoad((p) => p.setLoop(value));
@@ -298,7 +237,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get controls() {
     return this.#controls;
   }
-
   set controls(value) {
     this.#controls = value;
   }
@@ -306,7 +244,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get playsInline() {
     return this.#playsInline;
   }
-
   set playsInline(value) {
     this.#playsInline = value;
   }
@@ -314,7 +251,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get preload() {
     return this.#preload;
   }
-
   set preload(value) {
     this.#preload = value;
   }
@@ -322,7 +258,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get poster() {
     return this.#poster;
   }
-
   set poster(value) {
     this.#poster = value;
   }
@@ -330,12 +265,9 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get config() {
     return this.#config as Record<string, unknown>;
   }
-
   set config(value) {
     this.#config = value as VimeoConfig;
   }
-
-  // -- Buffer --
 
   get buffered() {
     return this.#progress > 0 ? createTimeRanges(0, this.#progress) : EMPTY_TIME_RANGES;
@@ -347,22 +279,14 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
       : EMPTY_TIME_RANGES;
   }
 
-  // -- Error --
-
   get error() {
     return this.#error;
   }
 
-  // -- Text tracks --
-
   get textTracks() {
-    if (!this.#textTracksHost) {
-      this.#textTracksHost = globalThis.document?.createElement('video') ?? null;
-    }
+    this.#textTracksHost ??= globalThis.document?.createElement('video') ?? null;
     return (this.#textTracksHost?.textTracks as TextTrackListLike) ?? EMPTY_TEXT_TRACKS;
   }
-
-  // -- Dimensions --
 
   get videoWidth() {
     return this.#videoWidth;
@@ -371,8 +295,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get videoHeight() {
     return this.#videoHeight;
   }
-
-  // -- Fullscreen / Picture-in-Picture --
 
   get isFullscreen() {
     return this.#isFullscreen;
@@ -397,39 +319,28 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   get disablePictureInPicture() {
     return this.#disablePictureInPicture;
   }
-
   set disablePictureInPicture(value) {
     this.#disablePictureInPicture = value;
   }
 
   async requestPictureInPicture() {
     await this.#loadComplete;
-    try {
-      await this.#player?.requestPictureInPicture?.();
+    await this.#player?.requestPictureInPicture?.().then(() => {
       this.#isPictureInPicture = true;
-    } catch (error) {
-      console.error(error);
-    }
+    }, console.error);
   }
 
   async exitPictureInPicture() {
     await this.#loadComplete;
-    try {
-      await this.#player?.exitPictureInPicture?.();
+    await this.#player?.exitPictureInPicture?.().then(() => {
       this.#isPictureInPicture = false;
-    } catch (error) {
-      console.error(error);
-    }
+    }, console.error);
   }
-
-  // -- Internals --
 
   /** Defer a player call until `loadComplete` resolves, swallowing rejections. */
   #afterLoad(fn: (player: VimeoPlayer) => Promise<unknown>) {
     this.#loadComplete.then(
-      () => {
-        if (this.#player) fn(this.#player).catch(() => {});
-      },
+      () => this.#player && void fn(this.#player).catch(() => {}),
       () => {}
     );
   }
@@ -441,7 +352,7 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
       loop: this.#loop,
       controls: this.#controls,
       playsInline: this.#playsInline,
-      preload: (this.#preload || vimeoMediaDefaultProps.preload) as VimeoPreload,
+      preload: this.#preload || vimeoMediaDefaultProps.preload,
       config: this.#config,
     };
   }
@@ -466,11 +377,9 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
 
   async #onLoaded() {
     this.#readyState = READY_STATE_HAVE_METADATA;
-
     const player = this.#player;
     if (player) {
-      // Pull initial state in parallel; each falls back to the current value
-      // so a single failure doesn't clobber the others.
+      // Each value falls back to the current one so a single failure isn't fatal.
       const [muted, volume, duration] = await Promise.all([
         player.getMuted().catch(() => this.#muted),
         player.getVolume().catch(() => this.#volume),
@@ -480,114 +389,94 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
       this.#volume = volume;
       this.#duration = duration;
     }
-
-    this.dispatchEvent(new Event('loadedmetadata'));
-    this.dispatchEvent(new Event('durationchange'));
-    this.dispatchEvent(new Event('volumechange'));
-    this.dispatchEvent(new Event('loadcomplete'));
+    for (const type of ['loadedmetadata', 'durationchange', 'volumechange', 'loadcomplete']) {
+      this.dispatchEvent(new Event(type));
+    }
     this.#loadComplete.resolve();
   }
 
   #bindPlayerEvents(player: VimeoPlayer) {
+    const emit = (type: string) => this.dispatchEvent(new Event(type));
     player.on('loaded', () => this.#onLoaded());
-    player.on('bufferstart', () => this.dispatchEvent(new Event('waiting')));
-
+    player.on('bufferstart', () => emit('waiting'));
     player.on('play', () => {
       this.#paused = false;
-      this.dispatchEvent(new Event('play'));
+      emit('play');
     });
-
     player.on('playing', () => {
       this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
       this.#paused = false;
-      this.dispatchEvent(new Event('playing'));
+      emit('playing');
     });
-
     player.on('seeking', () => {
       this.#seeking = true;
-      this.dispatchEvent(new Event('seeking'));
+      emit('seeking');
     });
-
     player.on('seeked', () => {
       this.#seeking = false;
-      this.dispatchEvent(new Event('seeked'));
+      emit('seeked');
     });
-
     player.on('pause', () => {
       this.#paused = true;
-      this.dispatchEvent(new Event('pause'));
+      emit('pause');
     });
-
     player.on('ended', () => {
       this.#paused = true;
       this.#ended = true;
-      this.dispatchEvent(new Event('ended'));
+      emit('ended');
     });
-
     player.on('playbackratechange', ({ playbackRate }) => {
       this.#playbackRate = playbackRate;
-      this.dispatchEvent(new Event('ratechange'));
+      emit('ratechange');
     });
-
     player.on('volumechange', ({ volume }) => {
       this.#volume = volume;
-      this.dispatchEvent(new Event('volumechange'));
+      emit('volumechange');
     });
-
     player.on('durationchange', ({ duration }) => {
       this.#duration = duration;
-      this.dispatchEvent(new Event('durationchange'));
+      emit('durationchange');
     });
-
     player.on('timeupdate', ({ seconds, duration }) => {
       this.#currentTime = seconds;
       if (Number.isFinite(duration) && duration !== this.#duration) this.#duration = duration;
-      this.dispatchEvent(new Event('timeupdate'));
+      emit('timeupdate');
     });
-
     player.on('progress', ({ seconds }) => {
       this.#progress = seconds;
-      this.dispatchEvent(new Event('progress'));
+      emit('progress');
     });
-
     player.on('resize', ({ videoWidth, videoHeight }) => {
       this.#videoWidth = videoWidth;
       this.#videoHeight = videoHeight;
-      this.dispatchEvent(new Event('resize'));
+      emit('resize');
     });
-
-    player.on('error', () => {
-      this.#error = { code: 1, message: 'Vimeo playback error' };
-      this.dispatchEvent(new Event('error'));
-      // Unblock callers awaiting load so play()/fullscreen/PiP don't hang.
-      this.#loadComplete.resolve();
-    });
-
     player.on('fullscreenchange', ({ fullscreen }) => {
       this.#isFullscreen = fullscreen;
-      this.dispatchEvent(new Event('fullscreenchange'));
+      emit('fullscreenchange');
     });
-
     player.on('enterpictureinpicture', () => {
       this.#isPictureInPicture = true;
-      this.dispatchEvent(new Event('enterpictureinpicture'));
+      emit('enterpictureinpicture');
     });
-
     player.on('leavepictureinpicture', () => {
       this.#isPictureInPicture = false;
-      this.dispatchEvent(new Event('leavepictureinpicture'));
+      emit('leavepictureinpicture');
+    });
+    player.on('error', () => {
+      this.#error = { code: 1, message: 'Vimeo playback error' };
+      emit('error');
+      // Unblock callers awaiting load so play()/fullscreen/PiP don't hang.
+      this.#loadComplete.resolve();
     });
   }
 
   #setupTextTracks(player: VimeoPlayer) {
     const doc = globalThis.document;
     if (isUndefined(doc)) return;
-
     this.#teardownTextTracks();
-
     const host = doc.createElement('video');
     this.#textTracksHost = host;
-
     player
       .getTextTracks()
       .then((tracks) => {
@@ -601,7 +490,6 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
         }
       })
       .catch(() => {});
-
     this.#textTracksDisconnect = new AbortController();
     host.textTracks?.addEventListener?.(
       'change',
@@ -621,52 +509,35 @@ export class VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements V
   }
 }
 
-// ----------------------------------------------------------------------------
-// Public utilities
-// ----------------------------------------------------------------------------
-
 /** Extract a Vimeo video id from a numeric id, vimeo.com URL, or player URL. */
 export function parseVimeoVideoId(src: string) {
   return parseVimeoSource(src)?.id ?? null;
 }
 
 /**
- * Parse a Vimeo source string. Recognizes:
- * - numeric ids (`'76979871'`),
- * - `vimeo.com/<id>` and `vimeo.com/video/<id>` URLs,
- * - `player.vimeo.com/video/<id>` URLs,
- * - `vimeo.com/event/<id>` URLs (live events),
- * - unlisted/event hash via `?h=` or `/<hash>` path segment.
+ * Parse a Vimeo source string. Recognizes numeric ids, `vimeo.com/<id>`,
+ * `vimeo.com/video/<id>`, `player.vimeo.com/video/<id>`, `vimeo.com/event/<id>`
+ * (live events), and unlisted/event hashes via `?h=` or a `/<hash>` segment.
  */
 export function parseVimeoSource(src: string): VimeoSource | null {
   if (!src) return null;
-
-  if (/^\d+$/.test(src)) {
-    return { id: Number(src), kind: 'video', hash: null };
-  }
-
+  if (/^\d+$/.test(src)) return { id: Number(src), kind: 'video', hash: null };
   const match = MATCH_SRC.exec(src);
   if (!match) return null;
-
   const kind = match[1] === 'event/' ? 'event' : 'video';
-  const id = Number(match[2]);
-  const pathHash = match[3] ?? null;
-
   let queryHash: string | null = null;
   try {
     queryHash = new URL(src).searchParams.get('h');
   } catch {
     // src isn't a valid URL — ignore.
   }
-
-  return { id, kind, hash: queryHash ?? pathHash };
+  return { id: Number(match[2]), kind, hash: queryHash ?? match[3] ?? null };
 }
 
 /** Build the iframe `src` URL for an initial Vimeo embed from the given props. */
 export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps> = {}) {
   const parsed = parseVimeoSource(src);
   if (!parsed) return '';
-
   const params: Record<string, unknown> = {
     // Hide Vimeo chrome by default; pass nothing only when controls is explicitly true.
     controls: props.controls === true ? null : 0,
@@ -680,19 +551,13 @@ export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps>
     // Vimeo-specific knobs (`autopause`, `byline`, `dnt`, …) flow through here.
     ...(props.config ?? undefined),
   };
-
   if (parsed.kind === 'event') {
     const hashPath = parsed.hash ? `/${parsed.hash}` : '';
     delete params.h;
     return `${EMBED_EVENT_BASE}/${parsed.id}/embed${hashPath}?${serialize(params)}`;
   }
-
   return `${EMBED_VIDEO_BASE}/${parsed.id}?${serialize(params)}`;
 }
-
-// ----------------------------------------------------------------------------
-// Module internals
-// ----------------------------------------------------------------------------
 
 const EMBED_VIDEO_BASE = 'https://player.vimeo.com/video';
 const EMBED_EVENT_BASE = 'https://vimeo.com/event';
@@ -703,19 +568,14 @@ const READY_STATE_HAVE_METADATA = 1;
 const READY_STATE_HAVE_FUTURE_DATA = 3;
 
 function createTimeRanges(start: number, end: number) {
-  return {
-    length: 1,
-    start: () => start,
-    end: () => end,
-  };
+  return { length: 1, start: () => start, end: () => end };
 }
 
 function toLoadVideoOptions(src: string, config: VimeoConfig) {
   const parsed = parseVimeoSource(src);
   if (!parsed) return null;
-  const baseUrl = parsed.kind === 'event' ? EMBED_EVENT_BASE : EMBED_VIDEO_BASE;
-  const path = parsed.kind === 'event' ? `${baseUrl}/${parsed.id}/embed` : `${baseUrl}/${parsed.id}`;
-  const url = `${path}${parsed.hash ? `?h=${parsed.hash}` : ''}` as VimeoUrl;
+  const base = parsed.kind === 'event' ? `${EMBED_EVENT_BASE}/${parsed.id}/embed` : `${EMBED_VIDEO_BASE}/${parsed.id}`;
+  const url = `${base}${parsed.hash ? `?h=${parsed.hash}` : ''}` as VimeoUrl;
   return { url, ...config } as LoadVideoOptions;
 }
 

--- a/packages/core/src/dom/media/vimeo/tests/index.test.ts
+++ b/packages/core/src/dom/media/vimeo/tests/index.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildVimeoIframeSrc, parseVimeoSource, parseVimeoVideoId, VimeoMedia, vimeoMediaDefaultProps } from '..';
+
+vi.mock('@vimeo/player', () => {
+  class MockPlayer {
+    static instances: MockPlayer[] = [];
+    target: unknown;
+    handlers = new Map<string, Set<(data: unknown) => void>>();
+    destroyed = false;
+
+    play = vi.fn(async () => {});
+    pause = vi.fn(async () => {});
+    setVolume = vi.fn(async (v: number) => v);
+    setMuted = vi.fn(async (v: boolean) => v);
+    setCurrentTime = vi.fn(async (s: number) => s);
+    setPlaybackRate = vi.fn(async (r: number) => r);
+    setLoop = vi.fn(async (v: boolean) => v);
+    loadVideo = vi.fn(async () => {});
+    unload = vi.fn(async () => {});
+    requestFullscreen = vi.fn(async () => {});
+    exitFullscreen = vi.fn(async () => {});
+    requestPictureInPicture = vi.fn(async () => {});
+    exitPictureInPicture = vi.fn(async () => {});
+    enableTextTrack = vi.fn(async () => {});
+    disableTextTrack = vi.fn(async () => {});
+    getMuted = vi.fn(async () => false);
+    getVolume = vi.fn(async () => 1);
+    getDuration = vi.fn(async () => 60);
+    getCurrentTime = vi.fn(async () => 0);
+    getTextTracks = vi.fn(async () => [] as unknown[]);
+    destroy = vi.fn(async () => {
+      this.destroyed = true;
+    });
+
+    constructor(target: unknown) {
+      this.target = target;
+      MockPlayer.instances.push(this);
+    }
+
+    on(event: string, handler: (data: unknown) => void): void {
+      let set = this.handlers.get(event);
+      if (!set) {
+        set = new Set();
+        this.handlers.set(event, set);
+      }
+      set.add(handler);
+    }
+
+    off(event: string, handler?: (data: unknown) => void): void {
+      const set = this.handlers.get(event);
+      if (!set) return;
+      if (handler) set.delete(handler);
+      else set.clear();
+    }
+
+    emit(event: string, data: unknown = {}): void {
+      this.handlers.get(event)?.forEach((handler) => handler(data));
+    }
+  }
+
+  return { default: MockPlayer };
+});
+
+function createIframe(): HTMLIFrameElement {
+  return document.createElement('iframe');
+}
+
+async function waitForVimeoLoaded(media: VimeoMedia): Promise<void> {
+  if (media.readyState >= 1 && Number.isFinite(media.duration)) return;
+  await new Promise<void>((resolve) => {
+    media.addEventListener('loadcomplete', () => resolve(), { once: true });
+  });
+}
+
+async function attachAndLoad(media: VimeoMedia): Promise<{ iframe: HTMLIFrameElement; player: MockPlayerLike }> {
+  const iframe = createIframe();
+  media.attach(iframe);
+  const player = media.engine as unknown as MockPlayerLike;
+  player.emit('loaded');
+  await waitForVimeoLoaded(media);
+  return { iframe, player };
+}
+
+interface MockPlayerLike {
+  emit(event: string, data?: unknown): void;
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  setVolume: ReturnType<typeof vi.fn>;
+  setMuted: ReturnType<typeof vi.fn>;
+  setCurrentTime: ReturnType<typeof vi.fn>;
+  setPlaybackRate: ReturnType<typeof vi.fn>;
+  setLoop: ReturnType<typeof vi.fn>;
+  loadVideo: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+}
+
+describe('parseVimeoVideoId', () => {
+  it('extracts numeric id from numeric string', () => {
+    expect(parseVimeoVideoId('76979871')).toBe(76979871);
+  });
+
+  it('extracts id from vimeo.com URL', () => {
+    expect(parseVimeoVideoId('https://vimeo.com/76979871')).toBe(76979871);
+  });
+
+  it('extracts id from player.vimeo.com URL', () => {
+    expect(parseVimeoVideoId('https://player.vimeo.com/video/76979871')).toBe(76979871);
+  });
+
+  it('extracts id from vimeo.com/video URL', () => {
+    expect(parseVimeoVideoId('https://vimeo.com/video/76979871')).toBe(76979871);
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseVimeoVideoId('')).toBe(null);
+  });
+
+  it('returns null for non-Vimeo URLs', () => {
+    expect(parseVimeoVideoId('https://example.com/video.mp4')).toBe(null);
+  });
+});
+
+describe('parseVimeoSource', () => {
+  it('detects events', () => {
+    expect(parseVimeoSource('https://vimeo.com/event/12345')).toEqual({ id: 12345, kind: 'event', hash: null });
+  });
+
+  it('extracts h param from query string', () => {
+    expect(parseVimeoSource('https://vimeo.com/12345?h=abc')).toEqual({ id: 12345, kind: 'video', hash: 'abc' });
+  });
+
+  it('extracts hash from event path', () => {
+    expect(parseVimeoSource('https://vimeo.com/event/12345/abc')).toEqual({ id: 12345, kind: 'event', hash: 'abc' });
+  });
+});
+
+describe('buildVimeoIframeSrc', () => {
+  it('builds embed URL from id with default playsinline and hidden controls', () => {
+    const src = buildVimeoIframeSrc('76979871');
+    expect(src).toContain('https://player.vimeo.com/video/76979871');
+    expect(src).toContain('playsinline=1');
+    expect(src).toContain('preload=metadata');
+    expect(src).toContain('controls=0');
+  });
+
+  it('encodes autoplay, defaultMuted, loop', () => {
+    const src = buildVimeoIframeSrc('76979871', {
+      autoplay: true,
+      defaultMuted: true,
+      loop: true,
+    });
+    expect(src).toContain('autoplay=1');
+    expect(src).toContain('muted=1');
+    expect(src).toContain('loop=1');
+  });
+
+  it('disables controls by default and when controls=false', () => {
+    expect(buildVimeoIframeSrc('76979871', { controls: false })).toContain('controls=0');
+  });
+
+  it('shows Vimeo controls when controls=true', () => {
+    const src = buildVimeoIframeSrc('76979871', { controls: true });
+    expect(src).not.toContain('controls=0');
+  });
+
+  it('forwards preload and Vimeo-specific config knobs', () => {
+    const src = buildVimeoIframeSrc('76979871', { preload: 'auto', config: { autopause: true } });
+    expect(src).toContain('preload=auto');
+    expect(src).toContain('autopause=1');
+  });
+
+  it('embeds h hash for unlisted videos', () => {
+    expect(buildVimeoIframeSrc('https://vimeo.com/12345?h=secret')).toContain('h=secret');
+  });
+
+  it('builds event embed URL with hashPath', () => {
+    const src = buildVimeoIframeSrc('https://vimeo.com/event/123/abc');
+    expect(src).toContain('https://vimeo.com/event/123/embed/abc');
+    expect(src).not.toContain('h=');
+  });
+
+  it('merges arbitrary config into params', () => {
+    const src = buildVimeoIframeSrc('76979871', { config: { background: true, byline: false } });
+    expect(src).toContain('background=1');
+    expect(src).toContain('byline=0');
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildVimeoIframeSrc('not-a-vimeo-url')).toBe('');
+  });
+});
+
+describe('VimeoMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new VimeoMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(vimeoMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('creates a Player when attached to an iframe', () => {
+    const media = new VimeoMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(media.target).toBe(iframe);
+    expect(media.engine).not.toBe(null);
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete after loaded', async () => {
+    const media = new VimeoMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete', 'durationchange'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    const { player } = await attachAndLoad(media);
+    expect(events).toContain('loadstart');
+    expect(events).toContain('loadedmetadata');
+    expect(events).toContain('loadcomplete');
+    expect(events).toContain('durationchange');
+    expect(media.duration).toBe(60);
+
+    // Re-emit doesn't re-fire load events:
+    events.length = 0;
+    player.emit('timeupdate', { seconds: 1, duration: 60 });
+    expect(events).toEqual([]);
+  });
+
+  it('updates state from player events', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+    player.emit('play', { seconds: 0, duration: 60, percent: 0 });
+    expect(media.paused).toBe(false);
+    expect(playSpy).toHaveBeenCalled();
+
+    player.emit('timeupdate', { seconds: 12.5, duration: 60, percent: 0.2 });
+    expect(media.currentTime).toBe(12.5);
+    expect(media.duration).toBe(60);
+
+    player.emit('progress', { seconds: 30 });
+    expect(media.buffered.length).toBe(1);
+    expect(media.buffered.end(0)).toBe(30);
+
+    player.emit('resize', { videoWidth: 1280, videoHeight: 720 });
+    expect(media.videoWidth).toBe(1280);
+    expect(media.videoHeight).toBe(720);
+
+    player.emit('volumechange', { volume: 0.25 });
+    expect(media.volume).toBe(0.25);
+
+    player.emit('pause', { seconds: 12.5, duration: 60, percent: 0.2 });
+    expect(media.paused).toBe(true);
+
+    player.emit('ended', { seconds: 60, duration: 60, percent: 1 });
+    expect(media.ended).toBe(true);
+  });
+
+  it('forwards play() and pause() to the player', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    await media.play();
+    expect(player.play).toHaveBeenCalledTimes(1);
+
+    media.pause();
+    expect(player.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards setters to the player after load', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    media.currentTime = 30;
+    media.volume = 0.5;
+    media.muted = true;
+    media.playbackRate = 1.5;
+    media.loop = true;
+
+    // setters defer via loadComplete microtask — flush.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(player.setCurrentTime).toHaveBeenCalledWith(30);
+    expect(player.setVolume).toHaveBeenCalledWith(0.5);
+    expect(player.setMuted).toHaveBeenCalledWith(true);
+    expect(player.setPlaybackRate).toHaveBeenCalledWith(1.5);
+    expect(player.setLoop).toHaveBeenCalledWith(true);
+  });
+
+  it('calls loadVideo when src changes after attach', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+    player.loadVideo.mockClear();
+
+    media.src = '76979871';
+    await Promise.resolve();
+    expect(player.loadVideo).toHaveBeenCalledWith({ url: 'https://player.vimeo.com/video/76979871' });
+  });
+
+  it('forwards fullscreen and pip requests', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    await media.requestFullscreen();
+    await media.exitFullscreen();
+    await media.requestPictureInPicture();
+    await media.exitPictureInPicture();
+
+    expect((player as unknown as { requestFullscreen: ReturnType<typeof vi.fn> }).requestFullscreen).toHaveBeenCalled();
+    expect((player as unknown as { exitFullscreen: ReturnType<typeof vi.fn> }).exitFullscreen).toHaveBeenCalled();
+    expect(
+      (player as unknown as { requestPictureInPicture: ReturnType<typeof vi.fn> }).requestPictureInPicture
+    ).toHaveBeenCalled();
+    expect(
+      (player as unknown as { exitPictureInPicture: ReturnType<typeof vi.fn> }).exitPictureInPicture
+    ).toHaveBeenCalled();
+  });
+
+  it('tracks played ranges via the played-ranges mixin', async () => {
+    const media = new VimeoMedia();
+    const { player } = await attachAndLoad(media);
+
+    player.emit('play', {});
+    player.emit('timeupdate', { seconds: 1 });
+    player.emit('timeupdate', { seconds: 2 });
+    player.emit('timeupdate', { seconds: 3 });
+    player.emit('pause', {});
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(3);
+  });
+
+  it('destroys the player on detach', () => {
+    const media = new VimeoMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = media.engine as unknown as MockPlayerLike;
+
+    media.detach();
+    expect(player.destroy).toHaveBeenCalled();
+    expect(media.target).toBe(null);
+    expect(media.engine).toBe(null);
+  });
+});

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -14,11 +14,13 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/media/dash/index': './src/dom/media/dash/index.ts',
     'dom/media/hls/index': './src/dom/media/hls/index.ts',
     'dom/media/native-hls/index': './src/dom/media/native-hls/index.ts',
+    'dom/media/media-played-ranges/index': './src/dom/media/media-played-ranges/index.ts',
     'dom/media/simple-hls-audio-only/index': './src/dom/media/simple-hls-audio-only/index.ts',
     'dom/media/simple-hls/index': './src/dom/media/simple-hls/index.ts',
     // Components
     'dom/media/mux/index': './src/dom/media/mux/index.ts',
     'dom/media/google-cast/index': './src/dom/media/google-cast/index.ts',
+    'dom/media/vimeo/index': './src/dom/media/vimeo/index.ts',
   },
   define: {
     __DEV__: mode === 'dev' ? 'true' : 'false',

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -10,17 +10,17 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     dom: './src/dom/index.ts',
     'dom/media/media-host/index': './src/dom/media/media-host.ts',
     'dom/media/custom-media-element/index': './src/dom/media/custom-media-element/index.ts',
+    'dom/media/media-played-ranges/index': './src/dom/media/media-played-ranges/index.ts',
     // Media
     'dom/media/dash/index': './src/dom/media/dash/index.ts',
     'dom/media/hls/index': './src/dom/media/hls/index.ts',
     'dom/media/native-hls/index': './src/dom/media/native-hls/index.ts',
-    'dom/media/media-played-ranges/index': './src/dom/media/media-played-ranges/index.ts',
     'dom/media/simple-hls-audio-only/index': './src/dom/media/simple-hls-audio-only/index.ts',
     'dom/media/simple-hls/index': './src/dom/media/simple-hls/index.ts',
+    'dom/media/vimeo/index': './src/dom/media/vimeo/index.ts',
     // Components
     'dom/media/mux/index': './src/dom/media/mux/index.ts',
     'dom/media/google-cast/index': './src/dom/media/google-cast/index.ts',
-    'dom/media/vimeo/index': './src/dom/media/vimeo/index.ts',
   },
   define: {
     __DEV__: mode === 'dev' ? 'true' : 'false',

--- a/packages/html/src/define/media/vimeo-video.ts
+++ b/packages/html/src/define/media/vimeo-video.ts
@@ -1,0 +1,14 @@
+import { VimeoVideo } from '../../media/vimeo-video';
+import { safeDefine } from '../safe-define';
+
+export class VimeoVideoElement extends VimeoVideo {
+  static readonly tagName = 'vimeo-video';
+}
+
+safeDefine(VimeoVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [VimeoVideoElement.tagName]: VimeoVideoElement;
+  }
+}

--- a/packages/html/src/media/vimeo-video/index.ts
+++ b/packages/html/src/media/vimeo-video/index.ts
@@ -26,7 +26,16 @@ class VimeoCustomMediaElement extends CustomMediaElement('iframe', VimeoMedia) {
           pointer-events: none;
         }
       </style>
-      <iframe part="iframe" allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen frameborder="0" width="100%" height="100%"${srcAttr}></iframe>
+      <iframe
+        part="iframe"
+        ${srcAttr}
+        allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        frameborder="0"
+        width="100%"
+        height="100%"
+        referrerpolicy="${escapeHtml(attrs.referrerpolicy ?? '')}"
+      ></iframe>
     `;
   };
 }
@@ -42,10 +51,4 @@ function templateAttrsToEmbedProps(attrs: Record<string, string>) {
   };
 }
 
-/**
- * Web component that embeds a Vimeo video via `@vimeo/player` and exposes an
- * `HTMLMediaElement`-like API. Supports unlisted videos, live events,
- * picture-in-picture, fullscreen, and arbitrary embed `config` (use this for
- * Vimeo-specific knobs like `autopause`, `byline`, `dnt`).
- */
 export class VimeoVideo extends MediaAttachMixin(VimeoCustomMediaElement) {}

--- a/packages/html/src/media/vimeo-video/index.ts
+++ b/packages/html/src/media/vimeo-video/index.ts
@@ -1,0 +1,51 @@
+import { CustomMediaElement } from '@videojs/core/dom/media/custom-media-element';
+import { buildVimeoIframeSrc, VimeoMedia } from '@videojs/core/dom/media/vimeo';
+import { escapeHtml } from '@videojs/utils/string';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class VimeoCustomMediaElement extends CustomMediaElement('iframe', VimeoMedia) {
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildVimeoIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: inline-block;
+          min-width: 300px;
+          min-height: 150px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        :host(:not([controls])) {
+          pointer-events: none;
+        }
+      </style>
+      <iframe part="iframe" allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen frameborder="0" width="100%" height="100%"${srcAttr}></iframe>
+    `;
+  };
+}
+
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    playsInline: attrs.playsinline !== undefined,
+    preload: (attrs.preload as 'none' | 'metadata' | 'auto' | undefined) ?? 'metadata',
+  };
+}
+
+/**
+ * Web component that embeds a Vimeo video via `@vimeo/player` and exposes an
+ * `HTMLMediaElement`-like API. Supports unlisted videos, live events,
+ * picture-in-picture, fullscreen, and arbitrary embed `config` (use this for
+ * Vimeo-specific knobs like `autopause`, `byline`, `dnt`).
+ */
+export class VimeoVideo extends MediaAttachMixin(VimeoCustomMediaElement) {}

--- a/packages/react/src/media/vimeo-video/index.tsx
+++ b/packages/react/src/media/vimeo-video/index.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import type { VimeoConfig, VimeoMediaProps } from '@videojs/core/dom/media/vimeo';
+import { buildVimeoIframeSrc, VimeoMedia, vimeoMediaDefaultProps } from '@videojs/core/dom/media/vimeo';
+import type { IframeHTMLAttributes, ReactNode, RefCallback } from 'react';
+import { forwardRef, useCallback, useState } from 'react';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface VimeoVideoProps
+  extends Omit<IframeHTMLAttributes<HTMLIFrameElement>, keyof VimeoMediaProps | 'muted'>,
+    Partial<VimeoMediaProps> {
+  /** Alias for `defaultMuted` — mirrors the HTML `<video muted>` attribute. */
+  muted?: boolean;
+  children?: ReactNode;
+}
+
+/**
+ * React component that embeds a Vimeo video via `@vimeo/player`. Renders an
+ * `<iframe>` whose `src` is built from the supplied props and attaches a
+ * `VimeoMedia` instance to the surrounding player. Supports unlisted videos,
+ * live events (`vimeo.com/event/<id>`), `preload`, and arbitrary extra Vimeo
+ * `config` (use this for Vimeo-specific knobs like `autopause`, `byline`,
+ * `dnt`).
+ */
+export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(function VimeoVideo(
+  { children, muted, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(VimeoMedia);
+
+  const props: Partial<VimeoMediaProps> & Record<string, unknown> = { ...rawProps };
+  const resolvedDefaultMuted = rawProps.defaultMuted ?? muted;
+  if (resolvedDefaultMuted !== undefined) props.defaultMuted = resolvedDefaultMuted;
+
+  const attachRef = useCallback<RefCallback<HTMLIFrameElement>>(
+    (element) => {
+      if (element) media.attach(element);
+      else media.detach();
+      return () => media.detach();
+    },
+    [media]
+  );
+
+  const composedRef = useComposedRefs(attachRef, ref);
+
+  // Compute the iframe src once on mount; subsequent prop changes are
+  // forwarded to VimeoMedia (which calls Player.loadVideo) so the iframe
+  // element itself isn't replaced on every render.
+  const [initialSrc] = useState(() => buildVimeoIframeSrc(props.src ?? '', { ...vimeoMediaDefaultProps, ...props }));
+
+  type VimeoSyncedProps = Pick<
+    VimeoMediaProps,
+    'src' | 'autoplay' | 'defaultMuted' | 'loop' | 'controls' | 'preload' | 'config'
+  >;
+
+  const iframeProps = useSyncProps<VimeoSyncedProps, Record<string, unknown>>(
+    media as VimeoMedia & VimeoSyncedProps,
+    props,
+    vimeoMediaDefaultProps
+  );
+  const config = props.config as VimeoConfig | null | undefined;
+  const dataConfig = config ? JSON.stringify(config) : undefined;
+  const referrerPolicy = (config as { referrerpolicy?: string } | null | undefined)?.referrerpolicy;
+
+  return (
+    <iframe
+      title="Vimeo video player"
+      allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      data-config={dataConfig}
+      referrerPolicy={referrerPolicy as IframeHTMLAttributes<HTMLIFrameElement>['referrerPolicy']}
+      {...iframeProps}
+      ref={composedRef}
+      src={initialSrc}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace VimeoVideo {
+  export type Props = VimeoVideoProps;
+}

--- a/packages/react/src/media/vimeo-video/index.tsx
+++ b/packages/react/src/media/vimeo-video/index.tsx
@@ -1,82 +1,42 @@
 'use client';
 
-import type { VimeoConfig, VimeoMediaProps } from '@videojs/core/dom/media/vimeo';
+import type { VimeoMediaProps } from '@videojs/core/dom/media/vimeo';
 import { buildVimeoIframeSrc, VimeoMedia, vimeoMediaDefaultProps } from '@videojs/core/dom/media/vimeo';
-import type { IframeHTMLAttributes, ReactNode, RefCallback } from 'react';
-import { forwardRef, useCallback, useState } from 'react';
+import type { ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
+import { useAttachIframe } from '../../utils/use-attach-iframe';
 import { useComposedRefs } from '../../utils/use-composed-refs';
 import { useMediaInstance } from '../../utils/use-media-instance';
 import { useSyncProps } from '../../utils/use-sync-props';
 
-export interface VimeoVideoProps
-  extends Omit<IframeHTMLAttributes<HTMLIFrameElement>, keyof VimeoMediaProps | 'muted'>,
-    Partial<VimeoMediaProps> {
-  /** Alias for `defaultMuted` — mirrors the HTML `<video muted>` attribute. */
-  muted?: boolean;
+export interface VimeoVideoProps extends Partial<VimeoMediaProps> {
   children?: ReactNode;
 }
 
-/**
- * React component that embeds a Vimeo video via `@vimeo/player`. Renders an
- * `<iframe>` whose `src` is built from the supplied props and attaches a
- * `VimeoMedia` instance to the surrounding player. Supports unlisted videos,
- * live events (`vimeo.com/event/<id>`), `preload`, and arbitrary extra Vimeo
- * `config` (use this for Vimeo-specific knobs like `autopause`, `byline`,
- * `dnt`).
- */
 export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(function VimeoVideo(
-  { children, muted, ...rawProps },
+  { children, ...rawProps },
   ref
 ) {
   const media = useMediaInstance(VimeoMedia);
-
   const props: Partial<VimeoMediaProps> & Record<string, unknown> = { ...rawProps };
-  const resolvedDefaultMuted = rawProps.defaultMuted ?? muted;
-  if (resolvedDefaultMuted !== undefined) props.defaultMuted = resolvedDefaultMuted;
-
-  const attachRef = useCallback<RefCallback<HTMLIFrameElement>>(
-    (element) => {
-      if (element) media.attach(element);
-      else media.detach();
-      return () => media.detach();
-    },
-    [media]
-  );
-
+  const attachRef = useAttachIframe(media);
   const composedRef = useComposedRefs(attachRef, ref);
-
-  // Compute the iframe src once on mount; subsequent prop changes are
-  // forwarded to VimeoMedia (which calls Player.loadVideo) so the iframe
-  // element itself isn't replaced on every render.
   const [initialSrc] = useState(() => buildVimeoIframeSrc(props.src ?? '', { ...vimeoMediaDefaultProps, ...props }));
-
-  type VimeoSyncedProps = Pick<
-    VimeoMediaProps,
-    'src' | 'autoplay' | 'defaultMuted' | 'loop' | 'controls' | 'preload' | 'config'
-  >;
-
-  const iframeProps = useSyncProps<VimeoSyncedProps, Record<string, unknown>>(
-    media as VimeoMedia & VimeoSyncedProps,
-    props,
-    vimeoMediaDefaultProps
-  );
-  const config = props.config as VimeoConfig | null | undefined;
-  const dataConfig = config ? JSON.stringify(config) : undefined;
-  const referrerPolicy = (config as { referrerpolicy?: string } | null | undefined)?.referrerpolicy;
+  const iframeProps = useSyncProps<VimeoMediaProps, Record<string, unknown>>(media, props, vimeoMediaDefaultProps);
 
   return (
     <iframe
       title="Vimeo video player"
+      src={initialSrc}
+      data-cross-origin-frame
       allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
       allowFullScreen
       frameBorder={0}
       width="100%"
       height="100%"
-      data-config={dataConfig}
-      referrerPolicy={referrerPolicy as IframeHTMLAttributes<HTMLIFrameElement>['referrerPolicy']}
+      referrerPolicy={props.config?.referrerPolicy}
       {...iframeProps}
       ref={composedRef}
-      src={initialSrc}
     >
       {children}
     </iframe>

--- a/packages/react/src/utils/use-attach-iframe.ts
+++ b/packages/react/src/utils/use-attach-iframe.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import type { MediaEngineHost } from '@videojs/core';
+import type { RefCallback } from 'react';
+import { useCallback } from 'react';
+
+export function useAttachIframe<T extends HTMLIFrameElement>(media: MediaEngineHost): RefCallback<T> {
+  return useCallback(
+    (element: T | null) => {
+      if (element) media.attach?.(element);
+      else media.detach?.();
+      return () => media.detach?.();
+    },
+    [media]
+  );
+}

--- a/packages/utils/src/string/escape-html.ts
+++ b/packages/utils/src/string/escape-html.ts
@@ -1,0 +1,9 @@
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
+}

--- a/packages/utils/src/string/index.ts
+++ b/packages/utils/src/string/index.ts
@@ -1,2 +1,3 @@
 export * from './casing';
+export * from './escape-html';
 export * from './generate-id';

--- a/packages/utils/src/string/tests/escape-html.test.ts
+++ b/packages/utils/src/string/tests/escape-html.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from '../escape-html';
+
+describe('escapeHtml', () => {
+  it('escapes HTML special characters', () => {
+    expect(escapeHtml('&<>"\'`')).toBe('&amp;&lt;&gt;&quot;&#39;&#96;');
+  });
+
+  it('preserves strings without HTML special characters', () => {
+    expect(escapeHtml('https://player.vimeo.com/video/123?autoplay=1')).toBe(
+      'https://player.vimeo.com/video/123?autoplay=1'
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@videojs/utils':
         specifier: workspace:*
         version: link:../utils
+      '@vimeo/player':
+        specifier: ^2.30.3
+        version: 2.30.4
       dashjs:
         specifier: ^5.0.0
         version: 5.1.1(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)
@@ -1000,28 +1003,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.6':
     resolution: {integrity: sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.6':
     resolution: {integrity: sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.6':
     resolution: {integrity: sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.6':
     resolution: {integrity: sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==}
@@ -1660,105 +1659,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2352,42 +2335,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -2472,28 +2449,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2582,84 +2555,72 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -2762,79 +2723,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3240,28 +3188,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -3582,6 +3526,9 @@ packages:
     resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@vimeo/player@2.30.4':
+    resolution: {integrity: sha512-M8m1UAhJSb+KCWuXDLWHViwj+3YY/0ogwFquRfMHs9e9LYjXT9iB7n+sOCKwUusbiXuU2HKmXx+FEGHtYZfUSg==}
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -5727,56 +5674,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -6240,6 +6179,9 @@ packages:
   nanostores@1.1.1:
     resolution: {integrity: sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  native-promise-only@0.8.1:
+    resolution: {integrity: sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -7998,6 +7940,10 @@ packages:
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  weakmap-polyfill@2.0.4:
+    resolution: {integrity: sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==}
+    engines: {node: '>=8.10.0'}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -11386,6 +11332,11 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vimeo/player@2.30.4':
+    dependencies:
+      native-promise-only: 0.8.1
+      weakmap-polyfill: 2.0.4
+
   '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
@@ -14745,6 +14696,8 @@ snapshots:
 
   nanostores@1.1.1: {}
 
+  native-promise-only@0.8.1: {}
+
   neotraverse@0.6.18: {}
 
   netlify-redirector@0.5.0: {}
@@ -16660,6 +16613,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  weakmap-polyfill@2.0.4: {}
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
Ported from https://github.com/videojs/v10/pull/1620

Refs #1435
Refs #1538

## Summary

Adds Vimeo as a first-class media source on the current media stack. A `VimeoMedia` host wraps `@vimeo/player` behind the standard `Video` surface, with HTML (`vimeo-video`) and React (`VimeoVideo`) components and sandbox demos.

This re-ports videojs/v10#1620 onto the current `HTMLMediaElementHost` + `attach`/`detach` architecture (the original PR targeted the `MediaLayer`/extension design).

## Changes

- `VimeoMedia` core host: wraps `@vimeo/player`, maps player events to the standard media API (play/pause, time, volume, fullscreen, PiP, text tracks), and parses ids/URLs including unlisted `h` hashes and live events. Driven via `attach(iframe)` / `detach()` to match how hosts are wired here.
- Played-range tracking reimplemented as a class mixin (`MediaPlayedRangesMixin`) rather than a layer/extension, so iframe-based hosts expose a `TimeRanges`-like `played`.
- `CustomMediaElement` gains minimal iframe-embed support: keep host-bound attrs (e.g. `src`) in the template, and skip mirroring attributes / track / source syncing onto the iframe.
- `escapeHtml` util to secure the iframe `src` in templates.
- Sandbox `vimeo-video` preset with HTML/React templates and shell wiring (no Tailwind skin variant, source picker disabled).

<details>
<summary>Architecture notes</summary>

- `VimeoMedia extends MediaPlayedRangesMixin(EventTarget) implements Video`. It's a leaf host with no native `<video>` target — the `target` is the `<iframe>` the player binds to.
- Did **not** port the original PR's lazy host-recreation / `upgradeProperty` reconnect rewrite of `CustomMediaElement`, since that lifecycle is shared by all media hosts; Vimeo follows the same construct-on-create / destroy-on-disconnect lifecycle as the others.
- Settles the `loadComplete` gate on player `error` so `play()` / fullscreen / PiP do not hang on load failure.

</details>

## Testing

- `pnpm -F @videojs/core test src/dom/media/vimeo src/dom/media/media-played-ranges`
- Full `core` / `utils` / `html` / `react` suites pass; `pnpm typecheck` and `pnpm check:workspace` clean for touched files.
- Sandbox: open the HTML and React Vimeo Video demos.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `CustomMediaElement` behavior for all iframe-based embeds and adds a new third-party dependency; playback and load-failure handling are security- and UX-sensitive but covered by tests.
> 
> **Overview**
> Adds **Vimeo** as a first-class embed source: a `VimeoMedia` host wraps `@vimeo/player` and exposes the standard media API via `attach(iframe)` / `detach()`, with URL parsing (unlisted `h`, live events) and iframe embed URL building.
> 
> **`MediaPlayedRangesMixin`** supplies a `TimeRanges`-like `played` for hosts without native `HTMLMediaElement.played`. **`CustomMediaElement`** is extended for iframe embeds: keep `src` (and similar) in the shadow template, skip attribute mirroring and track/source sync, and set `data-cross-origin-frame` on connect.
> 
> Ships **`vimeo-video`** / **`VimeoVideo`** (HTML + React), `useAttachIframe`, `escapeHtml` for safe iframe `src`, sandbox **`vimeo-video`** preset (fixed Vimeo URL, no Tailwind, source picker off), and unit tests for Vimeo, played ranges, and iframe custom elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf93da5a546cec22ee1b19a6a76074f90433c9f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->