### PR TITLE
chore(ci): drop edited trigger from issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,7 +1,7 @@
 name: Issue Triage
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, reopened]
 
 permissions:
   actions: read


### PR DESCRIPTION
## Problem

The Issue Triage workflow is real noisy

## Change

Don't trigger on `edited`

## Trade-off

We lose automatic re-triage when someone adds meaningful detail (e.g. a repro) in a later edit. 

A follow-up could add an idempotency guard to the prompt (check the bot's own prior comments before posting) so re-runs from any trigger don't repeat themselves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 205a63be97a9b9224f0ff7e3dfba011e0f0dbd07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->