### PR TITLE
feat(utils): extract getAnchorNames and addAnchorName

### DIFF
--- a/packages/core/src/dom/ui/popover/popup-positioner.ts
+++ b/packages/core/src/dom/ui/popover/popup-positioner.ts
@@ -1,4 +1,10 @@
-import { applyStyles, getPositionedSide, rafThrottle, supportsAnchorPositioning } from '@videojs/utils/dom';
+import {
+  applyStyles,
+  getAnchorNames,
+  getPositionedSide,
+  rafThrottle,
+  supportsAnchorPositioning,
+} from '@videojs/utils/dom';
 import { kebabCase } from '@videojs/utils/string';
 import { PopoverCSSVars } from '../../../core/ui/popover/popover-css-vars';
 import { isEventWithinElement } from '../../utils/event';
@@ -189,8 +195,7 @@ export class PopupPositioner {
     const triggerAnchor = this.#readStyle(trigger, 'anchor-name');
     this.#popupAnchor = this.#readStyle(popup, 'position-anchor');
 
-    const authoredNames = triggerAnchor.value.trim();
-    const names = authoredNames && authoredNames !== 'none' ? authoredNames.split(',').map((name) => name.trim()) : [];
+    const names = getAnchorNames(trigger);
     this.#triggerAnchorName = generatedName;
     this.#triggerAnchorAdded = !names.includes(generatedName);
     if (this.#triggerAnchorAdded) names.push(generatedName);
@@ -205,10 +210,7 @@ export class PopupPositioner {
 
     if (this.#triggerAnchorName && this.#triggerAnchorAdded) {
       const current = this.#readStyle(options.trigger, 'anchor-name');
-      const names = current.value
-        .split(',')
-        .map((name) => name.trim())
-        .filter((name) => name && name !== this.#triggerAnchorName);
+      const names = getAnchorNames(options.trigger).filter((name) => name !== this.#triggerAnchorName);
       this.#writeStyle(options.trigger, 'anchor-name', { value: names.join(', '), priority: current.priority });
     }
     if (this.#popupAnchor) this.#writeStyle(options.popup, 'position-anchor', this.#popupAnchor);

--- a/packages/utils/src/dom/index.ts
+++ b/packages/utils/src/dom/index.ts
@@ -37,7 +37,7 @@ export {
   type ShadowStyle,
 } from './shadow-styles';
 export { getSlottedElement, querySlot } from './slotted';
-export { applyStyles, resolveCSSLength } from './style';
+export { addAnchorName, applyStyles, getAnchorNames, resolveCSSLength } from './style';
 export { supportsAnchorPositioning, supportsAnimationFrame, supportsIdleCallback } from './supports';
 export { createTemplate, renderTemplate } from './template';
 export {

--- a/packages/utils/src/dom/style.ts
+++ b/packages/utils/src/dom/style.ts
@@ -14,12 +14,15 @@ export function getAnchorNames(element: HTMLElement): string[] {
 export function addAnchorName(element: HTMLElement, name: string): () => void {
   const anchor = `--${name}`;
   const anchors = getAnchorNames(element);
+  const added = !anchors.includes(anchor);
 
-  if (!anchors.includes(anchor)) {
+  if (added) {
     element.style.setProperty('anchor-name', [...anchors, anchor].join(', '));
   }
 
   return () => {
+    if (!added) return;
+
     const next = getAnchorNames(element).filter((name) => name !== anchor);
 
     if (next.length) {

--- a/packages/utils/src/dom/style.ts
+++ b/packages/utils/src/dom/style.ts
@@ -1,5 +1,35 @@
 import { kebabCase } from '../string/casing';
 
+export function getAnchorNames(element: HTMLElement): string[] {
+  const value = element.style.getPropertyValue('anchor-name').trim();
+
+  if (!value || value === 'none') return [];
+
+  return value
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+export function addAnchorName(element: HTMLElement, name: string): () => void {
+  const anchor = `--${name}`;
+  const anchors = getAnchorNames(element);
+
+  if (!anchors.includes(anchor)) {
+    element.style.setProperty('anchor-name', [...anchors, anchor].join(', '));
+  }
+
+  return () => {
+    const next = getAnchorNames(element).filter((name) => name !== anchor);
+
+    if (next.length) {
+      element.style.setProperty('anchor-name', next.join(', '));
+    } else {
+      element.style.removeProperty('anchor-name');
+    }
+  };
+}
+
 export function applyStyles(element: HTMLElement, styles: Record<string, string | undefined>): void {
   for (const [prop, value] of Object.entries(styles)) {
     if (typeof value === 'string') {

--- a/packages/utils/src/dom/tests/style.test.ts
+++ b/packages/utils/src/dom/tests/style.test.ts
@@ -34,6 +34,18 @@ describe('addAnchorName', () => {
     cleanupTooltip();
     expect(getAnchorNames(el)).toEqual([]);
   });
+
+  it('preserves a pre-existing anchor name on cleanup', () => {
+    const el = document.createElement('button');
+
+    el.style.setProperty('anchor-name', '--settings-menu');
+
+    const cleanup = addAnchorName(el, 'settings-menu');
+
+    cleanup();
+
+    expect(getAnchorNames(el)).toEqual(['--settings-menu']);
+  });
 });
 
 describe('resolveCSSLength', () => {

--- a/packages/utils/src/dom/tests/style.test.ts
+++ b/packages/utils/src/dom/tests/style.test.ts
@@ -1,6 +1,40 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveCSSLength } from '../style';
+import { addAnchorName, getAnchorNames, resolveCSSLength } from '../style';
+
+describe('getAnchorNames', () => {
+  it('returns normalized anchor names', () => {
+    const el = document.createElement('button');
+
+    el.style.setProperty('anchor-name', '--menu,  --tooltip');
+
+    expect(getAnchorNames(el)).toEqual(['--menu', '--tooltip']);
+  });
+
+  it('returns no names for none', () => {
+    const el = document.createElement('button');
+
+    el.style.setProperty('anchor-name', 'none');
+
+    expect(getAnchorNames(el)).toEqual([]);
+  });
+});
+
+describe('addAnchorName', () => {
+  it('composes anchor names and cleans up only its own name', () => {
+    const el = document.createElement('button');
+    const cleanupMenu = addAnchorName(el, 'settings-menu');
+    const cleanupTooltip = addAnchorName(el, 'settings-tooltip');
+
+    expect(getAnchorNames(el)).toEqual(['--settings-menu', '--settings-tooltip']);
+
+    cleanupMenu();
+    expect(getAnchorNames(el)).toEqual(['--settings-tooltip']);
+
+    cleanupTooltip();
+    expect(getAnchorNames(el)).toEqual([]);
+  });
+});
 
 describe('resolveCSSLength', () => {
   afterEach(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small DOM utility extraction with equivalent parsing behavior in popup positioning; new `addAnchorName` is exported but not yet adopted elsewhere in this diff.
> 
> **Overview**
> Moves **CSS anchor positioning** helpers into `@videojs/utils/dom` and re-exports **`getAnchorNames`** and **`addAnchorName`** from `style.ts`.
> 
> **`getAnchorNames`** normalizes an element’s inline `anchor-name` (comma-separated list, treats `none`/empty as no names). **`addAnchorName`** appends a `--{name}` entry and returns a cleanup that removes only that name, including when multiple anchors or a pre-existing name are present.
> 
> **`PopupPositioner`** now calls **`getAnchorNames`** when applying and restoring trigger anchor styles instead of duplicating split/trim logic. Vitest coverage was added for the new helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1409a6fda85f9cd3c9515c57373c373657f567e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->