### PR TITLE
fix(cd): fix npm publish process

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 # To use Turborepo Remote Caching, set the following environment variables.
 # env:
@@ -14,6 +15,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -23,6 +25,7 @@ jobs:
 
     steps:
       - uses: googleapis/release-please-action@v4
+        if: ${{ github.event_name == 'push' }}
         id: release
         with:
           # Use a fine grained token for release-please so this workflow
@@ -35,26 +38,26 @@ jobs:
       - uses: actions/checkout@v5
         # these if statements ensure that a publication only occurs when
         # a new release is created:
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
       - name: Setup pnpm
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v5
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm i --frozen-lockfile
 
       - name: Cache turbo build setup
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         uses: actions/cache@v5
         with:
           path: .turbo
@@ -63,15 +66,15 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Clean
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm clean
 
       - name: Build
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm build:packages
 
       - name: Build CDN bundles
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm build:cdn
 
       # The site build emits per-framework markdown to site/dist/docs/framework/{html,react}/.
@@ -80,17 +83,19 @@ jobs:
       # build:cli also depends on the site build transitively; turbo caches it, so this step
       # adds no rebuild cost — it just makes the dependency visible in CI.
       - name: Build site (required by html/react prepack and CLI)
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm build:site
 
       - name: Build CLI
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm build:cli
 
       - name: Publish
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: pnpm -r publish --filter "./packages/*" --access public --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update site/v10 branch
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.release.outputs.releases_created == 'true' }}
         run: git push origin HEAD:refs/heads/site/v10 --force


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches production publish and adds a manual path that can force-publish and force-push `site/v10`; mis-dispatch on main could ship unintended artifacts.
> 
> **Overview**
> **Fixes npm publish in production CD** by setting `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN` on the Publish step so `pnpm publish` can authenticate to the registry (with `registry-url` already configured on setup-node).
> 
> **Adds manual release path** via `workflow_dispatch` on `main`: the job is gated to `main` only for dispatches, **release-please runs only on push** (so manual runs don’t create duplicate releases), and build/publish/site branch update steps run when either a release was created **or** the workflow was dispatched manually—allowing republish/retry without a new release-please release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f08e6dd2d4288855a8ec89a469fa857a7cf49ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->