### PR TITLE
fix(core): add missing i18n translations

### DIFF
--- a/packages/core/src/core/i18n/locales/ar.ts
+++ b/packages/core/src/core/i18n/locales/ar.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'أغلق',
   Settings: 'الإعدادات',
   Quality: 'الجودة',
-  Audio: 'Audio',
+  Audio: 'الصوت',
   Default: 'افتراضي',
   Speed: 'السرعة',
   Captions: 'التسميات التوضيحية',

--- a/packages/core/src/core/i18n/locales/az.ts
+++ b/packages/core/src/core/i18n/locales/az.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Bağla',
   Settings: 'Parametrlər',
   Quality: 'Keyfiyyət',
-  Audio: 'Audio',
+  Audio: 'Səs',
   Default: 'Defolt',
   Speed: 'Sürət',
   Captions: 'Başlıqlar',

--- a/packages/core/src/core/i18n/locales/bg.ts
+++ b/packages/core/src/core/i18n/locales/bg.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'OK',
   Settings: 'Настройки',
   Quality: 'Качество',
-  Audio: 'Audio',
+  Audio: 'Аудио',
   Default: 'По подразбиране',
   Speed: 'Скорост',
   Captions: 'Надписи',

--- a/packages/core/src/core/i18n/locales/bn.ts
+++ b/packages/core/src/core/i18n/locales/bn.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'বন্ধ করুন',
   Settings: 'সেটিংস',
   Quality: 'গুণমান',
-  Audio: 'Audio',
+  Audio: 'অডিও',
   Default: 'ডিফল্ট',
   Speed: 'গতি',
   Captions: 'ক্যাপশন',

--- a/packages/core/src/core/i18n/locales/bs.ts
+++ b/packages/core/src/core/i18n/locales/bs.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'OK',
   Settings: 'Postavke',
   Quality: 'Kvalitet',
-  Audio: 'Audio',
+  Audio: 'Zvuk',
   Default: 'Zadano',
   Speed: 'Brzina',
   Captions: 'Titlovi',

--- a/packages/core/src/core/i18n/locales/ca.ts
+++ b/packages/core/src/core/i18n/locales/ca.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Tancar',
   Settings: 'Configuració',
   Quality: 'Qualitat',
-  Audio: 'Audio',
+  Audio: 'Àudio',
   Default: 'Predeterminat',
   Speed: 'Velocitat',
   Captions: 'Subtítols',

--- a/packages/core/src/core/i18n/locales/cs.ts
+++ b/packages/core/src/core/i18n/locales/cs.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'Zavřít',
   Settings: 'Nastavení',
   Quality: 'Kvalita',
-  Audio: 'Audio',
+  Audio: 'Zvuk',
   Default: 'Výchozí',
   Speed: 'Rychlost',
   Captions: 'Titulky',

--- a/packages/core/src/core/i18n/locales/cy.ts
+++ b/packages/core/src/core/i18n/locales/cy.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Cau',
   Settings: 'Gosodiadau',
   Quality: 'Ansawdd',
-  Audio: 'Audio',
+  Audio: 'Sain',
   Default: 'Rhagosodedig',
   Speed: 'Cyflymder',
   Captions: 'Capsiynau',

--- a/packages/core/src/core/i18n/locales/da.ts
+++ b/packages/core/src/core/i18n/locales/da.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'OK',
   Settings: 'Indstillinger',
   Quality: 'Kvalitet',
-  Audio: 'Audio',
+  Audio: 'Lyd',
   Default: 'Standard',
   Speed: 'Hastighed',
   Captions: 'Undertekster',

--- a/packages/core/src/core/i18n/locales/de.ts
+++ b/packages/core/src/core/i18n/locales/de.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Schließen',
   Settings: 'Einstellungen',
   Quality: 'Qualität',
-  Audio: 'Audio',
+  Audio: 'Ton',
   Default: 'Standard',
   Speed: 'Geschwindigkeit',
   Captions: 'Untertitel',

--- a/packages/core/src/core/i18n/locales/el.ts
+++ b/packages/core/src/core/i18n/locales/el.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Κλείσιμο',
   Settings: 'Ρυθμίσεις',
   Quality: 'Ποιότητα',
-  Audio: 'Audio',
+  Audio: 'Ήχος',
   Default: 'Προεπιλογή',
   Speed: 'Ταχύτητα',
   Captions: 'Λεζάντες',

--- a/packages/core/src/core/i18n/locales/et.ts
+++ b/packages/core/src/core/i18n/locales/et.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Sule',
   Settings: 'Seaded',
   Quality: 'Kvaliteet',
-  Audio: 'Audio',
+  Audio: 'Heli',
   Default: 'Vaikimisi',
   Speed: 'Kiirus',
   Captions: 'Subtiitrid',

