### PR TITLE
fix(cli): reject --media renderers invalid for the chosen --preset

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -1,7 +1,8 @@
 import * as p from '@clack/prompts';
 import { validateInstallationOptions } from '@/utils/installation/codegen';
+import { isRendererValidForUseCase } from '@/utils/installation/detect-renderer';
 import { RENDERER_LABELS } from '@/utils/installation/renderer-options';
-import type { InstallMethod, Renderer, UseCase } from '@/utils/installation/types';
+import { type InstallMethod, type Renderer, type UseCase, VALID_RENDERERS } from '@/utils/installation/types';
 import type { Framework } from '../utils/config.js';
 import { getConfigValue } from '../utils/config.js';
 import { docExistsInAnyFramework, readBundledDoc, readLlmsTxt } from '../utils/docs.js';
@@ -58,6 +59,12 @@ function mapPresetToUseCase(preset: string): UseCase {
   }
   return result;
 }
+
+const PRESET_NAMES: Record<UseCase, string> = {
+  'default-video': 'video',
+  'default-audio': 'audio',
+  'background-video': 'background-video',
+};
 
 const ALL_RENDERERS = Object.keys(RENDERER_LABELS) as Renderer[];
 
@@ -181,6 +188,17 @@ export async function handleDocs(flags: ParsedFlags, positionals: string[]): Pro
     const validation = validateInstallationOptions(opts);
     if (!validation.valid) {
       console.error(`Error: ${validation.reason}`);
+      process.exit(1);
+    }
+
+    // The interactive prompt builds its renderer list from VALID_RENDERERS[useCase],
+    // so an invalid renderer/use-case pairing can only arrive via the explicit
+    // `--media` flag. Reject it here to keep the CLI at parity with the UI.
+    if (!isRendererValidForUseCase(opts.renderer, opts.useCase)) {
+      const validMedia = VALID_RENDERERS[opts.useCase].join(', ');
+      console.error(
+        `Error: media type "${opts.renderer}" is not valid for the "${PRESET_NAMES[opts.useCase]}" preset. Valid options: ${validMedia}`
+      );
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/tests/docs.test.ts
+++ b/packages/cli/src/commands/tests/docs.test.ts
@@ -300,6 +300,22 @@ describe('handleDocs', () => {
         ).rejects.toThrow(ExitError);
         expect(errors()).toContain('no CDN build');
       });
+
+      it('errors when --media is not valid for the chosen --preset (dash + audio)', async () => {
+        await expect(
+          handleDocs(htmlFlags({ preset: 'audio', skin: 'default', media: 'dash' }), ['how-to/installation'])
+        ).rejects.toThrow(ExitError);
+        const err = errors();
+        expect(err).toContain('media type "dash" is not valid for the "audio" preset');
+        expect(err).toContain('html5-audio');
+      });
+
+      it('errors when --media is an audio-only renderer for the video preset (mux-audio + video)', async () => {
+        await expect(
+          handleDocs(htmlFlags({ preset: 'video', skin: 'default', media: 'mux-audio' }), ['how-to/installation'])
+        ).rejects.toThrow(ExitError);
+        expect(errors()).toContain('media type "mux-audio" is not valid for the "video" preset');
+      });
     });
 
     describe('React framework', () => {

--- a/packages/cli/src/site-modules.d.ts
+++ b/packages/cli/src/site-modules.d.ts
@@ -67,6 +67,7 @@ declare module '@/utils/installation/detect-renderer' {
   }
 
   export function detectRenderer(url: string, useCase: UseCase): DetectionResult | null;
+  export function isRendererValidForUseCase(renderer: Renderer, useCase: UseCase): boolean;
 }
 
 declare module '@/utils/installation/cdn-code' {


### PR DESCRIPTION
Closes #1749.

## Problem

The `@videojs/cli docs how-to/installation` command's `--media` flag validated only that the value was a *known* renderer — not that the renderer is valid for the chosen `--preset` (use case). The docs UI enforces this (its renderer dropdown is built from `VALID_RENDERERS[useCase]` via `buildOptions(useCase)`), so the CLI's non-interactive flag path could produce renderer/use-case combinations the UI can never generate, e.g.:

```sh
@videojs/cli docs how-to/installation --framework html --preset audio --media dash
```

— a nonsensical DASH **video** element inside an **audio** player. The interactive prompt was already safe because it builds its options from `buildOptions(useCase)`; only the explicit `--media` flag bypassed the constraint.

This was **pre-existing** (you could already run `--preset audio --media hls`); #1732 only widened the accepted `--media` set, so this is not a regression introduced there.

## Fix

After the use case and renderer are resolved in `handleDocs`, reject a `--media` value not in `VALID_RENDERERS[useCase]`, reusing the already-exported `isRendererValidForUseCase` from `detect-renderer.ts` (added to the CLI's `site-modules.d.ts` shim). The error names the offending renderer, the preset, and the valid options:

```
Error: media type "dash" is not valid for the "audio" preset. Valid options: html5-audio, mux-audio
```

This brings the CLI to parity with the UI's constraint — "CLI for robots, UI for humans — same experience."

## Changes

- `packages/cli/src/commands/docs.ts` — post-resolution guard + a `PRESET_NAMES` reverse map for the message; import `isRendererValidForUseCase` and `VALID_RENDERERS`.
- `packages/cli/src/site-modules.d.ts` — add the `isRendererValidForUseCase` signature to the `detect-renderer` shim.
- `packages/cli/src/commands/tests/docs.test.ts` — two new tests covering invalid combos (`dash` + audio, `mux-audio` + video).

## Verification

- `pnpm -F @videojs/cli test` — 64 tests pass (incl. the 2 new ones; these exercise the real site modules via aliases, not mocks).
- CLI package typecheck clean (`tsc --noEmit`); changed files lint clean.
- `pnpm check:workspace` — 7/7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBzZSgYohPBiwUXBGGRS7o)_