### PR TITLE
fix(test): update duration selectors for time inversion feature

### DIFF
--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -75,7 +75,12 @@ export const SELECTORS = {
   // Display elements
   // HTML uses attribute `type`, React uses `data-type`
   currentTime: 'media-time[type="current"], [data-type="current"].media-time',
-  duration: 'media-time[type="duration"], [data-type="duration"].media-time',
+  duration: [
+    'media-time[type="duration"]',
+    'media-time[type="remaining"]',
+    '[data-type="duration"].media-time',
+    '[data-type="remaining"].media-time',
+  ].join(', '),
   poster: 'media-poster, img[data-visible]',
   bufferingIndicator: 'media-buffering-indicator, .media-buffering-indicator',
   thumbnail: 'media-slider-thumbnail, .media-thumbnail__image',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test fixture-only change with no production or runtime impact.
> 
> **Overview**
> E2E shared selectors now treat the **duration** display as either total length or **remaining** time, matching players that invert the time label.
> 
> `SELECTORS.duration` was a single comma-separated string for `duration` only; it is now an array joined into one selector that also matches `media-time[type="remaining"]` and `[data-type="remaining"].media-time` (HTML and React), so assertions that use this helper still resolve the time readout when the UI shows countdown instead of duration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f069c66f257dd2dfbd39a3c3634fb023455317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->