### PR TITLE
feat(packages)!: support media components as markup

### DIFF
--- a/apps/sandbox/templates/html-mux-audio/main.ts
+++ b/apps/sandbox/templates/html-mux-audio/main.ts
@@ -35,8 +35,8 @@ async function render() {
         <${tag}>
           <mux-audio src="${SOURCES[state.source].url}" ${mediaAttrs} crossorigin="anonymous"></mux-audio>
           <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
-          <media-mux-data player-software-name="mux-audio"></media-mux-data>
-          <media-google-cast></media-google-cast>
+          <mux-data player-software-name="mux-audio"></mux-data>
+          <google-cast></google-cast>
         </${tag}>
       </audio-player>
     </div>

--- a/apps/sandbox/templates/html-mux-audio/main.ts
+++ b/apps/sandbox/templates/html-mux-audio/main.ts
@@ -1,7 +1,9 @@
 import '@app/styles.css';
 import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI18n } from '@app/shared/html/i18n';
 import '@videojs/html/audio/player';
+import '@videojs/html/media/google-cast';
 import '@videojs/html/media/mux-audio';
+import '@videojs/html/media/mux-data';
 import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
 import { loadAudioSkinTag } from '@app/shared/html/skins';
 import {
@@ -32,6 +34,9 @@ async function render() {
       <audio-player>
         <${tag}>
           <mux-audio src="${SOURCES[state.source].url}" ${mediaAttrs} crossorigin="anonymous"></mux-audio>
+          <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
+          <media-mux-data player-software-name="mux-audio"></media-mux-data>
+          <media-google-cast></media-google-cast>
         </${tag}>
       </audio-player>
     </div>

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -1,6 +1,8 @@
 import '@app/styles.css';
 import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI18n } from '@app/shared/html/i18n';
 import '@videojs/html/video/player';
+import '@videojs/html/media/google-cast';
+import '@videojs/html/media/mux-data';
 import '@videojs/html/media/mux-video';
 import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
 import { loadVideoSkinTag } from '@app/shared/html/skins';
@@ -36,6 +38,9 @@ async function render() {
       <${tag} class="aspect-video max-w-4xl mx-auto"${placeholder ? ` placeholdersrc="${placeholder}"` : ''}>
         <!-- The storyboard track is derived automatically from the Mux src. -->
         <mux-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline crossorigin="anonymous"></mux-video>
+        <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
+        <media-mux-data player-software-name="mux-video"></media-mux-data>
+        <media-google-cast></media-google-cast>
         ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
       </${tag}>
     </${playerTag}>

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -39,8 +39,8 @@ async function render() {
         <!-- The storyboard track is derived automatically from the Mux src. -->
         <mux-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline crossorigin="anonymous"></mux-video>
         <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
-        <media-mux-data player-software-name="mux-video"></media-mux-data>
-        <media-google-cast></media-google-cast>
+        <mux-data player-software-name="mux-video"></mux-data>
+        <google-cast></google-cast>
         ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
       </${tag}>
     </${playerTag}>

--- a/apps/sandbox/templates/react-mux-audio/main.tsx
+++ b/apps/sandbox/templates/react-mux-audio/main.tsx
@@ -10,7 +10,9 @@ import { useSkin } from '@app/shared/react/use-skin';
 import { useSource } from '@app/shared/react/use-source';
 import { SOURCES } from '@app/shared/sources';
 import type { Styling } from '@app/types';
+import { GoogleCast } from '@videojs/react/media/google-cast';
 import { MuxAudio } from '@videojs/react/media/mux-audio';
+import { MuxData } from '@videojs/react/media/mux-data';
 import { useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 
@@ -39,6 +41,9 @@ function App() {
             preload={preload}
             crossOrigin="anonymous"
           />
+          {/* Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. */}
+          <MuxData playerSoftwareName="mux-audio" />
+          <GoogleCast />
         </AudioSkinComponent>
       </AudioProvider>
     </SandboxI18nProvider>

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -12,6 +12,8 @@ import { useSkin } from '@app/shared/react/use-skin';
 import { useSource } from '@app/shared/react/use-source';
 import { isLiveSource, SOURCES } from '@app/shared/sources';
 import type { Styling } from '@app/types';
+import { GoogleCast } from '@videojs/react/media/google-cast';
+import { MuxData } from '@videojs/react/media/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
 import { useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -54,6 +56,9 @@ function App() {
             playsInline
             crossOrigin="anonymous"
           />
+          {/* Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. */}
+          <MuxData playerSoftwareName="mux-video" />
+          <GoogleCast />
         </VideoSkinComponent>
       </Provider>
     </SandboxI18nProvider>

--- a/packages/html/src/cdn/media/google-cast.ts
+++ b/packages/html/src/cdn/media/google-cast.ts
@@ -1,0 +1,1 @@
+import '../../define/media/google-cast';

--- a/packages/html/src/cdn/media/mux-data.ts
+++ b/packages/html/src/cdn/media/mux-data.ts
@@ -1,0 +1,1 @@
+import '../../define/media/mux-data';

--- a/packages/html/src/define/media/google-cast.ts
+++ b/packages/html/src/define/media/google-cast.ts
@@ -1,0 +1,12 @@
+import { GoogleCastElement } from '../../media/google-cast';
+import { safeDefine } from '../safe-define';
+
+export { GoogleCastElement };
+
+safeDefine(GoogleCastElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [GoogleCastElement.tagName]: GoogleCastElement;
+  }
+}

--- a/packages/html/src/define/media/mux-data.ts
+++ b/packages/html/src/define/media/mux-data.ts
@@ -1,0 +1,12 @@
+import { MuxDataElement } from '../../media/mux-data';
+import { safeDefine } from '../safe-define';
+
+export { MuxDataElement };
+
+safeDefine(MuxDataElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [MuxDataElement.tagName]: MuxDataElement;
+  }
+}

--- a/packages/html/src/media/dash-video/media.ts
+++ b/packages/html/src/media/dash-video/media.ts
@@ -1,12 +1,5 @@
 import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
 import { DashMedia } from '@videojs/media/dom/dash';
-import { GoogleCast } from '@videojs/media/dom/google-cast';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
-export class DashVideo extends MediaAttachMixin(CustomMediaElement('video', DashMedia)) {
-  constructor() {
-    super();
-    addMediaComponent(this.host, new GoogleCast());
-  }
-}
+export class DashVideo extends MediaAttachMixin(CustomMediaElement('video', DashMedia)) {}

--- a/packages/html/src/media/google-cast/google-cast-element.ts
+++ b/packages/html/src/media/google-cast/google-cast-element.ts
@@ -14,12 +14,12 @@ import { MediaComponentElement } from '../media-component-element';
  * ```html
  * <video-player>
  *   <hlsjs-video src="https://example.com/stream.m3u8"></hlsjs-video>
- *   <media-google-cast receiver="YOUR_APP_ID"></media-google-cast>
+ *   <google-cast receiver="YOUR_APP_ID"></google-cast>
  * </video-player>
  * ```
  */
 export class GoogleCastElement extends MediaComponentElement<GoogleCast> {
-  static readonly tagName = 'media-google-cast';
+  static readonly tagName = 'google-cast';
 
   static override properties = {
     src: { type: String },

--- a/packages/html/src/media/google-cast/google-cast-element.ts
+++ b/packages/html/src/media/google-cast/google-cast-element.ts
@@ -26,7 +26,8 @@ export class GoogleCastElement extends MediaComponentElement<GoogleCast> {
     contentType: { type: String, attribute: 'content-type' },
     streamType: { type: String, attribute: 'stream-type' },
     receiver: { type: String },
-  } satisfies PropertyDeclarationMap<'src' | 'contentType' | 'streamType' | 'receiver'>;
+    // `customData` takes an object, so it's a property-only prop.
+  } satisfies PropertyDeclarationMap<Exclude<keyof GoogleCastProps, 'customData'>>;
 
   protected createComponent(): GoogleCast {
     return new GoogleCast();

--- a/packages/html/src/media/google-cast/google-cast-element.ts
+++ b/packages/html/src/media/google-cast/google-cast-element.ts
@@ -1,0 +1,79 @@
+import type { PropertyDeclarationMap } from '@videojs/element';
+import { GoogleCast, type GoogleCastProps } from '@videojs/media/dom/google-cast';
+
+import { MediaComponentElement } from '../media-component-element';
+
+/**
+ * Adds Google Cast support to the surrounding player's media.
+ *
+ * Renders nothing — place it inside the player as a sibling of the media
+ * element and it registers a {@link GoogleCast} media component with the
+ * active media host.
+ *
+ * @example
+ * ```html
+ * <video-player>
+ *   <hlsjs-video src="https://example.com/stream.m3u8"></hlsjs-video>
+ *   <media-google-cast receiver="YOUR_APP_ID"></media-google-cast>
+ * </video-player>
+ * ```
+ */
+export class GoogleCastElement extends MediaComponentElement<GoogleCast> {
+  static readonly tagName = 'media-google-cast';
+
+  static override properties = {
+    src: { type: String },
+    contentType: { type: String, attribute: 'content-type' },
+    streamType: { type: String, attribute: 'stream-type' },
+    receiver: { type: String },
+  } satisfies PropertyDeclarationMap<'src' | 'contentType' | 'streamType' | 'receiver'>;
+
+  protected createComponent(): GoogleCast {
+    return new GoogleCast();
+  }
+
+  /** Source URL loaded on the Cast receiver. Falls back to the media's `src` / `currentSrc`. */
+  get src(): string {
+    return this.component.src ?? '';
+  }
+
+  set src(value: string | null | undefined) {
+    this.component.src = value ?? undefined;
+  }
+
+  /** MIME type of the Cast source. When unset, the receiver infers it from the URL. */
+  get contentType(): string | undefined {
+    return this.component.contentType;
+  }
+
+  set contentType(value: string | null | undefined) {
+    this.component.contentType = value ?? undefined;
+  }
+
+  /** Stream type used on the Cast receiver. Falls back to the media's `streamType`. */
+  get streamType(): GoogleCastProps['streamType'] {
+    return this.component.streamType;
+  }
+
+  set streamType(value: GoogleCastProps['streamType'] | null) {
+    this.component.streamType = value ?? undefined;
+  }
+
+  /** Cast receiver application ID. Defaults to Google's default media receiver. */
+  get receiver(): string | undefined {
+    return this.component.receiver;
+  }
+
+  set receiver(value: string | null | undefined) {
+    this.component.receiver = value ?? undefined;
+  }
+
+  /** Custom data sent to the Cast receiver with the load request. */
+  get customData(): GoogleCastProps['customData'] {
+    return this.component.customData;
+  }
+
+  set customData(value: GoogleCastProps['customData']) {
+    this.component.customData = value;
+  }
+}

--- a/packages/html/src/media/google-cast/index.ts
+++ b/packages/html/src/media/google-cast/index.ts
@@ -1,0 +1,1 @@
+export * from './google-cast-element';

--- a/packages/html/src/media/hlsjs-video/media.ts
+++ b/packages/html/src/media/hlsjs-video/media.ts
@@ -1,12 +1,5 @@
 import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
-import { GoogleCast } from '@videojs/media/dom/google-cast';
 import { HlsJsMedia } from '@videojs/media/dom/hls-js';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
-export class HlsJsVideo extends MediaAttachMixin(CustomMediaElement('video', HlsJsMedia)) {
-  constructor() {
-    super();
-    addMediaComponent(this.host, new GoogleCast());
-  }
-}
+export class HlsJsVideo extends MediaAttachMixin(CustomMediaElement('video', HlsJsMedia)) {}

--- a/packages/html/src/media/media-component-element.ts
+++ b/packages/html/src/media/media-component-element.ts
@@ -1,0 +1,83 @@
+import { ContextConsumer } from '@videojs/element/context';
+import type { Media } from '@videojs/media/dom';
+import {
+  addMediaComponent,
+  HTMLMediaElementHost,
+  type HTMLMediaTargetLike,
+  type MediaComponent,
+} from '@videojs/media/dom/media-host';
+
+import { mediaContext } from '../player/context';
+import { MediaElement } from '../ui/media-element';
+
+type MediaHost = HTMLMediaElementHost<HTMLMediaTargetLike, any>;
+
+/** Resolve the media host from a context media value (a media custom element or the host itself). */
+function resolveMediaHost(media: Media | null): MediaHost | null {
+  if (media instanceof HTMLMediaElementHost) return media;
+  const host = (media as { host?: unknown } | null)?.host;
+  return host instanceof HTMLMediaElementHost ? host : null;
+}
+
+/**
+ * Abstract base for elements that register a media component (e.g. Mux Data,
+ * Google Cast) with the media provided by the surrounding player.
+ *
+ * Place inside a player, as a sibling of the media element. The component is
+ * registered when a media host becomes available, follows the media when it
+ * changes, is removed when this element disconnects, and is destroyed with
+ * this element.
+ */
+export abstract class MediaComponentElement<Component extends MediaComponent> extends MediaElement {
+  #component: Component | null = null;
+  #host: MediaHost | null = null;
+  #removeComponent: (() => void) | null = null;
+
+  /**
+   * Create the media component this element registers. Called once, lazily.
+   *
+   * Must be a method rather than a field: upgrading an element that is already
+   * in the document runs its constructor while connected, so the media context
+   * callback below can fire before subclass field initializers have run.
+   */
+  protected abstract createComponent(): Component;
+
+  /** The media component instance registered with the media host. */
+  protected get component(): Component {
+    return (this.#component ??= this.createComponent());
+  }
+
+  constructor() {
+    super();
+    // Registers itself as a controller on this host; re-requests on reconnect.
+    new ContextConsumer(this, {
+      context: mediaContext,
+      subscribe: true,
+      callback: (value) => this.#setHost(resolveMediaHost(value.media)),
+    });
+  }
+
+  override disconnectedCallback(): void {
+    // Remove the component while the media chain is still live so it can
+    // clean up against the real underlying target.
+    this.#setHost(null);
+    super.disconnectedCallback();
+  }
+
+  override destroyCallback(): void {
+    this.#setHost(null);
+    // Don't create a component just to destroy it.
+    this.#component?.destroy?.();
+    super.destroyCallback();
+  }
+
+  #setHost(host: MediaHost | null): void {
+    if (this.#host === host) return;
+
+    this.#removeComponent?.();
+    this.#removeComponent = null;
+    this.#host = host;
+
+    if (host) this.#removeComponent = addMediaComponent(host, this.component);
+  }
+}

--- a/packages/html/src/media/mux-audio/media.ts
+++ b/packages/html/src/media/mux-audio/media.ts
@@ -1,7 +1,5 @@
 import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
-import { GoogleCast } from '@videojs/media/dom/google-cast';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
-import { MuxData, MuxMedia } from '@videojs/media/dom/mux';
+import { MuxMedia } from '@videojs/media/dom/mux';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
 const MuxAudioBase = MediaAttachMixin(CustomMediaElement('audio', MuxMedia));
@@ -9,8 +7,6 @@ const MuxAudioBase = MediaAttachMixin(CustomMediaElement('audio', MuxMedia));
 export class MuxAudio extends MuxAudioBase {
   constructor() {
     super();
-    addMediaComponent(this.host, new MuxData({ playerSoftwareName: 'mux-audio' }));
-    addMediaComponent(this.host, new GoogleCast());
     this.host.addEventListener('sourcechange', () => this.#reflectSrc());
   }
 

--- a/packages/html/src/media/mux-data/index.ts
+++ b/packages/html/src/media/mux-data/index.ts
@@ -1,0 +1,1 @@
+export * from './mux-data-element';

--- a/packages/html/src/media/mux-data/mux-data-element.ts
+++ b/packages/html/src/media/mux-data/mux-data-element.ts
@@ -34,15 +34,8 @@ export class MuxDataElement extends MediaComponentElement<MuxData> {
     playerSoftwareName: { type: String, attribute: 'player-software-name' },
     playerSoftwareVersion: { type: String, attribute: 'player-software-version' },
     playerInitTime: { type: Number, attribute: 'player-init-time' },
-  } satisfies PropertyDeclarationMap<
-    | 'envKey'
-    | 'beaconCollectionDomain'
-    | 'debug'
-    | 'disableCookies'
-    | 'playerSoftwareName'
-    | 'playerSoftwareVersion'
-    | 'playerInitTime'
-  >;
+    // `metadata` and `MuxDataSdk` take objects, so they're property-only props.
+  } satisfies PropertyDeclarationMap<Exclude<keyof MuxDataProps, 'metadata' | 'MuxDataSdk'>>;
 
   protected createComponent(): MuxData {
     return new MuxData();

--- a/packages/html/src/media/mux-data/mux-data-element.ts
+++ b/packages/html/src/media/mux-data/mux-data-element.ts
@@ -1,0 +1,131 @@
+import type { PropertyDeclarationMap } from '@videojs/element';
+import { MuxData, type MuxDataProps } from '@videojs/media/dom/mux';
+
+import { MediaComponentElement } from '../media-component-element';
+
+/**
+ * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding
+ * player's media.
+ *
+ * Renders nothing — place it inside the player as a sibling of the media
+ * element and it registers a {@link MuxData} media component with the active
+ * media host.
+ *
+ * Mux-hosted playback needs no `env-key`: the view reports the Mux playback ID
+ * as its `video_id`, which Mux attributes to the owning environment. Set
+ * `env-key` to monitor sources Mux doesn't host.
+ *
+ * @example
+ * ```html
+ * <video-player>
+ *   <mux-video src="https://stream.mux.com/abc123.m3u8"></mux-video>
+ *   <media-mux-data player-software-name="mux-video"></media-mux-data>
+ * </video-player>
+ * ```
+ */
+export class MuxDataElement extends MediaComponentElement<MuxData> {
+  static readonly tagName = 'media-mux-data';
+
+  static override properties = {
+    envKey: { type: String, attribute: 'env-key' },
+    beaconCollectionDomain: { type: String, attribute: 'beacon-collection-domain' },
+    debug: { type: Boolean },
+    disableCookies: { type: Boolean, attribute: 'disable-cookies' },
+    playerSoftwareName: { type: String, attribute: 'player-software-name' },
+    playerSoftwareVersion: { type: String, attribute: 'player-software-version' },
+    playerInitTime: { type: Number, attribute: 'player-init-time' },
+  } satisfies PropertyDeclarationMap<
+    | 'envKey'
+    | 'beaconCollectionDomain'
+    | 'debug'
+    | 'disableCookies'
+    | 'playerSoftwareName'
+    | 'playerSoftwareVersion'
+    | 'playerInitTime'
+  >;
+
+  protected createComponent(): MuxData {
+    return new MuxData();
+  }
+
+  /** Mux Data environment key for the beacons. Optional for Mux-hosted playback. */
+  get envKey(): string | undefined {
+    return this.component.envKey;
+  }
+
+  set envKey(value: string | null | undefined) {
+    this.component.envKey = value ?? undefined;
+  }
+
+  /** Custom domain beacons are sent to. */
+  get beaconCollectionDomain(): string | undefined {
+    return this.component.beaconCollectionDomain;
+  }
+
+  set beaconCollectionDomain(value: string | null | undefined) {
+    this.component.beaconCollectionDomain = value ?? undefined;
+  }
+
+  /** Enables Mux Data SDK debug logging. */
+  get debug(): boolean {
+    return this.component.debug;
+  }
+
+  set debug(value: boolean) {
+    this.component.debug = value;
+  }
+
+  /** Disables Mux Data SDK cookies. */
+  get disableCookies(): boolean {
+    return this.component.disableCookies;
+  }
+
+  set disableCookies(value: boolean) {
+    this.component.disableCookies = value;
+  }
+
+  /** Player software name reported to Mux Data (e.g. `mux-video`). */
+  get playerSoftwareName(): string | undefined {
+    return this.component.playerSoftwareName;
+  }
+
+  set playerSoftwareName(value: string | null | undefined) {
+    this.component.playerSoftwareName = value ?? undefined;
+  }
+
+  /** Player software version reported to Mux Data. Defaults to the Video.js version. */
+  get playerSoftwareVersion(): string | undefined {
+    return this.component.playerSoftwareVersion;
+  }
+
+  set playerSoftwareVersion(value: string | null | undefined) {
+    this.component.playerSoftwareVersion = value ?? undefined;
+  }
+
+  /** Epoch milliseconds the player was initialized. Defaults to the component's creation time. */
+  get playerInitTime(): number | undefined {
+    return this.component.playerInitTime;
+  }
+
+  set playerInitTime(value: number | null | undefined) {
+    this.component.playerInitTime = value ?? undefined;
+  }
+
+  /** Custom view metadata forwarded to the Mux Data SDK. */
+  get metadata(): MuxDataProps['metadata'] {
+    return this.component.metadata;
+  }
+
+  set metadata(value: MuxDataProps['metadata']) {
+    this.component.metadata = value;
+  }
+
+  /** Mux Data SDK used for monitoring. Set to `undefined` to disable monitoring. */
+  get MuxDataSdk(): MuxDataProps['MuxDataSdk'] {
+    return this.component.MuxDataSdk;
+  }
+
+  set MuxDataSdk(value: MuxDataProps['MuxDataSdk']) {
+    this.component.MuxDataSdk = value;
+  }
+}

--- a/packages/html/src/media/mux-data/mux-data-element.ts
+++ b/packages/html/src/media/mux-data/mux-data-element.ts
@@ -19,12 +19,12 @@ import { MediaComponentElement } from '../media-component-element';
  * ```html
  * <video-player>
  *   <mux-video src="https://stream.mux.com/abc123.m3u8"></mux-video>
- *   <media-mux-data player-software-name="mux-video"></media-mux-data>
+ *   <mux-data player-software-name="mux-video"></mux-data>
  * </video-player>
  * ```
  */
 export class MuxDataElement extends MediaComponentElement<MuxData> {
-  static readonly tagName = 'media-mux-data';
+  static readonly tagName = 'mux-data';
 
   static override properties = {
     envKey: { type: String, attribute: 'env-key' },

--- a/packages/html/src/media/mux-video/media.ts
+++ b/packages/html/src/media/mux-video/media.ts
@@ -1,8 +1,6 @@
 import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
-import { GoogleCast } from '@videojs/media/dom/google-cast';
 import { StreamTypes } from '@videojs/media/dom/hls-js';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
-import { MuxData, MuxMedia } from '@videojs/media/dom/mux';
+import { MuxMedia } from '@videojs/media/dom/mux';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
 const MuxVideoBase = MediaAttachMixin(CustomMediaElement('video', MuxMedia));
@@ -16,8 +14,6 @@ export class MuxVideo extends MuxVideoBase {
 
   constructor() {
     super();
-    addMediaComponent(this.host, new MuxData({ playerSoftwareName: 'mux-video' }));
-    addMediaComponent(this.host, new GoogleCast());
     // Storyboards aren't generated for live streams; re-evaluate when the type is detected.
     this.host.addEventListener('streamtypechange', () => this.#syncStoryboard());
     // Covers both the `src` attribute and the `source` property (JS-only).

--- a/packages/html/src/media/native-hls-video/media.ts
+++ b/packages/html/src/media/native-hls-video/media.ts
@@ -1,12 +1,5 @@
 import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
-import { GoogleCast } from '@videojs/media/dom/google-cast';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import { NativeHlsMedia } from '@videojs/media/dom/native-hls';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
 
-export class NativeHlsVideo extends MediaAttachMixin(CustomMediaElement('video', NativeHlsMedia)) {
-  constructor() {
-    super();
-    addMediaComponent(this.host, new GoogleCast());
-  }
-}
+export class NativeHlsVideo extends MediaAttachMixin(CustomMediaElement('video', NativeHlsMedia)) {}

--- a/packages/html/src/media/tests/google-cast.test.ts
+++ b/packages/html/src/media/tests/google-cast.test.ts
@@ -1,0 +1,128 @@
+import { ContextProvider } from '@videojs/element/context';
+import type { Media } from '@videojs/media/dom';
+import { GoogleCast } from '@videojs/media/dom/google-cast';
+import { getMediaComponents } from '@videojs/media/dom/media-host';
+import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mediaContext } from '../../player/context';
+import { MediaElement } from '../../ui/media-element';
+import { GoogleCastElement } from '../google-cast';
+
+class TestMediaProvider extends MediaElement {
+  readonly #provider = new ContextProvider(this, {
+    context: mediaContext,
+    initialValue: { media: null, setMedia: () => {} },
+  });
+
+  setMedia(media: Media | null) {
+    this.#provider.setValue({ media, setMedia: () => {} });
+  }
+}
+
+customElements.define('test-cast-provider', TestMediaProvider);
+customElements.define('test-google-cast', GoogleCastElement);
+
+function setup() {
+  const host = new HTMLVideoElementHost();
+  const provider = new TestMediaProvider();
+  const el = new GoogleCastElement();
+
+  provider.append(el);
+  document.body.append(provider);
+
+  return { host, provider, el };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('GoogleCastElement', () => {
+  it('registers a GoogleCast component with the media host from context', () => {
+    const { host, provider } = setup();
+
+    provider.setMedia(host as unknown as Media);
+
+    expect(getMediaComponents(host).get(GoogleCast)).toBeInstanceOf(GoogleCast);
+  });
+
+  it('leaves the component to the base class lazy getter', () => {
+    // An own `component` field would shadow the getter and be initialized after
+    // the base constructor — too late for a connected upgrade, where the media
+    // context callback registers the component from within that constructor.
+    expect(Object.getOwnPropertyNames(new GoogleCastElement())).not.toContain('component');
+  });
+
+  it('resolves the host from a media element host property', () => {
+    const { host, provider } = setup();
+
+    provider.setMedia({ host } as unknown as Media);
+
+    expect(getMediaComponents(host).get(GoogleCast)).toBeInstanceOf(GoogleCast);
+  });
+
+  it('ignores media that is not a media host', () => {
+    const { host, provider } = setup();
+
+    provider.setMedia(host as unknown as Media);
+    provider.setMedia(document.createElement('video') as unknown as Media);
+
+    expect(getMediaComponents(host).get(GoogleCast)).toBeUndefined();
+  });
+
+  it('forwards attributes to the component', () => {
+    const { host, provider, el } = setup();
+    provider.setMedia(host as unknown as Media);
+
+    el.setAttribute('receiver', 'APP_ID');
+    el.setAttribute('content-type', 'application/x-mpegURL');
+    el.setAttribute('stream-type', 'live');
+    el.setAttribute('src', 'https://example.com/stream.m3u8');
+
+    const component = getMediaComponents(host).get(GoogleCast)!;
+    expect(component.receiver).toBe('APP_ID');
+    expect(component.contentType).toBe('application/x-mpegURL');
+    expect(component.streamType).toBe('live');
+    expect(component.src).toBe('https://example.com/stream.m3u8');
+    // Properties read back from the component.
+    expect(el.receiver).toBe('APP_ID');
+  });
+
+  it('clears a component prop when its attribute is removed', () => {
+    const { el } = setup();
+
+    el.setAttribute('receiver', 'APP_ID');
+    el.removeAttribute('receiver');
+
+    expect(el.receiver).toBeUndefined();
+  });
+
+  it('moves the component when the media changes', () => {
+    const { host, provider } = setup();
+    const nextHost = new HTMLVideoElementHost();
+
+    provider.setMedia(host as unknown as Media);
+    provider.setMedia(nextHost as unknown as Media);
+
+    expect(getMediaComponents(host).get(GoogleCast)).toBeUndefined();
+    expect(getMediaComponents(nextHost).get(GoogleCast)).toBeInstanceOf(GoogleCast);
+  });
+
+  it('removes the component when the element disconnects', () => {
+    const { host, provider, el } = setup();
+    provider.setMedia(host as unknown as Media);
+
+    el.remove();
+
+    expect(getMediaComponents(host).get(GoogleCast)).toBeUndefined();
+  });
+
+  it('removes the component on destroy', () => {
+    const { host, provider, el } = setup();
+    provider.setMedia(host as unknown as Media);
+
+    el.destroy();
+
+    expect(getMediaComponents(host).get(GoogleCast)).toBeUndefined();
+  });
+});

--- a/packages/html/src/media/tests/media-component-element.test.ts
+++ b/packages/html/src/media/tests/media-component-element.test.ts
@@ -1,0 +1,110 @@
+import { ContextProvider } from '@videojs/element/context';
+import type { Media } from '@videojs/media/dom';
+import { getMediaComponents, type MediaComponent } from '@videojs/media/dom/media-host';
+import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mediaContext } from '../../player/context';
+import { MediaElement } from '../../ui/media-element';
+import { MediaComponentElement } from '../media-component-element';
+
+class FakeComponent implements MediaComponent {
+  destroyed = false;
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+class TestMediaProvider extends MediaElement {
+  readonly #provider = new ContextProvider(this, {
+    context: mediaContext,
+    initialValue: { media: null, setMedia: () => {} },
+  });
+
+  setMedia(media: Media | null) {
+    this.#provider.setValue({ media, setMedia: () => {} });
+  }
+}
+
+class TestMediaComponentElement extends MediaComponentElement<FakeComponent> {
+  static readonly tagName = 'test-media-component';
+
+  /**
+   * Subclass field initializers run after the base constructor, which is the
+   * window the media context callback can fire in during a custom element
+   * upgrade. Reading the component here proves it resolves that early.
+   */
+  readonly componentDuringFieldInit = this.component;
+
+  /** Exposes the protected component for assertions. */
+  get instance(): FakeComponent {
+    return this.component;
+  }
+
+  protected createComponent(): FakeComponent {
+    return new FakeComponent();
+  }
+}
+
+customElements.define('test-media-component-provider', TestMediaProvider);
+customElements.define(TestMediaComponentElement.tagName, TestMediaComponentElement);
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('MediaComponentElement', () => {
+  it('resolves the component before subclass fields initialize', () => {
+    const el = new TestMediaComponentElement();
+
+    expect(el.componentDuringFieldInit).toBeInstanceOf(FakeComponent);
+    // Created once and reused, not re-created per access.
+    expect(el.componentDuringFieldInit).toBe(el.instance);
+  });
+
+  it('registers the component with the media host from context', () => {
+    const host = new HTMLVideoElementHost();
+    const provider = new TestMediaProvider();
+    const el = new TestMediaComponentElement();
+
+    provider.append(el);
+    document.body.append(provider);
+    provider.setMedia(host as unknown as Media);
+
+    expect(getMediaComponents(host).get(FakeComponent)).toBe(el.instance);
+  });
+
+  it('destroys the component when the element is destroyed', () => {
+    const host = new HTMLVideoElementHost();
+    const provider = new TestMediaProvider();
+    const el = new TestMediaComponentElement();
+
+    provider.append(el);
+    document.body.append(provider);
+    provider.setMedia(host as unknown as Media);
+
+    el.destroy();
+
+    expect(el.instance.destroyed).toBe(true);
+    expect(getMediaComponents(host).get(FakeComponent)).toBeUndefined();
+  });
+
+  it('does not create a component when destroyed before use', () => {
+    const el = new TestMediaComponentElement();
+    // `componentDuringFieldInit` already forced creation, so assert through a
+    // subclass that never touches it.
+    class Untouched extends MediaComponentElement<FakeComponent> {
+      created = 0;
+      protected createComponent(): FakeComponent {
+        this.created++;
+        return new FakeComponent();
+      }
+    }
+    customElements.define('test-media-component-untouched', Untouched);
+
+    const untouched = new Untouched();
+    untouched.destroy();
+
+    expect(el.instance).toBeInstanceOf(FakeComponent);
+    expect(untouched.created).toBe(0);
+  });
+});

--- a/packages/html/src/media/tests/mux-data.test.ts
+++ b/packages/html/src/media/tests/mux-data.test.ts
@@ -1,0 +1,106 @@
+import { ContextProvider } from '@videojs/element/context';
+import type { Media } from '@videojs/media/dom';
+import { getMediaComponents } from '@videojs/media/dom/media-host';
+import { MuxData } from '@videojs/media/dom/mux';
+import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mediaContext } from '../../player/context';
+import { MediaElement } from '../../ui/media-element';
+import { MuxDataElement } from '../mux-data';
+
+class TestMediaProvider extends MediaElement {
+  readonly #provider = new ContextProvider(this, {
+    context: mediaContext,
+    initialValue: { media: null, setMedia: () => {} },
+  });
+
+  setMedia(media: Media | null) {
+    this.#provider.setValue({ media, setMedia: () => {} });
+  }
+}
+
+customElements.define('test-mux-data-provider', TestMediaProvider);
+customElements.define('test-mux-data', MuxDataElement);
+
+function setup() {
+  const host = new HTMLVideoElementHost();
+  const provider = new TestMediaProvider();
+  const el = new MuxDataElement();
+  // Prevent the real Mux SDK from initializing (and beaconing) in tests.
+  el.MuxDataSdk = undefined;
+
+  provider.append(el);
+  document.body.append(provider);
+
+  return { host, provider, el };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('MuxDataElement', () => {
+  it('registers when parsed into a connected player that already has media', () => {
+    const host = new HTMLVideoElementHost();
+    const provider = new TestMediaProvider();
+    document.body.append(provider);
+    provider.setMedia(host as unknown as Media);
+
+    provider.innerHTML = '<test-mux-data></test-mux-data>';
+
+    expect(getMediaComponents(host).get(MuxData)).toBeInstanceOf(MuxData);
+  });
+
+  it('leaves the component to the base class lazy getter', () => {
+    // An own `component` field would shadow the getter and be initialized after
+    // the base constructor — too late for a connected upgrade, where the media
+    // context callback registers the component from within that constructor.
+    expect(Object.getOwnPropertyNames(new MuxDataElement())).not.toContain('component');
+  });
+  it('registers a MuxData component with the media host from context', () => {
+    const { host, provider } = setup();
+
+    provider.setMedia(host as unknown as Media);
+
+    expect(getMediaComponents(host).get(MuxData)).toBeInstanceOf(MuxData);
+  });
+
+  it('forwards attributes to the component', () => {
+    const { host, provider, el } = setup();
+    provider.setMedia(host as unknown as Media);
+
+    el.setAttribute('env-key', 'test-key');
+    el.setAttribute('player-software-name', 'mux-video');
+    el.setAttribute('player-init-time', '1234');
+    el.setAttribute('debug', '');
+    el.setAttribute('disable-cookies', '');
+
+    const component = getMediaComponents(host).get(MuxData)!;
+    expect(component.envKey).toBe('test-key');
+    expect(component.playerSoftwareName).toBe('mux-video');
+    expect(component.playerInitTime).toBe(1234);
+    expect(component.debug).toBe(true);
+    expect(component.disableCookies).toBe(true);
+    // Properties read back from the component.
+    expect(el.envKey).toBe('test-key');
+  });
+
+  it('forwards the metadata property to the component', () => {
+    const { host, provider, el } = setup();
+    provider.setMedia(host as unknown as Media);
+
+    const metadata = { video_title: 'Test' };
+    el.metadata = metadata;
+
+    expect(getMediaComponents(host).get(MuxData)!.metadata).toEqual(metadata);
+  });
+
+  it('removes the component when the element disconnects', () => {
+    const { host, provider, el } = setup();
+    provider.setMedia(host as unknown as Media);
+
+    el.remove();
+
+    expect(getMediaComponents(host).get(MuxData)).toBeUndefined();
+  });
+});

--- a/packages/html/src/media/tests/mux-video.test.ts
+++ b/packages/html/src/media/tests/mux-video.test.ts
@@ -1,5 +1,3 @@
-import { getMediaComponents } from '@videojs/media/dom/media-host';
-import { MuxData } from '@videojs/media/dom/mux';
 import { afterEach, describe, expect, it } from 'vitest';
 import { MuxVideo } from '../mux-video';
 
@@ -7,8 +5,6 @@ customElements.define('test-mux-video', MuxVideo);
 
 function createMuxVideo() {
   const el = new MuxVideo();
-  // Prevent the real Mux SDK from initializing (and beaconing) in tests.
-  el.config = { muxData: { MuxDataSdk: undefined } };
   document.body.appendChild(el);
   return el;
 }
@@ -18,32 +14,12 @@ afterEach(() => {
 });
 
 describe('MuxVideo', () => {
-  it('constructs the mux data component with the player software name', () => {
-    const el = createMuxVideo();
-    const muxData = getMediaComponents(el.host).get(MuxData);
-
-    expect(muxData).toBeInstanceOf(MuxData);
-    expect(muxData?.playerSoftwareName).toBe('mux-video');
-  });
-
-  it('exposes the element config as plain values, not the component instance', () => {
+  it('exposes the element config as a property, not an attribute', () => {
     const el = createMuxVideo();
 
-    // `config` reflects exactly what was set — a plain namespace bag.
-    expect(el.config.muxData).toEqual({ MuxDataSdk: undefined });
-    expect(el.config.muxData).not.toBeInstanceOf(MuxData);
-  });
+    el.config = { preferPlayback: 'native' };
 
-  it('routes component config writes to the component', () => {
-    const el = createMuxVideo();
-    const muxData = getMediaComponents(el.host).get(MuxData);
-
-    el.config = { muxData: { envKey: 'test-key' } };
-
-    // The write reached the live component...
-    expect(muxData?.envKey).toBe('test-key');
-    // ...and config reads back the plain value, not the instance.
-    expect(el.config.muxData?.envKey).toBe('test-key');
+    expect(el.config.preferPlayback).toBe('native');
     expect(el.hasAttribute('config')).toBe(false);
   });
 

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -31,8 +31,10 @@ const presets = [
   'background',
 ];
 const media = [
+  'google-cast',
   'hlsjs-video',
   'mux-audio',
+  'mux-data',
   'mux-video',
   'native-hls-video',
   'simple-hls-audio-only',

--- a/packages/media/src/dom/google-cast/media.ts
+++ b/packages/media/src/dom/google-cast/media.ts
@@ -45,10 +45,13 @@ export class GoogleCast implements GoogleCastProps, MediaComponent {
 
     this.#media = host;
 
-    this.#provider ??= new GoogleCastProvider(this);
+    if (!this.#provider) {
+      this.#provider = new GoogleCastProvider(this);
+      this.#provider.remote.addEventListener('connect', this.#onStateChange);
+      this.#provider.remote.addEventListener('disconnect', this.#onStateChange);
+    }
+
     this.#override = this.#createRemoteOverride();
-    this.#provider.remote.addEventListener('connect', this.#onStateChange);
-    this.#provider.remote.addEventListener('disconnect', this.#onStateChange);
   }
 
   attach(target: HTMLMediaTargetLike) {

--- a/packages/media/src/dom/google-cast/media.ts
+++ b/packages/media/src/dom/google-cast/media.ts
@@ -18,15 +18,15 @@ export interface GoogleCastProps {
   customData?: Record<string, unknown> | null | undefined;
 }
 
-declare module '../media-host' {
-  interface MediaComponentConfig {
-    googleCast: GoogleCastProps;
-  }
-}
+export const googleCastDefaultProps: GoogleCastProps = {
+  src: undefined,
+  contentType: undefined,
+  streamType: undefined,
+  receiver: undefined,
+  customData: undefined,
+};
 
 export class GoogleCast implements GoogleCastProps, MediaComponent {
-  static readonly configKey = 'googleCast';
-
   #src: string | undefined;
   #contentType: string | undefined;
   #streamType: MediaStreamType | undefined;
@@ -93,7 +93,7 @@ export class GoogleCast implements GoogleCastProps, MediaComponent {
     return this.#src ?? this.#media?.querySelector('source')?.src ?? this.#media?.src ?? this.#media?.currentSrc ?? '';
   }
 
-  set src(value: string) {
+  set src(value: string | undefined) {
     if (this.#src === value) return;
     this.#src = value;
     this.#load();

--- a/packages/media/src/dom/google-cast/media.ts
+++ b/packages/media/src/dom/google-cast/media.ts
@@ -49,9 +49,8 @@ export class GoogleCast implements GoogleCastProps, MediaComponent {
       this.#provider = new GoogleCastProvider(this);
       this.#provider.remote.addEventListener('connect', this.#onStateChange);
       this.#provider.remote.addEventListener('disconnect', this.#onStateChange);
+      this.#override = this.#createRemoteOverride();
     }
-
-    this.#override = this.#createRemoteOverride();
   }
 
   attach(target: HTMLMediaTargetLike) {

--- a/packages/media/src/dom/google-cast/tests/media.test.ts
+++ b/packages/media/src/dom/google-cast/tests/media.test.ts
@@ -6,6 +6,16 @@ import { GoogleCast } from '../index';
 const mocks = vi.hoisted(() => {
   class FakeRemote extends EventTarget {
     state: 'disconnected' | 'connecting' | 'connected' = 'disconnected';
+    listenerCounts = new Map<string, number>();
+
+    override addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions
+    ) {
+      this.listenerCounts.set(type, (this.listenerCounts.get(type) ?? 0) + 1);
+      super.addEventListener(type, listener, options);
+    }
   }
 
   class FakeProvider {
@@ -64,6 +74,16 @@ afterEach(() => {
 });
 
 describe('GoogleCast', () => {
+  it('registers remote state listeners only once across media changes', () => {
+    const { googleCast, provider } = setup();
+    const nextHost = new HTMLVideoElementHost();
+
+    googleCast.setMedia(nextHost);
+
+    expect(provider.remote.listenerCounts.get('connect')).toBe(1);
+    expect(provider.remote.listenerCounts.get('disconnect')).toBe(1);
+  });
+
   describe('override swap on connect/disconnect', () => {
     it('routes host reads to the target while disconnected', () => {
       const { host, googleCast, provider } = setup();

--- a/packages/media/src/dom/google-cast/tests/media.test.ts
+++ b/packages/media/src/dom/google-cast/tests/media.test.ts
@@ -84,6 +84,16 @@ describe('GoogleCast', () => {
     expect(provider.remote.listenerCounts.get('disconnect')).toBe(1);
   });
 
+  it('keeps the provider override when media changes during a connected session', () => {
+    const { googleCast, provider } = setup();
+    const nextHost = new HTMLVideoElementHost();
+
+    connect(provider);
+    googleCast.setMedia(nextHost);
+
+    expect(googleCast.targetOverride).toBe(provider);
+  });
+
   describe('override swap on connect/disconnect', () => {
     it('routes host reads to the target while disconnected', () => {
       const { host, googleCast, provider } = setup();

--- a/packages/media/src/dom/media-host/media-host.ts
+++ b/packages/media/src/dom/media-host/media-host.ts
@@ -87,12 +87,11 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   destroy() {
     this.detach();
     this.#eventTypes.clear();
-
-    const components = getMediaComponents(this);
-    for (const component of components.values()) {
-      component.destroy?.();
-    }
-    components.clear();
+    // Media components are owned by whoever registered them (e.g. `<mux-data>`,
+    // `<google-cast>`), which may outlive this host. `detach()` above releases
+    // them from the target, so only drop the registrations here and leave
+    // destruction to the owner.
+    getMediaComponents(this).clear();
   }
 
   querySelectorAll<E extends Element = Element, S extends string = string>(selectors: S) {

--- a/packages/media/src/dom/media-host/media-host.ts
+++ b/packages/media/src/dom/media-host/media-host.ts
@@ -34,7 +34,6 @@ export interface MediaComponent<Target extends HTMLMediaTargetLike = HTMLMediaTa
 
 export interface MediaComponentConstructor<T extends MediaComponent = MediaComponent> {
   new (...args: any[]): T;
-  readonly configKey?: string;
 }
 
 export interface MediaComponents extends Map<MediaComponentConstructor, MediaComponent> {
@@ -42,11 +41,8 @@ export interface MediaComponents extends Map<MediaComponentConstructor, MediaCom
   set<T extends MediaComponent>(component: MediaComponentConstructor<T>, instance: T): this;
 }
 
-// biome-ignore lint/suspicious/noEmptyInterface: augmentation target for component config namespaces
-export interface MediaComponentConfig {}
-
-/** Host config bag: free-form host/engine settings plus per-component config namespaces. */
-export type MediaConfig = Partial<MediaComponentConfig> & Record<string, unknown>;
+/** Host config bag for host/engine settings. Media components are configured directly. */
+export type MediaConfig = Record<string, unknown>;
 
 export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events extends { [K in keyof Events]: EventLike }>
   extends EventTarget
@@ -159,12 +155,6 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   }
   set config(value: MediaConfig) {
     this.#config = value;
-
-    for (const component of getMediaComponents(this).values()) {
-      const ctor = component.constructor as MediaComponentConstructor;
-      const componentConfig = ctor.configKey && value[ctor.configKey];
-      if (componentConfig) Object.assign(component, componentConfig);
-    }
   }
 
   get title() {

--- a/packages/media/src/dom/mux/index.ts
+++ b/packages/media/src/dom/mux/index.ts
@@ -1,3 +1,3 @@
 export * from './media';
-export { MuxData, type MuxDataProps } from './mux-data';
+export { MuxData, type MuxDataProps, muxDataDefaultProps } from './mux-data';
 export * from './utils';

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -15,6 +15,19 @@ export interface MuxDataProps {
   metadata: MuxDataOptions['data'] | undefined;
 }
 
+export const muxDataDefaultProps: MuxDataProps = {
+  MuxDataSdk: Mux,
+  beaconCollectionDomain: undefined,
+  debug: false,
+  disableCookies: false,
+  envKey: undefined,
+  playerSoftwareName: undefined,
+  playerSoftwareVersion: getPlayerVersion(),
+  // Generated per instance; see `#generatePlayerInitTime()`.
+  playerInitTime: undefined,
+  metadata: undefined,
+};
+
 const MUX_VIDEO_DOMAIN = 'mux.com';
 
 export interface MuxDataMedia extends EventTarget {
@@ -22,24 +35,16 @@ export interface MuxDataMedia extends EventTarget {
   readonly src: string;
 }
 
-declare module '../media-host' {
-  interface MediaComponentConfig {
-    muxData: Partial<MuxDataProps>;
-  }
-}
-
 export class MuxData implements MuxDataProps {
-  static readonly configKey = 'muxData';
-
-  #MuxDataSdk: MuxDataSdk | undefined = Mux;
+  #MuxDataSdk: MuxDataSdk | undefined = muxDataDefaultProps.MuxDataSdk;
   #pendingInitialize: Promise<void> | null = null;
-  #beaconCollectionDomain: string | undefined;
-  #debug = false;
-  #disableCookies = false;
-  #metadata: MuxDataOptions['data'] | undefined;
-  #envKey: string | undefined;
-  #playerSoftwareName: string | undefined;
-  #playerSoftwareVersion: string | undefined = getPlayerVersion();
+  #beaconCollectionDomain: string | undefined = muxDataDefaultProps.beaconCollectionDomain;
+  #debug = muxDataDefaultProps.debug;
+  #disableCookies = muxDataDefaultProps.disableCookies;
+  #metadata: MuxDataOptions['data'] | undefined = muxDataDefaultProps.metadata;
+  #envKey: string | undefined = muxDataDefaultProps.envKey;
+  #playerSoftwareName: string | undefined = muxDataDefaultProps.playerSoftwareName;
+  #playerSoftwareVersion: string | undefined = muxDataDefaultProps.playerSoftwareVersion;
   #playerInitTime: number | undefined = this.#generatePlayerInitTime();
   #media: MuxDataMedia | null = null;
   #target: HTMLVideoElement | null = null;
@@ -112,6 +117,12 @@ export class MuxData implements MuxDataProps {
     this.#reinitialize();
   }
 
+  /**
+   * Mux Data environment key. Omitted from the beacon when unset, which is the
+   * norm for Mux-hosted playback: the view reports the Mux playback ID as its
+   * `video_id` (see {@link toVideoId}) and Mux attributes it to the owning
+   * environment. Set this to monitor sources Mux doesn't host.
+   */
   get envKey() {
     return this.#envKey;
   }

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -54,6 +54,8 @@ export class MuxData implements MuxDataProps {
   }
 
   setMedia(media: MuxDataMedia) {
+    if (this.#media === media) return;
+    this.#media?.removeEventListener('loadstart', this.#reinitialize);
     this.#media = media;
     this.#media.addEventListener('loadstart', this.#reinitialize);
   }
@@ -72,9 +74,9 @@ export class MuxData implements MuxDataProps {
   }
 
   destroy() {
+    this.detach();
     this.#media?.removeEventListener('loadstart', this.#reinitialize);
     this.#media = null;
-    this.#target = null;
   }
 
   get MuxDataSdk() {

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -91,6 +91,40 @@ describe('MuxData', () => {
     );
   });
 
+  it('moves its media listener when registered with another host', async () => {
+    const { sdk, monitor } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk });
+    const video = document.createElement('video');
+    const first = new FakeMedia();
+    const second = new FakeMedia();
+
+    data.setMedia(first);
+    data.attach(video);
+    await settle();
+
+    data.setMedia(second);
+    first.dispatchEvent(new Event('loadstart'));
+    await settle();
+    expect(monitor).toHaveBeenCalledTimes(1);
+
+    second.dispatchEvent(new Event('loadstart'));
+    await settle();
+    expect(monitor).toHaveBeenCalledTimes(2);
+  });
+
+  it('destroys active monitoring on destroy', () => {
+    const data = new MuxData();
+    const video = document.createElement('video');
+    const destroy = vi.fn();
+    Object.defineProperty(video, 'mux', { value: { destroy }, writable: true, configurable: true });
+
+    data.attach(video);
+    data.destroy();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(video.mux).toBeUndefined();
+  });
+
   it('stops re-monitoring after destroy', async () => {
     const { sdk, monitor } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { HlsJsMedia } from '../../hls-js';
-import { addMediaComponent } from '../../media-host';
+import type { HlsJsMedia } from '../../hls-js';
 import { MuxData } from '..';
 import type { MuxDataSdk } from '../types';
 
@@ -90,26 +89,6 @@ describe('MuxData', () => {
         data: expect.objectContaining({ video_id: 'abc123' }),
       })
     );
-  });
-
-  it('exposes mux config under host.config.muxData with inferred types', () => {
-    const media = new HlsJsMedia();
-    const muxData = new MuxData();
-    addMediaComponent(media, muxData);
-
-    // Type-level: `config.muxData` infers `Partial<MuxDataProps>` via the
-    // component's `configKey` augmentation, so the assignment/read are checked.
-    // This fails to compile if inference regresses.
-    media.config = { muxData: { envKey: 'key', debug: true } };
-    const envKey: string | undefined = media.config.muxData?.envKey;
-
-    expect(envKey).toBe('key');
-    // `config` stores the plain namespace POJO, not the component instance.
-    expect(media.config.muxData).toEqual({ envKey: 'key', debug: true });
-    expect(media.config.muxData).not.toBeInstanceOf(MuxData);
-    // The setter still routed those values onto the live component instance.
-    expect(muxData.envKey).toBe('key');
-    expect(muxData.debug).toBe(true);
   });
 
   it('stops re-monitoring after destroy', async () => {

--- a/packages/media/src/dom/tests/media-components.test.ts
+++ b/packages/media/src/dom/tests/media-components.test.ts
@@ -1,9 +1,45 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { HTMLAudioElementHost } from '../audio-host';
-import { getMediaProp } from '../utils';
+import type { MediaComponent } from '../media-host';
+import { addMediaComponent, getMediaProp } from '../utils';
 
 afterEach(() => {
   document.body.innerHTML = '';
+});
+
+class DetachableComponent implements MediaComponent {
+  detachCount = 0;
+  detach() {
+    this.detachCount++;
+  }
+}
+
+describe('addMediaComponent', () => {
+  it('detaches the component when it is unregistered', () => {
+    const host = new HTMLAudioElementHost();
+    host.attach(document.createElement('audio'));
+    const component = new DetachableComponent();
+
+    const remove = addMediaComponent(host, component);
+    remove();
+
+    expect(component.detachCount).toBe(1);
+  });
+
+  it('detaches the previous component when another instance replaces it', () => {
+    const host = new HTMLAudioElementHost();
+    host.attach(document.createElement('audio'));
+    const first = new DetachableComponent();
+    const second = new DetachableComponent();
+
+    const removeFirst = addMediaComponent(host, first);
+    addMediaComponent(host, second);
+    removeFirst();
+
+    expect(first.detachCount).toBe(1);
+    // The stale cleanup does not detach the replacement.
+    expect(second.detachCount).toBe(0);
+  });
 });
 
 describe('getMediaProp', () => {

--- a/packages/media/src/dom/tests/media-host.test.ts
+++ b/packages/media/src/dom/tests/media-host.test.ts
@@ -38,13 +38,6 @@ class CastLikeOverride implements MediaComponent {
   }
 }
 
-class ConfigurableComponent implements MediaComponent {
-  static readonly configKey = 'fake';
-  value = 0;
-  label = '';
-  destroy() {}
-}
-
 describe('HTMLMediaElementHost', () => {
   describe('component overrides', () => {
     it('returns the override value when a component exposes the property', () => {
@@ -190,62 +183,14 @@ describe('HTMLMediaElementHost', () => {
     });
   });
 
-  describe('component config binding', () => {
-    it('applies a component namespace onto the component when config is set', () => {
-      const host = new HTMLAudioElementHost();
-      const component = new ConfigurableComponent();
-      addMediaComponent(host, component);
-
-      host.config = { fake: { value: 3, label: 'a' } };
-
-      expect(component.value).toBe(3);
-      expect(component.label).toBe('a');
-    });
-
-    it('stores config as plain values, never component instances', () => {
-      const host = new HTMLAudioElementHost();
-      addMediaComponent(host, new ConfigurableComponent());
-
-      host.config = { fake: { value: 3 }, hlsJs: { debug: true } };
-
-      // `config` is a plain bag of what was set — reading it back yields the
-      // assigned POJO, never the component instance.
-      expect(host.config.fake).toEqual({ value: 3 });
-      expect(host.config.fake).not.toBeInstanceOf(ConfigurableComponent);
-      expect(host.config.hlsJs).toEqual({ debug: true });
-    });
-
+  describe('config', () => {
     it('returns the same object that was assigned', () => {
       const host = new HTMLAudioElementHost();
-      const value = { fake: { value: 1 }, a: 2 };
+      const value = { hlsJs: { debug: true }, a: 2 };
 
       host.config = value;
 
       expect(host.config).toBe(value);
-    });
-
-    it('round-trips through JSON without leaking component instances', () => {
-      const host = new HTMLAudioElementHost();
-      addMediaComponent(host, new ConfigurableComponent());
-
-      host.config = { fake: { value: 5, label: 'a' }, a: 1 };
-
-      // The stringified getter is valid input to the setter — plain values only.
-      const serialized = JSON.parse(JSON.stringify(host.config));
-      expect(serialized).toEqual({ fake: { value: 5, label: 'a' }, a: 1 });
-    });
-
-    it('does not apply config when the returned object is mutated directly', () => {
-      const host = new HTMLAudioElementHost();
-      const component = new ConfigurableComponent();
-      addMediaComponent(host, component);
-
-      // Only the setter applies namespaces to components; mutating the bag in
-      // place bypasses it.
-      host.config.fake = { value: 7, label: 'hi' };
-
-      expect(component.value).toBe(0);
-      expect(component.label).toBe('');
     });
 
     it('replaces the entire config object on set', () => {
@@ -257,73 +202,6 @@ describe('HTMLMediaElementHost', () => {
       // A new object replaces the old one wholesale; prior keys are dropped.
       expect(host.config.a).toBeUndefined();
       expect(host.config.b).toBe(2);
-    });
-
-    it('keeps component state when a later config omits its namespace', () => {
-      const host = new HTMLAudioElementHost();
-      const component = new ConfigurableComponent();
-      addMediaComponent(host, component);
-
-      host.config = { fake: { value: 5 }, a: 1 };
-      host.config = { b: 2 };
-
-      // The component retains its applied state even though the new config
-      // object no longer lists its namespace.
-      expect(component.value).toBe(5);
-      expect(host.config.fake).toBeUndefined();
-      expect(host.config.a).toBeUndefined();
-      expect(host.config.b).toBe(2);
-    });
-
-    it('overwrites component state only for keys present in the new config', () => {
-      const host = new HTMLAudioElementHost();
-      const component = new ConfigurableComponent();
-      addMediaComponent(host, component);
-
-      host.config = { fake: { value: 5, label: 'a' } };
-      host.config = { fake: { value: 9 } };
-
-      expect(component.value).toBe(9);
-      expect(component.label).toBe('a');
-    });
-
-    it('stops applying config to a removed component', () => {
-      const host = new HTMLAudioElementHost();
-      const component = new ConfigurableComponent();
-      const remove = addMediaComponent(host, component);
-
-      remove();
-      host.config = { fake: { value: 7 } };
-
-      expect(component.value).toBe(0);
-    });
-
-    it('adopts config set before the component was registered', () => {
-      const host = new HTMLAudioElementHost();
-      host.config = { fake: { value: 4, label: 'early' } };
-
-      const component = new ConfigurableComponent();
-      addMediaComponent(host, component);
-
-      expect(component.value).toBe(4);
-      expect(component.label).toBe('early');
-      // The plain value stays in the bag; it was never replaced.
-      expect(host.config.fake).toEqual({ value: 4, label: 'early' });
-    });
-
-    it('drops pre-registration component config after an intervening config reset', () => {
-      const host = new HTMLAudioElementHost();
-      host.config = { fake: { value: 4, label: 'early' } };
-      // A later config object replaces the bag wholesale, so the staged value is
-      // gone before the component registers.
-      host.config = { a: 1 };
-
-      const component = new ConfigurableComponent();
-      addMediaComponent(host, component);
-
-      expect(component.value).toBe(0);
-      expect(component.label).toBe('');
-      expect(host.config.fake).toBeUndefined();
     });
   });
 });

--- a/packages/media/src/dom/tests/media-host.test.ts
+++ b/packages/media/src/dom/tests/media-host.test.ts
@@ -20,6 +20,7 @@ class VolumeOverride implements MediaComponent {
 
 class AttachTracking implements MediaComponent {
   attach = vi.fn();
+  detach = vi.fn();
   destroy = vi.fn();
 }
 
@@ -135,7 +136,7 @@ describe('HTMLMediaElementHost', () => {
       expect(component.attach).not.toHaveBeenCalled();
     });
 
-    it('destroys and unregisters components on destroy', () => {
+    it('detaches and unregisters components on destroy', () => {
       const host = new HTMLAudioElementHost();
       const audio = document.createElement('audio');
       audio.muted = false;
@@ -147,11 +148,24 @@ describe('HTMLMediaElementHost', () => {
 
       host.destroy();
 
-      expect(component.destroy).toHaveBeenCalledTimes(1);
+      expect(component.detach).toHaveBeenCalledTimes(1);
 
-      // The destroyed override no longer participates in property resolution.
+      // The unregistered override no longer participates in property resolution.
       host.attach(audio);
       expect(host.muted).toBe(false);
+    });
+
+    it('does not destroy components it does not own on destroy', () => {
+      const host = new HTMLAudioElementHost();
+      host.attach(document.createElement('audio'));
+
+      const component = new AttachTracking();
+      addMediaComponent(host, component);
+
+      host.destroy();
+
+      // `<mux-data>` / `MuxData` own their component and may outlive the host.
+      expect(component.destroy).not.toHaveBeenCalled();
     });
 
     it('invokes the override method when it owns the property', async () => {

--- a/packages/media/src/dom/utils/media-components.ts
+++ b/packages/media/src/dom/utils/media-components.ts
@@ -21,13 +21,7 @@ export function addMediaComponent<T extends MediaComponent>(host: MediaHost, com
   // Get the component's constructor to use as the key for the component in the registry.
   const ctor = component.constructor as MediaComponentConstructor<T>;
 
-  // Adopt any config set under this namespace before the component registered.
-  const { configKey } = ctor;
-  const staged = configKey ? host.config[configKey] : undefined;
-
   components.set(ctor, component);
-
-  if (staged !== undefined) Object.assign(component, staged);
 
   component.setMedia?.(host);
 

--- a/packages/media/src/dom/utils/media-components.ts
+++ b/packages/media/src/dom/utils/media-components.ts
@@ -21,6 +21,9 @@ export function addMediaComponent<T extends MediaComponent>(host: MediaHost, com
   // Get the component's constructor to use as the key for the component in the registry.
   const ctor = component.constructor as MediaComponentConstructor<T>;
 
+  const previous = components.get(ctor);
+  if (previous && previous !== component) previous.detach?.();
+
   components.set(ctor, component);
 
   component.setMedia?.(host);
@@ -30,6 +33,7 @@ export function addMediaComponent<T extends MediaComponent>(host: MediaHost, com
 
   return () => {
     if (components.get(ctor) === component) {
+      component.detach?.();
       components.delete(ctor);
     }
   };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -158,5 +158,6 @@ export { useAttachMedia } from './utils/use-attach-media';
 export { composeRefs, useComposedRefs } from './utils/use-composed-refs';
 export { useDestroy } from './utils/use-destroy';
 export { useLatestRef } from './utils/use-latest-ref';
+export { useMediaComponent } from './utils/use-media-component';
 export { useMediaInstance } from './utils/use-media-instance';
 export { renderElement } from './utils/use-render';

--- a/packages/react/src/media/dash-video/media.tsx
+++ b/packages/react/src/media/dash-video/media.tsx
@@ -2,8 +2,6 @@
 
 import type { DashMediaProps } from '@videojs/media/dom/dash';
 import { DashMedia, dashMediaDefaultProps } from '@videojs/media/dom/dash';
-import { GoogleCast } from '@videojs/media/dom/google-cast';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import type { ReactNode, VideoHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 import { useAttachMedia } from '../../utils/use-attach-media';
@@ -18,9 +16,7 @@ export interface DashVideoProps
 }
 
 export const DashVideo = forwardRef<HTMLVideoElement, DashVideoProps>(function DashVideo({ children, ...props }, ref) {
-  const media = useMediaInstance(DashMedia, (media) => {
-    addMediaComponent(media, new GoogleCast());
-  });
+  const media = useMediaInstance(DashMedia);
   const attachRef = useAttachMedia(media);
   const composedRef = useComposedRefs(attachRef, ref);
   const htmlProps = useSyncProps(media, props, dashMediaDefaultProps);

--- a/packages/react/src/media/google-cast/google-cast.tsx
+++ b/packages/react/src/media/google-cast/google-cast.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { GoogleCastProps as GoogleCastComponentProps } from '@videojs/media/dom/google-cast';
+import { GoogleCast as GoogleCastComponent, googleCastDefaultProps } from '@videojs/media/dom/google-cast';
+import type { ReactNode } from 'react';
+
+import { useMediaComponent } from '../../utils/use-media-component';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export type GoogleCastProps = Partial<GoogleCastComponentProps>;
+
+/**
+ * Adds Google Cast support to the surrounding player's media.
+ *
+ * Renders nothing — place it inside the player provider as a sibling of the
+ * media component (e.g. `<HlsJsVideo />`) and it registers a `GoogleCast`
+ * media component with the active media.
+ *
+ * @example
+ * ```tsx
+ * <Player.Provider>
+ *   <HlsJsVideo src="https://example.com/stream.m3u8" />
+ *   <GoogleCast receiver="YOUR_APP_ID" />
+ * </Player.Provider>
+ * ```
+ */
+export function GoogleCast(props: GoogleCastProps): ReactNode {
+  const component = useMediaComponent(GoogleCastComponent);
+
+  useSyncProps(component, props, googleCastDefaultProps);
+
+  return null;
+}
+
+export namespace GoogleCast {
+  export type Props = GoogleCastProps;
+}

--- a/packages/react/src/media/google-cast/index.ts
+++ b/packages/react/src/media/google-cast/index.ts
@@ -1,0 +1,1 @@
+export * from './google-cast';

--- a/packages/react/src/media/hlsjs-video/media.tsx
+++ b/packages/react/src/media/hlsjs-video/media.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { GoogleCast } from '@videojs/media/dom/google-cast';
 import type { HlsMediaProps } from '@videojs/media/dom/hls-js';
 import { HlsJsMedia, hlsMediaDefaultProps } from '@videojs/media/dom/hls-js';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import type { ReactNode, VideoHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 import { useAttachMedia } from '../../utils/use-attach-media';
@@ -21,9 +19,7 @@ export const HlsJsVideo = forwardRef<HTMLVideoElement, HlsJsVideoProps>(function
   { children, ...props },
   ref
 ) {
-  const media = useMediaInstance(HlsJsMedia, (media) => {
-    addMediaComponent(media, new GoogleCast());
-  });
+  const media = useMediaInstance(HlsJsMedia);
   const attachRef = useAttachMedia(media);
   const composedRef = useComposedRefs(attachRef, ref);
   const htmlProps = useSyncProps(media, props, hlsMediaDefaultProps);

--- a/packages/react/src/media/mux-audio/media.tsx
+++ b/packages/react/src/media/mux-audio/media.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { GoogleCast } from '@videojs/media/dom/google-cast';
 import type { HlsMediaProps } from '@videojs/media/dom/hls-js';
 import { hlsMediaDefaultProps } from '@videojs/media/dom/hls-js';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import type { MuxMediaProps } from '@videojs/media/dom/mux';
-import { MuxData, MuxMedia, muxMediaDefaultProps } from '@videojs/media/dom/mux';
+import { MuxMedia, muxMediaDefaultProps } from '@videojs/media/dom/mux';
 import type { AudioHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import { useAttachMedia } from '../../utils/use-attach-media';
@@ -23,10 +21,7 @@ export interface MuxAudioProps
 const muxAudioDefaultProps: HlsMediaProps & MuxMediaProps = { ...hlsMediaDefaultProps, ...muxMediaDefaultProps };
 
 export const MuxAudio = forwardRef<HTMLAudioElement, MuxAudioProps>(function MuxAudio({ children, ...props }, ref) {
-  const media = useMediaInstance(MuxMedia, (media) => {
-    addMediaComponent(media, new MuxData({ playerSoftwareName: 'mux-audio' }));
-    addMediaComponent(media, new GoogleCast());
-  });
+  const media = useMediaInstance(MuxMedia);
   const attachRef = useAttachMedia(media);
   const composedRef = useComposedRefs(attachRef, ref);
   const htmlProps = useSyncProps(media, props, muxAudioDefaultProps);

--- a/packages/react/src/media/mux-data/index.ts
+++ b/packages/react/src/media/mux-data/index.ts
@@ -1,0 +1,1 @@
+export * from './mux-data';

--- a/packages/react/src/media/mux-data/mux-data.tsx
+++ b/packages/react/src/media/mux-data/mux-data.tsx
@@ -31,8 +31,13 @@ export type MuxDataProps = Partial<MuxDataComponentProps>;
  */
 export function MuxData(props: MuxDataProps): ReactNode {
   const component = useMediaComponent(MuxDataComponent);
+  const { MuxDataSdk, ...rest } = props;
+  const sdk = 'MuxDataSdk' in props ? MuxDataSdk : muxDataDefaultProps.MuxDataSdk;
 
-  useSyncProps(component, props, muxDataDefaultProps);
+  // `useSyncProps` treats `undefined` as "reset to default", but explicitly
+  // passing `MuxDataSdk={undefined}` is how consumers disable monitoring.
+  if (component.MuxDataSdk !== sdk) component.MuxDataSdk = sdk;
+  useSyncProps(component, rest, muxDataDefaultProps);
 
   return null;
 }

--- a/packages/react/src/media/mux-data/mux-data.tsx
+++ b/packages/react/src/media/mux-data/mux-data.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { MuxDataProps as MuxDataComponentProps } from '@videojs/media/dom/mux';
+import { MuxData as MuxDataComponent, muxDataDefaultProps } from '@videojs/media/dom/mux';
+import type { ReactNode } from 'react';
+
+import { useMediaComponent } from '../../utils/use-media-component';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export type MuxDataProps = Partial<MuxDataComponentProps>;
+
+/**
+ * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding
+ * player's media.
+ *
+ * Renders nothing — place it inside the player provider as a sibling of the
+ * media component (e.g. `<MuxVideo />`) and it registers a `MuxData` media
+ * component with the active media.
+ *
+ * Mux-hosted playback needs no `envKey`: the view reports the Mux playback ID
+ * as its `video_id`, which Mux attributes to the owning environment. Set
+ * `envKey` to monitor sources Mux doesn't host.
+ *
+ * @example
+ * ```tsx
+ * <Player.Provider>
+ *   <MuxVideo source={{ playbackId: 'abc123' }} />
+ *   <MuxData playerSoftwareName="mux-video" />
+ * </Player.Provider>
+ * ```
+ */
+export function MuxData(props: MuxDataProps): ReactNode {
+  const component = useMediaComponent(MuxDataComponent);
+
+  useSyncProps(component, props, muxDataDefaultProps);
+
+  return null;
+}
+
+export namespace MuxData {
+  export type Props = MuxDataProps;
+}

--- a/packages/react/src/media/mux-data/mux-data.tsx
+++ b/packages/react/src/media/mux-data/mux-data.tsx
@@ -32,11 +32,14 @@ export type MuxDataProps = Partial<MuxDataComponentProps>;
 export function MuxData(props: MuxDataProps): ReactNode {
   const component = useMediaComponent(MuxDataComponent);
   const { MuxDataSdk, ...rest } = props;
-  const sdk = 'MuxDataSdk' in props ? MuxDataSdk : muxDataDefaultProps.MuxDataSdk;
 
-  // `useSyncProps` treats `undefined` as "reset to default", but explicitly
-  // passing `MuxDataSdk={undefined}` is how consumers disable monitoring.
+  // `useSyncProps` treats an `undefined` prop as "reset to the default", but
+  // `MuxDataSdk={undefined}` is how consumers disable monitoring. Sync it here
+  // instead: passing the prop wins even when its value is `undefined`, and only
+  // omitting it falls back to the default SDK.
+  const sdk = 'MuxDataSdk' in props ? MuxDataSdk : muxDataDefaultProps.MuxDataSdk;
   if (component.MuxDataSdk !== sdk) component.MuxDataSdk = sdk;
+
   useSyncProps(component, rest, muxDataDefaultProps);
 
   return null;

--- a/packages/react/src/media/mux-video/media.tsx
+++ b/packages/react/src/media/mux-video/media.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { GoogleCast } from '@videojs/media/dom/google-cast';
 import type { HlsMediaProps } from '@videojs/media/dom/hls-js';
 import { hlsMediaDefaultProps, StreamTypes } from '@videojs/media/dom/hls-js';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import type { MuxMediaProps } from '@videojs/media/dom/mux';
-import { MuxData, MuxMedia, muxMediaDefaultProps } from '@videojs/media/dom/mux';
+import { MuxMedia, muxMediaDefaultProps } from '@videojs/media/dom/mux';
 import type { ReactNode, VideoHTMLAttributes } from 'react';
 import { forwardRef, useCallback, useSyncExternalStore } from 'react';
 import { useAttachMedia } from '../../utils/use-attach-media';
@@ -23,10 +21,7 @@ export interface MuxVideoProps
 const muxVideoDefaultProps: HlsMediaProps & MuxMediaProps = { ...hlsMediaDefaultProps, ...muxMediaDefaultProps };
 
 export const MuxVideo = forwardRef<HTMLVideoElement, MuxVideoProps>(function MuxVideo({ children, ...props }, ref) {
-  const media = useMediaInstance(MuxMedia, (media) => {
-    addMediaComponent(media, new MuxData({ playerSoftwareName: 'mux-video' }));
-    addMediaComponent(media, new GoogleCast());
-  });
+  const media = useMediaInstance(MuxMedia);
   const attachRef = useAttachMedia(media);
   const composedRef = useComposedRefs(attachRef, ref);
   const htmlProps = useSyncProps(media, props, muxVideoDefaultProps);

--- a/packages/react/src/media/native-hls-video/media.tsx
+++ b/packages/react/src/media/native-hls-video/media.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { GoogleCast } from '@videojs/media/dom/google-cast';
-import { addMediaComponent } from '@videojs/media/dom/media-host';
 import type { NativeHlsMediaProps } from '@videojs/media/dom/native-hls';
 import { NativeHlsMedia, nativeHlsMediaDefaultProps } from '@videojs/media/dom/native-hls';
 import type { ReactNode, VideoHTMLAttributes } from 'react';
@@ -21,9 +19,7 @@ export const NativeHlsVideo = forwardRef<HTMLVideoElement, NativeHlsVideoProps>(
   { children, ...props },
   ref
 ) {
-  const media = useMediaInstance(NativeHlsMedia, (media) => {
-    addMediaComponent(media, new GoogleCast());
-  });
+  const media = useMediaInstance(NativeHlsMedia);
   const attachRef = useAttachMedia(media);
   const composedRef = useComposedRefs(attachRef, ref);
   const htmlProps = useSyncProps(media, props, nativeHlsMediaDefaultProps);

--- a/packages/react/src/media/tests/google-cast.test.tsx
+++ b/packages/react/src/media/tests/google-cast.test.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import type { Media } from '@videojs/media';
+import { GoogleCast as GoogleCastComponent } from '@videojs/media/dom/google-cast';
+import { HlsJsMedia } from '@videojs/media/dom/hls-js';
+import { getMediaComponents } from '@videojs/media/dom/media-host';
+import { describe, expect, it } from 'vitest';
+import { createPlayerWrapper } from '../../testing/mocks';
+import { GoogleCast } from '../google-cast';
+
+function setup(media: Media | null = new HlsJsMedia()) {
+  const { value, Wrapper } = createPlayerWrapper();
+  value.media = media;
+  return { media, Wrapper };
+}
+
+describe('GoogleCast', () => {
+  it('registers a GoogleCast component with the media from context', () => {
+    const { media, Wrapper } = setup();
+
+    render(<GoogleCast />, { wrapper: Wrapper });
+
+    expect(getMediaComponents(media as HlsJsMedia).get(GoogleCastComponent)).toBeInstanceOf(GoogleCastComponent);
+  });
+
+  it('syncs props to the component', () => {
+    const { media, Wrapper } = setup();
+
+    render(<GoogleCast receiver="APP_ID" contentType="application/x-mpegURL" streamType="live" />, {
+      wrapper: Wrapper,
+    });
+
+    const component = getMediaComponents(media as HlsJsMedia).get(GoogleCastComponent)!;
+    expect(component.receiver).toBe('APP_ID');
+    expect(component.contentType).toBe('application/x-mpegURL');
+    expect(component.streamType).toBe('live');
+  });
+
+  it('resets a removed prop to its default', () => {
+    const { media, Wrapper } = setup();
+
+    const { rerender } = render(<GoogleCast receiver="APP_ID" />, { wrapper: Wrapper });
+    rerender(<GoogleCast />);
+
+    expect(getMediaComponents(media as HlsJsMedia).get(GoogleCastComponent)!.receiver).toBeUndefined();
+  });
+
+  it('removes the component on unmount', () => {
+    const { media, Wrapper } = setup();
+
+    const { unmount } = render(<GoogleCast />, { wrapper: Wrapper });
+    unmount();
+
+    expect(getMediaComponents(media as HlsJsMedia).get(GoogleCastComponent)).toBeUndefined();
+  });
+
+  it('ignores media that is not a media host', () => {
+    const video = document.createElement('video') as unknown as Media;
+    const { Wrapper } = setup(video);
+
+    render(<GoogleCast />, { wrapper: Wrapper });
+
+    expect(getMediaComponents(video as any).get(GoogleCastComponent)).toBeUndefined();
+  });
+});

--- a/packages/react/src/media/tests/mux-data.test.tsx
+++ b/packages/react/src/media/tests/mux-data.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import type { Media } from '@videojs/media';
-import { getMediaComponents } from '@videojs/media/dom/media-host';
+import { addMediaComponent, getMediaComponents } from '@videojs/media/dom/media-host';
 import { MuxData as MuxDataComponent, MuxMedia } from '@videojs/media/dom/mux';
 import { describe, expect, it, vi } from 'vitest';
 import { createPlayerWrapper } from '../../testing/mocks';
@@ -58,6 +58,27 @@ describe('MuxData', () => {
     rerender(<MuxData />);
 
     expect(getMediaComponents(media).get(MuxDataComponent)!.disableCookies).toBe(false);
+  });
+
+  it('keeps the component alive when the media host is destroyed while mounted', () => {
+    const { media, Wrapper } = setup();
+    const destroy = vi.spyOn(MuxDataComponent.prototype, 'destroy');
+
+    render(<MuxData />, { wrapper: Wrapper });
+    const component = getMediaComponents(media).get(MuxDataComponent)!;
+
+    media.destroy();
+
+    // The host detaches and unregisters components it doesn't own; this one is
+    // owned by the still-mounted `MuxData` and follows the next media.
+    expect(destroy).not.toHaveBeenCalled();
+    expect(getMediaComponents(media).get(MuxDataComponent)).toBeUndefined();
+
+    const next = new MuxMedia();
+    addMediaComponent(next, component);
+    expect(getMediaComponents(next).get(MuxDataComponent)).toBe(component);
+
+    destroy.mockRestore();
   });
 
   it('removes the component on unmount', () => {

--- a/packages/react/src/media/tests/mux-data.test.tsx
+++ b/packages/react/src/media/tests/mux-data.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import type { Media } from '@videojs/media';
 import { getMediaComponents } from '@videojs/media/dom/media-host';
 import { MuxData as MuxDataComponent, MuxMedia } from '@videojs/media/dom/mux';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createPlayerWrapper } from '../../testing/mocks';
 import { MuxData } from '../mux-data';
 
@@ -31,6 +31,24 @@ describe('MuxData', () => {
     expect(component.envKey).toBe('test-key');
     expect(component.playerSoftwareName).toBe('mux-video');
     expect(component.disableCookies).toBe(true);
+  });
+
+  it('disables monitoring when MuxDataSdk is explicitly undefined', () => {
+    const { media, Wrapper } = setup();
+    const MuxDataSdk = {
+      monitor: vi.fn(),
+      utils: { now: () => 0 },
+    } as unknown as NonNullable<MuxDataComponent['MuxDataSdk']>;
+
+    const { rerender } = render(<MuxData MuxDataSdk={MuxDataSdk} />, { wrapper: Wrapper });
+    const component = getMediaComponents(media).get(MuxDataComponent)!;
+    expect(component.MuxDataSdk).toBe(MuxDataSdk);
+
+    rerender(<MuxData MuxDataSdk={undefined} />);
+    expect(component.MuxDataSdk).toBeUndefined();
+
+    rerender(<MuxData />);
+    expect(component.MuxDataSdk).toBeDefined();
   });
 
   it('resets a removed prop to its default', () => {

--- a/packages/react/src/media/tests/mux-data.test.tsx
+++ b/packages/react/src/media/tests/mux-data.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import type { Media } from '@videojs/media';
+import { getMediaComponents } from '@videojs/media/dom/media-host';
+import { MuxData as MuxDataComponent, MuxMedia } from '@videojs/media/dom/mux';
+import { describe, expect, it } from 'vitest';
+import { createPlayerWrapper } from '../../testing/mocks';
+import { MuxData } from '../mux-data';
+
+function setup() {
+  const media = new MuxMedia();
+  const { value, Wrapper } = createPlayerWrapper();
+  value.media = media as unknown as Media;
+  return { media, Wrapper };
+}
+
+describe('MuxData', () => {
+  it('registers a MuxData component with the media from context', () => {
+    const { media, Wrapper } = setup();
+
+    render(<MuxData />, { wrapper: Wrapper });
+
+    expect(getMediaComponents(media).get(MuxDataComponent)).toBeInstanceOf(MuxDataComponent);
+  });
+
+  it('syncs props to the component', () => {
+    const { media, Wrapper } = setup();
+
+    render(<MuxData envKey="test-key" playerSoftwareName="mux-video" disableCookies />, { wrapper: Wrapper });
+
+    const component = getMediaComponents(media).get(MuxDataComponent)!;
+    expect(component.envKey).toBe('test-key');
+    expect(component.playerSoftwareName).toBe('mux-video');
+    expect(component.disableCookies).toBe(true);
+  });
+
+  it('resets a removed prop to its default', () => {
+    const { media, Wrapper } = setup();
+
+    const { rerender } = render(<MuxData disableCookies />, { wrapper: Wrapper });
+    rerender(<MuxData />);
+
+    expect(getMediaComponents(media).get(MuxDataComponent)!.disableCookies).toBe(false);
+  });
+
+  it('removes the component on unmount', () => {
+    const { media, Wrapper } = setup();
+
+    const { unmount } = render(<MuxData />, { wrapper: Wrapper });
+    unmount();
+
+    expect(getMediaComponents(media).get(MuxDataComponent)).toBeUndefined();
+  });
+});

--- a/packages/react/src/media/tests/mux-video.test.tsx
+++ b/packages/react/src/media/tests/mux-video.test.tsx
@@ -1,36 +1,15 @@
 import { render } from '@testing-library/react';
 import { HlsJsMedia } from '@videojs/media/dom/hls-js';
-import { MuxData, MuxMedia } from '@videojs/media/dom/mux';
+import { MuxMedia } from '@videojs/media/dom/mux';
 import { describe, expect, it, vi } from 'vitest';
 import { MuxVideo } from '../mux-video';
 
 describe('MuxVideo', () => {
-  it('routes component config to the MuxData component', () => {
-    const envKey = vi.spyOn(MuxData.prototype, 'envKey', 'set');
+  it('does not spread the config prop onto the element', () => {
+    const { container } = render(<MuxVideo config={{ preferPlayback: 'native' }} />);
 
-    // `useSyncProps` writes `media.config` during render, before the mount
-    // effect registers the components — `addMediaComponent` adopts the early value.
-    const { container } = render(<MuxVideo config={{ muxData: { envKey: 'test-key' } }} />);
-
-    expect(envKey).toHaveBeenCalledWith('test-key');
     // The config prop is consumed by the media, not spread onto the element.
     expect(container.querySelector('video')!.hasAttribute('config')).toBe(false);
-
-    envKey.mockRestore();
-  });
-
-  it('does not reinitialize mux data when the same config is re-rendered', () => {
-    const reinit = vi.spyOn(MuxData.prototype, 'envKey', 'set');
-
-    const { rerender } = render(<MuxVideo config={{ muxData: { envKey: 'test-key' } }} />);
-    rerender(<MuxVideo config={{ muxData: { envKey: 'test-key' } }} />);
-
-    // The setter runs per assignment but dedupes same values internally;
-    // assert it was only handed the same value.
-    expect(reinit).toHaveBeenCalledWith('test-key');
-    expect(reinit.mock.calls.every(([value]) => value === 'test-key')).toBe(true);
-
-    reinit.mockRestore();
   });
 
   it('derives the media src from the source prop', () => {

--- a/packages/react/src/utils/use-media-component.ts
+++ b/packages/react/src/utils/use-media-component.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import type { HTMLMediaTargetLike, MediaComponent } from '@videojs/media/dom/media-host';
+import { addMediaComponent, HTMLMediaElementHost } from '@videojs/media/dom/media-host';
+import { useEffect, useState } from 'react';
+
+import { useMedia } from '../player/context';
+import { useDestroy } from './use-destroy';
+
+/**
+ * Create a media component (e.g. `GoogleCast`, `MuxData`) and register it
+ * with the media provided by the surrounding player context.
+ *
+ * Instantiates the component class once, registers it when a media host is
+ * available, follows the media when it changes, and destroys the component
+ * on unmount. Media that is not a media host (e.g. a plain `<video>`
+ * element) cannot carry media components and is ignored.
+ */
+export function useMediaComponent<Component extends MediaComponent & { destroy(): void }>(
+  ComponentClass: new () => Component
+): Component {
+  const media = useMedia();
+  const [component] = useState(() => new ComponentClass());
+
+  useDestroy(component);
+
+  useEffect(() => {
+    if (!(media instanceof HTMLMediaElementHost)) return;
+    return addMediaComponent(media as HTMLMediaElementHost<HTMLMediaTargetLike, any>, component);
+  }, [media, component]);
+
+  return component;
+}

--- a/site/src/content/docs/concepts/cast.mdx
+++ b/site/src/content/docs/concepts/cast.mdx
@@ -1,6 +1,6 @@
 ---
 title: Google Cast
-description: Cast playback to Chromecast devices with built-in Google Cast support, and configure the receiver and load request
+description: Cast playback to Chromecast devices with the Google Cast component, and configure the receiver and load request
 ---
 
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
@@ -8,11 +8,12 @@ import DocsLink from '@/components/docs/DocsLink.astro';
 import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 import Aside from '@/components/Aside.astro';
 
-Video.js streaming media elements (HLS and DASH) have Google Cast built in. Add a <DocsLink slug="reference/cast-button">CastButton</DocsLink> and users can move playback to a Chromecast device while the browser stays in control:
+Add Google Cast to any Video.js streaming media element (HLS and DASH) by placing the Google Cast component next to it. Pair it with a <DocsLink slug="reference/cast-button">CastButton</DocsLink> and users can move playback to a Chromecast device while the browser stays in control:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
 import { CastButton, createPlayer } from '@videojs/react';
+import { GoogleCast } from '@videojs/react/media/google-cast';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 
@@ -29,6 +30,7 @@ export default function App() {
           playsInline
           loop
         />
+        <GoogleCast />
         <CastButton />
       </Player.Container>
     </Player.Provider>
@@ -48,13 +50,20 @@ export default function App() {
       playsinline
       loop
     ></hlsjs-video>
+    <media-google-cast></media-google-cast>
     <media-cast-button></media-cast-button>
   </media-container>
 </video-player>
 ```
+
+Register the `<media-google-cast>` element by importing `@videojs/html/media/google-cast`.
 </FrameworkCase>
 
-The pre-built <DocsLink slug="concepts/skins">skins</DocsLink> include a Cast button already. It appears when a Chromecast device is on the network and stays hidden otherwise.
+The component registers Google Cast with whichever media the player is using, so it works with any of the streaming media elements. The pre-built <DocsLink slug="concepts/skins">skins</DocsLink> include a Cast button already. It appears when a Chromecast device is on the network and stays hidden otherwise.
+
+<Aside type="caution">
+Casting needs this component. Without it, <DocsLink slug="reference/cast-button">CastButton</DocsLink> drives the browser's native Remote Playback API rather than a Cast session, so receivers and load requests don't apply.
+</Aside>
 
 <Aside type="note">
 Cast only works in Chromium-based browsers (Chrome, Edge, and others built on Blink). On other browsers, `remotePlaybackAvailability` is `'unsupported'`.
@@ -81,9 +90,9 @@ While `connected`, the media element's `play`, `pause`, `currentTime`, `volume`,
 
 ### The lazy-loaded SDK
 
-Video.js injects the Cast SDK (`cast_sender.js`) as a `<script>` tag the first time a Cast-capable media element loads in a Chromium browser. Browsers that can't cast never load the SDK.
+Video.js injects the Cast SDK (`cast_sender.js`) as a `<script>` tag the first time a Google Cast component is added in a Chromium browser. Browsers that can't cast — and players without the component — never load the SDK.
 
-Set `disableRemotePlayback` on the media element to opt out:
+Set `disableRemotePlayback` on the media element to opt out of remote playback entirely:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -100,11 +109,11 @@ Set `disableRemotePlayback` on the media element to opt out:
 ## Configure Cast
 
 <FrameworkCase frameworks={["react"]}>
-Pass Cast options under the `googleCast` key of the media element's `config` prop.
+Pass Cast options as props of the `GoogleCast` component.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Set Cast options under the `googleCast` key of the media element's `config` property. Set it from JavaScript — there is no HTML attribute for `config`.
+Set Cast options as attributes on the `<media-google-cast>` element. Object-valued options (like `customData`) are properties only.
 </FrameworkCase>
 
 ### Custom receiver application ID
@@ -113,17 +122,15 @@ By default, Video.js casts to Google's [Default Media Receiver](https://develope
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<HlsJsVideo
-  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
-  config={{ googleCast: { receiver: 'YOUR_APP_ID' } }} // [!code focus]
-/>
+<HlsJsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" />
+<GoogleCast receiver="YOUR_APP_ID" /> // [!code focus]
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-```ts
-const video = document.querySelector('hlsjs-video');
-video.config = { googleCast: { receiver: 'YOUR_APP_ID' } }; // [!code focus]
+```html
+<hlsjs-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"></hlsjs-video>
+<media-google-cast receiver="YOUR_APP_ID"></media-google-cast> <!-- [!code focus] -->
 ```
 </FrameworkCase>
 
@@ -133,17 +140,15 @@ Send extra data (auth tokens, user IDs) to the receiver with each load request v
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<HlsJsVideo
-  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
-  config={{ googleCast: { customData: { token: 'abc123', userId: 'u_789' } } }} // [!code focus]
-/>
+<HlsJsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" />
+<GoogleCast customData={{ token: 'abc123', userId: 'u_789' }} /> // [!code focus]
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
-const video = document.querySelector('hlsjs-video');
-video.config = { googleCast: { customData: { token: 'abc123', userId: 'u_789' } } }; // [!code focus]
+const googleCast = document.querySelector('media-google-cast');
+googleCast.customData = { token: 'abc123', userId: 'u_789' }; // [!code focus]
 ```
 </FrameworkCase>
 
@@ -153,49 +158,41 @@ By default the receiver loads the same URL the browser plays. Set `src` (and opt
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<HlsJsVideo
-  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
-  config={{
-    googleCast: {
-      src: 'https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8',
-      contentType: 'application/x-mpegURL',
-    },
-  }}
+<HlsJsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4" />
+<GoogleCast
+  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
+  contentType="application/x-mpegURL"
 />
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-```ts
-const video = document.querySelector('hlsjs-video');
-video.config = {
-  googleCast: {
-    src: 'https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8',
-    contentType: 'application/x-mpegURL',
-  },
-};
+```html
+<hlsjs-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"></hlsjs-video>
+<media-google-cast
+  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
+  content-type="application/x-mpegURL"
+></media-google-cast>
 ```
 </FrameworkCase>
 
 ### HLS on the receiver
 
-When the source (or `config.googleCast.src`) is an HLS playlist, Video.js inspects the playlist, detects the segment format (TS or fMP4), and sets `hlsSegmentFormat` / `hlsVideoSegmentFormat` on the Cast load request. The default media receiver plays HLS natively; no extra configuration needed.
+When the Cast source is an HLS playlist, Video.js inspects the playlist, detects the segment format (TS or fMP4), and sets `hlsSegmentFormat` / `hlsVideoSegmentFormat` on the Cast load request. The default media receiver plays HLS natively; no extra configuration needed.
 
 Set `streamType` to tell the receiver whether the stream is `'on-demand'` or `'live'`. When unset, it falls back to the player's `streamType`:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<HlsJsVideo
-  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
-  config={{ googleCast: { streamType: 'live' } }} // [!code focus]
-/>
+<HlsJsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" />
+<GoogleCast streamType="live" /> // [!code focus]
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-```ts
-const video = document.querySelector('hlsjs-video');
-video.config = { googleCast: { streamType: 'live' } }; // [!code focus]
+```html
+<hlsjs-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"></hlsjs-video>
+<media-google-cast stream-type="live"></media-google-cast> <!-- [!code focus] -->
 ```
 </FrameworkCase>
 

--- a/site/src/content/docs/concepts/cast.mdx
+++ b/site/src/content/docs/concepts/cast.mdx
@@ -50,13 +50,13 @@ export default function App() {
       playsinline
       loop
     ></hlsjs-video>
-    <media-google-cast></media-google-cast>
+    <google-cast></google-cast>
     <media-cast-button></media-cast-button>
   </media-container>
 </video-player>
 ```
 
-Register the `<media-google-cast>` element by importing `@videojs/html/media/google-cast`.
+Register the `<google-cast>` element by importing `@videojs/html/media/google-cast`.
 </FrameworkCase>
 
 The component registers Google Cast with whichever media the player is using, so it works with any of the streaming media elements. The pre-built <DocsLink slug="concepts/skins">skins</DocsLink> include a Cast button already. It appears when a Chromecast device is on the network and stays hidden otherwise.
@@ -113,7 +113,7 @@ Pass Cast options as props of the `GoogleCast` component.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-Set Cast options as attributes on the `<media-google-cast>` element. Object-valued options (like `customData`) are properties only.
+Set Cast options as attributes on the `<google-cast>` element. Object-valued options (like `customData`) are properties only.
 </FrameworkCase>
 
 ### Custom receiver application ID
@@ -130,7 +130,7 @@ By default, Video.js casts to Google's [Default Media Receiver](https://develope
 <FrameworkCase frameworks={["html"]}>
 ```html
 <hlsjs-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"></hlsjs-video>
-<media-google-cast receiver="YOUR_APP_ID"></media-google-cast> <!-- [!code focus] -->
+<google-cast receiver="YOUR_APP_ID"></google-cast> <!-- [!code focus] -->
 ```
 </FrameworkCase>
 
@@ -147,7 +147,7 @@ Send extra data (auth tokens, user IDs) to the receiver with each load request v
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
-const googleCast = document.querySelector('media-google-cast');
+const googleCast = document.querySelector('google-cast');
 googleCast.customData = { token: 'abc123', userId: 'u_789' }; // [!code focus]
 ```
 </FrameworkCase>
@@ -169,10 +169,10 @@ By default the receiver loads the same URL the browser plays. Set `src` (and opt
 <FrameworkCase frameworks={["html"]}>
 ```html
 <hlsjs-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"></hlsjs-video>
-<media-google-cast
+<google-cast
   src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
   content-type="application/x-mpegURL"
-></media-google-cast>
+></google-cast>
 ```
 </FrameworkCase>
 
@@ -192,7 +192,7 @@ Set `streamType` to tell the receiver whether the stream is `'on-demand'` or `'l
 <FrameworkCase frameworks={["html"]}>
 ```html
 <hlsjs-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"></hlsjs-video>
-<media-google-cast stream-type="live"></media-google-cast> <!-- [!code focus] -->
+<google-cast stream-type="live"></google-cast> <!-- [!code focus] -->
 ```
 </FrameworkCase>
 

--- a/site/src/content/docs/concepts/mux-data.mdx
+++ b/site/src/content/docs/concepts/mux-data.mdx
@@ -1,0 +1,135 @@
+---
+title: Mux Data
+description: Monitor playback quality and viewer experience by adding the Mux Data component to a player
+---
+
+import FrameworkCase from '@/components/docs/FrameworkCase.astro';
+import DocsLink from '@/components/docs/DocsLink.astro';
+import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
+import Aside from '@/components/Aside.astro';
+
+[Mux Data](https://www.mux.com/data) measures playback quality — startup time, rebuffering, playback failures, and watch time. Add the Mux Data component to a player and it monitors whichever media that player is playing:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="App.tsx"
+import { createPlayer } from '@videojs/react';
+import { MuxData } from '@videojs/react/media/mux-data';
+import { MuxVideo } from '@videojs/react/media/mux-video';
+import { videoFeatures } from '@videojs/react/video';
+
+const Player = createPlayer({ features: videoFeatures });
+
+export default function App() {
+  return (
+    <Player.Provider>
+      <Player.Container>
+        <MuxVideo source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }} playsInline />
+        <MuxData /> {/* [!code focus] */}
+      </Player.Container>
+    </Player.Provider>
+  );
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html title="index.html"
+<video-player>
+  <media-container>
+    <mux-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" playsinline></mux-video>
+    <media-mux-data></media-mux-data> <!-- [!code focus] -->
+  </media-container>
+</video-player>
+```
+
+Register the `<media-mux-data>` element by importing `@videojs/html/media/mux-data`.
+</FrameworkCase>
+
+That's the whole setup for Mux-hosted playback — no environment key required. The component renders nothing; place it inside the player, as a sibling of the media element.
+
+<Aside type="note">
+Mux Data is opt-in. No media element monitors playback on its own, Mux ones included, so nothing is measured and no beacons are sent until you add this component.
+</Aside>
+
+## Environment key
+
+Mux Data needs to know which environment a view belongs to. For Mux-hosted playback it works that out on its own: the component reports the Mux playback ID as the view's `video_id`, and Mux attributes the view to the environment that owns that playback ID.
+
+Set `envKey` when you monitor a source Mux doesn't host — a self-hosted HLS or DASH stream, for example. Find the key in the [Mux dashboard](https://dashboard.mux.com/settings/data):
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<HlsJsVideo src="https://example.com/stream.m3u8" />
+<MuxData envKey="YOUR_ENV_KEY" /> {/* [!code focus] */}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<hlsjs-video src="https://example.com/stream.m3u8"></hlsjs-video>
+<media-mux-data env-key="YOUR_ENV_KEY"></media-mux-data> <!-- [!code focus] -->
+```
+</FrameworkCase>
+
+An explicit key always wins, so set one to send Mux-hosted views to a specific environment.
+
+## Any media element works
+
+The component attaches to the media the player is using, not to a specific element type, so it monitors <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/dash-video">DashVideo</DocsLink>, and the rest alike. When the media exposes an [hls.js](https://github.com/video-dev/hls.js/) engine, the component hands that engine to the Mux Data SDK so it can report stream-level detail alongside the playback metrics.
+
+The `video_id` it reports is the Mux playback ID for streams served from `stream.mux.com`, and the source URL otherwise. Each view also gets a generated `view_session_id`. Override either through `metadata`.
+
+## Describe the view
+
+Pass Mux Data [metadata](https://www.mux.com/docs/guides/make-your-data-actionable-with-metadata) to label views with your own titles, viewer IDs, and custom dimensions. It's an object, so it's a property rather than an attribute:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<MuxData metadata={{ video_title: 'Big Buck Bunny', viewer_user_id: 'u_789' }} />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+const muxData = document.querySelector('media-mux-data');
+muxData.metadata = { video_title: 'Big Buck Bunny', viewer_user_id: 'u_789' }; // [!code focus]
+```
+</FrameworkCase>
+
+## Options
+
+<FrameworkCase frameworks={["react"]}>
+| Prop | Type | Description |
+|---|---|---|
+| `envKey` | `string` | Mux Data environment key the beacons are sent to. Optional for Mux-hosted playback |
+| `metadata` | `object` | Mux Data metadata for the view |
+| `playerSoftwareName` | `string` | Player name reported to Mux Data |
+| `playerSoftwareVersion` | `string` | Player version reported to Mux Data. Defaults to the Video.js version |
+| `playerInitTime` | `number` | Epoch milliseconds the player was initialized. Defaults to when the component was created |
+| `beaconCollectionDomain` | `string` | Custom domain the beacons are sent to |
+| `disableCookies` | `boolean` | Stops the SDK from setting cookies |
+| `debug` | `boolean` | Turns on SDK debug logging |
+| `MuxDataSdk` | `object` | SDK used for monitoring. Set it to `undefined` to switch monitoring off |
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+| Attribute | Property | Description |
+|---|---|---|
+| `env-key` | `envKey` | Mux Data environment key the beacons are sent to. Optional for Mux-hosted playback |
+| — | `metadata` | Mux Data metadata for the view |
+| `player-software-name` | `playerSoftwareName` | Player name reported to Mux Data |
+| `player-software-version` | `playerSoftwareVersion` | Player version reported to Mux Data. Defaults to the Video.js version |
+| `player-init-time` | `playerInitTime` | Epoch milliseconds the player was initialized. Defaults to when the element was created |
+| `beacon-collection-domain` | `beaconCollectionDomain` | Custom domain the beacons are sent to |
+| `disable-cookies` | `disableCookies` | Stops the SDK from setting cookies |
+| `debug` | `debug` | Turns on SDK debug logging |
+| — | `MuxDataSdk` | SDK used for monitoring. Set it to `undefined` to switch monitoring off |
+</FrameworkCase>
+
+Changing `MuxDataSdk`, `beaconCollectionDomain`, `debug`, or `disableCookies` restarts monitoring, which ends the current view and starts a new one. The rest update the view in place.
+
+## See also
+
+<DocsLinkCard slug="reference/mux-video">MuxVideo element reference</DocsLinkCard>
+<DocsLinkCard slug="reference/mux-audio">MuxAudio element reference</DocsLinkCard>
+<DocsLinkCard slug="concepts/cast">Google Cast — the other media component you compose onto a player</DocsLinkCard>

--- a/site/src/content/docs/concepts/mux-data.mdx
+++ b/site/src/content/docs/concepts/mux-data.mdx
@@ -37,12 +37,12 @@ export default function App() {
 <video-player>
   <media-container>
     <mux-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" playsinline></mux-video>
-    <media-mux-data></media-mux-data> <!-- [!code focus] -->
+    <mux-data></mux-data> <!-- [!code focus] -->
   </media-container>
 </video-player>
 ```
 
-Register the `<media-mux-data>` element by importing `@videojs/html/media/mux-data`.
+Register the `<mux-data>` element by importing `@videojs/html/media/mux-data`.
 </FrameworkCase>
 
 That's the whole setup for Mux-hosted playback — no environment key required. The component renders nothing; place it inside the player, as a sibling of the media element.
@@ -67,7 +67,7 @@ Set `envKey` when you monitor a source Mux doesn't host — a self-hosted HLS or
 <FrameworkCase frameworks={["html"]}>
 ```html
 <hlsjs-video src="https://example.com/stream.m3u8"></hlsjs-video>
-<media-mux-data env-key="YOUR_ENV_KEY"></media-mux-data> <!-- [!code focus] -->
+<mux-data env-key="YOUR_ENV_KEY"></mux-data> <!-- [!code focus] -->
 ```
 </FrameworkCase>
 
@@ -91,7 +91,7 @@ Pass Mux Data [metadata](https://www.mux.com/docs/guides/make-your-data-actionab
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
-const muxData = document.querySelector('media-mux-data');
+const muxData = document.querySelector('mux-data');
 muxData.metadata = { video_title: 'Big Buck Bunny', viewer_user_id: 'u_789' }; // [!code focus]
 ```
 </FrameworkCase>

--- a/site/src/content/docs/reference/cast-button.mdx
+++ b/site/src/content/docs/reference/cast-button.mdx
@@ -6,6 +6,7 @@ description: Accessible Cast toggle button with state reflection and keyboard su
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -40,6 +41,8 @@ import basicUsageHtmlTs from "@/components/docs/demos/cast-button/html/css/Basic
 Toggles a Google Cast session. Clicking the button while `disconnected` opens the Cast device picker; clicking while `connected` ends the session.
 
 The button does nothing when `availability` is not `'available'` — for example, when no Chromecast is on the network, or on browsers that don't support Cast.
+
+Cast sessions come from the <DocsLink slug="concepts/cast">Google Cast</DocsLink> component. Add it to the player next to your media element; without it the button drives the browser's native Remote Playback API instead, which offers no receiver or load-request configuration.
 
 ## Styling
 

--- a/site/src/content/docs/reference/mux-audio.mdx
+++ b/site/src/content/docs/reference/mux-audio.mdx
@@ -9,6 +9,8 @@ import MediaReference from "@/components/docs/api-reference/MediaReference.astro
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import DocsLinkCard from "@/components/docs/DocsLinkCard.astro";
 
 {/* React demos */}
 import BasicUsageDemoReact from "@/components/docs/demos/mux-audio/react/css/BasicUsage";
@@ -22,6 +24,35 @@ import basicUsageHtmlCss from "@/components/docs/demos/mux-audio/html/css/BasicU
 import basicUsageHtmlTs from "@/components/docs/demos/mux-audio/html/css/BasicUsage.ts?raw";
 
 Audio element for playing Mux-hosted HLS streams. Built on hls.js with Mux-specific optimizations.
+
+## Analytics and casting
+
+MuxAudio plays Mux streams. It doesn't monitor them or cast them — <DocsLink slug="concepts/mux-data">Mux Data</DocsLink> and <DocsLink slug="concepts/cast">Google Cast</DocsLink> are separate components you add to the player alongside it. Mux Data needs no environment key here, since Mux attributes the views to the environment that owns the playback ID:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+import { GoogleCast } from '@videojs/react/media/google-cast';
+import { MuxAudio } from '@videojs/react/media/mux-audio';
+import { MuxData } from '@videojs/react/media/mux-data';
+
+<MuxAudio source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }} />
+<MuxData playerSoftwareName="mux-audio" />
+<GoogleCast />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<mux-audio src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"></mux-audio>
+<media-mux-data player-software-name="mux-audio"></media-mux-data>
+<media-google-cast></media-google-cast>
+```
+
+Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/html/media/google-cast`.
+</FrameworkCase>
+
+<DocsLinkCard slug="concepts/mux-data">Mux Data — metadata, options, and configuration</DocsLinkCard>
+<DocsLinkCard slug="concepts/cast">Google Cast — receivers, load requests, and session state</DocsLinkCard>
 
 ## Examples
 

--- a/site/src/content/docs/reference/mux-audio.mdx
+++ b/site/src/content/docs/reference/mux-audio.mdx
@@ -44,8 +44,8 @@ import { MuxData } from '@videojs/react/media/mux-data';
 <FrameworkCase frameworks={["html"]}>
 ```html
 <mux-audio src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"></mux-audio>
-<media-mux-data player-software-name="mux-audio"></media-mux-data>
-<media-google-cast></media-google-cast>
+<mux-data player-software-name="mux-audio"></mux-data>
+<google-cast></google-cast>
 ```
 
 Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/html/media/google-cast`.

--- a/site/src/content/docs/reference/mux-video.mdx
+++ b/site/src/content/docs/reference/mux-video.mdx
@@ -44,8 +44,8 @@ import { MuxVideo } from '@videojs/react/media/mux-video';
 <FrameworkCase frameworks={["html"]}>
 ```html
 <mux-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" playsinline></mux-video>
-<media-mux-data player-software-name="mux-video"></media-mux-data>
-<media-google-cast></media-google-cast>
+<mux-data player-software-name="mux-video"></mux-data>
+<google-cast></google-cast>
 ```
 
 Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/html/media/google-cast`.

--- a/site/src/content/docs/reference/mux-video.mdx
+++ b/site/src/content/docs/reference/mux-video.mdx
@@ -9,6 +9,8 @@ import MediaReference from "@/components/docs/api-reference/MediaReference.astro
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import DocsLinkCard from "@/components/docs/DocsLinkCard.astro";
 
 {/* React demos */}
 import BasicUsageDemoReact from "@/components/docs/demos/mux-video/react/css/BasicUsage";
@@ -22,6 +24,35 @@ import basicUsageHtmlCss from "@/components/docs/demos/mux-video/html/css/BasicU
 import basicUsageHtmlTs from "@/components/docs/demos/mux-video/html/css/BasicUsage.ts?raw";
 
 Video element for playing Mux-hosted HLS streams. Built on hls.js with Mux-specific optimizations.
+
+## Analytics and casting
+
+MuxVideo plays Mux streams. It doesn't monitor them or cast them — <DocsLink slug="concepts/mux-data">Mux Data</DocsLink> and <DocsLink slug="concepts/cast">Google Cast</DocsLink> are separate components you add to the player alongside it. Mux Data needs no environment key here, since Mux attributes the views to the environment that owns the playback ID:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+import { GoogleCast } from '@videojs/react/media/google-cast';
+import { MuxData } from '@videojs/react/media/mux-data';
+import { MuxVideo } from '@videojs/react/media/mux-video';
+
+<MuxVideo source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }} playsInline />
+<MuxData playerSoftwareName="mux-video" />
+<GoogleCast />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<mux-video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" playsinline></mux-video>
+<media-mux-data player-software-name="mux-video"></media-mux-data>
+<media-google-cast></media-google-cast>
+```
+
+Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/html/media/google-cast`.
+</FrameworkCase>
+
+<DocsLinkCard slug="concepts/mux-data">Mux Data — metadata, options, and configuration</DocsLinkCard>
+<DocsLinkCard slug="concepts/cast">Google Cast — receivers, load requests, and session state</DocsLinkCard>
 
 ## Examples
 

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -42,6 +42,7 @@ export const sidebar: Sidebar = [
       { slug: 'concepts/ui-components' },
       { slug: 'concepts/accessibility' },
       { slug: 'concepts/cast', sidebarLabel: 'Google Cast' },
+      { slug: 'concepts/mux-data' },
       { slug: 'concepts/security' },
     ],
   },


### PR DESCRIPTION
Refs #1860

## Summary

Mux Data and Google Cast were composed into media elements at construction. They are their own components now — `<mux-data>` / `<google-cast>` in HTML, `MuxData` / `GoogleCast` in React — registered against whichever media the surrounding player provides. Media elements compose nothing by default.

## API changes

**New components.** Both render nothing and sit next to the media element inside the player. HTML options are attributes, React options are props.

```html
<video-player>
  <media-container>
    <mux-video src="https://stream.mux.com/abc123.m3u8" playsinline></mux-video>
    <mux-data player-software-name="mux-video"></mux-data>
    <google-cast receiver="YOUR_APP_ID"></google-cast>
  </media-container>
</video-player>
```

```tsx
<Player.Provider>
  <Player.Container>
    <MuxVideo source={{ playbackId: 'abc123' }} playsInline />
    <MuxData playerSoftwareName="mux-video" />
    <GoogleCast receiver="YOUR_APP_ID" />
  </Player.Container>
</Player.Provider>
```

Entry points: `@videojs/html/media/{mux-data,google-cast}` (also `@videojs/html/cdn/media/*`) and `@videojs/react/media/{mux-data,google-cast}`.

**Removed: implicit composition.** `<mux-video>` / `<mux-audio>` no longer monitor playback, and the HLS and DASH elements no longer register a Cast sender.

```diff
- <hlsjs-video src="…"></hlsjs-video>
+ <hlsjs-video src="…"></hlsjs-video>
+ <google-cast></google-cast>
```

**Removed: `config` namespace routing.** Options go on the component directly.

```diff
- video.config = { googleCast: { receiver: 'YOUR_APP_ID' } };
+ document.querySelector('google-cast').receiver = 'YOUR_APP_ID';
```

```diff
- <MuxVideo config={{ muxData: { envKey: 'KEY' } }} />
+ <MuxVideo />
+ <MuxData envKey="KEY" />
```

`MediaComponentConfig` and `MediaComponentConstructor.configKey` are gone; `MediaConfig` is now `Record<string, unknown>`. `config` still carries host/engine settings (`preferPlayback`, `contentType`, `hlsJs`).

**New building blocks** for composing your own media component: `MediaComponentElement` (HTML) and `useMediaComponent` (React), plus `googleCastDefaultProps` / `muxDataDefaultProps` from `@videojs/media`.

<details>
<summary>Implementation details</summary>

`MediaComponentElement` consumes `mediaContext`, resolves the media host from the context value (a media custom element's `.host`, or the host itself), and registers on change, disconnect, and destroy. `useMediaComponent` does the same through the player context.

The component instance comes from an abstract `createComponent()` behind a lazy getter rather than a field. Upgrading an element that is already in the document runs its constructor while connected, so `addController` requests media context from within that constructor — before subclass field initializers run. A field there resolves to `undefined` and throws in `addMediaComponent`.

Mux Data needs no `envKey` for Mux-hosted playback: the view already reports the Mux playback ID as its `video_id`, which Mux attributes to the owning environment.

</details>

## Testing

- `pnpm -F @videojs/media test` (401), `pnpm -F @videojs/html test` (271), `pnpm -F @videojs/react test` (366), `pnpm -F @videojs/core test` (1325), `pnpm -F site test` (512)
- `pnpm typecheck`, `pnpm build:site`
- Verified in Chromium against the CDN bundles with markup parsed before the definitions load, so the elements upgrade in place while connected: both register, `player-software-name` reaches the component, no errors. happy-dom can't cover this — it reports `isConnected` as `false` during an upgrade.
- Manual: `pnpm dev` → `html-mux-video`, `react-mux-video`, `html-mux-audio`, `react-mux-audio`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change: apps that relied on automatic Mux monitoring or Cast on media elements must add new components and migrate off `config.muxData`/`config.googleCast`.
> 
> **Overview**
> **Mux Data** and **Google Cast** are no longer wired into `mux-video`, `mux-audio`, or HLS/DASH media elements at construction. They are **opt-in** siblings inside the player: `<mux-data>` / `<google-cast>` (HTML) and `MuxData` / `GoogleCast` (React), which register with whatever media the player context provides.
> 
> The **`config` namespace routing is removed** (`config.googleCast`, `config.muxData`, `MediaComponentConfig`, `configKey`). Cast and Mux options are set on the new components directly; `config` remains for host/engine settings only.
> 
> New composition primitives: **`MediaComponentElement`** (HTML) and **`useMediaComponent`** (React), plus CDN entry points for the new elements. **Host `destroy()`** now detaches and clears registrations without calling `destroy()` on components—the markup/React owner owns lifecycle. Sandboxes and docs are updated to show explicit composition and a new Mux Data concept page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b534fdaa8623afd8c1c83c0de63c502e6bea1541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

