### PR TITLE
fix(packages): stabilize popup positioning

### DIFF
--- a/packages/core/src/dom/ui/popover/popup-positioner.ts
+++ b/packages/core/src/dom/ui/popover/popup-positioner.ts
@@ -141,21 +141,38 @@ export class PopupPositioner {
     const triggerRect = options.trigger.getBoundingClientRect();
     const boundaryRect = getPositioningBoundaryRect(this.#boundaryElement);
     const offsets = resolveOffsets(options.popup, options.cssVars);
-    const popupRect = getPopupPositionRect(options.popup, options.position.side);
-    const side = getPositionedSide(triggerRect, popupRect, boundaryRect, options.position, offsets);
-    const { positionAnchor: _, ...style } = getAnchorPositionStyle(
-      options.anchorName,
-      { ...options.position, side },
-      triggerRect,
-      supportsAnchorPositioning() ? undefined : popupRect,
-      boundaryRect,
-      offsets,
-      options.cssVars
-    );
+    const preferredPosition = options.position;
+    const anchorSupported = supportsAnchorPositioning();
+    const getPosition = (popupRect: DOMRect) => {
+      const side = getPositionedSide(triggerRect, popupRect, boundaryRect, preferredPosition, offsets);
+      const { positionAnchor: _, ...style } = getAnchorPositionStyle(
+        options.anchorName,
+        { ...preferredPosition, side },
+        triggerRect,
+        anchorSupported ? undefined : popupRect,
+        boundaryRect,
+        offsets,
+        options.cssVars
+      );
+
+      return { popupRect, side, style };
+    };
+    const position = getPosition(getPopupPositionRect(options.popup, preferredPosition.side));
 
     this.#capturePopupStyles(options.popup, options.cssVars ?? PopoverCSSVars);
-    applyStyles(options.popup, style);
-    options.onSideChange?.(side);
+    applyStyles(options.popup, position.style);
+    options.onSideChange?.(position.side);
+
+    if (anchorSupported || !options.onSideChange) return;
+
+    // Menu callbacks can constrain the popup from the available-size variables.
+    // Correct fallback coordinates synchronously so alignment is stable before paint.
+    const popupRect = getPopupPositionRect(options.popup, preferredPosition.side);
+    if (popupRect.width === position.popupRect.width && popupRect.height === position.popupRect.height) return;
+
+    const nextPosition = getPosition(popupRect);
+    applyStyles(options.popup, nextPosition.style);
+    if (nextPosition.side !== position.side) options.onSideChange(nextPosition.side);
   }
 
   #capturePopupStyles(popup: HTMLElement, cssVars: PositioningCSSVars): void {

--- a/packages/core/src/dom/ui/popover/tests/popup-positioner.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popup-positioner.test.ts
@@ -97,6 +97,34 @@ describe('PopupPositioner', () => {
     expect(disconnect).toHaveBeenCalledOnce();
   });
 
+  it('remeasures when the position callback changes the popup size', () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    const trigger = document.createElement('button');
+    const popup = document.createElement('div');
+    let popupWidth = 200;
+
+    mockRect(document.documentElement, 0, 0, 800, 600);
+    mockRect(trigger, 100, 200, 120, 40);
+    vi.spyOn(popup, 'getBoundingClientRect').mockImplementation(() => new DOMRect(0, 0, popupWidth, 80));
+    Object.defineProperty(popup, 'offsetWidth', { configurable: true, get: () => popupWidth });
+    Object.defineProperty(popup, 'offsetHeight', { configurable: true, value: 80 });
+
+    const onSideChange = vi.fn(() => {
+      popupWidth = 100;
+    });
+    const positioner = new PopupPositioner();
+    positioner.sync({
+      anchorName: 'settings',
+      position: { side: 'top', align: 'center' },
+      trigger,
+      popup,
+      onSideChange,
+    });
+
+    expect(popup.style.left).toBe('110px');
+    expect(onSideChange).toHaveBeenCalledOnce();
+  });
+
   it('preserves consumer-authored anchor styles', async () => {
     vi.resetModules();
     vi.doMock('@videojs/utils/dom', async (importOriginal) => {

--- a/packages/react/src/ui/menu/menu-content.tsx
+++ b/packages/react/src/ui/menu/menu-content.tsx
@@ -253,7 +253,7 @@ export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>(function
     open: state.open && !isSubmenu,
     anchorName,
     position: positionOptions,
-    trigger: menu.triggerElement,
+    triggerSource: menu,
     popupRef: internalRef,
     boundary,
     container,

--- a/packages/react/src/ui/popover/popover-popup.tsx
+++ b/packages/react/src/ui/popover/popover-popup.tsx
@@ -47,7 +47,7 @@ export const PopoverPopup = forwardRef<HTMLDivElement, PopoverPopupProps>(functi
     open: state.open,
     anchorName,
     position: posOpts,
-    trigger: popover.triggerElement,
+    triggerSource: popover,
     popupRef: internalRef,
     boundary,
     container,

--- a/packages/react/src/ui/popover/tests/popover.test.tsx
+++ b/packages/react/src/ui/popover/tests/popover.test.tsx
@@ -36,6 +36,8 @@ describe('Popover', () => {
       </Popover.Root>
     );
 
+    expect(screen.getByTestId('popup').style.top).toBe('30px');
+
     await waitFor(() => {
       for (const part of ['trigger', 'popup', 'arrow']) {
         expect(screen.getByTestId(part).getAttribute('data-side')).toBe('bottom');

--- a/packages/react/src/ui/popover/tests/popover.test.tsx
+++ b/packages/react/src/ui/popover/tests/popover.test.tsx
@@ -13,9 +13,10 @@ afterEach(() => {
 });
 
 describe('Popover', () => {
-  it('exposes the positioned side on every part', async () => {
+  it('positions default-open and remounted popups before paint', async () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
-      if (this.dataset.testid === 'trigger') return makeDOMRect(100, 10, 40, 20);
+      if (this.dataset.testid === 'trigger')
+        return makeDOMRect(this.hasAttribute('data-remounted') ? 200 : 100, 10, 40, 20);
       if (this.dataset.testid === 'popup') return makeDOMRect(0, 0, 100, 60);
       return makeDOMRect(0, 0, 300, 200);
     });
@@ -26,15 +27,22 @@ describe('Popover', () => {
       return this.dataset.testid === 'popup' ? 60 : 0;
     });
 
-    render(
+    const getPopover = (remounted = false) => (
       <Popover.Root defaultOpen side="top" boundary="viewport">
-        <Popover.Trigger data-testid="trigger">Open</Popover.Trigger>
+        <Popover.Trigger
+          key={remounted ? 'remounted' : 'initial'}
+          data-remounted={remounted ? '' : undefined}
+          data-testid="trigger"
+        >
+          Open
+        </Popover.Trigger>
         <Popover.Popup data-testid="popup">
           Content
           <Popover.Arrow data-testid="arrow" />
         </Popover.Popup>
       </Popover.Root>
     );
+    const { rerender } = render(getPopover());
 
     expect(screen.getByTestId('popup').style.top).toBe('30px');
 
@@ -43,5 +51,8 @@ describe('Popover', () => {
         expect(screen.getByTestId(part).getAttribute('data-side')).toBe('bottom');
       }
     });
+
+    rerender(getPopover(true));
+    expect(screen.getByTestId('popup').style.left).toBe('170px');
   });
 });

--- a/packages/react/src/ui/popover/use-popup-position.ts
+++ b/packages/react/src/ui/popover/use-popup-position.ts
@@ -19,7 +19,7 @@ interface UsePopupPositionOptions {
   open: boolean;
   anchorName: string;
   position: PositioningOptions | null;
-  trigger: HTMLElement | null;
+  triggerSource: { readonly triggerElement: HTMLElement | null };
   popupRef: RefObject<HTMLElement | null>;
   boundary: PositioningBoundary;
   container: MediaContainer | null;
@@ -31,7 +31,7 @@ export function usePopupPosition({
   open,
   anchorName,
   position,
-  trigger,
+  triggerSource,
   popupRef,
   boundary,
   container,
@@ -49,7 +49,7 @@ export function usePopupPosition({
     positioner.sync({
       anchorName,
       position,
-      trigger,
+      trigger: triggerSource.triggerElement,
       popup: popupRef.current,
       boundary,
       container,
@@ -58,7 +58,7 @@ export function usePopupPosition({
     });
 
     return () => positioner.cleanup();
-  }, [open, anchorName, position, trigger, popupRef, boundary, container, cssVars, onSideChange, positioner]);
+  }, [open, anchorName, position, triggerSource, popupRef, boundary, container, cssVars, onSideChange, positioner]);
 
   return POPOVER_RESET;
 }

--- a/packages/react/src/ui/popover/use-popup-position.ts
+++ b/packages/react/src/ui/popover/use-popup-position.ts
@@ -56,9 +56,9 @@ export function usePopupPosition({
       ...(cssVars ? { cssVars } : {}),
       ...(onSideChange ? { onSideChange } : {}),
     });
+  });
 
-    return () => positioner.cleanup();
-  }, [open, anchorName, position, triggerSource, popupRef, boundary, container, cssVars, onSideChange, positioner]);
+  useLayoutEffect(() => () => positioner.cleanup(), [positioner]);
 
   return POPOVER_RESET;
 }

--- a/packages/react/src/ui/tooltip/tooltip-popup.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-popup.tsx
@@ -49,7 +49,7 @@ export const TooltipPopup = forwardRef<HTMLDivElement, TooltipPopupProps>(functi
     open: state.open,
     anchorName,
     position: posOpts,
-    trigger: tooltip.triggerElement,
+    triggerSource: tooltip,
     popupRef: internalRef,
     boundary,
     container,


### PR DESCRIPTION
Closes #2079

Follow-up to #1904.

## Summary

Address two valid post-merge popup-positioning findings: default-open React popups initially measured a stale trigger value, and menu sizing could invalidate JavaScript fallback alignment after the first positioning pass.

## Changes

- Read the live trigger element during the React layout effect, after callback refs attach.
- Synchronously remeasure JavaScript fallback coordinates when a positioning callback changes popup dimensions.
- Cover immediate default-open positioning and callback-driven popup resizing with regression tests.

## Testing

- `pnpm -F @videojs/core test` (1,376 tests)
- `pnpm -F @videojs/react test` (384 tests)
- `pnpm -F @videojs/html test` (283 tests)
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared popup positioning used by popover, menu, and tooltip; behavior changes are targeted at layout timing and JS fallback, but incorrect edge cases could still cause visible misalignment.
> 
> **Overview**
> Fixes two popup alignment glitches: **stale trigger measurements** on first open and **wrong JS fallback coords** after menus resize the popup.
> 
> **React:** `usePopupPosition` now takes a `triggerSource` object and reads `triggerElement` inside a layout effect on every open pass, so default-open and remounted triggers are measured after callback refs attach instead of from a stale closure. Sync/cleanup are split so positioning re-runs in layout without tearing down the positioner on unrelated dep changes.
> 
> **Core:** When CSS anchor positioning is unavailable and `onSideChange` runs (e.g. menu root syncing available width), `PopupPositioner` **synchronously remeasures** the popup and reapplies fallback coordinates if the callback changed dimensions—so alignment is correct before paint.
> 
> Regression tests cover callback-driven resize remeasure and immediate positioning for default-open/remounted popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cedd8fe3780b6c6fe39a4f7d3a25ff9bd3d2a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->