### PR TITLE
fix(html): avoid menu item value render loop

### DIFF
--- a/packages/core/src/dom/ui/menu/menu-viewport-transition.ts
+++ b/packages/core/src/dom/ui/menu/menu-viewport-transition.ts
@@ -335,12 +335,24 @@ export function observeMenuViewContent(content: HTMLElement, onChange: () => voi
     });
   }
 
-  const observer = new MutationObserver(scheduleChange);
+  const observer = new MutationObserver((records) => {
+    const changed = records.some((record) => {
+      if (record.type !== 'attributes') return true;
+
+      const name = record.attributeName;
+      if (!name) return true;
+
+      return record.oldValue !== (record.target as Element).getAttribute(name);
+    });
+
+    if (changed) scheduleChange();
+  });
 
   observer.observe(content, {
     childList: true,
     subtree: true,
     attributes: true,
+    attributeOldValue: true,
     attributeFilter: MENU_VIEW_LAYOUT_ATTRS,
   });
 

--- a/packages/core/src/dom/ui/menu/tests/menu-viewport-transition.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/menu-viewport-transition.test.ts
@@ -172,11 +172,21 @@ describe('menu-viewport-transition', () => {
 
     expect(onChange).toHaveBeenCalledTimes(2);
 
-    cleanup();
-    item.setAttribute('data-availability', 'unavailable');
+    item.setAttribute('data-availability', 'available');
     await waitForMutationFrame();
 
     expect(onChange).toHaveBeenCalledTimes(2);
+
+    item.setAttribute('data-availability', 'unavailable');
+    await waitForMutationFrame();
+
+    expect(onChange).toHaveBeenCalledTimes(3);
+
+    cleanup();
+    item.setAttribute('data-availability', 'available');
+    await waitForMutationFrame();
+
+    expect(onChange).toHaveBeenCalledTimes(3);
   });
 
   it('toggles menu viewport data attributes for active and exiting phases', () => {

--- a/packages/html/src/ui/menu/menu-item-value-element.ts
+++ b/packages/html/src/ui/menu/menu-item-value-element.ts
@@ -17,6 +17,9 @@ export class MenuItemValueElement extends MediaElement {
   protected override update(_changed: PropertyValues): void {
     super.update(_changed);
 
-    this.textContent = this.#ctx.value?.label ?? '';
+    const label = this.#ctx.value?.label ?? '';
+    if (this.textContent !== label) {
+      this.textContent = label;
+    }
   }
 }

--- a/packages/html/src/ui/menu/tests/menu-item-value-element.test.ts
+++ b/packages/html/src/ui/menu/tests/menu-item-value-element.test.ts
@@ -172,6 +172,26 @@ describe('MenuItemValueElement', () => {
     });
   });
 
+  it('does not rewrite an unchanged label', async () => {
+    const { value } = setup(createPlaybackRateStore({ playbackRate: 1.5 }), 'playback-rate');
+
+    await value.updateComplete;
+    await waitForAssertion(() => {
+      expect(value.textContent).toBe('1.5×');
+    });
+
+    const mutations: MutationRecord[] = [];
+    const observer = new MutationObserver((records) => mutations.push(...records));
+    observer.observe(value, { childList: true, characterData: true, subtree: true });
+
+    value.requestUpdate();
+    await value.updateComplete;
+    await nextFrame();
+    observer.disconnect();
+
+    expect(mutations).toHaveLength(0);
+  });
+
   it('renders Off when captions are disabled', async () => {
     const { value } = setup(
       createTextTrackStore({


### PR DESCRIPTION
## Summary

Prevent menu value labels from rewriting identical text during render. This avoids a feedback loop where menu content observation can keep scheduling updates after the label has already settled.

## Changes

- Skip same-value textContent writes in menu item values
- Add a regression test that verifies unchanged labels do not produce DOM mutations

## Testing

- pnpm -F @videojs/html test src/ui/menu/tests/menu-item-value-element.test.ts
- pnpm exec biome check packages/html/src/ui/menu/menu-item-value-element.ts packages/html/src/ui/menu/tests/menu-item-value-element.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted DOM write and mutation-observer filtering in menu UI; no auth, data, or API surface changes.
> 
> **Overview**
> Stops a feedback loop where menu viewport layout kept rescheduling after value labels had already settled.
> 
> **`media-menu-item-value`** now assigns `textContent` only when the label string actually changes, so Lit re-renders with the same context label no longer touch the DOM.
> 
> **`observeMenuViewContent`** ignores attribute mutations whose value is unchanged (using `attributeOldValue`), while still reacting to child-list changes and real `data-availability` updates. Tests cover no-op attribute sets, post-cleanup behavior, and zero mutations on unchanged label re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eaeb6fc4f16df06ef53730c5b13da2b1a1f7524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->