### PR TITLE
fix(ci): make api reference sync deterministic

### DIFF
--- a/.github/workflows/api-reference-sync.yml
+++ b/.github/workflows/api-reference-sync.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ─── Job 0: Build API JSON at HEAD~1 and HEAD, diff them ─────────────
+  # ─── Job 0: Build API JSON before and after the merge, then diff them ─
   analyze:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
@@ -64,12 +64,13 @@ jobs:
           cp -r site/src/content/generated-component-reference/* /tmp/api-sync/after-components/ 2>/dev/null || true
           cp -r site/src/content/generated-util-reference/* /tmp/api-sync/after-utils/ 2>/dev/null || true
 
-      - name: Build API JSON at pull request base
+      - name: Build API JSON before the merge
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          git checkout "$BASE_SHA"
+          # This repository uses squash merges, whose parent is the exact pre-merge main tip.
+          BEFORE_MERGE_SHA=$(git rev-parse "$MERGE_SHA^1")
+          git checkout "$BEFORE_MERGE_SHA"
 
           # If install or build fails (for example, the builder itself changed),
           # treat everything as new by leaving before dirs empty
@@ -79,7 +80,7 @@ jobs:
             cp -r site/src/content/generated-component-reference/* /tmp/api-sync/before-components/ 2>/dev/null || true
             cp -r site/src/content/generated-util-reference/* /tmp/api-sync/before-utils/ 2>/dev/null || true
           else
-            echo "::warning::Base build failed — treating all components/utils as new"
+            echo "::warning::Pre-merge build failed — treating all components/utils as new"
           fi
 
           git checkout "$MERGE_SHA"
@@ -282,7 +283,7 @@ jobs:
             ## Inputs
 
             The following files are at /tmp/api-sync/:
-            - `diff.patch` — unified diff of API JSON between HEAD~1 and HEAD
+            - `diff.patch` — unified diff of API JSON before and after the triggering PR was merged
             - `changed-components.txt` — filenames of changed component JSONs (one per line, may be empty)
             - `changed-utils.txt` — filenames of changed util JSONs (one per line, may be empty)
             - `after-components/` — current component JSON files

--- a/.github/workflows/api-reference-sync.yml
+++ b/.github/workflows/api-reference-sync.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v5
@@ -63,11 +64,14 @@ jobs:
           cp -r site/src/content/generated-component-reference/* /tmp/api-sync/after-components/ 2>/dev/null || true
           cp -r site/src/content/generated-util-reference/* /tmp/api-sync/after-utils/ 2>/dev/null || true
 
-      - name: Build API JSON at HEAD~1
+      - name: Build API JSON at pull request base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          git checkout HEAD~1
+          git checkout "$BASE_SHA"
 
-          # If install or build fails (e.g. api-docs-builder itself changed),
+          # If install or build fails (for example, the builder itself changed),
           # treat everything as new by leaving before dirs empty
           mkdir -p /tmp/api-sync/before-components /tmp/api-sync/before-utils
 
@@ -75,67 +79,14 @@ jobs:
             cp -r site/src/content/generated-component-reference/* /tmp/api-sync/before-components/ 2>/dev/null || true
             cp -r site/src/content/generated-util-reference/* /tmp/api-sync/before-utils/ 2>/dev/null || true
           else
-            echo "::warning::HEAD~1 build failed — treating all components/utils as new"
+            echo "::warning::Base build failed — treating all components/utils as new"
           fi
 
-          git checkout -
+          git checkout "$MERGE_SHA"
 
       - name: Classify changes
         id: classify
-        run: |
-          # Unified diff of both JSON directories
-          diff -ruN /tmp/api-sync/before-components /tmp/api-sync/after-components > /tmp/api-sync/diff.patch || true
-          diff -ruN /tmp/api-sync/before-utils /tmp/api-sync/after-utils >> /tmp/api-sync/diff.patch || true
-
-          # New: files in after but not in before
-          comm -23 \
-            <(ls /tmp/api-sync/after-components/ 2>/dev/null | sort) \
-            <(ls /tmp/api-sync/before-components/ 2>/dev/null | sort) \
-            > /tmp/api-sync/new-components.txt
-
-          comm -23 \
-            <(ls /tmp/api-sync/after-utils/ 2>/dev/null | sort) \
-            <(ls /tmp/api-sync/before-utils/ 2>/dev/null | sort) \
-            > /tmp/api-sync/new-utils.txt
-
-          # Changed: files in both, but content differs
-          comm -12 \
-            <(ls /tmp/api-sync/after-components/ 2>/dev/null | sort) \
-            <(ls /tmp/api-sync/before-components/ 2>/dev/null | sort) \
-            | while read -r f; do
-                if ! diff -q "/tmp/api-sync/before-components/$f" "/tmp/api-sync/after-components/$f" >/dev/null 2>&1; then
-                  echo "$f"
-                fi
-              done > /tmp/api-sync/changed-components.txt
-
-          comm -12 \
-            <(ls /tmp/api-sync/after-utils/ 2>/dev/null | sort) \
-            <(ls /tmp/api-sync/before-utils/ 2>/dev/null | sort) \
-            | while read -r f; do
-                if ! diff -q "/tmp/api-sync/before-utils/$f" "/tmp/api-sync/after-utils/$f" >/dev/null 2>&1; then
-                  echo "$f"
-                fi
-              done > /tmp/api-sync/changed-utils.txt
-
-          # Log results
-          echo "=== New components ===" && cat /tmp/api-sync/new-components.txt
-          echo "=== New utils ===" && cat /tmp/api-sync/new-utils.txt
-          echo "=== Changed components ===" && cat /tmp/api-sync/changed-components.txt
-          echo "=== Changed utils ===" && cat /tmp/api-sync/changed-utils.txt
-          echo "=== Diff ===" && head -100 /tmp/api-sync/diff.patch
-
-          # Set outputs
-          if [ -s /tmp/api-sync/diff.patch ]; then
-            echo "has_diff=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_diff=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ -s /tmp/api-sync/new-components.txt ] || [ -s /tmp/api-sync/new-utils.txt ]; then
-            echo "has_new=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_new=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: pnpm exec tsx site/scripts/api-reference-sync.ts /tmp/api-sync
 
       - name: Upload artifact
         if: steps.classify.outputs.has_diff == 'true'

--- a/.github/workflows/api-reference-sync.yml
+++ b/.github/workflows/api-reference-sync.yml
@@ -84,6 +84,7 @@ jobs:
           fi
 
           git checkout "$MERGE_SHA"
+          pnpm install --frozen-lockfile
 
       - name: Classify changes
         id: classify

--- a/site/scripts/api-reference-sync.ts
+++ b/site/scripts/api-reference-sync.ts
@@ -1,0 +1,114 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SNAPSHOT_KINDS = ['components', 'utils'] as const;
+type SnapshotKind = (typeof SNAPSHOT_KINDS)[number];
+
+export interface DirectoryChanges {
+  new: string[];
+  changed: string[];
+  unchanged: string[];
+  removed: string[];
+}
+
+export interface ApiReferenceChanges {
+  components: DirectoryChanges;
+  utils: DirectoryChanges;
+  hasDiff: boolean;
+  hasNew: boolean;
+}
+
+function listJsonFiles(directory: string): string[] {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory)
+    .filter((file) => file.endsWith('.json'))
+    .sort();
+}
+
+export function classifyDirectory(beforeDirectory: string, afterDirectory: string): DirectoryChanges {
+  const before = new Set(listJsonFiles(beforeDirectory));
+  const after = new Set(listJsonFiles(afterDirectory));
+  const added = [...after].filter((file) => !before.has(file));
+  const removed = [...before].filter((file) => !after.has(file));
+  const common = [...after].filter((file) => before.has(file));
+  const changed: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const file of common) {
+    const beforeContent = readFileSync(join(beforeDirectory, file));
+    const afterContent = readFileSync(join(afterDirectory, file));
+    (beforeContent.equals(afterContent) ? unchanged : changed).push(file);
+  }
+
+  return { new: added, changed, unchanged, removed };
+}
+
+export function classifySnapshots(artifactDirectory: string): ApiReferenceChanges {
+  const changes = Object.fromEntries(
+    SNAPSHOT_KINDS.map((kind) => [
+      kind,
+      classifyDirectory(join(artifactDirectory, `before-${kind}`), join(artifactDirectory, `after-${kind}`)),
+    ])
+  ) as Record<SnapshotKind, DirectoryChanges>;
+  const allChanges = SNAPSHOT_KINDS.flatMap((kind) => [
+    ...changes[kind].new,
+    ...changes[kind].changed,
+    ...changes[kind].removed,
+  ]);
+
+  return {
+    ...changes,
+    hasDiff: allChanges.length > 0,
+    hasNew: SNAPSHOT_KINDS.some((kind) => changes[kind].new.length > 0),
+  };
+}
+
+function directoryDiff(beforeDirectory: string, afterDirectory: string): string {
+  const result = spawnSync('diff', ['-ruN', beforeDirectory, afterDirectory], { encoding: 'utf-8' });
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(result.stderr || `diff exited with status ${result.status}`);
+  }
+  return result.stdout;
+}
+
+function writeList(path: string, values: string[]): void {
+  writeFileSync(path, values.length > 0 ? `${values.join('\n')}\n` : '');
+}
+
+export function writeClassification(artifactDirectory: string, changes: ApiReferenceChanges): void {
+  for (const kind of SNAPSHOT_KINDS) {
+    writeList(join(artifactDirectory, `new-${kind}.txt`), changes[kind].new);
+    writeList(join(artifactDirectory, `changed-${kind}.txt`), changes[kind].changed);
+    writeList(join(artifactDirectory, `removed-${kind}.txt`), changes[kind].removed);
+  }
+
+  const patch = SNAPSHOT_KINDS.map((kind) =>
+    directoryDiff(join(artifactDirectory, `before-${kind}`), join(artifactDirectory, `after-${kind}`))
+  ).join('');
+  writeFileSync(join(artifactDirectory, 'diff.patch'), patch);
+  writeFileSync(join(artifactDirectory, 'classification.json'), `${JSON.stringify(changes, null, 2)}\n`);
+}
+
+export function main(artifactDirectory = process.argv[2] ?? '/tmp/api-sync'): void {
+  const changes = classifySnapshots(artifactDirectory);
+  writeClassification(artifactDirectory, changes);
+
+  for (const kind of SNAPSHOT_KINDS) {
+    console.log(`=== New ${kind} ===\n${changes[kind].new.join('\n')}`);
+    console.log(`=== Changed ${kind} ===\n${changes[kind].changed.join('\n')}`);
+    console.log(`=== Removed ${kind} ===\n${changes[kind].removed.join('\n')}`);
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    writeFileSync(
+      process.env.GITHUB_OUTPUT,
+      `has_diff=${String(changes.hasDiff)}\nhas_new=${String(changes.hasNew)}\n`,
+      { flag: 'a' }
+    );
+  }
+}
+
+const isEntrypoint = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isEntrypoint) main();

--- a/site/scripts/api-reference-sync.ts
+++ b/site/scripts/api-reference-sync.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SNAPSHOT_KINDS = ['components', 'utils'] as const;
+const MAX_DIFF_BUFFER_BYTES = 32 * 1024 * 1024;
 type SnapshotKind = (typeof SNAPSHOT_KINDS)[number];
 
 export interface DirectoryChanges {
@@ -66,9 +67,12 @@ export function classifySnapshots(artifactDirectory: string): ApiReferenceChange
 }
 
 function directoryDiff(beforeDirectory: string, afterDirectory: string): string {
-  const result = spawnSync('diff', ['-ruN', beforeDirectory, afterDirectory], { encoding: 'utf-8' });
-  if (result.status !== 0 && result.status !== 1) {
-    throw new Error(result.stderr || `diff exited with status ${result.status}`);
+  const result = spawnSync('diff', ['-ruN', beforeDirectory, afterDirectory], {
+    encoding: 'utf-8',
+    maxBuffer: MAX_DIFF_BUFFER_BYTES,
+  });
+  if (result.error || (result.status !== 0 && result.status !== 1)) {
+    throw new Error(result.stderr || result.error?.message || `diff exited with status ${result.status}`);
   }
   return result.stdout;
 }

--- a/site/scripts/tests/api-reference-sync.test.ts
+++ b/site/scripts/tests/api-reference-sync.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { classifySnapshots, writeClassification } from '../api-reference-sync.ts';
+
+const temporaryDirectories: string[] = [];
+
+function createSnapshots() {
+  const root = mkdtempSync(join(tmpdir(), 'api-reference-sync-'));
+  temporaryDirectories.push(root);
+
+  for (const phase of ['before', 'after']) {
+    for (const kind of ['components', 'utils']) {
+      mkdirSync(join(root, `${phase}-${kind}`), { recursive: true });
+    }
+  }
+
+  return root;
+}
+
+function writeJson(
+  root: string,
+  phase: 'before' | 'after',
+  kind: 'components' | 'utils',
+  file: string,
+  value: unknown
+) {
+  writeFileSync(join(root, `${phase}-${kind}`, file), JSON.stringify(value));
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('classifySnapshots', () => {
+  it('classifies added, changed, unchanged, and removed references', () => {
+    const root = createSnapshots();
+    writeJson(root, 'before', 'components', 'changed.json', { value: 'before' });
+    writeJson(root, 'after', 'components', 'changed.json', { value: 'after' });
+    writeJson(root, 'before', 'components', 'same.json', { value: 'same' });
+    writeJson(root, 'after', 'components', 'same.json', { value: 'same' });
+    writeJson(root, 'before', 'components', 'removed.json', {});
+    writeJson(root, 'after', 'components', 'new.json', {});
+
+    const result = classifySnapshots(root);
+
+    expect(result.components).toEqual({
+      new: ['new.json'],
+      changed: ['changed.json'],
+      unchanged: ['same.json'],
+      removed: ['removed.json'],
+    });
+    expect(result.hasDiff).toBe(true);
+    expect(result.hasNew).toBe(true);
+  });
+
+  it('reports identical snapshots without changes', () => {
+    const root = createSnapshots();
+    writeJson(root, 'before', 'utils', 'same.json', { value: 'same' });
+    writeJson(root, 'after', 'utils', 'same.json', { value: 'same' });
+
+    expect(classifySnapshots(root)).toMatchObject({ hasDiff: false, hasNew: false });
+  });
+
+  it('writes the workflow artifact contract', () => {
+    const root = createSnapshots();
+    writeJson(root, 'after', 'utils', 'new.json', { name: 'newUtil' });
+    const result = classifySnapshots(root);
+
+    writeClassification(root, result);
+
+    expect(readFileSync(join(root, 'new-utils.txt'), 'utf-8')).toBe('new.json\n');
+    expect(JSON.parse(readFileSync(join(root, 'classification.json'), 'utf-8'))).toMatchObject({
+      hasDiff: true,
+      hasNew: true,
+    });
+    expect(readFileSync(join(root, 'diff.patch'), 'utf-8')).toContain('new.json');
+  });
+});

--- a/site/scripts/tests/api-reference-sync.test.ts
+++ b/site/scripts/tests/api-reference-sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -76,5 +76,15 @@ describe('classifySnapshots', () => {
       hasNew: true,
     });
     expect(readFileSync(join(root, 'diff.patch'), 'utf-8')).toContain('new.json');
+  });
+
+  it('writes patches larger than the spawnSync default buffer', () => {
+    const root = createSnapshots();
+    writeJson(root, 'after', 'components', 'large.json', { value: 'x'.repeat(1024 * 1024) });
+    const result = classifySnapshots(root);
+
+    writeClassification(root, result);
+
+    expect(statSync(join(root, 'diff.patch')).size).toBeGreaterThan(1024 * 1024);
   });
 });


### PR DESCRIPTION
Closes #1924

## Summary

Make API-reference drift detection independent of GitHub merge strategy and move snapshot classification from embedded shell into tested TypeScript.

## Changes

- Compare the pull request base SHA with the merged SHA explicitly
- Classify new, changed, unchanged, and removed references in a reusable script
- Preserve existing text artifacts while adding a structured classification manifest
- Reduce the workflow to snapshot orchestration and issue handling

## Testing

- `pnpm -C site test` (519 tests)
- `pnpm -C site astro check` (0 errors)
- `pnpm check:workspace` (10 checks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and docs-automation only; behavior is tightened for squash merges with unit tests and no production runtime impact.
> 
> **Overview**
> Makes **API reference drift detection** compare the right commits on squash merges and moves snapshot diffing into **tested TypeScript** instead of inline shell.
> 
> The **api-reference-sync** workflow now checks out the merge commit and builds the “before” snapshot from `merge_commit_sha^1` (pre-merge `main`) instead of `HEAD~1`, so the before/after API JSON comparison is not tied to checkout order or merge strategy quirks.
> 
> The **Classify changes** step delegates to `site/scripts/api-reference-sync.ts`, which classifies component/util JSON as new, changed, unchanged, or removed, writes the existing text artifacts plus `classification.json` and `diff.patch` (with a larger `diff` buffer), and sets `has_diff` / `has_new` for downstream jobs. Vitest covers classification and large patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276e92d8c105cc2ce6407eab94c1e2381a4fe61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->