### PR TITLE
fix(packages): keep live edge indicator colored

### DIFF
--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -78,7 +78,7 @@ test.describe('Visual — Live Button', () => {
     });
 
     expect(styles.live).toEqual({ filter: 'none', opacity: '0.5' });
-    expect(styles.disabled.filter).not.toBe('none');
+    expect(styles.disabled).toEqual({ filter: 'none', opacity: '0.5' });
   });
 });
 

--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -49,6 +49,39 @@ for (const { name, path } of VISUAL_PAGES) {
   });
 }
 
+test.describe('Visual — Live Button', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/pages/html-video-mp4.html', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => customElements.get('video-skin'));
+  });
+
+  test('keeps the live-edge indicator colored when aria-disabled', async ({ page }) => {
+    const styles = await page.evaluate(() => {
+      const container = document.querySelector('video-skin')?.shadowRoot?.querySelector('media-container');
+      const liveButton = document.createElement('button');
+      liveButton.className = 'media-button media-button--live';
+      liveButton.setAttribute('aria-disabled', 'true');
+      liveButton.setAttribute('data-live-edge', '');
+
+      const disabledButton = document.createElement('button');
+      disabledButton.className = 'media-button';
+      disabledButton.setAttribute('aria-disabled', 'true');
+
+      container?.append(liveButton, disabledButton);
+
+      const liveStyle = getComputedStyle(liveButton);
+      const disabledStyle = getComputedStyle(disabledButton);
+      return {
+        live: { filter: liveStyle.filter, opacity: liveStyle.opacity },
+        disabled: { filter: disabledStyle.filter, opacity: disabledStyle.opacity },
+      };
+    });
+
+    expect(styles.live).toEqual({ filter: 'none', opacity: '0.5' });
+    expect(styles.disabled.filter).not.toBe('none');
+  });
+});
+
 // --- Portrait media layout ---
 
 test.describe('Visual — HTML Portrait Layout', () => {

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -37,7 +37,10 @@
   &[aria-disabled="true"] {
     cursor: not-allowed;
     opacity: 0.5;
-    filter: grayscale(1);
+
+    &:not([data-live-edge]) {
+      filter: grayscale(1);
+    }
   }
 }
 

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -37,10 +37,6 @@
   &[aria-disabled="true"] {
     cursor: not-allowed;
     opacity: 0.5;
-
-    &:not([data-live-edge]) {
-      filter: grayscale(1);
-    }
   }
 }
 

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -9,7 +9,7 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'not-aria-disabled:active:scale-[0.98]',
-    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:grayscale',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:not-data-[live-edge]:grayscale',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -9,7 +9,7 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'not-aria-disabled:active:scale-[0.98]',
-    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:not-data-[live-edge]:grayscale',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'focus-visible:outline-current focus-visible:outline-offset-2'
   ),
   primary: 'bg-white text-black font-medium text-shadow-none',

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -37,7 +37,10 @@
   &[aria-disabled="true"] {
     cursor: not-allowed;
     opacity: 0.5;
-    filter: grayscale(1);
+
+    &:not([data-live-edge]) {
+      filter: grayscale(1);
+    }
   }
 }
 

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -37,10 +37,6 @@
   &[aria-disabled="true"] {
     cursor: not-allowed;
     opacity: 0.5;
-
-    &:not([data-live-edge]) {
-      filter: grayscale(1);
-    }
   }
 }
 

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -10,7 +10,7 @@ export const button = {
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-current focus-visible:outline-offset-2',
     'not-aria-disabled:active:scale-[0.98]',
-    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:grayscale',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:not-data-[live-edge]:grayscale',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -10,7 +10,7 @@ export const button = {
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-current focus-visible:outline-offset-2',
     'not-aria-disabled:active:scale-[0.98]',
-    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:not-data-[live-edge]:grayscale',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
   ),


### PR DESCRIPTION
Closes #1920

## Summary

Keep the live-edge status indicator red while preserving the live button’s focusable `aria-disabled` state and inactive visual treatment. The availability-to-ARIA migration made the generic disabled grayscale filter apply to the entire live button, including its red status dot.

## Changes

- Remove grayscale from generic disabled-button styling while retaining opacity and cursor feedback
- Keep default/minimal and CSS/Tailwind skin variants in parity
- Add browser coverage proving live and ordinary disabled buttons preserve their colors and reduced opacity

## Testing

- `pnpm --filter @videojs/html... build`
- `pnpm build:sandbox`
- `pnpm --dir apps/e2e exec playwright test tests/visual/video-skin.spec.ts --project=vite-chromium --project=vite-webkit --grep "keeps the live-edge indicator colored"`
- `pnpm typecheck`