### PR TITLE
feat(site): wire videojs_changelog index into search

### DIFF
--- a/site/src/components/Search.tsx
+++ b/site/src/components/Search.tsx
@@ -1,7 +1,13 @@
 import { DocSearch } from '@docsearch/react';
 import { useStore } from '@nanostores/react';
 import { GITHUB_REPO_URL } from '@/consts';
-import { DOCSEARCH_API_KEY, DOCSEARCH_APP_ID, DOCSEARCH_BLOG_INDEX, DOCSEARCH_DOCS_INDEX } from '@/search.config';
+import {
+  DOCSEARCH_API_KEY,
+  DOCSEARCH_APP_ID,
+  DOCSEARCH_BLOG_INDEX,
+  DOCSEARCH_CHANGELOG_INDEX,
+  DOCSEARCH_DOCS_INDEX,
+} from '@/search.config';
 import { currentFramework } from '@/stores/preferences';
 
 interface SearchProps {
@@ -25,6 +31,9 @@ export default function Search({ className }: SearchProps) {
           },
           {
             name: DOCSEARCH_BLOG_INDEX,
+          },
+          {
+            name: DOCSEARCH_CHANGELOG_INDEX,
           },
         ]}
         getMissingResultsUrl={({ query }) =>

--- a/site/src/search.config.ts
+++ b/site/src/search.config.ts
@@ -3,3 +3,4 @@ export const DOCSEARCH_APP_ID = '5WD2PWU9HZ';
 export const DOCSEARCH_API_KEY = '68c102f304dc6e38fa3c2d167d2389ed';
 export const DOCSEARCH_DOCS_INDEX = 'videojs_docs';
 export const DOCSEARCH_BLOG_INDEX = 'videojs_blog';
+export const DOCSEARCH_CHANGELOG_INDEX = 'videojs_changelog';


### PR DESCRIPTION
Follow-up to the Algolia step in #1793.

## What

honestly does what it says in the title. idk what other tell you.

## Verify

After the crawler populates records, Cmd+K a version number (e.g. `beta.25`) → the release page should appear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmDNu5bXvQXyY1UWZkLfg6)_