### PR TITLE
fix(react): memoize Provider context value

### DIFF
--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -91,15 +91,6 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       return store.attach({ media, container });
     }, [media, container, store]);
 
-    // Memoize the context value so its identity only changes when one of its
-    // members actually changes. Without this, every render of a component
-    // above the Provider rebuilds the value object, which forces every
-    // `useContext(PlayerContext)` consumer to re-render even when nothing
-    // it depends on changed. `setMedia` and `setContainer` are `useState`
-    // setters and are identity-stable; `store` and `popupGroup` are also
-    // initialized once via `useState(() => ...)` and never change for the
-    // lifetime of the Provider. They're listed in the dep array to satisfy
-    // `useExhaustiveDependencies`. See #1296.
     const value = useMemo(
       () => ({ store, media, setMedia, container, setContainer, popupGroup }),
       [store, media, container, popupGroup]

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -16,7 +16,7 @@ import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import type { FC, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useDestroy } from '../utils/use-destroy';
 import { Container, PlayerContextProvider, useMedia, usePlayerContext } from './context';
@@ -91,11 +91,21 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       return store.attach({ media, container });
     }, [media, container, store]);
 
-    return (
-      <PlayerContextProvider value={{ store, media, setMedia, container, setContainer, popupGroup }}>
-        {children}
-      </PlayerContextProvider>
+    // Memoize the context value so its identity only changes when one of its
+    // members actually changes. Without this, every render of a component
+    // above the Provider rebuilds the value object, which forces every
+    // `useContext(PlayerContext)` consumer to re-render even when nothing
+    // it depends on changed. `setMedia` and `setContainer` are `useState`
+    // setters and are identity-stable; `store` and `popupGroup` are also
+    // initialized once via `useState(() => ...)` and never change for the
+    // lifetime of the Provider. They're listed in the dep array to satisfy
+    // `useExhaustiveDependencies`. See #1296.
+    const value = useMemo(
+      () => ({ store, media, setMedia, container, setContainer, popupGroup }),
+      [store, media, container, popupGroup]
     );
+
+    return <PlayerContextProvider value={value}>{children}</PlayerContextProvider>;
   }
 
   if (__DEV__ && config.displayName) {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -2,7 +2,7 @@ import { act, render, renderHook } from '@testing-library/react';
 import type { PlayerStore } from '@videojs/core/dom';
 import { defineSlice } from '@videojs/store';
 import type { ReactNode } from 'react';
-import { StrictMode } from 'react';
+import { StrictMode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { usePlayerContext } from '../context';
 import { createPlayer } from '../create-player';
@@ -187,6 +187,46 @@ describe('createPlayer', () => {
       );
 
       expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
+    });
+
+    it('provides a stable context value across parent re-renders (fix for #1296)', () => {
+      // Without memoization, the Provider rebuilds its context value on every
+      // render. Every `useContext(PlayerContext)` consumer then re-renders on
+      // any parent re-render, which (combined with callback-ref usage in
+      // media components) detaches and re-attaches the underlying media on
+      // every parent state change. At end-of-stream this rewinds the video.
+      const { Provider } = createPlayer({ features: [mockSlice] });
+
+      const receivedValues: unknown[] = [];
+
+      function ContextConsumer() {
+        const ctx = usePlayerContext();
+        receivedValues.push(ctx);
+        return null;
+      }
+
+      let forceParentRerender!: () => void;
+      function Parent() {
+        const [, setTick] = useState(0);
+        forceParentRerender = () => setTick((t) => t + 1);
+        return (
+          <Provider>
+            <ContextConsumer />
+          </Provider>
+        );
+      }
+
+      render(<Parent />);
+
+      const valueAfterMount = receivedValues[receivedValues.length - 1];
+
+      act(() => forceParentRerender());
+      act(() => forceParentRerender());
+      act(() => forceParentRerender());
+
+      const valueAfterRerenders = receivedValues[receivedValues.length - 1];
+
+      expect(valueAfterRerenders).toBe(valueAfterMount);
     });
   });
 

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -190,11 +190,6 @@ describe('createPlayer', () => {
     });
 
     it('provides a stable context value across parent re-renders (fix for #1296)', () => {
-      // Without memoization, the Provider rebuilds its context value on every
-      // render. Every `useContext(PlayerContext)` consumer then re-renders on
-      // any parent re-render, which (combined with callback-ref usage in
-      // media components) detaches and re-attaches the underlying media on
-      // every parent state change. At end-of-stream this rewinds the video.
       const { Provider } = createPlayer({ features: [mockSlice] });
 
       const receivedValues: unknown[] = [];


### PR DESCRIPTION
Replaces #1541 because the source fork has maintainer edits disabled, so the review cleanup could not be pushed there.

Related to #1296.

## What changed

- Memoizes the `createPlayer().Provider` context value so parent re-renders do not rebuild the value object unnecessarily.
- Adds a regression test that verifies the context value identity stays stable across parent re-renders.
- Applies the requested comment cleanup from #1541.

## Verification

- `pnpm --filter @videojs/react... build`
- `pnpm -F @videojs/react test src/player/tests/create-player.test.tsx`
- `pnpm lint:fix:file packages/react/src/player/create-player.tsx packages/react/src/player/tests/create-player.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small React Provider change with a focused regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes unnecessary context updates when the parent re-renders but player state is unchanged (**#1296**).
> 
> The `createPlayer().Provider` now builds its context value with **`useMemo`**, keyed on `store`, `media`, `container`, and `popupGroup`, instead of allocating a new object every render. Consumers that depend on context identity or shallow stability should no longer re-render solely because an ancestor updated.
> 
> A regression test forces several parent re-renders and asserts the context value reference stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf40bb2b51ddd4bc77f2a2d1c9796c1f7ecf83ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->