### PR TITLE
feat(spf): expose audio tracks & renditions on the SPF media adapter

### DIFF
--- a/packages/core/src/dom/media/simple-hls/index.ts
+++ b/packages/core/src/dom/media/simple-hls/index.ts
@@ -1,4 +1,8 @@
 import { SimpleHlsMediaMixin } from '@videojs/spf/hls';
+import { MediaTracksMixin } from '../../../core/media/media-tracks';
 import { HTMLVideoElementHost } from '../video-host';
+import { SimpleHlsMediaMediaTracksMixin } from './media-tracks';
 
-export class SimpleHlsMedia extends SimpleHlsMediaMixin(HTMLVideoElementHost) {}
+export class SimpleHlsMedia extends SimpleHlsMediaMediaTracksMixin(
+  MediaTracksMixin(SimpleHlsMediaMixin(HTMLVideoElementHost))
+) {}

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -1,9 +1,10 @@
 import { effect, untrack } from '@videojs/spf';
-import type { SimpleHlsMediaAPI } from '@videojs/spf/hls';
+import type { SimpleHlsEngineState, SimpleHlsMediaAPI } from '@videojs/spf/hls';
 import type { Constructor } from '@videojs/utils/types';
 import type { MediaVideoRenditionCapability, MediaVideoTrackCapability } from '../../../core/media/types';
 
 type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+type VideoRenditionInfo = NonNullable<SimpleHlsEngineState['videoRenditions']>[number];
 
 /**
  * Host surface the projection reads from: the SPF adapter (engine + src) plus
@@ -16,24 +17,6 @@ type MediaTracksHost = {
   destroy(): void;
 } & MediaVideoTrackCapability &
   MediaVideoRenditionCapability;
-
-/** A video rendition as parsed onto the engine's presentation (each SPF video track is one quality level). */
-type SpfVideoTrack = Extract<
-  NonNullable<NonNullable<ReturnType<SimpleHlsEngine['state']['presentation']['get']>>['selectionSets']>[number],
-  { type: 'video' }
->['switchingSets'][number]['tracks'][number];
-
-function videoTracksOf(engine: SimpleHlsEngine): SpfVideoTrack[] {
-  const presentation = engine.state.presentation.get();
-  const videoSet = presentation?.selectionSets?.find((set) => set.type === 'video');
-  return videoSet?.switchingSets[0]?.tracks ?? [];
-}
-
-function toFrameRate(frameRate: SpfVideoTrack['frameRate']): number | undefined {
-  if (!frameRate) return undefined;
-  const { frameRateNumerator, frameRateDenominator } = frameRate;
-  return frameRateDenominator ? frameRateNumerator / frameRateDenominator : frameRateNumerator;
-}
 
 /**
  * Projects the SPF engine's video renditions onto the media element's
@@ -52,8 +35,6 @@ function toFrameRate(frameRate: SpfVideoTrack['frameRate']): number | undefined 
 export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class SimpleHlsMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
     #disconnect: AbortController | null = null;
-    /** Ids of the renditions currently projected, in order — used to skip rebuilds on segment resolution. */
-    #renditionSignature = '';
 
     constructor(...args: any[]) {
       super(...args);
@@ -92,46 +73,35 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
       this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
 
       const disposeEffects = [
-        // Track `presentation` only; active-rendition reflection reads
-        // `selectedVideoTrackId` untracked so a resolve doesn't re-rebuild.
-        effect(() => this.#projectRenditions(engine, videoTracksOf(engine))),
+        // The engine dedups `videoRenditions` (emits a new array only when the
+        // rendition set changes), so this rebuilds only on real changes. Active
+        // reflection reads `selectedVideoTrackId` in its own effect.
+        effect(() => this.#projectRenditions(engine, engine.state.videoRenditions.get() ?? [])),
         effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
       ];
 
-      signal.addEventListener(
-        'abort',
-        () => {
-          for (const dispose of disposeEffects) dispose();
-        },
-        { once: true }
-      );
+      disposeEffects.forEach((dispose) => {
+        signal.addEventListener('abort', dispose, { once: true });
+      });
     }
 
-    #getSignaturesFor(tracks: SpfVideoTrack[]) {
-      return tracks.map((track) => track.id).join('|');
-    }
-
-    #projectRenditions(engine: SimpleHlsEngine, tracks: SpfVideoTrack[]): void {
-      const signature = this.#getSignaturesFor(tracks);
-      if (signature === this.#renditionSignature) return;
-      this.#renditionSignature = signature;
-
+    #projectRenditions(engine: SimpleHlsEngine, renditions: VideoRenditionInfo[]): void {
       this.#removeVideoTracks();
-      if (!tracks.length) return;
+      if (!renditions.length) return;
 
       const videoTrack = this.addVideoTrack('main');
       videoTrack.selected = true;
 
-      for (const track of tracks) {
+      for (const info of renditions) {
         const rendition = videoTrack.addRendition(
-          track.url,
-          track.width,
-          track.height,
-          track.codecs?.join(','),
-          track.bandwidth,
-          toFrameRate(track.frameRate)
+          info.url,
+          info.width,
+          info.height,
+          info.codecs?.join(','),
+          info.bandwidth,
+          toFrameRate(info.frameRate)
         );
-        rendition.id = track.id;
+        rendition.id = info.id;
       }
 
       this.#reflectActiveRendition(untrack(() => engine.state.selectedVideoTrackId.get()));
@@ -166,4 +136,11 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
   }
 
   return SimpleHlsMediaMediaTracks as unknown as Base;
+}
+
+/** Reduce the model's `FrameRate` (num/den) to the single number a DOM `VideoRendition` expects. */
+function toFrameRate(frameRate: VideoRenditionInfo['frameRate']): number | undefined {
+  if (!frameRate) return undefined;
+  const { frameRateNumerator, frameRateDenominator } = frameRate;
+  return frameRateDenominator ? frameRateNumerator / frameRateDenominator : frameRateNumerator;
 }

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -65,19 +65,19 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
 
     #connect(): void {
       this.#disconnect?.abort();
-      const controller = new AbortController();
-      this.#disconnect = controller;
-      const { signal } = controller;
+      this.#disconnect = new AbortController();
+      const { signal } = this.#disconnect;
       const { engine } = this;
 
       this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
 
       const disposeEffects = [
-        // The engine dedups `videoRenditions` (emits a new array only when the
+        // The engine dedupes `videoRenditions` (emits a new array only when the
         // rendition set changes), so this rebuilds only on real changes. Active
         // reflection reads `selectedVideoTrackId` in its own effect.
         effect(() => this.#projectRenditions(engine, engine.state.videoRenditions.get() ?? [])),
         effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
+        effect(() => this.#reflectSelectedRendition(engine.state.userVideoTrackSelection.get()?.id)),
       ];
 
       disposeEffects.forEach((dispose) => {
@@ -105,11 +105,18 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
       }
 
       this.#reflectActiveRendition(untrack(() => engine.state.selectedVideoTrackId.get()));
+      this.#reflectSelectedRendition(untrack(() => engine.state.userVideoTrackSelection.get()?.id));
     }
 
     #reflectActiveRendition(activeId: string | undefined): void {
       for (const rendition of this.videoRenditions) {
         rendition.active = rendition.id === activeId;
+      }
+    }
+
+    #reflectSelectedRendition(selectedId: string | undefined): void {
+      for (const rendition of this.videoRenditions) {
+        rendition.selected = !!selectedId && rendition.id === selectedId;
       }
     }
 

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -1,0 +1,169 @@
+import { effect, untrack } from '@videojs/spf';
+import type { SimpleHlsMediaAPI } from '@videojs/spf/hls';
+import type { Constructor } from '@videojs/utils/types';
+import type { MediaVideoRenditionCapability, MediaVideoTrackCapability } from '../../../core/media/types';
+
+type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+
+/**
+ * Host surface the projection reads from: the SPF adapter (engine + src) plus
+ * the media-tracks list infrastructure applied earlier in the mixin chain.
+ */
+type MediaTracksHost = {
+  readonly engine: SimpleHlsEngine;
+  get src(): string;
+  set src(value: string);
+  destroy(): void;
+} & MediaVideoTrackCapability &
+  MediaVideoRenditionCapability;
+
+/** A video rendition as parsed onto the engine's presentation (each SPF video track is one quality level). */
+type SpfVideoTrack = Extract<
+  NonNullable<NonNullable<ReturnType<SimpleHlsEngine['state']['presentation']['get']>>['selectionSets']>[number],
+  { type: 'video' }
+>['switchingSets'][number]['tracks'][number];
+
+function videoTracksOf(engine: SimpleHlsEngine): SpfVideoTrack[] {
+  const presentation = engine.state.presentation.get();
+  const videoSet = presentation?.selectionSets?.find((set) => set.type === 'video');
+  return videoSet?.switchingSets[0]?.tracks ?? [];
+}
+
+function toFrameRate(frameRate: SpfVideoTrack['frameRate']): number | undefined {
+  if (!frameRate) return undefined;
+  const { frameRateNumerator, frameRateDenominator } = frameRate;
+  return frameRateDenominator ? frameRateNumerator / frameRateDenominator : frameRateNumerator;
+}
+
+/**
+ * Projects the SPF engine's video renditions onto the media element's
+ * `videoTracks` / `videoRenditions` lists, and wires user rendition selection
+ * back to the engine's `userVideoTrackSelection` (a partial `{ id }` pins a
+ * quality level; clearing it re-enables ABR).
+ *
+ * Unlike hls.js — where the engine persists and events drive the projection —
+ * the SPF adapter rebuilds its engine on every `src` assignment, so the
+ * subscriptions are re-wired on each src change (see the `src` override).
+ *
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied
+ * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
+ * and friends.
+ */
+export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
+  class SimpleHlsMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
+    #disconnect: AbortController | null = null;
+    /** Ids of the renditions currently projected, in order — used to skip rebuilds on segment resolution. */
+    #renditionSignature = '';
+
+    constructor(...args: any[]) {
+      super(...args);
+      this.#connect();
+    }
+
+    get src(): string {
+      return super.src;
+    }
+
+    set src(value: string) {
+      // The canonical adapter destroys the engine (and its signals) on every
+      // src change and creates a fresh one, so we re-wire the projection against
+      // it. If the adapter ever moves to in-place source replacement (an open
+      // question in source-replacement.md / engine-adapter-integration.md), the
+      // engine becomes stable and this collapses to a one-time constructor wire.
+      this.#disconnect?.abort();
+      super.src = value;
+      this.#connect();
+    }
+
+    destroy(): void {
+      this.#disconnect?.abort();
+      this.#disconnect = null;
+      this.#removeVideoTracks();
+      super.destroy();
+    }
+
+    #connect(): void {
+      this.#disconnect?.abort();
+      const controller = new AbortController();
+      this.#disconnect = controller;
+      const { signal } = controller;
+      const { engine } = this;
+
+      this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
+
+      const disposeEffects = [
+        // Track `presentation` only; active-rendition reflection reads
+        // `selectedVideoTrackId` untracked so a resolve doesn't re-rebuild.
+        effect(() => this.#projectRenditions(engine, videoTracksOf(engine))),
+        effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
+      ];
+
+      signal.addEventListener(
+        'abort',
+        () => {
+          for (const dispose of disposeEffects) dispose();
+        },
+        { once: true }
+      );
+    }
+
+    #getSignaturesFor(tracks: SpfVideoTrack[]) {
+      return tracks.map((track) => track.id).join('|');
+    }
+
+    #projectRenditions(engine: SimpleHlsEngine, tracks: SpfVideoTrack[]): void {
+      const signature = this.#getSignaturesFor(tracks);
+      if (signature === this.#renditionSignature) return;
+      this.#renditionSignature = signature;
+
+      this.#removeVideoTracks();
+      if (!tracks.length) return;
+
+      const videoTrack = this.addVideoTrack('main');
+      videoTrack.selected = true;
+
+      for (const track of tracks) {
+        const rendition = videoTrack.addRendition(
+          track.url,
+          track.width,
+          track.height,
+          track.codecs?.join(','),
+          track.bandwidth,
+          toFrameRate(track.frameRate)
+        );
+        rendition.id = track.id;
+      }
+
+      this.#reflectActiveRendition(untrack(() => engine.state.selectedVideoTrackId.get()));
+    }
+
+    #reflectActiveRendition(activeId: string | undefined): void {
+      for (const rendition of this.videoRenditions) {
+        rendition.active = rendition.id === activeId;
+      }
+    }
+
+    #switchRendition = () => {
+      const { engine } = this;
+      const { selectedIndex } = this.videoRenditions;
+
+      // -1 clears the manual pin and hands quality back to ABR.
+      if (selectedIndex === -1) {
+        if (engine.state.userVideoTrackSelection.get()) engine.state.userVideoTrackSelection.set(undefined);
+        return;
+      }
+
+      const id = this.videoRenditions[selectedIndex]?.id;
+      if (!id || engine.state.userVideoTrackSelection.get()?.id === id) return;
+      engine.state.userVideoTrackSelection.set({ id });
+    };
+
+    #removeVideoTracks(): void {
+      for (const videoTrack of this.videoTracks) {
+        this.removeVideoTrack(videoTrack);
+      }
+    }
+  }
+
+  return SimpleHlsMediaMediaTracks as unknown as Base;
+}

