### PR TITLE
fix(site): surface native media properties on element reference pages

### DIFF
--- a/packages/core/src/dom/media/media-host.ts
+++ b/packages/core/src/dom/media/media-host.ts
@@ -125,6 +125,11 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
     this.dispatchEvent(new (event.constructor as typeof Event)(event.type, event));
   };
 
+  /**
+   * Current stream type (`'on-demand'`, `'live'`, or `'unknown'`). Defaults to
+   * `'unknown'`; detecting hosts update it automatically, and consumers can set
+   * it to override detection.
+   */
   get streamType() {
     return getProp(this, 'streamType') ?? this.#streamType;
   }

--- a/site/scripts/api-docs-builder/src/media-element-handler.ts
+++ b/site/scripts/api-docs-builder/src/media-element-handler.ts
@@ -24,7 +24,14 @@ import * as path from 'node:path';
 import * as ts from 'typescript';
 import * as tae from 'typescript-api-extractor';
 import { extractCSSVars } from './css-vars-handler.js';
-import type { HostPropertyDef, MediaElementReference, MediaElementResult, MediaEventDef } from './pipeline.js';
+import type {
+  HostPropertyDef,
+  MediaElementReference,
+  MediaElementResult,
+  MediaEventDef,
+  MediaTargetTag,
+  ReactMediaReference,
+} from './pipeline.js';
 
 // ─── Constants ──────────────────────────────────────────────────────
 
@@ -46,6 +53,12 @@ interface MediaElementSource {
   hostFilePath: string;
   hostClassName: string;
   mediaType: 'video' | 'audio';
+  targetTag: MediaTargetTag;
+}
+
+interface StaticMediaProperty {
+  property: string;
+  attribute: string;
 }
 
 // ─── Module Resolution ───────────────────────────────────────────────
@@ -206,6 +219,7 @@ function parseDefineFile(
     hostFilePath,
     hostClassName: hostInfo.hostClassName,
     mediaType: hostInfo.mediaType,
+    targetTag: hostInfo.targetTag,
   };
 }
 
