### PR TITLE
feat(packages): add settings persistence

### DIFF
--- a/apps/sandbox/app/shared/react/providers.ts
+++ b/apps/sandbox/app/shared/react/providers.ts
@@ -6,23 +6,23 @@ import { liveVideoFeatures } from '@videojs/react/live-video';
 import { videoFeatures } from '@videojs/react/video';
 
 export const { Provider: VideoProvider } = createPlayer({
-  features: [...videoFeatures, features.orientationLock],
+  features: [...videoFeatures, features.orientationLock, features.userPreferences],
 });
 
 export const { Provider: AudioProvider } = createPlayer({
-  features: audioFeatures,
+  features: [...audioFeatures, features.userPreferences],
 });
 
 export const { Provider: BackgroundVideoProvider } = createPlayer({
-  features: backgroundFeatures,
+  features: [...backgroundFeatures, features.userPreferences],
 });
 
 // Live providers register `liveFeature` so the LiveButton can read
 // `liveEdgeStart` / `targetLiveWindow` and seek to the live edge.
 export const { Provider: LiveVideoProvider } = createPlayer({
-  features: liveVideoFeatures,
+  features: [...liveVideoFeatures, features.userPreferences],
 });
 
 export const { Provider: LiveAudioProvider } = createPlayer({
-  features: liveAudioFeatures,
+  features: [...liveAudioFeatures, features.userPreferences],
 });

--- a/apps/sandbox/templates/simple-hls-react/main.tsx
+++ b/apps/sandbox/templates/simple-hls-react/main.tsx
@@ -7,13 +7,13 @@ import '@app/styles.css';
 // player with play/mute controls. SimpleHlsVideo registers itself via
 // useMediaAttach so the store discovers it without any querySelector.
 
-import { Container, createPlayer, MuteButton, PlayButton } from '@videojs/react';
+import { Container, createPlayer, features, MuteButton, PlayButton } from '@videojs/react';
 import { PauseIcon, PlayIcon, RestartIcon, VolumeHighIcon, VolumeOffIcon } from '@videojs/react/icons';
 import { SimpleHlsVideo } from '@videojs/react/media/simple-hls-video';
 import { videoFeatures } from '@videojs/react/video';
 import { createRoot } from 'react-dom/client';
 
