### PR TITLE
feat(media): support DRM protected playback

### DIFF
--- a/apps/sandbox/app/shared/mux.ts
+++ b/apps/sandbox/app/shared/mux.ts
@@ -5,5 +5,7 @@ import { SOURCES, type SourceId } from './sources';
 const MUX_PLAYBACK_ID = /^https:\/\/stream\.[^/]+\/([\w-]+?)(?:\.m3u8|\/[\w-]+\.mp4)/;
 
 export function getMuxAssetId(source: SourceId): string | undefined {
-  return SOURCES[source].url.match(MUX_PLAYBACK_ID)?.[1];
+  // A structured source names the playback ID outright; a plain URL hides it.
+  const { source: muxSource, url } = SOURCES[source];
+  return muxSource?.playbackId ?? url?.match(MUX_PLAYBACK_ID)?.[1];
 }

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -14,6 +14,25 @@ export interface SandboxSource {
   source?: MuxSource;
 }
 
+// The two DRM sources below are the same Mux asset reached two ways, so the
+// tokens are shared rather than repeated. DRM playback is always signed, and
+// each URL carries its own audience-scoped token: `playback` for the manifest,
+// `drm` for the license request, `thumbnail` / `storyboard` for the images.
+//
+// Read-only tokens for a throwaway demo asset, signed to expire in 2038 so the
+// sandbox keeps working. They grant nothing beyond playing this one video.
+const DRM_PLAYBACK_ID = 'FefhWnSMzDqz5z9yxssihdRx8dV6srhYJ8301uQBhRak';
+
+const DRM_TOKENS = {
+  playback:
+    'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InYiLCJleHAiOjIxNDc0ODM2NDd9.jXIpJZPB7diM5M6jMVRQ6dELY5YnONzC8jJClm7CT1nm-q25F5PiCvHcdLGqerjN1V_7T9cjhSX02p1i0UiABaKX2Wa4HCf6H6ZSKbY3MiCiRJHnfZzr_cVHCuBRXJlMzXesK_VzgP4kVrVi9-Sj8fGaeQmt4mB0sgtGGM7LpGV1IJdv_9aWnqQpQK7IeWi9ivNwa9Vw-PeppfOFdyQbqYJScIAY-_k6fzGaQucONyIolFGJZuBcan3nDRvCUpSFi0vPO87jf5Zbp6kn-HeARmUTYDPBLoeVSjttxYhoeDQYtNeqbuJ3Tj6S1_9TsE_SNSNZm3lxHoJCz5Wp_YcusQ',
+  drm: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6ImQiLCJleHAiOjIxNDc0ODM2NDd9.y7WKwBu0n87GaluPBJEMul4mxh-UlOFG_zClbEj3aZ23fXYmSfrpw-H2P3iFKtYt0DKiL-ta-J7EWiA74s77DTH2R70F86tvEFD0NQZ197qqClWtigOKkrpL1_o5RMXqjRf0lLAfwL6IFqm_Vhzf7mQTG99FRXKIU8S1q-zAEglWCYy1uZxQPivnSZxtK4IZZWmhHG6ot-VP_QkACc9cH8DIOpdYavjdXsPAxs3Ejx9ZUBQSqkjE7zyd11HhQvNzm9V_YxHJz5QgayOeWLEmwaKycFycHrR-INdVQwFAoK3EHF-tZngQpINuYoUHN5dPwzC8VJoFneLmdNAVuzbLkw',
+  thumbnail:
+    'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InQiLCJleHAiOjIxNDc0ODM2NDd9.gzoiMPjqjRSS8F1PjrvaOX4a0J9m-L1Egx3DIQVWbTWr89T21cSMJI5mPKs89umv0f7tvZjHjIaUY6L1wmdGR3FwVBLj5nvWx1DPWayJvqZbIv-2DoSCbTdui5tsPvgxtAAfmX_GGvb1UB4apGY6njapHmzMT__oTHTKvAM8e4waJGswtv9cr6V3TE8ysSqdS3_Cbme5e69S3IULjLHl21JSrHK-ABY7IzNxLOoT8lbyh77P3NMw-jF2joRVQK6hZJnAMY99_k8K2hRmGEQRMw-NTtOeM1gWQar6-Ksb7ZOZidshCHHqI69iF_ricl-Csb_c4O3ai3BZLviM7ZXRVg',
+  storyboard:
+    'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InMiLCJleHAiOjIxNDc0ODM2NDd9.Eh5a51KEYRbwWIvX7M3Z-9hMwmydt2XC9kq0m-oCmnSegnN0l-GOQoUvzFMOOCKJHbfVRTuLkEvoCjCgo1JEmTHKRDo7u_V5JDZbQf6xKjtJXlTEibNEi_wD3M_3DiuYYv3R5sNol97j-yGbJQ8_16HTv7muJhr7qI8S9sKr_zJgp_E0PyFBm6plaigWcDBMcXfcvK4I9IwTKBehlXw2sVy6eUarhmS_wtA6sNXJk8f2RG2fUnt6jq8HWQlpkrXTqJCDcQ69dwDzl_TOdDWWLN3dNBlmGyEjEZyHJD2podRdddV4Yu78_bq7ImCH05JpJqY_caX9seXS6uJh38HuIA',
+} as const;
+
 const SOURCE_MAP = {
   'hls-1': {
     label: 'HLS - Big Buck Bunny',
@@ -65,34 +84,47 @@ const SOURCE_MAP = {
     type: 'hls',
     subType: 'mp4',
   },
-  'hls-drm': {
-    // Structured rather than a URL: DRM playback is always signed, and every URL
-    // this asset needs carries its own audience-scoped token. `drm` is the one
-    // `MuxVideo` turns into FairPlay / Widevine / PlayReady license servers.
-    //
-    // Read-only tokens for a throwaway demo asset, signed to expire in 2038 so
-    // the sandbox keeps working. They grant nothing beyond playing this video.
-    label: 'HLS - DRM protected',
+  'mux-drm': {
+    // Mux-flavoured DRM: `drm.token` is all `MuxVideo` needs, because it derives
+    // every license server URL from the playback ID. Only the Mux presets can
+    // play it — nothing else knows how to read a Mux DRM token.
+    label: 'HLS - DRM protected (Mux token)',
     type: 'hls',
     subType: 'mp4',
     drm: true,
     source: {
-      playbackId: 'FefhWnSMzDqz5z9yxssihdRx8dV6srhYJ8301uQBhRak',
-      playback: {
-        token:
-          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InYiLCJleHAiOjIxNDc0ODM2NDd9.jXIpJZPB7diM5M6jMVRQ6dELY5YnONzC8jJClm7CT1nm-q25F5PiCvHcdLGqerjN1V_7T9cjhSX02p1i0UiABaKX2Wa4HCf6H6ZSKbY3MiCiRJHnfZzr_cVHCuBRXJlMzXesK_VzgP4kVrVi9-Sj8fGaeQmt4mB0sgtGGM7LpGV1IJdv_9aWnqQpQK7IeWi9ivNwa9Vw-PeppfOFdyQbqYJScIAY-_k6fzGaQucONyIolFGJZuBcan3nDRvCUpSFi0vPO87jf5Zbp6kn-HeARmUTYDPBLoeVSjttxYhoeDQYtNeqbuJ3Tj6S1_9TsE_SNSNZm3lxHoJCz5Wp_YcusQ',
-      },
-      drm: {
-        token:
-          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6ImQiLCJleHAiOjIxNDc0ODM2NDd9.y7WKwBu0n87GaluPBJEMul4mxh-UlOFG_zClbEj3aZ23fXYmSfrpw-H2P3iFKtYt0DKiL-ta-J7EWiA74s77DTH2R70F86tvEFD0NQZ197qqClWtigOKkrpL1_o5RMXqjRf0lLAfwL6IFqm_Vhzf7mQTG99FRXKIU8S1q-zAEglWCYy1uZxQPivnSZxtK4IZZWmhHG6ot-VP_QkACc9cH8DIOpdYavjdXsPAxs3Ejx9ZUBQSqkjE7zyd11HhQvNzm9V_YxHJz5QgayOeWLEmwaKycFycHrR-INdVQwFAoK3EHF-tZngQpINuYoUHN5dPwzC8VJoFneLmdNAVuzbLkw',
-      },
-      poster: {
-        token:
-          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InQiLCJleHAiOjIxNDc0ODM2NDd9.gzoiMPjqjRSS8F1PjrvaOX4a0J9m-L1Egx3DIQVWbTWr89T21cSMJI5mPKs89umv0f7tvZjHjIaUY6L1wmdGR3FwVBLj5nvWx1DPWayJvqZbIv-2DoSCbTdui5tsPvgxtAAfmX_GGvb1UB4apGY6njapHmzMT__oTHTKvAM8e4waJGswtv9cr6V3TE8ysSqdS3_Cbme5e69S3IULjLHl21JSrHK-ABY7IzNxLOoT8lbyh77P3NMw-jF2joRVQK6hZJnAMY99_k8K2hRmGEQRMw-NTtOeM1gWQar6-Ksb7ZOZidshCHHqI69iF_ricl-Csb_c4O3ai3BZLviM7ZXRVg',
-      },
-      storyboard: {
-        token:
-          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InMiLCJleHAiOjIxNDc0ODM2NDd9.Eh5a51KEYRbwWIvX7M3Z-9hMwmydt2XC9kq0m-oCmnSegnN0l-GOQoUvzFMOOCKJHbfVRTuLkEvoCjCgo1JEmTHKRDo7u_V5JDZbQf6xKjtJXlTEibNEi_wD3M_3DiuYYv3R5sNol97j-yGbJQ8_16HTv7muJhr7qI8S9sKr_zJgp_E0PyFBm6plaigWcDBMcXfcvK4I9IwTKBehlXw2sVy6eUarhmS_wtA6sNXJk8f2RG2fUnt6jq8HWQlpkrXTqJCDcQ69dwDzl_TOdDWWLN3dNBlmGyEjEZyHJD2podRdddV4Yu78_bq7ImCH05JpJqY_caX9seXS6uJh38HuIA',
+      playbackId: DRM_PLAYBACK_ID,
+      playback: { token: DRM_TOKENS.playback },
+      drm: { token: DRM_TOKENS.drm },
+      poster: { token: DRM_TOKENS.thumbnail },
+      storyboard: { token: DRM_TOKENS.storyboard },
+    },
+  },
+  'hls-drm': {
+    // The same asset, licensed the generic way: hls.js's own `drmSystems`, keyed
+    // by EME key system id and naming each license server outright. Works on any
+    // hls.js-backed element, and shows what `source.engine` still reaches.
+    label: 'HLS - DRM protected (engine config)',
+    type: 'hls',
+    subType: 'mp4',
+    drm: true,
+    source: {
+      src: `https://stream.mux.com/${DRM_PLAYBACK_ID}.m3u8?token=${DRM_TOKENS.playback}`,
+      engine: {
+        // hls.js only listens for `encrypted` when EME is switched on.
+        emeEnabled: true,
+        drmSystems: {
+          'com.apple.fps': {
+            licenseUrl: `https://license.mux.com/license/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+            serverCertificateUrl: `https://license.mux.com/appcert/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+          },
+          'com.widevine.alpha': {
+            licenseUrl: `https://license.mux.com/license/widevine/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+          },
+          'com.microsoft.playready': {
+            licenseUrl: `https://license.mux.com/license/playready/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+          },
+        },
       },
     },
   },
@@ -145,7 +177,9 @@ export const SOURCES: Record<SourceId, SandboxSource> = SOURCE_MAP;
 
 export const SOURCE_IDS = Object.keys(SOURCES) as SourceId[];
 export const NON_DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash' && !isDrmSource(id));
-/** Mux presets add the DRM asset: they are the only ones that can derive its license URLs. */
+/** hls.js-backed presets add the DRM asset that names its license servers outright. */
+export const HLSJS_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash' && id !== 'mux-drm');
+/** Mux presets add the DRM asset licensed by a Mux token, which only they can read. */
 export const MUX_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash');
 export const MP4_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'mp4');
 export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'dash');

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -224,12 +224,12 @@ export function getPosterSrc(source: SourceId): string | undefined {
   if (poster) return poster;
 
   const id = getMuxAssetId(source);
-  return id ? `https://image.mux.com/${id}/thumbnail.jpg${imageQuery(source, 'poster')}` : undefined;
+  return id ? `https://image.mux.com/${id}/thumbnail.webp${imageQuery(source, 'poster')}` : undefined;
 }
 
 export function getPlaceholderSrc(source: SourceId): string | undefined {
   const id = getMuxAssetId(source);
-  return id ? `https://image.mux.com/${id}/thumbnail.jpg${imageQuery(source, 'poster', 'width=20')}` : undefined;
+  return id ? `https://image.mux.com/${id}/thumbnail.webp${imageQuery(source, 'poster', 'width=20')}` : undefined;
 }
 
 export function getStoryboardSrc(source: SourceId): string | undefined {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -1,6 +1,20 @@
+import type { MuxSource } from '@videojs/media/dom/mux';
 import { getMuxAssetId } from './mux';
 
-export const SOURCES = {
+export interface SandboxSource {
+  label: string;
+  /** Plain media URL. Absent when the source needs more than a URL can carry. */
+  url?: string;
+  type: 'hls' | 'mp4' | 'dash' | 'none';
+  subType?: 'ts' | 'mp4';
+  live?: boolean;
+  /** DRM protected, so only a preset that can license it should offer it. */
+  drm?: boolean;
+  /** Structured source, for what a plain `url` cannot express. Takes precedence. */
+  source?: MuxSource;
+}
+
+const SOURCE_MAP = {
   'hls-1': {
     label: 'HLS - Big Buck Bunny',
     url: 'https://stream.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA.m3u8',
@@ -51,6 +65,37 @@ export const SOURCES = {
     type: 'hls',
     subType: 'mp4',
   },
+  'hls-drm': {
+    // Structured rather than a URL: DRM playback is always signed, and every URL
+    // this asset needs carries its own audience-scoped token. `drm` is the one
+    // `MuxVideo` turns into FairPlay / Widevine / PlayReady license servers.
+    //
+    // Read-only tokens for a throwaway demo asset, signed to expire in 2038 so
+    // the sandbox keeps working. They grant nothing beyond playing this video.
+    label: 'HLS - DRM protected',
+    type: 'hls',
+    subType: 'mp4',
+    drm: true,
+    source: {
+      playbackId: 'FefhWnSMzDqz5z9yxssihdRx8dV6srhYJ8301uQBhRak',
+      playback: {
+        token:
+          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InYiLCJleHAiOjIxNDc0ODM2NDd9.jXIpJZPB7diM5M6jMVRQ6dELY5YnONzC8jJClm7CT1nm-q25F5PiCvHcdLGqerjN1V_7T9cjhSX02p1i0UiABaKX2Wa4HCf6H6ZSKbY3MiCiRJHnfZzr_cVHCuBRXJlMzXesK_VzgP4kVrVi9-Sj8fGaeQmt4mB0sgtGGM7LpGV1IJdv_9aWnqQpQK7IeWi9ivNwa9Vw-PeppfOFdyQbqYJScIAY-_k6fzGaQucONyIolFGJZuBcan3nDRvCUpSFi0vPO87jf5Zbp6kn-HeARmUTYDPBLoeVSjttxYhoeDQYtNeqbuJ3Tj6S1_9TsE_SNSNZm3lxHoJCz5Wp_YcusQ',
+      },
+      drm: {
+        token:
+          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6ImQiLCJleHAiOjIxNDc0ODM2NDd9.y7WKwBu0n87GaluPBJEMul4mxh-UlOFG_zClbEj3aZ23fXYmSfrpw-H2P3iFKtYt0DKiL-ta-J7EWiA74s77DTH2R70F86tvEFD0NQZ197qqClWtigOKkrpL1_o5RMXqjRf0lLAfwL6IFqm_Vhzf7mQTG99FRXKIU8S1q-zAEglWCYy1uZxQPivnSZxtK4IZZWmhHG6ot-VP_QkACc9cH8DIOpdYavjdXsPAxs3Ejx9ZUBQSqkjE7zyd11HhQvNzm9V_YxHJz5QgayOeWLEmwaKycFycHrR-INdVQwFAoK3EHF-tZngQpINuYoUHN5dPwzC8VJoFneLmdNAVuzbLkw',
+      },
+      poster: {
+        token:
+          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InQiLCJleHAiOjIxNDc0ODM2NDd9.gzoiMPjqjRSS8F1PjrvaOX4a0J9m-L1Egx3DIQVWbTWr89T21cSMJI5mPKs89umv0f7tvZjHjIaUY6L1wmdGR3FwVBLj5nvWx1DPWayJvqZbIv-2DoSCbTdui5tsPvgxtAAfmX_GGvb1UB4apGY6njapHmzMT__oTHTKvAM8e4waJGswtv9cr6V3TE8ysSqdS3_Cbme5e69S3IULjLHl21JSrHK-ABY7IzNxLOoT8lbyh77P3NMw-jF2joRVQK6hZJnAMY99_k8K2hRmGEQRMw-NTtOeM1gWQar6-Ksb7ZOZidshCHHqI69iF_ricl-Csb_c4O3ai3BZLviM7ZXRVg',
+      },
+      storyboard: {
+        token:
+          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InMiLCJleHAiOjIxNDc0ODM2NDd9.Eh5a51KEYRbwWIvX7M3Z-9hMwmydt2XC9kq0m-oCmnSegnN0l-GOQoUvzFMOOCKJHbfVRTuLkEvoCjCgo1JEmTHKRDo7u_V5JDZbQf6xKjtJXlTEibNEi_wD3M_3DiuYYv3R5sNol97j-yGbJQ8_16HTv7muJhr7qI8S9sKr_zJgp_E0PyFBm6plaigWcDBMcXfcvK4I9IwTKBehlXw2sVy6eUarhmS_wtA6sNXJk8f2RG2fUnt6jq8HWQlpkrXTqJCDcQ69dwDzl_TOdDWWLN3dNBlmGyEjEZyHJD2podRdddV4Yu78_bq7ImCH05JpJqY_caX9seXS6uJh38HuIA',
+      },
+    },
+  },
   'hls-live': {
     label: 'HLS - Live Stream Big Buck Bunny',
     url: 'https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8',
@@ -89,12 +134,19 @@ export const SOURCES = {
     url: '',
     type: 'none',
   },
-} as const;
+} satisfies Record<string, SandboxSource>;
 
-export type SourceId = keyof typeof SOURCES;
+export type SourceId = keyof typeof SOURCE_MAP;
+
+// Annotated rather than `as const`: indexing by a `SourceId` yields one entry
+// shape, so callers see `url` and `source` as the optional fields they are
+// instead of a union of literal types that only some members share.
+export const SOURCES: Record<SourceId, SandboxSource> = SOURCE_MAP;
 
 export const SOURCE_IDS = Object.keys(SOURCES) as SourceId[];
-export const NON_DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash');
+export const NON_DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash' && !isDrmSource(id));
+/** Mux presets add the DRM asset: they are the only ones that can derive its license URLs. */
+export const MUX_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash');
 export const MP4_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'mp4');
 export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'dash');
 export const DEFAULT_SOURCE: SourceId = 'hls-1';
@@ -107,22 +159,39 @@ export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
-  return (SOURCES[id] as { live?: boolean }).live === true;
+  return SOURCES[id].live === true;
+}
+
+/** Returns true when the given source is DRM protected and needs signed tokens. */
+export function isDrmSource(id: SourceId): boolean {
+  return SOURCES[id].drm === true;
+}
+
+// A signed asset rejects an unsigned image URL, so a source that carries an
+// image token signs with it, alongside whatever params the caller asked for.
+function imageQuery(id: SourceId, kind: 'poster' | 'storyboard', params?: string): string {
+  const query = new URLSearchParams(params);
+
+  const token = SOURCES[id].source?.[kind]?.token;
+  if (token) query.set('token', token);
+
+  const search = query.toString();
+  return search ? `?${search}` : '';
 }
 
 export function getPosterSrc(source: SourceId): string | undefined {
   const id = getMuxAssetId(source);
-  return id ? `https://image.mux.com/${id}/thumbnail.jpg` : undefined;
+  return id ? `https://image.mux.com/${id}/thumbnail.jpg${imageQuery(source, 'poster')}` : undefined;
 }
 
 export function getPlaceholderSrc(source: SourceId): string | undefined {
   const id = getMuxAssetId(source);
-  return id ? `https://image.mux.com/${id}/thumbnail.jpg?width=20` : undefined;
+  return id ? `https://image.mux.com/${id}/thumbnail.jpg${imageQuery(source, 'poster', 'width=20')}` : undefined;
 }
 
 export function getStoryboardSrc(source: SourceId): string | undefined {
   // Storyboards aren't generated for live streams, so skip the request entirely.
   if (isLiveSource(source)) return undefined;
   const id = getMuxAssetId(source);
-  return id ? `https://image.mux.com/${id}/storyboard.vtt` : undefined;
+  return id ? `https://image.mux.com/${id}/storyboard.vtt${imageQuery(source, 'storyboard')}` : undefined;
 }

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -10,6 +10,11 @@ export interface SandboxSource {
   live?: boolean;
   /** DRM protected, so only a preset that can license it should offer it. */
   drm?: boolean;
+  /**
+   * Ready-made poster image URL, for a source with no Mux playback ID to derive
+   * one from. Takes precedence over the derived URL.
+   */
+  poster?: string;
   /** Structured source, for what a plain `url` cannot express. Takes precedence. */
   source?: MuxSource;
 }
@@ -108,6 +113,7 @@ const SOURCE_MAP = {
     type: 'hls',
     subType: 'mp4',
     drm: true,
+    poster: `https://image.mux.com/${DRM_PLAYBACK_ID}/thumbnail.webp?token=${DRM_TOKENS.thumbnail}`,
     source: {
       src: `https://stream.mux.com/${DRM_PLAYBACK_ID}.m3u8?token=${DRM_TOKENS.playback}`,
       engine: {
@@ -214,6 +220,9 @@ function imageQuery(id: SourceId, kind: 'poster' | 'storyboard', params?: string
 }
 
 export function getPosterSrc(source: SourceId): string | undefined {
+  const { poster } = SOURCES[source];
+  if (poster) return poster;
+
   const id = getMuxAssetId(source);
   return id ? `https://image.mux.com/${id}/thumbnail.jpg${imageQuery(source, 'poster')}` : undefined;
 }

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -7,7 +7,9 @@ import {
   DEFAULT_AUDIO_SOURCE,
   DEFAULT_DASH_SOURCE,
   DEFAULT_SOURCE,
+  isDrmSource,
   MP4_SOURCE_IDS,
+  MUX_SOURCE_IDS,
   NON_DASH_SOURCE_IDS,
   SOURCES,
 } from '@app/shared/sources';
@@ -60,6 +62,9 @@ export function App() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const pagePath = getPagePath(platform, preset);
+
+  // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs.
+  const supportsDrm = preset === 'mux-video';
 
   // Keep the URL in sync with all state.
   useEffect(() => {
@@ -127,6 +132,13 @@ export function App() {
     }
   }, [preset, source]);
 
+  // Constrain source away from DRM for presets that cannot license it
+  useEffect(() => {
+    if (!supportsDrm && isDrmSource(source)) {
+      setSource(DEFAULT_SOURCE);
+    }
+  }, [supportsDrm, source]);
+
   // CDN, background video, and vimeo video do not have a Tailwind skin variant.
   useEffect(() => {
     if ((platform === 'cdn' || preset === 'background-video' || preset === 'vimeo-video') && styling === 'tailwind') {
@@ -135,7 +147,13 @@ export function App() {
   }, [platform, preset, styling]);
 
   const availableSources =
-    preset === 'audio' ? MP4_SOURCE_IDS : preset === 'dash-video' ? DASH_SOURCE_IDS : NON_DASH_SOURCE_IDS;
+    preset === 'audio'
+      ? MP4_SOURCE_IDS
+      : preset === 'dash-video'
+        ? DASH_SOURCE_IDS
+        : supportsDrm
+          ? MUX_SOURCE_IDS
+          : NON_DASH_SOURCE_IDS;
 
   const handleSourceChange = useCallback((value: string) => setSource(value as SourceId), []);
 

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_AUDIO_SOURCE,
   DEFAULT_DASH_SOURCE,
   DEFAULT_SOURCE,
+  HLSJS_SOURCE_IDS,
   isDrmSource,
   MP4_SOURCE_IDS,
   MUX_SOURCE_IDS,
@@ -63,8 +64,20 @@ export function App() {
 
   const pagePath = getPagePath(platform, preset);
 
-  // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs.
-  const supportsDrm = preset === 'mux-video';
+  // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs;
+  // any hls.js-backed one can take license servers through `source.engine`. The
+  // CDN sandbox builds elements from attributes alone, so neither reaches it.
+  const structuredSource = platform !== 'cdn';
+  const availableSources =
+    preset === 'audio'
+      ? MP4_SOURCE_IDS
+      : preset === 'dash-video'
+        ? DASH_SOURCE_IDS
+        : structuredSource && preset === 'mux-video'
+          ? MUX_SOURCE_IDS
+          : structuredSource && preset === 'hlsjs-video'
+            ? HLSJS_SOURCE_IDS
+            : NON_DASH_SOURCE_IDS;
 
   // Keep the URL in sync with all state.
   useEffect(() => {
@@ -132,12 +145,12 @@ export function App() {
     }
   }, [preset, source]);
 
-  // Constrain source away from DRM for presets that cannot license it
+  // Constrain source away from DRM the preset cannot license
   useEffect(() => {
-    if (!supportsDrm && isDrmSource(source)) {
+    if (isDrmSource(source) && !availableSources.includes(source)) {
       setSource(DEFAULT_SOURCE);
     }
-  }, [supportsDrm, source]);
+  }, [availableSources, source]);
 
   // CDN, background video, and vimeo video do not have a Tailwind skin variant.
   useEffect(() => {
@@ -145,15 +158,6 @@ export function App() {
       setStyling('css');
     }
   }, [platform, preset, styling]);
-
-  const availableSources =
-    preset === 'audio'
-      ? MP4_SOURCE_IDS
-      : preset === 'dash-video'
-        ? DASH_SOURCE_IDS
-        : supportsDrm
-          ? MUX_SOURCE_IDS
-          : NON_DASH_SOURCE_IDS;
 
   const handleSourceChange = useCallback((value: string) => setSource(value as SourceId), []);
 

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -1,7 +1,7 @@
 import type { SKINS } from '@app/constants';
 import { SANDBOX_LOCALE_OPTION_GROUPS, type SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
 import { PRELOAD_VALUES, type PreloadValue } from '@app/shared/sandbox-listener';
-import type { SourceId } from '@app/shared/sources';
+import type { SandboxSource, SourceId } from '@app/shared/sources';
 import type { Platform, Preset, Skin, Styling } from '@app/types';
 import { useEffect, useId, useRef, useState } from 'react';
 
@@ -35,7 +35,7 @@ type NavbarProps = {
   platforms: readonly Platform[];
   stylings: readonly Styling[];
   presets: readonly Preset[];
-  sources: Record<SourceId, { label: string; url: string; type: string; subType?: string }>;
+  sources: Record<SourceId, SandboxSource>;
 };
 
 const SKIN_OPTIONS: readonly Skin[] = ['default', 'minimal'] satisfies readonly (typeof SKINS)[number][];

--- a/apps/sandbox/templates/html-hlsjs-video/main.ts
+++ b/apps/sandbox/templates/html-hlsjs-video/main.ts
@@ -32,16 +32,25 @@ async function render() {
   const mediaAttrs = renderMediaAttrs(state);
   const playerTag = live ? 'live-video-player' : 'video-player';
 
+  // A source carrying DRM license servers has no room in the `src` attribute, so
+  // it is assigned as an object below instead.
+  const { source, url } = SOURCES[state.source];
+  const srcAttr = source ? '' : ` src="${url}"`;
+
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <${playerTag}>
       <${tag} class="aspect-video max-w-4xl mx-auto">
-        <hlsjs-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline crossorigin="anonymous">
+        <hlsjs-video${srcAttr} ${mediaAttrs} playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </hlsjs-video>
         ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
       </${tag}>
     </${playerTag}>
   `);
+
+  if (source) {
+    document.querySelector('hlsjs-video')!.source = source;
+  }
 }
 
 render();

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -15,7 +15,6 @@ import {
   onSourceChange,
 } from '@app/shared/sandbox-listener';
 import { getPlaceholderSrc, getPosterSrc, isLiveSource, SOURCES } from '@app/shared/sources';
-import type { MuxSource } from '@videojs/media/dom/mux';
 
 const html = String.raw;
 
@@ -36,7 +35,7 @@ async function render() {
 
   // A source carrying signed tokens has no room in the `src` attribute, so it is
   // assigned as an object below instead.
-  const { source, url } = SOURCES[state.source] as { source?: MuxSource; url: string };
+  const { source, url } = SOURCES[state.source];
   const srcAttr = source ? '' : ` src="${url}"`;
 
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
@@ -52,7 +51,7 @@ async function render() {
     </${playerTag}>
   `);
 
-  // `source.drm.token` becomes the FairPlay / Widevine / PlayReady license
+  // A Mux `source.drm.token` becomes the FairPlay / Widevine / PlayReady license
   // servers; the playback, poster, and storyboard tokens sign the rest.
   if (source) {
     document.querySelector('mux-video')!.source = source;

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -15,6 +15,7 @@ import {
   onSourceChange,
 } from '@app/shared/sandbox-listener';
 import { getPlaceholderSrc, getPosterSrc, isLiveSource, SOURCES } from '@app/shared/sources';
+import type { MuxSource } from '@videojs/media/dom/mux';
 
 const html = String.raw;
 
@@ -33,11 +34,16 @@ async function render() {
   const mediaAttrs = renderMediaAttrs(state);
   const playerTag = live ? 'live-video-player' : 'video-player';
 
+  // A source carrying signed tokens has no room in the `src` attribute, so it is
+  // assigned as an object below instead.
+  const { source, url } = SOURCES[state.source] as { source?: MuxSource; url: string };
+  const srcAttr = source ? '' : ` src="${url}"`;
+
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <${playerTag}>
       <${tag} class="aspect-video max-w-4xl mx-auto"${placeholder ? ` placeholdersrc="${placeholder}"` : ''}>
         <!-- The storyboard track is derived automatically from the Mux src. -->
-        <mux-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline crossorigin="anonymous"></mux-video>
+        <mux-video${srcAttr} ${mediaAttrs} playsinline crossorigin="anonymous"></mux-video>
         <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
         <mux-data player-software-name="mux-video"></mux-data>
         <google-cast></google-cast>
@@ -45,6 +51,12 @@ async function render() {
       </${tag}>
     </${playerTag}>
   `);
+
+  // `source.drm.token` becomes the FairPlay / Widevine / PlayReady license
+  // servers; the playback, poster, and storyboard tokens sign the rest.
+  if (source) {
+    document.querySelector('mux-video')!.source = source;
+  }
 }
 
 render();

--- a/apps/sandbox/templates/react-dash-video/main.tsx
+++ b/apps/sandbox/templates/react-dash-video/main.tsx
@@ -32,7 +32,7 @@ function App() {
       <VideoProvider>
         <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
           <DashVideo
-            src={SOURCES[source].url}
+            src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-hlsjs-video/main.tsx
+++ b/apps/sandbox/templates/react-hlsjs-video/main.tsx
@@ -45,7 +45,7 @@ function App() {
           className="aspect-video max-w-4xl mx-auto"
         >
           <HlsJsVideo
-            src={SOURCES[source].url}
+            src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-hlsjs-video/main.tsx
+++ b/apps/sandbox/templates/react-hlsjs-video/main.tsx
@@ -34,6 +34,9 @@ function App() {
   const preload = usePreload();
   const Provider = live ? LiveVideoProvider : VideoProvider;
 
+  // A source carrying DRM license servers has no room in a plain `src`.
+  const { source: hlsSource, url } = SOURCES[source];
+
   return (
     <SandboxI18nProvider>
       <Provider>
@@ -45,7 +48,7 @@ function App() {
           className="aspect-video max-w-4xl mx-auto"
         >
           <HlsJsVideo
-            src={SOURCES[source].url ?? ''}
+            {...(hlsSource ? { source: hlsSource } : { src: url ?? '' })}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-mux-audio/main.tsx
+++ b/apps/sandbox/templates/react-mux-audio/main.tsx
@@ -34,7 +34,7 @@ function App() {
       <AudioProvider>
         <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
           <MuxAudio
-            src={SOURCES[source].url}
+            src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -12,7 +12,6 @@ import { useSkin } from '@app/shared/react/use-skin';
 import { useSource } from '@app/shared/react/use-source';
 import { isLiveSource, SOURCES } from '@app/shared/sources';
 import type { Styling } from '@app/types';
-import type { MuxSource } from '@videojs/media/dom/mux';
 import { GoogleCast } from '@videojs/react/media/google-cast';
 import { MuxData } from '@videojs/react/media/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
@@ -36,9 +35,9 @@ function App() {
   const preload = usePreload();
   const Provider = live ? LiveVideoProvider : VideoProvider;
 
-  // A source carrying signed tokens has no room in a plain `src`. Its
+  // A source carrying signed tokens has no room in a plain `src`. A Mux
   // `drm.token` becomes the FairPlay / Widevine / PlayReady license servers.
-  const { source: muxSource, url } = SOURCES[source] as { source?: MuxSource; url: string };
+  const { source: muxSource, url } = SOURCES[source];
 
   return (
     <SandboxI18nProvider>
@@ -53,7 +52,7 @@ function App() {
         >
           {/* The storyboard track is derived automatically from the Mux src. */}
           <MuxVideo
-            {...(muxSource ? { source: muxSource } : { src: url })}
+            {...(muxSource ? { source: muxSource } : { src: url ?? '' })}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -12,6 +12,7 @@ import { useSkin } from '@app/shared/react/use-skin';
 import { useSource } from '@app/shared/react/use-source';
 import { isLiveSource, SOURCES } from '@app/shared/sources';
 import type { Styling } from '@app/types';
+import type { MuxSource } from '@videojs/media/dom/mux';
 import { GoogleCast } from '@videojs/react/media/google-cast';
 import { MuxData } from '@videojs/react/media/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
@@ -35,6 +36,10 @@ function App() {
   const preload = usePreload();
   const Provider = live ? LiveVideoProvider : VideoProvider;
 
+  // A source carrying signed tokens has no room in a plain `src`. Its
+  // `drm.token` becomes the FairPlay / Widevine / PlayReady license servers.
+  const { source: muxSource, url } = SOURCES[source] as { source?: MuxSource; url: string };
+
   return (
     <SandboxI18nProvider>
       <Provider>
@@ -48,7 +53,7 @@ function App() {
         >
           {/* The storyboard track is derived automatically from the Mux src. */}
           <MuxVideo
-            src={SOURCES[source].url}
+            {...(muxSource ? { source: muxSource } : { src: url })}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -45,7 +45,7 @@ function App() {
           className="w-full aspect-video max-w-4xl mx-auto"
         >
           <NativeHlsVideo
-            src={SOURCES[source].url}
+            src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-simple-hls-audio-only/main.tsx
+++ b/apps/sandbox/templates/react-simple-hls-audio-only/main.tsx
@@ -30,7 +30,7 @@ function App() {
     <AudioProvider>
       <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
         <SimpleHlsAudioOnly
-          src={SOURCES[source].url}
+          src={SOURCES[source].url ?? ''}
           autoPlay={autoplay}
           muted={muted}
           loop={loop}

--- a/apps/sandbox/templates/react-simple-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-simple-hls-video/main.tsx
@@ -45,7 +45,7 @@ function App() {
           className="aspect-video max-w-4xl mx-auto"
         >
           <SimpleHlsVideo
-            src={SOURCES[source].url}
+            src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/spf-background-video/main.ts
+++ b/apps/sandbox/templates/spf-background-video/main.ts
@@ -34,10 +34,12 @@ const diagContext = document.getElementById('diag-context') as HTMLSpanElement;
 
 // ── Source picker ─────────────────────────────────────────────────────────────
 // The SPF MSE pipeline appends fMP4/CMAF segments directly (no MPEG-TS
-// transmuxing), so only fMP4 HLS sources play — exclude `.ts` and live.
+// transmuxing), so only fMP4 HLS sources play — exclude `.ts` and live. A source
+// with no plain `url` needs a structured source this demo has no way to hand
+// over (DRM, for one), so it is out too.
 const HLS_SOURCE_IDS = (Object.keys(SOURCES) as Array<keyof typeof SOURCES>).filter((id) => {
-  const source = SOURCES[id] as { type: string; subType?: string; live?: boolean };
-  return source.type === 'hls' && source.subType === 'mp4' && !source.live;
+  const source = SOURCES[id];
+  return source.type === 'hls' && source.subType === 'mp4' && !source.live && Boolean(source.url);
 });
 const DEFAULT_ID = (HLS_SOURCE_IDS[0] ?? 'hls-1') as keyof typeof SOURCES;
 

--- a/apps/sandbox/templates/spf-background-video/main.ts
+++ b/apps/sandbox/templates/spf-background-video/main.ts
@@ -87,7 +87,7 @@ function rebuildAdapter(): void {
   adapter = new BackgroundVideoMediaElement({ config: { maxResolution: currentMaxResolution } });
   // src before attach: the engine starts resolving the presentation before
   // play() (called inside attach) runs, so no teardown races the play promise.
-  adapter.src = SOURCES[currentSourceId].url;
+  adapter.src = SOURCES[currentSourceId].url ?? '';
   adapter.attach(video);
 
   (window as any).adapter = adapter;
@@ -124,7 +124,7 @@ loadBtn.addEventListener('click', () => {
   // Reassign src to cycle the presentation through
   // `unresolved → resolved`. That re-fires the picker, which reads the
   // current `maxResolution` via the adapter's closure.
-  adapter.src = SOURCES[currentSourceId].url;
+  adapter.src = SOURCES[currentSourceId].url ?? '';
 });
 
 // ── Diagnostic strip + rendition picker ──────────────────────────────────────

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -65,7 +65,7 @@ const HARNESS_PRESETS: Preset[] = [
 const PRESETS: Preset[] = [
   ...SOURCE_IDS.filter((id) => SOURCES[id].type === 'hls').map((id) => {
     const source = SOURCES[id];
-    const preset: Preset = { label: source.label, url: source.url };
+    const preset: Preset = { label: source.label, url: source.url ?? '' };
     if ('subType' in source && source.subType === 'ts') preset.unsupported = 'TS — unsupported';
     return preset;
   }),

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -63,10 +63,12 @@ const HARNESS_PRESETS: Preset[] = [
 // but flagged unsupported (disabled in the picker) rather than silently dropped.
 // Unsupported presets sort to the end (stable sort preserves registry order otherwise).
 const PRESETS: Preset[] = [
-  ...SOURCE_IDS.filter((id) => SOURCES[id].type === 'hls').map((id) => {
+  // A source with no plain `url` needs a structured source this harness has no
+  // way to hand over — DRM, for one, which SPF cannot play anyway.
+  ...SOURCE_IDS.filter((id) => SOURCES[id].type === 'hls' && SOURCES[id].url).map((id) => {
     const source = SOURCES[id];
     const preset: Preset = { label: source.label, url: source.url ?? '' };
-    if ('subType' in source && source.subType === 'ts') preset.unsupported = 'TS — unsupported';
+    if (source.subType === 'ts') preset.unsupported = 'TS — unsupported';
     return preset;
   }),
   ...HARNESS_PRESETS,

--- a/packages/media/src/dom/hls-js/drm.ts
+++ b/packages/media/src/dom/hls-js/drm.ts
@@ -1,35 +1,4 @@
-import type { Constructor, MixinReturn } from '@videojs/utils/types';
-import Hls, { type DRMSystemConfiguration, type DRMSystemsConfiguration, type MediaKeyFunc } from 'hls.js';
-import type { HlsEngineHost } from './types';
-
-/** DRM systems hls.js can negotiate, named after their common brand rather than their EME key system id. */
-export type DrmType = 'fairplay' | 'widevine' | 'playready';
-
-export interface DrmSystemConfig {
-  /** License (key) server URL for this DRM system. */
-  licenseUrl: string;
-  /**
-   * Server (application) certificate URL. Required for FairPlay; Widevine and
-   * PlayReady ignore it.
-   */
-  certificateUrl?: string | undefined;
-}
-
-/** License servers per DRM system. Configuring at least one enables EME on the hls.js engine. */
-export type DrmConfig = { [Type in DrmType]?: DrmSystemConfig | undefined };
-
-export interface HlsJsMediaDrmProps {
-  /** License servers per DRM system, or `null` when playback is not DRM-protected. */
-  drm: DrmConfig | null;
-}
-
-const DRM_TYPES = ['fairplay', 'widevine', 'playready'] as const;
-
-const KEY_SYSTEMS = {
-  fairplay: 'com.apple.fps',
-  widevine: 'com.widevine.alpha',
-  playready: 'com.microsoft.playready',
-} as const satisfies Record<DrmType, string>;
+import Hls, { type MediaKeyFunc } from 'hls.js';
 
 /**
  * Hardware-backed Widevine security level. Preferred (but not required) so
@@ -38,128 +7,45 @@ const KEY_SYSTEMS = {
 const HARDWARE_ROBUSTNESS = 'HW_SECURE_ALL';
 
 /**
- * Value-based identity for a DRM config. Lets callers compare configs cheaply
- * so a new object literal holding the same license servers (e.g. an inline
- * React prop) does not force an engine reload.
- */
-export function toDrmConfigKey(drm?: DrmConfig | null): string {
-  if (!drm) return '';
-  return DRM_TYPES.flatMap((type) => {
-    const system = drm[type];
-    // Mirror the engine config: systems without a license server are ignored.
-    return system?.licenseUrl ? [`${type}:${system.licenseUrl}:${system.certificateUrl ?? ''}`] : [];
-  }).join('|');
-}
-
-/**
- * Configures hls.js EME playback from a `DrmConfig` of license servers.
+ * Round off EME playback on a fresh engine. What to play and where to license
+ * it is hls.js's own configuration, reached through `source.engine`
+ * (`emeEnabled`, `drmSystems`); this only fills in what hls.js leaves to the
+ * caller:
  *
- * - Enables `emeEnabled` and maps each configured system to its EME key system
- *   id, only when DRM is actually configured, so `source.engine` stays
- *   authoritative for unprotected playback.
- * - Prefers a hardware-backed Widevine CDM, falling back to whatever
- *   robustness the browser offers.
- * - Defers to matching options in `source.engine` (`drmSystems`,
- *   `requestMediaKeySystemAccessFunc`), which remain a full escape hatch.
+ * - Prefers a hardware-backed Widevine CDM, falling back to whatever robustness
+ *   the browser offers.
+ * - Surfaces non-fatal key system errors in development, which are otherwise
+ *   silent.
+ *
+ * A `requestMediaKeySystemAccessFunc` of your own takes precedence over both.
  */
-export function HlsJsMediaDrmMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
-  class HlsJsMediaDrm extends (BaseClass as Constructor<HlsEngineHost>) {
-    #drm: DrmConfig | null = null;
-    #applied = false;
+export function setupDrm(engine: Hls): void {
+  // hls.js only runs EME while `emeEnabled` is set, so unprotected playback is
+  // left exactly as hls.js configured it.
+  if (!engine.config.emeEnabled) return;
 
-    constructor(...args: any[]) {
-      super(...args);
+  engine.config.requestMediaKeySystemAccessFunc =
+    engine.userConfig.requestMediaKeySystemAccessFunc ?? requestKeySystemAccess;
 
-      this.#drm = (args[0] as { drm?: DrmConfig | null } | undefined)?.drm ?? null;
-      // Apply before the engine attaches media: hls.js only starts listening for
-      // `encrypted` on the media element while `emeEnabled` is set.
-      this.#apply();
-
-      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#apply());
-
-      if (__DEV__) {
-        this.engine?.on(Hls.Events.ERROR, (_event, data) => {
-          // Fatal key system failures surface as media errors; non-fatal ones
-          // (e.g. output restricted → black frames) are otherwise silent.
-          if (data.fatal || data.type !== Hls.ErrorTypes.KEY_SYSTEM_ERROR) return;
-          console.warn(`[vjs-drm] ${data.details}`, data.error);
-        });
-      }
-    }
-
-    get drm(): DrmConfig | null {
-      return this.#drm;
-    }
-
-    set drm(value: DrmConfig | null) {
-      this.#drm = value;
-      this.#apply();
-    }
-
-    #requestKeySystemAccess: MediaKeyFunc = (keySystem, supportedConfigurations) => {
-      // Matched loosely: key systems are versioned (`com.apple.fps.1_0`) and
-      // vendor-prefixed (`com.widevine.alpha.experiment`) in the wild.
-      const configurations = keySystem.includes('widevine')
-        ? withHardwareRobustness(supportedConfigurations)
-        : supportedConfigurations;
-
-      return navigator.requestMediaKeySystemAccess(keySystem, configurations);
-    };
-
-    #apply(): void {
-      const { engine } = this;
-      if (!engine) return;
-
-      const drmSystems = this.#toDrmSystems();
-
-      if (!drmSystems) {
-        // Unprotected playback: leave EME alone unless we enabled it earlier, in
-        // which case restore what `source.engine` asked for.
-        if (this.#applied) this.#restore(engine);
-        return;
-      }
-
-      this.#applied = true;
-      engine.config.emeEnabled = true;
-      engine.config.drmSystems = { ...drmSystems, ...engine.userConfig.drmSystems };
-      engine.config.requestMediaKeySystemAccessFunc =
-        engine.userConfig.requestMediaKeySystemAccessFunc ?? this.#requestKeySystemAccess;
-    }
-
-    #restore(engine: Hls): void {
-      const { userConfig } = engine;
-      engine.config.emeEnabled = userConfig.emeEnabled ?? Hls.DefaultConfig.emeEnabled;
-      engine.config.drmSystems = userConfig.drmSystems ?? Hls.DefaultConfig.drmSystems;
-      engine.config.requestMediaKeySystemAccessFunc =
-        userConfig.requestMediaKeySystemAccessFunc ?? Hls.DefaultConfig.requestMediaKeySystemAccessFunc;
-      this.#applied = false;
-    }
-
-    #toDrmSystems(): DRMSystemsConfiguration | null {
-      const drm = this.#drm;
-      if (!drm) return null;
-
-      const systems: DRMSystemsConfiguration = {};
-
-      for (const type of DRM_TYPES) {
-        const system = drm[type];
-        if (!system?.licenseUrl) continue;
-
-        if (__DEV__ && type === 'fairplay' && !system.certificateUrl) {
-          console.warn('[vjs-drm] FairPlay needs a `certificateUrl` (server certificate) to request a license.');
-        }
-
-        const config: DRMSystemConfiguration = { licenseUrl: system.licenseUrl };
-        if (system.certificateUrl) config.serverCertificateUrl = system.certificateUrl;
-        systems[KEY_SYSTEMS[type]] = config;
-      }
-
-      return Object.keys(systems).length > 0 ? systems : null;
-    }
+  if (__DEV__) {
+    engine.on(Hls.Events.ERROR, (_event, data) => {
+      // Fatal key system failures surface as media errors; non-fatal ones
+      // (e.g. output restricted → black frames) are otherwise silent.
+      if (data.fatal || data.type !== Hls.ErrorTypes.KEY_SYSTEM_ERROR) return;
+      console.warn(`[vjs-drm] ${data.details}`, data.error);
+    });
   }
-
-  return HlsJsMediaDrm as unknown as MixinReturn<Base, HlsJsMediaDrmProps>;
 }
+
+const requestKeySystemAccess: MediaKeyFunc = (keySystem, supportedConfigurations) => {
+  // Matched loosely: key systems are versioned (`com.apple.fps.1_0`) and
+  // vendor-prefixed (`com.widevine.alpha.experiment`) in the wild.
+  const configurations = keySystem.includes('widevine')
+    ? withHardwareRobustness(supportedConfigurations)
+    : supportedConfigurations;
+
+  return navigator.requestMediaKeySystemAccess(keySystem, configurations);
+};
 
 /**
  * Duplicate the requested key system configurations with hardware-level video

--- a/packages/media/src/dom/hls-js/drm.ts
+++ b/packages/media/src/dom/hls-js/drm.ts
@@ -1,0 +1,219 @@
+import type { Constructor, MixinReturn } from '@videojs/utils/types';
+import Hls, { type DRMSystemConfiguration, type DRMSystemsConfiguration, type MediaKeyFunc } from 'hls.js';
+import type { HlsEngineHost } from './types';
+
+/** DRM systems hls.js can negotiate, named after their common brand rather than their EME key system id. */
+export type DrmType = 'fairplay' | 'widevine' | 'playready';
+
+export interface DrmSystemConfig {
+  /** License (key) server URL for this DRM system. */
+  licenseUrl: string;
+  /**
+   * Server (application) certificate URL. Required for FairPlay; Widevine and
+   * PlayReady ignore it.
+   */
+  certificateUrl?: string | undefined;
+}
+
+/** License servers per DRM system. Configuring at least one enables EME on the hls.js engine. */
+export type DrmConfig = { [Type in DrmType]?: DrmSystemConfig | undefined };
+
+export interface HlsJsMediaDrmProps {
+  /** License servers per DRM system, or `null` when playback is not DRM-protected. */
+  drm: DrmConfig | null;
+  /** DRM system negotiated for the current session, or `null` before a key system is selected. */
+  readonly drmType: DrmType | null;
+}
+
+const DRM_TYPES = ['fairplay', 'widevine', 'playready'] as const;
+
+const KEY_SYSTEMS = {
+  fairplay: 'com.apple.fps',
+  widevine: 'com.widevine.alpha',
+  playready: 'com.microsoft.playready',
+} as const satisfies Record<DrmType, string>;
+
+/**
+ * Hardware-backed Widevine security level. Preferred (but not required) so
+ * content restricted to L1 devices plays where the CDM supports it.
+ */
+const HARDWARE_ROBUSTNESS = 'HW_SECURE_ALL';
+
+/**
+ * Map an EME key system id to its common name. Matches on substrings because
+ * key systems are versioned (`com.apple.fps.1_0`) and vendor-prefixed
+ * (`com.widevine.alpha.experiment`).
+ */
+export function toDrmType(keySystem: string): DrmType | undefined {
+  if (keySystem.includes('fps')) return 'fairplay';
+  if (keySystem.includes('playready')) return 'playready';
+  if (keySystem.includes('widevine')) return 'widevine';
+  return undefined;
+}
+
+/**
+ * Value-based identity for a DRM config. Lets callers compare configs cheaply
+ * so a new object literal holding the same license servers (e.g. an inline
+ * React prop) does not force an engine reload.
+ */
+export function toDrmConfigKey(drm?: DrmConfig | null): string {
+  if (!drm) return '';
+  return DRM_TYPES.flatMap((type) => {
+    const system = drm[type];
+    // Mirror the engine config: systems without a license server are ignored.
+    return system?.licenseUrl ? [`${type}:${system.licenseUrl}:${system.certificateUrl ?? ''}`] : [];
+  }).join('|');
+}
+
+/**
+ * Configures hls.js EME playback from a `DrmConfig` of license servers, and
+ * reports the key system that was ultimately negotiated through `drmType`.
+ *
+ * - Enables `emeEnabled` and maps each configured system to its EME key system
+ *   id, only when DRM is actually configured, so `source.engine` stays
+ *   authoritative for unprotected playback.
+ * - Prefers a hardware-backed Widevine CDM, falling back to whatever
+ *   robustness the browser offers.
+ * - Defers to matching options in `source.engine` (`drmSystems`,
+ *   `requestMediaKeySystemAccessFunc`), which remain a full escape hatch.
+ *
+ * @fires drmtypechange - Fired when the negotiated DRM system changes. Read `drmType` for the new value.
+ */
+export function HlsJsMediaDrmMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
+  class HlsJsMediaDrm extends (BaseClass as Constructor<HlsEngineHost>) {
+    #drm: DrmConfig | null = null;
+    #drmType: DrmType | null = null;
+    #applied = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      this.#drm = (args[0] as { drm?: DrmConfig | null } | undefined)?.drm ?? null;
+      // Apply before the engine attaches media: hls.js only starts listening for
+      // `encrypted` on the media element while `emeEnabled` is set.
+      this.#apply();
+
+      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#apply());
+      this.engine?.on(Hls.Events.MEDIA_DETACHED, () => this.#reset());
+      this.engine?.on(Hls.Events.DESTROYING, () => this.#reset());
+
+      if (__DEV__) {
+        this.engine?.on(Hls.Events.ERROR, (_event, data) => {
+          // Fatal key system failures surface as media errors; non-fatal ones
+          // (e.g. output restricted → black frames) are otherwise silent.
+          if (data.fatal || data.type !== Hls.ErrorTypes.KEY_SYSTEM_ERROR) return;
+          console.warn(`[vjs-drm] ${data.details}`, data.error);
+        });
+      }
+    }
+
+    get drm(): DrmConfig | null {
+      return this.#drm;
+    }
+
+    set drm(value: DrmConfig | null) {
+      this.#drm = value;
+      this.#apply();
+    }
+
+    get drmType(): DrmType | null {
+      return this.#drmType;
+    }
+
+    #requestKeySystemAccess: MediaKeyFunc = (keySystem, supportedConfigurations) => {
+      const drmType = toDrmType(keySystem);
+
+      const configurations =
+        drmType === 'widevine' ? withHardwareRobustness(supportedConfigurations) : supportedConfigurations;
+
+      return navigator.requestMediaKeySystemAccess(keySystem, configurations).then((access) => {
+        this.#setDrmType(drmType ?? null);
+        return access;
+      });
+    };
+
+    #apply(): void {
+      const { engine } = this;
+      if (!engine) return;
+
+      const drmSystems = this.#toDrmSystems();
+
+      if (!drmSystems) {
+        // Unprotected playback: leave EME alone unless we enabled it earlier, in
+        // which case restore what `source.engine` asked for.
+        if (this.#applied) this.#restore(engine);
+        return;
+      }
+
+      this.#applied = true;
+      engine.config.emeEnabled = true;
+      engine.config.drmSystems = { ...drmSystems, ...engine.userConfig.drmSystems };
+      engine.config.requestMediaKeySystemAccessFunc =
+        engine.userConfig.requestMediaKeySystemAccessFunc ?? this.#requestKeySystemAccess;
+    }
+
+    #restore(engine: Hls): void {
+      const { userConfig } = engine;
+      engine.config.emeEnabled = userConfig.emeEnabled ?? Hls.DefaultConfig.emeEnabled;
+      engine.config.drmSystems = userConfig.drmSystems ?? Hls.DefaultConfig.drmSystems;
+      engine.config.requestMediaKeySystemAccessFunc =
+        userConfig.requestMediaKeySystemAccessFunc ?? Hls.DefaultConfig.requestMediaKeySystemAccessFunc;
+      this.#applied = false;
+      this.#setDrmType(null);
+    }
+
+    #reset(): void {
+      this.#setDrmType(null);
+    }
+
+    #setDrmType(value: DrmType | null): void {
+      if (this.#drmType === value) return;
+      this.#drmType = value;
+      this.dispatchEvent(new Event('drmtypechange'));
+    }
+
+    #toDrmSystems(): DRMSystemsConfiguration | null {
+      const drm = this.#drm;
+      if (!drm) return null;
+
+      const systems: DRMSystemsConfiguration = {};
+
+      for (const type of DRM_TYPES) {
+        const system = drm[type];
+        if (!system?.licenseUrl) continue;
+
+        if (__DEV__ && type === 'fairplay' && !system.certificateUrl) {
+          console.warn('[vjs-drm] FairPlay needs a `certificateUrl` (server certificate) to request a license.');
+        }
+
+        const config: DRMSystemConfiguration = { licenseUrl: system.licenseUrl };
+        if (system.certificateUrl) config.serverCertificateUrl = system.certificateUrl;
+        systems[KEY_SYSTEMS[type]] = config;
+      }
+
+      return Object.keys(systems).length > 0 ? systems : null;
+    }
+  }
+
+  return HlsJsMediaDrm as unknown as MixinReturn<Base, HlsJsMediaDrmProps>;
+}
+
+/**
+ * Duplicate the requested key system configurations with hardware-level video
+ * robustness ahead of the originals. `requestMediaKeySystemAccess()` resolves
+ * with the first supported entry, so this prefers a hardware CDM without
+ * failing when only software security is available.
+ */
+function withHardwareRobustness(configurations: MediaKeySystemConfiguration[]): MediaKeySystemConfiguration[] {
+  const hardware = configurations.map((configuration): MediaKeySystemConfiguration => {
+    const { videoCapabilities } = configuration;
+    if (!videoCapabilities) return configuration;
+
+    return {
+      ...configuration,
+      videoCapabilities: videoCapabilities.map((capability) => ({ ...capability, robustness: HARDWARE_ROBUSTNESS })),
+    };
+  });
+
+  return [...hardware, ...configurations];
+}

--- a/packages/media/src/dom/hls-js/drm.ts
+++ b/packages/media/src/dom/hls-js/drm.ts
@@ -21,8 +21,6 @@ export type DrmConfig = { [Type in DrmType]?: DrmSystemConfig | undefined };
 export interface HlsJsMediaDrmProps {
   /** License servers per DRM system, or `null` when playback is not DRM-protected. */
   drm: DrmConfig | null;
-  /** DRM system negotiated for the current session, or `null` before a key system is selected. */
-  readonly drmType: DrmType | null;
 }
 
 const DRM_TYPES = ['fairplay', 'widevine', 'playready'] as const;
@@ -40,18 +38,6 @@ const KEY_SYSTEMS = {
 const HARDWARE_ROBUSTNESS = 'HW_SECURE_ALL';
 
 /**
- * Map an EME key system id to its common name. Matches on substrings because
- * key systems are versioned (`com.apple.fps.1_0`) and vendor-prefixed
- * (`com.widevine.alpha.experiment`).
- */
-export function toDrmType(keySystem: string): DrmType | undefined {
-  if (keySystem.includes('fps')) return 'fairplay';
-  if (keySystem.includes('playready')) return 'playready';
-  if (keySystem.includes('widevine')) return 'widevine';
-  return undefined;
-}
-
-/**
  * Value-based identity for a DRM config. Lets callers compare configs cheaply
  * so a new object literal holding the same license servers (e.g. an inline
  * React prop) does not force an engine reload.
@@ -66,8 +52,7 @@ export function toDrmConfigKey(drm?: DrmConfig | null): string {
 }
 
 /**
- * Configures hls.js EME playback from a `DrmConfig` of license servers, and
- * reports the key system that was ultimately negotiated through `drmType`.
+ * Configures hls.js EME playback from a `DrmConfig` of license servers.
  *
  * - Enables `emeEnabled` and maps each configured system to its EME key system
  *   id, only when DRM is actually configured, so `source.engine` stays
@@ -76,13 +61,10 @@ export function toDrmConfigKey(drm?: DrmConfig | null): string {
  *   robustness the browser offers.
  * - Defers to matching options in `source.engine` (`drmSystems`,
  *   `requestMediaKeySystemAccessFunc`), which remain a full escape hatch.
- *
- * @fires drmtypechange - Fired when the negotiated DRM system changes. Read `drmType` for the new value.
  */
 export function HlsJsMediaDrmMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaDrm extends (BaseClass as Constructor<HlsEngineHost>) {
     #drm: DrmConfig | null = null;
-    #drmType: DrmType | null = null;
     #applied = false;
 
     constructor(...args: any[]) {
@@ -94,8 +76,6 @@ export function HlsJsMediaDrmMixin<Base extends Constructor<HlsEngineHost>>(Base
       this.#apply();
 
       this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#apply());
-      this.engine?.on(Hls.Events.MEDIA_DETACHED, () => this.#reset());
-      this.engine?.on(Hls.Events.DESTROYING, () => this.#reset());
 
       if (__DEV__) {
         this.engine?.on(Hls.Events.ERROR, (_event, data) => {
@@ -116,20 +96,14 @@ export function HlsJsMediaDrmMixin<Base extends Constructor<HlsEngineHost>>(Base
       this.#apply();
     }
 
-    get drmType(): DrmType | null {
-      return this.#drmType;
-    }
-
     #requestKeySystemAccess: MediaKeyFunc = (keySystem, supportedConfigurations) => {
-      const drmType = toDrmType(keySystem);
+      // Matched loosely: key systems are versioned (`com.apple.fps.1_0`) and
+      // vendor-prefixed (`com.widevine.alpha.experiment`) in the wild.
+      const configurations = keySystem.includes('widevine')
+        ? withHardwareRobustness(supportedConfigurations)
+        : supportedConfigurations;
 
-      const configurations =
-        drmType === 'widevine' ? withHardwareRobustness(supportedConfigurations) : supportedConfigurations;
-
-      return navigator.requestMediaKeySystemAccess(keySystem, configurations).then((access) => {
-        this.#setDrmType(drmType ?? null);
-        return access;
-      });
+      return navigator.requestMediaKeySystemAccess(keySystem, configurations);
     };
 
     #apply(): void {
@@ -159,17 +133,6 @@ export function HlsJsMediaDrmMixin<Base extends Constructor<HlsEngineHost>>(Base
       engine.config.requestMediaKeySystemAccessFunc =
         userConfig.requestMediaKeySystemAccessFunc ?? Hls.DefaultConfig.requestMediaKeySystemAccessFunc;
       this.#applied = false;
-      this.#setDrmType(null);
-    }
-
-    #reset(): void {
-      this.#setDrmType(null);
-    }
-
-    #setDrmType(value: DrmType | null): void {
-      if (this.#drmType === value) return;
-      this.#drmType = value;
-      this.dispatchEvent(new Event('drmtypechange'));
     }
 
     #toDrmSystems(): DRMSystemsConfiguration | null {

--- a/packages/media/src/dom/hls-js/hls-js-only.ts
+++ b/packages/media/src/dom/hls-js/hls-js-only.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsMediaAirPlayMixin } from './airplay-bridge';
+import { type DrmConfig, HlsJsMediaDrmMixin, type HlsJsMediaDrmProps } from './drm';
 import { HlsJsMediaErrorsMixin } from './errors';
 import { HlsJsMediaLiveMixin } from './live';
 import { HlsJsMediaMediaTracksMixin } from './media-tracks';
@@ -27,10 +28,17 @@ export const defaultHlsConfig: Partial<HlsConfig> = {
   autoStartLoad: false,
 };
 
+export interface HlsJsOnlyMediaParams {
+  /** Options forwarded to the hls.js constructor, merged over {@link defaultHlsConfig}. */
+  config: Partial<HlsConfig>;
+  /** License servers for DRM-protected playback. Consumed by the DRM mixin. */
+  drm?: DrmConfig | null;
+}
+
 class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost<Hls, HTMLVideoElement> {
   #engine: Hls | null = null;
 
-  constructor(params: { config: Partial<HlsConfig> }) {
+  constructor(params: HlsJsOnlyMediaParams) {
     super();
     this.#engine = new Hls({
       ...defaultHlsConfig,
@@ -70,7 +78,8 @@ class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost
 interface HlsJsMediaCapabilities
   extends MediaStreamTypeCapability,
     MediaLiveCapability,
-    Pick<MediaSourceCapability, 'preload'> {
+    Pick<MediaSourceCapability, 'preload'>,
+    HlsJsMediaDrmProps {
   readonly error: MediaError | null;
 }
 
@@ -80,7 +89,7 @@ const HlsJsOnlyMediaComposed = HlsJsMediaAirPlayMixin(
       HlsJsMediaStreamTypeMixin(
         HlsJsMediaMediaTracksMixin(
           HlsJsMediaMetadataTracksMixin(
-            HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(MediaTracksMixin(HlsJsOnlyMediaBase)))
+            HlsJsMediaTextTracksMixin(HlsJsMediaDrmMixin(HlsJsMediaErrorsMixin(MediaTracksMixin(HlsJsOnlyMediaBase))))
           )
         )
       )

--- a/packages/media/src/dom/hls-js/hls-js-only.ts
+++ b/packages/media/src/dom/hls-js/hls-js-only.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsMediaAirPlayMixin } from './airplay-bridge';
-import { type DrmConfig, HlsJsMediaDrmMixin, type HlsJsMediaDrmProps } from './drm';
+import { setupDrm } from './drm';
 import { HlsJsMediaErrorsMixin } from './errors';
 import { HlsJsMediaLiveMixin } from './live';
 import { HlsJsMediaMediaTracksMixin } from './media-tracks';
@@ -31,8 +31,6 @@ export const defaultHlsConfig: Partial<HlsConfig> = {
 export interface HlsJsOnlyMediaParams {
   /** Options forwarded to the hls.js constructor, merged over {@link defaultHlsConfig}. */
   config: Partial<HlsConfig>;
-  /** License servers for DRM-protected playback. Consumed by the DRM mixin. */
-  drm?: DrmConfig | null;
 }
 
 class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost<Hls, HTMLVideoElement> {
@@ -44,6 +42,8 @@ class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost
       ...defaultHlsConfig,
       ...params.config,
     });
+
+    setupDrm(this.#engine);
   }
 
   get engine() {
@@ -78,8 +78,7 @@ class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost
 interface HlsJsMediaCapabilities
   extends MediaStreamTypeCapability,
     MediaLiveCapability,
-    Pick<MediaSourceCapability, 'preload'>,
-    HlsJsMediaDrmProps {
+    Pick<MediaSourceCapability, 'preload'> {
   readonly error: MediaError | null;
 }
 
@@ -89,7 +88,7 @@ const HlsJsOnlyMediaComposed = HlsJsMediaAirPlayMixin(
       HlsJsMediaStreamTypeMixin(
         HlsJsMediaMediaTracksMixin(
           HlsJsMediaMetadataTracksMixin(
-            HlsJsMediaTextTracksMixin(HlsJsMediaDrmMixin(HlsJsMediaErrorsMixin(MediaTracksMixin(HlsJsOnlyMediaBase))))
+            HlsJsMediaTextTracksMixin(HlsJsMediaErrorsMixin(MediaTracksMixin(HlsJsOnlyMediaBase)))
           )
         )
       )

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -5,12 +5,10 @@ import { bridgeEvents } from '../../core/bridge-events';
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { NativeHlsMedia } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
-import { type DrmConfig, toDrmConfigKey } from './drm';
 import { HlsJsOnlyMedia } from './hls-js-only';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
 
-export type { DrmConfig, DrmSystemConfig, DrmType } from './drm';
 export { Hls };
 
 export type PlaybackType = (typeof PlaybackTypes)[keyof typeof PlaybackTypes];
@@ -39,8 +37,8 @@ export interface HlsMediaProps {
 /**
  * Structured HLS source: which source to play, plus how to play it.
  *
- * `preferPlayback`, `keySystems`, and `engine` are all read when the engine is
- * constructed, so changing any of them recreates it.
+ * `preferPlayback` and `engine` are both read when the engine is constructed, so
+ * changing either recreates it.
  */
 export interface HlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
@@ -53,12 +51,9 @@ export interface HlsSource {
    */
   preferPlayback?: PlaybackType | undefined;
   /**
-   * License servers per DRM system, keyed by brand (`fairplay` / `widevine` /
-   * `playready`) rather than EME key system id. Only honored by the hls.js
-   * (MSE) engine, which receives them as `drmSystems`.
+   * hls.js's own configuration, passed through untouched. DRM-protected
+   * playback is configured here, through `emeEnabled` and `drmSystems`.
    */
-  keySystems?: DrmConfig | undefined;
-  /** hls.js's own configuration, passed through untouched. */
   engine?: Partial<HlsJsConfig> | undefined;
 }
 
@@ -147,8 +142,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `type`, `keySystems`, and `engine` intact, so changing the URL never
-   * disturbs engine configuration.
+   * leaves `type` and `engine` intact, so changing the URL never disturbs engine
+   * configuration.
    */
   get src() {
     return this.#src;
@@ -157,11 +152,10 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, keySystems, engine } = this.#source ?? {};
+    const { type, preferPlayback, engine } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
-      ...(keySystems && { keySystems }),
       ...(engine && { engine }),
       ...(src && { src }),
     };
@@ -173,12 +167,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Structured source: what to play (`src`, an optional `type`) plus how to play
-   * it (`preferPlayback`, `keySystems`, `engine`). Assigning it derives `src`.
+   * it (`preferPlayback`, `engine`). Assigning it derives `src`.
    *
    * Sources are compared structurally, so reassigning an equivalent object — an
-   * inline React prop, for instance — is a no-op. Only a change under
-   * `keySystems` or `engine` (or a change to the resolved content type)
-   * recreates the playback engine.
+   * inline React prop, for instance — is a no-op. Only a change under `engine`
+   * (or a change to the resolved content type) recreates the playback engine.
    */
   get source(): HlsSource | null {
     return this.#source;
@@ -269,18 +262,16 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
       // Read the stored source, not the `source` getter: subclasses override the
       // getter to return what was assigned to them, while the fields below come
-      // from what they resolved and handed down (Mux derives `keySystems` here).
-      const { type, preferPlayback, keySystems, engine } = this.#source ?? {};
+      // from what they resolved and handed down (Mux fills in `engine` here).
+      const { type, preferPlayback, engine } = this.#source ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
-      if (__DEV__ && !useMse && keySystems) {
-        console.warn('[vjs-drm] `source.keySystems` requires the hls.js (MSE) engine; native HLS playback ignores it.');
+      if (__DEV__ && !useMse && engine?.emeEnabled) {
+        console.warn('[vjs-drm] DRM playback requires the hls.js (MSE) engine; native HLS playback ignores it.');
       }
 
-      this.#delegate = useMse
-        ? new HlsJsOnlyMedia({ config: { ...engine }, drm: keySystems ?? null })
-        : new NativeHlsMedia();
+      this.#delegate = useMse ? new HlsJsOnlyMedia({ config: { ...engine } }) : new NativeHlsMedia();
 
       bridgeEvents(this.#delegate, this);
 
@@ -325,14 +316,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
    * whenever the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, keySystems, engine } = this.#source ?? {};
-    return {
-      engine,
-      preferPlayback,
-      contentType: type ?? inferContentType(this.src),
-      // Compared by value: DRM options only take effect on a fresh engine.
-      keySystems: toDrmConfigKey(keySystems),
-    };
+    const { type, preferPlayback, engine } = this.#source ?? {};
+    return { engine, preferPlayback, contentType: type ?? inferContentType(this.src) };
   }
 
   #engineDestroy() {

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -75,7 +75,6 @@ class HlsMediaEvent extends Event {}
  * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
  * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
  * @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value.
- * @fires drmtypechange - Fired when the negotiated DRM system changes. Read `drmType` for the new value.
  */
 export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #delegate: HlsJsOnlyMedia | NativeHlsMedia | null = null;
@@ -144,15 +143,6 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   /** Selectable audio variants, populated only while the hls.js (MSE) engine is active; otherwise `undefined`. */
   get audioRenditions() {
     return this.#delegate instanceof HlsJsOnlyMedia ? this.#delegate.audioRenditions : undefined;
-  }
-
-  /**
-   * DRM system negotiated for the current session (`'fairplay'` /
-   * `'widevine'` / `'playready'`). `null` until a key system is selected, and
-   * for unprotected or natively played media.
-   */
-  get drmType() {
-    return this.#delegate instanceof HlsJsOnlyMedia ? this.#delegate.drmType : null;
   }
 
   /**

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -277,7 +277,10 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       this.#engineDestroy();
       this.#prevEngineConfigKey = this.#engineConfigKey();
 
-      const { type, preferPlayback, keySystems, engine } = this.source ?? {};
+      // Read the stored source, not the `source` getter: subclasses override the
+      // getter to return what was assigned to them, while the fields below come
+      // from what they resolved and handed down (Mux derives `keySystems` here).
+      const { type, preferPlayback, keySystems, engine } = this.#source ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
@@ -332,7 +335,7 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
    * whenever the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, keySystems, engine } = this.source ?? {};
+    const { type, preferPlayback, keySystems, engine } = this.#source ?? {};
     return {
       engine,
       preferPlayback,

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -5,10 +5,12 @@ import { bridgeEvents } from '../../core/bridge-events';
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { NativeHlsMedia } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
+import { type DrmConfig, toDrmConfigKey } from './drm';
 import { HlsJsOnlyMedia } from './hls-js-only';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
 
+export type { DrmConfig, DrmSystemConfig, DrmType } from './drm';
 export { Hls };
 
 export type PlaybackType = (typeof PlaybackTypes)[keyof typeof PlaybackTypes];
@@ -37,8 +39,8 @@ export interface HlsMediaProps {
 /**
  * Structured HLS source: which source to play, plus how to play it.
  *
- * `preferPlayback` and `engine` are both read when the engine is constructed, so
- * changing either recreates it.
+ * `preferPlayback`, `keySystems`, and `engine` are all read when the engine is
+ * constructed, so changing any of them recreates it.
  */
 export interface HlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
@@ -50,6 +52,12 @@ export interface HlsSource {
    * own HLS support. Ignored when the preferred path cannot play the source.
    */
   preferPlayback?: PlaybackType | undefined;
+  /**
+   * License servers per DRM system, keyed by brand (`fairplay` / `widevine` /
+   * `playready`) rather than EME key system id. Only honored by the hls.js
+   * (MSE) engine, which receives them as `drmSystems`.
+   */
+  keySystems?: DrmConfig | undefined;
   /** hls.js's own configuration, passed through untouched. */
   engine?: Partial<HlsJsConfig> | undefined;
 }
@@ -67,6 +75,7 @@ class HlsMediaEvent extends Event {}
  * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
  * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
  * @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value.
+ * @fires drmtypechange - Fired when the negotiated DRM system changes. Read `drmType` for the new value.
  */
 export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #delegate: HlsJsOnlyMedia | NativeHlsMedia | null = null;
@@ -138,9 +147,18 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
+   * DRM system negotiated for the current session (`'fairplay'` /
+   * `'widevine'` / `'playready'`). `null` until a key system is selected, and
+   * for unprotected or natively played media.
+   */
+  get drmType() {
+    return this.#delegate instanceof HlsJsOnlyMedia ? this.#delegate.drmType : null;
+  }
+
+  /**
    * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `type` and `engine` intact, so changing the URL never disturbs engine
-   * configuration.
+   * leaves `type`, `keySystems`, and `engine` intact, so changing the URL never
+   * disturbs engine configuration.
    */
   get src() {
     return this.#src;
@@ -149,10 +167,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, engine } = this.#source ?? {};
+    const { type, preferPlayback, keySystems, engine } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
+      ...(keySystems && { keySystems }),
       ...(engine && { engine }),
       ...(src && { src }),
     };
@@ -164,11 +183,12 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Structured source: what to play (`src`, an optional `type`) plus how to play
-   * it (`preferPlayback`, `engine`). Assigning it derives `src`.
+   * it (`preferPlayback`, `keySystems`, `engine`). Assigning it derives `src`.
    *
    * Sources are compared structurally, so reassigning an equivalent object — an
-   * inline React prop, for instance — is a no-op. Only a change under `engine`
-   * (or a change to the resolved content type) recreates the playback engine.
+   * inline React prop, for instance — is a no-op. Only a change under
+   * `keySystems` or `engine` (or a change to the resolved content type)
+   * recreates the playback engine.
    */
   get source(): HlsSource | null {
     return this.#source;
@@ -257,11 +277,17 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       this.#engineDestroy();
       this.#prevEngineConfigKey = this.#engineConfigKey();
 
-      const { type, preferPlayback, engine } = this.source ?? {};
+      const { type, preferPlayback, keySystems, engine } = this.source ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
-      this.#delegate = useMse ? new HlsJsOnlyMedia({ config: { ...engine } }) : new NativeHlsMedia();
+      if (__DEV__ && !useMse && keySystems) {
+        console.warn('[vjs-drm] `source.keySystems` requires the hls.js (MSE) engine; native HLS playback ignores it.');
+      }
+
+      this.#delegate = useMse
+        ? new HlsJsOnlyMedia({ config: { ...engine }, drm: keySystems ?? null })
+        : new NativeHlsMedia();
 
       bridgeEvents(this.#delegate, this);
 
@@ -306,8 +332,14 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
    * whenever the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, engine } = this.source ?? {};
-    return { engine, preferPlayback, contentType: type ?? inferContentType(this.src) };
+    const { type, preferPlayback, keySystems, engine } = this.source ?? {};
+    return {
+      engine,
+      preferPlayback,
+      contentType: type ?? inferContentType(this.src),
+      // Compared by value: DRM options only take effect on a fresh engine.
+      keySystems: toDrmConfigKey(keySystems),
+    };
   }
 
   #engineDestroy() {

--- a/packages/media/src/dom/hls-js/tests/drm.test.ts
+++ b/packages/media/src/dom/hls-js/tests/drm.test.ts
@@ -1,24 +1,16 @@
 import Hls from 'hls.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { HTMLVideoElementHost } from '../../video-host';
-import { HlsJsMediaDrmMixin, toDrmConfigKey } from '../drm';
-
-class FakeHost extends HTMLVideoElementHost {
-  engine: Hls | null;
-
-  constructor(params: { engine?: Hls | null; drm?: any } = {}) {
-    super();
-    this.engine = params.engine ?? null;
-  }
-}
-
-const HlsJsMediaDrm = HlsJsMediaDrmMixin(FakeHost);
+import { setupDrm } from '../drm';
 
 function createEngine(userConfig: Record<string, any> = {}): Hls {
   const listeners = new Map<string, Set<(...args: any[]) => void>>();
   return {
-    config: { emeEnabled: false, drmSystems: {}, requestMediaKeySystemAccessFunc: null },
+    config: {
+      emeEnabled: false,
+      requestMediaKeySystemAccessFunc: Hls.DefaultConfig.requestMediaKeySystemAccessFunc,
+      ...userConfig,
+    },
     userConfig,
     on(event: string, fn: (...args: any[]) => void) {
       if (!listeners.has(event)) listeners.set(event, new Set());
@@ -32,10 +24,6 @@ function createEngine(userConfig: Record<string, any> = {}): Hls {
     },
   } as unknown as Hls;
 }
-
-const FAIRPLAY = { licenseUrl: 'https://license.test/fairplay', certificateUrl: 'https://license.test/appcert' };
-const WIDEVINE = { licenseUrl: 'https://license.test/widevine' };
-const PLAYREADY = { licenseUrl: 'https://license.test/playready' };
 
 function stubKeySystemAccess() {
   const requestMediaKeySystemAccess = vi.fn(async () => ({}) as MediaKeySystemAccess);
@@ -55,96 +43,37 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('HlsJsMediaDrmMixin', () => {
-  it('leaves EME untouched when no DRM is configured', () => {
+describe('setupDrm', () => {
+  it('leaves an unprotected engine alone', () => {
     const engine = createEngine();
-    const host = new HlsJsMediaDrm({ engine });
 
-    expect(host.drm).toBeNull();
-    expect(engine.config.emeEnabled).toBe(false);
-    expect(engine.config.drmSystems).toEqual({});
-    expect(engine.config.requestMediaKeySystemAccessFunc).toBeNull();
-  });
+    setupDrm(engine);
 
-  it('maps configured systems to their EME key system ids', () => {
-    const engine = createEngine();
-    new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY, widevine: WIDEVINE, playready: PLAYREADY } });
-
-    expect(engine.config.emeEnabled).toBe(true);
-    expect(engine.config.drmSystems).toEqual({
-      'com.apple.fps': {
-        licenseUrl: FAIRPLAY.licenseUrl,
-        serverCertificateUrl: FAIRPLAY.certificateUrl,
-      },
-      'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl },
-      'com.microsoft.playready': { licenseUrl: PLAYREADY.licenseUrl },
-    });
-    expect(engine.config.requestMediaKeySystemAccessFunc).toBeTypeOf('function');
-  });
-
-  it('omits systems without a license URL', () => {
-    const engine = createEngine();
-    new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE, playready: { licenseUrl: '' } } });
-
-    expect(engine.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl } });
-  });
-
-  it('applies DRM assigned after construction', () => {
-    const engine = createEngine();
-    const host = new HlsJsMediaDrm({ engine });
-
-    host.drm = { widevine: WIDEVINE };
-
-    expect(host.drm).toEqual({ widevine: WIDEVINE });
-    expect(engine.config.emeEnabled).toBe(true);
-    expect(engine.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl } });
-  });
-
-  it('restores the user hls.js config when DRM is cleared', () => {
-    const engine = createEngine();
-    const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
-
-    host.drm = null;
-
-    expect(engine.config.emeEnabled).toBe(false);
-    expect(engine.config.drmSystems).toEqual({});
     expect(engine.config.requestMediaKeySystemAccessFunc).toBe(Hls.DefaultConfig.requestMediaKeySystemAccessFunc);
   });
 
-  it('re-applies on MANIFEST_LOADING', () => {
-    const engine = createEngine();
-    new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+  it('takes over key system access once EME is enabled', () => {
+    const engine = createEngine({ emeEnabled: true });
 
-    engine.config.emeEnabled = false;
-    (engine as any).emit(Hls.Events.MANIFEST_LOADING);
+    setupDrm(engine);
 
-    expect(engine.config.emeEnabled).toBe(true);
+    expect(engine.config.requestMediaKeySystemAccessFunc).not.toBe(Hls.DefaultConfig.requestMediaKeySystemAccessFunc);
   });
 
-  it('lets user hls.js options win over the derived config', () => {
+  it('defers to a caller-supplied key system access function', () => {
     const requestMediaKeySystemAccessFunc = vi.fn();
-    const engine = createEngine({
-      drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://custom.test/widevine' } },
-      requestMediaKeySystemAccessFunc,
-    });
+    const engine = createEngine({ emeEnabled: true, requestMediaKeySystemAccessFunc });
 
-    new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY, widevine: WIDEVINE } });
+    setupDrm(engine);
 
-    expect(engine.config.drmSystems).toEqual({
-      'com.apple.fps': {
-        licenseUrl: FAIRPLAY.licenseUrl,
-        serverCertificateUrl: FAIRPLAY.certificateUrl,
-      },
-      'com.widevine.alpha': { licenseUrl: 'https://custom.test/widevine' },
-    });
     expect(engine.config.requestMediaKeySystemAccessFunc).toBe(requestMediaKeySystemAccessFunc);
   });
 
   describe('key system access', () => {
     it('prefers hardware robustness for Widevine while keeping a fallback', async () => {
       const requestMediaKeySystemAccess = stubKeySystemAccess();
-      const engine = createEngine();
-      new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+      const engine = createEngine({ emeEnabled: true });
+      setupDrm(engine);
 
       const configurations = [{ videoCapabilities: videoCapabilities() }];
       await engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, configurations as any);
@@ -164,8 +93,8 @@ describe('HlsJsMediaDrmMixin', () => {
 
     it('passes configurations through unchanged for other key systems', async () => {
       const requestMediaKeySystemAccess = stubKeySystemAccess();
-      const engine = createEngine();
-      new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY } });
+      const engine = createEngine({ emeEnabled: true });
+      setupDrm(engine);
 
       const configurations = [{ videoCapabilities: videoCapabilities() }];
       await engine.config.requestMediaKeySystemAccessFunc!('com.apple.fps' as any, configurations as any);
@@ -177,8 +106,8 @@ describe('HlsJsMediaDrmMixin', () => {
       const requestMediaKeySystemAccess = stubKeySystemAccess();
       requestMediaKeySystemAccess.mockRejectedValueOnce(new Error('unsupported'));
 
-      const engine = createEngine();
-      new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+      const engine = createEngine({ emeEnabled: true });
+      setupDrm(engine);
 
       await expect(engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, [])).rejects.toThrow(
         'unsupported'
@@ -186,40 +115,31 @@ describe('HlsJsMediaDrmMixin', () => {
     });
   });
 
-  it('is inert without an engine', () => {
-    const host = new HlsJsMediaDrm({ engine: null, drm: { widevine: WIDEVINE } });
-    expect(host.drm).toEqual({ widevine: WIDEVINE });
-  });
-
-  it('warns in dev when FairPlay has no certificate URL', () => {
+  it('warns in dev about non-fatal key system errors', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const engine = createEngine();
+    const engine = createEngine({ emeEnabled: true });
 
-    new HlsJsMediaDrm({ engine, drm: { fairplay: { licenseUrl: FAIRPLAY.licenseUrl } } });
+    setupDrm(engine);
+    (engine as any).emit(Hls.Events.ERROR, {
+      fatal: false,
+      type: Hls.ErrorTypes.KEY_SYSTEM_ERROR,
+      details: 'keySystemStatusOutputRestricted',
+    });
 
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('certificateUrl'));
-  });
-});
-
-describe('toDrmConfigKey', () => {
-  it('is stable across equal configs in different objects', () => {
-    expect(toDrmConfigKey({ fairplay: { ...FAIRPLAY }, widevine: { ...WIDEVINE } })).toBe(
-      toDrmConfigKey({ widevine: { ...WIDEVINE }, fairplay: { ...FAIRPLAY } })
-    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('keySystemStatusOutputRestricted'), undefined);
   });
 
-  it('changes when a license or certificate URL changes', () => {
-    expect(toDrmConfigKey({ widevine: WIDEVINE })).not.toBe(
-      toDrmConfigKey({ widevine: { licenseUrl: 'https://other.test/widevine' } })
-    );
-    expect(toDrmConfigKey({ fairplay: FAIRPLAY })).not.toBe(
-      toDrmConfigKey({ fairplay: { licenseUrl: FAIRPLAY.licenseUrl } })
-    );
-  });
+  it('stays quiet for fatal errors, which surface as media errors', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const engine = createEngine({ emeEnabled: true });
 
-  it('treats missing, empty, and unusable configs alike', () => {
-    expect(toDrmConfigKey(null)).toBe(toDrmConfigKey(undefined));
-    expect(toDrmConfigKey({})).toBe(toDrmConfigKey(null));
-    expect(toDrmConfigKey({ widevine: { licenseUrl: '' } })).toBe(toDrmConfigKey(null));
+    setupDrm(engine);
+    (engine as any).emit(Hls.Events.ERROR, {
+      fatal: true,
+      type: Hls.ErrorTypes.KEY_SYSTEM_ERROR,
+      details: 'keySystemNoAccess',
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/media/src/dom/hls-js/tests/drm.test.ts
+++ b/packages/media/src/dom/hls-js/tests/drm.test.ts
@@ -2,7 +2,7 @@ import Hls from 'hls.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { HTMLVideoElementHost } from '../../video-host';
-import { HlsJsMediaDrmMixin, toDrmConfigKey, toDrmType } from '../drm';
+import { HlsJsMediaDrmMixin, toDrmConfigKey } from '../drm';
 
 class FakeHost extends HTMLVideoElementHost {
   engine: Hls | null;
@@ -100,20 +100,15 @@ describe('HlsJsMediaDrmMixin', () => {
     expect(engine.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl } });
   });
 
-  it('restores the user hls.js config when DRM is cleared', async () => {
-    stubKeySystemAccess();
+  it('restores the user hls.js config when DRM is cleared', () => {
     const engine = createEngine();
     const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
-
-    await engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, []);
-    expect(host.drmType).toBe('widevine');
 
     host.drm = null;
 
     expect(engine.config.emeEnabled).toBe(false);
     expect(engine.config.drmSystems).toEqual({});
     expect(engine.config.requestMediaKeySystemAccessFunc).toBe(Hls.DefaultConfig.requestMediaKeySystemAccessFunc);
-    expect(host.drmType).toBeNull();
   });
 
   it('re-applies on MANIFEST_LOADING', () => {
@@ -178,55 +173,22 @@ describe('HlsJsMediaDrmMixin', () => {
       expect(requestMediaKeySystemAccess).toHaveBeenCalledWith('com.apple.fps', configurations);
     });
 
-    it('reports the negotiated system and fires drmtypechange', async () => {
-      stubKeySystemAccess();
-      const engine = createEngine();
-      const host = new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY } });
-
-      const handler = vi.fn();
-      host.addEventListener('drmtypechange', handler);
-
-      expect(host.drmType).toBeNull();
-
-      await engine.config.requestMediaKeySystemAccessFunc!('com.apple.fps.1_0' as any, []);
-
-      expect(host.drmType).toBe('fairplay');
-      expect(handler).toHaveBeenCalledOnce();
-    });
-
-    it('does not report a system when access is denied', async () => {
+    it('propagates a denied request', async () => {
       const requestMediaKeySystemAccess = stubKeySystemAccess();
       requestMediaKeySystemAccess.mockRejectedValueOnce(new Error('unsupported'));
 
       const engine = createEngine();
-      const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+      new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
 
       await expect(engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, [])).rejects.toThrow(
         'unsupported'
       );
-      expect(host.drmType).toBeNull();
-    });
-
-    it('clears the negotiated system on MEDIA_DETACHED and DESTROYING', async () => {
-      stubKeySystemAccess();
-
-      for (const event of [Hls.Events.MEDIA_DETACHED, Hls.Events.DESTROYING]) {
-        const engine = createEngine();
-        const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
-
-        await engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, []);
-        expect(host.drmType).toBe('widevine');
-
-        (engine as any).emit(event);
-        expect(host.drmType).toBeNull();
-      }
     });
   });
 
   it('is inert without an engine', () => {
     const host = new HlsJsMediaDrm({ engine: null, drm: { widevine: WIDEVINE } });
     expect(host.drm).toEqual({ widevine: WIDEVINE });
-    expect(host.drmType).toBeNull();
   });
 
   it('warns in dev when FairPlay has no certificate URL', () => {
@@ -236,16 +198,6 @@ describe('HlsJsMediaDrmMixin', () => {
     new HlsJsMediaDrm({ engine, drm: { fairplay: { licenseUrl: FAIRPLAY.licenseUrl } } });
 
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('certificateUrl'));
-  });
-});
-
-describe('toDrmType', () => {
-  it('maps versioned and prefixed key systems to their common name', () => {
-    expect(toDrmType('com.apple.fps')).toBe('fairplay');
-    expect(toDrmType('com.apple.fps.1_0')).toBe('fairplay');
-    expect(toDrmType('com.widevine.alpha')).toBe('widevine');
-    expect(toDrmType('com.microsoft.playready.recommendation')).toBe('playready');
-    expect(toDrmType('org.w3.clearkey')).toBeUndefined();
   });
 });
 

--- a/packages/media/src/dom/hls-js/tests/drm.test.ts
+++ b/packages/media/src/dom/hls-js/tests/drm.test.ts
@@ -1,0 +1,273 @@
+import Hls from 'hls.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { HTMLVideoElementHost } from '../../video-host';
+import { HlsJsMediaDrmMixin, toDrmConfigKey, toDrmType } from '../drm';
+
+class FakeHost extends HTMLVideoElementHost {
+  engine: Hls | null;
+
+  constructor(params: { engine?: Hls | null; drm?: any } = {}) {
+    super();
+    this.engine = params.engine ?? null;
+  }
+}
+
+const HlsJsMediaDrm = HlsJsMediaDrmMixin(FakeHost);
+
+function createEngine(userConfig: Record<string, any> = {}): Hls {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  return {
+    config: { emeEnabled: false, drmSystems: {}, requestMediaKeySystemAccessFunc: null },
+    userConfig,
+    on(event: string, fn: (...args: any[]) => void) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(fn);
+    },
+    off(event: string, fn: (...args: any[]) => void) {
+      listeners.get(event)?.delete(fn);
+    },
+    emit(event: string, ...args: any[]) {
+      for (const fn of listeners.get(event) ?? []) fn(event, ...args);
+    },
+  } as unknown as Hls;
+}
+
+const FAIRPLAY = { licenseUrl: 'https://license.test/fairplay', certificateUrl: 'https://license.test/appcert' };
+const WIDEVINE = { licenseUrl: 'https://license.test/widevine' };
+const PLAYREADY = { licenseUrl: 'https://license.test/playready' };
+
+function stubKeySystemAccess() {
+  const requestMediaKeySystemAccess = vi.fn(async () => ({}) as MediaKeySystemAccess);
+  Object.defineProperty(navigator, 'requestMediaKeySystemAccess', {
+    value: requestMediaKeySystemAccess,
+    configurable: true,
+    writable: true,
+  });
+  return requestMediaKeySystemAccess;
+}
+
+function videoCapabilities() {
+  return [{ contentType: 'video/mp4;codecs="avc1.640028"' }];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('HlsJsMediaDrmMixin', () => {
+  it('leaves EME untouched when no DRM is configured', () => {
+    const engine = createEngine();
+    const host = new HlsJsMediaDrm({ engine });
+
+    expect(host.drm).toBeNull();
+    expect(engine.config.emeEnabled).toBe(false);
+    expect(engine.config.drmSystems).toEqual({});
+    expect(engine.config.requestMediaKeySystemAccessFunc).toBeNull();
+  });
+
+  it('maps configured systems to their EME key system ids', () => {
+    const engine = createEngine();
+    new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY, widevine: WIDEVINE, playready: PLAYREADY } });
+
+    expect(engine.config.emeEnabled).toBe(true);
+    expect(engine.config.drmSystems).toEqual({
+      'com.apple.fps': {
+        licenseUrl: FAIRPLAY.licenseUrl,
+        serverCertificateUrl: FAIRPLAY.certificateUrl,
+      },
+      'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl },
+      'com.microsoft.playready': { licenseUrl: PLAYREADY.licenseUrl },
+    });
+    expect(engine.config.requestMediaKeySystemAccessFunc).toBeTypeOf('function');
+  });
+
+  it('omits systems without a license URL', () => {
+    const engine = createEngine();
+    new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE, playready: { licenseUrl: '' } } });
+
+    expect(engine.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl } });
+  });
+
+  it('applies DRM assigned after construction', () => {
+    const engine = createEngine();
+    const host = new HlsJsMediaDrm({ engine });
+
+    host.drm = { widevine: WIDEVINE };
+
+    expect(host.drm).toEqual({ widevine: WIDEVINE });
+    expect(engine.config.emeEnabled).toBe(true);
+    expect(engine.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE.licenseUrl } });
+  });
+
+  it('restores the user hls.js config when DRM is cleared', async () => {
+    stubKeySystemAccess();
+    const engine = createEngine();
+    const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+
+    await engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, []);
+    expect(host.drmType).toBe('widevine');
+
+    host.drm = null;
+
+    expect(engine.config.emeEnabled).toBe(false);
+    expect(engine.config.drmSystems).toEqual({});
+    expect(engine.config.requestMediaKeySystemAccessFunc).toBe(Hls.DefaultConfig.requestMediaKeySystemAccessFunc);
+    expect(host.drmType).toBeNull();
+  });
+
+  it('re-applies on MANIFEST_LOADING', () => {
+    const engine = createEngine();
+    new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+
+    engine.config.emeEnabled = false;
+    (engine as any).emit(Hls.Events.MANIFEST_LOADING);
+
+    expect(engine.config.emeEnabled).toBe(true);
+  });
+
+  it('lets user hls.js options win over the derived config', () => {
+    const requestMediaKeySystemAccessFunc = vi.fn();
+    const engine = createEngine({
+      drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://custom.test/widevine' } },
+      requestMediaKeySystemAccessFunc,
+    });
+
+    new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY, widevine: WIDEVINE } });
+
+    expect(engine.config.drmSystems).toEqual({
+      'com.apple.fps': {
+        licenseUrl: FAIRPLAY.licenseUrl,
+        serverCertificateUrl: FAIRPLAY.certificateUrl,
+      },
+      'com.widevine.alpha': { licenseUrl: 'https://custom.test/widevine' },
+    });
+    expect(engine.config.requestMediaKeySystemAccessFunc).toBe(requestMediaKeySystemAccessFunc);
+  });
+
+  describe('key system access', () => {
+    it('prefers hardware robustness for Widevine while keeping a fallback', async () => {
+      const requestMediaKeySystemAccess = stubKeySystemAccess();
+      const engine = createEngine();
+      new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+
+      const configurations = [{ videoCapabilities: videoCapabilities() }];
+      await engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, configurations as any);
+
+      const [keySystem, requested] = requestMediaKeySystemAccess.mock.calls[0] as unknown as [
+        string,
+        MediaKeySystemConfiguration[],
+      ];
+
+      expect(keySystem).toBe('com.widevine.alpha');
+      expect(requested).toHaveLength(2);
+      expect(requested[0]!.videoCapabilities![0]!.robustness).toBe('HW_SECURE_ALL');
+      expect(requested[1]!.videoCapabilities![0]!.robustness).toBeUndefined();
+      // The caller's configurations must not be mutated.
+      expect(configurations[0]!.videoCapabilities[0]).not.toHaveProperty('robustness');
+    });
+
+    it('passes configurations through unchanged for other key systems', async () => {
+      const requestMediaKeySystemAccess = stubKeySystemAccess();
+      const engine = createEngine();
+      new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY } });
+
+      const configurations = [{ videoCapabilities: videoCapabilities() }];
+      await engine.config.requestMediaKeySystemAccessFunc!('com.apple.fps' as any, configurations as any);
+
+      expect(requestMediaKeySystemAccess).toHaveBeenCalledWith('com.apple.fps', configurations);
+    });
+
+    it('reports the negotiated system and fires drmtypechange', async () => {
+      stubKeySystemAccess();
+      const engine = createEngine();
+      const host = new HlsJsMediaDrm({ engine, drm: { fairplay: FAIRPLAY } });
+
+      const handler = vi.fn();
+      host.addEventListener('drmtypechange', handler);
+
+      expect(host.drmType).toBeNull();
+
+      await engine.config.requestMediaKeySystemAccessFunc!('com.apple.fps.1_0' as any, []);
+
+      expect(host.drmType).toBe('fairplay');
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('does not report a system when access is denied', async () => {
+      const requestMediaKeySystemAccess = stubKeySystemAccess();
+      requestMediaKeySystemAccess.mockRejectedValueOnce(new Error('unsupported'));
+
+      const engine = createEngine();
+      const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+
+      await expect(engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, [])).rejects.toThrow(
+        'unsupported'
+      );
+      expect(host.drmType).toBeNull();
+    });
+
+    it('clears the negotiated system on MEDIA_DETACHED and DESTROYING', async () => {
+      stubKeySystemAccess();
+
+      for (const event of [Hls.Events.MEDIA_DETACHED, Hls.Events.DESTROYING]) {
+        const engine = createEngine();
+        const host = new HlsJsMediaDrm({ engine, drm: { widevine: WIDEVINE } });
+
+        await engine.config.requestMediaKeySystemAccessFunc!('com.widevine.alpha' as any, []);
+        expect(host.drmType).toBe('widevine');
+
+        (engine as any).emit(event);
+        expect(host.drmType).toBeNull();
+      }
+    });
+  });
+
+  it('is inert without an engine', () => {
+    const host = new HlsJsMediaDrm({ engine: null, drm: { widevine: WIDEVINE } });
+    expect(host.drm).toEqual({ widevine: WIDEVINE });
+    expect(host.drmType).toBeNull();
+  });
+
+  it('warns in dev when FairPlay has no certificate URL', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const engine = createEngine();
+
+    new HlsJsMediaDrm({ engine, drm: { fairplay: { licenseUrl: FAIRPLAY.licenseUrl } } });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('certificateUrl'));
+  });
+});
+
+describe('toDrmType', () => {
+  it('maps versioned and prefixed key systems to their common name', () => {
+    expect(toDrmType('com.apple.fps')).toBe('fairplay');
+    expect(toDrmType('com.apple.fps.1_0')).toBe('fairplay');
+    expect(toDrmType('com.widevine.alpha')).toBe('widevine');
+    expect(toDrmType('com.microsoft.playready.recommendation')).toBe('playready');
+    expect(toDrmType('org.w3.clearkey')).toBeUndefined();
+  });
+});
+
+describe('toDrmConfigKey', () => {
+  it('is stable across equal configs in different objects', () => {
+    expect(toDrmConfigKey({ fairplay: { ...FAIRPLAY }, widevine: { ...WIDEVINE } })).toBe(
+      toDrmConfigKey({ widevine: { ...WIDEVINE }, fairplay: { ...FAIRPLAY } })
+    );
+  });
+
+  it('changes when a license or certificate URL changes', () => {
+    expect(toDrmConfigKey({ widevine: WIDEVINE })).not.toBe(
+      toDrmConfigKey({ widevine: { licenseUrl: 'https://other.test/widevine' } })
+    );
+    expect(toDrmConfigKey({ fairplay: FAIRPLAY })).not.toBe(
+      toDrmConfigKey({ fairplay: { licenseUrl: FAIRPLAY.licenseUrl } })
+    );
+  });
+
+  it('treats missing, empty, and unusable configs alike', () => {
+    expect(toDrmConfigKey(null)).toBe(toDrmConfigKey(undefined));
+    expect(toDrmConfigKey({})).toBe(toDrmConfigKey(null));
+    expect(toDrmConfigKey({ widevine: { licenseUrl: '' } })).toBe(toDrmConfigKey(null));
+  });
+});

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -3,7 +3,7 @@ import { MediaError } from '../../../core/media-error';
 import type { RemotePlaybackLike } from '../../../core/types';
 import { addMediaComponent, type MediaComponent } from '../../media-host';
 import { NativeHlsMedia } from '../../native-hls';
-import { ContentTypes, Hls, HlsJsMedia } from '../index';
+import { ContentTypes, Hls, HlsJsMedia, type HlsSource } from '../index';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -224,6 +224,73 @@ describe('HlsJsMedia', () => {
       // A new source object signals a fresh start: options set in `setup()` are
       // dropped rather than merged.
       expect(media.source).toEqual({ engine: { maxBufferLength: 60 } });
+    });
+  });
+
+  describe('drm', () => {
+    const WIDEVINE_LICENSE = 'https://license.test/widevine';
+
+    function setupMse(source: HlsSource) {
+      vi.spyOn(Hls, 'isSupported').mockReturnValue(true);
+
+      const video = document.createElement('video');
+      document.body.appendChild(video);
+
+      const media = new HlsJsMedia();
+      media.attach(video);
+      media.source = { ...source, src: 'https://example.com/video.m3u8' };
+      media.load();
+
+      return { media, video };
+    }
+
+    it('enables EME on the hls.js engine from `source.keySystems`', () => {
+      const { media } = setupMse({ keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } });
+
+      expect(media.engine!.config.emeEnabled).toBe(true);
+      expect(media.engine!.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } });
+      expect(media.drmType).toBeNull();
+    });
+
+    it('leaves EME disabled without `source.keySystems`', () => {
+      const { media } = setupMse({});
+      expect(media.engine!.config.emeEnabled).toBe(false);
+    });
+
+    it('reuses the engine for an equivalent key systems config', () => {
+      const { media } = setupMse({ keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } });
+      const engine = media.engine;
+
+      // Same license servers in a new object (e.g. an inline React prop).
+      media.source = { src: media.src, keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } };
+      media.load();
+
+      expect(media.engine).toBe(engine);
+    });
+
+    it('recreates the engine when a license server changes', () => {
+      const { media } = setupMse({ keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } });
+      const engine = media.engine;
+
+      media.source = { src: media.src, keySystems: { widevine: { licenseUrl: 'https://other.test/widevine' } } };
+      media.load();
+
+      expect(media.engine).not.toBe(engine);
+      expect(media.engine!.config.drmSystems).toEqual({
+        'com.widevine.alpha': { licenseUrl: 'https://other.test/widevine' },
+      });
+    });
+
+    it('warns and reports no DRM system for native playback', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { media } = setup();
+      media.source = { ...media.source, keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } };
+      media.load();
+
+      expect(media.engine).toBeNull();
+      expect(media.drmType).toBeNull();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('source.keySystems'));
     });
   });
 

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -249,7 +249,6 @@ describe('HlsJsMedia', () => {
 
       expect(media.engine!.config.emeEnabled).toBe(true);
       expect(media.engine!.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } });
-      expect(media.drmType).toBeNull();
     });
 
     it('leaves EME disabled without `source.keySystems`', () => {
@@ -281,7 +280,7 @@ describe('HlsJsMedia', () => {
       });
     });
 
-    it('warns and reports no DRM system for native playback', () => {
+    it('warns and builds no engine for native playback', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { media } = setup();
@@ -289,7 +288,6 @@ describe('HlsJsMedia', () => {
       media.load();
 
       expect(media.engine).toBeNull();
-      expect(media.drmType).toBeNull();
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('source.keySystems'));
     });
   });

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -244,34 +244,45 @@ describe('HlsJsMedia', () => {
       return { media, video };
     }
 
-    it('enables EME on the hls.js engine from `source.keySystems`', () => {
-      const { media } = setupMse({ keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } });
+    const drmEngine = { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } };
+
+    it('hands DRM options straight to the hls.js engine', () => {
+      const { media } = setupMse({ engine: drmEngine });
 
       expect(media.engine!.config.emeEnabled).toBe(true);
       expect(media.engine!.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } });
     });
 
-    it('leaves EME disabled without `source.keySystems`', () => {
+    it('leaves EME disabled for unprotected playback', () => {
       const { media } = setupMse({});
       expect(media.engine!.config.emeEnabled).toBe(false);
     });
 
-    it('reuses the engine for an equivalent key systems config', () => {
-      const { media } = setupMse({ keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } });
+    it('reuses the engine for an equivalent DRM config', () => {
+      const { media } = setupMse({ engine: drmEngine });
       const engine = media.engine;
 
       // Same license servers in a new object (e.g. an inline React prop).
-      media.source = { src: media.src, keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } };
+      media.source = {
+        src: media.src,
+        engine: { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } },
+      };
       media.load();
 
       expect(media.engine).toBe(engine);
     });
 
     it('recreates the engine when a license server changes', () => {
-      const { media } = setupMse({ keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } });
+      const { media } = setupMse({ engine: drmEngine });
       const engine = media.engine;
 
-      media.source = { src: media.src, keySystems: { widevine: { licenseUrl: 'https://other.test/widevine' } } };
+      media.source = {
+        src: media.src,
+        engine: {
+          emeEnabled: true,
+          drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://other.test/widevine' } },
+        },
+      };
       media.load();
 
       expect(media.engine).not.toBe(engine);
@@ -284,11 +295,11 @@ describe('HlsJsMedia', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { media } = setup();
-      media.source = { ...media.source, keySystems: { widevine: { licenseUrl: WIDEVINE_LICENSE } } };
+      media.source = { ...media.source, engine: drmEngine };
       media.load();
 
       expect(media.engine).toBeNull();
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('source.keySystems'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('DRM playback requires the hls.js (MSE) engine'));
     });
   });
 

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -1,6 +1,6 @@
 import { HlsJsMedia } from '../hls-js';
 import {
-  createMuxKeySystems,
+  createMuxDrmSystems,
   createMuxPosterURL,
   createMuxStoryboardURL,
   createMuxVideoURL,
@@ -60,9 +60,10 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * params). A `playback.token` replaces all other params — signed URLs bake
    * them into the token. Engine options live under `engine`.
    *
-   * A `drm.token` derives the inherited `keySystems` — Mux's FairPlay,
-   * Widevine, and PlayReady license servers for this playback ID. Naming
-   * `keySystems` yourself overrides that, for content Mux does not license.
+   * A `drm.token` fills in the inherited `engine.drmSystems` with Mux's
+   * FairPlay, Widevine, and PlayReady license servers for this playback ID.
+   * Naming `engine.drmSystems` yourself overrides that, for content Mux does
+   * not license.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -76,13 +77,13 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
 
     this.#source = source;
 
-    // Hand the same source down with `src` and `keySystems` resolved from the
-    // playback ID. The base keeps `src` in step, decides whether playback has to
-    // reload, and dispatches `sourcechange`.
+    // Hand the same source down with `src` and the DRM license servers resolved
+    // from the playback ID. The base keeps `src` in step, decides whether
+    // playback has to reload, and dispatches `sourcechange`.
     super.source = source && {
       ...source,
       src: createMuxVideoURL(source) ?? source.src ?? '',
-      keySystems: source.keySystems ?? createMuxKeySystems(source),
+      engine: withMuxDrm(source),
     };
   }
 
@@ -105,4 +106,16 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
       ...(storyboard && { storyboard }),
     };
   }
+}
+
+/**
+ * Fold Mux's derived license servers into the engine config, switching EME on
+ * so hls.js listens for `encrypted`. Whatever the caller set under `engine`
+ * wins, key by key, so `drmSystems` of their own replaces the derived set.
+ */
+function withMuxDrm(source: MuxSource): MuxSource['engine'] {
+  const drmSystems = createMuxDrmSystems(source);
+  if (!drmSystems) return source.engine;
+
+  return { emeEnabled: true, drmSystems, ...source.engine };
 }

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -1,5 +1,6 @@
 import { HlsJsMedia } from '../hls-js';
 import {
+  createMuxKeySystems,
   createMuxPosterURL,
   createMuxStoryboardURL,
   createMuxVideoURL,
@@ -58,6 +59,10 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * custom domain, and `playback` params (appended as `snake_case` query
    * params). A `playback.token` replaces all other params — signed URLs bake
    * them into the token. Engine options live under `engine`.
+   *
+   * A `drm.token` derives the inherited `keySystems` — Mux's FairPlay,
+   * Widevine, and PlayReady license servers for this playback ID. Naming
+   * `keySystems` yourself overrides that, for content Mux does not license.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -71,10 +76,14 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
 
     this.#source = source;
 
-    // Hand the same source down with `src` resolved from the playback ID. The
-    // base keeps `src` in step, decides whether playback has to reload, and
-    // dispatches `sourcechange`.
-    super.source = source && { ...source, src: createMuxVideoURL(source) ?? source.src ?? '' };
+    // Hand the same source down with `src` and `keySystems` resolved from the
+    // playback ID. The base keeps `src` in step, decides whether playback has to
+    // reload, and dispatches `sourcechange`.
+    super.source = source && {
+      ...source,
+      src: createMuxVideoURL(source) ?? source.src ?? '',
+      keySystems: source.keySystems ?? createMuxKeySystems(source),
+    };
   }
 
   /**

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { HlsJsMedia } from '../../hls-js';
+import { Hls, HlsJsMedia } from '../../hls-js';
 import { MuxMedia } from '..';
+
+// Header `{"alg":"HS256"}`, body sets `aud`, empty signature. Unpadded base64url,
+// like a real JWT, so it survives a query string untouched.
+function fakeJwt(payload: Record<string, unknown>): string {
+  const encode = (obj: unknown) => btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${encode({ alg: 'HS256' })}.${encode(payload)}.`;
+}
 
 // `source` and `src` request a load on a microtask, so give it a chance to run.
 function flushLoad() {
@@ -361,5 +368,96 @@ describe('MuxMedia', () => {
 
     expect(onSourceChange).not.toHaveBeenCalled();
     expect(media.source).toEqual({ playbackId: 'abc123', poster: { time: 5 } });
+  });
+
+  describe('drm', () => {
+    const DRM_TOKEN = fakeJwt({ aud: 'd' });
+    const PLAYBACK_TOKEN = fakeJwt({ aud: 'v' });
+
+    function setupMse() {
+      vi.spyOn(Hls, 'isSupported').mockReturnValue(true);
+
+      const media = new MuxMedia();
+      media.attach(document.createElement('video'));
+      return media;
+    }
+
+    it('configures the hls.js engine from a DRM token', async () => {
+      const media = setupMse();
+      media.source = { playbackId: 'abc123', playback: { token: PLAYBACK_TOKEN }, drm: { token: DRM_TOKEN } };
+      await flushLoad();
+
+      expect(media.engine!.config.emeEnabled).toBe(true);
+      expect(media.engine!.config.drmSystems).toEqual({
+        'com.apple.fps': {
+          licenseUrl: `https://license.mux.com/license/fairplay/abc123?token=${DRM_TOKEN}`,
+          serverCertificateUrl: `https://license.mux.com/appcert/fairplay/abc123?token=${DRM_TOKEN}`,
+        },
+        'com.widevine.alpha': { licenseUrl: `https://license.mux.com/license/widevine/abc123?token=${DRM_TOKEN}` },
+        'com.microsoft.playready': {
+          licenseUrl: `https://license.mux.com/license/playready/abc123?token=${DRM_TOKEN}`,
+        },
+      });
+    });
+
+    it('leaves EME alone without a DRM token', async () => {
+      const media = setupMse();
+      media.source = { playbackId: 'abc123' };
+      await flushLoad();
+
+      expect(media.engine!.config.emeEnabled).toBe(false);
+    });
+
+    it('keeps the Mux token out of the source handed to the engine', async () => {
+      const media = setupMse();
+      media.source = { playbackId: 'abc123', drm: { token: DRM_TOKEN } };
+      await flushLoad();
+
+      // `drm` stays Mux's own authoring input; only the derived license servers
+      // reach the HLS layer.
+      expect(media.source).toEqual({ playbackId: 'abc123', drm: { token: DRM_TOKEN } });
+    });
+
+    it('lets an explicit keySystems override the derived one', async () => {
+      const media = setupMse();
+      media.source = {
+        playbackId: 'abc123',
+        drm: { token: DRM_TOKEN },
+        keySystems: { widevine: { licenseUrl: 'https://drm.example/license' } },
+      };
+      await flushLoad();
+
+      expect(media.engine!.config.drmSystems).toEqual({
+        'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' },
+      });
+    });
+
+    it('does not reload for an equivalent DRM token', async () => {
+      const media = setupMse();
+      media.source = { playbackId: 'abc123', drm: { token: DRM_TOKEN } };
+      await flushLoad();
+
+      const loadstart = vi.fn();
+      media.addEventListener('loadstart', loadstart);
+
+      media.source = { playbackId: 'abc123', drm: { token: DRM_TOKEN } };
+      await flushLoad();
+
+      expect(loadstart).not.toHaveBeenCalled();
+    });
+
+    it('reloads when the DRM token changes', async () => {
+      const media = setupMse();
+      media.source = { playbackId: 'abc123', drm: { token: DRM_TOKEN } };
+      await flushLoad();
+
+      const loadstart = vi.fn();
+      media.addEventListener('loadstart', loadstart);
+
+      media.source = { playbackId: 'abc123', drm: { token: fakeJwt({ aud: 'd', exp: 1 }) } };
+      await flushLoad();
+
+      expect(loadstart).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -418,15 +418,17 @@ describe('MuxMedia', () => {
       expect(media.source).toEqual({ playbackId: 'abc123', drm: { token: DRM_TOKEN } });
     });
 
-    it('lets an explicit keySystems override the derived one', async () => {
+    it('lets an explicit engine.drmSystems override the derived one', async () => {
       const media = setupMse();
       media.source = {
         playbackId: 'abc123',
         drm: { token: DRM_TOKEN },
-        keySystems: { widevine: { licenseUrl: 'https://drm.example/license' } },
+        engine: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
       };
       await flushLoad();
 
+      // EME still switches on, but the caller's license servers stand.
+      expect(media.engine!.config.emeEnabled).toBe(true);
       expect(media.engine!.config.drmSystems).toEqual({
         'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' },
       });

--- a/packages/media/src/dom/mux/tests/utils.test.ts
+++ b/packages/media/src/dom/mux/tests/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createMuxKeySystems,
   createMuxPosterURL,
   createMuxQuery,
   createMuxStoryboardURL,
@@ -7,9 +8,10 @@ import {
   parseMuxVideoURL,
 } from '../utils';
 
-// Header `{"alg":"HS256"}`, body sets `aud`, empty signature.
+// Header `{"alg":"HS256"}`, body sets `aud`, empty signature. Unpadded base64url,
+// like a real JWT, so it survives a query string untouched.
 function fakeJwt(payload: Record<string, unknown>): string {
-  const encode = (obj: unknown) => btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_');
+  const encode = (obj: unknown) => btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   return `${encode({ alg: 'HS256' })}.${encode(payload)}.`;
 }
 
@@ -260,5 +262,41 @@ describe('createMuxStoryboardURL', () => {
 
   it('returns undefined for signed playback without a storyboard token', () => {
     expect(createMuxStoryboardURL({ playbackId: 'abc123', playback: { token: 'jwt' } })).toBeUndefined();
+  });
+});
+
+describe('createMuxKeySystems', () => {
+  const token = fakeJwt({ aud: 'd' });
+
+  it('derives every Mux license server from the DRM token', () => {
+    expect(createMuxKeySystems({ playbackId: 'abc123', drm: { token } })).toEqual({
+      fairplay: {
+        licenseUrl: `https://license.mux.com/license/fairplay/abc123?token=${token}`,
+        certificateUrl: `https://license.mux.com/appcert/fairplay/abc123?token=${token}`,
+      },
+      widevine: { licenseUrl: `https://license.mux.com/license/widevine/abc123?token=${token}` },
+      playready: { licenseUrl: `https://license.mux.com/license/playready/abc123?token=${token}` },
+    });
+  });
+
+  it('uses the custom domain', () => {
+    const keySystems = createMuxKeySystems({ playbackId: 'abc123', customDomain: 'example.com', drm: { token } });
+
+    expect(keySystems?.widevine?.licenseUrl).toBe(`https://license.example.com/license/widevine/abc123?token=${token}`);
+  });
+
+  it('returns undefined without a playbackId', () => {
+    expect(createMuxKeySystems()).toBeUndefined();
+    expect(createMuxKeySystems({ playbackId: '', drm: { token } })).toBeUndefined();
+  });
+
+  it('returns undefined without a DRM token', () => {
+    expect(createMuxKeySystems({ playbackId: 'abc123' })).toBeUndefined();
+    expect(createMuxKeySystems({ playbackId: 'abc123', drm: {} })).toBeUndefined();
+  });
+
+  it('returns undefined for a token with the wrong audience', () => {
+    // A playback token where a license token belongs: every license request would be rejected.
+    expect(createMuxKeySystems({ playbackId: 'abc123', drm: { token: fakeJwt({ aud: 'v' }) } })).toBeUndefined();
   });
 });

--- a/packages/media/src/dom/mux/tests/utils.test.ts
+++ b/packages/media/src/dom/mux/tests/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  createMuxKeySystems,
+  createMuxDrmSystems,
   createMuxPosterURL,
   createMuxQuery,
   createMuxStoryboardURL,
@@ -265,38 +265,40 @@ describe('createMuxStoryboardURL', () => {
   });
 });
 
-describe('createMuxKeySystems', () => {
+describe('createMuxDrmSystems', () => {
   const token = fakeJwt({ aud: 'd' });
 
   it('derives every Mux license server from the DRM token', () => {
-    expect(createMuxKeySystems({ playbackId: 'abc123', drm: { token } })).toEqual({
-      fairplay: {
+    expect(createMuxDrmSystems({ playbackId: 'abc123', drm: { token } })).toEqual({
+      'com.apple.fps': {
         licenseUrl: `https://license.mux.com/license/fairplay/abc123?token=${token}`,
-        certificateUrl: `https://license.mux.com/appcert/fairplay/abc123?token=${token}`,
+        serverCertificateUrl: `https://license.mux.com/appcert/fairplay/abc123?token=${token}`,
       },
-      widevine: { licenseUrl: `https://license.mux.com/license/widevine/abc123?token=${token}` },
-      playready: { licenseUrl: `https://license.mux.com/license/playready/abc123?token=${token}` },
+      'com.widevine.alpha': { licenseUrl: `https://license.mux.com/license/widevine/abc123?token=${token}` },
+      'com.microsoft.playready': { licenseUrl: `https://license.mux.com/license/playready/abc123?token=${token}` },
     });
   });
 
   it('uses the custom domain', () => {
-    const keySystems = createMuxKeySystems({ playbackId: 'abc123', customDomain: 'example.com', drm: { token } });
+    const drmSystems = createMuxDrmSystems({ playbackId: 'abc123', customDomain: 'example.com', drm: { token } });
 
-    expect(keySystems?.widevine?.licenseUrl).toBe(`https://license.example.com/license/widevine/abc123?token=${token}`);
+    expect(drmSystems?.['com.widevine.alpha']?.licenseUrl).toBe(
+      `https://license.example.com/license/widevine/abc123?token=${token}`
+    );
   });
 
   it('returns undefined without a playbackId', () => {
-    expect(createMuxKeySystems()).toBeUndefined();
-    expect(createMuxKeySystems({ playbackId: '', drm: { token } })).toBeUndefined();
+    expect(createMuxDrmSystems()).toBeUndefined();
+    expect(createMuxDrmSystems({ playbackId: '', drm: { token } })).toBeUndefined();
   });
 
   it('returns undefined without a DRM token', () => {
-    expect(createMuxKeySystems({ playbackId: 'abc123' })).toBeUndefined();
-    expect(createMuxKeySystems({ playbackId: 'abc123', drm: {} })).toBeUndefined();
+    expect(createMuxDrmSystems({ playbackId: 'abc123' })).toBeUndefined();
+    expect(createMuxDrmSystems({ playbackId: 'abc123', drm: {} })).toBeUndefined();
   });
 
   it('returns undefined for a token with the wrong audience', () => {
     // A playback token where a license token belongs: every license request would be rejected.
-    expect(createMuxKeySystems({ playbackId: 'abc123', drm: { token: fakeJwt({ aud: 'v' }) } })).toBeUndefined();
+    expect(createMuxDrmSystems({ playbackId: 'abc123', drm: { token: fakeJwt({ aud: 'v' }) } })).toBeUndefined();
   });
 });

--- a/packages/media/src/dom/mux/utils.ts
+++ b/packages/media/src/dom/mux/utils.ts
@@ -1,7 +1,7 @@
 import { parseJwt } from '@videojs/utils/jwt';
 import { isNil } from '@videojs/utils/predicate';
 import { camelCase, snakeCase } from '@videojs/utils/string';
-import type { HlsSource } from '../hls-js';
+import type { DrmConfig, HlsSource } from '../hls-js';
 
 export const MUX_VIDEO_DOMAIN = 'mux.com';
 
@@ -79,6 +79,12 @@ export interface MuxStoryboardParams {
 }
 
 export interface MuxDrmParams {
+  /**
+   * DRM license token: a JWT signed for the playback ID with the DRM (`d`)
+   * audience. Mux derives every license server URL from it, so it is the only
+   * thing a caller supplies. DRM playback is always signed, so a matching
+   * `playback.token` is required alongside it.
+   */
   token?: string | undefined;
 }
 
@@ -190,6 +196,38 @@ export function createMuxPosterURL(source?: MuxSource | null): string | undefine
   if (!token && playback?.token) return undefined;
 
   return `https://image.${customDomain}/${playbackId}/thumbnail.${ext}${createMuxQuery({ token, ...query })}`;
+}
+
+/**
+ * Build the DRM license servers a source describes, ready for the HLS layer's
+ * `source.keySystems`. Mux signs one license token per playback ID and serves
+ * every system from a URL derived from it, so `drm.token` is all a caller
+ * provides.
+ *
+ * Returns `undefined` when no license token is present, or when the token is
+ * not scoped to DRM — an unsigned license request is always rejected, so there
+ * is nothing useful to configure.
+ *
+ * @internal
+ */
+export function createMuxKeySystems(source?: MuxSource | null): DrmConfig | undefined {
+  if (!source?.playbackId) return undefined;
+  const { playbackId, customDomain = MUX_VIDEO_DOMAIN, drm } = source;
+  const { token } = drm ?? {};
+
+  // License tokens must carry the DRM (`d`) audience.
+  if (!token || parseJwt<MuxJWT>(token)?.aud !== 'd') return undefined;
+
+  const query = createMuxQuery({ token });
+  const url = (path: string) => `https://license.${customDomain}/${path}/${playbackId}${query}`;
+
+  // Every system is configured unconditionally: which one a browser negotiates
+  // is up to its CDM, and Mux serves all three from the same token.
+  return {
+    fairplay: { licenseUrl: url('license/fairplay'), certificateUrl: url('appcert/fairplay') },
+    widevine: { licenseUrl: url('license/widevine') },
+    playready: { licenseUrl: url('license/playready') },
+  };
 }
 
 /**

--- a/packages/media/src/dom/mux/utils.ts
+++ b/packages/media/src/dom/mux/utils.ts
@@ -1,7 +1,8 @@
 import { parseJwt } from '@videojs/utils/jwt';
 import { isNil } from '@videojs/utils/predicate';
 import { camelCase, snakeCase } from '@videojs/utils/string';
-import type { DrmConfig, HlsSource } from '../hls-js';
+import type { DRMSystemsConfiguration } from 'hls.js';
+import type { HlsSource } from '../hls-js';
 
 export const MUX_VIDEO_DOMAIN = 'mux.com';
 
@@ -199,10 +200,9 @@ export function createMuxPosterURL(source?: MuxSource | null): string | undefine
 }
 
 /**
- * Build the DRM license servers a source describes, ready for the HLS layer's
- * `source.keySystems`. Mux signs one license token per playback ID and serves
- * every system from a URL derived from it, so `drm.token` is all a caller
- * provides.
+ * Build the hls.js `drmSystems` a source describes, keyed by EME key system id.
+ * Mux signs one license token per playback ID and serves every system from a
+ * URL derived from it, so `drm.token` is all a caller provides.
  *
  * Returns `undefined` when no license token is present, or when the token is
  * not scoped to DRM — an unsigned license request is always rejected, so there
@@ -210,7 +210,7 @@ export function createMuxPosterURL(source?: MuxSource | null): string | undefine
  *
  * @internal
  */
-export function createMuxKeySystems(source?: MuxSource | null): DrmConfig | undefined {
+export function createMuxDrmSystems(source?: MuxSource | null): DRMSystemsConfiguration | undefined {
   if (!source?.playbackId) return undefined;
   const { playbackId, customDomain = MUX_VIDEO_DOMAIN, drm } = source;
   const { token } = drm ?? {};
@@ -224,9 +224,9 @@ export function createMuxKeySystems(source?: MuxSource | null): DrmConfig | unde
   // Every system is configured unconditionally: which one a browser negotiates
   // is up to its CDM, and Mux serves all three from the same token.
   return {
-    fairplay: { licenseUrl: url('license/fairplay'), certificateUrl: url('appcert/fairplay') },
-    widevine: { licenseUrl: url('license/widevine') },
-    playready: { licenseUrl: url('license/playready') },
+    'com.apple.fps': { licenseUrl: url('license/fairplay'), serverCertificateUrl: url('appcert/fairplay') },
+    'com.widevine.alpha': { licenseUrl: url('license/widevine') },
+    'com.microsoft.playready': { licenseUrl: url('license/playready') },
   };
 }
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -243,7 +243,7 @@ video.source = {
 ```
 </FrameworkCase>
 
-Only the hls.js (MSE) engine plays DRM-protected media, so native HLS playback ignores `keySystems` and warns in development. `certificateUrl` points at the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it. Read the negotiated system back from the element's `drmType`, which updates on `drmtypechange`. Anything hls.js exposes but Video.js doesn't normalize — a custom `requestMediaKeySystemAccessFunc`, say — still goes under `engine`, and wins over what `keySystems` derives.
+Only the hls.js (MSE) engine plays DRM-protected media, so native HLS playback ignores `keySystems` and warns in development. `certificateUrl` points at the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it. Which system a browser ends up using is its own choice — name every one you have a license server for. Anything hls.js exposes but Video.js doesn't normalize — a custom `requestMediaKeySystemAccessFunc`, say — still goes under `engine`, and wins over what `keySystems` derives.
 
 ## Mux sources name a playback ID
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -292,6 +292,37 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 `MuxVideo` uses the storyboard itself, adding the thumbnail `<track>` for you so hover previews work without extra markup. Live streams have no storyboard, so the track is dropped once the stream type is known, and signed playback without a matching storyboard token adds none.
 
+### DRM protected sources
+
+Mux signs one license token per playback ID and serves FairPlay, Widevine, and PlayReady from URLs derived from it, so `source.drm` takes that token and nothing else. It fills in the `keySystems` above for you:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<MuxVideo
+  source={{
+    playbackId,
+    playback: { token: playbackToken },
+    drm: { token: drmToken },
+  }}
+  playsInline
+/>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+video.source = {
+  playbackId,
+  playback: { token: playbackToken },
+  drm: { token: drmToken },
+};
+```
+</FrameworkCase>
+
+DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
+
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `keySystems` yourself takes precedence, for content Mux doesn't license.
+
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -125,7 +125,7 @@ video.source = { src, engine: { maxBufferLength: 60 } }; // no-op
 ```
 </FrameworkCase>
 
-Only a change to `engine`, `preferPlayback`, `keySystems`, or the resolved content type recreates the playback engine.
+Only a change to `engine`, `preferPlayback`, or the resolved content type recreates the playback engine.
 
 <Aside type="note">
 `source` holds an object, so it's a property, not an attribute — there is no `source=""` in HTML. `src` remains the attribute, and it's the one to reach for when your markup only names a URL.
@@ -209,18 +209,23 @@ video.source = { src: 'https://example.com/stream.m3u8', preferPlayback: 'native
 
 It's a preference, not a demand — Video.js falls back to whichever path can actually play the source. `HlsJsVideo`, `MuxVideo`, and `MuxAudio` accept it; DASH and Vimeo have no second playback path.
 
-`keySystems` names the license servers for DRM-protected playback, keyed by brand rather than by EME key system id:
+## DRM protected sources
+
+DRM is engine configuration like any other, so it goes under `engine` — for hls.js, that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <HlsJsVideo
   source={{
     src: 'https://example.com/protected.m3u8',
-    keySystems: {
-      widevine: { licenseUrl: 'https://license.example.com/widevine' },
-      fairplay: {
-        licenseUrl: 'https://license.example.com/fairplay',
-        certificateUrl: 'https://license.example.com/fairplay-cert',
+    engine: {
+      emeEnabled: true,
+      drmSystems: {
+        'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
+        'com.apple.fps': {
+          licenseUrl: 'https://license.example.com/fairplay',
+          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+        },
       },
     },
   }}
@@ -232,18 +237,25 @@ It's a preference, not a demand — Video.js falls back to whichever path can ac
 ```ts
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  keySystems: {
-    widevine: { licenseUrl: 'https://license.example.com/widevine' },
-    fairplay: {
-      licenseUrl: 'https://license.example.com/fairplay',
-      certificateUrl: 'https://license.example.com/fairplay-cert',
+  engine: {
+    emeEnabled: true,
+    drmSystems: {
+      'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
+      'com.apple.fps': {
+        licenseUrl: 'https://license.example.com/fairplay',
+        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+      },
     },
   },
 };
 ```
 </FrameworkCase>
 
-Only the hls.js (MSE) engine plays DRM-protected media, so native HLS playback ignores `keySystems` and warns in development. `certificateUrl` points at the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it. Which system a browser ends up using is its own choice — name every one you have a license server for. Anything hls.js exposes but Video.js doesn't normalize — a custom `requestMediaKeySystemAccessFunc`, say — still goes under `engine`, and wins over what `keySystems` derives.
+Name every system you hold a license server for — which one gets used is the browser's choice. `serverCertificateUrl` is the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it.
+
+Only the hls.js (MSE) engine plays DRM-protected media, so native HLS playback ignores all of this and warns in development.
+
+Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM first, falling back to whatever robustness the browser offers, so content restricted to L1 devices plays where it can. Supplying your own `requestMediaKeySystemAccessFunc` replaces that entirely.
 
 ## Mux sources name a playback ID
 
@@ -292,9 +304,9 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 `MuxVideo` uses the storyboard itself, adding the thumbnail `<track>` for you so hover previews work without extra markup. Live streams have no storyboard, so the track is dropped once the stream type is known, and signed playback without a matching storyboard token adds none.
 
-### DRM protected sources
+### Mux signs DRM with a token
 
-Mux signs one license token per playback ID and serves FairPlay, Widevine, and PlayReady from URLs derived from it, so `source.drm` takes that token and nothing else. It fills in the `keySystems` above for you:
+Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in the `engine.drmSystems` above for you, EME included:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -321,7 +333,7 @@ video.source = {
 
 DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
 
-A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `keySystems` yourself takes precedence, for content Mux doesn't license.
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `engine.drmSystems` yourself takes precedence, for content Mux doesn't license.
 
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -62,7 +62,7 @@ video.source = { src: 'https://example.com/asset?id=42', type: 'application/vnd.
 
 ## `src` and `source` stay in sync
 
-They are two views of the same thing, and writing either updates the other. Setting `source` derives `src`. Setting `src` replaces only the identity half and **keeps `type` and `engine` intact**:
+They are two views of the same thing, and writing either updates the other. Setting `source` derives `src`. Setting `src` replaces only the identity half and **keeps the rest, such as `type` and `engine`, intact**:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -125,7 +125,7 @@ video.source = { src, engine: { maxBufferLength: 60 } }; // no-op
 ```
 </FrameworkCase>
 
-Only a change to `engine`, `preferPlayback`, or the resolved content type recreates the playback engine.
+Only a change to `engine`, `preferPlayback`, `keySystems`, or the resolved content type recreates the playback engine.
 
 <Aside type="note">
 `source` holds an object, so it's a property, not an attribute — there is no `source=""` in HTML. `src` remains the attribute, and it's the one to reach for when your markup only names a URL.
@@ -191,7 +191,9 @@ Because `engine` replaces rather than merges, dropping a key restores the dash.j
 
 ### Options Video.js normalizes
 
-Where an option means the same thing across engines, it sits on `source` itself rather than inside `engine`. Today that's `preferPlayback`, which picks between [hls.js](https://github.com/video-dev/hls.js/) and the browser's own HLS support:
+Where an option means the same thing across engines, it sits on `source` itself rather than inside `engine`.
+
+`preferPlayback` picks between [hls.js](https://github.com/video-dev/hls.js/) and the browser's own HLS support:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -206,6 +208,42 @@ video.source = { src: 'https://example.com/stream.m3u8', preferPlayback: 'native
 </FrameworkCase>
 
 It's a preference, not a demand — Video.js falls back to whichever path can actually play the source. `HlsJsVideo`, `MuxVideo`, and `MuxAudio` accept it; DASH and Vimeo have no second playback path.
+
+`keySystems` names the license servers for DRM-protected playback, keyed by brand rather than by EME key system id:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<HlsJsVideo
+  source={{
+    src: 'https://example.com/protected.m3u8',
+    keySystems: {
+      widevine: { licenseUrl: 'https://license.example.com/widevine' },
+      fairplay: {
+        licenseUrl: 'https://license.example.com/fairplay',
+        certificateUrl: 'https://license.example.com/fairplay-cert',
+      },
+    },
+  }}
+/>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+video.source = {
+  src: 'https://example.com/protected.m3u8',
+  keySystems: {
+    widevine: { licenseUrl: 'https://license.example.com/widevine' },
+    fairplay: {
+      licenseUrl: 'https://license.example.com/fairplay',
+      certificateUrl: 'https://license.example.com/fairplay-cert',
+    },
+  },
+};
+```
+</FrameworkCase>
+
+Only the hls.js (MSE) engine plays DRM-protected media, so native HLS playback ignores `keySystems` and warns in development. `certificateUrl` points at the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it. Read the negotiated system back from the element's `drmType`, which updates on `drmtypechange`. Anything hls.js exposes but Video.js doesn't normalize — a custom `requestMediaKeySystemAccessFunc`, say — still goes under `engine`, and wins over what `keySystems` derives.
 
 ## Mux sources name a playback ID
 


### PR DESCRIPTION
Closes #1775
Refs #1411

## Summary

DRM playback for the Mux and hls.js media stacks. Mux needs only a signed license token; everything else is hls.js configuration.

## Public API

### `MuxSource.drm` now does something

It held a token nothing read. It now derives Mux's FairPlay, Widevine, and PlayReady license servers for the playback ID, and switches EME on:

```ts
video.source = {
  playbackId,
  playback: { token: playbackToken },
  drm: { token: drmToken },
};
```

DRM playback is always signed, so `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience. A `drm.token` that isn't scoped to DRM (`aud: 'd'`) is ignored rather than sent.

### Everything else goes through `source.engine`

No new field: DRM is engine configuration like any other.

```ts
video.source = {
  src: 'https://example.com/protected.m3u8',
  engine: {
    emeEnabled: true,
    drmSystems: {
      'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
      'com.apple.fps': {
        licenseUrl: 'https://license.example.com/fairplay',
        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
      },
    },
  },
};
```

Anything you set under `engine` beats what Mux derives, key by key, so your own `drmSystems` replaces the derived set while `emeEnabled` still gets switched on.

## Behavior

- **Hardware-backed Widevine.** Key system access asks for `HW_SECURE_ALL` first and falls back to whatever robustness the browser offers, so L1-restricted content plays where it can. A `requestMediaKeySystemAccessFunc` of your own replaces this.
- **Native HLS can't do EME**, so it ignores DRM config and warns in development.
- **Non-fatal key system errors** (output restricted → black frames) warn in development; they are silent otherwise.

## Fix

`HlsJsMedia` read playback fields off the `source` getter, which subclasses override to return what was assigned *to them* rather than what they resolved and handed down. It now reads its own stored source. Without this, nothing Mux derives reaches the engine.

## Testing

```bash
pnpm -F @videojs/media test
```

Covers the Mux license-server derivation and token audience check, engine reuse vs. rebuild, the Widevine robustness preference, and caller precedence.

Manual: `pnpm dev`, then the **MuxVideo** preset with the **HLS - DRM protected (Mux token)** source, or **HlsJsVideo** with **HLS - DRM protected (engine config)** — the same asset licensed both ways. Needs a CDM (Chrome/Edge for Widevine, Safari for FairPlay); screenshotting the video should produce a black frame.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches EME licensing and playback engine construction in core media paths, but changes are gated on `emeEnabled`, covered by tests, and native HLS is explicitly excluded with dev warnings.
> 
> **Overview**
> Adds **DRM playback** for the hls.js (MSE) stack and **Mux** elements: generic sources use `source.engine` (`emeEnabled`, `drmSystems`); `MuxVideo`/`MuxAudio` can supply `drm.token` to derive FairPlay, Widevine, and PlayReady license URLs and turn EME on, with explicit `engine.drmSystems` overriding the derived set.
> 
> The hls.js path wires a new **`setupDrm`** hook (hardware Widevine preference, dev warnings for non-fatal key-system errors) and documents that native HLS ignores DRM. **`HlsJsMedia`** now reads the stored `#source` when building the engine so Mux-resolved `engine` options (including DRM) actually reach hls.js, and engine rebuilds use deep comparison for nested `drmSystems`.
> 
> The **sandbox** gains typed structured sources (`url` optional, `source` for tokens), two DRM demo entries (Mux token vs engine config), preset-filtered source lists, and templates that assign `source` instead of `src` when needed; poster/storyboard helpers append image tokens for signed assets.
> 
> **Docs** describe generic DRM via `engine` and Mux token-based DRM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fed10c7c00cd80e69d723240f54f405501d4ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->