### PR TITLE
docs(site): update stale popup docs

### DIFF
--- a/site/src/content/docs/reference/popover.mdx
+++ b/site/src/content/docs/reference/popover.mdx
@@ -73,6 +73,7 @@ Use [CSS custom properties](#root-css-custom-properties) for positioning offsets
 media-popover {
   --media-popover-side-offset: 8px;
   --media-popover-align-offset: 0px;
+  --media-popover-boundary-offset: 8px;
 }
 ```
 </FrameworkCase>
@@ -84,6 +85,7 @@ React renders standard DOM elements. Add a `className` to style them:
 .popover {
   --media-popover-side-offset: 8px;
   --media-popover-align-offset: 0px;
+  --media-popover-boundary-offset: 8px;
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/tooltip.mdx
+++ b/site/src/content/docs/reference/tooltip.mdx
@@ -87,6 +87,7 @@ Use [CSS custom properties](#root-css-custom-properties) for positioning offsets
 media-tooltip {
   --media-tooltip-side-offset: 8px;
   --media-tooltip-align-offset: 0px;
+  --media-tooltip-boundary-offset: 8px;
 }
 ```
 </FrameworkCase>
@@ -98,6 +99,7 @@ React renders standard DOM elements. Add a `className` to style them:
 .tooltip-popup {
   --media-tooltip-side-offset: 8px;
   --media-tooltip-align-offset: 0px;
+  --media-tooltip-boundary-offset: 8px;
 }
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/use-player-context.mdx
+++ b/site/src/content/docs/reference/use-player-context.mdx
@@ -1,18 +1,18 @@
 ---
 title: usePlayerContext
-description: Hook to access the full player context including store, media element, and media setter
+description: Hook to access the full player context value
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
 import DocsLink from "@/components/docs/DocsLink.astro";
 
-`usePlayerContext` returns the full `PlayerContextValue` object, which includes the store, the current media element, and the media setter.
+`usePlayerContext` returns the full `PlayerContextValue` object for lower-level integrations that need direct access to player context fields.
 
 ```tsx title="DebugPanel.tsx"
 import { usePlayerContext } from "@videojs/react";
 
 function DebugPanel() {
-  const { store, media, setMedia } = usePlayerContext();
+  const { store, media, container, popupGroup } = usePlayerContext();
 
   return (
     <pre>
@@ -20,6 +20,8 @@ function DebugPanel() {
         {
           hasStore: !!store,
           hasMedia: !!media,
+          hasContainer: !!container,
+          hasPopupGroup: !!popupGroup,
           tagName: media?.tagName,
         },
         null,


### PR DESCRIPTION
Closes #1544

## Summary

Update the hand-authored reference docs for popup positioning and player context so they match the current API surface.

## Changes

- Document the popover and tooltip boundary offset CSS custom properties in styling examples.
- Refresh the `usePlayerContext` description and example so it no longer omits newer context fields.

## Testing

- `pnpm --dir site build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API behavior changes.
> 
> **Overview**
> Brings hand-authored reference pages in line with the current popup positioning and React player context APIs.
> 
> **Popover** and **Tooltip** styling examples now include `--media-popover-boundary-offset` and `--media-tooltip-boundary-offset` alongside the existing side/align offset variables.
> 
> The **`usePlayerContext`** page drops outdated wording about `setMedia`, reframes the hook for lower-level integrations, and updates the sample to surface `container` and `popupGroup` instead of `setMedia`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32cb460d347fe8a280fc806ebd75a3512986a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->