### PR TITLE
docs(site): backfill and prose-ify beta changelogs

### DIFF
--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -144,7 +144,7 @@ jobs:
 
             5. **Create a PR:**
                - Create branch: `docs/changelog-prose-${{ steps.version.outputs.version }}`
-               - Stage and commit the changed file: `docs(changelog): add prose for ${{ steps.version.outputs.version }}`
+               - Stage and commit the changed file: `docs(site): add changelog prose for ${{ steps.version.outputs.version }}` (commitlint's scope-enum has no `changelog` scope, so use `site`)
                - Push the branch and open a PR targeting `main`.
                - Include a link to the release in the PR body.
                - Keep the PR description concise.

--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -125,19 +125,22 @@ jobs:
                - Some PR numbers may resolve to null — skip those gracefully.
 
             3. **Rewrite the changelog body:**
-               - Replace the raw bullet list with narrative prose (100–300 words).
-               - Lead with the 1–3 most impactful changes, informed by epic/issue context.
-               - Group related PRs into cohesive stories rather than listing them individually.
-               - Call out breaking changes explicitly with migration guidance if applicable.
-               - Summarize smaller fixes briefly.
-               - Skip internal-only changes (CI, tooling, changelog maintenance).
+               - Replace the raw bullet list with narrative prose. Length scales with content: substantial releases get 100–300 words; small releases (a few bullets) get 1–3 honest sentences. Never pad to hit a word count.
+               - Write paragraphs only: no headings, bullet lists, or tables. Use backticks for identifiers (e.g., `deps.alwaysBundle`, `<media-gesture>`).
+               - Lead with the 1–3 most impactful changes, informed by epic/issue context. Vary the opening; do not default to "This release…".
+               - Group related PRs into cohesive stories rather than listing them individually (e.g., a feature landing across core, html, and react is one story with three links).
+               - Call out breaking changes explicitly with concrete migration guidance from the PR body (old name → new name, what to update). Do not bury them.
+               - Summarize smaller fixes briefly, grouped.
+               - Skip internal-only changes (CI, tooling, changelog maintenance) — unless the release is entirely internal, in which case describe it honestly in a sentence or two rather than leaving the body empty.
+               - Preserve PR links as inline markdown links in the prose (e.g., [#906](url)). Every change you mention keeps its PR link.
+               - Drop per-change author credits ("by @user") — the PR link carries attribution.
+               - If the raw file has a "New Contributors" section, remove it and end the prose with one sentence thanking first-time contributors by name, linking their GitHub profiles.
                - Follow `writing-style.md` strictly.
-               - Preserve PR links as inline markdown links in the prose (e.g., [#906](url)).
                - Do not fabricate — stick to what the PRs actually say.
 
             4. **Write the `description` field:**
-               - One sentence summarizing the release for SEO/RSS.
-               - Update the `description: ""` field in the file's YAML frontmatter.
+               - One concise sentence starting with a verb, summarizing the release for SEO/RSS (e.g., "Adds a hotkey system, gestures, and the mux-audio element."). Keep it under 140 characters.
+               - Update the `description: ""` field in the file's YAML frontmatter. Change nothing else in the frontmatter.
 
             5. **Create a PR:**
                - Create branch: `docs/changelog-prose-${{ steps.version.outputs.version }}`

--- a/site/src/content/changelog/10.0.0-beta.1.md
+++ b/site/src/content/changelog/10.0.0-beta.1.md
@@ -1,0 +1,20 @@
+---
+description: ""
+date: 2026-03-10
+version: "10.0.0-beta.1"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-alpha.11...@videojs/core@10.0.0-beta.1"
+---
+
+
+### 🚀 Features
+- *(site)* Ejected skins build script, docs page, and home page wiring ([#809](https://github.com/videojs/v10/pull/809)) by [@sampotts](https://github.com/sampotts)
+
+### 🐛 Bug Fixes
+- *(docs)* Update README contributing section for beta ([#847](https://github.com/videojs/v10/pull/847)) by [@decepulis](https://github.com/decepulis)
+- *(packages)* Update package READMEs for beta ([#848](https://github.com/videojs/v10/pull/848)) by [@decepulis](https://github.com/decepulis)
+- *(packages)* Set release-please manifest and package versions to beta.0 ([#850](https://github.com/videojs/v10/pull/850)) by [@decepulis](https://github.com/decepulis)
+
+### ⚙️ Miscellaneous Tasks
+- *(cd)* Transition from alpha/next to beta/latest ([#846](https://github.com/videojs/v10/pull/846)) by [@decepulis](https://github.com/decepulis)

--- a/site/src/content/changelog/10.0.0-beta.1.md
+++ b/site/src/content/changelog/10.0.0-beta.1.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Moves Video.js 10 from alpha to beta: packages now publish to the latest npm dist-tag."
 date: 2026-03-10
 version: "10.0.0-beta.1"
 prerelease: true
@@ -7,14 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-alpha.11...@videojs/core@10.0.0-beta.1"
 ---
 
-
-### 🚀 Features
-- *(site)* Ejected skins build script, docs page, and home page wiring ([#809](https://github.com/videojs/v10/pull/809)) by [@sampotts](https://github.com/sampotts)
-
-### 🐛 Bug Fixes
-- *(docs)* Update README contributing section for beta ([#847](https://github.com/videojs/v10/pull/847)) by [@decepulis](https://github.com/decepulis)
-- *(packages)* Update package READMEs for beta ([#848](https://github.com/videojs/v10/pull/848)) by [@decepulis](https://github.com/decepulis)
-- *(packages)* Set release-please manifest and package versions to beta.0 ([#850](https://github.com/videojs/v10/pull/850)) by [@decepulis](https://github.com/decepulis)
-
-### ⚙️ Miscellaneous Tasks
-- *(cd)* Transition from alpha/next to beta/latest ([#846](https://github.com/videojs/v10/pull/846)) by [@decepulis](https://github.com/decepulis)
+Video.js 10 is in beta. This release flips the npm dist-tags from alpha/`next` to beta/`latest` ([#846](https://github.com/videojs/v10/pull/846)): `npm install @videojs/html` now installs v10 without the `@next` suffix, and install commands, CDN URLs, and badges across the docs drop it too. The `next` tag stays frozen at `10.0.0-alpha.10`. Package READMEs, the contributing guide, and the release manifest were updated to match ([#847](https://github.com/videojs/v10/pull/847), [#848](https://github.com/videojs/v10/pull/848), [#850](https://github.com/videojs/v10/pull/850)). The site also gains ejected skins ([#809](https://github.com/videojs/v10/pull/809)): a build script generates copy-paste source for all four skins across HTML and React, in CSS and Tailwind variants, powering a new customize-skins docs page and the home page's "Take full control" demo.

--- a/site/src/content/changelog/10.0.0-beta.10.md
+++ b/site/src/content/changelog/10.0.0-beta.10.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Fixes thumbnail sprite tile bleeding, skin button text alignment, and missing React destroy cleanups."
 date: 2026-03-24
 version: "10.0.0-beta.10"
 prerelease: true
@@ -7,8 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.9...@videojs/core@10.0.0-beta.10"
 ---
 
-
-### 🐛 Bug Fixes
-- *(core)* Prevent sprite tile bleeding in thumbnail component ([#1053](https://github.com/videojs/v10/pull/1053)) by [@mihar-22](https://github.com/mihar-22)
-- *(skin)* Fix button text alignment and text shadow ([#1091](https://github.com/videojs/v10/pull/1091)) by [@sampotts](https://github.com/sampotts)
-- *(react)* Add missing destroy cleanups  ([#1096](https://github.com/videojs/v10/pull/1096)) by [@mihar-22](https://github.com/mihar-22)
+Three fixes land in beta.10: the thumbnail component no longer bleeds adjacent sprite tiles into the preview ([#1053](https://github.com/videojs/v10/pull/1053)), skin buttons get corrected text alignment and text shadow ([#1091](https://github.com/videojs/v10/pull/1091)), and the React player adds missing cleanups when a player is destroyed ([#1096](https://github.com/videojs/v10/pull/1096)).

--- a/site/src/content/changelog/10.0.0-beta.11.md
+++ b/site/src/content/changelog/10.0.0-beta.11.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Exports media component building blocks so you can build custom media components on public APIs."
 date: 2026-03-24
 version: "10.0.0-beta.11"
 prerelease: true
@@ -7,9 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.10...@videojs/core@10.0.0-beta.11"
 ---
 
-
-### 🚀 Features
-- *(packages)* Export media component building blocks ([#1098](https://github.com/videojs/v10/pull/1098)) by [@mihar-22](https://github.com/mihar-22)
-
-### ⚙️ Miscellaneous Tasks
-- Upgrade typescript 6, vitest 4, align spf package ([#1101](https://github.com/videojs/v10/pull/1101)) by [@mihar-22](https://github.com/mihar-22)
+Beta.11 exports the media component building blocks that the built-in HLS, DASH, and SimpleHLS components already use, so you can build custom media components, such as a new streaming protocol integration, without reaching into internal module paths ([#1098](https://github.com/videojs/v10/pull/1098)). `Delegate` and `DelegateMixin` ship from `@videojs/core`, `MediaProxyMixin` from `@videojs/core/dom`, and `@videojs/react` adds `useOptionalPlayer` plus media utilities including `useMediaInstance`, `attachMediaElement`, `mediaProps`, and `useComposedRefs`.

--- a/site/src/content/changelog/10.0.0-beta.12.md
+++ b/site/src/content/changelog/10.0.0-beta.12.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds the Mux video component, native HLS playback, HLS preload and error handling, and a new error dialog component."
 date: 2026-04-01
 version: "10.0.0-beta.12"
 prerelease: true
@@ -7,39 +7,10 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.11...@videojs/core@10.0.0-beta.12"
 ---
 
+Beta.12 brings Mux playback to Video.js. The new Mux video component builds on the HLS delegate, generates stream URLs from a `playbackId` (custom playback domains included), and initializes Mux Data monitoring automatically ([#1036](https://github.com/videojs/v10/pull/1036)); a follow-up corrects Mux Data initialization ([#1162](https://github.com/videojs/v10/pull/1162)).
 
-### 🚀 Features
-- Add Mux video component ([#1036](https://github.com/videojs/v10/pull/1036)) by [@luwes](https://github.com/luwes)
-- *(site)* Improve ejected skin output with usage examples and media elements ([#1108](https://github.com/videojs/v10/pull/1108)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Implement preload for HLS media ([#1125](https://github.com/videojs/v10/pull/1125)) by [@luwes](https://github.com/luwes)
-- Add native hls media + refactor ([#1154](https://github.com/videojs/v10/pull/1154)) by [@luwes](https://github.com/luwes)
-- *(packages)* Error dialog component ([#1077](https://github.com/videojs/v10/pull/1077)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Add error handling to Hls.js media ([#1164](https://github.com/videojs/v10/pull/1164)) by [@luwes](https://github.com/luwes)
+The HLS media stack matures alongside it. A new native HLS delegate drives playback through the browser's built-in support, and HLS media now picks between the Hls.js and native paths based on browser support, source type, and your `preferPlayback` setting ([#1154](https://github.com/videojs/v10/pull/1154), [#1150](https://github.com/videojs/v10/pull/1150)). HLS media also honors `preload`: hls.js no longer loads segments eagerly, `metadata` fetches a minimal buffer, and `none` defers loading until playback starts ([#1125](https://github.com/videojs/v10/pull/1125)). Fatal Hls.js errors now convert to a standard `MediaError` with consistent messages and surface as `error` events ([#1164](https://github.com/videojs/v10/pull/1164)).
 
-### 🐛 Bug Fixes
-- *(site)* Use client:idle for ejected skin tabs so hidden panels hydrate ([#1137](https://github.com/videojs/v10/pull/1137)) by [@mihar-22](https://github.com/mihar-22)
-- *(utils)* Polyfill AbortSignal.any for Chromium ≤115 ([#1142](https://github.com/videojs/v10/pull/1142)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Add Netlify redirects for old blog URLs ([#1144](https://github.com/videojs/v10/pull/1144)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Add visible "Details" label to API reference table toggle columns ([#1147](https://github.com/videojs/v10/pull/1147)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Increase blog body text to 18px for readability ([#1146](https://github.com/videojs/v10/pull/1146)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Use overflow-auto on TabsPanel to prevent layout jump ([#1148](https://github.com/videojs/v10/pull/1148)) by [@decepulis](https://github.com/decepulis)
-- Isolate preload mixin for hls delegate ([#1150](https://github.com/videojs/v10/pull/1150)) by [@luwes](https://github.com/luwes)
-- *(site)* Add missing space in navbar ([#1151](https://github.com/videojs/v10/pull/1151)) by [@decepulis](https://github.com/decepulis)
-- *(skin)* Responsive design fixes and improvements ([#1129](https://github.com/videojs/v10/pull/1129)) by [@sampotts](https://github.com/sampotts)
-- *(html)* HTML SSR safety and sandbox skin chunking ([#1155](https://github.com/videojs/v10/pull/1155)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Fix Mux data initialization ([#1162](https://github.com/videojs/v10/pull/1162)) by [@luwes](https://github.com/luwes)
+When playback fails, the new error dialog shows it. The `media-error-dialog` element in HTML and the compound `ErrorDialog` component in React (`Root`, `Popup`, `Title`, `Description`, `Close`) open automatically from the player's error state, stay hidden otherwise, and ship in every skin ([#1077](https://github.com/videojs/v10/pull/1077)).
 
-### 💼 Other
-- *(spf)* Migrate reactors from WritableState to TC39 Signals ([#1112](https://github.com/videojs/v10/pull/1112)) by [@cjpillsbury](https://github.com/cjpillsbury)
-
-### 🚜 Refactor
-- *(site)* Flatten skin into player in ejected output and replace poster slot with img ([#1127](https://github.com/videojs/v10/pull/1127)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Reorganize SVG assets into assets/icons and assets/logos ([#1138](https://github.com/videojs/v10/pull/1138)) by [@decepulis](https://github.com/decepulis)
-
-### 🧪 Testing
-- *(spf)* Restore headless browser config for vitest ([#1103](https://github.com/videojs/v10/pull/1103)) by [@mihar-22](https://github.com/mihar-22)
-
-### ⚙️ Miscellaneous Tasks
-- *(packages)* Upgrade tsdown 0.20.3 → 0.21.4 ([#1102](https://github.com/videojs/v10/pull/1102)) by [@mihar-22](https://github.com/mihar-22)
-- *(root)* Replace turbo watch with build-first dev scripts ([#1114](https://github.com/videojs/v10/pull/1114)) by [@mihar-22](https://github.com/mihar-22)
-- *(claude)* Add create-issue skill ([#1133](https://github.com/videojs/v10/pull/1133)) by [@mihar-22](https://github.com/mihar-22)
+On the site, ejected skins now output self-contained, copy-pasteable code with real media elements, a player wrapper, and usage examples ([#1108](https://github.com/videojs/v10/pull/1108), [#1127](https://github.com/videojs/v10/pull/1127)), and hidden skin tabs hydrate correctly ([#1137](https://github.com/videojs/v10/pull/1137)). Under the hood, SPF reactors migrated from `WritableState` to TC39 Signals ([#1112](https://github.com/videojs/v10/pull/1112)). A batch of fixes rounds out the release: an `AbortSignal.any` polyfill for Chromium 115 and earlier ([#1142](https://github.com/videojs/v10/pull/1142)), responsive skin improvements ([#1129](https://github.com/videojs/v10/pull/1129)), HTML SSR safety ([#1155](https://github.com/videojs/v10/pull/1155)), and assorted site polish ([#1144](https://github.com/videojs/v10/pull/1144), [#1146](https://github.com/videojs/v10/pull/1146), [#1147](https://github.com/videojs/v10/pull/1147), [#1148](https://github.com/videojs/v10/pull/1148), [#1151](https://github.com/videojs/v10/pull/1151)).

--- a/site/src/content/changelog/10.0.0-beta.13.md
+++ b/site/src/content/changelog/10.0.0-beta.13.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Fixes the React media proxy so event listeners attach to the media element instead of the delegate."
 date: 2026-04-01
 version: "10.0.0-beta.13"
 prerelease: true
@@ -7,10 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.12...@videojs/core@10.0.0-beta.13"
 ---
 
-
-### 🐛 Bug Fixes
-- *(core)* Fix media proxy for React ([#1169](https://github.com/videojs/v10/pull/1169)) by [@luwes](https://github.com/luwes)
-
-### ⚙️ Miscellaneous Tasks
-- Update changelog ([#1168](https://github.com/videojs/v10/pull/1168)) by [@mihar-22](https://github.com/mihar-22)
-- *(root)* Upgrade turbo to 2.9 ([#1167](https://github.com/videojs/v10/pull/1167)) by [@mihar-22](https://github.com/mihar-22)
+A fast follow-up to beta.12: with delegates now extending `EventTarget`, React players attached media event listeners to the delegate instance instead of the media element. The media proxy now forwards `addEventListener`, `removeEventListener`, and `dispatchEvent` to the attached target directly, and the native HLS delegate re-applies its stored `preload` and `src` on attach ([#1169](https://github.com/videojs/v10/pull/1169)). HTML players were never affected.

--- a/site/src/content/changelog/10.0.0-beta.13.md
+++ b/site/src/content/changelog/10.0.0-beta.13.md
@@ -1,0 +1,16 @@
+---
+description: ""
+date: 2026-04-01
+version: "10.0.0-beta.13"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.12...@videojs/core@10.0.0-beta.13"
+---
+
+
+### 🐛 Bug Fixes
+- *(core)* Fix media proxy for React ([#1169](https://github.com/videojs/v10/pull/1169)) by [@luwes](https://github.com/luwes)
+
+### ⚙️ Miscellaneous Tasks
+- Update changelog ([#1168](https://github.com/videojs/v10/pull/1168)) by [@mihar-22](https://github.com/mihar-22)
+- *(root)* Upgrade turbo to 2.9 ([#1167](https://github.com/videojs/v10/pull/1167)) by [@mihar-22](https://github.com/mihar-22)

--- a/site/src/content/changelog/10.0.0-beta.14.md
+++ b/site/src/content/changelog/10.0.0-beta.14.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds volume slider scroll support, UI-only CDN bundles for ejected players, and native HLS error handling."
 date: 2026-04-03
 version: "10.0.0-beta.14"
 prerelease: true
@@ -7,41 +7,12 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.13...@videojs/core@10.0.0-beta.14"
 ---
 
+Beta.14 lets you scroll to adjust volume: hover the volume slider and use the mouse wheel, with the step size configurable through a new `wheelStep` prop in both the HTML and React players ([#1175](https://github.com/videojs/v10/pull/1175)). The behavior is documented in the VolumeSlider reference ([#1195](https://github.com/videojs/v10/pull/1195)).
 
-### 🚀 Features
-- *(packages)* Volume slider scroll support ([#1175](https://github.com/videojs/v10/pull/1175)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Add llms.txt footer link to generated markdown pages ([#1201](https://github.com/videojs/v10/pull/1201)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Organize llms.txt indexes by sidebar structure ([#1203](https://github.com/videojs/v10/pull/1203)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Add ui bundles for eject ([#1206](https://github.com/videojs/v10/pull/1206)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Add native hls error handling ([#1190](https://github.com/videojs/v10/pull/1190)) by [@luwes](https://github.com/luwes)
-- *(html)* Add native hls video to cdn ([#1208](https://github.com/videojs/v10/pull/1208)) by [@luwes](https://github.com/luwes)
-- *(site)* Add storyboard to home page hero video ([#1093](https://github.com/videojs/v10/pull/1093)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Rotate poster time ([#1153](https://github.com/videojs/v10/pull/1153)) by [@heff](https://github.com/heff)
+Native HLS playback gets proper error handling: the player intercepts native `<video>` error events and re-dispatches them enriched with a `MediaError`, so errors from native HLS surface with the same shape as the rest of the pipeline ([#1190](https://github.com/videojs/v10/pull/1190)). The `native-hls-video` element also ships in the CDN build ([#1208](https://github.com/videojs/v10/pull/1208)).
 
-### 🐛 Bug Fixes
-- *(site)* Replace deprecated `turbo-ignore` with `turbo query affected` ([#1178](https://github.com/videojs/v10/pull/1178)) by [@decepulis](https://github.com/decepulis)
-- *(build)* Auto-stamp changelog version from release manifest ([#1179](https://github.com/videojs/v10/pull/1179)) by [@decepulis](https://github.com/decepulis)
-- *(ci)* Rewrite API reference sync workflow ([#1180](https://github.com/videojs/v10/pull/1180)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Use absolute URLs in generated LLM markdown files ([#1200](https://github.com/videojs/v10/pull/1200)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Fix invalid import specifiers in ejected React skins ([#1192](https://github.com/videojs/v10/pull/1192)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Include base and shared styles in ejected skin CSS ([#1196](https://github.com/videojs/v10/pull/1196)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Make tooltips visual-only and auto-forward media button labels ([#1174](https://github.com/videojs/v10/pull/1174)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Move TimeElement child creation from constructor to connectedCallback ([#1209](https://github.com/videojs/v10/pull/1209)) by [@luwes](https://github.com/luwes)
-- *(react)* Thumbnails broken when using hls media ([#1210](https://github.com/videojs/v10/pull/1210)) by [@mihar-22](https://github.com/mihar-22)
+Ejected (light DOM) player layouts get UI-only CDN presets, such as `cdn/video-ui.js` and `cdn/audio-ui.js`, that register the player, container, and all UI custom elements without creating a skin element ([#1206](https://github.com/videojs/v10/pull/1206)). Related eject fixes land alongside: ejected React skins use valid import specifiers ([#1192](https://github.com/videojs/v10/pull/1192)), and ejected skin CSS includes the base and shared styles ([#1196](https://github.com/videojs/v10/pull/1196)).
 
-### 🚜 Refactor
-- *(html)* SkinMixin -> SkinElement ([#1159](https://github.com/videojs/v10/pull/1159)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Extract BetaPill component ([#1198](https://github.com/videojs/v10/pull/1198)) by [@decepulis](https://github.com/decepulis)
+Tooltips are visual-only from this release: they render with `role="presentation"` and no ARIA link to their trigger, while media buttons always self-label with `aria-label`. This removes the double screen-reader readout, and buttons auto-forward their current label ("Play", "Pause") to the tooltip, so skins no longer need manual label components ([#1174](https://github.com/videojs/v10/pull/1174)).
 
-### 📚 Documentation
-- *(site)* Document wheelStep prop and scroll support in VolumeSlider ([#1195](https://github.com/videojs/v10/pull/1195)) by [@mihar-22](https://github.com/mihar-22)
-
-### ⚡ Performance
-- *(site)* Parallelize and cache pre-build scripts via turbo tasks ([#1202](https://github.com/videojs/v10/pull/1202)) by [@decepulis](https://github.com/decepulis)
-
-### ⚙️ Miscellaneous Tasks
-- *(design)* Archive implemented docs and simplify design skill conventions ([#1173](https://github.com/videojs/v10/pull/1173)) by [@mihar-22](https://github.com/mihar-22)
-- *(claude)* Update `create-issue` skill  ([#1172](https://github.com/videojs/v10/pull/1172)) by [@mihar-22](https://github.com/mihar-22)
-- Move sandbox to `apps/` ([#1171](https://github.com/videojs/v10/pull/1171)) by [@mihar-22](https://github.com/mihar-22)
-- *(ci)* Remove CI failure diagnosis workflow ([#1191](https://github.com/videojs/v10/pull/1191)) by [@mihar-22](https://github.com/mihar-22)
-- *(sandbox)* Fix app for mux, native hls ([#1207](https://github.com/videojs/v10/pull/1207)) by [@luwes](https://github.com/luwes)
+A few smaller fixes round out the release: thumbnails work again in React when using HLS media ([#1210](https://github.com/videojs/v10/pull/1210)), `TimeElement` creates its children in `connectedCallback` instead of the constructor ([#1209](https://github.com/videojs/v10/pull/1209)), `SkinMixin` is renamed to `SkinElement` ([#1159](https://github.com/videojs/v10/pull/1159)), and the docs site's LLM markdown output gains absolute URLs, footer links, and sidebar-organized indexes ([#1200](https://github.com/videojs/v10/pull/1200), [#1201](https://github.com/videojs/v10/pull/1201), [#1203](https://github.com/videojs/v10/pull/1203)).

--- a/site/src/content/changelog/10.0.0-beta.15.md
+++ b/site/src/content/changelog/10.0.0-beta.15.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Fixes default chapters and metadata tracks so storyboard thumbnails load reliably under hls.js."
 date: 2026-04-03
 version: "10.0.0-beta.15"
 prerelease: true
@@ -7,11 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.14...@videojs/core@10.0.0-beta.15"
 ---
 
-
-### 🐛 Bug Fixes
-- *(site)* Remove default attr from storyboard track elements ([#1211](https://github.com/videojs/v10/pull/1211)) by [@mihar-22](https://github.com/mihar-22)
-- *(ci)* Prevent non-fast-forward push in release-pr workflow ([#1213](https://github.com/videojs/v10/pull/1213)) by [@luwes](https://github.com/luwes)
-- *(core)* Enable default tracks for chapters and metadata ([#1216](https://github.com/videojs/v10/pull/1216)) by [@luwes](https://github.com/luwes)
-
-### ⚙️ Miscellaneous Tasks
-- *(ci)* Update workflows for new triage system ([#1217](https://github.com/videojs/v10/pull/1217)) by [@decepulis](https://github.com/decepulis)
+A small follow-up release: chapters and metadata text tracks marked `default` now activate reliably, fixing storyboard thumbnails that broke under hls.js when it cleared cues on manifest loads and media attaches ([#1216](https://github.com/videojs/v10/pull/1216)). That fix supersedes an interim workaround that had removed the `default` attribute from storyboard track elements ([#1211](https://github.com/videojs/v10/pull/1211)). The rest of the release is CI housekeeping.

--- a/site/src/content/changelog/10.0.0-beta.16.md
+++ b/site/src/content/changelog/10.0.0-beta.16.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds a hotkey system across core, HTML, and React, a core gesture system, sub-1x playback rates, and the mux-audio element."
 date: 2026-04-10
 version: "10.0.0-beta.16"
 prerelease: true
@@ -7,58 +7,10 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.15...@videojs/core@10.0.0-beta.16"
 ---
 
+Beta.16 ships the hotkey system. Core gains a hotkey coordinator with key pattern parsing, modifier support, conflict resolution by specificity, input safety in editable fields, and `aria-keyshortcuts` formatting ([#1238](https://github.com/videojs/v10/pull/1238)). The HTML package adds a declarative `<media-hotkey>` element and surfaces shortcuts on control buttons ([#1239](https://github.com/videojs/v10/pull/1239)), React gets the matching component ([#1241](https://github.com/videojs/v10/pull/1241)), and the preset audio and video skins now bind shortcuts out of the box: Space or `k` toggles play, `m` mutes, arrows seek and adjust volume, and `f`, `c`, and `i` handle fullscreen, subtitles, and picture-in-picture ([#1264](https://github.com/videojs/v10/pull/1264)). Follow-up fixes cover undefined options ([#1242](https://github.com/videojs/v10/pull/1242)), registry setup ([#1240](https://github.com/videojs/v10/pull/1240)), a redundant Shift modifier on the rate keys ([#1290](https://github.com/videojs/v10/pull/1290)), and Alt handling for non-letter characters ([#1304](https://github.com/videojs/v10/pull/1304)).
 
-### 🚀 Features
-- *(core)* Add sub-1x playback rates to defaults ([#1231](https://github.com/videojs/v10/pull/1231)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Add hotkey system with coordinator, actions, and ARIA support ([#1238](https://github.com/videojs/v10/pull/1238)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Add hotkeys ([#1239](https://github.com/videojs/v10/pull/1239)) by [@mihar-22](https://github.com/mihar-22)
-- *(react)* Add hotkeys ([#1241](https://github.com/videojs/v10/pull/1241)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Media element API reference builder ([#1256](https://github.com/videojs/v10/pull/1256)) by [@decepulis](https://github.com/decepulis)
-- *(packages)* Add mux-audio element and react component ([#1259](https://github.com/videojs/v10/pull/1259)) by [@luwes](https://github.com/luwes)
-- *(packages)* Add hotkey bindings to preset skins ([#1264](https://github.com/videojs/v10/pull/1264)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Add toggleControls to controls feature ([#1280](https://github.com/videojs/v10/pull/1280)) by [@mihar-22](https://github.com/mihar-22)
-- *(spf)* Architecture reactors ([#1218](https://github.com/videojs/v10/pull/1218)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(site)* Add default OG image for social sharing ([#1295](https://github.com/videojs/v10/pull/1295)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Add gesture system ([#1287](https://github.com/videojs/v10/pull/1287)) by [@mihar-22](https://github.com/mihar-22)
+The second headline lands in core: a gesture system with tap and double-tap recognition, pointer-type filtering, and left/center/right region targeting ([#1287](https://github.com/videojs/v10/pull/1287)). The `<media-gesture>` element and React bindings follow in beta.17.
 
-### 🐛 Bug Fixes
-- *(site)* True conditional rendering in FrameworkCase ([#1223](https://github.com/videojs/v10/pull/1223)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Use 0.2 and 0.7 for default playback rates ([#1236](https://github.com/videojs/v10/pull/1236)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Create HotkeyRegistryController once in connectedCallback ([#1240](https://github.com/videojs/v10/pull/1240)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Allow undefined hotkey options  ([#1242](https://github.com/videojs/v10/pull/1242)) by [@mihar-22](https://github.com/mihar-22)
-- Safari track bug, no playback ([#1226](https://github.com/videojs/v10/pull/1226)) by [@luwes](https://github.com/luwes)
-- *(packages)* Workspace drift ([#1270](https://github.com/videojs/v10/pull/1270)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Add pointer-events-none to hero heading ([#1278](https://github.com/videojs/v10/pull/1278)) by [@mihar-22](https://github.com/mihar-22)
-- *(react)* Align media component conventions ([#1281](https://github.com/videojs/v10/pull/1281)) by [@mihar-22](https://github.com/mihar-22)
-- *(utils)* Stable sort comparator and orphaned JSDoc ([#1286](https://github.com/videojs/v10/pull/1286)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Export SliderPreviewElement and ContextPartElement ([#1283](https://github.com/videojs/v10/pull/1283)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Add destroy guards to connectedCallback ([#1284](https://github.com/videojs/v10/pull/1284)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Consistent react versions ([#1285](https://github.com/videojs/v10/pull/1285)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Narrow react peer dependency to v18+ ([#1289](https://github.com/videojs/v10/pull/1289)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Remove redundant "Shift" modifier from playback rate hotkeys ([#1290](https://github.com/videojs/v10/pull/1290)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Time slider seek improvements ([#1291](https://github.com/videojs/v10/pull/1291)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Treat Alt as implicit modifier for non-letter character hotkeys ([#1304](https://github.com/videojs/v10/pull/1304)) by [@mihar-22](https://github.com/mihar-22)
+Beyond the headliners, the new `mux-audio` element and `MuxAudio` React component bring Mux-hosted HLS playback to audio-only players ([#1259](https://github.com/videojs/v10/pull/1259)), the default playback rates now include sub-1x speeds of 0.2, 0.5, and 0.7 ([#1231](https://github.com/videojs/v10/pull/1231), [#1236](https://github.com/videojs/v10/pull/1236)), the controls feature adds a `toggleControls` method ([#1280](https://github.com/videojs/v10/pull/1280)), and SPF gains architecture reactors ([#1218](https://github.com/videojs/v10/pull/1218)). The docs site now generates API reference pages for media elements ([#1256](https://github.com/videojs/v10/pull/1256)).
 
-### 💼 Other
-- Feature and preset reference — E2E tests + implementation ([#1248](https://github.com/videojs/v10/pull/1248)) by [@decepulis](https://github.com/decepulis)
-
-### 🚜 Refactor
-- *(packages)* Move slider throttle from commit to change ([#1219](https://github.com/videojs/v10/pull/1219)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Extract structured CSSVars for media element templates ([#1257](https://github.com/videojs/v10/pull/1257)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Extract PositionController from tooltip/popover ([#1282](https://github.com/videojs/v10/pull/1282)) by [@mihar-22](https://github.com/mihar-22)
-
-### 📚 Documentation
-- *(site)* Rename commitThrottle to changeThrottle in time-slider reference ([#1221](https://github.com/videojs/v10/pull/1221)) by [@mihar-22](https://github.com/mihar-22)
-- *(design)* Hotkeys ([#1222](https://github.com/videojs/v10/pull/1222)) by [@mihar-22](https://github.com/mihar-22)
-- *(design)* Gestures ([#1044](https://github.com/videojs/v10/pull/1044)) by [@luwes](https://github.com/luwes)
-- CLI for LLM-friendly Video.js installation ([#1205](https://github.com/videojs/v10/pull/1205)) by [@decepulis](https://github.com/decepulis)
-
-### 🧪 Testing
-- *(site)* Replace api-docs-builder design doc with E2E spec tests ([#1225](https://github.com/videojs/v10/pull/1225)) by [@decepulis](https://github.com/decepulis)
-
-### ⚙️ Miscellaneous Tasks
-- *(site)* Upgrade to Astro 6 ([#946](https://github.com/videojs/v10/pull/946)) by [@decepulis](https://github.com/decepulis)
-- Use title prefixes instead of issue types for triage ([#1227](https://github.com/videojs/v10/pull/1227)) by [@decepulis](https://github.com/decepulis)
-- *(ci)* Clarify Docs and Design prefix descriptions in triage bot ([#1228](https://github.com/videojs/v10/pull/1228)) by [@decepulis](https://github.com/decepulis)
-- *(build)* Add workspace consistency checker ([#1277](https://github.com/videojs/v10/pull/1277)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Standardize conventions ([#1279](https://github.com/videojs/v10/pull/1279)) by [@mihar-22](https://github.com/mihar-22)
+A batch of fixes rounds out the release: a Safari text-track bug that blocked playback ([#1226](https://github.com/videojs/v10/pull/1226)), smoother time slider seeking that starts dragging on pointer down and commits on release ([#1291](https://github.com/videojs/v10/pull/1291)), a React peer dependency narrowed to v18+ ([#1289](https://github.com/videojs/v10/pull/1289)), newly exported `SliderPreviewElement` and `ContextPartElement` ([#1283](https://github.com/videojs/v10/pull/1283)), and destroy guards in `connectedCallback` ([#1284](https://github.com/videojs/v10/pull/1284)).

--- a/site/src/content/changelog/10.0.0-beta.17.md
+++ b/site/src/content/changelog/10.0.0-beta.17.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Completes the gesture system with the media-gesture element, React gesture hooks, and default skin bindings."
 date: 2026-04-11
 version: "10.0.0-beta.17"
 prerelease: true
@@ -7,11 +7,6 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.16...@videojs/core@10.0.0-beta.17"
 ---
 
+Beta.17 completes the gesture story started in beta.16. The new `<media-gesture>` element registers tap and double-tap handlers on the player container and dispatches them to store actions; along the way, core media state gains `togglePaused`, `toggleFullscreen`, and `togglePictureInPicture`, and the picture-in-picture hotkey action is renamed from `togglePiP` to `togglePictureInPicture` ([#1305](https://github.com/videojs/v10/pull/1305)). React gets the matching `MediaGesture` component plus `useTapGesture` and `useDoubleTapGesture` hooks ([#1309](https://github.com/videojs/v10/pull/1309)). The default video skins and presets now ship gesture bindings out of the box: click to play or pause with a mouse, tap to toggle controls on touch, and double-tap to seek or enter fullscreen by region ([#1310](https://github.com/videojs/v10/pull/1310)).
 
-### 🚀 Features
-- *(html)* Add `<media-gesture>` element ([#1305](https://github.com/videojs/v10/pull/1305)) by [@mihar-22](https://github.com/mihar-22)
-- *(react)* Add gesture hooks and MediaGesture component ([#1309](https://github.com/videojs/v10/pull/1309)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Add gesture bindings to default skins and presets ([#1310](https://github.com/videojs/v10/pull/1310)) by [@mihar-22](https://github.com/mihar-22)
-
-### 🐛 Bug Fixes
-- *(html)* Replace bare side-effect imports with explicit safeDefine() in define modules ([#1307](https://github.com/videojs/v10/pull/1307)) by [@mihar-22](https://github.com/mihar-22)
+One fix rounds out the release: the HTML define modules now register custom elements with explicit, ordered `safeDefine()` calls instead of bare side-effect imports, which removes non-deterministic registration order when the entry points load as native ESM ([#1307](https://github.com/videojs/v10/pull/1307)).

--- a/site/src/content/changelog/10.0.0-beta.18.md
+++ b/site/src/content/changelog/10.0.0-beta.18.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Replaces DelegateMixin and ProxyMixin with MediaHost base classes, and adds the @videojs/cli docs command and versioned docs."
 date: 2026-04-14
 version: "10.0.0-beta.18"
 prerelease: true
@@ -7,32 +7,10 @@ breaking: true
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.17...@videojs/core@10.0.0-beta.18"
 ---
 
+The media element architecture gets a breaking overhaul in beta.18. `DelegateMixin` and `ProxyMixin` are gone, replaced by composable MediaHost base classes: `HTMLMediaElementHost`, `HTMLVideoElementHost`, and `HTMLAudioElementHost` ([#1292](https://github.com/videojs/v10/pull/1292)). If you built a custom media engine on the old mixins, extend one of the host classes instead and register it with `CustomMediaElement('video', YourMedia)`; the custom element discovers host properties at define time, wires up attribute observation automatically, and engines chain lifecycle through `super.attach()` and `super.detach()`. The `DelegateMixin` re-export is removed from `@videojs/html` and `@videojs/react`. Mux media elements lose the `playbackId` and `customDomain` props in the same change: pass a full `src` URL instead. A follow-up moves each host's observed attributes into its subclasses ([#1326](https://github.com/videojs/v10/pull/1326)).
 
-### 🚀 Features
-- *(site)* Add versioned docs infrastructure ([#1314](https://github.com/videojs/v10/pull/1314)) by [@decepulis](https://github.com/decepulis)
-- *(cli)* Add @videojs/cli docs command for LLM-friendly installation ([#1214](https://github.com/videojs/v10/pull/1214)) by [@decepulis](https://github.com/decepulis)
+Two documentation features ship alongside. The new `@videojs/cli` package puts Video.js docs in your terminal: `npx @videojs/cli docs how-to/installation --framework react --media hls` prints an installation guide with generated code, formatted for handing straight to an LLM or coding agent ([#1214](https://github.com/videojs/v10/pull/1214)). And videojs.org now runs on versioned docs infrastructure: the production site tracks the latest release, while pre-release docs deploy from `main` to their own site ([#1314](https://github.com/videojs/v10/pull/1314)).
 
-### 🐛 Bug Fixes
-- *(site)* Revert FrameworkCase conditional rendering ([#1317](https://github.com/videojs/v10/pull/1317)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Prevent images from overflowing on narrow viewports ([#1302](https://github.com/videojs/v10/pull/1302)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Reduce doubletap window from 300ms to 200ms ([#1328](https://github.com/videojs/v10/pull/1328)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Ignore gestures on interactive child elements ([#1327](https://github.com/videojs/v10/pull/1327)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Site accessibility rough edges ([#1330](https://github.com/videojs/v10/pull/1330)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Update text link hover style to gold underline ([#1149](https://github.com/videojs/v10/pull/1149)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Ignore non-primary pointer buttons in tap gesture ([#1329](https://github.com/videojs/v10/pull/1329)) by [@mihar-22](https://github.com/mihar-22)
+Gesture handling picks up three fixes: taps ignore non-primary pointer buttons ([#1329](https://github.com/videojs/v10/pull/1329)), gestures ignore interactive child elements ([#1327](https://github.com/videojs/v10/pull/1327)), and the double-tap window drops from 300ms to 200ms ([#1328](https://github.com/videojs/v10/pull/1328)).
 
-### 💼 Other
-- Media contracts ([#1297](https://github.com/videojs/v10/pull/1297)) by [@mihar-22](https://github.com/mihar-22)
-
-### 🚜 Refactor
-- *(packages)* [**breaking**] Replace DelegateMixin & ProxyMixin with MediaHost base classes ([#1292](https://github.com/videojs/v10/pull/1292)) by [@luwes](https://github.com/luwes)
-- *(site)* Replace BEM class names with @scope-based CSS isolation in demos ([#1315](https://github.com/videojs/v10/pull/1315)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Move media host observed attributes to subclasses ([#1326](https://github.com/videojs/v10/pull/1326)) by [@luwes](https://github.com/luwes)
-
-### 📚 Documentation
-- Improve intro of a11y guide ([#1318](https://github.com/videojs/v10/pull/1318)) by [@decepulis](https://github.com/decepulis)
-- Improve intro of a11y guide ([#1331](https://github.com/videojs/v10/pull/1331)) by [@decepulis](https://github.com/decepulis)
-
-### ⚙️ Miscellaneous Tasks
-- *(site)* Rewrite media element builder for MediaHost architecture ([#1334](https://github.com/videojs/v10/pull/1334)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Preset pipeline — scan source directories instead of barrel files ([#1333](https://github.com/videojs/v10/pull/1333)) by [@decepulis](https://github.com/decepulis)
+A batch of site fixes rounds out the release: a `FrameworkCase` conditional-rendering change is reverted ([#1317](https://github.com/videojs/v10/pull/1317)), images no longer overflow narrow viewports ([#1302](https://github.com/videojs/v10/pull/1302)), several accessibility rough edges are smoothed out ([#1330](https://github.com/videojs/v10/pull/1330)), text links get a gold underline on hover ([#1149](https://github.com/videojs/v10/pull/1149)), and the accessibility guide opens with a clearer intro ([#1318](https://github.com/videojs/v10/pull/1318), [#1331](https://github.com/videojs/v10/pull/1331)).

--- a/site/src/content/changelog/10.0.0-beta.19.md
+++ b/site/src/content/changelog/10.0.0-beta.19.md
@@ -1,12 +1,10 @@
 ---
-description: ""
+description: "Fixes the CLI bin path so npm exposes the executable after install."
 date: 2026-04-14
 version: "10.0.0-beta.19"
 prerelease: true
 breaking: false
-compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.19...@videojs/core@10.0.0-beta.19"
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.18...@videojs/core@10.0.0-beta.19"
 ---
 
-
-### 🐛 Bug Fixes
-- *(cli)* Replace deprecated noExternal with deps.alwaysBundle ([#1338](https://github.com/videojs/v10/pull/1338)) by [@decepulis](https://github.com/decepulis)
+Beta.19 fixes the Video.js CLI executable: the package's `bin` entry now points at the `.mjs` file tsdown outputs, so npm exposes the `videojs` command after install and `npx @videojs/cli docs` works ([#1337](https://github.com/videojs/v10/pull/1337)).

--- a/site/src/content/changelog/10.0.0-beta.2.md
+++ b/site/src/content/changelog/10.0.0-beta.2.md
@@ -1,0 +1,25 @@
+---
+description: ""
+date: 2026-03-10
+version: "10.0.0-beta.2"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.1...@videojs/core@10.0.0-beta.2"
+---
+
+
+### 🚀 Features
+- *(site)* Use HlsVideo in homepage HeroVideo component ([#854](https://github.com/videojs/v10/pull/854)) by [@decepulis](https://github.com/decepulis)
+- *(html)* Add CDN bundles and inline template minification ([#827](https://github.com/videojs/v10/pull/827)) by [@mihar-22](https://github.com/mihar-22)
+
+### 🐛 Bug Fixes
+- *(docs)* Update v10 blog post ([#852](https://github.com/videojs/v10/pull/852)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Move legacy banner to base layout and fix mobile text size ([#855](https://github.com/videojs/v10/pull/855)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Fix legacy banner layout on narrow viewports ([#856](https://github.com/videojs/v10/pull/856)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Center-align radio option labels in ImageRadioGroup ([#858](https://github.com/videojs/v10/pull/858)) by [@decepulis](https://github.com/decepulis)
+
+### 📚 Documentation
+- Discord link in blog post ([#863](https://github.com/videojs/v10/pull/863)) by [@heff](https://github.com/heff)
+
+### ⚙️ Miscellaneous Tasks
+- *(site)* Migrate to videojs.org and clean up remaining redirects ([#853](https://github.com/videojs/v10/pull/853)) by [@decepulis](https://github.com/decepulis)

--- a/site/src/content/changelog/10.0.0-beta.2.md
+++ b/site/src/content/changelog/10.0.0-beta.2.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds self-contained CDN bundles to @videojs/html and completes the site's move to videojs.org."
 date: 2026-03-10
 version: "10.0.0-beta.2"
 prerelease: true
@@ -7,19 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.1...@videojs/core@10.0.0-beta.2"
 ---
 
-
-### 🚀 Features
-- *(site)* Use HlsVideo in homepage HeroVideo component ([#854](https://github.com/videojs/v10/pull/854)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Add CDN bundles and inline template minification ([#827](https://github.com/videojs/v10/pull/827)) by [@mihar-22](https://github.com/mihar-22)
-
-### 🐛 Bug Fixes
-- *(docs)* Update v10 blog post ([#852](https://github.com/videojs/v10/pull/852)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Move legacy banner to base layout and fix mobile text size ([#855](https://github.com/videojs/v10/pull/855)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Fix legacy banner layout on narrow viewports ([#856](https://github.com/videojs/v10/pull/856)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Center-align radio option labels in ImageRadioGroup ([#858](https://github.com/videojs/v10/pull/858)) by [@decepulis](https://github.com/decepulis)
-
-### 📚 Documentation
-- Discord link in blog post ([#863](https://github.com/videojs/v10/pull/863)) by [@heff](https://github.com/heff)
-
-### ⚙️ Miscellaneous Tasks
-- *(site)* Migrate to videojs.org and clean up remaining redirects ([#853](https://github.com/videojs/v10/pull/853)) by [@decepulis](https://github.com/decepulis)
+`@videojs/html` now ships CDN bundles ([#827](https://github.com/videojs/v10/pull/827)): seven entry points covering video, audio, background, and media elements, each built as a single ESM file with zero external imports, in development and production modes with inline CSS and templates minified. Load them from `@videojs/html/cdn/`; the site's CDN examples already point there. This release also completes the site's migration to videojs.org and cleans up the remaining redirects ([#853](https://github.com/videojs/v10/pull/853)), and the homepage hero now streams HLS through the `HlsVideo` component ([#854](https://github.com/videojs/v10/pull/854)). A batch of site fixes rounds things out: legacy-site banner placement and layout on narrow viewports ([#855](https://github.com/videojs/v10/pull/855), [#856](https://github.com/videojs/v10/pull/856)), centered radio option labels in `ImageRadioGroup` ([#858](https://github.com/videojs/v10/pull/858)), and updates to the v10 announcement post, including a Discord link ([#852](https://github.com/videojs/v10/pull/852), [#863](https://github.com/videojs/v10/pull/863)).

--- a/site/src/content/changelog/10.0.0-beta.20.md
+++ b/site/src/content/changelog/10.0.0-beta.20.md
@@ -1,0 +1,12 @@
+---
+description: ""
+date: 2026-04-14
+version: "10.0.0-beta.20"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.19...@videojs/core@10.0.0-beta.20"
+---
+
+
+### 🐛 Bug Fixes
+- *(cli)* Replace deprecated noExternal with deps.alwaysBundle ([#1338](https://github.com/videojs/v10/pull/1338)) by [@decepulis](https://github.com/decepulis)

--- a/site/src/content/changelog/10.0.0-beta.20.md
+++ b/site/src/content/changelog/10.0.0-beta.20.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Fixes CLI packaging by bundling dependencies with deps.alwaysBundle."
 date: 2026-04-14
 version: "10.0.0-beta.20"
 prerelease: true
@@ -7,6 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.19...@videojs/core@10.0.0-beta.20"
 ---
 
-
-### 🐛 Bug Fixes
-- *(cli)* Replace deprecated noExternal with deps.alwaysBundle ([#1338](https://github.com/videojs/v10/pull/1338)) by [@decepulis](https://github.com/decepulis)
+A single packaging fix for the Video.js CLI: the build now bundles dependencies with `deps.alwaysBundle` instead of the deprecated `noExternal` option ([#1338](https://github.com/videojs/v10/pull/1338)).

--- a/site/src/content/changelog/10.0.0-beta.21.md
+++ b/site/src/content/changelog/10.0.0-beta.21.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds generated feature and preset reference tables to the docs site and fixes the CLI's npm repository URL."
 date: 2026-04-14
 version: "10.0.0-beta.21"
 prerelease: true
@@ -7,9 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.20...@videojs/core@10.0.0-beta.21"
 ---
 
-
-### 🚀 Features
-- *(site)* Feature and preset reference UI + docs integration ([#1258](https://github.com/videojs/v10/pull/1258)) by [@decepulis](https://github.com/decepulis)
-
-### 🐛 Bug Fixes
-- *(cli)* Normalize repository URL to match npm convention ([#1340](https://github.com/videojs/v10/pull/1340)) by [@decepulis](https://github.com/decepulis)
+The docs site now generates feature and preset reference tables straight from the source code: each feature page renders its state and actions from generated API data, and preset pages get framework-aware tables that cross-link to the features they include ([#1258](https://github.com/videojs/v10/pull/1258)). A small CLI fix rides along: `@videojs/cli` normalizes its repository URL to npm's convention, silencing a warning on every publish ([#1340](https://github.com/videojs/v10/pull/1340)).

--- a/site/src/content/changelog/10.0.0-beta.21.md
+++ b/site/src/content/changelog/10.0.0-beta.21.md
@@ -1,0 +1,15 @@
+---
+description: ""
+date: 2026-04-14
+version: "10.0.0-beta.21"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.20...@videojs/core@10.0.0-beta.21"
+---
+
+
+### 🚀 Features
+- *(site)* Feature and preset reference UI + docs integration ([#1258](https://github.com/videojs/v10/pull/1258)) by [@decepulis](https://github.com/decepulis)
+
+### 🐛 Bug Fixes
+- *(cli)* Normalize repository URL to match npm convention ([#1340](https://github.com/videojs/v10/pull/1340)) by [@decepulis](https://github.com/decepulis)

--- a/site/src/content/changelog/10.0.0-beta.22.md
+++ b/site/src/content/changelog/10.0.0-beta.22.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds Chromecast support via the Remote Playback API and a Playwright end-to-end test harness."
 date: 2026-04-18
 version: "10.0.0-beta.22"
 prerelease: true
@@ -7,16 +7,8 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.21...@videojs/core@10.0.0-beta.22"
 ---
 
+Chromecast arrives in beta.22 ([#1348](https://github.com/videojs/v10/pull/1348)). A `RemotePlayback` polyfill backed by the Cast Application Framework sender SDK wraps any media host, so the feature layer works the same whether it talks to native remote playback or a Chromecast session. On top of it, a `castFeature` store slice exposes `castState`, `castAvailability`, and `toggleCast` as reactive state, and a new `CastButton` component ships across HTML and React with enter/exit icons in the default and minimal skins. Controls stay visible while a cast session is connected.
 
-### 🚀 Features
-- *(site)* Serve branded OG images dynamically ([#1345](https://github.com/videojs/v10/pull/1345)) by [@decepulis](https://github.com/decepulis)
-- Add e2e test harness ([#1237](https://github.com/videojs/v10/pull/1237)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* Add chromecast support via remote playback API ([#1348](https://github.com/videojs/v10/pull/1348)) by [@luwes](https://github.com/luwes)
+The repo also gains a Playwright end-to-end test harness ([#1237](https://github.com/videojs/v10/pull/1237)): 200 tests across Chromium, WebKit, and Firefox that exercise video and audio controls, keyboard navigation, captions, and visual snapshots against packaged, ejected, and CDN consumption patterns.
 
-### 🐛 Bug Fixes
-- *(site)* Preserve casing for code identifiers in doc titles and OG images ([#1347](https://github.com/videojs/v10/pull/1347)) by [@decepulis](https://github.com/decepulis)
-- *(packages)* Add server-only bundles  ([#1349](https://github.com/videojs/v10/pull/1349)) by [@mihar-22](https://github.com/mihar-22)
-- *(react)* Prevent gesture tap from firing on slider interactions ([#1361](https://github.com/videojs/v10/pull/1361)) by [@mihar-22](https://github.com/mihar-22)
-
-### ◀️ Revert
-- *(packages)* Add server-only bundles ([#1349](https://github.com/videojs/v10/pull/1349)) ([#1354](https://github.com/videojs/v10/pull/1354)) by [@luwes](https://github.com/luwes)
+A few smaller changes round out the release: gesture taps no longer fire on slider interactions in React ([#1361](https://github.com/videojs/v10/pull/1361)), and videojs.org serves branded OG images dynamically ([#1345](https://github.com/videojs/v10/pull/1345)) with casing preserved for code identifiers in doc titles ([#1347](https://github.com/videojs/v10/pull/1347)). A server-only bundles change ([#1349](https://github.com/videojs/v10/pull/1349)) was reverted within this release ([#1354](https://github.com/videojs/v10/pull/1354)) and did not ship.

--- a/site/src/content/changelog/10.0.0-beta.23.md
+++ b/site/src/content/changelog/10.0.0-beta.23.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Renames cast APIs to google-cast and remote-playback, unifies fullscreen and PiP on media capabilities, and adds live streaming support."
 date: 2026-04-27
 version: "10.0.0-beta.23"
 prerelease: true
@@ -7,39 +7,10 @@ breaking: true
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.22...@videojs/core@10.0.0-beta.23"
 ---
 
+Beta.23 ships two breaking changes. First, the overloaded "cast" vocabulary splits into two concepts ([#1380](https://github.com/videojs/v10/pull/1380)): the Google Cast integration is now `google-cast`, and the generic W3C Remote Playback surface is now `remote-playback`. Update `CastableMediaMixin` to `GoogleCastMixin`, `castFeature` to `remotePlaybackFeature`, `selectCast` to `selectRemotePlayback`, and the state fields `castState`, `castAvailability`, and `toggleCast()` to `remotePlaybackState`, `remotePlaybackAvailability`, and `toggleRemotePlayback()`. The `CastButton` component and its `data-cast-state` attribute keep their names. The same PR keeps controls visible while the cast picker is open, hides buttons for unsupported features in the skins, and hides the cast button on non-Chromium browsers.
 
-### 🚀 Features
-- *(html)* Observe cast attributes on mux elements ([#1386](https://github.com/videojs/v10/pull/1386)) by [@luwes](https://github.com/luwes)
-- *(core)* Add HLS stream-type detection and live duration ([#1387](https://github.com/videojs/v10/pull/1387)) by [@luwes](https://github.com/luwes)
-- *(packages)* Add live-video and live-audio presets ([#1399](https://github.com/videojs/v10/pull/1399)) by [@luwes](https://github.com/luwes)
-- *(packages)* Support cli:omit markers for llm-only doc content ([#1466](https://github.com/videojs/v10/pull/1466)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Re-export reactive primitives from @videojs/element ([#1472](https://github.com/videojs/v10/pull/1472)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Add liveEdgeStart and targetLiveWindow properties ([#1445](https://github.com/videojs/v10/pull/1445)) by [@luwes](https://github.com/luwes)
+Second, fullscreen and picture-in-picture state moves onto the media capability interfaces ([#1469](https://github.com/videojs/v10/pull/1469)). `MediaFullscreenCapability` gains `isFullscreen` and `exitFullscreen`, `MediaPictureInPictureCapability` gains `isPictureInPicture` and `exitPictureInPicture`, and the presentation helpers `isFullscreenElement` and `isPictureInPictureElement` are renamed to `isFullscreen` and `isPictureInPicture`. If you call `exitFullscreen` directly, it now requires a `media` argument, and custom media hosts should implement the new getters and exit methods.
 
-### 🐛 Bug Fixes
-- *(react)* Rename MediaGesture and MediaHotkey to Gesture and Hotkey ([#1374](https://github.com/videojs/v10/pull/1374)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Only report Sentry errors from deployed function runtime ([#1393](https://github.com/videojs/v10/pull/1393)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Work around #1111 in create-player/player-controller demos ([#1403](https://github.com/videojs/v10/pull/1403)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Add astro check CI and reduce errors/hints ([#1109](https://github.com/videojs/v10/pull/1109)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Raise testTimeout to 15s for parallel-load reliability ([#1448](https://github.com/videojs/v10/pull/1448)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(site)* Exclude clientcode suspense fallback from llms and search ([#1467](https://github.com/videojs/v10/pull/1467)) by [@decepulis](https://github.com/decepulis)
+Live streaming is the headline feature work: HLS stream-type detection and live duration derived from the seekable window ([#1387](https://github.com/videojs/v10/pull/1387)), `liveEdgeStart` and `targetLiveWindow` properties modeled on the media-ui-extensions live-edge proposal ([#1445](https://github.com/videojs/v10/pull/1445)), and `live-video` and `live-audio` presets that drop seek and playback-rate UI for live sources ([#1399](https://github.com/videojs/v10/pull/1399)). Along the way, `streamTypeFeature` moved out of the base video and audio presets; opt in explicitly if you need stream-type state.
 
-### 💼 Other
-- *(cli)* Decouple cli tests from upstream builds ([#1402](https://github.com/videojs/v10/pull/1402)) by [@decepulis](https://github.com/decepulis)
-
-### 🚜 Refactor
-- *(react)* Replace prototype-walking and inferred class props ([#1376](https://github.com/videojs/v10/pull/1376)) by [@mihar-22](https://github.com/mihar-22)
-- *(packages)* [**breaking**] Rename cast to google-cast and remote-playback ([#1380](https://github.com/videojs/v10/pull/1380)) by [@luwes](https://github.com/luwes)
-- *(core)* [**breaking**] Unify fullscreen and pip on media capabilities ([#1469](https://github.com/videojs/v10/pull/1469)) by [@luwes](https://github.com/luwes)
-
-### 📚 Documentation
-- *(root)* Fix stale references and document sandbox workflow ([#1464](https://github.com/videojs/v10/pull/1464)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Add how-to guide for building custom components ([#1008](https://github.com/videojs/v10/pull/1008)) by [@decepulis](https://github.com/decepulis)
-
-### ⚡ Performance
-- *(site)* Trim site build time ([#1379](https://github.com/videojs/v10/pull/1379)) by [@decepulis](https://github.com/decepulis)
-
-### ⚙️ Miscellaneous Tasks
-- *(ci)* Exclude epic and priority labels from triage agent ([#1377](https://github.com/videojs/v10/pull/1377)) by [@decepulis](https://github.com/decepulis)
-- Update README milestone link ([#1444](https://github.com/videojs/v10/pull/1444)) by [@decepulis](https://github.com/decepulis)
-- *(root)* Migrate typecheck to @typescript/native-preview (tsgo) ([#1400](https://github.com/videojs/v10/pull/1400)) by [@mihar-22](https://github.com/mihar-22)
+Elsewhere, React's `MediaGesture` and `MediaHotkey` become `Gesture` and `Hotkey` with deprecated aliases for the old names ([#1374](https://github.com/videojs/v10/pull/1374)), mux elements observe cast attributes ([#1386](https://github.com/videojs/v10/pull/1386)), `@videojs/html` re-exports reactive primitives from `@videojs/element` ([#1472](https://github.com/videojs/v10/pull/1472)), and the docs gain a how-to guide for building custom components ([#1008](https://github.com/videojs/v10/pull/1008)).

--- a/site/src/content/changelog/10.0.0-beta.24.md
+++ b/site/src/content/changelog/10.0.0-beta.24.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds a menu system with keyboard navigation, a playback rate menu, a live button, gesture and hotkey indicators, and bundled docs."
 date: 2026-05-19
 version: "10.0.0-beta.24"
 prerelease: true
@@ -7,49 +7,12 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.23...@videojs/core@10.0.0-beta.24"
 ---
 
+Menus headline beta.24. A shared menu core with full DOM keyboard support ([#1503](https://github.com/videojs/v10/pull/1503)) handles open and close, roving focus, arrow-key and typeahead navigation, and nested submenus with view transitions, shipping as matching React components and HTML custom elements. The first consumer is the new playback rate menu ([#1527](https://github.com/videojs/v10/pull/1527)), which replaces the playback rate button in the shipped skins and improves shared popover behavior along the way: only one top-level popup opens at a time, positioning respects a configurable boundary, and menus close when the controls hide.
 
-### 🚀 Features
-- *(packages)* Add live button component ([#1473](https://github.com/videojs/v10/pull/1473)) by [@luwes](https://github.com/luwes)
-- *(packages)* Add UI support for gestures and hotkeys ([#1388](https://github.com/videojs/v10/pull/1388)) by [@sampotts](https://github.com/sampotts)
-- *(spf)* HLS engine composition walkthrough + doc-driven cleanups ([#1512](https://github.com/videojs/v10/pull/1512)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(core)* Menu core layer and DOM keyboard navigation ([#1503](https://github.com/videojs/v10/pull/1503)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Add playback rate menu ([#1527](https://github.com/videojs/v10/pull/1527)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Ship bundled markdown docs in html and react tarballs ([#1560](https://github.com/videojs/v10/pull/1560)) by [@decepulis](https://github.com/decepulis)
+Live streams get a dedicated live button ([#1473](https://github.com/videojs/v10/pull/1473)) that signals whether playback is at the live edge and seeks to it when activated; `data-live` and `data-edge` attributes drive skin styling, and the live presets render it next to the play button. Gestures and hotkeys gain visible feedback ([#1388](https://github.com/videojs/v10/pull/1388)): new status, volume, and seek indicators observe input activity and render transient overlays, with a screen-reader announcer alongside.
 
-### 🐛 Bug Fixes
-- *(icons)* Avoid hidden spinner animations ([#1476](https://github.com/videojs/v10/pull/1476)) by [@sampotts](https://github.com/sampotts)
-- *(ci)* Use biome to sort CSS properties ([#1490](https://github.com/videojs/v10/pull/1490)) by [@sampotts](https://github.com/sampotts)
-- *(icons)* Use icon exports in ejected skins ([#1489](https://github.com/videojs/v10/pull/1489)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add 'use client' to ejected skin Next.js output ([#1488](https://github.com/videojs/v10/pull/1488)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(skin)* Fix safari button alignment issue when zoomed ([#1495](https://github.com/videojs/v10/pull/1495)) by [@sampotts](https://github.com/sampotts)
-- *(build)* Resolve link-aliases root from repo root ([#1501](https://github.com/videojs/v10/pull/1501)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(html)* Set min dimensions on background-video host ([#1523](https://github.com/videojs/v10/pull/1523)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(core)* Resolve cast button ssr hydration mismatch ([#1518](https://github.com/videojs/v10/pull/1518)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(skin)* Fix minimal tailwind root sizing ([#1540](https://github.com/videojs/v10/pull/1540)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(react)* Replace any with unknown in isRenderProp type guard ([#1500](https://github.com/videojs/v10/pull/1500)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(docs)* Improve agentic discovery of llms.txt and eject ([#1564](https://github.com/videojs/v10/pull/1564)) by [@decepulis](https://github.com/decepulis)
-- *(spf)* Conventions, per-type specialization, config threading ([#1537](https://github.com/videojs/v10/pull/1537)) by [@cjpillsbury](https://github.com/cjpillsbury)
+The `@videojs/html` and `@videojs/react` tarballs now bundle the framework-specific markdown docs ([#1560](https://github.com/videojs/v10/pull/1560)), so AI coding agents reading `node_modules` find real documentation instead of a stub README; a companion fix improves discovery of `llms.txt` and the eject workflow ([#1564](https://github.com/videojs/v10/pull/1564)). The site adds a "Why Video.js?" concept page ([#1526](https://github.com/videojs/v10/pull/1526)). SPF gains a stage-by-stage walkthrough of the HLS engine composition, with cleanups that reorganize the package and move the engine export from `@videojs/spf/playback-engine` to `@videojs/spf/hls` ([#1512](https://github.com/videojs/v10/pull/1512), [#1537](https://github.com/videojs/v10/pull/1537)).
 
-### 📚 Documentation
-- *(design)* Menus ([#1078](https://github.com/videojs/v10/pull/1078)) by [@sampotts](https://github.com/sampotts)
-- *(design)* Add design doc for live presets ([#1395](https://github.com/videojs/v10/pull/1395)) by [@luwes](https://github.com/luwes)
-- *(site)* Warn that bundled HTML installs need type="module" ([#1530](https://github.com/videojs/v10/pull/1530)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(site)* Add 'use client' to homepage React snippet ([#1529](https://github.com/videojs/v10/pull/1529)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- Fix grammar in features concept guide ([#1511](https://github.com/videojs/v10/pull/1511)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(site)* Add "Why Video.js?" concept page ([#1526](https://github.com/videojs/v10/pull/1526)) by [@decepulis](https://github.com/decepulis)
-- *(design)* I18n ([#1122](https://github.com/videojs/v10/pull/1122)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Fix feature export names in features and presets guides ([#1513](https://github.com/videojs/v10/pull/1513)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(site)* Use togglePaused in playback feature example ([#1522](https://github.com/videojs/v10/pull/1522)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(claude)* Add css to tailwind migration skill ([#1548](https://github.com/videojs/v10/pull/1548)) by [@sampotts](https://github.com/sampotts)
+A long fix tail rounds out the release: the cast button no longer causes an SSR hydration mismatch ([#1518](https://github.com/videojs/v10/pull/1518)), spinner animations stop running while hidden ([#1476](https://github.com/videojs/v10/pull/1476)), Safari button alignment holds up when zoomed ([#1495](https://github.com/videojs/v10/pull/1495)), the minimal Tailwind skin sizes its root correctly ([#1540](https://github.com/videojs/v10/pull/1540)), background-video hosts get minimum dimensions ([#1523](https://github.com/videojs/v10/pull/1523)), ejected skins use icon exports ([#1489](https://github.com/videojs/v10/pull/1489)) and include `'use client'` in Next.js output ([#1488](https://github.com/videojs/v10/pull/1488)), and the `isRenderProp` type guard drops `any` for `unknown` ([#1500](https://github.com/videojs/v10/pull/1500)). Docs pick up small corrections across the installation, features, and presets guides ([#1530](https://github.com/videojs/v10/pull/1530), [#1529](https://github.com/videojs/v10/pull/1529), [#1513](https://github.com/videojs/v10/pull/1513), [#1522](https://github.com/videojs/v10/pull/1522), [#1511](https://github.com/videojs/v10/pull/1511)).
 
-### 🧪 Testing
-- *(sandbox)* Adapt playback rate E2E to menu UX ([#1545](https://github.com/videojs/v10/pull/1545)) by [@sampotts](https://github.com/sampotts)
-
-### ⚙️ Miscellaneous Tasks
-- *(ci)* Configure noUnknownProperty to allow corner-shape ([#1502](https://github.com/videojs/v10/pull/1502)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Upgrade astro to 6.3.1 ([#1499](https://github.com/videojs/v10/pull/1499)) by [@decepulis](https://github.com/decepulis)
-- *(ci)* Scope triage label to external authors ([#1550](https://github.com/videojs/v10/pull/1550)) by [@decepulis](https://github.com/decepulis)
-
-### New Contributors
-* @R-Delfino95 made their first contribution in [#1522](https://github.com/videojs/v10/pull/1522)
-* @spuppo-mux made their first contribution in [#1540](https://github.com/videojs/v10/pull/1540)
+Thanks to [@R-Delfino95](https://github.com/R-Delfino95) and [@spuppo-mux](https://github.com/spuppo-mux) for their first contributions to Video.js.

--- a/site/src/content/changelog/10.0.0-beta.3.md
+++ b/site/src/content/changelog/10.0.0-beta.3.md
@@ -1,0 +1,25 @@
+---
+description: ""
+date: 2026-03-11
+version: "10.0.0-beta.3"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.2...@videojs/core@10.0.0-beta.3"
+---
+
+
+### 🚀 Features
+- *(site)* Add optional OG image support to blog posts ([#878](https://github.com/videojs/v10/pull/878)) by [@decepulis](https://github.com/decepulis)
+
+### 🐛 Bug Fixes
+- *(html)* Remove commented error dialog blocks from video skins ([#865](https://github.com/videojs/v10/pull/865)) by [@mihar-22](https://github.com/mihar-22)
+- *(site)* Add missing slot="media" to HTML demo video elements ([#867](https://github.com/videojs/v10/pull/867)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Netlify aliases -> redirects ([#868](https://github.com/videojs/v10/pull/868)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Use custom domain for og:image on production deploys ([#880](https://github.com/videojs/v10/pull/880)) by [@decepulis](https://github.com/decepulis)
+- *(html)* Fix html container sizing ([#881](https://github.com/videojs/v10/pull/881)) by [@sampotts](https://github.com/sampotts)
+- *(core)* Resolve pip state against media target ([#883](https://github.com/videojs/v10/pull/883)) by [@mihar-22](https://github.com/mihar-22)
+- *(skins)* Remove legacy caption markup artifacts ([#882](https://github.com/videojs/v10/pull/882)) by [@mihar-22](https://github.com/mihar-22)
+
+### ⚙️ Miscellaneous Tasks
+- *(site)* Remove v8 link checker integration ([#879](https://github.com/videojs/v10/pull/879)) by [@decepulis](https://github.com/decepulis)
+- *(sandbox)* Sandbox cleanup ([#797](https://github.com/videojs/v10/pull/797)) by [@sampotts](https://github.com/sampotts)

--- a/site/src/content/changelog/10.0.0-beta.3.md
+++ b/site/src/content/changelog/10.0.0-beta.3.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Fixes HTML player container sizing and picture-in-picture state on proxied media, plus skin and site cleanups."
 date: 2026-03-11
 version: "10.0.0-beta.3"
 prerelease: true
@@ -7,19 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.2...@videojs/core@10.0.0-beta.3"
 ---
 
-
-### 🚀 Features
-- *(site)* Add optional OG image support to blog posts ([#878](https://github.com/videojs/v10/pull/878)) by [@decepulis](https://github.com/decepulis)
-
-### 🐛 Bug Fixes
-- *(html)* Remove commented error dialog blocks from video skins ([#865](https://github.com/videojs/v10/pull/865)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Add missing slot="media" to HTML demo video elements ([#867](https://github.com/videojs/v10/pull/867)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Netlify aliases -> redirects ([#868](https://github.com/videojs/v10/pull/868)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Use custom domain for og:image on production deploys ([#880](https://github.com/videojs/v10/pull/880)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Fix html container sizing ([#881](https://github.com/videojs/v10/pull/881)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Resolve pip state against media target ([#883](https://github.com/videojs/v10/pull/883)) by [@mihar-22](https://github.com/mihar-22)
-- *(skins)* Remove legacy caption markup artifacts ([#882](https://github.com/videojs/v10/pull/882)) by [@mihar-22](https://github.com/mihar-22)
-
-### ⚙️ Miscellaneous Tasks
-- *(site)* Remove v8 link checker integration ([#879](https://github.com/videojs/v10/pull/879)) by [@decepulis](https://github.com/decepulis)
-- *(sandbox)* Sandbox cleanup ([#797](https://github.com/videojs/v10/pull/797)) by [@sampotts](https://github.com/sampotts)
+Two player fixes lead this release. The HTML player now injects a light-DOM `base.css` stylesheet that sets `display: contents` on `<video-player>` and sizes the player and media elements correctly, fixing layout shift and styling issues with non-video elements ([#881](https://github.com/videojs/v10/pull/881)). Picture-in-picture state now resolves against the resolved media target, so PiP detection and request/exit paths work with proxied media hosts, trying the standard exit path before the WebKit fallback ([#883](https://github.com/videojs/v10/pull/883)). The skins shed leftover markup: commented-out error dialog blocks ([#865](https://github.com/videojs/v10/pull/865)) and legacy caption artifacts ([#882](https://github.com/videojs/v10/pull/882)). On the site, blog posts can set a custom OG image, served from the custom domain on production deploys ([#878](https://github.com/videojs/v10/pull/878), [#880](https://github.com/videojs/v10/pull/880)); HTML demo videos gained the missing `slot="media"` attribute ([#867](https://github.com/videojs/v10/pull/867)); and Netlify aliases became redirects ([#868](https://github.com/videojs/v10/pull/868)).

--- a/site/src/content/changelog/10.0.0-beta.4.md
+++ b/site/src/content/changelog/10.0.0-beta.4.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Streams HLS segment fetches through ReadableStream bodies and fixes mobile controls, skin styling, and site issues."
 date: 2026-03-12
 version: "10.0.0-beta.4"
 prerelease: true
@@ -7,24 +7,10 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.3...@videojs/core@10.0.0-beta.4"
 ---
 
+The headline change in beta.4 lands in the SPF playback engine: segment fetches now stream through `fetch`'s `ReadableStream` body ([#890](https://github.com/videojs/v10/pull/890)), so video data downloads and appends in overlapping chunks instead of waiting for each full segment. Bandwidth estimation samples throughput per chunk as data arrives, and source buffer setup now waits for all selected tracks before creating any `SourceBuffer`, which fixes a Firefox bug where appending video before the audio buffer exists permanently disables audio detection. A follow-up propagates `byteRange` when building segment load tasks ([#904](https://github.com/videojs/v10/pull/904)).
 
-### 🚀 Features
-- *(spf)* Stream segment fetches via ReadableStream body ([#890](https://github.com/videojs/v10/pull/890)) by [@cjpillsbury](https://github.com/cjpillsbury)
+In the player, custom media elements that aren't `HTMLMediaElement` instances now attach to the store and upgrade correctly ([#889](https://github.com/videojs/v10/pull/889)), and two issues that broke showing and hiding controls on mobile are fixed ([#896](https://github.com/videojs/v10/pull/896)).
 
-### 🐛 Bug Fixes
-- *(site)* Work around video layout quirks in hero ([#884](https://github.com/videojs/v10/pull/884)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Redirect trailing-slash URLs via edge function ([#885](https://github.com/videojs/v10/pull/885)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Filter devOnly posts from RSS feed ([#888](https://github.com/videojs/v10/pull/888)) by [@decepulis](https://github.com/decepulis)
-- Attaching media like elements and upgrade ([#889](https://github.com/videojs/v10/pull/889)) by [@luwes](https://github.com/luwes)
-- *(skin)* Standardize backdrop-filter and fix minimal root sizing ([#895](https://github.com/videojs/v10/pull/895)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Replace GA4 with PostHog cookieless analytics ([#894](https://github.com/videojs/v10/pull/894)) by [@decepulis](https://github.com/decepulis)
-- Mobile controls issues ([#896](https://github.com/videojs/v10/pull/896)) by [@luwes](https://github.com/luwes)
-- *(skin)* Add missing tooltip provider/group ([#902](https://github.com/videojs/v10/pull/902)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add playsinline to home and installation snippets ([#897](https://github.com/videojs/v10/pull/897)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Skip delay when switching between grouped tooltips ([#903](https://github.com/videojs/v10/pull/903)) by [@sampotts](https://github.com/sampotts)
-- *(spf)* Propagate byteRange when building segment load tasks ([#904](https://github.com/videojs/v10/pull/904)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(skin)* Fix fullscreen video clipping and border-radius handling ([#905](https://github.com/videojs/v10/pull/905)) by [@sampotts](https://github.com/sampotts)
+A batch of skin and tooltip fixes rounds out the player work: standardized `backdrop-filter` and minimal skin root sizing ([#895](https://github.com/videojs/v10/pull/895)), a missing tooltip provider and group ([#902](https://github.com/videojs/v10/pull/902)), no delay when switching between grouped tooltips ([#903](https://github.com/videojs/v10/pull/903)), and fullscreen video clipping and border-radius handling ([#905](https://github.com/videojs/v10/pull/905)).
 
-### ⚙️ Miscellaneous Tasks
-- *(changelog)* Use one root level changelog ([#900](https://github.com/videojs/v10/pull/900)) by [@luwes](https://github.com/luwes)
-- *(changelog)* Fix changelog-path ([#901](https://github.com/videojs/v10/pull/901)) by [@luwes](https://github.com/luwes)
+The videojs.org site also gets attention: hero video layout workarounds ([#884](https://github.com/videojs/v10/pull/884)), trailing-slash redirects via an edge function ([#885](https://github.com/videojs/v10/pull/885)), dev-only posts filtered from the RSS feed ([#888](https://github.com/videojs/v10/pull/888)), cookieless PostHog analytics replacing GA4 ([#894](https://github.com/videojs/v10/pull/894)), and `playsinline` added to the home and installation snippets ([#897](https://github.com/videojs/v10/pull/897)).

--- a/site/src/content/changelog/10.0.0-beta.4.md
+++ b/site/src/content/changelog/10.0.0-beta.4.md
@@ -1,0 +1,30 @@
+---
+description: ""
+date: 2026-03-12
+version: "10.0.0-beta.4"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.3...@videojs/core@10.0.0-beta.4"
+---
+
+
+### 🚀 Features
+- *(spf)* Stream segment fetches via ReadableStream body ([#890](https://github.com/videojs/v10/pull/890)) by [@cjpillsbury](https://github.com/cjpillsbury)
+
+### 🐛 Bug Fixes
+- *(site)* Work around video layout quirks in hero ([#884](https://github.com/videojs/v10/pull/884)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Redirect trailing-slash URLs via edge function ([#885](https://github.com/videojs/v10/pull/885)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Filter devOnly posts from RSS feed ([#888](https://github.com/videojs/v10/pull/888)) by [@decepulis](https://github.com/decepulis)
+- Attaching media like elements and upgrade ([#889](https://github.com/videojs/v10/pull/889)) by [@luwes](https://github.com/luwes)
+- *(skin)* Standardize backdrop-filter and fix minimal root sizing ([#895](https://github.com/videojs/v10/pull/895)) by [@sampotts](https://github.com/sampotts)
+- *(site)* Replace GA4 with PostHog cookieless analytics ([#894](https://github.com/videojs/v10/pull/894)) by [@decepulis](https://github.com/decepulis)
+- Mobile controls issues ([#896](https://github.com/videojs/v10/pull/896)) by [@luwes](https://github.com/luwes)
+- *(skin)* Add missing tooltip provider/group ([#902](https://github.com/videojs/v10/pull/902)) by [@sampotts](https://github.com/sampotts)
+- *(site)* Add playsinline to home and installation snippets ([#897](https://github.com/videojs/v10/pull/897)) by [@mihar-22](https://github.com/mihar-22)
+- *(core)* Skip delay when switching between grouped tooltips ([#903](https://github.com/videojs/v10/pull/903)) by [@sampotts](https://github.com/sampotts)
+- *(spf)* Propagate byteRange when building segment load tasks ([#904](https://github.com/videojs/v10/pull/904)) by [@cjpillsbury](https://github.com/cjpillsbury)
+- *(skin)* Fix fullscreen video clipping and border-radius handling ([#905](https://github.com/videojs/v10/pull/905)) by [@sampotts](https://github.com/sampotts)
+
+### ⚙️ Miscellaneous Tasks
+- *(changelog)* Use one root level changelog ([#900](https://github.com/videojs/v10/pull/900)) by [@luwes](https://github.com/luwes)
+- *(changelog)* Fix changelog-path ([#901](https://github.com/videojs/v10/pull/901)) by [@luwes](https://github.com/luwes)

--- a/site/src/content/changelog/10.0.0-beta.5.md
+++ b/site/src/content/changelog/10.0.0-beta.5.md
@@ -1,0 +1,15 @@
+---
+description: ""
+date: 2026-03-12
+version: "10.0.0-beta.5"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.4...@videojs/core@10.0.0-beta.5"
+---
+
+
+### 🐛 Bug Fixes
+- *(skin)* Only set poster object-fit: contain in fullscreen ([#906](https://github.com/videojs/v10/pull/906)) by [@sampotts](https://github.com/sampotts)
+- *(site)* Include HLS CDN script in installation builder ([#907](https://github.com/videojs/v10/pull/907)) by [@mihar-22](https://github.com/mihar-22)
+- *(skin)* Scope controls transitions to fine pointer only ([#909](https://github.com/videojs/v10/pull/909)) by [@mihar-22](https://github.com/mihar-22)
+- *(cd)* Add @videojs/skins to release please ([#910](https://github.com/videojs/v10/pull/910)) by [@sampotts](https://github.com/sampotts)

--- a/site/src/content/changelog/10.0.0-beta.5.md
+++ b/site/src/content/changelog/10.0.0-beta.5.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Fixes poster fullscreen sizing, scopes controls transitions to fine pointers, and adds the HLS CDN script to the installation builder."
 date: 2026-03-12
 version: "10.0.0-beta.5"
 prerelease: true
@@ -7,9 +7,4 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.4...@videojs/core@10.0.0-beta.5"
 ---
 
-
-### 🐛 Bug Fixes
-- *(skin)* Only set poster object-fit: contain in fullscreen ([#906](https://github.com/videojs/v10/pull/906)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Include HLS CDN script in installation builder ([#907](https://github.com/videojs/v10/pull/907)) by [@mihar-22](https://github.com/mihar-22)
-- *(skin)* Scope controls transitions to fine pointer only ([#909](https://github.com/videojs/v10/pull/909)) by [@mihar-22](https://github.com/mihar-22)
-- *(cd)* Add @videojs/skins to release please ([#910](https://github.com/videojs/v10/pull/910)) by [@sampotts](https://github.com/sampotts)
+A small follow-up to beta.4: the poster now only switches to `object-fit: contain` in fullscreen ([#906](https://github.com/videojs/v10/pull/906)), and controls show/hide transitions are scoped to fine-pointer devices so they no longer apply on touch ([#909](https://github.com/videojs/v10/pull/909)). The installation builder on videojs.org now includes the HLS CDN script ([#907](https://github.com/videojs/v10/pull/907)).

--- a/site/src/content/changelog/10.0.0-beta.6.md
+++ b/site/src/content/changelog/10.0.0-beta.6.md
@@ -1,0 +1,33 @@
+---
+description: ""
+date: 2026-03-15
+version: "10.0.0-beta.6"
+prerelease: true
+breaking: false
+compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.5...@videojs/core@10.0.0-beta.6"
+---
+
+
+### 🚀 Features
+- *(site)* Add shiki notation transformers ([#937](https://github.com/videojs/v10/pull/937)) by [@decepulis](https://github.com/decepulis)
+- Add slider preview thumbnails ([#935](https://github.com/videojs/v10/pull/935)) by [@sampotts](https://github.com/sampotts)
+
+### 🐛 Bug Fixes
+- *(site)* Improve whitespace around links ([#913](https://github.com/videojs/v10/pull/913)) by [@decepulis](https://github.com/decepulis)
+- *(site)* Fix Brightcove typo ([#915](https://github.com/videojs/v10/pull/915)) by [@decepulis](https://github.com/decepulis)
+- *(changelog)* Add root changelog generator ([#916](https://github.com/videojs/v10/pull/916)) by [@luwes](https://github.com/luwes)
+- *(site)* Restore blank lines in code blocks ([#945](https://github.com/videojs/v10/pull/945)) by [@decepulis](https://github.com/decepulis)
+- *(sandbox)* Use getMuxPosterSrc ([#950](https://github.com/videojs/v10/pull/950)) by [@sampotts](https://github.com/sampotts)
+- Add popover and tooltip safe areas ([#951](https://github.com/videojs/v10/pull/951)) by [@sampotts](https://github.com/sampotts)
+- *(html)* Simplify styles for slotted video ([#953](https://github.com/videojs/v10/pull/953)) by [@sampotts](https://github.com/sampotts)
+
+### 📚 Documentation
+- *(site)* Add skins & architecture concept pages ([#769](https://github.com/videojs/v10/pull/769)) by [@heff](https://github.com/heff)
+
+### ⚙️ Miscellaneous Tasks
+- *(changelog)* Remove keepachangelog header ([#918](https://github.com/videojs/v10/pull/918)) by [@luwes](https://github.com/luwes)
+- Ignore .claude/worktrees/ directory ([#932](https://github.com/videojs/v10/pull/932)) by [@mihar-22](https://github.com/mihar-22)
+- *(site)* Add Algolia site verification meta tag ([#939](https://github.com/videojs/v10/pull/939)) by [@decepulis](https://github.com/decepulis)
+
+### New Contributors
+* @esbie made their first contribution in [#917](https://github.com/videojs/v10/pull/917)

--- a/site/src/content/changelog/10.0.0-beta.6.md
+++ b/site/src/content/changelog/10.0.0-beta.6.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds slider preview thumbnails to the video skins and diff, focus, and word-highlight annotations to docs code blocks."
 date: 2026-03-15
 version: "10.0.0-beta.6"
 prerelease: true
@@ -7,27 +7,8 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.5...@videojs/core@10.0.0-beta.6"
 ---
 
+Beta.6 brings preview thumbnails to the time slider ([#935](https://github.com/videojs/v10/pull/935)): the default and minimal skins, in both HTML and React, now show a thumbnail of the frame under your pointer as you scrub. The same PR fixes thumbnail state when React connects after the image has already loaded or errored. Two smaller player fixes land alongside it: safe areas around popovers and tooltips ([#951](https://github.com/videojs/v10/pull/951)) and simpler styles for slotted video in the HTML player ([#953](https://github.com/videojs/v10/pull/953)).
 
-### 🚀 Features
-- *(site)* Add shiki notation transformers ([#937](https://github.com/videojs/v10/pull/937)) by [@decepulis](https://github.com/decepulis)
-- Add slider preview thumbnails ([#935](https://github.com/videojs/v10/pull/935)) by [@sampotts](https://github.com/sampotts)
+The docs site gains shiki notation transformers ([#937](https://github.com/videojs/v10/pull/937)), so code blocks support diff, focus, and word-highlight annotations, with copy buttons that strip the annotation comments. New concept pages cover skins and architecture ([#769](https://github.com/videojs/v10/pull/769)). Site polish includes restored blank lines in code blocks ([#945](https://github.com/videojs/v10/pull/945)), better whitespace around links ([#913](https://github.com/videojs/v10/pull/913)), and a Brightcove typo fix ([#915](https://github.com/videojs/v10/pull/915)).
 
-### 🐛 Bug Fixes
-- *(site)* Improve whitespace around links ([#913](https://github.com/videojs/v10/pull/913)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Fix Brightcove typo ([#915](https://github.com/videojs/v10/pull/915)) by [@decepulis](https://github.com/decepulis)
-- *(changelog)* Add root changelog generator ([#916](https://github.com/videojs/v10/pull/916)) by [@luwes](https://github.com/luwes)
-- *(site)* Restore blank lines in code blocks ([#945](https://github.com/videojs/v10/pull/945)) by [@decepulis](https://github.com/decepulis)
-- *(sandbox)* Use getMuxPosterSrc ([#950](https://github.com/videojs/v10/pull/950)) by [@sampotts](https://github.com/sampotts)
-- Add popover and tooltip safe areas ([#951](https://github.com/videojs/v10/pull/951)) by [@sampotts](https://github.com/sampotts)
-- *(html)* Simplify styles for slotted video ([#953](https://github.com/videojs/v10/pull/953)) by [@sampotts](https://github.com/sampotts)
-
-### 📚 Documentation
-- *(site)* Add skins & architecture concept pages ([#769](https://github.com/videojs/v10/pull/769)) by [@heff](https://github.com/heff)
-
-### ⚙️ Miscellaneous Tasks
-- *(changelog)* Remove keepachangelog header ([#918](https://github.com/videojs/v10/pull/918)) by [@luwes](https://github.com/luwes)
-- Ignore .claude/worktrees/ directory ([#932](https://github.com/videojs/v10/pull/932)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Add Algolia site verification meta tag ([#939](https://github.com/videojs/v10/pull/939)) by [@decepulis](https://github.com/decepulis)
-
-### New Contributors
-* @esbie made their first contribution in [#917](https://github.com/videojs/v10/pull/917)
+Thanks to [@esbie](https://github.com/esbie) for making their first contribution in [#917](https://github.com/videojs/v10/pull/917).

--- a/site/src/content/changelog/10.0.0-beta.7.md
+++ b/site/src/content/changelog/10.0.0-beta.7.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds a DashVideo media element, --media-color-primary skin theming, a poster component, and context-based media discovery."
 date: 2026-03-19
 version: "10.0.0-beta.7"
 prerelease: true
@@ -7,51 +7,10 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.6...@videojs/core@10.0.0-beta.7"
 ---
 
+Beta.7 brings MPEG-DASH playback: the new `DashVideo` media element ([#940](https://github.com/videojs/v10/pull/940)) is the DASH counterpart to `HlsVideo`, backed by dash.js v5 and available as `<dash-video>` for the web player and a `DashVideo` component for React.
 
-### 🚀 Features
-- *(skin)* Add --media-color-primary customization ([#957](https://github.com/videojs/v10/pull/957)) by [@sampotts](https://github.com/sampotts)
-- Add DashVideo media element (html, react) with sandbox support ([#940](https://github.com/videojs/v10/pull/940)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(sandbox)* Dynamically load skins by styling ([#989](https://github.com/videojs/v10/pull/989)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Add poster component to video skins ([#994](https://github.com/videojs/v10/pull/994)) by [@sampotts](https://github.com/sampotts)
-- *(html)* Add data-availability to volume slider ([#1001](https://github.com/videojs/v10/pull/1001)) by [@mihar-22](https://github.com/mihar-22)
-- *(skin)* Add pip-enter and pip-exit icons ([#1015](https://github.com/videojs/v10/pull/1015)) by [@sampotts](https://github.com/sampotts)
-- *(html)* Refactor attach contexts to carry state and setter ([#1024](https://github.com/videojs/v10/pull/1024)) by [@mihar-22](https://github.com/mihar-22)
+Skins gain two customization features. The new `--media-color-primary` CSS variable ([#957](https://github.com/videojs/v10/pull/957)) sets the control color across the default and minimal skins, in both CSS and Tailwind variants. Posters are now first-class too: a dedicated `<media-poster>` component ships in every video skin template, with a matching `poster` prop on the React video skin presets ([#994](https://github.com/videojs/v10/pull/994)).
 
-### 🐛 Bug Fixes
-- *(skin)* Bake in safari layout fix into skins ([#954](https://github.com/videojs/v10/pull/954)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add /logo-white.png public asset ([#972](https://github.com/videojs/v10/pull/972)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Rename MediaDelegateMixin and MediaProxyMixin ([#976](https://github.com/videojs/v10/pull/976)) by [@luwes](https://github.com/luwes)
-- Correct popup fallback positioning offsets ([#981](https://github.com/videojs/v10/pull/981)) by [@sampotts](https://github.com/sampotts)
-- *(utils)* Handle missing media.querySelectorAll for HLS ([#986](https://github.com/videojs/v10/pull/986)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Remove overflow in minimal video skin ([#993](https://github.com/videojs/v10/pull/993)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Add subtle control transitions on touch devices ([#985](https://github.com/videojs/v10/pull/985)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Suppress tooltip hover on touch pointer events ([#933](https://github.com/videojs/v10/pull/933)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Stub pointer:fine in tooltip touch suppression tests ([#998](https://github.com/videojs/v10/pull/998)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Prevent slider thumb jump on pointer release ([#990](https://github.com/videojs/v10/pull/990)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Sync playback feature state on seeked event ([#1000](https://github.com/videojs/v10/pull/1000)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Improve fullscreen and pip webkit fallback handling ([#999](https://github.com/videojs/v10/pull/999)) by [@mihar-22](https://github.com/mihar-22)
-- *(skin)* Fix HTML skin poster image alignment ([#1002](https://github.com/videojs/v10/pull/1002)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add font metric overrides to reduce display font layout shift ([#1010](https://github.com/videojs/v10/pull/1010)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Remove top-level await from ClientCode to fix Safari hydration ([#1006](https://github.com/videojs/v10/pull/1006)) by [@decepulis](https://github.com/decepulis)
-- *(skin)* Fixes for react poster image alignment ([#1003](https://github.com/videojs/v10/pull/1003)) by [@sampotts](https://github.com/sampotts)
-- *(html)* Restore deprecated slot="media" for backwards compatibility ([#1020](https://github.com/videojs/v10/pull/1020)) by [@mihar-22](https://github.com/mihar-22)
-- *(skin)* Hide volume popover when volume control is unsupported ([#1025](https://github.com/videojs/v10/pull/1025)) by [@mihar-22](https://github.com/mihar-22)
-- *(core)* Round thumbnail dimensions to prevent sub-pixel gaps ([#995](https://github.com/videojs/v10/pull/995)) by [@sampotts](https://github.com/sampotts)
-- *(html)* Extended media not working over cdn ([#1019](https://github.com/videojs/v10/pull/1019)) by [@mihar-22](https://github.com/mihar-22)
+Media discovery in the web player now runs on context instead of slots ([#997](https://github.com/videojs/v10/pull/997), docs in [#1018](https://github.com/videojs/v10/pull/1018)): skins accept media elements through the default slot, so you no longer need `slot="media"` on your `<video>` or `<hls-video>`. The named slot stays as a deprecated fallback ([#1020](https://github.com/videojs/v10/pull/1020)), so existing markup keeps working. Supporting refactors move the store attach lifecycle to the provider ([#975](https://github.com/videojs/v10/pull/975)) and let attach contexts carry state and a setter ([#1024](https://github.com/videojs/v10/pull/1024)). The CDN build now shares chunks between bundles, fixing extended media elements like `<hls-video>` when loaded from the CDN ([#1019](https://github.com/videojs/v10/pull/1019)).
 
-### 🚜 Refactor
-- *(packages)* Move store attach lifecycle to provider ([#975](https://github.com/videojs/v10/pull/975)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Context-based media discovery, remove slot="media" ([#997](https://github.com/videojs/v10/pull/997)) by [@mihar-22](https://github.com/mihar-22)
-- *(ci)* Collapse unchanged packages in bundle size report ([#1016](https://github.com/videojs/v10/pull/1016)) by [@mihar-22](https://github.com/mihar-22)
-
-### 📚 Documentation
-- *(site)* Clean up concept pages from #769 ([#970](https://github.com/videojs/v10/pull/970)) by [@decepulis](https://github.com/decepulis)
-- *(internal)* Add gesture as components decision ([#949](https://github.com/videojs/v10/pull/949)) by [@esbie](https://github.com/esbie)
-- *(site)* Add Slider and Tooltip API reference pages ([#862](https://github.com/videojs/v10/pull/862)) by [@decepulis](https://github.com/decepulis)
-- *(design)* Add SPF living design docs ([#899](https://github.com/videojs/v10/pull/899)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- Update site for context-based media discovery ([#1018](https://github.com/videojs/v10/pull/1018)) by [@mihar-22](https://github.com/mihar-22)
-
-### ⚙️ Miscellaneous Tasks
-- *(changelog)* Release please token ([#973](https://github.com/videojs/v10/pull/973)) by [@luwes](https://github.com/luwes)
-- *(sandbox)* Update sandbox deps ([#983](https://github.com/videojs/v10/pull/983)) by [@sampotts](https://github.com/sampotts)
-- *(cd)* Add changelog actions pipeline ([#1032](https://github.com/videojs/v10/pull/1032)) by [@decepulis](https://github.com/decepulis)
+A round of interaction fixes follows: tooltips no longer trigger on touch ([#933](https://github.com/videojs/v10/pull/933)), slider thumbs no longer jump on pointer release ([#990](https://github.com/videojs/v10/pull/990)), controls transition subtly on touch devices ([#985](https://github.com/videojs/v10/pull/985)), popup fallback positioning is corrected ([#981](https://github.com/videojs/v10/pull/981)), playback state syncs on the `seeked` event ([#1000](https://github.com/videojs/v10/pull/1000)), and fullscreen and picture-in-picture fall back more reliably in WebKit ([#999](https://github.com/videojs/v10/pull/999)). The volume popover now hides when volume control is unsupported ([#1025](https://github.com/videojs/v10/pull/1025)), backed by a new `data-availability` attribute on the volume slider ([#1001](https://github.com/videojs/v10/pull/1001)). Skin polish rounds out the release: the Safari layout fix is baked into the skins ([#954](https://github.com/videojs/v10/pull/954)), the minimal video skin drops an overflow ([#993](https://github.com/videojs/v10/pull/993)), poster image alignment is fixed in HTML and React ([#1002](https://github.com/videojs/v10/pull/1002), [#1003](https://github.com/videojs/v10/pull/1003)), thumbnail dimensions are rounded to prevent sub-pixel gaps ([#995](https://github.com/videojs/v10/pull/995)), new pip-enter and pip-exit icons land ([#1015](https://github.com/videojs/v10/pull/1015)), and HLS handles media elements without `querySelectorAll` ([#986](https://github.com/videojs/v10/pull/986)). The docs site also gains Slider and Tooltip API reference pages ([#862](https://github.com/videojs/v10/pull/862)).

--- a/site/src/content/changelog/10.0.0-beta.8.md
+++ b/site/src/content/changelog/10.0.0-beta.8.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Migrates site search from Pagefind to Algolia DocSearch and adds new docs on accessibility, browser support, skin styling, and AI."
 date: 2026-03-20
 version: "10.0.0-beta.8"
 prerelease: true
@@ -7,23 +7,8 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.7...@videojs/core@10.0.0-beta.8"
 ---
 
+Search on videojs.org moves from Pagefind to Algolia DocSearch v4 ([#941](https://github.com/videojs/v10/pull/941)). Instead of a static index built at deploy time, search now queries Algolia directly across two indexes: docs results ranked by relevance and filtered to the framework you are browsing, and blog results ranked by recency.
 
-### 🚀 Features
-- *(site)* Migrate search from Pagefind to Algolia DocSearch v4 ([#941](https://github.com/videojs/v10/pull/941)) by [@decepulis](https://github.com/decepulis)
+The docs also gain four new pages: an accessibility concepts page ([#1007](https://github.com/videojs/v10/pull/1007)), a "Build with AI" guide ([#1005](https://github.com/videojs/v10/pull/1005)), a guide to skin styling ([#958](https://github.com/videojs/v10/pull/958)), and a browser support concepts page ([#1035](https://github.com/videojs/v10/pull/1035)).
 
-### 🐛 Bug Fixes
-- *(site)* Redirect vjs10-site.netlify.app to videojs.org ([#1038](https://github.com/videojs/v10/pull/1038)) by [@decepulis](https://github.com/decepulis)
-- *(html)* Template minifier stripping out default slot tags ([#1045](https://github.com/videojs/v10/pull/1045)) by [@mihar-22](https://github.com/mihar-22)
-- *(docs)* Add missing DocsLinkCard import ([#1050](https://github.com/videojs/v10/pull/1050)) by [@sampotts](https://github.com/sampotts)
-- *(docs)* Add DocsLinkCard import to the correct page ([#1051](https://github.com/videojs/v10/pull/1051)) by [@sampotts](https://github.com/sampotts)
-- *(html)* Remove redundant CDN CSS files and inline background skin styles ([#1071](https://github.com/videojs/v10/pull/1071)) by [@mihar-22](https://github.com/mihar-22)
-
-### 📚 Documentation
-- *(site)* Add accessibility concepts page ([#1007](https://github.com/videojs/v10/pull/1007)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Add "Build with AI" guide ([#1005](https://github.com/videojs/v10/pull/1005)) by [@decepulis](https://github.com/decepulis)
-- *(skin)* Add docs on skin styling ([#958](https://github.com/videojs/v10/pull/958)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add browser support concept page ([#1035](https://github.com/videojs/v10/pull/1035)) by [@decepulis](https://github.com/decepulis)
-
-### ⚙️ Miscellaneous Tasks
-- *(root)* Migrate build scripts and plugins to TypeScript ([#1052](https://github.com/videojs/v10/pull/1052)) by [@mihar-22](https://github.com/mihar-22)
-- *(ci)* Add SPF to issue template package options ([#1058](https://github.com/videojs/v10/pull/1058)) by [@cjpillsbury](https://github.com/cjpillsbury)
+On the player side, the template minifier no longer strips default `<slot>` tags from HTML skins ([#1045](https://github.com/videojs/v10/pull/1045)), and the redundant CDN CSS files are gone ([#1071](https://github.com/videojs/v10/pull/1071)). HTML skin elements deliver their styles inside the JS bundle through shadow DOM `adoptedStyleSheets`, so the separate stylesheets were a no-op; if you load Video.js from a CDN, you can drop the `<link>` tags. A few small site fixes round out the release: vjs10-site.netlify.app now redirects to videojs.org ([#1038](https://github.com/videojs/v10/pull/1038)), and two docs pages recover their missing `DocsLinkCard` imports ([#1050](https://github.com/videojs/v10/pull/1050), [#1051](https://github.com/videojs/v10/pull/1051)).

--- a/site/src/content/changelog/10.0.0-beta.9.md
+++ b/site/src/content/changelog/10.0.0-beta.9.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds error handling to audio player skins and fixes SPF preload handling and an MSE parser-state bug."
 date: 2026-03-23
 version: "10.0.0-beta.9"
 prerelease: true
@@ -7,17 +7,8 @@ breaking: false
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.8...@videojs/core@10.0.0-beta.9"
 ---
 
+Audio players now surface playback errors ([#1048](https://github.com/videojs/v10/pull/1048)). The default and minimal audio skins gain an error dialog with a compact inline layout suited to the audio form factor, reusing the same `ErrorDialog` component as the video skins, and the audio presets in core now include the `error` feature.
 
-### 🚀 Features
-- *(skin)* Add error handling for audio players ([#1048](https://github.com/videojs/v10/pull/1048)) by [@sampotts](https://github.com/sampotts)
+Two SPF fixes improve HLS playback. `SpfMedia` now implements the `preload` IDL attribute, so setting `preload` on a `SimpleHlsVideo` element takes effect and persists across `src` changes instead of being silently dropped ([#1069](https://github.com/videojs/v10/pull/1069)). And when a segment append is aborted mid-flight, the engine now calls `sourceBuffer.abort()` to reset the MSE parser state, preventing Chrome's `CHUNK_DEMUXER_ERROR_APPEND_FAILED` on the next append ([#1081](https://github.com/videojs/v10/pull/1081)).
 
-### 🐛 Bug Fixes
-- *(docs)* Improvements to eject script ([#1012](https://github.com/videojs/v10/pull/1012)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Extract transition properties into CSS custom properties ([#1075](https://github.com/videojs/v10/pull/1075)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Quote poster prop value in react demo code template ([#1079](https://github.com/videojs/v10/pull/1079)) by [@mihar-22](https://github.com/mihar-22)
-- *(site)* Flatten error classes in ejected react skins ([#1080](https://github.com/videojs/v10/pull/1080)) by [@mihar-22](https://github.com/mihar-22)
-- *(spf)* Implement preload IDL attribute on SpfMedia ([#1069](https://github.com/videojs/v10/pull/1069)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(spf)* Call sourceBuffer.abort() on AbortError to reset MSE parser state ([#1081](https://github.com/videojs/v10/pull/1081)) by [@cjpillsbury](https://github.com/cjpillsbury)
-
-### 🚜 Refactor
-- *(react)* Simplify skin render props with element form ([#1068](https://github.com/videojs/v10/pull/1068)) by [@mihar-22](https://github.com/mihar-22)
+Elsewhere, skin transition properties move into CSS custom properties so they are easier to override ([#1075](https://github.com/videojs/v10/pull/1075)), the React skins simplify their render props with an element form ([#1068](https://github.com/videojs/v10/pull/1068)), and the skin eject script and ejected React skins pick up fixes ([#1012](https://github.com/videojs/v10/pull/1012), [#1080](https://github.com/videojs/v10/pull/1080)), along with a corrected `poster` prop in the site's React demo code template ([#1079](https://github.com/videojs/v10/pull/1079)).


### PR DESCRIPTION
Closes #1030

Backfills the missing beta changelog entries and translates all 24 of them into narrative prose, applying the rules from the `changelog-prose` workflow by hand since those releases predate the (now fixed, #1792) pipeline.

## What's here

**1. Raw backfill (#1030 as written)** — `docs(site): backfill raw changelogs for past betas`
Generates the 9 missing files (beta.1–6, beta.13, beta.20, beta.21) from root `CHANGELOG.md`, using the same extraction logic and frontmatter schema as the `release-pr.yml` site-extract step. Kept as its own commit so the raw → prose transformation is reviewable per file.

**2. Prose for all 24 betas** — `docs(site): add changelog prose for all beta releases`
Each entry follows the `changelog-prose.yml` prompt rules and `writing-style.md`: lead with the most impactful changes, group related PRs into stories (with PR context pulled from the linked PRs), explicit migration guidance for the breaking releases (beta.18, beta.23), `description` frontmatter filled in. Length scales with release size: big releases get 100–300 words, one-bullet releases get one honest sentence.

**3. Prompt refinements** — the policies honed during this pass, folded back into the workflow prompt so future automated runs match:
- Prose length scales with release content; never pad to hit a word count.
- Entirely-internal releases get an honest sentence or two instead of an empty body.
- Paragraphs only; no headings or bullet lists.
- Per-change author credits dropped (the PR link carries attribution); "New Contributors" sections become a closing thanks with profile links.
- Tighter `description` spec (verb-led, under 140 characters).
- Commit scope fixed to `docs(site)` — commitlint's scope-enum has no `changelog` scope, so PRs opened by the workflow would have failed the commit check.

## Data fixes found along the way

- **beta.19's pipeline-generated file was wrong**: it contained beta.20's content (#1338) and a self-referencing `compareUrl` (`beta.19...beta.19`) — an off-by-one from the pipeline run racing the release cut. It now documents its actual change (#1337, the CLI bin-path fix) with the correct compare URL. All other 23 `compareUrl`s were verified against the `CHANGELOG.md` footer.

## Verification

- Frontmatter diff-checked: only `description` changed in every pre-existing file (plus the beta.19 correction above).
- `astro sync` passes with no changelog collection errors.
- Every PR fact in the prose traces to a fetched PR body or the raw bullet title; nothing fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9r6aQkL82k4o3JqcfjkD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9r6aQkL82k4o3JqcfjkD3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and workflow-prompt changes only; no player or package runtime code. Review focus is factual accuracy of prose and frontmatter, especially breaking-change migration text.
> 
> **Overview**
> **Backfills missing v10 beta changelog pages and replaces raw bullet lists with narrative prose** across all 24 `10.0.0-beta.*` entries under `site/src/content/changelog/`, including verb-led `description` frontmatter for SEO/RSS.
> 
> New or regenerated files cover gaps such as beta.1–6, beta.13, beta.20, and beta.21; existing entries are rewritten as paragraph-only stories that group related PRs, keep inline PR links, drop per-change author lines, and spell out **migration guidance** for breaking releases (notably beta.18 MediaHost and beta.23 cast/fullscreen renames). **beta.19** is corrected: wrong pipeline content and a self-referencing `compareUrl` are replaced with the CLI bin-path fix and the proper compare range.
> 
> The **`changelog-prose` GitHub Actions prompt** is updated so future automated runs match this pass: length scales with release size, internal-only releases get honest short copy, paragraphs-only formatting, contributor sections become a closing thanks, tighter `description` rules, and PR commits use `docs(site)` for commitlint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36033ba940ba3372a713f8484533e8fff377fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->