### PR TITLE
feat(packages): remove native controls after mounting our controls

### DIFF
--- a/packages/core/src/core/media/predicate.ts
+++ b/packages/core/src/core/media/predicate.ts
@@ -3,6 +3,7 @@ import { isFunction, isObject, isUndefined } from '@videojs/utils/predicate';
 import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants';
 import type {
   MediaBufferCapability,
+  MediaControlsCapability,
   MediaErrorCapability,
   MediaLiveCapability,
   MediaPauseCapability,
@@ -54,6 +55,12 @@ export function isMediaPlaybackRateCapable(value: unknown): value is MediaPlayba
   if (!isObject(value)) return false;
   const media = value as Record<string, unknown>;
   return !isUndefined(media.playbackRate);
+}
+
+export function isMediaControlsCapable(value: unknown): value is MediaControlsCapability {
+  if (!isObject(value)) return false;
+  const media = value as Record<string, unknown>;
+  return !isUndefined(media.controls);
 }
 
 export function isMediaBufferCapable(value: unknown): value is MediaBufferCapability {

--- a/packages/core/src/core/media/tests/predicate.test.ts
+++ b/packages/core/src/core/media/tests/predicate.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../constants';
-import { isMediaBufferCapable, isMediaRemotePlaybackCapable, isMediaTextTrackCapable } from '../predicate';
+import {
+  isMediaBufferCapable,
+  isMediaControlsCapable,
+  isMediaRemotePlaybackCapable,
+  isMediaTextTrackCapable,
+} from '../predicate';
 
 describe('isMediaBufferCapable', () => {
   it('rejects empty time range stubs', () => {
@@ -20,6 +25,16 @@ describe('isMediaTextTrackCapable', () => {
 
   it('accepts defined non-stub text tracks', () => {
     expect(isMediaTextTrackCapable({ textTracks: Object.assign(new EventTarget(), { length: 0 }) })).toBe(true);
+  });
+});
+
+describe('isMediaControlsCapable', () => {
+  it('rejects media without native controls', () => {
+    expect(isMediaControlsCapable({})).toBe(false);
+  });
+
+  it('accepts media with native controls', () => {
+    expect(isMediaControlsCapable({ controls: false })).toBe(true);
   });
 });
 

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -45,7 +45,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="${controls}">
+      <media-controls class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
               <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
@@ -132,7 +132,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
     </media-container>
   `;
 }

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -28,7 +28,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="media-controls">
+      <media-controls class="media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
             <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
@@ -114,7 +114,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
     </media-container>
   `;
 }

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -14,7 +14,14 @@ import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
 import { TooltipLabelElement } from '../../ui/tooltip/tooltip-label-element';
 import { TooltipShortcutElement } from '../../ui/tooltip/tooltip-shortcut-element';
 import { safeDefine } from '../safe-define';
-import { defineErrorDialog, defineMenu, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
+import {
+  defineControls,
+  defineErrorDialog,
+  defineMenu,
+  defineTime,
+  defineTimeSlider,
+  defineVolumeSlider,
+} from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { AudioPlayerElement } from './player';
@@ -25,6 +32,7 @@ safeDefine(AudioPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.
+defineControls();
 defineErrorDialog();
 defineTimeSlider();
 defineVolumeSlider();

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -45,7 +45,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="${controls}">
+      <media-controls class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
               <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
@@ -127,7 +127,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
     </media-container>
   `;
 }

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -28,7 +28,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="media-surface media-controls">
+      <media-controls class="media-surface media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
             <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
@@ -110,7 +110,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
 
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -16,7 +16,7 @@ import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
 import { TooltipLabelElement } from '../../ui/tooltip/tooltip-label-element';
 import { TooltipShortcutElement } from '../../ui/tooltip/tooltip-shortcut-element';
 import { safeDefine } from '../safe-define';
-import { defineErrorDialog, defineMenu, defineSliders, defineTime } from '../ui/compounds';
+import { defineControls, defineErrorDialog, defineMenu, defineSliders, defineTime } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { AudioPlayerElement } from './player';
@@ -27,6 +27,7 @@ safeDefine(AudioPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.
+defineControls();
 defineErrorDialog();
 defineSliders();
 defineTime();

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -37,7 +37,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="${controls}">
+      <media-controls class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
               <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
@@ -72,7 +72,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
     </media-container>
   `;
 }

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -26,7 +26,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="media-controls">
+      <media-controls class="media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
             <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
@@ -61,7 +61,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
     </media-container>
   `;
 }

--- a/packages/html/src/define/live-audio/minimal-ui.ts
+++ b/packages/html/src/define/live-audio/minimal-ui.ts
@@ -10,7 +10,7 @@ import { PopoverElement } from '../../ui/popover/popover-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
 import { safeDefine } from '../safe-define';
-import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
+import { defineControls, defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { LiveAudioPlayerElement } from './player';
@@ -21,6 +21,7 @@ safeDefine(LiveAudioPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.
+defineControls();
 defineErrorDialog();
 defineTimeSlider();
 defineVolumeSlider();

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -37,7 +37,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="${controls}">
+      <media-controls class="${controls}">
         <media-tooltip-group>
           <div class="${buttonGroup}">
               <media-play-button commandfor="play-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.play.button)}">
@@ -72,7 +72,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
     </media-container>
   `;
 }

--- a/packages/html/src/define/live-audio/skin.ts
+++ b/packages/html/src/define/live-audio/skin.ts
@@ -26,7 +26,7 @@ function getTemplateHTML() {
         </div>
       </media-error-dialog>
 
-      <div class="media-surface media-controls">
+      <media-controls class="media-surface media-controls">
         <media-tooltip-group>
           <div class="media-button-group">
             <media-play-button commandfor="play-tooltip" class="media-button media-button--subtle media-button--icon media-button--play">
@@ -61,7 +61,7 @@ function getTemplateHTML() {
             </media-popover>
           </div>
         </media-tooltip-group>
-      </div>
+      </media-controls>
 
       <!-- Hotkeys -->
       <media-hotkey keys="Space" action="togglePaused"></media-hotkey>

--- a/packages/html/src/define/live-audio/ui.ts
+++ b/packages/html/src/define/live-audio/ui.ts
@@ -11,7 +11,7 @@ import { PopoverElement } from '../../ui/popover/popover-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
 import { safeDefine } from '../safe-define';
-import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
+import { defineControls, defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
 // Value import — player.ts body runs before this module's body.
 import { LiveAudioPlayerElement } from './player';
@@ -22,6 +22,7 @@ safeDefine(LiveAudioPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.
+defineControls();
 defineErrorDialog();
 defineTimeSlider();
 defineVolumeSlider();

--- a/packages/html/src/player/context.ts
+++ b/packages/html/src/player/context.ts
@@ -38,6 +38,21 @@ export type MediaContext = Context<typeof MEDIA_CONTEXT_KEY, MediaContextValue>;
 export const mediaContext = createContext<MediaContextValue, typeof MEDIA_CONTEXT_KEY>(MEDIA_CONTEXT_KEY);
 
 // ----------------------------------------
+// Controls Context
+// ----------------------------------------
+
+export const CONTROLS_CONTEXT_KEY = Symbol.for('@videojs/controls');
+
+export interface ControlsContextValue {
+  mounted: boolean;
+  register: () => () => void;
+}
+
+export type ControlsContext = Context<typeof CONTROLS_CONTEXT_KEY, ControlsContextValue>;
+
+export const controlsContext = createContext<ControlsContextValue, typeof CONTROLS_CONTEXT_KEY>(CONTROLS_CONTEXT_KEY);
+
+// ----------------------------------------
 // Container Context
 // ----------------------------------------
 

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -11,7 +11,7 @@ import { combine, createStore } from '@videojs/store';
 
 import { type ContainerMixin, createContainerMixin } from '../store/container-mixin';
 import { createProviderMixin, type ProviderMixin } from '../store/provider-mixin';
-import { containerContext, mediaContext, type PlayerContext, playerContext } from './context';
+import { containerContext, controlsContext, mediaContext, type PlayerContext, playerContext } from './context';
 import { PlayerController } from './player-controller';
 
 export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
@@ -90,6 +90,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
   const ProviderMixin = createProviderMixin<PlayerStore>({
     playerContext,
     mediaContext,
+    controlsContext,
     containerContext,
     factory: create,
   });

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -1,8 +1,48 @@
-import { audioFeatures, backgroundFeatures, videoFeatures } from '@videojs/core/dom';
-import { describe, expect, it } from 'vitest';
+import { audioFeatures, backgroundFeatures, type Media, videoFeatures } from '@videojs/core/dom';
+import { afterEach, describe, expect, it } from 'vitest';
 
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+import { ControlsElement } from '../../ui/controls/controls-element';
 import { MediaElement } from '../../ui/media-element';
 import { createPlayer } from '../create-player';
+
+function defineElement(tagName: string, Base: CustomElementConstructor): void {
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, Base);
+  }
+}
+
+function nextMicrotask(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+const { ProviderMixin } = createPlayer({ features: backgroundFeatures });
+
+class TestPlayerElement extends ProviderMixin(MediaElement) {}
+
+class TestMediaElement extends MediaAttachMixin(HTMLElement) {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot!.innerHTML = '<video controls></video>';
+  }
+
+  getMediaTarget(): Media | null {
+    return this.target as Media | null;
+  }
+
+  get target(): HTMLVideoElement | null {
+    return this.shadowRoot?.querySelector('video') ?? null;
+  }
+}
+
+defineElement('test-create-player-provider', TestPlayerElement);
+defineElement('test-create-player-media', TestMediaElement);
+defineElement('test-create-player-controls', ControlsElement);
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
 
 describe('createPlayer', () => {
   it('returns expected exports', () => {
@@ -58,5 +98,80 @@ describe('createPlayer', () => {
     expect(result.PlayerController).toBeDefined();
     expect(result.ProviderMixin).toBeInstanceOf(Function);
     expect(result.ContainerMixin).toBeInstanceOf(Function);
+  });
+
+  it('keeps native controls on fallback media without controls', async () => {
+    const player = document.createElement('test-create-player-provider');
+    const video = document.createElement('video');
+
+    video.controls = true;
+    player.append(video);
+    document.body.append(player);
+
+    await nextMicrotask();
+
+    expect(video.controls).toBe(true);
+  });
+
+  it('removes native controls from fallback media when controls attach', async () => {
+    const player = document.createElement('test-create-player-provider');
+    const video = document.createElement('video');
+    const controls = document.createElement('test-create-player-controls');
+
+    video.controls = true;
+    player.append(video, controls);
+    document.body.append(player);
+
+    await nextMicrotask();
+
+    expect(video.controls).toBe(false);
+  });
+
+  it('restores native controls after all controls disconnect', async () => {
+    const player = document.createElement('test-create-player-provider');
+    const video = document.createElement('video');
+    const firstControls = document.createElement('test-create-player-controls');
+    const secondControls = document.createElement('test-create-player-controls');
+
+    video.controls = true;
+    player.append(video, firstControls, secondControls);
+    document.body.append(player);
+
+    await nextMicrotask();
+
+    expect(video.controls).toBe(false);
+
+    firstControls.remove();
+
+    expect(video.controls).toBe(false);
+
+    secondControls.remove();
+
+    expect(video.controls).toBe(true);
+  });
+
+  it('keeps native controls on context-registered media without controls', async () => {
+    const player = document.createElement('test-create-player-provider');
+    const media = document.createElement('test-create-player-media') as TestMediaElement;
+
+    document.body.append(player);
+    player.append(media);
+
+    await nextMicrotask();
+
+    expect(media.target?.controls).toBe(true);
+  });
+
+  it('removes native controls from context-registered media when controls attach', async () => {
+    const player = document.createElement('test-create-player-provider');
+    const media = document.createElement('test-create-player-media') as TestMediaElement;
+    const controls = document.createElement('test-create-player-controls');
+
+    document.body.append(player);
+    player.append(media, controls);
+
+    await nextMicrotask();
+
+    expect(media.target?.controls).toBe(false);
   });
 });

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -5,15 +5,17 @@ import {
   type PlayerStore,
   type PlayerTarget,
 } from '@videojs/core/dom';
+import { isMediaControlsCapable } from '@videojs/core/media/predicate';
 import { ContextProvider } from '@videojs/element/context';
 import { isNull } from '@videojs/utils/predicate';
 import type { MediaElementConstructor } from '@/ui/media-element';
-import type { ContainerContext, MediaContext, PlayerContext } from '../player/context';
+import type { ContainerContext, ControlsContext, MediaContext, PlayerContext } from '../player/context';
 import type { PlayerProvider, PlayerProviderConstructor } from './types';
 
 export interface ProviderMixinConfig<Store extends PlayerStore> {
   playerContext: PlayerContext<Store>;
   mediaContext: MediaContext;
+  controlsContext: ControlsContext;
   containerContext: ContainerContext;
   factory: () => Store;
 }
@@ -45,13 +47,30 @@ export function createProviderMixin<Store extends PlayerStore>(
       #media: Media | null = null;
       #container: MediaContainer | null = null;
       #popupGroup = createPopupGroup();
+      #controlsCount = 0;
+      #nativeControlsHidden = false;
       #fallbackQueued = false;
 
       #setMedia = (media: Media | null): void => {
         if (this.#media === media) return;
+        this.#restoreNativeControls();
         this.#media = media;
         this.#mediaProvider.setValue({ media, setMedia: this.#setMedia });
         this.#tryAttach();
+      };
+
+      #registerControls = (): (() => void) => {
+        this.#controlsCount += 1;
+        this.#syncControlsContext();
+        this.#hideNativeControls();
+
+        return () => {
+          this.#controlsCount = Math.max(0, this.#controlsCount - 1);
+          if (!this.#controlsCount) {
+            this.#restoreNativeControls();
+          }
+          this.#syncControlsContext();
+        };
       };
 
       #setContainer = (container: MediaContainer | null): void => {
@@ -75,6 +94,11 @@ export function createProviderMixin<Store extends PlayerStore>(
         initialValue: { media: this.#media, setMedia: this.#setMedia },
       });
 
+      #controlsProvider = new ContextProvider(this, {
+        context: config.controlsContext,
+        initialValue: { mounted: false, register: this.#registerControls },
+      });
+
       #containerProvider = new ContextProvider(this, {
         context: config.containerContext,
         initialValue: {
@@ -96,6 +120,7 @@ export function createProviderMixin<Store extends PlayerStore>(
         super.connectedCallback();
         this.#playerProvider.setValue(this.store);
         this.#mediaProvider.setValue({ media: this.#media, setMedia: this.#setMedia });
+        this.#syncControlsContext();
         this.#containerProvider.setValue({
           container: this.#container,
           setContainer: this.#setContainer,
@@ -137,7 +162,29 @@ export function createProviderMixin<Store extends PlayerStore>(
         if (hasMediaChanged || hasContainerChanged) {
           this.#detachStore();
           this.#detach = store.attach(target);
+          this.#hideNativeControls();
         }
+      }
+
+      #hideNativeControls(): void {
+        if (!this.#controlsCount || !isMediaControlsCapable(this.#media) || !this.#media.controls) return;
+        this.#media.controls = false;
+        this.#nativeControlsHidden = true;
+      }
+
+      #restoreNativeControls(): void {
+        if (!this.#nativeControlsHidden) return;
+        if (isMediaControlsCapable(this.#media)) {
+          this.#media.controls = true;
+        }
+        this.#nativeControlsHidden = false;
+      }
+
+      #syncControlsContext(): void {
+        this.#controlsProvider.setValue({
+          mounted: this.#controlsCount > 0,
+          register: this.#registerControls,
+        });
       }
 
       #detachStore(): void {

--- a/packages/html/src/ui/controls/controls-element.ts
+++ b/packages/html/src/ui/controls/controls-element.ts
@@ -1,28 +1,55 @@
 import { ControlsCore, ControlsDataAttrs, POPUP_HOST_SELECTOR } from '@videojs/core';
-import { applyStateDataAttrs, logMissingFeature, selectControls } from '@videojs/core/dom';
+import { applyStateDataAttrs, selectControls } from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
-import { ContextProvider } from '@videojs/element/context';
+import { ContextEvent, ContextProvider } from '@videojs/element/context';
 import { isFunction } from '@videojs/utils/predicate';
 
-import { playerContext } from '../../player/context';
+import { controlsContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaElement } from '../media-element';
-import { controlsContext } from './context';
+import { controlsContext as controlsStateContext } from './context';
 
 export class ControlsElement extends MediaElement {
   static readonly tagName = 'media-controls';
 
   readonly #core = new ControlsCore();
   readonly #mediaState = new PlayerController(this, playerContext, selectControls);
-  readonly #provider = new ContextProvider(this, { context: controlsContext });
+  readonly #provider = new ContextProvider(this, { context: controlsStateContext });
+  #unsubscribeContext: (() => void) | null = null;
+  #unregister: (() => void) | null = null;
+  #registering = false;
   #visible = true;
 
   override connectedCallback(): void {
     super.connectedCallback();
 
-    if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
-      logMissingFeature(this.localName, this.#mediaState.displayName);
-    }
+    this.dispatchEvent(
+      new ContextEvent(
+        controlsContext,
+        this,
+        (value, unsubscribe) => {
+          this.#unsubscribeContext ??= unsubscribe ?? null;
+          if (!this.#unregister && !this.#registering) {
+            this.#registering = true;
+            try {
+              this.#unregister = value?.register() ?? null;
+            } finally {
+              this.#registering = false;
+            }
+          }
+        },
+        true
+      )
+    );
+  }
+
+  override disconnectedCallback(): void {
+    this.#registering = false;
+    this.#unsubscribeContext?.();
+    this.#unsubscribeContext = null;
+    this.#unregister?.();
+    this.#unregister = null;
+    super.disconnectedCallback();
   }
 
   protected override update(_changed: PropertyValues): void {

--- a/packages/react/src/media/audio.tsx
+++ b/packages/react/src/media/audio.tsx
@@ -3,17 +3,18 @@
 import type { AudioHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
-import { useMediaAttach } from '../player/context';
+import { useControlsMounted, useMediaAttach } from '../player/context';
 import { useComposedRefs } from '../utils/use-composed-refs';
 
 export interface AudioProps extends AudioHTMLAttributes<HTMLAudioElement> {}
 
-export const Audio = forwardRef<HTMLAudioElement, AudioProps>(function Audio({ children, ...props }, ref) {
+export const Audio = forwardRef<HTMLAudioElement, AudioProps>(function Audio({ children, controls, ...props }, ref) {
   const setMedia = useMediaAttach();
+  const controlsMounted = useControlsMounted();
   const composedRef = useComposedRefs(ref, setMedia);
 
   return (
-    <audio ref={composedRef} {...props}>
+    <audio ref={composedRef} controls={controlsMounted ? false : controls} {...props}>
       {children}
     </audio>
   );

--- a/packages/react/src/media/tests/audio.test.tsx
+++ b/packages/react/src/media/tests/audio.test.tsx
@@ -59,6 +59,39 @@ describe('Audio', () => {
   });
 
   describe('with Provider', () => {
+    it('renders native controls when controls are not mounted', () => {
+      const setMedia = vi.fn();
+      const store = createMockStore();
+      const value: PlayerContextValue = {
+        store: store as any,
+        media: null,
+        setMedia,
+        container: null,
+        setContainer: vi.fn(),
+      };
+
+      const { container } = render(<Audio controls />, { wrapper: createWrapper(value) });
+
+      expect(container.querySelector('audio')?.hasAttribute('controls')).toBe(true);
+    });
+
+    it('does not render native controls when controls are mounted', () => {
+      const setMedia = vi.fn();
+      const store = createMockStore();
+      const value: PlayerContextValue = {
+        store: store as any,
+        media: null,
+        setMedia,
+        controlsMounted: true,
+        container: null,
+        setContainer: vi.fn(),
+      };
+
+      const { container } = render(<Audio controls />, { wrapper: createWrapper(value) });
+
+      expect(container.querySelector('audio')?.hasAttribute('controls')).toBe(false);
+    });
+
     it('calls setMedia on mount', () => {
       const setMedia = vi.fn();
       const store = createMockStore();

--- a/packages/react/src/media/tests/video.test.tsx
+++ b/packages/react/src/media/tests/video.test.tsx
@@ -62,6 +62,39 @@ describe('Video', () => {
   });
 
   describe('with Provider', () => {
+    it('renders native controls when controls are not mounted', () => {
+      const setMedia = vi.fn();
+      const store = createMockStore();
+      const value: PlayerContextValue = {
+        store: store as any,
+        media: null,
+        setMedia,
+        container: null,
+        setContainer: vi.fn(),
+      };
+
+      const { container } = render(<Video controls />, { wrapper: createWrapper(value) });
+
+      expect(container.querySelector('video')?.hasAttribute('controls')).toBe(true);
+    });
+
+    it('does not render native controls when controls are mounted', () => {
+      const setMedia = vi.fn();
+      const store = createMockStore();
+      const value: PlayerContextValue = {
+        store: store as any,
+        media: null,
+        setMedia,
+        controlsMounted: true,
+        container: null,
+        setContainer: vi.fn(),
+      };
+
+      const { container } = render(<Video controls />, { wrapper: createWrapper(value) });
+
+      expect(container.querySelector('video')?.hasAttribute('controls')).toBe(false);
+    });
+
     it('calls setMedia on mount', () => {
       const setMedia = vi.fn();
       const store = createMockStore();

--- a/packages/react/src/media/video.tsx
+++ b/packages/react/src/media/video.tsx
@@ -3,17 +3,18 @@
 import type { VideoHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
-import { useMediaAttach } from '../player/context';
+import { useControlsMounted, useMediaAttach } from '../player/context';
 import { useComposedRefs } from '../utils/use-composed-refs';
 
 export interface VideoProps extends VideoHTMLAttributes<HTMLVideoElement> {}
 
-export const Video = forwardRef<HTMLVideoElement, VideoProps>(function Video({ children, ...props }, ref) {
+export const Video = forwardRef<HTMLVideoElement, VideoProps>(function Video({ children, controls, ...props }, ref) {
   const setMedia = useMediaAttach();
+  const controlsMounted = useControlsMounted();
   const composedRef = useComposedRefs(ref, setMedia);
 
   return (
-    <video ref={composedRef} {...props}>
+    <video ref={composedRef} controls={controlsMounted ? false : controls} {...props}>
       {children}
     </video>
   );

--- a/packages/react/src/player/context.tsx
+++ b/packages/react/src/player/context.tsx
@@ -13,6 +13,8 @@ export interface PlayerContextValue {
   store: UnknownStore;
   media: Media | null;
   setMedia: Dispatch<SetStateAction<Media | null>>;
+  controlsMounted?: boolean;
+  registerControls?: () => () => void;
   container: MediaContainer | null;
   setContainer: Dispatch<SetStateAction<HTMLElement | null>>;
   popupGroup?: PopupGroup;
@@ -113,6 +115,16 @@ export function useOptionalPopupGroup(): PopupGroup | undefined {
 export function useMediaAttach(): Dispatch<SetStateAction<Media | null>> | undefined {
   const ctx = useContext(PlayerContext);
   return ctx?.setMedia;
+}
+
+export function useControlsMounted(): boolean {
+  const ctx = useContext(PlayerContext);
+  return ctx?.controlsMounted ?? false;
+}
+
+export function useControlsRegister(): (() => () => void) | undefined {
+  const ctx = useContext(PlayerContext);
+  return ctx?.registerControls;
 }
 
 /** Access the container attach setter for connecting a container element to the player. */

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -12,11 +12,12 @@ import type {
   VideoPlayerStore,
 } from '@videojs/core/dom';
 import { createPopupGroup } from '@videojs/core/dom';
+import { isMediaControlsCapable } from '@videojs/core/media/predicate';
 import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import type { FC, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useDestroy } from '../utils/use-destroy';
 import { Container, PlayerContextProvider, useMedia, usePlayerContext } from './context';
@@ -74,6 +75,13 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     const [popupGroup] = useState(() => createPopupGroup());
     const [media, setMedia] = useState<Media | null>(null);
     const [container, setContainer] = useState<HTMLElement | null>(null);
+    const [controlsCount, setControlsCount] = useState(0);
+    const controlsMounted = controlsCount > 0;
+
+    const registerControls = useCallback(() => {
+      setControlsCount((count) => count + 1);
+      return () => setControlsCount((count) => Math.max(0, count - 1));
+    }, []);
 
     useDestroy(store);
 
@@ -82,8 +90,23 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       return store.attach({ media, container });
     }, [media, container, store]);
 
+    useEffect(() => {
+      if (controlsMounted && isMediaControlsCapable(media) && media.controls) media.controls = false;
+    }, [controlsMounted, media]);
+
     return (
-      <PlayerContextProvider value={{ store, media, setMedia, container, setContainer, popupGroup }}>
+      <PlayerContextProvider
+        value={{
+          store,
+          media,
+          setMedia,
+          controlsMounted,
+          registerControls,
+          container,
+          setContainer,
+          popupGroup,
+        }}
+      >
         {children}
       </PlayerContextProvider>
     );

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -1,9 +1,11 @@
-import { render, renderHook } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import type { PlayerStore } from '@videojs/core/dom';
 import { defineSlice } from '@videojs/store';
 import type { ReactNode } from 'react';
 import { StrictMode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+import { Video } from '../../media/video';
+import { Controls } from '../../ui/controls';
 import { createPlayer } from '../create-player';
 
 describe('createPlayer', () => {
@@ -109,6 +111,42 @@ describe('createPlayer', () => {
       );
 
       expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
+    });
+
+    it('keeps native controls without controls', () => {
+      const { Provider } = createPlayer({ features: [mockSlice] });
+
+      const { container } = render(
+        <Provider>
+          <Video controls />
+        </Provider>
+      );
+
+      const video = container.querySelector('video') as HTMLVideoElement;
+
+      expect(video.controls).toBe(true);
+    });
+
+    it('removes native controls when controls attach', async () => {
+      const { Provider } = createPlayer({ features: [mockSlice] });
+
+      const view = (
+        <Provider>
+          <Video controls />
+          <Controls.Root />
+        </Provider>
+      );
+      const { container, rerender } = render(view);
+
+      const video = container.querySelector('video') as HTMLVideoElement;
+
+      await waitFor(() => {
+        expect(video.controls).toBe(false);
+      });
+
+      rerender(view);
+
+      expect(video.controls).toBe(false);
     });
   });
 

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -28,6 +28,7 @@ import {
   VolumeOffIcon,
 } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Menu } from '@/ui/menu';
 import { MuteButton } from '@/ui/mute-button';
@@ -176,7 +177,7 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className={controls}>
+      <Controls.Root className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
             <Tooltip.Root side="top" boundary="viewport">
@@ -260,7 +261,7 @@ export function MinimalAudioSkinTailwind(props: MinimalAudioSkinProps): ReactNod
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
     </Container>
   );
 }

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -11,6 +11,7 @@ import {
   VolumeOffIcon,
 } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -123,7 +124,7 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className="media-controls">
+      <Controls.Root className="media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
             <Tooltip.Root side="top" boundary="viewport">
@@ -207,7 +208,7 @@ export function MinimalAudioSkin(props: MinimalAudioSkinProps): ReactNode {
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -28,6 +28,7 @@ import {
   VolumeOffIcon,
 } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -178,7 +179,7 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className={controls}>
+      <Controls.Root className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
             <Tooltip.Root side="top" boundary="viewport">
@@ -258,7 +259,7 @@ export function AudioSkinTailwind(props: AudioSkinProps): ReactNode {
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -11,6 +11,7 @@ import {
   VolumeOffIcon,
 } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { Menu } from '@/ui/menu';
@@ -123,7 +124,7 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className="media-surface media-controls">
+      <Controls.Root className="media-surface media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
             <Tooltip.Root side="top" boundary="viewport">
@@ -203,7 +204,7 @@ export function AudioSkin(props: AudioSkinProps): ReactNode {
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -13,6 +13,7 @@ import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -116,7 +117,7 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className={controls}>
+      <Controls.Root className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
             <Tooltip.Root side="top" boundary="viewport">
@@ -144,7 +145,7 @@ export function MinimalLiveAudioSkinTailwind(props: MinimalLiveAudioSkinProps): 
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -2,6 +2,7 @@ import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons/minimal';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -82,7 +83,7 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className="media-controls">
+      <Controls.Root className="media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
             <Tooltip.Root side="top" boundary="viewport">
@@ -110,7 +111,7 @@ export function MinimalLiveAudioSkin(props: MinimalLiveAudioSkinProps): ReactNod
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -13,6 +13,7 @@ import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -116,7 +117,7 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className={controls}>
+      <Controls.Root className={controls}>
         <Tooltip.Provider>
           <div className={buttonGroup}>
             <Tooltip.Root side="top" boundary="viewport">
@@ -144,7 +145,7 @@ export function LiveAudioSkinTailwind(props: LiveAudioSkinProps): ReactNode {
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -2,6 +2,7 @@ import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';
 import { Container, usePlayer } from '@/player/context';
+import { Controls } from '@/ui/controls';
 import { ErrorDialog } from '@/ui/error-dialog';
 import { Hotkey } from '@/ui/hotkey';
 import { LiveButton } from '@/ui/live-button';
@@ -90,7 +91,7 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
         </ErrorDialog.Popup>
       </ErrorDialog.Root>
 
-      <div className="media-surface media-controls">
+      <Controls.Root className="media-surface media-controls">
         <Tooltip.Provider>
           <div className="media-button-group">
             <Tooltip.Root side="top" boundary="viewport">
@@ -115,7 +116,7 @@ export function LiveAudioSkin(props: LiveAudioSkinProps): ReactNode {
             <VolumePopover />
           </div>
         </Tooltip.Provider>
-      </div>
+      </Controls.Root>
 
       {/* Hotkeys */}
       <Hotkey keys="Space" action="togglePaused" />

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectControls } from '@videojs/core/dom';
+import { selectControls } from '@videojs/core/dom';
 import type { ForwardedRef, ReactNode } from 'react';
-import { forwardRef, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
-import { usePlayer } from '../../player/context';
+import { useControlsRegister, usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
 import { ControlsContextProvider } from './context';
@@ -13,6 +13,11 @@ import { ControlsContextProvider } from './context';
 export interface ControlsRootProps extends UIComponentProps<'div', ControlsCore.State> {
   children?: ReactNode | undefined;
 }
+
+const fallbackState: ControlsCore.State = {
+  visible: true,
+  userActive: true,
+};
 
 /** Root container for player controls state and rendered control content. */
 export const ControlsRoot = forwardRef(function ControlsRoot(
@@ -22,12 +27,29 @@ export const ControlsRoot = forwardRef(function ControlsRoot(
   const { render, className, style, children, ...elementProps } = componentProps;
 
   const controls = usePlayer(selectControls);
+  const register = useControlsRegister();
 
   const [core] = useState(() => new ControlsCore());
 
+  useEffect(() => {
+    return register?.();
+  }, [register]);
+
   if (!controls) {
-    if (__DEV__) logMissingFeature('Controls.Root', 'controls');
-    return null;
+    return (
+      <ControlsContextProvider value={{ state: fallbackState, stateAttrMap: ControlsDataAttrs }}>
+        {renderElement(
+          'div',
+          { render, className, style },
+          {
+            state: fallbackState,
+            stateAttrMap: ControlsDataAttrs,
+            ref: [forwardedRef],
+            props: [{ children }, elementProps],
+          }
+        )}
+      </ControlsContextProvider>
+    );
   }
 
   core.setMedia(controls);


### PR DESCRIPTION
## Summary

Remove the native controls after  mounting our custom controls component. This allows for progressive enhancement and has been noted in the migration docs. 

Given it affects skins, I won't merge until @mihar-22 gives it the ok. 

Closes #1160 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core player attach lifecycle and mutates native `controls` on media elements across HTML and React; behavior is covered by new tests but regressions could affect fallback playback without custom UI.
> 
> **Overview**
> Enables **progressive enhancement**: media can ship with native `controls` until a custom controls UI mounts, then native controls are turned off and restored if all custom controls unmount.
> 
> A new **controls registration** path tracks mounted control roots (HTML `media-controls` via player context; React `Controls.Root` via `registerControls` / `controlsMounted`). The provider mixin and React provider use `isMediaControlsCapable` to set `media.controls = false` only while at least one controls instance is registered, with refcounting when multiple roots exist.
> 
> Skins and presets wrap control chrome in **`media-controls` / `Controls.Root`** instead of plain divs, and `defineControls()` is wired into audio/live-audio UI registration. React **`Video` / `Audio`** omit the `controls` attribute when `controlsMounted` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14150711a3f16a8228385fddde5a2f8b0bff4cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->