--- a/packages/core/src/dom/media/simple-hls/media-tracks.ts
+++ b/packages/core/src/dom/media/simple-hls/media-tracks.ts
@@ -1,10 +1,17 @@
 import { effect, untrack } from '@videojs/spf';
 import type { SimpleHlsEngineState, SimpleHlsMediaAPI } from '@videojs/spf/hls';
 import type { Constructor } from '@videojs/utils/types';
-import type { MediaVideoRenditionCapability, MediaVideoTrackCapability } from '../../../core/media/types';
+import type {
+  MediaAudioTrackCapability,
+  MediaVideoRenditionCapability,
+  MediaVideoTrackCapability,
+} from '../../../core/media/types';
 
 type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+/** A video rendition descriptor as published on the engine's `videoRenditions` slot. */
 type VideoRenditionInfo = NonNullable<SimpleHlsEngineState['videoRenditions']>[number];
+/** An audio track descriptor as published on the engine's `audioTracks` slot. */
+type AudioTrackInfo = NonNullable<SimpleHlsEngineState['audioTracks']>[number];
 
 /**
  * Host surface the projection reads from: the SPF adapter (engine + src) plus
@@ -16,13 +23,14 @@ type MediaTracksHost = {
   set src(value: string);
   destroy(): void;
 } & MediaVideoTrackCapability &
-  MediaVideoRenditionCapability;
+  MediaVideoRenditionCapability &
+  MediaAudioTrackCapability;
 
 /**
- * Projects the SPF engine's video renditions onto the media element's
- * `videoTracks` / `videoRenditions` lists, and wires user rendition selection
- * back to the engine's `userVideoTrackSelection` (a partial `{ id }` pins a
- * quality level; clearing it re-enables ABR).
+ * Projects the SPF engine's video renditions and audio tracks onto the media
+ * element's `videoTracks` / `videoRenditions` / `audioTracks` lists, and wires
+ * user selection back to the engine's `userVideoTrackSelection` /
+ * `userAudioTrackSelection`.
  *
  * Unlike hls.js — where the engine persists and events drive the projection —
  * the SPF adapter rebuilds its engine on every `src` assignment, so the
@@ -30,7 +38,7 @@ type MediaTracksHost = {
  *
  * Requires the media-tracks mixin (track-list infrastructure) to be applied
  * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
- * and friends.
+ * `audioTracks`, and friends.
  */
 export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
   class SimpleHlsMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
@@ -60,6 +68,7 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
       this.#disconnect?.abort();
       this.#disconnect = null;
       this.#removeVideoTracks();
+      this.#removeAudioTracks();
       super.destroy();
     }
 
