### PR TITLE
fix(skin): add missing classnames to tailwind menus

### DIFF
--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -1,6 +1,7 @@
 import { cn } from '@videojs/utils/style';
 
 import { popup } from './popup';
+import { surface } from './surface';
 
 const panelBase = cn(
   'absolute inset-0 overflow-auto overscroll-none p-1 outline-none translate-none',
@@ -44,6 +45,7 @@ const menuTokens = cn(
 
 const menuHostShell = cn(
   popup.popover,
+  surface,
   menuTokens,
   'max-w-(--media-popover-available-width,none) max-h-[min(var(--media-popover-available-height,var(--menu-max-height)),var(--menu-max-height))]',
   'box-border rounded-xl p-1 overscroll-none'


### PR DESCRIPTION
Pretty self explanatory but we were missing a className in the default skins menu styles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class composition only; no logic, auth, or data changes.
> 
> **Overview**
> Default Tailwind **menu** popovers (`menu.root` and `menu.settings`) were built from `popup.popover` only, so they did not get the shared **`surface`** treatment (background, backdrop, borders, shadow) that other popovers use.
> 
> This wires **`surface`** into **`menuHostShell`**, so standalone and settings menus match the rest of the skin’s popover look.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef8b1077e32dce389df41a0d66d34653f017e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->