### PR TITLE
fix(skin): aspect ratio related fixes

### DIFF
--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -62,7 +62,7 @@ test.describe('Visual — HTML Portrait Layout', () => {
 
       root.innerHTML = `
         <video-player>
-          <video-skin style="max-width: 800px; aspect-ratio: 16/9">
+          <video-skin style="width: 320px; aspect-ratio: 16/9">
             <video width="270" height="480" playsinline></video>
           </video-skin>
         </video-player>
@@ -80,6 +80,54 @@ test.describe('Visual — HTML Portrait Layout', () => {
 
     expect(box).not.toBeNull();
     expect(box!.width / box!.height).toBeCloseTo(16 / 9, 1);
+  });
+
+  test('caps portrait thumbnails to the configured max height', async ({ page }) => {
+    const src = `data:image/svg+xml,${encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="270" height="480" viewBox="0 0 270 480"><rect width="270" height="480" fill="black"/></svg>'
+    )}`;
+
+    await page.evaluate((url) => {
+      const thumbnail = document
+        .querySelector('video-skin')
+        ?.shadowRoot?.querySelector('media-slider-thumbnail') as HTMLElement & {
+        thumbnails?: Array<{ url: string; startTime: number; width: number; height: number }>;
+      };
+
+      if (!thumbnail) return;
+      thumbnail.thumbnails = [{ url, startTime: 0, width: 270, height: 480 }];
+    }, src);
+
+    await page.waitForFunction(() => {
+      const thumbnail = document.querySelector('video-skin')?.shadowRoot?.querySelector('media-slider-thumbnail');
+
+      return (
+        thumbnail &&
+        !thumbnail.hasAttribute('data-hidden') &&
+        !thumbnail.hasAttribute('data-loading') &&
+        parseFloat(getComputedStyle(thumbnail).height) > 0
+      );
+    });
+
+    const size = await page.evaluate(() => {
+      const thumbnail = document.querySelector('video-skin')!.shadowRoot!.querySelector('media-slider-thumbnail')!;
+      const style = getComputedStyle(thumbnail);
+      const probe = document.createElement('div');
+      probe.style.height = style.getPropertyValue('--media-slider-thumbnail-max-height');
+      document.body.append(probe);
+
+      const configuredMaxHeight = parseFloat(getComputedStyle(probe).height);
+      probe.remove();
+
+      return {
+        height: parseFloat(style.height),
+        configuredMaxHeight,
+        maxHeight: parseFloat(style.maxHeight),
+      };
+    });
+
+    expect(size.maxHeight).toBeCloseTo(size.configuredMaxHeight, 0);
+    expect(size.height).toBeLessThanOrEqual(size.maxHeight);
   });
 });
 

--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -50,6 +50,39 @@ for (const { name, path } of VISUAL_PAGES) {
   });
 }
 
+// --- Portrait media layout ---
+
+test.describe('Visual — HTML Portrait Layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/pages/html-video-mp4.html', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => customElements.get('video-skin'));
+    await page.evaluate(() => {
+      const root = document.getElementById('root');
+      if (!root) return;
+
+      root.innerHTML = `
+        <video-player>
+          <video-skin style="max-width: 800px; aspect-ratio: 16/9">
+            <video width="270" height="480" playsinline></video>
+          </video-skin>
+        </video-player>
+      `;
+    });
+  });
+
+  test('keeps the authored skin aspect ratio', async ({ page }) => {
+    const box = await page.evaluate(() => {
+      const container = document.querySelector('video-skin')?.shadowRoot?.querySelector('media-container');
+      const rect = container?.getBoundingClientRect();
+
+      return rect ? { height: rect.height, width: rect.width } : null;
+    });
+
+    expect(box).not.toBeNull();
+    expect(box!.width / box!.height).toBeCloseTo(16 / 9, 1);
+  });
+});
+
 // --- Captions snapshot (dedicated page with subtitle track baked in) ---
 
 test.describe('Visual — Captions', () => {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -31,6 +31,12 @@ export const SOURCES = {
     type: 'hls',
     subType: 'mp4',
   },
+  'hls-6': {
+    label: 'HLS - Tailwind (portrait)',
+    url: 'https://stream.mux.com/vth873zxidmhBVVRWBKcPTxnSQ302QqUm.m3u8',
+    type: 'hls',
+    subType: 'mp4',
+  },
   'hls-multi-audio': {
     label: 'HLS - Multi-language audio',
     url: 'https://stream.mux.com/s41JYeqIpBMBzE4OzxDyGR2yrp2hD1CQ6gJN9SlVGDQ.m3u8',

--- a/packages/html/src/define/shared.css
+++ b/packages/html/src/define/shared.css
@@ -12,6 +12,11 @@ media-tooltip-group {
   width: 100%;
 }
 
+media-container {
+  min-width: 0;
+  min-height: 0;
+}
+
 /* Hide volume popover when volume control is unsupported (e.g., iOS Safari). */
 .media-popover--volume:has(media-volume-slider[data-availability="unsupported"]) {
   display: none;

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -248,6 +248,7 @@
 
 .media-default-skin--video .media-slider__thumbnail {
   --media-slider-thumbnail-max-width: 11rem;
+  --media-slider-thumbnail-max-height: 8rem;
   --media-slider-thumbnail-padding: -1.125rem;
   /**
     Inset is the difference between the container width and the slider (100%) width.
@@ -285,10 +286,7 @@
 
   & .media-thumbnail__image {
     max-width: var(--media-slider-thumbnail-max-width);
-  }
-
-  &:has(.media-thumbnail__image[data-loading]) {
-    max-height: 6rem;
+    max-height: var(--media-slider-thumbnail-max-height);
   }
 }
 .media-default-skin--video .media-slider[data-pointing] .media-slider__thumbnail:has([role="img"]:not([data-hidden])) {

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -155,16 +155,22 @@ export const thumbnail = {
   root: cn(
     baseThumbnail.root,
     surface,
-    '[--media-slider-thumbnail-max-width:11rem] [--media-slider-thumbnail-padding:-1.125rem] [--media-slider-thumbnail-inset:calc((100cqi-100%)/2)]',
+    '[--media-slider-thumbnail-max-width:11rem]',
+    '[--media-slider-thumbnail-max-height:8rem]',
+    '[--media-slider-thumbnail-padding:-1.125rem]',
+    '[--media-slider-thumbnail-inset:calc((100cqi-100%)/2)]',
     'absolute [left:clamp(calc(var(--media-slider-thumbnail-max-width)/2+var(--media-slider-thumbnail-padding)-var(--media-slider-thumbnail-inset)),var(--media-slider-pointer),calc(100%-var(--media-slider-thumbnail-max-width)/2-var(--media-slider-thumbnail-padding)+var(--media-slider-thumbnail-inset)))] bottom-[calc(100%+1.2rem)] -translate-x-1/2',
     'opacity-0 scale-80 blur-sm origin-bottom',
     'transition-[scale,opacity,filter] duration-150',
     'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:opacity-100',
     'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:scale-100',
-    'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:blur-none',
-    'has-[[role=img][data-loading]]:max-h-24'
+    'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:blur-none'
   ),
-  image: cn(baseThumbnail.image, 'max-w-(--media-slider-thumbnail-max-width)'),
+  image: cn(
+    baseThumbnail.image,
+    'max-w-(--media-slider-thumbnail-max-width)',
+    'max-h-(--media-slider-thumbnail-max-height)'
+  ),
 };
 
 /* ==========================================================================

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -267,6 +267,7 @@
 
 .media-minimal-skin--video .media-slider__thumbnail {
   --media-slider-thumbnail-max-width: 11rem;
+  --media-slider-thumbnail-max-height: 8rem;
   --media-slider-thumbnail-padding: -0.5rem;
   /**
     Inset is the difference between the container width and the slider (100%) width.
@@ -317,10 +318,7 @@
 
   & .media-thumbnail__image {
     max-width: var(--media-slider-thumbnail-max-width);
-  }
-
-  &:has(.media-thumbnail__image[data-loading]) {
-    max-height: 6rem;
+    max-height: var(--media-slider-thumbnail-max-height);
   }
 }
 .media-minimal-skin--video .media-slider[data-pointing] .media-slider__thumbnail:has([role="img"]:not([data-hidden])) {

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -163,22 +163,28 @@ export const thumbnail = {
   ...baseThumbnail,
   root: cn(
     baseThumbnail.root,
-    '[--media-slider-thumbnail-max-width:11rem] [--media-slider-thumbnail-padding:-0.5rem] [--media-slider-thumbnail-inset:calc(100cqi-100%)]',
+    '[--media-slider-thumbnail-max-width:11rem]',
+    '[--media-slider-thumbnail-max-height:8rem]',
+    '[--media-slider-thumbnail-padding:-0.5rem]',
+    '[--media-slider-thumbnail-inset:calc(100cqi-100%)]',
     'absolute [left:clamp(calc(var(--media-slider-thumbnail-max-width)/2+var(--media-slider-thumbnail-padding)),var(--media-slider-pointer),calc(100%-var(--media-slider-thumbnail-max-width)/2-var(--media-slider-thumbnail-padding)+var(--media-slider-thumbnail-inset)))] bottom-full -translate-x-1/2',
     '@2xl/media-root:[left:var(--media-slider-pointer)]',
     'opacity-0 scale-80 blur-sm origin-bottom',
     'transition-[scale,opacity,filter] duration-150',
     'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:opacity-100',
     'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:scale-100',
-    'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:blur-none',
-    'has-[[role=img][data-loading]]:max-h-24'
+    'has-[[role=img]:not([data-hidden])]:group-data-pointing/slider:blur-none'
   ),
   imageWrapper: cn(
     baseThumbnail.imageWrapper,
     'after:absolute after:inset-0 after:rounded-[inherit]',
     'after:ring-1 after:ring-black/5 after:shadow-sm after:shadow-black/20'
   ),
-  image: cn(baseThumbnail.image, 'max-w-(--media-slider-thumbnail-max-width)'),
+  image: cn(
+    baseThumbnail.image,
+    'max-w-(--media-slider-thumbnail-max-width)',
+    'max-h-(--media-slider-thumbnail-max-height)'
+  ),
 };
 
 /* ==========================================================================


### PR DESCRIPTION
- Set `min-width: 0` and `min-height: 0` on `media-container` in the HTML skins so that slotted portrait videos can’t force the shadow container past the skin host’s authored aspect ratio. 
- Set a `max-height` on the slider thumbnails so that portrait thumbs don't overflow. I could have gone fancy here and used `cqb` units but I think this simple fix is enough for now. 
- Added a portrait video example (Dar's Tailwind video) as a source option for future testing. 

Closes #1716

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and layout-only changes with new visual tests; no playback, auth, or data-path changes.
> 
> **Overview**
> Fixes layout when **portrait** video is slotted into a skin with an authored **16:9** (or other) aspect ratio.
> 
> **`media-container`** in shared HTML skin CSS now uses **`min-width: 0`** and **`min-height: 0`** so slotted portrait media cannot expand the shadow container past the host’s aspect ratio.
> 
> **Slider storyboard thumbnails** in default and minimal skins (CSS and Tailwind) gain **`--media-slider-thumbnail-max-height: 8rem`** on the preview image, replacing the old loading-only container cap so tall portrait thumbs stay bounded.
> 
> Adds Playwright checks for authored aspect ratio and thumbnail height, plus sandbox source **`hls-6`** (portrait Tailwind HLS) for manual testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64a67f60762de87c1501f4adec5a603f722ad50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->