@@ -70,20 +79,28 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
       const { engine } = this;
 
       this.videoRenditions.addEventListener('change', this.#switchRendition, { signal });
+      this.audioTracks.addEventListener('change', this.#switchAudioTrack, { signal });
 
       const disposeEffects = [
-        // The engine dedupes `videoRenditions` (emits a new array only when the
-        // rendition set changes), so this rebuilds only on real changes. Active
-        // reflection reads `selectedVideoTrackId` in its own effect.
+        // The engine dedupes its projections (emits a new array only when the set
+        // changes), so these rebuild only on real changes. Selection reflection
+        // (active rendition / enabled audio track) reads the resolved id in its
+        // own effect.
         effect(() => this.#projectRenditions(engine, engine.state.videoRenditions.get() ?? [])),
         effect(() => this.#reflectActiveRendition(engine.state.selectedVideoTrackId.get())),
         effect(() => this.#reflectSelectedRendition(engine.state.userVideoTrackSelection.get()?.id)),
+        effect(() => this.#projectAudioTracks(engine, engine.state.audioTracks.get() ?? [])),
+        effect(() => this.#reflectEnabledAudioTrack(engine.state.selectedAudioTrackId.get())),
       ];
 
       disposeEffects.forEach((dispose) => {
         signal.addEventListener('abort', dispose, { once: true });
       });
     }
+
+    // -------------------------------------------------------------------------
+    // Video renditions
+    // -------------------------------------------------------------------------
 
     #projectRenditions(engine: SimpleHlsEngine, renditions: VideoRenditionInfo[]): void {
       this.#removeVideoTracks();
@@ -138,6 +155,64 @@ export function SimpleHlsMediaMediaTracksMixin<Base extends Constructor<MediaTra
     #removeVideoTracks(): void {
       for (const videoTrack of this.videoTracks) {
         this.removeVideoTrack(videoTrack);
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // Audio tracks (one per language)
+    // -------------------------------------------------------------------------
+
+    #projectAudioTracks(engine: SimpleHlsEngine, tracks: AudioTrackInfo[]): void {
+      this.#removeAudioTracks();
+      if (!tracks.length) return;
+
+      for (const info of tracks) {
+        const audioTrack = this.addAudioTrack(info.default ? 'main' : 'alternative', info.name, info.language ?? '');
+        audioTrack.id = info.id;
+      }
+
+      this.#reflectEnabledAudioTrack(untrack(() => engine.state.selectedAudioTrackId.get()));
+    }
+
+    #reflectEnabledAudioTrack(selectedId: string | undefined): void {
+      const infos = untrack(() => this.engine.state.audioTracks.get()) ?? [];
+      for (const track of this.audioTracks) {
+        const info = infos.find((candidate) => candidate.id === track.id);
+        track.enabled = !!selectedId && !!info?.trackIds.includes(selectedId);
+      }
+    }
+
+    #switchAudioTrack = () => {
+      const { engine } = this;
+      const infos = engine.state.audioTracks.get() ?? [];
+      const selectedId = engine.state.selectedAudioTrackId.get();
+      const currentInfo = infos.find((info) => info.trackIds.includes(selectedId ?? ''));
+
+      // `enabled` isn't exclusive like video `selected`, so prefer a newly
+      // enabled track over the one already playing.
+      const enabled = [...this.audioTracks].filter((track) => track.enabled);
+      const target = enabled.find((track) => track.id !== currentInfo?.id) ?? enabled[0];
+      if (!target) return;
+
+      // Disable the rest so future change events resolve unambiguously.
+      for (const track of enabled) {
+        if (track !== target) track.enabled = false;
+      }
+
+      // No-op when the target already matches the engine selection — this fires
+      // for our own `enabled` reflection (which dispatches the same `change`).
+      if (target.id === currentInfo?.id) return;
+
+      const info = infos.find((candidate) => candidate.id === target.id);
+      if (!info) return;
+      engine.state.userAudioTrackSelection.set(
+        info.language ? { language: info.language, name: info.name } : { name: info.name }
+      );
+    };
+
+    #removeAudioTracks(): void {
+      for (const audioTrack of this.audioTracks) {
+        this.removeAudioTrack(audioTrack);
       }
     }
   }

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -140,6 +140,60 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     expect(engine.state.userVideoTrackSelection.get()).toBeUndefined();
   });
 
+  it('preserves the manual pin selection across a rebuild', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([HD, SD]);
+    await flush();
+    host.videoRenditions.selectedIndex = 1; // pin SD
+    await flush();
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+
+    // Engine emits a changed set (a rendition added) that still contains the pin.
+    const UHD = rendition('v-2160', 3840, 2160, 18_000_000);
+    engine.state.videoRenditions.set([HD, SD, UHD]);
+    await flush();
+
+    // The pinned rendition stays selected — the UI must not fall back to Auto.
+    const { selectedIndex } = host.videoRenditions;
+    expect(selectedIndex).not.toBe(-1);
+    expect([...host.videoRenditions][selectedIndex]?.id).toBe('v-360');
+    // Restoring the pin must not spuriously rewrite/clear the engine selection.
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+  });
+
+  it('reflects a programmatic userVideoTrackSelection onto the selected rendition', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([HD, SD]);
+    await flush();
+
+    engine.state.userVideoTrackSelection.set({ id: 'v-360' });
+    await flush();
+
+    const { selectedIndex } = host.videoRenditions;
+    expect([...host.videoRenditions][selectedIndex]?.id).toBe('v-360');
+    // Reflection must not loop back into a rewrite.
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+  });
+
+  it('reflects a cleared pin as Auto (selectedIndex -1)', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([HD, SD]);
+    await flush();
+    engine.state.userVideoTrackSelection.set({ id: 'v-360' });
+    await flush();
+    expect(host.videoRenditions.selectedIndex).not.toBe(-1);
+
+    engine.state.userVideoTrackSelection.set(undefined);
+    await flush();
+    expect(host.videoRenditions.selectedIndex).toBe(-1);
+  });
+
   it('rebuilds renditions when the engine emits a new set', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -13,6 +13,9 @@ function createEngine() {
       videoRenditions: signal<any>(undefined),
       selectedVideoTrackId: signal<string | undefined>(undefined),
       userVideoTrackSelection: signal<{ id?: string } | undefined>(undefined),
+      audioTracks: signal<any>(undefined),
+      selectedAudioTrackId: signal<string | undefined>(undefined),
+      userAudioTrackSelection: signal<{ language?: string; name?: string } | undefined>(undefined),
     },
     context: {},
     destroy: async () => {},
@@ -63,6 +66,14 @@ function rendition(
 
 const HD = rendition('v-1080', 1920, 1080, 6_000_000);
 const SD = rendition('v-360', 640, 360, 800_000);
+
+function audioTrack(id: string, language: string, name: string, trackIds: string[], isDefault = false) {
+  return { id, language, name, default: isDefault, trackIds };
+}
+
+// Two languages, each collapsing two quality groups (hi/lo).
+const EN = audioTrack('en-hi', 'en', 'English', ['en-hi', 'en-lo'], true);
+const ES = audioTrack('es-hi', 'es', 'Spanish', ['es-hi', 'es-lo']);
 
 // Drain the effect microtask and the nested microtask the rendition-list
 // primitives use to dispatch add/remove/change events.
@@ -228,17 +239,74 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     expect(host.videoRenditions.length).toBe(2);
   });
 
