### PR TITLE
fix(react): address stale media reference

### DIFF
--- a/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { CAPTIONS_OFF_VALUE } from '@videojs/core';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { PlayerContextProvider, type PlayerContextValue } from '../../../player/context';
 import { createPlayerWrapper } from '../../../testing/mocks';
 import { Menu } from '../../menu';
 import { useCaptionsOptions } from '../use-captions-options';
@@ -43,6 +44,42 @@ function renderCaptionsMenu({
   );
 
   return { selectSubtitlesTrack };
+}
+
+function createReactiveTextTrackWrapper(initialState: Record<string, unknown>) {
+  const listeners = new Set<() => void>();
+  const store = {
+    state: initialState,
+    subscribe: (callback: () => void) => {
+      listeners.add(callback);
+      return () => listeners.delete(callback);
+    },
+    attach: vi.fn(() => vi.fn()),
+    destroy: vi.fn(),
+  };
+
+  const value: PlayerContextValue = {
+    store: store as unknown as PlayerContextValue['store'],
+    media: null,
+    setMedia: vi.fn(),
+    container: null,
+    setContainer: vi.fn(),
+  };
+
+  return {
+    updateState(next: Record<string, unknown>) {
+      store.state = next;
+      for (const listener of listeners) listener();
+    },
+    Wrapper({ children }: { children: ReactNode }) {
+      return <PlayerContextProvider value={value}>{children}</PlayerContextProvider>;
+    },
+  };
+}
+
+function CaptionsAvailability(): ReactNode {
+  const captions = useCaptionsOptions();
+  return <div data-testid="availability">{captions?.state.availability ?? 'missing'}</div>;
 }
 
 function CaptionsRadioGroup(): ReactNode {
@@ -93,5 +130,38 @@ describe('useCaptionsOptions', () => {
     fireEvent.click(screen.getByRole('menuitemradio', { name: 'Off' }));
 
     expect(selectSubtitlesTrack).toHaveBeenCalledWith(CAPTIONS_OFF_VALUE);
+  });
+
+  it('updates when caption tracks become available', () => {
+    const { Wrapper, updateState } = createReactiveTextTrackWrapper({
+      chaptersCues: [],
+      thumbnailCues: [],
+      thumbnailTrackSrc: null,
+      textTrackList: [],
+      subtitlesShowing: false,
+      selectSubtitlesTrack: vi.fn(),
+      toggleSubtitles: vi.fn(),
+    });
+
+    render(<CaptionsAvailability />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId('availability').textContent).toBe('unavailable');
+
+    act(() => {
+      updateState({
+        chaptersCues: [],
+        thumbnailCues: [],
+        thumbnailTrackSrc: null,
+        textTrackList: [
+          { kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' },
+          { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'showing' },
+        ],
+        subtitlesShowing: true,
+        selectSubtitlesTrack: vi.fn(),
+        toggleSubtitles: vi.fn(),
+      });
+    });
+
+    expect(screen.getByTestId('availability').textContent).toBe('available');
   });
 });

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -1,10 +1,6 @@
 'use client';
 
-import {
-  CAPTIONS_OFF_VALUE,
-  type CaptionsRadioGroupCore,
-  CaptionsRadioGroupCore as CaptionsRadioGroupCoreClass,
-} from '@videojs/core';
+import { CAPTIONS_OFF_VALUE, CaptionsRadioGroupCore } from '@videojs/core';
 import { logMissingFeature, selectTextTrack } from '@videojs/core/dom';
 import { useCallback, useState } from 'react';
 
