### PR TITLE
fix(packages): add settings tooltip

### DIFF
--- a/apps/e2e/page-objects/player.ts
+++ b/apps/e2e/page-objects/player.ts
@@ -106,6 +106,10 @@ export class PlayerPage {
     return this.tooltip.filter({ hasText: 'Play' }).first();
   }
 
+  get settingsTooltip(): Locator {
+    return this.tooltip.filter({ hasText: 'Settings' }).first();
+  }
+
   get popover(): Locator {
     return this.page.locator(SELECTORS.popover).first();
   }

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -207,6 +207,35 @@ for (const { name, path } of UI_VIDEO_PAGES) {
       await expect.poll(() => getMediaVolume(page)).toBeLessThan(0.5);
     });
 
+    test('settings button shows its tooltip on focus and still opens the menu', async ({ page }) => {
+      await player.showControls();
+      await player.settingsButton.focus();
+
+      await expect(player.settingsTooltip).toHaveAttribute(DATA_ATTRS.open, '', { timeout: 2_000 });
+
+      const playerBox = await player.playerRoot.boundingBox();
+      const triggerBox = await player.settingsButton.boundingBox();
+      const tooltipBox = await player.settingsTooltip.boundingBox();
+      if (!playerBox || !triggerBox || !tooltipBox) throw new Error('Settings tooltip not visible');
+      expect(tooltipBox.x).toBeGreaterThanOrEqual(playerBox.x);
+      expect(tooltipBox.y).toBeGreaterThanOrEqual(playerBox.y);
+      expect(tooltipBox.x + tooltipBox.width).toBeLessThanOrEqual(playerBox.x + playerBox.width);
+      expect(tooltipBox.y + tooltipBox.height).toBeLessThanOrEqual(playerBox.y + playerBox.height);
+      expect(tooltipBox.y + tooltipBox.height).toBeLessThanOrEqual(triggerBox.y);
+      expect(tooltipBox.y + tooltipBox.height).toBeGreaterThanOrEqual(triggerBox.y - 16);
+
+      await player.settingsButton.click();
+      await expect(player.settingsSpeedItem).toBeVisible();
+      await expect(player.settingsTooltip).not.toBeVisible();
+
+      await page.waitForTimeout(500);
+      await expect(player.settingsSpeedItem).toBeVisible();
+
+      await player.settingsButton.hover();
+      await page.waitForTimeout(700);
+      await expect(player.settingsTooltip).not.toBeVisible();
+    });
+
     test('buffering indicator follows waiting state', async ({ page }) => {
       await player.play();
       await page.evaluate((selector) => {

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -198,6 +198,7 @@ export function createPopover(options: PopoverOptions): PopoverApi {
   }
 
   function close(reason: PopoverOpenChangeReason = 'click'): void {
+    clearHoverTimeout();
     applyClose(reason);
   }
 

--- a/packages/core/src/dom/ui/popover/popover.ts
+++ b/packages/core/src/dom/ui/popover/popover.ts
@@ -89,6 +89,9 @@ export function createPopover(options: PopoverOptions): PopoverApi {
     close(reason: 'group-open') {
       applyClose(reason);
     },
+    get triggerElement() {
+      return triggerEl;
+    },
   };
 
   // --- Hover management ---

--- a/packages/core/src/dom/ui/popover/popup-group.ts
+++ b/packages/core/src/dom/ui/popover/popup-group.ts
@@ -2,26 +2,48 @@ export type PopupGroupCloseReason = 'group-open';
 
 export interface PopupGroupMember {
   close: (reason: PopupGroupCloseReason) => void;
+  readonly triggerElement: HTMLElement | null;
 }
 
 export interface PopupGroup {
   open: (member: PopupGroupMember) => void;
   close: (member: PopupGroupMember) => void;
+  isOpenFor: (trigger: HTMLElement | null) => boolean;
+  subscribe: (listener: () => void) => () => void;
 }
 
 export function createPopupGroup(): PopupGroup {
   let current: PopupGroupMember | null = null;
+  const listeners = new Set<() => void>();
+
+  function notify(): void {
+    for (const listener of listeners) listener();
+  }
 
   return {
     open(member) {
       if (current === member) return;
 
-      current?.close('group-open');
+      const previous = current;
       current = member;
+      previous?.close('group-open');
+      notify();
     },
 
     close(member) {
-      if (current === member) current = null;
+      if (current !== member) return;
+
+      current = null;
+      notify();
+    },
+
+    isOpenFor(trigger) {
+      return trigger !== null && current?.triggerElement === trigger;
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
     },
   };
 }

--- a/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
+++ b/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
@@ -1,6 +1,8 @@
 import { flush } from '@videojs/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TooltipGroupCore } from '../../../../core/ui/tooltip/tooltip-group-core';
+import { createPopupGroup } from '../../popover/popup-group';
+import { createTestPopover } from '../../popover/tests/popover-helpers';
 import { createTestTooltip } from './tooltip-helpers';
 
 describe('createTooltip', () => {
@@ -206,11 +208,14 @@ describe('createTooltip', () => {
         expect(onOpenChange).not.toHaveBeenCalled();
       });
 
-      it('does not open while its trigger popup is expanded', () => {
-        const { tooltip, onOpenChange } = createTestTooltip();
+      it('does not open while its trigger owns an open popup', () => {
+        const group = createPopupGroup();
+        const owner = createTestPopover({ group: () => group });
+        const { tooltip, onOpenChange } = createTestTooltip({ popupGroup: () => group });
         const trigger = document.createElement('button');
-        trigger.setAttribute('aria-expanded', 'true');
+        owner.popover.setTriggerElement(trigger);
         tooltip.setTriggerElement(trigger);
+        owner.popover.open();
 
         tooltip.triggerProps.onPointerEnter({
           clientX: 0,
@@ -227,16 +232,17 @@ describe('createTooltip', () => {
         expect(onOpenChange).not.toHaveBeenCalled();
       });
 
-      it('closes when its trigger popup expands', async () => {
-        const { tooltip, onOpenChange } = createTestTooltip();
+      it('closes when its trigger opens another popup', () => {
+        const group = createPopupGroup();
+        const owner = createTestPopover({ group: () => group });
+        const { tooltip, onOpenChange } = createTestTooltip({ popupGroup: () => group });
         const trigger = document.createElement('button');
-        trigger.setAttribute('aria-expanded', 'false');
+        owner.popover.setTriggerElement(trigger);
         tooltip.setTriggerElement(trigger);
         tooltip.open();
         onOpenChange.mockClear();
 
-        trigger.setAttribute('aria-expanded', 'true');
-        await Promise.resolve();
+        owner.popover.open();
 
         expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'imperative-action' });
       });

--- a/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
+++ b/packages/core/src/dom/ui/tooltip/tests/tooltip.test.ts
@@ -169,6 +169,78 @@ describe('createTooltip', () => {
         expect(onOpenChange).toHaveBeenCalledWith(true, { reason: 'hover' });
       });
 
+      it('closes on pointer down', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+        tooltip.open();
+        onOpenChange.mockClear();
+
+        tooltip.triggerProps.onPointerDown({
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'mouse',
+          buttons: 1,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        });
+
+        expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'imperative-action' });
+      });
+
+      it('cancels a pending hover open on pointer down', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+        const event = {
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'mouse' as const,
+          buttons: 0,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        };
+
+        tooltip.triggerProps.onPointerEnter(event);
+        tooltip.triggerProps.onPointerDown(event);
+        vi.advanceTimersByTime(600);
+
+        expect(onOpenChange).not.toHaveBeenCalled();
+      });
+
+      it('does not open while its trigger popup is expanded', () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+        const trigger = document.createElement('button');
+        trigger.setAttribute('aria-expanded', 'true');
+        tooltip.setTriggerElement(trigger);
+
+        tooltip.triggerProps.onPointerEnter({
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: 'mouse',
+          buttons: 0,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        });
+        tooltip.triggerProps.onFocusIn({ relatedTarget: null, preventDefault: vi.fn(), stopPropagation: vi.fn() });
+        vi.advanceTimersByTime(600);
+
+        expect(onOpenChange).not.toHaveBeenCalled();
+      });
+
+      it('closes when its trigger popup expands', async () => {
+        const { tooltip, onOpenChange } = createTestTooltip();
+        const trigger = document.createElement('button');
+        trigger.setAttribute('aria-expanded', 'false');
+        tooltip.setTriggerElement(trigger);
+        tooltip.open();
+        onOpenChange.mockClear();
+
+        trigger.setAttribute('aria-expanded', 'true');
+        await Promise.resolve();
+
+        expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'imperative-action' });
+      });
+
       it('does not open via focus after pointer down (tap)', () => {
         const { tooltip, onOpenChange } = createTestTooltip();
         const pointerEvent = {

--- a/packages/core/src/dom/ui/tooltip/tooltip.ts
+++ b/packages/core/src/dom/ui/tooltip/tooltip.ts
@@ -89,6 +89,24 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
   // suppressed during tap. The browser fires pointerdown → focus → pointerup,
   // so the flag is true during tap-triggered focus but false during keyboard Tab.
   let isPointerDown = false;
+  let expandedObserver: MutationObserver | null = null;
+
+  function isTriggerExpanded(): boolean {
+    return popover.triggerElement?.getAttribute('aria-expanded') === 'true';
+  }
+
+  function setTriggerElement(el: HTMLElement | null): void {
+    expandedObserver?.disconnect();
+    expandedObserver = null;
+    popover.setTriggerElement(el);
+
+    if (!el || typeof MutationObserver !== 'function') return;
+
+    expandedObserver = new MutationObserver(() => {
+      if (isTriggerExpanded()) popover.close('imperative-action');
+    });
+    expandedObserver.observe(el, { attributes: true, attributeFilter: ['aria-expanded'] });
+  }
 
   // Spread popover trigger props, omit onClick, guard disabled/touch on open handlers.
   const { onClick: _, ...baseTriggerProps } = popover.triggerProps;
@@ -96,14 +114,17 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
     ...baseTriggerProps,
     onPointerDown() {
       isPointerDown = true;
+      popover.close('imperative-action');
     },
     onPointerEnter(event) {
       if (options.disabled?.()) return;
+      if (isTriggerExpanded()) return;
       if (event.pointerType === 'touch') return;
       baseTriggerProps.onPointerEnter(event);
     },
     onFocusIn(event) {
       if (options.disabled?.()) return;
+      if (isTriggerExpanded()) return;
       if (isPointerDown) {
         isPointerDown = false;
         return;
@@ -128,7 +149,12 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
     get triggerElement() {
       return popover.triggerElement;
     },
+    setTriggerElement,
     open: () => popover.open('hover'),
     close: (reason: TooltipOpenChangeReason = 'hover') => popover.close(reason),
+    destroy() {
+      expandedObserver?.disconnect();
+      popover.destroy();
+    },
   };
 }

--- a/packages/core/src/dom/ui/tooltip/tooltip.ts
+++ b/packages/core/src/dom/ui/tooltip/tooltip.ts
@@ -9,6 +9,7 @@ import {
   type PopoverPopupProps,
   type PopoverTriggerProps,
 } from '../popover/popover';
+import type { PopupGroup } from '../popover/popup-group';
 import type { TransitionApi } from '../transition';
 
 export type TooltipOpenChangeReason = 'hover' | 'focus' | 'escape' | 'blur' | 'imperative-action';
@@ -27,6 +28,7 @@ export interface TooltipOptions {
   disableHoverablePopup?: () => boolean;
   disabled?: () => boolean;
   group?: () => TooltipGroupCore | undefined;
+  popupGroup?: () => PopupGroup | undefined;
 }
 
 export interface TooltipTriggerProps extends Omit<PopoverTriggerProps, 'onClick'> {
@@ -89,23 +91,28 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
   // suppressed during tap. The browser fires pointerdown → focus → pointerup,
   // so the flag is true during tap-triggered focus but false during keyboard Tab.
   let isPointerDown = false;
-  let expandedObserver: MutationObserver | null = null;
+  let popupGroup: PopupGroup | undefined;
+  let unsubscribe: (() => void) | undefined;
 
-  function isTriggerExpanded(): boolean {
-    return popover.triggerElement?.getAttribute('aria-expanded') === 'true';
+  function isTriggerPopupOpen(): boolean {
+    return popupGroup?.isOpenFor(popover.triggerElement) ?? false;
+  }
+
+  function syncPopupGroup(): void {
+    const next = options.popupGroup?.();
+    if (next === popupGroup) return;
+
+    unsubscribe?.();
+    popupGroup = next;
+    unsubscribe = popupGroup?.subscribe(() => {
+      if (isTriggerPopupOpen()) popover.close('imperative-action');
+    });
   }
 
   function setTriggerElement(el: HTMLElement | null): void {
-    expandedObserver?.disconnect();
-    expandedObserver = null;
     popover.setTriggerElement(el);
-
-    if (!el || typeof MutationObserver !== 'function') return;
-
-    expandedObserver = new MutationObserver(() => {
-      if (isTriggerExpanded()) popover.close('imperative-action');
-    });
-    expandedObserver.observe(el, { attributes: true, attributeFilter: ['aria-expanded'] });
+    syncPopupGroup();
+    if (isTriggerPopupOpen()) popover.close('imperative-action');
   }
 
   // Spread popover trigger props, omit onClick, guard disabled/touch on open handlers.
@@ -113,18 +120,21 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
   const triggerProps: TooltipTriggerProps = {
     ...baseTriggerProps,
     onPointerDown() {
+      syncPopupGroup();
       isPointerDown = true;
       popover.close('imperative-action');
     },
     onPointerEnter(event) {
+      syncPopupGroup();
       if (options.disabled?.()) return;
-      if (isTriggerExpanded()) return;
+      if (isTriggerPopupOpen()) return;
       if (event.pointerType === 'touch') return;
       baseTriggerProps.onPointerEnter(event);
     },
     onFocusIn(event) {
+      syncPopupGroup();
       if (options.disabled?.()) return;
-      if (isTriggerExpanded()) return;
+      if (isTriggerPopupOpen()) return;
       if (isPointerDown) {
         isPointerDown = false;
         return;
@@ -150,10 +160,13 @@ export function createTooltip(options: TooltipOptions): TooltipApi {
       return popover.triggerElement;
     },
     setTriggerElement,
-    open: () => popover.open('hover'),
+    open: () => {
+      syncPopupGroup();
+      if (!isTriggerPopupOpen()) popover.open('hover');
+    },
     close: (reason: TooltipOpenChangeReason = 'hover') => popover.close(reason),
     destroy() {
-      expandedObserver?.disconnect();
+      unsubscribe?.();
       popover.destroy();
     },
   };

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -122,7 +122,7 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <button commandfor="settings-menu" aria-labelledby="settings-label" class="${cn(button.base, button.subtle, button.icon, menu.settingsTrigger)}">
+            <button id="settings-trigger" commandfor="settings-menu" aria-labelledby="settings-label" class="${cn(button.base, button.subtle, button.icon, menu.settingsTrigger)}">
               ${renderIcon('gear', { class: cn(icon, menu.settingsIcon) })}
               ${renderText(settingsText, { id: 'settings-label', class: 'sr-only' })}
             </button>
@@ -240,6 +240,9 @@ function getTemplateHTML() {
                 </media-captions-radio-group>
               </media-menu>
             </media-menu>
+            <media-tooltip id="settings-tooltip" trigger="settings-trigger" side="top" class="${cn(popup.tooltip)}">
+              ${renderText(settingsText)}
+            </media-tooltip>
 
               <media-cast-button commandfor="cast-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.cast.button)}">
                 ${renderIcon('cast-enter', { class: cn(icon, iconState.cast.enter) })}

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -103,7 +103,7 @@ function getTemplateHTML() {
               <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
             </media-tooltip>
 
-            <button commandfor="settings-menu" aria-labelledby="settings-label" class="media-button media-button--subtle media-button--icon media-button--settings">
+            <button id="settings-trigger" commandfor="settings-menu" aria-labelledby="settings-label" class="media-button media-button--subtle media-button--icon media-button--settings">
               ${renderIcon('gear', { class: 'media-icon media-icon--settings' })}
               ${renderText(settingsText, { id: 'settings-label', class: 'media-sr-only' })}
             </button>
@@ -221,6 +221,9 @@ function getTemplateHTML() {
                 </media-captions-radio-group>
               </media-menu>
             </media-menu>
+            <media-tooltip id="settings-tooltip" trigger="settings-trigger" side="top" class="media-tooltip">
+              ${renderText(settingsText)}
+            </media-tooltip>
 
             <media-cast-button commandfor="cast-tooltip" class="media-button media-button--subtle media-button--icon media-button--cast">
               ${renderIcon('cast-enter', { class: 'media-icon media-icon--cast-enter' })}

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -120,7 +120,7 @@ function getTemplateHTML() {
                 <media-tooltip-shortcut class="${popup.tooltipShortcut}"></media-tooltip-shortcut>
               </media-tooltip>
 
-              <button commandfor="settings-menu" aria-labelledby="settings-label" class="${cn(button.base, button.subtle, button.icon, menu.settingsTrigger)}">
+              <button id="settings-trigger" commandfor="settings-menu" aria-labelledby="settings-label" class="${cn(button.base, button.subtle, button.icon, menu.settingsTrigger)}">
                 ${renderIcon('gear', { class: cn(icon, menu.settingsIcon) })}
                 ${renderText(settingsText, { id: 'settings-label', class: 'sr-only' })}
               </button>
@@ -238,6 +238,9 @@ function getTemplateHTML() {
                   </media-captions-radio-group>
                 </media-menu>
               </media-menu>
+              <media-tooltip id="settings-tooltip" trigger="settings-trigger" side="top" class="${cn(popup.tooltip)}">
+                ${renderText(settingsText)}
+              </media-tooltip>
             </div>
           </div>
 

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -98,7 +98,7 @@ function getTemplateHTML() {
                 <media-tooltip-shortcut class="media-tooltip__kbd"></media-tooltip-shortcut>
               </media-tooltip>
 
-              <button commandfor="settings-menu" aria-labelledby="settings-label" class="media-button media-button--subtle media-button--icon media-button--settings">
+              <button id="settings-trigger" commandfor="settings-menu" aria-labelledby="settings-label" class="media-button media-button--subtle media-button--icon media-button--settings">
                 ${renderIcon('gear', { class: 'media-icon media-icon--settings' })}
                 ${renderText(settingsText, { id: 'settings-label', class: 'media-sr-only' })}
               </button>
@@ -216,6 +216,9 @@ function getTemplateHTML() {
                   </media-captions-radio-group>
                 </media-menu>
               </media-menu>
+              <media-tooltip id="settings-tooltip" trigger="settings-trigger" side="top" class="media-surface media-tooltip">
+                ${renderText(settingsText)}
+              </media-tooltip>
             </div>
           </div>
 

--- a/packages/html/src/ui/position-controller.ts
+++ b/packages/html/src/ui/position-controller.ts
@@ -15,10 +15,13 @@ export class PositionController implements ReactiveController {
     host.addController(this);
   }
 
-  /** Discover a trigger element linked via `commandfor` attribute. */
-  findTrigger(): HTMLElement | null {
-    if (!this.#host.id) return null;
+  /** Discover an explicit trigger by ID or one linked via `commandfor`. */
+  findTrigger(trigger?: string): HTMLElement | null {
     const root = this.#host.getRootNode() as Document | ShadowRoot;
+    if (trigger) {
+      return root.getElementById(trigger);
+    }
+    if (!this.#host.id) return null;
     return root.querySelector<HTMLElement>(`[commandfor="${this.#host.id}"]`);
   }
 

--- a/packages/html/src/ui/tooltip/tests/tooltip-element.test.ts
+++ b/packages/html/src/ui/tooltip/tests/tooltip-element.test.ts
@@ -103,6 +103,20 @@ afterEach(() => {
 });
 
 describe('TooltipElement', () => {
+  it('uses an explicit trigger that already controls another popup', async () => {
+    defineTestElements();
+    const trigger = document.createElement('test-tooltip-trigger') as TestTriggerElement;
+    const tooltip = createElement(TooltipElement);
+    trigger.id = 'settings-trigger';
+    trigger.setAttribute('commandfor', 'settings-menu');
+    tooltip.trigger = trigger.id;
+    document.body.append(trigger, tooltip);
+
+    await tooltip.updateComplete;
+
+    expect(TooltipLabelElement.findIn(tooltip)?.textContent).toBe('Play');
+  });
+
   it('exposes the positioned side on the popup', async () => {
     const { tooltip, trigger } = setup();
 

--- a/packages/html/src/ui/tooltip/tooltip-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-element.ts
@@ -57,7 +57,8 @@ export class TooltipElement extends MediaElement {
     disableHoverablePopup: { type: Boolean, attribute: 'disable-hoverable-popup' },
     disabled: { type: Boolean },
     boundary: { type: String },
-  } satisfies PropertyDeclarationMap<keyof TooltipCore.Props | 'boundary'>;
+    trigger: { type: String },
+  } satisfies PropertyDeclarationMap<keyof TooltipCore.Props | 'boundary' | 'trigger'>;
 
   open = TooltipCore.defaultProps.open;
   defaultOpen = TooltipCore.defaultProps.defaultOpen;
@@ -68,6 +69,7 @@ export class TooltipElement extends MediaElement {
   disableHoverablePopup = TooltipCore.defaultProps.disableHoverablePopup;
   disabled = TooltipCore.defaultProps.disabled;
   boundary: PositioningBoundary = 'container';
+  trigger = '';
 
   readonly #core = new TooltipCore();
   readonly #i18n = new I18nController(this, i18nContext);
@@ -162,8 +164,7 @@ export class TooltipElement extends MediaElement {
     super.update(_changed);
     if (!this.#tooltip) return;
 
-    // Discover trigger via commandfor linkage.
-    const triggerEl = this.#position.findTrigger();
+    const triggerEl = this.#position.findTrigger(this.trigger);
     this.#syncTrigger(triggerEl);
 
     if (this.#currentTrigger && isLabelTrigger(this.#currentTrigger)) {

--- a/packages/html/src/ui/tooltip/tooltip-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-element.ts
@@ -104,6 +104,7 @@ export class TooltipElement extends MediaElement {
       disabled: () => this.disabled,
       // Lazy getter — group may arrive after connect via context.
       group: () => this.#groupConsumer.value,
+      popupGroup: () => this.#containerCtx.value?.popupGroup,
     });
 
     // Register self as the popup element — the element IS the popup.

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -189,9 +189,21 @@ function SettingsMenu(): ReactNode {
 
   return (
     <Menu.Root side="top" align="center">
-      <Menu.Trigger aria-label={t(settingsText)} render={<Button className={cn(button.icon, menu.settingsTrigger)} />}>
-        <GearIcon className={cn(icon, menu.settingsIcon)} />
-      </Menu.Trigger>
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <Menu.Trigger
+              aria-label={t(settingsText)}
+              render={<Button className={cn(button.icon, menu.settingsTrigger)} />}
+            >
+              <GearIcon className={cn(icon, menu.settingsIcon)} />
+            </Menu.Trigger>
+          }
+        />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label>{t(settingsText)}</Tooltip.Label>
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Menu.Content className={menu.settings}>
         <Menu.View className={menu.rootView}>
           <div className={menu.group}>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -132,9 +132,18 @@ function SettingsMenu(): ReactNode {
 
   return (
     <Menu.Root side="top" align="center">
-      <Menu.Trigger aria-label={t(settingsText)} className="media-button--settings" render={<Button />}>
-        <GearIcon className="media-icon media-icon--settings" />
-      </Menu.Trigger>
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <Menu.Trigger aria-label={t(settingsText)} className="media-button--settings" render={<Button />}>
+              <GearIcon className="media-icon media-icon--settings" />
+            </Menu.Trigger>
+          }
+        />
+        <Tooltip.Popup className="media-tooltip">
+          <Tooltip.Label>{t(settingsText)}</Tooltip.Label>
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Menu.Content className="media-popover media-menu media-menu--settings">
         <Menu.View className="media-menu__panel">
           <div className="media-menu__group">

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -191,9 +191,21 @@ function SettingsMenu(): ReactNode {
 
   return (
     <Menu.Root side="top" align="center">
-      <Menu.Trigger aria-label={t(settingsText)} render={<Button className={cn(button.icon, menu.settingsTrigger)} />}>
-        <GearIcon className={cn(icon, menu.settingsIcon)} />
-      </Menu.Trigger>
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <Menu.Trigger
+              aria-label={t(settingsText)}
+              render={<Button className={cn(button.icon, menu.settingsTrigger)} />}
+            >
+              <GearIcon className={cn(icon, menu.settingsIcon)} />
+            </Menu.Trigger>
+          }
+        />
+        <Tooltip.Popup className={cn(popup.tooltip)}>
+          <Tooltip.Label>{t(settingsText)}</Tooltip.Label>
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Menu.Content className={menu.settings}>
         <Menu.View className={menu.rootView}>
           <div className={menu.group}>

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -132,9 +132,18 @@ function SettingsMenu(): ReactNode {
 
   return (
     <Menu.Root side="top" align="center">
-      <Menu.Trigger aria-label={t(settingsText)} className="media-button--settings" render={<Button />}>
-        <GearIcon className="media-icon media-icon--settings" />
-      </Menu.Trigger>
+      <Tooltip.Root side="top">
+        <Tooltip.Trigger
+          render={
+            <Menu.Trigger aria-label={t(settingsText)} className="media-button--settings" render={<Button />}>
+              <GearIcon className="media-icon media-icon--settings" />
+            </Menu.Trigger>
+          }
+        />
+        <Tooltip.Popup className="media-surface media-tooltip">
+          <Tooltip.Label>{t(settingsText)}</Tooltip.Label>
+        </Tooltip.Popup>
+      </Tooltip.Root>
       <Menu.Content className="media-surface media-popover media-menu media-menu--settings">
         <Menu.View className="media-menu__panel">
           <div className="media-menu__group">

--- a/packages/react/src/ui/tooltip/tooltip-root.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-root.tsx
@@ -11,7 +11,7 @@ import { useSnapshot } from '@videojs/store/react';
 import { isUndefined } from '@videojs/utils/predicate';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
-import { useOptionalContainer } from '../../player/context';
+import { useOptionalContainer, useOptionalPopupGroup } from '../../player/context';
 import { useDestroy } from '../../utils/use-destroy';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { useSafeId } from '../../utils/use-safe-id';
@@ -44,6 +44,7 @@ export function TooltipRoot({
   ...coreProps
 }: TooltipRootProps): ReactNode {
   const container = useOptionalContainer();
+  const popupGroup = useOptionalPopupGroup();
   const controls = useOptionalControlsContext();
   const [core] = useState(() => new TooltipCore(coreProps));
   core.setProps(coreProps);
@@ -61,6 +62,7 @@ export function TooltipRoot({
   const disableHoverablePopupRef = useLatestRef(disableHoverablePopup);
   const disabledRef = useLatestRef(disabled);
   const groupRef = useLatestRef(groupFromContext);
+  const popupGroupRef = useLatestRef(popupGroup);
 
   const [tooltip] = useState(() => {
     const instance = createTooltip({
@@ -76,6 +78,7 @@ export function TooltipRoot({
       disableHoverablePopup: () => disableHoverablePopupRef.current,
       disabled: () => disabledRef.current,
       group: () => groupRef.current,
+      popupGroup: () => popupGroupRef.current,
     });
 
     // Apply defaultOpen on creation (uncontrolled only)


### PR DESCRIPTION
Closes #1898
Closes #1907
Closes #1909

## Summary

Add the missing Settings tooltip to the HTML and React video presets. The translation wording reported in these issues is handled separately in #1914.

## Changes

- Add the localized Settings tooltip to CSS and Tailwind video presets
- Keep the tooltip within the player positioning boundary
- Close and suppress the tooltip while the Settings menu is open
- Preserve composed CSS anchor names when React menu and tooltip triggers share a button

## Testing

- `pnpm -F @videojs/core test src/dom/ui/tooltip/tests/tooltip.test.ts src/dom/ui/popover/tests/popover.test.ts`
- `pnpm -F @videojs/html test src/ui/tooltip/tests/tooltip-element.test.ts`
- `pnpm -F @videojs/react test src/ui/menu/tests/menu.test.tsx src/ui/popover/tests/popover.test.tsx src/ui/tooltip/tests/tooltip.test.tsx`
- `pnpm --dir apps/e2e exec playwright test tests/video-controls.spec.ts --project vite-chromium --grep "settings button shows its tooltip" --trace off --reporter line`
- `pnpm -F @videojs/core build`
- `pnpm -F @videojs/html build`
- `pnpm -F @videojs/react build`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared popover/tooltip/popup-group primitives used across controls; behavior changes affect hover, focus, and click on any trigger that also opens a menu, though tests cover the settings path.
> 
> **Overview**
> Adds a **localized Settings tooltip** to HTML and React video presets (default and minimal skins), using an explicit `settings-trigger` id and `trigger="settings-trigger"` on `media-tooltip` so the tooltip shares the same button as the settings menu.
> 
> **Core popup/tooltip behavior** is extended so tooltips do not fight menus on one trigger: `PopupGroup` tracks each member’s `triggerElement`, exposes `isOpenFor` and `subscribe`, and popover `close()` clears pending hover timers. Tooltips accept `popupGroup`, close on pointer down, and suppress open/hover/focus while that trigger’s popup is open (HTML/React wire this from container context).
> 
> **HTML** gains a `trigger` attribute on `TooltipElement` and `PositionController.findTrigger()` resolves by id or `commandfor`. **React** wraps the settings `Menu.Trigger` in `Tooltip.Root` and passes `popupGroup` into `TooltipRoot`.
> 
> Coverage includes unit tests for popup-group coordination and an e2e test for focus tooltip, menu open, and tooltip suppression while the menu stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fa5b28ce192cd21c4eec33a03d99d8b93ab81c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->