### PR TITLE
fix(ci): report accurate bundle size diffs

### DIFF
--- a/.github/scripts/bundle-size-report.js
+++ b/.github/scripts/bundle-size-report.js
@@ -7,11 +7,13 @@
  * When --base is omitted, generates a local report showing current sizes.
  * When --base is provided, generates a comparison report with diffs.
  *
- * Reads JSON arrays of { name, size, type, category?, format, standaloneSize?,
- * lazySize?, totalSize? } entries produced by bundle-size.js.
+ * Reads JSON arrays of { name, size, type, category?, format, lazySize?,
+ * totalSize? } entries produced by bundle-size.js.
  */
 
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -34,31 +36,6 @@ function formatDelta(current, previous) {
   };
 }
 
-function statusIcon(current, previous) {
-  if (previous === undefined) return '🆕';
-  const diff = current - previous;
-  if (diff === 0) return '✅';
-  if (diff < 0) return '🔽';
-  if (previous === 0) return '🔴';
-  const pct = (diff / previous) * 100;
-  return pct > 10 ? '🔴' : '🔺';
-}
-
-function entryStatusIcon(current, previous) {
-  if (!previous) return '🆕';
-  const currentSize = comparisonSize(current);
-  const previousSize = comparisonSize(previous);
-  if (Math.abs(currentSize - previousSize) > 300) {
-    return statusIcon(currentSize, previousSize);
-  }
-  const currentLazy = comparisonLazySize(current);
-  const previousLazy = comparisonLazySize(previous);
-  if (currentLazy !== previousLazy) {
-    return statusIcon(currentLazy, previousLazy);
-  }
-  return statusIcon(currentLazy, previousLazy);
-}
-
 function lazySize(entry) {
   if (!entry) return 0;
   return (
@@ -79,19 +56,17 @@ function lazyDelta(current, previous) {
   return formatDelta(currentLazy, previousLazy).bytes;
 }
 
-function comparisonSize(entry) {
-  return entry?.standaloneSize ?? entry?.size ?? 0;
-}
+const HIGHLIGHT_THRESHOLD = 300;
 
-function comparisonLazySize(entry) {
-  return entry?.standaloneLazySize ?? lazySize(entry);
-}
-
-function comparisonLazyDelta(current, previous) {
-  const currentLazy = comparisonLazySize(current);
-  const previousLazy = comparisonLazySize(previous);
-  if (currentLazy === 0 && previousLazy === 0) return '—';
-  return formatDelta(currentLazy, previousLazy).bytes;
+function isHighlightedChange(current, previous) {
+  if (!previous) return true;
+  const totalDelta =
+    current.size + lazySize(current) - previous.size - lazySize(previous);
+  return (
+    Math.abs(current.size - previous.size) > HIGHLIGHT_THRESHOLD ||
+    Math.abs(lazySize(current) - lazySize(previous)) > HIGHLIGHT_THRESHOLD ||
+    Math.abs(totalDelta) > HIGHLIGHT_THRESHOLD
+  );
 }
 
 /** Preferred display order for packages. Unlisted packages sort to the end. */
@@ -196,11 +171,6 @@ function generateCategoryBreakdowns(entries, pkg) {
       }
     }
 
-    if (cat === 'ui') {
-      lines.push('');
-      lines.push('*Sizes are marginal over the root entry point.*');
-    }
-
     lines.push('</details>');
     lines.push('');
   }
@@ -233,24 +203,42 @@ function generateFlatBreakdown(entries, pkg) {
   return lines;
 }
 
+function generateComparisonTable(entries, removed, pkg, baseEntryMap) {
+  const lines = [
+    '| Path | Base initial | PR initial | Initial diff | Lazy diff |',
+    '|---|--:|--:|--:|--:|',
+  ];
+
+  for (const entry of entries) {
+    const el = entryLabel(entry.name, pkg);
+    const previousEntry = baseEntryMap[entry.name];
+    const prevInitial = previousEntry?.size;
+    const d = formatDelta(entry.size, prevInitial);
+    const baseSize = prevInitial !== undefined ? formatBytes(prevInitial) : '—';
+    const initialDelta = previousEntry ? `${d.bytes} (${d.pct})` : 'new';
+    lines.push(
+      `| ${el} | ${baseSize} | ${formatBytes(entry.size)} | ${initialDelta} | ${lazyDelta(entry, previousEntry)} |`,
+    );
+  }
+
+  for (const entry of removed) {
+    const el = entryLabel(entry.name, pkg);
+    lines.push(
+      `| ${el} | ${formatBytes(entry.size)} | — | removed | ${lazyDelta(undefined, entry)} |`,
+    );
+  }
+
+  lines.push('');
+  return lines;
+}
+
 // ---------------------------------------------------------------------------
 // Comparison report (CI — PR vs base)
 // ---------------------------------------------------------------------------
 
-function generateComparisonReport(current, base) {
+export function generateComparisonReport(current, base) {
   const currentMap = Object.fromEntries(current.map((e) => [e.name, e.size]));
   const baseEntryMap = Object.fromEntries(base.map((e) => [e.name, e]));
-
-  // Standalone size lookups — used to gate UI component diffs.
-  // UI marginal sizes shift when root content changes (brotli compression is
-  // non-linear), so we compare standalone sizes to decide IF a component
-  // actually changed, then display the marginal diff.
-  const baseStandaloneMap = Object.fromEntries(
-    base.map((e) => [e.name, e.standaloneSize ?? e.size]),
-  );
-  const currentStandaloneMap = Object.fromEntries(
-    current.map((e) => [e.name, e.standaloneSize ?? e.size]),
-  );
 
   const groups = groupByPackage(current);
 
@@ -286,26 +274,27 @@ function generateComparisonReport(current, base) {
     const baseEntries = baseGroups.get(pkg) ?? [];
     const pkgIcon = pkgIcons[pkg] ?? '📦';
 
-    // Entries with meaningful size changes (>300 B threshold).
-    // For UI components, gate on standalone size to filter out phantom diffs
-    // caused by brotli compression shifts when root content changes.
+    // Every byte is intentional here. Measurements are deterministic, so a
+    // reporting threshold would hide legitimate small improvements/regressions.
     const changed = entries.filter((e) => {
-      const prevStandalone = baseStandaloneMap[e.name];
-      // New entry — always surface
-      if (prevStandalone === undefined) return true;
-      const curStandalone = currentStandaloneMap[e.name];
-      const initialChanged = Math.abs(curStandalone - prevStandalone) > 300;
-      const currentLazy = comparisonLazySize(e);
       const previousEntry = baseEntryMap[e.name];
-      const previousLazy = comparisonLazySize(previousEntry);
-      const lazyChanged = Math.abs(currentLazy - previousLazy) > 300;
-      return initialChanged || lazyChanged;
+      if (!previousEntry) return true;
+      return (
+        e.size !== previousEntry.size ||
+        lazySize(e) !== lazySize(previousEntry)
+      );
     });
 
     // Entries that existed in base but are missing in PR (removed)
     const removed = baseEntries.filter((e) => currentMap[e.name] === undefined);
 
-    const hasChanges = changed.length > 0 || removed.length > 0;
+    const highlighted = changed.filter((entry) =>
+      isHighlightedChange(entry, baseEntryMap[entry.name]),
+    );
+    const small = changed.filter(
+      (entry) => !isHighlightedChange(entry, baseEntryMap[entry.name]),
+    );
+    const hasHighlightedChanges = highlighted.length > 0 || removed.length > 0;
 
     // Category breakdowns for packages with categories (html, react)
     const hasCategories = entries.some((e) => e.category);
@@ -315,36 +304,38 @@ function generateComparisonReport(current, base) {
         ? generateFlatBreakdown(entries, pkg)
         : [];
 
-    if (hasChanges) {
+    if (hasHighlightedChanges) {
       lines.push(`## ${pkgIcon} @videojs/${pkg}`);
       lines.push('');
-
-      lines.push('| Path | Base initial | PR initial | Diff | % | Lazy | |');
-      lines.push('|---|--:|--:|--:|--:|--:|:-:|');
-
-      for (const entry of changed) {
-        const el = entryLabel(entry.name, pkg);
-        const previousEntry = baseEntryMap[entry.name];
-        const prevInitial = previousEntry ? comparisonSize(previousEntry) : undefined;
-        const currentInitial = comparisonSize(entry);
-        const d = formatDelta(currentInitial, prevInitial);
-        const status = entryStatusIcon(entry, previousEntry);
-        const baseSize = prevInitial !== undefined ? formatBytes(prevInitial) : '—';
+      lines.push(
+        ...generateComparisonTable(
+          highlighted,
+          removed,
+          pkg,
+          baseEntryMap,
+        ),
+      );
+      if (small.length > 0) {
+        lines.push('<details>');
         lines.push(
-          `| ${el} | ${baseSize} | ${formatBytes(currentInitial)} | ${d.bytes} | ${d.pct} | ${comparisonLazyDelta(entry, previousEntry)} | ${status} |`,
+          `<summary>Small changes (${small.length}, ≤ ${HIGHLIGHT_THRESHOLD} B)</summary>`,
         );
+        lines.push('');
+        lines.push(...generateComparisonTable(small, [], pkg, baseEntryMap));
+        lines.push('</details>');
+        lines.push('');
       }
-
-      for (const entry of removed) {
-        const el = entryLabel(entry.name, pkg);
-        const previousInitial = comparisonSize(entry);
-        lines.push(
-          `| ${el} | ${formatBytes(previousInitial)} | — | −${formatBytes(previousInitial)} | −100% | ${comparisonLazyDelta(undefined, entry)} | 🗑️ |`,
-        );
-      }
-
-      lines.push('');
       lines.push(...breakdownLines);
+    } else if (small.length > 0) {
+      lines.push('<details>');
+      lines.push(
+        `<summary><b>${pkgIcon} @videojs/${pkg}</b> — ${small.length} small size ${small.length === 1 ? 'change' : 'changes'}</summary>`,
+      );
+      lines.push('');
+      lines.push(...generateComparisonTable(small, [], pkg, baseEntryMap));
+      lines.push(...breakdownLines);
+      lines.push('</details>');
+      lines.push('');
     } else {
       lines.push('<details>');
       lines.push(`<summary><b>${pkgIcon} @videojs/${pkg}</b> — no changes</summary>`);
@@ -362,16 +353,16 @@ function generateComparisonReport(current, base) {
   lines.push('<summary>ℹ️ How to interpret</summary>');
   lines.push('');
   lines.push(
-    'JS sizes are initial static graph totals (minified + brotli). Lazy dynamic chunks are shown separately when present.',
+    'Each entry is independently bundled, minified, and brotli-compressed. Initial size includes its static import graph; lazy dynamic chunks are reported separately.',
   );
   lines.push('');
-  lines.push('| Icon | Meaning |');
-  lines.push('|---|---|');
-  lines.push('| ✅ | No change |');
-  lines.push('| 🔺 | Increased ≤ 10% |');
-  lines.push('| 🔴 | Increased > 10% |');
-  lines.push('| 🔽 | Decreased |');
-  lines.push('| 🆕 | New (no baseline) |');
+  lines.push(
+    'Entries are not additive because their dependency graphs overlap. Preset rows represent realistic combined bundles.',
+  );
+  lines.push('');
+  lines.push(
+    `Changes of ${HIGHLIGHT_THRESHOLD} B or less across initial, lazy, and total size are collapsed, not discarded.`,
+  );
   lines.push('');
   lines.push('Run `pnpm size` locally to check current initial sizes.');
   lines.push('</details>');
@@ -564,4 +555,7 @@ function main() {
   }
 }
 
-main();
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) main();

--- a/.github/scripts/bundle-size.js
+++ b/.github/scripts/bundle-size.js
@@ -4,9 +4,9 @@
  * Auto-discovers packages from `packages/`, reads their `exports` field to find
  * entry points, and externalizes `peerDependencies`.
  *
- * JS sizes are initial static graph totals (minified + brotli). Lazy dynamic
- * chunks are measured separately so they stay visible without counting as
- * eager entry cost.
+ * Each JS export is bundled independently. Sizes are initial static graph
+ * totals (minified + brotli); lazy dynamic chunks are measured separately so
+ * they stay visible without counting as eager entry cost.
  *
  * Wildcard exports (e.g., `./ui/*`, `./media/⁕/index.js`) are resolved to
  * actual files on disk. Supports both file-level (`*.js`) and directory-level
@@ -155,12 +155,9 @@ function buildPresetEntry(pkgShortName, config, distDir) {
  * @property {'root' | 'subpath'} type
  * @property {string} [category] - preset, media, player, skin, ui, feature (only for html/react)
  * @property {'js' | 'css'} format
- * @property {number} [standaloneSize] - For UI components: standalone size used for stable diff gating
  * @property {number} [totalSize] - Initial + lazy dynamic chunk size
  * @property {number} [lazySize] - Lazy dynamic chunk size
  * @property {number} [chunkCount] - Number of dynamic chunks
- * @property {number} [standaloneTotalSize] - Standalone initial + lazy dynamic chunk size
- * @property {number} [standaloneLazySize] - Standalone lazy dynamic chunk size
  */
 
 function compressSize(code) {
@@ -179,17 +176,11 @@ function entryKey(path) {
   return relative(ROOT, path).replaceAll('\\', '/');
 }
 
-function staticOutputs(metafile, entryPoints) {
-  const entryPointsSet = entryPoints
-    ? new Set(entryPoints.map((entry) => entryKey(entry)))
-    : null;
+function staticOutputs(metafile, entryPoint) {
+  const entryPointKey = entryPoint ? entryKey(entryPoint) : '<stdin>';
   const outputs = new Set();
   const queue = Object.entries(metafile.outputs)
-    .filter(([, output]) =>
-      entryPointsSet
-        ? entryPointsSet.has(output.entryPoint)
-        : output.entryPoint === '<stdin>',
-    )
+    .filter(([, output]) => output.entryPoint === entryPointKey)
     .map(([path]) => path);
 
   for (const path of queue) {
@@ -219,10 +210,10 @@ function sizeFields(measurement) {
   };
 }
 
-/** Bundle entry points with esbuild and return initial and lazy sizes. */
-async function measure(entryPoints, external = []) {
+/** Bundle one entry point with esbuild and return initial and lazy sizes. */
+async function measure(entryPoint, external = []) {
   const result = await build({
-    entryPoints,
+    entryPoints: [entryPoint],
     bundle: true,
     minify: true,
     treeShaking: true,
@@ -239,7 +230,7 @@ async function measure(entryPoints, external = []) {
   const sizeByPath = new Map(
     result.outputFiles.map((file) => [file.path, compressSize(file.text)]),
   );
-  const staticPaths = staticOutputs(result.metafile, entryPoints);
+  const staticPaths = staticOutputs(result.metafile, entryPoint);
   let size = 0;
   let totalSize = 0;
 
@@ -534,13 +525,8 @@ async function main() {
 
     const rootCat = categorize(pkg.name);
 
-    // Always measure root — needed for UI marginal calculations even when
-    // the root itself is excluded from results (categorized packages skip
-    // root because presets are measured as virtual bundles instead).
-    const rootMeasurement = await measure([pkg.rootPath], pkg.external);
-    const rootSize = rootMeasurement.size;
-
     if (rootCat !== '_skip') {
+      const rootMeasurement = await measure(pkg.rootPath, pkg.external);
       results.push({
         name: pkg.name,
         ...sizeFields(rootMeasurement),
@@ -565,57 +551,14 @@ async function main() {
         continue;
       }
 
-      // UI components are measured as marginal over root (size) for display,
-      // plus standalone (standaloneSize) for stable cross-build diff gating.
-      // Marginal sizes shift when root content changes due to brotli
-      // compression non-linearity, so diffs must gate on standalone.
-      let size;
-      let standaloneSize;
-      let measurement;
-      let standaloneMeasurement;
-      if (cat === 'ui') {
-        const combined = await measure([pkg.rootPath, sub.path], pkg.external);
-        standaloneMeasurement = await measure([sub.path], pkg.external);
-        size = Math.max(0, combined.size - rootSize);
-        const lazySize = Math.max(
-          0,
-          combined.lazySize - rootMeasurement.lazySize,
-        );
-        measurement = {
-          size,
-          totalSize: size + lazySize,
-          lazySize,
-          chunkCount: Math.max(
-            0,
-            combined.chunkCount - rootMeasurement.chunkCount,
-          ),
-        };
-        standaloneSize = standaloneMeasurement.size;
-      } else {
-        measurement = await measure([sub.path], pkg.external);
-        size = measurement.size;
-      }
+      const measurement = await measure(sub.path, pkg.external);
 
       results.push({
         name: sub.name,
-        size,
+        ...sizeFields(measurement),
         type: 'subpath',
         ...(cat ? { category: cat } : {}),
         format: 'js',
-        ...(measurement && measurement.lazySize > 0
-          ? {
-              totalSize: measurement.totalSize,
-              lazySize: measurement.lazySize,
-              chunkCount: measurement.chunkCount,
-            }
-          : {}),
-        ...(standaloneSize !== undefined ? { standaloneSize } : {}),
-        ...(standaloneMeasurement && standaloneMeasurement.lazySize > 0
-          ? {
-              standaloneTotalSize: standaloneMeasurement.totalSize,
-              standaloneLazySize: standaloneMeasurement.lazySize,
-            }
-          : {}),
       });
     }
 

--- a/.github/scripts/tests/bundle-size-report.test.js
+++ b/.github/scripts/tests/bundle-size-report.test.js
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { generateComparisonReport } from '../bundle-size-report.js';
+
+function entry(name, size, extra = {}) {
+  return {
+    name,
+    size,
+    type: 'subpath',
+    format: 'js',
+    ...extra,
+  };
+}
+
+describe('generateComparisonReport', () => {
+  it('reports byte-level initial size changes', () => {
+    const base = [entry('@videojs/core/dom', 100)];
+    const current = [entry('@videojs/core/dom', 101)];
+
+    const report = generateComparisonReport(current, base);
+
+    assert.match(
+      report,
+      /\| `\/dom` \| 100 B \| 101 B \| \+1 B \(\+1\.0%\) \| — \|/,
+    );
+    assert.match(report, /1 small size change/);
+    assert.doesNotMatch(report, /@videojs\/core<\/b> — no changes/);
+  });
+
+  it('reports lazy-only changes', () => {
+    const base = [entry('@videojs/core/dom', 100, { lazySize: 10 })];
+    const current = [entry('@videojs/core/dom', 100, { lazySize: 20 })];
+
+    const report = generateComparisonReport(current, base);
+
+    assert.match(
+      report,
+      /\| `\/dom` \| 100 B \| 100 B \| 0 B \(0%\) \| \+10 B \|/,
+    );
+  });
+
+  it('reports added and removed entries', () => {
+    const base = [entry('@videojs/utils/removed', 50)];
+    const current = [entry('@videojs/utils/added', 25)];
+
+    const report = generateComparisonReport(current, base);
+
+    assert.match(report, /\| `\/added` \| — \| 25 B \| new \| — \|/);
+    assert.match(
+      report,
+      /\| `\/removed` \| 50 B \| — \| removed \| — \|/,
+    );
+  });
+
+  it('highlights changes whose combined initial and lazy delta exceeds the threshold', () => {
+    const base = [entry('@videojs/core/dom', 1000, { lazySize: 1000 })];
+    const current = [entry('@videojs/core/dom', 1200, { lazySize: 1200 })];
+
+    const report = generateComparisonReport(current, base);
+
+    assert.match(report, /## 🧩 @videojs\/core/);
+    assert.doesNotMatch(report, /small size change/);
+  });
+
+  it('collapses packages only when their measurements are identical', () => {
+    const measurements = [entry('@videojs/store', 200)];
+
+    const report = generateComparisonReport(measurements, measurements);
+
+    assert.match(report, /@videojs\/store<\/b> — no changes/);
+  });
+});

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install and build
         run: pnpm install && pnpm build:packages
 
+      - name: Test bundle size reporting
+        run: pnpm test:size
+
       - name: Measure bundle size
         run: node .github/scripts/bundle-size.js --json pr-size.json
 
@@ -50,7 +53,7 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Checkout PR scripts
         uses: actions/checkout@v5
@@ -65,8 +68,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: '.bundle-size-pr/.nvmrc'
           cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .bundle-size-pr/pnpm-lock.yaml
 
       - name: Cache turbo build setup
         uses: actions/cache@v5
@@ -81,6 +87,7 @@ jobs:
           pnpm install
 
           if [ -f .bundle-size-pr/.github/scripts/bundle-size.js ]; then
+            pnpm --dir .bundle-size-pr install --frozen-lockfile --ignore-scripts --filter video.js
             pnpm build:packages
             node .bundle-size-pr/.github/scripts/bundle-size.js --root . --json base-size.json
           else

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:e2e:sandbox": "pnpm --dir apps/e2e test:sandbox",
     "test:e2e:update": "pnpm --dir apps/e2e test:update",
     "test:e2e:install": "pnpm --dir apps/e2e run install:browsers && pnpm --dir apps/e2e run install:deps",
+    "test:size": "node --test .github/scripts/tests/*.test.js",
     "format:astro": "prettier --write 'site/src/**/*.astro'",
     "typecheck": "tsgo --build",
     "changelog": "git-cliff --config cliff.toml --output CHANGELOG.md",


### PR DESCRIPTION
Closes #1937

## Summary

Make pull request bundle-size comparisons reproducible and give every exported entry one clear, consumer-facing measurement. This removes misleading UI marginal calculations while keeping the report readable when shared dependencies affect many entries.

## Changes

- Measure each export independently and keep realistic combined preset measurements
- Report initial and lazy deltas for every changed entry, collapsing small changes instead of discarding them
- Compare against the event's immutable base SHA with the PR's Node and esbuild analyzer versions on both sides
- Cover byte-level, lazy-only, added, removed, highlighted, and unchanged report cases

<details>
<summary>Implementation details</summary>

The previous UI calculation subtracted independently chunked and brotli-compressed bundles. In current output, this produced three marginal costs larger than the corresponding complete standalone bundle. Removing the duplicate marginal builds also reduced a local full measurement from roughly 68 seconds to 38–39 seconds.

</details>

## Testing

- `pnpm build:packages`
- `pnpm test:size`
- `pnpm check:workspace`
- `pnpm lint`
- Prettier and `git diff --check`
- Two full measurements of identical inputs compared byte-for-byte

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI bundle-size scripts, workflow, and new tests; no runtime library or auth/data paths.
> 
> **Overview**
> **Bundle size measurement and PR reports now use one independent bundle per export**, dropping UI “marginal over root” math and `standaloneSize` fields that could disagree with real standalone totals and slow CI.
> 
> **Comparison reports** show initial and lazy deltas for every real change, use a simpler table (no status icons), and **collapse ≤300 B** changes into `<details>` instead of filtering them out. Help text now explains independent bundling and non-additive entries.
> 
> **CI** runs `pnpm test:size`, checks out the immutable **base SHA**, and measures base artifacts with the **PR’s** `bundle-size.js` / Node version from `.bundle-size-pr` so analyzer versions match both sides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f0b4e0132bfaf2b33faafaa1e285fe59fbdb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->