### PR TITLE
refactor: unify use-case, skin, and install-method pickers into shared option builders

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { validateInstallationOptions } from '@/utils/installation/codegen';
+import { INSTALL_METHOD_LABELS } from '@/utils/installation/install-method-options';
 import { RENDERER_LABELS } from '@/utils/installation/renderer-options';
 import type { InstallMethod, Renderer, UseCase } from '@/utils/installation/types';
 import type { Framework } from '../utils/config.js';
@@ -60,6 +61,7 @@ function mapPresetToUseCase(preset: string): UseCase {
 }
 
 const ALL_RENDERERS = Object.keys(RENDERER_LABELS) as Renderer[];
+const ALL_INSTALL_METHODS = Object.keys(INSTALL_METHOD_LABELS) as InstallMethod[];
 
 function validateMedia(media: string): Renderer {
   if (!ALL_RENDERERS.includes(media as Renderer)) {
@@ -70,8 +72,9 @@ function validateMedia(media: string): Renderer {
 }
 
 function validateInstallMethod(method: string, framework: Framework): InstallMethod {
-  const valid = framework === 'html' ? ['cdn', 'npm', 'pnpm', 'yarn', 'bun'] : ['npm', 'pnpm', 'yarn', 'bun'];
-  if (!valid.includes(method)) {
+  // CDN is HTML-only; react installs always go through a package manager.
+  const valid = framework === 'html' ? ALL_INSTALL_METHODS : ALL_INSTALL_METHODS.filter((m) => m !== 'cdn');
+  if (!valid.includes(method as InstallMethod)) {
     console.error(`Invalid install method: "${method}". Valid options: ${valid.join(', ')}`);
     process.exit(1);
   }

--- a/packages/cli/src/site-modules.d.ts
+++ b/packages/cli/src/site-modules.d.ts
@@ -97,6 +97,45 @@ declare module '@/utils/installation/renderer-options' {
   export function buildOptions(useCase: UseCase): RendererOption[];
 }
 
+declare module '@/utils/installation/usecase-options' {
+  import type { UseCase } from '@/utils/installation/types';
+
+  interface UseCaseOption {
+    value: UseCase | null;
+    label: string;
+    disabled?: boolean;
+  }
+
+  export const USE_CASE_LABELS: Record<UseCase, string>;
+  export function buildOptions(): UseCaseOption[];
+}
+
+declare module '@/utils/installation/skin-options' {
+  import type { Skin, UseCase } from '@/utils/installation/types';
+
+  interface SkinOption {
+    value: Skin | null;
+    label: string;
+    disabled?: boolean;
+  }
+
+  export const SKIN_LABELS: Record<Skin, string>;
+  export function buildOptions(useCase: UseCase): SkinOption[];
+}
+
+declare module '@/utils/installation/install-method-options' {
+  import type { InstallMethod } from '@/utils/installation/types';
+
+  interface InstallMethodOption {
+    value: InstallMethod | null;
+    label: string;
+    disabled?: boolean;
+  }
+
+  export const INSTALL_METHOD_LABELS: Record<InstallMethod, string>;
+  export function buildOptions(options: { includeCdn: boolean }): InstallMethodOption[];
+}
+
 declare module '@/content/cdn-media.json' {
   const entries: Array<{ id: string }>;
   export default entries;

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -3,8 +3,11 @@ import cdnMedia from '@/content/cdn-media.json';
 import { rendererSupportsCdn } from '@/utils/installation/cdn-code';
 import type { InstallationOptions } from '@/utils/installation/codegen';
 import { detectRenderer } from '@/utils/installation/detect-renderer';
-import { buildOptions } from '@/utils/installation/renderer-options';
+import { buildOptions as buildInstallMethodOptions } from '@/utils/installation/install-method-options';
+import { buildOptions as buildRendererOptions } from '@/utils/installation/renderer-options';
+import { buildOptions as buildSkinOptions } from '@/utils/installation/skin-options';
 import type { InstallMethod, Renderer, Skin, UseCase } from '@/utils/installation/types';
+import { buildOptions as buildUseCaseOptions } from '@/utils/installation/usecase-options';
 import type { Framework } from './config.js';
 
 const CDN_MEDIA_SUBPATHS = cdnMedia.map((entry) => entry.id);
@@ -26,49 +29,42 @@ export async function promptFramework(): Promise<Framework> {
   return value;
 }
 
-const PRESET_OPTIONS: Array<{ value: UseCase; label: string }> = [
-  { value: 'default-video', label: 'Video' },
-  { value: 'default-audio', label: 'Audio' },
-  { value: 'background-video', label: 'Background Video' },
-];
+// All option lists below reuse the installation page's shared builders so labels
+// and ordering stay in lockstep with the UI — there's a single source of truth
+// per picker, no drift between the CLI prompt and the docs page.
 
-// Reuse the installation page's option builder so labels and ordering stay in
-// lockstep with the UI.
+function useCaseOptions(): Array<{ value: UseCase; label: string }> {
+  return buildUseCaseOptions().map((option) => ({
+    value: option.value as UseCase,
+    label: option.label,
+  }));
+}
+
 function mediaOptionsForUseCase(useCase: UseCase): Array<{ value: Renderer; label: string }> {
-  return buildOptions(useCase).map((option) => ({
+  return buildRendererOptions(useCase).map((option) => ({
     value: option.value as Renderer,
     label: option.label,
   }));
 }
 
 function skinOptionsForUseCase(useCase: UseCase): Array<{ value: Skin; label: string }> {
-  if (useCase === 'background-video') {
-    return [{ value: 'video', label: 'Default' }];
-  }
-  const isAudio = useCase === 'default-audio';
-  return [
-    { value: isAudio ? 'audio' : 'video', label: 'Default' },
-    { value: isAudio ? 'minimal-audio' : 'minimal-video', label: 'Minimal' },
-    { value: 'none', label: 'None (headless)' },
-  ];
+  return buildSkinOptions(useCase).map((option) => ({
+    value: option.value as Skin,
+    label: option.label,
+  }));
 }
 
 function installMethodOptions(
   framework: Framework,
   renderer: Renderer
 ): Array<{ value: InstallMethod; label: string }> {
-  const options: Array<{ value: InstallMethod; label: string }> = [
-    { value: 'npm', label: 'npm' },
-    { value: 'pnpm', label: 'pnpm' },
-    { value: 'yarn', label: 'yarn' },
-    { value: 'bun', label: 'bun' },
-  ];
   // CDN is HTML-only, and only when the renderer ships a CDN build — matching
   // the install page, which hides the CDN tab for renderers without one.
-  if (framework === 'html' && supportsCdnInstall(renderer)) {
-    options.unshift({ value: 'cdn', label: 'CDN' });
-  }
-  return options;
+  const includeCdn = framework === 'html' && supportsCdnInstall(renderer);
+  return buildInstallMethodOptions({ includeCdn }).map((option) => ({
+    value: option.value as InstallMethod,
+    label: option.label,
+  }));
 }
 
 export interface PartialInstallFlags {
@@ -104,7 +100,7 @@ export async function promptInstallOptions(
     (await (async () => {
       const value = await p.select({
         message: 'Preset',
-        options: PRESET_OPTIONS,
+        options: useCaseOptions(),
       });
       if (p.isCancel(value)) process.exit(0);
       return value;

--- a/packages/cli/src/utils/tests/site-aliases.test.ts
+++ b/packages/cli/src/utils/tests/site-aliases.test.ts
@@ -15,6 +15,9 @@ const ALIASED_FILES = [
   'utils/installation/cdn-code.ts',
   'utils/installation/detect-renderer.ts',
   'utils/installation/renderer-options.ts',
+  'utils/installation/usecase-options.ts',
+  'utils/installation/skin-options.ts',
+  'utils/installation/install-method-options.ts',
   'consts.ts',
 ];
 

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
       __dirname,
       '../../site/src/utils/installation/renderer-options.ts'
     ),
+    '@/utils/installation/usecase-options': resolve(__dirname, '../../site/src/utils/installation/usecase-options.ts'),
+    '@/utils/installation/skin-options': resolve(__dirname, '../../site/src/utils/installation/skin-options.ts'),
+    '@/utils/installation/install-method-options': resolve(
+      __dirname,
+      '../../site/src/utils/installation/install-method-options.ts'
+    ),
     '@/content/cdn-media.json': resolve(__dirname, '../../site/src/content/cdn-media.json'),
     '@/consts': resolve(__dirname, '../../site/src/consts.ts'),
   },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -21,6 +21,15 @@ export default defineConfig({
         __dirname,
         '../../site/src/utils/installation/renderer-options.ts'
       ),
+      '@/utils/installation/usecase-options': resolve(
+        __dirname,
+        '../../site/src/utils/installation/usecase-options.ts'
+      ),
+      '@/utils/installation/skin-options': resolve(__dirname, '../../site/src/utils/installation/skin-options.ts'),
+      '@/utils/installation/install-method-options': resolve(
+        __dirname,
+        '../../site/src/utils/installation/install-method-options.ts'
+      ),
       // The real manifest is generated at build time (gitignored) and bundled
       // by tsdown. CLI tests are intentionally hermetic (`test` has no turbo
       // build dependency), so they resolve a committed fixture that mirrors the

--- a/site/src/components/installation/HTMLInstallTabsClient.tsx
+++ b/site/src/components/installation/HTMLInstallTabsClient.tsx
@@ -6,6 +6,7 @@ import { Tab, TabsList, TabsPanel, TabsRoot } from '@/components/Tabs';
 import { shared } from '@/components/typography/styles';
 import { installMethod, renderer } from '@/stores/installation';
 import { rendererSupportsCdn } from '@/utils/installation/cdn-code';
+import { buildOptions } from '@/utils/installation/install-method-options';
 import type { InstallMethod } from '@/utils/installation/types';
 import HTMLCdnCodeBlock from './HTMLCdnCodeBlock';
 
@@ -14,11 +15,22 @@ interface HTMLInstallTabsProps {
   cdnMedia: string[];
 }
 
+// npm installs with `install`; every other package manager uses `add`.
+const PACKAGE_MANAGER_COMMAND: Record<Exclude<InstallMethod, 'cdn'>, string> = {
+  npm: 'npm install @videojs/html',
+  pnpm: 'pnpm add @videojs/html',
+  yarn: 'yarn add @videojs/html',
+  bun: 'bun add @videojs/html',
+};
+
 export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
   const ref = useRef<HTMLDivElement>(null);
   const $renderer = useStore(renderer);
 
   const supportsCdn = rendererSupportsCdn($renderer, cdnMedia);
+  // Shared builder keeps the method set, labels, and ordering aligned with the
+  // CLI prompt; the first option (cdn when available, else npm) is the default.
+  const options = buildOptions({ includeCdn: supportsCdn });
 
   // Mirror the active install-method tab into the store so the usage code block
   // can react (e.g. CDN omits the JS imports). Observing from the stable
@@ -56,35 +68,21 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
           at once and desync installMethod from the visible tab. */}
       <TabsRoot key={supportsCdn ? 'with-cdn' : 'without-cdn'}>
         <TabsList label="Installation">
-          {supportsCdn && (
-            <Tab value="cdn" initial>
-              cdn
+          {options.map((option, index) => (
+            <Tab key={option.value} value={option.value!} initial={index === 0}>
+              {option.label}
             </Tab>
-          )}
-          <Tab value="npm" initial={!supportsCdn}>
-            npm
-          </Tab>
-          <Tab value="pnpm">pnpm</Tab>
-          <Tab value="yarn">yarn</Tab>
-          <Tab value="bun">bun</Tab>
+          ))}
         </TabsList>
-        {supportsCdn && (
-          <TabsPanel value="cdn" initial>
-            <HTMLCdnCodeBlock cdnMedia={cdnMedia} />
+        {options.map((option, index) => (
+          <TabsPanel key={option.value} value={option.value!} initial={index === 0}>
+            {option.value === 'cdn' ? (
+              <HTMLCdnCodeBlock cdnMedia={cdnMedia} />
+            ) : (
+              <ClientCode code={PACKAGE_MANAGER_COMMAND[option.value as Exclude<InstallMethod, 'cdn'>]} lang="bash" />
+            )}
           </TabsPanel>
-        )}
-        <TabsPanel value="npm" initial={!supportsCdn}>
-          <ClientCode code="npm install @videojs/html" lang="bash" />
-        </TabsPanel>
-        <TabsPanel value="pnpm">
-          <ClientCode code="pnpm add @videojs/html" lang="bash" />
-        </TabsPanel>
-        <TabsPanel value="yarn">
-          <ClientCode code="yarn add @videojs/html" lang="bash" />
-        </TabsPanel>
-        <TabsPanel value="bun">
-          <ClientCode code="bun add @videojs/html" lang="bash" />
-        </TabsPanel>
+        ))}
       </TabsRoot>
       {!supportsCdn && (
         <p className={clsx(shared.p, shared.prose)}>

--- a/site/src/components/installation/SkinPicker.tsx
+++ b/site/src/components/installation/SkinPicker.tsx
@@ -1,36 +1,37 @@
 import { useStore } from '@nanostores/react';
 import { Code2, Minus, Sparkles } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
-import type { ImageRadioOption } from '@/components/ImageRadioGroup';
 import ImageRadioGroup from '@/components/ImageRadioGroup';
 import { skin, useCase } from '@/stores/installation';
+import { buildOptions } from '@/utils/installation/skin-options';
 import type { Skin } from '@/utils/installation/types';
 
-const VIDEO_SKINS: ImageRadioOption<Skin>[] = [
-  { value: 'video', label: 'Default', image: <Sparkles size={32} /> },
-  { value: 'minimal-video', label: 'Minimal', image: <Minus size={32} /> },
-  { value: 'none', label: 'No Skin', image: <Code2 size={32} /> },
-];
-
-const AUDIO_SKINS: ImageRadioOption<Skin>[] = [
-  { value: 'audio', label: 'Default', image: <Sparkles size={32} /> },
-  { value: 'minimal-audio', label: 'Minimal', image: <Minus size={32} /> },
-  { value: 'none', label: 'No Skin', image: <Code2 size={32} /> },
-];
+const SKIN_ICONS: Record<Skin, ReactNode> = {
+  video: <Sparkles size={32} />,
+  audio: <Sparkles size={32} />,
+  'minimal-video': <Minus size={32} />,
+  'minimal-audio': <Minus size={32} />,
+  none: <Code2 size={32} />,
+};
 
 export default function SkinPicker() {
   const $skin = useStore(skin);
   const $useCase = useStore(useCase);
 
-  const options = $useCase === 'default-audio' ? AUDIO_SKINS : VIDEO_SKINS;
+  const options = buildOptions($useCase).map((option) => ({
+    value: option.value!,
+    label: option.label,
+    image: SKIN_ICONS[option.value!],
+  }));
 
   // Auto-switch skin when use case changes and current skin is invalid
   useEffect(() => {
-    const validValues = options.map((o) => o.value);
-    if (!validValues.includes(skin.get())) {
-      skin.set(options[0].value);
+    const valid = buildOptions($useCase);
+    if (!valid.some((o) => o.value === skin.get())) {
+      skin.set(valid[0]!.value!);
     }
-  }, [options]);
+  }, [$useCase]);
 
   return (
     <ImageRadioGroup value={$skin} onChange={(value) => skin.set(value)} options={options} aria-label="Select skin" />

--- a/site/src/components/installation/UseCasePicker.tsx
+++ b/site/src/components/installation/UseCasePicker.tsx
@@ -1,8 +1,16 @@
 import { useStore } from '@nanostores/react';
 import { Globe, Image } from 'lucide-react';
+import type { ReactNode } from 'react';
 import ImageRadioGroup from '@/components/ImageRadioGroup';
 import { useCase } from '@/stores/installation';
 import type { UseCase } from '@/utils/installation/types';
+import { buildOptions } from '@/utils/installation/usecase-options';
+
+const USE_CASE_ICONS: Record<UseCase, ReactNode> = {
+  'default-video': <Globe size={32} />,
+  'default-audio': <Globe size={32} />,
+  'background-video': <Image size={32} />,
+};
 
 export default function UseCasePicker() {
   const $useCase = useStore(useCase);
@@ -10,12 +18,12 @@ export default function UseCasePicker() {
   return (
     <ImageRadioGroup
       value={$useCase}
-      onChange={(value) => useCase.set(value as UseCase)}
-      options={[
-        { value: 'default-video' satisfies UseCase, label: 'Video', image: <Globe size={32} /> },
-        { value: 'default-audio' satisfies UseCase, label: 'Audio', image: <Globe size={32} /> },
-        { value: 'background-video' satisfies UseCase, label: 'Background Video', image: <Image size={32} /> },
-      ]}
+      onChange={(value) => useCase.set(value)}
+      options={buildOptions().map((option) => ({
+        value: option.value!,
+        label: option.label,
+        image: USE_CASE_ICONS[option.value!],
+      }))}
       aria-label="Select use case"
     />
   );

--- a/site/src/utils/installation/__tests__/install-method-options.test.ts
+++ b/site/src/utils/installation/__tests__/install-method-options.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildOptions } from '../install-method-options';
+
+describe('buildOptions', () => {
+  it('lists CDN first when available', () => {
+    expect(buildOptions({ includeCdn: true })).toEqual([
+      { value: 'cdn', label: 'CDN' },
+      { value: 'npm', label: 'npm' },
+      { value: 'pnpm', label: 'pnpm' },
+      { value: 'yarn', label: 'yarn' },
+      { value: 'bun', label: 'bun' },
+    ]);
+  });
+
+  it('omits CDN when unavailable', () => {
+    expect(buildOptions({ includeCdn: false })).toEqual([
+      { value: 'npm', label: 'npm' },
+      { value: 'pnpm', label: 'pnpm' },
+      { value: 'yarn', label: 'yarn' },
+      { value: 'bun', label: 'bun' },
+    ]);
+  });
+});

--- a/site/src/utils/installation/__tests__/skin-options.test.ts
+++ b/site/src/utils/installation/__tests__/skin-options.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildOptions } from '../skin-options';
+
+describe('buildOptions', () => {
+  it('returns video skins for default-video', () => {
+    expect(buildOptions('default-video')).toEqual([
+      { value: 'video', label: 'Default' },
+      { value: 'minimal-video', label: 'Minimal' },
+      { value: 'none', label: 'None (headless)' },
+    ]);
+  });
+
+  it('returns audio skins for default-audio', () => {
+    expect(buildOptions('default-audio')).toEqual([
+      { value: 'audio', label: 'Default' },
+      { value: 'minimal-audio', label: 'Minimal' },
+      { value: 'none', label: 'None (headless)' },
+    ]);
+  });
+
+  it('returns a single fixed skin for background-video', () => {
+    expect(buildOptions('background-video')).toEqual([{ value: 'video', label: 'Default' }]);
+  });
+});

--- a/site/src/utils/installation/__tests__/usecase-options.test.ts
+++ b/site/src/utils/installation/__tests__/usecase-options.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildOptions, USE_CASE_LABELS } from '../usecase-options';
+
+describe('buildOptions', () => {
+  it('returns use cases in the configured order', () => {
+    expect(buildOptions()).toEqual([
+      { value: 'default-video', label: 'Video' },
+      { value: 'default-audio', label: 'Audio' },
+      { value: 'background-video', label: 'Background Video' },
+    ]);
+  });
+
+  it('labels every use case', () => {
+    for (const option of buildOptions()) {
+      expect(option.label).toBe(USE_CASE_LABELS[option.value!]);
+    }
+  });
+});

--- a/site/src/utils/installation/install-method-options.ts
+++ b/site/src/utils/installation/install-method-options.ts
@@ -1,0 +1,20 @@
+import type { SelectOption } from '@/components/Select';
+import type { InstallMethod } from '@/utils/installation/types';
+
+export const INSTALL_METHOD_LABELS: Record<InstallMethod, string> = {
+  cdn: 'CDN',
+  npm: 'npm',
+  pnpm: 'pnpm',
+  yarn: 'yarn',
+  bun: 'bun',
+};
+
+const PACKAGE_MANAGERS: InstallMethod[] = ['npm', 'pnpm', 'yarn', 'bun'];
+
+// CDN is listed first when available — HTML-only, and only for renderers that
+// ship a CDN build. The caller decides availability (the install page from the
+// cdn-media manifest, the CLI from framework + manifest) so this stays pure.
+export function buildOptions({ includeCdn }: { includeCdn: boolean }): SelectOption<InstallMethod>[] {
+  const methods: InstallMethod[] = includeCdn ? ['cdn', ...PACKAGE_MANAGERS] : PACKAGE_MANAGERS;
+  return methods.map((value) => ({ value, label: INSTALL_METHOD_LABELS[value] }));
+}

--- a/site/src/utils/installation/skin-options.ts
+++ b/site/src/utils/installation/skin-options.ts
@@ -1,0 +1,28 @@
+import type { SelectOption } from '@/components/Select';
+import type { Skin, UseCase } from '@/utils/installation/types';
+
+export const SKIN_LABELS: Record<Skin, string> = {
+  video: 'Default',
+  audio: 'Default',
+  'minimal-video': 'Minimal',
+  'minimal-audio': 'Minimal',
+  none: 'None (headless)',
+};
+
+export function buildOptions(useCase: UseCase): SelectOption<Skin>[] {
+  // Background video has a single fixed skin, so there's no real choice — the UI
+  // hides the picker entirely and the CLI auto-selects this option.
+  if (useCase === 'background-video') {
+    return [{ value: 'video', label: SKIN_LABELS.video }];
+  }
+
+  const isAudio = useCase === 'default-audio';
+  const defaultSkin: Skin = isAudio ? 'audio' : 'video';
+  const minimalSkin: Skin = isAudio ? 'minimal-audio' : 'minimal-video';
+
+  return [
+    { value: defaultSkin, label: SKIN_LABELS[defaultSkin] },
+    { value: minimalSkin, label: SKIN_LABELS[minimalSkin] },
+    { value: 'none', label: SKIN_LABELS.none },
+  ];
+}

--- a/site/src/utils/installation/usecase-options.ts
+++ b/site/src/utils/installation/usecase-options.ts
@@ -1,0 +1,16 @@
+import type { SelectOption } from '@/components/Select';
+import type { UseCase } from '@/utils/installation/types';
+
+export const USE_CASE_LABELS: Record<UseCase, string> = {
+  'default-video': 'Video',
+  'default-audio': 'Audio',
+  'background-video': 'Background Video',
+};
+
+// Order doubles as guidance: video first as the common case, then audio, then
+// the background-video special case. Mirrors the UI radio group and CLI prompt.
+const USE_CASE_ORDER: UseCase[] = ['default-video', 'default-audio', 'background-video'];
+
+export function buildOptions(): SelectOption<UseCase>[] {
+  return USE_CASE_ORDER.map((value) => ({ value, label: USE_CASE_LABELS[value] }));
+}


### PR DESCRIPTION
Closes #1751. Follow-up from #1732.

#1732 introduced `site/src/utils/installation/renderer-options.ts` — a shared, pure module (label map + `buildOptions`) that the docs UI picker and the `@videojs/cli` prompt both consume so the **renderer** options can't drift. This PR extends that pattern to the three remaining installation pickers: **use case**, **skin**, and **install method**.

## What's in here

Three new shared modules alongside `renderer-options.ts`, each exporting a label map + a `buildOptions`-style function:

| Module | Exports | Consumed by |
| --- | --- | --- |
| `usecase-options.ts` | `USE_CASE_LABELS`, `buildOptions()` | `UseCasePicker.tsx`, CLI preset prompt |
| `skin-options.ts` | `SKIN_LABELS`, `buildOptions(useCase)` | `SkinPicker.tsx`, CLI skin prompt |
| `install-method-options.ts` | `INSTALL_METHOD_LABELS`, `buildOptions({ includeCdn })` | `HTMLInstallTabsClient.tsx`, CLI install-method prompt |

- **UI pickers** consume the builders and map their surface-specific bits on top — lucide icons for the radio groups, and the CDN/package-manager panels for the install tabs. The tabs' remount/observer logic is unchanged; the tab list and labels now come from the builder (CDN first when available = the default tab).
- **CLI prompt** (`packages/cli/src/utils/prompts.ts`) replaces `PRESET_OPTIONS`, `skinOptionsForUseCase`, and `installMethodOptions` with thin wrappers over the shared builders. The non-interactive `--install-method` validation in `docs.ts` now derives its accepted values from `INSTALL_METHOD_LABELS` (mirroring how `--media` already derives from `RENDERER_LABELS`).
- **CLI shim/config**: the three modules are declared in `site-modules.d.ts`, aliased in `tsdown.config.ts` + `vitest.config.ts`, and asserted in `site-aliases.test.ts`.

## Reconciled label drift

The issue flagged the skin "none" label as drifted. Reconciled, plus one more I found while wiring the tabs — **both are one-line flips if you'd prefer the other direction:**

| Option | Before (UI) | Before (CLI) | Now (both) |
| --- | --- | --- | --- |
| Skin "none" | `No Skin` | `None (headless)` | **`None (headless)`** |
| Install CDN tab | `cdn` | `CDN` | **`CDN`** |

I picked `None (headless)` (more descriptive for the dev audience — explains the consequence) and `CDN` (acronym convention, already the CLI's label). Happy to flip either.

> [!NOTE]
> The skin builder returns a single fixed `Default` option for `background-video` — matching the CLI today and the fact that the UI hides the skin picker entirely for that use case (`SkinPickerSectionClient` returns `null`).

## Tests & verification

- New unit tests for all three builders (`__tests__/{usecase,skin,install-method}-options.test.ts`), mirroring `renderer-options.test.ts`.
- Site suite green (90 tests); CLI suite green (65 tests, incl. the expanded alias test exercising the new modules through the real site source).
- Lint clean on changed files; CLI `tsdown` bundle builds (new aliases + shim resolve); `pnpm check:workspace` passes.

> [!NOTE]
> `pnpm typecheck` reports ~510 errors in `packages/{html,react,store}` on this branch **and on the base commit** — a pre-existing `tsgo` build-state issue in a fresh checkout, unrelated to this diff. The changed files (`site/`, `packages/cli/`) add zero type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMRTUmrr3wSHjY2y1ys2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMRTUmrr3wSHjY2y1ys2f4)_