+  it('projects the engine audio tracks (one per language)', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.audioTracks.set([EN, ES]);
+    await flush();
+
+    expect(host.audioTracks.length).toBe(2);
+    expect([...host.audioTracks].map((t) => t.label)).toEqual(['English', 'Spanish']);
+    expect([...host.audioTracks].map((t) => t.language)).toEqual(['en', 'es']);
+    expect(host.audioTracks[0]?.kind).toBe('main'); // default
+    expect(host.audioTracks[1]?.kind).toBe('alternative');
+  });
+
+  it('reflects the enabled audio track from selectedAudioTrackId (matching any quality group)', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.audioTracks.set([EN, ES]);
+    // A resolved id from the *low* Spanish group still enables the Spanish track.
+    engine.state.selectedAudioTrackId.set('es-lo');
+    await flush();
+
+    expect([...host.audioTracks].map((t) => t.enabled)).toEqual([false, true]);
+  });
+
+  it('feeds an enabled audio track back to userAudioTrackSelection by language + name', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.audioTracks.set([EN, ES]);
+    engine.state.selectedAudioTrackId.set('en-hi');
+    await flush();
+
+    const [, spanish] = [...host.audioTracks];
+    spanish!.enabled = true;
+    await flush();
+
+    expect(engine.state.userAudioTrackSelection.get()).toEqual({ language: 'es', name: 'Spanish' });
+  });
+
+  it('does not write a selection when reflection re-enables the already-playing track', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.audioTracks.set([EN, ES]);
+    engine.state.selectedAudioTrackId.set('en-hi');
+    await flush();
+
+    // Reflection enabled English (the playing track); no user change happened.
+    expect(host.audioTracks[0]?.enabled).toBe(true);
+    expect(engine.state.userAudioTrackSelection.get()).toBeUndefined();
+  });
+
   it('removes projected tracks on destroy', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
     engine.state.videoRenditions.set([HD, SD]);
+    engine.state.audioTracks.set([EN, ES]);
     await flush();
     expect(host.videoTracks.length).toBe(1);
+    expect(host.audioTracks.length).toBe(2);
 
     host.destroy();
 
     expect(host.videoTracks.length).toBe(0);
     expect(host.videoRenditions.length).toBe(0);
+    expect(host.audioTracks.length).toBe(0);
   });
 });

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -1,0 +1,203 @@
+import { signal } from '@videojs/spf';
+import type { SimpleHlsMediaAPI } from '@videojs/spf/hls';
+import { describe, expect, it } from 'vitest';
+import { MediaTracksMixin } from '../../../../core/media/media-tracks';
+import { HTMLVideoElementHost } from '../../video-host';
+import { SimpleHlsMediaMediaTracksMixin } from '../media-tracks';
+
+type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
+
+function createEngine() {
+  return {
+    state: {
+      presentation: signal<any>(undefined),
+      selectedVideoTrackId: signal<string | undefined>(undefined),
+      userVideoTrackSelection: signal<{ id?: string } | undefined>(undefined),
+    },
+    context: {},
+    destroy: async () => {},
+  };
+}
+
+type FakeEngine = ReturnType<typeof createEngine>;
+
+class FakeHost extends HTMLVideoElementHost {
+  #createEngine: () => FakeEngine;
+  #engine: FakeEngine;
+
+  constructor(create: () => FakeEngine) {
+    super();
+    this.#createEngine = create;
+    this.#engine = create();
+  }
+
+  get engine() {
+    return this.#engine as unknown as SimpleHlsEngine;
+  }
+
+  // Mirror the real adapter: a new src destroys the engine and starts a fresh one.
+  get src() {
+    return this.#engine.state.presentation.get()?.url ?? '';
+  }
+
+  set src(value: string) {
+    this.#engine = this.#createEngine();
+    if (value) this.#engine.state.presentation.set({ url: value });
+  }
+
+  destroy() {}
+}
+
+const Host = SimpleHlsMediaMediaTracksMixin(MediaTracksMixin(FakeHost));
+
+function videoTrack(id: string, width: number, height: number, bandwidth: number) {
+  return { id, type: 'video', url: `${id}.m3u8`, width, height, bandwidth, codecs: ['avc1.640028'] };
+}
+
+function presentationWith(tracks: Array<ReturnType<typeof videoTrack>>) {
+  return {
+    url: 'https://example.com/master.m3u8',
+    id: 'presentation',
+    selectionSets: [
+      { id: 'video-selection', type: 'video', switchingSets: [{ id: 'video-switching', type: 'video', tracks }] },
+    ],
+  };
+}
+
+const HD = videoTrack('v-1080', 1920, 1080, 6_000_000);
+const SD = videoTrack('v-360', 640, 360, 800_000);
+
+// Drain the effect microtask and the nested microtask the rendition-list
+// primitives use to dispatch add/remove/change events.
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('SimpleHlsMediaMediaTracksMixin', () => {
+  it('projects the engine presentation onto a selected video track with renditions', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    expect(host.videoTracks.length).toBe(1);
+    expect(host.videoTracks[0]?.selected).toBe(true);
+    expect(host.videoRenditions.length).toBe(2);
+    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080', 'v-360']);
+    expect([...host.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 360]);
+    expect([...host.videoRenditions].map((rendition) => rendition.bitrate)).toEqual([6_000_000, 800_000]);
+  });
+
+  it('marks the active rendition from selectedVideoTrackId', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    engine.state.selectedVideoTrackId.set('v-360');
+    await flush();
+
+    expect([...host.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+  });
+
+  it('forwards a rendition selection to userVideoTrackSelection', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    host.videoRenditions.selectedIndex = 1;
+    await flush();
+
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+  });
+
+  it('hands quality back to ABR when the selection is cleared', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    host.videoRenditions.selectedIndex = 1;
+    await flush();
+    expect(engine.state.userVideoTrackSelection.get()).toEqual({ id: 'v-360' });
+
+    host.videoRenditions.selectedIndex = -1;
+    await flush();
+    expect(engine.state.userVideoTrackSelection.get()).toBeUndefined();
+  });
+
+  it('does not rebuild renditions when a resolve mutates presentation without changing the track set', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    let added = 0;
+    let removed = 0;
+    host.videoRenditions.addEventListener('addrendition', () => added++);
+    host.videoRenditions.addEventListener('removerendition', () => removed++);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(added).toBe(2);
+
+    // A media-playlist resolution replaces the presentation object with the
+    // same renditions — the projection should be a no-op.
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    expect(added).toBe(2);
+    expect(removed).toBe(0);
+  });
+
+  it('rebuilds renditions when the track set changes', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(host.videoRenditions.length).toBe(2);
+
+    engine.state.presentation.set(presentationWith([HD]));
+    await flush();
+
+    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080']);
+  });
+
+  it('re-wires the projection to the fresh engine created on src change', async () => {
+    const engines: FakeEngine[] = [];
+    const host = new Host(() => {
+      const engine = createEngine();
+      engines.push(engine);
+      return engine;
+    });
+
+    // src change tears down engine[0] and creates engine[1].
+    host.src = 'https://example.com/next.m3u8';
+    engines[1]!.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(host.videoRenditions.length).toBe(2);
+
+    // The disconnected first engine must no longer drive the projection.
+    engines[0]!.state.presentation.set(presentationWith([HD]));
+    await flush();
+    expect(host.videoRenditions.length).toBe(2);
+  });
+
+  it('removes projected tracks on destroy', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+    expect(host.videoTracks.length).toBe(1);
+
+    host.destroy();
+
+    expect(host.videoTracks.length).toBe(0);
+    expect(host.videoRenditions.length).toBe(0);
+  });
+});

