### PR TITLE
fix(ci): run bundle size on stacked prs

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -2,8 +2,6 @@ name: Bundle Size
 
 on:
   pull_request:
-    branches:
-      - main
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

Allow the bundle size workflow to run for stacked pull requests, not only PRs targeting main. The report fix from #1710 already compares against the actual PR base, but stacked PRs were not getting fresh bundle reports because the workflow trigger was limited to main.

## Changes

- Remove the main-only branch filter from the Bundle Size workflow.
- Keep the existing base measurement behavior, which checks out `github.base_ref` and measures it with the PR script.

## Testing

1. `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bundle-size.yml'); puts 'valid yaml'"`
2. `git diff --check`
3. `pnpm exec biome check .github/workflows/bundle-size.yml` *(Biome ignores this path in repo config.)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no runtime or application code affected.
> 
> **Overview**
> **Bundle Size** CI now runs on **every** `pull_request`, not only when the base branch is `main`.
> 
> Stacked PRs (base = another feature branch) will get fresh PR/base measurements and the existing bundle-size comment, which already compares against `github.base_ref`. Job steps and report logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3126e974973f5a9c5e88b37b784dcd580331849f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->