-const { Provider } = createPlayer({ features: videoFeatures });
+const { Provider } = createPlayer({ features: [...videoFeatures, features.userPreferences] });
 
 const buttonStyle: React.CSSProperties = {
   background: 'none',

--- a/packages/core/src/dom/store/features/feature.parts.ts
+++ b/packages/core/src/dom/store/features/feature.parts.ts
@@ -12,6 +12,7 @@ import { sourceFeature } from './source';
 import { streamTypeFeature } from './stream-type';
 import { textTrackFeature } from './text-track';
 import { timeFeature } from './time';
+import { userPreferencesFeature } from './user-preferences';
 import { volumeFeature } from './volume';
 
 export { audioFeatures, backgroundFeatures, videoFeatures } from './presets';
@@ -32,5 +33,6 @@ export {
   streamTypeFeature as streamType,
   textTrackFeature as textTrack,
   timeFeature as time,
+  userPreferencesFeature as userPreferences,
   volumeFeature as volume,
 };

--- a/packages/core/src/dom/store/features/index.ts
+++ b/packages/core/src/dom/store/features/index.ts
@@ -15,4 +15,5 @@ export * from './source';
 export * from './stream-type';
 export * from './text-track';
 export * from './time';
+export * from './user-preferences';
 export * from './volume';

--- a/packages/core/src/dom/store/features/playback-rate.ts
+++ b/packages/core/src/dom/store/features/playback-rate.ts
@@ -1,29 +1,78 @@
 import { listen } from '@videojs/utils/dom';
+import { isNumber } from '@videojs/utils/predicate';
 import { isMediaPlaybackRateCapable } from '../../../core/media/predicate';
 import type { MediaPlaybackRateState } from '../../../core/media/state';
 import { definePlayerFeature } from '../../feature';
+import { getUserPreference, setUserPreference } from './user-preferences';
 
 const DEFAULT_RATES: readonly number[] = [0.2, 0.5, 0.7, 1, 1.2, 1.5, 1.7, 2];
+const DEFAULT_RATE = 1;
+const PREF_KEY = 'playbackRate';
+const UNSET = Symbol('unset');
 
 export const playbackRateFeature = definePlayerFeature({
   name: 'playbackRate',
-  state: ({ target }): MediaPlaybackRateState => ({
+  state: ({ target, get }): MediaPlaybackRateState => ({
     playbackRates: DEFAULT_RATES,
     playbackRate: 1,
     setPlaybackRate(rate: number) {
       const { media } = target();
-      if (isMediaPlaybackRateCapable(media)) media.playbackRate = rate;
+      if (!isMediaPlaybackRateCapable(media)) return;
+
+      media.playbackRate = rate;
+      if (isValidRate(rate)) setUserPreference(get(), PREF_KEY, rate);
     },
   }),
 
-  attach({ target, signal, set }) {
+  attach({ target, signal, set, store }) {
     const { media } = target;
 
     if (!isMediaPlaybackRateCapable(media)) return;
 
-    const sync = () => set({ playbackRate: media.playbackRate });
-    sync();
+    let applying = false;
+    let lastPreference: unknown = UNSET;
+
+    const apply = () => {
+      const rate = getUserPreference(store.state, PREF_KEY);
+      if (Object.is(rate, lastPreference)) return;
+      const hadPreference = lastPreference !== UNSET;
+      lastPreference = rate;
+      if (rate === undefined) {
+        if (hadPreference) setRate(DEFAULT_RATE);
+        return;
+      }
+      if (!isValidRate(rate)) return;
+
+      const { playbackRates } = store.state;
+      if (Array.isArray(playbackRates) && !playbackRates.includes(rate)) return;
+
+      setRate(rate);
+    };
+
+    const setRate = (rate: number) => {
+      applying = true;
+      media.playbackRate = rate;
+      set({ playbackRate: media.playbackRate });
+      applying = false;
+    };
+
+    const sync = () => {
+      set({ playbackRate: media.playbackRate });
+      if (!applying && isValidRate(media.playbackRate)) {
+        setUserPreference(store.state, PREF_KEY, media.playbackRate);
+      }
+    };
+
+    const unsubscribe = store.subscribe(apply);
+    signal.addEventListener('abort', unsubscribe, { once: true });
+
+    set({ playbackRate: media.playbackRate });
+    apply();
 
     listen(media, 'ratechange', sync, { signal });
   },
 });
+
+function isValidRate(value: unknown): value is number {
+  return isNumber(value) && Number.isFinite(value) && value > 0;
+}

--- a/packages/core/src/dom/store/features/tests/user-preferences.test.ts
+++ b/packages/core/src/dom/store/features/tests/user-preferences.test.ts
@@ -1,0 +1,574 @@
+import { combine, createStore, flush } from '@videojs/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { VideoRenditionLike } from '../../../../core/media/types';
+import type { PlayerTarget } from '../../../media/types';
+import { createMockVideo } from '../../../tests/test-helpers';
+import { playbackRateFeature } from '../playback-rate';
+import { qualityFeature } from '../quality';
+import { textTrackFeature } from '../text-track';
+import { timeFeature } from '../time';
+import {
+  getUserPreference,
+  setUserPreference,
+  type UserPreferencesStorage,
+  userPreferencesFeature,
+} from '../user-preferences';
+import { volumeFeature } from '../volume';
+
+const STORAGE_KEY = 'media:user-preferences';
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+class TestStorage implements UserPreferencesStorage {
+  values = new Map<string, string>();
+  setItem = vi.fn((key: string, value: string) => {
+    this.values.set(key, value);
+  });
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+}
+
+class BrokenStorage implements UserPreferencesStorage {
+  getItem(): string | null {
+    throw new Error('No storage');
+  }
+
+  setItem(): void {
+    throw new Error('No storage');
+  }
+}
+
+class TestTextTrackList extends EventTarget {
+  readonly length: number;
+  [index: number]: TextTrack;
+
+  constructor(tracks: TextTrack[]) {
+    super();
+    this.length = tracks.length;
+    for (const [index, track] of tracks.entries()) this[index] = track;
+  }
+
+  [Symbol.iterator](): Iterator<TextTrack> {
+    return Array.from({ length: this.length }, (_, index) => this[index]!).values();
+  }
+}
+
+class TestRenditionList extends EventTarget {
+  renditions: VideoRenditionLike[];
+
+  constructor(renditions: VideoRenditionLike[]) {
+    super();
+    this.renditions = renditions;
+  }
+
+  [Symbol.iterator](): Iterator<VideoRenditionLike> {
+    return this.renditions.values();
+  }
+
+  get length(): number {
+    return this.renditions.length;
+  }
+
+  get selectedIndex(): number {
+    return this.renditions.findIndex((rendition) => rendition.selected);
+  }
+
+  set selectedIndex(index: number) {
+    for (const [renditionIndex, rendition] of this.renditions.entries()) {
+      rendition.selected = renditionIndex === index;
+    }
+  }
+}
+
+function createTrack(
+  kind: TextTrackKind,
+  mode: TextTrackMode = 'disabled',
+  options: { id?: string; label?: string; language?: string } = {}
+): TextTrack {
+  return {
+    id: options.id ?? '',
+    kind,
+    mode,
+    label: options.label ?? '',
+    language: options.language ?? '',
+  } as TextTrack;
+}
+
+function createRendition(overrides: Partial<VideoRenditionLike>): VideoRenditionLike {
+  return {
+    id: undefined,
+    width: undefined,
+    height: undefined,
+    bitrate: undefined,
+    frameRate: undefined,
+    codec: undefined,
+    selected: false,
+    ...overrides,
+  };
+}
+
+function setTextTracks(video: HTMLVideoElement, tracks: TextTrack[]): TestTextTrackList {
+  const list = new TestTextTrackList(tracks);
+  Object.defineProperty(video, 'textTracks', {
+    configurable: true,
+    value: list,
+  });
+  return list;
+}
+
+function setRenditions(video: HTMLVideoElement, renditions: VideoRenditionLike[]): TestRenditionList {
+  const list = new TestRenditionList(renditions);
+  Object.defineProperty(video, 'videoRenditions', {
+    configurable: true,
+    value: list,
+  });
+  return list;
+}
+
+function createMedia(): HTMLVideoElement {
+  const video = createMockVideo({ volume: 1, muted: false });
+  video.playbackRate = 1;
+  setTextTracks(video, []);
+  setRenditions(video, []);
+  return video;
+}
+
+function spyMediaValue(media: HTMLVideoElement, key: 'playbackRate' | 'volume', initial: number) {
+  let value = initial;
+  const set = vi.fn((next: number) => {
+    value = next;
+  });
+
+  Object.defineProperty(media, key, {
+    configurable: true,
+    get: () => value,
+    set,
+  });
+
+  return set;
+}
+
+function createPlayerStore(storage: UserPreferencesStorage) {
+  return createStore<PlayerTarget>()(
+    combine(playbackRateFeature, volumeFeature, textTrackFeature, qualityFeature, userPreferencesFeature({ storage }))
+  );
+}
+
+async function ready(): Promise<void> {
+  await Promise.resolve();
+  flush();
+}
+
+function setLocalStorage(storage: UserPreferencesStorage): void {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+}
+
+afterEach(() => {
+  if (localStorageDescriptor) {
+    Object.defineProperty(globalThis, 'localStorage', localStorageDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, 'localStorage');
+  }
+});
+
+describe('userPreferencesFeature', () => {
+  it('stores generic preferences', () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, JSON.stringify({ playbackRate: 1.5 }));
+
+    const store = createStore<PlayerTarget>()(userPreferencesFeature({ storage }));
+
+    expect(store.state.getUserPreference('playbackRate')).toBe(1.5);
+    expect(getUserPreference(store.state, 'playbackRate')).toBe(1.5);
+
+    store.state.setUserPreference('theme', 'dark');
+    expect(JSON.parse(storage.values.get(STORAGE_KEY)!)).toEqual({
+      playbackRate: 1.5,
+      theme: 'dark',
+    });
+  });
+
+  it('no-ops when the feature is absent', () => {
+    const state = {};
+
+    expect(getUserPreference(state, 'theme')).toBeUndefined();
+    expect(() => setUserPreference(state, 'theme', 'dark')).not.toThrow();
+  });
+
+  it('ignores corrupt and unavailable storage', () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, '{nope');
+
+    const store = createStore<PlayerTarget>()(userPreferencesFeature({ storage }));
+    const brokenStore = createStore<PlayerTarget>()(userPreferencesFeature({ storage: new BrokenStorage() }));
+
+    expect(store.state.userPreferences).toEqual({});
+    expect(brokenStore.state.userPreferences).toEqual({});
+    expect(() => brokenStore.state.setUserPreference('theme', 'dark')).not.toThrow();
+  });
+
+  it('restores persisted media preferences', async () => {
+    const storage = new TestStorage();
+    storage.values.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        playbackRate: 1.5,
+        volume: { volume: 0.25, muted: true },
+        captions: { value: 'es' },
+        quality: 720,
+      })
+    );
+
+    const video = createMedia();
+    const spanish = createTrack('subtitles', 'disabled', { id: 'subtitles0', label: 'Spanish', language: 'es' });
+    setTextTracks(video, [createTrack('subtitles', 'disabled', { id: 'en' }), spanish]);
+    const renditions = setRenditions(video, [
+      createRendition({ id: '1080p', width: 1920, height: 1080 }),
+      createRendition({ id: '720p', width: 1280, height: 720 }),
+    ]);
+
+    const store = createPlayerStore(storage);
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(video.playbackRate).toBe(1.5);
+    expect(video.volume).toBe(0.25);
+    expect(video.muted).toBe(true);
+    expect(spanish.mode).toBe('showing');
+    expect(renditions.selectedIndex).toBe(-1);
+  });
+
+  it('persists changed media preferences', async () => {
+    const storage = new TestStorage();
+    const video = createMedia();
+    const spanish = createTrack('subtitles', 'disabled', { id: 'subtitles0', label: 'Spanish', language: 'es' });
+    const renditions = setRenditions(video, [
+      createRendition({ id: '1080p', width: 1920, height: 1080 }),
+      createRendition({ id: '720p', width: 1280, height: 720 }),
+    ]);
+    setTextTracks(video, [spanish]);
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    video.playbackRate = 1.5;
+    video.dispatchEvent(new Event('ratechange'));
+    store.state.setVolume(0.333);
+    store.state.selectSubtitlesTrack('subtitles0');
+    store.state.selectVideoRendition('720p');
+
+    expect(renditions.selectedIndex).toBe(1);
+    expect(JSON.parse(storage.values.get(STORAGE_KEY)!)).toEqual({
+      playbackRate: 1.5,
+      volume: { volume: 0.33, muted: false },
+      captions: { value: 'es', id: 'subtitles0' },
+    });
+  });
+
+  it('does not write defaults after attach or detach', async () => {
+    const storage = new TestStorage();
+    const video = createMedia();
+    const store = createPlayerStore(storage);
+    const detach = store.attach({ media: video, container: null });
+
+    await ready();
+    detach();
+    flush();
+
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('refreshes stored preferences when media reattaches', async () => {
+    const storage = new TestStorage();
+    const store = createPlayerStore(storage);
+    const video = createMedia();
+
+    const detach = store.attach({ media: video, container: null });
+    await ready();
+
+    video.playbackRate = 1.5;
+    video.dispatchEvent(new Event('ratechange'));
+    store.state.setVolume(0.25);
+    await ready();
+
+    expect(JSON.parse(storage.values.get(STORAGE_KEY)!)).toMatchObject({
+      playbackRate: 1.5,
+      volume: { volume: 0.25, muted: false },
+    });
+
+    detach();
+    flush();
+
+    expect(store.state.userPreferences).toEqual({});
+
+    const nextVideo = createMedia();
+    store.attach({ media: nextVideo, container: null });
+    await ready();
+
+    expect(nextVideo.playbackRate).toBe(1.5);
+    expect(nextVideo.volume).toBe(0.25);
+  });
+
+  it('does not reapply volume and playback rate for unrelated store changes', async () => {
+    const storage = new TestStorage();
+    storage.values.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        playbackRate: 1.5,
+        volume: { volume: 0.25, muted: false },
+      })
+    );
+
+    const video = createMedia();
+    const setPlaybackRate = spyMediaValue(video, 'playbackRate', 1);
+    const setVolume = spyMediaValue(video, 'volume', 1);
+    const store = createStore<PlayerTarget>()(
+      combine(playbackRateFeature, volumeFeature, timeFeature, userPreferencesFeature({ storage }))
+    );
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(video.playbackRate).toBe(1.5);
+    expect(video.volume).toBe(0.25);
+
+    setPlaybackRate.mockClear();
+    setVolume.mockClear();
+
+    video.currentTime = 10;
+    video.dispatchEvent(new Event('timeupdate'));
+    await ready();
+
+    expect(store.state.currentTime).toBe(10);
+    expect(setPlaybackRate).not.toHaveBeenCalled();
+    expect(setVolume).not.toHaveBeenCalled();
+  });
+
+  it('resets volume and playback rate when preferences are removed', async () => {
+    const storage = new TestStorage();
+    storage.values.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        playbackRate: 1.5,
+        volume: { volume: 0.25, muted: true },
+      })
+    );
+
+    const video = createMedia();
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(video.playbackRate).toBe(1.5);
+    expect(video.volume).toBe(0.25);
+    expect(video.muted).toBe(true);
+
+    store.state.setUserPreference('playbackRate', undefined);
+    store.state.setUserPreference('volume', undefined);
+    await ready();
+
+    expect(video.playbackRate).toBe(1);
+    expect(video.volume).toBe(1);
+    expect(video.muted).toBe(false);
+  });
+
+  it('does not persist captions off during track discovery', async () => {
+    const storage = new TestStorage();
+    const video = createMedia();
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    setTextTracks(video, [createTrack('subtitles', 'disabled', { id: 'en', label: 'English', language: 'en' })]);
+    video.dispatchEvent(new Event('loadstart'));
+    flush();
+
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('persists toggled captions using native track order', async () => {
+    const storage = new TestStorage();
+    const video = createMedia();
+    const english = createTrack('subtitles', 'disabled', { id: 'subtitles0', label: 'English', language: 'en' });
+    const spanish = createTrack('captions', 'disabled', { id: 'captions0', label: 'Spanish', language: 'es' });
+    setTextTracks(video, [english, spanish]);
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    store.state.toggleSubtitles(true);
+
+    expect(JSON.parse(storage.values.get(STORAGE_KEY)!)).toEqual({
+      captions: { value: 'en', id: 'subtitles0' },
+    });
+  });
+
+  it('restores same-language captions by track id', async () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, JSON.stringify({ captions: { value: 'en', id: 'descriptive' } }));
+
+    const video = createMedia();
+    const english = createTrack('subtitles', 'disabled', { id: 'english', label: 'English', language: 'en' });
+    const descriptive = createTrack('subtitles', 'disabled', {
+      id: 'descriptive',
+      label: 'English descriptive',
+      language: 'en',
+    });
+    setTextTracks(video, [english, descriptive]);
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(english.mode).toBe('disabled');
+    expect(descriptive.mode).toBe('showing');
+  });
+
+  it('does not replace restored captions with off on loadstart', async () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, JSON.stringify({ captions: { value: 'es' } }));
+
+    const video = createMedia();
+    const spanish = createTrack('subtitles', 'disabled', { id: 'subtitles0', label: 'Spanish', language: 'es' });
+    setTextTracks(video, [spanish]);
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(spanish.mode).toBe('showing');
+
+    setTextTracks(video, [createTrack('subtitles', 'disabled', { id: 'en', label: 'English', language: 'en' })]);
+    video.dispatchEvent(new Event('loadstart'));
+    flush();
+
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(JSON.parse(storage.values.get(STORAGE_KEY)!)).toEqual({ captions: { value: 'es' } });
+  });
+
+  it('retries captions when options arrive late', async () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, JSON.stringify({ captions: { value: 'es' } }));
+
+    const video = createMedia();
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    const spanish = createTrack('subtitles', 'disabled', { id: 'subtitles0', label: 'Spanish', language: 'es' });
+    setTextTracks(video, [spanish]);
+    video.dispatchEvent(new Event('loadstart'));
+    flush();
+
+    expect(spanish.mode).toBe('showing');
+  });
+
+  it('clears preferences when another tab removes the storage key', async () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, JSON.stringify({ playbackRate: 1.5, volume: { volume: 0.25, muted: true } }));
+    setLocalStorage(storage);
+
+    const video = createMedia();
+    const store = createStore<PlayerTarget>()(combine(playbackRateFeature, volumeFeature, userPreferencesFeature()));
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(video.playbackRate).toBe(1.5);
+    expect(video.volume).toBe(0.25);
+    expect(video.muted).toBe(true);
+    expect(store.state.userPreferences).toEqual({ playbackRate: 1.5, volume: { volume: 0.25, muted: true } });
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: STORAGE_KEY,
+        newValue: null,
+      })
+    );
+    flush();
+
+    expect(store.state.userPreferences).toEqual({});
+    expect(video.playbackRate).toBe(1);
+    expect(video.volume).toBe(1);
+    expect(video.muted).toBe(false);
+  });
+
+  it('disables captions when the captions preference is removed', async () => {
+    const storage = new TestStorage();
+    storage.values.set(STORAGE_KEY, JSON.stringify({ captions: { value: 'es' } }));
+
+    const video = createMedia();
+    const spanish = createTrack('subtitles', 'disabled', { id: 'subtitles0', label: 'Spanish', language: 'es' });
+    setTextTracks(video, [spanish]);
+    const store = createPlayerStore(storage);
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    expect(spanish.mode).toBe('showing');
+
+    store.state.setUserPreference('captions', undefined);
+    flush();
+
+    expect(spanish.mode).toBe('disabled');
+    expect(store.state.userPreferences).toEqual({});
+  });
+
+  it('applies valid storage events from another tab', async () => {
+    setLocalStorage(new TestStorage());
+
+    const video = createMedia();
+    const store = createStore<PlayerTarget>()(combine(playbackRateFeature, userPreferencesFeature()));
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: STORAGE_KEY,
+        newValue: JSON.stringify({ playbackRate: 1.5 }),
+      })
+    );
+    flush();
+
+    expect(video.playbackRate).toBe(1.5);
+  });
+
+  it('ignores unrelated and invalid storage events', async () => {
+    setLocalStorage(new TestStorage());
+
+    const video = createMedia();
+    const store = createStore<PlayerTarget>()(combine(playbackRateFeature, userPreferencesFeature()));
+
+    store.attach({ media: video, container: null });
+    await ready();
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'other',
+        newValue: JSON.stringify({ playbackRate: 1.5 }),
+      })
+    );
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: STORAGE_KEY,
+        newValue: '{nope',
+      })
+    );
+    flush();
+
+    expect(video.playbackRate).toBe(1);
+  });
+});

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -1,8 +1,17 @@
-import { findTrackElement, getTextTrackList, isCaptionOrSubtitleTrack, listen } from '@videojs/utils/dom';
+import { findTrackElement, isCaptionOrSubtitleTrack, listen } from '@videojs/utils/dom';
+import { isPlainObject, isString } from '@videojs/utils/predicate';
 import { isMediaTextTrackCapable, isQuerySelectorAllCapable } from '../../../core/media/predicate';
 import type { MediaTextCue, MediaTextTrack, MediaTextTrackState } from '../../../core/media/state';