@@ -220,9 +234,10 @@ function stripElementSuffix(name: string): string {
 function parseCustomMediaElementCall(
   sourceFile: ts.SourceFile,
   className: string
-): { hostClassName: string; mediaType: 'video' | 'audio' } | null {
+): { hostClassName: string; mediaType: 'video' | 'audio'; targetTag: MediaTargetTag } | null {
   let hostClassName: string | undefined;
   let mediaType: 'video' | 'audio' | undefined;
+  let targetTag: MediaTargetTag | undefined;
 
   ts.forEachChild(sourceFile, (node) => {
     if (!ts.isClassDeclaration(node)) return;
@@ -236,6 +251,15 @@ function parseCustomMediaElementCall(
     findCustomMediaElement(extendsExpr);
   });
 
+  // Media implementations may put template behavior on a local base class
+  // and export a thin mixed-in subclass (VimeoVideo is the real-world case).
+  // Each media module owns a single CustomMediaElement composition, so use
+  // that composition when it is not directly present in the exported class's
+  // extends expression.
+  if (!hostClassName || !mediaType || !targetTag) {
+    findCustomMediaElement(sourceFile);
+  }
+
   function findCustomMediaElement(node: ts.Node): void {
     if (
       ts.isCallExpression(node) &&
@@ -243,10 +267,11 @@ function parseCustomMediaElementCall(
       node.expression.text === 'CustomMediaElement'
     ) {
       if (node.arguments.length >= 2) {
-        // First arg: media type string literal ('video' or 'audio')
+        // First arg: rendered target tag (`video`, `audio`, or `iframe`).
         const tagArg = node.arguments[0]!;
-        if (ts.isStringLiteral(tagArg)) {
-          mediaType = tagArg.text === 'audio' ? 'audio' : 'video';
+        if (ts.isStringLiteral(tagArg) && ['video', 'audio', 'iframe'].includes(tagArg.text)) {
+          targetTag = tagArg.text as MediaTargetTag;
+          mediaType = targetTag === 'audio' ? 'audio' : 'video';
         }
         // Second arg: host class identifier
         const hostArg = node.arguments[1]!;
@@ -259,8 +284,8 @@ function parseCustomMediaElementCall(
     ts.forEachChild(node, findCustomMediaElement);
   }
 
-  if (!hostClassName || !mediaType) return null;
-  return { hostClassName, mediaType };
+  if (!hostClassName || !mediaType || !targetTag) return null;
+  return { hostClassName, mediaType, targetTag };
 }
 
 // ─── Host Property Extraction ───────────────────────────────────────
@@ -931,14 +956,14 @@ function serializeDefaultValue(
 // ─── Shared Data Extraction ──────────────────────────────────────────
 
 /**
- * Extract native attribute names from the `static properties` object inside
- * the CustomMediaElement factory. Each key maps to an attribute name via
- * `props[key].attribute ?? key.toLowerCase()`.
+ * Extract property-to-attribute mappings from the `static properties` object
+ * inside the CustomMediaElement factory. The property name is needed to
+ * classify standard attributes separately from Video.js-specific ones.
  */
-function extractStaticProperties(filePath: string): string[] {
+function extractStaticProperties(filePath: string): StaticMediaProperty[] {
   const content = fs.readFileSync(filePath, 'utf-8');
   const sourceFile = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true);
-  const attributes: string[] = [];
+  const properties: StaticMediaProperty[] = [];
 
   function visit(node: ts.Node): void {
     // Look for: static properties = { ... }
@@ -971,7 +996,7 @@ function extractStaticProperties(filePath: string): string[] {
           }
         }
 
-        attributes.push(attrName);
+        properties.push({ property: propName, attribute: attrName });
       }
       return;
     }
@@ -979,7 +1004,146 @@ function extractStaticProperties(filePath: string): string[] {
   }
 
   visit(sourceFile);
-  return attributes;
+  return properties;
+}
+
+// ─── React Surface Extraction ──────────────────────────────────────
+
+/**
+ * Extract the public React surface from the matching media component.
+ *
+ * Convention:
+ *   - `forwardRef<HTML*Element, *Props>` declares the public ref target.
+ *   - extending `VideoHTMLAttributes` / `AudioHTMLAttributes` opts into the
+ *     native React DOM props.
+ *   - the defaults object passed to `useSyncProps` is the runtime source of
+ *     truth for Video.js-specific props.
+ */
+function extractReactReference(
+  monorepoRoot: string,
+  source: MediaElementSource,
+  compilerOptions: ts.CompilerOptions,
+  propertyDefinitions: Record<string, HostPropertyDef>
+): ReactMediaReference | undefined {
+  const mediaDirectory = path.basename(path.dirname(source.mediaFilePath));
+  const reactFilePath = path.join(monorepoRoot, 'packages/react/src/media', mediaDirectory, 'index.tsx');
+  if (!fs.existsSync(reactFilePath)) return undefined;
+
+  const content = fs.readFileSync(reactFilePath, 'utf-8');
+  const sourceFile = ts.createSourceFile(reactFilePath, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const propsInterfaceName = `${source.className}Props`;
+  let target: MediaTargetTag | undefined;
+  let acceptsNativeProps = false;
+  let defaultsName: string | undefined;
+
+  function visit(node: ts.Node): void {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === propsInterfaceName) {
+      acceptsNativeProps =
+        node.heritageClauses?.some((clause) =>
+          clause.types.some((type) => /(?:Video|Audio)HTMLAttributes/.test(type.getText(sourceFile)))
+        ) ?? false;
+    }
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === source.className &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer) &&
+      ts.isIdentifier(node.initializer.expression) &&
+      node.initializer.expression.text === 'forwardRef'
+    ) {
+      const refType = node.initializer.typeArguments?.[0]?.getText(sourceFile);
+      if (refType === 'HTMLVideoElement') target = 'video';
+      if (refType === 'HTMLAudioElement') target = 'audio';
+      if (refType === 'HTMLIFrameElement') target = 'iframe';
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'useSyncProps' &&
+      node.arguments.length >= 3
+    ) {
+      const defaultsArg = node.arguments[2]!;
+      if (ts.isIdentifier(defaultsArg)) defaultsName = defaultsArg.text;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  if (!target) return undefined;
+
+  const props: Record<string, HostPropertyDef> = {};
+  if (defaultsName) {
+    const resolved = resolveConstObjectLiteral(defaultsName, sourceFile, reactFilePath, compilerOptions);
+    if (resolved) {
+      const defaultValues = resolveObjectLiteralEntries(
+        resolved.objectLiteral,
+        resolved.sourceFile,
+        resolved.filePath,
+        compilerOptions,
+        new Set()
+      );
+      const names = resolveObjectLiteralPropertyNames(
+        resolved.objectLiteral,
+        resolved.sourceFile,
+        resolved.filePath,
+        compilerOptions,
+        new Set()
+      );
+
+      for (const name of [...names].sort()) {
+        const definition = propertyDefinitions[name];
+        const prop: HostPropertyDef = definition
+          ? { ...definition, readonly: false }
+          : { type: 'unknown', readonly: false };
+        const defaultValue = defaultValues.get(name);
+        if (defaultValue !== undefined) prop.default = defaultValue;
+        props[name] = prop;
+      }
+    }
+  }
+
+  return { target, acceptsNativeProps, props };
+}
+
+/** Collect object-literal keys, including keys whose defaults are not serializable. */
+function resolveObjectLiteralPropertyNames(
+  objectLiteral: ts.ObjectLiteralExpression,
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  compilerOptions: ts.CompilerOptions,
+  visited: Set<string>
+): Set<string> {
+  const names = new Set<string>();
+
+  for (const prop of objectLiteral.properties) {
+    if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+      names.add(prop.name.text);
+      continue;
+    }
+
+    if (ts.isSpreadAssignment(prop) && ts.isIdentifier(prop.expression)) {
+      const resolved = resolveConstObjectLiteral(prop.expression.text, sourceFile, filePath, compilerOptions);
+      if (!resolved) continue;
+      const visitKey = `${resolved.filePath}::${prop.expression.text}`;
+      if (visited.has(visitKey)) continue;
+      visited.add(visitKey);
+      for (const name of resolveObjectLiteralPropertyNames(
+        resolved.objectLiteral,
+        resolved.sourceFile,
+        resolved.filePath,
+        compilerOptions,
+        visited
+      )) {
+        names.add(name);
+      }
+    }
+  }
+
+  return names;
 }
 
 // ─── Method Extraction ───────────────────────────────────────────────
@@ -1238,6 +1402,52 @@ function parseFiresTagComment(tag: ts.JSDocTag): { name: string; description: st
 function scanForDispatchEvents(sourceFile: ts.SourceFile, events: Set<string>): void {
   function visit(node: ts.Node): void {
     if (
+      ts.isForOfStatement(node) &&
+      ts.isVariableDeclarationList(node.initializer) &&
+      ts.isArrayLiteralExpression(node.expression)
+    ) {
+      const declaration = node.initializer.declarations[0];
+      const loopName = declaration && ts.isIdentifier(declaration.name) ? declaration.name.text : undefined;
+      let dispatchesLoopValue = false;
+
+      if (loopName) {
+        function findLoopDispatch(child: ts.Node): void {
+          if (
+            ts.isNewExpression(child) &&
+            ts.isIdentifier(child.expression) &&
+            child.expression.text === 'Event' &&
+            child.arguments?.[0] &&
+            ts.isIdentifier(child.arguments[0]) &&
+            child.arguments[0].text === loopName
+          ) {
+            dispatchesLoopValue = true;
+          }
+          ts.forEachChild(child, findLoopDispatch);
+        }
+        findLoopDispatch(node.statement);
+      }
+
+      if (dispatchesLoopValue) {
+        for (const element of node.expression.elements) {
+          if (ts.isStringLiteral(element)) events.add(element.text);
+        }
+      }
+    }
+
+    // Adapter implementations commonly use a local `emit` helper to bridge
+    // events from a third-party player (for example Vimeo). Literal calls are
+    // still an unambiguous declaration of the events the adapter implements.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'emit' &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      events.add(node.arguments[0].text);
+    }
+
+    if (
       ts.isCallExpression(node) &&
       ts.isPropertyAccessExpression(node.expression) &&
       node.expression.name.text === 'dispatchEvent' &&
@@ -1294,7 +1504,7 @@ export function generateMediaElementReferences(monorepoRoot: string): MediaEleme
   if (!fs.existsSync(customMediaPath)) return [];
 
   // Read shared data
-  const allAttributes = extractStaticProperties(customMediaPath);
+  const staticProperties = extractStaticProperties(customMediaPath);
 
   // Extract events from capability contract types
   const mediaTypesPath = path.join(monorepoRoot, 'packages/core/src/core/media/types.ts');
@@ -1334,7 +1544,13 @@ export function generateMediaElementReferences(monorepoRoot: string): MediaEleme
     lib: dedupeStrings([...(compilerOptions.lib ?? []), 'lib.dom.d.ts']),
   };
   const program = ts.createProgram(
-    dedupeStrings([customMediaPath, ...sources.map((s) => s.hostFilePath)]),
+    dedupeStrings([
+      customMediaPath,
+      mediaHostPath,
+      videoHostPath,
+      audioHostPath,
+      ...sources.map((s) => s.hostFilePath),
+    ]),
     programOptions
   );
   const checker = program.getTypeChecker();
@@ -1346,6 +1562,36 @@ export function generateMediaElementReferences(monorepoRoot: string): MediaEleme
   const nativeNames = customMediaSourceFile
     ? collectNativeMemberNames(program, customMediaSourceFile)
     : new Set<string>();
+
+  const baseHostProperties = extractHostProperties(mediaHostPath, 'HTMLMediaElementHost', compilerOptions, nativeNames);
+  const videoHostProperties = extractHostProperties(
+    videoHostPath,
+    'HTMLVideoElementHost',
+    compilerOptions,
+    nativeNames
+  );
+  const audioHostProperties = extractHostProperties(
+    audioHostPath,
+    'HTMLAudioElementHost',
+    compilerOptions,
+    nativeNames
+  );
+
+  function fillInferredTypes(properties: Record<string, HostPropertyDef>, filePath: string, className: string): void {
+    const inferredTypes = resolveInferredTypes(filePath, className, program, checker);
+    for (const [name, def] of Object.entries(properties)) {
+      if (def.type === 'unknown' && inferredTypes.has(name)) {
+        def.type = inferredTypes.get(name)!;
+      }
+    }
+  }
+
+  fillInferredTypes(baseHostProperties, mediaHostPath, 'HTMLMediaElementHost');
+  fillInferredTypes(videoHostProperties, videoHostPath, 'HTMLVideoElementHost');
+  fillInferredTypes(audioHostProperties, audioHostPath, 'HTMLAudioElementHost');
+
+  const videoBaseSurface = { ...baseHostProperties, ...videoHostProperties };
+  const audioBaseSurface = { ...baseHostProperties, ...audioHostProperties };
 
   const videoCSSVars: Record<string, { description: string }> = {};
   if (videoCSSVarsRaw) {
@@ -1371,25 +1617,39 @@ export function generateMediaElementReferences(monorepoRoot: string): MediaEleme
       nativeNames
     );
 
-    // The AST walk only reads explicit return-type annotations; getters without
-    // one fall back to the literal string 'unknown'. Fill those gaps from the
-    // type checker, which infers the real type across the mixin chain. Authored
-    // annotations are left untouched.
-    const inferredTypes = resolveInferredTypes(source.hostFilePath, source.hostClassName, program, checker);
-    for (const [name, def] of Object.entries(hostProperties)) {
-      if (def.type === 'unknown' && inferredTypes.has(name)) {
-        def.type = inferredTypes.get(name)!;
+    fillInferredTypes(hostProperties, source.hostFilePath, source.hostClassName);
+
+    const baseSurface =
+      source.targetTag === 'video' ? videoBaseSurface : source.targetTag === 'audio' ? audioBaseSurface : {};
+    const publicProperties = { ...baseSurface, ...hostProperties };
+    const propertyDefinitions: Record<string, HostPropertyDef> = {};
+    for (const [name, definition] of Object.entries(baseSurface)) {
+      if (!definition.overridesNative) propertyDefinitions[name] = definition;
+    }
+    Object.assign(propertyDefinitions, hostProperties);
+
+    const standardAttributes: string[] = [];
+    const customAttributes: Record<string, HostPropertyDef> = {};
+    for (const { property, attribute } of staticProperties) {
+      const definition = publicProperties[property];
+
+      if (source.targetTag === 'iframe') {
+        // Embed attributes only have media semantics when the synthetic host
+        // implements the corresponding property. Unmatched shared attributes
+        // are inert because iframe targets do not receive attribute forwarding.
+        if (definition) customAttributes[attribute] = { ...definition, readonly: false };
+        continue;
+      }
+
+      if (definition && !definition.overridesNative) {
+        customAttributes[attribute] = { ...definition, readonly: false };
+      } else {
+        standardAttributes.push(attribute);
       }
     }
 
-    // Native attributes are the COMPLETE markup-settable set from `static
-    // properties`. Host-owned names (src/preload/stream-type) intentionally
-    // overlap with hostProperties — this mirrors MDN's content-attribute vs
-    // IDL-property model: the same name is both a settable attribute and a
-    // richer JS property.
-    const nativeAttributes = [...allAttributes];
-
-    const cssCustomProperties = source.mediaType === 'video' ? videoCSSVars : audioCSSVars;
+    const cssCustomProperties =
+      source.targetTag === 'video' ? videoCSSVars : source.targetTag === 'audio' ? audioCSSVars : {};
 
     // Walk the host's mixin/parent chain collecting `@fires` descriptions. An
     // event is documented as element-specific iff it carries a `@fires` tag —
@@ -1397,8 +1657,24 @@ export function generateMediaElementReferences(monorepoRoot: string): MediaEleme
     // DOM events are never tagged, and a tagged event stays documented even when
     // it also lives in the typed media events contract (e.g. streamtypechange).
     const fires = new Map<string, string>();
-    extractDispatchedEvents(source.hostFilePath, source.hostClassName, compilerOptions, new Set(), new Set(), fires);
-    const elementSpecific: MediaEventDef[] = [...fires.keys()].sort().map((name) => {
+    const dispatchedEvents = new Set<string>();
+    extractDispatchedEvents(
+      source.hostFilePath,
+      source.hostClassName,
+      compilerOptions,
+      new Set(),
+      dispatchedEvents,
+      fires
+    );
+    const contractEvents = source.mediaType === 'video' ? videoEvents : audioEvents;
+    const contractEventNames = new Set(contractEvents);
+    const customEventNamesForElement = new Set(fires.keys());
+    if (source.targetTag === 'iframe') {
+      for (const name of dispatchedEvents) {
+        if (!contractEventNames.has(name)) customEventNamesForElement.add(name);
+      }
+    }
+    const customEvents: MediaEventDef[] = [...customEventNamesForElement].sort().map((name) => {
       const def: MediaEventDef = { name };
       const description = fires.get(name);
       if (description) def.description = description;
@@ -1411,22 +1687,52 @@ export function generateMediaElementReferences(monorepoRoot: string): MediaEleme
     // capability interfaces — these are never native, even on elements that
     // don't fire them (e.g. dash-video has no streamType, so streamtypechange
     // appears nowhere).
-    const elementSpecificNames = new Set(elementSpecific.map((e) => e.name));
-    const native = (source.mediaType === 'video' ? videoEvents : audioEvents).filter(
-      (n) => !elementSpecificNames.has(n) && !customEventNames.has(n)
+    const customEventSet = new Set(customEvents.map((event) => event.name));
+    const standardEvents = contractEvents.filter(
+      (name) =>
+        !customEventSet.has(name) &&
+        !customEventNames.has(name) &&
+        (source.targetTag !== 'iframe' || dispatchedEvents.has(name))
     );
 
-    const methods = source.mediaType === 'video' ? videoMethods : audioMethods;
+    const baseMethodNames =
+      source.targetTag === 'video' ? videoMethods : source.targetTag === 'audio' ? audioMethods : [];
+    const methods = mergeMethodNames(
+      baseMethodNames,
+      extractPublicMethodNames(source.hostFilePath, source.hostClassName)
+    );
+
+    const nativeProperties = Object.entries(baseSurface)
+      .filter(([name, definition]) => definition.overridesNative && !(name in hostProperties))
+      .map(([name]) => name)
+      .sort();
+
+    const react = extractReactReference(monorepoRoot, source, compilerOptions, publicProperties);
 
     const reference: MediaElementReference = {
       name: source.className,
       tagName: source.tagName,
       mediaType: source.mediaType,
-      hostProperties,
-      nativeAttributes,
-      events: { native, elementSpecific },
-      methods,
-      cssCustomProperties,
+      platforms: {
+        html: {
+          target: source.targetTag,
+          attributes: {
+            standard: standardAttributes.sort(),
+            custom: customAttributes,
+          },
+          properties: {
+            definitions: propertyDefinitions,
+            native: nativeProperties,
+          },
+          events: {
+            standard: standardEvents,
+            custom: customEvents,
+          },
+          methods,
+          cssCustomProperties,
+        },
+        ...(react ? { react } : {}),
+      },
     };
 
     results.push({ name: source.className, reference });

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -154,7 +154,6 @@ export function discoverComponents(monorepoRoot: string): ComponentSource[] {
 
 export function createComponentProgram(sources: ComponentSource[], monorepoRoot: string): ts.Program {
   const htmlUiPath = path.join(monorepoRoot, 'packages/html/src/ui');
-  const coreUiPath = path.join(monorepoRoot, 'packages/core/src/core/ui');
   const files: string[] = [];
 
   for (const source of sources) {
@@ -599,18 +598,40 @@ export interface MediaEventDef {
   description?: string;
 }
 
+export type MediaTargetTag = 'video' | 'audio' | 'iframe';
+
+export interface HtmlMediaReference {
+  target: MediaTargetTag;
+  attributes: {
+    standard: string[];
+    custom: Record<string, HostPropertyDef>;
+  };
+  properties: {
+    definitions: Record<string, HostPropertyDef>;
+    native: string[];
+  };
+  events: {
+    standard: string[];
+    custom: MediaEventDef[];
+  };
+  methods: string[];
+  cssCustomProperties: Record<string, { description: string }>;
+}
+
+export interface ReactMediaReference {
+  target: MediaTargetTag;
+  acceptsNativeProps: boolean;
+  props: Record<string, HostPropertyDef>;
+}
+
 export interface MediaElementReference {
   name: string;
   tagName: string;
   mediaType: 'video' | 'audio';
-  hostProperties: Record<string, HostPropertyDef>;
-  nativeAttributes: string[];
-  events: {
-    native: string[];
-    elementSpecific: MediaEventDef[];
+  platforms: {
+    html: HtmlMediaReference;
+    react?: ReactMediaReference;
   };
-  methods: string[];
-  cssCustomProperties: Record<string, { description: string }>;
 }
 
 export interface MediaElementResult {

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -1080,8 +1080,8 @@ describe('Preset pipeline (end-to-end)', () => {
 // MEDIA ELEMENT PIPELINE
 // ═══════════════════════════════════════════════════════════════════════
 //
-// Media elements are custom elements that wrap native <video>/<audio> with
-// streaming hosts (HLS, DASH, etc.). They are discovered from
+// Media elements are custom elements that adapt native <video>/<audio> targets
+// or embedded players. They are discovered from
 // packages/html/src/define/media/*.ts by looking for files that declare a
 // class with `static tagName`.
 //
@@ -1089,7 +1089,9 @@ describe('Preset pipeline (end-to-end)', () => {
 //   - Tag name from the element class's static tagName
 //   - Host properties by following the CustomMediaElement(tag, Host) call to the
 //     host class and walking its getter/setter pairs
-//   - Shared native attributes from static properties, events, and CSS vars
+//   - Standard/custom attributes from static properties and host accessors
+//   - Platform metadata from the matching React component conventions
+//   - Events and CSS vars for the HTML custom element
 //   - JSDoc descriptions from host getter/setter pairs
 //
 // Key behaviors:
@@ -1097,13 +1099,16 @@ describe('Preset pipeline (end-to-end)', () => {
 //   - Exclusion: container.ts (re-exports, no inline class), background-video.ts
 //     (no CustomMediaElement — uses MediaAttachMixin(HTMLElement) directly)
 //   - Host inheritance: child host extends parent, builder walks the chain
-//   - Attribute overlap: nativeAttributes is the COMPLETE markup-settable set
-//     (no dedup). Host-owned names (e.g., src, preload) appear in BOTH
-//     hostProperties and nativeAttributes (content-attribute vs IDL-property).
+//   - Attribute classification: standard attributes remain an MDN-linked list;
+//     Video.js-specific attributes use their corresponding host definitions.
 //   - Methods: native media methods are extracted ONCE per media type from the
 //     shared base host classes (media-host + video-host/audio-host).
-//   - Event buckets: element-specific (@fires-tagged) events live ONLY in
-//     elementSpecific, never in native.
+//   - Properties: the inherited native surface is compact, while source-authored
+//     definitions retain types, defaults, and descriptions.
+//   - Event buckets: custom (@fires-tagged) events live ONLY in `custom`, never
+//     in the standard MDN-linked list.
+//   - React: forwardRef and useSyncProps conventions produce the ref target and
+//     Video.js-specific prop table without per-element configuration.
 
 describe('Media element pipeline (end-to-end)', () => {
   const results = generateMediaElementReferences(FIXTURE_ROOT);
@@ -1119,7 +1124,7 @@ describe('Media element pipeline (end-to-end)', () => {
   describe('Discovery', () => {
     it('discovers media elements from define/media/ files', () => {
       const names = results.map((r) => r.name).sort();
-      expect(names).toEqual(['ComplexVideo', 'ExtendingVideo', 'MixinVideo', 'SimpleVideo', 'SpfAudio']);
+      expect(names).toEqual(['ComplexVideo', 'EmbedVideo', 'ExtendingVideo', 'MixinVideo', 'SimpleVideo', 'SpfAudio']);
     });
 
     it('excludes container (re-export, not inline class declaration)', () => {
@@ -1133,7 +1138,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('produces one result per media element', () => {
-      expect(results.length).toBe(5);
+      expect(results.length).toBe(6);
     });
   });
 
@@ -1154,7 +1159,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('extracts host properties with types and readonly flags', () => {
-      const props = findElement('SimpleVideo')!.reference.hostProperties;
+      const props = findElement('SimpleVideo')!.reference.platforms.html.properties.definitions;
 
       // src: read-write string
       expect(props.src).toMatchObject({
@@ -1172,19 +1177,15 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('excludes host lifecycle methods (attach, detach, destroy)', () => {
-      const props = findElement('SimpleVideo')!.reference.hostProperties;
+      const props = findElement('SimpleVideo')!.reference.platforms.html.properties.definitions;
       expect(props.attach).toBeUndefined();
       expect(props.detach).toBeUndefined();
       expect(props.destroy).toBeUndefined();
     });
 
-    it('includes the COMPLETE set of native attributes from static properties', () => {
+    it('separates standard attributes from Video.js-specific attributes', () => {
       const ref = findElement('SimpleVideo')!.reference;
-      // nativeAttributes is the full markup-settable set from `static
-      // properties` — no dedup against host props. `src` is settable as an
-      // attribute even though the host also exposes it as a richer property,
-      // so it appears in BOTH places (MDN content-attribute vs IDL-property).
-      expect(ref.nativeAttributes).toEqual(
+      expect(ref.platforms.html.attributes.standard).toEqual(
         expect.arrayContaining([
           'autoplay',
           'controls',
@@ -1196,14 +1197,37 @@ describe('Media element pipeline (end-to-end)', () => {
           'preload',
         ])
       );
-      expect(ref.nativeAttributes).toContain('src');
+      expect(ref.platforms.html.attributes.standard).toContain('src');
+      expect(ref.platforms.html.attributes.standard).not.toContain('stream-type');
+      expect(ref.platforms.html.attributes.custom['stream-type']).toMatchObject({
+        type: 'string',
+        readonly: false,
+      });
+      expect(ref.platforms.html.attributes.custom['stream-type'].description).toContain('Current stream type');
     });
 
     it('extracts native media methods from the shared base host classes', () => {
       const ref = findElement('SimpleVideo')!.reference;
       // Video methods = media-host methods + video-host methods, deduped + sorted.
       // Lifecycle methods (attach/detach/destroy) and accessors are excluded.
-      expect(ref.methods).toEqual(['canPlayType', 'load', 'pause', 'play', 'requestFullscreen']);
+      expect(ref.platforms.html.methods).toEqual(['canPlayType', 'load', 'pause', 'play', 'requestFullscreen']);
+    });
+
+    it('extracts native passthrough properties from the shared base host classes', () => {
+      const ref = findElement('SimpleVideo')!.reference;
+      // Video native properties = media-host + video-host accessors, filtered to
+      // genuine native members and deduped against hostProperties. `currentTime`
+      // and `volume` come from media-host; `videoWidth` is video-only.
+      expect(ref.platforms.html.properties.native).toEqual(['currentTime', 'videoWidth', 'volume']);
+      // Video.js-specific base accessors receive full definitions instead.
+      expect(ref.platforms.html.properties.native).not.toContain('streamType');
+      expect(ref.platforms.html.properties.native).not.toContain('isFullscreen');
+      expect(ref.platforms.html.properties.definitions.streamType).toBeDefined();
+      expect(ref.platforms.html.properties.definitions.isFullscreen).toBeDefined();
+      // `src` is native but re-declared in hostProperties → deduped out (shown in
+      // the rich table instead).
+      expect(ref.platforms.html.properties.definitions.src).toBeDefined();
+      expect(ref.platforms.html.properties.native).not.toContain('src');
     });
 
     it('includes events derived from VideoEvents capability contracts', () => {
@@ -1213,7 +1237,7 @@ describe('Media element pipeline (end-to-end)', () => {
       // Video.js events from MediaStreamTypeEvents/MediaLiveEvents
       // (streamtypechange) are NOT native and are excluded here — they only
       // appear in elementSpecific, and only on elements that @fires them.
-      expect(ref.events.native).toEqual([
+      expect(ref.platforms.html.events.standard).toEqual([
         'play',
         'playing',
         'waiting',
@@ -1239,23 +1263,23 @@ describe('Media element pipeline (end-to-end)', () => {
         'trackmodechange',
       ]);
       // SimpleHost dispatches no events of its own.
-      expect(ref.events.elementSpecific).toEqual([]);
+      expect(ref.platforms.html.events.custom).toEqual([]);
     });
 
     it('omits custom events entirely when the element does not @fires them', () => {
       // Regression guard: streamtypechange lives in the VideoEvents contract via
       // MediaStreamTypeEvents, but SimpleVideo has no @fires tag for it (and no
-      // streamType capability). A custom event must never leak into `native`
+      // streamType event documentation). A custom event must never leak into the standard list
       // (which points readers at MDN) — with no @fires it appears in NEITHER
       // bucket. Mirrors dash-video / simple-hls-video in the real monorepo.
       const ref = findElement('SimpleVideo')!.reference;
-      expect(ref.events.native).not.toContain('streamtypechange');
-      const elementSpecificNames = ref.events.elementSpecific.map((e) => e.name);
+      expect(ref.platforms.html.events.standard).not.toContain('streamtypechange');
+      const elementSpecificNames = ref.platforms.html.events.custom.map((e) => e.name);
       expect(elementSpecificNames).not.toContain('streamtypechange');
     });
 
     it('includes CSS custom properties from VideoCSSVars', () => {
-      const css = findElement('SimpleVideo')!.reference.cssCustomProperties;
+      const css = findElement('SimpleVideo')!.reference.platforms.html.cssCustomProperties;
       expect(css['--media-object-fit']).toEqual({
         description: 'Object fit for the video.',
       });
@@ -1281,12 +1305,13 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('extracts all host properties', () => {
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       const propNames = Object.keys(props).sort();
       expect(propNames).toEqual([
         'config',
         'debug',
         'engine',
+        'isFullscreen',
         'preferPlayback',
         'preload',
         'src',
@@ -1296,7 +1321,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('extracts JSDoc descriptions from host getters', () => {
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       expect(props.type.description).toBe('Explicit source type. When unset, inferred from the source URL extension.');
       expect(props.preferPlayback.description).toBe("Whether to prefer `'mse'` or `'native'` playback.");
       expect(props.debug.description).toBe('Enable debug logging.');
@@ -1304,7 +1329,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('marks readonly properties correctly', () => {
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       // engine: getter only → readonly
       expect(props.engine.readonly).toBe(true);
       // src: getter + setter → not readonly
@@ -1313,7 +1338,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('extracts property types', () => {
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       expect(props.src.type).toBe('string');
       expect(props.debug.type).toBe('boolean');
       expect(props.config.type).toContain('Record');
@@ -1324,18 +1349,18 @@ describe('Media element pipeline (end-to-end)', () => {
       // src and preload are richer host properties AND genuinely settable as
       // markup attributes — the intentional content-attribute vs IDL-property
       // overlap. They appear in hostProperties...
-      expect(ref.hostProperties.src).toBeDefined();
-      expect(ref.hostProperties.preload).toBeDefined();
+      expect(ref.platforms.html.properties.definitions.src).toBeDefined();
+      expect(ref.platforms.html.properties.definitions.preload).toBeDefined();
       // ...and ALSO in nativeAttributes (no dedup).
-      expect(ref.nativeAttributes).toContain('src');
-      expect(ref.nativeAttributes).toContain('preload');
+      expect(ref.platforms.html.attributes.standard).toContain('src');
+      expect(ref.platforms.html.attributes.standard).toContain('preload');
       // Other native attrs remain
-      expect(ref.nativeAttributes).toContain('autoplay');
-      expect(ref.nativeAttributes).toContain('controls');
+      expect(ref.platforms.html.attributes.standard).toContain('autoplay');
+      expect(ref.platforms.html.attributes.standard).toContain('controls');
     });
 
     it('extracts defaults from the co-located defaultProps export', () => {
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       // Literal values are emitted as source text (strings keep their quotes).
       expect(props.src.default).toBe("''");
       expect(props.debug.default).toBe('false');
@@ -1351,13 +1376,70 @@ describe('Media element pipeline (end-to-end)', () => {
     it('resolves const-object member defaults through imports', () => {
       // streamType: MediaStreamTypes.UNKNOWN — the builder resolves the member
       // access to its literal value in the imported `as const` object.
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       expect(props.streamType.default).toBe("'unknown'");
     });
 
     it('omits defaults for properties without a defaultProps entry', () => {
-      const props = findElement('ComplexVideo')!.reference.hostProperties;
+      const props = findElement('ComplexVideo')!.reference.platforms.html.properties.definitions;
       expect(props.engine.default).toBeUndefined();
+    });
+
+    it('extracts the matching React surface from source conventions', () => {
+      const react = findElement('ComplexVideo')!.reference.platforms.react;
+      expect(react).toMatchObject({
+        target: 'video',
+        acceptsNativeProps: true,
+      });
+      expect(Object.keys(react!.props).sort()).toEqual([
+        'config',
+        'debug',
+        'preferPlayback',
+        'preload',
+        'src',
+        'streamType',
+        'type',
+      ]);
+      expect(react!.props.streamType.default).toBe("'unknown'");
+      expect(react!.props.engine).toBeUndefined();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // EMBED MEDIA ELEMENT: EmbedVideo
+  // ─────────────────────────────────────────────────────────────────
+
+  describe('EmbedVideo (iframe-backed media)', () => {
+    it('uses the target declared by CustomMediaElement', () => {
+      const ref = findElement('EmbedVideo')!.reference;
+      expect(ref.platforms.html.target).toBe('iframe');
+      expect(ref.platforms.react?.target).toBe('iframe');
+    });
+
+    it('does not invent native video properties, methods, or CSS for an iframe target', () => {
+      const html = findElement('EmbedVideo')!.reference.platforms.html;
+      expect(html.properties.native).toEqual([]);
+      expect(html.methods).toEqual(['play']);
+      expect(html.cssCustomProperties).toEqual({});
+    });
+
+    it('documents only attributes implemented by the synthetic media host', () => {
+      const attributes = findElement('EmbedVideo')!.reference.platforms.html.attributes;
+      expect(attributes.standard).toEqual([]);
+      expect(Object.keys(attributes.custom).sort()).toEqual(['autoplay', 'src']);
+      expect(attributes.custom['stream-type']).toBeUndefined();
+    });
+
+    it('documents only events dispatched by the embedded media adapter', () => {
+      const events = findElement('EmbedVideo')!.reference.platforms.html.events;
+      expect(events.standard).toEqual(['play', 'waiting', 'loadedmetadata']);
+      expect(events.custom).toEqual([{ name: 'adapterready' }]);
+    });
+
+    it('extracts custom React props without claiming native media props', () => {
+      const react = findElement('EmbedVideo')!.reference.platforms.react;
+      expect(react).toMatchObject({ target: 'iframe', acceptsNativeProps: false });
+      expect(Object.keys(react!.props).sort()).toEqual(['autoplay', 'src']);
     });
   });
 
@@ -1377,7 +1459,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('includes own properties from ExtendingHost', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       expect(props.playbackId).toMatchObject({
         type: 'string',
         readonly: false,
@@ -1391,7 +1473,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('includes inherited properties from ComplexHost', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       // These are inherited from ComplexHost
       expect(props.src).toBeDefined();
       expect(props.type).toBeDefined();
@@ -1402,13 +1484,13 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('child overrides replace parent definitions', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       // ExtendingHost overrides debug with different JSDoc
       expect(props.debug.description).toBe('Overrides parent debug — adds network logging.');
     });
 
     it('inherited readonly flags are preserved', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       // engine is readonly in ComplexHost and not overridden
       expect(props.engine.readonly).toBe(true);
     });
@@ -1416,25 +1498,25 @@ describe('Media element pipeline (end-to-end)', () => {
     it('resolves spread defaults through the parent defaultProps import', () => {
       // extendingMediaDefaultProps = { ...complexMediaDefaultProps, ... } —
       // the builder must follow the spread to the imported object literal.
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       expect(props.src.default).toBe("''");
       expect(props.debug.default).toBe('false');
       expect(props.streamType.default).toBe("'unknown'");
     });
 
     it('extracts own defaults alongside spread defaults', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       expect(props.playbackId.default).toBe("''");
       expect(props.maxResolution.default).toBe('1080');
     });
 
     it('abbreviates non-empty object defaults', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       expect(props.tokens.default).toBe('{…}');
     });
 
     it('omits defaults for properties without an entry', () => {
-      const props = findElement('ExtendingVideo')!.reference.hostProperties;
+      const props = findElement('ExtendingVideo')!.reference.platforms.html.properties.definitions;
       expect(props.customDomain.default).toBeUndefined();
     });
   });
@@ -1450,16 +1532,16 @@ describe('Media element pipeline (end-to-end)', () => {
   describe('Event extraction from capability contracts', () => {
     it('video elements include text track events from VideoEvents', () => {
       const ref = findElement('SimpleVideo')!.reference;
-      expect(ref.events.native).toContain('addtrack');
-      expect(ref.events.native).toContain('removetrack');
-      expect(ref.events.native).toContain('changetrack');
-      expect(ref.events.native).toContain('trackmodechange');
+      expect(ref.platforms.html.events.standard).toContain('addtrack');
+      expect(ref.platforms.html.events.standard).toContain('removetrack');
+      expect(ref.platforms.html.events.standard).toContain('changetrack');
+      expect(ref.platforms.html.events.standard).toContain('trackmodechange');
     });
 
     it('all video elements share the same native event list', () => {
-      const simple = findElement('SimpleVideo')!.reference.events.native;
-      const complex = findElement('ComplexVideo')!.reference.events.native;
-      const extending = findElement('ExtendingVideo')!.reference.events.native;
+      const simple = findElement('SimpleVideo')!.reference.platforms.html.events.standard;
+      const complex = findElement('ComplexVideo')!.reference.platforms.html.events.standard;
+      const extending = findElement('ExtendingVideo')!.reference.platforms.html.events.standard;
       expect(complex).toEqual(simple);
       expect(extending).toEqual(simple);
     });
@@ -1490,7 +1572,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('walks function-declaration mixin (Shape A)', () => {
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.foo).toMatchObject({
         type: 'string',
         readonly: false,
@@ -1499,14 +1581,14 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('walks const-arrow mixin (Shape B)', () => {
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.volume).toBeDefined();
       expect(props.volume.type).toBe('number');
       expect(props.volume.readonly).toBe(false);
     });
 
     it('includes leaf-class own properties', () => {
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.bar).toMatchObject({
         type: 'number',
         readonly: false,
@@ -1515,12 +1597,12 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('marks volume as overridesNative (HTMLMediaElement member)', () => {
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.volume.overridesNative).toBe(true);
     });
 
     it('does not mark non-native properties as overridesNative', () => {
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.foo.overridesNative).toBeUndefined();
       expect(props.bar.overridesNative).toBeUndefined();
     });
@@ -1528,7 +1610,7 @@ describe('Media element pipeline (end-to-end)', () => {
     it('inherits parent description when child override has no JSDoc', () => {
       // src has JSDoc on MixinBaseHost; MixinB overrides without JSDoc.
       // The description should fall through from the base.
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.src.description).toBe('Source URL of the media.');
     });
 
@@ -1538,8 +1620,8 @@ describe('Media element pipeline (end-to-end)', () => {
       // ONLY in the elementSpecific bucket (where they carry their description);
       // they are excluded from native so they are never listed twice.
       const ref = findElement('MixinVideo')!.reference;
-      expect(ref.events.native).not.toContain('streamtypechange');
-      expect(ref.events.elementSpecific).toContainEqual({
+      expect(ref.platforms.html.events.standard).not.toContain('streamtypechange');
+      expect(ref.platforms.html.events.custom).toContainEqual({
         name: 'streamtypechange',
         description: 'Fired when the detected stream type changes.',
       });
@@ -1549,20 +1631,20 @@ describe('Media element pipeline (end-to-end)', () => {
       // foochange is dispatched via this.dispatchEvent(new Event('foochange')) but
       // has no @fires tag, so it is not surfaced — documentation requires a tag.
       const ref = findElement('MixinVideo')!.reference;
-      const elementSpecificNames = ref.events.elementSpecific.map((e) => e.name);
+      const elementSpecificNames = ref.platforms.html.events.custom.map((e) => e.name);
       expect(elementSpecificNames).not.toContain('foochange');
     });
 
     it('separates native events from element-specific events', () => {
       const ref = findElement('MixinVideo')!.reference;
-      const elementSpecificNames = ref.events.elementSpecific.map((e) => e.name);
-      expect(ref.events.native).toContain('play');
-      expect(ref.events.native).not.toContain('foochange');
+      const elementSpecificNames = ref.platforms.html.events.custom.map((e) => e.name);
+      expect(ref.platforms.html.events.standard).toContain('play');
+      expect(ref.platforms.html.events.standard).not.toContain('foochange');
       expect(elementSpecificNames).not.toContain('play');
     });
 
     it('extracts defaults declared in a mixin file', () => {
-      const props = findElement('MixinVideo')!.reference.hostProperties;
+      const props = findElement('MixinVideo')!.reference.platforms.html.properties.definitions;
       expect(props.foo.default).toBe("''");
     });
   });
@@ -1591,7 +1673,7 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('resolves the mixin through another package barrel', () => {
-      const props = findElement('SpfAudio')!.reference.hostProperties;
+      const props = findElement('SpfAudio')!.reference.platforms.html.properties.definitions;
       expect(props.src).toMatchObject({
         type: 'string',
         readonly: false,
@@ -1605,20 +1687,20 @@ describe('Media element pipeline (end-to-end)', () => {
     });
 
     it('extracts defaults declared next to the cross-package mixin', () => {
-      const props = findElement('SpfAudio')!.reference.hostProperties;
+      const props = findElement('SpfAudio')!.reference.platforms.html.properties.definitions;
       expect(props.src.default).toBe("''");
       expect(props.preload.default).toBe("''");
     });
 
     it('uses AudioEvents for native events (no text track events)', () => {
       const ref = findElement('SpfAudio')!.reference;
-      expect(ref.events.native).toContain('play');
-      expect(ref.events.native).not.toContain('addtrack');
+      expect(ref.platforms.html.events.standard).toContain('play');
+      expect(ref.platforms.html.events.standard).not.toContain('addtrack');
     });
 
     it('surfaces a @fires event with its tag description', () => {
       const ref = findElement('SpfAudio')!.reference;
-      expect(ref.events.elementSpecific).toContainEqual({
+      expect(ref.platforms.html.events.custom).toContainEqual({
         name: 'audiomodechange',
         description: 'Fired when the audio-only rendition changes.',
       });
@@ -1626,7 +1708,7 @@ describe('Media element pipeline (end-to-end)', () => {
 
     it('includes @fires-declared events without a scanned dispatch site', () => {
       const ref = findElement('SpfAudio')!.reference;
-      expect(ref.events.elementSpecific).toContainEqual({
+      expect(ref.platforms.html.events.custom).toContainEqual({
         name: 'manifestparsed',
         description: 'Fired after the multivariant playlist is parsed.',
       });
@@ -1634,21 +1716,31 @@ describe('Media element pipeline (end-to-end)', () => {
 
     it('sorts element-specific events by name', () => {
       const ref = findElement('SpfAudio')!.reference;
-      const names = ref.events.elementSpecific.map((e) => e.name);
+      const names = ref.platforms.html.events.custom.map((e) => e.name);
       expect(names).toEqual([...names].sort());
     });
 
     it('has empty AudioCSSVars', () => {
       const ref = findElement('SpfAudio')!.reference;
-      expect(ref.cssCustomProperties).toEqual({});
+      expect(ref.platforms.html.cssCustomProperties).toEqual({});
     });
 
     it('extracts audio methods from the shared base host (no video-only methods)', () => {
       const ref = findElement('SpfAudio')!.reference;
       // Audio methods = media-host methods + audio-host methods. The fixture
       // audio host adds none, so video-only methods (requestFullscreen) are absent.
-      expect(ref.methods).toEqual(['canPlayType', 'load', 'pause', 'play']);
-      expect(ref.methods).not.toContain('requestFullscreen');
+      expect(ref.platforms.html.methods).toEqual(['canPlayType', 'load', 'pause', 'play']);
+      expect(ref.platforms.html.methods).not.toContain('requestFullscreen');
+    });
+
+    it('extracts native properties from the shared base host (no video-only props)', () => {
+      const ref = findElement('SpfAudio')!.reference;
+      // Audio native properties = media-host accessors only (audio host adds
+      // none), filtered to native members and deduped against hostProperties
+      // (src is re-declared by the mixin). videoWidth is video-only → absent.
+      expect(ref.platforms.html.properties.native).toEqual(['currentTime', 'volume']);
+      expect(ref.platforms.html.properties.native).not.toContain('videoWidth');
+      expect(ref.platforms.html.properties.native).not.toContain('src');
     });
   });
 });

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/custom-media-element/index.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/custom-media-element/index.ts
@@ -81,6 +81,7 @@ export function CustomMediaElement(tag: string, Host: any) {
       poster: { type: String },
       preload: { type: String },
       src: { type: String },
+      streamType: { type: String, attribute: 'stream-type' },
     };
   }
 

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/embed/index.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/embed/index.ts
@@ -1,0 +1,40 @@
+/** Mock iframe-backed media host — mirrors VimeoMedia. */
+export const embedMediaDefaultProps = {
+  src: '',
+  autoplay: false,
+};
+
+export class EmbedHost extends EventTarget {
+  #src = embedMediaDefaultProps.src;
+  #autoplay = embedMediaDefaultProps.autoplay;
+
+  get src(): string {
+    return this.#src;
+  }
+  set src(value: string) {
+    this.#src = value;
+  }
+
+  get autoplay(): boolean {
+    return this.#autoplay;
+  }
+  set autoplay(value: boolean) {
+    this.#autoplay = value;
+  }
+
+  /** Start playback through the embedded player. */
+  play(): Promise<void> {
+    this.dispatchEvent(new Event('play'));
+    return Promise.resolve();
+  }
+
+  attach(_target: HTMLIFrameElement): void {
+    const emit = (type: string) => this.dispatchEvent(new Event(type));
+    emit('waiting');
+    for (const type of ['loadedmetadata', 'adapterready']) {
+      this.dispatchEvent(new Event(type));
+    }
+  }
+  detach(): void {}
+  destroy(): void {}
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/media-host.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/media-host.ts
@@ -4,6 +4,10 @@
  * Exercises method extraction: the builder collects public instance methods
  * from this class (per media type) for the reference's `methods` field.
  * Lifecycle methods (attach/detach/destroy) and accessors are excluded.
+ *
+ * Also exercises native-property extraction: getters/setters whose names match
+ * native HTMLMediaElement members surface in `nativeProperties`; non-native
+ * accessors (e.g. `streamType`) and re-declared natives (`src`) do not.
  */
 export class HTMLMediaElementHost {
   // Lifecycle methods — excluded from `methods`.
@@ -14,10 +18,32 @@ export class HTMLMediaElementHost {
   // Internal — excluded by the `_` prefix.
   _forward(): void {}
 
-  // Accessor — excluded (getters/setters are properties, not methods).
+  // Accessor — excluded from `methods` (it's a property, not a method). Native
+  // member, but re-declared on engine hosts → deduped out of nativeProperties.
   get src(): string {
     return '';
   }
+
+  // Native passthroughs — surface in nativeProperties.
+  get currentTime(): number {
+    return 0;
+  }
+  set currentTime(_value: number) {}
+
+  get volume(): number {
+    return 1;
+  }
+  set volume(_value: number) {}
+
+  // Video.js-specific — NOT a native member, so excluded from nativeProperties.
+  /**
+   * Current stream type (`'on-demand'`, `'live'`, or `'unknown'`). Consumers can
+   * set it when the host does not detect the stream type automatically.
+   */
+  get streamType(): string {
+    return 'unknown';
+  }
+  set streamType(_value: string) {}
 
   play(): Promise<void> {
     return Promise.resolve();

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/video-host.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/media/video-host.ts
@@ -2,12 +2,24 @@
  * Mock video host base — mirrors the real video-host.ts.
  *
  * Exercises video-specific method extraction: requestFullscreen is added on
- * top of the shared media-host methods for video elements only.
+ * top of the shared media-host methods for video elements only. Also exercises
+ * video-only native-property extraction (videoWidth) and a non-native helper
+ * (isFullscreen) that must be filtered out of nativeProperties.
  */
 import { HTMLMediaElementHost } from './media-host';
 
 export class HTMLVideoElementHost extends HTMLMediaElementHost {
   requestFullscreen(): Promise<void> {
     return Promise.resolve();
+  }
+
+  // Native HTMLVideoElement member — surfaces in nativeProperties (video only).
+  get videoWidth(): number {
+    return 0;
+  }
+
+  // Video.js-specific helper — NOT a native member, excluded.
+  get isFullscreen(): boolean {
+    return false;
   }
 }

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/define/media/embed-video.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/define/media/embed-video.ts
@@ -1,0 +1,5 @@
+import { EmbedVideo } from '../../media/embed-video';
+
+export class EmbedVideoElement extends EmbedVideo {
+  static readonly tagName = 'embed-video';
+}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/media/embed-video/index.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/media/embed-video/index.ts
@@ -1,0 +1,10 @@
+import { CustomMediaElement } from '../../../../core/src/dom/media/custom-media-element';
+import { EmbedHost } from '../../../../core/src/dom/media/embed';
+
+function MediaAttachMixin(base: any) {
+  return base;
+}
+
+class EmbedCustomMediaElement extends CustomMediaElement('iframe', EmbedHost) {}
+
+export class EmbedVideo extends MediaAttachMixin(EmbedCustomMediaElement) {}

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/media/complex-video/index.tsx
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/media/complex-video/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * Mock React media component.
+ *
+ * Exercises the source conventions used by real media components:
+ * native React video props, a forwarded native-element ref, and a defaults
+ * object passed to useSyncProps for Video.js-specific props.
+ */
+import { complexMediaDefaultProps } from '../../../../core/src/dom/media/complex';
+
+interface VideoHTMLAttributes<Element> {
+  element?: Element;
+}
+
+interface ComplexVideoProps extends VideoHTMLAttributes<HTMLVideoElement>, Partial<typeof complexMediaDefaultProps> {}
+
+declare function forwardRef<Ref, Props>(render: (props: Props, ref: Ref) => unknown): unknown;
+declare function useSyncProps(target: object, props: object, defaults: object): object;
+
+export const ComplexVideo = forwardRef<HTMLVideoElement, ComplexVideoProps>(function ComplexVideo(props, ref) {
+  useSyncProps({}, props, complexMediaDefaultProps);
+  return { ref };
+});

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/media/embed-video/index.tsx
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/media/embed-video/index.tsx
@@ -1,0 +1,11 @@
+import { embedMediaDefaultProps } from '../../../../core/src/dom/media/embed';
+
+interface EmbedVideoProps extends Partial<typeof embedMediaDefaultProps> {}
+
+declare function forwardRef<Ref, Props>(render: (props: Props, ref: Ref) => unknown): unknown;
+declare function useSyncProps(target: object, props: object, defaults: object): object;
+
+export const EmbedVideo = forwardRef<HTMLIFrameElement, EmbedVideoProps>(function EmbedVideo(props, ref) {
+  useSyncProps({}, props, embedMediaDefaultProps);
+  return { ref };
+});

--- a/site/src/components/docs/api-reference/HtmlMediaReference.astro
+++ b/site/src/components/docs/api-reference/HtmlMediaReference.astro
@@ -1,0 +1,186 @@
+---
+import A from '@/components/typography/A.astro';
+import H3 from '@/components/typography/H3Markdown.astro';
+import MarkdownCode from '@/components/typography/MarkdownCode.astro';
+import P from '@/components/typography/P.astro';
+import Table from '@/components/typography/Table.astro';
+import Tbody from '@/components/typography/Tbody.astro';
+import Td from '@/components/typography/Td.astro';
+import Th from '@/components/typography/Th.astro';
+import Thead from '@/components/typography/Thead.astro';
+import Tr from '@/components/typography/Tr.astro';
+import type { HtmlMediaReference } from '@/types/media-reference';
+import ApiCSSVarsTable from './ApiCSSVarsTable.astro';
+import CodeChip from './CodeChip.astro';
+import MediaHostPropsTable from './MediaHostPropsTable.astro';
+
+interface Section {
+  key: string;
+  title: string;
+  id: string;
+}
+
+interface Props {
+  media: string;
+  mediaType: 'video' | 'audio';
+  data: HtmlMediaReference;
+  sections: Section[];
+}
+
+const { media, mediaType, data, sections } = Astro.props;
+const attributesSection = sections.find((section) => section.key === 'attributes');
+const propertiesSection = sections.find((section) => section.key === 'properties');
+const methodsSection = sections.find((section) => section.key === 'methods');
+const eventsSection = sections.find((section) => section.key === 'events');
+const cssSection = sections.find((section) => section.key === 'cssCustomProperties');
+
+const targetTag = `<${data.target}>`;
+const mdnElementUrl = `https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${mediaType}`;
+const nativeInterface = data.target === 'audio' ? 'HTMLAudioElement' : 'HTMLVideoElement';
+const mdnApiUrl = `https://developer.mozilla.org/en-US/docs/Web/API/${nativeInterface}`;
+const standardAttributes = [...data.attributes.standard].sort();
+const nativeProperties = [...data.properties.native].sort();
+const methods = [...data.methods].sort();
+const standardEvents = [...data.events.standard].sort();
+---
+
+{
+  attributesSection && (
+    <>
+      <H3 id={attributesSection.id}>{attributesSection.title}</H3>
+      {standardAttributes.length > 0 && (
+        <P>
+          Forwards these standard media attributes to the internal{" "}
+          <MarkdownCode>{targetTag}</MarkdownCode>. See the{" "}
+          <A href={mdnElementUrl}>MDN media element reference</A>:{" "}
+          <span class="code-list">
+            {standardAttributes.map((attribute) => (
+              <CodeChip value={attribute} />
+            ))}
+          </span>
+        </P>
+      )}
+      {Object.keys(data.attributes.custom).length > 0 && (
+        <>
+          <P>
+            {data.target === "iframe"
+              ? "These attributes configure the embedded media adapter:"
+              : "These Video.js-specific attributes configure media behavior:"}
+          </P>
+          <MediaHostPropsTable
+            hostProperties={data.attributes.custom}
+            componentName={`${media}-attribute`}
+            nameLabel="Attribute"
+          />
+        </>
+      )}
+    </>
+  )
+}
+
+{
+  propertiesSection && (
+    <>
+      <H3 id={propertiesSection.id}>{propertiesSection.title}</H3>
+      {Object.keys(data.properties.definitions).length > 0 && (
+        <MediaHostPropsTable
+          hostProperties={data.properties.definitions}
+          componentName={media}
+        />
+      )}
+      {nativeProperties.length > 0 && (
+        <P>
+          Also exposes these properties from the native media API. See{" "}
+          <A href={mdnApiUrl}>{nativeInterface}</A> for details:{" "}
+          <span class="code-list">
+            {nativeProperties.map((property) => (
+              <CodeChip value={property} />
+            ))}
+          </span>
+        </P>
+      )}
+    </>
+  )
+}
+
+{
+  methodsSection && (
+    <>
+      <H3 id={methodsSection.id}>{methodsSection.title}</H3>
+      <P>
+        <span>Supports these media methods</span>
+        {data.target === "iframe" ? (
+          ": "
+        ) : (
+          <>
+            . See <A href={mdnApiUrl}>{nativeInterface}</A> for details:{" "}
+          </>
+        )}
+        <span class="code-list">
+          {methods.map((method) => (
+            <CodeChip value={method} />
+          ))}
+        </span>
+      </P>
+    </>
+  )
+}
+
+{
+  eventsSection && (
+    <>
+      <H3 id={eventsSection.id}>{eventsSection.title}</H3>
+      {standardEvents.length > 0 && (
+        <P>
+          {data.target === "iframe"
+            ? "Implements these standard media events through the embedded player: "
+            : "Re-dispatches these standard media events from the internal media element: "}
+          <span class="code-list">
+            {standardEvents.map((event) => (
+              <CodeChip value={event} />
+            ))}
+          </span>
+        </P>
+      )}
+      {data.events.custom.length > 0 ? (
+        <>
+          <P>Also emits these Video.js-specific events:</P>
+          <Table maxWidth={false} outerClass="my-6">
+            <Thead>
+              <Tr>
+                <Th>Event</Th>
+                <Th>Description</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {data.events.custom.map((event) => (
+                <Tr>
+                  <Td class="align-top">
+                    <MarkdownCode>{event.name}</MarkdownCode>
+                  </Td>
+                  <Td class="align-top">{event.description ?? ""}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </>
+      ) : (
+        <P>
+          This element emits no events beyond the standard media events above.
+        </P>
+      )}
+    </>
+  )
+}
+
+{
+  cssSection && (
+    <>
+      <H3 id={cssSection.id}>{cssSection.title}</H3>
+      <ApiCSSVarsTable
+        cssCustomProperties={data.cssCustomProperties}
+        componentName={media}
+      />
+    </>
+  )
+}

--- a/site/src/components/docs/api-reference/MediaHostPropsTable.astro
+++ b/site/src/components/docs/api-reference/MediaHostPropsTable.astro
@@ -19,9 +19,10 @@ import DetailRow from './DetailRow.astro';
 interface Props {
   hostProperties: Record<string, HostPropertyDef>;
   componentName: string;
+  nameLabel?: string;
 }
 
-const { hostProperties, componentName } = Astro.props;
+const { hostProperties, componentName, nameLabel = 'Property' } = Astro.props;
 
 const entries = Object.entries(hostProperties).sort(([a], [b]) => a.localeCompare(b));
 ---
@@ -29,7 +30,7 @@ const entries = Object.entries(hostProperties).sort(([a], [b]) => a.localeCompar
 <Table maxWidth={false} outerClass="my-6">
   <Thead>
     <Tr>
-      <Th>Property</Th>
+      <Th>{nameLabel}</Th>
       <Th>Type</Th>
       <Th>Default</Th>
       <Th>Details</Th>

--- a/site/src/components/docs/api-reference/MediaReference.astro
+++ b/site/src/components/docs/api-reference/MediaReference.astro
@@ -1,23 +1,12 @@
 ---
 import { getEntry } from 'astro:content';
 import ContentWidth from '@/components/frames/ContentWidth.astro';
-import A from '@/components/typography/A.astro';
 import H2 from '@/components/typography/H2Markdown.astro';
-import H3 from '@/components/typography/H3Markdown.astro';
-import MarkdownCode from '@/components/typography/MarkdownCode.astro';
-import P from '@/components/typography/P.astro';
-import Table from '@/components/typography/Table.astro';
-import Tbody from '@/components/typography/Tbody.astro';
-import Td from '@/components/typography/Td.astro';
-import Th from '@/components/typography/Th.astro';
-import Thead from '@/components/typography/Thead.astro';
-import Tr from '@/components/typography/Tr.astro';
 import type { MediaReference } from '@/types/media-reference';
 import { resolveReferenceSlug } from '@/utils/api-reference-overrides';
 import { createMediaReferenceModel } from '@/utils/mediaReferenceModel';
-import ApiCSSVarsTable from './ApiCSSVarsTable.astro';
-import CodeChip from './CodeChip.astro';
-import MediaHostPropsTable from './MediaHostPropsTable.astro';
+import HtmlMediaReference from './HtmlMediaReference.astro';
+import ReactMediaReference from './ReactMediaReference.astro';
 
 interface Props {
   media: string;
@@ -25,239 +14,32 @@ interface Props {
 
 const { media } = Astro.props;
 const framework = Astro.params.framework === 'react' ? 'react' : 'html';
-
 const entry = await getEntry('mediaReference', resolveReferenceSlug(media));
 const ref: MediaReference | null = entry?.data ?? null;
 if (!ref) return;
 
 const model = createMediaReferenceModel(media, ref);
 if (!model) return;
-
-const hostPropsSection = model.sections.find((s: { key: string }) => s.key === 'hostProperties');
-const nativeAttrsSection = model.sections.find((s: { key: string }) => s.key === 'nativeAttributes');
-const eventsSection = model.sections.find((s: { key: string }) => s.key === 'events');
-const methodsSection = model.sections.find((s: { key: string }) => s.key === 'methods');
-const cssVarsSection = model.sections.find((s: { key: string }) => s.key === 'cssCustomProperties');
-const mediaTag = `<${ref.mediaType}>`;
-
-const mdnElementUrl = `https://developer.mozilla.org/en-US/docs/Web/HTML/Element/${ref.mediaType}`;
-const mdnEventsUrl = 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement#events';
-const mdnMethodsUrl = 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement';
-
-// React prop spellings for the native attributes that differ from their HTML
-// attribute names.
-const REACT_PROP_NAMES: Record<string, string> = {
-  autoplay: 'autoPlay',
-  playsinline: 'playsInline',
-  crossorigin: 'crossOrigin',
-};
-
-const sortedNativeAttributes = [...(ref.nativeAttributes ?? [])].sort();
-const attributeNames =
-  framework === 'react' ? sortedNativeAttributes.map((attr) => REACT_PROP_NAMES[attr] ?? attr) : sortedNativeAttributes;
-
-const sortedNativeEvents = [...(ref.events.native ?? [])].sort();
-const sortedMethods = [...(ref.methods ?? [])].sort();
-
-// React exposes synthetic event props for the standard media events only.
-// Track-list and Picture-in-Picture events have no prop and must be handled
-// with a ref + addEventListener. Source: @types/react DOMAttributes.
-const REACT_MEDIA_EVENTS = new Set([
-  'abort',
-  'canplay',
-  'canplaythrough',
-  'durationchange',
-  'emptied',
-  'ended',
-  'error',
-  'loadeddata',
-  'loadedmetadata',
-  'loadstart',
-  'pause',
-  'play',
-  'playing',
-  'progress',
-  'ratechange',
-  'resize',
-  'seeked',
-  'seeking',
-  'stalled',
-  'suspend',
-  'timeupdate',
-  'volumechange',
-  'waiting',
-]);
-const reactMappedEvents = sortedNativeEvents.filter((event) => REACT_MEDIA_EVENTS.has(event));
-const reactRefOnlyEvents = sortedNativeEvents.filter((event) => !REACT_MEDIA_EVENTS.has(event));
-
-const elementSpecificEvents = ref.events.elementSpecific;
+const platform = model.platforms[framework];
+if (!platform) return;
 ---
 
 <ContentWidth>
   <H2 id={model.heading.id}>{model.heading.text}</H2>
-
   {
-    hostPropsSection && (
-      <>
-        <H3 id={hostPropsSection.id}>{hostPropsSection.title}</H3>
-        <MediaHostPropsTable
-          hostProperties={ref.hostProperties}
-          componentName={media}
-        />
-      </>
-    )
-  }
-
-  {
-    nativeAttrsSection && framework === "html" && (
-      <>
-        <H3 id={nativeAttrsSection.id}>{nativeAttrsSection.title}</H3>
-        <P>
-          Forwards these media attributes to the internal{" "}
-          <MarkdownCode>{mediaTag}</MarkdownCode> element. The standard ones
-          behave as described in the{" "}
-          <A href={mdnElementUrl}>MDN media attributes reference</A>:{" "}
-          <span class="code-list">
-            {attributeNames.map((attr) => (
-              <CodeChip value={attr} />
-            ))}
-          </span>
-        </P>
-      </>
-    )
-  }
-
-  {
-    nativeAttrsSection && framework === "react" && (
-      <>
-        <H3 id={nativeAttrsSection.id}>{nativeAttrsSection.title}</H3>
-        <P>
-          Renders a native <MarkdownCode>{mediaTag}</MarkdownCode> element and
-          accepts these media attributes as React props. The standard ones
-          behave as described in the{" "}
-          <A href={mdnElementUrl}>MDN media attributes reference</A>:{" "}
-          <span class="code-list">
-            {attributeNames.map((attr) => (
-              <CodeChip value={attr} />
-            ))}
-          </span>
-        </P>
-      </>
-    )
-  }
-
-  {
-    eventsSection && (
-      <>
-        <H3 id={eventsSection.id}>{eventsSection.title}</H3>
-        {framework === "html" ? (
-          <P>
-            Re-dispatches these media events from the internal{" "}
-            <MarkdownCode>{mediaTag}</MarkdownCode> element, so you can listen
-            for them directly. See <A href={mdnEventsUrl}>media events</A>:{" "}
-            <span class="code-list">
-              {sortedNativeEvents.map((event) => (
-                <CodeChip value={event} />
-              ))}
-            </span>
-          </P>
-        ) : (
-          <>
-            <P>
-              Handle these media events with React event props (e.g.{" "}
-              <MarkdownCode>onPlay</MarkdownCode>,{" "}
-              <MarkdownCode>onTimeUpdate</MarkdownCode>). See{" "}
-              <A href={mdnEventsUrl}>media events</A>:{" "}
-              <span class="code-list">
-                {reactMappedEvents.map((event) => (
-                  <CodeChip value={event} />
-                ))}
-              </span>
-            </P>
-            {reactRefOnlyEvents.length > 0 && (
-              <P>
-                These media events have no React prop — attach a listener
-                through a <MarkdownCode>ref</MarkdownCode> with{" "}
-                <MarkdownCode>addEventListener</MarkdownCode>:{" "}
-                <span class="code-list">
-                  {reactRefOnlyEvents.map((event) => (
-                    <CodeChip value={event} />
-                  ))}
-                </span>
-              </P>
-            )}
-          </>
-        )}
-        {elementSpecificEvents.length === 0 ? (
-          <P>
-            This element dispatches no events beyond the media events above.
-          </P>
-        ) : (
-          <>
-            <P>Beyond the media events above, this element emits:</P>
-            <Table maxWidth={false} outerClass="my-6">
-              <Thead>
-                <Tr>
-                  <Th>Event</Th>
-                  <Th>Description</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {elementSpecificEvents.map((event) => (
-                  <Tr>
-                    <Td class="align-top">
-                      <MarkdownCode>{event.name}</MarkdownCode>
-                    </Td>
-                    <Td class="align-top">{event.description ?? ""}</Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-            {framework === "react" && (
-              <P>
-                These events have no built-in React prop. Attach a listener to
-                the element through a <MarkdownCode>ref</MarkdownCode> with{" "}
-                <MarkdownCode>addEventListener</MarkdownCode>.
-              </P>
-            )}
-          </>
-        )}
-      </>
-    )
-  }
-
-  {
-    methodsSection && (
-      <>
-        <H3 id={methodsSection.id}>{methodsSection.title}</H3>
-        <P>
-          Supports these methods from the native media API. See{" "}
-          <A href={mdnMethodsUrl}>HTMLMediaElement</A> for the core methods:{" "}
-          <span class="code-list">
-            {sortedMethods.map((method) => (
-              <CodeChip value={method} />
-            ))}
-          </span>
-        </P>
-        {framework === "react" && (
-          <P>
-            In React, call these through a <MarkdownCode>ref</MarkdownCode> to
-            the element.
-          </P>
-        )}
-      </>
-    )
-  }
-
-  {
-    cssVarsSection && (
-      <>
-        <H3 id={cssVarsSection.id}>{cssVarsSection.title}</H3>
-        <ApiCSSVarsTable
-          cssCustomProperties={ref.cssCustomProperties}
-          componentName={media}
-        />
-      </>
+    framework === "html" ? (
+      <HtmlMediaReference
+        media={media}
+        mediaType={ref.mediaType}
+        data={platform.data}
+        sections={platform.sections}
+      />
+    ) : (
+      <ReactMediaReference
+        media={media}
+        data={platform.data}
+        sections={platform.sections}
+      />
     )
   }
 </ContentWidth>

--- a/site/src/components/docs/api-reference/ReactMediaReference.astro
+++ b/site/src/components/docs/api-reference/ReactMediaReference.astro
@@ -1,0 +1,81 @@
+---
+import A from '@/components/typography/A.astro';
+import H3 from '@/components/typography/H3Markdown.astro';
+import MarkdownCode from '@/components/typography/MarkdownCode.astro';
+import P from '@/components/typography/P.astro';
+import type { ReactMediaReference } from '@/types/media-reference';
+import MediaHostPropsTable from './MediaHostPropsTable.astro';
+
+interface Section {
+  key: string;
+  title: string;
+  id: string;
+}
+
+interface Props {
+  media: string;
+  data: ReactMediaReference;
+  sections: Section[];
+}
+
+const { media, data, sections } = Astro.props;
+const propsSection = sections.find((section) => section.key === 'props');
+const refSection = sections.find((section) => section.key === 'ref');
+const eventsSection = sections.find((section) => section.key === 'events');
+
+const targetTag = `<${data.target}>`;
+const nativeInterface =
+  data.target === 'video' ? 'HTMLVideoElement' : data.target === 'audio' ? 'HTMLAudioElement' : 'HTMLIFrameElement';
+const mdnApiUrl = `https://developer.mozilla.org/en-US/docs/Web/API/${nativeInterface}`;
+---
+
+{
+  propsSection && (
+    <>
+      <H3 id={propsSection.id}>{propsSection.title}</H3>
+      {data.acceptsNativeProps && (
+        <P>
+          Accepts the standard React props for a native{" "}
+          <MarkdownCode>{targetTag}</MarkdownCode>, plus these Video.js-specific
+          props:
+        </P>
+      )}
+      <MediaHostPropsTable
+        hostProperties={data.props}
+        componentName={media}
+        nameLabel="Prop"
+      />
+    </>
+  )
+}
+
+{
+  refSection && (
+    <>
+      <H3 id={refSection.id}>{refSection.title}</H3>
+      <P>
+        Forwards its ref to the rendered{" "}
+        <MarkdownCode>{targetTag}</MarkdownCode>. The ref is an{" "}
+        <A href={mdnApiUrl}>{nativeInterface}</A>
+        {data.target === "iframe"
+          ? ". Control playback with the component props and player APIs rather than the iframe ref."
+          : " and exposes its complete native property and method API."}
+      </P>
+    </>
+  )
+}
+
+{
+  eventsSection && (
+    <>
+      <H3 id={eventsSection.id}>{eventsSection.title}</H3>
+      <P>
+        Handle standard media events with React event props such as{" "}
+        <MarkdownCode>onPlay</MarkdownCode> and{" "}
+        <MarkdownCode>onTimeUpdate</MarkdownCode>. For native events without a
+        React prop, attach a listener through the ref with{" "}
+        <MarkdownCode>addEventListener</MarkdownCode>.
+      </P>
+    </>
+  )
+}

--- a/site/src/components/docs/api-reference/ReactMediaReference.astro
+++ b/site/src/components/docs/api-reference/ReactMediaReference.astro
@@ -22,6 +22,7 @@ const { media, data, sections } = Astro.props;
 const propsSection = sections.find((section) => section.key === 'props');
 const refSection = sections.find((section) => section.key === 'ref');
 const eventsSection = sections.find((section) => section.key === 'events');
+const hasVideoJsProps = Object.keys(data.props).length > 0;
 
 const targetTag = `<${data.target}>`;
 const nativeInterface =
@@ -33,18 +34,30 @@ const mdnApiUrl = `https://developer.mozilla.org/en-US/docs/Web/API/${nativeInte
   propsSection && (
     <>
       <H3 id={propsSection.id}>{propsSection.title}</H3>
-      {data.acceptsNativeProps && (
+      {data.acceptsNativeProps && hasVideoJsProps && (
         <P>
           Accepts the standard React props for a native{" "}
-          <MarkdownCode>{targetTag}</MarkdownCode>, plus these Video.js-specific
-          props:
+          <MarkdownCode>{targetTag}</MarkdownCode>
+          {", plus these Video.js-specific props:"}
         </P>
       )}
-      <MediaHostPropsTable
-        hostProperties={data.props}
-        componentName={media}
-        nameLabel="Prop"
-      />
+      {data.acceptsNativeProps && !hasVideoJsProps && (
+        <P>
+          Accepts the standard React props for a native{" "}
+          <MarkdownCode>{targetTag}</MarkdownCode>
+          {"."}
+        </P>
+      )}
+      {!data.acceptsNativeProps && hasVideoJsProps && (
+        <P>Accepts these Video.js-specific props:</P>
+      )}
+      {hasVideoJsProps && (
+        <MediaHostPropsTable
+          hostProperties={data.props}
+          componentName={media}
+          nameLabel="Prop"
+        />
+      )}
     </>
   )
 }

--- a/site/src/types/media-reference.ts
+++ b/site/src/types/media-reference.ts
@@ -13,20 +13,44 @@ export const MediaEventDefSchema = z.object({
   description: z.string().optional(),
 });
 
-export const MediaReferenceSchema = z.object({
-  name: z.string(),
-  tagName: z.string(),
-  mediaType: z.enum(['video', 'audio']),
-  hostProperties: z.record(z.string(), HostPropertyDefSchema),
-  nativeAttributes: z.array(z.string()),
-  events: z.object({
+const MediaTargetTagSchema = z.enum(['video', 'audio', 'iframe']);
+
+const HtmlMediaReferenceSchema = z.object({
+  target: MediaTargetTagSchema,
+  attributes: z.object({
+    standard: z.array(z.string()),
+    custom: z.record(z.string(), HostPropertyDefSchema),
+  }),
+  properties: z.object({
+    definitions: z.record(z.string(), HostPropertyDefSchema),
     native: z.array(z.string()),
-    elementSpecific: z.array(MediaEventDefSchema),
+  }),
+  events: z.object({
+    standard: z.array(z.string()),
+    custom: z.array(MediaEventDefSchema),
   }),
   methods: z.array(z.string()),
   cssCustomProperties: z.record(z.string(), z.object({ description: z.string() })),
 });
 
+const ReactMediaReferenceSchema = z.object({
+  target: MediaTargetTagSchema,
+  acceptsNativeProps: z.boolean(),
+  props: z.record(z.string(), HostPropertyDefSchema),
+});
+
+export const MediaReferenceSchema = z.object({
+  name: z.string(),
+  tagName: z.string(),
+  mediaType: z.enum(['video', 'audio']),
+  platforms: z.object({
+    html: HtmlMediaReferenceSchema,
+    react: ReactMediaReferenceSchema.optional(),
+  }),
+});
+
 export type HostPropertyDef = z.infer<typeof HostPropertyDefSchema>;
 export type MediaEventDef = z.infer<typeof MediaEventDefSchema>;
 export type MediaReference = z.infer<typeof MediaReferenceSchema>;
+export type HtmlMediaReference = MediaReference['platforms']['html'];
+export type ReactMediaReference = NonNullable<MediaReference['platforms']['react']>;

--- a/site/src/utils/mediaReferenceModel.js
+++ b/site/src/utils/mediaReferenceModel.js
@@ -43,7 +43,7 @@ const REACT_SUBSECTIONS = Object.freeze([
     key: 'props',
     title: 'Props',
     id: 'props',
-    isEmpty: (react) => Object.keys(react.props ?? {}).length === 0,
+    isEmpty: (react) => !react.acceptsNativeProps && Object.keys(react.props ?? {}).length === 0,
   },
   {
     key: 'ref',

--- a/site/src/utils/mediaReferenceModel.js
+++ b/site/src/utils/mediaReferenceModel.js
@@ -1,48 +1,67 @@
 /**
- * Centralized media element API subsection definitions.
- *
- * Mirrors componentReferenceModel.js for media elements. Produces heading/id
- * data consumed by both MediaReference.astro and satteriConditionalHeadings.
+ * Centralized media API subsection definitions shared by the renderer and the
+ * generated table of contents.
  */
 
-const MEDIA_REFERENCE_SUBSECTIONS = Object.freeze([
+const HTML_SUBSECTIONS = Object.freeze([
   {
-    key: 'hostProperties',
-    title: 'Host Properties',
-    id: 'host-properties',
-    isEmpty: (ref) => Object.keys(ref.hostProperties ?? {}).length === 0,
-  },
-  {
-    key: 'nativeAttributes',
+    key: 'attributes',
     title: 'Attributes',
     id: 'attributes',
-    isEmpty: (ref) => (ref.nativeAttributes ?? []).length === 0,
+    isEmpty: (html) =>
+      (html.attributes?.standard ?? []).length === 0 && Object.keys(html.attributes?.custom ?? {}).length === 0,
   },
   {
-    key: 'events',
-    title: 'Events',
-    id: 'events',
-    isEmpty: (ref) => (ref.events?.native ?? []).length === 0 && (ref.events?.elementSpecific ?? []).length === 0,
+    key: 'properties',
+    title: 'Properties',
+    id: 'properties',
+    isEmpty: (html) =>
+      Object.keys(html.properties?.definitions ?? {}).length === 0 && (html.properties?.native ?? []).length === 0,
   },
   {
     key: 'methods',
     title: 'Methods',
     id: 'methods',
-    isEmpty: (ref) => (ref.methods ?? []).length === 0,
+    isEmpty: (html) => (html.methods ?? []).length === 0,
+  },
+  {
+    key: 'events',
+    title: 'Events',
+    id: 'events',
+    isEmpty: (html) => (html.events?.standard ?? []).length === 0 && (html.events?.custom ?? []).length === 0,
   },
   {
     key: 'cssCustomProperties',
-    title: 'CSS Custom Properties',
+    title: 'CSS custom properties',
     id: 'css-custom-properties',
-    isEmpty: (ref) => Object.keys(ref.cssCustomProperties ?? {}).length === 0,
+    isEmpty: (html) => Object.keys(html.cssCustomProperties ?? {}).length === 0,
   },
 ]);
 
-export function createMediaReferenceModel(mediaName, ref) {
-  if (!ref) return null;
+const REACT_SUBSECTIONS = Object.freeze([
+  {
+    key: 'props',
+    title: 'Props',
+    id: 'props',
+    isEmpty: (react) => Object.keys(react.props ?? {}).length === 0,
+  },
+  {
+    key: 'ref',
+    title: 'Ref',
+    id: 'ref',
+    isEmpty: () => false,
+  },
+  {
+    key: 'events',
+    title: 'Events',
+    id: 'events',
+    isEmpty: (react) => !react.acceptsNativeProps,
+  },
+]);
 
-  const sections = MEDIA_REFERENCE_SUBSECTIONS.flatMap((definition) => {
-    if (definition.isEmpty(ref)) return [];
+function createSections(definitions, source) {
+  return definitions.flatMap((definition) => {
+    if (definition.isEmpty(source)) return [];
     return [
       {
         key: definition.key,
@@ -52,6 +71,10 @@ export function createMediaReferenceModel(mediaName, ref) {
       },
     ];
   });
+}
+
+export function createMediaReferenceModel(mediaName, ref) {
+  if (!ref) return null;
 
   return {
     mediaName,
@@ -60,7 +83,20 @@ export function createMediaReferenceModel(mediaName, ref) {
       depth: 2,
       text: 'API Reference',
     },
-    sections,
+    platforms: {
+      html: {
+        sections: createSections(HTML_SUBSECTIONS, ref.platforms.html),
+        data: ref.platforms.html,
+      },
+      ...(ref.platforms.react
+        ? {
+            react: {
+              sections: createSections(REACT_SUBSECTIONS, ref.platforms.react),
+              data: ref.platforms.react,
+            },
+          }
+        : {}),
+    },
     data: ref,
   };
 }
@@ -76,12 +112,17 @@ export function buildMediaReferenceTocHeadings(model) {
     },
   ];
 
-  for (const section of model.sections) {
-    headings.push({
-      depth: section.depth,
-      text: section.title,
-      slug: section.id,
-    });
+  for (const framework of ['html', 'react']) {
+    const platform = model.platforms[framework];
+    if (!platform) continue;
+    for (const section of platform.sections) {
+      headings.push({
+        depth: section.depth,
+        text: section.title,
+        slug: section.id,
+        frameworks: [framework],
+      });
+    }
   }
 
   return headings;

--- a/site/src/utils/tests/mediaReferenceModel.test.ts
+++ b/site/src/utils/tests/mediaReferenceModel.test.ts
@@ -64,6 +64,21 @@ describe('createMediaReferenceModel', () => {
     expect(model.platforms.react.sections.map((section) => section.key)).toEqual(['props', 'ref', 'events']);
   });
 
+  it('keeps the React props section when only standard native props are accepted', () => {
+    const ref = makeRef();
+    ref.platforms.react.props = {};
+    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    expect(model.platforms.react.sections.some((section) => section.key === 'props')).toBe(true);
+  });
+
+  it('omits the React props section when the component accepts no props', () => {
+    const ref = makeRef();
+    ref.platforms.react.acceptsNativeProps = false;
+    ref.platforms.react.props = {};
+    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    expect(model.platforms.react.sections.some((section) => section.key === 'props')).toBe(false);
+  });
+
   it('drops an empty HTML section', () => {
     const ref = makeRef();
     ref.platforms.html.properties = { definitions: {}, native: [] };

--- a/site/src/utils/tests/mediaReferenceModel.test.ts
+++ b/site/src/utils/tests/mediaReferenceModel.test.ts
@@ -6,17 +6,39 @@ function makeRef(overrides = {}) {
   return {
     name: 'HlsJsVideo',
     tagName: 'hlsjs-video',
-    hostProperties: {
-      src: { type: 'string', readonly: false },
-      streamType: { type: 'string', readonly: true },
+    mediaType: 'video',
+    platforms: {
+      html: {
+        target: 'video',
+        attributes: {
+          standard: ['src', 'autoplay', 'controls'],
+          custom: {
+            'stream-type': { type: 'string', readonly: false },
+          },
+        },
+        properties: {
+          definitions: {
+            src: { type: 'string', readonly: false },
+            streamType: { type: 'string', readonly: false },
+          },
+          native: ['currentTime', 'duration', 'volume'],
+        },
+        events: {
+          standard: ['play', 'pause'],
+          custom: [{ name: 'streamtypechange', description: 'Fired when the stream type changes.' }],
+        },
+        methods: ['canPlayType', 'load', 'pause', 'play'],
+        cssCustomProperties: { '--media-object-fit': { description: 'Object fit.' } },
+      },
+      react: {
+        target: 'video',
+        acceptsNativeProps: true,
+        props: {
+          src: { type: 'string', readonly: false },
+          streamType: { type: 'string', readonly: false },
+        },
+      },
     },
-    nativeAttributes: ['src', 'autoplay', 'controls', 'loop', 'muted', 'playsinline', 'poster'],
-    events: {
-      native: ['play', 'pause'],
-      elementSpecific: [{ name: 'streamtypechange', description: 'Fired when the stream type changes.' }],
-    },
-    methods: ['canPlayType', 'load', 'pause', 'play', 'requestFullscreen'],
-    cssCustomProperties: { '--media-object-fit': { description: 'Object fit.' } },
     ...overrides,
   };
 }
@@ -26,39 +48,41 @@ describe('createMediaReferenceModel', () => {
     expect(createMediaReferenceModel('HlsJsVideo', null)).toBeNull();
   });
 
-  it('titles the attributes section "Attributes"', () => {
+  it('uses the HTML API subsection order', () => {
     const model = createMediaReferenceModel('HlsJsVideo', makeRef());
-    const attrs = model.sections.find((s) => s.key === 'nativeAttributes');
-    expect(attrs).toMatchObject({ title: 'Attributes', id: 'attributes' });
+    expect(model.platforms.html.sections.map((section) => section.key)).toEqual([
+      'attributes',
+      'properties',
+      'methods',
+      'events',
+      'cssCustomProperties',
+    ]);
   });
 
-  it('drops sections with no data', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef({ hostProperties: {} }));
-    const keys = model.sections.map((s) => s.key);
-    expect(keys).not.toContain('hostProperties');
-  });
-
-  it('keeps the events section when only native events exist', () => {
-    const model = createMediaReferenceModel(
-      'DashVideo',
-      makeRef({ events: { native: ['play'], elementSpecific: [] } })
-    );
-    expect(model.sections.some((s) => s.key === 'events')).toBe(true);
-  });
-
-  it('includes a methods section after events when methods exist', () => {
+  it('uses React-specific props and ref sections', () => {
     const model = createMediaReferenceModel('HlsJsVideo', makeRef());
-    const keys = model.sections.map((s) => s.key);
-    expect(keys).toContain('methods');
-    expect(keys.indexOf('methods')).toBeGreaterThan(keys.indexOf('events'));
-    expect(keys.indexOf('methods')).toBeLessThan(keys.indexOf('cssCustomProperties'));
-    const methods = model.sections.find((s) => s.key === 'methods');
-    expect(methods).toMatchObject({ title: 'Methods', id: 'methods' });
+    expect(model.platforms.react.sections.map((section) => section.key)).toEqual(['props', 'ref', 'events']);
   });
 
-  it('drops the methods section when there are no methods', () => {
-    const model = createMediaReferenceModel('HlsJsVideo', makeRef({ methods: [] }));
-    expect(model.sections.some((s) => s.key === 'methods')).toBe(false);
+  it('drops an empty HTML section', () => {
+    const ref = makeRef();
+    ref.platforms.html.properties = { definitions: {}, native: [] };
+    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    expect(model.platforms.html.sections.some((section) => section.key === 'properties')).toBe(false);
+  });
+
+  it('keeps the HTML properties section when only native properties exist', () => {
+    const ref = makeRef();
+    ref.platforms.html.properties.definitions = {};
+    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    expect(model.platforms.html.sections.some((section) => section.key === 'properties')).toBe(true);
+  });
+
+  it('omits React events when the component does not accept native media props', () => {
+    const ref = makeRef();
+    ref.platforms.react.acceptsNativeProps = false;
+    const model = createMediaReferenceModel('HlsJsVideo', ref);
+    expect(model.platforms.react.sections.some((section) => section.key === 'events')).toBe(false);
   });
 });
 
@@ -67,10 +91,16 @@ describe('buildMediaReferenceTocHeadings', () => {
     expect(buildMediaReferenceTocHeadings(null)).toEqual([]);
   });
 
-  it('emits the API Reference heading followed by section headings', () => {
+  it('marks platform-specific headings for TOC filtering', () => {
     const model = createMediaReferenceModel('HlsJsVideo', makeRef());
     const headings = buildMediaReferenceTocHeadings(model);
     expect(headings[0]).toEqual({ depth: 2, text: 'API Reference', slug: 'api-reference' });
-    expect(headings).toContainEqual({ depth: 3, text: 'Attributes', slug: 'attributes' });
+    expect(headings).toContainEqual({
+      depth: 3,
+      text: 'Attributes',
+      slug: 'attributes',
+      frameworks: ['html'],
+    });
+    expect(headings).toContainEqual({ depth: 3, text: 'Props', slug: 'props', frameworks: ['react'] });
   });
 });


### PR DESCRIPTION
Fixes #1717

## Summary

Make media element reference pages describe the complete public API exposed by each framework. The generator now derives HTML and React reference surfaces from normal source conventions, keeping references accurate without per-element documentation configuration.

## Changes

- Surface inherited native media properties such as `currentTime`, `duration`, `volume`, `buffered`, `textTracks`, and video dimensions.
- Generate standard and Video.js-specific attributes from runtime property mappings, host accessors, JSDoc, and defaults; `stream-type` is now documented from its source definition.
- Give HTML and React distinct reference models: HTML documents custom-element attributes, properties, methods, events, and CSS; React documents component props, its native ref target, and event handling.
- Respect the actual rendered target (`video`, `audio`, or `iframe`), so iframe-backed adapters do not inherit fictional native video APIs and list only events they implement.
- Add black-box end-to-end fixtures for native inheritance, React conventions, and iframe-backed media.

<details>
<summary>Implementation details</summary>

The generator treats existing runtime conventions as its input: `CustomMediaElement(...)` declares the HTML target and property mappings, `forwardRef<...>` declares the React ref target, native React attribute inheritance opts into standard DOM props, and the defaults object passed to `useSyncProps` declares Video.js-specific React props. The shared frontend renders a normalized, platform-specific model.

</details>

## Testing

- `pnpm build:packages`
- `pnpm -F site api-docs`
- `pnpm test`
- `pnpm -F site test` (490 tests)
- `pnpm typecheck`
- `pnpm exec astro check` (0 errors)
- `pnpm lint`
- `pnpm check:workspace`
- Manual browser verification of the HTML and React reference pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large schema and generator changes affect all generated media reference JSON and docs pages; behavior is heavily tested but any missed consumer of the old shape would break at build time.
> 
> **Overview**
> **Media element API reference pages** now describe the full public surface per framework instead of a single flat host-property list.
> 
> The **api-docs builder** reshapes output into `platforms.html` and optional `platforms.react`: HTML gets target tag (`video` / `audio` / `iframe`), standard vs Video.js-specific attributes, property definitions plus a compact **native passthrough** list (from shared `media-host` / `video-host` / `audio-host`), methods, events, and CSS. React is inferred from `forwardRef`, `VideoHTMLAttributes` / `AudioHTMLAttributes`, and `useSyncProps` defaults. **`CustomMediaElement`** discovery now records `iframe` targets and can find compositions on thin subclasses (e.g. Vimeo-style). Iframe-backed elements skip fictional native video APIs; only host-implemented attributes and dispatched/`emit` events are documented.
> 
> **Site rendering** splits into `HtmlMediaReference.astro` and `ReactMediaReference.astro`, with TOC/section models updated for platform-specific headings. **`streamType`** on `HTMLMediaElementHost` gains JSDoc used in generated docs.
> 
> E2E fixtures add **EmbedVideo** (iframe), React convention tests, and native-property inheritance coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160c46be39f0316cdec5561a2ab8b0879aaff151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->