### PR TITLE
feat: content metadata via provider config and derived store state

### DIFF
--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -204,7 +204,8 @@ function reactVideoPage(media: string, resource: string, config: MediaTypeConfig
     ? `import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';`
     : `import { ${reactMedia.component} } from '${reactMedia.importPath}';\nimport { VideoSkin, videoFeatures } from '@videojs/react/video';`;
 
-  const posterProp = config.hasPoster ? ` poster={MEDIA.${resource}.poster}` : '';
+  // The poster is a provider prop now; the skin reads the resolved value.
+  const posterProp = config.hasPoster ? ` contentPoster={MEDIA.${resource}.poster}` : '';
   const storyboardTrack = config.hasStoryboard
     ? `\n          <track kind="metadata" label="thumbnails" src={MEDIA.${resource}.storyboard} default />`
     : '';
@@ -219,8 +220,8 @@ const Player = createPlayer({ features: videoFeatures });
 
 function App() {
   return (
-    <Player.Provider>
-      <VideoSkin${posterProp} style={{ maxWidth: 800, aspectRatio: '16/9' }}>
+    <Player.Provider${posterProp}>
+      <VideoSkin style={{ maxWidth: 800, aspectRatio: '16/9' }}>
         <${reactMedia.component} src={MEDIA.${resource}.url} playsInline crossOrigin="anonymous">${storyboardTrack}
         </${reactMedia.component}>
       </VideoSkin>

--- a/apps/sandbox/templates/react-dash-video/main.tsx
+++ b/apps/sandbox/templates/react-dash-video/main.tsx
@@ -29,7 +29,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <VideoProvider>
+      <VideoProvider contentPoster={poster}>
         <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
           <DashVideo
             src={SOURCES[source].url}

--- a/apps/sandbox/templates/react-hlsjs-video/main.tsx
+++ b/apps/sandbox/templates/react-hlsjs-video/main.tsx
@@ -36,14 +36,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="aspect-video max-w-4xl mx-auto"
-        >
+      <Provider contentPoster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="aspect-video max-w-4xl mx-auto">
           <HlsJsVideo
             src={SOURCES[source].url}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -35,9 +35,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
+      <Provider contentPoster={poster}>
         <VideoSkinComponent
-          poster={poster}
           placeholder={placeholder}
           skin={skin}
           styling={styling}

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -36,14 +36,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="w-full aspect-video max-w-4xl mx-auto"
-        >
+      <Provider contentPoster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="w-full aspect-video max-w-4xl mx-auto">
           <NativeHlsVideo
             src={SOURCES[source].url}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-simple-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-simple-hls-video/main.tsx
@@ -36,14 +36,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="aspect-video max-w-4xl mx-auto"
-        >
+      <Provider contentPoster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="aspect-video max-w-4xl mx-auto">
           <SimpleHlsVideo
             src={SOURCES[source].url}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-video/main.tsx
+++ b/apps/sandbox/templates/react-video/main.tsx
@@ -33,8 +33,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <VideoProvider>
-        <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+      <VideoProvider contentPoster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
           <Video
             src={SOURCES[source].url}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-vimeo-video/main.tsx
+++ b/apps/sandbox/templates/react-vimeo-video/main.tsx
@@ -17,7 +17,7 @@ function App() {
   const styling = useMemo(readStyling, []);
 
   return (
-    <VideoProvider>
+    <VideoProvider contentPoster={poster}>
       <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <VimeoVideo className="block w-full h-full" src={VIMEO_VIDEO_SRC} playsInline />
       </VideoSkinComponent>

--- a/internal/decisions/media/content-metadata.md
+++ b/internal/decisions/media/content-metadata.md
@@ -1,0 +1,41 @@
+---
+status: decided
+date: 2026-07-29
+---
+
+# Content metadata on the media API
+
+## Decision
+
+The media API gains three capabilities — `contentTitle`, `contentPoster`, and `contentPosterAlt` — each with its own change event and predicate.
+
+Four rules govern them:
+
+- **They are separate from `title` and `poster`, deliberately, and are not reconciled with them.**
+- **"Nothing" is `null` or `undefined`. An empty string is a real value** meaning deliberately blank.
+- **A media must never manufacture `''`** to stand in for absence.
+- **A media that reports a field clears it on source change and dispatches the change event.**
+
+## Context
+
+A developer often knows a video's title from their CMS. A media element often knows it too — a `mux-video` can fetch it from the Mux API. The player has to reconcile the two, which requires the media layer to have somewhere to *say* it. Adding these properties to the media surface is that whole job; how a given element populates them is its own business.
+
+The player-side half — three tier slots per field and a fixed resolve order — is [derived-state.md](../store/derived-state.md).
+
+## Alternatives Considered
+
+- **Reuse `title` and `poster`** — rejected. Those are the *developer's* settings on the element: the native tooltip, the `<video poster>` frame. The `content*` properties are *facts about the content*, usually from a backend. Merging them would erase a distinction that has real consequences — a developer setting `poster` for a frame to show before playback is not making a claim about the content. The plain names are out of scope for this work rather than a migration target.
+- **One capability holding every field** — rejected, and it contained a contradiction. Support was to be decided by whether the property is *declared*, but a `mux-video` offering a title and no poster would then either declare a `contentPoster` it can never fill or fail the check for a capability it partly implements. Per-field capabilities dissolve that structurally. The decisive argument: metadata will grow, and there is no way to require all of it from every donor. The accepted cost is that eight fields eventually means eight capabilities and eight events.
+- **Spell absence as `undefined`** — rejected. Both `null` and `undefined` read as absent to the resolve chain, but the predicates test `!isUndefined`, so `undefined` would make capability *flicker* as an attribute came and went. A feature checks capability once at attach and wires its listener then, so an attribute unset at that moment would mean a value arriving later never reaches the store. `null` keeps a declaring host permanently capable.
+- **Presence-based detection (`'contentTitle' in media`)** — rejected on consistency and correctness. All the predicates in `predicate.ts` use `!isUndefined`; the sole `in` check tests for a method. `in` also walks the prototype chain, so a getter on a shared host would make every host report capable.
+- **An `emptied` backstop in the player feature** — rejected. See below.
+
+## Rationale
+
+`empty: null` on the `CustomMediaElement` declarations is what makes the empty-string rule work end to end: removing `content-title` yields `null` (absent, fall through), while `content-title=""` yields `''` (present, suppress). The neighbouring `poster` and `src` declarations collapse to `''` — the wrong precedent sitting immediately beside the right one, `preload`.
+
+Suppression is why two empty-ish states are unavoidable. `content-title=""` — the backend supplies a title, the developer wants none shown — is expected to be common. Given that requirement, the only real choice is which of empty-string and null means which, and the platform already answers it: a removed attribute is absent, an attribute set to empty is present-and-empty.
+
+Capability is effectively constant for these fields, and that is accepted knowingly rather than discovered later. Any media host can carry a content title, so there is nothing to gate; the predicate is a formality that keeps the shape consistent with its neighbours.
+
+**The clearing contract's two halves are not equally enforced, and this matters to implementers.** Dispatching on change is structural — assigning through the host setter fires the event, so an implementer would have to work at skipping it. Clearing on source change is pure convention with nothing checking it. The player wires no fallback `emptied` listener, matching what the stream-type feature already assumes and what `hls-js` already honours by resetting itself on `MANIFEST_LOADING` and `DESTROYING`. A third-party media that declares a field and never clears it will show a stale value across a source change. That is a documented contract violation rather than a player bug, and adding defence-in-depth was judged not worth the weight — but it is the thing to check first if stale metadata is ever reported.

--- a/internal/decisions/store/derived-state.md
+++ b/internal/decisions/store/derived-state.md
@@ -1,0 +1,46 @@
+---
+status: decided
+date: 2026-07-29
+---
+
+# Derived state and symbol-keyed tier slots
+
+## Decision
+
+`@videojs/store` gains a `derived` primitive: a slice may declare formulas alongside its state, and the store computes them eagerly inside `patch`, folding the answers into the same frozen snapshot before it notifies.
+
+Three rules make it small:
+
+- **No dependency tracking.** Every formula reruns on every patch that changed something.
+- **A formula reads source keys only.** Reading another formula's output is a compile error, which is what removes run ordering and cycle detection.
+- **The formula is the only writer of its key.** `patch` strips derived keys from incoming partials and warns in `__DEV__`.
+
+Separately, features may keep **symbol-keyed slots** in their state as private inputs to a formula. `patch` iterates with `Reflect.ownKeys` so symbol keys participate; `createStore` installs accessors from `Object.keys`, so those slots get no public getter.
+
+This supersedes the "computed values keep derivation lazy" clause of [reactive-state.md](./reactive-state.md).
+
+## Context
+
+The content metadata feature needs one field to resolve from three independent inputs — a developer override, whatever the media reports, and a developer fallback — in a fixed order, no matter which arrives first. Separate slots per input resolve identically however the writes land; a single slot with write-time precedence reduces to last-write-wins with extra bookkeeping.
+
+That leaves the question of who computes the answer. Recomputing by hand at every write site worked until `detach`: it resets state by re-applying the initial state, which lives inside the store, so no feature-owned recompute can hang off it. The resolved value would snap back to the library default while the developer's override still sat in its slot — the exact bug the primitive exists to prevent.
+
+Full exploration in the metadata design notes; the tier model and its consequences are covered by [content-metadata.md](../media/content-metadata.md) on the media side.
+
+## Alternatives Considered
+
+- **Automatic dependency tracking** — a formula records what it read and reruns only when one of those keys changes. Rejected for now. The performance argument does not survive counting: a handful of formulas doing three or four property reads each costs about what deciding whether to rerun them costs, and the same `timeupdate` is re-rendering a progress bar. It also needs re-recording on every run, because a nullish-coalescing chain that finds a value early never reads the later slots and so understates its real dependencies. Formulas are authored as `({ get }) => …` either way, so tracking can be added later without editing a single formula.
+- **Compute on read** — expose derived values as getters on the snapshot. Rejected: `patch` spreads the current state, which flattens a getter into a stale value, so getters would have to be reinstalled after every patch and in the constructor. Eager keeps derived values ordinary properties, so store getters, selectors, `store.state`, and `shallowEqual` need no changes at all.
+- **One widened state type instead of a source/derived split** — rejected because it would make the type system assert two false things: that `combine`'s merged `state()` output contains the derived keys, and that a feature's `set` may write them.
+- **Visible string keys for tier slots** — honestly the more conventional choice, and it would make the slots show up in devtools and selector output for free. Rejected because those slots are implementation detail of one feature's resolve chain, not player state: every consumer wants the resolved answer, and three extra public keys per field (times however many metadata fields eventually land) is a large public surface to buy debuggability. The mitigation is that symbol keys are *internal, not secret* — `Reflect.ownKeys` on a snapshot still lists them. If debugging these turns out to be genuinely painful, a `__DEV__` inspection helper is the cheaper fix.
+- **Teaching the store which keys survive `detach`** — rejected. The information already exists in the feature: media slots are seeded in `state()` so the reset clears them, and developer slots are left out so it cannot reach them.
+
+## Rationale
+
+Eager compute-and-store is the version that changes the least. Every existing read path keeps working, because a derived key is still an ordinary value in a frozen snapshot.
+
+Making the formula the sole writer is what buys the real property: **`detach` stops being order-dependent.** Whether cleanup or the reset runs first, the source keys end up the same and the formula produces the same answer. Under hand-rolled recompute the ordering was load-bearing and silent when broken — a trap for whoever next touched `detach`.
+
+The honest cost of dropping tracking is that formulas must stay cheap, which is now documented on the `derived` field. The trigger to revisit is formula count or formula cost growing enough to measure.
+
+One acknowledged tension with [reactive-state.md](./reactive-state.md) beyond laziness: that record valued explicit updates partly because they make it obvious which keys a write changes, and a `derived` map means `patch({ someTier })` can change a key the caller never named. That is a real reduction in explicitness, accepted because the alternative — every call site remembering to write the tier and the answer together — moves the same knowledge somewhere less reliable and punishes forgetting with a silently wrong value.

--- a/internal/decisions/store/reactive-state.md
+++ b/internal/decisions/store/reactive-state.md
@@ -5,6 +5,10 @@ date: 2026-07-13
 
 # Use explicit store state and computed values
 
+> **Partly superseded 2026-07-29 by [derived-state.md](./derived-state.md).** Derivation is now eager rather than lazy, and a `derived` map means a patch can change keys the caller did not name — a real reduction in the explicitness this record valued. That record argues the trade-off. Everything else here still holds: no proxy mutation, no public queue, frozen snapshots, target-specific async in slices.
+>
+> Note also that "computed values" in the prose below most likely describes **selectors**, which exist and are lazy at read. It should not be read as a mandate that the newer `derived` primitive was fulfilling.
+
 ## Decision
 
 `@videojs/store` uses explicit state updates and computed values rather than proxy mutation, a public request queue, or implicit task orchestration.

--- a/internal/design/ui/poster-placeholder.md
+++ b/internal/design/ui/poster-placeholder.md
@@ -19,6 +19,21 @@ Poster placeholders provide a low-resolution or first-frame visual while the fin
 
 The same concept works in React and HTML and remains skinnable without a JavaScript animation API. Consumers are responsible for choosing a safe placeholder URL and for any media-frame generation policy.
 
+> **Note 2026-07-29 — the placeholder stays consumer-supplied; the poster no
+> longer has to be.** `content-poster` on the provider means the *poster* URL can
+> now come from the store, while "let a consumer supply the placeholder directly"
+> above is unchanged: the placeholder is a genuinely different image and a
+> different concept, not a low-resolution variant the player can derive.
+>
+> A store-backed placeholder (`contentPlaceholder`) is plausible future work and
+> deliberately not designed here. Whoever picks it up will hit this record's
+> first decision as a real tension and should read the blur-up implementation
+> first — the CSS custom property plus React's `loadedSrc` crossfade tracking.
+>
+> "Keep the placeholder decorative" also still holds, and is now load-bearing in
+> a second way: the poster owns the accessible name, and that name comes from
+> `content-poster-alt` when the author does not supply one.
+
 ## Current sources of truth
 
 - React implementation: `packages/react/src/ui/poster/poster.tsx`

--- a/internal/design/ui/poster.md
+++ b/internal/design/ui/poster.md
@@ -42,6 +42,35 @@ Like Media Chrome — component owns the `<img>` internally.
 
 Our approach makes the flexible path the default.
 
+> **Amended 2026-07-29 — the poster URL can come from the store.** With
+> `content-poster` settable on the provider, the poster reaches the screen by
+> **filling in, not taking over**, so the reasoning above still holds. React's
+> `<Poster>` reads the resolved value only when given no `src`; HTML's
+> `<media-poster>` fills an empty `src` on the image the author supplied and never
+> creates one. `srcset`, `loading`, `<picture>`, and framework image components
+> all keep working, and a local `src` short-circuits the store entirely.
+>
+> A local `src` is therefore not a fourth precedence tier — the component only
+> decides *whether to ask*. See
+> [content-metadata.md](/internal/decisions/media/content-metadata.md).
+>
+> **The platform asymmetry is deliberate.** React's component owns its image;
+> HTML's element is a wrapper around yours. User-visible behaviour is identical
+> and each side follows its platform's grain. Giving `<media-poster>` a shadow
+> root with an owned image is the only shape where zero author markup works, but
+> it was rejected: it adds a shadow root to an element family that deliberately
+> has none, needs part-based styling for the fallback, and needs manual slot
+> assignment, since native fallback content is suppressed when an empty slot
+> element is itself the assigned content. Default skins get zero-markup behaviour
+> instead by putting a fallback `<img>` inside their own poster slot.
+>
+> **`alt` is decided by presence, never emptiness.** An author writing `alt=""` is
+> deliberately marking the image decorative — which is what this record's
+> accessibility section already says is the author's judgment — so the element
+> fills a *missing* `alt` and never an empty one. The store supplies it via
+> `content-poster-alt`, whose library default is the empty string: decorative
+> rather than an image with no accessible name.
+
 ## Future
 
 1. **`data-ended`** — Show poster when media ends.

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -1,48 +1,15 @@
-import { type AttachContext, defineSlice, type SliceConfig, type StateContext } from '@videojs/store';
-import { isUndefined } from '@videojs/utils/predicate';
-import type { PlayerFeature, PlayerTarget } from './player';
+import type { EmptyObject } from '@videojs/utils/types';
+import type { PlayerFeature } from './player';
 
-export interface ConfigurablePlayerFeature<Config, State> extends PlayerFeature<State> {
-  (config?: Config): PlayerFeature<State>;
-}
-
-export interface ConfigurablePlayerFeatureConfig<Config, State>
-  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'state'> {
-  state: (ctx: StateContext<PlayerTarget>, config: Config) => State;
-  attach?: (ctx: AttachContext<PlayerTarget, State>, config: Config) => void;
-}
-
-const definePlayerSlice = defineSlice<PlayerTarget>();
-
-export function definePlayerFeature<State>(config: SliceConfig<PlayerTarget, State>): PlayerFeature<State>;
-export function definePlayerFeature<Config, State>(
-  config: ConfigurablePlayerFeatureConfig<Config, State>,
-  defaultConfig: Config
-): ConfigurablePlayerFeature<Config, State>;
-export function definePlayerFeature<Config, State>(
-  config: SliceConfig<PlayerTarget, State> | ConfigurablePlayerFeatureConfig<Config, State>,
-  defaultConfig?: Config
-): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> {
-  if (arguments.length === 1) {
-    return definePlayerSlice(config as SliceConfig<PlayerTarget, State>);
-  }
-
-  const { name, state, attach } = config as ConfigurablePlayerFeatureConfig<Config, State>;
-
-  const forConfig = (featureConfig: Config): PlayerFeature<State> =>
-    definePlayerSlice({
-      ...(isUndefined(name) ? {} : { name }),
-      state: (ctx) => state(ctx, featureConfig),
-      ...(attach ? { attach: (ctx) => attach(ctx, featureConfig) } : {}),
-    });
-
-  const defaultFeature = forConfig(defaultConfig as Config);
-  const feature = ((featureConfig?: Config) =>
-    isUndefined(featureConfig) ? defaultFeature : forConfig(featureConfig)) as ConfigurablePlayerFeature<Config, State>;
-
-  feature.state = defaultFeature.state;
-  if (defaultFeature.attach) feature.attach = defaultFeature.attach;
-  if (!isUndefined(name)) Object.defineProperty(feature, 'name', { value: name });
-
-  return feature;
+/**
+ * Defines a player feature: a store slice scoped to {@link PlayerTarget}, plus
+ * optional declarations for fields the developer can set on the provider.
+ *
+ * @param config - The feature's state, derived values, attach behaviour, and
+ *   provider prop declarations.
+ */
+export function definePlayerFeature<State, Derived = EmptyObject, ProviderProps = EmptyObject>(
+  config: PlayerFeature<State, Derived, ProviderProps>
+): PlayerFeature<State, Derived, ProviderProps> {
+  return config;
 }

--- a/packages/core/src/dom/index.ts
+++ b/packages/core/src/dom/index.ts
@@ -9,6 +9,7 @@ export * from './hotkey/coordinator';
 export * from './hotkey/hotkey';
 export * from './hotkey/hotkey-events';
 export * from './player';
+export * from './provider-props';
 export * from './store/features';
 export * from './store/selectors';
 export * from './ui/alert-dialog';

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -16,7 +16,15 @@ import type {
   MediaTimeState,
   MediaVolumeState,
 } from '@videojs/media';
-import type { AnySlice, Slice, Store, UnionSliceState } from '@videojs/store';
+import type { SliceConfig, Store, UnionSliceState } from '@videojs/store';
+import type { EmptyObject } from '@videojs/utils/types';
+import type { ProviderPropDeclarations } from './provider-props';
+// Type-only import, so the cycle back through `feature.ts` has no runtime edge.
+import type {
+  ContentMetadataDerived,
+  ContentMetadataProviderProps,
+  ContentMetadataSource,
+} from './store/features/content-metadata';
 
 export interface MediaContainer extends HTMLElement {}
 
@@ -25,9 +33,27 @@ export interface PlayerTarget {
   container: MediaContainer | null;
 }
 
-export type PlayerFeature<State> = Slice<PlayerTarget, State>;
+/**
+ * A store slice scoped to a player, optionally declaring fields the developer
+ * can set on the provider.
+ *
+ * `Derived` and `ProviderProps` both default to `{}`, so every existing
+ * `PlayerFeature<SomeState>` keeps compiling untouched.
+ */
+export interface PlayerFeature<State, Derived = EmptyObject, ProviderProps = EmptyObject>
+  extends SliceConfig<PlayerTarget, State, Derived> {
+  /**
+   * Fields this feature exposes on the player provider, as props in React and
+   * attributes in HTML.
+   *
+   * Named `providerProps` rather than `config`: "config" is already taken three
+   * times over in this codebase — store lifecycle callbacks, the media host's
+   * config bag, and the feature-configuration path this replaces.
+   */
+  providerProps?: ProviderPropDeclarations<State, ProviderProps>;
+}
 
-export type AnyPlayerFeature = AnySlice<PlayerTarget>;
+export type AnyPlayerFeature = PlayerFeature<any, any, any>;
 
 export type PlayerStore<Features extends AnyPlayerFeature[] = []> = Store<PlayerTarget, UnionSliceState<Features>>;
 
@@ -52,6 +78,7 @@ export type VideoFeatures = [
   PlayerFeature<MediaControlsState>,
   PlayerFeature<MediaTextTrackState>,
   PlayerFeature<MediaErrorState>,
+  PlayerFeature<ContentMetadataSource, ContentMetadataDerived, ContentMetadataProviderProps>,
 ];
 
 export type AudioFeatures = [
@@ -62,6 +89,7 @@ export type AudioFeatures = [
   PlayerFeature<MediaSourceState>,
   PlayerFeature<MediaBufferState>,
   PlayerFeature<MediaErrorState>,
+  PlayerFeature<ContentMetadataSource, ContentMetadataDerived, ContentMetadataProviderProps>,
 ];
 
 // TODO: Define background video features (e.g., playback, source, buffer)
@@ -86,6 +114,7 @@ export type LiveVideoFeatures = [
   PlayerFeature<MediaTextTrackState>,
   PlayerFeature<MediaErrorState>,
   PlayerFeature<MediaLiveState>,
+  PlayerFeature<ContentMetadataSource, ContentMetadataDerived, ContentMetadataProviderProps>,
 ];
 
 /**
@@ -102,6 +131,7 @@ export type LiveAudioFeatures = [
   PlayerFeature<MediaBufferState>,
   PlayerFeature<MediaErrorState>,
   PlayerFeature<MediaLiveState>,
+  PlayerFeature<ContentMetadataSource, ContentMetadataDerived, ContentMetadataProviderProps>,
 ];
 
 export type VideoPlayerStore = PlayerStore<VideoFeatures>;

--- a/packages/core/src/dom/presentation/orientation.ts
+++ b/packages/core/src/dom/presentation/orientation.ts
@@ -16,6 +16,11 @@ export type ScreenOrientationLockType =
   | 'portrait-secondary';
 
 export interface ScreenOrientationLockConfig {
+  /**
+   * Orientation to lock to. Read when the lock is requested rather than when the
+   * lock is created, so a caller may supply a getter that tracks a changing
+   * value.
+   */
   type?: ScreenOrientationLockType | undefined;
 }
 
@@ -24,9 +29,7 @@ interface ScreenOrientation {
   unlock?: (() => void) | undefined;
 }
 
-export function createScreenOrientationLock({
-  type = 'landscape',
-}: ScreenOrientationLockConfig = {}): ScreenOrientationLock {
+export function createScreenOrientationLock(config: ScreenOrientationLockConfig = {}): ScreenOrientationLock {
   let locked = false;
   let desired = false;
 
@@ -52,7 +55,7 @@ export function createScreenOrientationLock({
       if (!isFunction(lock)) return;
 
       try {
-        await lock.call(orientation, type);
+        await lock.call(orientation, config.type ?? 'landscape');
       } catch {
         return;
       }

--- a/packages/core/src/dom/provider-props.ts
+++ b/packages/core/src/dom/provider-props.ts
@@ -1,0 +1,203 @@
+import type { EmptyObject, Simplify, UnionToIntersection } from '@videojs/utils/types';
+import type { AnyPlayerFeature, PlayerFeature } from './player';
+
+// ----------------------------------------
+// Declaration
+// ----------------------------------------
+
+/** Constructors a provider prop may declare. Mirrors `PropertyDeclaration`'s `type`. */
+export type ProviderPropConstructor = typeof String | typeof Number | typeof Boolean;
+
+/** The constructor a given prop value type must declare. */
+export type ProviderPropConstructorFor<Value> = [Value] extends [string]
+  ? typeof String
+  : [Value] extends [number]
+    ? typeof Number
+    : [Value] extends [boolean]
+      ? typeof Boolean
+      : never;
+
+/** The names of a feature's own single-argument actions — the only valid write targets. */
+export type ProviderPropAction<State> = {
+  [K in keyof State]: State[K] extends (value: any) => any ? K : never;
+}[keyof State] &
+  string;
+
+/**
+ * How a feature exposes one user-settable field on the player provider.
+ *
+ * A feature that declares nothing contributes no props, which is every feature
+ * shipping today. Opting in is deliberate.
+ */
+export interface ProviderPropDeclaration<State, Value> {
+  /**
+   * Used for HTML attribute coercion and to check the declared prop type.
+   * Passed through to the element's `static properties` unchanged.
+   */
+  type: ProviderPropConstructorFor<Value>;
+  /**
+   * HTML attribute name. **Mandatory, not stylistic.** `ReactiveElement`
+   * registers the property name verbatim, and both the HTML parser and
+   * `setAttribute` lowercase attribute names — so a camelCase property without
+   * an explicit attribute would observe a name HTML can never produce, leaving
+   * the attribute silently dead.
+   */
+  attribute: string;
+  /**
+   * Name of the feature's own action that writes this field.
+   *
+   * Explicit rather than inferred from the property name. The tier slots behind
+   * a field are symbol keys private to the feature, and the provider is generic
+   * — built once for any feature set — so it has no way to reach them. Naming an
+   * action is how a generic provider hands a value to a feature that knows what
+   * to do with it, and it means the attribute path and the imperative path
+   * (`store.setContentTitle(...)`) run through one function and cannot drift.
+   */
+  action: ProviderPropAction<State>;
+}
+
+/** Every provider prop a feature declares, keyed by prop name. */
+export type ProviderPropDeclarations<State, Props> = {
+  [K in keyof Props]-?: ProviderPropDeclaration<State, NonNullable<Props[K]>>;
+};
+
+// ----------------------------------------
+// Inference
+// ----------------------------------------
+
+export type InferProviderProps<F> = F extends PlayerFeature<any, any, infer Props> ? Props : EmptyObject;
+
+/**
+ * Flattens the provider props of a feature list into one object type.
+ *
+ * This is what makes a prop exist only when its feature is composed — the same
+ * mechanism `UnionSliceState` already uses for state.
+ */
+export type UnionProviderProps<Features extends readonly AnyPlayerFeature[]> = Simplify<
+  UnionToIntersection<InferProviderProps<Features[number]>>
+>;
+
+// ----------------------------------------
+// Collection
+// ----------------------------------------
+
+export interface CollectedProviderProp {
+  name: string;
+  attribute: string;
+  type: ProviderPropConstructor;
+  action: string;
+}
+
+/** Prop names React reserves, which a feature must not shadow. */
+const RESERVED_PROP_NAMES = new Set(['children', 'key', 'ref']);
+
+/**
+ * Walks a feature list once and flattens every declaration into a single map.
+ *
+ * Called at `createPlayer` time, outside the component and outside the mixin,
+ * because the feature list is fixed by then.
+ */
+export function collectProviderProps(features: readonly AnyPlayerFeature[]): Map<string, CollectedProviderProp> {
+  const collected = new Map<string, CollectedProviderProp>();
+
+  for (const feature of features) {
+    const declarations = feature.providerProps;
+    if (!declarations) continue;
+
+    for (const [name, declaration] of Object.entries(declarations) as [
+      string,
+      ProviderPropDeclaration<unknown, unknown>,
+    ][]) {
+      if (__DEV__ && collected.has(name)) {
+        console.error(
+          `[vjs-player] createPlayer(): two features declare the provider prop "${name}" — the later one wins`
+        );
+      }
+
+      collected.set(name, {
+        name,
+        attribute: declaration.attribute,
+        type: declaration.type as ProviderPropConstructor,
+        action: declaration.action as string,
+      });
+    }
+  }
+
+  return collected;
+}
+
+/**
+ * Dev-only check that no declared prop name shadows something already on the
+ * provider.
+ *
+ * The trap this catches is not obvious. Declared props become entries in
+ * `static properties`, which `ReactiveElement` turns into real accessors with
+ * `Object.defineProperty(ctor.prototype, name, ...)`. Its own guard tests
+ * `Object.getOwnPropertyDescriptor`, which inspects *only* own properties — so a
+ * standard DOM property like `title`, living several links up the prototype
+ * chain, is invisible to it. The accessor gets installed anyway, shadowing the
+ * browser's property: setting `title` stops producing a native tooltip and
+ * starts feeding the store instead. `in` walks the prototype chain, which is
+ * exactly what that guard cannot do.
+ *
+ * Deliberately proportional. State keys and action names carry their own
+ * unchecked collision surface, so this is not a new rigor bar — just a cheap
+ * check at the one point where every declaration is visible together.
+ */
+export function assertNoProviderPropCollisions(
+  props: Map<string, CollectedProviderProp>,
+  prototype?: object | undefined
+): void {
+  if (!__DEV__) return;
+
+  for (const name of props.keys()) {
+    if (RESERVED_PROP_NAMES.has(name)) {
+      console.error(`[vjs-player] createPlayer(): provider prop "${name}" is a reserved React prop name`);
+    }
+
+    if (prototype && name in prototype) {
+      console.error(
+        `[vjs-player] createPlayer(): provider prop "${name}" already exists on the provider element's prototype chain — ` +
+          `declaring it would shadow that property`
+      );
+    }
+  }
+}
+
+// ----------------------------------------
+// Writing
+// ----------------------------------------
+
+/** A store exposing feature actions as callable members. */
+type ActionStore = Record<string, unknown>;
+
+/**
+ * Pushes every declared prop into the store through its feature's action.
+ *
+ * Writes unconditionally, with no diffing and no record of what was written
+ * last. `patch` already drops writes that change nothing, and an omitted prop
+ * and an explicit `undefined` deliberately mean the same thing — both clear the
+ * user's value and let resolution fall through, which is what removing an HTML
+ * attribute does too. Keeping a second copy of the truth in a ref could drift
+ * from the store across a remount or a store swap.
+ */
+export function writeProviderProps(
+  store: ActionStore,
+  props: Map<string, CollectedProviderProp>,
+  read: (name: string) => unknown
+): void {
+  for (const [name, declaration] of props) {
+    const action = store[declaration.action];
+
+    if (typeof action !== 'function') {
+      if (__DEV__) {
+        console.error(
+          `[vjs-player] provider prop "${name}" names the action "${declaration.action}", which the store does not expose`
+        );
+      }
+      continue;
+    }
+
+    (action as (value: unknown) => void)(read(name));
+  }
+}

--- a/packages/core/src/dom/store/features/content-metadata.ts
+++ b/packages/core/src/dom/store/features/content-metadata.ts
@@ -1,0 +1,208 @@
+import type { MediaContentMetadataState, MediaContentValue } from '@videojs/media';
+import {
+  isMediaContentPosterAltCapable,
+  isMediaContentPosterCapable,
+  isMediaContentTitleCapable,
+} from '@videojs/media';
+import { listen } from '@videojs/utils/dom';
+
+import { definePlayerFeature } from '../../feature';
+
+/**
+ * Value at the end of every resolve chain.
+ *
+ * A plain constant rather than a fourth slot, so it cannot be overwritten. A
+ * developer who set and then cleared a `default-content-title` would otherwise
+ * wipe the library's value too, leaving the chain ending in nothing and breaking
+ * the always-a-string guarantee at the worst possible moment.
+ *
+ * Empty string is also the right answer for each of these fields: nothing to
+ * render for a title or poster, and a decorative image for poster alt text.
+ */
+const LIBRARY_DEFAULT = '';
+
+// ----------------------------------------
+// Tier slots
+// ----------------------------------------
+
+/**
+ * Each field is three slots, not one, and they resolve in a fixed order:
+ * `user ?? media ?? developerDefault ?? LIBRARY_DEFAULT`.
+ *
+ * Separate slots rather than one slot with write-time precedence: a single slot
+ * would have to track where its value came from anyway in order to decide
+ * whether the media's write wins, could not recover when the developer cleared
+ * their value, and would be order-dependent — and write order genuinely differs
+ * by platform and by timing. Separate slots resolve identically however the
+ * writes arrive.
+ *
+ * Keys are symbols so they get no getter on the store (`createStore` installs
+ * accessors from `Object.keys`, which skips symbols) and never appear in
+ * selector output. They are *internal*, not secret: `Reflect.ownKeys` on a state
+ * snapshot will list them, which is what makes them debuggable.
+ *
+ * Which slots are seeded in `state()` is load-bearing, so do not "tidy" it.
+ * Media slots are seeded, so `detach`'s reset clears them — the media left, so
+ * its donated value should leave with it. User and default slots are left out,
+ * so the reset cannot reach them; they belong to the player, not the media.
+ */
+const USER_CONTENT_TITLE = Symbol('vjs.contentTitle.user');
+const MEDIA_CONTENT_TITLE = Symbol('vjs.contentTitle.media');
+const DEFAULT_CONTENT_TITLE = Symbol('vjs.contentTitle.default');
+
+const USER_CONTENT_POSTER = Symbol('vjs.contentPoster.user');
+const MEDIA_CONTENT_POSTER = Symbol('vjs.contentPoster.media');
+const DEFAULT_CONTENT_POSTER = Symbol('vjs.contentPoster.default');
+
+const USER_CONTENT_POSTER_ALT = Symbol('vjs.contentPosterAlt.user');
+const MEDIA_CONTENT_POSTER_ALT = Symbol('vjs.contentPosterAlt.media');
+const DEFAULT_CONTENT_POSTER_ALT = Symbol('vjs.contentPosterAlt.default');
+
+// ----------------------------------------
+// Types
+// ----------------------------------------
+
+/** The keys of {@link MediaContentMetadataState} the store computes rather than stores. */
+type ResolvedKey = 'contentTitle' | 'contentPoster' | 'contentPosterAlt';
+
+/**
+ * The feature's source state: its actions, plus symbol-keyed tier slots.
+ *
+ * The slots are typed through a symbol index signature rather than named keys so
+ * the symbols themselves stay module-private — naming them in the type would
+ * force them to be exported for declaration emit, making a private mechanism
+ * public API.
+ */
+export interface ContentMetadataSource extends Omit<MediaContentMetadataState, ResolvedKey> {
+  [tier: symbol]: MediaContentValue;
+}
+
+/** The resolved values, computed by the store and read-only to everyone else. */
+export type ContentMetadataDerived = Pick<MediaContentMetadataState, ResolvedKey>;
+
+/**
+ * Two provider inputs per field: an override and a fallback.
+ *
+ * This is how one fixed precedence chain expresses both of the product
+ * requirements that look opposite. "Override whatever the host provides" writes
+ * the override; "set a default unless the host provides one" writes the
+ * fallback. Two slots on one chain, not two precedences — so React's
+ * `value`/`defaultValue` framing is not needed.
+ *
+ * `null` is admissible because removing an HTML attribute yields `null`, and the
+ * generated prop type should not be narrower than the documented contract.
+ */
+export interface ContentMetadataProviderProps {
+  contentTitle?: string | null | undefined;
+  defaultContentTitle?: string | null | undefined;
+  contentPoster?: string | null | undefined;
+  defaultContentPoster?: string | null | undefined;
+  contentPosterAlt?: string | null | undefined;
+  defaultContentPosterAlt?: string | null | undefined;
+}
+
+// ----------------------------------------
+// Feature
+// ----------------------------------------
+
+/**
+ * Reconciles content metadata the developer supplies with content metadata the
+ * media reports.
+ *
+ * One feature holds every field rather than one feature per field: they share
+ * the machinery, a selector, and a declaration group. The trade is that feature
+ * granularity is opt-in granularity — a player wanting only a title still gets
+ * every field's props and state keys. Cost is types and a few state keys, not
+ * runtime work.
+ *
+ * On the media side this stays per-field: three capabilities, three events,
+ * three predicates. One feature consuming several capabilities is already the
+ * `streamType` pattern.
+ */
+export const contentMetadataFeature = definePlayerFeature<
+  ContentMetadataSource,
+  ContentMetadataDerived,
+  ContentMetadataProviderProps
+>({
+  name: 'contentMetadata',
+
+  state: ({ set }): ContentMetadataSource => ({
+    // Media slots only — see the tier-slot note above.
+    [MEDIA_CONTENT_TITLE]: undefined,
+    [MEDIA_CONTENT_POSTER]: undefined,
+    [MEDIA_CONTENT_POSTER_ALT]: undefined,
+
+    // Two plain actions per field rather than one parameterised by tier, so both
+    // appear in the imperative API where they are discoverable. These are
+    // state-only and never touch `target()`, which throws when nothing is
+    // attached — the developer can set metadata before any media exists.
+    setContentTitle: (value) => set({ [USER_CONTENT_TITLE]: value }),
+    setDefaultContentTitle: (value) => set({ [DEFAULT_CONTENT_TITLE]: value }),
+    setContentPoster: (value) => set({ [USER_CONTENT_POSTER]: value }),
+    setDefaultContentPoster: (value) => set({ [DEFAULT_CONTENT_POSTER]: value }),
+    setContentPosterAlt: (value) => set({ [USER_CONTENT_POSTER_ALT]: value }),
+    setDefaultContentPosterAlt: (value) => set({ [DEFAULT_CONTENT_POSTER_ALT]: value }),
+  }),
+
+  // `??` treats `null` and `undefined` alike, so a cleared attribute and an
+  // absent one both fall through — while an empty string, being neither, wins.
+  // That is the whole reason suppression works: `content-title=""` means the
+  // developer wants no title shown, and it beats whatever the media reports.
+  derived: {
+    contentTitle: ({ get }) =>
+      get(USER_CONTENT_TITLE) ?? get(MEDIA_CONTENT_TITLE) ?? get(DEFAULT_CONTENT_TITLE) ?? LIBRARY_DEFAULT,
+    contentPoster: ({ get }) =>
+      get(USER_CONTENT_POSTER) ?? get(MEDIA_CONTENT_POSTER) ?? get(DEFAULT_CONTENT_POSTER) ?? LIBRARY_DEFAULT,
+    contentPosterAlt: ({ get }) =>
+      get(USER_CONTENT_POSTER_ALT) ??
+      get(MEDIA_CONTENT_POSTER_ALT) ??
+      get(DEFAULT_CONTENT_POSTER_ALT) ??
+      LIBRARY_DEFAULT,
+  },
+
+  providerProps: {
+    contentTitle: { type: String, attribute: 'content-title', action: 'setContentTitle' },
+    defaultContentTitle: { type: String, attribute: 'default-content-title', action: 'setDefaultContentTitle' },
+    contentPoster: { type: String, attribute: 'content-poster', action: 'setContentPoster' },
+    defaultContentPoster: { type: String, attribute: 'default-content-poster', action: 'setDefaultContentPoster' },
+    contentPosterAlt: { type: String, attribute: 'content-poster-alt', action: 'setContentPosterAlt' },
+    defaultContentPosterAlt: {
+      type: String,
+      attribute: 'default-content-poster-alt',
+      action: 'setDefaultContentPosterAlt',
+    },
+  },
+
+  /**
+   * Fills the media tier from whatever the media reports.
+   *
+   * No `emptied` listener. A media that reports a metadata field is expected to
+   * clear it on source change and dispatch the change event — the same contract
+   * the stream-type feature already assumes, and which `hls-js` already honours
+   * by resetting itself on `MANIFEST_LOADING` and `DESTROYING`. Worth knowing
+   * that the contract's two halves are not equally enforced: dispatching is
+   * structural, because assigning through the host setter always fires the
+   * event, while clearing on a new source is pure convention.
+   */
+  attach({ target, signal, set }) {
+    const { media } = target;
+
+    if (isMediaContentTitleCapable(media)) {
+      const sync = () => set({ [MEDIA_CONTENT_TITLE]: media.contentTitle });
+      sync();
+      listen(media, 'contenttitlechange', sync, { signal });
+    }
+
+    if (isMediaContentPosterCapable(media)) {
+      const sync = () => set({ [MEDIA_CONTENT_POSTER]: media.contentPoster });
+      sync();
+      listen(media, 'contentposterchange', sync, { signal });
+    }
+
+    if (isMediaContentPosterAltCapable(media)) {
+      const sync = () => set({ [MEDIA_CONTENT_POSTER_ALT]: media.contentPosterAlt });
+      sync();
+      listen(media, 'contentposteraltchange', sync, { signal });
+    }
+  },
+});

--- a/packages/core/src/dom/store/features/feature.parts.ts
+++ b/packages/core/src/dom/store/features/feature.parts.ts
@@ -1,5 +1,6 @@
 import { audioTrackFeature } from './audio-track';
 import { bufferFeature } from './buffer';
+import { contentMetadataFeature } from './content-metadata';
 import { controlsFeature } from './controls';
 import { fullscreenFeature } from './fullscreen';
 import { liveFeature } from './live';
@@ -21,6 +22,7 @@ export { audioFeatures, backgroundFeatures, videoFeatures } from './presets';
 export {
   audioTrackFeature as audioTrack,
   bufferFeature as buffer,
+  contentMetadataFeature as contentMetadata,
   controlsFeature as controls,
   fullscreenFeature as fullscreen,
   liveFeature as live,

--- a/packages/core/src/dom/store/features/index.ts
+++ b/packages/core/src/dom/store/features/index.ts
@@ -1,5 +1,6 @@
 export * from './audio-track';
 export * from './buffer';
+export * from './content-metadata';
 export * from './controls';
 export * from './error';
 export * as features from './feature.parts';

--- a/packages/core/src/dom/store/features/orientation-lock.ts
+++ b/packages/core/src/dom/store/features/orientation-lock.ts
@@ -4,49 +4,107 @@ import { definePlayerFeature } from '../../feature';
 import { isFullscreen } from '../../presentation/fullscreen';
 import { createScreenOrientationLock, type ScreenOrientationLockType } from '../../presentation/orientation';
 
-export interface OrientationLockFeatureConfig {
-  /** Screen orientation type to lock while fullscreen is active. */
-  type?: ScreenOrientationLockType | undefined;
-}
+// Re-exported because it is now part of a public surface: the resolved value
+// appears on the store, and `orientation-lock` is a provider attribute.
+export type { ScreenOrientationLockType };
+
+/** Preserves the behaviour of the feature's former baked-in default. */
+const LIBRARY_DEFAULT: ScreenOrientationLockType = 'landscape';
+
+const USER_ORIENTATION_LOCK = Symbol('vjs.orientationLock.user');
 
 interface WebKitPresentationMedia extends HTMLMediaElement {
   webkitPresentationMode?: string;
 }
 
-export const orientationLockFeature = definePlayerFeature(
-  {
-    name: 'orientationLock',
-    state: () => ({}),
+export interface OrientationLockSource {
+  [tier: symbol]: ScreenOrientationLockType | null | undefined;
+  /**
+   * Screen orientation to lock to while fullscreen is active.
+   *
+   * Written through as-is with no membership check, matching how media-provided
+   * enums already behave. So this can hold a non-enum string at runtime, which
+   * is the same compile-time-only guarantee `MediaStreamType` has. The platform
+   * rejects a bad value when the lock is requested — silently, since that
+   * rejection is discarded.
+   */
+  setOrientationLock(value: ScreenOrientationLockType | null | undefined): void;
+}
 
-    attach({ target, signal }, config: OrientationLockFeatureConfig) {
-      const { media, container } = target;
-      const orientationLock = createScreenOrientationLock({ type: config.type });
+export interface OrientationLockDerived {
+  orientationLock: ScreenOrientationLockType;
+}
 
-      let wasFullscreen = false;
-      const sync = () => {
-        const fullscreen = isFullscreen(container, media);
+export interface OrientationLockProviderProps {
+  orientationLock?: ScreenOrientationLockType | null | undefined;
+}
 
-        if (!wasFullscreen && fullscreen) {
-          void orientationLock.lock();
-        } else if (wasFullscreen && !fullscreen) {
-          orientationLock.unlock();
-        }
+/**
+ * Locks screen orientation while the player is fullscreen.
+ *
+ * Declares **one** provider prop, not two, and this is useful news about the
+ * machinery rather than a special case: the `default*` tier means "use this
+ * unless the media says otherwise", and nothing in a video donates an
+ * orientation preference. A `defaultOrientationLock` would just be a second
+ * developer-supplied value with lower precedence than the first. Tiers are the
+ * feature's private business — "two entries per field" is a fact about content
+ * metadata, not about provider props.
+ */
+export const orientationLockFeature = definePlayerFeature<
+  OrientationLockSource,
+  OrientationLockDerived,
+  OrientationLockProviderProps
+>({
+  name: 'orientationLock',
 
-        wasFullscreen = fullscreen;
-      };
+  state: ({ set }): OrientationLockSource => ({
+    setOrientationLock: (value) => set({ [USER_ORIENTATION_LOCK]: value }),
+  }),
 
-      sync();
+  derived: {
+    orientationLock: ({ get }) => get(USER_ORIENTATION_LOCK) ?? LIBRARY_DEFAULT,
+  },
 
-      listen(document, 'fullscreenchange', sync, { signal });
-      listen(document, 'webkitfullscreenchange', sync, { signal });
+  providerProps: {
+    orientationLock: { type: String, attribute: 'orientation-lock', action: 'setOrientationLock' },
+  },
 
-      const video = media as WebKitPresentationMedia;
-      if ('webkitPresentationMode' in video) {
-        listen(media, 'webkitpresentationmodechanged', sync, { signal });
+  attach({ target, signal, get }) {
+    const { media, container } = target;
+
+    // Read the current value at lock time rather than capturing it up front.
+    // This is the behavioural change that makes the value reactive, and it is
+    // easy to miss: the store half looks finished while the lock still uses
+    // whatever was set when the media attached.
+    const orientationLock = createScreenOrientationLock({
+      get type() {
+        return get().orientationLock;
+      },
+    });
+
+    let wasFullscreen = false;
+    const sync = () => {
+      const fullscreen = isFullscreen(container, media);
+
+      if (!wasFullscreen && fullscreen) {
+        void orientationLock.lock();
+      } else if (wasFullscreen && !fullscreen) {
+        orientationLock.unlock();
       }
 
-      signal.addEventListener('abort', () => orientationLock.unlock(), { once: true });
-    },
+      wasFullscreen = fullscreen;
+    };
+
+    sync();
+
+    listen(document, 'fullscreenchange', sync, { signal });
+    listen(document, 'webkitfullscreenchange', sync, { signal });
+
+    const video = media as WebKitPresentationMedia;
+    if ('webkitPresentationMode' in video) {
+      listen(media, 'webkitpresentationmodechanged', sync, { signal });
+    }
+
+    signal.addEventListener('abort', () => orientationLock.unlock(), { once: true });
   },
-  { type: 'landscape' } satisfies OrientationLockFeatureConfig
-);
+});

--- a/packages/core/src/dom/store/features/presets.ts
+++ b/packages/core/src/dom/store/features/presets.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../player';
 import { audioTrackFeature } from './audio-track';
 import { bufferFeature } from './buffer';
+import { contentMetadataFeature } from './content-metadata';
 import { controlsFeature } from './controls';
 import { errorFeature } from './error';
 import { fullscreenFeature } from './fullscreen';
@@ -36,6 +37,7 @@ export const videoFeatures: VideoFeatures = [
   controlsFeature,
   textTrackFeature,
   errorFeature,
+  contentMetadataFeature,
 ];
 
 export const audioFeatures: AudioFeatures = [
@@ -46,6 +48,7 @@ export const audioFeatures: AudioFeatures = [
   sourceFeature,
   bufferFeature,
   errorFeature,
+  contentMetadataFeature,
 ];
 
 // TODO: Add background video features (e.g., playback, source, buffer)
@@ -70,6 +73,7 @@ export const liveVideoFeatures: LiveVideoFeatures = [
   textTrackFeature,
   errorFeature,
   liveFeature,
+  contentMetadataFeature,
 ];
 
 /**
@@ -86,4 +90,5 @@ export const liveAudioFeatures: LiveAudioFeatures = [
   bufferFeature,
   errorFeature,
   liveFeature,
+  contentMetadataFeature,
 ];

--- a/packages/core/src/dom/store/features/tests/content-metadata.test.ts
+++ b/packages/core/src/dom/store/features/tests/content-metadata.test.ts
@@ -1,0 +1,322 @@
+import { createStore } from '@videojs/store';
+import { describe, expect, it } from 'vitest';
+import type { PlayerTarget } from '../../../player';
+import { createMockVideo } from '../../../tests/test-helpers';
+import { contentMetadataFeature } from '../content-metadata';
+
+type ContentValue = string | null | undefined;
+
+/**
+ * A media that reports content metadata, standing in for something like
+ * `mux-video`. Assigning dispatches the change event, which is what lets a donor
+ * stay ignorant of the store.
+ */
+function createDonorMedia(initial: { title?: ContentValue; poster?: ContentValue; posterAlt?: ContentValue } = {}) {
+  const media = createMockVideo() as HTMLVideoElement & {
+    contentTitle: ContentValue;
+    contentPoster: ContentValue;
+    contentPosterAlt: ContentValue;
+  };
+
+  let title: ContentValue = initial.title ?? null;
+  let poster: ContentValue = initial.poster ?? null;
+  let posterAlt: ContentValue = initial.posterAlt ?? null;
+
+  Object.defineProperties(media, {
+    contentTitle: {
+      get: () => title,
+      set: (value: ContentValue) => {
+        title = value ?? null;
+        media.dispatchEvent(new Event('contenttitlechange'));
+      },
+      configurable: true,
+    },
+    contentPoster: {
+      get: () => poster,
+      set: (value: ContentValue) => {
+        poster = value ?? null;
+        media.dispatchEvent(new Event('contentposterchange'));
+      },
+      configurable: true,
+    },
+    contentPosterAlt: {
+      get: () => posterAlt,
+      set: (value: ContentValue) => {
+        posterAlt = value ?? null;
+        media.dispatchEvent(new Event('contentposteraltchange'));
+      },
+      configurable: true,
+    },
+  });
+
+  return media;
+}
+
+function createFeatureStore() {
+  return createStore<PlayerTarget>()(contentMetadataFeature);
+}
+
+describe('contentMetadataFeature', () => {
+  describe('library default', () => {
+    it('resolves every field to an empty string before anything is set', () => {
+      const store = createFeatureStore();
+
+      expect(store.contentTitle).toBe('');
+      expect(store.contentPoster).toBe('');
+      expect(store.contentPosterAlt).toBe('');
+    });
+
+    it('resolves to a string even with no media attached', () => {
+      const store = createFeatureStore();
+
+      store.setContentTitle('Set before any media');
+
+      expect(store.contentTitle).toBe('Set before any media');
+    });
+
+    it('exposes only resolved values and actions as state keys', () => {
+      const store = createFeatureStore();
+
+      // Tier slots are symbol-keyed, so they never surface here.
+      expect(Object.keys(store.state).sort()).toEqual([
+        'contentPoster',
+        'contentPosterAlt',
+        'contentTitle',
+        'setContentPoster',
+        'setContentPosterAlt',
+        'setContentTitle',
+        'setDefaultContentPoster',
+        'setDefaultContentPosterAlt',
+        'setDefaultContentTitle',
+      ]);
+    });
+  });
+
+  describe('precedence', () => {
+    it('prefers the developer override over the media', () => {
+      const store = createFeatureStore();
+      store.attach({ media: createDonorMedia({ title: 'From the backend' }), container: null });
+
+      expect(store.contentTitle).toBe('From the backend');
+
+      store.setContentTitle('From the developer');
+      expect(store.contentTitle).toBe('From the developer');
+    });
+
+    it('prefers the media over the developer fallback', () => {
+      const store = createFeatureStore();
+      store.setDefaultContentTitle('A fallback');
+      store.attach({ media: createDonorMedia({ title: 'From the backend' }), container: null });
+
+      expect(store.contentTitle).toBe('From the backend');
+    });
+
+    it('uses the developer fallback when the media reports nothing', () => {
+      const store = createFeatureStore();
+      store.setDefaultContentTitle('A fallback');
+      store.attach({ media: createDonorMedia(), container: null });
+
+      expect(store.contentTitle).toBe('A fallback');
+    });
+
+    it('resolves identically whichever order the tiers are written in', () => {
+      const overrideFirst = createFeatureStore();
+      overrideFirst.setContentTitle('Override');
+      overrideFirst.attach({ media: createDonorMedia({ title: 'Media' }), container: null });
+
+      const mediaFirst = createFeatureStore();
+      mediaFirst.attach({ media: createDonorMedia({ title: 'Media' }), container: null });
+      mediaFirst.setContentTitle('Override');
+
+      expect(overrideFirst.contentTitle).toBe('Override');
+      expect(mediaFirst.contentTitle).toBe('Override');
+    });
+
+    it('falls back through the chain when the override is cleared', () => {
+      const store = createFeatureStore();
+      store.setDefaultContentTitle('A fallback');
+      store.attach({ media: createDonorMedia({ title: 'From the backend' }), container: null });
+      store.setContentTitle('From the developer');
+
+      store.setContentTitle(undefined);
+      expect(store.contentTitle).toBe('From the backend');
+    });
+  });
+
+  describe('empty string suppresses, absence falls through', () => {
+    it('lets an empty override beat a media-provided value', () => {
+      const store = createFeatureStore();
+      store.attach({ media: createDonorMedia({ title: 'From the backend' }), container: null });
+
+      store.setContentTitle('');
+
+      expect(store.contentTitle).toBe('');
+    });
+
+    it('treats null as absence, so a removed attribute falls through', () => {
+      const store = createFeatureStore();
+      store.attach({ media: createDonorMedia({ title: 'From the backend' }), container: null });
+
+      store.setContentTitle('');
+      store.setContentTitle(null);
+
+      expect(store.contentTitle).toBe('From the backend');
+    });
+
+    it('lets an empty poster alt mean deliberately decorative', () => {
+      const store = createFeatureStore();
+      store.attach({ media: createDonorMedia({ posterAlt: 'A description' }), container: null });
+
+      store.setContentPosterAlt('');
+
+      expect(store.contentPosterAlt).toBe('');
+    });
+  });
+
+  describe('media reporting', () => {
+    it('picks up a value that arrives after attach', () => {
+      const media = createDonorMedia();
+      const store = createFeatureStore();
+      store.attach({ media, container: null });
+
+      expect(store.contentTitle).toBe('');
+
+      // A backend fetch resolving later. The listener was wired at attach even
+      // though there was no value then, which is what `empty: null` buys.
+      media.contentTitle = 'Arrived late';
+
+      expect(store.contentTitle).toBe('Arrived late');
+    });
+
+    it('tracks each field through its own event', () => {
+      const media = createDonorMedia();
+      const store = createFeatureStore();
+      store.attach({ media, container: null });
+
+      media.contentPoster = 'poster.jpg';
+      media.contentPosterAlt = 'A description';
+
+      expect(store.contentPoster).toBe('poster.jpg');
+      expect(store.contentPosterAlt).toBe('A description');
+      expect(store.contentTitle).toBe('');
+    });
+
+    it('supports a media reporting some fields but not others', () => {
+      const media = createMockVideo() as HTMLVideoElement & { contentTitle: ContentValue };
+      media.contentTitle = 'Only a title';
+
+      const store = createFeatureStore();
+      store.setDefaultContentPoster('fallback.jpg');
+      store.attach({ media, container: null });
+
+      expect(store.contentTitle).toBe('Only a title');
+      expect(store.contentPoster).toBe('fallback.jpg');
+    });
+
+    it('falls through when the media clears its own value', () => {
+      const media = createDonorMedia({ title: 'First video' });
+      const store = createFeatureStore();
+      store.setDefaultContentTitle('A fallback');
+      store.attach({ media, container: null });
+
+      expect(store.contentTitle).toBe('First video');
+
+      // The media is expected to clear itself on source change and dispatch.
+      // The feature wires no `emptied` backstop.
+      media.contentTitle = null;
+
+      expect(store.contentTitle).toBe('A fallback');
+    });
+
+    it('ignores a media that does not report content metadata at all', () => {
+      const store = createFeatureStore();
+      store.setContentTitle('From the developer');
+      store.attach({ media: createMockVideo(), container: null });
+
+      expect(store.contentTitle).toBe('From the developer');
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('keeps developer values and drops media values on detach', () => {
+      const store = createFeatureStore();
+      store.setContentTitle('From the developer');
+      store.setDefaultContentPoster('fallback.jpg');
+
+      const detach = store.attach({
+        media: createDonorMedia({ title: 'From the backend', poster: 'backend.jpg' }),
+        container: null,
+      });
+
+      expect(store.contentPoster).toBe('backend.jpg');
+
+      detach();
+
+      expect(store.contentTitle).toBe('From the developer');
+      expect(store.contentPoster).toBe('fallback.jpg');
+    });
+
+    it('re-resolves against the new media after a swap', () => {
+      const store = createFeatureStore();
+
+      const detach = store.attach({ media: createDonorMedia({ title: 'First' }), container: null });
+      expect(store.contentTitle).toBe('First');
+      detach();
+
+      store.attach({ media: createDonorMedia({ title: 'Second' }), container: null });
+      expect(store.contentTitle).toBe('Second');
+    });
+
+    it('leaves a developer override winning across a media swap', () => {
+      const store = createFeatureStore();
+      store.setContentTitle('Always this');
+
+      const detach = store.attach({ media: createDonorMedia({ title: 'First' }), container: null });
+      detach();
+      store.attach({ media: createDonorMedia({ title: 'Second' }), container: null });
+
+      expect(store.contentTitle).toBe('Always this');
+    });
+
+    it('stops listening to a detached media', () => {
+      const media = createDonorMedia({ title: 'First' });
+      const store = createFeatureStore();
+
+      const detach = store.attach({ media, container: null });
+      detach();
+
+      media.contentTitle = 'Changed after detach';
+
+      expect(store.contentTitle).toBe('');
+    });
+  });
+
+  describe('provider prop declarations', () => {
+    it('declares an override and a fallback for every field', () => {
+      expect(Object.keys(contentMetadataFeature.providerProps ?? {}).sort()).toEqual([
+        'contentPoster',
+        'contentPosterAlt',
+        'contentTitle',
+        'defaultContentPoster',
+        'defaultContentPosterAlt',
+        'defaultContentTitle',
+      ]);
+    });
+
+    it('gives every declaration an explicit kebab-case attribute', () => {
+      for (const [name, declaration] of Object.entries(contentMetadataFeature.providerProps ?? {})) {
+        expect(declaration.attribute).toBe(
+          name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`).replace(/^-/, '')
+        );
+      }
+    });
+
+    it('names an action the store actually exposes', () => {
+      const store = createFeatureStore();
+
+      for (const declaration of Object.values(contentMetadataFeature.providerProps ?? {})) {
+        expect(typeof store[declaration.action]).toBe('function');
+      }
+    });
+  });
+});

--- a/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
+++ b/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
@@ -58,12 +58,13 @@ describe('orientationLockFeature', () => {
     });
   });
 
-  it('locks the configured orientation type when fullscreen starts', async () => {
+  it('locks the orientation type set on the provider when fullscreen starts', async () => {
     const orientation = stubOrientation();
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature({ type: 'portrait' }));
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.setOrientationLock('portrait');
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -72,6 +73,58 @@ describe('orientationLockFeature', () => {
     await vi.waitFor(() => {
       expect(orientation.lock).toHaveBeenCalledWith('portrait');
     });
+  });
+
+  it('reads the orientation type at lock time, not at attach time', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.attach({ media: video, container });
+
+    // Changed after attach. Capturing the value up front is the easy mistake
+    // here, because the store half looks finished while the lock still uses
+    // whatever was set when the media attached.
+    store.setOrientationLock('portrait');
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('portrait');
+    });
+  });
+
+  it('falls back to landscape when the provider clears the value', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    store.setOrientationLock('portrait');
+    store.setOrientationLock(null);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    });
+  });
+
+  it('exposes the resolved value on the store', () => {
+    const store = createStore<PlayerTarget>()(orientationLockFeature);
+
+    expect(store.orientationLock).toBe('landscape');
+
+    store.setOrientationLock('portrait');
+    expect(store.orientationLock).toBe('portrait');
+  });
+
+  it('declares one provider prop, since nothing donates an orientation preference', () => {
+    expect(Object.keys(orientationLockFeature.providerProps ?? {})).toEqual(['orientationLock']);
   });
 
   it('unlocks when fullscreen exits', async () => {

--- a/packages/core/src/dom/store/selectors.ts
+++ b/packages/core/src/dom/store/selectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from '@videojs/store';
 
 import { audioTrackFeature } from './features/audio-track';
 import { bufferFeature } from './features/buffer';
+import { contentMetadataFeature } from './features/content-metadata';
 import { controlsFeature } from './features/controls';
 import { errorFeature } from './features/error';
 import { fullscreenFeature } from './features/fullscreen';
@@ -21,6 +22,8 @@ import { volumeFeature } from './features/volume';
 export const selectAudioTrack = createSelector(audioTrackFeature);
 /** Select the buffer state (buffered ranges, percent buffered). */
 export const selectBuffer = createSelector(bufferFeature);
+/** Select the resolved content metadata (contentTitle, contentPoster, contentPosterAlt) and its setters. */
+export const selectContentMetadata = createSelector(contentMetadataFeature);
 /** Select the controls state (controls visible, user-active). */
 export const selectControls = createSelector(controlsFeature);
 /** Select the error state (error, dismissed, dismissError). */

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -1,4 +1,5 @@
 import { createSelector, type StateContext } from '@videojs/store';
+import type { EmptyObject } from '@videojs/utils/types';
 import { describe, expect, it } from 'vitest';
 import { definePlayerFeature } from '../feature';
 import type { PlayerTarget } from '../player';
@@ -23,19 +24,36 @@ describe('definePlayerFeature', () => {
     expect(feature.state(stateContext).enabled).toBe(true);
   });
 
-  it('defines a configurable player feature', () => {
-    const feature = definePlayerFeature(
-      {
-        name: 'configurable',
-        state: (_ctx, config: { enabled: boolean }) => ({ enabled: config.enabled }),
-      },
-      { enabled: true }
-    );
+  it('defines a feature that derives state', () => {
+    const feature = definePlayerFeature<{ count: number }, { doubled: number }>({
+      name: 'derives',
+      state: () => ({ count: 2 }),
+      derived: { doubled: ({ get }) => get('count') * 2 },
+    });
 
-    expect(feature.name).toBe('configurable');
-    expect(feature.state(stateContext).enabled).toBe(true);
-    expect(feature().state(stateContext).enabled).toBe(true);
-    expect(feature({ enabled: false }).state(stateContext).enabled).toBe(false);
-    expect(createSelector(feature).displayName).toBe('configurable');
+    expect(feature.derived?.doubled({ get: () => 3 })).toBe(6);
+    expect(createSelector(feature).displayName).toBe('derives');
+  });
+
+  it('defines a feature that declares provider props', () => {
+    const feature = definePlayerFeature<
+      { setLabel: (value: string | null | undefined) => void },
+      EmptyObject,
+      { label?: string | null | undefined }
+    >({
+      name: 'declares',
+      state: ({ set }) => ({ setLabel: (value) => set({ label: value } as never) }),
+      providerProps: {
+        label: { type: String, attribute: 'label', action: 'setLabel' },
+      },
+    });
+
+    expect(feature.providerProps?.label).toEqual({ type: String, attribute: 'label', action: 'setLabel' });
+  });
+
+  it('leaves a feature that declares nothing contributing no provider props', () => {
+    const feature = definePlayerFeature({ name: 'plain', state: () => ({ enabled: true }) });
+
+    expect(feature.providerProps).toBeUndefined();
   });
 });

--- a/packages/core/src/dom/tests/provider-props.test.ts
+++ b/packages/core/src/dom/tests/provider-props.test.ts
@@ -1,0 +1,122 @@
+import type { EmptyObject } from '@videojs/utils/types';
+import { describe, expect, it, vi } from 'vitest';
+import { definePlayerFeature } from '../feature';
+import type { AnyPlayerFeature } from '../player';
+import {
+  assertNoProviderPropCollisions,
+  type CollectedProviderProp,
+  collectProviderProps,
+  writeProviderProps,
+} from '../provider-props';
+
+function featureDeclaring(props: Record<string, { attribute: string; action: string }>): AnyPlayerFeature {
+  return definePlayerFeature<Record<string, unknown>, EmptyObject, Record<string, string | null | undefined>>({
+    state: () => ({}),
+    providerProps: Object.fromEntries(
+      Object.entries(props).map(([name, { attribute, action }]) => [name, { type: String, attribute, action }])
+    ) as never,
+  });
+}
+
+describe('collectProviderProps', () => {
+  it('returns an empty map when no feature declares anything', () => {
+    const plain = definePlayerFeature({ state: () => ({ enabled: true }) });
+
+    expect(collectProviderProps([plain]).size).toBe(0);
+  });
+
+  it('flattens declarations across features', () => {
+    const a = featureDeclaring({ title: { attribute: 'title', action: 'setTitle' } });
+    const b = featureDeclaring({ lockTo: { attribute: 'lock-to', action: 'setLockTo' } });
+
+    const collected = collectProviderProps([a, b]);
+
+    expect([...collected.keys()]).toEqual(['title', 'lockTo']);
+    expect(collected.get('lockTo')).toMatchObject({ attribute: 'lock-to', action: 'setLockTo' });
+  });
+
+  it('errors in dev when two features declare the same prop name', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const a = featureDeclaring({ title: { attribute: 'title', action: 'setTitle' } });
+    const b = featureDeclaring({ title: { attribute: 'title', action: 'setOtherTitle' } });
+
+    collectProviderProps([a, b]);
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('two features declare the provider prop "title"'));
+    error.mockRestore();
+  });
+});
+
+describe('assertNoProviderPropCollisions', () => {
+  function collect(...names: string[]): Map<string, CollectedProviderProp> {
+    return new Map(names.map((name) => [name, { name, attribute: name, type: String, action: `set${name}` }]));
+  }
+
+  it('accepts names that collide with nothing', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    assertNoProviderPropCollisions(collect('contentTitle', 'contentPoster'), HTMLElement.prototype);
+
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it('catches an inherited DOM property that the own-property guard would miss', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // `title` lives on `HTMLElement.prototype`, several links up from a provider
+    // element's own prototype — which is exactly why `getOwnPropertyDescriptor`
+    // cannot see it and `in` can.
+    expect(Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'title')).toBeDefined();
+
+    class Provider extends HTMLElement {}
+    expect(Object.getOwnPropertyDescriptor(Provider.prototype, 'title')).toBeUndefined();
+
+    assertNoProviderPropCollisions(collect('title'), Provider.prototype);
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('already exists on the provider element'));
+    error.mockRestore();
+  });
+
+  it('catches React reserved prop names', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    assertNoProviderPropCollisions(collect('children'));
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('reserved React prop name'));
+    error.mockRestore();
+  });
+});
+
+describe('writeProviderProps', () => {
+  it('routes each prop to the action its feature named', () => {
+    const setTitle = vi.fn();
+    const setPoster = vi.fn();
+    const props = collectProviderProps([
+      featureDeclaring({
+        contentTitle: { attribute: 'content-title', action: 'setContentTitle' },
+        contentPoster: { attribute: 'content-poster', action: 'setContentPoster' },
+      }),
+    ]);
+
+    writeProviderProps({ setContentTitle: setTitle, setContentPoster: setPoster }, props, (name) =>
+      name === 'contentTitle' ? 'A title' : undefined
+    );
+
+    expect(setTitle).toHaveBeenCalledWith('A title');
+    // An omitted prop and an explicit undefined mean the same thing: clear the
+    // developer's value and let resolution fall through.
+    expect(setPoster).toHaveBeenCalledWith(undefined);
+  });
+
+  it('errors in dev when a declaration names an action the store does not expose', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const props = collectProviderProps([featureDeclaring({ title: { attribute: 'title', action: 'setMissing' } })]);
+
+    writeProviderProps({}, props, () => 'value');
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('which the store does not expose'));
+    error.mockRestore();
+  });
+});

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -32,7 +32,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster class="${poster(true)}">
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator}">

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -15,7 +15,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster>
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="media-buffering-indicator">

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -32,7 +32,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster class="${poster(true)}">
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator.root}">

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -15,7 +15,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster>
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="media-buffering-indicator">

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -42,7 +42,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster class="${poster(true)}">
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator}">

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -19,7 +19,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster>
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="media-buffering-indicator">

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -42,7 +42,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster class="${poster(true)}">
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="${bufferingIndicator.root}">

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -19,7 +19,11 @@ function getTemplateHTML() {
       <slot></slot>
 
       <media-poster>
-        <slot name="poster"></slot>
+        <slot name="poster">
+          <!-- Fallback image the skin owns. <media-poster> fills its src
+               from the store; an author-supplied poster replaces it. -->
+          <img />
+        </slot>
       </media-poster>
 
       <media-buffering-indicator class="media-buffering-indicator">

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -4,9 +4,11 @@ import type {
   AudioPlayerStore,
   PlayerStore,
   PlayerTarget,
+  UnionProviderProps,
   VideoFeatures,
   VideoPlayerStore,
 } from '@videojs/core/dom';
+import { collectProviderProps } from '@videojs/core/dom';
 import { combine, createStore } from '@videojs/store';
 
 import { type ContainerMixin, createContainerMixin } from '../store/container-mixin';
@@ -18,7 +20,10 @@ export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
   features: Features;
 }
 
-export interface CreatePlayerResult<Store extends PlayerStore> {
+export interface CreatePlayerResult<
+  Store extends PlayerStore,
+  Features extends AnyPlayerFeature[] = AnyPlayerFeature[],
+> {
   /** Context for consuming player in controllers. */
   context: PlayerContext<Store>;
 
@@ -29,7 +34,7 @@ export interface CreatePlayerResult<Store extends PlayerStore> {
   PlayerController: PlayerController.Constructor<Store>;
 
   /** Mixin that provides player context to descendants. */
-  ProviderMixin: ProviderMixin<Store>;
+  ProviderMixin: ProviderMixin<Store, UnionProviderProps<Features>>;
 
   /** Mixin that consumes player context and registers as the container element. */
   ContainerMixin: ContainerMixin<Store>;
@@ -60,7 +65,9 @@ export interface CreatePlayerResult<Store extends PlayerStore> {
  * @label Video
  * @param config - Player configuration with features.
  */
-export function createPlayer(config: CreatePlayerConfig<VideoFeatures>): CreatePlayerResult<VideoPlayerStore>;
+export function createPlayer(
+  config: CreatePlayerConfig<VideoFeatures>
+): CreatePlayerResult<VideoPlayerStore, VideoFeatures>;
 
 /**
  * Creates a player factory for audio media.
@@ -68,7 +75,9 @@ export function createPlayer(config: CreatePlayerConfig<VideoFeatures>): CreateP
  * @label Audio
  * @param config - Player configuration with features.
  */
-export function createPlayer(config: CreatePlayerConfig<AudioFeatures>): CreatePlayerResult<AudioPlayerStore>;
+export function createPlayer(
+  config: CreatePlayerConfig<AudioFeatures>
+): CreatePlayerResult<AudioPlayerStore, AudioFeatures>;
 
 /**
  * Creates a player factory with custom features.
@@ -78,13 +87,17 @@ export function createPlayer(config: CreatePlayerConfig<AudioFeatures>): CreateP
  */
 export function createPlayer<const Features extends AnyPlayerFeature[]>(
   config: CreatePlayerConfig<Features>
-): CreatePlayerResult<PlayerStore<Features>>;
+): CreatePlayerResult<PlayerStore<Features>, Features>;
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<PlayerStore> {
   const slice = combine<PlayerTarget, AnyPlayerFeature[]>(...config.features);
 
+  // Collected once per `createPlayer`, not per element: the feature list is fixed
+  // by the time this runs.
+  const providerProps = collectProviderProps(config.features);
+
   function create(): PlayerStore {
-    return createStore<PlayerTarget>()(slice);
+    return createStore<PlayerTarget>()(slice) as PlayerStore;
   }
 
   const ProviderMixin = createProviderMixin<PlayerStore>({
@@ -92,6 +105,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     mediaContext,
     containerContext,
     factory: create,
+    providerProps,
   });
 
   const ContainerMixin = createContainerMixin<PlayerStore>({

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -6,6 +6,7 @@ import {
   features,
   type PlayerStore,
   type PlayerTarget,
+  type ScreenOrientationLockType,
   type VideoPlayerStore,
   videoFeatures,
 } from '@videojs/core/dom';
@@ -53,14 +54,11 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('accepts the orientation lock feature alias with and without config', () => {
-    const configuredOrientationLock = features.orientationLock({ type: 'portrait' });
+  it('accepts the orientation lock feature alias', () => {
+    const result = createPlayer({ features: [features.orientationLock] });
 
-    const defaultResult = createPlayer({ features: [features.orientationLock] });
-    const configuredResult = createPlayer({ features: [configuredOrientationLock] });
-
-    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
-    assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(result);
+    assertType<ScreenOrientationLockType>(result.create().orientationLock);
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -1,7 +1,17 @@
-import { createPopupGroup, type MediaContainer, type PlayerStore, type PlayerTarget } from '@videojs/core/dom';
+import {
+  assertNoProviderPropCollisions,
+  type CollectedProviderProp,
+  createPopupGroup,
+  type MediaContainer,
+  type PlayerStore,
+  type PlayerTarget,
+  writeProviderProps,
+} from '@videojs/core/dom';
+import type { PropertyDeclarationMap, PropertyValues, ReactiveElement } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
 import type { Media } from '@videojs/media/dom';
 import { isNull } from '@videojs/utils/predicate';
+import type { EmptyObject } from '@videojs/utils/types';
 import type { MediaElementConstructor } from '@/ui/media-element';
 import type { ContainerContext, MediaContext, PlayerContext } from '../player/context';
 import type { PlayerProvider, PlayerProviderConstructor } from './types';
@@ -11,11 +21,13 @@ export interface ProviderMixinConfig<Store extends PlayerStore> {
   mediaContext: MediaContext;
   containerContext: ContainerContext;
   factory: () => Store;
+  /** Provider props collected from the feature list, keyed by prop name. */
+  providerProps: Map<string, CollectedProviderProp>;
 }
 
-export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaElementConstructor>(
+export type ProviderMixin<Store extends PlayerStore, Props = EmptyObject> = <Class extends MediaElementConstructor>(
   BaseClass: Class
-) => Class & PlayerProviderConstructor<Store>;
+) => Class & PlayerProviderConstructor<Store, Props>;
 
 /**
  * Create a mixin that provides player context to descendant elements and
@@ -28,13 +40,34 @@ export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaEleme
  * As a fallback for plain `<video>`/`<audio>` that can't consume context,
  * the provider queries its subtree after a microtask.
  *
- * @param config - Provider configuration with contexts and store factory.
+ * Fields declared by the composed features become ordinary reactive properties,
+ * so `<video-player content-title="…">` works through the attribute engine the
+ * element already has rather than a mechanism invented for this.
+ *
+ * @param config - Provider configuration with contexts, store factory, and props.
  */
-export function createProviderMixin<Store extends PlayerStore>(
+export function createProviderMixin<Store extends PlayerStore, Props = EmptyObject>(
   config: ProviderMixinConfig<Store>
-): ProviderMixin<Store> {
+): ProviderMixin<Store, Props> {
+  const declaredProperties: PropertyDeclarationMap = {};
+
+  for (const { name, attribute, type } of config.providerProps.values()) {
+    declaredProperties[name] = { type, attribute };
+  }
+
   return <Class extends MediaElementConstructor>(BaseClass: Class) => {
+    if (__DEV__) {
+      // Checked against the *base* prototype chain, before this class installs
+      // its own accessors, so an inherited DOM property is still visible.
+      assertNoProviderPropCollisions(config.providerProps, BaseClass.prototype);
+    }
+
     class PlayerProviderElement extends BaseClass implements PlayerProvider<Store> {
+      static properties: PropertyDeclarationMap = {
+        ...(BaseClass as unknown as typeof ReactiveElement).properties,
+        ...declaredProperties,
+      };
+
       #store: Store | null = config.factory();
       #detach: (() => void) | null = null;
       #media: Media | null = null;
@@ -96,6 +129,13 @@ export function createProviderMixin<Store extends PlayerStore>(
           setContainer: this.#setContainer,
           popupGroup: this.#popupGroup,
         });
+        // Before `#tryAttach()`, deliberately. Attributes are parsed during
+        // upgrade, but the element's first `update()` only runs a microtask after
+        // connect — so without this line the store would attach, and the media
+        // would report its own metadata, before the developer's values had landed.
+        // The ordering lives here because this callback is already the one place a
+        // reviewer looks for it.
+        this.#syncProviderProps();
         this.#tryAttach();
         this.#queueFallbackDiscovery();
       }
@@ -110,6 +150,30 @@ export function createProviderMixin<Store extends PlayerStore>(
         this.#store?.destroy();
         this.#store = null;
         super.destroyCallback();
+      }
+
+      /**
+       * Later changes take the ordinary Lit path: setting a declared property, or
+       * changing its attribute, requests an update, and the write happens here.
+       *
+       * Note the property *getter* keeps returning the element's own last-set
+       * value rather than the store's resolved value, because `ReactiveElement`'s
+       * generated accessor stores it under a symbol. That matters: after
+       * `el.contentTitle = undefined` hands control back to the media, reading the
+       * property must not report the media's title instead.
+       */
+      protected override willUpdate(changed: PropertyValues): void {
+        super.willUpdate(changed);
+        this.#syncProviderProps();
+      }
+
+      #syncProviderProps(): void {
+        if (!config.providerProps.size) return;
+
+        const store = this.#store;
+        if (!store || store.destroyed) return;
+
+        writeProviderProps(store as never, config.providerProps, (name) => (this as Record<string, unknown>)[name]);
       }
 
       #tryAttach(): void {
@@ -158,6 +222,9 @@ export function createProviderMixin<Store extends PlayerStore>(
       }
     }
 
-    return PlayerProviderElement;
+    // The declared props exist on the prototype at runtime but are never written
+    // as class fields, so the class type cannot see them — hence the assertion
+    // rather than a structural match.
+    return PlayerProviderElement as unknown as Class & PlayerProviderConstructor<Store, Props>;
   };
 }

--- a/packages/html/src/store/tests/provider-props.test.ts
+++ b/packages/html/src/store/tests/provider-props.test.ts
@@ -1,0 +1,171 @@
+import { type AnyPlayerFeature, contentMetadataFeature, features } from '@videojs/core/dom';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPlayer } from '../../player/create-player';
+import { MediaElement } from '../../ui/media-element';
+
+let tagCounter = 0;
+
+interface ProviderElement extends HTMLElement {
+  readonly store: Record<string, unknown>;
+  contentTitle?: string | null | undefined;
+  contentPoster?: string | null | undefined;
+  contentPosterAlt?: string | null | undefined;
+  defaultContentTitle?: string | null | undefined;
+}
+
+function defineProvider(featureList: AnyPlayerFeature[] = [features.playback, contentMetadataFeature]) {
+  const { ProviderMixin } = createPlayer({ features: featureList });
+  const tag = `test-provider-${++tagCounter}`;
+  const Ctor = ProviderMixin(MediaElement);
+  customElements.define(tag, Ctor as never);
+  return { tag, Ctor };
+}
+
+/** Parses markup so attributes land before `connectedCallback`, as in a real page. */
+function mount(tag: string, attributes = ''): ProviderElement {
+  const host = document.createElement('div');
+  host.innerHTML = `<${tag} ${attributes}></${tag}>`;
+  document.body.appendChild(host);
+  return host.firstElementChild as ProviderElement;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('provider props on an HTML provider', () => {
+  it('observes an attribute for every declared field', () => {
+    const { Ctor } = defineProvider();
+    const observed = (Ctor as unknown as { observedAttributes: string[] }).observedAttributes;
+
+    expect(observed).toContain('content-title');
+    expect(observed).toContain('content-poster');
+    expect(observed).toContain('content-poster-alt');
+    expect(observed).toContain('default-content-title');
+  });
+
+  it('reaches the store from an attribute present at parse time', () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title="A title"');
+
+    // Synchronously after connect, before any update cycle has run — the sync in
+    // `connectedCallback` is what makes this true, and it is what puts the value
+    // in place before the store attaches to any media.
+    expect(el.store.contentTitle).toBe('A title');
+  });
+
+  it('reaches the store for every declared field', () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title="A title" content-poster="poster.jpg" content-poster-alt="A description"');
+
+    expect(el.store.contentTitle).toBe('A title');
+    expect(el.store.contentPoster).toBe('poster.jpg');
+    expect(el.store.contentPosterAlt).toBe('A description');
+  });
+
+  it('writes the fallback tier from a default- attribute', () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'default-content-title="A fallback"');
+
+    expect(el.store.contentTitle).toBe('A fallback');
+  });
+
+  it('keeps an empty attribute as a suppressing value', () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title=""');
+
+    expect(el.store.contentTitle).toBe('');
+  });
+
+  it('updates the store when an attribute changes', async () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title="First"');
+
+    el.setAttribute('content-title', 'Second');
+    await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+    expect(el.store.contentTitle).toBe('Second');
+  });
+
+  it('falls back when an attribute is removed', async () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title="First" default-content-title="A fallback"');
+
+    el.removeAttribute('content-title');
+    await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+    // Removing an attribute yields null, which the resolve chain treats as absent.
+    expect(el.store.contentTitle).toBe('A fallback');
+  });
+
+  it('updates the store when a property is set', async () => {
+    const { tag } = defineProvider();
+    const el = mount(tag);
+
+    el.contentTitle = 'From a property';
+    await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+    expect(el.store.contentTitle).toBe('From a property');
+  });
+
+  it('reports the element’s own last-set value from the property, not the store’s', async () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title="From the developer"');
+
+    el.contentTitle = undefined;
+    await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+    // The property must keep reporting what was assigned to it. If it read the
+    // store's resolved value instead, handing control back to the media would make
+    // the property start reporting the media's title and stop round-tripping.
+    expect(el.contentTitle).toBeUndefined();
+  });
+
+  it('declares no properties when no composed feature declares any', () => {
+    const { Ctor } = defineProvider([features.playback]);
+    const observed = (Ctor as unknown as { observedAttributes: string[] }).observedAttributes;
+
+    expect(observed).not.toContain('content-title');
+  });
+
+  it('preserves developer values across a disconnect and reconnect', () => {
+    const { tag } = defineProvider();
+    const el = mount(tag, 'content-title="A title"');
+    const host = el.parentElement!;
+
+    el.remove();
+    host.appendChild(el);
+
+    expect(el.store.contentTitle).toBe('A title');
+  });
+
+  it('exposes the imperative setters on the store', () => {
+    const { tag } = defineProvider();
+    const el = mount(tag);
+
+    expect(typeof el.store.setContentTitle).toBe('function');
+
+    (el.store.setContentTitle as (value: string) => void)('From the setter');
+    expect(el.store.contentTitle).toBe('From the setter');
+  });
+});
+
+describe('orientation lock as a provider prop', () => {
+  it('observes orientation-lock and resolves it on the store', () => {
+    const { tag, Ctor } = defineProvider([features.orientationLock]);
+    const observed = (Ctor as unknown as { observedAttributes: string[] }).observedAttributes;
+
+    expect(observed).toContain('orientation-lock');
+
+    const el = mount(tag, 'orientation-lock="portrait"');
+    expect(el.store.orientationLock).toBe('portrait');
+  });
+
+  it('falls back to landscape when the attribute is absent', () => {
+    const { tag } = defineProvider([features.orientationLock]);
+    const el = mount(tag);
+
+    expect(el.store.orientationLock).toBe('landscape');
+  });
+});

--- a/packages/html/src/store/types.ts
+++ b/packages/html/src/store/types.ts
@@ -1,5 +1,5 @@
 import type { PlayerStore } from '@videojs/core/dom';
-import type { Constructor } from '@videojs/utils/types';
+import type { Constructor, EmptyObject } from '@videojs/utils/types';
 import type { MediaElement } from '@/ui/media-element';
 
 // ----------------------------------------
@@ -10,7 +10,14 @@ export interface PlayerProvider<Store extends PlayerStore> extends MediaElement 
   readonly store: Store;
 }
 
-export interface PlayerProviderConstructor<Store extends PlayerStore> extends Constructor<PlayerProvider<Store>> {}
+/**
+ * `Props` carries the fields declared by the composed features, so a provider
+ * element's type gains an instance property only when the feature that declares
+ * it is present. They are declared in types but never written as real class
+ * fields — `ReactiveElement` installs them on the prototype at runtime.
+ */
+export interface PlayerProviderConstructor<Store extends PlayerStore, Props = EmptyObject>
+  extends Constructor<PlayerProvider<Store> & Props> {}
 
 // ----------------------------------------
 // PlayerConsumer

--- a/packages/html/src/ui/poster/poster-element.ts
+++ b/packages/html/src/ui/poster/poster-element.ts
@@ -1,10 +1,26 @@
 import { PosterCore, PosterDataAttrs } from '@videojs/core';
-import { selectPlayback } from '@videojs/core/dom';
+import { selectContentMetadata, selectPlayback } from '@videojs/core/dom';
+import type { PropertyValues } from '@videojs/element';
 
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { MediaUIElement } from '../media-ui-element';
 
+/**
+ * Wrapper around a poster image.
+ *
+ * The author supplies the image element; this element supplies the URL from the
+ * store when the image has none. It never creates an image and never overwrites
+ * a `src` the author set, so a bare `<media-poster>` with no image inside renders
+ * nothing — by design. The element is a wrapper around *your* image, which keeps
+ * `srcset`, `loading="lazy"`, `<picture>`, and framework image components
+ * available.
+ *
+ * This is deliberately not symmetric with React's `<Poster>`, which owns its own
+ * image element. User-visible behaviour is identical; each side follows its
+ * platform's grain, and bringing this element to parity would mean adding a
+ * shadow root to an element family that deliberately has none.
+ */
 export class PosterElement extends MediaUIElement<PosterCore> {
   static readonly tagName = 'media-poster';
 
@@ -16,6 +32,7 @@ export class PosterElement extends MediaUIElement<PosterCore> {
   protected readonly core = new PosterCore();
   protected readonly stateAttrMap = PosterDataAttrs;
   protected readonly mediaState = new PlayerController(this, playerContext, selectPlayback);
+  readonly #contentMetadata = new PlayerController(this, playerContext, selectContentMetadata);
 
   override attributeChangedCallback(attr: string, oldValue: string | null, newValue: string | null): void {
     super.attributeChangedCallback(attr, oldValue, newValue);
@@ -27,5 +44,76 @@ export class PosterElement extends MediaUIElement<PosterCore> {
         this.style.removeProperty('--media-poster-placeholder');
       }
     }
+  }
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+    this.#fillImage();
+  }
+
+  /**
+   * Whether the author supplied each attribute themselves, snapshotted the first
+   * time an image is seen.
+   *
+   * Ownership has to be remembered rather than re-derived, because after the
+   * first fill the attribute is present either way. Re-checking presence would
+   * freeze the poster on whatever the store happened to hold at that moment —
+   * so a playlist advancing to the next video would keep the previous poster.
+   */
+  #authorOwnsSrc: boolean | undefined;
+  #authorOwnsAlt: boolean | undefined;
+
+  /**
+   * Fills the `src` and `alt` the author left for us on the image they supplied,
+   * and keeps them in step with the store afterwards.
+   *
+   * `alt` ownership is decided by *presence*, never emptiness: an author writing
+   * `alt=""` is deliberately marking the image decorative, and overwriting that
+   * would be an accessibility bug rather than a cosmetic one.
+   */
+  #fillImage(): void {
+    const metadata = this.#contentMetadata.value;
+    if (!metadata) return;
+
+    // Reaches through a slot so a default skin's fallback image is found too.
+    const image = this.#findImage();
+    if (!image) return;
+
+    this.#authorOwnsSrc ??= !!image.getAttribute('src');
+    this.#authorOwnsAlt ??= image.hasAttribute('alt');
+
+    if (!this.#authorOwnsSrc) {
+      // A resolved empty string means render nothing, so the attribute is removed
+      // rather than set to `""` — which would request the current page.
+      if (metadata.contentPoster) {
+        image.setAttribute('src', metadata.contentPoster);
+      } else {
+        image.removeAttribute('src');
+      }
+    }
+
+    if (!this.#authorOwnsAlt) {
+      image.setAttribute('alt', metadata.contentPosterAlt);
+    }
+  }
+
+  #findImage(): HTMLImageElement | null {
+    // Anything the author assigned to a slot wins over a skin's fallback image.
+    // `assignedNodes()` is deliberately un-flattened: it returns nothing when the
+    // slot is empty, which is how "the author supplied an image" is detected.
+    // Flattening would return the fallback here and conflate the two cases.
+    for (const slot of this.querySelectorAll('slot')) {
+      for (const node of slot.assignedNodes()) {
+        if (node instanceof HTMLImageElement) return node;
+        if (node instanceof Element) {
+          const nested = node.querySelector('img');
+          if (nested) return nested;
+        }
+      }
+    }
+
+    // Hand-composed markup, or a skin's fallback image sitting inside an empty
+    // slot — both are ordinary descendants from here.
+    return this.querySelector('img');
   }
 }

--- a/packages/html/src/ui/poster/tests/poster-element.test.ts
+++ b/packages/html/src/ui/poster/tests/poster-element.test.ts
@@ -1,0 +1,150 @@
+import { contentMetadataFeature, features } from '@videojs/core/dom';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPlayer } from '../../../player/create-player';
+import { MediaElement } from '../../media-element';
+import { PosterElement } from '../poster-element';
+
+const { ProviderMixin } = createPlayer({ features: [features.playback, contentMetadataFeature] });
+
+class TestProviderElement extends ProviderMixin(MediaElement) {
+  static readonly tagName = 'test-poster-provider';
+}
+
+beforeAll(() => {
+  customElements.define(TestProviderElement.tagName, TestProviderElement as never);
+  customElements.define(PosterElement.tagName, PosterElement);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+/**
+ * Lets the whole chain settle: the provider's update writes to the store, the
+ * store notifies on a microtask, the controller requests an update, and the
+ * poster updates.
+ */
+async function settle(poster: PosterElement) {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await (poster as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+}
+
+/** Mounts a provider wrapping `<media-poster>` and waits for the element's update cycle. */
+async function mount(providerAttrs: string, posterInner: string) {
+  const host = document.createElement('div');
+  host.innerHTML = `
+    <${TestProviderElement.tagName} ${providerAttrs}>
+      <media-poster>${posterInner}</media-poster>
+    </${TestProviderElement.tagName}>
+  `;
+  document.body.appendChild(host);
+
+  const poster = host.querySelector('media-poster') as PosterElement;
+  await (poster as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+  return { poster, image: poster.querySelector('img') };
+}
+
+describe('PosterElement content metadata', () => {
+  it('fills an empty src on the image the author supplied', async () => {
+    const { image } = await mount('content-poster="poster.jpg"', '<img />');
+
+    expect(image?.getAttribute('src')).toBe('poster.jpg');
+  });
+
+  it('never overwrites a src the author set', async () => {
+    const { image } = await mount('content-poster="from-store.jpg"', '<img src="mine.jpg" />');
+
+    expect(image?.getAttribute('src')).toBe('mine.jpg');
+  });
+
+  it('renders nothing when there is no image to fill', async () => {
+    const { poster } = await mount('content-poster="poster.jpg"', '');
+
+    // By design: the element is a wrapper around your image, and it never creates
+    // one.
+    expect(poster.querySelector('img')).toBeNull();
+  });
+
+  it('leaves the src alone when the resolved poster is empty', async () => {
+    const { image } = await mount('', '<img />');
+
+    // Not `src=""`, which would request the current page.
+    expect(image?.hasAttribute('src')).toBe(false);
+  });
+
+  it('fills a missing alt from the resolved alt text', async () => {
+    const { image } = await mount('content-poster="poster.jpg" content-poster-alt="A description"', '<img />');
+
+    expect(image?.getAttribute('alt')).toBe('A description');
+  });
+
+  it('fills a missing alt with an empty string, marking the image decorative', async () => {
+    const { image } = await mount('content-poster="poster.jpg"', '<img />');
+
+    // An image with no accessible name is an accessibility fault; an empty alt is
+    // the platform's marker for decorative, which is the right default.
+    expect(image?.getAttribute('alt')).toBe('');
+  });
+
+  it('never overwrites an author’s empty alt', async () => {
+    const { image } = await mount('content-poster="poster.jpg" content-poster-alt="A description"', '<img alt="" />');
+
+    // Presence, never emptiness. An author writing `alt=""` is deliberately
+    // marking the image decorative.
+    expect(image?.getAttribute('alt')).toBe('');
+  });
+
+  it('never overwrites an author’s alt text', async () => {
+    const { image } = await mount(
+      'content-poster="poster.jpg" content-poster-alt="From the store"',
+      '<img alt="Mine" />'
+    );
+
+    expect(image?.getAttribute('alt')).toBe('Mine');
+  });
+
+  it('fills an image nested inside a wrapper element', async () => {
+    const { poster } = await mount('content-poster="poster.jpg"', '<picture><img /></picture>');
+
+    expect(poster.querySelector('img')?.getAttribute('src')).toBe('poster.jpg');
+  });
+
+  it('follows the store when the resolved poster changes', async () => {
+    const { poster, image } = await mount('content-poster="first.jpg"', '<img />');
+    expect(image?.getAttribute('src')).toBe('first.jpg');
+
+    poster.closest(TestProviderElement.tagName)?.setAttribute('content-poster', 'second.jpg');
+    await settle(poster);
+
+    // Once filled, the attribute is present either way — so re-deriving ownership
+    // from presence would leave a playlist stuck on the first video's poster.
+    expect(image?.getAttribute('src')).toBe('second.jpg');
+  });
+
+  it('still refuses to touch an author’s src when the store changes', async () => {
+    const { poster, image } = await mount('content-poster="first.jpg"', '<img src="mine.jpg" />');
+
+    poster.closest(TestProviderElement.tagName)?.setAttribute('content-poster', 'second.jpg');
+    await settle(poster);
+
+    expect(image?.getAttribute('src')).toBe('mine.jpg');
+  });
+
+  it('keeps working when the content metadata feature is absent', async () => {
+    const bare = createPlayer({ features: [features.playback] });
+    class BareProvider extends bare.ProviderMixin(MediaElement) {}
+    const tag = 'test-poster-bare-provider';
+    customElements.define(tag, BareProvider as never);
+
+    const host = document.createElement('div');
+    host.innerHTML = `<${tag}><media-poster><img src="mine.jpg" /></media-poster></${tag}>`;
+    document.body.appendChild(host);
+
+    const poster = host.querySelector('media-poster') as PosterElement;
+    await (poster as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+    expect(poster.querySelector('img')?.getAttribute('src')).toBe('mine.jpg');
+  });
+});

--- a/packages/media/src/core/predicate.ts
+++ b/packages/media/src/core/predicate.ts
@@ -4,6 +4,9 @@ import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants'
 import type {
   MediaAudioTrackCapability,
   MediaBufferCapability,
+  MediaContentPosterAltCapability,
+  MediaContentPosterCapability,
+  MediaContentTitleCapability,
   MediaErrorCapability,
   MediaLiveCapability,
   MediaPauseCapability,
@@ -108,6 +111,40 @@ export function isMediaStreamTypeCapable(value: unknown): value is MediaStreamTy
   if (!isObject(value)) return false;
   const media = value as Record<string, unknown>;
   return !isUndefined(media.streamType);
+}
+
+/**
+ * These three read `!isUndefined` like every other predicate here, and that is
+ * load-bearing rather than incidental.
+ *
+ * `undefined` means the property is not declared at all. A host that *does*
+ * declare it reports `null` when it has nothing to say — which is why
+ * `CustomMediaElement` declarations for these fields must specify `empty: null`.
+ * Were absence spelled `undefined`, capability would flicker as an attribute
+ * came and went, and because a feature checks capability once at attach and
+ * wires its listener then, a value arriving later would never reach the store.
+ *
+ * The practical consequence, accepted deliberately: any host carrying the
+ * declaration is capable, always, so for these fields the check is a formality
+ * rather than a real branch. There is nothing to gate — any media host can
+ * carry content metadata.
+ */
+export function isMediaContentTitleCapable(value: unknown): value is MediaContentTitleCapability {
+  if (!isObject(value)) return false;
+  const media = value as Record<string, unknown>;
+  return !isUndefined(media.contentTitle);
+}
+
+export function isMediaContentPosterCapable(value: unknown): value is MediaContentPosterCapability {
+  if (!isObject(value)) return false;
+  const media = value as Record<string, unknown>;
+  return !isUndefined(media.contentPoster);
+}
+
+export function isMediaContentPosterAltCapable(value: unknown): value is MediaContentPosterAltCapability {
+  if (!isObject(value)) return false;
+  const media = value as Record<string, unknown>;
+  return !isUndefined(media.contentPosterAlt);
 }
 
 export function isMediaLiveCapable(value: unknown): value is MediaLiveCapability {

--- a/packages/media/src/core/state.ts
+++ b/packages/media/src/core/state.ts
@@ -1,4 +1,4 @@
-import type { ErrorLike, MediaFeatureAvailability, MediaStreamType, TextTrackKind } from './types';
+import type { ErrorLike, MediaContentValue, MediaFeatureAvailability, MediaStreamType, TextTrackKind } from './types';
 
 export type { TextTrackKind };
 
@@ -369,4 +369,44 @@ export interface MediaPictureInPictureState {
   exitPictureInPicture(): Promise<void>;
   /** Toggle picture-in-picture mode. */
   togglePictureInPicture(): Promise<void>;
+}
+
+/**
+ * Content metadata resolved by the player, plus the setters that feed it.
+ *
+ * `contentTitle`, `contentPoster`, and `contentPosterAlt` are computed from the
+ * developer's override, whatever the media reports, and the developer's
+ * fallback, in that order. Each is a plain `string`, so consumers never handle a
+ * missing value, and an **empty string means "render nothing"** — no title text,
+ * no poster element — rather than an element with an empty source. A component
+ * piping `contentPoster` straight into `src` must guard, because `<img src="">`
+ * requests the current page.
+ *
+ * The setters come in pairs. `setX` writes the developer's **override**, which
+ * beats anything the media reports; `setDefaultX` writes the developer's
+ * **fallback**, used only when the media reports nothing. These write the same
+ * two slots as the provider's `content-title` and `default-content-title`
+ * attributes, so the imperative and declarative paths cannot drift. Passing
+ * `null` or `undefined` clears a slot and lets resolution fall through; passing
+ * an empty string sets it to deliberately blank.
+ */
+export interface MediaContentMetadataState {
+  /** Title of the content. Empty string when nothing should be shown. */
+  contentTitle: string;
+  /** URL of a poster image for the content. Empty string when there is none. */
+  contentPoster: string;
+  /**
+   * Alternative text describing the content poster.
+   *
+   * Empty string is the correct default: it marks the image decorative, which
+   * is what an empty `alt` already means in HTML, rather than leaving an image
+   * with no accessible name.
+   */
+  contentPosterAlt: string;
+  setContentTitle(value: MediaContentValue): void;
+  setDefaultContentTitle(value: MediaContentValue): void;
+  setContentPoster(value: MediaContentValue): void;
+  setDefaultContentPoster(value: MediaContentValue): void;
+  setContentPosterAlt(value: MediaContentValue): void;
+  setDefaultContentPosterAlt(value: MediaContentValue): void;
 }

--- a/packages/media/src/core/types.ts
+++ b/packages/media/src/core/types.ts
@@ -464,6 +464,71 @@ export interface MediaLiveCapability {
 }
 
 // ----------------------------------------
+// Content metadata
+// ----------------------------------------
+
+/**
+ * A metadata value the media is reporting about its content.
+ *
+ * `null` and `undefined` both mean "the media has nothing to say" and let the
+ * player fall through to a lower-precedence source. An **empty string is a real
+ * value** meaning "deliberately blank" — a media must never manufacture one to
+ * stand in for absence.
+ *
+ * @see {@link MediaContentTitleCapability}
+ */
+export type MediaContentValue = string | null | undefined;
+
+/**
+ * Content metadata is deliberately separate from the element's own `title` and
+ * `poster`.
+ *
+ * `title` and `poster` are the *developer's* settings on the media element —
+ * the native tooltip and the `<video poster>` frame. The `content*` properties
+ * are *facts about the content itself*, usually supplied by a backend: a
+ * `mux-video` that fetches a title from the Mux API reports it here. Merging the
+ * two would erase that distinction, so they are not reconciled.
+ *
+ * A media that reports content metadata is expected to **clear it on source
+ * change** and dispatch the change event. Only the dispatch half is
+ * structurally enforced — assigning through the host setter always fires the
+ * event, whereas clearing on a new source is convention with nothing checking
+ * it. The player wires no fallback listener; see
+ * `internal/decisions/media/content-metadata.md`.
+ */
+export interface MediaContentTitleEvents {
+  contenttitlechange: EventLike;
+}
+
+export interface MediaContentTitleCapability {
+  /** Title of the content, or nothing if the media has no opinion. */
+  readonly contentTitle: MediaContentValue;
+}
+
+export interface MediaContentPosterEvents {
+  contentposterchange: EventLike;
+}
+
+export interface MediaContentPosterCapability {
+  /** URL of a poster image for the content, or nothing if the media has no opinion. */
+  readonly contentPoster: MediaContentValue;
+}
+
+export interface MediaContentPosterAltEvents {
+  contentposteraltchange: EventLike;
+}
+
+export interface MediaContentPosterAltCapability {
+  /**
+   * Alternative text describing the content poster.
+   *
+   * An empty string is the platform's marker for a decorative image, so it is a
+   * meaningful value here rather than a stand-in for absence.
+   */
+  readonly contentPosterAlt: MediaContentValue;
+}
+
+// ----------------------------------------
 // Remote playback
 // ----------------------------------------
 
@@ -547,7 +612,10 @@ export interface MediaFullEvents
     MediaErrorEvents,
     TextTrackListEvents,
     MediaStreamTypeEvents,
-    MediaLiveEvents {}
+    MediaLiveEvents,
+    MediaContentTitleEvents,
+    MediaContentPosterEvents,
+    MediaContentPosterAltEvents {}
 
 export interface MediaFull<Events extends { [K in keyof Events]: EventLike } = MediaFullEvents>
   extends Media<Events>,
@@ -565,7 +633,10 @@ export interface MediaFull<Events extends { [K in keyof Events]: EventLike } = M
     MediaRemotePlaybackCapability,
     MediaControlsCapability,
     MediaAutoplayCapability,
-    MediaConfigCapability {}
+    MediaConfigCapability,
+    MediaContentTitleCapability,
+    MediaContentPosterCapability,
+    MediaContentPosterAltCapability {}
 
 export interface VideoEvents extends MediaFullEvents, MediaPictureInPictureEvents, MediaVideoDimensionsEvents {}
 
@@ -601,6 +672,9 @@ export interface MediaTargetLike
     MediaAutoplayCapability,
     Partial<MediaLiveCapability>,
     Partial<MediaStreamTypeCapability>,
+    Partial<MediaContentTitleCapability>,
+    Partial<MediaContentPosterCapability>,
+    Partial<MediaContentPosterAltCapability>,
     Partial<MediaConfigCapability> {
   title: string;
 }

--- a/packages/media/src/core/types.ts
+++ b/packages/media/src/core/types.ts
@@ -479,15 +479,18 @@ export interface MediaLiveCapability {
  */
 export type MediaContentValue = string | null | undefined;
 
+export interface MediaContentTitleEvents {
+  contenttitlechange: EventLike;
+}
+
 /**
  * Content metadata is deliberately separate from the element's own `title` and
- * `poster`.
+ * `poster`, and the two are never reconciled.
  *
- * `title` and `poster` are the *developer's* settings on the media element —
- * the native tooltip and the `<video poster>` frame. The `content*` properties
- * are *facts about the content itself*, usually supplied by a backend: a
- * `mux-video` that fetches a title from the Mux API reports it here. Merging the
- * two would erase that distinction, so they are not reconciled.
+ * `title` and `poster` are the *developer's* settings on the media element — the
+ * native tooltip and the `<video poster>` frame. The `content*` properties are
+ * *facts about the content itself*, usually supplied by a backend: a `mux-video`
+ * that fetches a title from the Mux API reports it here.
  *
  * A media that reports content metadata is expected to **clear it on source
  * change** and dispatch the change event. Only the dispatch half is
@@ -496,10 +499,6 @@ export type MediaContentValue = string | null | undefined;
  * it. The player wires no fallback listener; see
  * `internal/decisions/media/content-metadata.md`.
  */
-export interface MediaContentTitleEvents {
-  contenttitlechange: EventLike;
-}
-
 export interface MediaContentTitleCapability {
   /** Title of the content, or nothing if the media has no opinion. */
   readonly contentTitle: MediaContentValue;
@@ -509,6 +508,13 @@ export interface MediaContentPosterEvents {
   contentposterchange: EventLike;
 }
 
+/**
+ * A poster image describing the content, separate from the element's own
+ * `poster` attribute.
+ *
+ * @see {@link MediaContentTitleCapability} for why both exist and for the
+ * clearing contract every content-metadata field shares.
+ */
 export interface MediaContentPosterCapability {
   /** URL of a poster image for the content, or nothing if the media has no opinion. */
   readonly contentPoster: MediaContentValue;
@@ -518,6 +524,12 @@ export interface MediaContentPosterAltEvents {
   contentposteraltchange: EventLike;
 }
 
+/**
+ * Alternative text for {@link MediaContentPosterCapability}.
+ *
+ * @see {@link MediaContentTitleCapability} for why both exist and for the
+ * clearing contract every content-metadata field shares.
+ */
 export interface MediaContentPosterAltCapability {
   /**
    * Alternative text describing the content poster.

--- a/packages/media/src/dom/custom-media-element/custom-media-element.ts
+++ b/packages/media/src/dom/custom-media-element/custom-media-element.ts
@@ -132,6 +132,14 @@ export function CustomMediaElement<T extends Constructor<MediaHost>>(
       preload: { type: String, empty: null },
       src: { type: String, empty: '' },
       streamType: { type: String, attribute: 'stream-type', empty: 'unknown' },
+      // `empty: null`, following `preload` above rather than `poster` and `src`.
+      // Removing the attribute must mean "nothing to say" so the player falls
+      // through to a lower-precedence source; collapsing to `''` would instead
+      // assert a deliberately blank title, and would also make the capability
+      // predicate flicker. See `MediaContentTitleCapability`.
+      contentTitle: { type: String, attribute: 'content-title', empty: null },
+      contentPoster: { type: String, attribute: 'content-poster', empty: null },
+      contentPosterAlt: { type: String, attribute: 'content-poster-alt', empty: null },
     };
 
     static get observedAttributes() {

--- a/packages/media/src/dom/custom-media-element/tests/custom-media-element.test.ts
+++ b/packages/media/src/dom/custom-media-element/tests/custom-media-element.test.ts
@@ -646,6 +646,49 @@ describe('CustomMediaElement', () => {
     });
   });
 
+  describe('content metadata reflection', () => {
+    it('sets the host contentTitle from the content-title attribute', () => {
+      const el = create(defineVideoElement());
+      el.setAttribute('content-title', 'A title');
+      expect(el.contentTitle).toBe('A title');
+    });
+
+    it('keeps an empty attribute as an empty string, not absence', () => {
+      const el = create(defineVideoElement());
+      el.setAttribute('content-title', '');
+      expect(el.contentTitle).toBe('');
+    });
+
+    it('reports null when the attribute is removed, per empty: null', () => {
+      const el = create(defineVideoElement());
+      el.setAttribute('content-title', 'A title');
+      el.removeAttribute('content-title');
+
+      // Not `''`. Absence has to stay distinguishable from a deliberately blank
+      // title, or the player cannot fall through to a lower-precedence source.
+      expect(el.contentTitle).toBeNull();
+    });
+
+    it('does not forward content metadata to the inner media element', () => {
+      const el = create(defineVideoElement());
+      el.setAttribute('content-title', 'A title');
+      el.setAttribute('content-poster', 'poster.jpg');
+
+      expect(el.target!.hasAttribute('content-title')).toBe(false);
+      expect(el.target!.hasAttribute('content-poster')).toBe(false);
+    });
+
+    it('maps each field to its kebab-case attribute', () => {
+      const el = create(defineVideoElement());
+
+      el.setAttribute('content-poster', 'poster.jpg');
+      el.setAttribute('content-poster-alt', 'A description');
+
+      expect(el.contentPoster).toBe('poster.jpg');
+      expect(el.contentPosterAlt).toBe('A description');
+    });
+  });
+
   describe('event delegation', () => {
     it('forwards non-composed media events from the target to the host', () => {
       const el = create(defineVideoElement());

--- a/packages/media/src/dom/media-host/media-host.ts
+++ b/packages/media/src/dom/media-host/media-host.ts
@@ -2,6 +2,7 @@ import type { EventListenerFor, EventType, QueriedElement } from '@videojs/utils
 import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
 import {
   type EventLike,
+  type MediaContentValue,
   type MediaFull,
   type MediaStreamType,
   MediaStreamTypes,
@@ -55,6 +56,9 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
   #target: Target | null = null;
   #eventTypes = new Set<string>();
   #streamType: MediaStreamType = MediaStreamTypes.UNKNOWN;
+  #contentTitle: MediaContentValue = null;
+  #contentPoster: MediaContentValue = null;
+  #contentPosterAlt: MediaContentValue = null;
   #config: MediaConfig = {};
 
   protected get target() {
@@ -144,6 +148,48 @@ export class HTMLMediaElementHost<Target extends HTMLMediaTargetLike, Events ext
     this.#streamType = value;
     setMediaProp(this, 'streamType', value);
     this.dispatchEvent(new Event('streamtypechange'));
+  }
+
+  /**
+   * Title of the content, as reported by the media itself — distinct from
+   * {@link title}, which is the developer's setting on the element.
+   *
+   * The backing field starts as `null`, not `undefined`: `null` reads as
+   * "nothing to say" to the player's resolve chain while still satisfying the
+   * capability predicate, so a host stays capable even before a value arrives.
+   * Deliberately **no** `?? ''` fallback — that would erase the difference
+   * between "absent" and "deliberately blank", which the player depends on.
+   */
+  get contentTitle(): MediaContentValue {
+    return getMediaProp(this, 'contentTitle') ?? this.#contentTitle;
+  }
+  set contentTitle(value: MediaContentValue) {
+    if (this.contentTitle === value) return;
+    this.#contentTitle = value ?? null;
+    setMediaProp(this, 'contentTitle', value);
+    this.dispatchEvent(new Event('contenttitlechange'));
+  }
+
+  /** URL of a poster image for the content, as reported by the media itself. */
+  get contentPoster(): MediaContentValue {
+    return getMediaProp(this, 'contentPoster') ?? this.#contentPoster;
+  }
+  set contentPoster(value: MediaContentValue) {
+    if (this.contentPoster === value) return;
+    this.#contentPoster = value ?? null;
+    setMediaProp(this, 'contentPoster', value);
+    this.dispatchEvent(new Event('contentposterchange'));
+  }
+
+  /** Alternative text describing the content poster. */
+  get contentPosterAlt(): MediaContentValue {
+    return getMediaProp(this, 'contentPosterAlt') ?? this.#contentPosterAlt;
+  }
+  set contentPosterAlt(value: MediaContentValue) {
+    if (this.contentPosterAlt === value) return;
+    this.#contentPosterAlt = value ?? null;
+    setMediaProp(this, 'contentPosterAlt', value);
+    this.dispatchEvent(new Event('contentposteraltchange'));
   }
 
   get liveEdgeStart() {

--- a/packages/media/src/dom/tests/content-metadata.test.ts
+++ b/packages/media/src/dom/tests/content-metadata.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isMediaContentPosterAltCapable,
+  isMediaContentPosterCapable,
+  isMediaContentTitleCapable,
+} from '../../core/predicate';
+import { HTMLMediaElementHost, type HTMLMediaTargetLike } from '../media-host';
+
+class TestHost extends HTMLMediaElementHost<HTMLMediaTargetLike, Record<string, Event>> {}
+
+describe('HTMLMediaElementHost content metadata', () => {
+  it('reports null rather than an empty string when nothing has been set', () => {
+    const host = new TestHost();
+
+    expect(host.contentTitle).toBeNull();
+    expect(host.contentPoster).toBeNull();
+    expect(host.contentPosterAlt).toBeNull();
+  });
+
+  it('dispatches a change event when a value is assigned', () => {
+    const host = new TestHost();
+    const listener = vi.fn();
+
+    host.addEventListener('contenttitlechange', listener);
+    host.contentTitle = 'A title';
+
+    expect(host.contentTitle).toBe('A title');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch when the value is unchanged', () => {
+    const host = new TestHost();
+    const listener = vi.fn();
+
+    host.contentTitle = 'A title';
+    host.addEventListener('contenttitlechange', listener);
+    host.contentTitle = 'A title';
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('keeps an empty string as a real value distinct from absence', () => {
+    const host = new TestHost();
+    const listener = vi.fn();
+
+    host.addEventListener('contenttitlechange', listener);
+    host.contentTitle = '';
+
+    expect(host.contentTitle).toBe('');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalises a cleared value to null so the host stays capable', () => {
+    const host = new TestHost();
+
+    host.contentTitle = 'A title';
+    host.contentTitle = undefined;
+
+    expect(host.contentTitle).toBeNull();
+    expect(isMediaContentTitleCapable(host)).toBe(true);
+  });
+
+  it('dispatches a separate event per field', () => {
+    const host = new TestHost();
+    const title = vi.fn();
+    const poster = vi.fn();
+    const posterAlt = vi.fn();
+
+    host.addEventListener('contenttitlechange', title);
+    host.addEventListener('contentposterchange', poster);
+    host.addEventListener('contentposteraltchange', posterAlt);
+
+    host.contentPoster = 'poster.jpg';
+
+    expect(poster).toHaveBeenCalledTimes(1);
+    expect(title).not.toHaveBeenCalled();
+    expect(posterAlt).not.toHaveBeenCalled();
+  });
+
+  it('keeps content metadata separate from the element’s own title and poster', () => {
+    const host = new TestHost();
+
+    host.contentTitle = 'Content title';
+
+    // `title` is the developer's setting on the element and is a different
+    // concept; the two are deliberately not reconciled.
+    expect(host.title).toBe('');
+    expect(host.contentTitle).toBe('Content title');
+  });
+});
+
+describe('content metadata predicates', () => {
+  it('report capable for any host carrying the declaration', () => {
+    const host = new TestHost();
+
+    expect(isMediaContentTitleCapable(host)).toBe(true);
+    expect(isMediaContentPosterCapable(host)).toBe(true);
+    expect(isMediaContentPosterAltCapable(host)).toBe(true);
+  });
+
+  it('report not capable for a media that does not declare the property', () => {
+    expect(isMediaContentTitleCapable({ paused: true })).toBe(false);
+    expect(isMediaContentPosterCapable({ paused: true })).toBe(false);
+    expect(isMediaContentPosterAltCapable({ paused: true })).toBe(false);
+  });
+
+  it('report capable when the value is null, so capability cannot flicker', () => {
+    expect(isMediaContentTitleCapable({ contentTitle: null })).toBe(true);
+  });
+
+  it('report not capable when the value is undefined', () => {
+    expect(isMediaContentTitleCapable({ contentTitle: undefined })).toBe(false);
+  });
+});

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -5,18 +5,22 @@ import {
   type AnyPlayerStore,
   type AudioFeatures,
   type AudioPlayerStore,
+  assertNoProviderPropCollisions,
+  collectProviderProps,
   createPopupGroup,
   type PlayerStore,
   type PlayerTarget,
+  type UnionProviderProps,
   type VideoFeatures,
   type VideoPlayerStore,
+  writeProviderProps,
 } from '@videojs/core/dom';
 import type { Media } from '@videojs/media/dom';
 import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import type { FC, ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 import { useDestroy } from '../utils/use-destroy';
 import { Container } from './container';
@@ -27,12 +31,19 @@ export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
   displayName?: string;
 }
 
-export interface ProviderProps {
+/**
+ * Props every provider accepts, plus one per field declared by the composed
+ * features — so a prop exists only when the feature that owns it is composed.
+ */
+export type ProviderProps<Features extends AnyPlayerFeature[] = AnyPlayerFeature[]> = UnionProviderProps<Features> & {
   children: ReactNode;
-}
+};
 
-export interface CreatePlayerResult<Store extends PlayerStore> {
-  Provider: FC<ProviderProps>;
+export interface CreatePlayerResult<
+  Store extends PlayerStore,
+  Features extends AnyPlayerFeature[] = AnyPlayerFeature[],
+> {
+  Provider: FC<ProviderProps<Features>>;
   Container: typeof Container;
   usePlayer: UsePlayerHook<Store>;
   useMedia: () => Media | null;
@@ -49,7 +60,9 @@ export type UsePlayerHook<Store extends PlayerStore> = {
  * @label Video
  * @param config - Player configuration with features and optional display name.
  */
-export function createPlayer(config: CreatePlayerConfig<VideoFeatures>): CreatePlayerResult<VideoPlayerStore>;
+export function createPlayer(
+  config: CreatePlayerConfig<VideoFeatures>
+): CreatePlayerResult<VideoPlayerStore, VideoFeatures>;
 
 /**
  * Create a player for audio media.
@@ -57,7 +70,9 @@ export function createPlayer(config: CreatePlayerConfig<VideoFeatures>): CreateP
  * @label Audio
  * @param config - Player configuration with features and optional display name.
  */
-export function createPlayer(config: CreatePlayerConfig<AudioFeatures>): CreatePlayerResult<AudioPlayerStore>;
+export function createPlayer(
+  config: CreatePlayerConfig<AudioFeatures>
+): CreatePlayerResult<AudioPlayerStore, AudioFeatures>;
 
 /**
  * Create a player with custom features.
@@ -67,16 +82,60 @@ export function createPlayer(config: CreatePlayerConfig<AudioFeatures>): CreateP
  */
 export function createPlayer<const Features extends AnyPlayerFeature[]>(
   config: CreatePlayerConfig<Features>
-): CreatePlayerResult<PlayerStore<Features>>;
+): CreatePlayerResult<PlayerStore<Features>, Features>;
 
-export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
-  function Provider({ children }: ProviderProps): ReactNode {
-    const [store, setStore] = useState(() => createStore<PlayerTarget>()(combine(...config.features)));
+export function createPlayer(
+  config: CreatePlayerConfig<AnyPlayerFeature[]>
+): CreatePlayerResult<AnyPlayerStore, AnyPlayerFeature[]> {
+  // Collected once at factory scope: the feature list is fixed by the time
+  // `createPlayer` runs, so there is nothing to recompute per mount.
+  const providerProps = collectProviderProps(config.features);
+
+  if (__DEV__) {
+    assertNoProviderPropCollisions(providerProps);
+  }
+
+  // Defined out here rather than inside the component so the attach effect below
+  // can reference it without taking a per-render binding as a dependency.
+  const createPlayerStore = () => createStore<PlayerTarget>()(combine(...config.features));
+
+  function Provider({ children, ...props }: ProviderProps): ReactNode {
+    const readProp = (name: string) => (props as Record<string, unknown>)[name];
+
+    // Seeded during construction rather than written during render. The store
+    // built here has no subscribers yet, so a render React throws away — a
+    // sibling suspending, a transition abandoned — discards the store along with
+    // the seeded values. Seeding still happens during render, including on the
+    // server, so server HTML carries the right values and there is no hydration
+    // flash.
+    const [store, setStore] = useState(() => {
+      const created = createPlayerStore();
+      if (providerProps.size) writeProviderProps(created as never, providerProps, readProp);
+      return created;
+    });
     const [popupGroup] = useState(() => createPopupGroup());
     const [media, setMedia] = useState<Media | null>(null);
     const [container, setContainer] = useState<HTMLElement | null>(null);
 
     useDestroy(store);
+
+    // Later prop changes go through a layout effect, not the render body: a
+    // committed consumer must never observe a value written by a render that
+    // never committed. The cost is that on the render where a prop changes,
+    // children render the stale value first — children render and run their
+    // layout effects before the parent's. Nothing flashes, because
+    // `scheduleFlush` drains its microtask before paint. A passive effect would
+    // be worse: it permits a paint in between, turning an invisible stale pass
+    // into a visible one-frame flash of the old value.
+    //
+    // Called unconditionally, including during a server render, where React warns
+    // about `useLayoutEffect`. That warning is about the call being made, not
+    // about this design: seeding covers the server, and a server render happens
+    // once, so there are no later changes to miss.
+    useLayoutEffect(() => {
+      if (!providerProps.size || store.destroyed) return;
+      writeProviderProps(store as never, providerProps, readProp);
+    });
 
     useEffect(() => {
       if (!media) return;
@@ -84,8 +143,10 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       // The store may have been destroyed during an asynchronous gap between React
       // effect cleanup and re-setup (e.g., React <Activity> hide → reveal). The
       // useState initializer does not re-run in this case.
+      // Not seeded here: replacing the store re-renders, and the layout effect
+      // above then writes the current props into it before the browser paints.
       if (store.destroyed) {
-        setStore(createStore<PlayerTarget>()(combine(...config.features)));
+        setStore(createPlayerStore);
         return;
       }
 

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -9,6 +9,7 @@ import {
   videoFeatures,
 } from '@videojs/core/dom';
 import type { Slice } from '@videojs/store';
+import type { ReactNode } from 'react';
 import { assertType, describe, it } from 'vitest';
 
 import { type CreatePlayerResult, createPlayer } from '../create-player';
@@ -46,14 +47,10 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('accepts the orientation lock feature alias with and without config', () => {
-    const configuredOrientationLock = features.orientationLock({ type: 'portrait' });
+  it('accepts the orientation lock feature alias', () => {
+    const result = createPlayer({ features: [features.orientationLock] });
 
-    const defaultResult = createPlayer({ features: [features.orientationLock] });
-    const configuredResult = createPlayer({ features: [configuredOrientationLock] });
-
-    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
-    assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(result);
   });
 
   it('resolves extended video features to generic PlayerStore', () => {
@@ -87,5 +84,87 @@ describe('createPlayer', () => {
     });
 
     assertType<CreatePlayerResult<PlayerStore<[...typeof audioFeatures, typeof analyticsFeature]>>>(result);
+  });
+});
+
+describe('Provider props are gated on composition', () => {
+  it('accepts declared props when the owning feature is composed', () => {
+    const { Provider } = createPlayer({ features: videoFeatures });
+
+    assertType<ReactNode>(
+      <Provider contentTitle="A title" contentPoster="poster.jpg" contentPosterAlt="A description">
+        {null}
+      </Provider>
+    );
+  });
+
+  it('accepts both the override and the fallback for every field', () => {
+    const { Provider } = createPlayer({ features: videoFeatures });
+
+    assertType<ReactNode>(
+      <Provider
+        defaultContentTitle="A fallback title"
+        defaultContentPoster="fallback.jpg"
+        defaultContentPosterAlt="A fallback description"
+      >
+        {null}
+      </Provider>
+    );
+  });
+
+  it('accepts null, since removing an HTML attribute yields null', () => {
+    const { Provider } = createPlayer({ features: videoFeatures });
+
+    assertType<ReactNode>(<Provider contentTitle={null}>{null}</Provider>);
+  });
+
+  it('rejects a declared prop when its feature is absent', () => {
+    // This assertion is the entire point of the design: a prop must not exist
+    // when the feature that declares it is not composed.
+    const { Provider } = createPlayer({ features: [features.playback] });
+
+    assertType<ReactNode>(
+      // @ts-expect-error — contentMetadataFeature is not composed
+      <Provider contentTitle="A title">{null}</Provider>
+    );
+  });
+
+  it('rejects a prop no feature declares', () => {
+    const { Provider } = createPlayer({ features: videoFeatures });
+
+    assertType<ReactNode>(
+      // @ts-expect-error — no feature declares `nonsense`
+      <Provider nonsense="value">{null}</Provider>
+    );
+  });
+});
+
+describe('store state types', () => {
+  it('exposes resolved content metadata as readonly strings', () => {
+    const { usePlayer } = createPlayer({ features: videoFeatures });
+    const store = usePlayer();
+
+    assertType<string>(store.contentTitle);
+    assertType<string>(store.contentPoster);
+    assertType<string>(store.contentPosterAlt);
+  });
+
+  it('marks derived keys readonly on the store', () => {
+    const { usePlayer } = createPlayer({ features: videoFeatures });
+    const store = usePlayer();
+
+    // Regression test for the readonly marking surviving `BaseStore`'s
+    // `[key: string]: unknown` index signature.
+    // @ts-expect-error — contentTitle is derived, so the formula is its only writer
+    store.contentTitle = 'nope';
+  });
+
+  it('exposes the imperative setters', () => {
+    const { usePlayer } = createPlayer({ features: videoFeatures });
+    const store = usePlayer();
+
+    assertType<void>(store.setContentTitle('A title'));
+    assertType<void>(store.setDefaultContentTitle(null));
+    assertType<void>(store.setContentPoster(undefined));
   });
 });

--- a/packages/react/src/player/tests/provider-props.test.tsx
+++ b/packages/react/src/player/tests/provider-props.test.tsx
@@ -1,0 +1,218 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { contentMetadataFeature, features } from '@videojs/core/dom';
+import { StrictMode, useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPlayer } from '../create-player';
+
+afterEach(cleanup);
+
+const { Provider, usePlayer } = createPlayer({ features: [features.playback, contentMetadataFeature] });
+
+function ReadTitle({ onRead }: { onRead: (title: string) => void }) {
+  const title = usePlayer((state) => (state as { contentTitle: string }).contentTitle);
+  onRead(title);
+  return <span data-testid="title">{title}</span>;
+}
+
+describe('Provider props', () => {
+  it('seeds the store during render, so the first paint is correct', () => {
+    const reads: string[] = [];
+
+    render(
+      <Provider contentTitle="A title">
+        <ReadTitle onRead={(title) => reads.push(title)} />
+      </Provider>
+    );
+
+    // The very first read already sees the value — no flash of the library
+    // default, which is what makes server rendering work.
+    expect(reads[0]).toBe('A title');
+  });
+
+  it('seeds every declared field', () => {
+    let seen: { title: string; poster: string; posterAlt: string } | undefined;
+
+    function ReadAll() {
+      const state = usePlayer((s) => s as { contentTitle: string; contentPoster: string; contentPosterAlt: string });
+      seen = { title: state.contentTitle, poster: state.contentPoster, posterAlt: state.contentPosterAlt };
+      return null;
+    }
+
+    render(
+      <Provider contentTitle="A title" contentPoster="poster.jpg" contentPosterAlt="A description">
+        <ReadAll />
+      </Provider>
+    );
+
+    expect(seen).toEqual({ title: 'A title', poster: 'poster.jpg', posterAlt: 'A description' });
+  });
+
+  it('updates when a prop changes', async () => {
+    function Harness() {
+      const [title, setTitle] = useState('First');
+      return (
+        <Provider contentTitle={title}>
+          <button type="button" onClick={() => setTitle('Second')}>
+            change
+          </button>
+          <ReadTitle onRead={() => {}} />
+        </Provider>
+      );
+    }
+
+    const { getByRole, getByTestId } = render(<Harness />);
+
+    expect(getByTestId('title').textContent).toBe('First');
+
+    getByRole('button').click();
+
+    // The layout effect writes, `scheduleFlush` queues a microtask, consumers
+    // re-render. The microtask drains before paint, so nothing flashes.
+    await Promise.resolve();
+    expect(getByTestId('title').textContent).toBe('Second');
+  });
+
+  it('clears the developer value when a prop is removed', async () => {
+    function Harness() {
+      const [title, setTitle] = useState<string | undefined>('First');
+      return (
+        <Provider contentTitle={title}>
+          <button type="button" onClick={() => setTitle(undefined)}>
+            clear
+          </button>
+          <ReadTitle onRead={() => {}} />
+        </Provider>
+      );
+    }
+
+    const { getByRole, getByTestId } = render(<Harness />);
+    getByRole('button').click();
+    await Promise.resolve();
+
+    // An omitted prop and an explicit undefined mean the same thing, matching a
+    // removed HTML attribute.
+    expect(getByTestId('title').textContent).toBe('');
+  });
+
+  it('keeps an empty string as a suppressing value', () => {
+    const { getByTestId } = render(
+      <Provider contentTitle="">
+        <ReadTitle onRead={() => {}} />
+      </Provider>
+    );
+
+    expect(getByTestId('title').textContent).toBe('');
+  });
+
+  it('survives the development double render', () => {
+    const reads: string[] = [];
+
+    render(
+      <StrictMode>
+        <Provider contentTitle="A title">
+          <ReadTitle onRead={(title) => reads.push(title)} />
+        </Provider>
+      </StrictMode>
+    );
+
+    // Every read agrees; the repeated write is a no-op because `patch` drops
+    // writes that change nothing.
+    expect(new Set(reads)).toEqual(new Set(['A title']));
+  });
+
+  it('does not write to a subscribed store during the render phase', async () => {
+    const duringChildRender: string[] = [];
+
+    function Harness() {
+      const [title, setTitle] = useState('First');
+      return (
+        <Provider contentTitle={title}>
+          <button type="button" onClick={() => setTitle('Second')}>
+            change
+          </button>
+          <ReadTitle onRead={(read) => duringChildRender.push(read)} />
+        </Provider>
+      );
+    }
+
+    const { getByRole, getByTestId } = render(<Harness />);
+    duringChildRender.length = 0;
+
+    await act(async () => {
+      getByRole('button').click();
+    });
+
+    // Children render before the parent's layout effect, so on the pass where the
+    // prop changes the child still sees the old value. That staleness is the
+    // *evidence* the write is not in the Provider's render body: were it there,
+    // the child's first render would already have seen 'Second'. Keeping writes
+    // out of render is what stops a render React throws away from leaving a value
+    // behind in a store other components are already subscribed to.
+    expect(duringChildRender[0]).toBe('First');
+
+    // And it is invisible: the write, its notification, and the re-render all
+    // land before the browser paints.
+    expect(duringChildRender[duringChildRender.length - 1]).toBe('Second');
+    expect(getByTestId('title').textContent).toBe('Second');
+  });
+
+  it('discards seeded values with a store whose render never commits', () => {
+    // Seeding writes into a store built inside the `useState` initializer, which
+    // nothing is subscribed to yet. If React throws that render away, the store
+    // goes with it — there is no shared object left holding the value.
+    const first = createPlayer({ features: [features.playback, contentMetadataFeature] });
+    const second = createPlayer({ features: [features.playback, contentMetadataFeature] });
+
+    let firstStore: Record<string, unknown> | undefined;
+    let secondStore: Record<string, unknown> | undefined;
+
+    function GrabFirst() {
+      firstStore = first.usePlayer() as unknown as Record<string, unknown>;
+      return null;
+    }
+    function GrabSecond() {
+      secondStore = second.usePlayer() as unknown as Record<string, unknown>;
+      return null;
+    }
+
+    render(
+      <first.Provider contentTitle="Mine">
+        <GrabFirst />
+      </first.Provider>
+    );
+    render(
+      <second.Provider contentTitle="Theirs">
+        <GrabSecond />
+      </second.Provider>
+    );
+
+    // Each Provider owns its own store, so no second component races to write
+    // the same slot.
+    expect(firstStore?.contentTitle).toBe('Mine');
+    expect(secondStore?.contentTitle).toBe('Theirs');
+  });
+
+  it('exposes the imperative setters alongside the props', () => {
+    let store: Record<string, unknown> | undefined;
+
+    function Grab() {
+      store = usePlayer() as unknown as Record<string, unknown>;
+      return null;
+    }
+
+    render(
+      <Provider contentTitle="From a prop">
+        <Grab />
+      </Provider>
+    );
+
+    const setContentTitle = store?.setContentTitle as ((value: string) => void) | undefined;
+    expect(setContentTitle).toBeInstanceOf(Function);
+
+    // The attribute path and the imperative path run through one function, so
+    // they cannot drift.
+    setContentTitle?.('From the setter');
+    expect(store?.contentTitle).toBe('From the setter');
+  });
+});

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -16,7 +16,6 @@ import {
   root,
   slider,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -64,7 +63,6 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { MinimalLiveVideoSkinProps } from './minimal-skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
@@ -200,7 +198,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -210,13 +208,7 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
     <Container className={cn(root(false), className)} style={containerStyle} {...rest}>
       {children}
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -1,5 +1,4 @@
 import { captionsText } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -47,7 +46,6 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { BaseVideoSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
@@ -169,7 +167,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNode {
-  const { children, className, poster, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -183,9 +181,7 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
     >
       {children}
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -16,7 +16,6 @@ import {
   root,
   slider,
 } from '@videojs/skins/default/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -64,7 +63,6 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { LiveVideoSkinProps } from './skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
@@ -200,7 +198,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -210,13 +208,7 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
     <Container className={cn(root(false), className)} style={containerStyle} {...rest}>
       {children}
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -1,5 +1,4 @@
 import { captionsText } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -47,7 +46,6 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { BaseVideoSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
@@ -166,7 +164,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
-  const { children, className, poster, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -180,9 +178,7 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
     >
       {children}
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/types.ts
+++ b/packages/react/src/presets/types.ts
@@ -1,6 +1,4 @@
 import type { CSSProperties, PropsWithChildren } from 'react';
-import type { Poster } from '@/ui/poster';
-import type { RenderProp } from '@/utils/types';
 
 export type BaseSkinProps<T = unknown> = PropsWithChildren<
   T & {
@@ -10,7 +8,9 @@ export type BaseSkinProps<T = unknown> = PropsWithChildren<
 >;
 
 export type BaseVideoSkinProps<T = unknown> = BaseSkinProps<T> & {
-  poster?: string | RenderProp<Poster.State> | undefined;
-  /** Low-resolution placeholder shown behind the poster while it loads (blur-up effect). */
+  /**
+   * Low-resolution placeholder shown behind the poster while it loads (blur-up
+   * effect). A different concept from the poster itself, and a different image.
+   */
   placeholder?: string | undefined;
 };

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -29,7 +29,6 @@ import {
   thumbnail,
   time,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -89,7 +88,6 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { MinimalVideoSkinProps } from './minimal-skin';
 
 const SEEK_TIME = 10;
@@ -415,7 +413,7 @@ function SettingsMenu(): ReactNode {
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -425,13 +423,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
     <Container className={cn(root(false), className)} style={containerStyle} {...rest}>
       {children}
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -6,7 +6,6 @@ import {
   settingsText,
   speedText,
 } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -66,7 +65,6 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { BaseVideoSkinProps } from '../types';
 
 const SEEK_TIME = 10;
@@ -350,7 +348,7 @@ function SettingsMenu(): ReactNode {
 }
 
 export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
-  const { children, className, poster, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -364,9 +362,7 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
     >
       {children}
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -29,7 +29,6 @@ import {
   thumbnail,
   time,
 } from '@videojs/skins/default/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -89,7 +88,6 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { VideoSkinProps } from './skin';
 
 const SEEK_TIME = 10;
@@ -415,7 +413,7 @@ function SettingsMenu(): ReactNode {
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -425,13 +423,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
     <Container className={cn(root(false), className)} style={containerStyle} {...rest}>
       {children}
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -6,7 +6,6 @@ import {
   settingsText,
   speedText,
 } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, type CSSProperties, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -66,7 +65,6 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { BaseVideoSkinProps } from '../types';
 
 const SEEK_TIME = 10;
@@ -350,7 +348,7 @@ function SettingsMenu(): ReactNode {
 }
 
 export function VideoSkin(props: VideoSkinProps): ReactNode {
-  const { children, className, poster, placeholder, style, ...rest } = props;
+  const { children, className, placeholder, style, ...rest } = props;
 
   const containerStyle = placeholder
     ? ({ '--media-poster-placeholder': `url(${placeholder})`, ...style } as CSSProperties)
@@ -364,9 +362,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
     >
       {children}
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { PosterCore, PosterDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectPlayback } from '@videojs/core/dom';
+import { logMissingFeature, selectContentMetadata, selectPlayback } from '@videojs/core/dom';
+import { isUndefined } from '@videojs/utils/predicate';
 import type { ForwardedRef, SyntheticEvent } from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 
@@ -13,6 +14,13 @@ export interface PosterProps extends UIComponentProps<'img', PosterCore.State> {
 
 /**
  * Displays the video poster image. Shows before playback starts, hides after.
+ *
+ * With no `src`, reads the resolved `contentPoster` and `contentPosterAlt` from
+ * the store, so `<video-player content-poster="…">` reaches the screen with no
+ * prop threading. A local `src` short-circuits that and the store is not
+ * consulted at all — the component only decides *whether to ask*, which is why
+ * this is not a fourth precedence tier. `srcSet`, `loading`, and the `render`
+ * prop keep working either way.
  *
  * @example
  * ```tsx
@@ -32,12 +40,26 @@ export const Poster = forwardRef(function Poster(
   const { render, className, style, ...elementProps } = componentProps;
 
   const playback = usePlayer(selectPlayback);
+  const contentMetadata = usePlayer(selectContentMetadata);
 
   const [core] = useState(() => new PosterCore());
 
+  const localSrc = (elementProps as { src?: string }).src;
+  const localAlt = (elementProps as { alt?: string }).alt;
+
+  // An absent `src` means nothing was provided, so the store wins. A resolved
+  // empty string means render nothing rather than an image whose empty `src`
+  // would request the current page.
+  const resolvedSrc = isUndefined(localSrc) ? contentMetadata?.contentPoster || undefined : localSrc;
+
+  // Presence, never emptiness: an author writing `alt=""` is deliberately
+  // marking the image decorative, and overwriting that would be an
+  // accessibility regression rather than a cosmetic one.
+  const resolvedAlt = isUndefined(localAlt) ? contentMetadata?.contentPosterAlt : localAlt;
+
   // Track when the current src has finished loading so the CSS blur-up
   // sequence can show the placeholder first, then crossfade to the full image.
-  const src = (elementProps as { src?: string }).src;
+  const src = resolvedSrc;
   const [loadedSrc, setLoadedSrc] = useState<string | undefined>(undefined);
   const loaded = loadedSrc === src;
   const imgRef = useRef<HTMLImageElement | null>(null);
@@ -69,7 +91,11 @@ export const Poster = forwardRef(function Poster(
       state: core.getState(),
       stateAttrMap: PosterDataAttrs,
       ref: [forwardedRef, imgRef],
-      props: [elementProps, { 'data-loaded': loaded ? '' : undefined, onLoad: handleLoad }],
+      props: [
+        elementProps,
+        { src: resolvedSrc, alt: resolvedAlt },
+        { 'data-loaded': loaded ? '' : undefined, onLoad: handleLoad },
+      ],
     }
   );
 });

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -47,10 +47,11 @@ export const Poster = forwardRef(function Poster(
   const localSrc = (elementProps as { src?: string }).src;
   const localAlt = (elementProps as { alt?: string }).alt;
 
-  // An absent `src` means nothing was provided, so the store wins. A resolved
-  // empty string means render nothing rather than an image whose empty `src`
-  // would request the current page.
-  const resolvedSrc = isUndefined(localSrc) ? contentMetadata?.contentPoster || undefined : localSrc;
+  // An absent `src` means nothing was provided, so the store wins. Empty is
+  // treated as absent on both sides — the deliberate local exception to Q3's
+  // "empty string is a real value", because `<img src="">` resolves to the
+  // current page URL and would request the document again.
+  const resolvedSrc = (isUndefined(localSrc) ? contentMetadata?.contentPoster : localSrc) || undefined;
 
   // Presence, never emptiness: an author writing `alt=""` is deliberately
   // marking the image decorative, and overwriting that would be an
@@ -79,6 +80,19 @@ export const Poster = forwardRef(function Poster(
 
   if (!playback) {
     if (__DEV__) logMissingFeature('Poster', 'playback');
+    return null;
+  }
+
+  // Nothing to show means no element, rather than an image with no source. The
+  // skins now render `<Poster />` unconditionally, so without this every player
+  // without a poster would carry a meaningless `<img>` — and the blur-up
+  // placeholder, which keys off `img[data-visible]:not([data-loaded])`, would
+  // stay on screen forever waiting for a load that can never happen.
+  //
+  // `srcSet` and `render` are the escape hatches for `<picture>` and framework
+  // image components, which supply their own source, so their presence means
+  // there is something to render after all.
+  if (!resolvedSrc && !(elementProps as { srcSet?: string }).srcSet && isUndefined(render)) {
     return null;
   }
 

--- a/packages/react/src/ui/poster/tests/poster.test.tsx
+++ b/packages/react/src/ui/poster/tests/poster.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Poster } from '../poster';
+
+afterEach(cleanup);
+
+function createWrapper(state: Record<string, unknown> = {}) {
+  return createPlayerWrapper({
+    paused: true,
+    ended: false,
+    play: vi.fn(),
+    pause: vi.fn(),
+    togglePaused: vi.fn(),
+    contentPoster: '',
+    contentPosterAlt: '',
+    setContentPoster: vi.fn(),
+    setDefaultContentPoster: vi.fn(),
+    setContentPosterAlt: vi.fn(),
+    setDefaultContentPosterAlt: vi.fn(),
+    contentTitle: '',
+    setContentTitle: vi.fn(),
+    setDefaultContentTitle: vi.fn(),
+    ...state,
+  }).Wrapper;
+}
+
+describe('Poster', () => {
+  it('reads the resolved poster from the store when given no src', () => {
+    const Wrapper = createWrapper({ contentPoster: 'from-store.jpg' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('poster').getAttribute('src')).toBe('from-store.jpg');
+  });
+
+  it('uses a local src and ignores the store', () => {
+    const Wrapper = createWrapper({ contentPoster: 'from-store.jpg' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" src="local.jpg" />
+      </Wrapper>
+    );
+
+    // A component-level short-circuit, not a fourth precedence tier: the
+    // component only decides whether to ask the store.
+    expect(screen.getByTestId('poster').getAttribute('src')).toBe('local.jpg');
+  });
+
+  it('renders no src when the resolved value is an empty string', () => {
+    const Wrapper = createWrapper({ contentPoster: '' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" />
+      </Wrapper>
+    );
+
+    // Not `src=""`, which would request the current page.
+    expect(screen.getByTestId('poster').hasAttribute('src')).toBe(false);
+  });
+
+  it('reads the resolved alt text from the store', () => {
+    const Wrapper = createWrapper({ contentPoster: 'from-store.jpg', contentPosterAlt: 'A description' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('poster').getAttribute('alt')).toBe('A description');
+  });
+
+  it('keeps an author’s empty alt, which marks the image decorative', () => {
+    const Wrapper = createWrapper({ contentPoster: 'from-store.jpg', contentPosterAlt: 'A description' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" alt="" />
+      </Wrapper>
+    );
+
+    // Presence, never emptiness — overwriting a deliberate `alt=""` would be an
+    // accessibility regression, not a cosmetic one.
+    expect(screen.getByTestId('poster').getAttribute('alt')).toBe('');
+  });
+
+  it('passes srcSet and loading through untouched', () => {
+    const Wrapper = createWrapper({ contentPoster: 'from-store.jpg' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" srcSet="wide.jpg 2x" loading="lazy" />
+      </Wrapper>
+    );
+
+    const img = screen.getByTestId('poster');
+    expect(img.getAttribute('srcset')).toBe('wide.jpg 2x');
+    expect(img.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('still renders when the content metadata feature is absent', () => {
+    const Wrapper = createPlayerWrapper({
+      paused: true,
+      ended: false,
+      play: vi.fn(),
+      pause: vi.fn(),
+      togglePaused: vi.fn(),
+    }).Wrapper;
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" src="local.jpg" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('poster').getAttribute('src')).toBe('local.jpg');
+  });
+});

--- a/packages/react/src/ui/poster/tests/poster.test.tsx
+++ b/packages/react/src/ui/poster/tests/poster.test.tsx
@@ -53,17 +53,60 @@ describe('Poster', () => {
     expect(screen.getByTestId('poster').getAttribute('src')).toBe('local.jpg');
   });
 
-  it('renders no src when the resolved value is an empty string', () => {
+  it('renders nothing when the resolved value is an empty string', () => {
     const Wrapper = createWrapper({ contentPoster: '' });
 
-    render(
+    const { container } = render(
       <Wrapper>
         <Poster data-testid="poster" />
       </Wrapper>
     );
 
-    // Not `src=""`, which would request the current page.
-    expect(screen.getByTestId('poster').hasAttribute('src')).toBe(false);
+    // No element, rather than `src=""` (which requests the current page) or an
+    // `<img>` with no source at all. The skins render `<Poster />`
+    // unconditionally, so this is the only thing standing between a player with
+    // no poster and a stray image element.
+    expect(screen.queryByTestId('poster')).toBeNull();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders nothing for a local empty src', () => {
+    const Wrapper = createWrapper({ contentPoster: 'from-store.jpg' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" src="" />
+      </Wrapper>
+    );
+
+    // The deliberate local exception to "an empty string is a real value": an
+    // empty `src` short-circuits the store like any other local src, then means
+    // nothing to render.
+    expect(screen.queryByTestId('poster')).toBeNull();
+  });
+
+  it('still renders with no resolved src when srcSet supplies the image', () => {
+    const Wrapper = createWrapper({ contentPoster: '' });
+
+    render(
+      <Wrapper>
+        <Poster data-testid="poster" srcSet="wide.jpg 2x" />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('poster').getAttribute('srcset')).toBe('wide.jpg 2x');
+  });
+
+  it('still renders with no resolved src when a render prop supplies the element', () => {
+    const Wrapper = createWrapper({ contentPoster: '' });
+
+    render(
+      <Wrapper>
+        <Poster render={() => <picture data-testid="custom" />} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('custom')).toBeTruthy();
   });
 
   it('reads the resolved alt text from the store', () => {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -119,8 +119,10 @@ const store = createStore<HTMLMediaElement>()(mediaSlice);
 
 Behavior:
 - State factories are called in order, results merged (last wins on conflict)
+- `derived` maps are merged too, with a `__DEV__` warning on duplicate keys
 - All attach handlers run; errors are caught and reported via `reportError`
-- Use `UnionSliceState<Slices>` for combined state type inference
+- Use `UnionSliceState<Slices>` for combined state type inference — it includes
+  derived keys, marked `readonly`
 
 ```ts
 import type { UnionSliceState } from '@videojs/store';
@@ -128,6 +130,48 @@ import type { UnionSliceState } from '@videojs/store';
 const slices = [volumeSlice, playbackSlice] as const;
 type MediaState = UnionSliceState<typeof slices>;
 ```
+
+### Derived State
+
+A slice can declare values the store computes from its own state. Declare them
+in `derived`, alongside `state`:
+
+```ts
+import { defineSlice } from '@videojs/store';
+
+const timeSlice = defineSlice<HTMLMediaElement>()<
+  { currentTime: number; duration: number },
+  { remaining: number }
+>({
+  state: () => ({ currentTime: 0, duration: 0 }),
+  derived: {
+    remaining: ({ get }) => Math.max(0, get('duration') - get('currentTime')),
+  },
+});
+
+const store = createStore<HTMLMediaElement>()(timeSlice);
+store.remaining; // read like any other state
+```
+
+Derived keys are ordinary values on the frozen snapshot, so store getters,
+selectors, `store.state`, and `shallowEqual` all treat them like anything else.
+
+Three rules keep the primitive small:
+
+- **Every formula reruns on every patch that changed something.** There is no
+  dependency tracking, so **formulas must be cheap** — `patch` runs on every
+  `timeupdate`.
+- **A formula reads source keys only.** Reading another formula's output is a
+  compile error, which is why there is no run order and no cycle detection.
+- **The formula is the only writer of its key.** Writing a derived key through
+  `patch` is dropped, with a `__DEV__` warning. It is a type error too, since a
+  slice's `set` is typed against source keys.
+
+`combine` merges the `derived` maps of every slice, warning in `__DEV__` on a
+duplicate key.
+
+Rationale and the alternatives considered are in
+[derived-state.md](https://github.com/videojs/v10/blob/main/internal/decisions/store/derived-state.md).
 
 ### Actions
 
@@ -310,6 +354,13 @@ import { createState, flush, isState } from '@videojs/store';
 // Create state container
 const state = createState({ volume: 1, muted: false });
 
+// Optionally with derived formulas, recomputed inside every patch that changed
+// something and folded into the same snapshot before subscribers are notified
+const withDerived = createState({ currentTime: 0, duration: 60 }, {
+  remaining: ({ get }) => get('duration') - get('currentTime'),
+});
+withDerived.current.remaining; // 60
+
 // Read via .current
 const { volume } = state.current; // 1
 
@@ -317,6 +368,10 @@ const { volume } = state.current; // 1
 state.patch({ volume: 0.5 });
 state.patch({ volume: 0.5, muted: true });
 // Only ONE notification fires (after microtask)
+
+// patch() ignores writes that change nothing, and only copies the state object
+// once it finds a real change. It iterates with Reflect.ownKeys, so symbol-keyed
+// entries participate — slices use those for private inputs to a derived value.
 
 // Subscribe to changes
 state.subscribe(() => {

--- a/packages/store/src/core/combine.ts
+++ b/packages/store/src/core/combine.ts
@@ -1,4 +1,13 @@
-import type { AttachContext, InferSliceState, Slice, StateContext, UnionSliceState } from './slice';
+import type {
+  AnySlice,
+  AttachContext,
+  InferSliceSource,
+  Slice,
+  StateContext,
+  UnionSliceDerived,
+  UnionSliceSource,
+} from './slice';
+import type { DerivedFormulas } from './state';
 
 /**
  * Combines multiple slices into a single slice.
@@ -6,10 +15,12 @@ import type { AttachContext, InferSliceState, Slice, StateContext, UnionSliceSta
  * @param slices - The slices to combine.
  * @returns A new slice that represents the combination of the input slices.
  */
-export function combine<Target, const Slices extends Slice<Target, any>[]>(
+export function combine<Target, const Slices extends Slice<Target, any, any>[]>(
   ...slices: Slices
-): Slice<Target, UnionSliceState<Slices>> {
-  return {
+): Slice<Target, UnionSliceSource<Slices>, UnionSliceDerived<Slices>> {
+  const derived = mergeDerived(slices);
+
+  const combined: Slice<Target, UnionSliceSource<Slices>, any> = {
     state: (ctx: StateContext<Target>) => {
       const states = slices.map((slice) => slice.state(ctx));
 
@@ -25,17 +36,49 @@ export function combine<Target, const Slices extends Slice<Target, any>[]>(
         }
       }
 
-      return Object.assign({}, ...states) as UnionSliceState<Slices>;
+      return Object.assign({}, ...states) as UnionSliceSource<Slices>;
     },
 
-    attach: (ctx: AttachContext<Target, UnionSliceState<Slices>>) => {
+    attach: (ctx: AttachContext<Target, UnionSliceSource<Slices>, UnionSliceDerived<Slices>>) => {
       for (const slice of slices) {
         try {
-          slice.attach?.(ctx as AttachContext<Target, InferSliceState<typeof slice>>);
+          slice.attach?.(ctx as AttachContext<Target, InferSliceSource<typeof slice>>);
         } catch (err) {
           ctx.reportError(err);
         }
       }
     },
   };
+
+  // Assigned conditionally so a feature set with no formulas produces a slice
+  // with no `derived` key at all, letting the store skip the recompute pass.
+  if (derived) combined.derived = derived as NonNullable<typeof combined.derived>;
+
+  return combined as Slice<Target, UnionSliceSource<Slices>, UnionSliceDerived<Slices>>;
+}
+
+/**
+ * Flattens every slice's `derived` map into one. Returns `undefined` when no
+ * slice declares any.
+ */
+function mergeDerived(slices: readonly AnySlice[]): DerivedFormulas | undefined {
+  let merged: DerivedFormulas | undefined;
+
+  for (const slice of slices) {
+    if (!slice.derived) continue;
+
+    const formulas = slice.derived as DerivedFormulas;
+
+    for (const key of Reflect.ownKeys(formulas)) {
+      if (__DEV__ && merged && key in merged) {
+        console.warn(
+          `[vjs-store] combine(): duplicate derived key "${String(key)}" — later slice overwrites earlier one`
+        );
+      }
+
+      (merged ??= {})[key] = formulas[key as string]!;
+    }
+  }
+
+  return merged;
 }

--- a/packages/store/src/core/combine.ts
+++ b/packages/store/src/core/combine.ts
@@ -71,8 +71,12 @@ function mergeDerived(slices: readonly AnySlice[]): DerivedFormulas | undefined 
 
     for (const key of Reflect.ownKeys(formulas)) {
       if (__DEV__ && merged && key in merged) {
+        // Names the slice, unlike the duplicate-state-key warning above. That
+        // one leaves you grepping every feature for the key; a formula is even
+        // harder to find by hand, so the name is worth the interpolation.
+        const from = slice.name ? ` declared by "${slice.name}"` : '';
         console.warn(
-          `[vjs-store] combine(): duplicate derived key "${String(key)}" — later slice overwrites earlier one`
+          `[vjs-store] combine(): duplicate derived key "${String(key)}"${from} — later slice overwrites earlier one`
         );
       }
 

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -28,7 +28,10 @@ const stateContext: StateContext<unknown> = {
  */
 export function createSelector<S extends AnySlice>(slice: S): Selector<object, InferSliceState<S> | undefined> {
   const initialState = slice.state(stateContext);
-  const keys = Object.keys(initialState as object);
+  // Derived keys are not in `state()`, so they have to be unioned in explicitly
+  // or a slice's computed values would be missing from its own selector — and a
+  // slice whose keys are *all* derived would hit the always-undefined stub below.
+  const keys = [...Object.keys(initialState as object), ...(slice.derived ? Object.keys(slice.derived) : [])];
 
   const firstKey = keys[0];
 

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -1,4 +1,4 @@
-import type { Simplify, UnionToIntersection } from '@videojs/utils/types';
+import type { EmptyObject, Simplify, UnionToIntersection } from '@videojs/utils/types';
 import type { AbortControllerRegistry } from './abort-controller-registry';
 import type { UnknownState } from './state';
 
@@ -6,18 +6,20 @@ import type { UnknownState } from './state';
 // Attach
 // ----------------------------------------
 
-export type Attach<Target, State> = (ctx: AttachContext<Target, State>) => void;
+export type Attach<Target, State, Derived = EmptyObject> = (ctx: AttachContext<Target, State, Derived>) => void;
 
 export interface AttachStore {
   readonly state: UnknownState;
   subscribe: (callback: () => void) => () => void;
 }
 
-export interface AttachContext<Target, State> {
+export interface AttachContext<Target, State, Derived = EmptyObject> {
   target: Target;
   signal: AbortSignal;
   store: AttachStore;
-  get: () => Readonly<State>;
+  /** Reads everything, including this slice's derived values. */
+  get: () => Readonly<State & Derived>;
+  /** Writes source keys only. A derived key's formula is its own sole writer. */
   set: (partial: Partial<State>) => void;
   reportError: (error: unknown) => void;
 }
@@ -50,22 +52,57 @@ export interface StateContext<Target> {
 // Slice
 // ----------------------------------------
 
-export interface SliceConfig<Target, State> {
+// ----------------------------------------
+// Derived
+// ----------------------------------------
+
+/**
+ * Read access handed to a derived formula.
+ *
+ * Only *source* keys are readable. A formula that tried to read another
+ * formula's output would not compile, which is what removes the need for run
+ * ordering and cycle detection.
+ */
+export interface DerivedContext<Source> {
+  get: <K extends keyof Source>(key: K) => Source[K];
+}
+
+/** One formula per derived key, each a plain function of the slice's source state. */
+export type DerivedMap<Source, Derived> = {
+  [K in keyof Derived]: (ctx: DerivedContext<Source>) => Derived[K];
+};
+
+// ----------------------------------------
+// Slice
+// ----------------------------------------
+
+export interface SliceConfig<Target, State, Derived = EmptyObject> {
   /** Debug label. Used as `displayName` on selectors created from this slice. */
   name?: string;
   state: (ctx: StateContext<Target>) => State;
-  attach?: (ctx: AttachContext<Target, State>) => void;
+  /**
+   * Values the store computes from this slice's own state, recomputed inside
+   * every patch that changed something and folded into the same snapshot.
+   *
+   * Derived keys are readable on the store like any other state, but are
+   * `readonly` in the types and rejected by `patch` at runtime — the formula is
+   * the only writer.
+   */
+  derived?: DerivedMap<State, Derived>;
+  attach?: (ctx: AttachContext<Target, State, Derived>) => void;
 }
 
-export type Slice<Target, State> = SliceConfig<Target, State>;
+export type Slice<Target, State, Derived = EmptyObject> = SliceConfig<Target, State, Derived>;
 
-export type AnySlice<Target = any> = Slice<Target, any>;
+export type AnySlice<Target = any> = Slice<Target, any, any>;
 
 // ----------------------------------------
 // Factory
 // ----------------------------------------
 
-export type SliceFactory<Target> = <State>(config: SliceConfig<Target, State>) => Slice<Target, State>;
+export type SliceFactory<Target> = <State, Derived = EmptyObject>(
+  config: SliceConfig<Target, State, Derived>
+) => Slice<Target, State, Derived>;
 
 export function defineSlice<Target>(): SliceFactory<Target> {
   return (config) => config;
@@ -75,8 +112,23 @@ export function defineSlice<Target>(): SliceFactory<Target> {
 // Inference
 // ----------------------------------------
 
-export type InferSliceTarget<S> = S extends Slice<infer Target, any> ? Target : never;
+export type InferSliceTarget<S> = S extends Slice<infer Target, any, any> ? Target : never;
 
-export type InferSliceState<S> = S extends Slice<any, infer State> ? State : never;
+/** The keys a slice's `state()` returns — the only keys `set` accepts. */
+export type InferSliceSource<S> = S extends Slice<any, infer State, any> ? State : never;
+
+/** The keys a slice's formulas produce. */
+export type InferSliceDerived<S> = S extends Slice<any, any, infer Derived> ? Derived : never;
+
+/** Everything readable on a slice: its source state plus its derived keys, read-only. */
+export type InferSliceState<S> = InferSliceSource<S> & Readonly<InferSliceDerived<S>>;
+
+export type UnionSliceSource<Slices extends AnySlice[]> = Simplify<
+  UnionToIntersection<InferSliceSource<Slices[number]>>
+>;
+
+export type UnionSliceDerived<Slices extends AnySlice[]> = Simplify<
+  UnionToIntersection<InferSliceDerived<Slices[number]>>
+>;
 
 export type UnionSliceState<Slices extends AnySlice[]> = Simplify<UnionToIntersection<InferSliceState<Slices[number]>>>;

--- a/packages/store/src/core/state.ts
+++ b/packages/store/src/core/state.ts
@@ -17,6 +17,14 @@ export interface WritableState<T> extends State<T> {
   patch: (partial: Partial<T>) => void;
 }
 
+/**
+ * Runtime shape of a slice's `derived` map, erased of its key/value types.
+ *
+ * Each formula receives a `get` bound to the snapshot being built and returns
+ * that key's value. See `DerivedMap` in `slice.ts` for the typed authoring shape.
+ */
+export type DerivedFormulas = Record<PropertyKey, (ctx: { get: (key: PropertyKey) => any }) => unknown>;
+
 let isFlushScheduled = false;
 function scheduleFlush(): void {
   if (isFlushScheduled) return;
@@ -32,15 +40,17 @@ export function flush(): void {
   pendingContainers.clear();
 }
 
-const hasOwnProp = Object.prototype.hasOwnProperty;
-
 class StateContainer<T> implements WritableState<T> {
   #current: T;
   #listeners = new Set<StateChange>();
   #pending = false;
+  #derived: [PropertyKey, DerivedFormulas[PropertyKey]][];
+  #derivedKeys: Set<PropertyKey>;
 
-  constructor(initial: T) {
+  constructor(initial: T, derived?: DerivedFormulas) {
     this.#current = Object.freeze({ ...initial });
+    this.#derived = derived ? Reflect.ownKeys(derived).map((key) => [key, derived[key as string]!]) : [];
+    this.#derivedKeys = new Set(this.#derived.map(([key]) => key));
   }
 
   get current(): Readonly<T> {
@@ -48,24 +58,61 @@ class StateContainer<T> implements WritableState<T> {
   }
 
   patch(partial: Partial<T>): void {
-    const next = { ...this.#current };
+    // Copy lazily. Provider config writes every declared field on every update,
+    // so no-op patches arrive in bulk and a copy per patch would be wasted work.
+    // `next` doubling as the changed flag is why there isn't a separate one.
+    let next: T | undefined;
 
-    let changed = false;
-
-    for (const key in partial) {
-      if (!hasOwnProp.call(partial, key)) continue;
+    // `Reflect.ownKeys` rather than `for...in`: tier slots are symbol-keyed and
+    // `for...in` skips symbols entirely, which made a symbol patch a silent no-op.
+    // It also returns own keys only, so the old `hasOwnProperty` guard is redundant.
+    for (const key of Reflect.ownKeys(partial) as (keyof T)[]) {
+      // A derived key's formula is its only writer. Anything else — the reset in
+      // `detach`, plain-JavaScript callers the compiler can't reach — is dropped
+      // so the ordering of writes inside this method never becomes load-bearing.
+      if (this.#derivedKeys.has(key)) {
+        if (__DEV__) {
+          console.warn(
+            `[vjs-store] patch(): ignoring write to derived key "${String(key)}" — its formula is the only writer`
+          );
+        }
+        continue;
+      }
 
       const value = partial[key];
 
       if (!Object.is(this.#current[key], value)) {
+        next ??= { ...this.#current };
         next[key] = value!;
-        changed = true;
       }
     }
 
-    if (changed) {
-      this.#current = Object.freeze(next);
-      this.#markPending();
+    // Nothing changed means no formula input changed, so derived values can't
+    // have changed either — the whole pass is skipped.
+    if (!next) return;
+
+    this.#recompute(next);
+
+    this.#current = Object.freeze(next);
+    this.#markPending();
+  }
+
+  /**
+   * Runs every formula against the candidate snapshot and folds the answers in,
+   * before the snapshot is frozen. There is no dependency tracking: formulas are
+   * cheap and few, and re-running all of them costs about what deciding which to
+   * re-run would. See `internal/decisions/store/derived-state.md`.
+   */
+  #recompute(next: T): void {
+    if (!this.#derived.length) return;
+
+    const get = (key: PropertyKey) => next[key as keyof T];
+
+    for (const [key, formula] of this.#derived) {
+      const value = formula({ get }) as T[keyof T];
+      if (!Object.is(next[key as keyof T], value)) {
+        next[key as keyof T] = value;
+      }
     }
   }
 
@@ -101,8 +148,8 @@ class StateContainer<T> implements WritableState<T> {
   }
 }
 
-export function createState<T>(initial: T): WritableState<T> {
-  return new StateContainer(initial);
+export function createState<T>(initial: T, derived?: DerivedFormulas): WritableState<T> {
+  return new StateContainer(initial, derived);
 }
 
 export function isState(value: unknown): value is State<object> {

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -1,21 +1,33 @@
 import { isNull, isObject } from '@videojs/utils/predicate';
+import type { EmptyObject } from '@videojs/utils/types';
 import { AbortControllerRegistry } from './abort-controller-registry';
 import type { StoreCallbacks } from './config';
 import { throwDestroyedError, throwNoTargetError } from './errors';
 import type { AttachContext, Slice, StateContext } from './slice';
-import type { StateChange, State as StateContainer, SubscribeOptions, UnknownState, WritableState } from './state';
+import type {
+  DerivedFormulas,
+  StateChange,
+  State as StateContainer,
+  SubscribeOptions,
+  UnknownState,
+  WritableState,
+} from './state';
 import { createState } from './state';
 
 const STORE_SYMBOL = Symbol.for('@videojs/store');
 
 export interface StoreOptions<Target, State> extends StoreCallbacks<Target, State> {}
 
-export function createStore<Target = unknown>(): <State>(
-  slice: Slice<Target, State>,
+export function createStore<Target = unknown>(): <State, Derived = EmptyObject>(
+  slice: Slice<Target, State, Derived>,
   options?: StoreOptions<Target, State>
-) => Store<Target, State> {
-  return <State>(slice: Slice<Target, State>, options: StoreOptions<Target, State> = {}): Store<Target, State> => {
-    type TargetStore = Store<Target, State>;
+) => Store<Target, State & Readonly<Derived>> {
+  return <State, Derived>(
+    slice: Slice<Target, State, Derived>,
+    options: StoreOptions<Target, State> = {}
+  ): Store<Target, State & Readonly<Derived>> => {
+    type StoreState = State & Readonly<Derived>;
+    type TargetStore = Store<Target, StoreState>;
 
     // Closure state
     let target: Target | null = null;
@@ -25,24 +37,33 @@ export function createStore<Target = unknown>(): <State>(
     const signals = new AbortControllerRegistry();
 
     // Reactive state - initialized after building slice state
-    let state: WritableState<State>;
+    let state: WritableState<StoreState>;
 
     function validate() {
       if (destroyed) throwDestroyedError();
       if (!target) throwNoTargetError();
     }
 
-    const initialState = slice.state({
+    const initialSourceState = slice.state({
       target: () => {
         validate();
         return target!;
       },
       signals,
       get: () => state.current as Readonly<Record<string, unknown>>,
-      set: (partial) => state.patch(partial as Partial<State>),
+      set: (partial) => state.patch(partial as Partial<StoreState>),
     } satisfies StateContext<Target>);
 
-    state = createState(initialState);
+    // Seed derived values before the getter loop below, so derived keys get
+    // accessors like any other state. Each formula runs with every tier slot
+    // still absent, which is how a library default gets stated once — in the
+    // formula — rather than duplicated into `state()`.
+    const derived = slice.derived as DerivedFormulas | undefined;
+    const initialState = derived
+      ? ({ ...initialSourceState, ...seedDerived(initialSourceState as object, derived) } as StoreState)
+      : (initialSourceState as unknown as StoreState);
+
+    state = createState(initialState, derived);
 
     const store = {
       [STORE_SYMBOL]: true,
@@ -63,9 +84,12 @@ export function createStore<Target = unknown>(): <State>(
       subscribe,
     } as unknown as TargetStore;
 
+    // `Object.keys` skips symbols by design: tier slots are internal symbol-keyed
+    // inputs and get no public getter. They are still enumerable via
+    // `Reflect.ownKeys` on the snapshot — internal, not secret.
     for (const key of Object.keys(initialState as object)) {
       Object.defineProperty(store, key, {
-        get: () => state.current[key as keyof State],
+        get: () => state.current[key as keyof StoreState],
         enumerable: true,
       });
     }
@@ -86,11 +110,11 @@ export function createStore<Target = unknown>(): <State>(
       target = newTarget;
 
       // Create attach context
-      const attachContext: AttachContext<Target, State> = {
+      const attachContext: AttachContext<Target, State, Derived> = {
         target: newTarget,
         signal: signals.base,
-        get: () => state.current,
-        set: (partial) => state.patch(partial),
+        get: () => state.current as Readonly<State & Derived>,
+        set: (partial) => state.patch(partial as Partial<StoreState>),
         reportError,
         store: {
           get state() {
@@ -123,7 +147,9 @@ export function createStore<Target = unknown>(): <State>(
       if (isNull(target)) return;
       signals.reset();
       target = null;
-      state.patch(initialState);
+      // Source keys only. `patch` would drop derived keys anyway, but passing
+      // them would trip its dev warning on every ordinary detach.
+      state.patch(initialSourceState as Partial<StoreState>);
     }
 
     function destroy(): void {
@@ -145,6 +171,18 @@ export function createStore<Target = unknown>(): <State>(
       }
     }
   };
+}
+
+/** Runs every formula once against the source state, for the initial snapshot. */
+function seedDerived(source: object, derived: DerivedFormulas): Record<PropertyKey, unknown> {
+  const get = (key: PropertyKey) => (source as Record<PropertyKey, unknown>)[key];
+  const seeded: Record<PropertyKey, unknown> = {};
+
+  for (const key of Reflect.ownKeys(derived)) {
+    seeded[key] = derived[key as string]!({ get });
+  }
+
+  return seeded;
 }
 
 export function isStore(value: unknown): value is AnyStore {

--- a/packages/store/src/core/tests/derived.test-d.ts
+++ b/packages/store/src/core/tests/derived.test-d.ts
@@ -1,0 +1,75 @@
+import { assertType, describe, it } from 'vitest';
+
+import { combine } from '../combine';
+import { defineSlice } from '../slice';
+import { createStore } from '../store';
+
+class MockTarget extends EventTarget {}
+
+const slice = defineSlice<MockTarget>();
+
+const doubler = slice<{ count: number }, { doubled: number }>({
+  state: () => ({ count: 1 }),
+  derived: { doubled: ({ get }) => get('count') * 2 },
+});
+
+const labeller = slice<{ label: string }, { shouted: string }>({
+  state: () => ({ label: '' }),
+  derived: { shouted: ({ get }) => get('label').toUpperCase() },
+});
+
+describe('derived types', () => {
+  it('exposes derived keys on the store alongside source keys', () => {
+    const store = createStore<MockTarget>()(doubler);
+
+    assertType<number>(store.count);
+    assertType<number>(store.doubled);
+  });
+
+  it('folds derived keys from every combined slice into the store type', () => {
+    const store = createStore<MockTarget>()(combine(doubler, labeller));
+
+    assertType<number>(store.doubled);
+    assertType<string>(store.shouted);
+  });
+
+  it('marks derived keys readonly on the store', () => {
+    const store = createStore<MockTarget>()(doubler);
+
+    store.count = 2;
+
+    // Regression test, not a spike: `BaseStore` carries a `[key: string]: unknown`
+    // index signature, and a readonly member has to win over it for this marking
+    // to be worth anything. Verified against TypeScript 5.9 and 6.0.
+    // @ts-expect-error — derived keys are readonly
+    store.doubled = 4;
+  });
+
+  it('rejects a write to a derived key through a slice’s own set', () => {
+    slice<{ count: number }, { doubled: number }>({
+      state: () => ({ count: 1 }),
+      derived: { doubled: ({ get }) => get('count') * 2 },
+      attach({ set }) {
+        set({ count: 2 });
+
+        // `attach` is typed against source state only, so the derived key is not
+        // assignable — the runtime filter in `patch` is belt-and-braces for the
+        // paths the compiler cannot reach.
+        // @ts-expect-error — `doubled` is not a source key
+        set({ doubled: 4 });
+      },
+    });
+  });
+
+  it('rejects a formula reading another formula’s output', () => {
+    slice<{ count: number }, { doubled: number; quadrupled: number }>({
+      state: () => ({ count: 1 }),
+      derived: {
+        doubled: ({ get }) => get('count') * 2,
+        // This is what removes the need for run ordering and cycle detection.
+        // @ts-expect-error — `doubled` is not a source key
+        quadrupled: ({ get }) => get('doubled') * 2,
+      },
+    });
+  });
+});

--- a/packages/store/src/core/tests/derived.test.ts
+++ b/packages/store/src/core/tests/derived.test.ts
@@ -334,6 +334,7 @@ describe('combine with derived', () => {
       derived: { total: ({ get }) => get('count') },
     });
     const b = slice<{ other: number }, { total: number }>({
+      name: 'second',
       state: () => ({ other: 2 }),
       derived: { total: ({ get }) => get('other') },
     });
@@ -341,6 +342,9 @@ describe('combine with derived', () => {
     createStore<MockTarget>()(combine(a, b));
 
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate derived key "total"'));
+    // Names the offending slice, unlike the duplicate-state-key warning beside
+    // it — a formula is harder to find by grepping than a state key.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"second"'));
     warn.mockRestore();
   });
 

--- a/packages/store/src/core/tests/derived.test.ts
+++ b/packages/store/src/core/tests/derived.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { combine } from '../combine';
+import { createSelector } from '../selector';
+import { defineSlice } from '../slice';
+import { flush, type WritableState } from '../state';
+import { createStore } from '../store';
+
+class MockTarget extends EventTarget {
+  value = 0;
+}
+
+const slice = defineSlice<MockTarget>();
+
+const USER = Symbol('user');
+const MEDIA = Symbol('media');
+const DEFAULT = Symbol('default');
+
+const LIBRARY_DEFAULT = '';
+
+type Tier = string | null | undefined;
+
+interface TitleSource {
+  /** User and default tiers are deliberately absent from `state()` so the reset in `detach` cannot reach them. */
+  [USER]?: Tier;
+  /** The media tier *is* seeded, so the reset clears it when the media goes away. */
+  [MEDIA]: Tier;
+  [DEFAULT]?: Tier;
+  setTitle: (value: Tier) => void;
+  setMediaTitle: (value: Tier) => void;
+  setDefaultTitle: (value: Tier) => void;
+}
+
+interface TitleDerived {
+  title: string;
+}
+
+/** Mirrors the metadata feature: three symbol-keyed tier slots, one derived answer. */
+function titleSlice() {
+  return slice<TitleSource, TitleDerived>({
+    name: 'title',
+    state: ({ set }): TitleSource => ({
+      [MEDIA]: undefined,
+      setTitle: (value) => set({ [USER]: value }),
+      setMediaTitle: (value) => set({ [MEDIA]: value }),
+      setDefaultTitle: (value) => set({ [DEFAULT]: value }),
+    }),
+    derived: {
+      title: ({ get }) => get(USER) ?? get(MEDIA) ?? get(DEFAULT) ?? LIBRARY_DEFAULT,
+    },
+  });
+}
+
+/** Escape hatch for the one test that deliberately writes a derived key. */
+function writable(store: { $state: unknown }): WritableState<Record<PropertyKey, unknown>> {
+  return store.$state as WritableState<Record<PropertyKey, unknown>>;
+}
+
+beforeEach(() => {
+  flush();
+});
+
+describe('derived', () => {
+  it('seeds the derived value from its formula before getters are installed', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    expect(store.title).toBe(LIBRARY_DEFAULT);
+    expect(Object.keys(store.state)).toContain('title');
+  });
+
+  it('recomputes when a source key changes', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setMediaTitle('from media');
+    expect(store.title).toBe('from media');
+
+    store.setTitle('from user');
+    expect(store.title).toBe('from user');
+  });
+
+  it('resolves tiers in user, media, default, library order regardless of write order', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setDefaultTitle('developer default');
+    expect(store.title).toBe('developer default');
+
+    store.setMediaTitle('from media');
+    expect(store.title).toBe('from media');
+
+    store.setTitle('from user');
+    expect(store.title).toBe('from user');
+
+    // Clearing a tier falls back through the rest of the chain.
+    store.setTitle(undefined);
+    expect(store.title).toBe('from media');
+
+    store.setMediaTitle(undefined);
+    expect(store.title).toBe('developer default');
+
+    store.setDefaultTitle(undefined);
+    expect(store.title).toBe(LIBRARY_DEFAULT);
+  });
+
+  it('resolves the same answer whichever order the tiers are written in', () => {
+    const forwards = createStore<MockTarget>()(titleSlice());
+    forwards.setTitle('user');
+    forwards.setMediaTitle('media');
+
+    const backwards = createStore<MockTarget>()(titleSlice());
+    backwards.setMediaTitle('media');
+    backwards.setTitle('user');
+
+    expect(forwards.title).toBe(backwards.title);
+    expect(forwards.title).toBe('user');
+  });
+
+  it('treats an empty string as a value that beats lower tiers', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setMediaTitle('from media');
+    store.setTitle('');
+
+    expect(store.title).toBe('');
+  });
+
+  it('treats null the same as undefined, so a cleared attribute falls through', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setMediaTitle('from media');
+    store.setTitle(null);
+
+    expect(store.title).toBe('from media');
+  });
+
+  it('recomputes before the snapshot is frozen, so no intermediate value is observable', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+    const seen: string[] = [];
+
+    store.subscribe(() => seen.push(store.title));
+
+    store.setTitle('a');
+    flush();
+
+    expect(seen).toEqual(['a']);
+    expect(Object.isFrozen(store.state)).toBe(true);
+  });
+
+  it('fires a single notification for a patch that changes source and derived keys', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+    const listener = vi.fn();
+
+    store.subscribe(listener);
+
+    writable(store).patch({ [USER]: 'a', [MEDIA]: 'b' });
+    flush();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when a patch changes nothing', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+    const listener = vi.fn();
+
+    store.setMediaTitle('same');
+    flush();
+
+    store.subscribe(listener);
+    store.setMediaTitle('same');
+    flush();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('ignores a direct write to a derived key and warns in dev', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setTitle('from user');
+    writable(store).patch({ title: 'smuggled' });
+
+    expect(store.title).toBe('from user');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('derived key "title"'));
+
+    warn.mockRestore();
+  });
+
+  it('installs derived keys as getter-only properties', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    expect(() => {
+      (store as unknown as Record<string, unknown>).title = 'nope';
+    }).toThrow();
+  });
+});
+
+describe('derived through detach', () => {
+  it('preserves user and default tiers, clears the media tier, and re-resolves', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+    const detach = store.attach(new MockTarget());
+
+    store.setTitle('from user');
+    store.setMediaTitle('from media');
+    expect(store.title).toBe('from user');
+
+    detach();
+
+    // The media tier was in the initial state, so the reset cleared it. The user
+    // tier was not, so the reset could not reach it — and the formula, being the
+    // only writer of `title`, restores the right answer.
+    expect(store.state[MEDIA]).toBeUndefined();
+    expect(store.title).toBe('from user');
+  });
+
+  it('falls back to the developer default after detach when no user value is set', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+    const detach = store.attach(new MockTarget());
+
+    store.setDefaultTitle('developer default');
+    store.setMediaTitle('from media');
+    expect(store.title).toBe('from media');
+
+    detach();
+    expect(store.title).toBe('developer default');
+  });
+
+  it('leaves the resolved value correct across detach and reattach', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    let detach = store.attach(new MockTarget());
+    store.setTitle('from user');
+    store.setMediaTitle('first');
+    detach();
+
+    detach = store.attach(new MockTarget());
+    store.setMediaTitle('second');
+    expect(store.title).toBe('from user');
+
+    store.setTitle(undefined);
+    expect(store.title).toBe('second');
+
+    detach();
+  });
+
+  it('does not warn when detach resets state', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = createStore<MockTarget>()(titleSlice());
+
+    const detach = store.attach(new MockTarget());
+    store.setMediaTitle('from media');
+    detach();
+
+    // `detach` resets from a source-only copy, so it never trips the
+    // derived-write warning on an ordinary teardown.
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('derived with symbol keys', () => {
+  it('gives symbol-keyed slots no getter on the store', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    expect(USER in store).toBe(false);
+    expect(MEDIA in store).toBe(false);
+    expect(Object.keys(store.state)).not.toContain(MEDIA);
+  });
+
+  it('keeps symbol-keyed slots readable on the snapshot', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setMediaTitle('from media');
+
+    expect(store.state[MEDIA]).toBe('from media');
+    expect(Object.getOwnPropertySymbols(store.state)).toContain(MEDIA);
+  });
+
+  it('participates in the no-op check like a string key', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+    const before = store.state;
+
+    store.setMediaTitle(undefined);
+
+    expect(store.state).toBe(before);
+  });
+
+  it('keeps snapshots frozen against external mutation', () => {
+    const store = createStore<MockTarget>()(titleSlice());
+
+    store.setMediaTitle('from media');
+
+    expect(() => {
+      (store.state as unknown as Record<symbol, unknown>)[MEDIA] = 'mutated';
+    }).toThrow();
+  });
+
+  it('excludes symbol slots from combine duplicate-key warnings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    createStore<MockTarget>()(combine(titleSlice(), slice({ state: () => ({ other: 1 }) })));
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('combine with derived', () => {
+  it('merges derived maps across slices', () => {
+    const a = slice<{ count: number; setCount: (n: number) => void }, { doubled: number }>({
+      state: ({ set }) => ({ count: 1, setCount: (n) => set({ count: n }) }),
+      derived: { doubled: ({ get }) => get('count') * 2 },
+    });
+    const b = slice<{ label: string; setLabel: (s: string) => void }, { shouted: string }>({
+      state: ({ set }) => ({ label: 'hi', setLabel: (s) => set({ label: s }) }),
+      derived: { shouted: ({ get }) => get('label').toUpperCase() },
+    });
+
+    const store = createStore<MockTarget>()(combine(a, b));
+
+    expect(store.doubled).toBe(2);
+    expect(store.shouted).toBe('HI');
+
+    store.setCount(5);
+    store.setLabel('bye');
+
+    expect(store.doubled).toBe(10);
+    expect(store.shouted).toBe('BYE');
+  });
+
+  it('warns on a duplicate derived key across slices', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const a = slice<{ count: number }, { total: number }>({
+      state: () => ({ count: 1 }),
+      derived: { total: ({ get }) => get('count') },
+    });
+    const b = slice<{ other: number }, { total: number }>({
+      state: () => ({ other: 2 }),
+      derived: { total: ({ get }) => get('other') },
+    });
+
+    createStore<MockTarget>()(combine(a, b));
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate derived key "total"'));
+    warn.mockRestore();
+  });
+
+  it('leaves slices without derived maps untouched', () => {
+    const a = slice({ state: () => ({ count: 0 }) });
+    const b = slice({ state: () => ({ label: '' }) });
+
+    const store = createStore<MockTarget>()(combine(a, b));
+
+    expect(store.state).toEqual({ count: 0, label: '' });
+  });
+});
+
+describe('createSelector with derived', () => {
+  it('includes derived keys in selector output', () => {
+    const feature = titleSlice();
+    const selectTitle = createSelector(feature);
+    const store = createStore<MockTarget>()(combine(feature, slice({ state: () => ({ other: 1 }) })));
+
+    store.setMediaTitle('from media');
+
+    expect(selectTitle(store.state)).toMatchObject({ title: 'from media' });
+  });
+
+  it('resolves a slice whose only non-action key is derived', () => {
+    const feature = slice<{ count: number }, { doubled: number }>({
+      name: 'doubler',
+      state: () => ({ count: 2 }),
+      derived: { doubled: ({ get }) => get('count') * 2 },
+    });
+
+    const selectDoubler = createSelector(feature);
+    const store = createStore<MockTarget>()(feature);
+
+    expect(selectDoubler(store.state)).toEqual({ count: 2, doubled: 4 });
+  });
+});

--- a/packages/utils/src/types/types.ts
+++ b/packages/utils/src/types/types.ts
@@ -22,6 +22,16 @@ export type Falsy<T> = T | false | null | undefined;
 
 export type EnsureFunction<T> = T extends (...args: any[]) => any ? T : never;
 
+/**
+ * An object type with no members.
+ *
+ * Exists so generic defaults can say "nothing here" once, in a named way, rather
+ * than repeating a bare `{}` — which reads as "any non-nullish value" everywhere
+ * else and is linted accordingly.
+ */
+// biome-ignore lint/complexity/noBannedTypes: naming `{}` once is the point of this alias
+export type EmptyObject = {};
+
 export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
 
 export type NonNullableObject<T extends object> = {

--- a/rfc/player-api.md
+++ b/rfc/player-api.md
@@ -65,9 +65,23 @@ Reviewers cautioned against making one default skin account for every possible f
 
 There was also concern that feature bundles could become another preset taxonomy. Bundles remain ejectable convenience arrays, and the individual feature definitions remain the underlying contract.
 
+## Amendment 2026-07-29 — the provider takes configuration
+
+The provider now accepts developer-settable fields, as React props and HTML attributes. A feature declares which fields it exposes and which of its own actions writes each one; `createPlayer` collects those declarations and puts them on the provider. A field therefore exists only when the feature that declares it is composed — the same composition gating this RFC established for state, extended to the public provider surface.
+
+This is amended here rather than recorded elsewhere because it changes a public API this RFC settled: at the time of writing, neither provider accepted any configuration at all. React's `ProviderProps` was literally `{ children }`, and `<video-player>` declared no attributes. All developer configuration arrived on the *media* element and was read back by features.
+
+Two earlier positions need reconciling:
+
+- **This RFC deferred "symbol feature keys with `store.get` and `store.has`"** (see alternatives above) on the grounds that selectors gave typed lookup with less API surface. The metadata feature does use symbol keys — but for private tier slots with no public accessor, no lookup API, and no way for a consumer to obtain the symbol. The instinct that rejected them then (keep the store's public surface small) is the same instinct that keeps these private now. See [derived-state.md](/internal/decisions/store/derived-state.md).
+- **[provider-attach.md](/internal/decisions/player/provider-attach.md) flagged "provider mixin grows in complexity"**, and [context-media-discovery.md](/internal/decisions/player/context-media-discovery.md) values "no attribute ceremony". Both concerns are real and partly conceded: the provider does grow, and it does grow attributes. The mitigation is that features opt in — every feature shipping today declares nothing and contributes nothing — and that the mechanism reuses the element's existing `static properties` engine rather than inventing a third attribute system.
+
+The alternative was to keep configuration on the media element. Rejected because content metadata is a fact about the *content*, not about a media engine, and because the same value has to be settable when no media is attached at all.
+
 ## Consequences
 
 - The feature list is the type and bundle boundary for a player.
+- Provider props are part of that boundary: a declared field exists only when its feature is composed.
 - React and HTML share state and composition concepts while exposing platform-appropriate adapters.
 - Controls depend on selectors instead of the full store when practical.
 - Provider/container separation adds visible composition in HTML, but preserves cross-platform parity and enables extended player layouts.


### PR DESCRIPTION
> [!WARNING]
> **Draft. AI-generated in one shot, for reference — not for review.**

Implements the metadata design end to end: developers provide metadata through
the provider, media can provide it too, and the store reconciles them by
precedence. All three fields — `contentTitle`, `contentPoster`, `contentPosterAlt`
— across store, media, core, React, and HTML. Orientation lock is migrated onto
the same mechanism and the old configurable-feature path is deleted.

```html
<video-player content-title="From my CMS" default-content-poster="fallback.jpg">
```

```tsx
<Player.Provider contentTitle="From my CMS" defaultContentPoster="fallback.jpg">
```

## Layers

Seven commits, one per layer, in the order the design notes suggested.

| Commit | What |
| --- | --- |
| `feat(store)` | `derived` primitive; symbol-aware, lazily-copying `patch` |
| `feat(media)` | three capabilities, events, predicates, host accessors |
| `feat(core)` | provider-prop declarations, `contentMetadataFeature`, presets, orientation lock |
| `feat(react)` | provider props, store-reading `<Poster>` |
| `feat(html)` | provider attributes, `<media-poster>` filling the author's image |
| `chore(sandbox)` | templates and the e2e generator moved to the provider |
| `docs(design)` | two new records, three amendments |

## Checks

`pnpm typecheck` clean. `pnpm lint` clean on all 68 changed source files.
**2,582 tests pass** across the five packages (139 store / 427 media / 1362 core /
374 react / 280 html), including ~90 new ones.

`pnpm check:workspace` passes 9 of 10 — the failure is `.claude/plans: must
resolve to .agents/plans`, which is pre-existing local environment state
(confirmed by running it on a clean tree) and unrelated to this branch.

The gate checklist from the design notes holds: derived values recompute on tier
writes; symbol tiers stay absent from `store.state`, selector output, and
`combine`'s duplicate-key warning; detach-then-reattach preserves developer tiers,
clears the media tier, and leaves the resolved value correct; provider props are
composition-gated, proven with `@ts-expect-error`; the seeding path survives the
development double render; and three fields share the machinery without the
authoring cost feeling silly.

## The one thing the design left open, and what I decided

**The HTML write path** was explicitly "early ideas only" and was the largest gap.
I decided it as follows, and this is the part most worth a second opinion:

- Declared fields become ordinary reactive properties, so the attribute engine the
  element already has does the work. No third attribute system.
- The write happens in **two** places on purpose. An explicit sync in
  `connectedCallback` *before* `#tryAttach()`, because attributes are parsed
  during upgrade but the first `update()` only runs a microtask after connect — so
  without it the store would attach, and the media would report its own metadata,
  before the developer's values landed. Later changes take the ordinary Lit path
  via `willUpdate`.
- The Q12 trap resolved itself: `ReactiveElement`'s generated accessor already
  keeps its own symbol-keyed backing value, so the property keeps reporting what
  was assigned rather than the store's resolved value. No custom accessor needed.

Two smaller open items I also had to decide:

- **The declaration field is named `providerProps`, not `config`.** "Config" is
  already taken three times over — store lifecycle callbacks, the media host's
  config bag, and the path this replaces.
- **The media tier may supply poster alt text.** The design leaned yes; the
  three-tier shape was free once the machinery existed.

## Two bugs the design would have shipped

Both found by writing the tests, and both fixed here:

1. **`createScreenOrientationLock` destructured `type` eagerly**, so "read the
   value at lock time" silently did not work — the store half looks finished while
   the lock still uses whatever was set at attach. Now read from `config.type`
   inside `lock()`.
2. **`<media-poster>` deciding `alt`/`src` ownership by presence on every pass
   would freeze a playlist on the first video's poster**, because after the first
   fill the attribute is present either way. Ownership is now snapshotted once.

## Known gaps

- **Prose docs are not updated.** The skins' `poster` prop is removed, and
  `site/src/content/docs/` still documents it (along with the `packages/cli/docs/`
  bundle generated from it). Deliberately out of scope for a reference PR —
  content writing deserves the `write-docs` workflow, not a one-shot.
- **`AttachContext.get()` now returns source *and* derived state.** A small
  widening the notes did not anticipate, needed because orientation lock reads its
  own resolved value at lock time. Writes stay source-only.
- **`EmptyObject` was added to `@videojs/utils/types`** so the new generic
  defaults could avoid a bare `{}`. The only in-repo precedent for that lint was
  in `packages/spf`, which I was told to treat as a separate project and did not
  read.
- **Not addressed, consistent with the notes:** analytics and Google Cast still
  cannot reach resolved values — they sit below the store. `google-cast-provider.ts`
  still builds Cast metadata from the raw element poster and sets no title.
- **`contentPlaceholder` is not built.** Still a genuinely different concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
