### PR TITLE
feat(spf): text tracks switching

### DIFF
--- a/.claude/plans/spf-text-track-switching-refactor.md
+++ b/.claude/plans/spf-text-track-switching-refactor.md
@@ -1,0 +1,97 @@
+# SPF text-track selection → track-switching refactor
+
+Working reference for migrating text-track selection onto the `track-switching`
+rule chain so it gains **constraints** (failed-CDN pruning) and **CDN priority**,
+and converting the bidirectional `syncTextTracks` write path to a **user-intent
+signal** so `selectedTextTrackId` becomes single-writer.
+
+Branch: `feat/spf-text-tracks-switching`. Shipped feature docs
+(`internal/design/spf/features/subtitles.md`,
+`internal/design/spf/text-track-architecture.md`) describe current reality and
+get updated at phase 5, not before.
+
+## Problem
+
+- `selectTextTrack` (entry-once, opt-in default pick) and `syncTextTracks` (DOM
+  `change` → write) both write `selectedTextTrackId` — `subtitles.md` flags this
+  multi-writer slot as "intentionally orthogonal." It's the smell to remove.
+- Text selection never runs the rule chain, so it ignores `excludeFailedCdns`
+  and `preferActiveCdn`. A failed CDN or CDN priority has no effect on captions.
+
+## Agreed design
+
+**Intent signal** — `userTextTrackSelection: Partial<TextTrack> | 'off' | undefined`
+
+| Value | Meaning | Resolution |
+|---|---|---|
+| `undefined` | auto — no user preference | `preferredSubtitleLanguage` config → `DEFAULT=YES + AUTOSELECT=YES` → none |
+| `Partial<TextTrack>` (language-based) | explicit on | `filterByUserSelection` narrows; `preferActiveCdn` picks surviving-CDN copy; head |
+| `'off'` | explicit none | terminal short-circuits to no-selection; sticky through re-eval |
+
+- **Not cleared on source unload** — mirrors `userVideoTrackSelection` /
+  `userAudioTrackSelection` (embedder-owned, persistent). Stickiness (sticky
+  language + sticky off across sources) falls out for free; no clear-on-unload
+  behavior to add. Config-driven opt-out is a later addition.
+- DOM bridge writes a **language-based** partial (mirrors the audio sibling), so
+  a pick re-resolves per-source. Known limitation: two same-language tracks
+  differing by forced/characteristics resolve by language alone; the terminal
+  tie-breaks deterministically. Enrich the partial later if it bites.
+
+**Ownership** — `selectedTextTrackId` becomes the single-writer **output** of
+`switchTextTrack`, cleared per-source by the helper's existing exit cleanup.
+
+**Text chain** (`setupTrackSwitching` variant):
+- constraints: `[excludeFailedCdns]` — no `excludeUnplayableTracks` (`canPlayTrack`
+  is MSE-based, wrong probe for text; text playability is SPF-parser support).
+- rules: `[filterByUserSelection, preferActiveCdn]`
+- `resolveSelection: pickResolvedTextTrack` — the one text-specific terminal that
+  understands `'off'` / auto / explicit + opt-in policy. `filterByUserSelection`
+  and `preferActiveCdn` stay shared and untouched (the picker, not the filter,
+  understands `'off'`).
+
+**Framework touch-point** — `setupTrackSwitching` gains an optional
+`resolveSelection(candidates, deps) => string | undefined`, defaulting to the
+chain head. Video/audio don't supply it → unchanged. `SelectionKey` /
+`UserSelectionKey` each gain one literal.
+
+**Consumer-facing change** — programmatic selection moves from writing
+`selectedTextTrackId` to writing `userTextTrackSelection` (via `shareSignals` /
+`onSignalsReady`); `selectedTextTrackId` becomes read-only output.
+
+## Open items (iterate during implementation)
+
+- **Echo guard** — once the resolver can override the user (pick `es`, es only on
+  a failed CDN → resolved `undefined` → mode-mirror disables → `change` event),
+  the DOM bridge must not write that correction back as "user turned off."
+  Prototype: track the modes SPF itself sets, write back only genuine user
+  deltas; fall back to extending the settling window if not worth the state.
+- **Same-language ambiguity** — see DOM-bridge note above.
+- **Empty candidate set** — keep current behavior: `if (!tracks.length) return`
+  leaves the prior pick (no caption flicker when every text CDN is cooled down;
+  recovers on cooldown). `'off'`/auto-declines go through `resolveSelection`
+  (non-empty set → undefined), distinct from the empty-set case.
+
+## Phases (TDD per phase, one commit each, check in at each boundary)
+
+1. **No-selection seam in `setupTrackSwitching`.** Add `resolveSelection` config +
+   `selectChainHead` default; thread into the effect. Export `setupTrackSwitching`
+   for tests (module-only, like `applyRules`). Tests: undefined resolution clears
+   the slot; non-default picker is threaded the chain candidates; video/audio
+   default path unchanged.
+2. **`switchTextTrack` variant + `pickResolvedTextTrack`.** Port `pickTextTrack`
+   policy into the terminal; handle off/auto/explicit; add `selectedTextTrackId`
+   to `SelectionKey`, `userTextTrackSelection` to `UserSelectionKey`. Tests:
+   auto-default, explicit language, off-stays-off across re-eval, failed-CDN
+   re-resolution, CDN-priority copy selection.
+3. **Refactor `syncTextTracks`.** Change-bridge writes `userTextTrackSelection`
+   (language partial / `'off'`) instead of `selectedTextTrackId`; mode-mirror
+   still reads `selectedTextTrackId`; echo guard. Tests: DOM pick → intent →
+   resolved → mode round-trip without echo; resolver override corrects DOM
+   without write-back.
+4. **Remove `selectTextTrack` text path + engine rewire.** Compose
+   `switchTextTrack` after `deriveCdnPriority` / `setupFailoverMonitor`, before
+   `resolveTextTrack`; expose `userTextTrackSelection` via `shareSignals`.
+   Full-engine test.
+5. **Docs.** Update `subtitles.md` (state slots → single-writer; implementation
+   surface) and `text-track-architecture.md` (bidirectional section → intent
+   model + echo guard).

--- a/apps/sandbox/templates/spf-segment-loading/index.html
+++ b/apps/sandbox/templates/spf-segment-loading/index.html
@@ -118,9 +118,9 @@
         border: 1px solid #ddd;
         border-radius: 4px;
       }
-      #rendition-picker h2, #audio-track-picker h2, #resolution-status h2 { margin-top: 0; font-size: 14px; }
+      #rendition-picker h2, #audio-track-picker h2, #text-track-picker h2, #resolution-status h2 { margin-top: 0; font-size: 14px; }
 