--- a/packages/core/src/core/i18n/locales/eu.ts
+++ b/packages/core/src/core/i18n/locales/eu.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Itxi',
   Settings: 'Ezarpenak',
   Quality: 'Kalitatea',
-  Audio: 'Audio',
+  Audio: 'Audioa',
   Default: 'Lehenetsia',
   Speed: 'Abiadura',
   Captions: 'Azpitituluak',

--- a/packages/core/src/core/i18n/locales/fa.ts
+++ b/packages/core/src/core/i18n/locales/fa.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'بستن',
   Settings: 'تنظیمات',
   Quality: 'کیفیت',
-  Audio: 'Audio',
+  Audio: 'صدا',
   Default: 'پیش‌فرض',
   Speed: 'سرعت',
   Captions: 'زیرنویس‌ها',

--- a/packages/core/src/core/i18n/locales/fi.ts
+++ b/packages/core/src/core/i18n/locales/fi.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'OK',
   Settings: 'Asetukset',
   Quality: 'Laatu',
-  Audio: 'Audio',
+  Audio: 'Ääni',
   Default: 'Oletus',
   Speed: 'Nopeus',
   Captions: 'Tekstitykset',

--- a/packages/core/src/core/i18n/locales/gd.ts
+++ b/packages/core/src/core/i18n/locales/gd.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Dùin',
   Settings: 'Roghainnean',
   Quality: 'Càileachd',
-  Audio: 'Audio',
+  Audio: 'Fuaim',
   Default: 'Bunaiteach',
   Speed: 'Astar',
   Captions: 'Caipseanan',

--- a/packages/core/src/core/i18n/locales/gl.ts
+++ b/packages/core/src/core/i18n/locales/gl.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Pechar',
   Settings: 'Axustes',
   Quality: 'Calidade',
-  Audio: 'Audio',
+  Audio: 'Son',
   Default: 'Predeterminado',
   Speed: 'Velocidade',
   Captions: 'Subtítulos para xordos',

--- a/packages/core/src/core/i18n/locales/he.ts
+++ b/packages/core/src/core/i18n/locales/he.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'סְגוֹר',
   Settings: 'הגדרות',
   Quality: 'איכות',
-  Audio: 'Audio',
+  Audio: 'שמע',
   Default: 'ברירת מחדל',
   Speed: 'מהירות',
   Captions: 'כתוביות',

--- a/packages/core/src/core/i18n/locales/hi.ts
+++ b/packages/core/src/core/i18n/locales/hi.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'बंद करें',
   Settings: 'सेटिंग्स',
   Quality: 'गुणवत्ता',
-  Audio: 'Audio',
+  Audio: 'ऑडियो',
   Default: 'डिफ़ॉल्ट',
   Speed: 'गति',
   Captions: 'कैप्शन',

--- a/packages/core/src/core/i18n/locales/hr.ts
+++ b/packages/core/src/core/i18n/locales/hr.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'Zatvori',
   Settings: 'Postavke',
   Quality: 'Kvaliteta',
-  Audio: 'Audio',
+  Audio: 'Zvuk',
   Default: 'Zadano',
   Speed: 'Brzina',
   Captions: 'Titlovi',

--- a/packages/core/src/core/i18n/locales/hu.ts
+++ b/packages/core/src/core/i18n/locales/hu.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Bezárás',
   Settings: 'Beállítások',
   Quality: 'Minőség',
-  Audio: 'Audio',
+  Audio: 'Hang',
   Default: 'Alapértelmezett',
   Speed: 'Sebesség',
   Captions: 'Feliratok',

