### PR TITLE
docs(site): refresh write-guides page and align docs skill Diátaxis guidance

### DIFF
--- a/.claude/skills/docs/SKILL.md
+++ b/.claude/skills/docs/SKILL.md
@@ -46,9 +46,9 @@ This skill adds writing guidance on top of those. When in doubt, the source file
 
 ## Documentation types
 
-### Site documentation (Diataxis)
+### Site documentation (Diátaxis)
 
-The site follows the [Diataxis](https://diataxis.fr/) framework:
+The site follows the [Diátaxis](https://diataxis.fr/) framework:
 
 | Mode | Directory | Purpose |
 |------|-----------|---------|
@@ -58,14 +58,7 @@ The site follows the [Diataxis](https://diataxis.fr/) framework:
 
 **When in doubt, write a concept page.** Most new documentation should be concept pages.
 
-| Concept page | How-to guide |
-|---|---|
-| **Preferred** — default choice | Use sparingly |
-| Reference while working | Learning from scratch |
-| One concept per page | Multi-step narrative |
-| Scannable, minimal prose | Explains "why" at each step |
-| No prerequisites | Has prerequisites |
-| Jump in anywhere | Sequential |
+The canonical guidance — full mode definitions and the concept vs how-to decision table — lives in `site/src/content/docs/how-to/write-guides.mdx`. Read it before choosing a mode.
 
 ### Package documentation
 

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -10,11 +10,19 @@ import ServerCode from '@/components/Code/ServerCode.astro';
 import { TabsRoot, TabsList, TabsPanel, Tab } from '@/components/Tabs.tsx';
 import DocsLink from '@/components/docs/DocsLink.astro';
 import Aside from '@/components/Aside.astro';
+import Demo from '@/components/docs/demos/Demo.astro';
+import BasicUsageDemoReact from '@/components/docs/demos/play-button/react/css/BasicUsage';
+import basicUsageReactTsx from '@/components/docs/demos/play-button/react/css/BasicUsage.tsx?raw';
+import basicUsageReactCss from '@/components/docs/demos/play-button/react/css/BasicUsage.css?raw';
+import BasicUsageDemoHtml from '@/components/docs/demos/play-button/html/css/BasicUsage.astro';
+import basicUsageHtml from '@/components/docs/demos/play-button/html/css/BasicUsage.html?raw';
+import basicUsageHtmlCss from '@/components/docs/demos/play-button/html/css/BasicUsage.css?raw';
+import basicUsageHtmlTs from '@/components/docs/demos/play-button/html/css/BasicUsage.ts?raw';
 
 What is a guide? In this context, it's a document in the docs that's not an API reference. For API references, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink>.
 
 <Aside type="tip">
-Oh hey by the way. A lot of this knowledge is encoded in the `docs-guide` Claude skill. You should still read it, but, now your LLM can help you along the way, too.
+Oh hey by the way. A lot of this knowledge is encoded in the `docs` Claude skill. You should still read it, but, now your LLM can help you along the way, too.
 </Aside>
 
 ## 1. Understand our documentation structure
@@ -25,7 +33,16 @@ First, read and understand [Diátaxis](https://diataxis.fr/). We organize docume
 2. **How-to guides** (`src/content/docs/how-to/`): Spans multiple concepts in order to achieve a specific outcome with step-by-step instructions. 
 3. **Reference pages** (`src/content/docs/reference/`): Component API documentation. These are scaffolded using the `api-reference` skill and the api-docs-builder. Again, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink> for details.
 
-When in doubt, you probably want a concept page.
+**When in doubt, write a concept page.** Most new documentation should be concept pages. Use this table to decide between the two:
+
+| Concept page | How-to guide |
+|---|---|
+| **Preferred** — default choice | Use sparingly |
+| Reference while working | Learning from scratch |
+| One concept per page | Multi-step narrative |
+| Scannable, minimal prose | Explains "why" at each step |
+| No prerequisites | Has prerequisites |
+| Jump in anywhere | Sequential |
 
 ## 2. Create a guide in the correct content folder
 
@@ -54,21 +71,23 @@ Next, open `src/docs.config.ts` and add your guide to the appropriate section of
 
 ```ts
 {
-  slug: 'how-to/write-guides',
-  title: 'Writing guides'
+  slug: 'how-to/write-guides'
 }
 ```
 
-If you want the guide to only apply to specific frameworks or styles, you can specify those as well:
+The sidebar label defaults to the guide's `title` frontmatter; override it with `sidebarLabel`. If you want the guide to only apply to specific frameworks, you can specify that as well:
 
 ```ts
 {
   slug: 'how-to/write-guides',
-  title: 'Writing guides',
-  frameworks: ['react'], // Only for React
-  styles: ['css'] // Only for CSS
+  sidebarLabel: 'Writing guides',
+  frameworks: ['react'] // Only for React
 }
 ```
+
+<Aside type="note">
+There is no `styles` restriction on sidebar items. Style is a client-side preference — every guide renders for all styles. To show style-specific content, use `<StyleCase>` within the guide, as shown below.
+</Aside>
 
 ## 4. Follow our writing style
 
@@ -87,7 +106,7 @@ Keep documentation clear, human, and useful. Here are the key rules:
 ## 5. Understand MDX and our components
 
 ### `<FrameworkCase>` and `<StyleCase>`
-First, understand that the guide you write will be rendered for every framework / style combination (e.g., HTML + CSS, React + CSS) unless you restrict it in the sidebar config as shown above.
+First, understand that the guide you write will be rendered for every framework / style combination (e.g., HTML + CSS, React + CSS) unless you restrict it to specific frameworks in the sidebar config as shown above.
 
 Use the `<FrameworkCase>` and `<StyleCase>` components to conditionally show content to just one framework or style:
 
@@ -228,6 +247,24 @@ we can use 3 backticks ``` in new line and write snippet and close with 3 backti
     <p>Test</p>
   </body>
 </html>
+```
+
+#### Code frames and titles
+
+Every standalone code block is automatically wrapped in a `<CodeFrame>` — the tabbed header and copy button you see on the examples above. You don't write it yourself; the `satteriCodeFrame` MDX plugin injects it. Code blocks inside an authored `<TabsPanel>` are left alone, since the tab group is already their frame.
+
+The frame's tab shows the language by default. To show a filename instead, add `title="..."` to the fence meta:
+
+````markdown
+```ts title="App.ts"
+console.log('Hello, Video.js!');
+```
+````
+
+Which renders as:
+
+```ts title="App.ts"
+console.log('Hello, Video.js!');
 ```
 
 ### Code annotations
@@ -443,7 +480,7 @@ You would just get
 To work around this, use `<ServerCode />` instead of triple backticks.
 
 <Aside type="caution">
-Unlike regular markdown code blocks, `<ServerCode>` does **not** automatically get wrapped in a frame. You should use `TabsRoot` with a single `TabPanel` to make it look pretty
+Unlike regular markdown code blocks, which are automatically wrapped in a `<CodeFrame>` as described above, `<ServerCode>` renders a bare `<pre>` with **no** frame. You should use `TabsRoot` with a single `TabsPanel` to make it look pretty.
 </Aside>
 
 ```mdx
@@ -475,6 +512,59 @@ function Component() {
 }`} lang="tsx" />
   </TabsPanel>
 </TabsRoot>
+
+### `<Demo>`, for a live preview with tabbed source code
+
+Use `<Demo>` to show a live, interactive example alongside the code that produces it. This is the standard pattern on reference pages (e.g., <DocsLink slug="reference/play-button">PlayButton</DocsLink>).
+
+Pass the source files via the `files` prop — each entry has a `title`, `code` (a `?raw` import), and `lang` — and place the rendered demo in the default slot. Any `css` file in `files` is automatically scoped to the demo, so the demo's styles won't leak into the page.
+
+Demos are framework-specific, so wrap each variant in `<FrameworkCase>` (and `<StyleCase>`, if applicable):
+
+```mdx
+import Demo from '@/components/docs/demos/Demo.astro';
+import BasicUsageDemoReact from '@/components/docs/demos/play-button/react/css/BasicUsage';
+import basicUsageReactTsx from '@/components/docs/demos/play-button/react/css/BasicUsage.tsx?raw';
+import basicUsageReactCss from '@/components/docs/demos/play-button/react/css/BasicUsage.css?raw';
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+```
+
+Which renders as:
+
+<FrameworkCase frameworks={["react"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTsx, lang: "tsx" },
+      { title: "App.css", code: basicUsageReactCss, lang: "css" },
+    ]}>
+      <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+  <StyleCase styles={["css"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageHtml, lang: "html" },
+      { title: "index.css", code: basicUsageHtmlCss, lang: "css" },
+      { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+</FrameworkCase>
+
+See the "Interactive Demos" section of `site/CLAUDE.md` for how to author the demo files themselves (directory structure, CSS class naming, and the HTML `.astro` wrapper).
 
 ## Literally any other component
 

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -29,9 +29,20 @@ Oh hey by the way. A lot of this knowledge is encoded in the `docs` Claude skill
 
 First, read and understand [Diátaxis](https://diataxis.fr/). We organize documentation into three modes:
 
-1. **Concept pages** (`src/content/docs/concepts/`): Explain how and why things work. General understanding, spanning multiple APIs, can be applied to multiple outcomes. As we write guides, what are things we need people to understand in multiple places and don’t want to duplicate the content?
-2. **How-to guides** (`src/content/docs/how-to/`): Spans multiple concepts in order to achieve a specific outcome with step-by-step instructions. 
+1. **Concept pages** (`src/content/docs/concepts/`): Explain how and why things work — design decisions, trade-offs, and context. General understanding, spanning multiple APIs, can be applied to multiple outcomes. As we write guides, what are things we need people to understand in multiple places and don’t want to duplicate the content? Diátaxis calls this mode "explanation."
+2. **How-to guides** (`src/content/docs/how-to/`): Spans multiple concepts in order to achieve a specific outcome with step-by-step instructions. Address a real user goal, assume competence, and link to concept pages instead of explaining inline.
 3. **Reference pages** (`src/content/docs/reference/`): Component API documentation. These are scaffolded using the `api-reference` skill and the api-docs-builder. Again, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink> for details.
+
+<Aside type="note">
+Diátaxis has a fourth mode — learning-oriented **tutorials**. We deliberately don't have a tutorials section; learning-oriented content lives in the Getting started how-to guides instead.
+</Aside>
+
+To pick a mode, use the Diátaxis [compass](https://diataxis.fr/compass/). Ask two questions: does the content inform **action** (practical steps) or **cognition** (understanding)? And does it serve the reader's **study** (acquiring skills) or their **work** (applying them)?
+
+| | Informs action | Informs cognition |
+|---|---|---|
+| **Serves work** | How-to guide | Reference page |
+| **Serves study** | How-to guide (Getting started) | Concept page |
 
 **When in doubt, write a concept page.** Most new documentation should be concept pages. Use this table to decide between the two:
 
@@ -43,6 +54,8 @@ First, read and understand [Diátaxis](https://diataxis.fr/). We organize docume
 | Scannable, minimal prose | Explains "why" at each step |
 | No prerequisites | Has prerequisites |
 | Jump in anywhere | Sequential |
+
+Whichever mode you choose, **don't mix modes on one page**. Step-by-step instructions creeping into a concept page belong in a how-to guide; background explanation swelling a how-to step belongs in a concept page — link to it instead. Each mode serves a different reader need, and blending them dilutes both.
 
 ## 2. Create a guide in the correct content folder
 

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -34,7 +34,7 @@ First, read and understand [Diátaxis](https://diataxis.fr/). We organize docume
 3. **Reference pages** (`src/content/docs/reference/`): Component API documentation. These are scaffolded using the `api-reference` skill and the api-docs-builder. Again, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink> for details.
 
 <Aside type="note">
-Diátaxis has a fourth mode — learning-oriented **tutorials**. We deliberately don't have a tutorials section; learning-oriented content lives in the Getting started how-to guides instead.
+Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials section yet — something we've intentionally chosen to omit, for now. Learning-oriented content lives in the Getting started how-to guides instead.
 </Aside>
 
 To pick a mode, use the Diátaxis [compass](https://diataxis.fr/compass/). Ask two questions: does the content inform **action** (practical steps) or **cognition** (understanding)? And does it serve the reader's **study** (acquiring skills) or their **work** (applying them)?


### PR DESCRIPTION
Closes #1808

The `docs` skill declares `write-guides.mdx` a source of truth, but the two had drifted and the page had gone stale. This refreshes the page against the current MDX pipeline and makes it the canonical home for the Diátaxis guidance, with the skill deferring to it.

## Staleness fixes (`site/src/content/docs/how-to/write-guides.mdx`)

- **Skill name**: the tip aside referenced a `docs-guide` skill — it's named `docs`.
- **Sidebar config example**: removed the unsupported `styles: ['css']` restriction (style is a client-side preference; every guide renders for all styles — use `<StyleCase>` in content). Also fixed the stale `title:` field found along the way — the actual `Guide` field is `sidebarLabel` (`site/src/types/docs.ts`), which defaults to the guide's `title` frontmatter.
- **Code frames**: documented the Sätteri `satteriCodeFrame` auto-wrap — every standalone fence renders inside a `<CodeFrame>`, with `title="..."` fence meta for filenames, and blocks inside an authored `<TabsPanel>` left alone — including a rendered `title="App.ts"` example.
- **`<ServerCode>` caution re-verified**: still accurate (it renders a bare `<pre>` via `Shared.tsx`); reworded to contrast with the new fence auto-wrapping and fixed the `TabPanel` → `TabsPanel` typo.
- **`<Demo>`**: added the missing section — `files` prop shape, automatic CSS scoping, framework-specific wrapping — with live play-button demos rendered for both React and HTML routes.

## Diátaxis alignment

- The page now carries the canonical guidance: the bold concept-page-preferred default and the concept vs how-to decision table (previously only in the skill).
- The skill's Diátaxis section keeps its compact mode table and default rule but defers to `write-guides.mdx` for the full guidance instead of duplicating the decision table.
- Encoded two Diátaxis tools the repo hadn't captured: the two-question **compass** (action/cognition × study/work) mapped onto our three modes, with a note that we deliberately have no tutorials section (learning-oriented content lives in Getting started how-tos), and the **don't-mix-modes** rule with concrete symptoms.

## Verification

- `pnpm build:site` passes (14/14 tasks).
- The page is `devOnly`, so it was also verified against the dev server: both `/docs/framework/react/how-to/write-guides` and `/docs/framework/html/how-to/write-guides` render, with the new sections, code-frame example, and live demos present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jk33yY4w5PkThQjkysDWgc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jk33yY4w5PkThQjkysDWgc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Claude skill text only; no runtime or API behavior changes.
> 
> **Overview**
> Makes **`write-guides.mdx`** the single canonical place for Diátaxis guidance and brings the page in line with the current docs toolchain.
> 
> The **`docs` skill** now keeps only a compact mode table and points authors to `write-guides.mdx` instead of duplicating the concept vs how-to decision table.
> 
> **`write-guides.mdx`** gains the full Diátaxis material (compass, tutorials omission, decision table, don’t-mix-modes), fixes stale author guidance (`docs` skill name, sidebar uses `sidebarLabel` not `title`, no `styles` on sidebar items), and documents **auto `<CodeFrame>`** wrapping, **`title="..."`** on fences, updated **`<ServerCode>`** vs frames, plus a new **`<Demo>`** section with live React/HTML play-button examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e163bf0af363be4bb83ff20f223445e5dbaab0e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->