### PR TITLE
Discovery: route config inputs through feature actions

### DIFF
--- a/internal/design/store/resolved-feature-state.md
+++ b/internal/design/store/resolved-feature-state.md
@@ -56,13 +56,13 @@ The config declaration also identifies lifecycle ownership:
 ```ts
 config: {
   contentTitle: {
-    state: USER_CONTENT_TITLE,
     action: SET_USER_CONTENT_TITLE,
+    preserve: USER_CONTENT_TITLE,
   },
 }
 ```
 
-The feature-level `config` object is routing metadata, not a second place that stores values. `definePlayerFeature` derives the store's detach-persistence keys from this map. Detach restores ordinary source state to its initial values while preserving the mapped user-owned keys. Media state therefore resets, while provider and imperative user values survive.
+The feature-level `config` object is routing metadata, not a second place that stores values. `action` receives configuration updates, while `preserve` identifies the user-owned source-state key whose value survives detach. `definePlayerFeature` derives the store's detach-persistence keys from this map. Detach restores ordinary source state to its initial values while preserving the mapped user-owned keys. Media state therefore resets, while provider and imperative user values survive.
 
 ## Provider adapters
 

--- a/internal/design/store/resolved-feature-state.md
+++ b/internal/design/store/resolved-feature-state.md
@@ -5,7 +5,7 @@ date: 2026-08-04
 
 # Resolved player feature state
 
-This record describes a provider-action prototype for resolving one public value from inputs with different owners and lifetimes. Source and tests define the prototype's current behavior.
+This record describes a config-action prototype for resolving one public value from inputs with different owners and lifetimes. Source and tests define the prototype's current behavior.
 
 ## Media interaction
 
@@ -39,22 +39,22 @@ HTML exposes the same inputs as `content-title` and `default-content-title`. Con
 
 A feature can use three kinds of state:
 
-- Provider-owned and media-owned inputs live in private, symbol-keyed source `state`.
-- A feature's `provider` map connects each user-facing input to its private state key and private action.
+- User-owned and media-owned inputs live in private, symbol-keyed source `state`.
+- A feature's `config` map connects each user-facing input to its private state key and private action.
 - `derived` calculates the public value from source state.
 
 Features choose their own formula. A value with fallbacks can use:
 
 ```ts
-providerOverride ?? attachedMediaValue ?? providerFallback ?? featureFallback
+userOverride ?? attachedMediaValue ?? userFallback ?? featureFallback
 ```
 
 Only resolved values appear in the public store. Lower-priority values continue updating under an override, so removing the override reveals the latest value.
 
-The provider declaration also identifies lifecycle ownership:
+The config declaration also identifies lifecycle ownership:
 
 ```ts
-provider: {
+config: {
   contentTitle: {
     state: USER_CONTENT_TITLE,
     action: SET_USER_CONTENT_TITLE,
@@ -62,11 +62,11 @@ provider: {
 }
 ```
 
-`definePlayerFeature` derives the store's detach-persistence keys from this map. Detach restores ordinary source state to its initial values while preserving the mapped provider-owned keys. Media state therefore resets, while provider and imperative user values survive.
+The feature-level `config` object is routing metadata, not a second place that stores values. `definePlayerFeature` derives the store's detach-persistence keys from this map. Detach restores ordinary source state to its initial values while preserving the mapped user-owned keys. Media state therefore resets, while provider and imperative user values survive.
 
 ## Provider adapters
 
-Selected provider keys become React props and HTML properties and attributes. Their TypeScript value types come from the mapped action's parameter. Each adapter applies changes through its normal lifecycle by invoking that private action. Provider input flows one way: store actions do not rewrite props, properties, or attributes.
+Selected config keys become React provider props and HTML provider properties and attributes. Their TypeScript value types come from the mapped action's parameter. Each adapter applies changes through its normal lifecycle by invoking that private action. Configuration flows one way: store actions do not rewrite props, properties, or attributes.
 
 React seeds a new store before the first render, then forwards only committed prop changes after render. HTML forwards reactive property changes and kebab-cases the corresponding attribute names.
 
@@ -87,15 +87,15 @@ Media provides metadata through `contentData` and emits `contentdatachange` when
 
 - **Publish every input** — exposes private values and hides which lifecycle owns them.
 - **Keep user input in media state** — clears user input when media detaches.
-- **A generic store config namespace** — gives provider values a separate lifetime automatically and permits atomic patches, but adds config snapshots, controllers, generics, and a second input API throughout the store.
+- **A generic store config namespace** — gives user values a separate lifetime automatically and permits atomic patches, but adds config snapshots, controllers, generics, and a second input API throughout the store.
 - **Replay provider props after detach** — cannot preserve imperative user writes and risks restoring stale props.
 - **Put formulas inside `state`** — makes feature types harder to understand.
 
 ## Tradeoffs
 
-The provider map is narrow and feature-owned, and ordinary store actions handle every user write. In exchange, each provider-backed value needs a private source key plus a private action, and the store needs explicit detach-persistence metadata.
+The config map is narrow and feature-owned, and ordinary store actions handle every user write. In exchange, each configurable value needs a private source key plus a private action, and the store needs explicit detach-persistence metadata.
 
-Adapters invoke actions one at a time, and the store derives a snapshot after each action. Subscriber notification is coalesced, so normal consumers observe the final values. The behavioral difference appears on failure: if a later action or derived formula throws, earlier actions remain applied. A generic config patch can derive a multi-key update before committing any of it. This prototype does not add a separate batching abstraction.
+Adapters invoke actions one at a time, and the store derives a snapshot after each action. Subscriber notification is coalesced, so normal consumers observe the final values. The behavioral difference appears on failure: if a later action or derived formula throws, earlier actions remain applied. A generic store-config patch can derive a multi-key update before committing any of it. This prototype does not add a separate batching abstraction.
 
 ## Deliberate limits
 

--- a/internal/design/store/resolved-feature-state.md
+++ b/internal/design/store/resolved-feature-state.md
@@ -1,11 +1,11 @@
 ---
-status: implemented
+status: draft
 date: 2026-08-04
 ---
 
 # Resolved player feature state
 
-This record defines how a player feature resolves one public value from inputs with different owners and lifetimes. Source, exports, and tests define the current API.
+This record describes a provider-action prototype for resolving one public value from inputs with different owners and lifetimes. Source and tests define the prototype's current behavior.
 
 ## Media interaction
 
@@ -35,13 +35,13 @@ Or a user may provide a fallback that media can override:
 
 HTML exposes the same inputs as `content-title` and `default-content-title`. Consumers read the resolved value through the store and update user input through feature actions such as `setContentTitle`.
 
-## Decision
+## Proposed design
 
 A feature can use three kinds of state:
 
-- `config` stores user input for the provider lifetime.
-- `state` stores feature actions and values read from media. Media-owned values reset on detach.
-- `derived` calculates the public value from `config` and `state`.
+- Provider-owned and media-owned inputs live in private, symbol-keyed source `state`.
+- A feature's `provider` map connects each user-facing input to its private state key and private action.
+- `derived` calculates the public value from source state.
 
 Features choose their own formula. A value with fallbacks can use:
 
@@ -51,9 +51,24 @@ providerOverride ?? attachedMediaValue ?? providerFallback ?? featureFallback
 
 Only resolved values appear in the public store. Lower-priority values continue updating under an override, so removing the override reveals the latest value.
 
+The provider declaration also identifies lifecycle ownership:
+
+```ts
+provider: {
+  contentTitle: {
+    state: USER_CONTENT_TITLE,
+    action: SET_USER_CONTENT_TITLE,
+  },
+}
+```
+
+`definePlayerFeature` derives the store's detach-persistence keys from this map. Detach restores ordinary source state to its initial values while preserving the mapped provider-owned keys. Media state therefore resets, while provider and imperative user values survive.
+
 ## Provider adapters
 
-Selected config keys become React props and HTML properties and attributes. Each adapter applies changes through its normal lifecycle. Provider input flows one way: store actions do not rewrite props, properties, or attributes. Adapters must preserve the feature's declared value types.
+Selected provider keys become React props and HTML properties and attributes. Their TypeScript value types come from the mapped action's parameter. Each adapter applies changes through its normal lifecycle by invoking that private action. Provider input flows one way: store actions do not rewrite props, properties, or attributes.
+
+React seeds a new store before the first render, then forwards only committed prop changes after render. HTML forwards reactive property changes and kebab-cases the corresponding attribute names. This prototype assumes string-valued HTML inputs; it deliberately does not add runtime type metadata for future arbitrary input types.
 
 ## Example: content title
 
@@ -72,7 +87,15 @@ Media provides metadata through `contentData` and emits `contentdatachange` when
 
 - **Publish every input** — exposes private values and hides which lifecycle owns them.
 - **Keep user input in media state** — clears user input when media detaches.
+- **A generic store config namespace** — gives provider values a separate lifetime automatically and permits atomic patches, but adds config snapshots, controllers, generics, and a second input API throughout the store.
+- **Replay provider props after detach** — cannot preserve imperative user writes and risks restoring stale props.
 - **Put formulas inside `state`** — makes feature types harder to understand.
+
+## Tradeoffs
+
+The provider map is narrow and feature-owned, and ordinary store actions handle every user write. In exchange, each provider-backed value needs a private source key plus a private action, and the store needs explicit detach-persistence metadata.
+
+Adapters invoke actions one at a time. Subscriber notification is coalesced, but a later action throwing can leave earlier values applied. A generic config patch can validate and derive a multi-key update before committing it. This prototype does not add a separate batching abstraction.
 
 ## Deliberate limits
 

--- a/internal/design/store/resolved-feature-state.md
+++ b/internal/design/store/resolved-feature-state.md
@@ -1,11 +1,11 @@
 ---
-status: draft
+status: implemented
 date: 2026-08-04
 ---
 
 # Resolved player feature state
 
-This record describes a config-action prototype for resolving one public value from inputs with different owners and lifetimes. Source and tests define the prototype's current behavior.
+This record defines how a player feature resolves one public value from inputs with different owners and lifetimes. Source and tests define the current behavior.
 
 ## Media interaction
 
@@ -35,7 +35,7 @@ Or a user may provide a fallback that media can override:
 
 HTML exposes the same inputs as `content-title` and `default-content-title`. Consumers read the resolved value through the store and update user input through feature actions such as `setContentTitle`.
 
-## Proposed design
+## Decision
 
 A feature can use three kinds of state:
 
@@ -95,7 +95,7 @@ Media provides metadata through `contentData` and emits `contentdatachange` when
 
 The config map is narrow and feature-owned, and ordinary store actions handle every user write. In exchange, each configurable value needs a private source key plus a private action, and the store needs explicit detach-persistence metadata.
 
-Adapters invoke actions one at a time, and the store derives a snapshot after each action. Subscriber notification is coalesced, so normal consumers observe the final values. The behavioral difference appears on failure: if a later action or derived formula throws, earlier actions remain applied. A generic store-config patch can derive a multi-key update before committing any of it. This prototype does not add a separate batching abstraction.
+Adapters invoke actions one at a time, and the store derives a snapshot after each action. Subscriber notification is coalesced, so normal consumers observe the final values. The behavioral difference appears on failure: if a later action or derived formula throws, earlier actions remain applied. A generic store-config patch can derive a multi-key update before committing any of it. This design does not add a separate batching abstraction.
 
 ## Deliberate limits
 

--- a/internal/design/store/resolved-feature-state.md
+++ b/internal/design/store/resolved-feature-state.md
@@ -68,7 +68,7 @@ provider: {
 
 Selected provider keys become React props and HTML properties and attributes. Their TypeScript value types come from the mapped action's parameter. Each adapter applies changes through its normal lifecycle by invoking that private action. Provider input flows one way: store actions do not rewrite props, properties, or attributes.
 
-React seeds a new store before the first render, then forwards only committed prop changes after render. HTML forwards reactive property changes and kebab-cases the corresponding attribute names. This prototype assumes string-valued HTML inputs; it deliberately does not add runtime type metadata for future arbitrary input types.
+React seeds a new store before the first render, then forwards only committed prop changes after render. HTML forwards reactive property changes and kebab-cases the corresponding attribute names.
 
 ## Example: content title
 
@@ -95,7 +95,7 @@ Media provides metadata through `contentData` and emits `contentdatachange` when
 
 The provider map is narrow and feature-owned, and ordinary store actions handle every user write. In exchange, each provider-backed value needs a private source key plus a private action, and the store needs explicit detach-persistence metadata.
 
-Adapters invoke actions one at a time. Subscriber notification is coalesced, but a later action throwing can leave earlier values applied. A generic config patch can validate and derive a multi-key update before committing it. This prototype does not add a separate batching abstraction.
+Adapters invoke actions one at a time, and the store derives a snapshot after each action. Subscriber notification is coalesced, so normal consumers observe the final values. The behavioral difference appears on failure: if a later action or derived formula throws, earlier actions remain applied. A generic config patch can derive a multi-key update before committing any of it. This prototype does not add a separate batching abstraction.
 
 ## Deliberate limits
 

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -13,7 +13,7 @@ export interface ConfigurablePlayerFeature<Config, State> extends PlayerFeature<
 }
 
 export interface ConfigurablePlayerFeatureConfig<Config, State>