@@ -28,8 +24,10 @@ export interface CaptionsOptionsResult {
 }
 
 export function useCaptionsOptions(props?: CaptionsOptionsProps): CaptionsOptionsResult | null {
+  'use no memo';
+
   const media = usePlayer(selectTextTrack);
-  const [core] = useState(() => new CaptionsRadioGroupCoreClass());
+  const [core] = useState(() => new CaptionsRadioGroupCore());
 
   core.setProps(props ?? {});
 


### PR DESCRIPTION
Fixes an issue where the caption options are sometimes missing in React menus in the Astro/docs site. 

This isn't an ideal fix but it seems because we're updating state outside of the React render flow it causes these weird conditions. We should re-visit how we handle core state in the React hooks as this is likely to crop up again. 

----

## Why `useCaptionsOptions` needs `'use no memo'`

### Context: React Compiler on the docs site

The Astro docs site enables the [React Compiler](https://react.dev/learn/react-compiler) for all React code via `babel-plugin-react-compiler` in `site/astro.config.mjs`. That plugin automatically memoizes components and hooks so React can skip work when it believes inputs haven't changed.

Most of the monorepo does **not** run through that pipeline — only the site's React demos do. So this bug shows up on docs pages (e.g. the React Menu reference demo) but not in `@videojs/react` unit tests, which run plain React without the compiler.

### What the hook does

`useCaptionsOptions` follows the same pattern as `usePlaybackRateOptions`:

1. Subscribe to store state with `usePlayer(selectTextTrack)`.
2. Keep a long-lived `CaptionsRadioGroupCore` instance in `useState`.
3. **During render**, imperatively project UI state: `core.setMedia(media)` → `core.getState()`.

That projection reads `media.textTrackList` and sets `availability` to `'available'` only when caption/subtitle tracks exist. The menu uses that availability to show or hide the Captions row via `data-availability` (hidden when `unavailable`).

### Why captions are special

Text tracks don't all exist on the first render. The `textTrack` feature syncs asynchronously — on `addtrack`, `<track>` `load`, `change`, `loadstart`, etc. — and patches `textTrackList` into the store after attach.

Typical timeline on the docs demo:

1. **First render** — `textTrackList` is `[]` → `availability: 'unavailable'` → Captions hidden.
2. **Tracks load** — store updates → `usePlayer` triggers a re-render.
3. **Expected** — hook re-runs projection → `availability: 'available'` → Captions appears.

With React Compiler enabled, step 3 often doesn't happen correctly.

### What React Compiler gets wrong

The hook mixes two models React Compiler isn't great at reconciling:

- **Declarative subscription** — `usePlayer` / `useSyncExternalStore` (store updates should cause fresh output).
- **Imperative projection** — mutating a class instance (`core.setMedia`) during render and reading derived state from it.

The compiler auto-memoizes the hook and can reuse a stale snapshot of the projected result — effectively skipping `setMedia` + `getState()` on later renders even after `textTrackList` has been populated. The store and DOM are correct (tracks are there), but the hook still returns `availability: 'unavailable'`, so the Settings menu shows Speed but not Captions.

`'use no memo'` opts this function out of compiler auto-memoization so every render re-runs the projection with the current `media` from `usePlayer`.

### Why other hooks don't need it

Hooks like `usePlaybackRateOptions` use the same shape, but their availability usually stabilizes on the first meaningful render — playback rates are present as soon as the media feature attaches. Captions is the hook where store data **changes after** the first projection in normal usage, which is exactly when compiler memoization bites.

That's also why unit tests pass without `'use no memo'`: Vitest doesn't run the compiler, and the test explicitly simulates a store update that standard React handles fine.

### Summary

| | Without React Compiler | With React Compiler (docs site) |
|---|---|---|
| Tracks load after attach | Hook re-projects → Captions appears | Hook output can stay stale → Captions hidden |
| Fix | None needed | `'use no memo'` on `useCaptionsOptions` |

The directive is a targeted escape hatch for one hook whose imperative render-time projection conflicts with automatic memoization — not a general requirement for the React package. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted React Compiler escape hatch and test coverage on one hook; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Captions** sometimes missing from React settings menus on the docs site when subtitle tracks load after the first render.
> 
> `useCaptionsOptions` opts out of React Compiler auto-memoization with **`'use no memo'`** so each render re-runs `core.setMedia` / `getState()` with the latest `usePlayer(selectTextTrack)` snapshot. Without that, the compiler can reuse stale hook output and keep `availability` at **`unavailable`** even after `textTrackList` is populated asynchronously.
> 
> Imports are tightened to use `CaptionsRadioGroupCore` directly. A new unit test drives a reactive mock store from empty tracks to loaded tracks and asserts **`availability`** flips from **`unavailable`** to **`available`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5113c9b0505b8be4642f3bd9126cdec323246e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->