### PR TITLE
fix: link to CML in SPF

### DIFF
--- a/packages/spf/src/media/types/index.ts
+++ b/packages/spf/src/media/types/index.ts
@@ -4,7 +4,7 @@
  * Based on CMAF-HAM (Common Media Application Format - Hypothetical Application Model)
  * Protocol-agnostic representation of streaming media content.
  *
- * @see https://github.com/AcademySoftwareFoundation/common-media-library
+ * @see https://github.com/streaming-video-technology-alliance/common-media-library
  */
 
 // =============================================================================


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only URL change in a comment; no runtime or API behavior affected.
> 
> **Overview**
> Updates the **Common Media Library** reference in the SPF core types header so the `@see` URL points at `streaming-video-technology-alliance/common-media-library` instead of the old `AcademySoftwareFoundation` GitHub org.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac847b91b8325cb875c1ce85fbd1370934b252c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->