### PR TITLE
fix(html): register tooltip label and shortcut in live presets

### DIFF
--- a/packages/html/src/define/live-audio/minimal-ui.ts
+++ b/packages/html/src/define/live-audio/minimal-ui.ts
@@ -10,6 +10,8 @@ import { PlayButtonElement } from '../../ui/play-button/play-button-element';
 import { PopoverElement } from '../../ui/popover/popover-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { TooltipLabelElement } from '../../ui/tooltip/tooltip-label-element';
+import { TooltipShortcutElement } from '../../ui/tooltip/tooltip-shortcut-element';
 import { safeDefine } from '../safe-define';
 import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
@@ -33,5 +35,7 @@ safeDefine(LiveButtonElement);
 safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);
 safeDefine(PopoverElement);
+safeDefine(TooltipLabelElement);
+safeDefine(TooltipShortcutElement);
 safeDefine(TooltipElement);
 safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/live-audio/ui.ts
+++ b/packages/html/src/define/live-audio/ui.ts
@@ -14,6 +14,8 @@ import { PopoverElement } from '../../ui/popover/popover-element';
 import { TextElement } from '../../ui/text/text-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { TooltipLabelElement } from '../../ui/tooltip/tooltip-label-element';
+import { TooltipShortcutElement } from '../../ui/tooltip/tooltip-shortcut-element';
 import { safeDefine } from '../safe-define';
 import { defineErrorDialog, defineTime, defineTimeSlider, defineVolumeSlider } from '../ui/compounds';
 
@@ -41,5 +43,7 @@ safeDefine(MuteButtonElement);
 safeDefine(PlayButtonElement);
 safeDefine(PopoverElement);
 safeDefine(TextElement);
+safeDefine(TooltipLabelElement);
+safeDefine(TooltipShortcutElement);
 safeDefine(TooltipElement);
 safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/live-video/minimal-ui.ts
+++ b/packages/html/src/define/live-video/minimal-ui.ts
@@ -19,6 +19,8 @@ import { PopoverElement } from '../../ui/popover/popover-element';
 import { PosterElement } from '../../ui/poster/poster-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { TooltipLabelElement } from '../../ui/tooltip/tooltip-label-element';
+import { TooltipShortcutElement } from '../../ui/tooltip/tooltip-shortcut-element';
 import { safeDefine } from '../safe-define';
 import {
   defineControls,
@@ -62,5 +64,7 @@ safeDefine(PiPButtonElement);
 safeDefine(PlayButtonElement);
 safeDefine(PopoverElement);
 safeDefine(PosterElement);
+safeDefine(TooltipLabelElement);
+safeDefine(TooltipShortcutElement);
 safeDefine(TooltipElement);
 safeDefine(TooltipGroupElement);

--- a/packages/html/src/define/live-video/ui.ts
+++ b/packages/html/src/define/live-video/ui.ts
@@ -21,6 +21,8 @@ import { PosterElement } from '../../ui/poster/poster-element';
 import { TextElement } from '../../ui/text/text-element';
 import { TooltipElement } from '../../ui/tooltip/tooltip-element';
 import { TooltipGroupElement } from '../../ui/tooltip/tooltip-group-element';
+import { TooltipLabelElement } from '../../ui/tooltip/tooltip-label-element';
+import { TooltipShortcutElement } from '../../ui/tooltip/tooltip-shortcut-element';
 import { safeDefine } from '../safe-define';
 import {
   defineControls,
@@ -64,5 +66,7 @@ safeDefine(PlayButtonElement);
 safeDefine(PopoverElement);
 safeDefine(PosterElement);
 safeDefine(TextElement);
+safeDefine(TooltipLabelElement);
+safeDefine(TooltipShortcutElement);
 safeDefine(TooltipElement);
 safeDefine(TooltipGroupElement);


### PR DESCRIPTION
## Summary

Every tooltip in a `live-video` or `live-audio` skin throws on first update: the presets register `TooltipElement` and `TooltipGroupElement` but never `TooltipLabelElement` / `TooltipShortcutElement`, which their skin templates use. Those elements stay unupgraded, so `#syncContent` calls `setSyncedText` on a plain `HTMLElement`.

```
TypeError: labelEl?.setSyncedText is not a function
    at #syncContent (ui/tooltip/tooltip-element.ts)
```

The `video` and `audio` presets already register both — only the four `live-*` entries were missed.

## Changes

- Register `TooltipLabelElement` and `TooltipShortcutElement` in `live-video/ui.ts`, `live-video/minimal-ui.ts`, `live-audio/ui.ts`, and `live-audio/minimal-ui.ts`, in the same order the `video` preset uses (label and shortcut before their parent `TooltipElement`).

No behavior change beyond the tooltips starting to work: label text and keyboard-shortcut hints now render instead of throwing, so hovering any control in a live skin no longer floods the console.

## Testing

`pnpm typecheck` clean · `pnpm -F @videojs/html test` 231 pass · `pnpm check:workspace` 8/8.

Manual, before and after (Chromium):

```bash
pnpm -F @videojs/sandbox dev
# → http://localhost:5173/html-simple-hls-video/?source=hls-live
```

Built `@videojs/html` at unpatched `main` and captured `pageerror` events on load: `['labelEl?.setSyncedText is not a function']`. With this commit applied and rebuilt: `[]`. Hover any control to see the tooltip label and shortcut render.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small registration parity fix aligned with existing video/audio presets; no new behavior beyond fixing broken tooltips.
> 
> **Overview**
> **Live audio and live video** UI entry points (`live-audio/ui`, `live-audio/minimal-ui`, `live-video/ui`, `live-video/minimal-ui`) now register `TooltipLabelElement` and `TooltipShortcutElement`, matching the non-live `audio` / `video` presets.
> 
> Without those definitions, tooltip markup in live skins stayed unupgraded, so `TooltipElement`’s content sync called `setSyncedText` on plain elements and threw on hover. Tooltips in live skins should render labels and shortcut hints instead of erroring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45da51599c1142f2c3688d33fa4d3d79849e6013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->