### PR TITLE
fix(ci): relay release event through workflow_dispatch for changelog prose

### DIFF
--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -3,21 +3,51 @@ name: Changelog Prose
 on:
   release:
     types: [published]
-
-permissions:
-  actions: read
-  contents: write
-  pull-requests: write
-  issues: read
+  # claude-code-action does not support the `release` event, so the dispatch
+  # job relays core releases into a workflow_dispatch run. Manual dispatch
+  # also lets us backfill prose for a release that was missed.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag (e.g. @videojs/core@10.0.0-beta.24)'
+        required: true
+        type: string
+      release_url:
+        description: 'Release URL (defaults to the tag release page)'
+        required: false
+        type: string
 
 concurrency:
-  group: changelog-prose-${{ github.event.release.tag_name }}
+  group: changelog-prose-${{ github.event.release.tag_name || inputs.tag_name }}
   cancel-in-progress: true
 
 jobs:
-  prose:
-    if: startsWith(github.event.release.tag_name, '@videojs/core@')
+  dispatch:
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, '@videojs/core@')
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    steps:
+      - name: Relay release to workflow_dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          gh workflow run changelog-prose.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --field tag_name="$TAG_NAME" \
+            --field release_url="$RELEASE_URL"
+
+  prose:
+    if: github.event_name == 'workflow_dispatch' && startsWith(inputs.tag_name, '@videojs/core@')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+      issues: read
 
     steps:
       - name: Checkout code
@@ -27,10 +57,18 @@ jobs:
 
       - name: Parse version
         id: version
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+          RELEASE_URL: ${{ inputs.release_url }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
-          VERSION="${TAG#@videojs/core@}"
+          VERSION="${TAG_NAME#@videojs/core@}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ -n "$RELEASE_URL" ]; then
+            echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          else
+            ENCODED_TAG=$(jq -rn --arg tag "$TAG_NAME" '$tag | @uri')
+            echo "release_url=https://github.com/${GITHUB_REPOSITORY}/releases/tag/${ENCODED_TAG}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Guard — check raw changelog exists
         id: guard
@@ -55,7 +93,7 @@ jobs:
             You are the changelog prose writer for Video.js 10.
 
             Version: ${{ steps.version.outputs.version }}
-            Release URL: ${{ github.event.release.html_url }}
+            Release URL: ${{ steps.version.outputs.release_url }}
 
             Your task is to rewrite a raw changelog file into polished narrative prose, then open a PR with the result.
 


### PR DESCRIPTION
The #462 epic intends to build a pipeline that generates human-readable changelogs in the docs on every release. The first step? Using an LLM to  turn our mechanical changelogs into narrative prose. We built this in #1029 but it's broken. This PR aims to fix it.

## Problem

The `Changelog Prose` workflow has failed on every release since it landed (e.g. [run 26121269875](https://github.com/videojs/v10/actions/runs/26121269875)). The job dies before Claude ever starts:

```
##[error]Action failed with error: Unsupported event type: release
```

## Fix

Keep the `release: published` trigger, but split the workflow into two jobs:

- **`dispatch`** — runs on the `release` event, filters for `@videojs/core@*` tags, and relays the tag/URL into a `workflow_dispatch` run of this same workflow via `gh workflow run`. (`workflow_dispatch` is exempt from the `GITHUB_TOKEN` recursion guard, so the default token with `actions: write` is sufficient — no new PAT needed.)
- **`prose`** — runs on `workflow_dispatch`, which the action supports. Same guard + prompt as before, now driven by `tag_name`/`release_url` inputs instead of the release payload.

Side benefit: prose for missed releases (beta.22, beta.23, beta.24) can be backfilled by manually dispatching the workflow with the release tag once this merges.

## As long as we're here

Also hardened while in here: release tag/URL are passed through env vars rather than interpolated into scripts, `release_url` falls back to the tag's release page when not provided, and permissions are scoped per job.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XvU1qtEarEbskzieqU6tj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow wiring and scripting changes; no runtime product or auth logic.
> 
> **Overview**
> Fixes **Changelog Prose** failing on `release` because `claude-code-action` does not support that event.
> 
> The workflow now keeps `release: published` but adds a **`dispatch`** job that filters `@videojs/core@*` tags and re-triggers the same workflow via **`workflow_dispatch`** with `tag_name` and `release_url`. The **`prose`** job runs only on `workflow_dispatch`, using those inputs instead of `github.event.release`. Manual dispatch also allows backfilling missed releases.
> 
> **Hardening:** workflow-level permissions are removed in favor of per-job scopes; tag and URL are passed through env vars in shell steps; `release_url` defaults to the tag’s GitHub release page when omitted; concurrency keys off `inputs.tag_name` when dispatched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b566fe99b3bad66c20f93c0a74f8f9edb78d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->