### PR TITLE
feat(packages): add youtube media with html and react components

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -13,4 +13,5 @@ export const PRESETS = [
   'audio',
   'background-video',
   'vimeo-video',
+  'youtube-video',
 ] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -197,6 +197,8 @@ export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02n
 
 export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 
+export const YOUTUBE_VIDEO_SRC = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return SOURCES[id].live === true;

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -23,6 +23,7 @@ function getPagePath(platform: Platform, preset: Preset): string {
   if (platform === 'cdn') return '/cdn/';
   if (preset === 'background-video') return `/${platform}-background-video/`;
   if (preset === 'vimeo-video') return `/${platform}-vimeo-video/`;
+  if (preset === 'youtube-video') return `/${platform}-youtube-video/`;
   return `/${platform}-${preset}/`;
 }
 
@@ -152,9 +153,12 @@ export function App() {
     }
   }, [availableSources, source]);
 
-  // CDN, background video, and vimeo video do not have a Tailwind skin variant.
+  // CDN, background video, and embed (Vimeo/YouTube) videos do not have a Tailwind skin variant.
   useEffect(() => {
-    if ((platform === 'cdn' || preset === 'background-video' || preset === 'vimeo-video') && styling === 'tailwind') {
+    if (
+      (platform === 'cdn' || preset === 'background-video' || preset === 'vimeo-video' || preset === 'youtube-video') &&
+      styling === 'tailwind'
+    ) {
       setStyling('css');
     }
   }, [platform, preset, styling]);
@@ -190,6 +194,7 @@ export function App() {
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}
         isVimeoVideo={preset === 'vimeo-video'}
+        isYouTubeVideo={preset === 'youtube-video'}
         platforms={PLATFORMS}
         stylings={STYLINGS}
         presets={PRESETS}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -32,6 +32,7 @@ type NavbarProps = {
   isMuxVideo: boolean;
   isMuxAudio: boolean;
   isVimeoVideo: boolean;
+  isYouTubeVideo: boolean;
   platforms: readonly Platform[];
   stylings: readonly Styling[];
   presets: readonly Preset[];
@@ -58,6 +59,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   audio: 'Audio',
   'background-video': 'Background Video',
   'vimeo-video': 'Vimeo Video',
+  'youtube-video': 'YouTube Video',
 };
 
 export function Navbar({
@@ -87,6 +89,7 @@ export function Navbar({
   isMuxVideo,
   isMuxAudio,
   isVimeoVideo,
+  isYouTubeVideo,
   platforms,
   stylings,
   presets,
@@ -115,7 +118,7 @@ export function Navbar({
           options={stylings.map((s) => ({
             value: s,
             label: s === 'css' ? 'CSS' : 'Tailwind',
-            disabled: s === 'tailwind' && (isBackgroundVideo || isVimeoVideo || platform === 'cdn'),
+            disabled: s === 'tailwind' && (isBackgroundVideo || isVimeoVideo || isYouTubeVideo || platform === 'cdn'),
           }))}
         />
 
@@ -148,7 +151,7 @@ export function Navbar({
               return true;
             })
             .map((id) => ({ value: id, label: sources[id].label }))}
-          disabled={isBackgroundVideo || isVimeoVideo}
+          disabled={isBackgroundVideo || isVimeoVideo || isYouTubeVideo}
         />
       </div>
 

--- a/apps/sandbox/templates/html-youtube-video/index.html
+++ b/apps/sandbox/templates/html-youtube-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML YouTube Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-youtube-video/main.ts
+++ b/apps/sandbox/templates/html-youtube-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/youtube-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { YOUTUBE_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <youtube-video class="block w-full h-full" src="${YOUTUBE_VIDEO_SRC}" playsinline></youtube-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-youtube-video/index.html
+++ b/apps/sandbox/templates/react-youtube-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React YouTube Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-youtube-video/main.tsx
+++ b/apps/sandbox/templates/react-youtube-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoProvider } from '@app/shared/react/providers';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { YOUTUBE_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { YouTubeVideo } from '@videojs/react/media/youtube-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoProvider>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <YouTubeVideo className="block w-full h-full" src={YOUTUBE_VIDEO_SRC} playsInline />
+      </VideoSkinComponent>
+    </VideoProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/define/media/youtube-video.ts
+++ b/packages/html/src/define/media/youtube-video.ts
@@ -1,0 +1,14 @@
+import { YouTubeVideo } from '../../media/youtube-video';
+import { safeDefine } from '../safe-define';
+
+export class YouTubeVideoElement extends YouTubeVideo {
+  static readonly tagName = 'youtube-video';
+}
+
+safeDefine(YouTubeVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [YouTubeVideoElement.tagName]: YouTubeVideoElement;
+  }
+}

--- a/packages/html/src/media/youtube-video/index.ts
+++ b/packages/html/src/media/youtube-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/youtube-video/media.ts
+++ b/packages/html/src/media/youtube-video/media.ts
@@ -1,0 +1,54 @@
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { buildYouTubeIframeSrc, YouTubeMedia } from '@videojs/media/dom/youtube';
+import { escapeHtml } from '@videojs/utils/string';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class YouTubeCustomMediaElement extends CustomMediaElement('iframe', YouTubeMedia) {
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildYouTubeIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: inline-block;
+          min-width: 300px;
+          min-height: 150px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        :host(:not([controls])) {
+          pointer-events: none;
+        }
+      </style>
+      <iframe
+        part="iframe"
+        ${srcAttr}
+        allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        frameborder="0"
+        width="100%"
+        height="100%"
+        referrerpolicy="${escapeHtml(attrs.referrerpolicy ?? '')}"
+      ></iframe>
+    `;
+  };
+}
+
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    playsInline: attrs.playsinline !== undefined,
+    preload: (attrs.preload as 'none' | 'metadata' | 'auto' | undefined) ?? 'metadata',
+  };
+}
+
+export class YouTubeVideo extends MediaAttachMixin(YouTubeCustomMediaElement) {}

--- a/packages/media/src/dom/utils/embed-params.ts
+++ b/packages/media/src/dom/utils/embed-params.ts
@@ -1,0 +1,15 @@
+/**
+ * Serialize embed options into a query string. Booleans become `1`/`0`, which is
+ * how both the YouTube and Vimeo embeds spell them, and nullish values are
+ * dropped so an unset option is absent rather than the string `"undefined"`.
+ */
+export function serializeEmbedParams(props: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  for (const key in props) {
+    const val = props[key];
+    if (val === true || val === '') params.set(key, '1');
+    else if (val === false) params.set(key, '0');
+    else if (val != null) params.set(key, String(val));
+  }
+  return params.toString();
+}

--- a/packages/media/src/dom/utils/index.ts
+++ b/packages/media/src/dom/utils/index.ts
@@ -6,5 +6,5 @@ export {
   getMediaProp,
   setMediaProp,
 } from './media-components';
-export { createPublicPromise, type PublicPromise } from './public-promise';
+
 export { createTimeRange } from './time-ranges';

--- a/packages/media/src/dom/utils/index.ts
+++ b/packages/media/src/dom/utils/index.ts
@@ -1,3 +1,4 @@
+export { serializeEmbedParams } from './embed-params';
 export {
   addMediaComponent,
   getMediaComponents,
@@ -5,3 +6,5 @@ export {
   getMediaProp,
   setMediaProp,
 } from './media-components';
+export { createPublicPromise, type PublicPromise } from './public-promise';
+export { createTimeRange } from './time-ranges';

--- a/packages/media/src/dom/utils/public-promise.ts
+++ b/packages/media/src/dom/utils/public-promise.ts
@@ -1,0 +1,21 @@
+export interface PublicPromise<T> extends Promise<T> {
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+/**
+ * A promise that can be settled from outside the executor. Embed hosts use one
+ * as a load barrier: calls that need a loaded player await it, and whichever
+ * event finishes the load resolves it.
+ */
+export function createPublicPromise<T>(): PublicPromise<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  }) as PublicPromise<T>;
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}

--- a/packages/media/src/dom/utils/time-ranges.ts
+++ b/packages/media/src/dom/utils/time-ranges.ts
@@ -1,0 +1,10 @@
+import type { TimeRangeLike } from '../../core/types';
+
+/**
+ * A `TimeRanges`-shaped object holding a single range. Embed hosts only ever
+ * know one contiguous buffered or seekable span, so they report it through this
+ * rather than constructing a real `TimeRanges`, which has no public constructor.
+ */
+export function createTimeRange(start: number, end: number): TimeRangeLike {
+  return { length: 1, start: () => start, end: () => end };
+}

--- a/packages/media/src/dom/vimeo/media.ts
+++ b/packages/media/src/dom/vimeo/media.ts
@@ -5,6 +5,7 @@ import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 
 import type { ErrorLike, MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
+import { createPublicPromise, createTimeRange, type PublicPromise, serializeEmbedParams } from '../utils';
 
 export type { default as VimeoPlayerApi } from '@vimeo/player';
 
@@ -357,12 +358,12 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
   }
 
   get buffered() {
-    return this.#progress > 0 ? createTimeRanges(0, this.#progress) : EMPTY_TIME_RANGES;
+    return this.#progress > 0 ? createTimeRange(0, this.#progress) : EMPTY_TIME_RANGES;
   }
 
   get seekable() {
     return this.#duration > 0 && Number.isFinite(this.#duration)
-      ? createTimeRanges(0, this.#duration)
+      ? createTimeRange(0, this.#duration)
       : EMPTY_TIME_RANGES;
   }
 
@@ -649,9 +650,9 @@ export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps>
   if (parsed.kind === 'event') {
     const hashPath = parsed.hash ? `/${parsed.hash}` : '';
     delete params.h;
-    return `${EMBED_EVENT_BASE}/${parsed.id}/embed${hashPath}?${serialize(params)}`;
+    return `${EMBED_EVENT_BASE}/${parsed.id}/embed${hashPath}?${serializeEmbedParams(params)}`;
   }
-  return `${EMBED_VIDEO_BASE}/${parsed.id}?${serialize(params)}`;
+  return `${EMBED_VIDEO_BASE}/${parsed.id}?${serializeEmbedParams(params)}`;
 }
 
 const EMBED_VIDEO_BASE = 'https://player.vimeo.com/video';
@@ -662,42 +663,10 @@ const READY_STATE_HAVE_NOTHING = 0;
 const READY_STATE_HAVE_METADATA = 1;
 const READY_STATE_HAVE_FUTURE_DATA = 3;
 
-function createTimeRanges(start: number, end: number) {
-  return { length: 1, start: () => start, end: () => end };
-}
-
 function toLoadVideoOptions(src: string, engine?: VimeoEngineConfig) {
   const parsed = parseVimeoSource(src);
   if (!parsed) return null;
   const base = parsed.kind === 'event' ? `${EMBED_EVENT_BASE}/${parsed.id}/embed` : `${EMBED_VIDEO_BASE}/${parsed.id}`;
   const url = `${base}${parsed.hash ? `?h=${parsed.hash}` : ''}` as VimeoUrl;
   return { url, ...engine } as LoadVideoOptions;
-}
-
-function serialize(props: Record<string, unknown>) {
-  const params = new URLSearchParams();
-  for (const key in props) {
-    const val = props[key];
-    if (val === true || val === '') params.set(key, '1');
-    else if (val === false) params.set(key, '0');
-    else if (val != null) params.set(key, String(val));
-  }
-  return params.toString();
-}
-
-interface PublicPromise<T> extends Promise<T> {
-  resolve: (value: T) => void;
-  reject: (reason?: unknown) => void;
-}
-
-function createPublicPromise<T>(): PublicPromise<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  }) as PublicPromise<T>;
-  promise.resolve = resolve;
-  promise.reject = reject;
-  return promise;
 }

--- a/packages/media/src/dom/vimeo/media.ts
+++ b/packages/media/src/dom/vimeo/media.ts
@@ -1,3 +1,4 @@
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
 import { deepEqual } from '@videojs/utils/object';
 import { isNull, isString, isUndefined } from '@videojs/utils/predicate';
 import VimeoPlayer, { type LoadVideoOptions, type VimeoEmbedParameters, type VimeoUrl } from '@vimeo/player';
@@ -5,7 +6,7 @@ import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 
 import type { ErrorLike, MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
-import { createPublicPromise, createTimeRange, type PublicPromise, serializeEmbedParams } from '../utils';
+import { createTimeRange, serializeEmbedParams } from '../utils';
 
 export type { default as VimeoPlayerApi } from '@vimeo/player';
 

--- a/packages/media/src/dom/vimeo/tests/media.test.ts
+++ b/packages/media/src/dom/vimeo/tests/media.test.ts
@@ -579,6 +579,19 @@ describe('VimeoMedia', () => {
     expect(played.end(0)).toBe(3);
   });
 
+  it('unblocks pending play() when detached before load completes', async () => {
+    const media = new VimeoMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    // Await load without the player ever emitting `loaded`.
+    const pending = media.play();
+    media.detach();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
   it('destroys the player on detach', () => {
     const media = new VimeoMedia();
     const iframe = createIframe();

--- a/packages/media/src/dom/youtube/iframe-api.ts
+++ b/packages/media/src/dom/youtube/iframe-api.ts
@@ -1,0 +1,77 @@
+// Minimal typings and loader for the YouTube iframe API
+// (https://developers.google.com/youtube/iframe_api_reference).
+// The API arrives from a script tag, so there is no npm SDK to type against.
+
+import { loadScript } from '@videojs/utils/dom';
+import { MediaError } from '../../core/media-error';
+
+export interface YouTubePlayerApi {
+  playVideo(): void;
+  pauseVideo(): void;
+  seekTo(seconds: number, allowSeekAhead: boolean): void;
+  mute(): void;
+  unMute(): void;
+  isMuted(): boolean;
+  setVolume(volume: number): void;
+  getVolume(): number;
+  getDuration(): number;
+  getCurrentTime(): number;
+  getPlaybackRate(): number;
+  setPlaybackRate(rate: number): void;
+  getVideoLoadedFraction(): number;
+  getPlayerState(): number;
+  loadVideoById(options: { videoId: string; startSeconds?: number }): void;
+  cueVideoById(options: { videoId: string; startSeconds?: number }): void;
+  loadPlaylist(options: { list: string; listType?: string }): void;
+  cuePlaylist(options: { list: string; listType?: string }): void;
+  stopVideo(): void;
+  getOption(module: string, option: string): unknown;
+  setOption(module: string, option: string, value: unknown): void;
+  addEventListener(type: string, listener: (event: { data: number }) => void): void;
+  destroy(): void;
+}
+
+export interface YouTubePlayerEvents {
+  onReady?: () => void;
+  onError?: (event: { data: number }) => void;
+}
+
+export interface YouTubeApi {
+  Player: new (target: HTMLIFrameElement, options: { events?: YouTubePlayerEvents }) => YouTubePlayerApi;
+  ready(callback: () => void): void;
+}
+
+export interface YouTubeCaptionTrack {
+  languageCode?: string;
+  displayName?: string;
+}
+
+const API_URL = 'https://www.youtube.com/iframe_api';
+
+/** Load the iframe API once, reusing it if another host already pulled it in. */
+export async function loadYouTubeApi(): Promise<YouTubeApi> {
+  const existing = (globalThis as { YT?: YouTubeApi }).YT;
+  if (existing?.Player) return existing;
+  await loadScript(API_URL);
+  const api = (globalThis as { YT?: YouTubeApi }).YT;
+  if (!api) throw new Error('YouTube iframe API failed to load');
+  // The loader stub exposes `YT.ready` before `YT.Player` is defined.
+  await new Promise<void>((resolve) => api.ready(resolve));
+  return api;
+}
+
+// https://developers.google.com/youtube/iframe_api_reference#onStateChange
+export const STATE_UNSTARTED = -1;
+export const STATE_ENDED = 0;
+export const STATE_PLAYING = 1;
+export const STATE_PAUSED = 2;
+export const STATE_BUFFERING = 3;
+
+// https://developers.google.com/youtube/iframe_api_reference#onError
+export const youtubeErrorCodeToMediaErrorCode: Record<number, number> = {
+  2: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // invalid parameter (e.g. malformed video id)
+  5: MediaError.MEDIA_ERR_DECODE, // HTML5 player error
+  100: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // video not found, removed, or private
+  101: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // embedding not allowed
+  150: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // embedding not allowed (alias of 101)
+};

--- a/packages/media/src/dom/youtube/index.ts
+++ b/packages/media/src/dom/youtube/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/media/src/dom/youtube/index.ts
+++ b/packages/media/src/dom/youtube/index.ts
@@ -1,1 +1,6 @@
+// The iframe API module is internal apart from the player typings, which the
+// `engine` getter surfaces.
+export type { YouTubeApi, YouTubePlayerApi } from './iframe-api';
 export * from './media';
+export * from './props';
+export * from './source';

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -682,10 +682,13 @@ export function parseYouTubeSource(src: string): YouTubeSource | null {
   const noCookie = src.includes('-nocookie');
   const videoMatch = VIDEO_MATCH_SRC.exec(src);
   const listMatch = PLAYLIST_MATCH_SRC.exec(src);
-  if (!videoMatch && !listMatch) return null;
+  // Playlist embed URLs use the `videoseries` placeholder in the video id slot.
+  const videoId = videoMatch?.[1] ?? null;
+  const id = videoId === 'videoseries' ? null : videoId;
+  if (!id && !listMatch) return null;
   return {
-    id: videoMatch?.[1] ?? null,
-    kind: videoMatch ? 'video' : 'playlist',
+    id,
+    kind: id ? 'video' : 'playlist',
     listId: listMatch?.[1] ?? null,
     startTime: parseStartTime(src),
     noCookie,

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -110,6 +110,10 @@ const YouTubeMediaBase = MediaPlayedRangesMixin(EventTarget);
 export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   #target: HTMLIFrameElement | null = null;
   #player: YouTubePlayerApi | null = null;
+  /** The iframe API rejects `cueVideoById`/`loadVideoById` before `onReady`. */
+  #playerReady = false;
+  /** A load was requested before the player was ready; replay it on `onReady`. */
+  #pendingLoad = false;
   #loadComplete = createPublicPromise<void>();
   /** Guards async player creation across attach/detach cycles. */
   #attachId = 0;
@@ -178,6 +182,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
       // The iframe API throws if the iframe was already removed.
     }
     this.#player = null;
+    this.#playerReady = false;
+    this.#pendingLoad = false;
     this.#target = null;
     // Unblock callers awaiting load; they re-check `#player` (now null) and no-op.
     this.#loadComplete.resolve();
@@ -206,9 +212,14 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     return this.#readyState;
   }
 
-  /** Reload the current source via the iframe API; no-op until the player is ready. */
+  /** Reload the current source via the iframe API; deferred until the player is ready. */
   async load() {
-    if (!this.#player || !this.#src) return;
+    if (!this.#src) return;
+    if (!this.#player || !this.#playerReady) {
+      // `cueVideoById`/`loadVideoById` fail before `onReady`; replay the load then.
+      this.#pendingLoad = !!this.#target;
+      return;
+    }
     this.#resetState();
     this.#loadComplete = createPublicPromise<void>();
     this.dispatchEvent(new Event('emptied'));
@@ -404,7 +415,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     if (attachId !== this.#attachId || this.#target !== target) return;
     const player = new api.Player(target, {
       events: {
-        onReady: () => this.#onLoaded(),
+        onReady: () => this.#onPlayerReady(),
         onError: (event) => this.#onError(event.data),
       },
     });
@@ -455,6 +466,18 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     this.#volume = 1;
     this.#error = null;
     this.#isFullscreen = false;
+  }
+
+  #onPlayerReady() {
+    this.#playerReady = true;
+    if (this.#pendingLoad) {
+      // The iframe was built from a stale src; skip its metadata and reload.
+      // The post-cue state change completes the load (see `#bindPlayerEvents`).
+      this.#pendingLoad = false;
+      void this.load();
+      return;
+    }
+    this.#onLoaded();
   }
 
   #onLoaded() {

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -762,13 +762,18 @@ async function loadYouTubeApi(): Promise<YouTubeApi> {
 
 /**
  * Parse the `t` parameter from a YouTube URL and convert it to seconds.
- * Supports formats like: `t=171`, `t=171s`, `t=2m51s`, `t=2m`.
+ * Supports formats like: `t=171`, `t=171s`, `t=2m51s`, `t=2m`, `t=1h30m15s`.
  */
 function parseStartTime(url: string): number | null {
-  const tValue = /[?&]t=([\dms]+)/i.exec(url)?.[1]?.toLowerCase();
+  const tValue = /[?&]t=([\dhms]+)/i.exec(url)?.[1]?.toLowerCase();
   if (!tValue) return null;
   let totalSeconds = 0;
   let hasValue = false;
+  const hours = /(\d+)h/.exec(tValue)?.[1];
+  if (hours) {
+    totalSeconds += Number.parseInt(hours, 10) * 3600;
+    hasValue = true;
+  }
   const minutes = /(\d+)m/.exec(tValue)?.[1];
   if (minutes) {
     totalSeconds += Number.parseInt(minutes, 10) * 60;

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -178,6 +178,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     }
     this.#player = null;
     this.#target = null;
+    // Unblock callers awaiting load; they re-check `#player` (now null) and no-op.
+    this.#loadComplete.resolve();
     this.#resetState();
   }
 

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -8,7 +8,8 @@
 import { loadScript } from '@videojs/utils/dom';
 import { isNumber, isUndefined } from '@videojs/utils/predicate';
 import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
-import type { ErrorLike, MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
+import { MediaError } from '../../core/media-error';
+import type { MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
 
 /**
@@ -135,7 +136,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   #playbackRate = 1;
   #progress = 0;
   #readyState = READY_STATE_HAVE_NOTHING;
-  #error: ErrorLike | null = null;
+  #error: MediaError | null = null;
   #isFullscreen = false;
   #pollInterval: ReturnType<typeof setInterval> | null = null;
   #textTracksHost: HTMLVideoElement | null = null;
@@ -213,7 +214,13 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     this.dispatchEvent(new Event('emptied'));
     this.dispatchEvent(new Event('loadstart'));
     const parsed = parseYouTubeSource(this.#src);
-    if (!parsed) return;
+    if (!parsed) {
+      this.#error = new MediaError(`Unrecognized YouTube source: ${this.#src}`, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen don't hang.
+      this.#loadComplete.resolve();
+      return;
+    }
     if (parsed.kind === 'playlist' && parsed.listId) {
       const options = { list: parsed.listId, listType: 'playlist' };
       if (this.#autoplay) this.#player.loadPlaylist(options);
@@ -388,7 +395,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     try {
       api = await loadYouTubeApi();
     } catch {
-      this.#error = { code: 2, message: 'Failed to load the YouTube iframe API' };
+      this.#error = new MediaError('Failed to load the YouTube iframe API', MediaError.MEDIA_ERR_NETWORK);
       this.dispatchEvent(new Event('error'));
       // Unblock callers awaiting load so play()/fullscreen don't hang.
       this.#loadComplete.resolve();
@@ -469,10 +476,13 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   }
 
   #onError(code: number) {
-    this.#error = {
-      code,
-      message: `YouTube iframe player error #${code}; visit https://developers.google.com/youtube/iframe_api_reference#onError for the full error message.`,
-    };
+    const error = new MediaError(
+      `YouTube iframe player error #${code}; visit https://developers.google.com/youtube/iframe_api_reference#onError for the full error message.`,
+      youtubeErrorCodeToMediaErrorCode[code] ?? MediaError.MEDIA_ERR_CUSTOM,
+      true
+    );
+    error.data = { youtubeErrorCode: code };
+    this.#error = error;
     this.dispatchEvent(new Event('error'));
     // Unblock callers awaiting load so play()/fullscreen don't hang.
     this.#loadComplete.resolve();
@@ -694,6 +704,15 @@ const EMBED_BASE_NOCOOKIE = 'https://www.youtube-nocookie.com/embed';
 const VIDEO_MATCH_SRC =
   /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((?:\w|-){11})/;
 const PLAYLIST_MATCH_SRC = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/.*?[?&]list=)([\w-]+)/;
+
+// https://developers.google.com/youtube/iframe_api_reference#onError
+const youtubeErrorCodeToMediaErrorCode: Record<number, number> = {
+  2: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // invalid parameter (e.g. malformed video id)
+  5: MediaError.MEDIA_ERR_DECODE, // HTML5 player error
+  100: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // video not found, removed, or private
+  101: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // embedding not allowed
+  150: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // embedding not allowed (alias of 101)
+};
 
 // https://developers.google.com/youtube/iframe_api_reference#onStateChange
 const STATE_UNSTARTED = -1;

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -5,158 +5,27 @@
 // Source: https://github.com/muxinc/media-elements
 // License: MIT
 
-import { loadScript } from '@videojs/utils/dom';
 import { deepEqual } from '@videojs/utils/object';
 import { isNumber, isUndefined } from '@videojs/utils/predicate';
 import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 import { MediaError } from '../../core/media-error';
-import type { MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
+import type { TextTrackListLike, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
-
-/**
- * YouTube engine options, spelled exactly as YouTube spells them
- * (https://developers.google.com/youtube/player_parameters). They are serialized
- * onto the embed URL verbatim, so what you write here is what the player reads.
- *
- * Parameters the host owns are deliberately absent: `autoplay`, `controls`, and
- * `playsinline` come from the props of the same name, so configuring them here
- * would give two ways to say one thing. Parameters YouTube has deprecated
- * (`modestbranding`, `showinfo`, `autohide`, `theme`, and `listType: 'search'`)
- * are absent too. The index signature still carries anything not listed here, so
- * undocumented knobs and whatever YouTube adds next keep working.
- */
-export interface YouTubeEngineConfig extends Record<string, unknown> {
-  /** ISO 639-1 language to display captions in. Pair with `cc_load_policy`. */
-  cc_lang_pref?: string;
-  /** Show closed captions by default, even if the viewer has turned them off. */
-  cc_load_policy?: 1;
-  /** Progress-bar highlight color. Defaults to `'red'`. */
-  color?: 'red' | 'white';
-  /** Stop responding to keyboard controls. Defaults to `0`. */
-  disablekb?: 0 | 1;
-  /** Allow the player to be driven through the IFrame Player API. Defaults to `0`. */
-  enablejsapi?: 0 | 1;
-  /** Stop playback this many seconds from the start of the video. */
-  end?: number;
-  /** Display the fullscreen button. Defaults to `1`. */
-  fs?: 0 | 1;
-  /** Player interface language: an ISO 639-1 code or full locale (`fr`, `fr-ca`). */
-  hl?: string;
-  /** Show video annotations (`1`) or hide them (`3`). Defaults to `1`. */
-  iv_load_policy?: 1 | 3;
-  /** Playlist id (prefixed with `PL`) or channel name, depending on `listType`. */
-  list?: string;
-  /** What `list` refers to. */
-  listType?: 'playlist' | 'user_uploads';
-  /** Repeat playback. Looping a single video also needs `playlist` set to the same id. */
-  loop?: 0 | 1;
-  /** Embedding domain. Set it whenever `enablejsapi` is `1`. */
-  origin?: string;
-  /** Comma-separated video ids to play after the one named by the URL path. */
-  playlist?: string;
-  /** Draw related videos from the same channel (`0`) or anywhere (`1`). Defaults to `1`. */
-  rel?: 0 | 1;
-  /** Begin playback this many seconds from the start of the video. */
-  start?: number;
-  /** Embedding URL reported to YouTube Analytics for widget-hosted players. */
-  widget_referrer?: string;
-  /** `referrerpolicy` for the embed iframe. Not a YouTube player parameter. */
-  referrerPolicy?: ReferrerPolicy;
-}
-
-/** Structured YouTube source: which source to play, plus how to play it. */
-export interface YouTubeSource {
-  /** YouTube URL or id. Mirrors the host's `src` property. */
-  src?: string | undefined;
-  /** YouTube's own player parameters, passed through untouched. */
-  engine?: YouTubeEngineConfig | undefined;
-}
-
-/** Parsed pieces of a YouTube source URL. */
-export interface ParsedYouTubeSource {
-  /** 11-character video id (null for playlist-only sources). */
-  id: string | null;
-  /** `'video'` for single videos, `'playlist'` for playlist sources. */
-  kind: 'video' | 'playlist';
-  /** Playlist id (the `list` parameter). */
-  listId: string | null;
-  /** Start time in seconds parsed from the `t` parameter. */
-  startTime: number | null;
-  /** Whether the source uses the youtube-nocookie.com privacy-enhanced host. */
-  noCookie: boolean;
-}
-
-export interface YouTubeMediaProps {
-  src: string;
-  autoplay: boolean;
-  defaultMuted: boolean;
-  muted: boolean;
-  loop: boolean;
-  controls: boolean;
-  playsInline: boolean;
-  preload: MediaPreloadType;
-  poster: string;
-  source: YouTubeSource | null;
-}
-
-export const youtubeMediaDefaultProps: YouTubeMediaProps = {
-  src: '',
-  autoplay: false,
-  defaultMuted: false,
-  muted: false,
-  loop: false,
-  controls: false,
-  playsInline: true,
-  preload: 'metadata',
-  poster: '',
-  source: null,
-};
-
-/**
- * Minimal typings for the YouTube iframe API
- * (https://developers.google.com/youtube/iframe_api_reference).
- * The API is loaded from a script tag, so there is no npm SDK to type against.
- */
-export interface YouTubePlayerApi {
-  playVideo(): void;
-  pauseVideo(): void;
-  seekTo(seconds: number, allowSeekAhead: boolean): void;
-  mute(): void;
-  unMute(): void;
-  isMuted(): boolean;
-  setVolume(volume: number): void;
-  getVolume(): number;
-  getDuration(): number;
-  getCurrentTime(): number;
-  getPlaybackRate(): number;
-  setPlaybackRate(rate: number): void;
-  getVideoLoadedFraction(): number;
-  getPlayerState(): number;
-  loadVideoById(options: { videoId: string; startSeconds?: number }): void;
-  cueVideoById(options: { videoId: string; startSeconds?: number }): void;
-  loadPlaylist(options: { list: string; listType?: string }): void;
-  cuePlaylist(options: { list: string; listType?: string }): void;
-  stopVideo(): void;
-  getOption(module: string, option: string): unknown;
-  setOption(module: string, option: string, value: unknown): void;
-  addEventListener(type: string, listener: (event: { data: number }) => void): void;
-  destroy(): void;
-}
-
-interface YouTubePlayerEvents {
-  onReady?: () => void;
-  onError?: (event: { data: number }) => void;
-}
-
-export interface YouTubeApi {
-  Player: new (target: HTMLIFrameElement, options: { events?: YouTubePlayerEvents }) => YouTubePlayerApi;
-  ready(callback: () => void): void;
-}
-
-interface YouTubeCaptionTrack {
-  languageCode?: string;
-  displayName?: string;
-}
+import { createPublicPromise, createTimeRange, type PublicPromise } from '../utils';
+import {
+  loadYouTubeApi,
+  STATE_BUFFERING,
+  STATE_ENDED,
+  STATE_PAUSED,
+  STATE_PLAYING,
+  STATE_UNSTARTED,
+  type YouTubeApi,
+  type YouTubeCaptionTrack,
+  type YouTubePlayerApi,
+  youtubeErrorCodeToMediaErrorCode,
+} from './iframe-api';
+import { youtubeMediaDefaultProps } from './props';
+import { buildYouTubeIframeSrc, parseYouTubeSource, type YouTubeSource } from './source';
 
 const YouTubeMediaBase = MediaPlayedRangesMixin(EventTarget);
 
@@ -471,12 +340,12 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   }
 
   get buffered() {
-    return this.#progress > 0 ? createTimeRanges(0, this.#progress) : EMPTY_TIME_RANGES;
+    return this.#progress > 0 ? createTimeRange(0, this.#progress) : EMPTY_TIME_RANGES;
   }
 
   get seekable() {
     return this.#duration > 0 && Number.isFinite(this.#duration)
-      ? createTimeRanges(0, this.#duration)
+      ? createTimeRange(0, this.#duration)
       : EMPTY_TIME_RANGES;
   }
 
@@ -797,159 +666,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   }
 }
 
-/** Extract a YouTube video id from a raw 11-character id or any recognized URL. */
-export function parseYouTubeVideoId(src: string) {
-  return parseYouTubeSource(src)?.id ?? null;
-}
-
-/**
- * Parse a YouTube source string. Recognizes raw 11-character ids, `youtu.be`
- * short links, `watch?v=`, `embed/`, `v/`, `shorts/` and `live/` URLs (with or
- * without the `-nocookie` host), playlist URLs via the `list` parameter, and
- * start times via the `t` parameter.
- */
-export function parseYouTubeSource(src: string): ParsedYouTubeSource | null {
-  if (!src) return null;
-  if (/^[\w-]{11}$/.test(src)) {
-    return { id: src, kind: 'video', listId: null, startTime: null, noCookie: false };
-  }
-  const noCookie = src.includes('-nocookie');
-  const videoMatch = VIDEO_MATCH_SRC.exec(src);
-  const listMatch = PLAYLIST_MATCH_SRC.exec(src);
-  // Playlist embed URLs use the `videoseries` placeholder in the video id slot.
-  const videoId = videoMatch?.[1] ?? null;
-  const id = videoId === 'videoseries' ? null : videoId;
-  if (!id && !listMatch) return null;
-  return {
-    id,
-    kind: id ? 'video' : 'playlist',
-    listId: listMatch?.[1] ?? null,
-    startTime: parseStartTime(src),
-    noCookie,
-  };
-}
-
-/** Build the iframe `src` URL for an initial YouTube embed from the given props. */
-export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaProps> = {}) {
-  const parsed = parseYouTubeSource(src);
-  if (!parsed) return '';
-  const embedBase = parsed.noCookie ? EMBED_BASE_NOCOOKIE : EMBED_BASE;
-  const params: Record<string, unknown> = {
-    // Hide YouTube chrome by default; pass nothing only when controls is explicitly true.
-    controls: props.controls === true ? null : 0,
-    autoplay: props.autoplay,
-    loop: props.loop,
-    mute: props.defaultMuted,
-    playsinline: props.playsInline ?? youtubeMediaDefaultProps.playsInline,
-    preload: props.preload ?? youtubeMediaDefaultProps.preload,
-    // https://developers.google.com/youtube/player_parameters#Parameters
-    enablejsapi: 1,
-    rel: 0,
-    iv_load_policy: 3,
-    start: parsed.startTime,
-    // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
-    ...(props.source?.engine ?? undefined),
-  };
-  if (parsed.kind === 'playlist' && parsed.listId) {
-    return `${embedBase}?${serialize({ listType: 'playlist', list: parsed.listId, ...params })}`;
-  }
-  return `${embedBase}/${parsed.id}?${serialize(params)}`;
-}
-
-const API_URL = 'https://www.youtube.com/iframe_api';
-const EMBED_BASE = 'https://www.youtube.com/embed';
-const EMBED_BASE_NOCOOKIE = 'https://www.youtube-nocookie.com/embed';
-const VIDEO_MATCH_SRC =
-  /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((?:\w|-){11})/;
-const PLAYLIST_MATCH_SRC = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/.*?[?&]list=)([\w-]+)/;
-
-// https://developers.google.com/youtube/iframe_api_reference#onError
-const youtubeErrorCodeToMediaErrorCode: Record<number, number> = {
-  2: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // invalid parameter (e.g. malformed video id)
-  5: MediaError.MEDIA_ERR_DECODE, // HTML5 player error
-  100: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // video not found, removed, or private
-  101: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // embedding not allowed
-  150: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, // embedding not allowed (alias of 101)
-};
-
-// https://developers.google.com/youtube/iframe_api_reference#onStateChange
-const STATE_UNSTARTED = -1;
-const STATE_ENDED = 0;
-const STATE_PLAYING = 1;
-const STATE_PAUSED = 2;
-const STATE_BUFFERING = 3;
-
 const READY_STATE_HAVE_NOTHING = 0;
 const READY_STATE_HAVE_METADATA = 1;
 const READY_STATE_HAVE_FUTURE_DATA = 3;
 const READY_STATE_HAVE_ENOUGH_DATA = 4;
-
-async function loadYouTubeApi(): Promise<YouTubeApi> {
-  const existing = (globalThis as { YT?: YouTubeApi }).YT;
-  if (existing?.Player) return existing;
-  await loadScript(API_URL);
-  const api = (globalThis as { YT?: YouTubeApi }).YT;
-  if (!api) throw new Error('YouTube iframe API failed to load');
-  // The loader stub exposes `YT.ready` before `YT.Player` is defined.
-  await new Promise<void>((resolve) => api.ready(resolve));
-  return api;
-}
-
-/**
- * Parse the `t` parameter from a YouTube URL and convert it to seconds.
- * Supports formats like: `t=171`, `t=171s`, `t=2m51s`, `t=2m`, `t=1h30m15s`.
- */
-function parseStartTime(url: string): number | null {
-  const tValue = /[?&]t=([\dhms]+)/i.exec(url)?.[1]?.toLowerCase();
-  if (!tValue) return null;
-  let totalSeconds = 0;
-  let hasValue = false;
-  const hours = /(\d+)h/.exec(tValue)?.[1];
-  if (hours) {
-    totalSeconds += Number.parseInt(hours, 10) * 3600;
-    hasValue = true;
-  }
-  const minutes = /(\d+)m/.exec(tValue)?.[1];
-  if (minutes) {
-    totalSeconds += Number.parseInt(minutes, 10) * 60;
-    hasValue = true;
-  }
-  const seconds = /(\d+)s?$/.exec(tValue)?.[1];
-  if (seconds) {
-    totalSeconds += Number.parseInt(seconds, 10);
-    hasValue = true;
-  }
-  return hasValue ? totalSeconds : null;
-}
-
-function createTimeRanges(start: number, end: number) {
-  return { length: 1, start: () => start, end: () => end };
-}
-
-function serialize(props: Record<string, unknown>) {
-  const params = new URLSearchParams();
-  for (const key in props) {
-    const val = props[key];
-    if (val === true || val === '') params.set(key, '1');
-    else if (val === false) params.set(key, '0');
-    else if (val != null) params.set(key, String(val));
-  }
-  return params.toString();
-}
-
-interface PublicPromise<T> extends Promise<T> {
-  resolve: (value: T) => void;
-  reject: (reason?: unknown) => void;
-}
-
-function createPublicPromise<T>(): PublicPromise<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  }) as PublicPromise<T>;
-  promise.resolve = resolve;
-  promise.reject = reject;
-  return promise;
-}

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -17,8 +17,54 @@ import { MediaPlayedRangesMixin } from '../media-played-ranges';
  * YouTube engine options. Player parameters are YouTube's engine configuration,
  * so they are serialized verbatim onto the embed URL
  * (https://developers.google.com/youtube/player_parameters).
+ *
+ * Parameters YouTube has deprecated (`modestbranding`, `showinfo`, `autohide`,
+ * `theme`, and `listType: 'search'`) are deliberately absent. The index
+ * signature still carries anything not listed here, including whatever YouTube
+ * adds next.
  */
 export interface YouTubeEngineConfig extends Record<string, unknown> {
+  /** Play the initial video as soon as the player loads. Defaults to `0`. */
+  autoplay?: 0 | 1;
+  /** ISO 639-1 language to display captions in. Pair with `cc_load_policy`. */
+  cc_lang_pref?: string;
+  /** Show closed captions by default, even if the viewer has turned them off. */
+  cc_load_policy?: 1;
+  /** Progress-bar highlight color. Defaults to `'red'`. */
+  color?: 'red' | 'white';
+  /** Display the player controls. Defaults to `1`. */
+  controls?: 0 | 1;
+  /** Stop responding to keyboard controls. Defaults to `0`. */
+  disablekb?: 0 | 1;
+  /** Allow the player to be driven through the IFrame Player API. Defaults to `0`. */
+  enablejsapi?: 0 | 1;
+  /** Stop playback this many seconds from the start of the video. */
+  end?: number;
+  /** Display the fullscreen button. Defaults to `1`. */
+  fs?: 0 | 1;
+  /** Player interface language: an ISO 639-1 code or full locale (`fr`, `fr-ca`). */
+  hl?: string;
+  /** Show video annotations (`1`) or hide them (`3`). Defaults to `1`. */
+  iv_load_policy?: 1 | 3;
+  /** Playlist id (prefixed with `PL`) or channel name, depending on `listType`. */
+  list?: string;
+  /** What `list` refers to. */
+  listType?: 'playlist' | 'user_uploads';
+  /** Repeat playback. Looping a single video also needs `playlist` set to the same id. */
+  loop?: 0 | 1;
+  /** Embedding domain. Set it whenever `enablejsapi` is `1`. */
+  origin?: string;
+  /** Comma-separated video ids to play after the one named by the URL path. */
+  playlist?: string;
+  /** Play inline rather than fullscreen on iOS. */
+  playsinline?: 0 | 1;
+  /** Draw related videos from the same channel (`0`) or anywhere (`1`). Defaults to `1`. */
+  rel?: 0 | 1;
+  /** Begin playback this many seconds from the start of the video. */
+  start?: number;
+  /** Embedding URL reported to YouTube Analytics for widget-hosted players. */
+  widget_referrer?: string;
+  /** `referrerpolicy` for the embed iframe. Not a YouTube player parameter. */
   referrerPolicy?: ReferrerPolicy;
 }
 
@@ -782,10 +828,8 @@ export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaPr
     preload: props.preload ?? youtubeMediaDefaultProps.preload,
     // https://developers.google.com/youtube/player_parameters#Parameters
     enablejsapi: 1,
-    showinfo: 0,
     rel: 0,
     iv_load_policy: 3,
-    modestbranding: 1,
     start: parsed.startTime,
     // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
     ...(props.source?.engine ?? undefined),

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -1,0 +1,771 @@
+// Adapted from `youtube-video-element` from `muxinc/media-elements`,
+// ported to TypeScript and reshaped as a media host to fit the v10
+// media-host architecture (mirrors `dom/vimeo`).
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { loadScript } from '@videojs/utils/dom';
+import { isNumber, isUndefined } from '@videojs/utils/predicate';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
+import type { ErrorLike, MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+
+/**
+ * Public YouTube embed configuration. Serialized onto the iframe URL as
+ * player parameters (https://developers.google.com/youtube/player_parameters).
+ */
+export interface YouTubeConfig extends Record<string, unknown> {
+  referrerPolicy?: ReferrerPolicy;
+}
+
+/** Parsed pieces of a YouTube source URL. */
+export interface YouTubeSource {
+  /** 11-character video id (null for playlist-only sources). */
+  id: string | null;
+  /** `'video'` for single videos, `'playlist'` for playlist sources. */
+  kind: 'video' | 'playlist';
+  /** Playlist id (the `list` parameter). */
+  listId: string | null;
+  /** Start time in seconds parsed from the `t` parameter. */
+  startTime: number | null;
+  /** Whether the source uses the youtube-nocookie.com privacy-enhanced host. */
+  noCookie: boolean;
+}
+
+export interface YouTubeMediaProps {
+  src: string;
+  autoplay: boolean;
+  defaultMuted: boolean;
+  muted: boolean;
+  loop: boolean;
+  controls: boolean;
+  playsInline: boolean;
+  preload: MediaPreloadType;
+  poster: string;
+  config: YouTubeConfig;
+}
+
+export const youtubeMediaDefaultProps: YouTubeMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  muted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  config: {},
+};
+
+/**
+ * Minimal typings for the YouTube iframe API
+ * (https://developers.google.com/youtube/iframe_api_reference).
+ * The API is loaded from a script tag, so there is no npm SDK to type against.
+ */
+export interface YouTubePlayerApi {
+  playVideo(): void;
+  pauseVideo(): void;
+  seekTo(seconds: number, allowSeekAhead: boolean): void;
+  mute(): void;
+  unMute(): void;
+  isMuted(): boolean;
+  setVolume(volume: number): void;
+  getVolume(): number;
+  getDuration(): number;
+  getCurrentTime(): number;
+  getPlaybackRate(): number;
+  setPlaybackRate(rate: number): void;
+  getVideoLoadedFraction(): number;
+  getPlayerState(): number;
+  loadVideoById(options: { videoId: string; startSeconds?: number }): void;
+  cueVideoById(options: { videoId: string; startSeconds?: number }): void;
+  loadPlaylist(options: { list: string; listType?: string }): void;
+  cuePlaylist(options: { list: string; listType?: string }): void;
+  getOption(module: string, option: string): unknown;
+  setOption(module: string, option: string, value: unknown): void;
+  addEventListener(type: string, listener: (event: { data: number }) => void): void;
+  destroy(): void;
+}
+
+interface YouTubePlayerEvents {
+  onReady?: () => void;
+  onError?: (event: { data: number }) => void;
+}
+
+export interface YouTubeApi {
+  Player: new (target: HTMLIFrameElement, options: { events?: YouTubePlayerEvents }) => YouTubePlayerApi;
+  ready(callback: () => void): void;
+}
+
+interface YouTubeCaptionTrack {
+  languageCode?: string;
+  displayName?: string;
+}
+
+const YouTubeMediaBase = MediaPlayedRangesMixin(EventTarget);
+
+export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
+  #target: HTMLIFrameElement | null = null;
+  #player: YouTubePlayerApi | null = null;
+  #loadComplete = createPublicPromise<void>();
+  /** Guards async player creation across attach/detach cycles. */
+  #attachId = 0;
+
+  #src = youtubeMediaDefaultProps.src;
+  #autoplay = youtubeMediaDefaultProps.autoplay;
+  #defaultMuted = youtubeMediaDefaultProps.defaultMuted;
+  #loop = youtubeMediaDefaultProps.loop;
+  #controls = youtubeMediaDefaultProps.controls;
+  #playsInline = youtubeMediaDefaultProps.playsInline;
+  #preload = youtubeMediaDefaultProps.preload;
+  #poster = youtubeMediaDefaultProps.poster;
+  #config = youtubeMediaDefaultProps.config;
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #loaded = false;
+  #playFired = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #volume = 1;
+  #muted = false;
+  #playbackRate = 1;
+  #progress = 0;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: ErrorLike | null = null;
+  #isFullscreen = false;
+  #pollInterval: ReturnType<typeof setInterval> | null = null;
+  #textTracksHost: HTMLVideoElement | null = null;
+  #textTracksDisconnect: AbortController | null = null;
+
+  static PLAYER_SOFTWARE_NAME = 'youtube-video';
+
+  /** Underlying YouTube iframe API player instance (null until the API loads). */
+  get engine() {
+    return this.#player;
+  }
+
+  get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /** Bind the iframe hosting the embed, loading the iframe API and creating a player. */
+  attach(target: HTMLIFrameElement | null): void {
+    if (!target || this.#target === target) return;
+    if (this.#target) this.detach();
+    this.#target = target;
+    if (!target.src) {
+      const initialSrc = buildYouTubeIframeSrc(this.#src, this.#snapshotProps());
+      if (initialSrc) target.src = initialSrc;
+    }
+    this.#loadComplete = createPublicPromise<void>();
+    this.dispatchEvent(new Event('loadstart'));
+    void this.#createPlayer(target);
+  }
+
+  detach(): void {
+    if (!this.#target) return;
+    this.#attachId++;
+    this.#stopPolling();
+    this.#teardownTextTracks();
+    try {
+      this.#player?.destroy();
+    } catch {
+      // The iframe API throws if the iframe was already removed.
+    }
+    this.#player = null;
+    this.#target = null;
+    this.#resetState();
+  }
+
+  override destroy() {
+    this.detach();
+    super.destroy();
+  }
+
+  get src() {
+    return this.#src;
+  }
+  set src(value) {
+    if (this.#src === value) return;
+    this.#src = value;
+    void this.load();
+  }
+
+  get currentSrc() {
+    return this.#target?.src ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /** Reload the current source via the iframe API; no-op until the player is ready. */
+  async load() {
+    if (!this.#player || !this.#src) return;
+    this.#resetState();
+    this.#loadComplete = createPublicPromise<void>();
+    this.dispatchEvent(new Event('emptied'));
+    this.dispatchEvent(new Event('loadstart'));
+    const parsed = parseYouTubeSource(this.#src);
+    if (!parsed) return;
+    if (parsed.kind === 'playlist' && parsed.listId) {
+      const options = { list: parsed.listId, listType: 'playlist' };
+      if (this.#autoplay) this.#player.loadPlaylist(options);
+      else this.#player.cuePlaylist(options);
+    } else if (parsed.id) {
+      const options: { videoId: string; startSeconds?: number } = { videoId: parsed.id };
+      if (parsed.startTime != null) options.startSeconds = parsed.startTime;
+      if (this.#autoplay) this.#player.loadVideoById(options);
+      else this.#player.cueVideoById(options);
+    }
+  }
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    await this.#loadComplete;
+    this.#player?.playVideo();
+  }
+
+  pause() {
+    this.#player?.pauseVideo();
+  }
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#currentTime = value;
+    // `seekTo` keeps the player paused when called from a paused state.
+    this.#afterLoad((p) => p.seekTo(value, true));
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  get volume() {
+    return this.#volume;
+  }
+  set volume(value) {
+    if (this.#volume === value) return;
+    this.#volume = value;
+    this.#afterLoad((p) => p.setVolume(value * 100));
+  }
+
+  get muted() {
+    return this.#muted;
+  }
+  set muted(value) {
+    if (this.#muted === value) return;
+    this.#muted = value;
+    this.#afterLoad((p) => (value ? p.mute() : p.unMute()));
+  }
+
+  get playbackRate() {
+    return this.#playbackRate;
+  }
+  set playbackRate(value) {
+    if (this.#playbackRate === value) return;
+    this.#playbackRate = value;
+    this.#afterLoad((p) => p.setPlaybackRate(value));
+  }
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+  set autoplay(value) {
+    this.#autoplay = value;
+  }
+
+  get defaultMuted() {
+    return this.#defaultMuted;
+  }
+  set defaultMuted(value) {
+    this.#defaultMuted = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+  set loop(value) {
+    // The iframe API has no single-video loop; ENDED restarts playback instead.
+    this.#loop = value;
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+  set controls(value) {
+    this.#controls = value;
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+  set playsInline(value) {
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+  set preload(value) {
+    this.#preload = value;
+  }
+
+  get poster() {
+    return this.#poster;
+  }
+  set poster(value) {
+    this.#poster = value;
+  }
+
+  get config() {
+    return this.#config as Record<string, unknown>;
+  }
+  set config(value) {
+    this.#config = value as YouTubeConfig;
+  }
+
+  get buffered() {
+    return this.#progress > 0 ? createTimeRanges(0, this.#progress) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRanges(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  get textTracks() {
+    this.#textTracksHost ??= globalThis.document?.createElement('video') ?? null;
+    return (this.#textTracksHost?.textTracks as TextTrackListLike) ?? EMPTY_TEXT_TRACKS;
+  }
+
+  get isFullscreen() {
+    return this.#isFullscreen;
+  }
+
+  // The iframe API exposes no fullscreen controls, so fullscreen targets the iframe itself.
+  async requestFullscreen() {
+    await this.#target?.requestFullscreen?.();
+    this.#isFullscreen = true;
+  }
+
+  async exitFullscreen() {
+    const doc = globalThis.document;
+    if (doc?.fullscreenElement && doc.fullscreenElement === this.#target) {
+      await doc.exitFullscreen();
+    }
+    this.#isFullscreen = false;
+  }
+
+  async #createPlayer(target: HTMLIFrameElement) {
+    const attachId = this.#attachId;
+    let api: YouTubeApi;
+    try {
+      api = await loadYouTubeApi();
+    } catch {
+      this.#error = { code: 2, message: 'Failed to load the YouTube iframe API' };
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen don't hang.
+      this.#loadComplete.resolve();
+      return;
+    }
+    if (attachId !== this.#attachId || this.#target !== target) return;
+    const player = new api.Player(target, {
+      events: {
+        onReady: () => this.#onLoaded(),
+        onError: (event) => this.#onError(event.data),
+      },
+    });
+    this.#player = player;
+    this.#bindPlayerEvents(player);
+    this.#setupTextTracks(player);
+  }
+
+  /** Defer a player call until `loadComplete` resolves, swallowing failures. */
+  #afterLoad(fn: (player: YouTubePlayerApi) => void) {
+    this.#loadComplete.then(
+      () => {
+        if (!this.#player) return;
+        try {
+          fn(this.#player);
+        } catch {
+          // The iframe API throws if the player was destroyed mid-flight.
+        }
+      },
+      () => {}
+    );
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      defaultMuted: this.#defaultMuted,
+      loop: this.#loop,
+      controls: this.#controls,
+      playsInline: this.#playsInline,
+      preload: this.#preload || youtubeMediaDefaultProps.preload,
+      config: this.#config,
+    };
+  }
+
+  #resetState() {
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    this.#muted = false;
+    this.#paused = !this.#autoplay;
+    this.#ended = false;
+    this.#playbackRate = 1;
+    this.#progress = 0;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#loaded = false;
+    this.#playFired = false;
+    this.#volume = 1;
+    this.#error = null;
+    this.#isFullscreen = false;
+  }
+
+  #onLoaded() {
+    if (this.#loaded) return;
+    this.#loaded = true;
+    this.#readyState = READY_STATE_HAVE_METADATA;
+    const player = this.#player;
+    if (player) {
+      this.#duration = player.getDuration() || Number.NaN;
+      this.#muted = player.isMuted();
+      this.#volume = player.getVolume() / 100;
+      this.#playbackRate = player.getPlaybackRate();
+    }
+    for (const type of ['loadedmetadata', 'durationchange', 'volumechange', 'loadcomplete']) {
+      this.dispatchEvent(new Event(type));
+    }
+    this.#loadComplete.resolve();
+    this.#startPolling();
+  }
+
+  #onError(code: number) {
+    this.#error = {
+      code,
+      message: `YouTube iframe player error #${code}; visit https://developers.google.com/youtube/iframe_api_reference#onError for the full error message.`,
+    };
+    this.dispatchEvent(new Event('error'));
+    // Unblock callers awaiting load so play()/fullscreen don't hang.
+    this.#loadComplete.resolve();
+  }
+
+  #bindPlayerEvents(player: YouTubePlayerApi) {
+    const emit = (type: string) => this.dispatchEvent(new Event(type));
+
+    player.addEventListener('onStateChange', ({ data: state }) => {
+      // Subsequent loads (`cueVideoById`/`loadVideoById`) never re-fire
+      // `onReady`, so any post-load state transition completes the load.
+      if (!this.#loaded && state !== STATE_UNSTARTED) this.#onLoaded();
+
+      if (state === STATE_PLAYING || state === STATE_BUFFERING) {
+        if (!this.#playFired) {
+          this.#playFired = true;
+          this.#paused = false;
+          this.#ended = false;
+          emit('play');
+        }
+        this.#syncTextTracks(player);
+      }
+
+      if (state === STATE_BUFFERING) {
+        emit('waiting');
+      } else if (state === STATE_PLAYING) {
+        if (this.#seeking) {
+          this.#seeking = false;
+          emit('seeked');
+        }
+        this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+        this.#paused = false;
+        emit('playing');
+      } else if (state === STATE_PAUSED) {
+        const diff = Math.abs(player.getCurrentTime() - this.#currentTime);
+        if (!this.#seeking && diff > 0.1) {
+          this.#seeking = true;
+          emit('seeking');
+        }
+        this.#playFired = false;
+        this.#paused = true;
+        emit('pause');
+      } else if (state === STATE_ENDED) {
+        this.#playFired = false;
+        this.#paused = true;
+        emit('pause');
+        this.#ended = true;
+        emit('ended');
+        if (this.#loop) void this.play();
+      }
+    });
+
+    player.addEventListener('onPlaybackRateChange', () => {
+      this.#playbackRate = player.getPlaybackRate();
+      emit('ratechange');
+    });
+
+    player.addEventListener('onVolumeChange', () => {
+      this.#volume = player.getVolume() / 100;
+      this.#muted = player.isMuted();
+      emit('volumechange');
+    });
+  }
+
+  // The iframe API pushes no timeupdate/progress/seek events, so poll like the
+  // original `youtube-video-element` does.
+  #startPolling() {
+    this.#stopPolling();
+    this.#pollInterval = setInterval(() => this.#poll(), 50);
+  }
+
+  #stopPolling() {
+    if (this.#pollInterval !== null) {
+      clearInterval(this.#pollInterval);
+      this.#pollInterval = null;
+    }
+  }
+
+  #poll() {
+    const player = this.#player;
+    if (!player) return;
+
+    const time = player.getCurrentTime();
+    const duration = player.getDuration();
+    const bufferedEnd = player.getVideoLoadedFraction() * duration;
+
+    if (this.#seeking && bufferedEnd > 0.1) {
+      this.#seeking = false;
+      this.dispatchEvent(new Event('seeked'));
+    } else if (!this.#seeking && Math.abs(time - this.#currentTime) > 0.1) {
+      this.#seeking = true;
+      this.dispatchEvent(new Event('seeking'));
+    }
+
+    if (time !== this.#currentTime) {
+      this.#currentTime = time;
+      this.dispatchEvent(new Event('timeupdate'));
+    }
+
+    if (isNumber(duration) && duration > 0 && duration !== this.#duration) {
+      this.#duration = duration;
+      this.dispatchEvent(new Event('durationchange'));
+    }
+
+    if (bufferedEnd !== this.#progress) {
+      this.#progress = bufferedEnd;
+      if (duration > 0 && bufferedEnd >= duration) {
+        this.#readyState = READY_STATE_HAVE_ENOUGH_DATA;
+      }
+      this.dispatchEvent(new Event('progress'));
+    }
+  }
+
+  #setupTextTracks(player: YouTubePlayerApi) {
+    const doc = globalThis.document;
+    if (isUndefined(doc)) return;
+    this.#teardownTextTracks();
+    const host = doc.createElement('video');
+    this.#textTracksHost = host;
+    this.#textTracksDisconnect = new AbortController();
+    host.textTracks?.addEventListener?.(
+      'change',
+      () => {
+        const showing = Array.from(host.textTracks).find((t) => t.mode === 'showing');
+        try {
+          player.setOption('captions', 'track', showing ? { languageCode: showing.language } : {});
+        } catch {
+          // The iframe API throws if the player was destroyed mid-flight.
+        }
+      },
+      { signal: this.#textTracksDisconnect.signal }
+    );
+  }
+
+  /** Caption metadata is only available once playback starts. */
+  #syncTextTracks(player: YouTubePlayerApi) {
+    const host = this.#textTracksHost;
+    if (!host) return;
+    const trackList = (player.getOption('captions', 'tracklist') ?? []) as YouTubeCaptionTrack[];
+    for (const track of trackList) {
+      if (!track.languageCode) continue;
+      if (Array.from(host.textTracks).some((t) => t.language === track.languageCode)) continue;
+      try {
+        host.addTextTrack?.('subtitles', track.displayName ?? '', track.languageCode);
+      } catch {
+        // jsdom or unsupported environments.
+      }
+    }
+  }
+
+  #teardownTextTracks() {
+    this.#textTracksDisconnect?.abort();
+    this.#textTracksDisconnect = null;
+    this.#textTracksHost = null;
+  }
+}
+
+/** Extract a YouTube video id from a raw 11-character id or any recognized URL. */
+export function parseYouTubeVideoId(src: string) {
+  return parseYouTubeSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a YouTube source string. Recognizes raw 11-character ids, `youtu.be`
+ * short links, `watch?v=`, `embed/`, `v/`, `shorts/` and `live/` URLs (with or
+ * without the `-nocookie` host), playlist URLs via the `list` parameter, and
+ * start times via the `t` parameter.
+ */
+export function parseYouTubeSource(src: string): YouTubeSource | null {
+  if (!src) return null;
+  if (/^[\w-]{11}$/.test(src)) {
+    return { id: src, kind: 'video', listId: null, startTime: null, noCookie: false };
+  }
+  const noCookie = src.includes('-nocookie');
+  const videoMatch = VIDEO_MATCH_SRC.exec(src);
+  const listMatch = PLAYLIST_MATCH_SRC.exec(src);
+  if (!videoMatch && !listMatch) return null;
+  return {
+    id: videoMatch?.[1] ?? null,
+    kind: videoMatch ? 'video' : 'playlist',
+    listId: listMatch?.[1] ?? null,
+    startTime: parseStartTime(src),
+    noCookie,
+  };
+}
+
+/** Build the iframe `src` URL for an initial YouTube embed from the given props. */
+export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaProps> = {}) {
+  const parsed = parseYouTubeSource(src);
+  if (!parsed) return '';
+  const embedBase = parsed.noCookie ? EMBED_BASE_NOCOOKIE : EMBED_BASE;
+  const params: Record<string, unknown> = {
+    // Hide YouTube chrome by default; pass nothing only when controls is explicitly true.
+    controls: props.controls === true ? null : 0,
+    autoplay: props.autoplay,
+    loop: props.loop,
+    mute: props.defaultMuted,
+    playsinline: props.playsInline ?? youtubeMediaDefaultProps.playsInline,
+    preload: props.preload ?? youtubeMediaDefaultProps.preload,
+    // https://developers.google.com/youtube/player_parameters#Parameters
+    enablejsapi: 1,
+    showinfo: 0,
+    rel: 0,
+    iv_load_policy: 3,
+    modestbranding: 1,
+    start: parsed.startTime,
+    // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
+    ...(props.config ?? undefined),
+  };
+  if (parsed.kind === 'playlist' && parsed.listId) {
+    return `${embedBase}?${serialize({ listType: 'playlist', list: parsed.listId, ...params })}`;
+  }
+  return `${embedBase}/${parsed.id}?${serialize(params)}`;
+}
+
+const API_URL = 'https://www.youtube.com/iframe_api';
+const EMBED_BASE = 'https://www.youtube.com/embed';
+const EMBED_BASE_NOCOOKIE = 'https://www.youtube-nocookie.com/embed';
+const VIDEO_MATCH_SRC =
+  /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((?:\w|-){11})/;
+const PLAYLIST_MATCH_SRC = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/.*?[?&]list=)([\w-]+)/;
+
+// https://developers.google.com/youtube/iframe_api_reference#onStateChange
+const STATE_UNSTARTED = -1;
+const STATE_ENDED = 0;
+const STATE_PLAYING = 1;
+const STATE_PAUSED = 2;
+const STATE_BUFFERING = 3;
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_FUTURE_DATA = 3;
+const READY_STATE_HAVE_ENOUGH_DATA = 4;
+
+async function loadYouTubeApi(): Promise<YouTubeApi> {
+  const existing = (globalThis as { YT?: YouTubeApi }).YT;
+  if (existing?.Player) return existing;
+  await loadScript(API_URL);
+  const api = (globalThis as { YT?: YouTubeApi }).YT;
+  if (!api) throw new Error('YouTube iframe API failed to load');
+  // The loader stub exposes `YT.ready` before `YT.Player` is defined.
+  await new Promise<void>((resolve) => api.ready(resolve));
+  return api;
+}
+
+/**
+ * Parse the `t` parameter from a YouTube URL and convert it to seconds.
+ * Supports formats like: `t=171`, `t=171s`, `t=2m51s`, `t=2m`.
+ */
+function parseStartTime(url: string): number | null {
+  const tValue = /[?&]t=([\dms]+)/i.exec(url)?.[1]?.toLowerCase();
+  if (!tValue) return null;
+  let totalSeconds = 0;
+  let hasValue = false;
+  const minutes = /(\d+)m/.exec(tValue)?.[1];
+  if (minutes) {
+    totalSeconds += Number.parseInt(minutes, 10) * 60;
+    hasValue = true;
+  }
+  const seconds = /(\d+)s?$/.exec(tValue)?.[1];
+  if (seconds) {
+    totalSeconds += Number.parseInt(seconds, 10);
+    hasValue = true;
+  }
+  return hasValue ? totalSeconds : null;
+}
+
+function createTimeRanges(start: number, end: number) {
+  return { length: 1, start: () => start, end: () => end };
+}
+
+function serialize(props: Record<string, unknown>) {
+  const params = new URLSearchParams();
+  for (const key in props) {
+    const val = props[key];
+    if (val === true || val === '') params.set(key, '1');
+    else if (val === false) params.set(key, '0');
+    else if (val != null) params.set(key, String(val));
+  }
+  return params.toString();
+}
+
+interface PublicPromise<T> extends Promise<T> {
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createPublicPromise<T>(): PublicPromise<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  }) as PublicPromise<T>;
+  promise.resolve = resolve;
+  promise.reject = reject;
+  return promise;
+}

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -14,26 +14,24 @@ import type { MediaPreloadType, TextTrackListLike, Video } from '../../core/type
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
 
 /**
- * YouTube engine options. Player parameters are YouTube's engine configuration,
- * so they are serialized verbatim onto the embed URL
- * (https://developers.google.com/youtube/player_parameters).
+ * YouTube engine options, spelled exactly as YouTube spells them
+ * (https://developers.google.com/youtube/player_parameters). They are serialized
+ * onto the embed URL verbatim, so what you write here is what the player reads.
  *
- * Parameters YouTube has deprecated (`modestbranding`, `showinfo`, `autohide`,
- * `theme`, and `listType: 'search'`) are deliberately absent. The index
- * signature still carries anything not listed here, including whatever YouTube
- * adds next.
+ * Parameters the host owns are deliberately absent: `autoplay`, `controls`, and
+ * `playsinline` come from the props of the same name, so configuring them here
+ * would give two ways to say one thing. Parameters YouTube has deprecated
+ * (`modestbranding`, `showinfo`, `autohide`, `theme`, and `listType: 'search'`)
+ * are absent too. The index signature still carries anything not listed here, so
+ * undocumented knobs and whatever YouTube adds next keep working.
  */
 export interface YouTubeEngineConfig extends Record<string, unknown> {
-  /** Play the initial video as soon as the player loads. Defaults to `0`. */
-  autoplay?: 0 | 1;
   /** ISO 639-1 language to display captions in. Pair with `cc_load_policy`. */
   cc_lang_pref?: string;
   /** Show closed captions by default, even if the viewer has turned them off. */
   cc_load_policy?: 1;
   /** Progress-bar highlight color. Defaults to `'red'`. */
   color?: 'red' | 'white';
-  /** Display the player controls. Defaults to `1`. */
-  controls?: 0 | 1;
   /** Stop responding to keyboard controls. Defaults to `0`. */
   disablekb?: 0 | 1;
   /** Allow the player to be driven through the IFrame Player API. Defaults to `0`. */
@@ -56,8 +54,6 @@ export interface YouTubeEngineConfig extends Record<string, unknown> {
   origin?: string;
   /** Comma-separated video ids to play after the one named by the URL path. */
   playlist?: string;
-  /** Play inline rather than fullscreen on iOS. */
-  playsinline?: 0 | 1;
   /** Draw related videos from the same channel (`0`) or anywhere (`1`). Defaults to `1`. */
   rel?: 0 | 1;
   /** Begin playback this many seconds from the start of the video. */

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -6,6 +6,7 @@
 // License: MIT
 
 import { loadScript } from '@videojs/utils/dom';
+import { deepEqual } from '@videojs/utils/object';
 import { isNumber, isUndefined } from '@videojs/utils/predicate';
 import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 import { MediaError } from '../../core/media-error';
@@ -13,15 +14,24 @@ import type { MediaPreloadType, TextTrackListLike, Video } from '../../core/type
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
 
 /**
- * Public YouTube embed configuration. Serialized onto the iframe URL as
- * player parameters (https://developers.google.com/youtube/player_parameters).
+ * YouTube engine options. Player parameters are YouTube's engine configuration,
+ * so they are serialized verbatim onto the embed URL
+ * (https://developers.google.com/youtube/player_parameters).
  */
-export interface YouTubeConfig extends Record<string, unknown> {
+export interface YouTubeEngineConfig extends Record<string, unknown> {
   referrerPolicy?: ReferrerPolicy;
 }
 
-/** Parsed pieces of a YouTube source URL. */
+/** Structured YouTube source: which source to play, plus how to play it. */
 export interface YouTubeSource {
+  /** YouTube URL or id. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** YouTube's own player parameters, passed through untouched. */
+  engine?: YouTubeEngineConfig | undefined;
+}
+
+/** Parsed pieces of a YouTube source URL. */
+export interface ParsedYouTubeSource {
   /** 11-character video id (null for playlist-only sources). */
   id: string | null;
   /** `'video'` for single videos, `'playlist'` for playlist sources. */
@@ -44,7 +54,7 @@ export interface YouTubeMediaProps {
   playsInline: boolean;
   preload: MediaPreloadType;
   poster: string;
-  config: YouTubeConfig;
+  source: YouTubeSource | null;
 }
 
 export const youtubeMediaDefaultProps: YouTubeMediaProps = {
@@ -57,7 +67,7 @@ export const youtubeMediaDefaultProps: YouTubeMediaProps = {
   playsInline: true,
   preload: 'metadata',
   poster: '',
-  config: {},
+  source: null,
 };
 
 /**
@@ -126,7 +136,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   #playsInline = youtubeMediaDefaultProps.playsInline;
   #preload = youtubeMediaDefaultProps.preload;
   #poster = youtubeMediaDefaultProps.poster;
-  #config = youtubeMediaDefaultProps.config;
+  #source: YouTubeSource | null = youtubeMediaDefaultProps.source;
 
   #paused = true;
   #ended = false;
@@ -166,7 +176,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
       const initialSrc = buildYouTubeIframeSrc(this.#src, this.#snapshotProps());
       if (initialSrc) target.src = initialSrc;
     }
-    this.#loadComplete = createPublicPromise<void>();
+    this.#beginLoad();
     this.dispatchEvent(new Event('loadstart'));
     void this.#createPlayer(target);
   }
@@ -198,10 +208,14 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   get src() {
     return this.#src;
   }
+  /** YouTube URL or id. Setting it re-derives `source`, carrying its player parameters over. */
   set src(value) {
-    if (this.#src === value) return;
-    this.#src = value;
-    void this.load();
+    const { engine } = this.#source ?? {};
+    const next: YouTubeSource = { ...(engine && { engine }), ...(value && { src: value }) };
+
+    // Everything happens in the `source` setter, so there is one path for storing
+    // it, deciding on a load, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
   }
 
   get currentSrc() {
@@ -221,7 +235,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
       return;
     }
     this.#resetState();
-    this.#loadComplete = createPublicPromise<void>();
+    const load = this.#beginLoad();
     this.dispatchEvent(new Event('emptied'));
     this.dispatchEvent(new Event('loadstart'));
     const parsed = parseYouTubeSource(this.#src);
@@ -229,7 +243,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
       this.#error = new MediaError(`Unrecognized YouTube source: ${this.#src}`, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
       this.dispatchEvent(new Event('error'));
       // Unblock callers awaiting load so play()/fullscreen don't hang.
-      this.#loadComplete.resolve();
+      load.resolve();
       return;
     }
     if (parsed.kind === 'playlist' && parsed.listId) {
@@ -242,6 +256,17 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
       if (this.#autoplay) this.#player.loadVideoById(options);
       else this.#player.cueVideoById(options);
     }
+  }
+
+  /**
+   * Take over as the current load, returning its barrier. Settling the outgoing
+   * one is what keeps a superseded load from stranding callers that are already
+   * waiting; every exit from `load()` settles the barrier it was handed.
+   */
+  #beginLoad(): PublicPromise<void> {
+    this.#loadComplete.resolve();
+    this.#loadComplete = createPublicPromise<void>();
+    return this.#loadComplete;
   }
 
   get paused() {
@@ -356,11 +381,33 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     this.#poster = value;
   }
 
-  get config() {
-    return this.#config as Record<string, unknown>;
+  /**
+   * Structured source: the YouTube URL or ID in `src`, plus player parameters
+   * under `engine`. Replacing it re-derives `src`; assigning an equivalent source
+   * is a no-op.
+   */
+  get source(): YouTubeSource | null {
+    return this.#source;
   }
-  set config(value) {
-    this.#config = value as YouTubeConfig;
+  set source(value: YouTubeSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    const src = source?.src ?? '';
+    const srcChanged = this.#src !== src;
+    // Player parameters are read when the embed is built, so a change to them
+    // needs a reload of its own even though the URL is the same.
+    const engineChanged = !deepEqual(this.#source?.engine ?? null, source?.engine ?? null);
+
+    this.#source = source;
+    this.#src = src;
+
+    if (srcChanged || engineChanged) void this.load();
+
+    // Assigning is always a source change, so it is always announced.
+    this.dispatchEvent(new Event('sourcechange'));
   }
 
   get buffered() {
@@ -388,7 +435,10 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
 
   // The iframe API exposes no fullscreen controls, so fullscreen targets the iframe itself.
   async requestFullscreen() {
-    await this.#target?.requestFullscreen?.();
+    // Nothing entered fullscreen if there is no element to request it on, so the
+    // flag must not claim otherwise.
+    if (!this.#target?.requestFullscreen) return;
+    await this.#target.requestFullscreen();
     this.#isFullscreen = true;
   }
 
@@ -406,22 +456,41 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     try {
       api = await loadYouTubeApi();
     } catch {
+      // A failed API load belongs to the attach that started it; a newer one must
+      // not be marked failed or have its load unblocked.
+      if (this.#isStale(attachId)) return;
       this.#error = new MediaError('Failed to load the YouTube iframe API', MediaError.MEDIA_ERR_NETWORK);
       this.dispatchEvent(new Event('error'));
       // Unblock callers awaiting load so play()/fullscreen don't hang.
       this.#loadComplete.resolve();
       return;
     }
-    if (attachId !== this.#attachId || this.#target !== target) return;
+    if (this.#isStale(attachId) || this.#target !== target) return;
     const player = new api.Player(target, {
       events: {
-        onReady: () => this.#onPlayerReady(),
-        onError: (event) => this.#onError(event.data),
+        onReady: () => {
+          if (this.#isStale(attachId)) return;
+          this.#onPlayerReady();
+        },
+        onError: (event) => {
+          if (this.#isStale(attachId)) return;
+          this.#onError(event.data);
+        },
       },
     });
     this.#player = player;
-    this.#bindPlayerEvents(player);
+    this.#bindPlayerEvents(player, attachId);
     this.#setupTextTracks(player);
+  }
+
+  /**
+   * Whether a callback belongs to a superseded attach. `destroy()` does not stop
+   * the iframe API from invoking callbacks it already scheduled, so anything a
+   * player reports has to be matched against the attach that created it before
+   * it is allowed to touch state.
+   */
+  #isStale(attachId: number) {
+    return attachId !== this.#attachId;
   }
 
   /** Defer a player call until `loadComplete` resolves, swallowing failures. */
@@ -447,7 +516,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
       controls: this.#controls,
       playsInline: this.#playsInline,
       preload: this.#preload || youtubeMediaDefaultProps.preload,
-      config: this.#config,
+      source: this.#source,
     };
   }
 
@@ -511,10 +580,11 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     this.#loadComplete.resolve();
   }
 
-  #bindPlayerEvents(player: YouTubePlayerApi) {
+  #bindPlayerEvents(player: YouTubePlayerApi, attachId: number) {
     const emit = (type: string) => this.dispatchEvent(new Event(type));
 
     player.addEventListener('onStateChange', ({ data: state }) => {
+      if (this.#isStale(attachId)) return;
       // Subsequent loads (`cueVideoById`/`loadVideoById`) never re-fire
       // `onReady`, so any post-load state transition completes the load.
       if (!this.#loaded && state !== STATE_UNSTARTED) this.#onLoaded();
@@ -559,11 +629,13 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     });
 
     player.addEventListener('onPlaybackRateChange', () => {
+      if (this.#isStale(attachId)) return;
       this.#playbackRate = player.getPlaybackRate();
       emit('ratechange');
     });
 
     player.addEventListener('onVolumeChange', () => {
+      if (this.#isStale(attachId)) return;
       this.#volume = player.getVolume() / 100;
       this.#muted = player.isMuted();
       emit('volumechange');
@@ -674,7 +746,7 @@ export function parseYouTubeVideoId(src: string) {
  * without the `-nocookie` host), playlist URLs via the `list` parameter, and
  * start times via the `t` parameter.
  */
-export function parseYouTubeSource(src: string): YouTubeSource | null {
+export function parseYouTubeSource(src: string): ParsedYouTubeSource | null {
   if (!src) return null;
   if (/^[\w-]{11}$/.test(src)) {
     return { id: src, kind: 'video', listId: null, startTime: null, noCookie: false };
@@ -716,7 +788,7 @@ export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaPr
     modestbranding: 1,
     start: parsed.startTime,
     // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
-    ...(props.config ?? undefined),
+    ...(props.source?.engine ?? undefined),
   };
   if (parsed.kind === 'playlist' && parsed.listId) {
     return `${embedBase}?${serialize({ listType: 'playlist', list: parsed.listId, ...params })}`;

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -5,13 +5,14 @@
 // Source: https://github.com/muxinc/media-elements
 // License: MIT
 
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
 import { deepEqual } from '@videojs/utils/object';
 import { isNumber, isUndefined } from '@videojs/utils/predicate';
 import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 import { MediaError } from '../../core/media-error';
 import type { TextTrackListLike, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
-import { createPublicPromise, createTimeRange, type PublicPromise } from '../utils';
+import { createTimeRange } from '../utils';
 import {
   loadYouTubeApi,
   STATE_BUFFERING,

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -340,6 +340,9 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
 
   async play() {
     await this.#loadComplete;
+    // The embed still holds the stopped video, so playing it would resume a
+    // source that was cleared.
+    if (!this.#src) return;
     this.#player?.playVideo();
   }
 
@@ -643,8 +646,10 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     player.addEventListener('onStateChange', ({ data: state }) => {
       if (this.#isStale(attachId)) return;
       // Subsequent loads (`cueVideoById`/`loadVideoById`) never re-fire
-      // `onReady`, so any post-load state transition completes the load.
-      if (!this.#loaded && state !== STATE_UNSTARTED) this.#onLoaded();
+      // `onReady`, so any post-load state transition completes the load. With no
+      // src there is no load to complete, and `stopVideo()` reports a transition
+      // of its own — completing on that would put the cleared state right back.
+      if (this.#src && !this.#loaded && state !== STATE_UNSTARTED) this.#onLoaded();
 
       if (state === STATE_PLAYING || state === STATE_BUFFERING) {
         if (!this.#playFired) {

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -136,6 +136,7 @@ export interface YouTubePlayerApi {
   cueVideoById(options: { videoId: string; startSeconds?: number }): void;
   loadPlaylist(options: { list: string; listType?: string }): void;
   cuePlaylist(options: { list: string; listType?: string }): void;
+  stopVideo(): void;
   getOption(module: string, option: string): unknown;
   setOption(module: string, option: string, value: unknown): void;
   addEventListener(type: string, listener: (event: { data: number }) => void): void;
@@ -270,14 +271,28 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
 
   /** Reload the current source via the iframe API; deferred until the player is ready. */
   async load() {
-    if (!this.#src) return;
     if (!this.#player || !this.#playerReady) {
       // `cueVideoById`/`loadVideoById` fail before `onReady`; replay the load then.
+      // A cleared src replays too, so the barrier below always gets settled.
       this.#pendingLoad = !!this.#target;
       return;
     }
-    this.#resetState();
     const load = this.#beginLoad();
+    // Reset before bailing on an empty src: a cleared source has nothing to load,
+    // but what we report about the old video still has to go.
+    this.#resetState();
+    if (!this.#src) {
+      // The embed has to stop too. Left running it keeps playing, and the poll
+      // writes the state just cleared straight back.
+      load.resolve();
+      this.#stopPolling();
+      try {
+        this.#player.stopVideo();
+      } catch {
+        // The iframe API throws if the player was destroyed mid-flight.
+      }
+      return;
+    }
     this.dispatchEvent(new Event('emptied'));
     this.dispatchEvent(new Event('loadstart'));
     const parsed = parseYouTubeSource(this.#src);

--- a/packages/media/src/dom/youtube/props.ts
+++ b/packages/media/src/dom/youtube/props.ts
@@ -1,0 +1,28 @@
+import type { MediaPreloadType } from '../../core/types';
+import type { YouTubeSource } from './source';
+
+export interface YouTubeMediaProps {
+  src: string;
+  autoplay: boolean;
+  defaultMuted: boolean;
+  muted: boolean;
+  loop: boolean;
+  controls: boolean;
+  playsInline: boolean;
+  preload: MediaPreloadType;
+  poster: string;
+  source: YouTubeSource | null;
+}
+
+export const youtubeMediaDefaultProps: YouTubeMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  muted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  source: null,
+};

--- a/packages/media/src/dom/youtube/source.ts
+++ b/packages/media/src/dom/youtube/source.ts
@@ -1,0 +1,167 @@
+import { serializeEmbedParams } from '../utils';
+import { type YouTubeMediaProps, youtubeMediaDefaultProps } from './props';
+
+/**
+ * YouTube engine options, spelled exactly as YouTube spells them
+ * (https://developers.google.com/youtube/player_parameters). They are serialized
+ * onto the embed URL verbatim, so what you write here is what the player reads.
+ *
+ * Parameters the host owns are deliberately absent: `autoplay`, `controls`, and
+ * `playsinline` come from the props of the same name, so configuring them here
+ * would give two ways to say one thing. Parameters YouTube has deprecated
+ * (`modestbranding`, `showinfo`, `autohide`, `theme`, and `listType: 'search'`)
+ * are absent too. The index signature still carries anything not listed here, so
+ * undocumented knobs and whatever YouTube adds next keep working.
+ */
+export interface YouTubeEngineConfig extends Record<string, unknown> {
+  /** ISO 639-1 language to display captions in. Pair with `cc_load_policy`. */
+  cc_lang_pref?: string;
+  /** Show closed captions by default, even if the viewer has turned them off. */
+  cc_load_policy?: 1;
+  /** Progress-bar highlight color. Defaults to `'red'`. */
+  color?: 'red' | 'white';
+  /** Stop responding to keyboard controls. Defaults to `0`. */
+  disablekb?: 0 | 1;
+  /** Allow the player to be driven through the IFrame Player API. Defaults to `0`. */
+  enablejsapi?: 0 | 1;
+  /** Stop playback this many seconds from the start of the video. */
+  end?: number;
+  /** Display the fullscreen button. Defaults to `1`. */
+  fs?: 0 | 1;
+  /** Player interface language: an ISO 639-1 code or full locale (`fr`, `fr-ca`). */
+  hl?: string;
+  /** Show video annotations (`1`) or hide them (`3`). Defaults to `1`. */
+  iv_load_policy?: 1 | 3;
+  /** Playlist id (prefixed with `PL`) or channel name, depending on `listType`. */
+  list?: string;
+  /** What `list` refers to. */
+  listType?: 'playlist' | 'user_uploads';
+  /** Repeat playback. Looping a single video also needs `playlist` set to the same id. */
+  loop?: 0 | 1;
+  /** Embedding domain. Set it whenever `enablejsapi` is `1`. */
+  origin?: string;
+  /** Comma-separated video ids to play after the one named by the URL path. */
+  playlist?: string;
+  /** Draw related videos from the same channel (`0`) or anywhere (`1`). Defaults to `1`. */
+  rel?: 0 | 1;
+  /** Begin playback this many seconds from the start of the video. */
+  start?: number;
+  /** Embedding URL reported to YouTube Analytics for widget-hosted players. */
+  widget_referrer?: string;
+  /** `referrerpolicy` for the embed iframe. Not a YouTube player parameter. */
+  referrerPolicy?: ReferrerPolicy;
+}
+
+/** Structured YouTube source: which source to play, plus how to play it. */
+export interface YouTubeSource {
+  /** YouTube URL or id. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** YouTube's own player parameters, passed through untouched. */
+  engine?: YouTubeEngineConfig | undefined;
+}
+
+/** Parsed pieces of a YouTube source URL. */
+export interface ParsedYouTubeSource {
+  /** 11-character video id (null for playlist-only sources). */
+  id: string | null;
+  /** `'video'` for single videos, `'playlist'` for playlist sources. */
+  kind: 'video' | 'playlist';
+  /** Playlist id (the `list` parameter). */
+  listId: string | null;
+  /** Start time in seconds parsed from the `t` parameter. */
+  startTime: number | null;
+  /** Whether the source uses the youtube-nocookie.com privacy-enhanced host. */
+  noCookie: boolean;
+}
+
+/** Extract a YouTube video id from a raw 11-character id or any recognized URL. */
+export function parseYouTubeVideoId(src: string) {
+  return parseYouTubeSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a YouTube source string. Recognizes raw 11-character ids, `youtu.be`
+ * short links, `watch?v=`, `embed/`, `v/`, `shorts/` and `live/` URLs (with or
+ * without the `-nocookie` host), playlist URLs via the `list` parameter, and
+ * start times via the `t` parameter.
+ */
+export function parseYouTubeSource(src: string): ParsedYouTubeSource | null {
+  if (!src) return null;
+  if (/^[\w-]{11}$/.test(src)) {
+    return { id: src, kind: 'video', listId: null, startTime: null, noCookie: false };
+  }
+  const noCookie = src.includes('-nocookie');
+  const videoMatch = VIDEO_MATCH_SRC.exec(src);
+  const listMatch = PLAYLIST_MATCH_SRC.exec(src);
+  // Playlist embed URLs use the `videoseries` placeholder in the video id slot.
+  const videoId = videoMatch?.[1] ?? null;
+  const id = videoId === 'videoseries' ? null : videoId;
+  if (!id && !listMatch) return null;
+  return {
+    id,
+    kind: id ? 'video' : 'playlist',
+    listId: listMatch?.[1] ?? null,
+    startTime: parseStartTime(src),
+    noCookie,
+  };
+}
+
+/** Build the iframe `src` URL for an initial YouTube embed from the given props. */
+export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaProps> = {}) {
+  const parsed = parseYouTubeSource(src);
+  if (!parsed) return '';
+  const embedBase = parsed.noCookie ? EMBED_BASE_NOCOOKIE : EMBED_BASE;
+  const params: Record<string, unknown> = {
+    // Hide YouTube chrome by default; pass nothing only when controls is explicitly true.
+    controls: props.controls === true ? null : 0,
+    autoplay: props.autoplay,
+    loop: props.loop,
+    mute: props.defaultMuted,
+    playsinline: props.playsInline ?? youtubeMediaDefaultProps.playsInline,
+    preload: props.preload ?? youtubeMediaDefaultProps.preload,
+    // https://developers.google.com/youtube/player_parameters#Parameters
+    enablejsapi: 1,
+    rel: 0,
+    iv_load_policy: 3,
+    start: parsed.startTime,
+    // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
+    ...(props.source?.engine ?? undefined),
+  };
+  if (parsed.kind === 'playlist' && parsed.listId) {
+    return `${embedBase}?${serializeEmbedParams({ listType: 'playlist', list: parsed.listId, ...params })}`;
+  }
+  return `${embedBase}/${parsed.id}?${serializeEmbedParams(params)}`;
+}
+
+/**
+ * Parse the `t` parameter from a YouTube URL and convert it to seconds.
+ * Supports formats like: `t=171`, `t=171s`, `t=2m51s`, `t=2m`, `t=1h30m15s`.
+ */
+function parseStartTime(url: string): number | null {
+  const tValue = /[?&]t=([\dhms]+)/i.exec(url)?.[1]?.toLowerCase();
+  if (!tValue) return null;
+  let totalSeconds = 0;
+  let hasValue = false;
+  const hours = /(\d+)h/.exec(tValue)?.[1];
+  if (hours) {
+    totalSeconds += Number.parseInt(hours, 10) * 3600;
+    hasValue = true;
+  }
+  const minutes = /(\d+)m/.exec(tValue)?.[1];
+  if (minutes) {
+    totalSeconds += Number.parseInt(minutes, 10) * 60;
+    hasValue = true;
+  }
+  const seconds = /(\d+)s?$/.exec(tValue)?.[1];
+  if (seconds) {
+    totalSeconds += Number.parseInt(seconds, 10);
+    hasValue = true;
+  }
+  return hasValue ? totalSeconds : null;
+}
+
+const EMBED_BASE = 'https://www.youtube.com/embed';
+const EMBED_BASE_NOCOOKIE = 'https://www.youtube-nocookie.com/embed';
+const VIDEO_MATCH_SRC =
+  /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((?:\w|-){11})/;
+const PLAYLIST_MATCH_SRC = /(?:youtu\.be\/|youtube(?:-nocookie)?\.com\/.*?[?&]list=)([\w-]+)/;

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -163,6 +163,9 @@ describe('parseYouTubeSource', () => {
     expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=171s')?.startTime).toBe(171);
     expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=2m51s')?.startTime).toBe(171);
     expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=2m')?.startTime).toBe(120);
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=1h30m15s')?.startTime).toBe(5415);
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=1h')?.startTime).toBe(3600);
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=1h5s')?.startTime).toBe(3605);
   });
 
   it('detects the nocookie host', () => {

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -370,6 +370,30 @@ describe('YouTubeMedia', () => {
     media.detach();
   });
 
+  it('defers the load when src changes before the player is ready', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = await waitForEngine(media);
+
+    // Player exists but `onReady` hasn't fired; cueing now would fail.
+    media.src = 'https://youtu.be/dQw4w9WgXcQ?t=10';
+    await Promise.resolve();
+    expect(player.cueVideoById).not.toHaveBeenCalled();
+
+    // The deferred load replays once the player is ready.
+    player.ready();
+    await Promise.resolve();
+    expect(player.cueVideoById).toHaveBeenCalledWith({ videoId: 'dQw4w9WgXcQ', startSeconds: 10 });
+
+    const loadCompleteSpy = vi.fn();
+    media.addEventListener('loadcomplete', loadCompleteSpy);
+    player.emit('onStateChange', STATE.CUED);
+    expect(loadCompleteSpy).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
   it('loads (instead of cueing) the new video when autoplay is set', async () => {
     const media = new YouTubeMedia();
     media.autoplay = true;

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -1,0 +1,448 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildYouTubeIframeSrc,
+  parseYouTubeSource,
+  parseYouTubeVideoId,
+  YouTubeMedia,
+  youtubeMediaDefaultProps,
+} from '..';
+
+vi.mock(import('@videojs/utils/dom'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return { ...mod, loadScript: vi.fn(async () => {}) };
+});
+
+interface StateChangeEvent {
+  data: number;
+}
+
+interface MockPlayerEvents {
+  onReady?: () => void;
+  onError?: (event: StateChangeEvent) => void;
+}
+
+class MockPlayer {
+  static instances: MockPlayer[] = [];
+  target: unknown;
+  events: MockPlayerEvents | undefined;
+  listeners = new Map<string, Set<(event: StateChangeEvent) => void>>();
+
+  playVideo = vi.fn();
+  pauseVideo = vi.fn();
+  seekTo = vi.fn();
+  mute = vi.fn();
+  unMute = vi.fn();
+  isMuted = vi.fn(() => false);
+  setVolume = vi.fn();
+  getVolume = vi.fn(() => 100);
+  getDuration = vi.fn(() => 60);
+  getCurrentTime = vi.fn(() => 0);
+  getPlaybackRate = vi.fn(() => 1);
+  setPlaybackRate = vi.fn();
+  getVideoLoadedFraction = vi.fn(() => 0);
+  getPlayerState = vi.fn(() => -1);
+  loadVideoById = vi.fn();
+  cueVideoById = vi.fn();
+  loadPlaylist = vi.fn();
+  cuePlaylist = vi.fn();
+  getOption = vi.fn(() => []);
+  setOption = vi.fn();
+  destroy = vi.fn();
+
+  constructor(target: unknown, options?: { events?: MockPlayerEvents }) {
+    this.target = target;
+    this.events = options?.events;
+    MockPlayer.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: StateChangeEvent) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  emit(type: string, data = 0): void {
+    this.listeners.get(type)?.forEach((listener) => listener({ data }));
+  }
+
+  ready(): void {
+    this.events?.onReady?.();
+  }
+}
+
+// https://developers.google.com/youtube/iframe_api_reference#onStateChange
+const STATE = { UNSTARTED: -1, ENDED: 0, PLAYING: 1, PAUSED: 2, BUFFERING: 3, CUED: 5 } as const;
+
+beforeEach(() => {
+  MockPlayer.instances.length = 0;
+  vi.stubGlobal('YT', {
+    Player: MockPlayer,
+    ready: (callback: () => void) => callback(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createIframe(): HTMLIFrameElement {
+  return document.createElement('iframe');
+}
+
+async function waitForEngine(media: YouTubeMedia): Promise<MockPlayer> {
+  await vi.waitFor(() => {
+    if (!media.engine) throw new Error('player not created yet');
+  });
+  return media.engine as unknown as MockPlayer;
+}
+
+async function attachAndLoad(media: YouTubeMedia): Promise<{ iframe: HTMLIFrameElement; player: MockPlayer }> {
+  const iframe = createIframe();
+  media.attach(iframe);
+  const player = await waitForEngine(media);
+  player.ready();
+  return { iframe, player };
+}
+
+describe('parseYouTubeVideoId', () => {
+  it('extracts id from a raw 11-character id', () => {
+    expect(parseYouTubeVideoId('aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+  });
+
+  it('extracts id from watch URL', () => {
+    expect(parseYouTubeVideoId('https://www.youtube.com/watch?v=aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+  });
+
+  it('extracts id from youtu.be short link', () => {
+    expect(parseYouTubeVideoId('https://youtu.be/aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+  });
+
+  it('extracts id from embed, shorts, and live URLs', () => {
+    expect(parseYouTubeVideoId('https://www.youtube.com/embed/aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+    expect(parseYouTubeVideoId('https://www.youtube.com/shorts/aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+    expect(parseYouTubeVideoId('https://www.youtube.com/live/aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+  });
+
+  it('extracts id from nocookie host', () => {
+    expect(parseYouTubeVideoId('https://www.youtube-nocookie.com/watch?v=aqz-KE-bpKQ')).toBe('aqz-KE-bpKQ');
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseYouTubeVideoId('')).toBe(null);
+  });
+
+  it('returns null for non-YouTube URLs', () => {
+    expect(parseYouTubeVideoId('https://example.com/video.mp4')).toBe(null);
+  });
+});
+
+describe('parseYouTubeSource', () => {
+  it('detects playlists', () => {
+    expect(parseYouTubeSource('https://www.youtube.com/playlist?list=PLv3TTBr1W_9tppikBxAE_G6qjWdBljBHJ')).toEqual({
+      id: null,
+      kind: 'playlist',
+      listId: 'PLv3TTBr1W_9tppikBxAE_G6qjWdBljBHJ',
+      startTime: null,
+      noCookie: false,
+    });
+  });
+
+  it('keeps the video id when a watch URL also has a list param', () => {
+    const parsed = parseYouTubeSource('https://www.youtube.com/watch?v=aqz-KE-bpKQ&list=PLv3TTBr1W_9tppikBxAE');
+    expect(parsed?.kind).toBe('video');
+    expect(parsed?.id).toBe('aqz-KE-bpKQ');
+    expect(parsed?.listId).toBe('PLv3TTBr1W_9tppikBxAE');
+  });
+
+  it('parses start times in t param formats', () => {
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=171')?.startTime).toBe(171);
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=171s')?.startTime).toBe(171);
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=2m51s')?.startTime).toBe(171);
+    expect(parseYouTubeSource('https://youtu.be/aqz-KE-bpKQ?t=2m')?.startTime).toBe(120);
+  });
+
+  it('detects the nocookie host', () => {
+    expect(parseYouTubeSource('https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ')?.noCookie).toBe(true);
+  });
+});
+
+describe('buildYouTubeIframeSrc', () => {
+  it('builds embed URL with default playsinline, hidden controls, and jsapi enabled', () => {
+    const src = buildYouTubeIframeSrc('https://www.youtube.com/watch?v=aqz-KE-bpKQ');
+    expect(src).toContain('https://www.youtube.com/embed/aqz-KE-bpKQ');
+    expect(src).toContain('playsinline=1');
+    expect(src).toContain('preload=metadata');
+    expect(src).toContain('controls=0');
+    expect(src).toContain('enablejsapi=1');
+  });
+
+  it('encodes autoplay, defaultMuted, loop', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
+      autoplay: true,
+      defaultMuted: true,
+      loop: true,
+    });
+    expect(src).toContain('autoplay=1');
+    expect(src).toContain('mute=1');
+    expect(src).toContain('loop=1');
+  });
+
+  it('shows YouTube controls when controls=true', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { controls: true });
+    expect(src).not.toContain('controls=0');
+  });
+
+  it('forwards preload and YouTube-specific config knobs', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { preload: 'auto', config: { cc_load_policy: 1 } });
+    expect(src).toContain('preload=auto');
+    expect(src).toContain('cc_load_policy=1');
+  });
+
+  it('embeds start time from the t param', () => {
+    expect(buildYouTubeIframeSrc('https://youtu.be/aqz-KE-bpKQ?t=2m51s')).toContain('start=171');
+  });
+
+  it('uses the nocookie embed base for nocookie sources', () => {
+    expect(buildYouTubeIframeSrc('https://www.youtube-nocookie.com/watch?v=aqz-KE-bpKQ')).toContain(
+      'https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ'
+    );
+  });
+
+  it('builds playlist embed URL', () => {
+    const src = buildYouTubeIframeSrc('https://www.youtube.com/playlist?list=PLv3TTBr1W_9tppikBxAE');
+    expect(src).toContain('https://www.youtube.com/embed?');
+    expect(src).toContain('listType=playlist');
+    expect(src).toContain('list=PLv3TTBr1W_9tppikBxAE');
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildYouTubeIframeSrc('not-a-youtube-url')).toBe('');
+  });
+});
+
+describe('YouTubeMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new YouTubeMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(youtubeMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sets the initial iframe src and creates a player when attached', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.src).toContain('https://www.youtube.com/embed/aqz-KE-bpKQ');
+    expect(media.target).toBe(iframe);
+
+    await waitForEngine(media);
+    expect(media.engine).not.toBe(null);
+    media.detach();
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete after ready', async () => {
+    const media = new YouTubeMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete', 'durationchange'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    await attachAndLoad(media);
+    expect(events).toContain('loadstart');
+    expect(events).toContain('loadedmetadata');
+    expect(events).toContain('loadcomplete');
+    expect(events).toContain('durationchange');
+    expect(media.duration).toBe(60);
+    expect(media.readyState).toBeGreaterThanOrEqual(1);
+    media.detach();
+  });
+
+  it('updates state from player state changes', async () => {
+    const media = new YouTubeMedia();
+    const { player } = await attachAndLoad(media);
+
+    const playSpy = vi.fn();
+    const waitingSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+    media.addEventListener('waiting', waitingSpy);
+
+    player.emit('onStateChange', STATE.BUFFERING);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(waitingSpy).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(false);
+
+    player.emit('onStateChange', STATE.PLAYING);
+    expect(media.paused).toBe(false);
+    expect(media.readyState).toBe(3);
+    // play only fires once per playback start
+    expect(playSpy).toHaveBeenCalledTimes(1);
+
+    player.getVolume.mockReturnValue(25);
+    player.emit('onVolumeChange');
+    expect(media.volume).toBe(0.25);
+
+    player.getPlaybackRate.mockReturnValue(1.5);
+    player.emit('onPlaybackRateChange');
+    expect(media.playbackRate).toBe(1.5);
+
+    player.emit('onStateChange', STATE.PAUSED);
+    expect(media.paused).toBe(true);
+
+    player.emit('onStateChange', STATE.ENDED);
+    expect(media.ended).toBe(true);
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('forwards play() and pause() to the player', async () => {
+    const media = new YouTubeMedia();
+    const { player } = await attachAndLoad(media);
+
+    await media.play();
+    expect(player.playVideo).toHaveBeenCalledTimes(1);
+
+    media.pause();
+    expect(player.pauseVideo).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('replays on ended when loop is set', async () => {
+    const media = new YouTubeMedia();
+    media.loop = true;
+    const { player } = await attachAndLoad(media);
+
+    player.emit('onStateChange', STATE.ENDED);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(player.playVideo).toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('forwards setters to the player after load', async () => {
+    const media = new YouTubeMedia();
+    const { player } = await attachAndLoad(media);
+
+    media.currentTime = 30;
+    media.volume = 0.5;
+    media.muted = true;
+    media.playbackRate = 1.5;
+
+    // setters defer via loadComplete microtask — flush.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(player.seekTo).toHaveBeenCalledWith(30, true);
+    expect(player.setVolume).toHaveBeenCalledWith(50);
+    expect(player.mute).toHaveBeenCalled();
+    expect(player.setPlaybackRate).toHaveBeenCalledWith(1.5);
+    media.detach();
+  });
+
+  it('cues the new video when src changes after attach', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = await waitForEngine(media);
+    player.ready();
+
+    media.src = 'https://youtu.be/dQw4w9WgXcQ?t=10';
+    await Promise.resolve();
+    expect(player.cueVideoById).toHaveBeenCalledWith({ videoId: 'dQw4w9WgXcQ', startSeconds: 10 });
+
+    // A post-load state change completes the reload.
+    const loadCompleteSpy = vi.fn();
+    media.addEventListener('loadcomplete', loadCompleteSpy);
+    player.emit('onStateChange', STATE.CUED);
+    expect(loadCompleteSpy).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('loads (instead of cueing) the new video when autoplay is set', async () => {
+    const media = new YouTubeMedia();
+    media.autoplay = true;
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = await waitForEngine(media);
+    player.ready();
+
+    media.src = 'https://youtu.be/dQw4w9WgXcQ';
+    await Promise.resolve();
+    expect(player.loadVideoById).toHaveBeenCalledWith({ videoId: 'dQw4w9WgXcQ' });
+    media.detach();
+  });
+
+  it('surfaces player errors', async () => {
+    const media = new YouTubeMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = await waitForEngine(media);
+
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+    player.events?.onError?.({ data: 150 });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toMatchObject({ code: 150 });
+    media.detach();
+  });
+
+  it('tracks played ranges via the played-ranges mixin', async () => {
+    const media = new YouTubeMedia();
+    const { player } = await attachAndLoad(media);
+
+    player.emit('onStateChange', STATE.PLAYING);
+    // Advance time in sub-0.1s steps so polling reports timeupdate, not a seek.
+    player.getCurrentTime.mockReturnValue(0.08);
+    await vi.waitFor(() => {
+      if (media.currentTime !== 0.08) throw new Error('time not polled yet');
+    });
+    player.getCurrentTime.mockReturnValue(0.16);
+    await vi.waitFor(() => {
+      if (media.currentTime !== 0.16) throw new Error('time not polled yet');
+    });
+    player.emit('onStateChange', STATE.PAUSED);
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(0.16);
+    media.detach();
+  });
+
+  it('destroys the player on detach', async () => {
+    const media = new YouTubeMedia();
+    const { player } = await attachAndLoad(media);
+
+    media.detach();
+    expect(player.destroy).toHaveBeenCalled();
+    expect(media.target).toBe(null);
+    expect(media.engine).toBe(null);
+  });
+
+  it('does not create a player when detached before the API resolves', async () => {
+    const media = new YouTubeMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+    media.detach();
+
+    // Flush the async player creation path.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(media.engine).toBe(null);
+  });
+});

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -432,6 +432,19 @@ describe('YouTubeMedia', () => {
     expect(media.engine).toBe(null);
   });
 
+  it('unblocks pending play() when detached before load completes', async () => {
+    const media = new YouTubeMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    // Await load without the player ever becoming ready.
+    const pending = media.play();
+    media.detach();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
   it('does not create a player when detached before the API resolves', async () => {
     const media = new YouTubeMedia();
     const iframe = createIframe();

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -151,6 +151,20 @@ describe('parseYouTubeSource', () => {
     });
   });
 
+  it('detects playlists in videoseries embed URLs', () => {
+    expect(parseYouTubeSource('https://www.youtube.com/embed/videoseries?list=PLv3TTBr1W_9tppikBxAE')).toEqual({
+      id: null,
+      kind: 'playlist',
+      listId: 'PLv3TTBr1W_9tppikBxAE',
+      startTime: null,
+      noCookie: false,
+    });
+  });
+
+  it('returns null for a videoseries embed URL without a list param', () => {
+    expect(parseYouTubeSource('https://www.youtube.com/embed/videoseries')).toBe(null);
+  });
+
   it('keeps the video id when a watch URL also has a list param', () => {
     const parsed = parseYouTubeSource('https://www.youtube.com/watch?v=aqz-KE-bpKQ&list=PLv3TTBr1W_9tppikBxAE');
     expect(parsed?.kind).toBe('video');
@@ -220,6 +234,14 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).toContain('https://www.youtube.com/embed?');
     expect(src).toContain('listType=playlist');
     expect(src).toContain('list=PLv3TTBr1W_9tppikBxAE');
+  });
+
+  it('builds playlist embed URL from a videoseries embed source', () => {
+    const src = buildYouTubeIframeSrc('https://www.youtube.com/embed/videoseries?list=PLv3TTBr1W_9tppikBxAE');
+    expect(src).toContain('https://www.youtube.com/embed?');
+    expect(src).toContain('listType=playlist');
+    expect(src).toContain('list=PLv3TTBr1W_9tppikBxAE');
+    expect(src).not.toContain('videoseries');
   });
 
   it('returns empty string for invalid src', () => {

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -46,6 +46,7 @@ class MockPlayer {
   cueVideoById = vi.fn();
   loadPlaylist = vi.fn();
   cuePlaylist = vi.fn();
+  stopVideo = vi.fn();
   getOption = vi.fn(() => []);
   setOption = vi.fn();
   destroy = vi.fn();
@@ -686,5 +687,42 @@ describe('YouTubeMedia source', () => {
 
     expect(media.src).toBe('');
     expect(media.source).toBe(null);
+  });
+
+  it('stops the embed and resets state when the source is cleared', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'aqz-KE-bpKQ';
+    const { player } = await attachAndLoad(media);
+    player.emit('onStateChange', STATE.PLAYING);
+    expect(media.duration).toBe(60);
+
+    media.source = null;
+    await Promise.resolve();
+
+    // Left running, the embed keeps playing and the poll writes state back.
+    expect(player.stopVideo).toHaveBeenCalled();
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    expect(media.paused).toBe(true);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('unblocks pending play() when the source is cleared before the player is ready', async () => {
+    const media = new YouTubeMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = await waitForEngine(media);
+
+    // Setting src while the player is still loading defers the load, so the
+    // clear below is what the replay on ready has to cope with. Nothing else
+    // settles the barrier `attach()` opened.
+    media.src = 'aqz-KE-bpKQ';
+    media.source = null;
+    const pending = media.play();
+    player.ready();
+
+    await expect(pending).resolves.toBeUndefined();
+    media.detach();
   });
 });

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -213,8 +213,8 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).not.toContain('controls=0');
   });
 
-  it('forwards preload and YouTube-specific config knobs', () => {
-    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { preload: 'auto', config: { cc_load_policy: 1 } });
+  it('forwards preload and YouTube-specific engine knobs', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { preload: 'auto', source: { engine: { cc_load_policy: 1 } } });
     expect(src).toContain('preload=auto');
     expect(src).toContain('cc_load_policy=1');
   });
@@ -533,5 +533,111 @@ describe('YouTubeMedia', () => {
     await Promise.resolve();
 
     expect(media.engine).toBe(null);
+  });
+
+  it('ignores ready and state callbacks from a superseded player', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const { player: stale } = await attachAndLoad(media);
+
+    media.detach();
+    const { player: current } = await attachAndLoad(media);
+    expect(current).not.toBe(stale);
+
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    // The iframe API keeps invoking callbacks it already scheduled for the
+    // destroyed player; none of them may touch the new session's state.
+    stale.ready();
+    stale.emit('onStateChange', STATE.PLAYING);
+    stale.getVolume.mockReturnValue(10);
+    stale.emit('onVolumeChange');
+
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    expect(media.volume).toBe(1);
+    media.detach();
+  });
+
+  it('unblocks waiters from a superseded load when a reload starts first', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const { player } = await attachAndLoad(media);
+
+    // Start a second load and wait on its barrier without ever completing it.
+    media.src = 'https://youtu.be/dQw4w9WgXcQ';
+    const pending = media.play();
+
+    // A third load takes over; the waiter above must not be stranded on the
+    // barrier it already captured.
+    media.src = 'https://youtu.be/9bZkp7q19f0';
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(player.cueVideoById).toHaveBeenLastCalledWith({ videoId: '9bZkp7q19f0' });
+    media.detach();
+  });
+
+  it('does not report fullscreen when there is no element to request it on', async () => {
+    const media = new YouTubeMedia();
+
+    await media.requestFullscreen();
+
+    expect(media.isFullscreen).toBe(false);
+  });
+});
+
+describe('YouTubeMedia source', () => {
+  it('derives src from a structured source and announces the change', async () => {
+    const media = new YouTubeMedia();
+    const sourceChange = vi.fn();
+    media.addEventListener('sourcechange', sourceChange);
+
+    media.source = { src: 'https://www.youtube.com/watch?v=aqz-KE-bpKQ' };
+
+    expect(media.src).toBe('https://www.youtube.com/watch?v=aqz-KE-bpKQ');
+    expect(sourceChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-derives source from src, carrying engine options over', () => {
+    const media = new YouTubeMedia();
+    media.source = { src: 'aqz-KE-bpKQ', engine: { cc_load_policy: 1 } };
+
+    media.src = 'dQw4w9WgXcQ';
+
+    expect(media.source).toEqual({ engine: { cc_load_policy: 1 }, src: 'dQw4w9WgXcQ' });
+  });
+
+  it('reloads when only engine options change', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'aqz-KE-bpKQ';
+    const { player } = await attachAndLoad(media);
+    player.cueVideoById.mockClear();
+
+    media.source = { src: 'aqz-KE-bpKQ', engine: { cc_load_policy: 1 } };
+    await Promise.resolve();
+
+    expect(player.cueVideoById).toHaveBeenCalledWith({ videoId: 'aqz-KE-bpKQ' });
+    media.detach();
+  });
+
+  it('serializes engine options onto the initial iframe src', () => {
+    const media = new YouTubeMedia();
+    media.source = { src: 'aqz-KE-bpKQ', engine: { hl: 'fr' } };
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.src).toContain('hl=fr');
+    media.detach();
+  });
+
+  it('clears src when the source is set to null', () => {
+    const media = new YouTubeMedia();
+    media.source = { src: 'aqz-KE-bpKQ' };
+
+    media.source = null;
+
+    expect(media.src).toBe('');
+    expect(media.source).toBe(null);
   });
 });

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -219,6 +219,45 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).toContain('cc_load_policy=1');
   });
 
+  it('serializes the documented player parameters', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
+      source: {
+        engine: {
+          cc_lang_pref: 'fr',
+          color: 'white',
+          disablekb: 1,
+          end: 90,
+          fs: 0,
+          hl: 'fr-ca',
+          origin: 'https://example.com',
+          playlist: 'aqz-KE-bpKQ',
+          widget_referrer: 'https://widgets.example.com',
+        },
+      },
+    });
+    expect(src).toContain('cc_lang_pref=fr');
+    expect(src).toContain('color=white');
+    expect(src).toContain('disablekb=1');
+    expect(src).toContain('end=90');
+    expect(src).toContain('fs=0');
+    expect(src).toContain('hl=fr-ca');
+    expect(src).toContain(`origin=${encodeURIComponent('https://example.com')}`);
+    expect(src).toContain('playlist=aqz-KE-bpKQ');
+    expect(src).toContain(`widget_referrer=${encodeURIComponent('https://widgets.example.com')}`);
+  });
+
+  it('lets engine options override the defaults the host sets', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { source: { engine: { rel: 1, iv_load_policy: 1 } } });
+    expect(src).toContain('rel=1');
+    expect(src).toContain('iv_load_policy=1');
+  });
+
+  it('omits parameters YouTube has deprecated', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ');
+    expect(src).not.toContain('modestbranding');
+    expect(src).not.toContain('showinfo');
+  });
+
   it('embeds start time from the t param', () => {
     expect(buildYouTubeIframeSrc('https://youtu.be/aqz-KE-bpKQ?t=2m51s')).toContain('start=171');
   });

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
 import {
   buildYouTubeIframeSrc,
   parseYouTubeSource,
@@ -384,6 +385,27 @@ describe('YouTubeMedia', () => {
     media.detach();
   });
 
+  it('errors and unblocks pending play() when src is unrecognized', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
+    const iframe = createIframe();
+    media.attach(iframe);
+    const player = await waitForEngine(media);
+    player.ready();
+
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    media.src = 'https://example.com/not-a-youtube-url';
+    await Promise.resolve();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
   it('surfaces player errors', async () => {
     const media = new YouTubeMedia();
     const iframe = createIframe();
@@ -395,7 +417,12 @@ describe('YouTubeMedia', () => {
     player.events?.onError?.({ data: 150 });
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    expect(media.error).toMatchObject({ code: 150 });
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error).toMatchObject({
+      code: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,
+      fatal: true,
+      data: { youtubeErrorCode: 150 },
+    });
     media.detach();
   });
 

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -381,6 +381,7 @@ describe('YouTubeMedia', () => {
 
   it('forwards play() and pause() to the player', async () => {
     const media = new YouTubeMedia();
+    media.src = 'aqz-KE-bpKQ';
     const { player } = await attachAndLoad(media);
 
     await media.play();
@@ -393,6 +394,7 @@ describe('YouTubeMedia', () => {
 
   it('replays on ended when loop is set', async () => {
     const media = new YouTubeMedia();
+    media.src = 'aqz-KE-bpKQ';
     media.loop = true;
     const { player } = await attachAndLoad(media);
 
@@ -705,6 +707,37 @@ describe('YouTubeMedia source', () => {
     expect(media.currentTime).toBe(0);
     expect(media.paused).toBe(true);
     await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('does not let a cleared source come back through a state change', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'aqz-KE-bpKQ';
+    const { player } = await attachAndLoad(media);
+    player.emit('onStateChange', STATE.PLAYING);
+
+    media.source = null;
+    await Promise.resolve();
+    // `stopVideo()` reports a transition of its own.
+    player.emit('onStateChange', STATE.ENDED);
+
+    expect(media.duration).toBeNaN();
+    expect(media.readyState).toBe(0);
+    expect(media.currentTime).toBe(0);
+    media.detach();
+  });
+
+  it('does not play a source that was cleared', async () => {
+    const media = new YouTubeMedia();
+    media.src = 'aqz-KE-bpKQ';
+    const { player } = await attachAndLoad(media);
+
+    media.source = null;
+    await Promise.resolve();
+    player.playVideo.mockClear();
+    await media.play();
+
+    expect(player.playVideo).not.toHaveBeenCalled();
     media.detach();
   });
 

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -219,7 +219,7 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).toContain('cc_load_policy=1');
   });
 
-  it('serializes the documented player parameters', () => {
+  it('serializes engine options verbatim', () => {
     const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
       source: {
         engine: {
@@ -244,6 +244,14 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).toContain(`origin=${encodeURIComponent('https://example.com')}`);
     expect(src).toContain('playlist=aqz-KE-bpKQ');
     expect(src).toContain(`widget_referrer=${encodeURIComponent('https://widgets.example.com')}`);
+  });
+
+  it('carries undeclared engine options through', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
+      // Undocumented knobs and whatever YouTube adds next stay usable.
+      source: { engine: { some_future_param: 'x' } },
+    });
+    expect(src).toContain('some_future_param=x');
   });
 
   it('lets engine options override the defaults the host sets', () => {

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -19,6 +19,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/simple-hls-audio-only/index': './src/dom/simple-hls-audio-only/index.ts',
     'dom/simple-hls/index': './src/dom/simple-hls/index.ts',
     'dom/vimeo/index': './src/dom/vimeo/index.ts',
+    'dom/youtube/index': './src/dom/youtube/index.ts',
     'dom/mux/index': './src/dom/mux/index.ts',
     'dom/google-cast/index': './src/dom/google-cast/index.ts',
   },

--- a/packages/react/src/media/youtube-video/index.ts
+++ b/packages/react/src/media/youtube-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/youtube-video/media.tsx
+++ b/packages/react/src/media/youtube-video/media.tsx
@@ -22,7 +22,8 @@ export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(fun
   const attachRef = useAttachIframe(media);
   const composedRef = useComposedRefs(attachRef, ref);
   const [initialSrc] = useState(() =>
-    buildYouTubeIframeSrc(props.src ?? '', { ...youtubeMediaDefaultProps, ...props })
+    // `source.src` is the only other way to name a video, so honor it when `src` is absent.
+    buildYouTubeIframeSrc(props.src || props.source?.src || '', { ...youtubeMediaDefaultProps, ...props })
   );
   const iframeProps = useSyncProps<YouTubeMediaProps, Record<string, unknown>>(media, props, youtubeMediaDefaultProps);
 
@@ -36,7 +37,7 @@ export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(fun
       frameBorder={0}
       width="100%"
       height="100%"
-      referrerPolicy={props.config?.referrerPolicy}
+      referrerPolicy={props.source?.engine?.referrerPolicy}
       {...iframeProps}
       ref={composedRef}
     >

--- a/packages/react/src/media/youtube-video/media.tsx
+++ b/packages/react/src/media/youtube-video/media.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { YouTubeMediaProps } from '@videojs/media/dom/youtube';
+import { buildYouTubeIframeSrc, YouTubeMedia, youtubeMediaDefaultProps } from '@videojs/media/dom/youtube';
+import type { ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
+import { useAttachIframe } from '../../utils/use-attach-iframe';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface YouTubeVideoProps extends Partial<YouTubeMediaProps> {
+  children?: ReactNode;
+}
+
+export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(function YouTubeVideo(
+  { children, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(YouTubeMedia);
+  const props: Partial<YouTubeMediaProps> & Record<string, unknown> = { ...rawProps };
+  const attachRef = useAttachIframe(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const [initialSrc] = useState(() =>
+    buildYouTubeIframeSrc(props.src ?? '', { ...youtubeMediaDefaultProps, ...props })
+  );
+  const iframeProps = useSyncProps<YouTubeMediaProps, Record<string, unknown>>(media, props, youtubeMediaDefaultProps);
+
+  return (
+    <iframe
+      title="YouTube video player"
+      src={initialSrc}
+      data-cross-origin-frame
+      allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      referrerPolicy={props.config?.referrerPolicy}
+      {...iframeProps}
+      ref={composedRef}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace YouTubeVideo {
+  export type Props = YouTubeVideoProps;
+}

--- a/packages/utils/src/function/index.ts
+++ b/packages/utils/src/function/index.ts
@@ -1,5 +1,6 @@
 export { composeCallbacks } from './compose-callbacks';
 export { identity } from './identity';
 export { noop } from './noop';
+export { createPublicPromise, type PublicPromise } from './public-promise';
 export { type Throttled, throttle } from './throttle';
 export { tryCatch } from './try-catch';

--- a/packages/utils/src/function/public-promise.ts
+++ b/packages/utils/src/function/public-promise.ts
@@ -4,9 +4,18 @@ export interface PublicPromise<T> extends Promise<T> {
 }
 
 /**
- * A promise that can be settled from outside the executor. Embed hosts use one
- * as a load barrier: calls that need a loaded player await it, and whichever
- * event finishes the load resolves it.
+ * A promise that can be settled from outside its executor.
+ *
+ * Useful as a barrier that one piece of code waits on and another settles — for
+ * example an in-flight load that callers await until whichever event finishes it
+ * resolves.
+ *
+ * @example
+ * ```ts
+ * const ready = createPublicPromise<void>();
+ * element.addEventListener('load', () => ready.resolve(), { once: true });
+ * await ready;
+ * ```
  */
 export function createPublicPromise<T>(): PublicPromise<T> {
   let resolve!: (value: T) => void;

--- a/packages/utils/src/function/tests/public-promise.test.ts
+++ b/packages/utils/src/function/tests/public-promise.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { createPublicPromise } from '../public-promise';
+
+describe('createPublicPromise', () => {
+  it('resolves from outside the executor', async () => {
+    const promise = createPublicPromise<string>();
+
+    promise.resolve('done');
+
+    await expect(promise).resolves.toBe('done');
+  });
+
+  it('rejects from outside the executor', async () => {
+    const promise = createPublicPromise<void>();
+
+    promise.reject(new Error('nope'));
+
+    await expect(promise).rejects.toThrow('nope');
+  });
+
+  it('settles awaiters that started before it was resolved', async () => {
+    const promise = createPublicPromise<number>();
+    const awaited = Promise.all([promise, promise]);
+
+    promise.resolve(1);
+
+    await expect(awaited).resolves.toEqual([1, 1]);
+  });
+
+  it('ignores a second settle, as promises do', async () => {
+    const promise = createPublicPromise<string>();
+
+    promise.resolve('first');
+    promise.resolve('second');
+
+    await expect(promise).resolves.toBe('first');
+  });
+
+  it('is a real promise, so it chains', async () => {
+    const promise = createPublicPromise<number>();
+
+    promise.resolve(2);
+
+    await expect(promise.then((value) => value * 2)).resolves.toBe(4);
+  });
+});


### PR DESCRIPTION
fix #1434

## Summary

Adds a YouTube media host so the player drives YouTube embeds the same way it drives Vimeo ones. Playback logic is ported from [`youtube-video-element`](https://github.com/muxinc/media-elements/blob/main/packages/youtube-video-element/youtube-video-element.js) into the v10 media-host architecture.

## API

New in `@videojs/media/dom/youtube`: `YouTubeMedia`, `parseYouTubeSource`, `parseYouTubeVideoId`, `buildYouTubeIframeSrc`, and the `YouTubeSource` / `YouTubeEngineConfig` / `ParsedYouTubeSource` types.

```html
<!-- import '@videojs/html/media/youtube-video' -->
<video-player>
  <video-skin>
    <youtube-video src="https://youtu.be/aqz-KE-bpKQ" playsinline></youtube-video>
  </video-skin>
</video-player>
```

```tsx
// import { YouTubeVideo } from '@videojs/react/media/youtube-video';
<Player.Provider>
  <VideoSkin>
    <YouTubeVideo src="https://youtu.be/aqz-KE-bpKQ" playsInline />
  </VideoSkin>
</Player.Provider>
```

`source` carries the URL plus YouTube's own player parameters under `engine`, matching every other media element:

```tsx
<YouTubeVideo
  source={{
    src: 'https://youtu.be/aqz-KE-bpKQ',
    engine: { cc_load_policy: 1, cc_lang_pref: 'fr', color: 'white' },
  }}
/>
```

```ts
video.source = { src: 'https://youtu.be/aqz-KE-bpKQ', engine: { hl: 'fr-ca' } };
```

`engine` is typed against the [player parameters reference](https://developers.google.com/youtube/player_parameters) and spelled the way YouTube spells it, so `color: 'blue'` is a compile error. Deprecated parameters are excluded, as are the ones the host already owns — set `autoplay`, `controls`, and `playsInline` through the props. Undeclared parameters still pass through.

## Changes

- Accepts watch, `youtu.be`, `embed`, `shorts`, and `live` URLs, raw 11-character ids, playlists (`list=`, `embed/videoseries`), `t=1h30m15s` start times, and the `-nocookie` host
- Media state, played ranges, and the caption tracklist map from iframe API events; loop is re-implemented on `ended`, since the API has no single-video loop
- `<youtube-video>` custom element and `<YouTubeVideo>` React component
- Sandbox preset with HTML and React templates

<details>
<summary>Implementation details</summary>

- YouTube ships no npm SDK, so the iframe API loads through the existing `loadScript` helper against local typings — no new dependency
- The API emits no `timeupdate`/`progress`/`seeking`, so a 50ms poll derives them (as the original element does)
- Player creation is async. An attach id guards every callback, so a player destroyed by a detach cannot write state into a newer attach — the case React Strict Mode remounts hit
- `src` changes reuse the player via `cueVideoById`/`loadVideoById` instead of rebuilding the iframe. `onReady` only fires once, so any post-load state transition completes the load
- Every exit from `load()` settles its load barrier, so a superseded load never strands a pending `play()`

</details>

## Testing

`pnpm -F @videojs/media test youtube` — 50 tests covering URL parsing, embed URL building, and `YouTubeMedia` against a mocked `YT.Player`. Manual: `pnpm dev` → sandbox → "YouTube Video" preset, in both HTML and React.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New third-party iframe API integration with async attach/detach and load-barrier logic; well-tested but playback behavior depends on external YouTube scripts.
> 
> **Overview**
> Adds **YouTube embed playback** alongside Vimeo: a new `@videojs/media/dom/youtube` stack (`YouTubeMedia`, URL parsing, embed URL building, iframe API loader) wired into **`<youtube-video>`** and **`<YouTubeVideo>`**, plus a sandbox **YouTube Video** preset (HTML + React).
> 
> **`YouTubeMedia`** mirrors the Vimeo host pattern—`source`/`engine` for player params, load barriers for `play()`, attach-id guards for async API callbacks, `cueVideoById`/`loadVideoById` for src changes, polling for time/progress, and loop on `ended`. Shared embed helpers move into **`serializeEmbedParams`**, **`createTimeRange`**, and **`createPublicPromise`** (Vimeo refactored to use them).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 679c2b7e64c0a0bb85aa1c40792733223ee4ed53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

