### PR TITLE
docs(site): update localized label docs

### DIFF
--- a/site/src/content/docs/reference/play-button.mdx
+++ b/site/src/content/docs/reference/play-button.mdx
@@ -89,7 +89,7 @@ media-play-button:not([data-started]) .play-icon { display: none; }
 
 ## Accessibility
 
-Renders a `<button>` element with an automatic `aria-label` that updates based on state: "Play", "Pause", or "Replay". Override with the `label` prop (accepts a string or function). Keyboard activation: <kbd>Enter</kbd> / <kbd>Space</kbd>.
+Renders a `<button>` element with an automatic `aria-label` that updates based on state: "Play", "Pause", or "Replay". Override with the `label` prop, which accepts a translation key, custom string, or function returning either. Keyboard activation: <kbd>Enter</kbd> / <kbd>Space</kbd>.
 
 ## Examples
 

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -83,7 +83,7 @@ media-time-slider[data-seeking] {
 
 ## Accessibility
 
-Renders with `role="slider"` and automatic `aria-label` of "Seek". Override with the `label` prop. Keyboard controls:
+Renders with `role="slider"` and an automatic `aria-label` that resolves to "Seek" from the active locale. Override with the `label` prop. Keyboard controls:
 
 - <kbd>Arrow Left</kbd> / <kbd>Arrow Right</kbd>: step by `step` increment
 - <kbd>Page Up</kbd> / <kbd>Page Down</kbd>: step by `largeStep` increment

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -63,7 +63,7 @@ React renders a `<div>` element. Add a `className` to style it:
 
 ## Accessibility
 
-Renders with `role="slider"` and automatic `aria-label` of "Volume". Override with the `label` prop. Keyboard controls:
+Renders with `role="slider"` and an automatic `aria-label` that resolves to "Volume" from the active locale. Override with the `label` prop. Keyboard controls:
 
 - <kbd>Arrow Left</kbd> / <kbd>Arrow Right</kbd>: step by `step` increment
 - <kbd>Page Up</kbd> / <kbd>Page Down</kbd>: step by `largeStep` increment


### PR DESCRIPTION
Closes #1703

## Summary

Update stale accessibility wording for localized control labels so the reference docs match the i18n-aware API surface.

## Changes

- Clarify that `PlayButton` labels can be translation keys, custom strings, or functions returning either.
- Reword `TimeSlider` and `VolumeSlider` default aria-label text to describe locale resolution instead of hardcoded defaults.

## Testing

- `pnpm --dir site build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API changes.
> 
> **Overview**
> Updates **Accessibility** sections in three reference pages so they match the i18n-aware `label` and default `aria-label` behavior.
> 
> **PlayButton** docs now state that `label` can be a translation key, a custom string, or a function returning either—not only a string or function.
> 
> **TimeSlider** and **VolumeSlider** docs no longer describe fixed English defaults ("Seek", "Volume"); they explain that the automatic `aria-label` comes from the **active locale**, with `label` still available to override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d243b83d840ca07b92d27d231152de153f0be19d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->