--- a/packages/core/src/core/i18n/locales/ja.ts
+++ b/packages/core/src/core/i18n/locales/ja.ts
@@ -55,7 +55,7 @@ export default {
   OK: '閉じる',
   Settings: '設定',
   Quality: '画質',
-  Audio: 'Audio',
+  Audio: '音声',
   Default: 'デフォルト',
   Speed: '速度',
   Captions: 'キャプション',

--- a/packages/core/src/core/i18n/locales/ko.ts
+++ b/packages/core/src/core/i18n/locales/ko.ts
@@ -55,7 +55,7 @@ export default {
   OK: '닫기',
   Settings: '설정',
   Quality: '품질',
-  Audio: 'Audio',
+  Audio: '오디오',
   Default: '기본값',
   Speed: '속도',
   Captions: '캡션',

--- a/packages/core/src/core/i18n/locales/lv.ts
+++ b/packages/core/src/core/i18n/locales/lv.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Aizvērt',
   Settings: 'Iestatījumi',
   Quality: 'Kvalitāte',
-  Audio: 'Audio',
+  Audio: 'Skaņa',
   Default: 'Noklusējuma',
   Speed: 'Ātrums',
   Captions: 'Subtitri',

--- a/packages/core/src/core/i18n/locales/mr.ts
+++ b/packages/core/src/core/i18n/locales/mr.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'बंद',
   Settings: 'सेटिंग्ज',
   Quality: 'गुणवत्ता',
-  Audio: 'Audio',
+  Audio: 'ऑडिओ',
   Default: 'डीफॉल्ट',
   Speed: 'गती',
   Captions: 'मथळे',

--- a/packages/core/src/core/i18n/locales/nb.ts
+++ b/packages/core/src/core/i18n/locales/nb.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Lukk',
   Settings: 'Innstillinger',
   Quality: 'Kvalitet',
-  Audio: 'Audio',
+  Audio: 'Lyd',
   Default: 'Standard',
   Speed: 'Hastighet',
   Captions: 'Teksting',

--- a/packages/core/src/core/i18n/locales/ne.ts
+++ b/packages/core/src/core/i18n/locales/ne.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'बन्द गर्नुहोस्',
   Settings: 'सेटिङहरू',
   Quality: 'गुणस्तर',
-  Audio: 'Audio',
+  Audio: 'अडियो',
   Default: 'पूर्वनिर्धारित',
   Speed: 'गति',
   Captions: 'क्याप्शन',

--- a/packages/core/src/core/i18n/locales/nl.ts
+++ b/packages/core/src/core/i18n/locales/nl.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Sluiten',
   Settings: 'Instellingen',
   Quality: 'Kwaliteit',
-  Audio: 'Audio',
+  Audio: 'Geluid',
   Default: 'Standaard',
   Speed: 'Snelheid',
   Captions: 'Ondertiteling',

--- a/packages/core/src/core/i18n/locales/nn.ts
+++ b/packages/core/src/core/i18n/locales/nn.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Lukk',
   Settings: 'Innstillingar',
   Quality: 'Kvalitet',
-  Audio: 'Audio',
+  Audio: 'Lyd',
   Default: 'Standard',
   Speed: 'Fart',
   Captions: 'Teksting',

--- a/packages/core/src/core/i18n/locales/oc.ts
+++ b/packages/core/src/core/i18n/locales/oc.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Tampar',
   Settings: 'Paramètres',
   Quality: 'Qualitat',
-  Audio: 'Audio',
+  Audio: 'Àudio',
   Default: 'Per defaut',
   Speed: 'Velocitat',
   Captions: 'Legendas',

--- a/packages/core/src/core/i18n/locales/pl.ts
+++ b/packages/core/src/core/i18n/locales/pl.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Zamknij',
   Settings: 'Ustawienia',
   Quality: 'Jakość',
-  Audio: 'Audio',
+  Audio: 'Dźwięk',
   Default: 'Domyślne',
   Speed: 'Szybkość',
   Captions: 'Napisy',

--- a/packages/core/src/core/i18n/locales/pt-BR.ts
+++ b/packages/core/src/core/i18n/locales/pt-BR.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Fechar',
   Settings: 'Configurações',
   Quality: 'Qualidade',
-  Audio: 'Audio',
+  Audio: 'Áudio',
   Default: 'Padrão',
   Speed: 'Velocidade',
   Captions: 'Legendas',

--- a/packages/core/src/core/i18n/locales/pt-PT.ts
+++ b/packages/core/src/core/i18n/locales/pt-PT.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Fechar',
   Settings: 'Definições',
   Quality: 'Qualidade',
-  Audio: 'Audio',
+  Audio: 'Áudio',
   Default: 'Predefinição',
   Speed: 'Velocidade',
   Captions: 'Legendas',

--- a/packages/core/src/core/i18n/locales/ro.ts
+++ b/packages/core/src/core/i18n/locales/ro.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Închidere',
   Settings: 'Setări',
   Quality: 'Calitate',
-  Audio: 'Audio',
+  Audio: 'Sunet',
   Default: 'Implicit',
   Speed: 'Viteză',
   Captions: 'Subtitrări',

--- a/packages/core/src/core/i18n/locales/ru.ts
+++ b/packages/core/src/core/i18n/locales/ru.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Закрыть',
   Settings: 'Настройки',
   Quality: 'Качество',
-  Audio: 'Audio',
+  Audio: 'Аудио',
   Default: 'По умолчанию',
   Speed: 'Скорость',
   Captions: 'Субтитры',

--- a/packages/core/src/core/i18n/locales/sk.ts
+++ b/packages/core/src/core/i18n/locales/sk.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Zatvoriť',
   Settings: 'Nastavenia',
   Quality: 'Kvalita',
-  Audio: 'Audio',
+  Audio: 'Zvuk',
   Default: 'Predvolené',
   Speed: 'Rýchlosť',
   Captions: 'Titulky',

--- a/packages/core/src/core/i18n/locales/sl.ts
+++ b/packages/core/src/core/i18n/locales/sl.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Zapri',
   Settings: 'Nastavitve',
   Quality: 'Kakovost',
-  Audio: 'Audio',
+  Audio: 'Zvok',
   Default: 'Privzeto',
   Speed: 'Hitrost',
   Captions: 'Podnapisi',

--- a/packages/core/src/core/i18n/locales/sr.ts
+++ b/packages/core/src/core/i18n/locales/sr.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'Zatvori',
   Settings: 'Podešavanja',
   Quality: 'Kvalitet',
-  Audio: 'Audio',
+  Audio: 'Zvuk',
   Default: 'Подразумевано',
   Speed: 'Brzina',
   Captions: 'Titlovi',

--- a/packages/core/src/core/i18n/locales/sv.ts
+++ b/packages/core/src/core/i18n/locales/sv.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Stäng',
   Settings: 'Inställningar',
   Quality: 'Kvalitet',
-  Audio: 'Audio',
+  Audio: 'Ljud',
   Default: 'Standard',
   Speed: 'Hastighet',
   Captions: 'Textning',

--- a/packages/core/src/core/i18n/locales/te.ts
+++ b/packages/core/src/core/i18n/locales/te.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'మూసివేయండి',
   Settings: 'సెట్టింగ్‌లు',
   Quality: 'నాణ్యత',
-  Audio: 'Audio',
+  Audio: 'ఆడియో',
   Default: 'డిఫాల్ట్',
   Speed: 'వేగం',
   Captions: 'శీర్షికలు',

--- a/packages/core/src/core/i18n/locales/th.ts
+++ b/packages/core/src/core/i18n/locales/th.ts
@@ -53,7 +53,7 @@ export default {
   OK: 'ปิด',
   Settings: 'การตั้งค่า',
   Quality: 'คุณภาพ',
-  Audio: 'Audio',
+  Audio: 'เสียง',
   Default: 'ค่าเริ่มต้น',
   Speed: 'ความเร็ว',
   Captions: 'คำบรรยาย',

--- a/packages/core/src/core/i18n/locales/tr.ts
+++ b/packages/core/src/core/i18n/locales/tr.ts
@@ -55,7 +55,7 @@ export default {
   OK: 'Kapat',
   Settings: 'Ayarlar',
   Quality: 'Kalite',
-  Audio: 'Audio',
+  Audio: 'Ses',
   Default: 'Varsayılan',
   Speed: 'Hız',
   Captions: 'Altyazılar',

--- a/packages/core/src/core/i18n/locales/uk.ts
+++ b/packages/core/src/core/i18n/locales/uk.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Закрити',
   Settings: 'Налаштування',
   Quality: 'Якість',
-  Audio: 'Audio',
+  Audio: 'Аудіо',
   Default: 'За замовчуванням',
   Speed: 'Швидкість',
   Captions: 'Субтитри',

--- a/packages/core/src/core/i18n/locales/vi.ts
+++ b/packages/core/src/core/i18n/locales/vi.ts
@@ -54,7 +54,7 @@ export default {
   OK: 'Đóng',
   Settings: 'Cài đặt',
   Quality: 'Chất lượng',
-  Audio: 'Audio',
+  Audio: 'Âm thanh',
   Default: 'Mặc định',
   Speed: 'Tốc độ',
   Captions: 'Phụ đề',

--- a/packages/core/src/core/i18n/locales/zh-CN.ts
+++ b/packages/core/src/core/i18n/locales/zh-CN.ts
@@ -53,7 +53,7 @@ export default {
   OK: '关闭',
   Settings: '设置',
   Quality: '画质',
-  Audio: 'Audio',
+  Audio: '音频',
   Default: '默认',
   Speed: '速度',
   Captions: '字幕',

--- a/packages/core/src/core/i18n/locales/zh-TW.ts
+++ b/packages/core/src/core/i18n/locales/zh-TW.ts
@@ -53,7 +53,7 @@ export default {
   OK: '關閉',
   Settings: '設定',
   Quality: '畫質',
-  Audio: 'Audio',
+  Audio: '音訊',
   Default: '預設',
   Speed: '速度',
   Captions: '字幕',


### PR DESCRIPTION
Add missing translations for "Audio".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only locale updates with no logic or API changes; worst case is an incorrect translation in the UI.
> 
> **Overview**
> Replaces the untranslated English placeholder for the **`Audio`** settings label across **40+ locale files** under `packages/core/src/core/i18n/locales/`, so the audio track menu shows localized text (e.g. German **Ton**, Japanese **音声**, Arabic **الصوت**) instead of the literal string `Audio`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268b11f8ea481eb0157a92908b7ff9f631a7d2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->