### PR TITLE
fix(site): install musl resvg binary so Netlify can bundle the OG function

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,24 @@ minimumReleaseAge: 1440
 shellEmulator: true
 trustPolicy: no-downgrade
 
+# Also install musl Linux binaries alongside the current platform's. The site's
+# OG image route depends on the native @resvg/resvg-js binding, and the
+# @astrojs/netlify (v8) adapter bundles the serverless function by tracing the
+# server entry with @vercel/nft, then calling fs.realpath on every traced file.
+# nft can't tell glibc from musl statically, so it traces BOTH Linux resvg
+# binaries — but pnpm only installs the glibc variant on Netlify, so realpath
+# on the missing musl binary throws ENOENT and the build fails. Installing the
+# musl variant too gives nft a real file to resolve. ("current" keeps the host
+# default; on non-Linux hosts the os filter excludes Linux packages entirely.)
+supportedArchitectures:
+  os:
+    - current
+  cpu:
+    - current
+  libc:
+    - current
+    - musl
+
 packages:
   - 'packages/*'
   - 'apps/*'


### PR DESCRIPTION
The site build has been failing on `main` since the Astro 7 / Vite 8 upgrade because we pulled in a stricter version of the Netlify adapter that can't cope with how pnpm installs native addons. 

This adds one pnpm config block to fix it.

## The deets

> [!NOTE]
> I edited this, but, there's still some AI jargon in there my brain failed to totally parse. Sorry. Here be vibe-dragons.

When Astro deploys an SSR route to Netlify, the `@astrojs/netlify` adapter has to package that route as a Netlify Function. To do that, it runs `@vercel/nft` (Node File Trace) over the server entry to discover every file the function will need at runtime, then copies those files into the function bundle.

Our OG-image route is server-rendered and uses `@resvg/resvg-js` to rasterize SVG → PNG. resvg is a native Rust addon, so it doesn't ship as one package — it ships as a family of platform-specific binaries declared as `optionalDependencies`, and the loader picks the right `.node` at runtime.

Two reasonable behaviors collide here:

1. **nft over-traces native addons.** It statically sees resvg `require`-ing several platform binaries. It can prune by OS (the build runs on Linux, so darwin/win32 drop out), but it **can't tell glibc from musl statically** — so it keeps *both* Linux variants (`gnu` and `musl`) in the file list.
2. **pnpm only installs the binary that matches the host.** Netlify is glibc, so pnpm installs `…-linux-x64-gnu` and skips `…-linux-x64-musl` (the package declares `libc: [musl]`, which pnpm filters out). The musl path never exists on disk.
3. **The adapter's copy step calls `fs.realpath` on every traced file** — including the musl binary nft listed but pnpm never installed. `realpath` on a missing path throws `ENOENT`, the `astro:build:done` hook crashes unhandled, and the whole build exits non-zero:

```
[ERROR] [@astrojs/netlify] An unhandled error occurred while running the "astro:build:done" hook
ENOENT: no such file or directory, realpath
  '/opt/build/repo/node_modules/.pnpm/@resvg+resvg-js@2.6.2/node_modules/@resvg/resvg-js-linux-x64-musl'
    at async copyDependenciesToFunction (@astrojs/netlify/dist/lib/nft.js:40:26)
```

## The fix

Make the missing binary present so nft's `realpath` resolves. pnpm has a knob for exactly this — `supportedArchitectures` — which installs optional deps for architectures beyond the host's:

```yaml
# pnpm-workspace.yaml
supportedArchitectures:
  os: [current]
  cpu: [current]
  libc: [current, musl]
```

pnpm now installs both Linux variants, the musl symlink exists, the copy step succeeds, and the unused musl `.node` rides along in the bundle (~1 MB; the glibc binary still loads at runtime). `os: [current]` keeps the OS filter intact, so it only adds musl-libc **Linux** binaries — macOS/Windows dev installs are unaffected.

**Alternative considered:** the adapter's `excludeFiles` option could drop the musl path from the trace instead, avoiding the dead binary. But it's an exact-string match against a hashed `.pnpm/…` path, so it's brittle across version bumps. `supportedArchitectures` is the more durable fix; the cost is ~1 MB of unused binary in the function.

---

https://claude.ai/code/session_017FVfYwxbfNWwUkzhRdTr3k

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workspace-only install policy change for optional native binaries; no application logic or auth/data paths touched.
> 
> **Overview**
> Adds **`supportedArchitectures`** to `pnpm-workspace.yaml` so pnpm installs both glibc and **musl** Linux optional binaries for native deps like `@resvg/resvg-js`, not only the host libc.
> 
> This unblocks Netlify site builds that started failing after the Astro 7 / `@astrojs/netlify` v8 upgrade: `@vercel/nft` traces both Linux resvg variants, but the adapter’s copy step calls `realpath` on every traced path—when the musl package was never installed, the build crashed with **ENOENT**. Installing the musl variant gives nft a real path to resolve; runtime still uses the glibc binary on Netlify (~1 MB extra in the function bundle).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67c1e6f841e4868464fcadcddab885869aa71e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->