### PR TITLE
fix(core): remove 1-9 digit key seek from slider keyboard handler

### DIFF
--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -291,12 +291,6 @@ export function createSlider(options: SliderOptions): SliderApi {
         case 'End':
           newPercent = 100;
           break;
-        default:
-          // Suppress when any modifier is held to avoid hijacking browser/OS shortcuts.
-          if (!event.metaKey && !event.ctrlKey && !event.altKey && event.key >= '0' && event.key <= '9') {
-            newPercent = Number(event.key) * 10;
-          }
-          break;
       }
 
       if (newPercent !== null) {

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -562,57 +562,6 @@ describe('createSlider', () => {
       slider.destroy();
     });
 
-    it('numeric keys jump to N * 10%', () => {
-      const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ onValueChange }));
-
-      slider.thumbProps.onKeyDown(keyboardEvent('5'));
-      expect(onValueChange).toHaveBeenCalledWith(50);
-
-      onValueChange.mockClear();
-      slider.thumbProps.onKeyDown(keyboardEvent('0'));
-      expect(onValueChange).toHaveBeenCalledWith(0);
-
-      onValueChange.mockClear();
-      slider.thumbProps.onKeyDown(keyboardEvent('9'));
-      expect(onValueChange).toHaveBeenCalledWith(90);
-
-      slider.destroy();
-    });
-
-    it('numeric keys do not fire when metaKey is held', () => {
-      const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ onValueChange }));
-
-      slider.thumbProps.onKeyDown(keyboardEvent('5', { metaKey: true }));
-
-      expect(onValueChange).not.toHaveBeenCalled();
-
-      slider.destroy();
-    });
-
-    it('numeric keys do not fire when ctrlKey is held', () => {
-      const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ onValueChange }));
-
-      slider.thumbProps.onKeyDown(keyboardEvent('5', { ctrlKey: true }));
-
-      expect(onValueChange).not.toHaveBeenCalled();
-
-      slider.destroy();
-    });
-
-    it('numeric keys do not fire when altKey is held', () => {
-      const onValueChange = vi.fn();
-      const slider = createSlider(createOptions({ onValueChange }));
-
-      slider.thumbProps.onKeyDown(keyboardEvent('5', { altKey: true }));
-
-      expect(onValueChange).not.toHaveBeenCalled();
-
-      slider.destroy();
-    });
-
     it('clamps to 0-100 range', () => {
       const onValueChange = vi.fn();
       const slider = createSlider(createOptions({ getPercent: () => 99, getStepPercent: () => 5, onValueChange }));


### PR DESCRIPTION
The slider's keydown handler was directly handling digit keys 0–9 to seek to decile positions (10%, 20%, etc.). This meant removing <media-hotkey keys="0-9"> from an ejected skin had no effect, the keys still fired through the slider.

Now this logic belongs exclusively in the <media-hotkey> layer where it can be opted out of.

Removes the digit key handling from createSlider and the corresponding tests.

Closes #1655

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow keyboard behavior change in the slider DOM layer; digit seek remains available via hotkeys when configured.
> 
> **Overview**
> Removes **0–9 digit keyboard seeking** from `createSlider`’s thumb `onKeyDown` handler so decile jumps (0%, 10%, …, 90%) are no longer hard-coded in the slider UI layer.
> 
> **Arrow keys, Home/End, Page Up/Down**, and related stepping behavior are unchanged. Digit-based seek is intended to live only in **`<media-hotkey>`** (`0-9` → `seekToPercent`), so custom/ejected skins can drop those hotkeys without the progress slider still intercepting number keys when the thumb is focused.
> 
> Corresponding unit tests for numeric keys and modifier suppression are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bf118da41fa420d7f121218332063c03d77c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->