### PR TITLE
fix(ci): unbreak changelog prose pipeline and add beta.25 prose

### DIFF
--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -88,7 +88,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model sonnet
+            --model opus
             --max-turns 50
             --allowedTools "Bash(gh:*)" "Bash(git:*)" "Bash(jq:*)" "Bash(cat:*)" "Bash(ls:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(grep:*)" "Bash(sed:*)" "Bash(wc:*)" "Read" "Edit" "Write" "Glob" "Grep"
           prompt: |
@@ -105,6 +105,7 @@ jobs:
                - Read `.claude/skills/docs/references/writing-style.md` for tone and style rules.
                - Read the raw changelog at `site/src/content/changelog/${{ steps.version.outputs.version }}.md`.
                - Read other existing `.md` files in `site/src/content/changelog/` (if any) to match their tone and format.
+               - List the available docs pages so you can link them: `ls site/src/content/docs/concepts site/src/content/docs/how-to site/src/content/docs/reference`. A page's slug is its path under `site/src/content/docs/` without the extension (e.g. `reference/menu.mdx` → `reference/menu`).
 
             2. **Gather PR context:**
                - Extract all PR numbers (e.g., `#906`) from the raw changelog body.
@@ -125,20 +126,21 @@ jobs:
                  ```
                - This gives you PR title, body, linked issues (with body), and parent epics in one API call.
                - Some PR numbers may resolve to null — skip those gracefully.
+               - Check the raw file's "Revert" section (and `git log` for the release range if needed) for features that landed and were reverted before this release. Track these so you can exclude them in step 3.
 
             3. **Rewrite the changelog body:**
-               - Replace the raw bullet list with narrative prose. Length scales with content: substantial releases get 100–300 words; small releases (a few bullets) get 1–3 honest sentences. Never pad to hit a word count.
-               - Write paragraphs only: no headings, bullet lists, or tables. Use backticks for identifiers (e.g., `deps.alwaysBundle`, `<media-gesture>`).
-               - Lead with the 1–3 most impactful changes, informed by epic/issue context. Vary the opening; do not default to "This release…".
-               - Group related PRs into cohesive stories rather than listing them individually (e.g., a feature landing across core, html, and react is one story with three links).
-               - Call out breaking changes explicitly with concrete migration guidance from the PR body (old name → new name, what to update). Do not bury them.
-               - Summarize smaller fixes briefly, grouped.
-               - Skip internal-only changes (CI, tooling, changelog maintenance) — unless the release is entirely internal, in which case describe it honestly in a sentence or two rather than leaving the body empty.
-               - Preserve PR links as inline markdown links in the prose (e.g., [#906](url)). Every change you mention keeps its PR link.
-               - Drop per-change author credits ("by @user") — the PR link carries attribution.
-               - If the raw file has a "New Contributors" section, remove it and end the prose with one sentence thanking first-time contributors by name, linking their GitHub profiles.
-               - Follow `writing-style.md` strictly.
-               - Do not fabricate — stick to what the PRs actually say.
+               - Tell a story, don't list PRs. Group related changes into cohesive narratives (a feature landing across core, html, and react is one story with three links), and lead with what player users actually touch. Framework-internal engine work (e.g. SPF) is secondary: keep it to one short section unless the release is primarily about it.
+               - Length scales with the release. Big releases earn room to breathe; small releases get a few honest sentences. Don't be prescriptive about word counts — never pad to hit a length, and never compress a substantial release into a dense wall of clauses.
+               - Structure for scanning. For substantial releases, use `##` section headings to group the story into a few themes, each with a short lede and one or two tight paragraphs. Keep headings short and in sentence case — they render uppercase. A short bulleted list is good for a scattershot or catch-all section (assorted polish, grouped fixes). Small releases can stay a sentence or two with no headings.
+               - Open with a hook. Lead with one sentence that frames the release's throughline, written like a person talking to a peer — not a restatement of the top bullets. Vary the opening; never default to "This release…".
+               - Put breaking changes in their own `## Breaking changes` section, one bullet per change, with concrete migration guidance from the PR body (old name → new name, what to update). Reference it from the body where the feature is introduced (an in-page link like `[Breaking changes](#breaking-changes)` is fine). Never bury a breaking change in prose.
+               - Link to docs, not just PRs. When a change has a matching docs page (listed in step 1), link it. Docs URLs are framework-scoped and have no framework-agnostic route, so link both frameworks as separate words: `… for [HTML](/docs/framework/html/{slug}/) and [React](/docs/framework/react/{slug}/)`, where `{slug}` is the page's path under `site/src/content/docs/` minus the extension (e.g. `concepts/cast`, `reference/menu`). Only link pages that exist — never invent one, since a feature can ship without a reference page.
+               - Use backticks for identifiers (e.g., `deps.alwaysBundle`, `<media-gesture>`).
+               - Preserve PR links as inline markdown links in the prose (e.g., [#906](url)). Every change you mention keeps its PR link. Drop per-change author credits ("by @user") — the PR link carries attribution.
+               - Omit features reverted before this release. If a PR appears alongside a revert of it (the raw file's Revert section, or a revert commit in the range), it did not ship — leave it out entirely.
+               - Summarize smaller fixes briefly, grouped. Skip internal-only changes (CI, tooling, changelog maintenance) — unless the release is entirely internal, in which case describe it honestly in a sentence or two rather than leaving the body empty.
+               - If the raw file has a "New Contributors" section, remove it and end with one sentence thanking first-time contributors by name, linking their GitHub profiles.
+               - Follow `writing-style.md` strictly. Do not fabricate — stick to what the PRs actually say.
 
             4. **Write the `description` field:**
                - One concise sentence starting with a verb, summarizing the release for SEO/RSS (e.g., "Adds a hotkey system, gestures, and the mux-audio element."). Keep it under 140 characters.

--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -89,8 +89,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model sonnet
-            --max-turns 20
-            --allowedTools "Bash(gh:*)" "Bash(git:*)" "Read" "Edit" "Write" "Glob" "Grep"
+            --max-turns 50
+            --allowedTools "Bash(gh:*)" "Bash(git:*)" "Bash(jq:*)" "Bash(cat:*)" "Bash(ls:*)" "Bash(head:*)" "Bash(tail:*)" "Bash(grep:*)" "Bash(sed:*)" "Bash(wc:*)" "Read" "Edit" "Write" "Glob" "Grep"
           prompt: |
             You are the changelog prose writer for Video.js 10.
 

--- a/.github/workflows/changelog-prose.yml
+++ b/.github/workflows/changelog-prose.yml
@@ -35,10 +35,12 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
         run: |
+          # --raw-field, not --field: tag names start with "@", which --field
+          # expands as a read-from-file reference and fails.
           gh workflow run changelog-prose.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --field tag_name="$TAG_NAME" \
-            --field release_url="$RELEASE_URL"
+            --raw-field tag_name="$TAG_NAME" \
+            --raw-field release_url="$RELEASE_URL"
 
   prose:
     if: github.event_name == 'workflow_dispatch' && startsWith(inputs.tag_name, '@videojs/core@')

--- a/site/src/content/changelog/10.0.0-beta.25.md
+++ b/site/src/content/changelog/10.0.0-beta.25.md
@@ -1,5 +1,5 @@
 ---
-description: "Adds a quality menu, settings menu, AirPlay and Vimeo support, SPF multi-CDN failover, and Google Cast on by default."
+description: "Adds a quality menu, settings menu, AirPlay and Vimeo support, Google Cast on by default, and SPF multi-CDN failover."
 date: 2026-07-07
 version: "10.0.0-beta.25"
 prerelease: true
@@ -7,16 +7,52 @@ breaking: true
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.24...@videojs/core@10.0.0-beta.25"
 ---
 
-Quality selection headlines beta.25. Core gains media tracks and renditions state ([#1664](https://github.com/videojs/v10/pull/1664)) and a quality selection model ([#1693](https://github.com/videojs/v10/pull/1693)), surfaced as a quality menu in the shipped skins ([#1694](https://github.com/videojs/v10/pull/1694)) whose Auto option shows the currently resolved rendition ([#1698](https://github.com/videojs/v10/pull/1698)). The menu system from beta.24 keeps growing: a settings menu gathers playback options in one place ([#1615](https://github.com/videojs/v10/pull/1615)), audio tracks get their own menu ([#1714](https://github.com/videojs/v10/pull/1714)), and menus pick up clearer group labels, mutation handling, and style polish ([#1643](https://github.com/videojs/v10/pull/1643), [#1739](https://github.com/videojs/v10/pull/1739), [#1725](https://github.com/videojs/v10/pull/1725)).
+Beta.24 gave us the menu machinery. Beta.25 fills it with things worth opening, and pushes the player out to the rest of the room: remote playback now spans both AirPlay and Chromecast, and Vimeo joins the list of sources you can hand it.
 
-Three changes are breaking. HLS and DASH media now include Google Cast by default ([#1661](https://github.com/videojs/v10/pull/1661)): features like Cast and Mux Data are composed as media components and configured through namespaced options such as `media.config.googleCast.receiver` and `media.config.hlsJs.capLevelToPlayerSize`, replacing the `cast-src`, `prefer-playback`, and `debug` element attributes. The hls.js-backed stack is renamed to make its engine explicit ([#1753](https://github.com/videojs/v10/pull/1753)): update `<hls-video>` to `<hlsjs-video>`, `HlsVideo` to `HlsJsVideo`, and `…/media/hls-video` import subpaths to `…/media/hlsjs-video`. And the media capability predicates (`isMediaPauseCapable` and friends) moved from `@videojs/core/dom` to `@videojs/core` ([#1705](https://github.com/videojs/v10/pull/1705)).
+## Menus grow up
 
-Remote playback rounds out beyond Cast: an AirPlay button ships in the html and react packages ([#1531](https://github.com/videojs/v10/pull/1531), [#1614](https://github.com/videojs/v10/pull/1614)), and MSE-backed streams can now hand off to AirPlay ([#1692](https://github.com/videojs/v10/pull/1692)). Vimeo joins the media lineup with a host and matching components ([#1667](https://github.com/videojs/v10/pull/1667)), and the installation flow on the site and in the CLI offers DASH, Mux, and Vimeo sources ([#1732](https://github.com/videojs/v10/pull/1732)) backed by a CDN media-availability manifest ([#1737](https://github.com/videojs/v10/pull/1737)).
+The headline is a quality menu ([#1694](https://github.com/videojs/v10/pull/1694)). Getting there took real plumbing: core now tracks media tracks and renditions ([#1664](https://github.com/videojs/v10/pull/1664)) and models quality selection on top of them ([#1693](https://github.com/videojs/v10/pull/1693)). The skins surface all of that as a menu whose Auto option tells you the rendition actually playing, not just the word "Auto" ([#1698](https://github.com/videojs/v10/pull/1698)).
 
-SPF, the stream processing framework behind the in-house engine, has a busy release: multi-CDN support with automatic failover ([#1668](https://github.com/videojs/v10/pull/1668), [#1671](https://github.com/videojs/v10/pull/1671)), capability probing ([#1676](https://github.com/videojs/v10/pull/1676)), text track switching ([#1687](https://github.com/videojs/v10/pull/1687)), multi-track audio ([#1605](https://github.com/videojs/v10/pull/1605)), an audio-only engine composition ([#1584](https://github.com/videojs/v10/pull/1584)), and phase one of background video with a `maxResolution` cap ([#1602](https://github.com/videojs/v10/pull/1602), [#1654](https://github.com/videojs/v10/pull/1654)).
+Quality isn't the only new menu. A settings menu gathers playback options in one place ([#1615](https://github.com/videojs/v10/pull/1615)), and audio tracks get a menu of their own ([#1714](https://github.com/videojs/v10/pull/1714)). The menu system itself grew up alongside them, with clearer group labels, handling for items that come and go at runtime, and a pass of style polish ([#1643](https://github.com/videojs/v10/pull/1643), [#1739](https://github.com/videojs/v10/pull/1739), [#1725](https://github.com/videojs/v10/pull/1725)).
 
-Player polish continues: scrubber previews show timestamps ([#1652](https://github.com/videojs/v10/pull/1652)), the time display toggles between elapsed and remaining ([#1669](https://github.com/videojs/v10/pull/1669)), the time slider supports `pauseOnDrag` ([#1596](https://github.com/videojs/v10/pull/1596)), fullscreen can lock orientation ([#1656](https://github.com/videojs/v10/pull/1656)), popovers respect a positioning boundary ([#1627](https://github.com/videojs/v10/pull/1627)), tooltips pair labels with shortcut hints ([#1494](https://github.com/videojs/v10/pull/1494)), and posters support a blur-up placeholder ([#1632](https://github.com/videojs/v10/pull/1632)).
+See the menu reference for [HTML](/docs/framework/html/reference/menu/) and [React](/docs/framework/react/reference/menu/), or the quality feature for [HTML](/docs/framework/html/reference/feature-quality/) and [React](/docs/framework/react/reference/feature-quality/).
 
-Among the fixes: `serializeAttributes` escapes HTML special characters, closing an XSS vector ([#1670](https://github.com/videojs/v10/pull/1670)); mobile controls no longer flash on the first tap after auto-hide ([#1556](https://github.com/videojs/v10/pull/1556)); React recovers from destroyed stores under `<Activity>` ([#1587](https://github.com/videojs/v10/pull/1587)) and memoizes the Provider context value ([#1787](https://github.com/videojs/v10/pull/1787)); and dash.js is upgraded to 5.2.0 ([#1724](https://github.com/videojs/v10/pull/1724)). The docs site adds this changelog section ([#1793](https://github.com/videojs/v10/pull/1793)), API reference pages for the media elements ([#1342](https://github.com/videojs/v10/pull/1342)), a menu reference ([#1673](https://github.com/videojs/v10/pull/1673)), and guides for Google Cast and self-hosted builds ([#1681](https://github.com/videojs/v10/pull/1681), [#1680](https://github.com/videojs/v10/pull/1680)).
+## AirPlay and Chromecast
+
+Remote playback grew in both directions. There's now an AirPlay button in the html and react packages ([#1531](https://github.com/videojs/v10/pull/1531), [#1614](https://github.com/videojs/v10/pull/1614)), and MSE-backed streams can hand off to AirPlay too ([#1692](https://github.com/videojs/v10/pull/1692)). On the Chromecast side, HLS and DASH media now ship with Google Cast on by default ([#1661](https://github.com/videojs/v10/pull/1661)), so the cast button works with no extra setup. That last one changes how you configure media; see [Breaking changes](#breaking-changes) below.
+
+Read the AirPlay button reference for [HTML](/docs/framework/html/reference/airplay-button/) and [React](/docs/framework/react/reference/airplay-button/), and the Google Cast guide for [HTML](/docs/framework/html/concepts/cast/) and [React](/docs/framework/react/concepts/cast/).
+
+## Vimeo joins the lineup
+
+You can now point the player at a Vimeo video. Beta.25 adds a Vimeo media host with matching html and react components ([#1667](https://github.com/videojs/v10/pull/1667)). Vimeo also shows up as a source option in the installation flow, both on the site and in the CLI, alongside DASH and Mux ([#1732](https://github.com/videojs/v10/pull/1732)), backed by a manifest that tracks which media each CDN actually has ([#1737](https://github.com/videojs/v10/pull/1737)).
+
+Pick a source and try it from the installation guide for [HTML](/docs/framework/html/how-to/installation/) and [React](/docs/framework/react/how-to/installation/).
+
+## Polish
+
+A lot of small things got better:
+
+- Scrubber previews show a timestamp as you drag ([#1652](https://github.com/videojs/v10/pull/1652)).
+- The time display toggles between elapsed and remaining on click ([#1669](https://github.com/videojs/v10/pull/1669)).
+- The time slider can pause on drag and resume on release ([#1596](https://github.com/videojs/v10/pull/1596)).
+- Fullscreen can lock orientation on mobile ([#1656](https://github.com/videojs/v10/pull/1656)).
+- Popovers stay inside a positioning boundary instead of spilling offscreen ([#1627](https://github.com/videojs/v10/pull/1627)).
+- Tooltips pair a label with its keyboard shortcut ([#1494](https://github.com/videojs/v10/pull/1494)).
+- Posters support a blur-up placeholder ([#1632](https://github.com/videojs/v10/pull/1632)).
+
+On the fix side, `serializeAttributes` now escapes HTML special characters, closing an XSS hole ([#1670](https://github.com/videojs/v10/pull/1670)); mobile controls no longer flash on the first tap after auto-hiding ([#1556](https://github.com/videojs/v10/pull/1556)); React recovers cleanly when a store is destroyed under `<Activity>` ([#1587](https://github.com/videojs/v10/pull/1587)) and memoizes the provider context value ([#1787](https://github.com/videojs/v10/pull/1787)); and dash.js is up to 5.2.0 ([#1724](https://github.com/videojs/v10/pull/1724)).
+
+## Under the hood: SPF
+
+The stream processing framework behind our in-house engine had a busy release too: multi-CDN support with automatic failover ([#1668](https://github.com/videojs/v10/pull/1668), [#1671](https://github.com/videojs/v10/pull/1671)), capability probing ([#1676](https://github.com/videojs/v10/pull/1676)), text track and multi-track audio switching ([#1687](https://github.com/videojs/v10/pull/1687), [#1605](https://github.com/videojs/v10/pull/1605)), an audio-only engine composition ([#1584](https://github.com/videojs/v10/pull/1584)), and the first phase of background video with a `maxResolution` cap ([#1602](https://github.com/videojs/v10/pull/1602), [#1654](https://github.com/videojs/v10/pull/1654)).
+
+## Breaking changes
+
+Three changes need attention when you upgrade:
+
+- **Google Cast is on by default** ([#1661](https://github.com/videojs/v10/pull/1661)). HLS and DASH media now compose features like Cast and Mux Data as media components, configured through namespaced options such as `media.config.googleCast.receiver` and `media.config.hlsJs.capLevelToPlayerSize`. These replace the `cast-src`, `prefer-playback`, and `debug` element attributes.
+- **The hls.js stack is renamed to make its engine explicit** ([#1753](https://github.com/videojs/v10/pull/1753)). Update `<hls-video>` to `<hlsjs-video>`, `HlsVideo` to `HlsJsVideo`, and any `…/media/hls-video` import subpaths to `…/media/hlsjs-video`.
+- **Media capability predicates moved to core** ([#1705](https://github.com/videojs/v10/pull/1705)). `isMediaPauseCapable` and friends now live in `@videojs/core` instead of `@videojs/core/dom`.
 
 Thanks to [@Jerricho93](https://github.com/Jerricho93) for their first contribution to Video.js.

--- a/site/src/content/changelog/10.0.0-beta.25.md
+++ b/site/src/content/changelog/10.0.0-beta.25.md
@@ -1,5 +1,5 @@
 ---
-description: ""
+description: "Adds a quality menu, settings menu, AirPlay and Vimeo support, SPF multi-CDN failover, and Google Cast on by default."
 date: 2026-07-07
 version: "10.0.0-beta.25"
 prerelease: true
@@ -7,111 +7,16 @@ breaking: true
 compareUrl: "https://github.com/videojs/v10/compare/@videojs/core@10.0.0-beta.24...@videojs/core@10.0.0-beta.25"
 ---
 
+Quality selection headlines beta.25. Core gains media tracks and renditions state ([#1664](https://github.com/videojs/v10/pull/1664)) and a quality selection model ([#1693](https://github.com/videojs/v10/pull/1693)), surfaced as a quality menu in the shipped skins ([#1694](https://github.com/videojs/v10/pull/1694)) whose Auto option shows the currently resolved rendition ([#1698](https://github.com/videojs/v10/pull/1698)). The menu system from beta.24 keeps growing: a settings menu gathers playback options in one place ([#1615](https://github.com/videojs/v10/pull/1615)), audio tracks get their own menu ([#1714](https://github.com/videojs/v10/pull/1714)), and menus pick up clearer group labels, mutation handling, and style polish ([#1643](https://github.com/videojs/v10/pull/1643), [#1739](https://github.com/videojs/v10/pull/1739), [#1725](https://github.com/videojs/v10/pull/1725)).
 
-### 🚀 Features
-- *(packages)* Airplay button ([#1531](https://github.com/videojs/v10/pull/1531)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(spf)* Basic audio only use case + use-case-composition doc-type + implementation skills ([#1584](https://github.com/videojs/v10/pull/1584)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(packages)* Constrain popovers to positioning boundary ([#1627](https://github.com/videojs/v10/pull/1627)) by [@sampotts](https://github.com/sampotts)
-- *(spf)* Background looping video (phase 1) ([#1602](https://github.com/videojs/v10/pull/1602)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(packages)* Update menu group labels ([#1643](https://github.com/videojs/v10/pull/1643)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Show scrubber preview timestamps ([#1652](https://github.com/videojs/v10/pull/1652)) by [@sampotts](https://github.com/sampotts)
-- *(spf)* Multi-track audio + skills building features and behaviors ([#1605](https://github.com/videojs/v10/pull/1605)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(core)* Lock fullscreen orientation ([#1656](https://github.com/videojs/v10/pull/1656)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Add settings menu ([#1615](https://github.com/videojs/v10/pull/1615)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add pre-release docs banner on main.videojs.org ([#1575](https://github.com/videojs/v10/pull/1575)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(spf)* Multi-cdn support ([#1668](https://github.com/videojs/v10/pull/1668)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(site)* List required css imports per skin in preset reference ([#1521](https://github.com/videojs/v10/pull/1521)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(media)* [**breaking**] Add Google Cast by default to HLS, DASH media ([#1661](https://github.com/videojs/v10/pull/1661)) by [@luwes](https://github.com/luwes)
-- *(core)* Add media tracks and renditions support ([#1664](https://github.com/videojs/v10/pull/1664)) by [@luwes](https://github.com/luwes)
-- *(spf)* Add maxResolution to SPF Background Video ([#1654](https://github.com/videojs/v10/pull/1654)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(spf)* Multi cdn failover ([#1671](https://github.com/videojs/v10/pull/1671)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(spf)* Capability probing ([#1676](https://github.com/videojs/v10/pull/1676)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(core)* Add quality selection state ([#1693](https://github.com/videojs/v10/pull/1693)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Add quality menu UI ([#1694](https://github.com/videojs/v10/pull/1694)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Add resolved rendition to auto label ([#1698](https://github.com/videojs/v10/pull/1698)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Compound tooltips with label and shortcut parts ([#1494](https://github.com/videojs/v10/pull/1494)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Add vimeo media host and html/react components ([#1667](https://github.com/videojs/v10/pull/1667)) by [@luwes](https://github.com/luwes)
-- *(packages)* Add poster placeholder blur-up pattern ([#1632](https://github.com/videojs/v10/pull/1632)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(core)* Add i18n foundation with English locale and UI wiring ([#1589](https://github.com/videojs/v10/pull/1589)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Add built-in locale packs and lazy loadLocale ([#1590](https://github.com/videojs/v10/pull/1590)) by [@sampotts](https://github.com/sampotts)
-- *(site)* API reference pages for media elements ([#1342](https://github.com/videojs/v10/pull/1342)) by [@decepulis](https://github.com/decepulis)
-- *(spf)* Text tracks switching ([#1687](https://github.com/videojs/v10/pull/1687)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- Add a CDN media-availability manifest and read it across install surfaces ([#1737](https://github.com/videojs/v10/pull/1737)) by [@decepulis](https://github.com/decepulis)
-- Add DASH, Mux, and Vimeo as installation source types (UI + CLI) ([#1732](https://github.com/videojs/v10/pull/1732)) by [@decepulis](https://github.com/decepulis)
-- *(packages)* Add audio tracks menu ([#1714](https://github.com/videojs/v10/pull/1714)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Support AirPlay on MSE ([#1692](https://github.com/videojs/v10/pull/1692)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(packages)* Add pauseOnDrag to time slider ([#1596](https://github.com/videojs/v10/pull/1596)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(packages)* Add time display toggle ([#1669](https://github.com/videojs/v10/pull/1669)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Add changelog section ([#1793](https://github.com/videojs/v10/pull/1793)) by [@decepulis](https://github.com/decepulis)
+Three changes are breaking. HLS and DASH media now include Google Cast by default ([#1661](https://github.com/videojs/v10/pull/1661)): features like Cast and Mux Data are composed as media components and configured through namespaced options such as `media.config.googleCast.receiver` and `media.config.hlsJs.capLevelToPlayerSize`, replacing the `cast-src`, `prefer-playback`, and `debug` element attributes. The hls.js-backed stack is renamed to make its engine explicit ([#1753](https://github.com/videojs/v10/pull/1753)): update `<hls-video>` to `<hlsjs-video>`, `HlsVideo` to `HlsJsVideo`, and `…/media/hls-video` import subpaths to `…/media/hlsjs-video`. And the media capability predicates (`isMediaPauseCapable` and friends) moved from `@videojs/core/dom` to `@videojs/core` ([#1705](https://github.com/videojs/v10/pull/1705)).
 
-### 🐛 Bug Fixes
-- *(skin)* Minor design tweaks ([#1597](https://github.com/videojs/v10/pull/1597)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Disable toggle captions when there are no captions ([#1598](https://github.com/videojs/v10/pull/1598)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Cache shiki highlighters during dev HMR ([#1619](https://github.com/videojs/v10/pull/1619)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Prevent initial pause icon flash ([#1622](https://github.com/videojs/v10/pull/1622)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Restore overflow on audio skins ([#1623](https://github.com/videojs/v10/pull/1623)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Scope menu data attributes ([#1628](https://github.com/videojs/v10/pull/1628)) by [@sampotts](https://github.com/sampotts)
-- *(spf)* Add emptied listener to track-current-time behavior ([#1634](https://github.com/videojs/v10/pull/1634)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(core)* Focus selected radio menu items ([#1645](https://github.com/videojs/v10/pull/1645)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Update trigger aria-expanded on close ([#1644](https://github.com/videojs/v10/pull/1644)) by [@sampotts](https://github.com/sampotts)
-- *(test)* Update slider thumbnail selector ([#1653](https://github.com/videojs/v10/pull/1653)) by [@sampotts](https://github.com/sampotts)
-- *(spf)* Refactor track switching to rules ([#1658](https://github.com/videojs/v10/pull/1658)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(packages)* Fix ejected skin slider setup ([#1660](https://github.com/videojs/v10/pull/1660)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Prevent mobile controls flash on first tap after auto-hide ([#1556](https://github.com/videojs/v10/pull/1556)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(test)* Update e2e menu selectors ([#1674](https://github.com/videojs/v10/pull/1674)) by [@sampotts](https://github.com/sampotts)
-- *(docs)* Replace <Controls /> with <Controls.Root> in code samples ([#1492](https://github.com/videojs/v10/pull/1492)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(react)* Address stale media reference ([#1677](https://github.com/videojs/v10/pull/1677)) by [@sampotts](https://github.com/sampotts)
-- *(test)* Stabilize e2e tests ([#1678](https://github.com/videojs/v10/pull/1678)) by [@sampotts](https://github.com/sampotts)
-- *(core)* Remove 1-9 digit key seek from slider keyboard handler ([#1690](https://github.com/videojs/v10/pull/1690)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(site)* Update use-media reference for mediahost architecture ([#1702](https://github.com/videojs/v10/pull/1702)) by [@luwes](https://github.com/luwes)
-- *(packages)* Escape HTML special chars in serializeAttributes to prevent XSS ([#1670](https://github.com/videojs/v10/pull/1670)) by [@Jerricho93](https://github.com/Jerricho93)
-- *(ci)* Report lazy bundle chunks separately ([#1710](https://github.com/videojs/v10/pull/1710)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Add missing classnames to tailwind menus ([#1712](https://github.com/videojs/v10/pull/1712)) by [@sampotts](https://github.com/sampotts)
-- *(ci)* Run bundle size on stacked prs ([#1713](https://github.com/videojs/v10/pull/1713)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Pre-bundle react-dom so dev islands hydrate ([#1711](https://github.com/videojs/v10/pull/1711)) by [@decepulis](https://github.com/decepulis)
-- *(core)* Upgrade dash.js to 5.2.0 ([#1724](https://github.com/videojs/v10/pull/1724)) by [@luwes](https://github.com/luwes)
-- *(site)* Resolve api reference slug mismatch on airplay and hlsjs pages ([#1755](https://github.com/videojs/v10/pull/1755)) by [@luwes](https://github.com/luwes)
-- *(skin)* Aspect ratio related fixes ([#1726](https://github.com/videojs/v10/pull/1726)) by [@sampotts](https://github.com/sampotts)
-- *(packages)* Handle menu child mutations ([#1739](https://github.com/videojs/v10/pull/1739)) by [@sampotts](https://github.com/sampotts)
-- *(skin)* Improvements to menu styles ([#1725](https://github.com/videojs/v10/pull/1725)) by [@sampotts](https://github.com/sampotts)
-- *(react)* Recover from StoreError: DESTROYED on React <Activity> hide/reveal ([#1587](https://github.com/videojs/v10/pull/1587)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(site)* Install musl resvg binary so Netlify can bundle the OG function ([#1759](https://github.com/videojs/v10/pull/1759)) by [@decepulis](https://github.com/decepulis)
-- *(skin)* Improve buffering, overlays, and input feedback ([#1547](https://github.com/videojs/v10/pull/1547)) by [@sampotts](https://github.com/sampotts)
-- *(test)* Update duration selectors for time inversion feature ([#1760](https://github.com/videojs/v10/pull/1760)) by [@sampotts](https://github.com/sampotts)
-- *(react)* Memoize Provider context value ([#1787](https://github.com/videojs/v10/pull/1787)) by [@mihar-22](https://github.com/mihar-22)
-- *(html)* Avoid menu item value render loop ([#1791](https://github.com/videojs/v10/pull/1791)) by [@sampotts](https://github.com/sampotts)
-- *(site)* Skip docs links for features without reference pages ([#1394](https://github.com/videojs/v10/pull/1394)) by [@decepulis](https://github.com/decepulis)
-- *(ci)* Relay release event through workflow_dispatch for changelog prose ([#1792](https://github.com/videojs/v10/pull/1792)) by [@decepulis](https://github.com/decepulis)
+Remote playback rounds out beyond Cast: an AirPlay button ships in the html and react packages ([#1531](https://github.com/videojs/v10/pull/1531), [#1614](https://github.com/videojs/v10/pull/1614)), and MSE-backed streams can now hand off to AirPlay ([#1692](https://github.com/videojs/v10/pull/1692)). Vimeo joins the media lineup with a host and matching components ([#1667](https://github.com/videojs/v10/pull/1667)), and the installation flow on the site and in the CLI offers DASH, Mux, and Vimeo sources ([#1732](https://github.com/videojs/v10/pull/1732)) backed by a CDN media-availability manifest ([#1737](https://github.com/videojs/v10/pull/1737)).
 
-### 🚜 Refactor
-- *(core)* Airplay button ([#1614](https://github.com/videojs/v10/pull/1614)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(core)* Rework media config as a plain getter/setter ([#1697](https://github.com/videojs/v10/pull/1697)) by [@luwes](https://github.com/luwes)
-- *(core)* [**breaking**] Move media capability predicates to core layer ([#1705](https://github.com/videojs/v10/pull/1705)) by [@luwes](https://github.com/luwes)
-- Rename SPF background-looping-video into background-video ([#1731](https://github.com/videojs/v10/pull/1731)) by [@spuppo-mux](https://github.com/spuppo-mux)
-- *(packages)* [**breaking**] Rename hls media stack to hlsjs naming ([#1753](https://github.com/videojs/v10/pull/1753)) by [@luwes](https://github.com/luwes)
+SPF, the stream processing framework behind the in-house engine, has a busy release: multi-CDN support with automatic failover ([#1668](https://github.com/videojs/v10/pull/1668), [#1671](https://github.com/videojs/v10/pull/1671)), capability probing ([#1676](https://github.com/videojs/v10/pull/1676)), text track switching ([#1687](https://github.com/videojs/v10/pull/1687)), multi-track audio ([#1605](https://github.com/videojs/v10/pull/1605)), an audio-only engine composition ([#1584](https://github.com/videojs/v10/pull/1584)), and phase one of background video with a `maxResolution` cap ([#1602](https://github.com/videojs/v10/pull/1602), [#1654](https://github.com/videojs/v10/pull/1654)).
 
-### 📚 Documentation
-- *(spf)* Seed feature registry, clusters reference, and document-feature skill ([#1581](https://github.com/videojs/v10/pull/1581)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(spf)* Track switching design ([#1631](https://github.com/videojs/v10/pull/1631)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(site)* Add "No Skin" option to installation skin picker ([#1525](https://github.com/videojs/v10/pull/1525)) by [@ronald-urbina](https://github.com/ronald-urbina)
-- *(react)* Clarify usePlayer typed vs untyped store access ([#1663](https://github.com/videojs/v10/pull/1663)) by [@Jerricho93](https://github.com/Jerricho93)
-- *(site)* Document self-hosted and offline player builds ([#1680](https://github.com/videojs/v10/pull/1680)) by [@R-Delfino95](https://github.com/R-Delfino95)
-- *(site)* Add Google Cast documentation ([#1681](https://github.com/videojs/v10/pull/1681)) by [@Jerricho93](https://github.com/Jerricho93)
-- *(site)* Backfill and prose-ify beta changelogs ([#1794](https://github.com/videojs/v10/pull/1794)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Add menu reference ([#1673](https://github.com/videojs/v10/pull/1673)) by [@sampotts](https://github.com/sampotts)
+Player polish continues: scrubber previews show timestamps ([#1652](https://github.com/videojs/v10/pull/1652)), the time display toggles between elapsed and remaining ([#1669](https://github.com/videojs/v10/pull/1669)), the time slider supports `pauseOnDrag` ([#1596](https://github.com/videojs/v10/pull/1596)), fullscreen can lock orientation ([#1656](https://github.com/videojs/v10/pull/1656)), popovers respect a positioning boundary ([#1627](https://github.com/videojs/v10/pull/1627)), tooltips pair labels with shortcut hints ([#1494](https://github.com/videojs/v10/pull/1494)), and posters support a blur-up placeholder ([#1632](https://github.com/videojs/v10/pull/1632)).
 
-### ⚡ Performance
-- *(site)* Migrate markdown pipeline to Sätteri ([#1733](https://github.com/videojs/v10/pull/1733)) by [@decepulis](https://github.com/decepulis)
+Among the fixes: `serializeAttributes` escapes HTML special characters, closing an XSS vector ([#1670](https://github.com/videojs/v10/pull/1670)); mobile controls no longer flash on the first tap after auto-hide ([#1556](https://github.com/videojs/v10/pull/1556)); React recovers from destroyed stores under `<Activity>` ([#1587](https://github.com/videojs/v10/pull/1587)) and memoizes the Provider context value ([#1787](https://github.com/videojs/v10/pull/1787)); and dash.js is upgraded to 5.2.0 ([#1724](https://github.com/videojs/v10/pull/1724)). The docs site adds this changelog section ([#1793](https://github.com/videojs/v10/pull/1793)), API reference pages for the media elements ([#1342](https://github.com/videojs/v10/pull/1342)), a menu reference ([#1673](https://github.com/videojs/v10/pull/1673)), and guides for Google Cast and self-hosted builds ([#1681](https://github.com/videojs/v10/pull/1681), [#1680](https://github.com/videojs/v10/pull/1680)).
 
-### ⚙️ Miscellaneous Tasks
-- *(build)* Quiet tsdown size reports in local dev ([#1569](https://github.com/videojs/v10/pull/1569)) by [@sampotts](https://github.com/sampotts)
-- Add playwright MCP server to project config ([#1625](https://github.com/videojs/v10/pull/1625)) by [@cjpillsbury](https://github.com/cjpillsbury)
-- *(root)* Rename agents alias to .agents ([#1649](https://github.com/videojs/v10/pull/1649)) by [@luwes](https://github.com/luwes)
-- *(ci)* Drop edited trigger from issue triage ([#1700](https://github.com/videojs/v10/pull/1700)) by [@decepulis](https://github.com/decepulis)
-- *(site)* Upgrade to Astro 7 and consolidate on Vite 8 ([#1721](https://github.com/videojs/v10/pull/1721)) by [@decepulis](https://github.com/decepulis)
-
-### ◀️ Revert
-- *(core)* Unmerge i18n stack base ([#1707](https://github.com/videojs/v10/pull/1707)) by [@sampotts](https://github.com/sampotts)
-
-### New Contributors
-* @Jerricho93 made their first contribution in [#1670](https://github.com/videojs/v10/pull/1670)
+Thanks to [@Jerricho93](https://github.com/Jerricho93) for their first contribution to Video.js.


### PR DESCRIPTION
## Summary

The prose-ified changelog for `@videojs/core@10.0.0-beta.25` never got published today. Two independent bugs in `.github/workflows/changelog-prose.yml` were responsible; this PR fixes both and includes the beta.25 prose itself.

**Bug 1 — the release relay never fired.** The `dispatch` job (added in #1792) runs `gh workflow run --field tag_name="$TAG_NAME"`, but release tags start with `@` (`@videojs/core@10.0.0-beta.25`), which `--field` interprets as a read-from-file reference:

```
error parsing "tag_name" value: open videojs/core@10.0.0-beta.25: no such file or directory
```

Fixed by switching to `--raw-field`, which passes the value literally.

**Bug 2 — the prose job can't finish even when dispatched.** A manual `workflow_dispatch` for beta.25 (run [28894382161](https://github.com/videojs/v10/actions/runs/28894382161)) failed with `error_max_turns`: 11 of its 20 turns were permission denials, because piped commands like `gh api graphql | jq` don't match the `gh`/`git`-only Bash allowlist. Fixed by allowing common read-only text utilities (`jq`, `cat`, `head`, `grep`, `sed`, …) and raising `--max-turns` to 50.

**Beta.25 prose.** Since the pipeline couldn't produce it, this PR also adds the prose for `site/src/content/changelog/10.0.0-beta.25.md`, written per the workflow prompt and `writing-style.md`: leads with quality selection, calls out the three breaking changes (#1661, #1753, #1705) with migration guidance, and skips internal-only and net-reverted changes (the i18n stack, #1707).

## Changes

- `.github/workflows/changelog-prose.yml`: `--field` → `--raw-field` in the dispatch relay; widen `--allowedTools` and raise `--max-turns` for the prose job.
- `site/src/content/changelog/10.0.0-beta.25.md`: replace raw git-cliff bullets with narrative prose and fill in the frontmatter `description`.

## Testing

- Reproduced the relay failure from the beta.23–25 run logs; verified `--raw-field` is the documented `gh` flag for literal string inputs.
- Verified the entry renders correctly on the Netlify deploy preview: [changelog/10.0.0-beta.25](https://deploy-preview-1810--vjs10-site.netlify.app/changelog/10.0.0-beta.25).

Release: https://github.com/videojs/v10/releases/tag/%40videojs%2Fcore%4010.0.0-beta.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018H1XZpVx3z9n6rCWyxGbeN

---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions dispatch inputs, automation settings, and site changelog content—no player runtime or auth paths.
>
> **Overview**
> **CI:** The release relay in `changelog-prose.yml` now passes `tag_name` and `release_url` with `gh workflow run --raw-field` instead of `--field`, with a comment explaining that `@`-prefixed tags were being misread as file paths.
>
> **Prose automation:** The Claude Code step raises `--max-turns` to 50 and widens `allowedTools` (extra Bash utilities) so the agent can gather PR context and rewrite changelogs more reliably.
>
> **Docs:** `site/src/content/changelog/10.0.0-beta.25.md` drops the long categorized bullet list in favor of narrative paragraphs (quality/settings menus, breaking Cast/hlsjs/capability moves, AirPlay/Vimeo/SPF, fixes/docs), sets frontmatter `description`, and ends with a first-time contributor thank-you.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d34884b8cc2bee54be4dcb5b92007a847663189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Touches GitHub Actions inputs, automation config, and changelog markdown only—no player runtime, auth, or data paths.
> 
> **Overview**
> **CI:** The release relay in `changelog-prose.yml` now passes `tag_name` and `release_url` with `gh workflow run --raw-field` instead of `--field`, so `@videojs/core@…` tags are not treated as file paths.
> 
> **Prose automation:** The Claude step switches to **opus**, raises `--max-turns` to **50**, and widens Bash `allowedTools` (e.g. `jq`, `grep`, `sed`) so PR context gathering can finish. The rewrite prompt is expanded: themed `##` sections, doc links for HTML/React, a dedicated **Breaking changes** block, and rules to drop reverted work (e.g. i18n).
> 
> **Site:** `site/src/content/changelog/10.0.0-beta.25.md` replaces the raw git-cliff bullets with narrative prose (menus/quality, Cast/AirPlay/Vimeo, polish, SPF), fills frontmatter `description`, and documents the three breaking migrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f2bd813b0a73acb4008c8982ed5570c322a496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->