-  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'derived' | 'preserveOnDetach' | 'state'> {
+  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'derived' | 'preserve' | 'state'> {
   state: (ctx: StateContext<PlayerTarget>, config: Config) => State;
   attach?: (ctx: AttachContext<PlayerTarget, State>, config: Config) => void;
 }
@@ -28,7 +28,7 @@ type DerivedValues<Definitions extends Record<string, (...args: any[]) => unknow
 
 type StaticPlayerFeatureConfig<State, Derived, Config extends PlayerFeatureConfig> = Omit<
   SliceConfig<PlayerTarget, State, Derived>,
-  'preserveOnDetach'
+  'preserve'
 > & {
   config?: Config;
 };
@@ -67,7 +67,7 @@ export function definePlayerFeature<Config, State>(
 
     return {
       ...feature,
-      ...(preserved.length > 0 ? { preserveOnDetach: preserved } : {}),
+      ...(preserved.length > 0 ? { preserve: preserved } : {}),
     } as PlayerFeature<State>;
   }
 

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -1,29 +1,58 @@
 import {
   type AttachContext,
+  type DerivedContext,
   defineSlice,
   type SliceConfig,
-  type SliceFactory,
   type StateContext,
 } from '@videojs/store';
 import { isUndefined } from '@videojs/utils/predicate';
-import type { PlayerFeature, PlayerTarget } from './player';
+import type {
+  AnyPlayerFeature,
+  PlayerFeature,
+  PlayerProviderBinding,
+  PlayerProviderDefinition,
+  PlayerTarget,
+} from './player';
 
 export interface ConfigurablePlayerFeature<Config, State> extends PlayerFeature<State> {
   (config?: Config): PlayerFeature<State>;
 }
 
 export interface ConfigurablePlayerFeatureConfig<Config, State>
-  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'config' | 'derived' | 'state'> {
+  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'derived' | 'preserveOnDetach' | 'state'> {
   state: (ctx: StateContext<PlayerTarget>, config: Config) => State;
   attach?: (ctx: AttachContext<PlayerTarget, State>, config: Config) => void;
 }
 
 const definePlayerSlice = defineSlice<PlayerTarget>();
 
-/** Define a static player feature. */
-export function definePlayerFeature<State>(config: SliceConfig<PlayerTarget, State>): PlayerFeature<State>;
-/** Define a player feature with responsive user-facing config. */
-export function definePlayerFeature<Config>(): SliceFactory<PlayerTarget, Config>;
+type DerivedFunctions<State> = Record<string, (ctx: DerivedContext<State>) => unknown>;
+
+type DerivedValues<Definitions extends Record<string, (...args: any[]) => unknown>> = {
+  [Key in keyof Definitions]: ReturnType<Definitions[Key]>;
+};
+
+type StaticPlayerFeatureConfig<State, Derived, Provider extends PlayerProviderDefinition> = Omit<
+  SliceConfig<PlayerTarget, State, Derived>,
+  'preserveOnDetach'
+> & {
+  provider?: Provider;
+};
+
+/** Define a static player feature with derived state and optional provider inputs. */
+export function definePlayerFeature<
+  State,
+  const Definitions extends DerivedFunctions<State>,
+  const Provider extends PlayerProviderDefinition = Record<never, never>,
+>(
+  config: Omit<StaticPlayerFeatureConfig<State, DerivedValues<Definitions>, Provider>, 'derived'> & {
+    derived: Definitions;
+  }
+): PlayerFeature<State, DerivedValues<Definitions>, Provider>;
+/** Define a static player feature with optional provider inputs. */
+export function definePlayerFeature<State, const Provider extends PlayerProviderDefinition = Record<never, never>>(
+  config: Omit<StaticPlayerFeatureConfig<State, object, Provider>, 'derived'> & { derived?: never }
+): PlayerFeature<State, object, Provider>;
 /**
  * Define the legacy factory-configured form used by static feature variants.
  * Currently used for orientation lock and scheduled for removal in #1942.
@@ -33,15 +62,19 @@ export function definePlayerFeature<Config, State>(
   defaultConfig: Config
 ): ConfigurablePlayerFeature<Config, State>;
 export function definePlayerFeature<Config, State>(
-  config?: SliceConfig<PlayerTarget, State> | ConfigurablePlayerFeatureConfig<Config, State>,
+  config:
+    | StaticPlayerFeatureConfig<State, object, PlayerProviderDefinition>
+    | ConfigurablePlayerFeatureConfig<Config, State>,
   defaultConfig?: Config
-): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> | SliceFactory<PlayerTarget, Config> {
-  if (arguments.length === 0) {
-    return defineSlice<PlayerTarget, Config>();
-  }
-
+): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> {
   if (arguments.length === 1) {
-    return config as PlayerFeature<State>;
+    const feature = config as StaticPlayerFeatureConfig<State, object, PlayerProviderDefinition>;
+    const preserved = Object.values(feature.provider ?? {}).map((binding) => binding.state);
+
+    return {
+      ...feature,
+      ...(preserved.length > 0 ? { preserveOnDetach: preserved } : {}),
+    } as PlayerFeature<State>;
   }
 
   const { name, state, attach } = config as ConfigurablePlayerFeatureConfig<Config, State>;
@@ -62,4 +95,32 @@ export function definePlayerFeature<Config, State>(
   if (!isUndefined(name)) Object.defineProperty(feature, 'name', { value: name });
 
   return feature;
+}
+
+/** Merge the provider declarations from the selected player features. */
+export function combinePlayerProviderDefinitions(features: readonly AnyPlayerFeature[]): PlayerProviderDefinition {
+  const definitions = features.map((feature) => feature.provider ?? {});
+
+  if (__DEV__) {
+    const seen = new Set<string>();
+    for (const definition of definitions) {
+      for (const key of Object.keys(definition)) {
+        if (seen.has(key)) {
+          console.warn(`[vjs-core] duplicate provider key "${key}" — later feature overwrites earlier one`);
+        }
+        seen.add(key);
+      }
+    }
+  }
+
+  return Object.assign({}, ...definitions);
+}
+
+/** Forward one provider input through its feature-owned private action. */
+export function setPlayerProviderValue(store: object, binding: PlayerProviderBinding, value: unknown): void {
+  const action = (store as Record<PropertyKey, unknown>)[binding.action];
+  if (typeof action !== 'function') {
+    throw new TypeError(`Missing provider action "${String(binding.action)}"`);
+  }
+  action(value);
 }

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -6,13 +6,7 @@ import {
   type StateContext,
 } from '@videojs/store';
 import { isUndefined } from '@videojs/utils/predicate';
-import type {
-  AnyPlayerFeature,
-  PlayerConfigBinding,
-  PlayerConfigDefinition,
-  PlayerFeature,
-  PlayerTarget,
-} from './player';
+import type { AnyPlayerFeature, PlayerFeature, PlayerFeatureConfig, PlayerTarget } from './player';
 
 export interface ConfigurablePlayerFeature<Config, State> extends PlayerFeature<State> {
   (config?: Config): PlayerFeature<State>;
@@ -32,7 +26,7 @@ type DerivedValues<Definitions extends Record<string, (...args: any[]) => unknow
   [Key in keyof Definitions]: ReturnType<Definitions[Key]>;
 };
 
-type StaticPlayerFeatureConfig<State, Derived, Config extends PlayerConfigDefinition> = Omit<
+type StaticPlayerFeatureConfig<State, Derived, Config extends PlayerFeatureConfig> = Omit<
   SliceConfig<PlayerTarget, State, Derived>,
   'preserveOnDetach'
 > & {
@@ -43,14 +37,14 @@ type StaticPlayerFeatureConfig<State, Derived, Config extends PlayerConfigDefini
 export function definePlayerFeature<
   State,
   const Definitions extends DerivedFunctions<State>,
-  const Config extends PlayerConfigDefinition = Record<never, never>,
+  const Config extends PlayerFeatureConfig = Record<never, never>,
 >(
   definition: Omit<StaticPlayerFeatureConfig<State, DerivedValues<Definitions>, Config>, 'derived'> & {
     derived: Definitions;
   }
 ): PlayerFeature<State, DerivedValues<Definitions>, Config>;
 /** Define a static player feature with optional configuration inputs. */
-export function definePlayerFeature<State, const Config extends PlayerConfigDefinition = Record<never, never>>(
+export function definePlayerFeature<State, const Config extends PlayerFeatureConfig = Record<never, never>>(
   definition: Omit<StaticPlayerFeatureConfig<State, object, Config>, 'derived'> & { derived?: never }
 ): PlayerFeature<State, object, Config>;
 /**
@@ -63,13 +57,13 @@ export function definePlayerFeature<Config, State>(
 ): ConfigurablePlayerFeature<Config, State>;
 export function definePlayerFeature<Config, State>(
   definition:
-    | StaticPlayerFeatureConfig<State, object, PlayerConfigDefinition>
+    | StaticPlayerFeatureConfig<State, object, PlayerFeatureConfig>
     | ConfigurablePlayerFeatureConfig<Config, State>,
   defaultConfig?: Config
 ): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> {
   if (arguments.length === 1) {
-    const feature = definition as StaticPlayerFeatureConfig<State, object, PlayerConfigDefinition>;
-    const preserved = Object.values(feature.config ?? {}).map((binding) => binding.state);
+    const feature = definition as StaticPlayerFeatureConfig<State, object, PlayerFeatureConfig>;
+    const preserved = Object.values(feature.config ?? {}).map((entry) => entry.preserve);
 
     return {
       ...feature,
@@ -98,7 +92,7 @@ export function definePlayerFeature<Config, State>(
 }
 
 /** Merge the configuration declarations from the selected player features. */
-export function combinePlayerConfigDefinitions(features: readonly AnyPlayerFeature[]): PlayerConfigDefinition {
+export function combinePlayerFeatureConfigs(features: readonly AnyPlayerFeature[]): PlayerFeatureConfig {
   const definitions = features.map((feature) => feature.config ?? {});
 
   if (__DEV__) {
@@ -117,10 +111,10 @@ export function combinePlayerConfigDefinitions(features: readonly AnyPlayerFeatu
 }
 
 /** Forward one configuration input through its feature-owned private action. */
-export function setPlayerConfigValue(store: object, binding: PlayerConfigBinding, value: unknown): void {
-  const action = (store as Record<PropertyKey, unknown>)[binding.action];
+export function setPlayerConfigValue(store: object, entry: PlayerFeatureConfig[string], value: unknown): void {
+  const action = (store as Record<PropertyKey, unknown>)[entry.action];
   if (typeof action !== 'function') {
-    throw new TypeError(`Missing config action "${String(binding.action)}"`);
+    throw new TypeError(`Missing config action "${String(entry.action)}"`);
   }
   action(value);
 }

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -8,9 +8,9 @@ import {
 import { isUndefined } from '@videojs/utils/predicate';
 import type {
   AnyPlayerFeature,
+  PlayerConfigBinding,
+  PlayerConfigDefinition,
   PlayerFeature,
-  PlayerProviderBinding,
-  PlayerProviderDefinition,
   PlayerTarget,
 } from './player';
 
@@ -32,44 +32,44 @@ type DerivedValues<Definitions extends Record<string, (...args: any[]) => unknow
   [Key in keyof Definitions]: ReturnType<Definitions[Key]>;
 };
 
-type StaticPlayerFeatureConfig<State, Derived, Provider extends PlayerProviderDefinition> = Omit<
+type StaticPlayerFeatureConfig<State, Derived, Config extends PlayerConfigDefinition> = Omit<
   SliceConfig<PlayerTarget, State, Derived>,
   'preserveOnDetach'
 > & {
-  provider?: Provider;
+  config?: Config;
 };
 
-/** Define a static player feature with derived state and optional provider inputs. */
+/** Define a static player feature with derived state and optional configuration inputs. */
 export function definePlayerFeature<
   State,
   const Definitions extends DerivedFunctions<State>,
-  const Provider extends PlayerProviderDefinition = Record<never, never>,
+  const Config extends PlayerConfigDefinition = Record<never, never>,
 >(
-  config: Omit<StaticPlayerFeatureConfig<State, DerivedValues<Definitions>, Provider>, 'derived'> & {
+  definition: Omit<StaticPlayerFeatureConfig<State, DerivedValues<Definitions>, Config>, 'derived'> & {
     derived: Definitions;
   }
-): PlayerFeature<State, DerivedValues<Definitions>, Provider>;
-/** Define a static player feature with optional provider inputs. */
-export function definePlayerFeature<State, const Provider extends PlayerProviderDefinition = Record<never, never>>(
-  config: Omit<StaticPlayerFeatureConfig<State, object, Provider>, 'derived'> & { derived?: never }
-): PlayerFeature<State, object, Provider>;
+): PlayerFeature<State, DerivedValues<Definitions>, Config>;
+/** Define a static player feature with optional configuration inputs. */
+export function definePlayerFeature<State, const Config extends PlayerConfigDefinition = Record<never, never>>(
+  definition: Omit<StaticPlayerFeatureConfig<State, object, Config>, 'derived'> & { derived?: never }
+): PlayerFeature<State, object, Config>;
 /**
  * Define the legacy factory-configured form used by static feature variants.
  * Currently used for orientation lock and scheduled for removal in #1942.
  */
 export function definePlayerFeature<Config, State>(
-  config: ConfigurablePlayerFeatureConfig<Config, State>,
+  definition: ConfigurablePlayerFeatureConfig<Config, State>,
   defaultConfig: Config
 ): ConfigurablePlayerFeature<Config, State>;
 export function definePlayerFeature<Config, State>(
-  config:
-    | StaticPlayerFeatureConfig<State, object, PlayerProviderDefinition>
+  definition:
+    | StaticPlayerFeatureConfig<State, object, PlayerConfigDefinition>
     | ConfigurablePlayerFeatureConfig<Config, State>,
   defaultConfig?: Config
 ): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> {
   if (arguments.length === 1) {
-    const feature = config as StaticPlayerFeatureConfig<State, object, PlayerProviderDefinition>;
-    const preserved = Object.values(feature.provider ?? {}).map((binding) => binding.state);
+    const feature = definition as StaticPlayerFeatureConfig<State, object, PlayerConfigDefinition>;
+    const preserved = Object.values(feature.config ?? {}).map((binding) => binding.state);
 
     return {
       ...feature,
@@ -77,7 +77,7 @@ export function definePlayerFeature<Config, State>(
     } as PlayerFeature<State>;
   }
 
-  const { name, state, attach } = config as ConfigurablePlayerFeatureConfig<Config, State>;
+  const { name, state, attach } = definition as ConfigurablePlayerFeatureConfig<Config, State>;
 
   const forConfig = (featureConfig: Config): PlayerFeature<State> =>
     definePlayerSlice({
@@ -97,16 +97,16 @@ export function definePlayerFeature<Config, State>(
   return feature;
 }
 
-/** Merge the provider declarations from the selected player features. */
-export function combinePlayerProviderDefinitions(features: readonly AnyPlayerFeature[]): PlayerProviderDefinition {
-  const definitions = features.map((feature) => feature.provider ?? {});
+/** Merge the configuration declarations from the selected player features. */
+export function combinePlayerConfigDefinitions(features: readonly AnyPlayerFeature[]): PlayerConfigDefinition {
+  const definitions = features.map((feature) => feature.config ?? {});
 
   if (__DEV__) {
     const seen = new Set<string>();
     for (const definition of definitions) {
       for (const key of Object.keys(definition)) {
         if (seen.has(key)) {
-          console.warn(`[vjs-core] duplicate provider key "${key}" — later feature overwrites earlier one`);
+          console.warn(`[vjs-core] duplicate config key "${key}" — later feature overwrites earlier one`);
         }
         seen.add(key);
       }
@@ -116,11 +116,11 @@ export function combinePlayerProviderDefinitions(features: readonly AnyPlayerFea
   return Object.assign({}, ...definitions);
 }
 
-/** Forward one provider input through its feature-owned private action. */
-export function setPlayerProviderValue(store: object, binding: PlayerProviderBinding, value: unknown): void {
+/** Forward one configuration input through its feature-owned private action. */
+export function setPlayerConfigValue(store: object, binding: PlayerConfigBinding, value: unknown): void {
   const action = (store as Record<PropertyKey, unknown>)[binding.action];
   if (typeof action !== 'function') {
-    throw new TypeError(`Missing provider action "${String(binding.action)}"`);
+    throw new TypeError(`Missing config action "${String(binding.action)}"`);
   }
   action(value);
 }

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -27,52 +27,52 @@ export interface PlayerTarget {
   container: MediaContainer | null;
 }
 
-export interface PlayerProviderBinding<
+export interface PlayerConfigBinding<
   StateKey extends PropertyKey = PropertyKey,
   ActionKey extends PropertyKey = PropertyKey,
 > {
   /** User-owned source-state key preserved when media detaches. */
   state: StateKey;
-  /** Private source-state action that receives provider updates. */
+  /** Private source-state action that receives configuration updates. */
   action: ActionKey;
 }
 
-export type PlayerProviderDefinition = Record<string, PlayerProviderBinding>;
+export type PlayerConfigDefinition = Record<string, PlayerConfigBinding>;
 
 export type PlayerFeature<
   State,
   Derived = object,
-  Provider extends PlayerProviderDefinition = Record<never, never>,
+  Config extends PlayerConfigDefinition = Record<never, never>,
 > = Slice<PlayerTarget, State, Derived> & {
-  provider?: Provider;
+  config?: Config;
 };
 
-export type AnyPlayerFeature = AnySlice<PlayerTarget> & { provider?: PlayerProviderDefinition };
+export type AnyPlayerFeature = AnySlice<PlayerTarget> & { config?: PlayerConfigDefinition };
 
 type ActionInput<Action> = Action extends (value: infer Value) => unknown ? Value : never;
 
-export type InferPlayerFeatureProviderConfig<Feature extends AnyPlayerFeature> = Feature extends {
-  provider?: infer Provider extends PlayerProviderDefinition;
+export type InferPlayerFeatureConfig<Feature extends AnyPlayerFeature> = Feature extends {
+  config?: infer Config extends PlayerConfigDefinition;
 }
   ? {
-      [Key in keyof Provider]: Provider[Key]['action'] extends keyof InferSliceSourceState<Feature>
-        ? ActionInput<InferSliceSourceState<Feature>[Provider[Key]['action']]>
+      [Key in keyof Config]: Config[Key]['action'] extends keyof InferSliceSourceState<Feature>
+        ? ActionInput<InferSliceSourceState<Feature>[Config[Key]['action']]>
         : never;
     }
   : object;
 
-export type UnionPlayerProviderConfig<Features extends readonly AnyPlayerFeature[]> = Features extends readonly []
+export type UnionPlayerConfig<Features extends readonly AnyPlayerFeature[]> = Features extends readonly []
   ? object
-  : Simplify<UnionToIntersection<InferPlayerFeatureProviderConfig<Features[number]>>>;
+  : Simplify<UnionToIntersection<InferPlayerFeatureConfig<Features[number]>>>;
 
-declare const PLAYER_PROVIDER_CONFIG: unique symbol;
+declare const PLAYER_CONFIG: unique symbol;
 
 export type PlayerStore<Features extends AnyPlayerFeature[] = []> = Store<PlayerTarget, UnionSliceState<Features>> & {
-  readonly [PLAYER_PROVIDER_CONFIG]?: UnionPlayerProviderConfig<Features>;
+  readonly [PLAYER_CONFIG]?: UnionPlayerConfig<Features>;
 };
 
-export type InferPlayerProviderConfig<Store> = Store extends {
-  readonly [PLAYER_PROVIDER_CONFIG]?: infer Config;
+export type InferPlayerConfig<Store> = Store extends {
+  readonly [PLAYER_CONFIG]?: infer Config;
 }
   ? Config
   : object;

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -27,32 +27,30 @@ export interface PlayerTarget {
   container: MediaContainer | null;
 }
 
-export interface PlayerConfigBinding<
-  StateKey extends PropertyKey = PropertyKey,
-  ActionKey extends PropertyKey = PropertyKey,
-> {
-  /** User-owned source-state key preserved when media detaches. */
-  state: StateKey;
-  /** Private source-state action that receives configuration updates. */
-  action: ActionKey;
-}
+export type PlayerFeatureConfig = Record<
+  string,
+  {
+    /** Private source-state action that receives configuration updates. */
+    action: PropertyKey;
+    /** User-owned source-state key preserved when media detaches. */
+    preserve: PropertyKey;
+  }
+>;
 
-export type PlayerConfigDefinition = Record<string, PlayerConfigBinding>;
-
-export type PlayerFeature<
+export type PlayerFeature<State, Derived = object, Config extends PlayerFeatureConfig = Record<never, never>> = Slice<
+  PlayerTarget,
   State,
-  Derived = object,
-  Config extends PlayerConfigDefinition = Record<never, never>,
-> = Slice<PlayerTarget, State, Derived> & {
+  Derived
+> & {
   config?: Config;
 };
 
-export type AnyPlayerFeature = AnySlice<PlayerTarget> & { config?: PlayerConfigDefinition };
+export type AnyPlayerFeature = AnySlice<PlayerTarget> & { config?: PlayerFeatureConfig };
 
 type ActionInput<Action> = Action extends (value: infer Value) => unknown ? Value : never;
 
 export type InferPlayerFeatureConfig<Feature extends AnyPlayerFeature> = Feature extends {
-  config?: infer Config extends PlayerConfigDefinition;
+  config?: infer Config extends PlayerFeatureConfig;
 }
   ? {
       [Key in keyof Config]: Config[Key]['action'] extends keyof InferSliceSourceState<Feature>

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -16,7 +16,8 @@ import type {
   MediaTimeState,
   MediaVolumeState,
 } from '@videojs/media';
-import type { AnySlice, Slice, Store, UnionSliceConfig, UnionSliceState } from '@videojs/store';
+import type { AnySlice, InferSliceSourceState, Slice, Store, UnionSliceState } from '@videojs/store';
+import type { Simplify, UnionToIntersection } from '@videojs/utils/types';
 import type { metadataFeature } from './store/features/metadata';
 
 export interface MediaContainer extends HTMLElement {}
@@ -26,15 +27,55 @@ export interface PlayerTarget {
   container: MediaContainer | null;
 }
 
-export type PlayerFeature<State, Config = object, Derived = object> = Slice<PlayerTarget, State, Config, Derived>;
+export interface PlayerProviderBinding<
+  StateKey extends PropertyKey = PropertyKey,
+  ActionKey extends PropertyKey = PropertyKey,
+> {
+  /** User-owned source-state key preserved when media detaches. */
+  state: StateKey;
+  /** Private source-state action that receives provider updates. */
+  action: ActionKey;
+}
 
-export type AnyPlayerFeature = AnySlice<PlayerTarget>;
+export type PlayerProviderDefinition = Record<string, PlayerProviderBinding>;
 
-export type PlayerStore<Features extends AnyPlayerFeature[] = []> = Store<
-  PlayerTarget,
-  UnionSliceState<Features>,
-  UnionSliceConfig<Features>
->;
+export type PlayerFeature<
+  State,
+  Derived = object,
+  Provider extends PlayerProviderDefinition = Record<never, never>,
+> = Slice<PlayerTarget, State, Derived> & {
+  provider?: Provider;
+};
+
+export type AnyPlayerFeature = AnySlice<PlayerTarget> & { provider?: PlayerProviderDefinition };
+
+type ActionInput<Action> = Action extends (value: infer Value) => unknown ? Value : never;
+
+export type InferPlayerFeatureProviderConfig<Feature extends AnyPlayerFeature> = Feature extends {
+  provider?: infer Provider extends PlayerProviderDefinition;
+}
+  ? {
+      [Key in keyof Provider]: Provider[Key]['action'] extends keyof InferSliceSourceState<Feature>
+        ? ActionInput<InferSliceSourceState<Feature>[Provider[Key]['action']]>
+        : never;
+    }
+  : object;
+
+export type UnionPlayerProviderConfig<Features extends readonly AnyPlayerFeature[]> = Features extends readonly []
+  ? object
+  : Simplify<UnionToIntersection<InferPlayerFeatureProviderConfig<Features[number]>>>;
+
+declare const PLAYER_PROVIDER_CONFIG: unique symbol;
+
+export type PlayerStore<Features extends AnyPlayerFeature[] = []> = Store<PlayerTarget, UnionSliceState<Features>> & {
+  readonly [PLAYER_PROVIDER_CONFIG]?: UnionPlayerProviderConfig<Features>;
+};
+
+export type InferPlayerProviderConfig<Store> = Store extends {
+  readonly [PLAYER_PROVIDER_CONFIG]?: infer Config;
+}
+  ? Config
+  : object;
 
 export type AnyPlayerStore = Store<PlayerTarget, object>;
 

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -4,39 +4,55 @@ import { listen } from '@videojs/utils/dom';
 import { definePlayerFeature } from '../../feature';
 
 const MEDIA_CONTENT_TITLE = Symbol('vjs.contentTitle.media');
+const USER_CONTENT_TITLE = Symbol('vjs.contentTitle.user');
+const USER_DEFAULT_CONTENT_TITLE = Symbol('vjs.defaultContentTitle.user');
+const SET_USER_CONTENT_TITLE = Symbol('vjs.contentTitle.user.set');
+const SET_USER_DEFAULT_CONTENT_TITLE = Symbol('vjs.defaultContentTitle.user.set');
 const DEFAULT_CONTENT_TITLE = '';
-
-export interface MetadataConfig {
-  /** User title override. */
-  contentTitle: string | null;
-  /** User fallback after the media-owned title tier. */
-  defaultContentTitle: string | null;
-}
 
 interface MetadataSourceState extends Omit<MediaMetadataState, 'contentTitle'> {
   [MEDIA_CONTENT_TITLE]: MediaContentValue;
+  [USER_CONTENT_TITLE]: MediaContentValue;
+  [USER_DEFAULT_CONTENT_TITLE]: MediaContentValue;
+  [SET_USER_CONTENT_TITLE](value: MediaContentValue): void;
+  [SET_USER_DEFAULT_CONTENT_TITLE](value: MediaContentValue): void;
 }
 
 /**
  * Resolves user, media, and fallback content-title metadata into player state.
  * Included in the standard audio, video, and live presets.
  */
-export const metadataFeature = definePlayerFeature<MetadataConfig>()({
+export const metadataFeature = definePlayerFeature({
   name: 'metadata',
-  config: {
-    contentTitle: null,
-    defaultContentTitle: null,
+  provider: {
+    contentTitle: {
+      state: USER_CONTENT_TITLE,
+      action: SET_USER_CONTENT_TITLE,
+    },
+    defaultContentTitle: {
+      state: USER_DEFAULT_CONTENT_TITLE,
+      action: SET_USER_DEFAULT_CONTENT_TITLE,
+    },
   },
-  state: ({ config }): MetadataSourceState => ({
-    [MEDIA_CONTENT_TITLE]: undefined,
-    setContentTitle: (value) => config.set({ contentTitle: value }),
-    setDefaultContentTitle: (value) => config.set({ defaultContentTitle: value }),
-  }),
+  state: ({ set }): MetadataSourceState => {
+    const setUserContentTitle = (value: MediaContentValue) => set({ [USER_CONTENT_TITLE]: value });
+    const setUserDefaultContentTitle = (value: MediaContentValue) => set({ [USER_DEFAULT_CONTENT_TITLE]: value });
+
+    return {
+      [MEDIA_CONTENT_TITLE]: undefined,
+      [USER_CONTENT_TITLE]: undefined,
+      [USER_DEFAULT_CONTENT_TITLE]: undefined,
+      [SET_USER_CONTENT_TITLE]: setUserContentTitle,
+      [SET_USER_DEFAULT_CONTENT_TITLE]: setUserDefaultContentTitle,
+      setContentTitle: setUserContentTitle,
+      setDefaultContentTitle: setUserDefaultContentTitle,
+    };
+  },
   derived: {
-    contentTitle: ({ get, config }) =>
-      config.get().contentTitle ??
+    contentTitle: ({ get }) =>
+      get()[USER_CONTENT_TITLE] ??
       get()[MEDIA_CONTENT_TITLE] ??
-      config.get().defaultContentTitle ??
+      get()[USER_DEFAULT_CONTENT_TITLE] ??
       DEFAULT_CONTENT_TITLE,
   },
   attach({ target, signal, set }) {

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -26,12 +26,12 @@ export const metadataFeature = definePlayerFeature({
   name: 'metadata',
   config: {
     contentTitle: {
-      state: USER_CONTENT_TITLE,
       action: SET_USER_CONTENT_TITLE,
+      preserve: USER_CONTENT_TITLE,
     },
     defaultContentTitle: {
-      state: USER_DEFAULT_CONTENT_TITLE,
       action: SET_USER_DEFAULT_CONTENT_TITLE,
+      preserve: USER_DEFAULT_CONTENT_TITLE,
     },
   },
   state: ({ set }): MetadataSourceState => {

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -24,7 +24,7 @@ interface MetadataSourceState extends Omit<MediaMetadataState, 'contentTitle'> {
  */
 export const metadataFeature = definePlayerFeature({
   name: 'metadata',
-  provider: {
+  config: {
     contentTitle: {
       state: USER_CONTENT_TITLE,
       action: SET_USER_CONTENT_TITLE,

--- a/packages/core/src/dom/store/features/tests/metadata.test.ts
+++ b/packages/core/src/dom/store/features/tests/metadata.test.ts
@@ -61,9 +61,9 @@ describe('metadataFeature', () => {
   });
 
   it('treats empty and whitespace-only strings as literal values', () => {
-    const store = createStore<PlayerTarget>()(metadataFeature, {
-      config: { contentTitle: '', defaultContentTitle: 'fallback' },
-    });
+    const store = createStore<PlayerTarget>()(metadataFeature);
+    store.setDefaultContentTitle('fallback');
+    store.setContentTitle('');
 
     expect(store.contentTitle).toBe('');
 
@@ -72,9 +72,8 @@ describe('metadataFeature', () => {
   });
 
   it('subscribes to content data before an asynchronous title arrives', () => {
-    const store = createStore<PlayerTarget>()(metadataFeature, {
-      config: { defaultContentTitle: 'fallback' },
-    });
+    const store = createStore<PlayerTarget>()(metadataFeature);
+    store.setDefaultContentTitle('fallback');
     const media = new ContentDataMedia({});
     const addEventListener = vi.spyOn(media, 'addEventListener');
 
@@ -110,9 +109,8 @@ describe('metadataFeature', () => {
   });
 
   it('does not listen to unsupported media', () => {
-    const store = createStore<PlayerTarget>()(metadataFeature, {
-      config: { defaultContentTitle: 'fallback' },
-    });
+    const store = createStore<PlayerTarget>()(metadataFeature);
+    store.setDefaultContentTitle('fallback');
     const unsupported = new ContentDataMedia(undefined);
     const addEventListener = vi.spyOn(unsupported, 'addEventListener');
 
@@ -122,16 +120,14 @@ describe('metadataFeature', () => {
     expect(addEventListener).not.toHaveBeenCalledWith('contentdatachange', expect.anything());
   });
 
-  it('resets media metadata on detach while preserving provider config', () => {
-    const store = createStore<PlayerTarget>()(metadataFeature, {
-      config: { defaultContentTitle: 'fallback' },
-    });
+  it('resets media metadata on detach while preserving provider-owned state', () => {
+    const store = createStore<PlayerTarget>()(metadataFeature);
+    store.setDefaultContentTitle('fallback');
     const detach = store.attach(target(new ContentDataMedia({ title: 'media' })));
 
     detach();
 
     expect(store.contentTitle).toBe('fallback');
-    expect(store.$config.get().defaultContentTitle).toBe('fallback');
   });
 
   it('selects only resolved metadata and public writers', () => {

--- a/packages/core/src/dom/store/features/tests/metadata.test.ts
+++ b/packages/core/src/dom/store/features/tests/metadata.test.ts
@@ -120,7 +120,7 @@ describe('metadataFeature', () => {
     expect(addEventListener).not.toHaveBeenCalledWith('contentdatachange', expect.anything());
   });
 
-  it('resets media metadata on detach while preserving provider-owned state', () => {
+  it('resets media metadata on detach while preserving user-owned state', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
     store.setDefaultContentTitle('fallback');
     const detach = store.attach(target(new ContentDataMedia({ title: 'media' })));

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -53,7 +53,7 @@ describe('definePlayerFeature', () => {
       },
     });
 
-    expect(feature.preserveOnDetach).toEqual([USER_LABEL]);
+    expect(feature.preserve).toEqual([USER_LABEL]);
     expect(combinePlayerFeatureConfigs([feature])).toEqual(feature.config);
 
     const store = createStore<PlayerTarget>()(feature);

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -1,6 +1,11 @@
-import { createSelector, type StateContext } from '@videojs/store';
+import { createSelector, createStore, type StateContext } from '@videojs/store';
 import { assertType, describe, expect, it } from 'vitest';
-import { type ConfigurablePlayerFeatureConfig, definePlayerFeature } from '../feature';
+import {
+  type ConfigurablePlayerFeatureConfig,
+  combinePlayerProviderDefinitions,
+  definePlayerFeature,
+  setPlayerProviderValue,
+} from '../feature';
 import type { PlayerTarget } from '../player';
 
 const stateContext = {
@@ -8,10 +13,6 @@ const stateContext = {
     throw new Error('Target is not available in this test.');
   },
   signals: undefined as unknown as StateContext<PlayerTarget>['signals'],
-  config: {
-    get: () => ({}),
-    set: () => {},
-  },
   get: () => ({}),
   set: () => {},
 } satisfies StateContext<PlayerTarget>;
@@ -25,6 +26,42 @@ describe('definePlayerFeature', () => {
 
     expect(feature.name).toBe('plain');
     expect(feature.state(stateContext).enabled).toBe(true);
+  });
+
+  it('routes provider inputs through private actions and derives detach persistence', () => {
+    const USER_LABEL = Symbol('userLabel');
+    const SET_USER_LABEL = Symbol('setUserLabel');
+
+    interface SourceState {
+      [USER_LABEL]: string | undefined;
+      [SET_USER_LABEL](value: string | undefined): void;
+    }
+
+    const feature = definePlayerFeature({
+      provider: {
+        label: {
+          state: USER_LABEL,
+          action: SET_USER_LABEL,
+        },
+      },
+      state: ({ set }): SourceState => ({
+        [USER_LABEL]: undefined,
+        [SET_USER_LABEL]: (value) => set({ [USER_LABEL]: value }),
+      }),
+      derived: {
+        label: ({ get }) => get()[USER_LABEL] ?? 'fallback',
+      },
+    });
+
+    expect(feature.preserveOnDetach).toEqual([USER_LABEL]);
+    expect(combinePlayerProviderDefinitions([feature])).toEqual(feature.provider);
+
+    const store = createStore<PlayerTarget>()(feature);
+    setPlayerProviderValue(store, feature.provider!.label, 'provided');
+    const detach = store.attach({} as PlayerTarget);
+    detach();
+
+    expect(store.label).toBe('provided');
   });
 
   it('defines a configurable player feature', () => {

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -2,7 +2,7 @@ import { createSelector, createStore, type StateContext } from '@videojs/store';
 import { assertType, describe, expect, it } from 'vitest';
 import {
   type ConfigurablePlayerFeatureConfig,
-  combinePlayerConfigDefinitions,
+  combinePlayerFeatureConfigs,
   definePlayerFeature,
   setPlayerConfigValue,
 } from '../feature';
@@ -40,8 +40,8 @@ describe('definePlayerFeature', () => {
     const feature = definePlayerFeature({
       config: {
         label: {
-          state: USER_LABEL,
           action: SET_USER_LABEL,
+          preserve: USER_LABEL,
         },
       },
       state: ({ set }): SourceState => ({
@@ -54,7 +54,7 @@ describe('definePlayerFeature', () => {
     });
 
     expect(feature.preserveOnDetach).toEqual([USER_LABEL]);
-    expect(combinePlayerConfigDefinitions([feature])).toEqual(feature.config);
+    expect(combinePlayerFeatureConfigs([feature])).toEqual(feature.config);
 
     const store = createStore<PlayerTarget>()(feature);
     setPlayerConfigValue(store, feature.config!.label, 'provided');

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -2,9 +2,9 @@ import { createSelector, createStore, type StateContext } from '@videojs/store';
 import { assertType, describe, expect, it } from 'vitest';
 import {
   type ConfigurablePlayerFeatureConfig,
-  combinePlayerProviderDefinitions,
+  combinePlayerConfigDefinitions,
   definePlayerFeature,
-  setPlayerProviderValue,
+  setPlayerConfigValue,
 } from '../feature';
 import type { PlayerTarget } from '../player';
 
@@ -28,7 +28,7 @@ describe('definePlayerFeature', () => {
     expect(feature.state(stateContext).enabled).toBe(true);
   });
 
-  it('routes provider inputs through private actions and derives detach persistence', () => {
+  it('routes config inputs through private actions and derives detach persistence', () => {
     const USER_LABEL = Symbol('userLabel');
     const SET_USER_LABEL = Symbol('setUserLabel');
 
@@ -38,7 +38,7 @@ describe('definePlayerFeature', () => {
     }
 
     const feature = definePlayerFeature({
-      provider: {
+      config: {
         label: {
           state: USER_LABEL,
           action: SET_USER_LABEL,
@@ -54,10 +54,10 @@ describe('definePlayerFeature', () => {
     });
 
     expect(feature.preserveOnDetach).toEqual([USER_LABEL]);
-    expect(combinePlayerProviderDefinitions([feature])).toEqual(feature.provider);
+    expect(combinePlayerConfigDefinitions([feature])).toEqual(feature.config);
 
     const store = createStore<PlayerTarget>()(feature);
-    setPlayerProviderValue(store, feature.provider!.label, 'provided');
+    setPlayerConfigValue(store, feature.config!.label, 'provided');
     const detach = store.attach({} as PlayerTarget);
     detach();
 
@@ -80,7 +80,7 @@ describe('definePlayerFeature', () => {
     expect(createSelector(feature).displayName).toBe('configurable');
   });
 
-  it('keeps provider config out of the legacy feature-factory shape', () => {
+  it('keeps static config declarations out of the legacy feature-factory shape', () => {
     type LegacyConfig = ConfigurablePlayerFeatureConfig<{ enabled: boolean }, { enabled: boolean }>;
 
     assertType<LegacyConfig>({

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -1,11 +1,12 @@
-import type {
-  AnyPlayerFeature,
-  AudioFeatures,
-  AudioPlayerStore,
-  PlayerStore,
-  PlayerTarget,
-  VideoFeatures,
-  VideoPlayerStore,
+import {
+  type AnyPlayerFeature,
+  type AudioFeatures,
+  type AudioPlayerStore,
+  combinePlayerProviderDefinitions,
+  type PlayerStore,
+  type PlayerTarget,
+  type VideoFeatures,
+  type VideoPlayerStore,
 } from '@videojs/core/dom';
 import { combine, createStore } from '@videojs/store';
 
@@ -82,7 +83,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<PlayerStore> {
   const slice = combine(...config.features);
-  const configKeys = Object.keys(slice.config ?? {});
+  const provider = combinePlayerProviderDefinitions(config.features);
 
   function create(): PlayerStore {
     return createStore<PlayerTarget>()(slice);
@@ -93,7 +94,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     mediaContext,
     containerContext,
     factory: create,
-    configKeys,
+    provider,
   });
 
   const ContainerMixin = createContainerMixin<PlayerStore>({

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -2,7 +2,7 @@ import {
   type AnyPlayerFeature,
   type AudioFeatures,
   type AudioPlayerStore,
-  combinePlayerConfigDefinitions,
+  combinePlayerFeatureConfigs,
   type PlayerStore,
   type PlayerTarget,
   type VideoFeatures,
@@ -83,7 +83,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<PlayerStore> {
   const slice = combine(...config.features);
-  const configDefinition = combinePlayerConfigDefinitions(config.features);
+  const featureConfig = combinePlayerFeatureConfigs(config.features);
 
   function create(): PlayerStore {
     return createStore<PlayerTarget>()(slice);
@@ -94,7 +94,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     mediaContext,
     containerContext,
     factory: create,
-    config: configDefinition,
+    config: featureConfig,
   });
 
   const ContainerMixin = createContainerMixin<PlayerStore>({

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -2,7 +2,7 @@ import {
   type AnyPlayerFeature,
   type AudioFeatures,
   type AudioPlayerStore,
-  combinePlayerProviderDefinitions,
+  combinePlayerConfigDefinitions,
   type PlayerStore,
   type PlayerTarget,
   type VideoFeatures,
@@ -83,7 +83,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<PlayerStore> {
   const slice = combine(...config.features);
-  const provider = combinePlayerProviderDefinitions(config.features);
+  const configDefinition = combinePlayerConfigDefinitions(config.features);
 
   function create(): PlayerStore {
     return createStore<PlayerTarget>()(slice);
@@ -94,7 +94,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     mediaContext,
     containerContext,
     factory: create,
-    provider,
+    config: configDefinition,
   });
 
   const ContainerMixin = createContainerMixin<PlayerStore>({

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -55,7 +55,7 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('infers provider properties from selected feature config', () => {
+  it('infers provider properties from selected features', () => {
     const withMetadata = createPlayer({ features: [metadataFeature] });
     const withoutMetadata = createPlayer({ features: [features.playback] });
     const MetadataProvider = withMetadata.ProviderMixin(MediaElement);

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -55,7 +55,7 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('infers provider properties from selected features', () => {
+  it('infers config properties from selected features', () => {
     const withMetadata = createPlayer({ features: [metadataFeature] });
     const withoutMetadata = createPlayer({ features: [features.playback] });
     const MetadataProvider = withMetadata.ProviderMixin(MediaElement);

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -108,7 +108,7 @@ describe('createPlayer', () => {
     expect(player.store.contentTitle).toBe('Imperative title');
   });
 
-  it('leaves provider attributes inert when their feature is absent', () => {
+  it('leaves config attributes inert when their feature is absent', () => {
     const { ProviderMixin } = createPlayer({ features: backgroundFeatures });
     const ProviderElement = ProviderMixin(MediaElement);
 

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -64,7 +64,7 @@ describe('createPlayer', () => {
     expect(result.ContainerMixin).toBeInstanceOf(Function);
   });
 
-  it('maps selected feature config to kebab-cased reactive properties and attributes', async () => {
+  it('maps selected feature inputs to kebab-cased reactive properties and attributes', async () => {
     const { ProviderMixin } = createPlayer({ features: [metadataFeature] });
     const ProviderElement = ProviderMixin(MediaElement);
     const tagName = 'test-metadata-provider';
@@ -108,7 +108,7 @@ describe('createPlayer', () => {
     expect(player.store.contentTitle).toBe('Imperative title');
   });
 
-  it('leaves config attributes inert when their feature is absent', () => {
+  it('leaves provider attributes inert when their feature is absent', () => {
     const { ProviderMixin } = createPlayer({ features: backgroundFeatures });
     const ProviderElement = ProviderMixin(MediaElement);
 

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -1,4 +1,11 @@
-import { createPopupGroup, type MediaContainer, type PlayerStore, type PlayerTarget } from '@videojs/core/dom';
+import {
+  createPopupGroup,
+  type MediaContainer,
+  type PlayerProviderDefinition,
+  type PlayerStore,
+  type PlayerTarget,
+  setPlayerProviderValue,
+} from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
 import type { Media } from '@videojs/media/dom';
@@ -13,7 +20,7 @@ export interface ProviderMixinConfig<Store extends PlayerStore> {
   mediaContext: MediaContext;
   containerContext: ContainerContext;
   factory: () => Store;
-  configKeys: readonly string[];
+  provider: PlayerProviderDefinition;
 }
 
 export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaElementConstructor>(
@@ -36,11 +43,13 @@ export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaEleme
 export function createProviderMixin<Store extends PlayerStore>(
   config: ProviderMixinConfig<Store>
 ): ProviderMixin<Store> {
+  const providerKeys = Object.keys(config.provider);
+
   return <Class extends MediaElementConstructor>(BaseClass: Class) => {
     class PlayerProviderElement extends BaseClass {
       static properties = {
         ...(BaseClass as unknown as { properties: PropertyDeclarationMap }).properties,
-        ...Object.fromEntries(config.configKeys.map((key) => [key, { type: String, attribute: kebabCase(key) }])),
+        ...Object.fromEntries(providerKeys.map((key) => [key, { type: String, attribute: kebabCase(key) }])),
       };
 
       #store: Store | null = config.factory();
@@ -125,18 +134,12 @@ export function createProviderMixin<Store extends PlayerStore>(
       protected override willUpdate(changed: PropertyValues): void {
         super.willUpdate(changed);
 
-        // Provider config flows one way: only actual reactive property changes
+        // Provider inputs flow one way: only actual reactive property changes
         // write to the store. Store-side writers do not reflect back here.
-        const patch: Record<string, unknown> = {};
-        let hasConfigChange = false;
-
-        for (const key of config.configKeys) {
+        for (const key of providerKeys) {
           if (!changed.has(key)) continue;
-          patch[key] = (this as unknown as Record<string, unknown>)[key];
-          hasConfigChange = true;
+          setPlayerProviderValue(this.store, config.provider[key]!, (this as unknown as Record<string, unknown>)[key]);
         }
-
-        if (hasConfigChange) this.store.$config.set(patch);
       }
 
       #tryAttach(): void {
@@ -171,10 +174,9 @@ export function createProviderMixin<Store extends PlayerStore>(
         const store = this.store;
         if (this.#configuredStore === store) return;
 
-        const patch = Object.fromEntries(
-          config.configKeys.map((key) => [key, (this as unknown as Record<string, unknown>)[key]])
-        );
-        store.$config.set(patch);
+        for (const key of providerKeys) {
+          setPlayerProviderValue(store, config.provider[key]!, (this as unknown as Record<string, unknown>)[key]);
+        }
         this.#configuredStore = store;
       }
 

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -1,10 +1,10 @@
 import {
   createPopupGroup,
   type MediaContainer,
-  type PlayerProviderDefinition,
+  type PlayerConfigDefinition,
   type PlayerStore,
   type PlayerTarget,
-  setPlayerProviderValue,
+  setPlayerConfigValue,
 } from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
@@ -20,7 +20,7 @@ export interface ProviderMixinConfig<Store extends PlayerStore> {
   mediaContext: MediaContext;
   containerContext: ContainerContext;
   factory: () => Store;
-  provider: PlayerProviderDefinition;
+  config: PlayerConfigDefinition;
 }
 
 export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaElementConstructor>(
@@ -38,21 +38,21 @@ export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaEleme
  * As a fallback for plain `<video>`/`<audio>` that can't consume context,
  * the provider queries its subtree after a microtask.
  *
- * @param config - Provider configuration with contexts and store factory.
+ * @param options - Provider options with contexts, store factory, and feature configuration.
  */
 export function createProviderMixin<Store extends PlayerStore>(
-  config: ProviderMixinConfig<Store>
+  options: ProviderMixinConfig<Store>
 ): ProviderMixin<Store> {
-  const providerKeys = Object.keys(config.provider);
+  const configKeys = Object.keys(options.config);
 
   return <Class extends MediaElementConstructor>(BaseClass: Class) => {
     class PlayerProviderElement extends BaseClass {
       static properties = {
         ...(BaseClass as unknown as { properties: PropertyDeclarationMap }).properties,
-        ...Object.fromEntries(providerKeys.map((key) => [key, { type: String, attribute: kebabCase(key) }])),
+        ...Object.fromEntries(configKeys.map((key) => [key, { type: String, attribute: kebabCase(key) }])),
       };
 
-      #store: Store | null = config.factory();
+      #store: Store | null = options.factory();
       #configuredStore: Store | null = null;
       #detach: (() => void) | null = null;
       #media: Media | null = null;
@@ -79,17 +79,17 @@ export function createProviderMixin<Store extends PlayerStore>(
       };
 
       #playerProvider = new ContextProvider(this, {
-        context: config.playerContext,
+        context: options.playerContext,
         initialValue: this.store,
       });
 
       #mediaProvider = new ContextProvider(this, {
-        context: config.mediaContext,
+        context: options.mediaContext,
         initialValue: { media: this.#media, setMedia: this.#setMedia },
       });
 
       #containerProvider = new ContextProvider(this, {
-        context: config.containerContext,
+        context: options.containerContext,
         initialValue: {
           container: this.#container,
           setContainer: this.#setContainer,
@@ -99,7 +99,7 @@ export function createProviderMixin<Store extends PlayerStore>(
 
       get store(): Store {
         if (isNull(this.#store)) {
-          this.#store = config.factory();
+          this.#store = options.factory();
         }
 
         return this.#store;
@@ -134,11 +134,11 @@ export function createProviderMixin<Store extends PlayerStore>(
       protected override willUpdate(changed: PropertyValues): void {
         super.willUpdate(changed);
 
-        // Provider inputs flow one way: only actual reactive property changes
+        // Configuration flows one way: only actual reactive property changes
         // write to the store. Store-side writers do not reflect back here.
-        for (const key of providerKeys) {
+        for (const key of configKeys) {
           if (!changed.has(key)) continue;
-          setPlayerProviderValue(this.store, config.provider[key]!, (this as unknown as Record<string, unknown>)[key]);
+          setPlayerConfigValue(this.store, options.config[key]!, (this as unknown as Record<string, unknown>)[key]);
         }
       }
 
@@ -174,8 +174,8 @@ export function createProviderMixin<Store extends PlayerStore>(
         const store = this.store;
         if (this.#configuredStore === store) return;
 
-        for (const key of providerKeys) {
-          setPlayerProviderValue(store, config.provider[key]!, (this as unknown as Record<string, unknown>)[key]);
+        for (const key of configKeys) {
+          setPlayerConfigValue(store, options.config[key]!, (this as unknown as Record<string, unknown>)[key]);
         }
         this.#configuredStore = store;
       }

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -1,7 +1,7 @@
 import {
   createPopupGroup,
   type MediaContainer,
-  type PlayerConfigDefinition,
+  type PlayerFeatureConfig,
   type PlayerStore,
   type PlayerTarget,
   setPlayerConfigValue,
@@ -20,7 +20,7 @@ export interface ProviderMixinConfig<Store extends PlayerStore> {
   mediaContext: MediaContext;
   containerContext: ContainerContext;
   factory: () => Store;
-  config: PlayerConfigDefinition;
+  config: PlayerFeatureConfig;
 }
 
 export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaElementConstructor>(

--- a/packages/html/src/store/types.ts
+++ b/packages/html/src/store/types.ts
@@ -1,4 +1,4 @@
-import type { InferPlayerProviderConfig, PlayerStore } from '@videojs/core/dom';
+import type { InferPlayerConfig, PlayerStore } from '@videojs/core/dom';
 import type { Constructor } from '@videojs/utils/types';
 import type { MediaElement } from '@/ui/media-element';
 
@@ -7,7 +7,7 @@ import type { MediaElement } from '@/ui/media-element';
 // ----------------------------------------
 
 type ProviderProperties<Store extends PlayerStore> = {
-  -readonly [Key in keyof InferPlayerProviderConfig<Store>]?: InferPlayerProviderConfig<Store>[Key] | undefined;
+  -readonly [Key in keyof InferPlayerConfig<Store>]?: InferPlayerConfig<Store>[Key] | undefined;
 };
 
 export type PlayerProvider<Store extends PlayerStore> = MediaElement &

--- a/packages/html/src/store/types.ts
+++ b/packages/html/src/store/types.ts
@@ -1,5 +1,4 @@
-import type { PlayerStore } from '@videojs/core/dom';
-import type { ConfigPatch, InferStoreConfig } from '@videojs/store';
+import type { InferPlayerProviderConfig, PlayerStore } from '@videojs/core/dom';
 import type { Constructor } from '@videojs/utils/types';
 import type { MediaElement } from '@/ui/media-element';
 
@@ -7,8 +6,12 @@ import type { MediaElement } from '@/ui/media-element';
 // PlayerProvider
 // ----------------------------------------
 
+type ProviderProperties<Store extends PlayerStore> = {
+  -readonly [Key in keyof InferPlayerProviderConfig<Store>]?: InferPlayerProviderConfig<Store>[Key] | undefined;
+};
+
 export type PlayerProvider<Store extends PlayerStore> = MediaElement &
-  ConfigPatch<InferStoreConfig<Store>> & {
+  ProviderProperties<Store> & {
     readonly store: Store;
   };
 

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -5,13 +5,13 @@ import {
   type AnyPlayerStore,
   type AudioFeatures,
   type AudioPlayerStore,
-  combinePlayerProviderDefinitions,
+  combinePlayerConfigDefinitions,
   createPopupGroup,
-  type InferPlayerProviderConfig,
-  type PlayerProviderDefinition,
+  type InferPlayerConfig,
+  type PlayerConfigDefinition,
   type PlayerStore,
   type PlayerTarget,
-  setPlayerProviderValue,
+  setPlayerConfigValue,
   type VideoFeatures,
   type VideoPlayerStore,
 } from '@videojs/core/dom';
@@ -38,7 +38,7 @@ export type ProviderProps<Config = object> = {
 };
 
 export interface CreatePlayerResult<Store extends PlayerStore> {
-  Provider: FC<ProviderProps<InferPlayerProviderConfig<Store>>>;
+  Provider: FC<ProviderProps<InferPlayerConfig<Store>>>;
   Container: typeof Container;
   usePlayer: UsePlayerHook<Store>;
   useMedia: () => Media | null;
@@ -77,43 +77,43 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
   const slice = combine(...config.features);
-  const provider = combinePlayerProviderDefinitions(config.features);
-  const providerKeys = Object.keys(provider);
+  const configDefinition = combinePlayerConfigDefinitions(config.features);
+  const configKeys = Object.keys(configDefinition);
 
   function createConfiguredStore(values: Record<string, unknown>) {
     const store = createStore<PlayerTarget>()(slice);
-    applyProviderValues(store, provider, values);
+    applyConfigValues(store, configDefinition, values);
     return store;
   }
 
   function Provider(props: ProviderProps<any>): ReactNode {
     const { children } = props;
     // Only inputs declared by selected features are forwarded to store actions.
-    const providerValues = pickProviderValues(props, providerKeys);
-    const [store, setStore] = useState(() => createConfiguredStore(providerValues));
-    const syncedValues = useRef({ store, values: providerValues });
+    const configValues = pickConfigValues(props, configKeys);
+    const [store, setStore] = useState(() => createConfiguredStore(configValues));
+    const syncedValues = useRef({ store, values: configValues });
     const [popupGroup] = useState(() => createPopupGroup());
     const [media, setMedia] = useState<Media | null>(null);
     const [container, setContainer] = useState<HTMLElement | null>(null);
 
     useDestroy(store);
 
-    // Sync committed provider props to the existing store.
+    // Sync committed configuration props to the existing store.
     useLayoutEffect(() => {
       const previous = syncedValues.current;
 
       // Replacement stores are seeded from this render's props during creation.
       if (previous.store !== store) {
-        syncedValues.current = { store, values: providerValues };
+        syncedValues.current = { store, values: configValues };
         return;
       }
 
-      for (const key of providerKeys) {
-        if (Object.is(previous.values[key], providerValues[key])) continue;
-        setPlayerProviderValue(store, provider[key]!, providerValues[key]);
+      for (const key of configKeys) {
+        if (Object.is(previous.values[key], configValues[key])) continue;
+        setPlayerConfigValue(store, configDefinition[key]!, configValues[key]);
       }
 
-      syncedValues.current = { store, values: providerValues };
+      syncedValues.current = { store, values: configValues };
     });
 
     useEffect(() => {
@@ -155,12 +155,12 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
   };
 }
 
-function pickProviderValues(props: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
+function pickConfigValues(props: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
   return Object.fromEntries(keys.map((key) => [key, props[key]]));
 }
 
-function applyProviderValues(store: object, provider: PlayerProviderDefinition, values: Record<string, unknown>): void {
-  for (const key of Object.keys(provider)) {
-    setPlayerProviderValue(store, provider[key]!, values[key]);
+function applyConfigValues(store: object, definition: PlayerConfigDefinition, values: Record<string, unknown>): void {
+  for (const key of Object.keys(definition)) {
+    setPlayerConfigValue(store, definition[key]!, values[key]);
   }
 }

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -5,10 +5,10 @@ import {
   type AnyPlayerStore,
   type AudioFeatures,
   type AudioPlayerStore,
-  combinePlayerConfigDefinitions,
+  combinePlayerFeatureConfigs,
   createPopupGroup,
   type InferPlayerConfig,
-  type PlayerConfigDefinition,
+  type PlayerFeatureConfig,
   type PlayerStore,
   type PlayerTarget,
   setPlayerConfigValue,
@@ -77,12 +77,12 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
   const slice = combine(...config.features);
-  const configDefinition = combinePlayerConfigDefinitions(config.features);
-  const configKeys = Object.keys(configDefinition);
+  const featureConfig = combinePlayerFeatureConfigs(config.features);
+  const configKeys = Object.keys(featureConfig);
 
   function createConfiguredStore(values: Record<string, unknown>) {
     const store = createStore<PlayerTarget>()(slice);
-    applyConfigValues(store, configDefinition, values);
+    applyConfigValues(store, featureConfig, values);
     return store;
   }
 
@@ -110,7 +110,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
       for (const key of configKeys) {
         if (Object.is(previous.values[key], configValues[key])) continue;
-        setPlayerConfigValue(store, configDefinition[key]!, configValues[key]);
+        setPlayerConfigValue(store, featureConfig[key]!, configValues[key]);
       }
 
       syncedValues.current = { store, values: configValues };
@@ -159,8 +159,8 @@ function pickConfigValues(props: Record<string, unknown>, keys: readonly string[
   return Object.fromEntries(keys.map((key) => [key, props[key]]));
 }
 
-function applyConfigValues(store: object, definition: PlayerConfigDefinition, values: Record<string, unknown>): void {
-  for (const key of Object.keys(definition)) {
-    setPlayerConfigValue(store, definition[key]!, values[key]);
+function applyConfigValues(store: object, config: PlayerFeatureConfig, values: Record<string, unknown>): void {
+  for (const key of Object.keys(config)) {
+    setPlayerConfigValue(store, config[key]!, values[key]);
   }
 }

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -5,14 +5,18 @@ import {
   type AnyPlayerStore,
   type AudioFeatures,
   type AudioPlayerStore,
+  combinePlayerProviderDefinitions,
   createPopupGroup,
+  type InferPlayerProviderConfig,
+  type PlayerProviderDefinition,
   type PlayerStore,
   type PlayerTarget,
+  setPlayerProviderValue,
   type VideoFeatures,
   type VideoPlayerStore,
 } from '@videojs/core/dom';
 import type { Media } from '@videojs/media/dom';
-import type { ConfigPatch, InferStoreConfig, InferStoreState } from '@videojs/store';
+import type { InferStoreState } from '@videojs/store';
 import { combine, createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import type { FC, ReactNode } from 'react';
@@ -27,12 +31,14 @@ export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
   displayName?: string;
 }
 
-export type ProviderProps<Config = object> = ConfigPatch<Config> & {
+export type ProviderProps<Config = object> = {
+  [Key in keyof Config]?: Config[Key] | undefined;
+} & {
   children: ReactNode;
 };
 
 export interface CreatePlayerResult<Store extends PlayerStore> {
-  Provider: FC<ProviderProps<InferStoreConfig<Store>>>;
+  Provider: FC<ProviderProps<InferPlayerProviderConfig<Store>>>;
   Container: typeof Container;
   usePlayer: UsePlayerHook<Store>;
   useMedia: () => Media | null;
@@ -71,14 +77,21 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
   const slice = combine(...config.features);
-  const configKeys = Object.keys(slice.config ?? {});
+  const provider = combinePlayerProviderDefinitions(config.features);
+  const providerKeys = Object.keys(provider);
+
+  function createConfiguredStore(values: Record<string, unknown>) {
+    const store = createStore<PlayerTarget>()(slice);
+    applyProviderValues(store, provider, values);
+    return store;
+  }
 
   function Provider(props: ProviderProps<any>): ReactNode {
     const { children } = props;
-    // Only config declared by selected features belongs in the store.
-    const providerConfig = pickFeatureConfig(props, configKeys);
-    const [store, setStore] = useState(() => createStore<PlayerTarget>()(slice, { config: providerConfig }));
-    const syncedConfig = useRef({ store, values: providerConfig });
+    // Only inputs declared by selected features are forwarded to store actions.
+    const providerValues = pickProviderValues(props, providerKeys);
+    const [store, setStore] = useState(() => createConfiguredStore(providerValues));
+    const syncedValues = useRef({ store, values: providerValues });
     const [popupGroup] = useState(() => createPopupGroup());
     const [media, setMedia] = useState<Media | null>(null);
     const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -87,25 +100,20 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
     // Sync committed provider props to the existing store.
     useLayoutEffect(() => {
-      const previous = syncedConfig.current;
+      const previous = syncedValues.current;
 
       // Replacement stores are seeded from this render's props during creation.
       if (previous.store !== store) {
-        syncedConfig.current = { store, values: providerConfig };
+        syncedValues.current = { store, values: providerValues };
         return;
       }
 
-      const patch: Record<string, unknown> = {};
-      let changed = false;
-
-      for (const key of configKeys) {
-        if (Object.is(previous.values[key], providerConfig[key])) continue;
-        patch[key] = providerConfig[key];
-        changed = true;
+      for (const key of providerKeys) {
+        if (Object.is(previous.values[key], providerValues[key])) continue;
+        setPlayerProviderValue(store, provider[key]!, providerValues[key]);
       }
 
-      if (changed) store.$config.set(patch);
-      syncedConfig.current = { store, values: providerConfig };
+      syncedValues.current = { store, values: providerValues };
     });
 
     useEffect(() => {
@@ -115,7 +123,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
       // effect cleanup and re-setup (e.g., React <Activity> hide → reveal). The
       // useState initializer does not re-run in this case.
       if (store.destroyed) {
-        setStore(createStore<PlayerTarget>()(slice, { config: syncedConfig.current.values }));
+        setStore(createConfiguredStore(syncedValues.current.values));
         return;
       }
 
@@ -147,6 +155,12 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
   };
 }
 
-function pickFeatureConfig(props: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
+function pickProviderValues(props: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
   return Object.fromEntries(keys.map((key) => [key, props[key]]));
+}
+
+function applyProviderValues(store: object, provider: PlayerProviderDefinition, values: Record<string, unknown>): void {
+  for (const key of Object.keys(provider)) {
+    setPlayerProviderValue(store, provider[key]!, values[key]);
+  }
 }

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -47,7 +47,7 @@ describe('createPlayer', () => {
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
   });
 
-  it('infers provider config from selected features', () => {
+  it('infers config props from selected features', () => {
     const withMetadata = createPlayer({ features: [metadataFeature] });
     const withoutMetadata = createPlayer({ features: [features.playback] });
 

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -113,7 +113,7 @@ describe('createPlayer', () => {
       expect(store).not.toBe(originalStore);
     });
 
-    it('seeds current config when replacing a destroyed store', () => {
+    it('seeds current provider inputs when replacing a destroyed store', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
       let setMedia!: (media: HTMLMediaElement | null) => void;
@@ -220,7 +220,7 @@ describe('createPlayer', () => {
       expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
     });
 
-    it('seeds config for the first render and syncs only changed props after commit', () => {
+    it('seeds provider inputs for the first render and syncs only changed props after commit', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
 
@@ -244,8 +244,6 @@ describe('createPlayer', () => {
         </Provider>
       );
 
-      expect(store.$config.get().defaultContentTitle).toBe('Imperative fallback');
-
       rerender(
         <Provider contentTitle="Updated title">
           <Consumer />
@@ -261,7 +259,7 @@ describe('createPlayer', () => {
       expect(store.contentTitle).toBe('Imperative fallback');
     });
 
-    it('seeds provider config during SSR', () => {
+    it('seeds provider inputs during SSR', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
@@ -277,7 +275,7 @@ describe('createPlayer', () => {
       ).toContain('SSR title');
     });
 
-    it('hydrates with the same initial provider config', async () => {
+    it('hydrates with the same initial provider inputs', async () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
@@ -305,7 +303,7 @@ describe('createPlayer', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    it('does not apply config from an abandoned render', () => {
+    it('does not apply provider inputs from an abandoned render', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
 
@@ -347,7 +345,7 @@ describe('createPlayer', () => {
         </Boundary>
       );
 
-      expect(committedStore.$config.get().contentTitle).toBe('Committed title');
+      expect(committedStore.contentTitle).toBe('Committed title');
       consoleError.mockRestore();
     });
 

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -113,7 +113,7 @@ describe('createPlayer', () => {
       expect(store).not.toBe(originalStore);
     });
 
-    it('seeds current provider inputs when replacing a destroyed store', () => {
+    it('seeds current config inputs when replacing a destroyed store', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
       let setMedia!: (media: HTMLMediaElement | null) => void;
@@ -220,7 +220,7 @@ describe('createPlayer', () => {
       expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
     });
 
-    it('seeds provider inputs for the first render and syncs only changed props after commit', () => {
+    it('seeds config inputs for the first render and syncs only changed props after commit', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
 
@@ -259,7 +259,7 @@ describe('createPlayer', () => {
       expect(store.contentTitle).toBe('Imperative fallback');
     });
 
-    it('seeds provider inputs during SSR', () => {
+    it('seeds config inputs during SSR', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
@@ -275,7 +275,7 @@ describe('createPlayer', () => {
       ).toContain('SSR title');
     });
 
-    it('hydrates with the same initial provider inputs', async () => {
+    it('hydrates with the same initial config inputs', async () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
@@ -303,7 +303,7 @@ describe('createPlayer', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    it('does not apply provider inputs from an abandoned render', () => {
+    it('does not apply config inputs from an abandoned render', () => {
       const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
 

--- a/packages/store/src/core/combine.ts
+++ b/packages/store/src/core/combine.ts
@@ -44,7 +44,7 @@ export function combine<const Slices extends readonly AnySlice[]>(
       return Object.assign({}, ...states) as SourceState;
     },
 
-    preserveOnDetach: Array.from(new Set(slices.flatMap((slice) => slice.preserveOnDetach ?? []))),
+    preserve: Array.from(new Set(slices.flatMap((slice) => slice.preserve ?? []))),
 
     derived: Object.assign({}, ...derivedDefinitions) as any,
 

--- a/packages/store/src/core/combine.ts
+++ b/packages/store/src/core/combine.ts
@@ -6,7 +6,6 @@ import type {
   InferSliceTarget,
   Slice,
   StateContext,
-  UnionSliceConfig,
   UnionSliceDerivedState,
   UnionSliceSourceState,
 } from './slice';
@@ -23,28 +22,18 @@ type CombinedTarget<Slices extends readonly AnySlice[]> = Slices extends readonl
  */
 export function combine<const Slices extends readonly AnySlice[]>(
   ...slices: Slices
-): Slice<
-  CombinedTarget<Slices>,
-  UnionSliceSourceState<Slices>,
-  UnionSliceConfig<Slices>,
-  UnionSliceDerivedState<Slices>
-> {
+): Slice<CombinedTarget<Slices>, UnionSliceSourceState<Slices>, UnionSliceDerivedState<Slices>> {
   type SourceState = UnionSliceSourceState<Slices>;
-  type Config = UnionSliceConfig<Slices>;
   type Target = CombinedTarget<Slices>;
 
-  const configs = slices.map((slice) => slice.config ?? {});
   const derivedDefinitions = slices.map((slice) => slice.derived ?? {});
 
   if (__DEV__) {
-    warnDuplicates('config', configs);
     warnDuplicates('derived', derivedDefinitions);
   }
 
   return {
-    config: Object.assign({}, ...configs) as Config,
-
-    state: (ctx: StateContext<Target, Config>) => {
+    state: (ctx: StateContext<Target>) => {
       const states = slices.map((slice) => slice.state(ctx));
 
       if (__DEV__) {
@@ -54,6 +43,8 @@ export function combine<const Slices extends readonly AnySlice[]>(
 
       return Object.assign({}, ...states) as SourceState;
     },
+
+    preserveOnDetach: Array.from(new Set(slices.flatMap((slice) => slice.preserveOnDetach ?? []))),
 
     derived: Object.assign({}, ...derivedDefinitions) as any,
 

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -6,10 +6,6 @@ import type { AnySlice, InferSliceState, StateContext } from './slice';
 
 const stateContext: StateContext<unknown> = {
   target: throwNoTargetError,
-  config: {
-    get: throwNoTargetError,
-    set: throwNoTargetError,
-  },
   signals: new AbortControllerRegistry(),
   get: throwNoTargetError,
   set: throwNoTargetError,

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -70,7 +70,7 @@ export interface SliceConfig<Target, State, Derived = object> {
   name?: string;
   state: (ctx: StateContext<Target>) => State;
   /** Source-state keys whose current values survive detach. */
-  preserveOnDetach?: readonly PropertyKey[];
+  preserve?: readonly PropertyKey[];
   /** Formulas evaluated from slice state before publication. */
   derived?: DerivedDefinition<State, Derived>;
   attach?: (ctx: AttachContext<Target, State>) => void;

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -109,7 +109,8 @@ export function defineSlice<Target>(): SliceFactory<Target> {
 
 export type InferSliceTarget<S> = S extends Slice<infer Target, any, any> ? Target : never;
 
-export type InferSliceSourceState<S> = S extends Slice<any, infer State, any> ? State : never;
+/** Infer from the state factory so intersections with feature metadata preserve exact source state. */
+export type InferSliceSourceState<S> = S extends { state: (...args: any[]) => infer State } ? State : never;
 
 export type InferSliceDerivedState<S> = S extends Slice<any, any, infer Derived> ? Derived : never;
 

--- a/packages/store/src/core/slice.ts
+++ b/packages/store/src/core/slice.ts
@@ -3,21 +3,6 @@ import type { AbortControllerRegistry } from './abort-controller-registry';
 import type { UnknownState } from './state';
 
 // ----------------------------------------
-// Config
-// ----------------------------------------
-
-/** A shallow config update. Explicit `undefined` restores a key's declared initial value. */
-export type ConfigPatch<Config> = {
-  [Key in keyof Config]?: Config[Key] | undefined;
-};
-
-/** Read and patch the provider-lifetime configuration declared by selected slices. */
-export interface ConfigController<Config> {
-  get: () => Readonly<Config>;
-  set: (partial: ConfigPatch<Config>) => void;
-}
-
-// ----------------------------------------
 // Attach
 // ----------------------------------------
 
@@ -41,11 +26,9 @@ export interface AttachContext<Target, State> {
 // State Context
 // ----------------------------------------
 
-export interface StateContext<Target, Config = object> {
+export interface StateContext<Target> {
   /** Returns the current target. Throws if not attached. */
   target: () => Target;
-  /** User-defined, provider-lifetime configuration. */
-  config: ConfigController<Config>;
   /**
    * Cancellation signals for async operations.
    *
@@ -68,78 +51,72 @@ export interface StateContext<Target, Config = object> {
 // ----------------------------------------
 
 /** Read-only inputs available while an eager derived formula is evaluated. */
-export interface DerivedContext<State, Config> {
+export interface DerivedContext<State> {
   /** Returns the immutable slice state before derived values. */
   get: () => Readonly<State>;
-  /** Read-only access to the immutable provider configuration snapshot. */
-  config: Pick<ConfigController<Config>, 'get'>;
 }
 
 /** Formula map used to produce public derived state. */
-export type DerivedDefinition<State, Config, Derived> = {
-  [Key in keyof Derived]: (ctx: DerivedContext<State, Config>) => Derived[Key];
+export type DerivedDefinition<State, Derived> = {
+  [Key in keyof Derived]: (ctx: DerivedContext<State>) => Derived[Key];
 };
 
 // ----------------------------------------
 // Slice
 // ----------------------------------------
 
-export interface SliceConfig<Target, State, Config = object, Derived = object> {
+export interface SliceConfig<Target, State, Derived = object> {
   /** Debug label. Used as `displayName` on selectors created from this slice. */
   name?: string;
-  /** Initial provider-lifetime configuration. */
-  config?: Config;
-  state: (ctx: StateContext<Target, Config>) => State;
-  /** Formulas evaluated from slice state and provider config before publication. */
-  derived?: DerivedDefinition<State, Config, Derived>;
+  state: (ctx: StateContext<Target>) => State;
+  /** Source-state keys whose current values survive detach. */
+  preserveOnDetach?: readonly PropertyKey[];
+  /** Formulas evaluated from slice state before publication. */
+  derived?: DerivedDefinition<State, Derived>;
   attach?: (ctx: AttachContext<Target, State>) => void;
 }
 
-export type Slice<Target, State, Config = object, Derived = object> = SliceConfig<Target, State, Config, Derived>;
+export type Slice<Target, State, Derived = object> = SliceConfig<Target, State, Derived>;
 
-export type AnySlice<Target = any> = Slice<Target, any, any, object>;
+export type AnySlice<Target = any> = Slice<Target, any, object>;
 
 // ----------------------------------------
 // Factory
 // ----------------------------------------
 
-type DerivedFunctions<State, Config> = Record<string, (ctx: DerivedContext<State, Config>) => unknown>;
+type DerivedFunctions<State> = Record<string, (ctx: DerivedContext<State>) => unknown>;
 
 type DerivedValues<Definitions extends Record<string, (...args: any[]) => unknown>> = {
   [Key in keyof Definitions]: ReturnType<Definitions[Key]>;
 };
 
-export interface SliceFactory<Target, Config = object> {
-  <State, const Definitions extends DerivedFunctions<State, Config>>(
-    config: Omit<SliceConfig<Target, State, Config, DerivedValues<Definitions>>, 'derived'> & {
+export interface SliceFactory<Target> {
+  <State, const Definitions extends DerivedFunctions<State>>(
+    config: Omit<SliceConfig<Target, State, DerivedValues<Definitions>>, 'derived'> & {
       derived: Definitions;
     }
-  ): Slice<Target, State, Config, DerivedValues<Definitions>>;
-  <State>(
-    config: Omit<SliceConfig<Target, State, Config>, 'derived'> & { derived?: never }
-  ): Slice<Target, State, Config>;
+  ): Slice<Target, State, DerivedValues<Definitions>>;
+  <State>(config: Omit<SliceConfig<Target, State>, 'derived'> & { derived?: never }): Slice<Target, State>;
 }
 
-export function defineSlice<Target, Config = object>(): SliceFactory<Target, Config> {
-  return ((config: SliceConfig<Target, unknown, Config, unknown>) => config) as SliceFactory<Target, Config>;
+export function defineSlice<Target>(): SliceFactory<Target> {
+  return ((config: SliceConfig<Target, unknown, unknown>) => config) as SliceFactory<Target>;
 }
 
 // ----------------------------------------
 // Inference
 // ----------------------------------------
 
-export type InferSliceTarget<S> = S extends Slice<infer Target, any, any, any> ? Target : never;
+export type InferSliceTarget<S> = S extends Slice<infer Target, any, any> ? Target : never;
 
-export type InferSliceSourceState<S> = S extends Slice<any, infer State, any, any> ? State : never;
+export type InferSliceSourceState<S> = S extends Slice<any, infer State, any> ? State : never;
 
-export type InferSliceConfig<S> = S extends Slice<any, any, infer Config, any> ? Config : never;
-
-export type InferSliceDerivedState<S> = S extends Slice<any, any, any, infer Derived> ? Derived : never;
+export type InferSliceDerivedState<S> = S extends Slice<any, any, infer Derived> ? Derived : never;
 
 export type PublicSourceState<State> = Pick<State, Extract<keyof State, string>>;
 
 export type InferSliceState<S> =
-  S extends Slice<any, infer State, any, infer Derived> ? Simplify<PublicSourceState<State> & Derived> : never;
+  S extends Slice<any, infer State, infer Derived> ? Simplify<PublicSourceState<State> & Derived> : never;
 
 type IntersectSlices<Slices extends readonly AnySlice[], Value> = Slices extends readonly []
   ? object
@@ -148,11 +125,6 @@ type IntersectSlices<Slices extends readonly AnySlice[], Value> = Slices extends
 export type UnionSliceSourceState<Slices extends readonly AnySlice[]> = IntersectSlices<
   Slices,
   InferSliceSourceState<Slices[number]>
->;
-
-export type UnionSliceConfig<Slices extends readonly AnySlice[]> = IntersectSlices<
-  Slices,
-  InferSliceConfig<Slices[number]>
 >;
 
 export type UnionSliceDerivedState<Slices extends readonly AnySlice[]> = IntersectSlices<

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -203,7 +203,7 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
       target = null;
 
       const resetState = { ...initialSourceState } as SourceState;
-      for (const key of slice.preserveOnDetach ?? []) {
+      for (const key of slice.preserve ?? []) {
         (resetState as Record<PropertyKey, unknown>)[key] = (sourceState as Record<PropertyKey, unknown>)[key];
       }
       setSource(resetState);

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -96,7 +96,7 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
     }
 
     // Private symbol-backed source actions remain available to feature-owned
-    // provider adapters without becoming part of the public state snapshot.
+    // configuration adapters without becoming part of the public state snapshot.
     for (const key of Object.getOwnPropertySymbols(sourceState as object)) {
       if (typeof sourceState[key as keyof SourceState] !== 'function') continue;
       Object.defineProperty(store, key, {

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -5,9 +5,6 @@ import { throwDestroyedError, throwNoTargetError } from './errors';
 import type {
   AnySlice,
   AttachContext,
-  ConfigController,
-  ConfigPatch,
-  InferSliceConfig,
   InferSliceDerivedState,
   InferSliceSourceState,
   InferSliceState,
@@ -19,29 +16,25 @@ import { createState } from './state';
 const STORE_SYMBOL = Symbol.for('@videojs/store');
 const hasOwnProp = Object.prototype.hasOwnProperty;
 
-export interface StoreOptions<Target, State, Config = object> extends StoreCallbacks<Target, State> {
-  /** Initial provider configuration overlaid on the slice-declared defaults. */
-  config?: ConfigPatch<Config>;
-}
+export interface StoreOptions<Target, State> extends StoreCallbacks<Target, State> {}
 
 export interface StoreFactory<Target> {
   <S extends AnySlice<Target>>(
     slice: S,
-    options?: StoreOptions<Target, InferSliceState<S>, InferSliceConfig<S>>
-  ): Store<Target, InferSliceState<S>, InferSliceConfig<S>>;
+    options?: StoreOptions<Target, InferSliceState<S>>
+  ): Store<Target, InferSliceState<S>>;
   <State>(slice: import('./slice').Slice<Target, State>, options?: StoreOptions<Target, State>): Store<Target, State>;
 }
 
 export function createStore<Target = unknown>(): StoreFactory<Target> {
   return (<S extends AnySlice<Target>>(
     slice: S,
-    options: StoreOptions<Target, InferSliceState<S>, InferSliceConfig<S>> = {}
-  ): Store<Target, InferSliceState<S>, InferSliceConfig<S>> => {
+    options: StoreOptions<Target, InferSliceState<S>> = {}
+  ): Store<Target, InferSliceState<S>> => {
     type SourceState = InferSliceSourceState<S>;
     type DerivedState = InferSliceDerivedState<S>;
     type PublicState = InferSliceState<S>;
-    type Config = InferSliceConfig<S>;
-    type TargetStore = Store<Target, PublicState, Config>;
+    type TargetStore = Store<Target, PublicState>;
 
     // Closure state
     let target: Target | null = null;
@@ -50,8 +43,6 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
     const setupAbort = new AbortController();
     const signals = new AbortControllerRegistry();
 
-    const initialConfig = freezeCopy((slice.config ?? {}) as Config);
-    let configState = patchConfig(initialConfig, initialConfig, options.config)?.next ?? initialConfig;
     let sourceState: Readonly<SourceState>;
 
     // Reactive public state - initialized after building slice source state.
@@ -62,35 +53,26 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
       if (!target) throwNoTargetError();
     }
 
-    const configController: ConfigController<Config> = {
-      get: () => configState,
-      set: setConfig,
-    };
-
     const initialSourceState = freezeCopy(
       slice.state({
         target: () => {
           validate();
           return target!;
         },
-        config: configController,
         signals,
         get: () => sourceState as Readonly<Record<PropertyKey, unknown>>,
         set: (partial) => setSource(partial as Partial<SourceState>),
-      } satisfies StateContext<Target, Config>)
+      } satisfies StateContext<Target>)
     );
 
     sourceState = initialSourceState;
-    const initialDerivedState = derive(sourceState, configState);
+    const initialDerivedState = derive(sourceState);
     state = createState(publish(sourceState, initialDerivedState));
 
     const store = {
       [STORE_SYMBOL]: true,
       get $state() {
         return state;
-      },
-      get $config() {
-        return configController;
       },
       get target() {
         return target;
@@ -113,6 +95,15 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
       });
     }
 
+    // Private symbol-backed source actions remain available to feature-owned
+    // provider adapters without becoming part of the public state snapshot.
+    for (const key of Object.getOwnPropertySymbols(sourceState as object)) {
+      if (typeof sourceState[key as keyof SourceState] !== 'function') continue;
+      Object.defineProperty(store, key, {
+        get: () => sourceState[key as keyof SourceState],
+      });
+    }
+
     try {
       options.onSetup?.({ store, signal: setupAbort.signal });
     } catch (error) {
@@ -121,20 +112,14 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
 
     return store;
 
-    function derive(source: Readonly<SourceState>, config: Readonly<Config>): DerivedState {
+    function derive(source: Readonly<SourceState>): DerivedState {
       const result: Record<string, unknown> = {};
       const definitions = slice.derived as
-        | Record<
-            string,
-            (ctx: { get: () => Readonly<SourceState>; config: { get: () => Readonly<Config> } }) => unknown
-          >
+        | Record<string, (ctx: { get: () => Readonly<SourceState> }) => unknown>
         | undefined;
       if (!definitions) return result as DerivedState;
 
-      const ctx = {
-        get: () => source,
-        config: { get: () => config },
-      };
+      const ctx = { get: () => source };
 
       for (const key of Object.keys(definitions)) {
         result[key] = definitions[key]!(ctx);
@@ -159,18 +144,8 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
       if (!patched) return;
 
       // Derive before committing so a thrown formula leaves every snapshot unchanged.
-      const nextDerived = derive(patched.next, configState);
+      const nextDerived = derive(patched.next);
       sourceState = patched.next;
-      state.replace(publish(sourceState, nextDerived));
-    }
-
-    function setConfig(partial: ConfigPatch<Config>): void {
-      const patched = patchConfig(configState, initialConfig, partial);
-      if (!patched) return;
-
-      // Derive before committing so a thrown formula leaves every snapshot unchanged.
-      const nextDerived = derive(sourceState, patched.next);
-      configState = patched.next;
       state.replace(publish(sourceState, nextDerived));
     }
 
@@ -226,7 +201,12 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
       if (isNull(target)) return;
       signals.reset();
       target = null;
-      setSource(initialSourceState as SourceState);
+
+      const resetState = { ...initialSourceState } as SourceState;
+      for (const key of slice.preserveOnDetach ?? []) {
+        (resetState as Record<PropertyKey, unknown>)[key] = (sourceState as Record<PropertyKey, unknown>)[key];
+      }
+      setSource(resetState);
     }
 
     function destroy(): void {
@@ -269,28 +249,6 @@ function patchSource<State>(current: Readonly<State>, partial: Partial<State>): 
   return changed ? { next: Object.freeze(next) } : null;
 }
 
-function patchConfig<Config>(
-  current: Readonly<Config>,
-  initial: Readonly<Config>,
-  partial: ConfigPatch<Config> | undefined
-): { next: Readonly<Config> } | null {
-  if (!partial) return null;
-
-  const next = { ...current } as Config;
-  let changed = false;
-
-  for (const key of Reflect.ownKeys(partial as object) as (keyof Config)[]) {
-    if (!hasOwnProp.call(partial, key)) continue;
-    const supplied = partial[key];
-    const value = supplied === undefined ? initial[key] : supplied;
-    if (Object.is(current[key], value)) continue;
-    (next as { -readonly [Key in keyof Config]: Config[Key] })[key] = value as Config[keyof Config];
-    changed = true;
-  }
-
-  return changed ? { next: Object.freeze(next) } : null;
-}
-
 export function isStore(value: unknown): value is AnyStore {
   return isObject(value) && STORE_SYMBOL in value;
 }
@@ -299,14 +257,9 @@ export function isStore(value: unknown): value is AnyStore {
 // Types
 // ----------------------------------------
 
-export interface BaseStore<Target = unknown, State = UnknownState, Config = object> {
+export interface BaseStore<Target = unknown, State = UnknownState> {
   [key: string]: unknown;
   readonly $state: StateContainer<State>;
-  /**
-   * Low-level provider adapter infrastructure for reading and patching declared
-   * feature config. Consumers should prefer feature-authored state actions.
-   */
-  readonly $config: ConfigController<Config>;
   readonly target: Target | null;
   readonly destroyed: boolean;
   readonly state: State;
@@ -315,14 +268,12 @@ export interface BaseStore<Target = unknown, State = UnknownState, Config = obje
   subscribe(callback: StateChange, options?: SubscribeOptions): () => void;
 }
 
-export type Store<Target = unknown, State = UnknownState, Config = object> = BaseStore<Target, State, Config> & State;
+export type Store<Target = unknown, State = UnknownState> = BaseStore<Target, State> & State;
 
-export type AnyStore<Target = any> = BaseStore<Target, object, any>;
+export type AnyStore<Target = any> = BaseStore<Target, object>;
 
 export type UnknownStore<Target = unknown> = Store<Target, UnknownState>;
 
 export type InferStoreTarget<S extends AnyStore> = S extends { readonly target: infer Target | null } ? Target : never;
 
 export type InferStoreState<S extends AnyStore> = S extends { readonly state: infer State } ? State : never;
-
-export type InferStoreConfig<S extends AnyStore> = S['$config'] extends ConfigController<infer Config> ? Config : never;

--- a/packages/store/src/core/tests/combine.test.ts
+++ b/packages/store/src/core/tests/combine.test.ts
@@ -77,7 +77,7 @@ describe('combine', () => {
 
   it('combines keys preserved on detach', () => {
     const a = slice({
-      preserveOnDetach: ['label'],
+      preserve: ['label'],
       state: ({ set }) => ({ label: 'initial', setLabel: (label: string) => set({ label }) }),
     });
     const b = slice({ state: ({ set }) => ({ count: 0, setCount: (count: number) => set({ count }) }) });

--- a/packages/store/src/core/tests/combine.test.ts
+++ b/packages/store/src/core/tests/combine.test.ts
@@ -75,17 +75,21 @@ describe('combine', () => {
     warn.mockRestore();
   });
 
-  it('warns on duplicate config keys and uses the later initial value', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const configuredSlice = defineSlice<MockTarget, { label: string }>();
-    const a = configuredSlice({ config: { label: 'first' }, state: () => ({}) });
-    const b = configuredSlice({ config: { label: 'second' }, state: () => ({}) });
-
+  it('combines keys preserved on detach', () => {
+    const a = slice({
+      preserveOnDetach: ['label'],
+      state: ({ set }) => ({ label: 'initial', setLabel: (label: string) => set({ label }) }),
+    });
+    const b = slice({ state: ({ set }) => ({ count: 0, setCount: (count: number) => set({ count }) }) });
     const store = createStore<MockTarget>()(combine(a, b));
+    const detach = store.attach(new MockTarget());
 
-    expect(store.$config.get().label).toBe('second');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate config key "label"'));
-    warn.mockRestore();
+    store.setLabel('configured');
+    store.setCount(1);
+    detach();
+
+    expect(store.label).toBe('configured');
+    expect(store.count).toBe(0);
   });
 
   it('warns on state/derived overlap and publishes the derived value', () => {

--- a/packages/store/src/core/tests/store.test.ts
+++ b/packages/store/src/core/tests/store.test.ts
@@ -247,49 +247,57 @@ describe('store', () => {
     });
   });
 
-  describe('config and derived state', () => {
+  describe('persistent and derived state', () => {
     const INTERNAL_VALUE = Symbol('internalValue');
-
-    interface TestConfig {
-      value: string | null;
-      fallback: string;
-    }
+    const USER_VALUE = Symbol('userValue');
+    const SET_USER_VALUE = Symbol('setUserValue');
 
     interface TestSourceState {
       [INTERNAL_VALUE]: string | undefined;
+      [USER_VALUE]: string | null | undefined;
+      [SET_USER_VALUE](value: string | null | undefined): void;
       setInternal(value: string | undefined): void;
       setValue(value: string | null): void;
     }
 
-    const responsiveSlice = defineSlice<MockMedia, TestConfig>()({
-      config: { value: null, fallback: 'fallback' },
-      state: ({ config, set }): TestSourceState => ({
-        [INTERNAL_VALUE]: undefined,
-        setInternal: (value) => set({ [INTERNAL_VALUE]: value }),
-        setValue: (value) => config.set({ value }),
-      }),
+    const responsiveSlice = defineSlice<MockMedia>()({
+      preserveOnDetach: [USER_VALUE],
+      state: ({ set }): TestSourceState => {
+        const setUserValue = (value: string | null | undefined) => set({ [USER_VALUE]: value });
+
+        return {
+          [INTERNAL_VALUE]: undefined,
+          [USER_VALUE]: undefined,
+          [SET_USER_VALUE]: setUserValue,
+          setInternal: (value) => set({ [INTERNAL_VALUE]: value }),
+          setValue: setUserValue,
+        };
+      },
       derived: {
-        resolved: ({ config, get }) => config.get().value ?? get()[INTERNAL_VALUE] ?? config.get().fallback,
+        resolved: ({ get }) => get()[USER_VALUE] ?? get()[INTERNAL_VALUE] ?? 'fallback',
       },
     });
 
-    it('overlays initial config and resets explicit undefined to the declared initial value', () => {
-      const store = createStore<MockMedia>()(responsiveSlice, { config: { value: 'initial' } });
+    it('makes private symbol actions available without publishing their state', () => {
+      const store = createStore<MockMedia>()(responsiveSlice);
+      const setUserValue = (store as unknown as Record<PropertyKey, unknown>)[SET_USER_VALUE];
 
+      expect(setUserValue).toBeInstanceOf(Function);
+      expect(INTERNAL_VALUE in store).toBe(false);
+      expect(USER_VALUE in store).toBe(false);
+      expect(Object.getOwnPropertySymbols(store.state)).toEqual([]);
+
+      (setUserValue as (value: string | undefined) => void)('initial');
       expect(store.resolved).toBe('initial');
-      expect(store.$config.get()).toEqual({ value: 'initial', fallback: 'fallback' });
 
-      store.$config.set({ value: undefined });
-
+      (setUserValue as (value: string | undefined) => void)(undefined);
       expect(store.resolved).toBe('fallback');
-      expect(store.$config.get().value).toBeNull();
     });
 
     it('publishes source and derived changes atomically while keeping symbols internal', () => {
       const store = createStore<MockMedia>()(responsiveSlice);
 
       expect(Object.getOwnPropertySymbols(store.state)).toEqual([]);
-      expect(Object.getOwnPropertySymbols(store)).toEqual([Symbol.for('@videojs/store')]);
 
       store.setInternal('media');
 
@@ -298,7 +306,9 @@ describe('store', () => {
     });
 
     it('keeps lower-precedence source state live without publishing an unchanged public snapshot', () => {
-      const store = createStore<MockMedia>()(responsiveSlice, { config: { value: 'user' } });
+      const store = createStore<MockMedia>()(responsiveSlice);
+      store.setValue('user');
+      flush();
       const listener = vi.fn();
       store.subscribe(listener);
       const publicSnapshot = store.state;
@@ -317,30 +327,31 @@ describe('store', () => {
       expect(listener).toHaveBeenCalledOnce();
     });
 
-    it('resets source state on detach while preserving config', () => {
-      const store = createStore<MockMedia>()(responsiveSlice, { config: { fallback: 'configured fallback' } });
+    it('resets attachment state on detach while preserving declared source keys', () => {
+      const store = createStore<MockMedia>()(responsiveSlice);
+      store.setValue('user');
       const detach = store.attach(new MockMedia());
 
       store.setInternal('media');
-      expect(store.resolved).toBe('media');
+      expect(store.resolved).toBe('user');
 
       detach();
 
-      expect(store.resolved).toBe('configured fallback');
-      expect(store.$config.get().fallback).toBe('configured fallback');
+      expect(store.resolved).toBe('user');
+
+      store.setValue(null);
+      expect(store.resolved).toBe('fallback');
     });
 
-    it('does not commit config when a derived formula throws', () => {
-      interface ThrowingConfig {
-        value: number;
-      }
-
-      const throwingSlice = defineSlice<MockMedia, ThrowingConfig>()({
-        config: { value: 1 },
-        state: () => ({}),
+    it('does not commit source state when a derived formula throws', () => {
+      const throwingSlice = defineSlice<MockMedia>()({
+        state: ({ set }) => ({
+          value: 1,
+          setValue: (value: number) => set({ value }),
+        }),
         derived: {
-          doubled: ({ config }) => {
-            const { value } = config.get();
+          doubled: ({ get }) => {
+            const { value } = get();
             if (value < 0) throw new Error('invalid value');
             return value * 2;
           },
@@ -350,11 +361,11 @@ describe('store', () => {
       const listener = vi.fn();
       store.subscribe(listener);
 
-      expect(() => store.$config.set({ value: -1 })).toThrow('invalid value');
+      expect(() => store.setValue(-1)).toThrow('invalid value');
       flush();
 
       expect(store.doubled).toBe(2);
-      expect(store.$config.get().value).toBe(1);
+      expect(store.state.value).toBe(1);
       expect(listener).not.toHaveBeenCalled();
     });
   });

--- a/packages/store/src/core/tests/store.test.ts
+++ b/packages/store/src/core/tests/store.test.ts
@@ -261,7 +261,7 @@ describe('store', () => {
     }
 
     const responsiveSlice = defineSlice<MockMedia>()({
-      preserveOnDetach: [USER_VALUE],
+      preserve: [USER_VALUE],
       state: ({ set }): TestSourceState => {
         const setUserValue = (value: string | null | undefined) => set({ [USER_VALUE]: value });
 


### PR DESCRIPTION
Refs #1946

> [!IMPORTANT]
> This is a stacked architecture POC targeting `codex/user-configured-feature`. It exists to compare this approach with #1946; it is not an independent replacement for the metadata feature.

## Why

[Wes and Rahim asked](https://mux.slack.com/archives/C096HT3S8F4/p1785959872164509) whether user-configured values could live in ordinary feature state and be updated through feature actions, avoiding a generic store `config` concept.

This branch makes that alternative concrete while preserving the hard lifecycle and rendering constraints from #1946: user values survive media detach, media values reset, React never mutates an existing external store during render, HTML inputs remain one-way, and provider props still depend on the selected features.

## Proposed shape

```ts
config: {
  contentTitle: {
    action: SET_USER_CONTENT_TITLE,
    preserve: USER_CONTENT_TITLE,
  },
},
state: ({ set }) => ({
  [USER_CONTENT_TITLE]: undefined,
  [SET_USER_CONTENT_TITLE]: (value) => set({ [USER_CONTENT_TITLE]: value }),
}),
derived: {
  contentTitle: ({ get }) =>
    get()[USER_CONTENT_TITLE] ??
    get()[MEDIA_CONTENT_TITLE] ??
    get()[USER_DEFAULT_CONTENT_TITLE] ??
    DEFAULT_CONTENT_TITLE,
},
```

The feature-level `config` object is a `PlayerFeatureConfig` routing map, not a second value store. Each entry says which private action receives an external input and which user-owned source-state key is preserved across detach.

The player adapters merge the selected features' `config` maps and route each prop or property update through its private action. `definePlayerFeature` derives the combined slice's `preserve` list from those entries. The generic store knows only which source keys survive detach; it does not know about providers, config, or metadata.

Generic eager `derived` state remains. Removing it would make each mutation site and detach responsible for synchronizing resolved public values.

## Preserved behavior

- `user override ?? media value ?? user fallback ?? feature fallback` precedence
- hidden lower-priority values continue updating
- user-configured and imperative user values survive detach; media-owned values reset
- prop removal forwards a nullish value and reveals the next precedence tier
- React first render, SSR, hydration, destroyed-store replacement, and abandoned-render safety
- HTML kebab-cased attributes and one-way property flow
- feature-selected React and HTML TypeScript inputs

## Tradeoffs exposed by this PR

- Each configurable input needs both a private source key and a private action.
- When several config props change together, their actions update the store one at a time and derived state runs after each action. Notifications are coalesced, so normal consumers observe the final values. The difference appears if a later action or derived formula throws: earlier actions remain applied, whereas the generic store-config model can derive the whole patch before committing it.
- TypeScript infers consumer input types from action parameters, but a malformed map does not currently get the strongest possible diagnostic at the feature declaration. Tightening that constraint caused emitted feature state to collapse to `unknown` in this prototype.

## Testing

- `@videojs/store`: 38 focused tests
- `@videojs/core`: 12 focused tests
- `@videojs/react`: 20 focused tests
- `@videojs/html`: 8 focused tests
- Store, core, React, and HTML package typechecks