### PR TITLE
fix(test): stabilize e2e tests

### DIFF
--- a/apps/e2e/tests/error-dialog.spec.ts
+++ b/apps/e2e/tests/error-dialog.spec.ts
@@ -1,9 +1,22 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 test.describe('Error Dialog', () => {
   let player: PlayerPage;
+
+  async function triggerError(page: Page) {
+    await page.evaluate(() => {
+      const video = document.querySelector('video') as HTMLVideoElement;
+      if (!video) return;
+
+      Object.defineProperty(video, 'error', {
+        configurable: true,
+        value: { code: 4, message: 'Test media error' },
+      });
+      video.dispatchEvent(new Event('error'));
+    });
+  }
 
   test.beforeEach(async ({ page }) => {
     player = new PlayerPage(page);
@@ -14,11 +27,7 @@ test.describe('Error Dialog', () => {
   test('shows error dialog on media load failure', async ({ page }) => {
     const errorDialog = page.locator(SELECTORS.errorDialog).first();
 
-    // Set an invalid source to trigger a media error
-    await page.evaluate(() => {
-      const video = document.querySelector('video') as HTMLVideoElement;
-      if (video) video.src = 'https://example.com/does-not-exist.mp4';
-    });
+    await triggerError(page);
 
     // Error dialog should appear with data-open
     await expect(errorDialog).toHaveAttribute(DATA_ATTRS.open, '', { timeout: 15_000 });
@@ -27,11 +36,7 @@ test.describe('Error Dialog', () => {
   test('error dialog can be dismissed', async ({ page }) => {
     const errorDialog = page.locator(SELECTORS.errorDialog).first();
 
-    // Trigger error
-    await page.evaluate(() => {
-      const video = document.querySelector('video') as HTMLVideoElement;
-      if (video) video.src = 'https://example.com/does-not-exist.mp4';
-    });
+    await triggerError(page);
 
     await expect(errorDialog).toHaveAttribute(DATA_ATTRS.open, '', { timeout: 15_000 });
 

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -4,7 +4,7 @@ import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 for (const { name, path, media, skipBrowsers } of ALL_VIDEO_PAGES as readonly PageEntry[]) {
-  const usesSettingsMenu = !path.includes('/cdn-video') && !path.includes('/ejected');
+  const rateMenu = !path.includes('/cdn-video') && !path.includes('/ejected');
   test.describe(`Video Controls — ${name}`, () => {
     test.skip(({ browserName }) => {
       return skipBrowsers?.includes(browserName as 'chromium' | 'webkit' | 'firefox') ?? false;
@@ -27,11 +27,7 @@ for (const { name, path, media, skipBrowsers } of ALL_VIDEO_PAGES as readonly Pa
       await expect(player.muteButton).toHaveAttribute(DATA_ATTRS.volumeLevel);
       await expect(player.fullscreenButton).toHaveAttribute(DATA_ATTRS.availability);
       await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.availability);
-      if (usesSettingsMenu) {
-        await expect(player.settingsButton).toBeAttached();
-      } else {
-        await expect(player.captionsButton).toHaveAttribute(DATA_ATTRS.availability);
-      }
+      await expect(player.settingsButton).toBeAttached();
       await expect(player.duration).not.toHaveText('');
       await player.showControls();
       await expect(player.controls).toBeAttached();
@@ -96,7 +92,7 @@ for (const { name, path, media, skipBrowsers } of ALL_VIDEO_PAGES as readonly Pa
 
     // --- Playback Rate ---
 
-    (usesSettingsMenu ? test : test.skip)('playback rate menu changes selected rate', async () => {
+    (rateMenu ? test : test.skip)('playback rate menu changes selected rate', async () => {
       const initialRate = await player.getPlaybackRate();
 
       await player.selectAlternativePlaybackRate();


### PR DESCRIPTION
## Summary

- Update video controls E2E coverage to expect the settings button across video skins.
- Make error dialog tests trigger media errors deterministically instead of relying on remote load failure behavior.

## Root cause

The video skin tests still expected a standalone captions button on ejected/CDN pages after those skins moved captions behind settings. The error dialog tests also relied on WebKit surfacing an invalid remote source as a media error, which was not deterministic.

## Validation

- `pnpm build:packages`
- `pnpm build:cdn`
- `pnpm -F site ejected-skins`
- `pnpm --dir apps/e2e generate-pages`
- `pnpm --dir apps/e2e sync-ejected-skins`
- `pnpm --dir apps/e2e exec playwright test tests/video-controls.spec.ts --project=vite-chromium`
- `pnpm --dir apps/e2e exec playwright test tests/video-controls.spec.ts --project=vite-webkit`
- `pnpm --dir apps/e2e exec playwright test tests/error-dialog.spec.ts --project=vite-webkit`
- `pnpm --dir apps/e2e exec playwright test tests/error-dialog.spec.ts --project=vite-chromium`
- `pnpm --dir apps/e2e exec playwright test --project=vite-chromium --project=vite-webkit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths affected.
> 
> **Overview**
> Stabilizes E2E coverage by aligning assertions with current player skins and by faking media errors instead of depending on network/browser behavior.
> 
> **Error dialog tests** now use a shared `triggerError` helper that sets `video.error` and dispatches an `error` event, replacing invalid remote `src` URLs that were flaky (especially in WebKit).
> 
> **Video controls tests** always assert the **settings** control is present on every page, dropping the old split that expected a standalone captions button on CDN/ejected skins. Playback-rate menu coverage still skips CDN/ejected pages via the renamed `rateMenu` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcaf7db284f466298146209e04b85cb08e2c8925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->