### PR TITLE
feat: add DASH, Mux, and Vimeo as installation source types (UI + CLI)

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -59,8 +59,6 @@ function mapPresetToUseCase(preset: string): UseCase {
   return result;
 }
 
-// Derived from the shared label map so the CLI's accepted renderers never drift
-// from the installation page's.
 const ALL_RENDERERS = Object.keys(RENDERER_LABELS) as Renderer[];
 
 function validateMedia(media: string): Renderer {
@@ -187,7 +185,7 @@ export async function handleDocs(flags: ParsedFlags, positionals: string[]): Pro
     }
 
     // The interactive prompt hides CDN for renderers without a CDN build; guard
-    // the non-interactive flag path so `--media vimeo --install-method cdn`
+    // the non-interactive flag path so a `--install-method cdn` request for one
     // can't emit a broken snippet.
     if (opts.installMethod === 'cdn' && !supportsCdnInstall(opts.renderer)) {
       console.error(

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { validateInstallationOptions } from '@/utils/installation/codegen';
+import { RENDERER_LABELS } from '@/utils/installation/renderer-options';
 import type { InstallMethod, Renderer, UseCase } from '@/utils/installation/types';
 import type { Framework } from '../utils/config.js';
 import { getConfigValue } from '../utils/config.js';
@@ -58,7 +59,9 @@ function mapPresetToUseCase(preset: string): UseCase {
   return result;
 }
 
-const ALL_RENDERERS: Renderer[] = ['html5-video', 'html5-audio', 'hls', 'background-video'];
+// Derived from the shared label map so the CLI's accepted renderers never drift
+// from the installation page's.
+const ALL_RENDERERS = Object.keys(RENDERER_LABELS) as Renderer[];
 
 function validateMedia(media: string): Renderer {
   if (!ALL_RENDERERS.includes(media as Renderer)) {
@@ -114,7 +117,7 @@ Installation flags (for docs how-to/installation):
   --preset <video|audio|background-video>
   --skin <default|minimal|none>
   --source-url <url>
-  --media <html5-video|html5-audio|hls|background-video>
+  --media <html5-video|html5-audio|hls|dash|mux-video|mux-audio|vimeo|background-video>
   --install-method <cdn|npm|pnpm|yarn|bun>`;
 
 export async function handleDocs(flags: ParsedFlags, positionals: string[]): Promise<void> {
@@ -184,10 +187,12 @@ export async function handleDocs(flags: ParsedFlags, positionals: string[]): Pro
     }
 
     // The interactive prompt hides CDN for renderers without a CDN build; guard
-    // the non-interactive flag path so a `--install-method cdn` request for one
+    // the non-interactive flag path so `--media vimeo --install-method cdn`
     // can't emit a broken snippet.
     if (opts.installMethod === 'cdn' && !supportsCdnInstall(opts.renderer)) {
-      console.error('Error: this source type has no CDN build. Install it with npm, pnpm, yarn, or bun.');
+      console.error(
+        `Error: ${RENDERER_LABELS[opts.renderer]} has no CDN build. Install it with npm, pnpm, yarn, or bun.`
+      );
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/tests/docs.test.ts
+++ b/packages/cli/src/commands/tests/docs.test.ts
@@ -265,6 +265,41 @@ describe('handleDocs', () => {
         ]);
         expect(output()).toContain('background-video-player');
       });
+
+      it('generates DASH media variant', async () => {
+        await handleDocs(htmlFlags({ media: 'dash' }), ['how-to/installation']);
+        const out = output();
+        expect(out).toContain('<dash-video src=');
+        expect(out).toContain("import '@videojs/html/media/dash-video'");
+      });
+
+      it('generates Mux media variant', async () => {
+        await handleDocs(htmlFlags({ media: 'mux-video' }), ['how-to/installation']);
+        const out = output();
+        expect(out).toContain('<mux-video src=');
+        expect(out).toContain("import '@videojs/html/media/mux-video'");
+      });
+
+      it('generates Vimeo media variant via npm', async () => {
+        await handleDocs(htmlFlags({ media: 'vimeo' }), ['how-to/installation']);
+        const out = output();
+        expect(out).toContain('<vimeo-video src=');
+        expect(out).toContain("import '@videojs/html/media/vimeo-video'");
+      });
+
+      it('generates a CDN media script for renderers with a CDN build (mux)', async () => {
+        await handleDocs(htmlFlags({ media: 'mux-video', 'install-method': 'cdn' }), ['how-to/installation']);
+        const out = output();
+        expect(out).toContain('<script');
+        expect(out).toContain('media/mux-video.js');
+      });
+
+      it('errors when requesting CDN for a renderer without a CDN build (vimeo)', async () => {
+        await expect(
+          handleDocs(htmlFlags({ media: 'vimeo', 'install-method': 'cdn' }), ['how-to/installation'])
+        ).rejects.toThrow(ExitError);
+        expect(errors()).toContain('no CDN build');
+      });
     });
 
     describe('React framework', () => {

--- a/packages/cli/src/site-modules.d.ts
+++ b/packages/cli/src/site-modules.d.ts
@@ -7,7 +7,15 @@
  */
 
 declare module '@/utils/installation/types' {
-  export type Renderer = 'background-video' | 'hls' | 'html5-audio' | 'html5-video';
+  export type Renderer =
+    | 'background-video'
+    | 'dash'
+    | 'hls'
+    | 'html5-audio'
+    | 'html5-video'
+    | 'mux-audio'
+    | 'mux-video'
+    | 'vimeo';
   export type Skin = 'video' | 'audio' | 'minimal-video' | 'minimal-audio' | 'none';
   export type UseCase = 'default-video' | 'default-audio' | 'background-video';
   export type InstallMethod = 'cdn' | 'npm' | 'pnpm' | 'yarn' | 'bun';
@@ -65,6 +73,27 @@ declare module '@/utils/installation/cdn-code' {
 
   export function generateCdnCode(useCase: UseCase, skin: Skin, renderer: Renderer): string;
   export function rendererSupportsCdn(renderer: Renderer, cdnMediaSubpaths: readonly string[]): boolean;
+}
+
+declare module '@/utils/installation/renderer-options' {
+  import type { Renderer, UseCase } from '@/utils/installation/types';
+
+  // Mirrors the site's `SelectOption`/`SelectGroup` shapes, narrowed to the
+  // fields the CLI uses. The site module imports those types from a React
+  // component; the CLI only ever reads `value`/`label`.
+  interface RendererOption {
+    value: Renderer | null;
+    label: string;
+    disabled?: boolean;
+  }
+  interface RendererGroup {
+    label: string;
+    options: RendererOption[];
+  }
+
+  export const RENDERER_LABELS: Record<Renderer, string>;
+  export function buildOptions(useCase: UseCase): RendererOption[];
+  export function buildGroups(useCase: UseCase): RendererGroup[] | null;
 }
 
 declare module '@/content/cdn-media.json' {

--- a/packages/cli/src/site-modules.d.ts
+++ b/packages/cli/src/site-modules.d.ts
@@ -39,7 +39,8 @@ declare module '@/utils/installation/codegen' {
   export function validateInstallationOptions(opts: InstallationOptions): ValidationResult;
 
   export function generateHTMLInstallCode(
-    opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>
+    opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>,
+    cdnMediaSubpaths: readonly string[]
   ): Record<'cdn' | 'npm' | 'pnpm' | 'yarn' | 'bun', string>;
 
   export function generateReactInstallCode(): Record<'npm' | 'pnpm' | 'yarn' | 'bun', string>;
@@ -71,29 +72,29 @@ declare module '@/utils/installation/detect-renderer' {
 declare module '@/utils/installation/cdn-code' {
   import type { Renderer, Skin, UseCase } from '@/utils/installation/types';
 
-  export function generateCdnCode(useCase: UseCase, skin: Skin, renderer: Renderer): string;
+  export function generateCdnCode(
+    useCase: UseCase,
+    skin: Skin,
+    renderer: Renderer,
+    cdnMediaSubpaths: readonly string[]
+  ): string;
   export function rendererSupportsCdn(renderer: Renderer, cdnMediaSubpaths: readonly string[]): boolean;
 }
 
 declare module '@/utils/installation/renderer-options' {
   import type { Renderer, UseCase } from '@/utils/installation/types';
 
-  // Mirrors the site's `SelectOption`/`SelectGroup` shapes, narrowed to the
-  // fields the CLI uses. The site module imports those types from a React
-  // component; the CLI only ever reads `value`/`label`.
+  // Mirrors the site's `SelectOption` shape, narrowed to the fields the CLI
+  // uses. The site module imports that type from a React component; the CLI only
+  // ever reads `value`/`label`.
   interface RendererOption {
     value: Renderer | null;
     label: string;
     disabled?: boolean;
   }
-  interface RendererGroup {
-    label: string;
-    options: RendererOption[];
-  }
 
   export const RENDERER_LABELS: Record<Renderer, string>;
   export function buildOptions(useCase: UseCase): RendererOption[];
-  export function buildGroups(useCase: UseCase): RendererGroup[] | null;
 }
 
 declare module '@/content/cdn-media.json' {

--- a/packages/cli/src/utils/format.ts
+++ b/packages/cli/src/utils/format.ts
@@ -1,3 +1,4 @@
+import cdnMedia from '@/content/cdn-media.json';
 import {
   generateHTMLInstallCode,
   generateHTMLUsageCode,
@@ -7,6 +8,8 @@ import {
   type InstallationOptions,
 } from '@/utils/installation/codegen';
 
+const CDN_MEDIA_SUBPATHS = cdnMedia.map((entry) => entry.id);
+
 export function formatInstallationCode(opts: InstallationOptions): string {
   if (opts.framework === 'html') {
     return formatHTMLInstallation(opts);
@@ -15,7 +18,7 @@ export function formatInstallationCode(opts: InstallationOptions): string {
 }
 
 function formatHTMLInstallation(opts: InstallationOptions): string {
-  const install = generateHTMLInstallCode(opts);
+  const install = generateHTMLInstallCode(opts, CDN_MEDIA_SUBPATHS);
   const usage = generateHTMLUsageCode(opts);
   const sections: string[] = [];
 

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -7,12 +7,8 @@ import { buildOptions } from '@/utils/installation/renderer-options';
 import type { InstallMethod, Renderer, Skin, UseCase } from '@/utils/installation/types';
 import type { Framework } from './config.js';
 
-// Media subpaths that ship a CDN build, from the generated manifest (bundled at
-// build time). Mirrors how the installation page reads the `cdnMedia` content
-// collection — same source of truth, so the CLI gates CDN exactly like the UI.
 const CDN_MEDIA_SUBPATHS = cdnMedia.map((entry) => entry.id);
 
-/** Whether a renderer can be installed via CDN (parity with the install page). */
 export function supportsCdnInstall(renderer: Renderer): boolean {
   return rendererSupportsCdn(renderer, CDN_MEDIA_SUBPATHS);
 }
@@ -36,10 +32,8 @@ const PRESET_OPTIONS: Array<{ value: UseCase; label: string }> = [
   { value: 'background-video', label: 'Background Video' },
 ];
 
-// Reuse the installation page's option builder so labels and ordering (Files →
-// streaming formats → hosting services) stay in lockstep with the UI. Grouped
-// section headers are a UI affordance clack's single-select can't render, but
-// the order and labels carry the same taxonomy.
+// Reuse the installation page's option builder so labels and ordering stay in
+// lockstep with the UI.
 function mediaOptionsForUseCase(useCase: UseCase): Array<{ value: Renderer; label: string }> {
   return buildOptions(useCase).map((option) => ({
     value: option.value as Renderer,
@@ -70,7 +64,7 @@ function installMethodOptions(
     { value: 'bun', label: 'bun' },
   ];
   // CDN is HTML-only, and only when the renderer ships a CDN build — matching
-  // the install page, which hides the CDN tab for renderers like Vimeo.
+  // the install page, which hides the CDN tab for renderers without one.
   if (framework === 'html' && supportsCdnInstall(renderer)) {
     options.unshift({ value: 'cdn', label: 'CDN' });
   }

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -3,12 +3,16 @@ import cdnMedia from '@/content/cdn-media.json';
 import { rendererSupportsCdn } from '@/utils/installation/cdn-code';
 import type { InstallationOptions } from '@/utils/installation/codegen';
 import { detectRenderer } from '@/utils/installation/detect-renderer';
+import { buildOptions } from '@/utils/installation/renderer-options';
 import type { InstallMethod, Renderer, Skin, UseCase } from '@/utils/installation/types';
-import { VALID_RENDERERS } from '@/utils/installation/types';
 import type { Framework } from './config.js';
 
+// Media subpaths that ship a CDN build, from the generated manifest (bundled at
+// build time). Mirrors how the installation page reads the `cdnMedia` content
+// collection — same source of truth, so the CLI gates CDN exactly like the UI.
 const CDN_MEDIA_SUBPATHS = cdnMedia.map((entry) => entry.id);
 
+/** Whether a renderer can be installed via CDN (parity with the install page). */
 export function supportsCdnInstall(renderer: Renderer): boolean {
   return rendererSupportsCdn(renderer, CDN_MEDIA_SUBPATHS);
 }
@@ -32,17 +36,14 @@ const PRESET_OPTIONS: Array<{ value: UseCase; label: string }> = [
   { value: 'background-video', label: 'Background Video' },
 ];
 
+// Reuse the installation page's option builder so labels and ordering (Files →
+// streaming formats → hosting services) stay in lockstep with the UI. Grouped
+// section headers are a UI affordance clack's single-select can't render, but
+// the order and labels carry the same taxonomy.
 function mediaOptionsForUseCase(useCase: UseCase): Array<{ value: Renderer; label: string }> {
-  const RENDERER_LABELS: Record<Renderer, string> = {
-    'background-video': 'Background Video',
-    hls: 'HLS',
-    'html5-audio': 'HTML5 Audio',
-    'html5-video': 'HTML5 Video',
-  };
-
-  return VALID_RENDERERS[useCase].map((r) => ({
-    value: r,
-    label: RENDERER_LABELS[r],
+  return buildOptions(useCase).map((option) => ({
+    value: option.value as Renderer,
+    label: option.label,
   }));
 }
 
@@ -69,7 +70,7 @@ function installMethodOptions(
     { value: 'bun', label: 'bun' },
   ];
   // CDN is HTML-only, and only when the renderer ships a CDN build — matching
-  // the install page, which hides the CDN tab for renderers without one.
+  // the install page, which hides the CDN tab for renderers like Vimeo.
   if (framework === 'html' && supportsCdnInstall(renderer)) {
     options.unshift({ value: 'cdn', label: 'CDN' });
   }

--- a/packages/cli/src/utils/tests/prompts.test.ts
+++ b/packages/cli/src/utils/tests/prompts.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { supportsCdnInstall } from '../prompts.js';
 
-// Wires the cdn-media manifest into the CLI the same way the install page reads
-// the cdnMedia collection. Every current renderer ships (or is covered by) a
-// CDN build, so all resolve true; the no-CDN path (e.g. Vimeo) arrives with the
-// new rendering engines. `rendererSupportsCdn`'s false branch is unit-tested in
-// cdn-code.test.ts.
+// Mirrors the install page's CDN gating: preset renderers and media renderers
+// whose bundle ships a CDN build support CDN; Vimeo (no CDN build) does not.
 describe('supportsCdnInstall', () => {
-  it('returns true for preset renderers (covered by the preset bundle)', () => {
+  it('returns true for preset renderers', () => {
     expect(supportsCdnInstall('html5-video')).toBe(true);
     expect(supportsCdnInstall('html5-audio')).toBe(true);
     expect(supportsCdnInstall('background-video')).toBe(true);
   });
 
-  it('returns true for hls, whose media bundle ships a CDN build', () => {
+  it('returns true for media renderers with a CDN build', () => {
     expect(supportsCdnInstall('hls')).toBe(true);
+    expect(supportsCdnInstall('dash')).toBe(true);
+    expect(supportsCdnInstall('mux-video')).toBe(true);
+    expect(supportsCdnInstall('mux-audio')).toBe(true);
+  });
+
+  it('returns false for vimeo, which has no CDN build', () => {
+    expect(supportsCdnInstall('vimeo')).toBe(false);
   });
 });

--- a/packages/cli/src/utils/tests/site-aliases.test.ts
+++ b/packages/cli/src/utils/tests/site-aliases.test.ts
@@ -14,6 +14,7 @@ const ALIASED_FILES = [
   'utils/installation/types.ts',
   'utils/installation/cdn-code.ts',
   'utils/installation/detect-renderer.ts',
+  'utils/installation/renderer-options.ts',
   'consts.ts',
 ];
 

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
     '@/utils/installation/types': resolve(__dirname, '../../site/src/utils/installation/types.ts'),
     '@/utils/installation/cdn-code': resolve(__dirname, '../../site/src/utils/installation/cdn-code.ts'),
     '@/utils/installation/detect-renderer': resolve(__dirname, '../../site/src/utils/installation/detect-renderer.ts'),
+    '@/utils/installation/renderer-options': resolve(
+      __dirname,
+      '../../site/src/utils/installation/renderer-options.ts'
+    ),
     '@/content/cdn-media.json': resolve(__dirname, '../../site/src/content/cdn-media.json'),
     '@/consts': resolve(__dirname, '../../site/src/consts.ts'),
   },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
         __dirname,
         '../../site/src/utils/installation/detect-renderer.ts'
       ),
+      '@/utils/installation/renderer-options': resolve(
+        __dirname,
+        '../../site/src/utils/installation/renderer-options.ts'
+      ),
       // The real manifest is generated at build time (gitignored) and bundled
       // by tsdown. CLI tests are intentionally hermetic (`test` has no turbo
       // build dependency), so they resolve a committed fixture that mirrors the

--- a/site/src/components/Select.tsx
+++ b/site/src/components/Select.tsx
@@ -10,18 +10,10 @@ export interface SelectOption<T = string> {
   disabled?: boolean;
 }
 
-export interface SelectGroup<T = string> {
-  label: string;
-  options: SelectOption<T>[];
-}
-
 export interface SelectProps<T = string> {
   value: T | null;
   onChange: (value: T | null) => void;
-  /** Flat options. Provide this or `groups`, not both. */
-  options?: SelectOption<T>[];
-  /** Grouped options, rendered as labelled sections. Provide this or `options`. */
-  groups?: SelectGroup<T>[];
+  options: SelectOption<T>[];
   className?: string;
   'aria-label'?: string;
   'data-testid'?: string;
@@ -31,35 +23,12 @@ export function Select<T extends string = string>({
   value,
   onChange,
   options,
-  groups,
   className,
   'aria-label': ariaLabel,
   'data-testid': dataTestId,
 }: SelectProps<T>) {
-  // Base UI resolves the selected value's label for the trigger from `items`,
-  // so it always receives the flattened set regardless of grouping.
-  const flatOptions = options ?? groups?.flatMap((group) => group.options) ?? [];
-
-  const renderItem = (option: SelectOption<T>) => (
-    <BaseSelect.Item
-      key={option.value}
-      value={option.value}
-      disabled={option.disabled}
-      className={clsx(
-        'flex items-center gap-2 p-2',
-        option.disabled ? 'opacity-50 cursor-default' : 'cursor-pointer intent:bg-manila-75 dark:intent:bg-warm-gray',
-        option.value === value && 'bg-manila-75 dark:bg-warm-gray'
-      )}
-    >
-      <BaseSelect.ItemText>{option.label}</BaseSelect.ItemText>
-      <BaseSelect.ItemIndicator className="ml-auto inline-flex items-center">
-        <Check width={'1rem'} />
-      </BaseSelect.ItemIndicator>
-    </BaseSelect.Item>
-  );
-
   return (
-    <BaseSelect.Root value={value} onValueChange={onChange} items={flatOptions}>
+    <BaseSelect.Root value={value} onValueChange={onChange} items={options}>
       <BaseSelect.Trigger
         className={twMerge(
           clsx(
@@ -92,14 +61,25 @@ export function Select<T extends string = string>({
             }
           >
             <BaseSelect.List>
-              {groups
-                ? groups.map((group) => (
-                    <BaseSelect.Group key={group.label}>
-                      <BaseSelect.GroupLabel className="p-2 font-bold">{group.label}</BaseSelect.GroupLabel>
-                      {group.options.map(renderItem)}
-                    </BaseSelect.Group>
-                  ))
-                : flatOptions.map(renderItem)}
+              {options.map((option) => (
+                <BaseSelect.Item
+                  key={option.value}
+                  value={option.value}
+                  disabled={option.disabled}
+                  className={clsx(
+                    'flex items-center gap-2 p-2',
+                    option.disabled
+                      ? 'opacity-50 cursor-default'
+                      : 'cursor-pointer intent:bg-manila-75 dark:intent:bg-warm-gray',
+                    option.value === value && 'bg-manila-75 dark:bg-warm-gray'
+                  )}
+                >
+                  <BaseSelect.ItemText>{option.label}</BaseSelect.ItemText>
+                  <BaseSelect.ItemIndicator className="ml-auto inline-flex items-center">
+                    <Check width={'1rem'} />
+                  </BaseSelect.ItemIndicator>
+                </BaseSelect.Item>
+              ))}
             </BaseSelect.List>
           </BaseSelect.Popup>
         </BaseSelect.Positioner>

--- a/site/src/components/Select.tsx
+++ b/site/src/components/Select.tsx
@@ -10,10 +10,18 @@ export interface SelectOption<T = string> {
   disabled?: boolean;
 }
 
+export interface SelectGroup<T = string> {
+  label: string;
+  options: SelectOption<T>[];
+}
+
 export interface SelectProps<T = string> {
   value: T | null;
   onChange: (value: T | null) => void;
-  options: SelectOption<T>[];
+  /** Flat options. Provide this or `groups`, not both. */
+  options?: SelectOption<T>[];
+  /** Grouped options, rendered as labelled sections. Provide this or `options`. */
+  groups?: SelectGroup<T>[];
   className?: string;
   'aria-label'?: string;
   'data-testid'?: string;
@@ -23,12 +31,35 @@ export function Select<T extends string = string>({
   value,
   onChange,
   options,
+  groups,
   className,
   'aria-label': ariaLabel,
   'data-testid': dataTestId,
 }: SelectProps<T>) {
+  // Base UI resolves the selected value's label for the trigger from `items`,
+  // so it always receives the flattened set regardless of grouping.
+  const flatOptions = options ?? groups?.flatMap((group) => group.options) ?? [];
+
+  const renderItem = (option: SelectOption<T>) => (
+    <BaseSelect.Item
+      key={option.value}
+      value={option.value}
+      disabled={option.disabled}
+      className={clsx(
+        'flex items-center gap-2 p-2',
+        option.disabled ? 'opacity-50 cursor-default' : 'cursor-pointer intent:bg-manila-75 dark:intent:bg-warm-gray',
+        option.value === value && 'bg-manila-75 dark:bg-warm-gray'
+      )}
+    >
+      <BaseSelect.ItemText>{option.label}</BaseSelect.ItemText>
+      <BaseSelect.ItemIndicator className="ml-auto inline-flex items-center">
+        <Check width={'1rem'} />
+      </BaseSelect.ItemIndicator>
+    </BaseSelect.Item>
+  );
+
   return (
-    <BaseSelect.Root value={value} onValueChange={onChange} items={options}>
+    <BaseSelect.Root value={value} onValueChange={onChange} items={flatOptions}>
       <BaseSelect.Trigger
         className={twMerge(
           clsx(
@@ -61,25 +92,14 @@ export function Select<T extends string = string>({
             }
           >
             <BaseSelect.List>
-              {options.map((option) => (
-                <BaseSelect.Item
-                  key={option.value}
-                  value={option.value}
-                  disabled={option.disabled}
-                  className={clsx(
-                    'flex items-center gap-2 p-2',
-                    option.disabled
-                      ? 'opacity-50 cursor-default'
-                      : 'cursor-pointer intent:bg-manila-75 dark:intent:bg-warm-gray',
-                    option.value === value && 'bg-manila-75 dark:bg-warm-gray'
-                  )}
-                >
-                  <BaseSelect.ItemText>{option.label}</BaseSelect.ItemText>
-                  <BaseSelect.ItemIndicator className="ml-auto inline-flex items-center">
-                    <Check width={'1rem'} />
-                  </BaseSelect.ItemIndicator>
-                </BaseSelect.Item>
-              ))}
+              {groups
+                ? groups.map((group) => (
+                    <BaseSelect.Group key={group.label}>
+                      <BaseSelect.GroupLabel className="p-2 font-bold">{group.label}</BaseSelect.GroupLabel>
+                      {group.options.map(renderItem)}
+                    </BaseSelect.Group>
+                  ))
+                : flatOptions.map(renderItem)}
             </BaseSelect.List>
           </BaseSelect.Popup>
         </BaseSelect.Positioner>

--- a/site/src/components/installation/HTMLCdnCodeBlock.tsx
+++ b/site/src/components/installation/HTMLCdnCodeBlock.tsx
@@ -3,10 +3,15 @@ import ClientCode from '@/components/Code/ClientCode';
 import { renderer, skin, useCase } from '@/stores/installation';
 import { generateCdnCode } from '@/utils/installation/cdn-code';
 
-export default function HTMLCdnCodeBlock() {
+interface HTMLCdnCodeBlockProps {
+  /** Media subpaths that ship a CDN build, from the cdn-media manifest. */
+  cdnMedia: string[];
+}
+
+export default function HTMLCdnCodeBlock({ cdnMedia }: HTMLCdnCodeBlockProps) {
   const $useCase = useStore(useCase);
   const $skin = useStore(skin);
   const $renderer = useStore(renderer);
 
-  return <ClientCode code={generateCdnCode($useCase, $skin, $renderer)} lang="html" />;
+  return <ClientCode code={generateCdnCode($useCase, $skin, $renderer, cdnMedia)} lang="html" />;
 }

--- a/site/src/components/installation/HTMLInstallTabsClient.tsx
+++ b/site/src/components/installation/HTMLInstallTabsClient.tsx
@@ -38,6 +38,16 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
     return () => observer.disconnect();
   }, []);
 
+  // When CDN availability flips, the tab set remounts and resets to its initial
+  // tab (cdn when available, else npm). That reset swaps in new DOM nodes rather
+  // than toggling `data-tab-active` on existing ones, so the observer above
+  // doesn't catch it — sync the store explicitly. Without this, a stale `cdn`
+  // can survive onto a renderer with no CDN build (e.g. Vimeo), where the usage
+  // block would then wrongly drop its required JS import lines.
+  useEffect(() => {
+    installMethod.set(supportsCdn ? 'cdn' : 'npm');
+  }, [supportsCdn]);
+
   return (
     <div ref={ref}>
       {/* Remount the tab set when CDN availability changes so the active tab

--- a/site/src/components/installation/HTMLInstallTabsClient.tsx
+++ b/site/src/components/installation/HTMLInstallTabsClient.tsx
@@ -60,7 +60,7 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
         </TabsList>
         {supportsCdn && (
           <TabsPanel value="cdn" initial>
-            <HTMLCdnCodeBlock />
+            <HTMLCdnCodeBlock cdnMedia={cdnMedia} />
           </TabsPanel>
         )}
         <TabsPanel value="npm" initial={!supportsCdn}>

--- a/site/src/components/installation/RendererSelect.tsx
+++ b/site/src/components/installation/RendererSelect.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { Select } from '@/components/Select';
 import { renderer, sourceUrl, useCase } from '@/stores/installation';
 import { articleFor, detectRenderer } from '@/utils/installation/detect-renderer';
-import { buildGroups, buildOptions } from '@/utils/installation/renderer-options';
+import { buildOptions } from '@/utils/installation/renderer-options';
 import { VALID_RENDERERS } from '@/utils/installation/types';
 
 export default function RendererSelect() {
@@ -11,8 +11,7 @@ export default function RendererSelect() {
   const $useCase = useStore(useCase);
   const $sourceUrl = useStore(sourceUrl);
 
-  const groups = buildGroups($useCase);
-  const options = groups ? undefined : buildOptions($useCase);
+  const options = buildOptions($useCase);
   const detection = detectRenderer($sourceUrl, $useCase);
   const detectedRenderer = detection?.renderer ?? null;
 
@@ -82,7 +81,6 @@ export default function RendererSelect() {
             if (value) renderer.set(value);
           }}
           options={options}
-          groups={groups ?? undefined}
           aria-label="Select renderer"
         />
       </div>

--- a/site/src/components/installation/RendererSelect.tsx
+++ b/site/src/components/installation/RendererSelect.tsx
@@ -1,41 +1,18 @@
 import { useStore } from '@nanostores/react';
 import { useEffect } from 'react';
-import { Select, type SelectOption } from '@/components/Select';
+import { Select } from '@/components/Select';
 import { renderer, sourceUrl, useCase } from '@/stores/installation';
 import { articleFor, detectRenderer } from '@/utils/installation/detect-renderer';
-import type { Renderer, UseCase } from '@/utils/installation/types';
+import { buildGroups, buildOptions } from '@/utils/installation/renderer-options';
 import { VALID_RENDERERS } from '@/utils/installation/types';
-
-const RENDERER_LABELS: Record<Renderer, string> = {
-  'background-video': 'Background Video',
-  // cloudflare: 'Cloudflare',
-  // dash: 'DASH',
-  hls: 'HLS',
-  'html5-audio': 'HTML5 Audio',
-  'html5-video': 'HTML5 Video',
-  // jwplayer: 'JW Player',
-  // 'mux-audio': 'Mux',
-  // 'mux-background-video': 'Mux Background Video',
-  // 'mux-video': 'Mux',
-  // spotify: 'Spotify',
-  // vimeo: 'Vimeo',
-  // wistia: 'Wistia',
-  // youtube: 'YouTube',
-};
-
-function buildOptions(useCase: UseCase): SelectOption<Renderer>[] {
-  return VALID_RENDERERS[useCase].map((r) => ({
-    value: r,
-    label: RENDERER_LABELS[r],
-  }));
-}
 
 export default function RendererSelect() {
   const $renderer = useStore(renderer);
   const $useCase = useStore(useCase);
   const $sourceUrl = useStore(sourceUrl);
 
-  const options = buildOptions($useCase);
+  const groups = buildGroups($useCase);
+  const options = groups ? undefined : buildOptions($useCase);
   const detection = detectRenderer($sourceUrl, $useCase);
   const detectedRenderer = detection?.renderer ?? null;
 
@@ -105,6 +82,7 @@ export default function RendererSelect() {
             if (value) renderer.set(value);
           }}
           options={options}
+          groups={groups ?? undefined}
           aria-label="Select renderer"
         />
       </div>

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -44,3 +44,9 @@ export const VJS10_DEMO_VIDEO: VideoSource = {
   mp4: 'https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4',
   poster: 'https://image.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/thumbnail.webp',
 };
+
+// Standalone third-party samples for source types that aren't the shared Mux
+// asset above: Mux doesn't serve DASH, and Vimeo is a hosting service. The DASH
+// value matches the sample used by the site's DASH reference demo.
+export const VJS10_DEMO_DASH = 'https://dash.akamaized.net/akamai/streamroot/050714/Spring_4Ktest.mpd';
+export const VJS10_DEMO_VIMEO = 'https://vimeo.com/648359100';

--- a/site/src/content/docs/how-to/installation.mdx
+++ b/site/src/content/docs/how-to/installation.mdx
@@ -43,7 +43,7 @@ npx @videojs/cli docs how-to/installation \
   --framework <html|react> \
   --preset <video|audio|background-video> \
   --skin <default|minimal|none> \
-  --media <html5-video|html5-audio|hls|background-video> \
+  --media <html5-video|html5-audio|hls|dash|mux-video|mux-audio|vimeo|background-video> \
   --source-url <url> \
   --install-method <cdn|npm|pnpm|yarn|bun>
 ```

--- a/site/src/utils/installation/__tests__/cdn-code.test.ts
+++ b/site/src/utils/installation/__tests__/cdn-code.test.ts
@@ -4,7 +4,7 @@ import { generateCdnCode, rendererSupportsCdn } from '../cdn-code';
 describe('generateCdnCode', () => {
   // Media subpaths that ship a CDN build. The media script is emitted only for
   // renderers whose subpath is in this set.
-  const manifest = ['hls-video', 'dash-video', 'mux-video', 'mux-audio'];
+  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio'];
 
   it('generates video preset CDN tags for html5-video', () => {
     expect(generateCdnCode('default-video', 'video', 'html5-video', manifest)).toEqual(

--- a/site/src/utils/installation/__tests__/cdn-code.test.ts
+++ b/site/src/utils/installation/__tests__/cdn-code.test.ts
@@ -15,6 +15,26 @@ describe('generateCdnCode', () => {
     );
   });
 
+  it('includes the dash media bundle when renderer is dash', () => {
+    expect(generateCdnCode('default-video', 'video', 'dash')).toEqual(
+      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/dash-video.js"></script>`
+    );
+  });
+
+  it('includes the mux media bundle when renderer is mux-video', () => {
+    expect(generateCdnCode('default-video', 'video', 'mux-video')).toEqual(
+      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-video.js"></script>`
+    );
+  });
+
+  it('never emits a CDN media script for vimeo (no CDN build)', () => {
+    expect(generateCdnCode('default-video', 'video', 'vimeo')).toEqual(
+      `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>`
+    );
+  });
+
   it('generates background preset CDN tags', () => {
     expect(generateCdnCode('background-video', 'video', 'background-video')).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/background.js"></script>`
@@ -35,7 +55,8 @@ describe('generateCdnCode', () => {
 });
 
 describe('rendererSupportsCdn', () => {
-  const manifest = ['hlsjs-video'];
+  // Mirrors the manifest entries that ship a CDN build.
+  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio'];
 
   it('returns true for preset renderers (covered by the preset bundle, no media subpath)', () => {
     expect(rendererSupportsCdn('html5-video', manifest)).toBe(true);
@@ -43,11 +64,14 @@ describe('rendererSupportsCdn', () => {
     expect(rendererSupportsCdn('background-video', manifest)).toBe(true);
   });
 
-  it('returns true for a media renderer whose subpath is in the manifest', () => {
+  it('returns true for media renderers whose subpath is in the manifest', () => {
     expect(rendererSupportsCdn('hls', manifest)).toBe(true);
+    expect(rendererSupportsCdn('dash', manifest)).toBe(true);
+    expect(rendererSupportsCdn('mux-video', manifest)).toBe(true);
+    expect(rendererSupportsCdn('mux-audio', manifest)).toBe(true);
   });
 
-  it('returns false for a media renderer whose subpath is absent from the manifest', () => {
-    expect(rendererSupportsCdn('hls', [])).toBe(false);
+  it('returns false for vimeo, which has no CDN build', () => {
+    expect(rendererSupportsCdn('vimeo', manifest)).toBe(false);
   });
 });

--- a/site/src/utils/installation/__tests__/cdn-code.test.ts
+++ b/site/src/utils/installation/__tests__/cdn-code.test.ts
@@ -2,53 +2,57 @@ import { describe, expect, it } from 'vitest';
 import { generateCdnCode, rendererSupportsCdn } from '../cdn-code';
 
 describe('generateCdnCode', () => {
+  // Media subpaths that ship a CDN build. The media script is emitted only for
+  // renderers whose subpath is in this set.
+  const manifest = ['hls-video', 'dash-video', 'mux-video', 'mux-audio'];
+
   it('generates video preset CDN tags for html5-video', () => {
-    expect(generateCdnCode('default-video', 'video', 'html5-video')).toEqual(
+    expect(generateCdnCode('default-video', 'video', 'html5-video', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>`
     );
   });
 
   it('includes hls media bundle when renderer is hls', () => {
-    expect(generateCdnCode('default-video', 'minimal-video', 'hls')).toEqual(
+    expect(generateCdnCode('default-video', 'minimal-video', 'hls', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-minimal.js"></script>
 <script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/hlsjs-video.js"></script>`
     );
   });
 
   it('includes the dash media bundle when renderer is dash', () => {
-    expect(generateCdnCode('default-video', 'video', 'dash')).toEqual(
+    expect(generateCdnCode('default-video', 'video', 'dash', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
 <script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/dash-video.js"></script>`
     );
   });
 
   it('includes the mux media bundle when renderer is mux-video', () => {
-    expect(generateCdnCode('default-video', 'video', 'mux-video')).toEqual(
+    expect(generateCdnCode('default-video', 'video', 'mux-video', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
 <script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/media/mux-video.js"></script>`
     );
   });
 
-  it('never emits a CDN media script for vimeo (no CDN build)', () => {
-    expect(generateCdnCode('default-video', 'video', 'vimeo')).toEqual(
+  it('omits the media script for a media renderer absent from the manifest', () => {
+    expect(generateCdnCode('default-video', 'video', 'vimeo', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>`
     );
   });
 
   it('generates background preset CDN tags', () => {
-    expect(generateCdnCode('background-video', 'video', 'background-video')).toEqual(
+    expect(generateCdnCode('background-video', 'video', 'background-video', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/background.js"></script>`
     );
   });
 
   it('generates headless video CDN tag when skin is none', () => {
-    expect(generateCdnCode('default-video', 'none', 'html5-video')).toEqual(
+    expect(generateCdnCode('default-video', 'none', 'html5-video', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-headless.js"></script>`
     );
   });
 
   it('generates headless audio CDN tag when skin is none', () => {
-    expect(generateCdnCode('default-audio', 'none', 'html5-audio')).toEqual(
+    expect(generateCdnCode('default-audio', 'none', 'html5-audio', manifest)).toEqual(
       `<script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/audio-headless.js"></script>`
     );
   });

--- a/site/src/utils/installation/__tests__/codegen.test.ts
+++ b/site/src/utils/installation/__tests__/codegen.test.ts
@@ -133,6 +133,41 @@ describe('generateHTMLUsageCode', () => {
     expect(result.js).toContain("import '@videojs/html/media/hlsjs-video'");
   });
 
+  it('uses the dash-video tag, playsinline, and media import for DASH', () => {
+    const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'dash' });
+    expect(result.html).toContain('<dash-video src=');
+    expect(result.html).toContain('playsinline');
+    expect(result.html).toContain('.mpd');
+    expect(result.js).toContain("import '@videojs/html/media/dash-video'");
+  });
+
+  it('uses the mux-video tag, playsinline, and media import for Mux video', () => {
+    const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'mux-video' });
+    expect(result.html).toContain('<mux-video src=');
+    expect(result.html).toContain('playsinline');
+    expect(result.js).toContain("import '@videojs/html/media/mux-video'");
+  });
+
+  it('uses the vimeo-video tag and media import, without playsinline (iframe)', () => {
+    const result = generateHTMLUsageCode({ ...baseHTML, renderer: 'vimeo' });
+    expect(result.html).toContain('<vimeo-video src=');
+    expect(result.html).not.toContain('playsinline');
+    expect(result.html).toContain('vimeo.com');
+    expect(result.js).toContain("import '@videojs/html/media/vimeo-video'");
+  });
+
+  it('uses the mux-audio tag without playsinline for the audio use case', () => {
+    const result = generateHTMLUsageCode({
+      ...baseHTML,
+      useCase: 'default-audio',
+      skin: 'audio',
+      renderer: 'mux-audio',
+    });
+    expect(result.html).toContain('<mux-audio src=');
+    expect(result.html).not.toContain('playsinline');
+    expect(result.js).toContain("import '@videojs/html/media/mux-audio'");
+  });
+
   it('uses minimal skin tag', () => {
     const result = generateHTMLUsageCode({ ...baseHTML, skin: 'minimal-video' });
     expect(result.html).toContain('<video-minimal-skin>');
@@ -177,6 +212,28 @@ describe('generateReactCreateCode', () => {
     expect(code).toContain("import { VideoSkin } from '@videojs/react/video'");
     expect(code).toContain("import { HlsJsVideo } from '@videojs/react/media/hlsjs-video'");
     expect(code).toContain('<HlsJsVideo src={src} playsInline />');
+  });
+
+  it('uses separate media import for DASH', () => {
+    const result = generateReactCreateCode({ ...baseReact, renderer: 'dash' });
+    const code = result['MyPlayer.tsx'];
+    expect(code).toContain("import { DashVideo } from '@videojs/react/media/dash-video'");
+    expect(code).toContain('<DashVideo src={src} playsInline />');
+  });
+
+  it('uses separate media import for Mux video', () => {
+    const result = generateReactCreateCode({ ...baseReact, renderer: 'mux-video' });
+    const code = result['MyPlayer.tsx'];
+    expect(code).toContain("import { MuxVideo } from '@videojs/react/media/mux-video'");
+    expect(code).toContain('<MuxVideo src={src} playsInline />');
+  });
+
+  it('uses separate media import for Vimeo without playsInline (iframe)', () => {
+    const result = generateReactCreateCode({ ...baseReact, renderer: 'vimeo' });
+    const code = result['MyPlayer.tsx'];
+    expect(code).toContain("import { VimeoVideo } from '@videojs/react/media/vimeo-video'");
+    expect(code).toContain('<VimeoVideo src={src} />');
+    expect(code).not.toContain('playsInline');
   });
 
   it('uses audio features and components', () => {

--- a/site/src/utils/installation/__tests__/codegen.test.ts
+++ b/site/src/utils/installation/__tests__/codegen.test.ts
@@ -52,8 +52,10 @@ describe('validateInstallationOptions', () => {
 });
 
 describe('generateHTMLInstallCode', () => {
+  const manifest = ['hlsjs-video', 'dash-video', 'mux-video', 'mux-audio'];
+
   it('returns install commands for all methods', () => {
-    const result = generateHTMLInstallCode(baseHTML);
+    const result = generateHTMLInstallCode(baseHTML, manifest);
     expect(result.npm).toBe('npm install @videojs/html');
     expect(result.pnpm).toBe('pnpm add @videojs/html');
     expect(result.yarn).toBe('yarn add @videojs/html');
@@ -61,13 +63,13 @@ describe('generateHTMLInstallCode', () => {
   });
 
   it('returns CDN script tags', () => {
-    const result = generateHTMLInstallCode(baseHTML);
+    const result = generateHTMLInstallCode(baseHTML, manifest);
     expect(result.cdn).toContain('<script');
     expect(result.cdn).toContain('cdn.jsdelivr.net');
   });
 
   it('includes HLS media script in CDN output', () => {
-    const result = generateHTMLInstallCode({ ...baseHTML, renderer: 'hls' });
+    const result = generateHTMLInstallCode({ ...baseHTML, renderer: 'hls' }, manifest);
     expect(result.cdn).toContain('media/hlsjs-video.js');
   });
 });

--- a/site/src/utils/installation/__tests__/detect-renderer.test.ts
+++ b/site/src/utils/installation/__tests__/detect-renderer.test.ts
@@ -3,15 +3,36 @@ import { articleFor, detectRenderer, isRendererValidForUseCase } from '../detect
 
 describe('detectRenderer', () => {
   describe('domain rules', () => {
-    // Domain-specific rules (YouTube, Vimeo, Mux, Spotify, Cloudflare, JW Player, Wistia)
-    // are commented out until their renderer elements are implemented.
-    // Mux stream.mux.com URLs with .m3u8 extension are detected as HLS via extension rules.
-
-    it('detects stream.mux.com .m3u8 as HLS', () => {
+    it('detects stream.mux.com as Mux (video), taking precedence over the .m3u8 extension rule', () => {
       expect(detectRenderer('https://stream.mux.com/abc123.m3u8', 'default-video')).toEqual({
-        renderer: 'hls',
-        label: 'HLS',
+        renderer: 'mux-video',
+        label: 'Mux',
       });
+    });
+
+    it('resolves a Mux host to mux-audio in an audio use case (falls through from the mux-video rule)', () => {
+      expect(detectRenderer('https://stream.mux.com/abc123.m3u8', 'default-audio')).toEqual({
+        renderer: 'mux-audio',
+        label: 'Mux',
+      });
+    });
+
+    it('detects vimeo.com as Vimeo', () => {
+      expect(detectRenderer('https://vimeo.com/648359100', 'default-video')).toEqual({
+        renderer: 'vimeo',
+        label: 'Vimeo',
+      });
+    });
+
+    it('detects player.vimeo.com as Vimeo', () => {
+      expect(detectRenderer('https://player.vimeo.com/video/648359100', 'default-video')).toEqual({
+        renderer: 'vimeo',
+        label: 'Vimeo',
+      });
+    });
+
+    it('returns null for a Vimeo URL in an audio use case (no audio fallthrough)', () => {
+      expect(detectRenderer('https://vimeo.com/648359100', 'default-audio')).toBeNull();
     });
   });
 
@@ -23,7 +44,16 @@ describe('detectRenderer', () => {
       });
     });
 
-    // .mpd detection commented out until DASH renderer is implemented
+    it('detects .mpd as DASH', () => {
+      expect(detectRenderer('https://example.com/video.mpd', 'default-video')).toEqual({
+        renderer: 'dash',
+        label: 'DASH',
+      });
+    });
+
+    it('returns null for .mpd in an audio use case', () => {
+      expect(detectRenderer('https://example.com/video.mpd', 'default-audio')).toBeNull();
+    });
 
     it('detects .mp4 as HTML5 Video', () => {
       expect(detectRenderer('https://example.com/video.mp4', 'default-video')).toEqual({
@@ -167,5 +197,20 @@ describe('isRendererValidForUseCase', () => {
 
   it('html5-video is not valid for background-video', () => {
     expect(isRendererValidForUseCase('html5-video', 'background-video')).toBe(false);
+  });
+
+  it('dash and mux-video are valid for default-video', () => {
+    expect(isRendererValidForUseCase('dash', 'default-video')).toBe(true);
+    expect(isRendererValidForUseCase('mux-video', 'default-video')).toBe(true);
+  });
+
+  it('vimeo is valid for default-video but not default-audio', () => {
+    expect(isRendererValidForUseCase('vimeo', 'default-video')).toBe(true);
+    expect(isRendererValidForUseCase('vimeo', 'default-audio')).toBe(false);
+  });
+
+  it('mux-audio is valid for default-audio but not default-video', () => {
+    expect(isRendererValidForUseCase('mux-audio', 'default-audio')).toBe(true);
+    expect(isRendererValidForUseCase('mux-audio', 'default-video')).toBe(false);
   });
 });

--- a/site/src/utils/installation/__tests__/renderer-options.test.ts
+++ b/site/src/utils/installation/__tests__/renderer-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildGroups, buildOptions } from '../renderer-options';
+import { buildOptions } from '../renderer-options';
 
 describe('buildOptions', () => {
   it('returns flat options in the configured order for default-video', () => {
@@ -11,34 +11,11 @@ describe('buildOptions', () => {
       { value: 'vimeo', label: 'Vimeo' },
     ]);
   });
-});
 
-describe('buildGroups', () => {
-  it('groups default-video into Files / Streaming formats / Hosting services', () => {
-    expect(buildGroups('default-video')).toEqual([
-      { label: 'Files', options: [{ value: 'html5-video', label: 'HTML5 Video' }] },
-      {
-        label: 'Streaming formats',
-        options: [
-          { value: 'hls', label: 'HLS' },
-          { value: 'dash', label: 'DASH' },
-        ],
-      },
-      {
-        label: 'Hosting services',
-        options: [
-          { value: 'mux-video', label: 'Mux' },
-          { value: 'vimeo', label: 'Vimeo' },
-        ],
-      },
+  it('returns flat options for default-audio', () => {
+    expect(buildOptions('default-audio')).toEqual([
+      { value: 'html5-audio', label: 'HTML5 Audio' },
+      { value: 'mux-audio', label: 'Mux' },
     ]);
-  });
-
-  it('returns null for default-audio (all sections would be single-item)', () => {
-    expect(buildGroups('default-audio')).toBeNull();
-  });
-
-  it('returns null for background-video (single renderer)', () => {
-    expect(buildGroups('background-video')).toBeNull();
   });
 });

--- a/site/src/utils/installation/__tests__/renderer-options.test.ts
+++ b/site/src/utils/installation/__tests__/renderer-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { buildGroups, buildOptions } from '../renderer-options';
+
+describe('buildOptions', () => {
+  it('returns flat options in the configured order for default-video', () => {
+    expect(buildOptions('default-video')).toEqual([
+      { value: 'html5-video', label: 'HTML5 Video' },
+      { value: 'hls', label: 'HLS' },
+      { value: 'dash', label: 'DASH' },
+      { value: 'mux-video', label: 'Mux' },
+      { value: 'vimeo', label: 'Vimeo' },
+    ]);
+  });
+});
+
+describe('buildGroups', () => {
+  it('groups default-video into Files / Streaming formats / Hosting services', () => {
+    expect(buildGroups('default-video')).toEqual([
+      { label: 'Files', options: [{ value: 'html5-video', label: 'HTML5 Video' }] },
+      {
+        label: 'Streaming formats',
+        options: [
+          { value: 'hls', label: 'HLS' },
+          { value: 'dash', label: 'DASH' },
+        ],
+      },
+      {
+        label: 'Hosting services',
+        options: [
+          { value: 'mux-video', label: 'Mux' },
+          { value: 'vimeo', label: 'Vimeo' },
+        ],
+      },
+    ]);
+  });
+
+  it('returns null for default-audio (all sections would be single-item)', () => {
+    expect(buildGroups('default-audio')).toBeNull();
+  });
+
+  it('returns null for background-video (single renderer)', () => {
+    expect(buildGroups('background-video')).toBeNull();
+  });
+});

--- a/site/src/utils/installation/cdn-code.ts
+++ b/site/src/utils/installation/cdn-code.ts
@@ -27,27 +27,28 @@ function getMediaSubpath(renderer: Renderer): string | null {
 // Whether a renderer can be installed via CDN, given the set of media subpaths
 // that ship a CDN build (from the cdn-media manifest). Preset renderers always
 // can (no separate media script); media renderers can only if their subpath is
-// in the manifest. Vimeo has no CDN build, so it resolves to false.
+// in the manifest.
 export function rendererSupportsCdn(renderer: Renderer, cdnMediaSubpaths: readonly string[]): boolean {
   const subpath = getMediaSubpath(renderer);
   return subpath === null || cdnMediaSubpaths.includes(subpath);
 }
 
-// The media subpath to load via CDN, or null when none is needed. Vimeo has no
-// CDN build; the install UI hides the CDN option when it's selected, so this is
-// never reached for it, but we guard here too.
-function getCdnMediaSubpath(renderer: Renderer): string | null {
-  if (renderer === 'vimeo') return null;
-  return getMediaSubpath(renderer);
-}
-
-export function generateCdnCode(useCase: UseCase, skin: Skin, renderer: Renderer): string {
+export function generateCdnCode(
+  useCase: UseCase,
+  skin: Skin,
+  renderer: Renderer,
+  cdnMediaSubpaths: readonly string[]
+): string {
   const name = getCdnFileName(useCase, skin);
-  const mediaSubpath = getCdnMediaSubpath(renderer);
+  const mediaSubpath = getMediaSubpath(renderer);
 
   const scriptLines = [`<script type="module" src="${CDN_BASE}/${name}.js"></script>`];
 
-  if (mediaSubpath) {
+  // Emit a media script only when that media ships a CDN build, per the
+  // manifest. A media renderer whose subpath isn't in the manifest gets just the
+  // preset script; if it gains a CDN build later, the manifest carries it and
+  // this starts emitting automatically — no code change needed.
+  if (mediaSubpath !== null && cdnMediaSubpaths.includes(mediaSubpath)) {
     scriptLines.push(`<script type="module" src="${CDN_BASE}/media/${mediaSubpath}.js"></script>`);
   }
 

--- a/site/src/utils/installation/cdn-code.ts
+++ b/site/src/utils/installation/cdn-code.ts
@@ -1,4 +1,4 @@
-import type { Renderer, Skin, UseCase } from '@/utils/installation/types';
+import { getMediaSubpath, type Renderer, type Skin, type UseCase } from '@/utils/installation/types';
 
 const CDN_BASE = 'https://cdn.jsdelivr.net/npm/@videojs/html/cdn';
 
@@ -8,20 +8,6 @@ function getCdnFileName(useCase: UseCase, skin: Skin): string {
   if (skin === 'minimal-video') return 'video-minimal';
   if (skin === 'minimal-audio') return 'audio-minimal';
   return skin;
-}
-
-// Renderer → media subpath name, independent of whether a CDN build exists.
-// Preset renderers (html5-video/audio, background-video) are covered by the
-// preset bundle and have no separate media script, so they map to null.
-function getMediaSubpath(renderer: Renderer): string | null {
-  const map: Partial<Record<Renderer, string>> = {
-    hls: 'hlsjs-video',
-    dash: 'dash-video',
-    'mux-video': 'mux-video',
-    'mux-audio': 'mux-audio',
-    vimeo: 'vimeo-video',
-  };
-  return map[renderer] ?? null;
 }
 
 // Whether a renderer can be installed via CDN, given the set of media subpaths

--- a/site/src/utils/installation/cdn-code.ts
+++ b/site/src/utils/installation/cdn-code.ts
@@ -16,20 +16,28 @@ function getCdnFileName(useCase: UseCase, skin: Skin): string {
 function getMediaSubpath(renderer: Renderer): string | null {
   const map: Partial<Record<Renderer, string>> = {
     hls: 'hlsjs-video',
+    dash: 'dash-video',
+    'mux-video': 'mux-video',
+    'mux-audio': 'mux-audio',
+    vimeo: 'vimeo-video',
   };
   return map[renderer] ?? null;
 }
 
 // Whether a renderer can be installed via CDN, given the set of media subpaths
 // that ship a CDN build (from the cdn-media manifest). Preset renderers always
-// can (no separate media script); a media renderer can only if its subpath is
-// in the manifest.
+// can (no separate media script); media renderers can only if their subpath is
+// in the manifest. Vimeo has no CDN build, so it resolves to false.
 export function rendererSupportsCdn(renderer: Renderer, cdnMediaSubpaths: readonly string[]): boolean {
   const subpath = getMediaSubpath(renderer);
   return subpath === null || cdnMediaSubpaths.includes(subpath);
 }
 
+// The media subpath to load via CDN, or null when none is needed. Vimeo has no
+// CDN build; the install UI hides the CDN option when it's selected, so this is
+// never reached for it, but we guard here too.
 function getCdnMediaSubpath(renderer: Renderer): string | null {
+  if (renderer === 'vimeo') return null;
   return getMediaSubpath(renderer);
 }
 

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -84,10 +84,11 @@ function getMediaImportSubpath(renderer: Renderer): string | null {
 // ---------------------------------------------------------------------------
 
 export function generateHTMLInstallCode(
-  opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>
+  opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>,
+  cdnMediaSubpaths: readonly string[]
 ): Record<'cdn' | 'npm' | 'pnpm' | 'yarn' | 'bun', string> {
   return {
-    cdn: generateCdnCode(opts.useCase, opts.skin, opts.renderer),
+    cdn: generateCdnCode(opts.useCase, opts.skin, opts.renderer, cdnMediaSubpaths),
     npm: 'npm install @videojs/html',
     pnpm: 'pnpm add @videojs/html',
     yarn: 'yarn add @videojs/html',

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -1,6 +1,12 @@
 import { VJS10_DEMO_DASH, VJS10_DEMO_VIDEO, VJS10_DEMO_VIMEO } from '@/consts';
 import { generateCdnCode } from '@/utils/installation/cdn-code';
-import type { InstallMethod, Renderer, Skin, UseCase } from '@/utils/installation/types';
+import {
+  getMediaSubpath,
+  type InstallMethod,
+  type Renderer,
+  type Skin,
+  type UseCase,
+} from '@/utils/installation/types';
 
 export interface InstallationOptions {
   framework: 'html' | 'react';
@@ -66,17 +72,6 @@ function getSkinImportParts(skin: Exclude<Skin, 'none'>): { group: string; skinF
   if (skin === 'minimal-video') return { group: 'video', skinFile: 'minimal-skin' };
   if (skin === 'minimal-audio') return { group: 'audio', skinFile: 'minimal-skin' };
   return { group: skin, skinFile: 'skin' };
-}
-
-function getMediaImportSubpath(renderer: Renderer): string | null {
-  const map: Partial<Record<Renderer, string>> = {
-    hls: 'hlsjs-video',
-    dash: 'dash-video',
-    'mux-video': 'mux-video',
-    'mux-audio': 'mux-audio',
-    vimeo: 'vimeo-video',
-  };
-  return map[renderer] ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -198,14 +193,14 @@ ${skinMediaComment}
 
 function generateHTMLJSImports(useCase: UseCase, skin: Skin, renderer: Renderer): string {
   if (useCase === 'background-video') {
-    const mediaSubpath = getMediaImportSubpath(renderer);
+    const mediaSubpath = getMediaSubpath(renderer);
     const mediaImport = mediaSubpath ? `\nimport '@videojs/html/media/${mediaSubpath}';` : '';
     return `import '@videojs/html/background/player';
 import '@videojs/html/background/skin';
 import '@videojs/html/background/video';${mediaImport}`;
   }
   const group = skin === 'none' ? getGroupFromUseCase(useCase) : getSkinImportParts(skin).group;
-  const mediaSubpath = getMediaImportSubpath(renderer);
+  const mediaSubpath = getMediaSubpath(renderer);
   const mediaImport = mediaSubpath ? `\nimport '@videojs/html/media/${mediaSubpath}';` : '';
   if (skin === 'none') {
     return `import '@videojs/html/${group}/player';${mediaImport}`;
@@ -264,15 +259,6 @@ function isPresetRenderer(renderer: Renderer): boolean {
   return renderer === 'html5-video' || renderer === 'html5-audio' || renderer === 'background-video';
 }
 
-function getRendererMediaSubpath(renderer: Renderer): string {
-  const map: Partial<Record<Renderer, string>> = {
-    hls: 'hlsjs-video',
-    dash: 'dash-video',
-    vimeo: 'vimeo-video',
-  };
-  return map[renderer] ?? renderer;
-}
-
 export function generateReactCreateCode(
   opts: Pick<InstallationOptions, 'useCase' | 'skin' | 'renderer'>
 ): Record<'MyPlayer.tsx', string> {
@@ -305,7 +291,7 @@ export function generateReactCreateCode(
       presetImport = `import { ${rendererComponent} } from '@videojs/react/${group}';`;
     } else {
       presetImport = '';
-      mediaImport = `import { ${rendererComponent} } from '@videojs/react/media/${getRendererMediaSubpath(renderer)}';`;
+      mediaImport = `import { ${rendererComponent} } from '@videojs/react/media/${getMediaSubpath(renderer) ?? renderer}';`;
     }
   } else {
     const { skinFile } = getSkinImportParts(skin);
@@ -315,7 +301,7 @@ export function generateReactCreateCode(
       presetImport = `import { ${skinComponent}, ${rendererComponent} } from '@videojs/react/${group}';`;
     } else {
       presetImport = `import { ${skinComponent} } from '@videojs/react/${group}';`;
-      mediaImport = `import { ${rendererComponent} } from '@videojs/react/media/${getRendererMediaSubpath(renderer)}';`;
+      mediaImport = `import { ${rendererComponent} } from '@videojs/react/media/${getMediaSubpath(renderer) ?? renderer}';`;
     }
   }
 

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -1,4 +1,4 @@
-import { VJS10_DEMO_VIDEO } from '@/consts';
+import { VJS10_DEMO_DASH, VJS10_DEMO_VIDEO, VJS10_DEMO_VIMEO } from '@/consts';
 import { generateCdnCode } from '@/utils/installation/cdn-code';
 import type { InstallMethod, Renderer, Skin, UseCase } from '@/utils/installation/types';
 
@@ -26,15 +26,36 @@ export function validateInstallationOptions(opts: InstallationOptions): Validati
 // ---------------------------------------------------------------------------
 
 function getDefaultSourceUrl(renderer: Renderer): string {
-  return renderer === 'hls' ? VJS10_DEMO_VIDEO.hls : VJS10_DEMO_VIDEO.mp4;
+  const map: Record<Renderer, string> = {
+    'html5-video': VJS10_DEMO_VIDEO.mp4,
+    // Pre-existing quirk: the audio default points at a video .mp4. Fixing it
+    // needs a real audio asset we don't have — tracked as a follow-up.
+    'html5-audio': VJS10_DEMO_VIDEO.mp4,
+    hls: VJS10_DEMO_VIDEO.hls,
+    'background-video': VJS10_DEMO_VIDEO.mp4,
+    dash: VJS10_DEMO_DASH,
+    // Mux media take a stream.mux.com source; the demo HLS URL is already one.
+    'mux-video': VJS10_DEMO_VIDEO.hls,
+    'mux-audio': VJS10_DEMO_VIDEO.hls,
+    vimeo: VJS10_DEMO_VIMEO,
+  };
+  return map[renderer];
 }
 
 function resolveSourceUrl(sourceUrl: string, renderer: Renderer): string {
   return sourceUrl.trim() || getDefaultSourceUrl(renderer);
 }
 
+// Whether the rendered media element takes the `playsinline` attribute. Vimeo
+// renders an <iframe> and mux-audio renders audio, so neither gets it.
 function isVideoLikeRenderer(renderer: Renderer): boolean {
-  return renderer === 'html5-video' || renderer === 'hls' || renderer === 'background-video';
+  return (
+    renderer === 'html5-video' ||
+    renderer === 'hls' ||
+    renderer === 'background-video' ||
+    renderer === 'dash' ||
+    renderer === 'mux-video'
+  );
 }
 
 function getGroupFromUseCase(useCase: UseCase): string {
@@ -50,6 +71,10 @@ function getSkinImportParts(skin: Exclude<Skin, 'none'>): { group: string; skinF
 function getMediaImportSubpath(renderer: Renderer): string | null {
   const map: Partial<Record<Renderer, string>> = {
     hls: 'hlsjs-video',
+    dash: 'dash-video',
+    'mux-video': 'mux-video',
+    'mux-audio': 'mux-audio',
+    vimeo: 'vimeo-video',
   };
   return map[renderer] ?? null;
 }
@@ -90,9 +115,13 @@ export function generateReactInstallCode(): Record<'npm' | 'pnpm' | 'yarn' | 'bu
 function getRendererTag(renderer: Renderer): string {
   const map: Record<Renderer, string> = {
     'background-video': 'background-video',
+    dash: 'dash-video',
     hls: 'hlsjs-video',
     'html5-audio': 'audio',
     'html5-video': 'video',
+    'mux-audio': 'mux-audio',
+    'mux-video': 'mux-video',
+    vimeo: 'vimeo-video',
   };
   return map[renderer];
 }
@@ -200,9 +229,13 @@ export function generateHTMLUsageCode(
 function getRendererComponent(renderer: Renderer): string {
   const map: Record<Renderer, string> = {
     'background-video': 'BackgroundVideo',
+    dash: 'DashVideo',
     hls: 'HlsJsVideo',
     'html5-audio': 'Audio',
     'html5-video': 'Video',
+    'mux-audio': 'MuxAudio',
+    'mux-video': 'MuxVideo',
+    vimeo: 'VimeoVideo',
   };
   return map[renderer];
 }
@@ -233,6 +266,8 @@ function isPresetRenderer(renderer: Renderer): boolean {
 function getRendererMediaSubpath(renderer: Renderer): string {
   const map: Partial<Record<Renderer, string>> = {
     hls: 'hlsjs-video',
+    dash: 'dash-video',
+    vimeo: 'vimeo-video',
   };
   return map[renderer] ?? renderer;
 }

--- a/site/src/utils/installation/detect-renderer.ts
+++ b/site/src/utils/installation/detect-renderer.ts
@@ -7,20 +7,29 @@ export interface DetectionResult {
 }
 
 const DOMAIN_RULES: Array<{ match: (hostname: string) => boolean; renderer: Renderer; label: string }> = [
+  // Mux is matched by hostname before the `.m3u8` extension rule below, so a
+  // `stream.mux.com` URL resolves to a Mux renderer (with Mux Data) rather than
+  // generic HLS. The two Mux rules are ordered video-then-audio; the loop's
+  // use-case guard skips the invalid one and `continue`s to the next.
+  {
+    match: (h) => h === 'stream.mux.com' || h === 'mux.com' || h === 'www.mux.com',
+    renderer: 'mux-video',
+    label: 'Mux',
+  },
+  {
+    match: (h) => h === 'stream.mux.com' || h === 'mux.com' || h === 'www.mux.com',
+    renderer: 'mux-audio',
+    label: 'Mux',
+  },
+  {
+    match: (h) => h === 'vimeo.com' || h === 'www.vimeo.com' || h === 'player.vimeo.com',
+    renderer: 'vimeo',
+    label: 'Vimeo',
+  },
   // {
   //   match: (h) => h === 'youtube.com' || h === 'www.youtube.com' || h === 'youtu.be' || h === 'm.youtube.com',
   //   renderer: 'youtube',
   //   label: 'YouTube',
-  // },
-  // {
-  //   match: (h) => h === 'vimeo.com' || h === 'www.vimeo.com' || h === 'player.vimeo.com',
-  //   renderer: 'vimeo',
-  //   label: 'Vimeo',
-  // },
-  // {
-  //   match: (h) => h === 'stream.mux.com' || h === 'mux.com' || h === 'www.mux.com',
-  //   renderer: 'mux-video',
-  //   label: 'Mux',
   // },
   // {
   //   match: (h) => h === 'open.spotify.com',
@@ -77,10 +86,11 @@ export function detectRenderer(url: string, useCase: UseCase): DetectionResult |
   const parsed = parseUrl(trimmed);
   if (!parsed) return null;
 
-  // Check domain rules first
+  // Check domain rules first. When a host matches but its renderer isn't valid
+  // for the current use case, keep looking (so e.g. a Mux URL in an audio use
+  // case falls through from the mux-video rule to the mux-audio rule).
   for (const rule of DOMAIN_RULES) {
-    if (rule.match(parsed.hostname)) {
-      if (!isRendererValidForUseCase(rule.renderer, useCase)) return null;
+    if (rule.match(parsed.hostname) && isRendererValidForUseCase(rule.renderer, useCase)) {
       return { renderer: rule.renderer, label: rule.label };
     }
   }
@@ -93,10 +103,10 @@ export function detectRenderer(url: string, useCase: UseCase): DetectionResult |
     return { renderer: 'hls', label: 'HLS' };
   }
 
-  // if (ext === '.mpd') {
-  //   if (!isRendererValidForUseCase('dash', useCase)) return null;
-  //   return { renderer: 'dash', label: 'DASH' };
-  // }
+  if (ext === '.mpd') {
+    if (!isRendererValidForUseCase('dash', useCase)) return null;
+    return { renderer: 'dash', label: 'DASH' };
+  }
 
   if (VIDEO_EXTENSIONS.has(ext)) {
     if (!isRendererValidForUseCase('html5-video', useCase)) return null;
@@ -117,19 +127,13 @@ export function isRendererValidForUseCase(renderer: Renderer, useCase: UseCase):
 
 const RENDERER_ARTICLES: Record<Renderer, 'a' | 'an'> = {
   'background-video': 'a',
-  // cloudflare: 'a',
-  // dash: 'a',
+  dash: 'a',
   hls: 'an',
   'html5-audio': 'an',
   'html5-video': 'an',
-  // jwplayer: 'a',
-  // 'mux-audio': 'a',
-  // 'mux-background-video': 'a',
-  // 'mux-video': 'a',
-  // spotify: 'a',
-  // vimeo: 'a',
-  // wistia: 'a',
-  // youtube: 'a',
+  'mux-audio': 'a',
+  'mux-video': 'a',
+  vimeo: 'a',
 };
 
 export function articleFor(renderer: Renderer): 'a' | 'an' {

--- a/site/src/utils/installation/renderer-options.ts
+++ b/site/src/utils/installation/renderer-options.ts
@@ -1,4 +1,4 @@
-import type { SelectGroup, SelectOption } from '@/components/Select';
+import type { SelectOption } from '@/components/Select';
 import type { Renderer, UseCase } from '@/utils/installation/types';
 import { VALID_RENDERERS } from '@/utils/installation/types';
 
@@ -13,34 +13,9 @@ export const RENDERER_LABELS: Record<Renderer, string> = {
   vimeo: 'Vimeo',
 };
 
-// Sections teach the source-type taxonomy at the point of choice: plain files,
-// then open streaming formats, then hosting services. Renderers absent here
-// (e.g. background-video) fall back to an ungrouped list.
-const RENDERER_SECTIONS: Array<{ label: string; renderers: Renderer[] }> = [
-  { label: 'Files', renderers: ['html5-video', 'html5-audio'] },
-  { label: 'Streaming formats', renderers: ['hls', 'dash'] },
-  { label: 'Hosting services', renderers: ['mux-video', 'mux-audio', 'vimeo'] },
-];
-
 export function buildOptions(useCase: UseCase): SelectOption<Renderer>[] {
   return VALID_RENDERERS[useCase].map((r) => ({
     value: r,
     label: RENDERER_LABELS[r],
   }));
-}
-
-// Build labelled sections for the use case, dropping empty ones. Returns null
-// unless grouping actually earns its keep — there must be at least two sections
-// and at least one with more than one item. That keeps single-item use cases
-// (background) and all-single-item ones (audio: HTML5 Audio + Mux) flat rather
-// than stacking lone headers over lone items; the caller renders a flat list.
-export function buildGroups(useCase: UseCase): SelectGroup<Renderer>[] | null {
-  const valid = VALID_RENDERERS[useCase];
-  const groups = RENDERER_SECTIONS.map((section) => ({
-    label: section.label,
-    options: section.renderers.filter((r) => valid.includes(r)).map((r) => ({ value: r, label: RENDERER_LABELS[r] })),
-  })).filter((group) => group.options.length > 0);
-
-  const worthGrouping = groups.length > 1 && groups.some((group) => group.options.length > 1);
-  return worthGrouping ? groups : null;
 }

--- a/site/src/utils/installation/renderer-options.ts
+++ b/site/src/utils/installation/renderer-options.ts
@@ -1,0 +1,46 @@
+import type { SelectGroup, SelectOption } from '@/components/Select';
+import type { Renderer, UseCase } from '@/utils/installation/types';
+import { VALID_RENDERERS } from '@/utils/installation/types';
+
+export const RENDERER_LABELS: Record<Renderer, string> = {
+  'background-video': 'Background Video',
+  dash: 'DASH',
+  hls: 'HLS',
+  'html5-audio': 'HTML5 Audio',
+  'html5-video': 'HTML5 Video',
+  'mux-audio': 'Mux',
+  'mux-video': 'Mux',
+  vimeo: 'Vimeo',
+};
+
+// Sections teach the source-type taxonomy at the point of choice: plain files,
+// then open streaming formats, then hosting services. Renderers absent here
+// (e.g. background-video) fall back to an ungrouped list.
+const RENDERER_SECTIONS: Array<{ label: string; renderers: Renderer[] }> = [
+  { label: 'Files', renderers: ['html5-video', 'html5-audio'] },
+  { label: 'Streaming formats', renderers: ['hls', 'dash'] },
+  { label: 'Hosting services', renderers: ['mux-video', 'mux-audio', 'vimeo'] },
+];
+
+export function buildOptions(useCase: UseCase): SelectOption<Renderer>[] {
+  return VALID_RENDERERS[useCase].map((r) => ({
+    value: r,
+    label: RENDERER_LABELS[r],
+  }));
+}
+
+// Build labelled sections for the use case, dropping empty ones. Returns null
+// unless grouping actually earns its keep — there must be at least two sections
+// and at least one with more than one item. That keeps single-item use cases
+// (background) and all-single-item ones (audio: HTML5 Audio + Mux) flat rather
+// than stacking lone headers over lone items; the caller renders a flat list.
+export function buildGroups(useCase: UseCase): SelectGroup<Renderer>[] | null {
+  const valid = VALID_RENDERERS[useCase];
+  const groups = RENDERER_SECTIONS.map((section) => ({
+    label: section.label,
+    options: section.renderers.filter((r) => valid.includes(r)).map((r) => ({ value: r, label: RENDERER_LABELS[r] })),
+  })).filter((group) => group.options.length > 0);
+
+  const worthGrouping = groups.length > 1 && groups.some((group) => group.options.length > 1);
+  return worthGrouping ? groups : null;
+}

--- a/site/src/utils/installation/types.ts
+++ b/site/src/utils/installation/types.ts
@@ -1,4 +1,12 @@
-export type Renderer = 'background-video' | 'hls' | 'html5-audio' | 'html5-video';
+export type Renderer =
+  | 'background-video'
+  | 'dash'
+  | 'hls'
+  | 'html5-audio'
+  | 'html5-video'
+  | 'mux-audio'
+  | 'mux-video'
+  | 'vimeo';
 
 export type Skin = 'video' | 'audio' | 'minimal-video' | 'minimal-audio' | 'none';
 
@@ -6,8 +14,11 @@ export type UseCase = 'default-video' | 'default-audio' | 'background-video';
 
 export type InstallMethod = 'cdn' | 'npm' | 'pnpm' | 'yarn' | 'bun';
 
+// Order is also guidance: index 0 is the fallback default when there's no URL
+// detection, and the list reads top-to-bottom as what we steer users toward —
+// common files first, then open streaming formats, then hosting services.
 export const VALID_RENDERERS: Record<UseCase, Renderer[]> = {
-  'default-video': ['html5-video', 'hls'],
-  'default-audio': ['html5-audio'],
+  'default-video': ['html5-video', 'hls', 'dash', 'mux-video', 'vimeo'],
+  'default-audio': ['html5-audio', 'mux-audio'],
   'background-video': ['background-video'],
 };

--- a/site/src/utils/installation/types.ts
+++ b/site/src/utils/installation/types.ts
@@ -22,3 +22,17 @@ export const VALID_RENDERERS: Record<UseCase, Renderer[]> = {
   'default-audio': ['html5-audio', 'mux-audio'],
   'background-video': ['background-video'],
 };
+
+// Renderer → media subpath name, independent of whether a CDN build exists.
+// Preset renderers (html5-video/audio, background-video) are covered by their
+// preset bundle and have no separate media script, so they map to null.
+export function getMediaSubpath(renderer: Renderer): string | null {
+  const map: Partial<Record<Renderer, string>> = {
+    hls: 'hlsjs-video',
+    dash: 'dash-video',
+    'mux-video': 'mux-video',
+    'mux-audio': 'mux-audio',
+    vimeo: 'vimeo-video',
+  };
+  return map[renderer] ?? null;
+}


### PR DESCRIPTION
Closes #1255.

Adds DASH, Mux, and Vimeo to the installation guide and installation CLI.

## How do I review this?
### Where?
- [React](https://deploy-preview-1732--vjs10-site.netlify.app/docs/framework/react/how-to/installation)
- [HTML](https://deploy-preview-1732--vjs10-site.netlify.app/docs/framework/html/how-to/installation)

### What?
Try the picker or drop in a Mux / Vimeo / DASH URL

<img width="300" alt="CleanShot 2026-06-25 at 15 50 16@2x" src="https://github.com/user-attachments/assets/9d80b3ec-b05a-4cbe-b2cc-dfdcc3473a3f" />

## Out of scope (follow-ups)
#1749, #1750, #1751 

---

https://claude.ai/code/session_01Kd5A9UsSz5Ka7nYhEik3Fd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to installation docs/codegen, CLI flags, and UI picker behavior with broad test coverage; no auth or core playback runtime changes in this diff.
> 
> **Overview**
> Adds **DASH**, **Mux** (video and audio), and **Vimeo** as selectable media source types on the installation guide and in `@videojs/cli docs how-to/installation`, including generated HTML/React snippets, imports, and CDN script tags where builds exist.
> 
> Renderer labels and picker ordering are centralized in shared `renderer-options` (site + CLI) so the UI and CLI stay aligned. CDN install snippets and the CDN tab are gated by the **cdn-media manifest**: DASH, HLS, and Mux get extra media scripts when listed; **Vimeo** is npm-only—the CLI errors on `--install-method cdn`, and the install tabs reset `installMethod` when CDN becomes unavailable so usage code doesn’t drop required JS imports.
> 
> URL auto-detection now prefers **Mux** over generic HLS for `stream.mux.com`, recognizes Vimeo hosts, maps **`.mpd`** to DASH, and falls through Mux video→audio rules by use case. Demo sample URLs for DASH and Vimeo were added for empty `--source-url`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44fdfd8881f30b43abedf741e895e78f414589b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->