### PR TITLE
docs: move Google Cast lower in Concepts sidebar

### DIFF
--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -36,12 +36,12 @@ export const sidebar: Sidebar = [
     llmsDescription:
       'Understanding-oriented pages that explain how and why things work. Read these to build a mental model of the library.',
     contents: [
-      { slug: 'concepts/cast', sidebarLabel: 'Google Cast' },
       { slug: 'concepts/features' },
       { slug: 'concepts/skins' },
       { slug: 'concepts/presets' },
       { slug: 'concepts/ui-components' },
       { slug: 'concepts/accessibility' },
+      { slug: 'concepts/cast', sidebarLabel: 'Google Cast' },
     ],
   },
   {


### PR DESCRIPTION
## What & why

Moves the **Google Cast** concept entry from the top of the **Concepts** section of the docs sidebar down to the bottom, below the more foundational concepts (Features, Skins, Presets, UI components, Accessibility).

## Changes

- `site/src/docs.config.ts` — reordered the `Concepts` section `contents` so `concepts/cast` (labeled "Google Cast") is now last instead of first.

## Testing

- `pnpm -F site test sidebar.test.ts` — all 37 sidebar tests pass. (Sidebar tests validate no duplicate slugs and that a first guide resolves per framework; ordering within a section is not asserted, so the reorder is safe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146KwfYxv9abnktLTRvpd5A

---
_Generated by [Claude Code](https://claude.ai/code/session_0146KwfYxv9abnktLTRvpd5A)_