### PR TITLE
fix(site): preserve directives when normalizing imports

### DIFF
--- a/site/scripts/normalize-imports.ts
+++ b/site/scripts/normalize-imports.ts
@@ -14,6 +14,7 @@ function getImportStatementText(source: string, node: ts.ImportDeclaration): str
 
 export function normalizeImports(source: string): string {
   const sourceFile = createSourceFile('imports.tsx', source);
+  const directives: string[] = [];
   const sideEffectImports = new Set<string>();
   // Map<module, Map<identifierName, { isType, alias? }>>
   const namedImports = new Map<string, Map<string, { isType: boolean; alias: string | undefined }>>();
@@ -22,6 +23,7 @@ export function normalizeImports(source: string): string {
 
   for (const statement of sourceFile.statements) {
     if (isDirectivePrologueStatement(statement)) {
+      directives.push(source.slice(statement.getFullStart(), statement.getEnd()).trim());
       bodyStart = statement.getEnd();
       continue;
     }
@@ -48,7 +50,7 @@ export function normalizeImports(source: string): string {
     if (!namedBindings || !ts.isNamedImports(namedBindings)) continue;
 
     const names = namedImports.get(specifier) ?? new Map<string, { isType: boolean; alias: string | undefined }>();
-    const isStatementTypeOnly = Boolean(importClause.isTypeOnly);
+    const isStatementTypeOnly = importClause.phaseModifier === ts.SyntaxKind.TypeKeyword;
 
     for (const element of namedBindings.elements) {
       const isType = element.isTypeOnly || isStatementTypeOnly;
@@ -77,10 +79,11 @@ export function normalizeImports(source: string): string {
     }),
   ];
   const body = source.slice(bodyStart).replace(/^\s+/, '');
+  const header = [directives.join('\n'), importLines.join('\n')].filter(Boolean).join('\n\n');
 
-  if (importLines.length === 0) {
+  if (!header) {
     return body;
   }
 
-  return `${importLines.join('\n')}\n\n${body}`;
+  return `${header}\n\n${body}`;
 }

--- a/site/scripts/tests/normalize-imports.test.ts
+++ b/site/scripts/tests/normalize-imports.test.ts
@@ -88,6 +88,24 @@ describe('normalizeImports', () => {
     expect(normalizeImports(input)).toBe("import * as React from 'react';\n\nconst x = 1;");
   });
 
+  it('preserves directives before normalized imports', () => {
+    const input = [
+      "'use client';",
+      "import { Foo } from 'mod';",
+      "import { Bar } from 'mod';",
+      '',
+      'const x = 1;',
+    ].join('\n');
+
+    expect(normalizeImports(input)).toBe("'use client';\n\nimport { Foo, Bar } from 'mod';\n\nconst x = 1;");
+  });
+
+  it('preserves multiple directives without imports', () => {
+    const input = ["'use strict';", "'use client';", '', 'const x = 1;'].join('\n');
+
+    expect(normalizeImports(input)).toBe("'use strict';\n'use client';\n\nconst x = 1;");
+  });
+
   it('orders: side-effect, raw, then named imports', () => {
     const input = [
       "import { useState } from 'react';",


### PR DESCRIPTION
Closes #1926

## Summary

Preserve module directive prologues when consolidating imports so generated React source does not silently lose directives such as `use client`.

## Changes

- Emit directive prologues before normalized import groups
- Preserve multiple directives even when a module has no imports
- Replace the deprecated TypeScript import-clause check with `phaseModifier`
- Add regression coverage for both directive shapes

## Testing

- `pnpm -C site test` (518 tests)
- `pnpm -C site ejected-skins`
- Generated `ejected-skins.json` is byte-for-byte unchanged
- `pnpm -C site astro check` (0 errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the site import-normalization script and its tests; behavior fix for generated source with no auth or runtime security impact.
> 
> **Overview**
> **`normalizeImports`** now keeps module directive prologues (e.g. `'use client'`) at the top of the file when it merges import lines, instead of dropping them during ejected-skin / generated React output.
> 
> Directive strings are collected while scanning the prologue, emitted ahead of the normalized import block (with a blank line between directives and imports), and still returned when there are no imports. Statement-level `import type` detection uses **`importClause.phaseModifier === ts.SyntaxKind.TypeKeyword`** instead of the deprecated **`isTypeOnly`** flag.
> 
> Regression tests cover directives above merged imports and multiple directives with no imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53d24fbff752b181fb05d52a38ca2ba816a9a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->