### PR TITLE
refactor(core): invoke media methods via callProp

### DIFF
--- a/packages/core/src/dom/media/media-host.ts
+++ b/packages/core/src/dom/media/media-host.ts
@@ -9,9 +9,9 @@ import {
   type TextTrackLike,
 } from '../../core/media/types';
 import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants';
-import { getComponents, getProp, setProp } from './utils';
+import { callProp, getComponents, getProp, setProp } from './utils';
 
-export { addComponent, getComponents, getOwner, getProp, setProp } from './utils';
+export { addComponent, callProp, getComponents, getOwner, getProp, setProp } from './utils';
 
 export interface HTMLMediaTargetLike extends MediaTargetLike, EventTarget {
   querySelector<E extends Element = Element>(selectors: string): E | null;
@@ -182,12 +182,11 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   }
 
   play() {
-    const play = getProp(this, 'play');
-    return play?.() ?? Promise.reject(new DOMException('No media is attached.', 'NotSupportedError'));
+    return callProp(this, 'play') ?? Promise.reject(new DOMException('No media is attached.', 'NotSupportedError'));
   }
 
   pause() {
-    getProp(this, 'pause')?.();
+    callProp(this, 'pause');
   }
 
   get autoplay() {
@@ -242,11 +241,11 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   }
 
   load() {
-    return getProp(this, 'load')?.();
+    return callProp(this, 'load');
   }
 
   canPlayType(type: string) {
-    return getProp(this, 'canPlayType')?.(type) ?? '';
+    return callProp(this, 'canPlayType', type) ?? '';
   }
 
   get volume() {
@@ -305,7 +304,7 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   }
 
   addTextTrack(kind: TextTrackKind, label?: string, language?: string) {
-    return getProp(this, 'addTextTrack')?.(kind, label, language) as TextTrackLike;
+    return callProp(this, 'addTextTrack', kind, label, language) as TextTrackLike;
   }
 
   get remote() {

--- a/packages/core/src/dom/media/tests/utils.test.ts
+++ b/packages/core/src/dom/media/tests/utils.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { HTMLAudioElementHost } from '../audio-host';
+import { addComponent, type Component } from '../media-host';
+import { callProp, getProp } from '../utils';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+class PlayOverride implements Component {
+  readonly api = {
+    playCount: 0,
+    play() {
+      this.playCount++;
+      return Promise.resolve();
+    },
+  };
+
+  get targetOverride() {
+    return this.api;
+  }
+}
+
+describe('getProp', () => {
+  it('returns the owner value', () => {
+    const host = new HTMLAudioElementHost();
+    const audio = document.createElement('audio');
+    audio.loop = true;
+    host.attach(audio);
+
+    expect(getProp(host, 'loop')).toBe(true);
+  });
+
+  it('returns undefined when nothing is attached', () => {
+    const host = new HTMLAudioElementHost();
+    expect(getProp(host, 'loop')).toBeUndefined();
+  });
+});
+
+describe('callProp', () => {
+  it('invokes the method with its owner as `this`', async () => {
+    const host = new HTMLAudioElementHost();
+    host.attach(document.createElement('audio'));
+
+    const component = new PlayOverride();
+    addComponent(host, component);
+
+    await callProp(host, 'play');
+
+    expect(component.api.playCount).toBe(1);
+  });
+
+  it('returns the method result', () => {
+    const host = new HTMLAudioElementHost();
+    const audio = document.createElement('audio');
+    host.attach(audio);
+
+    expect(callProp(host, 'canPlayType', 'video/mp4')).toBe(audio.canPlayType('video/mp4'));
+  });
+
+  it('returns undefined when no owner exposes the method', () => {
+    const host = new HTMLAudioElementHost();
+    expect(callProp(host, 'play')).toBeUndefined();
+  });
+});

--- a/packages/core/src/dom/media/utils.ts
+++ b/packages/core/src/dom/media/utils.ts
@@ -17,10 +17,11 @@ export function getComponents(host: Host) {
   return map;
 }
 
-export function addComponent<T extends Component>(host: Host, instance: T) {
+export function addComponent<T extends Component>(host: Host, component: T) {
   const components = getComponents(host);
-  const ctor = instance.constructor as ComponentConstructor<T>;
-  components.set(ctor, instance);
+  // Get the component's constructor to use as the key for the component in the registry.
+  const ctor = component.constructor as ComponentConstructor<T>;
+  components.set(ctor, component);
 
   // Expose a live binding on `host.config`: reads return the component, writes assign onto it.
   const { configKey } = ctor;
@@ -30,32 +31,47 @@ export function addComponent<T extends Component>(host: Host, instance: T) {
     Object.defineProperty(host.config, configKey, {
       enumerable: true,
       configurable: true,
-      get: () => instance,
-      set: (value) => Object.assign(instance, value),
+      get: () => component,
+      set: (value) => Object.assign(component, value),
     });
-    if (initial) Object.assign(instance, initial);
+
+    if (initial) Object.assign(component, initial);
   }
 
-  instance.setMedia?.(host);
+  component.setMedia?.(host);
+
   // @ts-expect-error `target` is protected, but these helpers are the host's own machinery.
-  if (host.target) instance.attach?.(host.target);
+  if (host.target) component.attach?.(host.target);
+
   return () => {
-    if (components.get(ctor) === instance) {
+    if (components.get(ctor) === component) {
       components.delete(ctor);
+
       if (configKey) delete host.config[configKey];
     }
   };
 }
 
 export function getProp<T extends TargetLike, K extends keyof T>(host: Host<T>, prop: K): T[K] | undefined {
-  const own = getOwner(host, prop);
-  const result = own?.[prop];
-  return isFunction(result) ? (result.bind(own) as T[K]) : result;
+  return getOwner(host, prop)?.[prop];
 }
 
 export function setProp<T extends TargetLike, K extends keyof T>(host: Host<T>, prop: K, value: T[K]): void {
   const own = getOwner(host, prop);
   if (own) (own as Record<K, T[K]>)[prop] = value;
+}
+
+type AnyFn = (...args: any[]) => any;
+
+/** Invoke a media method on its owner, preserving the owner as `this`. Returns `undefined` when no owner exposes it. */
+export function callProp<K extends keyof TargetLike>(
+  host: Host,
+  prop: K,
+  ...args: Parameters<Extract<TargetLike[K], AnyFn>>
+): ReturnType<Extract<TargetLike[K], AnyFn>> | undefined {
+  const own = getOwner(host, prop);
+  const fn = own?.[prop];
+  return isFunction(fn) ? fn.apply(own, args) : undefined;
 }
 
 /** Find the object that owns a media property: the first component `override` exposing it, otherwise the attached target. */


### PR DESCRIPTION
Fix for feedback from https://github.com/videojs/v10/pull/1661

## Summary

Media methods (`play`, `pause`, `load`, `canPlayType`, `addTextTrack`) now invoke through the owner directly instead of reading a function prop and calling it detached. This removes the need to bind on every access — and the referential-stability cache that bind required — since a function reference is never handed out.

## Changes

- Add `callProp(host, prop, ...args)` to resolve the owning component/target and invoke the method with the owner as `this`, returning `undefined` when no owner exposes it.
- Simplify `getProp` to return the raw owner value (no `isFunction` branch, no `bind`).
- Route the host's function-prop accessors through `callProp`.

<details>
<summary>Why not cache the bound function?</summary>

Every consumer invokes immediately and discards the function, so no caller observes referential identity. The `bind` only ever existed to fix `this` on a detached call. Resolving and invoking in one step makes the cache unnecessary. `callProp` is typed against the concrete `TargetLike` constraint so `Parameters`/`ReturnType` inference resolves inside the generic host.

</details>

## Testing

Covered by `utils.test.ts` (`callProp` receiver/return/no-owner) and existing `media-host.test.ts`. `pnpm -F @videojs/core build` and the `core` typecheck pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core playback/control delegation (`play`, `pause`, etc.) where component overrides must keep correct `this`; behavior is intended to be equivalent but is on a sensitive path.
> 
> **Overview**
> Media host methods no longer pull detached function references from **`getProp`** and call them without the correct receiver. **`callProp`** resolves the owning component override or attached target and invokes the method with that owner as **`this`**.
> 
> **`getProp`** now returns the raw property value only (no **`bind`** / function branch). **`play`**, **`pause`**, **`load`**, **`canPlayType`**, and **`addTextTrack`** on **`HTMLMediaElementHost`** route through **`callProp`**, with the same fallbacks when nothing is attached (e.g. rejected **`play`**). **`callProp`** is re-exported from the media host module.
> 
> Adds **`utils.test.ts`** covering **`getProp`** and **`callProp`** (receiver, return value, missing owner). Minor **`addComponent`** naming/comments only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b2f997e1c040dc187f16b599e0586227b0db564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->