### PR TITLE
feat(spf): expose video tracks & renditions on the SPF media adapter

### DIFF
--- a/packages/core/src/dom/media/simple-hls/index.ts
+++ b/packages/core/src/dom/media/simple-hls/index.ts
@@ -1,4 +1,8 @@
 import { SimpleHlsMediaMixin } from '@videojs/spf/hls';
+import { MediaTracksMixin } from '../../../core/media/media-tracks';
 import { HTMLVideoElementHost } from '../video-host';
+import { SimpleHlsMediaMediaTracksMixin } from './media-tracks';
 
-export class SimpleHlsMedia extends SimpleHlsMediaMixin(HTMLVideoElementHost) {}
+export class SimpleHlsMedia extends SimpleHlsMediaMediaTracksMixin(
+  MediaTracksMixin(SimpleHlsMediaMixin(HTMLVideoElementHost))
+) {}

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -1,9 +1,10 @@
 import { effect, untrack } from '@videojs/spf';
-import type { SimpleHlsMediaAPI } from '@videojs/spf/hls';
+import type { SimpleHlsEngineState, SimpleHlsMediaAPI } from '@videojs/spf/hls';
 import type { Constructor } from '@videojs/utils/types';
 import type { MediaVideoRenditionCapability, MediaVideoTrackCapability } from '../../../core/media/types';
 
 type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+type VideoRenditionInfo = NonNullable<SimpleHlsEngineState['videoRenditions']>[number];
 
 /**
  * Host surface the projection reads from: the SPF adapter (engine + src) plus
@@ -16,24 +17,6 @@ type MediaTracksHost = {
   destroy(): void;
 } & MediaVideoTrackCapability &
   MediaVideoRenditionCapability;
-
-/** A video rendition as parsed onto the engine's presentation (each SPF video track is one quality level). */
-type SpfVideoTrack = Extract<
-  NonNullable<NonNullable<ReturnType<SimpleHlsEngine['state']['presentation']['get']>>['selectionSets']>[number],
-  { type: 'video' }
->['switchingSets'][number]['tracks'][number];
-
-function videoTracksOf(engine: SimpleHlsEngine): SpfVideoTrack[] {
-  const presentation = engine.state.presentation.get();
-  const videoSet = presentation?.selectionSets?.find((set) => set.type === 'video');
-  return videoSet?.switchingSets[0]?.tracks ?? [];
-}
-
-function toFrameRate(frameRate: SpfVideoTrack['frameRate']): number | undefined {
-  if (!frameRate) return undefined;
-  const { frameRateNumerator, frameRateDenominator } = frameRate;
-  return frameRateDenominator ? frameRateNumerator / frameRateDenominator : frameRateNumerator;
-}
 
 /**
  * Projects the SPF engine's video renditions onto the media element's
@@ -52,8 +35,6 @@ function toFrameRate(frameRate: SpfVideoTrack['frameRate']): number | undefined 
 export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class SimpleHlsMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
     #disconnect: AbortController | null = null;
-    /** Ids of the renditions currently projected, in order — used to skip rebuilds on segment resolution. */
-    #renditionSignature = '';
 
     constructor(...args: any[]) {
       super(...args);
@@ -92,46 +73,35 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
       this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
 
       const disposeEffects = [
-        // Track `presentation` only; active-rendition reflection reads
-        // `selectedVideoTrackId` untracked so a resolve doesn't re-rebuild.
-        effect(() => this.#projectRenditions(engine, videoTracksOf(engine))),
+        // The engine dedups `videoRenditions` (emits a new array only when the
+        // rendition set changes), so this rebuilds only on real changes. Active
+        // reflection reads `selectedVideoTrackId` in its own effect.
+        effect(() => this.#projectRenditions(engine, engine.state.videoRenditions.get() ?? [])),
         effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
       ];
 
-      signal.addEventListener(
-        'abort',
-        () => {
-          for (const dispose of disposeEffects) dispose();
-        },
-        { once: true }
-      );
+      disposeEffects.forEach((dispose) => {
+        signal.addEventListener('abort', dispose, { once: true });
+      });
     }
 
-    #getSignaturesFor(tracks: SpfVideoTrack[]) {
-      return tracks.map((track) => track.id).join('|');
-    }
-
-    #projectRenditions(engine: SimpleHlsEngine, tracks: SpfVideoTrack[]): void {
-      const signature = this.#getSignaturesFor(tracks);
-      if (signature === this.#renditionSignature) return;
-      this.#renditionSignature = signature;
-
+    #projectRenditions(engine: SimpleHlsEngine, renditions: VideoRenditionInfo[]): void {
       this.#removeVideoTracks();
-      if (!tracks.length) return;
+      if (!renditions.length) return;
 
       const videoTrack = this.addVideoTrack('main');
       videoTrack.selected = true;
 
-      for (const track of tracks) {
+      for (const info of renditions) {
         const rendition = videoTrack.addRendition(
-          track.url,
-          track.width,
-          track.height,
-          track.codecs?.join(','),
-          track.bandwidth,
-          toFrameRate(track.frameRate)
+          info.url,
+          info.width,
+          info.height,
+          info.codecs?.join(','),
+          info.bandwidth,
+          toFrameRate(info.frameRate)
         );
-        rendition.id = track.id;
+        rendition.id = info.id;
       }
 
       this.#reflectActiveRendition(untrack(() => engine.state.selectedVideoTrackId.get()));
@@ -166,4 +136,11 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
   }
 
   return SimpleHlsMediaMediaTracks as unknown as Base;
+}
+
+/** Reduce the model's `FrameRate` (num/den) to the single number a DOM `VideoRendition` expects. */
+function toFrameRate(frameRate: VideoRenditionInfo['frameRate']): number | undefined {
+  if (!frameRate) return undefined;
+  const { frameRateNumerator, frameRateDenominator } = frameRate;
+  return frameRateDenominator ? frameRateNumerator / frameRateDenominator : frameRateNumerator;
 }

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -65,19 +65,19 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
 
     #connect(): void {
       this.#disconnect?.abort();
-      const controller = new AbortController();
-      this.#disconnect = controller;
-      const { signal } = controller;
+      this.#disconnect = new AbortController();
+      const { signal } = this.#disconnect;
       const { engine } = this;
 
       this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
 
       const disposeEffects = [
-        // The engine dedups `videoRenditions` (emits a new array only when the
+        // The engine dedupes `videoRenditions` (emits a new array only when the
         // rendition set changes), so this rebuilds only on real changes. Active
         // reflection reads `selectedVideoTrackId` in its own effect.
         effect(() => this.#projectRenditions(engine, engine.state.videoRenditions.get() ?? [])),
         effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
+        effect(() => this.#reflectSelectedRendition(engine.state.userVideoTrackSelection.get()?.id)),
       ];
 
       disposeEffects.forEach((dispose) => {
@@ -105,11 +105,18 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
       }
 
       this.#reflectActiveRendition(untrack(() => engine.state.selectedVideoTrackId.get()));
+      this.#reflectSelectedRendition(untrack(() => engine.state.userVideoTrackSelection.get()?.id));
     }
 
     #reflectActiveRendition(activeId: string | undefined): void {
       for (const rendition of this.videoRenditions) {
         rendition.active = rendition.id === activeId;
+      }
+    }
+
+    #reflectSelectedRendition(selectedId: string | undefined): void {
+      for (const rendition of this.videoRenditions) {
+        rendition.selected = !!selectedId && rendition.id === selectedId;
       }
     }
 

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -1,0 +1,169 @@
+import { effect, untrack } from '@videojs/spf';
+import type { SimpleHlsMediaAPI } from '@videojs/spf/hls';
+import type { Constructor } from '@videojs/utils/types';
+import type { MediaVideoRenditionCapability, MediaVideoTrackCapability } from '../../../core/media/types';
+
+type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+
+/**
+ * Host surface the projection reads from: the SPF adapter (engine + src) plus
+ * the media-tracks list infrastructure applied earlier in the mixin chain.
+ */
+type MediaTracksHost = {
+  readonly engine: SimpleHlsEngine;
+  get src(): string;
+  set src(value: string);
+  destroy(): void;
+} & MediaVideoTrackCapability &
+  MediaVideoRenditionCapability;
+
+/** A video rendition as parsed onto the engine's presentation (each SPF video track is one quality level). */
+type SpfVideoTrack = Extract<
+  NonNullable<NonNullable<ReturnType<SimpleHlsEngine['state']['presentation']['get']>>['selectionSets']>[number],
+  { type: 'video' }
+>['switchingSets'][number]['tracks'][number];
+
+function videoTracksOf(engine: SimpleHlsEngine): SpfVideoTrack[] {
+  const presentation = engine.state.presentation.get();
+  const videoSet = presentation?.selectionSets?.find((set) => set.type === 'video');
+  return videoSet?.switchingSets[0]?.tracks ?? [];
+}
+
+function toFrameRate(frameRate: SpfVideoTrack['frameRate']): number | undefined {
+  if (!frameRate) return undefined;
+  const { frameRateNumerator, frameRateDenominator } = frameRate;
+  return frameRateDenominator ? frameRateNumerator / frameRateDenominator : frameRateNumerator;
+}
+
+/**
+ * Projects the SPF engine's video renditions onto the media element's
+ * `videoTracks` / `videoRenditions` lists, and wires user rendition selection
+ * back to the engine's `userVideoTrackSelection` (a partial `{ id }` pins a
+ * quality level; clearing it re-enables ABR).
+ *
+ * Unlike hls.js — where the engine persists and events drive the projection —
+ * the SPF adapter rebuilds its engine on every `src` assignment, so the
+ * subscriptions are re-wired on each src change (see the `src` override).
+ *
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied
+ * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
+ * and friends.
+ */
+export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
+  class SimpleHlsMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
+    #disconnect: AbortController | null = null;
+    /** Ids of the renditions currently projected, in order — used to skip rebuilds on segment resolution. */
+    #renditionSignature = '';
+
+    constructor(...args: any[]) {
+      super(...args);
+      this.#connect();
+    }
+
+    get src(): string {
+      return super.src;
+    }
+
+    set src(value: string) {
+      // The canonical adapter destroys the engine (and its signals) on every
+      // src change and creates a fresh one, so we re-wire the projection against
+      // it. If the adapter ever moves to in-place source replacement (an open
+      // question in source-replacement.md / engine-adapter-integration.md), the
+      // engine becomes stable and this collapses to a one-time constructor wire.
+      this.#disconnect?.abort();
+      super.src = value;
+      this.#connect();
+    }
+
+    destroy(): void {
+      this.#disconnect?.abort();
+      this.#disconnect = null;
+      this.#removeVideoTracks();
+      super.destroy();
+    }
+
+    #connect(): void {
+      this.#disconnect?.abort();
+      const controller = new AbortController();
+      this.#disconnect = controller;
+      const { signal } = controller;
+      const { engine } = this;
+
+      this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
+
+      const disposeEffects = [
+        // Track `presentation` only; active-rendition reflection reads
+        // `selectedVideoTrackId` untracked so a resolve doesn't re-rebuild.
+        effect(() => this.#projectRenditions(engine, videoTracksOf(engine))),
+        effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
+      ];
+
+      signal.addEventListener(
+        'abort',
+        () => {
+          for (const dispose of disposeEffects) dispose();
+        },
+        { once: true }
+      );
+    }
+
+    #getSignaturesFor(tracks: SpfVideoTrack[]) {
+      return tracks.map((track) => track.id).join('|');
+    }
+
+    #projectRenditions(engine: SimpleHlsEngine, tracks: SpfVideoTrack[]): void {
+      const signature = this.#getSignaturesFor(tracks);
+      if (signature === this.#renditionSignature) return;
+      this.#renditionSignature = signature;
+
+      this.#removeVideoTracks();
+      if (!tracks.length) return;
+
+      const videoTrack = this.addVideoTrack('main');
+      videoTrack.selected = true;
+
+      for (const track of tracks) {
+        const rendition = videoTrack.addRendition(
+          track.url,
+          track.width,
+          track.height,
+          track.codecs?.join(','),
+          track.bandwidth,
+          toFrameRate(track.frameRate)
+        );
+        rendition.id = track.id;
+      }
+
+      this.#reflectActiveRendition(untrack(() => engine.state.selectedVideoTrackId.get()));
+    }
+
+    #reflectActiveRendition(activeId: string | undefined): void {
+      for (const rendition of this.videoRenditions) {
+        rendition.active = rendition.id === activeId;
+      }
+    }
+
+    #switchRendition = () => {
+      const { engine } = this;
+      const { selectedIndex } = this.videoRenditions;
+
+      // -1 clears the manual pin and hands quality back to ABR.
+      if (selectedIndex === -1) {
+        if (engine.state.userVideoTrackSelection.get()) engine.state.userVideoTrackSelection.set(undefined);
+        return;
+      }
+
+      const id = this.videoRenditions[selectedIndex]?.id;
+      if (!id || engine.state.userVideoTrackSelection.get()?.id === id) return;
+      engine.state.userVideoTrackSelection.set({ id });
+    };
+
+    #removeVideoTracks(): void {
+      for (const videoTrack of this.videoTracks) {
+        this.removeVideoTrack(videoTrack);
+      }
+    }
+  }
+
+  return SimpleHlsMediaMediaTracks as unknown as Base;
+}

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -140,6 +140,60 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     expect(engine.state.userVideoTrackSelection.get()).toBeUndefined();
   });
 
