### PR TITLE
fix(packages): prevent controls click triggering interactions

### DIFF
--- a/apps/e2e/tests/gestures.spec.ts
+++ b/apps/e2e/tests/gestures.spec.ts
@@ -53,6 +53,13 @@ test.describe('Mouse Gestures', () => {
     await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
   });
 
+  test('click on controls container does not trigger container gesture', async () => {
+    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
+    await player.controls.dispatchEvent('pointerdown', { button: 0, pointerType: 'mouse' });
+    await player.controls.dispatchEvent('pointerup', { button: 0, pointerType: 'mouse' });
+    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
+  });
+
   test('click on slider does not trigger container gesture', async ({ page }) => {
     // Start playback so the slider has a seekable range
     await player.play();
@@ -89,6 +96,13 @@ test.describe('React Mouse Gestures', () => {
     await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
     await player.playButton.click();
     await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused, { timeout: 5_000 });
+  });
+
+  test('click on controls container does not trigger container gesture', async () => {
+    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
+    await player.controls.dispatchEvent('pointerdown', { button: 0, pointerType: 'mouse' });
+    await player.controls.dispatchEvent('pointerup', { button: 0, pointerType: 'mouse' });
+    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
   });
 
   test('click on slider does not trigger container gesture', async ({ page }) => {

--- a/packages/core/src/dom/gesture/tests/gesture.test.ts
+++ b/packages/core/src/dom/gesture/tests/gesture.test.ts
@@ -464,6 +464,24 @@ describe('interactive child filtering', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it('does not fire from any child inside a marked controls surface', () => {
+    const container = setup();
+    const controls = document.createElement('div');
+    const label = document.createElement('span');
+    controls.setAttribute('data-interactive', '');
+    controls.appendChild(label);
+    container.appendChild(controls);
+
+    const handler = vi.fn();
+    createTapGesture(container, handler);
+
+    pointerDown(label);
+    vi.advanceTimersByTime(50);
+    pointerUp(label, { pointerType: 'mouse', clientX: 150 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('fires when event originates from a non-interactive child', () => {
     const container = setup();
     const overlay = document.createElement('div');

--- a/packages/html/src/ui/controls/controls-element.ts
+++ b/packages/html/src/ui/controls/controls-element.ts
@@ -20,6 +20,8 @@ export class ControlsElement extends MediaElement {
   override connectedCallback(): void {
     super.connectedCallback();
 
+    this.setAttribute('data-interactive', '');
+
     if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -98,6 +98,18 @@ afterEach(() => {
 });
 
 describe('ControlsElement', () => {
+  it('marks the controls surface as interactive', async () => {
+    const provider = document.createElement('test-controls-player-provider') as TestPlayerProviderElement;
+    const controls = createDefinedElement(ControlsElement);
+
+    document.body.append(provider);
+    provider.append(controls);
+
+    await controls.updateComplete;
+
+    expect(controls.hasAttribute('data-interactive')).toBe(true);
+  });
+
   it('closes owned popovers, menus, and tooltips when controls hide', async () => {
     const provider = document.createElement('test-controls-player-provider') as TestPlayerProviderElement;
     const controls = createDefinedElement(ControlsElement);

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -42,7 +42,7 @@ export const ControlsRoot = forwardRef(function ControlsRoot(
           state,
           stateAttrMap: ControlsDataAttrs,
           ref: [forwardedRef],
-          props: [{ children }, elementProps],
+          props: [{ children }, elementProps, { 'data-interactive': '' }],
         }
       )}
     </ControlsContextProvider>

--- a/packages/react/src/ui/controls/tests/controls.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { ControlsRoot } from '../controls-root';
+
+describe('ControlsRoot', () => {
+  it('marks the controls surface as interactive', () => {
+    const { Wrapper } = createPlayerWrapper({
+      controlsVisible: true,
+      userActive: true,
+    });
+    const { getByTestId } = render(<ControlsRoot data-testid="controls" />, { wrapper: Wrapper });
+
+    expect(getByTestId('controls').hasAttribute('data-interactive')).toBe(true);
+  });
+});


### PR DESCRIPTION
Add the `data-interactive` escape hatch the controls container, preventing clicks from triggering any click interactions bound to the main container. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted DOM attribute change with tests; affects gesture hit-testing only, not playback or auth.
> 
> **Overview**
> Clicks on the **controls bar** (not just individual buttons or sliders) were still bubbling into the player’s container tap gesture and could toggle play/pause. This PR marks the whole controls root as an interactive surface so those pointer events are ignored by container gestures.
> 
> **HTML** `ControlsElement` sets `data-interactive` in `connectedCallback`. **React** `ControlsRoot` passes the same attribute on its root `div`. Unit tests cover both implementations, core gesture behavior for descendants inside a `data-interactive` ancestor, and **e2e** tests for HTML and React verify pointer events on the controls container do not change playback state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3be0a229f51c35700e38f096957d1ce8eaca146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->