--- a/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
+++ b/packages/core/src/dom/media/simple-hls/tests/media-tracks.test.ts
@@ -10,7 +10,7 @@ type SimpleHlsEngine = SimpleHlsMediaAPI['engine'];
 function createEngine() {
   return {
     state: {
-      presentation: signal<any>(undefined),
+      videoRenditions: signal<any>(undefined),
       selectedVideoTrackId: signal<string | undefined>(undefined),
       userVideoTrackSelection: signal<{ id?: string } | undefined>(undefined),
     },
@@ -24,6 +24,7 @@ type FakeEngine = ReturnType<typeof createEngine>;
 class FakeHost extends HTMLVideoElementHost {
   #createEngine: () => FakeEngine;
   #engine: FakeEngine;
+  #src = '';
 
   constructor(create: () => FakeEngine) {
     super();
@@ -37,12 +38,12 @@ class FakeHost extends HTMLVideoElementHost {
 
   // Mirror the real adapter: a new src destroys the engine and starts a fresh one.
   get src() {
-    return this.#engine.state.presentation.get()?.url ?? '';
+    return this.#src;
   }
 
   set src(value: string) {
+    this.#src = value;
     this.#engine = this.#createEngine();
-    if (value) this.#engine.state.presentation.set({ url: value });
   }
 
   destroy() {}
@@ -50,22 +51,18 @@ class FakeHost extends HTMLVideoElementHost {
 
 const Host = SimpleHlsMediaMediaTracksMixin(MediaTracksMixin(FakeHost));
 
-function videoTrack(id: string, width: number, height: number, bandwidth: number) {
-  return { id, type: 'video', url: `${id}.m3u8`, width, height, bandwidth, codecs: ['avc1.640028'] };
+function rendition(
+  id: string,
+  width: number,
+  height: number,
+  bandwidth: number,
+  frameRate?: { frameRateNumerator: number; frameRateDenominator?: number }
+) {
+  return { id, url: `${id}.m3u8`, width, height, bandwidth, codecs: ['avc1.640028'], frameRate };
 }
 
-function presentationWith(tracks: Array<ReturnType<typeof videoTrack>>) {
-  return {
-    url: 'https://example.com/master.m3u8',
-    id: 'presentation',
-    selectionSets: [
-      { id: 'video-selection', type: 'video', switchingSets: [{ id: 'video-switching', type: 'video', tracks }] },
-    ],
-  };
-}
-
-const HD = videoTrack('v-1080', 1920, 1080, 6_000_000);
-const SD = videoTrack('v-360', 640, 360, 800_000);
+const HD = rendition('v-1080', 1920, 1080, 6_000_000);
+const SD = rendition('v-360', 640, 360, 800_000);
 
 // Drain the effect microtask and the nested microtask the rendition-list
 // primitives use to dispatch add/remove/change events.
@@ -74,39 +71,51 @@ function flush() {
 }
 
 describe('SimpleHlsMediaMediaTracksMixin', () => {
-  it('projects the engine presentation onto a selected video track with renditions', async () => {
+  it('projects the engine renditions onto a selected video track', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     expect(host.videoTracks.length).toBe(1);
     expect(host.videoTracks[0]?.selected).toBe(true);
     expect(host.videoRenditions.length).toBe(2);
-    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080', 'v-360']);
-    expect([...host.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 360]);
-    expect([...host.videoRenditions].map((rendition) => rendition.bitrate)).toEqual([6_000_000, 800_000]);
+    expect([...host.videoRenditions].map((r) => r.id)).toEqual(['v-1080', 'v-360']);
+    expect([...host.videoRenditions].map((r) => r.height)).toEqual([1080, 360]);
+    expect([...host.videoRenditions].map((r) => r.bitrate)).toEqual([6_000_000, 800_000]);
+  });
+
+  it('reduces the model frame rate to a number on the projected rendition', async () => {
+    const engine = createEngine();
+    const host = new Host(() => engine);
+
+    engine.state.videoRenditions.set([
+      rendition('v-1080', 1920, 1080, 6_000_000, { frameRateNumerator: 30000, frameRateDenominator: 1001 }),
+    ]);
+    await flush();
+
+    expect(host.videoRenditions[0]?.frameRate).toBeCloseTo(29.97, 2);
   });
 
   it('marks the active rendition from selectedVideoTrackId', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     engine.state.selectedVideoTrackId.set('v-360');
     await flush();
 
-    expect([...host.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+    expect([...host.videoRenditions].map((r) => r.active)).toEqual([false, true]);
   });
 
   it('forwards a rendition selection to userVideoTrackSelection', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     host.videoRenditions.selectedIndex = 1;
@@ -119,7 +128,7 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
 
     host.videoRenditions.selectedIndex = 1;
@@ -131,40 +140,18 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     expect(engine.state.userVideoTrackSelection.get()).toBeUndefined();
   });
 
-  it('does not rebuild renditions when a resolve mutates presentation without changing the track set', async () => {
+  it('rebuilds renditions when the engine emits a new set', async () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    let added = 0;
-    let removed = 0;
-    host.videoRenditions.addEventListener('addrendition', () => added++);
-    host.videoRenditions.addEventListener('removerendition', () => removed++);
-
-    engine.state.presentation.set(presentationWith([HD, SD]));
-    await flush();
-    expect(added).toBe(2);
-
-    // A media-playlist resolution replaces the presentation object with the
-    // same renditions — the projection should be a no-op.
-    engine.state.presentation.set(presentationWith([HD, SD]));
-    await flush();
-
-    expect(added).toBe(2);
-    expect(removed).toBe(0);
-  });
-
-  it('rebuilds renditions when the track set changes', async () => {
-    const engine = createEngine();
-    const host = new Host(() => engine);
-
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
     expect(host.videoRenditions.length).toBe(2);
 
-    engine.state.presentation.set(presentationWith([HD]));
+    engine.state.videoRenditions.set([HD]);
     await flush();
 
-    expect([...host.videoRenditions].map((rendition) => rendition.id)).toEqual(['v-1080']);
+    expect([...host.videoRenditions].map((r) => r.id)).toEqual(['v-1080']);
   });
 
   it('re-wires the projection to the fresh engine created on src change', async () => {
@@ -177,12 +164,12 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
 
     // src change tears down engine[0] and creates engine[1].
     host.src = 'https://example.com/next.m3u8';
-    engines[1]!.state.presentation.set(presentationWith([HD, SD]));
+    engines[1]!.state.videoRenditions.set([HD, SD]);
     await flush();
     expect(host.videoRenditions.length).toBe(2);
 
     // The disconnected first engine must no longer drive the projection.
-    engines[0]!.state.presentation.set(presentationWith([HD]));
+    engines[0]!.state.videoRenditions.set([HD]);
     await flush();
     expect(host.videoRenditions.length).toBe(2);
   });
@@ -191,7 +178,7 @@ describe('SimpleHlsMediaMediaTracksMixin', () => {
     const engine = createEngine();
     const host = new Host(() => engine);
 
-    engine.state.presentation.set(presentationWith([HD, SD]));
+    engine.state.videoRenditions.set([HD, SD]);
     await flush();
     expect(host.videoTracks.length).toBe(1);
 

--- a/packages/spf/src/media/utils/tests/track-selection.test.ts
+++ b/packages/spf/src/media/utils/tests/track-selection.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { AudioTrack, Presentation, VideoTrack } from '../../types';
-import { getResolvedSelectedTrackDuration, getVideoRenditions, type TrackSelectionState } from '../track-selection';
+import {
+  getAudioTracks,
+  getResolvedSelectedTrackDuration,
+  getVideoRenditions,
+  type TrackSelectionState,
+} from '../track-selection';
 
 function createPresentation(config: { video?: VideoTrack[]; audio?: AudioTrack[]; duration?: number }): Presentation {
   const selectionSets = [];
@@ -175,5 +180,40 @@ describe('getVideoRenditions', () => {
     expect(getVideoRenditions({})).toEqual([]);
     expect(getVideoRenditions({ presentation: { url: 'x.m3u8' } })).toEqual([]);
     expect(getVideoRenditions({ presentation: createPresentation({ audio: [resolvedAudioTrack()] }) })).toEqual([]);
+  });
+});
+
+describe('getAudioTracks', () => {
+  it('collapses per-(language × group) tracks to one entry per language', () => {
+    const presentation = createPresentation({
+      audio: [
+        resolvedAudioTrack({ id: 'en-hi', language: 'en', name: 'English', groupId: 'audio-hi', default: true }),
+        resolvedAudioTrack({ id: 'es-hi', language: 'es', name: 'Spanish', groupId: 'audio-hi' }),
+        resolvedAudioTrack({ id: 'en-lo', language: 'en', name: 'English', groupId: 'audio-lo' }),
+        resolvedAudioTrack({ id: 'es-lo', language: 'es', name: 'Spanish', groupId: 'audio-lo' }),
+      ],
+    });
+
+    const tracks = getAudioTracks({ presentation });
+    expect(tracks.map((t) => t.name)).toEqual(['English', 'Spanish']);
+    expect(tracks.map((t) => t.language)).toEqual(['en', 'es']);
+    expect(tracks[0]).toMatchObject({ id: 'en-hi', default: true, trackIds: ['en-hi', 'en-lo'] });
+    expect(tracks[1]).toMatchObject({ id: 'es-hi', trackIds: ['es-hi', 'es-lo'] });
+  });
+
+  it('keeps same-language tracks with different names distinct', () => {
+    const presentation = createPresentation({
+      audio: [
+        resolvedAudioTrack({ id: 'en', language: 'en', name: 'English' }),
+        resolvedAudioTrack({ id: 'en-cc', language: 'en', name: 'English (commentary)' }),
+      ],
+    });
+
+    expect(getAudioTracks({ presentation }).map((t) => t.name)).toEqual(['English', 'English (commentary)']);
+  });
+
+  it('returns an empty array when the presentation is unresolved or has no audio', () => {
+    expect(getAudioTracks({})).toEqual([]);
+    expect(getAudioTracks({ presentation: createPresentation({ video: [resolvedVideoTrack()] }) })).toEqual([]);
   });
 });

--- a/packages/spf/src/media/utils/tests/track-selection.test.ts
+++ b/packages/spf/src/media/utils/tests/track-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AudioTrack, Presentation, VideoTrack } from '../../types';
-import { getResolvedSelectedTrackDuration, type TrackSelectionState } from '../track-selection';
+import { getResolvedSelectedTrackDuration, getVideoRenditions, type TrackSelectionState } from '../track-selection';
 
 function createPresentation(config: { video?: VideoTrack[]; audio?: AudioTrack[]; duration?: number }): Presentation {
   const selectionSets = [];
@@ -130,5 +130,50 @@ describe('getResolvedSelectedTrackDuration', () => {
 
   it('returns undefined when there is no presentation', () => {
     expect(getResolvedSelectedTrackDuration({})).toBeUndefined();
+  });
+});
+
+describe('getVideoRenditions', () => {
+  it('maps the first video switching set to normalized rendition info', () => {
+    const presentation = createPresentation({
+      video: [
+        resolvedVideoTrack({ id: 'hd', url: 'hd.m3u8', width: 1920, height: 1080, bandwidth: 6_000_000 }),
+        resolvedVideoTrack({ id: 'sd', url: 'sd.m3u8', width: 640, height: 360, bandwidth: 800_000 }),
+      ],
+    });
+
+    expect(getVideoRenditions({ presentation })).toEqual([
+      {
+        id: 'hd',
+        url: 'hd.m3u8',
+        width: 1920,
+        height: 1080,
+        codecs: ['avc1.42E01E'],
+        bandwidth: 6_000_000,
+        frameRate: undefined,
+      },
+      {
+        id: 'sd',
+        url: 'sd.m3u8',
+        width: 640,
+        height: 360,
+        codecs: ['avc1.42E01E'],
+        bandwidth: 800_000,
+        frameRate: undefined,
+      },
+    ]);
+  });
+
+  it('carries the raw FrameRate through (DOM consumers normalize)', () => {
+    const frameRate = { frameRateNumerator: 30000, frameRateDenominator: 1001 };
+    const presentation = createPresentation({ video: [resolvedVideoTrack({ frameRate })] });
+
+    expect(getVideoRenditions({ presentation })[0]?.frameRate).toEqual(frameRate);
+  });
+
+  it('returns an empty array when the presentation is unresolved or has no video', () => {
+    expect(getVideoRenditions({})).toEqual([]);
+    expect(getVideoRenditions({ presentation: { url: 'x.m3u8' } })).toEqual([]);
+    expect(getVideoRenditions({ presentation: createPresentation({ audio: [resolvedAudioTrack()] }) })).toEqual([]);
   });
 });

--- a/packages/spf/src/media/utils/track-selection.ts
+++ b/packages/spf/src/media/utils/track-selection.ts
@@ -1,11 +1,13 @@
 import type {
   AudioTrack,
+  FrameRate,
   MaybeResolvedPresentation,
   PartiallyResolvedAudioTrack,
   PartiallyResolvedTextTrack,
   PartiallyResolvedVideoTrack,
   TextTrack,
   TrackType,
+  VideoSelectionSet,
   VideoTrack,
 } from '../types';
 import { isResolvedTrack } from '../types';
@@ -79,4 +81,42 @@ export function getResolvedSelectedTrackDuration(state: TrackSelectionState): nu
     if (audio && isResolvedTrack(audio)) return audio.duration;
   }
   return undefined;
+}
+
+/**
+ * A selectable video rendition (quality level) from the presentation. Each
+ * video track in the selected video switching set is one rendition, carried in
+ * the model's own vocabulary (`bandwidth`, `codecs`, `FrameRate`); DOM
+ * consumers map these onto their platform shapes.
+ */
+export interface VideoRenditionInfo {
+  id: string;
+  url: string;
+  width?: number;
+  height?: number;
+  codecs?: string[];
+  bandwidth: number;
+  frameRate?: FrameRate;
+}
+
+/**
+ * Read the selectable video renditions from a presentation — the tracks of the
+ * first video switching set. Returns an empty array when the presentation is
+ * unresolved or carries no video.
+ *
+ * @param presentation - The engine's current (maybe-resolved) presentation.
+ */
+export function getVideoRenditions(state: TrackSelectionState): VideoRenditionInfo[] {
+  const { presentation } = state;
+  const videoSet = presentation?.selectionSets?.find((set): set is VideoSelectionSet => set.type === 'video');
+
+  return (videoSet?.switchingSets[0]?.tracks ?? []).map((track) => ({
+    id: track.id,
+    url: track.url,
+    width: track.width,
+    height: track.height,
+    codecs: track.codecs,
+    bandwidth: track.bandwidth,
+    frameRate: track.frameRate,
+  }));
 }

--- a/packages/spf/src/media/utils/track-selection.ts
+++ b/packages/spf/src/media/utils/track-selection.ts
@@ -1,4 +1,5 @@
 import type {
+  AudioSelectionSet,
   AudioTrack,
   FrameRate,
   MaybeResolvedPresentation,
@@ -119,4 +120,47 @@ export function getVideoRenditions(state: TrackSelectionState): VideoRenditionIn
     bandwidth: track.bandwidth,
     frameRate: track.frameRate,
   }));
+}
+
+/**
+ * A selectable audio track — one per distinct language, collapsing the model's
+ * per-(language × quality-group) tracks. `trackIds` lists the underlying track
+ * ids so consumers can map a resolved `selectedAudioTrackId` back to its group.
+ */
+export interface AudioTrackInfo {
+  id: string;
+  language?: string;
+  name: string;
+  default?: boolean;
+  trackIds: string[];
+}
+
+/**
+ * Read the selectable audio tracks from a presentation — the tracks of the first
+ * audio switching set, collapsed to one entry per (language, name) in manifest
+ * order. Returns an empty array when the presentation is unresolved or carries
+ * no audio.
+ */
+export function getAudioTracks(state: TrackSelectionState): AudioTrackInfo[] {
+  const { presentation } = state;
+  const audioSet = presentation?.selectionSets?.find((set): set is AudioSelectionSet => set.type === 'audio');
+
+  const byLanguage = new Map<string, AudioTrackInfo>();
+  for (const track of audioSet?.switchingSets[0]?.tracks ?? []) {
+    const key = `${track.language ?? ''}.${track.name}`;
+    const existing = byLanguage.get(key);
+    if (existing) {
+      existing.trackIds.push(track.id);
+      if (track.default) existing.default = true;
+    } else {
+      byLanguage.set(key, {
+        id: track.id,
+        language: track.language,
+        name: track.name,
+        default: track.default,
+        trackIds: [track.id],
+      });
+    }
+  }
+  return [...byLanguage.values()];
 }

--- a/packages/spf/src/playback/behaviors/derive-audio-tracks.ts
+++ b/packages/spf/src/playback/behaviors/derive-audio-tracks.ts
@@ -1,0 +1,66 @@
+/**
+ * **Audio tracks.** While a presentation is resolved, owns the `audioTracks`
+ * signal: the selectable audio tracks (one per language, collapsing the model's
+ * per-quality-group tracks), normalized to {@link AudioTrackInfo}. Cleared on
+ * src unload. A read-only projection consumers (e.g. the DOM media adapter) bind
+ * to without reaching through `presentation`.
+ *
+ * Mirrors `deriveVideoRenditions`: `'presentation-unresolved'` ↔
+ * `'presentation-resolved'`, resolved state owns the signal, entry-returned
+ * cleanup clears on exit, writes skipped when the track set is unchanged.
+ */
+
+import { defineBehavior } from '../../core/composition/create-composition';
+import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
+import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
+import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../media/types';
+import { type AudioTrackInfo, getAudioTracks } from '../../media/utils/track-selection';
+
+export interface DeriveAudioTracksState {
+  presentation?: MaybeResolvedPresentation;
+  audioTracks?: AudioTrackInfo[];
+}
+
+const sameAudioTracks = (a: AudioTrackInfo[] | undefined, b: AudioTrackInfo[]): boolean =>
+  !!a && a.length === b.length && a.every((track, index) => track.id === b[index]?.id);
+
+export const deriveAudioTracks = defineBehavior({
+  stateKeys: ['presentation', 'audioTracks'],
+  contextKeys: [],
+  setup: ({
+    state,
+  }: {
+    state: {
+      presentation: ReadonlySignal<DeriveAudioTracksState['presentation']>;
+      audioTracks: Signal<DeriveAudioTracksState['audioTracks']>;
+    };
+  }) => {
+    const derivedStateSignal = computed(() =>
+      isResolvedPresentation(state.presentation.get())
+        ? ('presentation-resolved' as const)
+        : ('presentation-unresolved' as const)
+    );
+
+    return createMachineReactor({
+      initial: 'presentation-unresolved',
+      monitor: () => derivedStateSignal.get(),
+      states: {
+        'presentation-unresolved': {},
+        'presentation-resolved': {
+          // Cleanup-binds-to-setup: the track list is valid for exactly
+          // 'presentation-resolved'. Clear fires on exit (src unload + destroy).
+          entry: () => () => state.audioTracks.set(undefined),
+          effects: [
+            () => {
+              const presentation = state.presentation.get();
+              if (!isResolvedPresentation(presentation)) return;
+              const next = getAudioTracks({ presentation });
+              // `peek` reads without subscribing, so this never self-triggers.
+              if (!sameAudioTracks(peek(state.audioTracks), next)) state.audioTracks.set(next);
+            },
+          ],
+        },
+      },
+    });
+  },
+});

--- a/packages/spf/src/playback/behaviors/derive-video-renditions.ts
+++ b/packages/spf/src/playback/behaviors/derive-video-renditions.ts
@@ -1,0 +1,70 @@
+/**
+ * **Video renditions.** While a presentation is resolved, owns the
+ * `videoRenditions` signal: the selectable quality levels of the first video
+ * switching set, normalized to {@link VideoRenditionInfo}. Cleared on src
+ * unload. A read-only projection consumers (e.g. the DOM media adapter) bind to
+ * without reaching through `presentation`.
+ *
+ * Lifecycle mirrors `deriveCdnPriority`: `'presentation-unresolved'` ↔
+ * `'presentation-resolved'`. The resolved state owns the signal; its
+ * entry-returned cleanup clears it on exit (canonical cleanup-binds-to-setup).
+ *
+ * A live reload swaps in a new presentation object carrying the same renditions,
+ * so writes are skipped when the rendition id-set is unchanged — re-emitting a
+ * fresh array would re-fire consumers for an identical list.
+ */
+
+import { defineBehavior } from '../../core/composition/create-composition';
+import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
+import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
+import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../media/types';
+import { getVideoRenditions, type VideoRenditionInfo } from '../../media/utils/track-selection';
+
+export interface DeriveVideoRenditionsState {
+  presentation?: MaybeResolvedPresentation;
+  videoRenditions?: VideoRenditionInfo[];
+}
+
+const sameRenditions = (a: VideoRenditionInfo[] | undefined, b: VideoRenditionInfo[]): boolean =>
+  !!a && a.length === b.length && a.every((rendition, index) => rendition.id === b[index]?.id);
+
+export const deriveVideoRenditions = defineBehavior({
+  stateKeys: ['presentation', 'videoRenditions'],
+  contextKeys: [],
+  setup: ({
+    state,
+  }: {
+    state: {
+      presentation: ReadonlySignal<DeriveVideoRenditionsState['presentation']>;
+      videoRenditions: Signal<DeriveVideoRenditionsState['videoRenditions']>;
+    };
+  }) => {
+    const derivedStateSignal = computed(() =>
+      isResolvedPresentation(state.presentation.get())
+        ? ('presentation-resolved' as const)
+        : ('presentation-unresolved' as const)
+    );
+
+    return createMachineReactor({
+      initial: 'presentation-unresolved',
+      monitor: () => derivedStateSignal.get(),
+      states: {
+        'presentation-unresolved': {},
+        'presentation-resolved': {
+          // Cleanup-binds-to-setup: the rendition list is valid for exactly
+          // 'presentation-resolved'. Clear fires on exit (src unload + destroy).
+          entry: () => () => state.videoRenditions.set(undefined),
+          effects: [
+            () => {
+              const presentation = state.presentation.get();
+              if (!isResolvedPresentation(presentation)) return;
+              const next = getVideoRenditions({ presentation });
+              // `peek` reads without subscribing, so this never self-triggers.
+              if (!sameRenditions(peek(state.videoRenditions), next)) state.videoRenditions.set(next);
+            },
+          ],
+        },
+      },
+    });
+  },
+});

--- a/packages/spf/src/playback/behaviors/tests/derive-audio-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/derive-audio-tracks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { StateSignals } from '../../../core/composition/create-composition';
+import { signal } from '../../../core/signals/primitives';
+import type { MaybeResolvedPresentation, PartiallyResolvedAudioTrack, Presentation } from '../../../media/types';
+import type { AudioTrackInfo } from '../../../media/utils/track-selection';
+import { type DeriveAudioTracksState, deriveAudioTracks } from '../derive-audio-tracks';
+
+function makeState(initial: Partial<DeriveAudioTracksState> = {}): StateSignals<DeriveAudioTracksState> {
+  return {
+    presentation: signal<MaybeResolvedPresentation | undefined>(initial.presentation),
+    audioTracks: signal<AudioTrackInfo[] | undefined>(initial.audioTracks),
+  };
+}
+
+const track = (id: string, language: string, name: string, groupId: string): PartiallyResolvedAudioTrack =>
+  ({
+    type: 'audio',
+    id,
+    url: `${id}.m3u8`,
+    codecs: ['mp4a.40.2'],
+    mimeType: 'audio/mp4',
+    bandwidth: 128_000,
+    groupId,
+    name,
+    language,
+  }) as PartiallyResolvedAudioTrack;
+
+const presentationWith = (tracks: PartiallyResolvedAudioTrack[]): Presentation =>
+  ({
+    id: 'pres-1',
+    url: 'https://example.com/master.m3u8',
+    startTime: 0,
+    selectionSets: [
+      {
+        id: 'audio-set',
+        type: 'audio' as const,
+        switchingSets: [{ id: 'audio-switching', type: 'audio' as const, tracks }],
+      },
+    ],
+  }) as Presentation;
+
+// Two languages across two quality groups.
+const AUDIO = [
+  track('en-hi', 'en', 'English', 'audio-hi'),
+  track('es-hi', 'es', 'Spanish', 'audio-hi'),
+  track('en-lo', 'en', 'English', 'audio-lo'),
+  track('es-lo', 'es', 'Spanish', 'audio-lo'),
+];
+
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+describe('deriveAudioTracks', () => {
+  it('does nothing without a presentation', async () => {
+    const state = makeState();
+    const reactor = deriveAudioTracks.setup({ state });
+    await flush();
+    expect(state.audioTracks.get()).toBeUndefined();
+    reactor.destroy();
+  });
+
+  it('publishes one audio track per language on src load', async () => {
+    const state = makeState({ presentation: presentationWith(AUDIO) });
+    const reactor = deriveAudioTracks.setup({ state });
+    await flush();
+
+    expect(state.audioTracks.get()?.map((t) => t.name)).toEqual(['English', 'Spanish']);
+    expect(state.audioTracks.get()?.[0]?.trackIds).toEqual(['en-hi', 'en-lo']);
+    reactor.destroy();
+  });
+
+  it('skips the write when a reload carries the same track set', async () => {
+    const state = makeState({ presentation: presentationWith(AUDIO) });
+    const reactor = deriveAudioTracks.setup({ state });
+    await flush();
+    const first = state.audioTracks.get();
+
+    state.presentation.set(presentationWith(AUDIO));
+    await flush();
+
+    expect(state.audioTracks.get()).toBe(first);
+    reactor.destroy();
+  });
+
+  it('clears the tracks on src unload', async () => {
+    const state = makeState({ presentation: presentationWith(AUDIO) });
+    const reactor = deriveAudioTracks.setup({ state });
+    await flush();
+    expect(state.audioTracks.get()).toBeDefined();
+
+    state.presentation.set(undefined);
+    await flush();
+
+    expect(state.audioTracks.get()).toBeUndefined();
+    reactor.destroy();
+  });
+});

--- a/packages/spf/src/playback/behaviors/tests/derive-video-renditions.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/derive-video-renditions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { StateSignals } from '../../../core/composition/create-composition';
+import { signal } from '../../../core/signals/primitives';
+import type { MaybeResolvedPresentation, PartiallyResolvedVideoTrack, Presentation } from '../../../media/types';
+import type { VideoRenditionInfo } from '../../../media/utils/track-selection';
+import { type DeriveVideoRenditionsState, deriveVideoRenditions } from '../derive-video-renditions';
+
+function makeState(initial: Partial<DeriveVideoRenditionsState> = {}): StateSignals<DeriveVideoRenditionsState> {
+  return {
+    presentation: signal<MaybeResolvedPresentation | undefined>(initial.presentation),
+    videoRenditions: signal<VideoRenditionInfo[] | undefined>(initial.videoRenditions),
+  };
+}
+
+const track = (id: string, width: number, height: number, bandwidth: number): PartiallyResolvedVideoTrack => ({
+  type: 'video',
+  id,
+  url: `${id}.m3u8`,
+  codecs: ['avc1.640028'],
+  mimeType: 'video/mp4',
+  bandwidth,
+  width,
+  height,
+});
+
+const presentationWith = (tracks: PartiallyResolvedVideoTrack[]): Presentation =>
+  ({
+    id: 'pres-1',
+    url: 'https://example.com/master.m3u8',
+    startTime: 0,
+    selectionSets: [
+      {
+        id: 'video-set',
+        type: 'video' as const,
+        switchingSets: [{ id: 'video-switching', type: 'video' as const, tracks }],
+      },
+    ],
+  }) as Presentation;
+
+const HD = track('v-1080', 1920, 1080, 6_000_000);
+const SD = track('v-360', 640, 360, 800_000);
+
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+describe('deriveVideoRenditions', () => {
+  it('does nothing without a presentation', async () => {
+    const state = makeState();
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+    expect(state.videoRenditions.get()).toBeUndefined();
+    reactor.destroy();
+  });
+
+  it('publishes the video renditions on src load', async () => {
+    const state = makeState({ presentation: presentationWith([HD, SD]) });
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+
+    expect(state.videoRenditions.get()?.map((r) => r.id)).toEqual(['v-1080', 'v-360']);
+    expect(state.videoRenditions.get()?.map((r) => r.height)).toEqual([1080, 360]);
+    reactor.destroy();
+  });
+
+  it('skips the write when a reload carries the same rendition set', async () => {
+    const state = makeState({ presentation: presentationWith([HD, SD]) });
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+    const first = state.videoRenditions.get();
+
+    // A live reload swaps in a new presentation object with identical renditions.
+    state.presentation.set(presentationWith([HD, SD]));
+    await flush();
+
+    expect(state.videoRenditions.get()).toBe(first);
+    reactor.destroy();
+  });
+
+  it('clears the renditions on src unload', async () => {
+    const state = makeState({ presentation: presentationWith([HD, SD]) });
+    const reactor = deriveVideoRenditions.setup({ state });
+    await flush();
+    expect(state.videoRenditions.get()).toBeDefined();
+
+    state.presentation.set(undefined);
+    await flush();
+
+    expect(state.videoRenditions.get()).toBeUndefined();
+    reactor.destroy();
+  });
+});

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -18,7 +18,7 @@ import {
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
 import type { AudioTrack, CanPlayTrack, MaybeResolvedPresentation, TextTrack, VideoTrack } from '../../../media/types';
 import type { GetCdnId } from '../../../media/utils/cdn';
-import { getResolvedSelectedTrackDuration } from '../../../media/utils/track-selection';
+import { getResolvedSelectedTrackDuration, type VideoRenditionInfo } from '../../../media/utils/track-selection';
 import type { BandwidthConfig, BandwidthState } from '../../../network/bandwidth-estimator';
 import type { SegmentLoaderActor } from '../../actors/dom/segment-loader';
 import type { SourceBufferActor } from '../../actors/dom/source-buffer';
@@ -29,6 +29,7 @@ import {
   type PresentationDurationResolver,
 } from '../../behaviors/calculate-presentation-duration';
 import { deriveCdnPriority } from '../../behaviors/derive-cdn-priority';
+import { deriveVideoRenditions } from '../../behaviors/derive-video-renditions';
 import { endOfStream } from '../../behaviors/dom/end-of-stream';
 import { loadAudioSegments, loadTextTrackSegments, loadVideoSegments } from '../../behaviors/dom/load-segments';
 import { setupAudioBufferActors, setupVideoBufferActors } from '../../behaviors/dom/setup-buffer-actors';
@@ -103,6 +104,13 @@ export interface SimpleHlsEngineState {
   failedCdns?: string[];
   currentTime?: number;
   loadActivated?: boolean;
+  /**
+   * Selectable video quality levels of the resolved presentation, ascending by
+   * declaration order. Derived from `presentation` by `deriveVideoRenditions`;
+   * a read-only projection consumers bind to (e.g. the DOM media adapter's
+   * `videoRenditions`). Cleared on src unload.
+   */
+  videoRenditions?: VideoRenditionInfo[];
 }
 
 /**
@@ -320,6 +328,10 @@ export function createSimpleHlsEngine(
       // redundant streams (the norm) never hit it — the first-listed CDN is
       // already the primary we'd pick anyway.
       deriveCdnPriority,
+
+      // Projects the resolved presentation's video quality levels onto the
+      // `videoRenditions` slot for consumers (e.g. the DOM media adapter).
+      deriveVideoRenditions,
 
       // CDN failover cooldown: owns the expiry half of failover — watches
       // `failedCdns` (tripped directly by track resolution on a failed

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -18,7 +18,11 @@ import {
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
 import type { AudioTrack, CanPlayTrack, MaybeResolvedPresentation, TextTrack, VideoTrack } from '../../../media/types';
 import type { GetCdnId } from '../../../media/utils/cdn';
-import { getResolvedSelectedTrackDuration, type VideoRenditionInfo } from '../../../media/utils/track-selection';
+import {
+  type AudioTrackInfo,
+  getResolvedSelectedTrackDuration,
+  type VideoRenditionInfo,
+} from '../../../media/utils/track-selection';
 import type { BandwidthConfig, BandwidthState } from '../../../network/bandwidth-estimator';
 import type { SegmentLoaderActor } from '../../actors/dom/segment-loader';
 import type { SourceBufferActor } from '../../actors/dom/source-buffer';
@@ -28,6 +32,7 @@ import {
   calculatePresentationDuration,
   type PresentationDurationResolver,
 } from '../../behaviors/calculate-presentation-duration';
+import { deriveAudioTracks } from '../../behaviors/derive-audio-tracks';
 import { deriveCdnPriority } from '../../behaviors/derive-cdn-priority';
 import { deriveVideoRenditions } from '../../behaviors/derive-video-renditions';
 import { endOfStream } from '../../behaviors/dom/end-of-stream';
@@ -111,6 +116,13 @@ export interface SimpleHlsEngineState {
    * `videoRenditions`). Cleared on src unload.
    */
   videoRenditions?: VideoRenditionInfo[];
+  /**
+   * Selectable audio tracks (one per language) of the resolved presentation.
+   * Derived from `presentation` by `deriveAudioTracks`; a read-only projection
+   * consumers bind to (e.g. the DOM media adapter's `audioTracks`). Cleared on
+   * src unload.
+   */
+  audioTracks?: AudioTrackInfo[];
 }
 
 /**
@@ -332,6 +344,10 @@ export function createSimpleHlsEngine(
       // Projects the resolved presentation's video quality levels onto the
       // `videoRenditions` slot for consumers (e.g. the DOM media adapter).
       deriveVideoRenditions,
+
+      // Projects the resolved presentation's audio tracks (one per language)
+      // onto the `audioTracks` slot for consumers (e.g. the DOM media adapter).
+      deriveAudioTracks,
 
       // CDN failover cooldown: owns the expiry half of failover — watches
       // `failedCdns` (tripped directly by track resolution on a failed


### PR DESCRIPTION
Part 2 of https://github.com/videojs/v10/issues/1795 (video → audio → streamType → live → parity/autoplay).

Based on https://github.com/videojs/v10/pull/1803 (not using that as a base because the branch is on my fork so correct this after 1803 is merged)

## What changed

- SPF: `getAudioTracks(state)` selector collapses the model's per-(language x quality-group) audio tracks into one AudioTrackInfo per (language, name), carrying trackIds. `deriveAudioTracks` behavior publishes `state.audioTracks` (same reactor as `deriveVideoRenditions`: derive on resolve, clear on unload, skip unchanged).
- Core (media-tracks.ts): projects audioTracks -> `AudioTrackList (kind = default ? 'main' : 'alternative', label = name, language)`; reflects enabled from selectedAudioTrackId; feeds a newly-enabled track back to `userAudioTrackSelection`.

## Design decisions

- The SPF model doesn't split the way the DOM does. SPF stores a flat (language x quality-group) list in one switching set; the DOM wants one AudioTrack per language. The dedupe is model logic, so it lives in SPF (getAudioTracks). trackIds is what lets the adapter map a resolved `selectedAudioTrackId` (a specific group) back to its language track.
`enabled` reflects the resolved `selectedAudioTrackId`, not the track pinned by the user. Audio exposes a single `enabled` property (vs. video which exposes active + selected). It's restored on rebuild via the untracked reflect in `#projectAudioTracks`.
- Write by { language, name }. name disambiguates same-language tracks (e.g. "English" vs "English commentary"); language alone would be ambiguous.

## Deferred: `audioRenditions`
Left empty (as in HlsJsMedia, which never populates it). 

Test plan
- spf: getAudioTracks (language collapse, same-language-different-name kept distinct, empty cases); deriveAudioTracks behavior (publish/skip-unchanged/clear).
- core: projects one track per language, reflects enabled from any quality group of the selected language, feeds selection back as { language, name }, no-write when reflection re-enables the playing track, removes on destroy.
- Full core dom/media + spf engine/behaviors green; typecheck, lint, check:workspace clean.
`<simple-hls-video>.audioTracks` flows through `CustomMediaElement` automatically (same path as video).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches playback track selection and DOM↔engine sync with feedback-loop guards; behavior is well covered by tests but mistakes could affect ABR pinning or audio switching at runtime.
> 
> **Overview**
> Exposes **video renditions** and **audio tracks** on the Simple HLS DOM media element by deriving engine signals from the resolved presentation and projecting them onto `videoRenditions` / `audioTracks`, with two-way wiring for quality and language selection.
> 
> **SPF layer:** Adds `getVideoRenditions` and `getAudioTracks` (audio collapsed to one entry per language+name with `trackIds` for quality-group mapping). New `deriveVideoRenditions` and `deriveAudioTracks` behaviors publish `state.videoRenditions` and `state.audioTracks` on resolve, clear on unload, and skip redundant writes when the id-set is unchanged. Both are composed into the Simple HLS engine.
> 
> **Core adapter:** `SimpleHlsMedia` now stacks `MediaTracksMixin` and `SimpleHlsMediaMediaTracksMixin`, which sync engine signals to DOM track lists, reflect active/selected renditions and enabled audio from engine selection, forward user picks to `userVideoTrackSelection` / `userAudioTrackSelection` (including ABR when rendition index is -1), and re-subscribe on each `src` change because the SPF engine is recreated per assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf4dc0367f7cc83506e38e0140b7667f7134edd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->