+  it('preserves the manual pin selection across a rebuild', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([HD, SD]);
+    await flush();
+    host.videoRenditions.selectedIndex = 1; // pin SD
+    await flush();
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+
+    // Engine emits a changed set (a rendition added) that still contains the pin.
+    const UHD = rendition('v-2160', 3840, 2160, 18_000_000);
+    engine.state.videoRenditions.set([HD, SD, UHD]);
+    await flush();
+
+    // The pinned rendition stays selected — the UI must not fall back to Auto.
+    const { selectedIndex } = host.videoRenditions;
+    expect(selectedIndex).not.toBe(-1);
+    expect([...host.videoRenditions][selectedIndex]?.id).toBe('v-360');
+    // Restoring the pin must not spuriously rewrite/clear the engine selection.
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+  });
+
+  it('reflects a programmatic userVideoTrackSelection onto the selected rendition', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([HD, SD]);
+    await flush();
+
+    engine.state.userVideoTrackSelection.set({ id: 'v-360' });
+    await flush();
+
+    const { selectedIndex } = host.videoRenditions;
+    expect([...host.videoRenditions][selectedIndex]?.id).toBe('v-360');
+    // Reflection must not loop back into a rewrite.
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+  });
+
+  it('reflects a cleared pin as Auto (selectedIndex -1)', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([HD, SD]);
+    await flush();
+    engine.state.userVideoTrackSelection.set({ id: 'v-360' });
+    await flush();
+    expect(host.videoRenditions.selectedIndex).not.toBe(-1);
+
+    engine.state.userVideoTrackSelection.set(undefined);
+    await flush();
+    expect(host.videoRenditions.selectedIndex).toBe(-1);
+  });
+
   it('rebuilds renditions when the engine emits a new set', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -1,0 +1,203 @@
+import { signal } from '@videojs/spf';
+import type { SimpleHlsMediaAPI } from '@videojs/spf/hls';
+import { describe, expect, it } from 'vitest';
+import { MediaTracksMixin } from '../../../../core/media/media-tracks';
+import { HTMLVideoElementHost } from '../../video-host';
+import { SimpleHlsMediaMediaTracksMixin } from '../media-tracks';
+
+type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+
+function createEngine() {
+  return {
+    state: {
+      presentation: signal<any>(undefined),
+      selectedVideoTrackId: signal<string | undefined>(undefined),
+      userVideoTrackSelection: signal<{ id?: string } | undefined>(undefined),
+    },
+    context: {},
+    destroy: async () => {},
+  };
+}
+
+type FakeEngine = ReturnType<typeof createEngine>;
+
+class FakeHost extends HTMLVideoElementHost {
+  #createEngine: () => FakeEngine;
+  #engine: FakeEngine;
+
+  constructor(create: () => FakeEngine) {
+    super();
+    this.#createEngine = create;
+    this.#engine = create();
+  }
+
+  get engine() {
+    return this.#engine as unknown as SimpleHlsEngine;
+  }
+
+  // Mirror the real adapter: a new src destroys the engine and starts a fresh one.
+  get src() {
+    return this.#engine.state.presentation.get()?.url ?? '';
+  }
+
+  set src(value: string) {
+    this.#engine = this.#createEngine();
+    if (value) this.#engine.state.presentation.set({ url: value });
+  }
+
+  destroy() {}
+}
+
+const Host = SimpleHlsMediaMediaTracksMixin(MediaTracksMixin(FakeHost));
+
+function videoTrack(id: string, width: number, height: number, bandwidth: number) {
+  return { id, type: 'video', url: `${id}.m3u8`, width, height, bandwidth, codecs: ['avc1.640028'] };
+}
+
+function presentationWith(tracks: Array<ReturnType<typeof videoTrack>>) {
+  return {
+    url: 'https://example.com/master.m3u8',
+    id: 'presentation',
+    selectionSets: [
+      { id: 'video-selection', type: 'video', switchingSets: [{ id: 'video-switching', type: 'video', tracks }] },
+    ],
+  };
+}
+
+const HD = videoTrack('v-1080', 1920, 1080, 6_000_000);
+const SD = videoTrack('v-360', 640, 360, 800_000);
+
+// Drain the effect microtask and the nested microtask the rendition-list
+// primitives use to dispatch add/remove/change events.
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('SimpleHlsMediaMediaTracksMixin', () => {
+  it('projects the engine presentation onto a selected video track with renditions', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    expect(host.videoTracks.length).toBe(1);
+    expect(host.videoTracks[0]?.selected).toBe(true);
+    expect(host.videoRenditions.length).toBe(2);
+    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080', 'v-360']);
+    expect([...host.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 360]);
+    expect([...host.videoRenditions].map((rendition) => rendition.bitrate)).toEqual([6_000_000, 800_000]);
+  });
+
+  it('marks the active rendition from selectedVideoTrackId', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    engine.state.selectedVideoTrackId.set('v-360');
+    await flush();
+
+    expect([...host.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+  });
+
+  it('forwards a rendition selection to userVideoTrackSelection', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    host.videoRenditions.selectedIndex = 1;
+    await flush();
+
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+  });
+
+  it('hands quality back to ABR when the selection is cleared', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    host.videoRenditions.selectedIndex = 1;
+    await flush();
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+
+    host.videoRenditions.selectedIndex = -1;
+    await flush();
+    expect(engine.state.userVideoTrackSelection.get()).toBeUndefined();
+  });
+
+  it('does not rebuild renditions when a resolve mutates presentation without changing the track set', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    let added = 0;
+    let removed = 0;
+    host.videoRenditions.addEventListener('addrendition', () => added++);
+    host.videoRenditions.addEventListener('removerendition', () => removed++);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(added).toBe(2);
+
+    // A media-playlist resolution replaces the presentation object with the
+    // same renditions — the projection should be a no-op.
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    expect(added).toBe(2);
+    expect(removed).toBe(0);
+  });
+
+  it('rebuilds renditions when the track set changes', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(host.videoRenditions.length).toBe(2);
+
+    engine.state.presentation.set(presentationWith([HD]));
+    await flush();
+
+    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080']);
+  });
+
+  it('re-wires the projection to the fresh engine created on src change', async () => {
+    const engines: FakeEngine[] = [];
+    const host = new Host(() => {
+      const engine = createEngine();
+      engines.push(engine);
+      return engine;
+    });
+
+    // src change tears down engine[0] and creates engine[1].
+    host.src = 'https://example.com/next.m3u8';
+    engines[1]!.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(host.videoRenditions.length).toBe(2);
+
+    // The disconnected first engine must no longer drive the projection.
+    engines[0]!.state.presentation.set(presentationWith([HD]));
+    await flush();
+    expect(host.videoRenditions.length).toBe(2);
+  });
+
+  it('removes projected tracks on destroy', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(host.videoTracks.length).toBe(1);
+
+    host.destroy();
+
+    expect(host.videoTracks.length).toBe(0);
+    expect(host.videoRenditions.length).toBe(0);
+  });
+});

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -10,7 +10,7 @@ type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
 function createEngine() {
   return {
     state: {
-      presentation: signal<any>(undefined),
+      videoRenditions: signal<any>(undefined),
       selectedVideoTrackId: signal<string | undefined>(undefined),
       userVideoTrackSelection: signal<{ id?: string } | undefined>(undefined),
     },
@@ -24,6 +24,7 @@ type FakeEngine = ReturnType<typeof createEngine>;
 class FakeHost extends HTMLVideoElementHost {
   #createEngine: () => FakeEngine;
   #engine: FakeEngine;
+  #src = '';
 
   constructor(create: () => FakeEngine) {
     super();
@@ -37,12 +38,12 @@ class FakeHost extends HTMLVideoElementHost {
 
   // Mirror the real adapter: a new src destroys the engine and starts a fresh one.
   get src() {
-    return this.#engine.state.presentation.get()?.url ?? '';
+    return this.#src;
   }
 
   set src(value: string) {
+    this.#src = value;
     this.#engine = this.#createEngine();
-    if (value) this.#engine.state.presentation.set({ url: value });
   }
 
   destroy() {}
@@ -50,22 +51,18 @@ class FakeHost extends HTMLVideoElementHost {
 
 const Host = SimpleHlsMediaMediaTracksMixin(MediaTracksMixin(FakeHost));
 
-function videoTrack(id: string, width: number, height: number, bandwidth: number) {
-  return { id, type: 'video', url: `${id}.m3u8`, width, height, bandwidth, codecs: ['avc1.640028'] };
+function rendition(
+  id: string,
+  width: number,
+  height: number,
+  bandwidth: number,
+  frameRate?: { frameRateNumerator: number; frameRateDenominator?: number }
+) {
+  return { id, url: `${id}.m3u8`, width, height, bandwidth, codecs: ['avc1.640028'], frameRate };
 }
 
-function presentationWith(tracks: Array<ReturnType<typeof videoTrack>>) {
-  return {
-    url: 'https://example.com/master.m3u8',
-    id: 'presentation',
-    selectionSets: [
-      { id: 'video-selection', type: 'video', switchingSets: [{ id: 'video-switching', type: 'video', tracks }] },
-    ],
-  };
-}
-
-const HD = videoTrack('v-1080', 1920, 1080, 6_000_000);
-const SD = videoTrack('v-360', 640, 360, 800_000);
+const HD = rendition('v-1080', 1920, 1080, 6_000_000);
+const SD = rendition('v-360', 640, 360, 800_000);
 
 // Drain the effect microtask and the nested microtask the rendition-list
 // primitives use to dispatch add/remove/change events.
@@ -74,39 +71,51 @@ function flush() {
 }
 
 describe('SimpleHlsMediaMediaTracksMixin', () => {
-  it('projects the engine presentation onto a selected video track with renditions', async () => {
+  it('projects the engine renditions onto a selected video track', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     expect(host.videoTracks.length).toBe(1);
     expect(host.videoTracks[0]?.selected).toBe(true);
     expect(host.videoRenditions.length).toBe(2);
-    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080', 'v-360']);
-    expect([...host.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 360]);
-    expect([...host.videoRenditions].map((rendition) => rendition.bitrate)).toEqual([6_000_000, 800_000]);
+    expect([...host.videoRenditions].map((r) => r.id)).toEqual(['v-1080', 'v-360']);
+    expect([...host.videoRenditions].map((r) => r.height)).toEqual([1080, 360]);
+    expect([...host.videoRenditions].map((r) => r.bitrate)).toEqual([6_000_000, 800_000]);
+  });
+
+  it('reduces the model frame rate to a number on the projected rendition', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([
+      rendition('v-1080', 1920, 1080, 6_000_000, { frameRateNumerator: 30000, frameRateDenominator: 1001 }),
+    ]);
+    await flush();
+
+    expect(host.videoRenditions[0]?.frameRate).toBeCloseTo(29.97, 2);
   });
 
   it('marks the active rendition from selectedVideoTrackId', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     engine.state.selectedVideoTrackId.set('v-360');
     await flush();
 
-    expect([...host.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+    expect([...host.videoRenditions].map((r) => r.active)).toEqual([false, true]);
   });
 
   it('forwards a rendition selection to userVideoTrackSelection', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     host.videoRenditions.selectedIndex = 1;
@@ -119,7 +128,7 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     host.videoRenditions.selectedIndex = 1;
@@ -131,40 +140,18 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     expect(engine.state.userVideoTrackSelection.get()).toBeUndefined();
   });
 
-  it('does not rebuild renditions when a resolve mutates presentation without changing the track set', async () => {
+  it('rebuilds renditions when the engine emits a new set', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    let added = 0;
-    let removed = 0;
-    host.videoRenditions.addEventListener('addrendition', () => added++);
-    host.videoRenditions.addEventListener('removerendition', () => removed++);
-
-    engine.state.presentation.set(presentationWith([HD, SD]));
-    await flush();
-    expect(added).toBe(2);
-
-    // A media-playlist resolution replaces the presentation object with the
-    // same renditions — the projection should be a no-op.
-    engine.state.presentation.set(presentationWith([HD, SD]));
-    await flush();
-
-    expect(added).toBe(2);
-    expect(removed).toBe(0);
-  });
-
-  it('rebuilds renditions when the track set changes', async () => {
-    const engine = createEngine();
-    const host = new Host(() => engine);
-
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
     expect(host.videoRenditions.length).toBe(2);
 
-    engine.state.presentation.set(presentationWith([HD]));
+    engine.state.videoRenditions.set([HD]);
     await flush();
 
-    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080']);
+    expect([...host.videoRenditions].map((r) => r.id)).toEqual(['v-1080']);
   });
 
   it('re-wires the projection to the fresh engine created on src change', async () => {
@@ -177,12 +164,12 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
 
     // src change tears down engine[0] and creates engine[1].
     host.src = 'https://example.com/next.m3u8';
-    engines[1]!.state.presentation.set(presentationWith([HD, SD]));
+    engines[1]!.state.videoRenditions.set([HD, SD]);
     await flush();
     expect(host.videoRenditions.length).toBe(2);
 
     // The disconnected first engine must no longer drive the projection.
-    engines[0]!.state.presentation.set(presentationWith([HD]));
+    engines[0]!.state.videoRenditions.set([HD]);
     await flush();
     expect(host.videoRenditions.length).toBe(2);
   });
@@ -191,7 +178,7 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
     expect(host.videoTracks.length).toBe(1);
 

--- a/packages/spf/src/media/utils/tests/track-selection.test.ts
+++ b/packages/spf/src/media/utils/tests/track-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AudioTrack, Presentation, VideoTrack } from '../../types';
-import { getResolvedSelectedTrackDuration, type TrackSelectionState } from '../track-selection';
+import { getResolvedSelectedTrackDuration, getVideoRenditions, type TrackSelectionState } from '../track-selection';
 
 function createPresentation(config: { video?: VideoTrack[]; audio?: AudioTrack[]; duration?: number }): Presentation {
   const selectionSets = [];
@@ -130,5 +130,50 @@ describe('getResolvedSelectedTrackDuration', () => {
 
   it('returns undefined when there is no presentation', () => {
     expect(getResolvedSelectedTrackDuration({})).toBeUndefined();
+  });
+});
+
+describe('getVideoRenditions', () => {
+  it('maps the first video switching set to normalized rendition info', () => {
+    const presentation = createPresentation({
+      video: [
+        resolvedVideoTrack({ id: 'hd', url: 'hd.m3u8', width: 1920, height: 1080, bandwidth: 6_000_000 }),
+        resolvedVideoTrack({ id: 'sd', url: 'sd.m3u8', width: 640, height: 360, bandwidth: 800_000 }),
+      ],
+    });
+
+    expect(getVideoRenditions({ presentation })).toEqual([
+      {
+        id: 'hd',
+        url: 'hd.m3u8',
+        width: 1920,
+        height: 1080,
+        codecs: ['avc1.42E01E'],
+        bandwidth: 6_000_000,
+        frameRate: undefined,
+      },
+      {
+        id: 'sd',
+        url: 'sd.m3u8',
+        width: 640,
+        height: 360,
+        codecs: ['avc1.42E01E'],
+        bandwidth: 800_000,
+        frameRate: undefined,
+      },
+    ]);
+  });
+
+  it('carries the raw FrameRate through (DOM consumers normalize)', () => {
+    const frameRate = { frameRateNumerator: 30000, frameRateDenominator: 1001 };
+    const presentation = createPresentation({ video: [resolvedVideoTrack({ frameRate })] });
+
+    expect(getVideoRenditions({ presentation })[0]?.frameRate).toEqual(frameRate);
+  });
+
+  it('returns an empty array when the presentation is unresolved or has no video', () => {
+    expect(getVideoRenditions({})).toEqual([]);
+    expect(getVideoRenditions({ presentation: { url: 'x.m3u8' } })).toEqual([]);
+    expect(getVideoRenditions({ presentation: createPresentation({ audio: [resolvedAudioTrack()] }) })).toEqual([]);
   });
 });

--- a/packages/spf/src/media/utils/track-selection.ts
+++ b/packages/spf/src/media/utils/track-selection.ts
@@ -1,11 +1,13 @@
 import type {
   AudioTrack,
+  FrameRate,
   MaybeResolvedPresentation,
   PartiallyResolvedAudioTrack,
   PartiallyResolvedTextTrack,
   PartiallyResolvedVideoTrack,
   TextTrack,
   TrackType,
+  VideoSelectionSet,
   VideoTrack,
 } from '../types';
 import { isResolvedTrack } from '../types';
@@ -79,4 +81,42 @@ export function getResolvedSelectedTrackDuration(state: TrackSelectionState): nu
     if (audio && isResolvedTrack(audio)) return audio.duration;
   }
   return undefined;
+}
+
+/**
+ * A selectable video rendition (quality level) from the presentation. Each
+ * video track in the selected video switching set is one rendition, carried in
+ * the model's own vocabulary (`bandwidth`, `codecs`, `FrameRate`); DOM
+ * consumers map these onto their platform shapes.
+ */
+export interface VideoRenditionInfo {
+  id: string;
+  url: string;
+  width?: number;
+  height?: number;
+  codecs?: string[];
+  bandwidth: number;
+  frameRate?: FrameRate;
+}
+
+/**
+ * Read the selectable video renditions from a presentation — the tracks of the
+ * first video switching set. Returns an empty array when the presentation is
+ * unresolved or carries no video.
+ *
+ * @param presentation - The engine's current (maybe-resolved) presentation.
+ */
+export function getVideoRenditions(state: TrackSelectionState): VideoRenditionInfo[] {
+  const { presentation } = state;
+  const videoSet = presentation?.selectionSets?.find((set): set is VideoSelectionSet => set.type === 'video');
+
+  return (videoSet?.switchingSets[0]?.tracks ?? []).map((track) => ({
+    id: track.id,
+    url: track.url,
+    width: track.width,
+    height: track.height,
+    codecs: track.codecs,
+    bandwidth: track.bandwidth,
+    frameRate: track.frameRate,
+  }));
 }

--- a/packages/spf/src/playback/behaviors/derive-video-renditions.ts
+++ b/packages/spf/src/playback/behaviors/derive-video-renditions.ts
@@ -1,0 +1,70 @@
+/**
+ * **Video renditions.** While a presentation is resolved, owns the
+ * `videoRenditions` signal: the selectable quality levels of the first video
+ * switching set, normalized to {@link VideoRenditionInfo}. Cleared on src
+ * unload. A read-only projection consumers (e.g. the DOM media adapter) bind to
+ * without reaching through `presentation`.
+ *
+ * Lifecycle mirrors `deriveCdnPriority`: `'presentation-unresolved'` ↔
+ * `'presentation-resolved'`. The resolved state owns the signal; its
+ * entry-returned cleanup clears it on exit (canonical cleanup-binds-to-setup).
+ *
+ * A live reload swaps in a new presentation object carrying the same renditions,
+ * so writes are skipped when the rendition id-set is unchanged — re-emitting a
+ * fresh array would re-fire consumers for an identical list.
+ */
+
+import { defineBehavior } from '../../core/composition/create-composition';
+import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
+import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
+import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../media/types';
+import { getVideoRenditions, type VideoRenditionInfo } from '../../media/utils/track-selection';
+
+export interface DeriveVideoRenditionsState {
+  presentation?: MaybeResolvedPresentation;
+  videoRenditions?: VideoRenditionInfo[];
+}
+
+const sameRenditions = (a: VideoRenditionInfo[] | undefined, b: VideoRenditionInfo[]): boolean =>
+  !!a && a.length === b.length && a.every((rendition, index) => rendition.id === b[index]?.id);
+
+export const deriveVideoRenditions = defineBehavior({
+  stateKeys: ['presentation', 'videoRenditions'],
+  contextKeys: [],
+  setup: ({
+    state,
+  }: {
+    state: {
+      presentation: ReadonlySignal<DeriveVideoRenditionsState['presentation']>;
+      videoRenditions: Signal<DeriveVideoRenditionsState['videoRenditions']>;
+    };
+  }) => {
+    const derivedStateSignal = computed(() =>
+      isResolvedPresentation(state.presentation.get())
+        ? ('presentation-resolved' as const)
+        : ('presentation-unresolved' as const)
+    );
+
+    return createMachineReactor({
+      initial: 'presentation-unresolved',
+      monitor: () => derivedStateSignal.get(),
+      states: {
+        'presentation-unresolved': {},
+        'presentation-resolved': {
+          // Cleanup-binds-to-setup: the rendition list is valid for exactly
+          // 'presentation-resolved'. Clear fires on exit (src unload + destroy).
+          entry: () => () => state.videoRenditions.set(undefined),
+          effects: [
+            () => {
+              const presentation = state.presentation.get();
+              if (!isResolvedPresentation(presentation)) return;
+              const next = getVideoRenditions({ presentation });
+              // `peek` reads without subscribing, so this never self-triggers.
+              if (!sameRenditions(peek(state.videoRenditions), next)) state.videoRenditions.set(next);
+            },
+          ],
+        },
+      },
+    });
+  },
+});

--- a/packages/spf/src/playback/behaviors/tests/derive-video-renditions.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/derive-video-renditions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { StateSignals } from '../../../core/composition/create-composition';
+import { signal } from '../../../core/signals/primitives';
+import type { MaybeResolvedPresentation, PartiallyResolvedVideoTrack, Presentation } from '../../../media/types';
+import type { VideoRenditionInfo } from '../../../media/utils/track-selection';
+import { type DeriveVideoRenditionsState, deriveVideoRenditions } from '../derive-video-renditions';
+
+function makeState(initial: Partial<DeriveVideoRenditionsState> = {}): StateSignals<DeriveVideoRenditionsState> {
+  return {
+    presentation: signal<MaybeResolvedPresentation | undefined>(initial.presentation),
+    videoRenditions: signal<VideoRenditionInfo[] | undefined>(initial.videoRenditions),
+  };
+}
+
+const track = (id: string, width: number, height: number, bandwidth: number): PartiallyResolvedVideoTrack => ({
+  type: 'video',
+  id,
+  url: `${id}.m3u8`,
+  codecs: ['avc1.640028'],
+  mimeType: 'video/mp4',
+  bandwidth,
+  width,
+  height,
+});
+
+const presentationWith = (tracks: PartiallyResolvedVideoTrack[]): Presentation =>
+  ({
+    id: 'pres-1',
+    url: 'https://example.com/master.m3u8',
+    startTime: 0,
+    selectionSets: [
+      {
+        id: 'video-set',
+        type: 'video' as const,
+        switchingSets: [{ id: 'video-switching', type: 'video' as const, tracks }],
+      },
+    ],
+  }) as Presentation;
+
+const HD = track('v-1080', 1920, 1080, 6_000_000);
+const SD = track('v-360', 640, 360, 800_000);
+
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+describe('deriveVideoRenditions', () => {
+  it('does nothing without a presentation', async () => {
+    const state = makeState();
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+    expect(state.videoRenditions.get()).toBeUndefined();
+    reactor.destroy();
+  });
+
+  it('publishes the video renditions on src load', async () => {
+    const state = makeState({ presentation: presentationWith([HD, SD]) });
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+
+    expect(state.videoRenditions.get()?.map((r) => r.id)).toEqual(['v-1080', 'v-360']);
+    expect(state.videoRenditions.get()?.map((r) => r.height)).toEqual([1080, 360]);
+    reactor.destroy();
+  });
+
+  it('skips the write when a reload carries the same rendition set', async () => {
+    const state = makeState({ presentation: presentationWith([HD, SD]) });
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+    const first = state.videoRenditions.get();
+
+    // A live reload swaps in a new presentation object with identical renditions.
+    state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    expect(state.videoRenditions.get()).toBe(first);
+    reactor.destroy();
+  });
+
+  it('clears the renditions on src unload', async () => {
+    const state = makeState({ presentation: presentationWith([HD, SD]) });
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+    expect(state.videoRenditions.get()).toBeDefined();
+
+    state.presentation.set(undefined);
+    await flush();
+
+    expect(state.videoRenditions.get()).toBeUndefined();
+    reactor.destroy();
+  });
+});

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -18,7 +18,7 @@ import {
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
 import type { AudioTrack, CanPlayTrack, MaybeResolvedPresentation, TextTrack, VideoTrack } from '../../../media/types';
 import type { GetCdnId } from '../../../media/utils/cdn';
-import { getResolvedSelectedTrackDuration } from '../../../media/utils/track-selection';
+import { getResolvedSelectedTrackDuration, type VideoRenditionInfo } from '../../../media/utils/track-selection';
 import type { BandwidthConfig, BandwidthState } from '../../../network/bandwidth-estimator';
 import type { SegmentLoaderActor } from '../../actors/dom/segment-loader';
 import type { SourceBufferActor } from '../../actors/dom/source-buffer';
@@ -29,6 +29,7 @@ import {
   type PresentationDurationResolver,
 } from '../../behaviors/calculate-presentation-duration';
 import { deriveCdnPriority } from '../../behaviors/derive-cdn-priority';
+import { deriveVideoRenditions } from '../../behaviors/derive-video-renditions';
 import { endOfStream } from '../../behaviors/dom/end-of-stream';
 import { loadAudioSegments, loadTextTrackSegments, loadVideoSegments } from '../../behaviors/dom/load-segments';
 import { setupAudioBufferActors, setupVideoBufferActors } from '../../behaviors/dom/setup-buffer-actors';
@@ -103,6 +104,13 @@ export interface SimpleHlsEngineState {
   failedCdns?: string[];
   currentTime?: number;
   loadActivated?: boolean;
+  /**
+   * Selectable video quality levels of the resolved presentation, ascending by
+   * declaration order. Derived from `presentation` by `deriveVideoRenditions`;
+   * a read-only projection consumers bind to (e.g. the DOM media adapter's
+   * `videoRenditions`). Cleared on src unload.
+   */
+  videoRenditions?: VideoRenditionInfo[];
 }
 
 /**
@@ -320,6 +328,10 @@ export function createSimpleHlsEngine(
       // redundant streams (the norm) never hit it — the first-listed CDN is
       // already the primary we'd pick anyway.
       deriveCdnPriority,
+
+      // Projects the resolved presentation's video quality levels onto the
+      // `videoRenditions` slot for consumers (e.g. the DOM media adapter).
+      deriveVideoRenditions,
 
       // CDN failover cooldown: owns the expiry half of failover — watches
       // `failedCdns` (tripped directly by track resolution on a failed


### PR DESCRIPTION
Part 1 of #1795 (video → audio → streamType → live → parity/autoplay).

**What:** SimpleHlsMedia now projects the SPF engine's video renditions onto the standard videoTracks / videoRenditions DOM surface (read, write, events) so a quality menu binds to it with no adapter-specific code, matching HlsJsMedia.

**How:** 
- The HLS SPF engine gains a derived `videoRenditions` signal (new `deriveVideoRenditions` behavior, mirroring `deriveCdnPriority`): projects the resolved presentation's video switching set, clears on src unload, skips writes when a reload carries the same set.
- A core projection mixin (`SimpleHlsMediaMediaTracksMixin`) subscribes to that signal via effect, builds one selected main video track + a VideoRendition per level, and writes selection back: 
  - `selectedIndex` → `userVideoTrackSelection = { selectedIndex }`, 
  - `-1` → clear (ABR).
  
## Design decisions:
- Tried to follow the no SPF -> core dependency rule. Initially had everything implemented in core, then moved part to SPF with the behavior.
- SPF publishes model vocabulary (bandwidth, codecs[], FrameRate); core owns DOM mapping (`codecs.join(','), FrameRate → number`). Kept them in the mixin file since they are only used there, but could move as helpers later.
- Re-wire on src: the adapter **currently** destroys+recreates the engine per src, so subscriptions re-wire via one AbortController per connect. 
- Order = manifest declaration order (what SPF already handled), deterministic but unsorted. Not sorted here; a bandwidth-ascending sort in the selector is a one-liner if we later want hls.js-style ordering.

## Trade-offs / open questions:

- First selection/switching set only: CMAF permits multiple selection sets and multiple switching sets; fine for single-video-track HLS, generalizing is a follow-up.
- Adapter destroy-recreate vs. in-place source replacement is unresolved (source-replacement.md / engine-adapter-integration.md). The src re-wire exists solely to compensate for destroy-recreate; if that's resolved toward in-place, the projection collapses to a one-time constructor wire.

## Test plan:

- spf: deriveVideoRenditions behavior (derive/skip-unchanged/clear); getVideoRenditions selector.
- core: projection read/write/events, active reflection, frameRate → number, rebuild-on-set-change, re-wire-on-src, destroy.
- Full core dom/media (338) + spf engine/behaviors (417) green; typecheck, lint, check:workspace clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches playback quality selection and DOM track projection with bidirectional sync; scope is bounded by tests and mirrors existing patterns, but wrong wiring could affect ABR or UI selection state.
> 
> **Overview**
> **SimpleHlsMedia** now exposes the standard **`videoTracks` / `videoRenditions`** surface (read, write, events) so quality UIs can bind without adapter-specific APIs, aligned with the Hls.js media path.
> 
> On the **SPF HLS engine**, a new **`deriveVideoRenditions`** behavior (patterned after `deriveCdnPriority`) derives selectable quality levels from the resolved presentation’s first video switching set into a **`videoRenditions`** signal, clears on unload, and skips redundant signal writes when a reload keeps the same rendition ids. **`getVideoRenditions`** in track-selection utilities performs the presentation → `VideoRenditionInfo` mapping.
> 
> In **core**, **`SimpleHlsMediaMediaTracksMixin`** subscribes to that signal, builds one main track with a `VideoRendition` per level (including `FrameRate` → numeric frame rate), reflects **active** playback and **selected** manual pin from engine state, and maps **`videoRenditions.selectedIndex`** to **`userVideoTrackSelection`** (`{ id }` pins a level; **`-1`** clears for ABR). Subscriptions **re-wire on each `src` change** because the adapter recreates the engine per assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98b4738011d28a3fc59de985d8a13d347f00d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->