### PR TITLE
fix(docs): fix broken code block styles

### DIFF
--- a/site/src/styles/shiki-transformers.css
+++ b/site/src/styles/shiki-transformers.css
@@ -76,3 +76,15 @@
     opacity: 1;
   }
 }
+
+/*
+ * Markdown component overrides also decorate fenced code in recent Sätteri
+ * versions. Keep the inline-code treatment out of Shiki blocks.
+ */
+.astro-code > code {
+  padding: 0;
+  overflow-wrap: normal;
+  background-color: transparent;
+  border: 0;
+  border-radius: 0;
+}


### PR DESCRIPTION
Fixes an issue with the code block styling introduced by the recent dependency updates. 

Before:

<img width="1570" height="440" alt="CleanShot 2026-07-30 at 11 29 46@2x" src="https://github.com/user-attachments/assets/b3e38477-4d2a-48ef-bb7c-eb7e7016c26f" />

After: 

<img width="1582" height="450" alt="CleanShot 2026-07-30 at 11 34 21@2x" src="https://github.com/user-attachments/assets/ef64d309-ee17-43d4-9670-1aac944d14ca" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site CSS-only change with no auth, data, or runtime logic impact.
> 
> **Overview**
> **Fixes fenced code block appearance** after recent markdown/Sätteri dependency updates, where inline `code` styling (padding, border, background, rounded corners) was incorrectly applied inside Shiki output.
> 
> Adds a `.astro-code > code` override in `shiki-transformers.css` that resets those properties so block highlighting keeps its intended layout and wrapping (`overflow-wrap: normal`), without changing inline code elsewhere in prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01495a085962378436c24251b377a4ef8065f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->