### PR TITLE
fix(spf): load final segment when seeking to exact end (#1828)

### DIFF
--- a/packages/spf/src/media/buffer/forward-buffer.ts
+++ b/packages/spf/src/media/buffer/forward-buffer.ts
@@ -169,16 +169,24 @@ export function getSegmentsToLoad(
   // - Overlaps buffer window [currentTime, targetTime)
   // - Not already buffered at that time position
   const toLoad = segments.filter((seg, i) => {
-    // Segment must overlap the buffer window
     const segmentEnd = seg.startTime + seg.duration;
-    // Strict `>` for the overlap so a segment the playhead has just finished
-    // (endTime === currentTime at an interior boundary) isn't reloaded. The
-    // final segment is the exception: at currentTime === total duration its
-    // endTime equals currentTime, so `>` would drop it and it would never load
-    // → endOfStream() never fires and a seek-to-end stalls (#1828). Include the
-    // last segment when the playhead is at/within it.
     const isLast = i === segments.length - 1;
-    const isInRange = seg.startTime < targetTime && (segmentEnd > currentTime || (isLast && segmentEnd >= currentTime));
+    // Interior segments use strict `>` so a segment the playhead just finished
+    // (endTime === currentTime at a boundary) isn't reloaded. The terminal
+    // segment has no successor and no reachable position past it — the playhead
+    // is clamped to the presentation's range — so it needs no upper bound: it's
+    // loadable whenever the forward window reaches it. That resolves the
+    // exact-end seek (#1828) and the post-loop re-seek — where
+    // `MediaSource.duration`, clamped by `endOfStream()` to the true buffered
+    // end, has grown a hair past the model's EXTINF-derived end — with no
+    // dependency on any duration value.
+    //
+    // LIVE: for an un-ended live/DVR presentation `isLast` is the sliding edge
+    // segment; loading it eagerly here is benign today (forward-window-bounded,
+    // deduped by the buffered check), but the live effort should confirm the
+    // edge / end-of-stream interaction when it lands.
+    const overlapsPlayhead = isLast || segmentEnd > currentTime;
+    const isInRange = seg.startTime < targetTime && overlapsPlayhead;
 
     // Must not have a segment buffered at this time position
     const isNotBuffered = !bufferedStartTimes.has(seg.startTime);

--- a/packages/spf/src/media/buffer/forward-buffer.ts
+++ b/packages/spf/src/media/buffer/forward-buffer.ts
@@ -168,10 +168,17 @@ export function getSegmentsToLoad(
   // Find segments to load:
   // - Overlaps buffer window [currentTime, targetTime)
   // - Not already buffered at that time position
-  const toLoad = segments.filter((seg) => {
+  const toLoad = segments.filter((seg, i) => {
     // Segment must overlap the buffer window
     const segmentEnd = seg.startTime + seg.duration;
-    const isInRange = seg.startTime < targetTime && segmentEnd > currentTime;
+    // Strict `>` for the overlap so a segment the playhead has just finished
+    // (endTime === currentTime at an interior boundary) isn't reloaded. The
+    // final segment is the exception: at currentTime === total duration its
+    // endTime equals currentTime, so `>` would drop it and it would never load
+    // → endOfStream() never fires and a seek-to-end stalls (#1828). Include the
+    // last segment when the playhead is at/within it.
+    const isLast = i === segments.length - 1;
+    const isInRange = seg.startTime < targetTime && (segmentEnd > currentTime || (isLast && segmentEnd >= currentTime));
 
     // Must not have a segment buffered at this time position
     const isNotBuffered = !bufferedStartTimes.has(seg.startTime);

--- a/packages/spf/src/media/buffer/tests/forward-buffer.test.ts
+++ b/packages/spf/src/media/buffer/tests/forward-buffer.test.ts
@@ -279,15 +279,14 @@ describe('getSegmentsToLoad', () => {
       expect(toLoad).toHaveLength(2); // Load both segments within 30s
     });
 
-    it('should handle currentTime after all segments', () => {
+    it('past all segments, does not reload interior segments the playhead has passed', () => {
+      // A playhead past every segment is unreachable in practice (clamped to the
+      // presentation's range), but the rule stays well-defined: interior segments
+      // behind the playhead are NOT reloaded. The terminal segment has no
+      // successor, so it stays selectable — see the exact-end / overshoot cases.
       const segments: Segment[] = [createSegment(0, 6), createSegment(6, 6)];
-
-      const bufferedSegments: Segment[] = [];
-      const currentTime = 100;
-
-      const toLoad = getSegmentsToLoad(segments, bufferedSegments, currentTime);
-
-      expect(toLoad).toHaveLength(0); // No segments in range
+      const toLoad = getSegmentsToLoad(segments, [], 100);
+      expect(toLoad.map((s) => s.id)).toEqual(['seg-6']); // only the terminal segment
     });
 
     it('should not load segments beyond target', () => {
@@ -411,6 +410,19 @@ describe('getSegmentsToLoad', () => {
       const segments = [createSegment(0, 6), createSegment(6, 6), createSegment(12, 6)] as const;
       // Playhead dragged to the exact end (duration = 18), nothing buffered there.
       const toLoad = getSegmentsToLoad(segments, [], 18);
+      expect(toLoad.map((s) => s.id)).toEqual(['seg-12']);
+    });
+
+    it('loads the final segment when currentTime slightly exceeds its model end', () => {
+      // Post-loop re-seek variant of #1828. After the first end, endOfStream()
+      // clamps MediaSource.duration to the true buffered end, which can run a
+      // hair past the model's EXTINF-derived last-segment end. A later seek to
+      // that grown duration lands just past the last segment's endTime — its
+      // real media still covers the position, so it must still be selected, or
+      // the loader goes idle and the seek stalls.
+      const segments = [createSegment(0, 6), createSegment(6, 6), createSegment(12, 6)] as const;
+      // Model end = 18; duration grew to 18.03, seek lands past seg-12's endTime.
+      const toLoad = getSegmentsToLoad(segments, [], 18.03);
       expect(toLoad.map((s) => s.id)).toEqual(['seg-12']);
     });
 

--- a/packages/spf/src/media/buffer/tests/forward-buffer.test.ts
+++ b/packages/spf/src/media/buffer/tests/forward-buffer.test.ts
@@ -401,4 +401,26 @@ describe('getSegmentsToLoad', () => {
       expect(toLoad[0]?.id).toBe('seg-18');
     });
   });
+
+  describe('exact-end boundary (#1828)', () => {
+    it('loads the final segment when currentTime is exactly the total duration', () => {
+      // Regression for #1828: seeking to currentTime === duration must still
+      // select the last segment. A strict `endTime > currentTime` overlap test
+      // drops the final segment (whose endTime === duration), so it never loads
+      // and endOfStream() never fires → the seek stalls forever.
+      const segments = [createSegment(0, 6), createSegment(6, 6), createSegment(12, 6)] as const;
+      // Playhead dragged to the exact end (duration = 18), nothing buffered there.
+      const toLoad = getSegmentsToLoad(segments, [], 18);
+      expect(toLoad.map((s) => s.id)).toEqual(['seg-12']);
+    });
+
+    it('does not re-select a finished segment at a mid-stream boundary', () => {
+      // Guard: the fix is scoped to the final segment. At an interior boundary
+      // (currentTime === a non-last segment's endTime) the just-finished segment
+      // must NOT be reloaded — only the segments the playhead is entering.
+      const segments = [createSegment(0, 6), createSegment(6, 6), createSegment(12, 6)] as const;
+      const toLoad = getSegmentsToLoad(segments, [], 6);
+      expect(toLoad.map((s) => s.id)).toEqual(['seg-6', 'seg-12']);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1828.

## Summary

Seeking to `currentTime === duration` exactly (while playing) stalled indefinitely — the final segment was never selected by the forward-load window, so `endOfStream()` never fired and the seek couldn't complete.

## Root cause

`getSegmentsToLoad` filtered segments with a strict `endTime > currentTime` overlap test. At `currentTime === duration` the final segment's `endTime === duration`, so it was excluded, never loaded, and the `MediaSource` stayed `open` (readyState 1, `seeking` stuck true).

## Fix

Include the final segment at the end boundary (`isLast && endTime >= currentTime`) in `getSegmentsToLoad`; interior boundaries keep strict `>` so a just-finished segment isn't reloaded. (`packages/spf/src/media/buffer/forward-buffer.ts`)

## Smoke test

Deploy preview (this PR's Vercel branch build), looping so the end boundary is exercised:
https://v10-sandbox-git-fix-spf-exact-end-seek-stall-mux.vercel.app/spf-segment-loading/?muted=true&autoplay=true&loop=true&preload=auto

Watch it reach the end (drag the scrubber near the end to get there quickly). Confirm across **Chromium, Firefox, and Safari/WebKit**:

- With `loop=true` (the link above): the stream reaches the end and **restarts cleanly from the beginning** — no stall at the boundary.
- Remove `&loop=true`: the stream reaches the end and **stops cleanly at `ended`** (not frozen mid-seek), and pressing play again restarts from the start.

Pre-fix, the stream instead **stalled at the very end** — the final segment never loaded, so it neither ended nor looped. Any VOD exercises this (a general segment-loader edge, not relocation-specific); the page default is a Mux VOD.

## Testing

- **Unit:** regression test (exact-end → loads final segment; fails before the fix) + guard test (mid-stream boundary does not re-select the finished segment). `forward-buffer` 21/21, `segment-loader` actor 5/5, typecheck + biome clean.
- **Browser smoke** (sandbox `/spf-segment-loading/`, Mux VOD, seek to exact `duration` while playing): reaches `ended` in ~0.5s — last segment loads, `MediaSource` → `ended`, buffered extends to the full end. On the same harness pre-fix: stalls (`seeking` stuck true, `MediaSource` `open`, buffered never reaches the end).

## Notes

- General segment-loader edge — reproduces on native 0-based sources, so it is **not** caused by the non-zero-PTS relocation work.
- Branched off `feat/spf-non-zero-pts-relocation` and targets it for a clean diff, but touches only pre-existing code, so it's cleanly cherry-pickable to `main` if it should land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core forward-buffer segment selection used by the segment loader; behavior change is narrow (terminal segment only) but affects end-of-VOD and loop seeks across all SPF playback.
> 
> **Overview**
> Fixes **#1828** by changing how `getSegmentsToLoad` decides whether a segment overlaps the playhead. Interior segments still require **`segmentEnd > currentTime`** so a segment you just finished at a boundary is not re-fetched; the **last** segment is always treated as overlapping when it falls in the forward window, so seeks to **`currentTime === duration`** (and slight overshoot after loop/`MediaSource.duration` clamping) still queue the final segment for load.
> 
> Without that, the last segment was dropped at the exact end, **`endOfStream()`** never ran, and playback could stall with **`seeking`** stuck. Tests were updated for the “past all segments” case and new **exact-end** regressions plus a mid-stream boundary guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef1590cb497d7d93293e40f4982b0d21ccf2a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

