### PR TITLE
feat(spf): Add AirPlay support

### DIFF
--- a/packages/spf/src/media/dom/mse/mediasource-setup.ts
+++ b/packages/spf/src/media/dom/mse/mediasource-setup.ts
@@ -69,7 +69,18 @@ export interface AttachMediaSourceResult {
 /**
  * Attach a MediaSource to an HTMLMediaElement.
  *
- * Uses srcObject for ManagedMediaSource (Safari), or createObjectURL for regular MediaSource.
+ * For ManagedMediaSource (Safari), the object URL is attached as a `<source>`
+ * child element rather than `srcObject`. This is the WebKit-recommended AirPlay
+ * pattern: `srcObject` makes the element commit to the MSE resource and ignore
+ * every `<source>` child, which leaves any sibling native-HLS `<source>`
+ * (appended by `setupAirPlay` for AirPlay handoff) inert — Safari has no
+ * AirPlay-capable resource to hand off and reverts to local playback. Attaching
+ * the MSE as the *first* `<source>` keeps local playback on MSE while letting
+ * the AirPlay `<source>` coexist as a second, native-playable alternative.
+ * https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay/
+ *
+ * Regular MediaSource (Chromium/Firefox, no AirPlay) keeps using the `src`
+ * attribute.
  *
  * @param mediaSource - The MediaSource to attach
  * @param mediaElement - The media element to attach to
@@ -83,23 +94,33 @@ export interface AttachMediaSourceResult {
  * detach();
  */
 export function attachMediaSource(mediaSource: MediaSource, mediaElement: HTMLMediaElement): AttachMediaSourceResult {
-  // ManagedMediaSource requires srcObject instead of createObjectURL
   const isManagedMediaSource = supportsManagedMediaSource() && mediaSource instanceof ManagedMediaSource!;
 
   if (isManagedMediaSource) {
-    // ManagedMediaSource requires disableRemotePlayback — without it Safari
-    // will not fire sourceopen.
-    (mediaElement as HTMLMediaElement & { disableRemotePlayback: boolean }).disableRemotePlayback = true;
+    // MMS opens with either `disableRemotePlayback = true` or a source
+    // alternative present; `setupAirPlay` flips this back to `false` once open
+    // so the AirPlay picker is offered.
+    mediaElement.disableRemotePlayback = true;
 
-    // Use srcObject for ManagedMediaSource
-    (mediaElement as HTMLMediaElement & { srcObject: MediaSource | null }).srcObject = mediaSource;
+    const url = URL.createObjectURL(mediaSource);
+    const sourceEl = document.createElement('source');
+    sourceEl.type = 'video/mp4';
+    sourceEl.src = url;
+
+    // Drop any bare `src` and insert the MSE source as the FIRST child so local
+    // playback selects MSE, and a `setupAirPlay`-appended native-HLS `<source>`
+    // stays second (AirPlay fallback). `load()` re-runs resource selection.
+    mediaElement.removeAttribute('src');
+    mediaElement.prepend(sourceEl);
+    mediaElement.load();
 
     const detach = (): void => {
-      (mediaElement as HTMLMediaElement & { srcObject: MediaSource | null }).srcObject = null;
+      sourceEl.remove();
       mediaElement.load(); // Reset the element
+      URL.revokeObjectURL(url);
     };
 
-    return { url: '', detach };
+    return { url, detach };
   }
 
   // Use createObjectURL for regular MediaSource

--- a/packages/spf/src/playback/actors/dom/segment-loader.ts
+++ b/packages/spf/src/playback/actors/dom/segment-loader.ts
@@ -78,9 +78,9 @@ type SegmentLoaderLoadMessage = {
 /**
  * `stop` message sent to a SegmentLoaderActor.
  *
- * - halts loading: aborts the in-flight fetch and the whole queued
- *   forward-buffer batch, discards any half-appended segment, and returns
- *   the actor to `idle`.
+ * - halts loading: aborts the pending queue and returns the actor to
+ *   `idle`. The in-flight fetch is left to complete and the SourceBuffer
+ *   is deliberately not touched.
  */
 type SegmentLoaderStopMessage = { type: 'stop' };
 

--- a/packages/spf/src/playback/actors/dom/segment-loader.ts
+++ b/packages/spf/src/playback/actors/dom/segment-loader.ts
@@ -55,6 +55,14 @@ export type SegmentLoaderTrack = VideoTrack | AudioTrack;
 /**
  * Message sent to a SegmentLoaderActor.
  *
+ * @see {@link SegmentLoaderLoadMessage}
+ * @see {@link SegmentLoaderStopMessage}
+ * */
+export type SegmentLoaderMessage = SegmentLoaderLoadMessage | SegmentLoaderStopMessage;
+
+/**
+ * `load`  message sent to a SegmentLoaderActor.
+ *
  * `range` is optional to distinguish loading modes:
  * - No range: load init segment only (metadata preload mode)
  * - With range: load init + all segments overlapping [start, end]
@@ -62,11 +70,19 @@ export type SegmentLoaderTrack = VideoTrack | AudioTrack;
  * `start` and `end` are raw time values — no segment snapping.
  * The actor maps them onto segment boundaries internally.
  */
-export type SegmentLoaderMessage = {
+type SegmentLoaderLoadMessage = {
   type: 'load';
   track: SegmentLoaderTrack;
   range?: { start: number; end: number };
 };
+/**
+ * `stop` message sent to a SegmentLoaderActor.
+ *
+ * - halts loading: aborts the in-flight fetch and the whole queued
+ *   forward-buffer batch, discards any half-appended segment, and returns
+ *   the actor to `idle`.
+ */
+type SegmentLoaderStopMessage = { type: 'stop' };
 
 // ============================================================================
 // LOAD TASK
@@ -307,7 +323,7 @@ export function createSegmentLoaderActor(
    *
    * Case 3 — Segments: all segments in the load window not yet committed.
    */
-  const planTasks = (message: SegmentLoaderMessage): LoadTask[] => {
+  const planTasks = (message: SegmentLoaderLoadMessage): LoadTask[] => {
     const { track, range } = message;
     // `peek` for the same reason as `getBufferedSegments` above — avoid
     // leaking the SourceBufferActor snapshot into the calling dispatcher's
@@ -510,6 +526,11 @@ export function createSegmentLoaderActor(
               }
               scheduleAll(allTasks, ctx);
             }
+          },
+          stop: (_message, ctx) => {
+            const { runner } = ctx;
+            runner.abortPending();
+            ctx.transition('idle');
           },
         },
       },

--- a/packages/spf/src/playback/actors/dom/tests/segment-loader.test.ts
+++ b/packages/spf/src/playback/actors/dom/tests/segment-loader.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { signal } from '../../../../core/signals/primitives';
-import type { AudioTrack } from '../../../../media/types';
+import type { AddressableObject, AudioTrack } from '../../../../media/types';
 import { createSegmentLoaderActor } from '../segment-loader';
 import type {
   SourceBufferActor,
@@ -232,6 +232,54 @@ describe('createSegmentLoaderActor — planTasks cross-rendition switch', () => 
 
     expect(initMsg.meta.trackId).toBe('audio-es');
     expect(initMsg.meta.language).toBe('es');
+
+    loader.destroy();
+  });
+});
+
+describe('createSegmentLoaderActor — stop message', () => {
+  it('drops the queued batch and returns to idle', async () => {
+    const bufferActor = createMockBufferActor();
+
+    let segmentFetches = 0;
+    // Init resolves immediately; segment fetches hang so the first stays
+    // in-flight (the serial runner never reaches the queued ones).
+    const hangingFetch = vi.fn(async (addressable: AddressableObject): Promise<AsyncIterable<Uint8Array>> => {
+      if (addressable.url.includes('init')) return (async function* () {})();
+      segmentFetches++;
+      return new Promise<AsyncIterable<Uint8Array>>(() => {});
+    });
+
+    const loader = createSegmentLoaderActor(bufferActor as unknown as SourceBufferActor, hangingFetch);
+
+    const track = makeAudioTrack('audio-en', { language: 'en' });
+    loader.send({ type: 'load', track, range: { start: 0, end: 20 } });
+
+    // Init appended, first segment in-flight, the rest queued behind it.
+    await vi.waitFor(() => expect(segmentFetches).toBe(1));
+    expect(loader.snapshot.get().value).toBe('loading');
+
+    loader.send({ type: 'stop' });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // `stop` aborts the pending queue and returns to idle. (The in-flight
+    // fetch is left to complete — the SPF `stopLoad()` deliberately doesn't
+    // poke the SourceBuffer / MediaSource, which can disrupt an in-flight
+    // AirPlay handoff.)
+    expect(segmentFetches).toBe(1);
+    expect(loader.snapshot.get().value).toBe('idle');
+
+    loader.destroy();
+  });
+
+  it('is a no-op when idle', () => {
+    const bufferActor = createMockBufferActor();
+    const loader = createSegmentLoaderActor(bufferActor as unknown as SourceBufferActor, mockFetchBytes);
+
+    expect(() => loader.send({ type: 'stop' })).not.toThrow();
+    expect(loader.snapshot.get().value).toBe('idle');
+    expect(bufferActor.send).not.toHaveBeenCalled();
 
     loader.destroy();
   });

--- a/packages/spf/src/playback/actors/dom/tests/text-track-segment-loader.test.ts
+++ b/packages/spf/src/playback/actors/dom/tests/text-track-segment-loader.test.ts
@@ -308,9 +308,10 @@ describe('TextTrackSegmentLoaderActor', () => {
     textTracksActor.destroy();
   });
 
-  it('stops the in-flight fetch + queued batch and returns to idle on stop', async () => {
+  it('drops the queued batch and returns to idle on stop', async () => {
     let fetches = 0;
-    // Each segment resolve hangs so the first stays in-flight until aborted.
+    // Each segment resolve hangs so the first stays in-flight; `stop` drops
+    // the queue behind it and leaves the in-flight fetch to complete.
     const resolveVttSegment = vi.fn((_url: string) => {
       fetches++;
       return new Promise<VTTCue[]>(() => {});

--- a/packages/spf/src/playback/actors/dom/tests/text-track-segment-loader.test.ts
+++ b/packages/spf/src/playback/actors/dom/tests/text-track-segment-loader.test.ts
@@ -307,4 +307,35 @@ describe('TextTrackSegmentLoaderActor', () => {
 
     textTracksActor.destroy();
   });
+
+  it('stops the in-flight fetch + queued batch and returns to idle on stop', async () => {
+    let fetches = 0;
+    // Each segment resolve hangs so the first stays in-flight until aborted.
+    const resolveVttSegment = vi.fn((_url: string) => {
+      fetches++;
+      return new Promise<VTTCue[]>(() => {});
+    });
+    const video = makeMediaElement(['track-en']);
+    const textTracksActor = createTextTracksActor(video);
+    const actor = createTextTrackSegmentLoaderActor(textTracksActor, resolveVttSegment);
+    const track = makeResolvedTextTrack('track-en', [
+      'https://example.com/seg-0.vtt',
+      'https://example.com/seg-1.vtt',
+      'https://example.com/seg-2.vtt',
+    ]);
+
+    actor.send({ type: 'load', track, range: { start: 0, end: Infinity } });
+    await vi.waitFor(() => expect(fetches).toBe(1));
+    expect(actor.snapshot.get().value).toBe('loading');
+
+    actor.send({ type: 'stop' });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Queued segments never fetch; the actor is back to idle.
+    expect(fetches).toBe(1);
+    expect(actor.snapshot.get().value).toBe('idle');
+
+    actor.destroy();
+    textTracksActor.destroy();
+  });
 });

--- a/packages/spf/src/playback/actors/text-track-segment-loader.ts
+++ b/packages/spf/src/playback/actors/text-track-segment-loader.ts
@@ -14,17 +14,33 @@ import type { TextTracksActor } from './text-tracks';
 // =============================================================================
 
 /**
- * Mirrors the v/a `SegmentLoaderMessage` shape. `range` carries the
- * forward-window anchor (`range.start` is treated as the load anchor;
- * the actor computes its own forward window internally via
- * `getSegmentsToLoad`). When `range` is omitted (metadata mode), this
- * actor is a no-op — text tracks have no init-segment concept.
+ * Mirrors the v/a `SegmentLoaderMessage` shape.
+ * Message sent to a TextTrackSegmentLoaderActor.
+ *
+ * @see {@link TextTrackSegmentLoaderLoadMessage}
+ * @see {@link TextTrackSegmentLoaderStopMessage}
+ * */
+export type TextTrackSegmentLoaderMessage = TextTrackSegmentLoaderLoadMessage | TextTrackSegmentLoaderStopMessage;
+
+/**
+ * Mirrors the v/a `SegmentLoaderMessage` shape.
+ *
+ * `load`
+ * — `range` carries the forward-window anchor (`range.start` is
+ *   treated as the load anchor; the actor computes its own forward window
+ *   internally via `getSegmentsToLoad`). When `range` is omitted (metadata
+ *   mode), this actor is a no-op — text tracks have no init-segment concept.
  */
-export type TextTrackSegmentLoaderMessage = {
+export type TextTrackSegmentLoaderLoadMessage = {
   type: 'load';
   track: TextTrack;
   range?: { start: number; end: number };
 };
+
+/**
+ * `stop` - aborts the in-flight fetch + queued batch and returns to `idle`
+ */
+export type TextTrackSegmentLoaderStopMessage = { type: 'stop' };
 
 /** Finite states of the actor. */
 export type TextTrackSegmentLoaderActorState = 'idle' | 'loading' | 'destroyed';
@@ -128,7 +144,7 @@ export function createTextTrackSegmentLoaderActor<C extends Cue>(
    * no init-segment concept, so there's nothing to load until a range
    * arrives via `'full-range'` dispatch.
    */
-  const planTasks = (message: TextTrackSegmentLoaderMessage): TextLoadTask[] => {
+  const planTasks = (message: TextTrackSegmentLoaderLoadMessage): TextLoadTask[] => {
     const { track, range } = message;
     if (!range) return [];
     const trackId = track.id;
@@ -234,6 +250,10 @@ export function createTextTrackSegmentLoaderActor<C extends Cue>(
               runner.abortAll();
               scheduleAll(tasks, ctx);
             }
+          },
+          stop: (_message, ctx) => {
+            ctx.runner.abortPending();
+            ctx.transition('idle');
           },
         },
       },

--- a/packages/spf/src/playback/actors/text-track-segment-loader.ts
+++ b/packages/spf/src/playback/actors/text-track-segment-loader.ts
@@ -38,7 +38,8 @@ export type TextTrackSegmentLoaderLoadMessage = {
 };
 
 /**
- * `stop` - aborts the in-flight fetch + queued batch and returns to `idle`
+ * `stop` - aborts the pending queue and returns to `idle`. The in-flight
+ * fetch is left to complete.
  */
 export type TextTrackSegmentLoaderStopMessage = { type: 'stop' };
 

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -1,0 +1,136 @@
+/**
+ * **Bridge MSE playback to AirPlay on WebKit.**
+ * MSE streams can't be handed to an AirPlay receiver directly.
+ * The WebKit-recommended workaround is to append a fallback
+ * `<source type="application/x-mpegURL">` carrying the original manifest URL:
+ * Safari exposes the AirPlay picker and, when a wireless target is selected,
+ * plays that native-HLS source on the receiver. When the wireless target engages
+ * this behavior suspends engine loading (`state.loadSuspended`) so we don't
+ * double-fetch alongside the receiver.
+ * https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay/
+ *
+ * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'airplay-capable'`):
+ * gated on a WebKit-AirPlay-capable media element being in scope. The entry
+ * appends the fallback `<source>`, wires the wireless-target listener, keeps
+ * the source URL current from `state.presentation`, and enables the AirPlay
+ * picker once the MediaSource is open; state-exit cleanup (detach, source
+ * reset, behavior destroy) removes the source, drops the listener, and releases
+ * any active suspend. No-op on non-WebKit platforms (Chromium, Firefox) —
+ * `deriveState` never leaves `'preconditions-unmet'`.
+ * *
+ * MMS and AirPlay want *opposite* values of `disableRemotePlayback` on the same
+ * element, so they must be **sequenced**:
+ *
+ * - **MMS needs `true` to open.** `setupMediaSource` sets
+ *   `disableRemotePlayback = true` when it attaches a ManagedMediaSource —
+ *   Safari won't fire `sourceopen` (and MSE playback never starts) otherwise.
+ * - **AirPlay needs `false` to offer the picker.** Flipping to `false` *before*
+ *   the source opens would prevent `sourceopen`. So we wait: `setupMediaSource`
+ *   publishes `context.mediaSource` exactly once the MS is open, and we flip
+ *   `disableRemotePlayback = false` gated on that.
+ *   The gate re-fires per source (the slot clears + republishes on reset).
+ * - **Author opt-out wins.** TODO: To be replaced by an explicit state signal
+ *   A `disableRemotePlayback === true` read at attach
+ *   is the author's explicit choice to disable remote playback, so we set
+ *   nothing up. The read is unambiguous because the entry runs on the
+ *   synchronous `mediaElement`-attach transition and `setupAirPlay` is composed
+ *   *before* `setupMediaSource`, so this read precedes MMS's programmatic
+ *   `true` even when the presentation is already resolved at attach.
+ */
+
+import { isWebKitAirPlayCapable, listen, type WebKitVideoElement } from '@videojs/utils/dom';
+import { defineBehavior } from '../../../core/composition/create-composition';
+import type { Reactor } from '../../../core/reactors/create-machine-reactor';
+import { createMachineReactor } from '../../../core/reactors/create-machine-reactor';
+import { effect } from '../../../core/signals/effect';
+import { computed, peek, type ReadonlySignal, type Signal } from '../../../core/signals/primitives';
+import type { MaybeResolvedPresentation } from '../../../media/types';
+
+type AirPlayFsmState = 'preconditions-unmet' | 'airplay-capable';
+
+function deriveState(mediaElement: HTMLMediaElement | undefined): AirPlayFsmState {
+  if (!mediaElement || !isWebKitAirPlayCapable(mediaElement)) return 'preconditions-unmet';
+  return 'airplay-capable';
+}
+
+function setupAirPlaySetup({
+  state,
+  context,
+}: {
+  state: {
+    presentation: ReadonlySignal<MaybeResolvedPresentation | undefined>;
+    loadSuspended: Signal<boolean | undefined>;
+  };
+  context: {
+    mediaElement: ReadonlySignal<HTMLMediaElement | undefined>;
+    mediaSource: ReadonlySignal<MediaSource | undefined>;
+  };
+}): Reactor<AirPlayFsmState | 'destroying' | 'destroyed'> {
+  const derivedStateSignal = computed(() => deriveState(context.mediaElement.get()));
+
+  return createMachineReactor<AirPlayFsmState>({
+    initial: 'preconditions-unmet',
+    monitor: () => derivedStateSignal.get(),
+    states: {
+      'preconditions-unmet': {},
+
+      'airplay-capable': {
+        entry: () => {
+          const mediaElement = context.mediaElement.get() as WebKitVideoElement;
+
+          // Author opt-out: a pre-set `true` is the author's explicit
+          // choice to disable remote playback — set nothing up. Safe as
+          // author-intent: this runs before any programmatic MMS write
+          // (`setupAirPlay` is composed before `setupMediaSource`).
+          // TODO: use state signal
+          if (mediaElement.disableRemotePlayback) return;
+
+          const sourceEl = document.createElement('source');
+          sourceEl.type = 'application/x-mpegURL';
+          mediaElement.append(sourceEl);
+
+          // Suspend engine loading while the wireless target is active so we
+          // don't double-fetch alongside the receiver; resume when it turns
+          // off.
+          const sync = () => {
+            const isWireless = !!mediaElement.webkitCurrentPlaybackTargetIsWireless;
+            state.loadSuspended.set(isWireless);
+          };
+          const controller = new AbortController();
+          listen(mediaElement, 'webkitcurrentplaybacktargetiswirelesschanged', sync, {
+            signal: controller.signal,
+          });
+
+          // Keep the fallback source URL current from the presentation.
+          const disposeSrc = effect(() => {
+            const url = peek(state.presentation)?.url ?? '';
+            sourceEl.src = url;
+          });
+
+          // Enable the AirPlay picker only once the (Managed)MediaSource is open
+          const disposeEnablePicker = effect(() => {
+            if (context.mediaSource.get()) mediaElement.disableRemotePlayback = false;
+          });
+
+          // AirPlay may already be active at (re)attach.
+          sync();
+
+          return () => {
+            disposeSrc();
+            disposeEnablePicker();
+            controller.abort();
+            sourceEl.remove();
+            // Don't strand loading suspended if we detach mid-wireless.
+            state.loadSuspended.set(false);
+          };
+        },
+      },
+    },
+  });
+}
+
+export const setupAirPlay = defineBehavior({
+  stateKeys: ['presentation', 'loadSuspended'],
+  contextKeys: ['mediaElement', 'mediaSource'],
+  setup: setupAirPlaySetup,
+});

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -29,13 +29,12 @@
  *   publishes `context.mediaSource` exactly once the MS is open, and we flip
  *   `disableRemotePlayback = false` gated on that.
  *   The gate re-fires per source (the slot clears + republishes on reset).
- * - **Author opt-out wins.** TODO: To be replaced by an explicit state signal
- *   A `disableRemotePlayback === true` read at attach
- *   is the author's explicit choice to disable remote playback, so we set
- *   nothing up. The read is unambiguous because the entry runs on the
- *   synchronous `mediaElement`-attach transition and `setupAirPlay` is composed
- *   *before* `setupMediaSource`, so this read precedes MMS's programmatic
- *   `true` even when the presentation is already resolved at attach.
+ * - **Author opt-out wins.** `state.disableRemotePlayback` (written only by the
+ *   media adapter's IDL property, never by MMS/programmatic code) is the
+ *   author's intent. A `true` read at entry is unambiguously the author's choice
+ *   to disable remote playback, so we set nothing up. Because the intent lives
+ *   on its own signal rather than the shared DOM property, this no longer
+ *   depends on reading before MMS's programmatic write — folds in #1800.
  */
 
 import { isWebKitAirPlayCapable, listen, type WebKitVideoElement } from '@videojs/utils/dom';
@@ -60,6 +59,7 @@ function setupAirPlaySetup({
   state: {
     presentation: ReadonlySignal<MaybeResolvedPresentation | undefined>;
     loadSuspended: Signal<boolean | undefined>;
+    disableRemotePlayback: ReadonlySignal<boolean | undefined>;
   };
   context: {
     mediaElement: ReadonlySignal<HTMLMediaElement | undefined>;
@@ -78,20 +78,25 @@ function setupAirPlaySetup({
         entry: () => {
           const mediaElement = context.mediaElement.get() as WebKitVideoElement;
 
-          // Author opt-out: a pre-set `true` is the author's explicit
-          // choice to disable remote playback — set nothing up. Safe as
-          // author-intent: this runs before any programmatic MMS write
-          // (`setupAirPlay` is composed before `setupMediaSource`).
-          // TODO: use state signal
-          if (mediaElement.disableRemotePlayback) return;
+          // Author opt-out: `state.disableRemotePlayback` is the author's
+          // intent, written only by the media adapter's IDL property — never by
+          // MMS/programmatic code. So a `true` here is unambiguously the author's
+          // choice to disable remote playback: set nothing up, leaving the
+          // element's remote playback disabled.
+          if (state.disableRemotePlayback.get()) return;
 
           const sourceEl = document.createElement('source');
           sourceEl.type = 'application/x-mpegURL';
           mediaElement.append(sourceEl);
 
-          // Suspend engine loading while the wireless target is active so we
-          // don't double-fetch alongside the receiver; resume when it turns
-          // off.
+          // Reflect the wireless target on `state.loadSuspended`: suspend engine
+          // loading while active so we don't double-fetch alongside the receiver,
+          // resume when it turns off.
+          //
+          // NOTE: on disengage Safari has already closed our MMS and doesn't
+          // re-select the MSE `<source>`, so local MSE playback can't actually
+          // resume — see the AirPlay feature doc's known-limitation on
+          // MMS/AirPlay return.
           const sync = () => {
             const isWireless = !!mediaElement.webkitCurrentPlaybackTargetIsWireless;
             state.loadSuspended.set(isWireless);
@@ -130,7 +135,7 @@ function setupAirPlaySetup({
 }
 
 export const setupAirPlay = defineBehavior({
-  stateKeys: ['presentation', 'loadSuspended'],
+  stateKeys: ['presentation', 'loadSuspended', 'disableRemotePlayback'],
   contextKeys: ['mediaElement', 'mediaSource'],
   setup: setupAirPlaySetup,
 });

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -13,10 +13,11 @@
  * gated on a WebKit-AirPlay-capable media element being in scope. The entry
  * appends the fallback `<source>`, wires the wireless-target listener, keeps
  * the source URL current from `state.presentation`, and enables the AirPlay
- * picker once the MediaSource is open; state-exit cleanup (detach, source
- * reset, behavior destroy) removes the source, drops the listener, and releases
- * any active suspend. No-op on non-WebKit platforms (Chromium, Firefox) —
- * `deriveState` never leaves `'preconditions-unmet'`.
+ * picker once the MediaSource is open; state-exit cleanup (author opt-out,
+ * detach, source reset, behavior destroy) removes the source, drops the
+ * listener, restores the element's `disableRemotePlayback` default, and
+ * releases any active suspend. No-op on non-WebKit platforms (Chromium,
+ * Firefox) — `deriveState` never leaves `'preconditions-unmet'`.
  *
  * MMS and AirPlay want *opposite* values of `disableRemotePlayback` on the same
  * element, so it is **sequenced**:
@@ -30,9 +31,9 @@
  *   MS is open. Re-fires per source (the slot clears + republishes on reset).
  * - **Author opt-out wins.** `state.disableRemotePlayback` is the author's
  *   intent, written only by the media adapter's IDL property; MMS/programmatic
- *   code touch the element's own `disableRemotePlayback` instead. So a `true`
- *   there, read at entry, is unambiguously the author's choice to disable remote
- *   playback, and the behavior sets nothing up.
+ *   code touch the element's own `disableRemotePlayback` instead. A `true`
+ *   there is unambiguously the author's choice to disable remote playback, so
+ *   it holds the machine in `'preconditions-unmet'` and nothing is set up.
  */
 
 import { isWebKitAirPlayCapable, listen, type WebKitVideoElement } from '@videojs/utils/dom';
@@ -45,8 +46,12 @@ import type { MaybeResolvedPresentation } from '../../../media/types';
 
 type AirPlayFsmState = 'preconditions-unmet' | 'airplay-capable';
 
-function deriveState(mediaElement: HTMLMediaElement | undefined): AirPlayFsmState {
+function deriveState(
+  mediaElement: HTMLMediaElement | undefined,
+  authorDisabledRemotePlayback: boolean | undefined
+): AirPlayFsmState {
   if (!mediaElement || !isWebKitAirPlayCapable(mediaElement)) return 'preconditions-unmet';
+  if (authorDisabledRemotePlayback) return 'preconditions-unmet';
   return 'airplay-capable';
 }
 
@@ -64,7 +69,7 @@ function setupAirPlaySetup({
     mediaSource: ReadonlySignal<MediaSource | undefined>;
   };
 }): Reactor<AirPlayFsmState | 'destroying' | 'destroyed'> {
-  const derivedStateSignal = computed(() => deriveState(context.mediaElement.get()));
+  const derivedStateSignal = computed(() => deriveState(context.mediaElement.get(), state.disableRemotePlayback.get()));
 
   return createMachineReactor<AirPlayFsmState>({
     initial: 'preconditions-unmet',
@@ -75,13 +80,6 @@ function setupAirPlaySetup({
       'airplay-capable': {
         entry: () => {
           const mediaElement = context.mediaElement.get() as WebKitVideoElement;
-
-          // Author opt-out: `state.disableRemotePlayback` is the author's
-          // intent, written only by the media adapter's IDL property — never by
-          // MMS/programmatic code. So a `true` here is unambiguously the author's
-          // choice to disable remote playback: set nothing up, leaving the
-          // element's remote playback disabled.
-          if (state.disableRemotePlayback.get()) return;
 
           const sourceEl = document.createElement('source');
           sourceEl.type = 'application/x-mpegURL';
@@ -122,6 +120,9 @@ function setupAirPlaySetup({
             disposeEnablePicker();
             controller.abort();
             sourceEl.remove();
+            // Undo the picker enable: hand the element back to its MMS-default
+            // `disableRemotePlayback = true`.
+            mediaElement.disableRemotePlayback = true;
             // Don't strand loading suspended if we detach mid-wireless.
             state.loadSuspended.set(false);
           };

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -42,7 +42,7 @@ import { defineBehavior } from '../../../core/composition/create-composition';
 import type { Reactor } from '../../../core/reactors/create-machine-reactor';
 import { createMachineReactor } from '../../../core/reactors/create-machine-reactor';
 import { effect } from '../../../core/signals/effect';
-import { computed, peek, type ReadonlySignal, type Signal } from '../../../core/signals/primitives';
+import { computed, type ReadonlySignal, type Signal } from '../../../core/signals/primitives';
 import type { MaybeResolvedPresentation } from '../../../media/types';
 
 type AirPlayFsmState = 'preconditions-unmet' | 'airplay-capable';
@@ -106,10 +106,10 @@ function setupAirPlaySetup({
             signal: controller.signal,
           });
 
-          // Keep the fallback source URL current from the presentation.
+          // Keep the fallback source URL in sync with the presentation.
+          const sourceUrl = computed(() => state.presentation.get()?.url ?? '');
           const disposeSrc = effect(() => {
-            const url = peek(state.presentation)?.url ?? '';
-            sourceEl.src = url;
+            sourceEl.src = sourceUrl.get();
           });
 
           // Enable the AirPlay picker only once the (Managed)MediaSource is open

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -11,13 +11,15 @@
  *
  * Single-positive-state reactor (`'preconditions-unmet'` ↔ `'airplay-capable'`):
  * gated on a WebKit-AirPlay-capable media element being in scope. The entry
- * appends the fallback `<source>`, wires the wireless-target listener, keeps
- * the source URL current from `state.presentation`, and enables the AirPlay
- * picker once the MediaSource is open; state-exit cleanup (author opt-out,
- * detach, source reset, behavior destroy) removes the source, drops the
- * listener, restores the element's `disableRemotePlayback` default, and
- * releases any active suspend. No-op on non-WebKit platforms (Chromium,
- * Firefox) — `deriveState` never leaves `'preconditions-unmet'`.
+ * wires the wireless-target listener, then — gated on `context.mediaSource` —
+ * appends the fallback `<source>` (kept current from `state.presentation`) and
+ * enables the AirPlay picker once the MediaSource is open, removing the source
+ * the moment the MediaSource detaches so it never survives an MSE teardown.
+ * State-exit cleanup (author opt-out, detach, source reset, behavior destroy)
+ * removes the source, drops the listener, restores the element's
+ * `disableRemotePlayback` default, and releases any active suspend. No-op on
+ * non-WebKit platforms (Chromium, Firefox) — `deriveState` never leaves
+ * `'preconditions-unmet'`.
  *
  * MMS and AirPlay want *opposite* values of `disableRemotePlayback` on the same
  * element, so it is **sequenced**:
@@ -81,10 +83,6 @@ function setupAirPlaySetup({
         entry: () => {
           const mediaElement = context.mediaElement.get() as WebKitVideoElement;
 
-          const sourceEl = document.createElement('source');
-          sourceEl.type = 'application/x-mpegURL';
-          mediaElement.append(sourceEl);
-
           // Reflect the wireless target on `state.loadSuspended`: suspend engine
           // loading while active so we don't double-fetch alongside the receiver,
           // resume when it turns off.
@@ -101,25 +99,43 @@ function setupAirPlaySetup({
             signal: controller.signal,
           });
 
-          // Keep the fallback source URL in sync with the presentation.
           const sourceUrl = computed(() => state.presentation.get()?.url ?? '');
-          const disposeSrc = effect(() => {
-            sourceEl.src = sourceUrl.get();
-          });
 
-          // Enable the AirPlay picker only once the (Managed)MediaSource is open
-          const disposeEnablePicker = effect(() => {
-            if (context.mediaSource.get()) mediaElement.disableRemotePlayback = false;
+          // This effect combines:
+          // - adding a native HLS fallback source when the
+          // mediaSource is attached/destroying it when its detached.
+          // - keeping this sourceEl's src in sync with the current presentation.
+          // The created source is also cleaned on state exit.
+          // The dependence on context.mediaSource helps us append the source after the
+          // MMS has been attached and opened (therefore we can flip disableRemotePlayback).
+          // Being in this state also implies that the author has not disabled remote playback
+          let sourceEl: HTMLSourceElement | null = null;
+          const disposeSource = effect(() => {
+            const hasMediaSource = !!context.mediaSource.get();
+            const url = sourceUrl.get();
+
+            if (!hasMediaSource) {
+              sourceEl?.remove();
+              sourceEl = null;
+            } else {
+              if (!sourceEl || sourceEl.parentNode !== mediaElement) {
+                sourceEl = document.createElement('source');
+                sourceEl.type = 'application/x-mpegURL';
+                mediaElement.append(sourceEl);
+                mediaElement.disableRemotePlayback = false;
+              }
+              sourceEl.src = url;
+            }
           });
 
           // AirPlay may already be active at (re)attach.
           sync();
 
           return () => {
-            disposeSrc();
-            disposeEnablePicker();
+            disposeSource();
             controller.abort();
-            sourceEl.remove();
+            sourceEl?.remove();
+            sourceEl = null;
             // Undo the picker enable: hand the element back to its MMS-default
             // `disableRemotePlayback = true`.
             mediaElement.disableRemotePlayback = true;

--- a/packages/spf/src/playback/behaviors/dom/airplay.ts
+++ b/packages/spf/src/playback/behaviors/dom/airplay.ts
@@ -17,24 +17,22 @@
  * reset, behavior destroy) removes the source, drops the listener, and releases
  * any active suspend. No-op on non-WebKit platforms (Chromium, Firefox) —
  * `deriveState` never leaves `'preconditions-unmet'`.
- * *
+ *
  * MMS and AirPlay want *opposite* values of `disableRemotePlayback` on the same
- * element, so they must be **sequenced**:
+ * element, so it is **sequenced**:
  *
  * - **MMS needs `true` to open.** `setupMediaSource` sets
  *   `disableRemotePlayback = true` when it attaches a ManagedMediaSource —
  *   Safari won't fire `sourceopen` (and MSE playback never starts) otherwise.
  * - **AirPlay needs `false` to offer the picker.** Flipping to `false` *before*
- *   the source opens would prevent `sourceopen`. So we wait: `setupMediaSource`
- *   publishes `context.mediaSource` exactly once the MS is open, and we flip
- *   `disableRemotePlayback = false` gated on that.
- *   The gate re-fires per source (the slot clears + republishes on reset).
- * - **Author opt-out wins.** `state.disableRemotePlayback` (written only by the
- *   media adapter's IDL property, never by MMS/programmatic code) is the
- *   author's intent. A `true` read at entry is unambiguously the author's choice
- *   to disable remote playback, so we set nothing up. Because the intent lives
- *   on its own signal rather than the shared DOM property, this no longer
- *   depends on reading before MMS's programmatic write — folds in #1800.
+ *   the source opens would prevent `sourceopen`, so the flip is gated on
+ *   `context.mediaSource` — which `setupMediaSource` publishes exactly once the
+ *   MS is open. Re-fires per source (the slot clears + republishes on reset).
+ * - **Author opt-out wins.** `state.disableRemotePlayback` is the author's
+ *   intent, written only by the media adapter's IDL property; MMS/programmatic
+ *   code touch the element's own `disableRemotePlayback` instead. So a `true`
+ *   there, read at entry, is unambiguously the author's choice to disable remote
+ *   playback, and the behavior sets nothing up.
  */
 
 import { isWebKitAirPlayCapable, listen, type WebKitVideoElement } from '@videojs/utils/dom';
@@ -95,8 +93,7 @@ function setupAirPlaySetup({
           //
           // NOTE: on disengage Safari has already closed our MMS and doesn't
           // re-select the MSE `<source>`, so local MSE playback can't actually
-          // resume — see the AirPlay feature doc's known-limitation on
-          // MMS/AirPlay return.
+          // resume until the source is reloaded.
           const sync = () => {
             const isWireless = !!mediaElement.webkitCurrentPlaybackTargetIsWireless;
             state.loadSuspended.set(isWireless);

--- a/packages/spf/src/playback/behaviors/dom/load-segments.ts
+++ b/packages/spf/src/playback/behaviors/dom/load-segments.ts
@@ -73,6 +73,8 @@ export interface SegmentLoadingState {
   currentTime?: number;
   /** True once a preload-overriding event has fired for the current source. */
   loadActivated?: boolean;
+  /** Suspends all forward-buffer loading while `true` */
+  loadSuspended?: boolean;
   selectedVideoTrackId?: string;
   selectedAudioTrackId?: string;
   selectedTextTrackId?: string;
@@ -89,7 +91,7 @@ export interface SegmentLoadingContext {
 // REACTOR
 // ============================================================================
 
-type SegmentLoadingFsmState = 'preconditions-unmet' | 'dormant' | 'metadata-only' | 'full-range';
+type SegmentLoadingFsmState = 'preconditions-unmet' | 'dormant' | 'metadata-only' | 'full-range' | 'suspended';
 
 type SelectedTrackKey = 'selectedVideoTrackId' | 'selectedAudioTrackId' | 'selectedTextTrackId';
 type SegmentLoaderActorKey = 'videoSegmentLoaderActor' | 'audioSegmentLoaderActor' | 'textTrackSegmentLoaderActor';
@@ -99,18 +101,19 @@ type SegmentLoadingStateMap<K extends SelectedTrackKey> = {
   preload: ReadonlySignal<SegmentLoadingState['preload']>;
   currentTime: ReadonlySignal<SegmentLoadingState['currentTime']>;
   loadActivated: ReadonlySignal<SegmentLoadingState['loadActivated']>;
+  loadSuspended: ReadonlySignal<SegmentLoadingState['loadSuspended']>;
 } & { [P in K]: ReadonlySignal<SegmentLoadingState[P]> };
 
-/** Shared `'load'` message shape parameterized over the resolved track type. */
-interface LoadMessage<Track> {
-  type: 'load';
-  track: Track;
-  range?: { start: number; end: number };
-}
+/**
+ * Shared message shape parameterized over the resolved track type. `load`
+ * drives fetching; `stop` halts it (the SPF `stopLoad()` analogue, sent when
+ * loading is suspended).
+ */
+type LoaderMessage<Track> = { type: 'load'; track: Track; range?: { start: number; end: number } } | { type: 'stop' };
 
 /** Structural constraint for any segment-loader-style actor. */
 interface SegmentLoaderLike<Track> {
-  send: (message: LoadMessage<Track>) => void;
+  send: (message: LoaderMessage<Track>) => void;
 }
 
 /**
@@ -162,6 +165,7 @@ function setupSegmentLoading<
   });
 
   const derivedStateSignal = computed<SegmentLoadingFsmState>(() => {
+    if (state.loadSuspended.get()) return 'suspended';
     if (!context[loaderKey].get() || !selectedTrack.get()) return 'preconditions-unmet';
     if (state.loadActivated.get() || state.preload.get() === 'auto') return 'full-range';
     if (state.preload.get() === 'none') return 'dormant';
@@ -174,6 +178,16 @@ function setupSegmentLoading<
     states: {
       'preconditions-unmet': {},
       dormant: {},
+      suspended: {
+        // Fires once on entry. Tell the loader actor to halt: abort the
+        // in-flight fetch + queued batch (the `'dormant'` gate only prevents
+        // *new* dispatches; an actor mid-forward-buffer keeps fetching
+        // without this). `peek` — the loader is already gated by
+        // `derivedStateSignal`; entry is auto-untracked besides.
+        entry: () => {
+          peek(context[loaderKey])?.send({ type: 'stop' });
+        },
+      },
       'metadata-only': {
         // Fires once on entry. Matches HTMLMediaElement's preload='metadata'
         // semantics — load enough to surface metadata for the entry-time
@@ -229,7 +243,7 @@ const TEXT_SEGMENT_LOADING_CONFIG = {
 // ============================================================================
 
 export const loadVideoSegments = defineBehavior({
-  stateKeys: ['presentation', 'preload', 'currentTime', 'loadActivated', 'selectedVideoTrackId'],
+  stateKeys: ['presentation', 'preload', 'currentTime', 'loadActivated', 'loadSuspended', 'selectedVideoTrackId'],
   contextKeys: ['videoSegmentLoaderActor'],
   setup: ({
     state,
@@ -250,7 +264,7 @@ export const loadVideoSegments = defineBehavior({
 });
 
 export const loadAudioSegments = defineBehavior({
-  stateKeys: ['presentation', 'preload', 'currentTime', 'loadActivated', 'selectedAudioTrackId'],
+  stateKeys: ['presentation', 'preload', 'currentTime', 'loadActivated', 'loadSuspended', 'selectedAudioTrackId'],
   contextKeys: ['audioSegmentLoaderActor'],
   setup: ({
     state,
@@ -271,7 +285,7 @@ export const loadAudioSegments = defineBehavior({
 });
 
 export const loadTextTrackSegments = defineBehavior({
-  stateKeys: ['presentation', 'preload', 'currentTime', 'loadActivated', 'selectedTextTrackId'],
+  stateKeys: ['presentation', 'preload', 'currentTime', 'loadActivated', 'loadSuspended', 'selectedTextTrackId'],
   contextKeys: ['textTrackSegmentLoaderActor'],
   setup: ({
     state,

--- a/packages/spf/src/playback/behaviors/dom/load-segments.ts
+++ b/packages/spf/src/playback/behaviors/dom/load-segments.ts
@@ -179,10 +179,10 @@ function setupSegmentLoading<
       'preconditions-unmet': {},
       dormant: {},
       suspended: {
-        // Fires once on entry. Tell the loader actor to halt: abort the
-        // in-flight fetch + queued batch (the `'dormant'` gate only prevents
-        // *new* dispatches; an actor mid-forward-buffer keeps fetching
-        // without this). `peek` — the loader is already gated by
+        // Fires once on entry. Tell the loader actor to halt: drop the
+        // pending queue so an actor mid-forward-buffer stops scheduling new
+        // fetches (the `'dormant'` gate only prevents *new* dispatches). The
+        // in-flight fetch is left to complete. `peek` — the loader is already gated by
         // `derivedStateSignal`; entry is auto-untracked besides.
         entry: () => {
           peek(context[loaderKey])?.send({ type: 'stop' });

--- a/packages/spf/src/playback/behaviors/dom/setup-buffer-actors.ts
+++ b/packages/spf/src/playback/behaviors/dom/setup-buffer-actors.ts
@@ -183,14 +183,28 @@ function setupBufferActors<K extends SelectedTrackKey, A extends BufferActorKey,
           context[actorKey].set(bufferActor);
           context[loaderKey].set(segmentLoader);
 
-          // State-exit cleanup — fires when `mediaSource` detaches, the
-          // selection unsets, or the behavior is destroyed. Destroy the
-          // loader before its upstream buffer-actor so any in-flight
-          // `appendBuffer` is aborted before the buffer-actor's own
+          // Destroy the loader before its upstream buffer-actor so any
+          // in-flight `appendBuffer` is aborted before the buffer-actor's own
           // teardown.
-          return () => {
+          const teardownActors = () => {
             segmentLoader.destroy();
             bufferActor.destroy();
+          };
+
+          // Close the actors when the user agent closes the MediaSource out from under
+          // us — notably on an AirPlay handoff (see `setupAirPlay`).
+          //
+          // Without this the loader would keep trying to append to a dead buffer,
+          // throwing InvalidStateErrors. Aborting the runners settles those tasks as
+          // AbortError (ignored).
+          const disconnect = new AbortController();
+          mediaSource.addEventListener('sourceclose', teardownActors, { signal: disconnect.signal });
+
+          // State-exit cleanup — fires when `mediaSource` detaches, the
+          // selection unsets, or the behavior is destroyed.
+          return () => {
+            disconnect.abort();
+            teardownActors();
             context[loaderKey].set(undefined);
             context[actorKey].set(undefined);
           };

--- a/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
@@ -82,7 +82,7 @@ describe('setupAirPlay', () => {
     reactor.destroy();
   });
 
-  it('appends the fallback HLS source on attach', async () => {
+  it('appends the fallback HLS source once the MediaSource is open', async () => {
     stubWebKit(true);
     const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
     const reactor = setupAirPlay.setup({ state, context });
@@ -91,9 +91,43 @@ describe('setupAirPlay', () => {
     context.mediaElement.set(video);
     await flush();
 
+    // No MediaSource yet → no fallback source (it must not exist without an
+    // MSE to sit behind, or `load()` would select it for local native HLS).
+    expect(fallbackSourceOf(video)).toBeNull();
+
+    context.mediaSource.set(fakeMediaSource);
+    await flush();
+
     const source = fallbackSourceOf(video);
     expect(source).not.toBeNull();
     expect(source?.src).toBe('https://example.com/a.m3u8');
+
+    reactor.destroy();
+  });
+
+  it('removes the fallback source when the MediaSource detaches, re-appends on the next open', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo();
+    context.mediaElement.set(video);
+    context.mediaSource.set(fakeMediaSource);
+    await flush();
+    expect(fallbackSourceOf(video)).not.toBeNull();
+
+    // A src change tears down the MSE (setupMediaSource clears the slot). The
+    // fallback must go with it — a leftover would be the sole source when
+    // detach's `load()` runs, starting local native HLS.
+    context.mediaSource.set(undefined);
+    await flush();
+    expect(fallbackSourceOf(video)).toBeNull();
+
+    // The next source opens → fallback re-appears, now carrying the new URL.
+    state.presentation.set({ url: 'https://example.com/b.m3u8' });
+    context.mediaSource.set({} as MediaSource);
+    await flush();
+    expect(fallbackSourceOf(video)?.src).toBe('https://example.com/b.m3u8');
 
     reactor.destroy();
   });
@@ -130,11 +164,12 @@ describe('setupAirPlay', () => {
 
     const video = makeWebKitVideo();
     context.mediaElement.set(video);
+    context.mediaSource.set(fakeMediaSource);
     await flush();
     expect(fallbackSourceOf(video)?.src).toBe('https://example.com/a.m3u8');
 
-    // A source change must update the fallback so a later AirPlay engage casts
-    // the current stream, not the attach-time one.
+    // A presentation update (same MediaSource) must refresh the fallback so a
+    // later AirPlay engage casts the current stream, not the attach-time one.
     state.presentation.set({ url: 'https://example.com/b.m3u8' });
     await flush();
     expect(fallbackSourceOf(video)?.src).toBe('https://example.com/b.m3u8');
@@ -207,10 +242,11 @@ describe('setupAirPlay', () => {
     const video = makeWebKitVideo({ disableRemotePlayback: true });
     state.disableRemotePlayback.set(true);
     context.mediaElement.set(video);
+    context.mediaSource.set(fakeMediaSource);
     await flush();
     expect(fallbackSourceOf(video)).toBeNull();
 
-    // Clearing the opt-out after attach must run setup.
+    // Clearing the opt-out after attach must run setup (MediaSource is open).
     state.disableRemotePlayback.set(false);
     await flush();
     expect(fallbackSourceOf(video)).not.toBeNull();
@@ -262,6 +298,7 @@ describe('setupAirPlay', () => {
 
     const video = makeWebKitVideo({ wireless: true });
     context.mediaElement.set(video);
+    context.mediaSource.set(fakeMediaSource);
     await flush();
     expect(fallbackSourceOf(video)).not.toBeNull();
     expect(state.loadSuspended.get()).toBe(true);
@@ -290,6 +327,7 @@ describe('setupAirPlay', () => {
 
     const video = makeWebKitVideo();
     context.mediaElement.set(video);
+    context.mediaSource.set(fakeMediaSource);
     await flush();
     expect(fallbackSourceOf(video)).not.toBeNull();
 

--- a/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { signal } from '../../../../core/signals/primitives';
+import type { MaybeResolvedPresentation } from '../../../../media/types';
+import { setupAirPlay } from '../airplay';
+
+// jsdom/Chromium lack WebKit's AirPlay APIs; stub the global support flag that
+// `isWebKitAirPlayCapable` probes for. See `utils/dom/tests/webkit.test.ts`.
+const AIRPLAY_KEY = 'WebKitPlaybackTargetAvailabilityEvent';
+function stubWebKit(present: boolean): void {
+  if (present) {
+    (globalThis as unknown as Record<string, unknown>)[AIRPLAY_KEY] = class {};
+  } else {
+    delete (globalThis as unknown as Record<string, unknown>)[AIRPLAY_KEY];
+  }
+}
+
+const WIRELESS_EVENT = 'webkitcurrentplaybacktargetiswirelesschanged';
+
+interface WebKitVideoLike extends HTMLVideoElement {
+  webkitCurrentPlaybackTargetIsWireless: boolean;
+}
+
+/**
+ * A real `<video>` decorated with the WebKit AirPlay flag so
+ * `isWebKitAirPlayCapable` recognizes it (`'…IsWireless' in media`).
+ */
+function makeWebKitVideo(opts: { wireless?: boolean; disableRemotePlayback?: boolean } = {}): WebKitVideoLike {
+  const video = document.createElement('video') as WebKitVideoLike;
+  video.webkitCurrentPlaybackTargetIsWireless = opts.wireless ?? false;
+  video.disableRemotePlayback = opts.disableRemotePlayback ?? false;
+  return video;
+}
+
+function setWireless(video: WebKitVideoLike, wireless: boolean): void {
+  video.webkitCurrentPlaybackTargetIsWireless = wireless;
+  video.dispatchEvent(new Event(WIRELESS_EVENT));
+}
+
+function makeSignals(presentation?: MaybeResolvedPresentation) {
+  return {
+    state: {
+      presentation: signal<MaybeResolvedPresentation | undefined>(presentation),
+      loadSuspended: signal<boolean | undefined>(undefined),
+      // Author intent, written by the adapter's `disableRemotePlayback` property.
+      disableRemotePlayback: signal<boolean | undefined>(undefined),
+    },
+    context: {
+      mediaElement: signal<HTMLMediaElement | undefined>(undefined),
+      // `setupMediaSource` publishes this only once the MediaSource is open;
+      // the AirPlay behavior enables the picker gated on it.
+      mediaSource: signal<MediaSource | undefined>(undefined),
+    },
+  };
+}
+
+/** Stand-in for a published, open MediaSource (only identity matters here). */
+const fakeMediaSource = {} as MediaSource;
+
+/** Drain microtasks (reactor transition + entry effects) plus any nested effects. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function sourceOf(video: HTMLMediaElement): HTMLSourceElement | null {
+  return video.querySelector('source[type="application/x-mpegURL"]');
+}
+
+describe('setupAirPlay', () => {
+  afterEach(() => stubWebKit(false));
+
+  it('is a no-op on non-WebKit platforms', async () => {
+    stubWebKit(false);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo();
+    context.mediaElement.set(video);
+    await flush();
+
+    expect(sourceOf(video)).toBeNull();
+
+    // A wireless event must not touch load state on an unsupported platform.
+    setWireless(video, true);
+    await flush();
+    expect(state.loadSuspended.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  it('appends the fallback HLS source on attach', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo();
+    context.mediaElement.set(video);
+    await flush();
+
+    const source = sourceOf(video);
+    expect(source).not.toBeNull();
+    expect(source?.src).toBe('https://example.com/a.m3u8');
+
+    reactor.destroy();
+  });
+
+  it('enables the AirPlay picker only once the MediaSource is open (sourceopen)', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    // Author didn't opt out.
+    const video = makeWebKitVideo();
+    context.mediaElement.set(video);
+    await flush();
+
+    // Simulate setupMediaSource's MMS path disabling remote playback so the
+    // ManagedMediaSource can fire `sourceopen`. AirPlay must NOT flip it back
+    // yet — doing so before open would prevent the source from opening.
+    video.disableRemotePlayback = true;
+    await flush();
+    expect(video.disableRemotePlayback).toBe(true);
+
+    // MediaSource opens → setupMediaSource publishes it → picker enabled.
+    context.mediaSource.set(fakeMediaSource);
+    await flush();
+    expect(video.disableRemotePlayback).toBe(false);
+
+    reactor.destroy();
+  });
+
+  it('sets the fallback source URL from the presentation at attach', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo();
+    context.mediaElement.set(video);
+    await flush();
+    expect(sourceOf(video)?.src).toBe('https://example.com/a.m3u8');
+
+    // The source URL is read with `peek`, so it is set once at attach and does
+    // not live-track later presentation changes (a deliberate choice to avoid
+    // re-setting `src` on a mid-cast AirPlay session).
+    state.presentation.set({ url: 'https://example.com/b.m3u8' });
+    await flush();
+    expect(sourceOf(video)?.src).toBe('https://example.com/a.m3u8');
+
+    reactor.destroy();
+  });
+
+  it('honors an author opt-out (disableRemotePlayback=true) — sets nothing up', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    // Author's explicit opt-out, expressed through the adapter signal (not the
+    // DOM property). The `<video>` starts with the flag MMS would leave set.
+    const video = makeWebKitVideo({ disableRemotePlayback: true, wireless: true });
+    state.disableRemotePlayback.set(true);
+    context.mediaElement.set(video);
+    await flush();
+
+    expect(sourceOf(video)).toBeNull();
+    // No wireless listener wired → no suspend even though the target is wireless.
+    expect(state.loadSuspended.get()).toBeUndefined();
+
+    // Even once the MediaSource opens, the picker stays disabled — the author
+    // opted out, so the enable-picker effect was never wired.
+    context.mediaSource.set(fakeMediaSource);
+    await flush();
+    expect(video.disableRemotePlayback).toBe(true);
+
+    reactor.destroy();
+  });
+
+  it('suspends loading while the wireless target is active and resumes when it turns off', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo({ wireless: false });
+    context.mediaElement.set(video);
+    await flush();
+    // Sync at attach: not wireless → not suspended.
+    expect(state.loadSuspended.get()).toBe(false);
+
+    setWireless(video, true);
+    await flush();
+    expect(state.loadSuspended.get()).toBe(true);
+
+    setWireless(video, false);
+    await flush();
+    expect(state.loadSuspended.get()).toBe(false);
+
+    reactor.destroy();
+  });
+
+  it('suspends immediately when AirPlay is already active at attach', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo({ wireless: true });
+    context.mediaElement.set(video);
+    await flush();
+
+    expect(state.loadSuspended.get()).toBe(true);
+
+    reactor.destroy();
+  });
+
+  it('cleans up on detach: removes the source, drops the listener, releases suspend', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo({ wireless: true });
+    context.mediaElement.set(video);
+    await flush();
+    expect(sourceOf(video)).not.toBeNull();
+    expect(state.loadSuspended.get()).toBe(true);
+
+    context.mediaElement.set(undefined);
+    await flush();
+
+    expect(sourceOf(video)).toBeNull();
+    // Detaching mid-wireless must not strand loading suspended.
+    expect(state.loadSuspended.get()).toBe(false);
+
+    // The listener is gone — a stray wireless event does nothing.
+    setWireless(video, true);
+    await flush();
+    expect(state.loadSuspended.get()).toBe(false);
+
+    reactor.destroy();
+  });
+
+  it('cleans up on destroy', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo();
+    context.mediaElement.set(video);
+    await flush();
+    expect(sourceOf(video)).not.toBeNull();
+
+    reactor.destroy();
+    await flush();
+
+    expect(sourceOf(video)).toBeNull();
+  });
+});

--- a/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
@@ -172,6 +172,52 @@ describe('setupAirPlay', () => {
     reactor.destroy();
   });
 
+  it('tears down when the author opts out after attach', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    const video = makeWebKitVideo({ wireless: true });
+    context.mediaElement.set(video);
+    context.mediaSource.set(fakeMediaSource);
+    await flush();
+    // Set up: fallback source present, picker enabled, suspended (wireless).
+    expect(fallbackSourceOf(video)).not.toBeNull();
+    expect(video.disableRemotePlayback).toBe(false);
+    expect(state.loadSuspended.get()).toBe(true);
+
+    // Framework binds the opt-out after attach() — the machine must react.
+    state.disableRemotePlayback.set(true);
+    await flush();
+
+    expect(fallbackSourceOf(video)).toBeNull();
+    // Picker enablement is undone, not merely left in place.
+    expect(video.disableRemotePlayback).toBe(true);
+    expect(state.loadSuspended.get()).toBe(false);
+
+    reactor.destroy();
+  });
+
+  it('runs setup when an initial opt-out is cleared after attach', async () => {
+    stubWebKit(true);
+    const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
+    const reactor = setupAirPlay.setup({ state, context });
+
+    // Author opted out at attach → nothing is set up.
+    const video = makeWebKitVideo({ disableRemotePlayback: true });
+    state.disableRemotePlayback.set(true);
+    context.mediaElement.set(video);
+    await flush();
+    expect(fallbackSourceOf(video)).toBeNull();
+
+    // Clearing the opt-out after attach must run setup.
+    state.disableRemotePlayback.set(false);
+    await flush();
+    expect(fallbackSourceOf(video)).not.toBeNull();
+
+    reactor.destroy();
+  });
+
   // Note: This just tests loadSuspended but the way Safari handles MMS, SPF wont load once we turn wireless off.
   it('suspends loading while the wireless target is active and resumes when it turns off', async () => {
     stubWebKit(true);
@@ -224,6 +270,8 @@ describe('setupAirPlay', () => {
     await flush();
 
     expect(fallbackSourceOf(video)).toBeNull();
+    // Cleanup hands the element back to its MMS-default remote-playback state.
+    expect(video.disableRemotePlayback).toBe(true);
     // Detaching mid-wireless must not strand loading suspended.
     expect(state.loadSuspended.get()).toBe(false);
 

--- a/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/airplay.test.ts
@@ -41,13 +41,10 @@ function makeSignals(presentation?: MaybeResolvedPresentation) {
     state: {
       presentation: signal<MaybeResolvedPresentation | undefined>(presentation),
       loadSuspended: signal<boolean | undefined>(undefined),
-      // Author intent, written by the adapter's `disableRemotePlayback` property.
       disableRemotePlayback: signal<boolean | undefined>(undefined),
     },
     context: {
       mediaElement: signal<HTMLMediaElement | undefined>(undefined),
-      // `setupMediaSource` publishes this only once the MediaSource is open;
-      // the AirPlay behavior enables the picker gated on it.
       mediaSource: signal<MediaSource | undefined>(undefined),
     },
   };
@@ -59,7 +56,7 @@ const fakeMediaSource = {} as MediaSource;
 /** Drain microtasks (reactor transition + entry effects) plus any nested effects. */
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-function sourceOf(video: HTMLMediaElement): HTMLSourceElement | null {
+function fallbackSourceOf(video: HTMLMediaElement): HTMLSourceElement | null {
   return video.querySelector('source[type="application/x-mpegURL"]');
 }
 
@@ -75,7 +72,7 @@ describe('setupAirPlay', () => {
     context.mediaElement.set(video);
     await flush();
 
-    expect(sourceOf(video)).toBeNull();
+    expect(fallbackSourceOf(video)).toBeNull();
 
     // A wireless event must not touch load state on an unsupported platform.
     setWireless(video, true);
@@ -94,7 +91,7 @@ describe('setupAirPlay', () => {
     context.mediaElement.set(video);
     await flush();
 
-    const source = sourceOf(video);
+    const source = fallbackSourceOf(video);
     expect(source).not.toBeNull();
     expect(source?.src).toBe('https://example.com/a.m3u8');
 
@@ -126,7 +123,7 @@ describe('setupAirPlay', () => {
     reactor.destroy();
   });
 
-  it('sets the fallback source URL from the presentation at attach', async () => {
+  it('keeps the fallback source URL in sync with the presentation', async () => {
     stubWebKit(true);
     const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
     const reactor = setupAirPlay.setup({ state, context });
@@ -134,14 +131,18 @@ describe('setupAirPlay', () => {
     const video = makeWebKitVideo();
     context.mediaElement.set(video);
     await flush();
-    expect(sourceOf(video)?.src).toBe('https://example.com/a.m3u8');
+    expect(fallbackSourceOf(video)?.src).toBe('https://example.com/a.m3u8');
 
-    // The source URL is read with `peek`, so it is set once at attach and does
-    // not live-track later presentation changes (a deliberate choice to avoid
-    // re-setting `src` on a mid-cast AirPlay session).
+    // A source change must update the fallback so a later AirPlay engage casts
+    // the current stream, not the attach-time one.
     state.presentation.set({ url: 'https://example.com/b.m3u8' });
     await flush();
-    expect(sourceOf(video)?.src).toBe('https://example.com/a.m3u8');
+    expect(fallbackSourceOf(video)?.src).toBe('https://example.com/b.m3u8');
+
+    // Cleared presentation empties the fallback src.
+    state.presentation.set(undefined);
+    await flush();
+    expect(fallbackSourceOf(video)?.getAttribute('src')).toBe('');
 
     reactor.destroy();
   });
@@ -158,7 +159,7 @@ describe('setupAirPlay', () => {
     context.mediaElement.set(video);
     await flush();
 
-    expect(sourceOf(video)).toBeNull();
+    expect(fallbackSourceOf(video)).toBeNull();
     // No wireless listener wired → no suspend even though the target is wireless.
     expect(state.loadSuspended.get()).toBeUndefined();
 
@@ -171,6 +172,7 @@ describe('setupAirPlay', () => {
     reactor.destroy();
   });
 
+  // Note: This just tests loadSuspended but the way Safari handles MMS, SPF wont load once we turn wireless off.
   it('suspends loading while the wireless target is active and resumes when it turns off', async () => {
     stubWebKit(true);
     const { state, context } = makeSignals({ url: 'https://example.com/a.m3u8' });
@@ -215,13 +217,13 @@ describe('setupAirPlay', () => {
     const video = makeWebKitVideo({ wireless: true });
     context.mediaElement.set(video);
     await flush();
-    expect(sourceOf(video)).not.toBeNull();
+    expect(fallbackSourceOf(video)).not.toBeNull();
     expect(state.loadSuspended.get()).toBe(true);
 
     context.mediaElement.set(undefined);
     await flush();
 
-    expect(sourceOf(video)).toBeNull();
+    expect(fallbackSourceOf(video)).toBeNull();
     // Detaching mid-wireless must not strand loading suspended.
     expect(state.loadSuspended.get()).toBe(false);
 
@@ -241,11 +243,11 @@ describe('setupAirPlay', () => {
     const video = makeWebKitVideo();
     context.mediaElement.set(video);
     await flush();
-    expect(sourceOf(video)).not.toBeNull();
+    expect(fallbackSourceOf(video)).not.toBeNull();
 
     reactor.destroy();
     await flush();
 
-    expect(sourceOf(video)).toBeNull();
+    expect(fallbackSourceOf(video)).toBeNull();
   });
 });

--- a/packages/spf/src/playback/behaviors/dom/tests/load-segments-track-switch.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/load-segments-track-switch.test.ts
@@ -31,6 +31,7 @@ function makeState(initial: SegmentLoadingState = {}): StateSignals<SegmentLoadi
     preload: signal<string | undefined>(initial.preload),
     currentTime: signal<number | undefined>(initial.currentTime),
     loadActivated: signal<boolean | undefined>(initial.loadActivated),
+    loadSuspended: signal<boolean | undefined>(initial.loadSuspended),
     selectedVideoTrackId: signal<string | undefined>(initial.selectedVideoTrackId),
     selectedAudioTrackId: signal<string | undefined>(initial.selectedAudioTrackId),
     selectedTextTrackId: signal<string | undefined>(initial.selectedTextTrackId),

--- a/packages/spf/src/playback/behaviors/dom/tests/load-segments.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/load-segments.test.ts
@@ -24,6 +24,7 @@ function makeState(initial: SegmentLoadingState = {}): StateSignals<SegmentLoadi
     preload: signal<string | undefined>(initial.preload),
     currentTime: signal<number | undefined>(initial.currentTime),
     loadActivated: signal<boolean | undefined>(initial.loadActivated),
+    loadSuspended: signal<boolean | undefined>(initial.loadSuspended),
     selectedVideoTrackId: signal<string | undefined>(initial.selectedVideoTrackId),
     selectedAudioTrackId: signal<string | undefined>(initial.selectedAudioTrackId),
     selectedTextTrackId: signal<string | undefined>(initial.selectedTextTrackId),
@@ -325,6 +326,125 @@ describe('loadSegments orchestration (F5)', () => {
     });
 
     cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSuspended — hard suspend gate (AirPlay wireless / stopLoad analogue)
+// ---------------------------------------------------------------------------
+
+describe('loadSegments orchestration (loadSuspended)', () => {
+  function makePresentation(segments: Segment[]) {
+    return {
+      id: 'p1',
+      url: 'http://example.com/playlist.m3u8',
+      startTime: 0,
+      duration: segments.reduce((acc, s) => acc + s.duration, 0),
+      selectionSets: [
+        {
+          id: 'ss1',
+          type: 'video' as const,
+          switchingSets: [{ id: 'sw1', type: 'video' as const, tracks: [makeResolvedVideoTrack(segments)] }],
+        },
+      ],
+    };
+  }
+
+  it('does not load segments while suspended, even with preload="auto"', async () => {
+    const segments = [makeSegment('s1', 0, 10), makeSegment('s2', 10, 10)];
+
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+      fetchedUrls.push(url);
+      return Promise.resolve(new Response(new ArrayBuffer(100)));
+    });
+
+    const { actor } = makeSourceBufferWithActor();
+    const { cleanup } = setupLoadSegments(
+      {
+        preload: 'auto',
+        loadSuspended: true,
+        selectedVideoTrackId: 'track-1',
+        currentTime: 0,
+        presentation: makePresentation(segments),
+      },
+      actor,
+      'video'
+    );
+
+    // Give the (suspended) loader ample time to prove it stays dormant.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchedUrls).not.toContain('http://example.com/init.mp4');
+    expect(fetchedUrls).not.toContain('http://example.com/s1.m4s');
+
+    cleanup();
+  });
+
+  it('resumes loading when suspend is released', async () => {
+    const segments = [makeSegment('s1', 0, 10), makeSegment('s2', 10, 10)];
+
+    const fetchedUrls: string[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+      fetchedUrls.push(url);
+      return Promise.resolve(new Response(new ArrayBuffer(100)));
+    });
+
+    const { actor } = makeSourceBufferWithActor();
+    const { state, cleanup } = setupLoadSegments(
+      {
+        preload: 'auto',
+        loadSuspended: true,
+        selectedVideoTrackId: 'track-1',
+        currentTime: 0,
+        presentation: makePresentation(segments),
+      },
+      actor,
+      'video'
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchedUrls).not.toContain('http://example.com/s1.m4s');
+
+    state.loadSuspended.set(false);
+
+    await vi.waitFor(() => {
+      expect(fetchedUrls).toContain('http://example.com/init.mp4');
+      expect(fetchedUrls).toContain('http://example.com/s1.m4s');
+    });
+
+    cleanup();
+  });
+
+  it('sends a stop message to the loader on suspend and re-dispatches on resume', async () => {
+    // Fake loader captures the messages the dispatcher sends — proving the
+    // `'suspended'` state actively halts the actor (not just parks the
+    // dispatcher). The actor-level tests cover what `stop` does to in-flight
+    // work; this pins the FSM → actor wiring.
+    const send = vi.fn();
+    const fakeLoader = { send } as unknown as SegmentLoaderActor;
+    const state = makeState({
+      preload: 'auto',
+      selectedVideoTrackId: 'track-1',
+      currentTime: 0,
+      presentation: makePresentation([makeSegment('s1', 0, 10)]),
+    });
+    const context = makeContext({ videoSegmentLoaderActor: fakeLoader });
+    const reactor = loadVideoSegments.setup({ state, context });
+
+    // preload:'auto' → 'full-range' → an initial load dispatch.
+    await vi.waitFor(() => expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: 'load' })));
+    send.mockClear();
+
+    state.loadSuspended.set(true);
+    await vi.waitFor(() => expect(send).toHaveBeenCalledWith({ type: 'stop' }));
+    send.mockClear();
+
+    state.loadSuspended.set(false);
+    await vi.waitFor(() => expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: 'load' })));
+
+    reactor.destroy();
   });
 });
 

--- a/packages/spf/src/playback/behaviors/dom/tests/load-text-track-segments.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/load-text-track-segments.test.ts
@@ -24,6 +24,7 @@ interface TextTrackSegmentLoadingState {
   currentTime?: number;
   preload?: string;
   loadActivated?: boolean;
+  loadSuspended?: boolean;
 }
 
 interface TextTrackSegmentLoadingContext {
@@ -54,6 +55,7 @@ function makeState(initial: TextTrackSegmentLoadingState = {}): StateSignals<Tex
     currentTime: signal<number | undefined>(initial.currentTime),
     preload: signal<string | undefined>(initial.preload),
     loadActivated: signal<boolean | undefined>(initial.loadActivated),
+    loadSuspended: signal<boolean | undefined>(initial.loadSuspended),
   };
 }
 

--- a/packages/spf/src/playback/behaviors/dom/tests/setup-buffer-actors.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/setup-buffer-actors.test.ts
@@ -41,6 +41,12 @@ vi.mock('../../../actors/dom/segment-loader', async (importOriginal) => {
   };
 });
 
+// Fake MediaSource — a real EventTarget so `sourceclose` can be dispatched to
+// the behavior's teardown listener; identity is preserved for call assertions.
+function makeMediaSource(): MediaSource {
+  return new EventTarget() as unknown as MediaSource;
+}
+
 // Helper to create a resolved video track
 function createResolvedVideoTrack(id = 'video-1'): VideoTrack {
   return {
@@ -219,7 +225,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const videoTrack = createResolvedVideoTrack();
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    const mediaSource = {} as MediaSource;
+    const mediaSource = makeMediaSource();
     context.mediaSource.set(mediaSource);
     state.presentation.set(createPresentationWithTracks({ video: videoTrack }));
     state.selectedVideoTrackId.set('video-1');
@@ -236,6 +242,33 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     cleanup();
   });
 
+  it('closes the actors when the MediaSource fires sourceclose (AirPlay handoff)', async () => {
+    const videoTrack = createResolvedVideoTrack();
+    const { state, context, cleanup } = setupSetupBufferActors();
+
+    const mediaSource = makeMediaSource();
+    context.mediaSource.set(mediaSource);
+    state.presentation.set(createPresentationWithTracks({ video: videoTrack }));
+    state.selectedVideoTrackId.set('video-1');
+
+    await vi.waitFor(() => expect(context.videoBufferActor.get()).toBeDefined());
+    const loader = context.videoSegmentLoaderActor.get()!;
+    const bufferActor = context.videoBufferActor.get()!;
+
+    // Safari closes the MMS out from under us — the actors must stop rather
+    // than keep appending into a now-defunct SourceBuffer.
+    mediaSource.dispatchEvent(new Event('sourceclose'));
+
+    expect(loader.destroy).toHaveBeenCalled();
+    expect(bufferActor.snapshot.get().value).toBe('destroyed');
+    // Only the actors are torn down — `context.mediaSource` and the slots are
+    // left in place for the normal source-reset path.
+    expect(context.videoBufferActor.get()).toBe(bufferActor);
+    expect(context.mediaSource.get()).toBe(mediaSource);
+
+    cleanup();
+  });
+
   it('creates audio buffer + loader actors for audio-only source', async () => {
     const { createSourceBuffer } = await import('../../../../media/dom/mse/mediasource-setup');
     const { createSegmentLoaderActor } = await import('../../../actors/dom/segment-loader');
@@ -243,7 +276,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const audioTrack = createResolvedAudioTrack();
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    const mediaSource = {} as MediaSource;
+    const mediaSource = makeMediaSource();
     context.mediaSource.set(mediaSource);
     state.presentation.set(createPresentationWithTracks({ audio: audioTrack }));
     state.selectedAudioTrackId.set('audio-1');
@@ -268,7 +301,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const audioTrack = createResolvedAudioTrack();
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    const mediaSource = {} as MediaSource;
+    const mediaSource = makeMediaSource();
     context.mediaSource.set(mediaSource);
     state.presentation.set(createPresentationWithTracks({ video: videoTrack, audio: audioTrack }));
     state.selectedVideoTrackId.set('video-1');
@@ -296,7 +329,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const audioTrack = createResolvedAudioTrack();
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    context.mediaSource.set({} as MediaSource);
+    context.mediaSource.set(makeMediaSource());
     state.presentation.set(createPresentationWithTracks({ video: videoTrack, audio: audioTrack }));
 
     // Video selection lands first; audio selection has not landed yet.
@@ -331,7 +364,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
 
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    const mediaSource = {} as MediaSource;
+    const mediaSource = makeMediaSource();
     context.mediaSource.set(mediaSource);
     state.presentation.set(createPresentationWithTracks({ audio: partiallyResolvedAudio as AudioTrack }));
     state.selectedAudioTrackId.set('audio-1');
@@ -352,7 +385,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const videoTrack: VideoTrack = { ...createResolvedVideoTrack(), codecs: [] };
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    context.mediaSource.set({} as MediaSource);
+    context.mediaSource.set(makeMediaSource());
     state.presentation.set(createPresentationWithTracks({ video: videoTrack }));
     state.selectedVideoTrackId.set('video-1');
 
@@ -370,7 +403,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const videoTrack = createResolvedVideoTrack();
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    context.mediaSource.set({} as MediaSource);
+    context.mediaSource.set(makeMediaSource());
     state.presentation.set(createPresentationWithTracks({ video: videoTrack }));
     state.selectedVideoTrackId.set('video-1');
 
@@ -410,7 +443,7 @@ describe('setupVideoBufferActors + setupAudioBufferActors', () => {
     const videoTrack = createResolvedVideoTrack();
     const { state, context, cleanup } = setupSetupBufferActors();
 
-    const mediaSource = {} as MediaSource;
+    const mediaSource = makeMediaSource();
     context.mediaSource.set(mediaSource);
     state.presentation.set(createPresentationWithTracks({ video: videoTrack }));
     state.selectedVideoTrackId.set('video-1');

--- a/packages/spf/src/playback/engines/hls/adapter.ts
+++ b/packages/spf/src/playback/engines/hls/adapter.ts
@@ -11,11 +11,13 @@ import {
 export interface SimpleHlsMediaProps {
   src: string;
   preload: '' | 'none' | 'metadata' | 'auto';
+  disableRemotePlayback: boolean;
 }
 
 export const simpleHlsMediaDefaultProps: SimpleHlsMediaProps = {
   src: '',
   preload: '',
+  disableRemotePlayback: false,
 };
 
 export interface SimpleHlsMediaAPI extends SimpleHlsMediaProps {
@@ -48,6 +50,7 @@ export function SimpleHlsMediaMixin<Base extends Constructor<any>>(BaseClass: Ba
     #config: SimpleHlsEngineConfig;
     #signals!: SimpleHlsEngineSignals;
     #preload: '' | 'none' | 'metadata' | 'auto' = simpleHlsMediaDefaultProps.preload;
+    #disableRemotePlayback: boolean = simpleHlsMediaDefaultProps.disableRemotePlayback;
 
     /** Pending loadstart listener from a deferred play() retry, if any. */
     #loadstartListener: (() => void) | null = null;
@@ -107,6 +110,25 @@ export function SimpleHlsMediaMixin<Base extends Constructor<any>>(BaseClass: Ba
       // value = '' resets the IDL mirror (so `get preload` reflects '') but does
       // not patch state — the engine keeps its current preload until an explicit
       // W3C value replaces it.
+    }
+
+    // -------------------------------------------------------------------------
+    // disableRemotePlayback — synchronous IDL attribute (WHATWG Remote Playback)
+    // Author intent for whether the AirPlay/remote picker is offered. Mirrors
+    // the DOM attribute name; the value flows to `state.disableRemotePlayback`,
+    // which `setupAirPlay` reads to honor an explicit opt-out. The underlying
+    // <video>'s own `disableRemotePlayback` stays programmatically managed
+    // (ManagedMediaSource needs it `true` to open; AirPlay flips it `false` once
+    // the source is open), so author intent and the effective flag stay distinct.
+    // -------------------------------------------------------------------------
+
+    get disableRemotePlayback(): boolean {
+      return this.#disableRemotePlayback;
+    }
+
+    set disableRemotePlayback(value: boolean) {
+      this.#disableRemotePlayback = value;
+      this.#signals.state.disableRemotePlayback.set(value);
     }
 
     // -------------------------------------------------------------------------

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -113,6 +113,15 @@ export interface SimpleHlsEngineState {
    * back.
    */
   loadSuspended?: boolean;
+  /**
+   * Author intent for the AirPlay/remote-playback picker, written by the media
+   * adapter's `disableRemotePlayback` IDL property. `true` is an explicit
+   * opt-out: `setupAirPlay` reads it at attach and sets nothing up, leaving the
+   * element's remote playback disabled. Distinct from the underlying
+   * `<video>.disableRemotePlayback`, which stays programmatically managed
+   * (ManagedMediaSource / AirPlay).
+   */
+  disableRemotePlayback?: boolean;
 }
 
 /**
@@ -267,6 +276,7 @@ const shareSignals = makeShareSignals<SimpleHlsEngineState, SimpleHlsEngineConte
   'userVideoTrackSelection',
   'userAudioTrackSelection',
   'userTextTrackSelection',
+  'disableRemotePlayback',
 ]);
 
 /**

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -29,6 +29,7 @@ import {
   type PresentationDurationResolver,
 } from '../../behaviors/calculate-presentation-duration';
 import { deriveCdnPriority } from '../../behaviors/derive-cdn-priority';
+import { setupAirPlay } from '../../behaviors/dom/airplay';
 import { endOfStream } from '../../behaviors/dom/end-of-stream';
 import { loadAudioSegments, loadTextTrackSegments, loadVideoSegments } from '../../behaviors/dom/load-segments';
 import { setupAudioBufferActors, setupVideoBufferActors } from '../../behaviors/dom/setup-buffer-actors';
@@ -103,6 +104,15 @@ export interface SimpleHlsEngineState {
   failedCdns?: string[];
   currentTime?: number;
   loadActivated?: boolean;
+  /**
+   * Suspend all segment loading. Owned by `setupAirPlay`, which sets it while the
+   * AirPlay wireless target is active so the engine doesn't double-fetch alongside
+   * the receiver.
+   * Read by the `loadXSegments` behaviors, which enter a `'suspended'` state
+   * (aborting all pending loading) while it's `true` and auto-resume when it flips
+   * back.
+   */
+  loadSuspended?: boolean;
 }
 
 /**
@@ -345,6 +355,9 @@ export function createSimpleHlsEngine(
       updateMediaSourceDuration,
       setupVideoBufferActors,
       setupAudioBufferActors,
+
+      // AirPlay/MSE bridge (WebKit only; no-op elsewhere).
+      setupAirPlay,
 
       // Playback tracking
       trackCurrentTime,


### PR DESCRIPTION

Closes #1801. Adds AirPlay support to the SPF HLS engine. 

## What it adds

- **`setupAirPlay` behavior**: on WebKit, appends a fallback `<source type="application/x-mpegURL">` so Safari can hand the native HLS stream to an AirPlay receiver while local playback runs through MSE. Composed into `createSimpleHlsEngine`.
- **Load suspension while casting**: a new `loadSuspended` state slot (the SPF analogue of hls.js `stopLoad()`) drives the segment-load FSM to a `'suspended'` state that halts the loaders, so we don't double-fetch alongside the receiver.
- **`disableRemotePlayback` sequencing + author intent (#1800)**: MMS needs the flag `true` to fire `sourceopen`; AirPlay needs it `false` to show the picker. These are sequenced, flip to `false` only once the MediaSource is open.  Author intent lives on its own adapter-written signal, so an explicit opt-out is honored and never confused with MMS's programmatic write. It's folded into the reactor's state derivation, so toggling it after attach() runs teardown/setup.

## Lifecycle correctness

- **Fallback source tracks the MediaSource.** The native-HLS <source> is appended only while `context.mediaSource` is open and removed when the slot clears, so on a src change it doesn't linger and get selected for local native HLS against the next MMS attach. Chosen over reacting to `sourceclose` (which fires on AirPlay engage, when the receiver still needs the source).
- **Actor teardown on MMS close**. When Safari closes the ManagedMediaSource (notably on an AirPlay handoff), the per-type buffer + segment-loader actors are torn down on `sourceclose`, so the in-flight append that stop deliberately leaves running doesn't keep calling appendBuffer on a defunct SourceBuffer and spamming `InvalidStateError`.

## Known limitation

After an AirPlay session ends, Safari closes our ManagedMediaSource and doesn't re-select the MSE `<source>`, so local MSE playback can't resume until the source is reloaded. Casting itself works; only the return-to-local is affected. The append errors this used to produce are now suppressed by tearing down the buffer actors on `sourceclose`. Tracked for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MSE attach on Safari (ManagedMediaSource), playback loading FSM, and remote-playback flags; behavior is gated to WebKit and covered by tests, but cast/handoff edge cases (e.g. post-AirPlay local resume) remain a known limitation.
> 
> **Overview**
> Adds **AirPlay for the SPF HLS engine on WebKit** by bridging MSE local playback with a native HLS handoff path, and pausing segment loading while casting.
> 
> **ManagedMediaSource attach** no longer uses `srcObject`; it prepends an MSE `<source>` (blob URL) so a second native-HLS `<source>` from AirPlay setup can coexist per WebKit’s MSE+AirPlay pattern.
> 
> New **`setupAirPlay` behavior** (composed into `createSimpleHlsEngine`): on capable WebKit video, after `mediaSource` is open, appends `application/x-mpegURL` fallback from `presentation.url`, toggles `disableRemotePlayback` on the element only after open (MMS still needs `true` to open), honors author **`disableRemotePlayback`** on adapter state, and sets **`loadSuspended`** while `webkitCurrentPlaybackTargetIsWireless` is true.
> 
> **Load suspension**: `loadXSegments` gains a **`suspended`** state when `loadSuspended` is true; on entry it sends **`stop`** to video/audio/text segment loaders (abort pending queue, leave in-flight fetch alone). **`sourceclose`** on `mediaSource` tears down buffer/loader actors so appends don’t continue after Safari closes MMS on handoff.
> 
> **`SimpleHlsMedia`** exposes **`disableRemotePlayback`** IDL wired to engine state, separate from programmatic element flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20a2d6b5570cb3867b01ec8a68431a319b0aa8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->