-      #audio-track-buttons { display: flex; flex-wrap: wrap; gap: 8px; }
+      #audio-track-buttons, #text-track-buttons { display: flex; flex-wrap: wrap; gap: 8px; }
       .audio-track-btn {
         padding: 6px 12px;
         font-family: monospace;
@@ -249,6 +249,11 @@
     <div id="audio-track-picker">
       <h2>Audio Tracks</h2>
       <div id="audio-track-buttons">Waiting for presentation…</div>
+    </div>
+
+    <div id="text-track-picker">
+      <h2>Subtitles / Captions</h2>
+      <div id="text-track-buttons">Waiting for presentation…</div>
     </div>
 
     <div id="resolution-status">

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -72,6 +72,19 @@ function getTextTracks(presentation: SimpleHlsEngineState['presentation']) {
   return presentation?.selectionSets?.find((s) => s.type === 'text')?.switchingSets[0]?.tracks ?? [];
 }
 
+// Drive the *native* TextTrack modes — what a captions button / browser UI
+// touches — so a user selection flows through the syncTextTracks DOM→intent
+// bridge (change event → userTextTrackSelection) rather than writing the SPF
+// signal directly. `showId === undefined` disables all (Off).
+function setNativeTextMode(showId: string | undefined) {
+  const tt = video.textTracks;
+  for (let i = 0; i < tt.length; i++) {
+    const track = tt[i];
+    if (!track || (track.kind !== 'subtitles' && track.kind !== 'captions')) continue;
+    track.mode = track.id === showId ? 'showing' : 'disabled';
+  }
+}
+
 // ── Display functions ─────────────────────────────────────────────────────────
 function updateShareUrl() {
   const p = new URLSearchParams();
@@ -406,9 +419,13 @@ function updateAudioTrackSelection(
 
 // Subtitle/caption picker. Text selection changes are user-driven and
 // infrequent, so this rebuilds the button list on each change (no build/update
-// split like the audio picker, which fights frequent ABR churn). Writes the
-// userTextTrackSelection *intent* — a language partial, 'off', or undefined
-// (auto) — which switchTextTrack resolves into selectedTextTrackId.
+// split like the audio picker, which fights frequent ABR churn).
+//
+// Off + language buttons drive the *native* TextTrack mode (like a captions
+// button), so selection exercises the real syncTextTracks DOM→intent bridge.
+// "Reset to auto" has no native-mode analog (it means "forget my preference"),
+// so it writes userTextTrackSelection=undefined directly — the programmatic
+// escape hatch. Highlighting reads the resolved selectedTextTrackId + intent.
 function renderTextTrackPicker() {
   if (!engine || !signals) return;
   const presentation = engine.state.presentation.get();
@@ -459,8 +476,8 @@ function renderTextTrackPicker() {
   offBtn.className = `audio-track-btn${offSelected ? (isOff ? ' selected-pinned' : ' selected-default') : ''}`;
   offBtn.textContent = `Off${offSelected ? (isOff ? ' 🔇' : ' 🌐') : ''}`;
   offBtn.addEventListener('click', () => {
-    log("Text track intent: 'off'", 'warning');
-    signals!.state.userTextTrackSelection.set('off');
+    log('Disabling all text tracks via native mode (bridges to off intent)', 'warning');
+    setNativeTextMode(undefined);
   });
   textTrackButtonsDiv.appendChild(offBtn);
 
@@ -481,9 +498,8 @@ function renderTextTrackPicker() {
     btn.textContent = `${language ?? '—'} · ${label}${badge}`;
     btn.title = `kind: ${track.kind}${track.forced ? ' · forced' : ''} · id: ${track.id}`;
     btn.addEventListener('click', () => {
-      const filter = language ? { language } : { id: track.id };
-      log(`Text track intent: ${JSON.stringify(filter)}`, 'warning');
-      signals!.state.userTextTrackSelection.set(filter);
+      log(`Showing ${language ?? track.id} via native mode (bridges to intent)`, 'warning');
+      setNativeTextMode(track.id);
     });
     textTrackButtonsDiv.appendChild(btn);
   }

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -536,15 +536,16 @@ function startEngine(src: string) {
       prev.hasPresentation = true;
     }
 
-    // Auto-select first text track when presentation arrives
-    if (state.presentation && !state.selectedTextTrackId && state.presentation.selectionSets) {
+    // Auto-select first text track when presentation arrives, via intent:
+    // switchTextTrack resolves userTextTrackSelection into selectedTextTrackId.
+    if (state.presentation && !state.userTextTrackSelection && state.presentation.selectionSets) {
       const textSet = state.presentation.selectionSets.find((s) => s.type === 'text');
       const firstText = textSet?.switchingSets?.[0]?.tracks?.[0];
       if (firstText) {
         log(`Auto-selecting text track: ${firstText.id}`);
-        // TODO(stage-d): selectedTextTrackId is the deferred reconciler case —
-        // direct write into composition state until intent/state split lands.
-        engine.state.selectedTextTrackId.set(firstText.id);
+        engine.state.userTextTrackSelection.set(
+          firstText.language ? { language: firstText.language } : { id: firstText.id }
+        );
       }
     }
 

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -18,6 +18,7 @@ const logsDiv = document.getElementById('logs') as HTMLDivElement;
 const stateDiv = document.getElementById('state') as HTMLDivElement;
 const renditionButtonsDiv = document.getElementById('rendition-buttons') as HTMLDivElement;
 const audioTrackButtonsDiv = document.getElementById('audio-track-buttons') as HTMLDivElement;
+const textTrackButtonsDiv = document.getElementById('text-track-buttons') as HTMLDivElement;
 const resolutionListDiv = document.getElementById('resolution-list') as HTMLDivElement;
 const nowPlayingQualityDiv = document.getElementById('now-playing-quality') as HTMLDivElement;
 const throughputDiv = document.getElementById('throughput-display') as HTMLDivElement;
@@ -65,6 +66,10 @@ function getVideoTracks(presentation: SimpleHlsEngineState['presentation']) {
 
 function getAudioTracks(presentation: SimpleHlsEngineState['presentation']) {
   return presentation?.selectionSets?.find((s) => s.type === 'audio')?.switchingSets[0]?.tracks ?? [];
+}
+
+function getTextTracks(presentation: SimpleHlsEngineState['presentation']) {
+  return presentation?.selectionSets?.find((s) => s.type === 'text')?.switchingSets[0]?.tracks ?? [];
 }
 
 // ── Display functions ─────────────────────────────────────────────────────────
@@ -399,6 +404,91 @@ function updateAudioTrackSelection(
   }
 }
 
+// Subtitle/caption picker. Text selection changes are user-driven and
+// infrequent, so this rebuilds the button list on each change (no build/update
+// split like the audio picker, which fights frequent ABR churn). Writes the
+// userTextTrackSelection *intent* — a language partial, 'off', or undefined
+// (auto) — which switchTextTrack resolves into selectedTextTrackId.
+function renderTextTrackPicker() {
+  if (!engine || !signals) return;
+  const presentation = engine.state.presentation.get();
+  const selectedTextTrackId = engine.state.selectedTextTrackId.get();
+  const intent = engine.state.userTextTrackSelection.get();
+  const tracks = getTextTracks(presentation);
+
+  if (tracks.length === 0) {
+    textTrackButtonsDiv.textContent = presentation ? 'No text tracks found' : 'Waiting for presentation…';
+    return;
+  }
+
+  const isOff = intent === 'off';
+  const isPinned = intent !== undefined && intent !== 'off';
+  const selectedTrack = tracks.find((track) => track.id === selectedTextTrackId);
+  const selectedKey = selectedTrack ? selectedTrack.language || selectedTrack.id : undefined;
+
+  textTrackButtonsDiv.innerHTML = '';
+
+  // Status row: current intent (auto / pinned / off) + reset.
+  const statusRow = document.createElement('div');
+  statusRow.className = 'audio-status';
+  const modeLabel = document.createElement('span');
+  modeLabel.className = isPinned || isOff ? 'mode-pinned' : 'mode-default';
+  modeLabel.textContent = isOff
+    ? '🔇 Off (user)'
+    : isPinned
+      ? `🔒 Pinned: ${JSON.stringify(intent)}`
+      : '🌐 Auto (default policy)';
+  statusRow.appendChild(modeLabel);
+  if (intent !== undefined) {
+    const resetBtn = document.createElement('button');
+    resetBtn.type = 'button';
+    resetBtn.className = 'clear-filter-btn';
+    resetBtn.textContent = 'Reset to auto';
+    resetBtn.addEventListener('click', () => {
+      log('Cleared userTextTrackSelection (back to default policy)', 'success');
+      signals!.state.userTextTrackSelection.set(undefined);
+    });
+    statusRow.appendChild(resetBtn);
+  }
+  textTrackButtonsDiv.appendChild(statusRow);
+
+  // Off button — explicit 'off' intent; highlighted whenever nothing resolves.
+  const offBtn = document.createElement('button');
+  offBtn.type = 'button';
+  const offSelected = !selectedTextTrackId;
+  offBtn.className = `audio-track-btn${offSelected ? (isOff ? ' selected-pinned' : ' selected-default') : ''}`;
+  offBtn.textContent = `Off${offSelected ? (isOff ? ' 🔇' : ' 🌐') : ''}`;
+  offBtn.addEventListener('click', () => {
+    log("Text track intent: 'off'", 'warning');
+    signals!.state.userTextTrackSelection.set('off');
+  });
+  textTrackButtonsDiv.appendChild(offBtn);
+
+  // One button per selection identity (language, else id).
+  const seen = new Set<string>();
+  for (const track of tracks) {
+    const language = track.language || undefined;
+    const key = language ?? track.id;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const label = 'label' in track && track.label ? track.label : track.id;
+    const isSelected = key === selectedKey;
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `audio-track-btn${isSelected ? (isPinned ? ' selected-pinned' : ' selected-default') : ''}`;
+    const badge = isSelected ? (isPinned ? ' 🔒' : ' 🌐') : '';
+    btn.textContent = `${language ?? '—'} · ${label}${badge}`;
+    btn.title = `kind: ${track.kind}${track.forced ? ' · forced' : ''} · id: ${track.id}`;
+    btn.addEventListener('click', () => {
+      const filter = language ? { language } : { id: track.id };
+      log(`Text track intent: ${JSON.stringify(filter)}`, 'warning');
+      signals!.state.userTextTrackSelection.set(filter);
+    });
+    textTrackButtonsDiv.appendChild(btn);
+  }
+}
+
 function renderResolutionStatus() {
   if (!engine) return;
   const presentation = engine.state.presentation.get();
@@ -527,26 +617,15 @@ function startEngine(src: string) {
   };
   const prevContext = { hasMediaSource: false, hasVideoBuffer: false, hasAudioBuffer: false };
 
-  // State logger + auto-select first text track
+  // State logger. Text selection is driven by the Subtitles/Captions picker
+  // (userTextTrackSelection intent) — no auto-select here, so the engine's real
+  // opt-in default policy is what runs on load.
   const stopStateLogger = effect(() => {
     const state = snapshot(engine.state);
 
     if (state.presentation && !prev.hasPresentation) {
       log('Presentation resolved');
       prev.hasPresentation = true;
-    }
-
-    // Auto-select first text track when presentation arrives, via intent:
-    // switchTextTrack resolves userTextTrackSelection into selectedTextTrackId.
-    if (state.presentation && !state.userTextTrackSelection && state.presentation.selectionSets) {
-      const textSet = state.presentation.selectionSets.find((s) => s.type === 'text');
-      const firstText = textSet?.switchingSets?.[0]?.tracks?.[0];
-      if (firstText) {
-        log(`Auto-selecting text track: ${firstText.id}`);
-        engine.state.userTextTrackSelection.set(
-          firstText.language ? { language: firstText.language } : { id: firstText.id }
-        );
-      }
     }
 
     if (state.selectedVideoTrackId && state.selectedVideoTrackId !== prev.selectedVideoTrackId) {
@@ -573,6 +652,7 @@ function startEngine(src: string) {
   const stopThroughputUI = effect(() => updateThroughputDisplay());
   const stopRenditionUI = effect(() => renderRenditionPicker());
   const stopAudioPickerUI = effect(() => renderAudioTrackPicker());
+  const stopTextPickerUI = effect(() => renderTextTrackPicker());
   const stopResolutionUI = effect(() => renderResolutionStatus());
 
   // Context logger
@@ -636,6 +716,7 @@ function startEngine(src: string) {
     stopThroughputUI();
     stopRenditionUI();
     stopAudioPickerUI();
+    stopTextPickerUI();
     stopResolutionUI();
     stopContextLogger();
   };

--- a/internal/design/spf/architecture.md
+++ b/internal/design/spf/architecture.md
@@ -116,7 +116,7 @@ The orchestration hub. Initializes all features in a fixed order, wiring shared 
 | 0a | `syncPreload` | Bidirectional sync of `mediaElement.preload` ↔ `state.preload` (backfilled to `'metadata'` by default) before any buffering decisions |
 | 0b | `trackPlaybackInitiated` | `play` event → `state.playbackInitiated = true` |
 | 1 | `resolvePresentation` | Fetch multivariant playlist, parse tracks |
-| 2 | `selectVideoTrack` / `selectAudioTrack` / `selectTextTrack` | Choose initial tracks |
+| 2 | `selectVideoTrack` / `selectAudioTrack` / `switchTextTrack` | Choose initial tracks |
 | 3 | `resolveTrack` | Fetch media playlist for each selected track |
 | 3.5 | `calculatePresentationDuration` | Derive duration from playlists |
 | 4 | `setupMediaSource` | Create `MediaSource`, attach to `<video>` |

--- a/internal/design/spf/conventions/behaviors.md
+++ b/internal/design/spf/conventions/behaviors.md
@@ -244,7 +244,7 @@ If the purpose overlaps with another behavior's purpose — both writing the sam
 **Diagnostic — do the writers share a decision-making domain?**
 
 - **Same domain → likely split-symptom; consider merging.** Multiple writers that read the *same inputs* and choose among the *same options* are aspects of one concern. Example: `selectVideoTrack` (default on load) and `quality-switching` (ABR over bandwidth) both decide what to write to `selectedVideoTrackId` based on presentation + bandwidth + config. They're two aspects of one "manage video track selection" concern; merging dissolves the multi-writer arrangement.
-- **Different domains → legitimate multi-writer; keep separate.** Writers that reflect *genuinely different inputs* (config-driven default vs DOM-driven user action; intent vs derived default; programmatic vs network-event-driven) belong in separate behaviors. Example: `selectTextTrack` (config-driven default) and `sync-text-tracks` (DOM `change`-event-driven) both write `selectedTextTrackId` but reflect different sources of truth.
+- **Different domains → separate behaviors, but prefer an intent slot over co-writing the resolved slot.** Writers that reflect *genuinely different inputs* (config-driven default vs DOM-driven user action; programmatic vs network-event-driven) belong in separate behaviors — but route them to a shared *intent* slot that a single owner resolves, rather than co-writing the resolved output. Example: text selection once had `selectTextTrack` (config default) and `sync-text-tracks` (DOM `change`) both writing `selectedTextTrackId`. That multi-writer was resolved by moving the DOM bridge to write `userTextTrackSelection` (intent) and making `switchTextTrack` the single writer of the resolved `selectedTextTrackId` (see [clusters.md § multi-writer](../features/clusters.md)).
 
 Make this decision *after* the refactor proposal lands so the simpler shape is what you're evaluating, not the current shape. The decomposition merge often slots cleanly into the larger refactor of the *other* writer — e.g., `selectVideoTrack` would naturally merge into a refactored `quality-switching` rather than land as a standalone change.
 
@@ -512,7 +512,7 @@ When a behavior's logic varies by media type (video / audio / text), prefer **se
 // good — narrow per-type keys, no runtime discriminant, dead code drops out
 export const selectVideoTrack = defineBehavior({ ... });
 export const selectAudioTrack = defineBehavior({ ... });
-export const selectTextTrack = defineBehavior({ ... });
+// (text selection is the switchTextTrack variant in track-switching.ts)
 ```
 
 Engines opt into specific tracks (e.g. an audio-only engine uses `selectAudioTrack` only). This wins on **A — Reusability** (engines aren't forced to carry video logic), **C — Patternability** (call sites read the same shape regardless of type), and **E — Size** (unused specializations tree-shake out).
@@ -788,7 +788,7 @@ Per-export JSDoc (already conventional) describes individual exports; the file-l
 
 - Behaviors are named as **descriptive verbs**: `syncPreload`, `selectVideoTrack`, `loadVideoSegments`, `endOfStream`. No `*Behavior` suffix.
 - Files match the exported name in kebab-case: `sync-preload.ts` exports `syncPreload`.
-- Per-type specializations co-locate in one module: `select-tracks.ts` exports `selectVideoTrack` / `selectAudioTrack` / `selectTextTrack`.
+- Per-type specializations co-locate in one module: `select-tracks.ts` exports `selectVideoTrack` / `selectAudioTrack`; `track-switching.ts` exports `switchVideoTrack` / `switchAudioTrack` / `switchTextTrack`.
 - Behavior factories are named `make*`: `makeShareSignals`. The factory's product is a Behavior; the prefix distinguishes the factory from a Behavior export.
 - Setup-shape helpers are named `setup*`: `setupTrackResolution`. The shape is a `Behavior.setup`-style function called from inside a per-type behavior's setup.
 - **Name by the unit-of-work this behavior triggers, not by its downstream observable.** When per-type-specialized behaviors exist (video / audio / text), the names must match the work they share — sibling consistency is load-bearing. `loadVideoSegments` triggers segment fetches; segments produce frames downstream, but we don't call it `loadVideoFrames`. Same for audio (`loadAudioSegments`, not `loadAudioSamples`) and text (`loadTextTrackSegments`, not `loadTextTrackCues`). A name that breaks the sibling pattern is a sniff that the author was thinking about a different layer than the convention assumes.

--- a/internal/design/spf/features/audio-playback.md
+++ b/internal/design/spf/features/audio-playback.md
@@ -81,7 +81,6 @@ audio behaviors composed alongside video and text:
 ```ts
 // Track selection (reads config for initial preferences).
 selectAudioTrack,
-selectTextTrack,
 
 // Resolve selected tracks (fetch media playlists)
 resolveVideoTrack,

--- a/internal/design/spf/features/capability-probing.md
+++ b/internal/design/spf/features/capability-probing.md
@@ -130,9 +130,11 @@ layer onto specific phases per the
 ## Likely cross-cutting impact
 
 - **Selection behaviors** — `selectVideoTrack` / `switchVideoQuality`
-  / `selectAudioTrack` / `selectTextTrack` pickers read filtered set,
-  not raw `presentation.selectionSets`. Same shape as the
-  `userVideoTrackSelection` constraint pattern in `video-abr`.
+  / `selectAudioTrack` pickers read filtered set, not raw
+  `presentation.selectionSets`. Same shape as the `userVideoTrackSelection`
+  constraint pattern in `video-abr`. (`switchTextTrack` is excluded — its
+  capability constraint is omitted, since `canPlayTrack`/`isTypeSupported`
+  is the wrong probe for SPF-parsed WebVTT text.)
 - **`mse-mms-pipeline` late-failure path** — `createSourceBuffer`'s
   throw on unsupported codec becomes a defensive fallback. With
   upstream filtering it should rarely fire; the throw stays as a

--- a/internal/design/spf/features/clusters.md
+++ b/internal/design/spf/features/clusters.md
@@ -124,7 +124,7 @@ The selection model — which audio / video / text tracks are available, which i
 
 **Docs.** `subtitles`, `video-abr`, `audio-playback`, `multi-language-audio`, `hevc-variant-selection` (cluster D consumer, video codec axis), `5.1-surround-selection` (cluster D consumer, audio channel-count axis), `audio-abr` (audio sibling of video-abr), `multi-signal-abr` (algorithm extension to ABR with non-bandwidth signals).
 
-**Foundational primitives.** Per-track resolution (`resolveVideoTrack` / `resolveAudioTrack` / `resolveTextTrack` sharing `setupTrackResolution`); per-track selection (`selectVideoTrack` / `selectAudioTrack` / `selectTextTrack`); the `selected*TrackId` slot family.
+**Foundational primitives.** Per-track resolution (`resolveVideoTrack` / `resolveAudioTrack` / `resolveTextTrack` sharing `setupTrackResolution`); per-track selection (`selectVideoTrack` / `selectAudioTrack` for the simple default-pick path; `switchVideoTrack` / `switchAudioTrack` / `switchTextTrack` for the track-switching chain); the `selected*TrackId` slot family.
 
 **Maps to Notion cluster C** ("Track & variant registry").
 
@@ -284,7 +284,7 @@ Two or more behaviors write to the same state slot from different decision domai
 
 **Signals.** A `selected*TrackId` or similar slot named on more than one behavior's writer list; a "default + user-action" pattern; orthogonal-by-design coordination.
 
-**Where it shows up.** `selectedTextTrackId` (default-on-load via `selectTextTrack` + DOM user-action via `syncTextTracks`). Proposed `selectedAudioTrackId` for multi-language audio (default + programmatic write).
+**Where it shows up.** Formerly `selectedTextTrackId` (default-on-load via `selectTextTrack` + DOM user-action via `syncTextTracks`) — since resolved to a single-writer output of `switchTextTrack`, with the dual-input relocated to the `userTextTrackSelection` *intent* slot (DOM `change` bridge + consumer via `shareSignals`). That's the canonical resolution of this pattern: route differing inputs to a shared intent slot and let one owner derive the resolved slot, rather than co-writing the resolved slot. Proposed `selectedAudioTrackId` for multi-language audio (default + programmatic write).
 
 **Skill action when this pattern is suspected.** Characterize the existing writer(s) and the proposed writer along three axes: (1) decision domain (config vs DOM vs intent vs derived), (2) trigger (one-shot transition vs ongoing reactive), (3) cost (cheap write vs side-effect-heavy write — e.g., audio writes trigger flush + re-resolve + replan). If the proposed writer doesn't share decision domain or cost with the existing pattern, the multi-writer convention may not transfer cleanly.
 

--- a/internal/design/spf/features/multi-language-audio.md
+++ b/internal/design/spf/features/multi-language-audio.md
@@ -148,7 +148,7 @@ Resolved during implementation:
 ## Related features
 
 - **[audio-playback](./audio-playback.md)** — single-rendition baseline this feature extends. The "Language-aware default selection" gap there is now resolved.
-- **[subtitles](./subtitles.md)** — direct template for the selection-picker shape; multi-writer state slot pattern. Subtitles uses orthogonal multi-writer (`selectTextTrack` + DOM `change`); audio uses constraint+filter — different shapes.
+- **[subtitles](./subtitles.md)** — now the same shape as audio: text selection moved onto the track-switching chain (`switchTextTrack`) with a `userTextTrackSelection` constraint+filter, converging on this feature's `userAudioTrackSelection` pattern. (Text adds an `'off'`/opt-in terminal and resolves the former `selectedTextTrackId` multi-writer to a single-writer output, with the DOM `change` bridge writing intent instead.)
 - **[video-abr](./video-abr.md)** — `userVideoTrackSelection` constraint+filter precedent. Same shape as audio's new `userAudioTrackSelection` slot.
 - **[audio-abr](./audio-abr.md)** *(documented; pending implementation)* — destination-architecture sibling. When implemented, `switchAudioQuality` will replace `selectAudioTrack` as the `selectedAudioTrackId` writer; `userAudioTrackSelection` filter shape carries over.
 - **[5.1-surround-selection](./5.1-surround-selection.md)** *(coarse, not yet documented, candidate)* — codec-change extension. Tier 2 mid-stream flush is designed extensible to codec-change routing.

--- a/internal/design/spf/features/source-replacement.md
+++ b/internal/design/spf/features/source-replacement.md
@@ -110,7 +110,7 @@ source change, not via the resolved/unresolved cascade):
 | Behavior | Per-source reset |
 |---|---|
 | `trackLoadTriggers` | `loadActivated` reset to `false` on `(mediaElement, presentation.url)` identity change |
-| `selectAudioTrack` / `selectTextTrack` / `switchVideoQuality` | Re-run pickers when presentation transitions to resolved with new content |
+| `selectAudioTrack` / `switchTextTrack` / `switchVideoQuality` | Re-pick when presentation transitions to resolved with new content |
 
 **Cross-source preservation:**
 

--- a/internal/design/spf/features/subtitles.md
+++ b/internal/design/spf/features/subtitles.md
@@ -23,9 +23,10 @@ What's implemented today, organized from base case to richer support. Each row i
 |---|---|---|
 | Base WebVTT captions | Single subtitle track, segmented WebVTT, browser-native parsing | `resolveVttSegment` uses an offscreen `<video><track>`; VTTCue settings (position, line, align, size) pass through; voice spans, regions, ruby pass through opaquely |
 | Multi-language tracks | Any number of subtitle renditions surfaced from a multivariant playlist | `LANGUAGE`, `NAME`, `DEFAULT`, `AUTOSELECT`, `FORCED`, `URI` parsed from `#EXT-X-MEDIA:TYPE=SUBTITLES` |
-| Default selection | Three-tier picker: `preferredSubtitleLanguage` → `DEFAULT=YES + AUTOSELECT=YES` → none | Forced-only tracks excluded by default (Apple-spec compliance); opt-in via `includeForcedTracks` |
-| User selection (DOM-driven) | Browser captions UI / host-page button → DOM `mode='showing'` → state | `change` listener on `mediaElement.textTracks`; Chromium settling-window guard prevents auto-pick false positives |
-| Programmatic selection | Consumer writes `state.selectedTextTrackId` via `onSignalsReady` callback | `syncTextTracks` mirrors the write into DOM `mode` |
+| Default selection | Auto (no user intent) runs the opt-in three-tier policy: `preferredSubtitleLanguage` → `DEFAULT=YES + AUTOSELECT=YES` → none | `switchTextTrack`'s terminal (`pickResolvedTextTrack` → `pickTextTrackFromTracks`) over the constrained, CDN-scoped candidates. Forced-only tracks excluded by default (Apple-spec); opt-in via `includeForcedTracks` |
+| User selection (DOM-driven) | Browser captions UI / host-page button → DOM `mode='showing'` → `userTextTrackSelection` intent → resolved into `selectedTextTrackId` | `change` listener on `mediaElement.textTracks` writes a language-based partial (or `'off'`); Chromium settling-window + echo guard (`showingId === selectedTextTrackId`) reject auto-pick / mirror echoes |
+| Programmatic selection | Consumer writes `state.userTextTrackSelection` (partial / `'off'`) via `onSignalsReady` | `switchTextTrack` resolves it; `syncTextTracks` mirrors the resolved id into DOM `mode`. (Was a direct `selectedTextTrackId` write.) |
+| Constraint- & CDN-aware selection | Selection runs the track-switching chain: failed-CDN renditions pruned, narrowed to the active CDN | `[excludeFailedCdns]` + `[preferActiveCdn]`; re-resolves on failover. Sticky language / `'off'` intent persists across source changes |
 | Cue deduplication | Per-track cue cache in `TextTracksActor`; segment reloads don't double-add | Dedup by exact `(startTime, endTime, text)` match |
 | Preload-aware segment loading | FSM gates fetches: `'preconditions-unmet' → 'dormant' → 'metadata-only' → 'full-range'` driven by `preload` + `loadActivated` | `metadata-only` is a no-op for text (no init-segment concept) |
 | Source-reset cleanup | `'clear'` message to `TextTracksActor` evicts cue + segment cache; `<track>` elements removed | Symmetric with manifest unload |
@@ -49,9 +50,9 @@ Extension boundaries — each could become its own feature doc or a phase extens
 
 | Behavior | File | Responsibility |
 |---|---|---|
-| `selectTextTrack` | `packages/spf/src/playback/behaviors/select-tracks.ts` | Default selection via config-driven picker (three-tier logic) |
+| `switchTextTrack` | `packages/spf/src/playback/behaviors/track-switching.ts` | Owns `selectedTextTrackId`: resolves `userTextTrackSelection` intent (incl. `'off'` / opt-in default policy) against failed-CDN-pruned, active-CDN-scoped renditions; may resolve to none |
 | `resolveTextTrack` | `packages/spf/src/playback/behaviors/resolve-track.ts` | Fetches media playlist for selected text track |
-| `syncTextTracks` | `packages/spf/src/playback/behaviors/dom/sync-text-tracks.ts` | DOM `<track>` lifecycle + bidirectional state ↔ DOM sync |
+| `syncTextTracks` | `packages/spf/src/playback/behaviors/dom/sync-text-tracks.ts` | DOM `<track>` lifecycle; one-way mirror of resolved id → `mode`; DOM `change` → `userTextTrackSelection` intent (echo-guarded) |
 | `setupTextTrackActors` | `packages/spf/src/playback/behaviors/dom/setup-text-track-actors.ts` | Creates `TextTracksActor` + `TextTrackSegmentLoaderActor`; element-bound lifecycle |
 | `loadTextTrackSegments` | `packages/spf/src/playback/behaviors/dom/load-segments.ts` | Dispatches `'load'` messages to segment-loader actor |
 
@@ -64,7 +65,9 @@ Extension boundaries — each could become its own feature doc or a phase extens
 
 **State slots:**
 
-- `selectedTextTrackId` — **multi-writer.** `selectTextTrack` writes on default-on-load / clear-on-unload; `syncTextTracks` writes from DOM user action. The two writers are intentionally orthogonal and don't conflict.
+- `selectedTextTrackId` — **single-writer output**, owned by `switchTextTrack` (cleared on src unload by its exit cleanup). Other behaviors only read it.
+- `userTextTrackSelection` — the user-intent **input**: `Partial<TextTrack>` (language-based) selects, `'off'` disables, `undefined` is auto. Written by `syncTextTracks` (DOM) and consumers (`shareSignals` / `onSignalsReady`); both are intent surfaces, so dual-write is last-write-wins by design. Materialized by `shareSignals`; **not** cleared on src unload (sticky preference, like `userAudioTrackSelection`).
+- `cdnPriority`, `failedCdns` — read by the chain (active-CDN scope + failed-CDN constraint).
 - `presentation`, `preload`, `loadActivated`, `currentTime` — read-only consumers.
 
 **Manifest parsing:** `parseMultivariantPlaylist` (`packages/spf/src/media/hls/parse-multivariant.ts`) extracts subtitle renditions; each becomes a `PartiallyResolvedTextTrack` carrying language, default, autoselect, forced metadata.
@@ -77,15 +80,18 @@ Extension boundaries — each could become its own feature doc or a phase extens
 {
   preferredSubtitleLanguage?: string;   // BCP-47 language tag for default selection
   includeForcedTracks?: boolean;        // default false — exclude forced-only tracks from auto-selection
-  enableDefaultTrack?: boolean;         // default true — honor DEFAULT=YES + AUTOSELECT=YES
+  enableDefaultTrack?: boolean;         // default false — honor DEFAULT=YES + AUTOSELECT=YES when set
   resolveTextTrackSegment?: (url: string) => Promise<Cue[]>;  // override VTT parser
+  getCdnId?: (url: string) => string;   // shared CDN-id derivation (active-CDN scope + failed-CDN constraint)
 }
 ```
 
 ## Verification
 
-- **Unit test:** `packages/spf/src/playback/behaviors/dom/tests/sync-text-tracks.test.ts` — covers DOM `<track>` slot allocation for multi-language manifests (creates a presentation with `en` + `es` tracks; verifies `srclang` on each `<track>`). Does **not** cover default-selection logic, segment loading, or cue dedup — those live in adjacent test files for the respective behaviors / actors.
-- **Sandbox:** no dedicated multi-language captions demo today. `apps/sandbox/src/spf-segment-loading/` is video/audio-only.
+- **Unit tests:**
+  - `packages/spf/src/playback/behaviors/tests/track-switching.test.ts` — `switchTextTrack` selection: auto-default policy, explicit language, `'off'` (incl. sticky across a candidate-set refresh), stale-pick fall-through, FORCED exclusion, CDN co-location + failover re-resolution; plus the `setupTrackSwitching` `resolveSelection` no-selection seam.
+  - `packages/spf/src/playback/behaviors/dom/tests/sync-text-tracks.test.ts` — `<track>` slot allocation, mode mirror, the DOM `change` → `userTextTrackSelection` intent bridge, and the echo guard (mirror echo + resolver correction are not written back).
+- **Sandbox:** no dedicated multi-language captions demo today. `apps/sandbox/src/spf-segment-loading/` auto-selects the first text track via `userTextTrackSelection` but isn't a focused captions demo.
 
 ## Related features
 
@@ -94,7 +100,9 @@ References to other features in the registry. Bracketed entries are candidate fe
 - **preload-modes** — `loadTextTrackSegments` reads the same `(preload, loadActivated)` gate state as the audio/video segment loaders; the load-mode FSM rows are direct consumers of the preload-modes contract.
 - **buffer-management** — text tracks share the per-type segment-loading dispatcher pattern with video/audio (the `'preconditions-unmet' → 'dormant' → 'metadata-only' → 'full-range'` FSM is the same shape). Text uses `TextTrackSegmentLoaderActor` rather than the v/a `SegmentLoaderActor`, but the dispatcher contract is unified.
 - **hls-multivariant-parsing** *(not yet documented)* — subtitle rendition extraction is one slice of manifest parsing.
-- **track-registry-primitive** *(coarse, not yet documented)* — `selectedTextTrackId` is currently the only multi-writer track-id slot. A generalized track-registry primitive likely emerges when multi-language audio is added.
+- **track-switching** — text selection is now a `switchTextTrack` variant of the shared track-switching chain (constraints + rules + a `resolveSelection` terminal). It diverges from video/audio in being *optional* (opt-in / `'off'`), which is what motivated the no-selection terminal seam.
+- **multi-cdn-failover** — text selection consumes the same `failedCdns` constraint + `cdnPriority` scope as video/audio, so captions co-locate on the active CDN and re-resolve on failover.
+- **track-registry-primitive** *(coarse, not yet documented)* — `selectedTextTrackId` is now a single-writer resolved output; the dual-input (DOM + consumer) lives on the `userTextTrackSelection` *intent* slot, which is the natural multi-writer. Any generalized registry primitive would formalize the intent → resolved split rather than a multi-writer resolved slot.
 - **styled-webvtt-cues** *(coarse, not yet documented)* — candidate extension for SPF-side cue styling.
 - **text-track-error-recovery** *(coarse, not yet documented)* — candidate extension for retry / fallback / state-surfacing on segment fetch errors.
 

--- a/internal/design/spf/text-track-architecture.md
+++ b/internal/design/spf/text-track-architecture.md
@@ -56,8 +56,9 @@ time — neither reactor has any global state.
 
 ### `syncTextTracks`
 
-Manages `<track>` element lifecycle and bridges DOM `TextTrackList` changes back
-to `selectedTextTrackId` in state.
+Manages `<track>` element lifecycle, mirrors the resolved `selectedTextTrackId`
+into DOM modes one way, and bridges DOM `TextTrackList` changes into the
+`userTextTrackSelection` intent slot (see Key Pattern 6).
 
 ```
 'preconditions-unmet' ──── mediaElement + tracks available ────→ 'set-up'
@@ -69,9 +70,11 @@ any state ──── destroy() ────→ 'destroying' ────→ 'd
 
 **`'set-up'` owns two independent effects:**
 - Effect 1 — creates `<track>` elements on entry; exit cleanup removes them and
-  clears `selectedTextTrackId`
+  sends `'clear'` to the `TextTracksActor`. (It no longer clears
+  `selectedTextTrackId` — that slot is owned and cleared by `switchTextTrack`.)
 - Effect 2 — syncs `mode` on entry (reactive: re-runs when `selectedTextTrackId`
-  changes) + attaches `'change'` listener to bridge DOM back to state
+  changes) one way + attaches `'change'` listener to bridge DOM actions into the
+  `userTextTrackSelection` intent slot (see Key Pattern 6)
 
 **`'preconditions-unmet'`** has no effects — the `monitor` handles the
 exit transition.
@@ -276,36 +279,41 @@ run.
 
 ---
 
-### 6. Bidirectional sync — the `change` event bridge
+### 6. DOM → intent bridge + one-way mode mirror
 
-`syncTextTracks` bridges DOM → state by listening to `TextTrackList`'s `'change'`
-event. The browser fires this event when track modes change, including when SPF
-itself sets modes via `syncModes()`.
+> **Updated (text-track-switching refactor).** `syncTextTracks` is no longer
+> bidirectional on the resolved id. It mirrors the resolved `selectedTextTrackId`
+> into DOM modes **one way**, and bridges DOM `change` events to the
+> `userTextTrackSelection` *intent* slot, which `switchTextTrack` resolves back
+> into `selectedTextTrackId`. So DOM action and the resolver never contend for
+> one slot.
 
-A `setTimeout(..., 0)` guard distinguishes SPF-initiated mode changes from
-user/browser-initiated ones. During the settling window (immediately after initial
-mode sync), `'change'` events re-apply the intended modes rather than writing back
-to state. After the window closes, a `'change'` event is treated as external
-selection and updates `selectedTextTrackId`:
+`syncTextTracks` listens to `TextTrackList`'s `'change'`. Two guards reject
+non-user changes:
+
+1. **Settling window** (`setTimeout(..., 0)`) — swallows Chromium's init-time
+   auto-selection before the resolved selection has settled, re-applying our
+   modes instead of writing intent.
+2. **Echo guard** — `selectedTextTrackId` is exactly the id this behavior last
+   drove into the DOM (initial sync, mirror effect, or a resolver-driven
+   correction), so a `change` still showing it is our own echo and is ignored.
+   This also covers the case where the resolver *overrides* the user (e.g. the
+   picked track's CDN failed → resolved id stays put → mirror disables the track):
+   the resulting `change` matches the resolved id, so it isn't written back as a
+   spurious `'off'`.
+
+A genuine user pick (showing id differs from the resolved id) is written as
+intent — a language-based partial (sticky across sources) or `'off'`:
 
 ```typescript
-let syncTimeout: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
-  syncTimeout = undefined;
-}, 0);
-
 const onChange = () => {
-  if (syncTimeout) {
-    // Inside settling window: browser auto-selection overriding modes.
-    // Re-apply without touching state.
-    syncModes(mediaElement.textTracks, untrack(() => selectedTextTrackIdSignal.get()));
+  if (inSettlingWindow) {
+    syncTextTrackModes(mediaElement.textTracks, state.selectedTextTrackId.get());
     return;
   }
-  // Outside settling window: treat as user selection, write back to state.
-  const showingTrack = Array.from(mediaElement.textTracks)
-    .find(t => t.mode === 'showing' && (t.kind === 'subtitles' || t.kind === 'captions'));
-  const newId = showingTrack?.id;
-  if (newId === untrack(() => selectedTextTrackIdSignal.get())) return;
-  update(state, { selectedTextTrackId: newId });
+  const showingId = getShowingSubtitlesTrackFromMedia(mediaElement)?.id || undefined;
+  if (showingId === state.selectedTextTrackId.get()) return; // echo
+  state.userTextTrackSelection.set(deriveTextTrackIntent(showingId, modelTextTracks));
 };
 ```
 
@@ -395,8 +403,14 @@ The `setTimeout(..., 0)` window in `syncTextTracks` is a Chromium workaround for
 browser auto-selection behavior. It is a best-effort heuristic, not a robust solution.
 The `'change'` event is dispatched as a task (async, after the current script), so the
 guard fires before the event under normal conditions — but this is not formally guaranteed.
-Alternative approaches (e.g., tracking which modes SPF set, comparing before/after) were
-not explored during the spike.
+
+The text-track-switching refactor added the complementary approach the spike left
+unexplored: an echo guard that compares the showing id against `selectedTextTrackId`
+(the id SPF last drove into the DOM). That covers steady-state echoes and
+resolver-driven corrections without timing. The settling window is still needed
+for the *initial* Chromium auto-pick (before any resolved selection exists), so the
+two coexist — the window narrowed to just the init race, the echo guard handling
+the rest.
 
 ---
 

--- a/internal/design/spf/use-cases/audio-only-mode-override.md
+++ b/internal/design/spf/use-cases/audio-only-mode-override.md
@@ -96,7 +96,7 @@ From `createSimpleHlsEngine`'s composition, omit:
 
 **Text-track-side** *(Phase 1 ships without subtitle support; future phase
 may add back):*
-- `selectTextTrack` — no subtitle rendition selection
+- `switchTextTrack` — no subtitle rendition selection
 - `resolveTextTrack` — no subtitle media playlist fetch
 - `syncTextTracks` — no `TextTrack` slot sync
 - `setupTextTrackActors` — no text-track actors

--- a/internal/design/spf/use-cases/background-looping-video.md
+++ b/internal/design/spf/use-cases/background-looping-video.md
@@ -54,8 +54,8 @@ configuration. Alternative-implementation buckets surface in Phase 3.
 From [`createSimpleHlsEngine`](../../../../packages/spf/src/playback/engines/hls/engine.ts):
 
 - `syncPreload`, `trackLoadTriggers` — no preload-state monitoring or DOM `play`/`seeking` activation; replaced by `loadActivated: true` initial state.
-- `selectAudioTrack`, `selectTextTrack`, `resolveAudioTrack`, `resolveTextTrack`, `setupAudioBufferActors`, `loadAudioSegments` — no audio side.
-- `syncTextTracks`, `setupTextTrackActors`, `loadTextTrackSegments` — no text-track machinery.
+- `selectAudioTrack`, `resolveAudioTrack`, `setupAudioBufferActors`, `loadAudioSegments` — no audio side.
+- `switchTextTrack`, `resolveTextTrack`, `syncTextTracks`, `setupTextTrackActors`, `loadTextTrackSegments` — no text-track machinery.
 - `switchVideoQuality` — no ABR; commits to a single rendition for the session.
 
 ### Added

--- a/packages/spf/docs/hls-engine.md
+++ b/packages/spf/docs/hls-engine.md
@@ -29,7 +29,7 @@ export function createSimpleHlsEngine(
       // Track selection (reads config for initial preferences)
       selectVideoTrack,
       selectAudioTrack,
-      selectTextTrack,
+      switchTextTrack,
 
       // Resolve selected tracks (fetch media playlists)
       resolveVideoTrack,
@@ -187,21 +187,21 @@ Once the manifest is resolved, the engine picks one track per type:
 ```ts
 selectVideoTrack,
 selectAudioTrack,
-selectTextTrack,
+switchTextTrack,
 ```
 
-Each is a separate `defineBehavior` export from `playback/behaviors/select-tracks.ts`, with narrow `stateKeys` matching exactly the slots it touches:
+Video and audio use `defineBehavior` exports from `playback/behaviors/select-tracks.ts`, with narrow `stateKeys` matching exactly the slots they touch:
 
 - `selectVideoTrack` declares `['presentation', 'selectedVideoTrackId']`
 - `selectAudioTrack` declares `['presentation', 'selectedAudioTrackId']`
-- `selectTextTrack` declares `['presentation', 'selectedTextTrackId']` and reads `config` for preferred-language / default-track preferences
+- `switchTextTrack` (from `playback/behaviors/track-switching.ts`) declares `['presentation', 'selectedTextTrackId']` and resolves the standing `userTextTrackSelection` intent against the constrained, CDN-scoped renditions — reading `config` for preferred-language / default-track preferences. Unlike the simple `select*` variants it can resolve to no selection (captions are opt-in / off-able).
 
 The behaviors share a small `pickFirstTrackId` helper for the presentation traversal, but the bodies are inlined per type. No engine-side wrappers, no `config.type` discriminant carried at runtime — each export is type-honest about which signal it writes (`state.selectedVideoTrackId.set(...)` vs. `state.selectedAudioTrackId.set(...)`).
 
 The behaviors themselves are split across two locations on purpose:
 
-- **Pure logic** lives in `media/primitives/select-tracks.ts` — `pickVideoTrack`, `pickAudioTrack`, `pickTextTrack`. No signals, no effects. Just functions that take a `Presentation` and a config and return an id.
-- **Orchestrations** live in `playback/behaviors/select-tracks.ts` — `selectVideoTrack`, `selectAudioTrack`, `selectTextTrack`. These wrap the pure logic in `effect()`, gate on preconditions, and write the chosen id to `state.selected{Video,Audio,Text}TrackId`.
+- **Pure logic** lives in `media/primitives/select-tracks.ts` — `pickVideoTrack`, `pickAudioTrack`, `pickTextTrack` / `pickTextTrackFromTracks`. No signals, no effects. Just functions that take a `Presentation` (or track list) and a config and return an id.
+- **Orchestrations** live in `playback/behaviors/select-tracks.ts` (`selectVideoTrack`, `selectAudioTrack`) and `playback/behaviors/track-switching.ts` (`switchTextTrack`, plus the `switch*` ABR variants). These wrap the pure logic in `effect()`, gate on preconditions, and write the chosen id to `state.selected{Video,Audio,Text}TrackId`.
 
 The split keeps the framework-free helpers reusable outside SPF, while the SPF-integrated behaviors stay thin and easy to swap.
 

--- a/packages/spf/src/all.ts
+++ b/packages/spf/src/all.ts
@@ -101,5 +101,14 @@ export { syncPreload } from './playback/behaviors/sync-preload';
 // Features — Track Switching (video ABR + audio language selection)
 // =============================================================================
 
-export type { SwitchVideoTrackConfig, TrackSwitchingState } from './playback/behaviors/track-switching';
-export { DEFAULT_INITIAL_BANDWIDTH, switchAudioTrack, switchVideoTrack } from './playback/behaviors/track-switching';
+export type {
+  SwitchTextTrackConfig,
+  SwitchVideoTrackConfig,
+  TrackSwitchingState,
+} from './playback/behaviors/track-switching';
+export {
+  DEFAULT_INITIAL_BANDWIDTH,
+  switchAudioTrack,
+  switchTextTrack,
+  switchVideoTrack,
+} from './playback/behaviors/track-switching';

--- a/packages/spf/src/media/dom/text/tests/text-track-slots.test.ts
+++ b/packages/spf/src/media/dom/text/tests/text-track-slots.test.ts
@@ -43,11 +43,14 @@ describe('addSubtitlesTracksToMedia', () => {
     expect(tracks[1]!.hasAttribute('data-src-track')).toBe(true);
   });
 
-  it('marks elements as default when the model is default', () => {
+  it('does not propagate the model default to the <track> default attribute', () => {
+    // Setting `default` makes the browser auto-activate the slot on insertion,
+    // which syncTextTracks would record as user intent — bypassing SPF's opt-in
+    // selection policy. SPF owns selection, so slots carry no selection hint.
     const media = document.createElement('video');
     addSubtitlesTracksToMedia(media, [makeModelTrack({ default: true })]);
 
-    expect((media.children[0] as HTMLTrackElement).default).toBe(true);
+    expect((media.children[0] as HTMLTrackElement).default).toBe(false);
   });
 
   it('omits srclang when the model has no language', () => {

--- a/packages/spf/src/media/dom/text/text-track-slots.ts
+++ b/packages/spf/src/media/dom/text/text-track-slots.ts
@@ -30,7 +30,12 @@ export function addSubtitlesTracksToMedia(
     el.label = modelTrack.label;
     el.toggleAttribute('data-src-track', true);
     if (modelTrack.language) el.srclang = modelTrack.language;
-    if (modelTrack.default) el.default = true;
+    // Deliberately NOT propagating `modelTrack.default` to the `default`
+    // attribute: that makes the browser auto-activate the slot on insertion,
+    // which fires a `change` that `syncTextTracks` records as user intent —
+    // auto-enabling captions past SPF's opt-in policy (`enableDefaultTrack`
+    // governs DEFAULT=YES handling in `switchTextTrack`, not the browser). SPF
+    // owns selection; these slots are containers, so they carry no selection hint.
     mediaElement.appendChild(el);
   }
 }

--- a/packages/spf/src/media/primitives/select-tracks.ts
+++ b/packages/spf/src/media/primitives/select-tracks.ts
@@ -107,7 +107,7 @@ export interface TextSelectionConfig {
  * select, or `undefined` to leave the slot unset.
  *
  * Behaviors that own a track-selection slot (`selectAudioTrack`,
- * `selectTextTrack`, `selectVideoTrack`, `switchVideoTrack`) accept a
+ * `selectVideoTrack`, `switchVideoTrack`) accept a
  * `TrackPicker` via config. The behavior passes its own config straight
  * through as the picker's second argument — pickers that need richer
  * options (language preferences, default-track filtering, bandwidth-aware
@@ -295,9 +295,10 @@ export function pickAudioTrack(
 }
 
 /**
- * Pick text track to activate. Conforms to the `TrackPicker` contract so it
- * can be used directly as a default picker for `selectTextTrack` without an
- * adapter wrapper.
+ * Pick text track to activate from a presentation. Conforms to the
+ * `TrackPicker` contract. The candidate-list core (`pickTextTrackFromTracks`)
+ * is the opt-in default policy `switchTextTrack`'s terminal applies once it has
+ * narrowed the renditions.
  *
  * Selection priority (if enabled):
  * 1. User preference (preferredSubtitleLanguage)

--- a/packages/spf/src/media/primitives/select-tracks.ts
+++ b/packages/spf/src/media/primitives/select-tracks.ts
@@ -1,5 +1,12 @@
 import { DEFAULT_QUALITY_CONFIG, selectQuality } from '../abr/quality-selection';
-import type { AudioSelectionSet, MaybeResolvedPresentation, TrackType, VideoSelectionSet } from '../types';
+import type {
+  AudioSelectionSet,
+  MaybeResolvedPresentation,
+  PartiallyResolvedTextTrack,
+  TextTrack,
+  TrackType,
+  VideoSelectionSet,
+} from '../types';
 import { SelectedTrackIdKeyByType } from '../utils/track-selection';
 
 /**
@@ -303,33 +310,42 @@ export function pickTextTrack(
   presentation: MaybeResolvedPresentation,
   config?: TextSelectionConfig
 ): string | undefined {
-  const textSet = presentation.selectionSets?.find((set) => set.type === 'text');
-  if (!textSet?.switchingSets?.[0]?.tracks.length) return undefined;
+  const tracks = presentation.selectionSets?.find((set) => set.type === 'text')?.switchingSets?.[0]?.tracks;
+  if (!tracks?.length) return undefined;
+  return pickTextTrackFromTracks(tracks, config);
+}
 
-  const tracks = textSet.switchingSets[0].tracks;
-
-  // Filter out FORCED tracks by default (following hls.js/http-streaming pattern)
-  // Per Apple spec: regular tracks MUST contain forced content when both exist
+/**
+ * Default text-track policy over an explicit candidate list (rather than a whole
+ * presentation): the opt-in three-tier pick `pickTextTrack` delegates to, factored
+ * out so a caller that has already narrowed the candidates — a constrained,
+ * CDN-scoped track-switching chain — applies the same policy without re-deriving
+ * from the presentation.
+ *
+ * Priority: `preferredSubtitleLanguage` match → `DEFAULT=YES + AUTOSELECT=YES`
+ * (only when `enableDefaultTrack`) → `undefined` (opt-in). FORCED tracks are
+ * excluded unless `includeForcedTracks` (Apple-spec: a regular track must carry
+ * forced content when both exist, so a forced-only track is redundant).
+ */
+export function pickTextTrackFromTracks(
+  tracks: readonly (PartiallyResolvedTextTrack | TextTrack)[],
+  config?: TextSelectionConfig
+): string | undefined {
   const availableTracks = config?.includeForcedTracks ? tracks : tracks.filter((track) => !track.forced);
-
   if (availableTracks.length === 0) return undefined;
 
   const { preferredSubtitleLanguage, enableDefaultTrack = false } = config ?? {};
 
-  // 1. Preferred language match (if specified)
   if (preferredSubtitleLanguage) {
     const languageMatch = availableTracks.find((track) => track.language === preferredSubtitleLanguage);
     if (languageMatch) return languageMatch.id;
   }
 
-  // 2. DEFAULT track (if enabled AND track has both DEFAULT=YES + AUTOSELECT=YES)
-  //    Note: Parser only sets default=true when BOTH attributes present
   if (enableDefaultTrack) {
     const defaultTrack = availableTracks.find((track) => track.default === true);
     if (defaultTrack) return defaultTrack.id;
   }
 
-  // 3. User opt-in (no auto-selection)
   return undefined;
 }
 

--- a/packages/spf/src/playback/behaviors/dom/sync-text-tracks.ts
+++ b/packages/spf/src/playback/behaviors/dom/sync-text-tracks.ts
@@ -4,11 +4,13 @@
  * available, allocate one slot in `mediaElement.textTracks` per model text
  * track — via creating `<track>` children, since that's the only spec
  * mechanism for adding *and* removing entries to `textTracks` (no
- * `removeTextTrack` API exists). Once slots are provisioned, mirror
- * `selectedTextTrackId` into their `mode`s, and propagate user-initiated
- * DOM `change` events back to `selectedTextTrackId` so non-SPF consumers
- * (host-page captions buttons, browser native UI, video.js store) remain
- * the canonical write path for selection.
+ * `removeTextTrack` API exists). Once slots are provisioned, mirror the
+ * resolved `selectedTextTrackId` into their `mode`s (one-way: state → DOM),
+ * and propagate user-initiated DOM `change` events back to
+ * `userTextTrackSelection` — the standing *intent* (a language-based partial,
+ * or `'off'`) that `switchTextTrack` resolves into `selectedTextTrackId`. So
+ * non-SPF consumers (host-page captions buttons, browser native UI, video.js
+ * store) drive selection by expressing intent, not by writing the resolved id.
  *
  * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'sync-active'`):
  * the entry allocates the slots, applies the initial selection, attaches
@@ -27,14 +29,21 @@
  * presentation reusing a trackId would have `getSegmentsToLoad` treat
  * its segments as already-buffered and skip loading them.
  *
- * Multi-writer with `selectTextTrack` is intentional and orthogonal:
- * `selectTextTrack` owns the *default-on-load / clear-on-unload* contract
- * for `selectedTextTrackId`; this behavior writes only from DOM `change`
- * events. They reflect distinct decision-making domains (config-driven
- * intent vs DOM-driven user action), so this behavior never clears the
- * slot on source unload — that's `selectTextTrack`'s contract. (It *does*
- * write `undefined` when a user disables all tracks via native UI, since
- * that's a real user action that should round-trip into SPF state.)
+ * Single-writer separation: `selectedTextTrackId` is the resolved *output*
+ * owned solely by `switchTextTrack`; this behavior only reads it (to mirror
+ * modes). The write path here is `userTextTrackSelection` — the user-intent
+ * *input* — so DOM action and the resolver never contend for one slot. The
+ * intent isn't cleared on source unload (it's a standing preference, like
+ * `userAudioTrackSelection`); `'off'` is written when the user disables all
+ * tracks via native UI.
+ *
+ * Echo guard: `selectedTextTrackId` is exactly the id this behavior last drove
+ * into the DOM, so a `change` event still showing it is our own echo (or a
+ * resolver-driven correction — e.g. the picked track's CDN failed and the
+ * resolver disabled it) and is ignored, never written back as a spurious user
+ * action. Only a showing id that *differs* from the resolved id is a real user
+ * pick. The settling-window guard additionally swallows Chromium's init-time
+ * auto-selection before the resolved selection has settled.
  */
 
 import { listen } from '@videojs/utils/dom';
@@ -81,6 +90,21 @@ function deriveState(
   return getTracksByType(presentation, 'text').length > 0 ? 'sync-active' : 'preconditions-unmet';
 }
 
+/**
+ * Map the DOM-showing track back to standing user intent. No showing track is an
+ * explicit `'off'`. Otherwise prefer a language-based partial (so the pick
+ * persists across source changes); fall back to `{ id }` for a track without a
+ * language (precise within a source, just not portable).
+ */
+function deriveTextTrackIntent(
+  showingId: string | undefined,
+  modelTextTracks: readonly (PartiallyResolvedTextTrack | TextTrack)[]
+): Partial<TextTrack> | 'off' {
+  if (!showingId) return 'off';
+  const language = modelTextTracks.find((track) => track.id === showingId)?.language;
+  return language ? { language } : { id: showingId };
+}
+
 function syncTextTracksSetup({
   state,
   context,
@@ -88,7 +112,11 @@ function syncTextTracksSetup({
 }: {
   state: {
     presentation: ReadonlySignal<MaybeResolvedPresentation | undefined>;
-    selectedTextTrackId: Signal<string | undefined>;
+    // Read-only here: the resolved output owned by `switchTextTrack`, mirrored
+    // into DOM modes and used as the echo-guard reference.
+    selectedTextTrackId: ReadonlySignal<string | undefined>;
+    // The write path: standing user intent the DOM bridge feeds.
+    userTextTrackSelection: Signal<Partial<TextTrack> | 'off' | undefined>;
   };
   context: {
     mediaElement: ReadonlySignal<HTMLMediaElement | undefined>;
@@ -153,9 +181,14 @@ function syncTextTracksSetup({
             const showingTrack = getShowingSubtitlesTrackFromMedia(mediaElement);
             // `showingTrack.id` matches the SPF id we set when the slot was
             // allocated. Empty-string ids fall through to `undefined`.
-            const nextId = showingTrack?.id || undefined;
-            if (nextId === state.selectedTextTrackId.get()) return;
-            state.selectedTextTrackId.set(nextId);
+            const showingId = showingTrack?.id || undefined;
+            // Echo guard: selectedTextTrackId is the id we last drove into the
+            // DOM (mirror / resolver correction). A change still showing it is our
+            // own echo — ignore it rather than write spurious intent.
+            if (showingId === state.selectedTextTrackId.get()) return;
+            // Genuine user action → write intent (resolved into selectedTextTrackId
+            // by switchTextTrack), not the resolved id.
+            state.userTextTrackSelection.set(deriveTextTrackIntent(showingId, modelTextTracks));
           };
 
           const unlisten = listen(mediaElement.textTracks, 'change', onChange);
@@ -189,7 +222,7 @@ function syncTextTracksSetup({
 }
 
 export const syncTextTracks = defineBehavior({
-  stateKeys: ['presentation', 'selectedTextTrackId'],
+  stateKeys: ['presentation', 'selectedTextTrackId', 'userTextTrackSelection'],
   contextKeys: ['mediaElement', 'textTracksActor'],
   setup: syncTextTracksSetup,
 });

--- a/packages/spf/src/playback/behaviors/dom/tests/sync-text-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/sync-text-tracks.test.ts
@@ -5,7 +5,7 @@ import {
   getShowingSubtitlesTrackFromMedia,
   removeAllSubtitlesTracksFromMedia,
 } from '../../../../media/dom/text/text-track-slots';
-import type { MaybeResolvedPresentation } from '../../../../media/types';
+import type { MaybeResolvedPresentation, TextTrack } from '../../../../media/types';
 import { createTextTracksActor, type TextTracksActor } from '../../../actors/dom/text-tracks';
 import { syncTextTracks } from '../sync-text-tracks';
 
@@ -18,6 +18,7 @@ const baseConfig = {
 interface State {
   presentation?: MaybeResolvedPresentation;
   selectedTextTrackId?: string | undefined;
+  userTextTrackSelection?: Partial<TextTrack> | 'off' | undefined;
 }
 
 interface Context {
@@ -58,6 +59,7 @@ function setup(initialState: State = {}, initialContext: Context = {}) {
   const state = {
     presentation: signal<MaybeResolvedPresentation | undefined>(initialState.presentation),
     selectedTextTrackId: signal<string | undefined>(initialState.selectedTextTrackId),
+    userTextTrackSelection: signal<Partial<TextTrack> | 'off' | undefined>(initialState.userTextTrackSelection),
   };
   const context = {
     mediaElement: signal<HTMLMediaElement | undefined>(initialContext.mediaElement),
@@ -201,7 +203,7 @@ describe('syncTextTracks', () => {
     reactor.destroy();
   });
 
-  it('bridges external mode change → selectedTextTrackId', async () => {
+  it('bridges external mode change → userTextTrackSelection (language intent)', async () => {
     const mediaElement = document.createElement('video');
     const presentation = makePresentation([
       { id: 'track-en', language: 'en' },
@@ -221,12 +223,15 @@ describe('syncTextTracks', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    expect(state.selectedTextTrackId.get()).toBe('track-es');
+    // Language-based intent (sticky across sources), not the resolved id.
+    expect(state.userTextTrackSelection.get()).toEqual({ language: 'es' });
+    // This behavior never writes the resolved id (switchTextTrack owns it).
+    expect(state.selectedTextTrackId.get()).toBeUndefined();
 
     reactor.destroy();
   });
 
-  it('clears selectedTextTrackId when external code disables all tracks', async () => {
+  it("writes 'off' intent when external code disables all tracks", async () => {
     const mediaElement = document.createElement('video');
     const presentation = makePresentation([
       { id: 'track-en', language: 'en' },
@@ -246,7 +251,53 @@ describe('syncTextTracks', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    expect(state.selectedTextTrackId.get()).toBeUndefined();
+    expect(state.userTextTrackSelection.get()).toBe('off');
+
+    reactor.destroy();
+  });
+
+  it('ignores its own mode echo when the resolved selection drives the change (no write-back)', async () => {
+    const mediaElement = document.createElement('video');
+    const presentation = makePresentation([
+      { id: 'track-en', language: 'en' },
+      { id: 'track-es', language: 'es' },
+    ]);
+
+    const { state, context, reactor } = setup({ presentation, selectedTextTrackId: 'track-en' });
+    context.mediaElement.set(mediaElement);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // The resolver moves the selection; the mirror drives the DOM modes, which
+    // fires a 'change'. showingId === selectedTextTrackId → echo → not written back.
+    state.selectedTextTrackId.set('track-es');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const [enEl, esEl] = Array.from(mediaElement.children) as HTMLTrackElement[];
+    expect(enEl!.track.mode).toBe('disabled');
+    expect(esEl!.track.mode).toBe('showing');
+    expect(state.userTextTrackSelection.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  it("does not write 'off' when a resolver correction disables the DOM selection", async () => {
+    const mediaElement = document.createElement('video');
+    const presentation = makePresentation([
+      { id: 'track-en', language: 'en' },
+      { id: 'track-es', language: 'es' },
+    ]);
+
+    const { state, context, reactor } = setup({ presentation, selectedTextTrackId: 'track-en' });
+    context.mediaElement.set(mediaElement);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Resolver clears the resolved id (e.g. the picked track's CDN failed). The
+    // mirror disables every track → 'change' shows nothing, which equals the
+    // resolved id (undefined) → echo → no spurious 'off' intent.
+    state.selectedTextTrackId.set(undefined);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(state.userTextTrackSelection.get()).toBeUndefined();
 
     reactor.destroy();
   });
@@ -286,7 +337,7 @@ describe('syncTextTracks', () => {
     reactor.destroy();
   });
 
-  it('preserves selectedTextTrackId on src unload (selectTextTrack owns the clear)', async () => {
+  it('never writes selectedTextTrackId on src unload (switchTextTrack owns it)', async () => {
     const mediaElement = document.createElement('video');
     const presentation = makePresentation([{ id: 'track-en', language: 'en' }]);
 
@@ -297,6 +348,8 @@ describe('syncTextTracks', () => {
     state.presentation.set(undefined);
     await new Promise((resolve) => setTimeout(resolve, 50));
 
+    // This behavior reads but never writes the resolved id, so unload leaves it
+    // untouched (switchTextTrack clears it on its own src-unload exit).
     expect(state.selectedTextTrackId.get()).toBe('track-en');
 
     reactor.destroy();

--- a/packages/spf/src/playback/behaviors/select-tracks.ts
+++ b/packages/spf/src/playback/behaviors/select-tracks.ts
@@ -1,22 +1,20 @@
 /**
- * **Default audio/text/video track selection on src load / unselect on src unload.**
+ * **Default audio/video track selection on src load / unselect on src unload.**
  * When a presentation is resolved, sets `selectedVideoTrackId` /
- * `selectedAudioTrackId` / `selectedTextTrackId` to a per-type-picker default
- * if no selection already exists. When the presentation is unset/reset
- * (transitions back to unresolved), clears the selection so a stale id from
- * the previous source doesn't persist.
+ * `selectedAudioTrackId` to a per-type-picker default if no selection already
+ * exists. When the presentation is unset/reset (transitions back to unresolved),
+ * clears the selection so a stale id from the previous source doesn't persist.
  *
  * Lifecycle-driven: each transition fires its work once. Does not police the
  * selection between transitions; external writes (user picks, ABR, programmatic
  * filter-driven re-picks) are left alone.
  *
  * Picker is config-driven: each per-type export wires a sensible default
- * (`pickAudioTrack` for audio — three-tier language-aware; `pickTextTrack`
- * for text; `pickFirstTrackId` for video) and the caller can supply their
- * own via `config.picker` for custom selection logic. The behavior's
- * `config` is forwarded to the picker as its second argument, so options
- * like `preferredAudioLanguage` / `preferredSubtitleLanguage` reach the
- * picker without an intermediate wrapping layer.
+ * (`pickAudioTrack` for audio — three-tier language-aware; `pickFirstTrackId`
+ * for video) and the caller can supply their own via `config.picker` for custom
+ * selection logic. The behavior's `config` is forwarded to the picker as its
+ * second argument, so options like `preferredAudioLanguage` reach the picker
+ * without an intermediate wrapping layer.
  *
  * Compose `selectVideoTrack` for the simple "pick a default video track"
  * behavior, or `switchVideoTrack` (`./track-switching.ts`) for the
@@ -28,6 +26,10 @@
  * the same `selected*TrackId` slot). The simple variants tree-shake out
  * the heavier machinery (bandwidth estimator, quality selection, flush
  * orchestration).
+ *
+ * Text selection has no simple variant here — it's owned by `switchTextTrack`
+ * (`./track-switching.ts`), which resolves standing `userTextTrackSelection`
+ * intent against the constrained, CDN-scoped renditions.
  */
 
 import { defineBehavior } from '../../core/composition/create-composition';
@@ -37,14 +39,12 @@ import {
   type AudioSelectionConfig,
   pickAudioTrack,
   pickFirstTrackId,
-  pickTextTrack,
-  type TextSelectionConfig,
   type TrackPicker,
   type TrackSelectionState,
   type VideoSelectionConfig,
 } from '../../media/primitives/select-tracks';
 import { isResolvedPresentation } from '../../media/types';
-import { AUDIO_TYPE_CONFIG, TEXT_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../primitives/track-types';
+import { AUDIO_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../primitives/track-types';
 
 // ============================================================================
 // Specialization helper
@@ -57,7 +57,7 @@ import { AUDIO_TYPE_CONFIG, TEXT_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../primi
 // on entering 'presentation-unresolved' — is shared.
 // ============================================================================
 
-type SelectedTrackKey = 'selectedVideoTrackId' | 'selectedAudioTrackId' | 'selectedTextTrackId';
+type SelectedTrackKey = 'selectedVideoTrackId' | 'selectedAudioTrackId';
 
 type SelectStateMap<K extends SelectedTrackKey> = {
   presentation: ReadonlySignal<TrackSelectionState['presentation']>;
@@ -119,10 +119,10 @@ function setupTrackSelection<K extends SelectedTrackKey, PickerConfig>({
 // Default pickers
 //
 // Each variant resolves its picker as `config?.picker ?? <default>` and
-// forwards the whole engine config as `pickerConfig`, so rich pickers
-// (`pickAudioTrack`, `pickTextTrack`) read their options directly. Audio
-// and text use their primitive pickers as-is; video adapts
-// `pickFirstTrackId` (positional `type` arg) into the `TrackPicker` shape.
+// forwards the whole engine config as `pickerConfig`, so a rich picker
+// (`pickAudioTrack`) reads its options directly. Audio uses its primitive
+// picker as-is; video adapts `pickFirstTrackId` (positional `type` arg) into
+// the `TrackPicker` shape.
 // ============================================================================
 
 /** Default video picker: first track in the video selection set. */
@@ -209,41 +209,6 @@ export const selectAudioTrack = defineBehavior({
       config: {
         selectedKey: AUDIO_TYPE_CONFIG.selectedKey,
         picker: config?.picker ?? pickAudioTrack,
-        pickerConfig: config,
-      },
-    }),
-});
-
-/**
- * Config for `selectTextTrack`. Pass `picker` to fully override selection
- * logic; otherwise the default `pickTextTrack` is used, which honors the
- * other fields.
- */
-export interface SelectTextTrackConfig extends TextSelectionConfig {
-  picker?: TrackPicker<SelectTextTrackConfig>;
-}
-
-/**
- * Select a text track based on user preferences (preferred language,
- * default-track auto-select, forced-track filtering). Clears the selection
- * on src unload.
- *
- * Unlike audio selection, the default text picker returns `undefined` when
- * no preference matches, leaving the selection unset — text-track
- * selection is user opt-in.
- *
- * @example
- * const reactor = selectTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
- */
-export const selectTextTrack = defineBehavior({
-  stateKeys: ['presentation', 'selectedTextTrackId'],
-  contextKeys: [],
-  setup: ({ state, config }: { state: SelectStateMap<'selectedTextTrackId'>; config?: SelectTextTrackConfig }) =>
-    setupTrackSelection({
-      state,
-      config: {
-        selectedKey: TEXT_TYPE_CONFIG.selectedKey,
-        picker: config?.picker ?? pickTextTrack,
         pickerConfig: config,
       },
     }),

--- a/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
@@ -11,7 +11,7 @@ import type {
   TextSelectionSet,
   VideoSelectionSet,
 } from '../../../media/types';
-import { selectAudioTrack, selectTextTrack, selectVideoTrack } from '../select-tracks';
+import { selectAudioTrack, selectVideoTrack } from '../select-tracks';
 
 function makeState(initial: TrackSelectionState = {}): StateSignals<TrackSelectionState> {
   return {
@@ -349,34 +349,6 @@ describe('selectAudioTrack', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(state.selectedAudioTrackId.get()).toBe('audio-en');
-
-    reactor.destroy();
-  });
-});
-
-describe('selectTextTrack', () => {
-  it('does not auto-select text track', async () => {
-    const textTracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-      },
-    ];
-
-    const presentation = createPresentation({ text: textTracks });
-    const state = makeState({ presentation });
-
-    const reactor = selectTextTrack.setup({ state, config: {} });
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(state.selectedTextTrackId.get()).toBeUndefined();
 
     reactor.destroy();
   });

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -17,8 +17,10 @@ import {
   applyRules,
   type SelectionRule,
   type SwitchVideoTrackConfig,
+  setupTrackSwitching,
   switchAudioTrack,
   switchVideoTrack,
+  type TrackSwitchingStateMap,
 } from '../track-switching';
 
 // ============================================================================
@@ -1090,6 +1092,73 @@ describe('excludeUnplayableTracks (capability constraint)', () => {
     expect(errorSpy).toHaveBeenCalled();
 
     errorSpy.mockRestore();
+    reactor.destroy();
+  });
+});
+
+// ============================================================================
+// setupTrackSwitching — resolveSelection seam
+//
+// The variant-supplied final-pick hook. Defaults to the chain head (video/audio
+// always-pick); a variant with optional selection (text) may resolve to
+// `undefined` to clear the slot. Exercised here directly via the helper rather
+// than through a variant, since no text variant exists yet.
+// ============================================================================
+
+describe('setupTrackSwitching (resolveSelection)', () => {
+  it('defaults to the chain head when resolveSelection is absent', async () => {
+    const state: TrackSwitchingStateMap<'selectedVideoTrackId'> = makeState({
+      presentation: createPresentation(tracks),
+    });
+    const reactor = setupTrackSwitching({
+      state,
+      config: { selectionKey: 'selectedVideoTrackId', getTracks: () => tracks, rules: [] },
+    });
+    await flush();
+    // No rules → candidate order preserved → head is the pick.
+    expect(state.selectedVideoTrackId.get()).toBe('360p');
+    reactor.destroy();
+  });
+
+  it('clears the slot when resolveSelection returns undefined', async () => {
+    const state: TrackSwitchingStateMap<'selectedVideoTrackId'> = makeState({
+      presentation: createPresentation(tracks),
+      selectedVideoTrackId: '720p',
+    });
+    const reactor = setupTrackSwitching({
+      state,
+      config: {
+        selectionKey: 'selectedVideoTrackId',
+        getTracks: () => tracks,
+        rules: [],
+        resolveSelection: () => undefined,
+      },
+    });
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBeUndefined();
+    reactor.destroy();
+  });
+
+  it('threads the chain survivors to resolveSelection', async () => {
+    const seen: string[][] = [];
+    const state: TrackSwitchingStateMap<'selectedVideoTrackId'> = makeState({
+      presentation: createPresentation(tracks),
+    });
+    const reactor = setupTrackSwitching({
+      state,
+      config: {
+        selectionKey: 'selectedVideoTrackId',
+        getTracks: () => tracks,
+        rules: [],
+        resolveSelection: (candidates) => {
+          seen.push(candidates.map((track) => track.id));
+          return candidates[candidates.length - 1]!.id;
+        },
+      },
+    });
+    await flush();
+    expect(seen.at(-1)).toEqual(['360p', '720p', '1080p']);
+    expect(state.selectedVideoTrackId.get()).toBe('1080p');
     reactor.destroy();
   });
 });

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -5,8 +5,11 @@ import type {
   AudioSelectionSet,
   AudioTrack,
   MaybeResolvedPresentation,
+  PartiallyResolvedTextTrack,
   PartiallyResolvedVideoTrack,
   Presentation,
+  TextSelectionSet,
+  TextTrack,
   VideoSelectionSet,
   VideoTrack,
 } from '../../../media/types';
@@ -19,6 +22,7 @@ import {
   type SwitchVideoTrackConfig,
   setupTrackSwitching,
   switchAudioTrack,
+  switchTextTrack,
   switchVideoTrack,
   type TrackSwitchingStateMap,
 } from '../track-switching';
@@ -1160,5 +1164,210 @@ describe('setupTrackSwitching (resolveSelection)', () => {
     expect(seen.at(-1)).toEqual(['360p', '720p', '1080p']);
     expect(state.selectedVideoTrackId.get()).toBe('1080p');
     reactor.destroy();
+  });
+});
+
+// ============================================================================
+// switchTextTrack — intent-resolved, optional selection
+// ============================================================================
+
+describe('switchTextTrack', () => {
+  const textTrack = (
+    id: string,
+    opts: { language?: string; default?: boolean; forced?: boolean; host?: string } = {}
+  ): PartiallyResolvedTextTrack => ({
+    type: 'text',
+    id,
+    url: `https://${opts.host ?? 'cdn-a.example.com'}/${id}.m3u8`,
+    bandwidth: 256,
+    mimeType: 'application/mp4',
+    groupId: 'text',
+    label: id,
+    kind: 'subtitles',
+    language: opts.language,
+    default: opts.default,
+    forced: opts.forced,
+  });
+
+  const textPresentation = (textTracks: PartiallyResolvedTextTrack[]): Presentation =>
+    ({
+      id: 'presentation-text',
+      url: 'https://example.com/playlist.m3u8',
+      selectionSets: [
+        {
+          id: 'text-set',
+          type: 'text' as const,
+          switchingSets: [{ id: 'text-switching', type: 'text' as const, tracks: textTracks }],
+        } as TextSelectionSet,
+      ],
+    }) as Presentation;
+
+  interface TextState {
+    presentation?: MaybeResolvedPresentation;
+    selectedTextTrackId?: string;
+    userTextTrackSelection?: Partial<TextTrack> | 'off';
+    cdnPriority?: string[];
+    failedCdns?: string[];
+  }
+
+  const makeTextState = (initial: Partial<TextState> = {}): StateSignals<TextState> => ({
+    presentation: signal<MaybeResolvedPresentation | undefined>(initial.presentation),
+    selectedTextTrackId: signal<string | undefined>(initial.selectedTextTrackId),
+    userTextTrackSelection: signal<Partial<TextTrack> | 'off' | undefined>(initial.userTextTrackSelection),
+    cdnPriority: signal<string[] | undefined>(initial.cdnPriority),
+    failedCdns: signal<string[] | undefined>(initial.failedCdns),
+  });
+
+  const enEs = () => [textTrack('en', { language: 'en' }), textTrack('es', { language: 'es' })];
+
+  describe('default policy (auto — no user intent)', () => {
+    it('does not auto-select when no preference matches (opt-in)', async () => {
+      const state = makeTextState({ presentation: textPresentation(enEs()) });
+      const reactor = switchTextTrack.setup({ state });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBeUndefined();
+      reactor.destroy();
+    });
+
+    it('auto-selects the preferredSubtitleLanguage match', async () => {
+      const state = makeTextState({ presentation: textPresentation(enEs()) });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'es' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es');
+      reactor.destroy();
+    });
+
+    it('auto-selects the DEFAULT track when enableDefaultTrack and no preference', async () => {
+      const state = makeTextState({
+        presentation: textPresentation([
+          textTrack('en', { language: 'en' }),
+          textTrack('es', { language: 'es', default: true }),
+        ]),
+      });
+      const reactor = switchTextTrack.setup({ state, config: { enableDefaultTrack: true } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es');
+      reactor.destroy();
+    });
+
+    it('excludes FORCED tracks from auto-selection by default', async () => {
+      const state = makeTextState({
+        presentation: textPresentation([textTrack('es-forced', { language: 'es', forced: true })]),
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'es' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBeUndefined();
+      reactor.destroy();
+    });
+
+    it('includes FORCED tracks when includeForcedTracks is set', async () => {
+      const state = makeTextState({
+        presentation: textPresentation([textTrack('es-forced', { language: 'es', forced: true })]),
+      });
+      const reactor = switchTextTrack.setup({
+        state,
+        config: { preferredSubtitleLanguage: 'es', includeForcedTracks: true },
+      });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es-forced');
+      reactor.destroy();
+    });
+
+    it('clears the selection on src unload', async () => {
+      const state = makeTextState({ presentation: textPresentation(enEs()) });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'es' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es');
+      state.presentation.set(undefined);
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBeUndefined();
+      reactor.destroy();
+    });
+  });
+
+  describe('user intent', () => {
+    it('honors an explicit user selection over the default policy', async () => {
+      const state = makeTextState({
+        presentation: textPresentation(enEs()),
+        userTextTrackSelection: { language: 'es' },
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es');
+      reactor.destroy();
+    });
+
+    it("resolves explicit 'off' to no selection, even when a default would match", async () => {
+      const state = makeTextState({
+        presentation: textPresentation([textTrack('en', { language: 'en' })]),
+        userTextTrackSelection: 'off',
+        selectedTextTrackId: 'en',
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBeUndefined();
+      reactor.destroy();
+    });
+
+    it("keeps 'off' sticky across a candidate-set change (live refresh)", async () => {
+      const state = makeTextState({
+        presentation: textPresentation([textTrack('en', { language: 'en' })]),
+        userTextTrackSelection: 'off',
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBeUndefined();
+
+      // New resolved presentation (stays resolved) — re-runs the chain; 'off' holds.
+      state.presentation.set({ ...textPresentation(enEs()), id: 'pres-2' });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBeUndefined();
+      reactor.destroy();
+    });
+
+    it('falls through to the default policy when an explicit pick is stale (language gone)', async () => {
+      const state = makeTextState({
+        presentation: textPresentation([textTrack('en', { language: 'en' })]),
+        userTextTrackSelection: { language: 'es' },
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
+      await flush();
+      // No 'es' candidate → explicit match empty → default policy picks 'en'.
+      expect(state.selectedTextTrackId.get()).toBe('en');
+      reactor.destroy();
+    });
+  });
+
+  describe('CDN constraints + scope', () => {
+    const esBothCdns = () => [
+      textTrack('es-a', { language: 'es', host: 'cdn-a.example.com' }),
+      textTrack('es-b', { language: 'es', host: 'cdn-b.example.com' }),
+    ];
+
+    it('co-locates captions on the active CDN (cdnPriority)', async () => {
+      const state = makeTextState({
+        presentation: textPresentation(esBothCdns()),
+        cdnPriority: ['https://cdn-a.example.com', 'https://cdn-b.example.com'],
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'es' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es-a');
+      reactor.destroy();
+    });
+
+    it('re-resolves to the surviving CDN when the active CDN fails', async () => {
+      const state = makeTextState({
+        presentation: textPresentation(esBothCdns()),
+        cdnPriority: ['https://cdn-a.example.com', 'https://cdn-b.example.com'],
+      });
+      const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'es' } });
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es-a');
+
+      state.failedCdns.set(['https://cdn-a.example.com']);
+      await flush();
+      expect(state.selectedTextTrackId.get()).toBe('es-b');
+      reactor.destroy();
+    });
   });
 });

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -1,6 +1,6 @@
 /**
  * **Per-type track selection as a rule chain.** While a presentation is
- * resolved, owns that type's `selected{Video,Audio}TrackId` signal: pick a
+ * resolved, owns that type's `selected{Video,Audio,Text}TrackId` signal: pick a
  * default, react to user intent and algorithmic ranking, and clear it on src
  * unload.
  *
@@ -32,14 +32,20 @@
  * resolved state owns the signal; its entry-returned cleanup clears it on exit
  * (canonical cleanup-binds-to-setup per `reactors.md`).
  *
- * The pick is the head of the chain's result (`applyRules(...)[0]`). Each
- * variant supplies its **constraints + rule chain** via config;
- * `setupTrackSwitching` owns only the lifecycle and runs what it's given. Both
- * variants today run constraints `[excludeFailedCdns]` then rules
- * `[filterByUserSelection, preferActiveCdn, rankByBandwidth]`; `switchVideoTrack`
- * also accepts ABR tuning config, `switchAudioTrack` takes none. (The active-CDN
- * *scope* is the sticky-pick half of multi-CDN; the failed-CDN *constraint* is
- * the failover half — prune the cooled-down CDN, the scope falls to the next.)
+ * The pick is the chain's result mapped to a slot value by `resolveSelection`
+ * (default: the head, `applyRules(...)[0]`). Each variant supplies its
+ * **constraints + rule chain (+ optional resolveSelection)** via config;
+ * `setupTrackSwitching` owns only the lifecycle and runs what it's given. Video
+ * and audio run constraints `[excludeFailedCdns, excludeUnplayableTracks]` then
+ * rules `[filterByUserSelection, preferActiveCdn, rankByBandwidth]` and take the
+ * head; `switchVideoTrack` also accepts ABR tuning config, `switchAudioTrack`
+ * takes none. `switchTextTrack` differs — selection is *optional* (captions are
+ * opt-in / off-able), so it runs `[excludeFailedCdns]` + `[preferActiveCdn]` and
+ * supplies a text terminal (`pickResolvedTextTrack`) that resolves standing user
+ * intent (`userTextTrackSelection`, incl. `'off'`) and may yield no selection.
+ * (The active-CDN *scope* is the sticky-pick half of multi-CDN; the failed-CDN
+ * *constraint* is the failover half — prune the cooled-down CDN, the scope falls
+ * to the next.)
  *
  * When the pre-pass prunes a type's candidates to empty, the behavior leaves any
  * prior pick in place and makes no new pick; the late `createSourceBuffer` check
@@ -56,14 +62,20 @@ import { type AnySlotMap, defineBehavior } from '../../core/composition/create-c
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
 import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
 import { DEFAULT_QUALITY_CONFIG, type QualityConfig, resolutionArea } from '../../media/abr/quality-selection';
-import { matchesPartialTrack } from '../../media/primitives/select-tracks';
+import {
+  matchesPartialTrack,
+  pickTextTrackFromTracks,
+  type TextSelectionConfig,
+} from '../../media/primitives/select-tracks';
 import {
   type AudioTrack,
   type CanPlayTrack,
   isResolvedPresentation,
   type MaybeResolvedPresentation,
   type PartiallyResolvedAudioTrack,
+  type PartiallyResolvedTextTrack,
   type PartiallyResolvedVideoTrack,
+  type TextTrack,
   type VideoTrack,
 } from '../../media/types';
 import { getCdnId as defaultGetCdnId, type GetCdnId } from '../../media/utils/cdn';
@@ -87,6 +99,7 @@ export interface TrackSwitchingState {
   presentation?: MaybeResolvedPresentation;
   selectedVideoTrackId?: string;
   selectedAudioTrackId?: string;
+  selectedTextTrackId?: string;
 }
 
 /**
@@ -265,7 +278,7 @@ export type ResolveSelection<T extends SwitchableTrack, State = unknown, Context
   deps: SelectionRuleDeps<State, Context, Config>
 ) => string | undefined;
 
-type SelectionKey = 'selectedVideoTrackId' | 'selectedAudioTrackId';
+type SelectionKey = 'selectedVideoTrackId' | 'selectedAudioTrackId' | 'selectedTextTrackId';
 type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
 
 // Each mapped value references `P` so TS keeps the per-key dependency and
@@ -401,6 +414,7 @@ type CapabilityConstraintConfig<S extends SelectionKey, T extends SwitchableTrac
 
 type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
 type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
+type TextTrackCandidate = PartiallyResolvedTextTrack | TextTrack;
 
 // ----------------------------------------------------------------------------
 // Rules — defined outside the behavior closure, parameterized only by their
@@ -566,6 +580,57 @@ function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
  */
 function selectChainHead<T extends SwitchableTrack>(candidates: readonly T[]): string {
   return candidates[0]!.id;
+}
+
+/**
+ * State the text terminal reads: the lifecycle map plus an *optional*
+ * `userTextTrackSelection` — the standing user intent. `Partial<TextTrack>` is an
+ * explicit pick (language-based), `'off'` is explicit no-captions, `undefined` is
+ * auto (no preference). The slot exists only when the composition materializes it
+ * (`shareSignals`); the terminal reads it defensively and treats absence as auto.
+ *
+ * Unlike `user*TrackSelection` for video/audio, this carries the `'off'` sentinel
+ * and feeds the terminal pick (not the shared `filterByUserSelection`) — text is
+ * the only type whose selection is legitimately optional, so the off/auto logic
+ * lives in one text-specific place rather than widening the shared filter.
+ */
+type TextSelectionStateMap = TrackSwitchingStateMap<'selectedTextTrackId'> & {
+  userTextTrackSelection?: ReadonlySignal<Partial<TextTrack> | 'off' | undefined>;
+};
+
+/** Config the text terminal reads: the base config plus the opt-in default policy. */
+type TextTerminalConfig = TrackSwitchingConfig<'selectedTextTrackId', TextTrackCandidate> & TextSelectionConfig;
+
+/**
+ * Terminal pick for text — the `resolveSelection` the text variant supplies.
+ * Resolves the standing `userTextTrackSelection` intent against the chain's
+ * survivors (already CDN-failover-pruned and active-CDN-scoped):
+ *
+ *   - `'off'` → no selection (clear the slot). Sticky through re-evaluation, so a
+ *     live refresh or failover re-run can't re-assert a default.
+ *   - explicit `Partial<TextTrack>` → narrow to the match (language-based). A
+ *     stale pick whose match is gone (e.g. the language dropped on a source
+ *     change) falls through to the default policy.
+ *   - auto (`undefined`) → the opt-in default policy (`preferredSubtitleLanguage`
+ *     → `DEFAULT=YES + AUTOSELECT=YES` → none), shared with `pickTextTrack`.
+ *
+ * Returning `undefined` is a real outcome (captions are opt-in), which is why the
+ * text variant relies on `setupTrackSwitching`'s no-selection seam.
+ */
+function pickResolvedTextTrack<T extends TextTrackCandidate>(
+  candidates: readonly T[],
+  { state, config }: SelectionRuleDeps<TextSelectionStateMap, AnySlotMap, TextTerminalConfig>
+): string | undefined {
+  const intent = state.userTextTrackSelection?.get();
+  if (intent === 'off') return undefined;
+  if (intent) {
+    // The stored intent is a `Partial<TextTrack>`; cast to the candidate's own
+    // partial shape so the generic `matchesPartialTrack` accepts it (every field
+    // it carries — language, forced — exists on the candidate too).
+    const matched = candidates.filter((track) => matchesPartialTrack(track, intent as Partial<T>));
+    if (matched.length) return matched[0]!.id;
+  }
+  return pickTextTrackFromTracks(candidates, config);
 }
 
 // `context` is the composition's context map, threaded in by each variant's
@@ -772,6 +837,67 @@ export const switchAudioTrack = defineBehavior({
         getTracks: (presentation) => getTracksByType(presentation, 'audio') as readonly AudioTrackCandidate[],
         constraints: [excludeFailedCdns, excludeUnplayableTracks],
         rules: [filterByUserSelection, preferActiveCdn, rankByBandwidth],
+      },
+    }),
+});
+
+// ============================================================================
+// Variant: switchTextTrack — intent-resolved, optional selection
+// ============================================================================
+
+/**
+ * Config for `switchTextTrack` — the opt-in default policy
+ * (`preferredSubtitleLanguage` / `includeForcedTracks` / `enableDefaultTrack`,
+ * via `TextSelectionConfig`) read by the terminal when the user has no standing
+ * intent, plus the `getCdnId` override shared with the CDN constraint + scope.
+ */
+export interface SwitchTextTrackConfig extends TextSelectionConfig {
+  /** Override CDN-id derivation (shared by the failed-CDN constraint + active-CDN scope). */
+  getCdnId?: GetCdnId;
+}
+
+/**
+ * Manage `selectedTextTrackId` as the single-writer **output** of standing user
+ * intent (`userTextTrackSelection`) resolved against the playable, CDN-scoped
+ * text renditions: clear on src unload; re-resolve when a CDN fails or recovers.
+ *
+ * Unlike video/audio, the selection is *optional* — captions are opt-in and the
+ * user can turn them off — so the chain skips the bandwidth ranker and the shared
+ * user-selection filter, and supplies a text-specific terminal
+ * (`pickResolvedTextTrack`) that may resolve to no-selection via
+ * `setupTrackSwitching`'s `resolveSelection` seam. Constraints are failed-CDN only
+ * (`excludeUnplayableTracks`/`canPlayTrack` is MSE-based — the wrong probe for
+ * text, whose playability is SPF-parser support); the active-CDN scope co-locates
+ * captions with the surviving CDN on failover.
+ *
+ * @example
+ * const reactor = switchTextTrack.setup({ state, config: { preferredSubtitleLanguage: 'en' } });
+ */
+export const switchTextTrack = defineBehavior({
+  stateKeys: ['presentation', 'selectedTextTrackId'],
+  contextKeys: [],
+  setup: ({
+    state,
+    config,
+    ...otherProps
+  }: {
+    state: TrackSwitchingStateMap<'selectedTextTrackId'>;
+    config?: SwitchTextTrackConfig;
+  }) =>
+    // Explicit type args pin the candidate type to `TextTrackCandidate`. Video and
+    // audio let it infer to the `SwitchableTrack` constraint (harmless — every
+    // rule is assignable up to it), but the text terminal needs the narrower type
+    // (it reads text-only fields), so it's named here rather than inferred.
+    setupTrackSwitching<'selectedTextTrackId', TextTrackCandidate, TextTerminalConfig & SwitchTextTrackConfig>({
+      ...otherProps,
+      state,
+      config: {
+        ...config,
+        selectionKey: 'selectedTextTrackId',
+        getTracks: (presentation) => getTracksByType(presentation, 'text') as readonly TextTrackCandidate[],
+        constraints: [excludeFailedCdns],
+        rules: [preferActiveCdn],
+        resolveSelection: pickResolvedTextTrack,
       },
     }),
 });

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -251,6 +251,20 @@ type SwitchableTrack = {
   codecs?: string[];
 };
 
+/**
+ * Map the rule chain's surviving candidates to the final selection id, or
+ * `undefined` for a deliberate no-selection. Defaults to the chain head
+ * (`selectChainHead`) — the always-pick contract video and audio rely on
+ * (`applyRules` guarantees a non-empty result, so the head is always there). A
+ * variant whose selection is legitimately optional (text: opt-in captions,
+ * explicit off) supplies its own picker that may return `undefined`; the helper
+ * writes that straight through to the slot, clearing it.
+ */
+export type ResolveSelection<T extends SwitchableTrack, State = unknown, Context = unknown, Config = unknown> = (
+  candidates: readonly T[],
+  deps: SelectionRuleDeps<State, Context, Config>
+) => string | undefined;
+
 type SelectionKey = 'selectedVideoTrackId' | 'selectedAudioTrackId';
 type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
 
@@ -266,7 +280,7 @@ type UserSelectionKey = 'userVideoTrackSelection' | 'userAudioTrackSelection';
 // so the behavior never assumes a rule-only signal exists. Those slots are
 // materialized by whoever owns them: `shareSignals` for the consumer-input
 // `user*TrackSelection`, the buffer-actor sampler for `bandwidthState`.
-type TrackSwitchingStateMap<S extends SelectionKey> = {
+export type TrackSwitchingStateMap<S extends SelectionKey> = {
   presentation: ReadonlySignal<TrackSwitchingState['presentation']>;
 } & { [P in S]: Signal<TrackSwitchingState[P]> };
 
@@ -275,18 +289,26 @@ type TrackSwitchingStateMap<S extends SelectionKey> = {
  * slot to write and clear (`selectionKey`), how to enumerate candidate tracks
  * (`getTracks`), the optional **hard-constraints pre-pass** (`constraints`,
  * applied before the chain to prune the unplayable), and the **rule chain** to
- * run (`rules`). Rule-/constraint-specific config is deliberately absent — each
- * declares the fields it reads as *optional* on its own config view
- * (`UserSelectionConfig`, `BandwidthRankerConfig`), so the behavior never
- * enumerates them. The variant builds the concrete config as this base plus
- * whatever its chain consults; it flows through untouched as the `C` type param
- * on `setupTrackSwitching`.
+ * run (`rules`), and how to map the chain's survivors to the final pick
+ * (`resolveSelection`, defaulting to the chain head). Rule-/constraint-specific
+ * config is deliberately absent — each declares the fields it reads as *optional*
+ * on its own config view (`UserSelectionConfig`, `BandwidthRankerConfig`), so the
+ * behavior never enumerates them. The variant builds the concrete config as this
+ * base plus whatever its chain consults; it flows through untouched as the `C`
+ * type param on `setupTrackSwitching`.
  */
 interface TrackSwitchingConfig<S extends SelectionKey, T extends SwitchableTrack> {
   selectionKey: S;
   getTracks: (presentation: MaybeResolvedPresentation) => readonly T[];
   constraints?: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>[];
   rules: readonly SelectionRule<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>[];
+  /**
+   * Map the chain's surviving candidates to the final selection id. Optional —
+   * absent means the chain head (`selectChainHead`), the always-pick path video
+   * and audio use. A variant with optional selection (text) supplies one that
+   * may return `undefined`.
+   */
+  resolveSelection?: ResolveSelection<T, TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>;
 }
 
 /**
@@ -537,19 +559,28 @@ function rankByBandwidth<S extends SelectionKey, T extends SwitchableTrack>(
   return [...fitting, ...over];
 }
 
+/**
+ * Default final pick: the chain head. `applyRules` never narrows to nothing and
+ * early-bails to a single survivor, so video and audio always converge to a
+ * track and the head is the pick.
+ */
+function selectChainHead<T extends SwitchableTrack>(candidates: readonly T[]): string {
+  return candidates[0]!.id;
+}
+
 // `context` is the composition's context map, threaded in by each variant's
 // rest-spread and typed as the generic slot-map shape (`AnySlotMap`). It can't
 // be a typed param on the `defineBehavior` setup without widening `ContextMap`
 // to its constraint and forcing the slot required, so the variants forward it
 // untyped via the rest and it lands here — absent on direct setup calls, and
 // passed straight through to the rules (which don't read it yet).
-function setupTrackSwitching<
+export function setupTrackSwitching<
   S extends SelectionKey,
   T extends SwitchableTrack,
   C extends TrackSwitchingConfig<S, T>,
 >(deps: { state: TrackSwitchingStateMap<S>; context?: AnySlotMap; config: C }) {
   const { state, config } = deps;
-  const { selectionKey, getTracks, rules } = config;
+  const { selectionKey, getTracks, rules, resolveSelection = selectChainHead } = config;
 
   const derivedStateSignal = computed(() =>
     isResolvedPresentation(state.presentation.get())
@@ -643,9 +674,12 @@ function setupTrackSwitching<
               console.error('[track-switching] applyRules returned no candidates');
               return;
             }
+            // Map survivors to the final id. Defaults to the chain head; a
+            // variant with optional selection (text) may resolve to `undefined`,
+            // which clears the slot (e.g. explicit off, opt-in decline).
             // No change-guard needed: the slot uses default (Object.is) equality,
-            // so re-setting the same id is a no-op (no notify, no re-fire).
-            state[selectionKey].set(candidates[0]!.id);
+            // so re-setting the same value is a no-op (no notify, no re-fire).
+            state[selectionKey].set(resolveSelection(candidates, deps));
           },
         ],
       },

--- a/packages/spf/src/playback/engines/hls/engine-audio-only.ts
+++ b/packages/spf/src/playback/engines/hls/engine-audio-only.ts
@@ -139,7 +139,7 @@ const shareSignals = makeShareSignals<SimpleHlsAudioOnlyEngineState, SimpleHlsAu
  * Subtractive composition variant of `createSimpleHlsEngine`: omits
  * video-side behaviors (`resolveVideoTrack`, `switchVideoTrack`,
  * `setupVideoBufferActors`, `loadVideoSegments`) and text-track behaviors
- * (`selectTextTrack`, `resolveTextTrack`, `syncTextTracks`,
+ * (`switchTextTrack`, `resolveTextTrack`, `syncTextTracks`,
  * `setupTextTrackActors`, `loadTextTrackSegments`). The remaining audio
  * pipeline composes unchanged.
  *

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -16,7 +16,7 @@ import {
   removeAllSubtitlesTracksFromMedia,
 } from '../../../media/dom/text/text-track-slots';
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
-import type { AudioTrack, CanPlayTrack, MaybeResolvedPresentation, VideoTrack } from '../../../media/types';
+import type { AudioTrack, CanPlayTrack, MaybeResolvedPresentation, TextTrack, VideoTrack } from '../../../media/types';
 import type { GetCdnId } from '../../../media/utils/cdn';
 import { getResolvedSelectedTrackDuration } from '../../../media/utils/track-selection';
 import type { BandwidthConfig, BandwidthState } from '../../../network/bandwidth-estimator';
@@ -40,10 +40,9 @@ import { trackLoadTriggers } from '../../behaviors/dom/track-load-triggers';
 import { updateMediaSourceDuration } from '../../behaviors/dom/update-mediasource-duration';
 import { type ParsePresentation, resolvePresentation } from '../../behaviors/resolve-presentation';
 import { resolveAudioTrack, resolveTextTrack, resolveVideoTrack } from '../../behaviors/resolve-track';
-import { selectTextTrack } from '../../behaviors/select-tracks';
 import { type FailoverMonitorConfig, setupFailoverMonitor } from '../../behaviors/setup-failover-monitor';
 import { syncPreload } from '../../behaviors/sync-preload';
-import { switchAudioTrack, switchVideoTrack } from '../../behaviors/track-switching';
+import { switchAudioTrack, switchTextTrack, switchVideoTrack } from '../../behaviors/track-switching';
 
 // ============================================================================
 // HLS Engine State & Context
@@ -75,6 +74,15 @@ export interface SimpleHlsEngineState {
    * when it changes. Multi-language-audio Tier 2 programmatic-write path.
    */
   userAudioTrackSelection?: Partial<AudioTrack>;
+  /**
+   * Consumer-driven *intent* for text selection, resolved into
+   * `selectedTextTrackId` by `switchTextTrack`. A language-based partial
+   * (`{ language: 'es' }`) selects captions, `'off'` disables them, and absence
+   * means auto (the engine's `preferredSubtitleLanguage` / DEFAULT-track policy).
+   * Also the write path for the DOM caption UI (via `syncTextTracks`); unlike the
+   * resolved id it persists across source changes (sticky preference).
+   */
+  userTextTrackSelection?: Partial<TextTrack> | 'off';
   /**
    * The CDNs the source is served from (track-URL origins), in manifest
    * priority order — most-preferred first (mirrors HLS content steering's
@@ -248,6 +256,7 @@ export interface SimpleHlsEngineConfig extends ShareSignalsConfig<SimpleHlsEngin
 const shareSignals = makeShareSignals<SimpleHlsEngineState, SimpleHlsEngineContext>([
   'userVideoTrackSelection',
   'userAudioTrackSelection',
+  'userTextTrackSelection',
 ]);
 
 /**
@@ -317,13 +326,9 @@ export function createSimpleHlsEngine(
       // media-playlist fetch) and removes each CDN once its cooldown lapses.
       setupFailoverMonitor,
 
-      // Track selection (reads config for initial preferences).
-      // Video selection lives in switchVideoTrack (composed below);
-      // audio selection lives in switchAudioTrack (composed below) —
-      // both are slot owners with filter-reactivity, mirroring shapes.
-      selectTextTrack,
-
-      // Resolve selected tracks (fetch media playlists)
+      // Resolve selected tracks (fetch media playlists). Composed before the
+      // switch* slot owners; selection is reactive, so a resolve* re-fires once
+      // its switch* sets the id (same convergence for all three types).
       resolveVideoTrack,
       resolveAudioTrack,
       resolveTextTrack,
@@ -348,6 +353,12 @@ export function createSimpleHlsEngine(
       // Mid-stream audio-buffer flush on language switch is handled in
       // `segment-loader`'s `planTasks` (predicate: language differs from
       // the previously-buffered track) — not in switchAudioTrack itself.
+
+      // Text selection: resolves `userTextTrackSelection` intent (incl. 'off',
+      // or the configured preferred-language / DEFAULT-track policy) against the
+      // failed-CDN-pruned, active-CDN-scoped text renditions. Optional selection
+      // (captions are opt-in), so it can resolve to none.
+      switchTextTrack,
 
       // Segment loading
       loadVideoSegments,

--- a/packages/spf/src/playback/engines/hls/tests/engine.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine.test.ts
@@ -1739,11 +1739,13 @@ http://example.com/video-seg1.m4s
         expect(tracks[0]!.srclang).toBe('en');
         expect(tracks[0]!.default).toBe(false);
 
-        // Spanish track (DEFAULT)
+        // Spanish track (DEFAULT=YES in the manifest) — the `default` attribute
+        // is deliberately NOT propagated to the <track> element (it would make the
+        // browser auto-activate it, bypassing SPF's opt-in selection policy).
         expect(tracks[1]!.kind).toBe('subtitles');
         expect(tracks[1]!.label).toBe('Spanish');
         expect(tracks[1]!.srclang).toBe('es');
-        expect(tracks[1]!.default).toBe(true);
+        expect(tracks[1]!.default).toBe(false);
 
         // French track
         expect(tracks[2]!.kind).toBe('subtitles');


### PR DESCRIPTION
## TL;DR

Migrates text-track (caption/subtitle) selection onto the track-switching rule chain introduced in #1658, so captions gain the same **failed-CDN constraint** (drop tracks on a CDN in failover cooldown) and **active-CDN scope** that video/audio already run. Because captions are opt-in and off-able, it adds an optional-selection seam (a variant may resolve to *no* pick). The text slot is split into a sticky `userTextTrackSelection` **intent input** (DOM + programmatic) and a single-writer `selectedTextTrackId` **resolved output**, retiring the old `selectTextTrack` behavior. Internal SPF only (alpha).

## For reviewers — how to read this PR

### Bucket 1 — Runtime (focus here)

**Targeted careful read:**
- `track-switching.ts` (+204) — the `resolveSelection` seam (optional terminal; defaults to the rule-chain head, so video/audio are unchanged); `switchTextTrack` runs `[excludeFailedCdns, preferActiveCdn]` then `pickResolvedTextTrack`, resolving `userTextTrackSelection` (language partial / `'off'` / `undefined`→auto) against the constrained candidates and may select nothing. Verify the optional-none path stays distinct from the empty-candidate *clear* path added for capability-probing (no-pick-by-intent vs. constraints-emptied)
- `sync-text-tracks.ts` (+69) — DOM→intent bridge now writes `userTextTrackSelection`, not the resolved id (single-writer invariant: `switchTextTrack` is the sole writer of `selectedTextTrackId`); the echo guard (`showingId === selectedTextTrackId`) must also absorb resolver-driven mode corrections (e.g. a pick disabled because its CDN failed) without writing back a spurious `'off'`
- `engine.ts` (+31) — `switchTextTrack` composed in place of `selectTextTrack`; `userTextTrackSelection` exposed via `shareSignals` as the programmatic + DOM write path
- `media/primitives/select-tracks.ts` (Δ) — `pickTextTrackFromTracks` extracted from `pickTextTrack`; shared auto-default policy (preferred language → `DEFAULT`+`AUTOSELECT` → none; forced excluded) across the presentation-picker and the candidate-list terminal

**Skim structure only:** `behaviors/select-tracks.ts` (`selectTextTrack` + `SelectTextTrackConfig` removed, `pickTextTrack` stays — no dangling refs), `engine-audio-only.ts` / `text-track-slots.ts` / `all.ts` (wiring + exports), `engine.test.ts` (`<track>.default` assertion flipped to `false`)

**Skim file:** Tests — `track-switching.test.ts` (+278), `sync-text-tracks.test.ts` (+65), `select-tracks.test.ts` (Δ) — assertion shape across intent-resolution, optional-none, and echo-guard mode corrections

**Sandbox (runtime-adjacent), skim file:** `spf-segment-loading/main.ts` (+124) — subtitle picker driven via native `textTracks[id].mode` so a click exercises the real DOM→intent bridge, not a direct slot write

### Bucket 2 — Design docs (skim)

**Skim file:** `text-track-architecture.md` (+72) — the intent-input + single-writer-output model; one-way mode mirror + DOM→intent bridge + echo guard; `enableDefaultTrack` default corrected to `false`

**Skim or skip:** `subtitles.md` (+28) and the stale-`selectTextTrack`-reference sweep across the registry (`architecture`, `conventions/behaviors`, `capability-probing` — text has no capability constraint —, `clusters`, `multi-language-audio`, `source-replacement`, `audio-playback`, `audio-only-mode-override`, `background-looping-video`, `hls-engine`)

### Bucket 3 — Working-reference plan, no runtime (skip)

**Skim or skip:** `.claude/plans/spf-text-track-switching-refactor.md`

## Smoke test

**Sandbox:** `/spf-segment-loading/?src=https://stream.mux.com/s41JYeqIpBMBzE4OzxDyGR2yrp2hD1CQ6gJN9SlVGDQ.m3u8?redundant_streams=true`

- Load locally (`pnpm dev:sandbox` → paste the path into the running Vite server) or via the PR's deploy preview. Press **Play** (the harness video is `preload="none"`). `redundant_streams=true` lists each rendition on multiple CDNs, so text selection exercises the active-CDN scope it now runs through.
- **Observe:**
  - The Subtitles/Captions picker fills with one button per language + **Off**; on load it sits at the engine's opt-in default (off unless a `DEFAULT`+`AUTOSELECT` rendition), **not** auto-enabled.
  - Click a language → captions render for it; the status row shows it pinned.
  - Click **Off** → captions hide and stay off (no resolver echo flips it back on).
  - "Reset to auto" → returns to the opt-in default.

## What changed — by surface

**Text selection onto the track-switching chain.** `switchTextTrack` replaces `selectTextTrack`, running the same `applyConstraints` pre-pass (failed-CDN constraint) + active-CDN scope as video/audio. A new optional `resolveSelection(candidates, deps)` hook on `setupTrackSwitching` lets a variant resolve to `undefined` (the head-of-chain default assumed a track is always picked); text supplies `pickResolvedTextTrack`, which resolves the standing intent against the constrained candidates.

**Intent input vs. resolved output.** The single `selectedTextTrackId` slot is split: `userTextTrackSelection` (a language partial, `'off'`, or `undefined`=auto) is the sticky intent written by the DOM bridge and programmatic callers; `selectedTextTrackId` becomes a single-writer resolved output of `switchTextTrack`. This removes the multi-writer contention where the DOM action and the resolver both wrote one slot.

**Engine rewire + cleanup.** `engine.ts` composes `switchTextTrack`, exposes `userTextTrackSelection` via `shareSignals`, and the dead `selectTextTrack` behavior + `SelectTextTrackConfig` are removed (the `pickTextTrack` primitive stays, refactored to share its auto-default policy).

**`DEFAULT=YES` `<track>` fix.** SPF no longer sets the `default` attribute on its `<track>` elements — that made the browser auto-activate the slot, firing a `change` the bridge recorded as user intent and enabling captions past SPF's opt-in policy.

**Doc cascade.** `text-track-architecture.md` + `subtitles.md` rewritten to the `switchTextTrack` model; stale `selectTextTrack` / multi-writer references swept across the registry.

## Notable design decisions

- **DOM bridge writes intent (`userTextTrackSelection`), not the resolved id.** Alternative considered: keep the bridge writing `selectedTextTrackId` directly (status quo). Rejected because the DOM action and the `switchTextTrack` resolver then contend for one slot; routing the DOM through the intent slot makes `selectedTextTrackId` single-writer and lets the resolver own corrections (e.g. disabling a pick whose CDN failed).
- **Optional selection via a `resolveSelection` seam, not a separate text path.** Alternative considered: special-case text inside `setupTrackSwitching` or give text its own selection behavior. Rejected because a generic optional-terminal hook (defaulting to the chain head) keeps video/audio untouched while unifying text onto the same chain — that's what gives captions the failed-CDN constraint + active-CDN scope they previously lacked.
- **`DEFAULT=YES` is honored by engine policy, not the browser's `default` attribute.** Alternative considered: keep propagating `default` so the UA hints the slot. Rejected because SPF owns selection (`switchTextTrack`), and the attribute auto-activated captions past the `enableDefaultTrack=false` opt-in policy.

## Breaking changes

Internal SPF only (alpha; no external consumers). The `selectTextTrack` behavior and `SelectTextTrackConfig` are removed; text selection now runs the track-switching chain, `selectedTextTrackId` is a resolved output (write `userTextTrackSelection` instead), and SPF-owned `<track>` elements no longer carry `default`.

## Test plan

- [x] Full SPF suite green (`pnpm -F @videojs/spf test` — 1042 passed / 14 skipped), including new `switchTextTrack` intent-resolution, optional-none, and echo-guard tests.
- [x] Playwright smoke of the DOM→intent bridge against a multi-language source: native mode-set → intent → resolved id; **Off** → `'off'` (echo guard holds); reset → opt-in default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core track-selection and DOM caption sync with a breaking alpha API (`selectedTextTrackId` read-only; write `userTextTrackSelection`), but behavior is heavily unit-tested and scoped to SPF internals.
> 
> **Overview**
> Moves caption/subtitle selection onto the shared **track-switching** rule chain so text renditions get **failed-CDN pruning** and **active-CDN scoping** like video/audio. **`selectTextTrack` is removed**; the HLS engine composes **`switchTextTrack`** instead and exposes sticky **`userTextTrackSelection`** via `shareSignals`.
> 
> **Intent vs resolved id:** DOM and programmatic callers write **`userTextTrackSelection`** (language partial, `'off'`, or `undefined` = auto); **`switchTextTrack`** is the sole writer of **`selectedTextTrackId`**. **`syncTextTracks`** mirrors the resolved id into native `TextTrack.mode` one way and bridges `change` events to intent, with settling-window + **echo guard** so resolver-driven disables are not recorded as user “off.”
> 
> **Framework seam:** `setupTrackSwitching` gains optional **`resolveSelection`** (default chain head); text uses **`pickResolvedTextTrack`** so selection can legitimately clear. Text skips MSE **`excludeUnplayableTracks`**; user intent is handled in the terminal, not **`filterByUserSelection`**.
> 
> **Opt-in policy fix:** SPF-owned `<track>` elements no longer set the browser **`default`** attribute (avoids auto-enable bypassing `enableDefaultTrack`). Sandbox adds a subtitles picker driven through native modes to exercise the DOM→intent path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3d26be85c272c17d69ade530f5be9ea09b8b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->