-import type { TextTrackLike } from '../../../core/media/types';
+import type { TextTrackLike, TextTrackListLike } from '../../../core/media/types';
 import { definePlayerFeature } from '../../feature';
+import { getUserPreference, setUserPreference } from './user-preferences';
+
+const PREF_KEY = 'captions';
+const VALUE_OFF = 'off';
+
+interface TextTrackMedia {
+  textTracks: TextTrackListLike;
+}
 
 function getTrackId(track: TextTrackLike, index: number): string {
   return track.id || `track:${index}:${track.kind}:${track.language}:${track.label}`;
@@ -10,7 +19,7 @@ function getTrackId(track: TextTrackLike, index: number): string {
 
 export const textTrackFeature = definePlayerFeature({
   name: 'textTrack',
-  state: ({ target }): MediaTextTrackState => ({
+  state: ({ target, get }): MediaTextTrackState => ({
     chaptersCues: [],
     thumbnailCues: [],
     thumbnailTrackSrc: null,
@@ -20,31 +29,32 @@ export const textTrackFeature = definePlayerFeature({
       const { media } = target();
       if (!isMediaTextTrackCapable(media)) return false;
 
-      const subtitlesTracks = getTextTrackList(media, isCaptionOrSubtitleTrack);
+      const subtitlesTracks = getCaptionTrackItems(media);
       if (!subtitlesTracks.length) return false;
 
-      const showing = subtitlesTracks.some((track) => track.mode === 'showing');
+      const showing = subtitlesTracks.some(({ track }) => track.mode === 'showing');
       const nextShowing = forceShow ?? !showing;
 
-      for (const track of subtitlesTracks) {
+      for (const { track } of subtitlesTracks) {
         track.mode = nextShowing ? 'showing' : 'disabled';
       }
 
+      const value = nextShowing ? getTrackPreference(subtitlesTracks[0]!.track) : { value: VALUE_OFF };
+      if (value) setUserPreference(get(), PREF_KEY, value);
       return nextShowing;
     },
     selectSubtitlesTrack(value: string) {
       const { media } = target();
       if (!isMediaTextTrackCapable(media)) return;
 
-      const subtitlesTracks = Array.from(media.textTracks)
-        .map((track, index) => ({ index, track }))
-        .filter(({ track }) => isCaptionOrSubtitleTrack(track));
+      const subtitlesTracks = getCaptionTrackItems(media);
       if (!subtitlesTracks.length) return;
 
-      if (value === 'off') {
+      if (value === VALUE_OFF) {
         for (const { track } of subtitlesTracks) {
           track.mode = 'disabled';
         }
+        setUserPreference(get(), PREF_KEY, { value } satisfies TextTrackPreference);
         return;
       }
 
@@ -55,19 +65,53 @@ export const textTrackFeature = definePlayerFeature({
       for (const { track: candidate } of subtitlesTracks) {
         candidate.mode = candidate === track ? 'showing' : 'disabled';
       }
+
+      const prefValue = getTrackPreference(track);
+      if (prefValue) setUserPreference(get(), PREF_KEY, prefValue);
     },
   }),
 
-  attach({ target, signal, set }) {
+  attach({ target, signal, set, store }) {
     const { media } = target;
 
     if (!isMediaTextTrackCapable(media)) return;
 
     let trackCleanup: AbortController | null = null;
+    let ready = false;
+    let pending = getTextTrackPreference(store.state);
+    let lastStored = getPreferenceString(pending);
 
-    const sync = () => {
+    const apply = (value: TextTrackPreference): boolean => {
+      const tracks = getCaptionTrackItems(media);
+      if (!tracks.length) return false;
+
+      if (value.value === VALUE_OFF) {
+        for (const { track } of tracks) track.mode = 'disabled';
+        return true;
+      }
+
+      const active =
+        (value.id !== undefined ? tracks.find(({ track }) => track.id === value.id) : undefined) ??
+        tracks.find(({ index, track }) => {
+          return getTrackPreferenceValue(track) === value.value || getTrackId(track, index) === value.value;
+        });
+      if (!active) return false;
+
+      for (const { track } of tracks) {
+        track.mode = track === active.track ? 'showing' : 'disabled';
+      }
+
+      return true;
+    };
+
+    const sync = (persist = false) => {
       trackCleanup?.abort();
       trackCleanup = new AbortController();
+      const hadPending = pending !== undefined;
+
+      if (pending && apply(pending)) {
+        pending = undefined;
+      }
 
       let chaptersTrack: TextTrackLike | null = null;
       let thumbnailTrack: TextTrackLike | null = null;
@@ -115,23 +159,92 @@ export const textTrackFeature = definePlayerFeature({
 
       for (const trackEl of [...tracks, ...shadowTracks]) {
         if (!trackEl.track?.cues?.length) {
-          listen(trackEl, 'load', sync, { signal: trackCleanup.signal });
+          listen(trackEl, 'load', () => sync(), { signal: trackCleanup.signal });
         }
       }
 
       set({ chaptersCues, thumbnailCues, thumbnailTrackSrc, textTrackList, subtitlesShowing });
+
+      if (persist && ready && !hadPending) {
+        const value = getCurrentTextTrackPreference(media);
+        if (value && (value.value !== VALUE_OFF || lastStored !== undefined)) {
+          lastStored = getPreferenceString(value);
+          setUserPreference(store.state, PREF_KEY, value);
+        }
+      }
+
+      ready = true;
+    };
+
+    const syncPreference = () => {
+      const value = getTextTrackPreference(store.state);
+      const nextStored = getPreferenceString(value);
+      if (nextStored === lastStored) return;
+
+      pending = value ?? (lastStored !== undefined ? { value: VALUE_OFF } : undefined);
+      lastStored = nextStored;
+      sync();
     };
 
     sync();
+    const unsubscribe = store.subscribe(syncPreference);
+    signal.addEventListener('abort', unsubscribe, { once: true });
 
     const textTracks = media.textTracks;
     if (textTracks instanceof EventTarget) {
-      listen(textTracks, 'addtrack', sync, { signal });
-      listen(textTracks, 'removetrack', sync, { signal });
-      listen(textTracks, 'change', sync, { signal });
+      listen(textTracks, 'addtrack', () => sync(true), { signal });
+      listen(textTracks, 'removetrack', () => sync(true), { signal });
+      listen(textTracks, 'change', () => sync(true), { signal });
     }
-    listen(media, 'loadstart', sync, { signal });
+    listen(media, 'loadstart', () => sync(), { signal });
 
     signal.addEventListener('abort', () => trackCleanup?.abort(), { once: true });
   },
 });
+
+interface TextTrackPreference {
+  value: string;
+  id?: string | undefined;
+}
+
+function isTextTrackPreference(value: unknown): value is TextTrackPreference {
+  return isPlainObject(value) && isString(value.value) && (value.id === undefined || isString(value.id));
+}
+
+function getTextTrackPreference(state: Readonly<Record<string, unknown>>): TextTrackPreference | undefined {
+  const value = getUserPreference(state, PREF_KEY);
+  return isTextTrackPreference(value) ? value : undefined;
+}
+
+function getCurrentTextTrackPreference(media: TextTrackMedia): TextTrackPreference | undefined {
+  const tracks = getCaptionTrackItems(media);
+  if (!tracks.length) return undefined;
+
+  const item = tracks.find(({ track }) => track.mode === 'showing');
+  if (!item) return { value: VALUE_OFF };
+
+  return getTrackPreference(item.track);
+}
+
+function getCaptionTrackItems(media: TextTrackMedia): { index: number; track: TextTrackLike }[] {
+  return Array.from(media.textTracks)
+    .map((track, index) => ({ index, track }))
+    .filter(({ track }) => isCaptionOrSubtitleTrack(track));
+}
+
+function getTrackPreferenceValue(track: TextTrackLike): string | undefined {
+  return track.language || track.id || track.label || undefined;
+}
+
+function getTrackPreference(track: TextTrackLike): TextTrackPreference | undefined {
+  const value = getTrackPreferenceValue(track);
+  if (!value) return undefined;
+  return {
+    value,
+    ...(track.id ? { id: track.id } : {}),
+  };
+}
+
+function getPreferenceString(value: TextTrackPreference | undefined): string | undefined {
+  return value ? `${value.value}:${value.id ?? ''}` : undefined;
+}

--- a/packages/core/src/dom/store/features/user-preferences.ts
+++ b/packages/core/src/dom/store/features/user-preferences.ts
@@ -1,0 +1,150 @@
+import { listen } from '@videojs/utils/dom';
+import { isFunction, isPlainObject } from '@videojs/utils/predicate';
+
+import { definePlayerFeature } from '../../feature';
+
+export interface UserPreferencesStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface UserPreferencesFeatureConfig {
+  /** Storage key for persisted media user preferences. */
+  key?: string | undefined;
+  /** Storage backend. Defaults to `localStorage` when available. */
+  storage?: UserPreferencesStorage | undefined;
+}
+
+export interface UserPreferencesState {
+  userPreferences: Record<string, unknown>;
+  getUserPreference<Value = unknown>(key: string): Value | undefined;
+  setUserPreference(key: string, value: unknown): void;
+}
+
+const DEFAULT_KEY = 'media:user-preferences';
+
+export const userPreferencesFeature = definePlayerFeature(
+  {
+    name: 'userPreferences',
+    state: ({ get, set }, config: UserPreferencesFeatureConfig): UserPreferencesState => {
+      const key = config.key ?? DEFAULT_KEY;
+      const storage = getStorage(config.storage);
+
+      return {
+        userPreferences: storage ? read(storage, key) : {},
+        getUserPreference<Value = unknown>(prefKey: string): Value | undefined {
+          return getUserPreference(get(), prefKey);
+        },
+        setUserPreference(prefKey: string, value: unknown): void {
+          const current = get().userPreferences;
+          const prefs = isPlainObject(current) ? current : {};
+          const next = { ...prefs };
+
+          if (value === undefined) {
+            delete next[prefKey];
+          } else {
+            next[prefKey] = value;
+          }
+
+          set({ userPreferences: next });
+          if (storage) write(storage, key, next);
+        },
+      };
+    },
+
+    attach({ signal, get, set }, config: UserPreferencesFeatureConfig) {
+      const key = config.key ?? DEFAULT_KEY;
+      const storage = getStorage(config.storage);
+      if (!storage) return;
+      const prefsStorage = storage;
+
+      const next = read(prefsStorage, key);
+      if (stringify(get().userPreferences) !== stringify(next)) {
+        set({ userPreferences: next });
+      }
+
+      if (prefsStorage === getLocalStorage() && typeof window !== 'undefined') {
+        listen(
+          window,
+          'storage',
+          (event) => {
+            if (event.key !== key) return;
+            if (event.newValue === null) {
+              set({ userPreferences: {} });
+              return;
+            }
+
+            const next = parseObject(event.newValue);
+            if (!next) return;
+
+            set({ userPreferences: next });
+          },
+          { signal }
+        );
+      }
+    },
+  },
+  {} satisfies UserPreferencesFeatureConfig
+);
+
+function getStorage(storage?: UserPreferencesStorage): UserPreferencesStorage | null {
+  if (storage) return storage;
+  return getLocalStorage();
+}
+
+function getLocalStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function read(storage: UserPreferencesStorage, key: string): Record<string, unknown> {
+  try {
+    const value = storage.getItem(key);
+    if (!value) return {};
+    return parseObject(value) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function write(storage: UserPreferencesStorage, key: string, value: Record<string, unknown>): void {
+  try {
+    storage.setItem(key, stringify(value));
+  } catch {}
+}
+
+function parseObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export function getUserPreference<Value = unknown>(
+  state: Readonly<{ userPreferences?: unknown }>,
+  key: string
+): Value | undefined {
+  const prefs = state.userPreferences;
+  if (!isPlainObject(prefs)) return undefined;
+  return prefs[key] as Value | undefined;
+}
+
+export function setUserPreference(state: Readonly<{ setUserPreference?: unknown }>, key: string, value: unknown): void {
+  const setter = state.setUserPreference;
+  if (isFunction(setter)) setter(key, value);
+}
+
+export namespace userPreferencesFeature {
+  export type Config = UserPreferencesFeatureConfig;
+  export type Storage = UserPreferencesStorage;
+  export type State = UserPreferencesState;
+}

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -1,15 +1,21 @@
 import { listen } from '@videojs/utils/dom';
+import { isBoolean, isNumber, isPlainObject } from '@videojs/utils/predicate';
 import { isMediaVolumeCapable } from '../../../core/media/predicate';
 import type { MediaVolumeState } from '../../../core/media/state';
-import type { MediaFeatureAvailability } from '../../../core/media/types';
+import type { MediaFeatureAvailability, MediaVolumeCapability } from '../../../core/media/types';
 import { definePlayerFeature } from '../../feature';
+import { getUserPreference, setUserPreference } from './user-preferences';
 
 /** Volume to restore when unmuting at zero. */
 const UNMUTE_VOLUME = 0.25;
+const DEFAULT_VOLUME = 1;
+const DEFAULT_MUTED = false;
+const PREF_KEY = 'volume';
+const UNSET = Symbol('unset');
 
 export const volumeFeature = definePlayerFeature({
   name: 'volume',
-  state: ({ target }): MediaVolumeState => ({
+  state: ({ target, get }): MediaVolumeState => ({
     volume: 1,
     muted: false,
     volumeAvailability: 'unavailable',
@@ -24,6 +30,7 @@ export const volumeFeature = definePlayerFeature({
       }
 
       media.volume = clamped;
+      setUserPreference(get(), PREF_KEY, getVolumePreference(media));
       return media.volume;
     },
 
@@ -39,23 +46,71 @@ export const volumeFeature = definePlayerFeature({
         media.muted = true;
       }
 
+      setUserPreference(get(), PREF_KEY, getVolumePreference(media));
       return media.muted;
     },
   }),
 
-  attach({ target, signal, set }) {
+  attach({ target, signal, set, store }) {
     const { media } = target;
 
     if (!isMediaVolumeCapable(media)) return;
 
     set({ volumeAvailability: canSetVolume() });
 
-    const sync = () => set({ volume: media.volume, muted: media.muted });
-    sync();
+    let applying = false;
+    let lastPreference: unknown = UNSET;
+
+    const apply = () => {
+      const value = getUserPreference(store.state, PREF_KEY);
+      if (Object.is(value, lastPreference)) return;
+      const hadPreference = lastPreference !== UNSET;
+      lastPreference = value;
+      if (value === undefined) {
+        if (hadPreference) setVolume(DEFAULT_VOLUME, DEFAULT_MUTED);
+        return;
+      }
+      if (!isVolumePreference(value)) return;
+
+      setVolume(value.volume, value.muted);
+    };
+
+    const setVolume = (volume: number, muted: boolean) => {
+      applying = true;
+      media.volume = volume;
+      media.muted = muted;
+      set({ volume: media.volume, muted: media.muted });
+      applying = false;
+    };
+
+    const sync = () => {
+      set({ volume: media.volume, muted: media.muted });
+      if (!applying) {
+        setUserPreference(store.state, PREF_KEY, getVolumePreference(media));
+      }
+    };
+
+    const unsubscribe = store.subscribe(apply);
+    signal.addEventListener('abort', unsubscribe, { once: true });
+
+    set({ volume: media.volume, muted: media.muted });
+    apply();
 
     listen(media, 'volumechange', sync, { signal });
   },
 });
+
+interface VolumePreference {
+  volume: number;
+  muted: boolean;
+}
+
+function getVolumePreference(media: MediaVolumeCapability): VolumePreference {
+  return {
+    volume: Math.round(media.volume * 100) / 100,
+    muted: media.muted,
+  };
+}
 
 /** Check if volume can be programmatically set (fails on iOS Safari). */
 function canSetVolume(): MediaFeatureAvailability {
@@ -66,4 +121,15 @@ function canSetVolume(): MediaFeatureAvailability {
   } catch {
     return 'unsupported';
   }
+}
+
+function isVolumePreference(value: unknown): value is VolumePreference {
+  return (
+    isPlainObject(value) &&
+    isNumber(value.volume) &&
+    Number.isFinite(value.volume) &&
+    value.volume >= 0 &&
+    value.volume <= 1 &&
+    isBoolean(value.muted)
+  );
 }

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -1,5 +1,12 @@
 import type { AudioPlayerStore, PlayerStore, PlayerTarget, VideoPlayerStore } from '@videojs/core/dom';
-import { audioFeatures, backgroundFeatures, definePlayerFeature, features, videoFeatures } from '@videojs/core/dom';
+import {
+  audioFeatures,
+  backgroundFeatures,
+  definePlayerFeature,
+  features,
+  userPreferencesFeature,
+  videoFeatures,
+} from '@videojs/core/dom';
 import type { Slice } from '@videojs/store';
 import { assertType, describe, it } from 'vitest';
 
@@ -52,6 +59,20 @@ describe('createPlayer', () => {
 
     assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
     assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
+  });
+
+  it('accepts user preferences with and without config', () => {
+    const configuredUserPreferences = userPreferencesFeature({ key: 'custom:user-preferences' });
+
+    const defaultResult = createPlayer({ features: [...videoFeatures, userPreferencesFeature()] });
+    const configuredResult = createPlayer({ features: [...audioFeatures, configuredUserPreferences] });
+
+    assertType<CreatePlayerResult<PlayerStore<[...typeof videoFeatures, ReturnType<typeof userPreferencesFeature>]>>>(
+      defaultResult
+    );
+    assertType<CreatePlayerResult<PlayerStore<[...typeof audioFeatures, typeof configuredUserPreferences]>>>(
+      configuredResult
+    );
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -1,5 +1,5 @@
 import type { AudioPlayerStore, PlayerStore, PlayerTarget, VideoPlayerStore } from '@videojs/core/dom';
-import { audioFeatures, definePlayerFeature, features, videoFeatures } from '@videojs/core/dom';
+import { audioFeatures, definePlayerFeature, features, userPreferencesFeature, videoFeatures } from '@videojs/core/dom';
 import type { Slice } from '@videojs/store';
 import { assertType, describe, it } from 'vitest';
 
@@ -46,6 +46,20 @@ describe('createPlayer', () => {
 
     assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
     assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
+  });
+
+  it('accepts user preferences with and without config', () => {
+    const configuredUserPreferences = userPreferencesFeature({ key: 'custom:user-preferences' });
+
+    const defaultResult = createPlayer({ features: [...videoFeatures, userPreferencesFeature()] });
+    const configuredResult = createPlayer({ features: [...audioFeatures, configuredUserPreferences] });
+
+    assertType<CreatePlayerResult<PlayerStore<[...typeof videoFeatures, ReturnType<typeof userPreferencesFeature>]>>>(
+      defaultResult
+    );
+    assertType<CreatePlayerResult<PlayerStore<[...typeof audioFeatures, typeof configuredUserPreferences]>>>(
+      configuredResult
+    );
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -29,6 +29,11 @@ interface FeatureSource {
   stateTypeName?: string;
 }
 
+interface InterfaceSource {
+  decl: ts.InterfaceDeclaration;
+  sourceFile: ts.SourceFile;
+}
+
 // ─── Discovery ────────────────────────────────────────────────────
 
 function discoverFeatureSources(featuresDir: string): FeatureSource[] {
@@ -197,22 +202,26 @@ export function generateFeatureReferences(monorepoRoot: string): FeatureResult[]
   const sources = discoverFeatureSources(featuresDir);
   if (sources.length === 0) return [];
 
-  // Create a TS program with the state file for the checker
+  // Create a TS program with the shared state file and feature files for the checker.
+  // Most feature state interfaces live in media/state.ts, but opt-in utility
+  // features can keep their state type next to the implementation.
   const tsconfigPath = path.join(monorepoRoot, 'tsconfig.base.json');
   const config = tae.loadConfig(tsconfigPath);
   config.options.rootDir = monorepoRoot;
-  const program = ts.createProgram([stateFilePath], config.options);
+  const program = ts.createProgram([stateFilePath, ...sources.map((source) => source.filePath)], config.options);
   const checker = program.getTypeChecker();
-  const stateSourceFile = program.getSourceFile(stateFilePath);
-  if (!stateSourceFile) return [];
 
   // Build a map of interface name → declaration
-  const interfaces = new Map<string, ts.InterfaceDeclaration>();
-  ts.forEachChild(stateSourceFile, (node) => {
-    if (ts.isInterfaceDeclaration(node)) {
-      interfaces.set(node.name.text, node);
-    }
-  });
+  const interfaces = new Map<string, InterfaceSource>();
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!sourceFile.fileName.startsWith(monorepoRoot)) continue;
+
+    ts.forEachChild(sourceFile, (node) => {
+      if (ts.isInterfaceDeclaration(node)) {
+        interfaces.set(node.name.text, { decl: node, sourceFile });
+      }
+    });
+  }
 
   const results: FeatureResult[] = [];
   for (const source of sources) {
@@ -228,11 +237,11 @@ export function generateFeatureReferences(monorepoRoot: string): FeatureResult[]
       continue;
     }
 
-    const interfaceDecl = interfaces.get(source.stateTypeName);
-    if (!interfaceDecl) continue;
+    const interfaceSource = interfaces.get(source.stateTypeName);
+    if (!interfaceSource) continue;
 
-    const description = getJSDocDescription(interfaceDecl);
-    const { state, actions } = extractInterfaceMembers(interfaceDecl, checker, stateSourceFile);
+    const description = getJSDocDescription(interfaceSource.decl);
+    const { state, actions } = extractInterfaceMembers(interfaceSource.decl, checker, interfaceSource.sourceFile);
 
     const ref: FeatureReference = {
       name: source.name,

--- a/site/src/content/docs/reference/feature-user-preferences.mdx
+++ b/site/src/content/docs/reference/feature-user-preferences.mdx
@@ -1,0 +1,103 @@
+---
+title: User preferences
+description: Opt-in storage for player user preferences
+---
+
+import FeatureReference from "@/components/docs/api-reference/FeatureReference.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+
+Persists selected media preferences across player instances. To opt in, add it to your `features` array as shown below. It is not included in the default presets.
+
+<FeatureReference feature="userPreferences" />
+
+### Usage
+
+The feature stores one JSON object in `localStorage` under `media:user-preferences` by default.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="player.tsx"
+import { createPlayer, features } from '@videojs/react';
+import { videoFeatures } from '@videojs/react/video';
+
+export const Player = createPlayer({
+  features: [...videoFeatures, features.userPreferences],
+});
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="player.ts"
+import { createPlayer, features } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const player = createPlayer({
+  features: [...videoFeatures, features.userPreferences],
+});
+```
+</FrameworkCase>
+
+Pass a config object to change the storage key or provide a custom storage backend.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="player.tsx"
+import { createPlayer, features } from '@videojs/react';
+import { videoFeatures } from '@videojs/react/video';
+
+export const Player = createPlayer({
+  features: [
+    ...videoFeatures,
+    features.userPreferences({ key: 'my-player:preferences' }),
+  ],
+});
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="player.ts"
+import { createPlayer, features } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const player = createPlayer({
+  features: [
+    ...videoFeatures,
+    features.userPreferences({ key: 'my-player:preferences' }),
+  ],
+});
+```
+</FrameworkCase>
+
+### Stored preferences
+
+Built-in features currently persist:
+
+- Playback rate
+- Volume and muted state
+- Captions/subtitles selection
+
+Quality selection is not persisted. Rendition ids and quality ladders vary across sources, so storing a quality choice is easy to make fragile.
+
+When the default `localStorage` backend is used, changes from another same-origin tab are applied through the browser `storage` event.
+
+### Custom storage
+
+Custom storage should provide a [Web Storage-compatible API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API). The feature only uses `getItem()` and `setItem()`, so the storage object can be any adapter with those methods.
+
+```ts
+const memory = new Map<string, string>();
+
+const storage = {
+  getItem(key: string) {
+    return memory.get(key) ?? null;
+  },
+  setItem(key: string, value: string) {
+    memory.set(key, value);
+  },
+};
+
+const player = createPlayer({
+  features: [
+    ...videoFeatures,
+    features.userPreferences({ storage }),
+  ],
+});
+```

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -160,6 +160,7 @@ export const sidebar: Sidebar = [
       { slug: 'reference/feature-stream-type' },
       { slug: 'reference/feature-text-tracks' },
       { slug: 'reference/feature-time' },
+      { slug: 'reference/feature-user-preferences' },
       { slug: 'reference/feature-volume' },
     ],
   },


### PR DESCRIPTION
## Summary

Add a _opt-in_ user preferences feature to provide a way to persist settings across page loads and sync across tabs. Currently, it stores volume, caption language, playback rate. 

## Decisions

- I considered the feature being self contained and listening for events but ultimately felt cleaner if features themselves had control over get/set from the persistence storage. 
- Default storage key is `media:user-preferences`. 

## Visuals

There are no visual changes. 


Closes #944 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attach/sync behavior for core playback features and localStorage, with nuanced caption and cross-tab edge cases; defaults are unchanged unless the feature is enabled.
> 
> **Overview**
> Adds an **opt-in** `features.userPreferences` module that persists a single JSON blob (default key `media:user-preferences`) via `localStorage` or a custom Web Storage–compatible adapter, with cross-tab updates through the `storage` event.
> 
> **Playback rate**, **volume/mute**, and **captions/subtitles** features now read and write their own keys through shared `getUserPreference` / `setUserPreference` helpers: values restore on attach, sync on user changes, reset when a preference is cleared, and avoid writing defaults on attach/detach. Caption restore handles late track discovery, same-language disambiguation by track id, and guarded persistence so track churn does not overwrite stored language with “off.”
> 
> Sandbox React providers and the simple HLS template opt in; docs and API reference generation are extended for the new feature (including state types defined beside the implementation). Broad integration tests cover storage failures, reattach, and tab sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ca56e9926da5561121ea8c9baf31a085cc1f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->