### PR TITLE
chore(root): improve issue creation skill

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-issue
-description: Draft or create a videojs/v10 GitHub issue. Use when asked to file a bug, feature, task, or repository issue.
+description: Draft or create a videojs/v10 GitHub issue and its native planning relationships. Use when asked to file a bug, feature, task, epic, or repository issue.
 ---
 
 # Create a GitHub issue
@@ -8,21 +8,31 @@ description: Draft or create a videojs/v10 GitHub issue. Use when asked to file 
 ## Workflow
 
 1. Gather the observed behavior, expected behavior, motivation, affected surface, reproduction or acceptance criteria, and relevant links.
-2. Search open and closed issues for duplicates or useful prior art.
+2. Search open and closed issues and discussions for duplicates, prior art, and established planning relationships. Verify any supplied or clearly established parent issue; do not guess a parent from loose similarity. Route substantial feature proposals to a discussion when the repository template requires one.
 3. Inspect the relevant code or docs when needed to make the issue actionable; do not invent a root cause.
-4. Do not add labels or a type prefix. The triage bot owns both so auto-triage has one source of truth.
-5. Draft:
+4. Choose native relationships by meaning:
+   - Use a parent/sub-issue relationship when the child is part of the parent's completion scope. If a parent is known, create the issue as its sub-issue. If creating an epic, create or attach issue-sized child work as sub-issues.
+   - Use blocked-by/blocking relationships for sequencing, not hierarchy. Use ordinary references for merely related work.
+   - Do not silently reparent an existing issue; confirm before replacing its current parent.
+5. Do not add labels or a type prefix. The triage bot owns both so auto-triage has one source of truth.
+6. Draft:
    - A concise Title Case title without a type prefix.
    - Context and user impact.
    - Reproduction for bugs, or scope/acceptance criteria for features.
+   - One independently closable outcome per issue; split separable outcomes into sub-issues.
+   - Outcome-oriented acceptance criteria; keep implementation tasks out unless they are necessary constraints.
    - Relevant implementation notes only when verified.
-6. Show the final draft and obtain confirmation before creating the external issue unless the user explicitly authorized immediate creation.
-7. Create it without labels using `gh issue create` or the available GitHub connector and return the URL.
+7. Keep hierarchy out of body task lists:
+   - Never mirror child epics or issues as checklist items such as `- [ ] #123`; native sub-issues are the progress tracker.
+   - Use checkboxes only for small completion steps that do not merit their own issues, and plain bullets for informational or non-actionable lists.
+8. Show the final draft and planned parent/dependency relationships, then obtain confirmation before creating external issues unless the user explicitly authorized immediate creation.
+9. Create the issue without labels using the available GitHub connector or `gh issue create`. Pass a known parent with `--parent <number-or-url>` and verified dependencies with `--blocked-by` or `--blocking`. If the issue already exists, attach it with `gh issue edit <child> --parent <parent>` or `gh issue edit <parent> --add-sub-issue <child>`.
+10. Verify the created issue and relationships with the connector or `gh issue view <child> --json url,parent,blockedBy,blocking`. Return the issue URL and the linked parent or dependencies; report a failed relationship instead of implying it succeeded.
 
 Keep the issue focused on the problem and acceptance boundary. Do not prescribe an unverified implementation.
 
 ## Example
 
-Input: “Draft an issue for captions disappearing after a source change.”
+Input: “Create an issue under #873 for captions disappearing after a source change.”
 
-Output: A concise title and evidence-backed body with impact, reproduction, expected behavior, and acceptance criteria.
+Output: A concise, evidence-backed issue created with `--parent 873`, with the native parent relationship verified and no duplicate child checklist in either body.


### PR DESCRIPTION
Closes #2078

## Summary

Improve the `create-issue` skill so issue hierarchy and planning relationships are represented by GitHub native features instead of duplicated Markdown tracking. Newly created issues now link to known parents, while issue bodies remain focused on context and acceptance boundaries.

## Changes

- Verify a supplied or clearly established parent epic/issue and create the new issue with the native `--parent` relationship
- Create or attach issue-sized child work as GitHub sub-issues, including `--add-sub-issue` guidance for existing issues
- Prohibit mirroring child epics or issues as body checklist items; native sub-issues are the progress tracker
- Reserve checkboxes for small completion steps that do not merit their own issues, and plain bullets for informational or non-actionable lists
- Distinguish parent hierarchy from `blocked-by`/`blocking` dependencies and ordinary related references
- Require one independently closable outcome per issue and split separable outcomes into sub-issues
- Prevent silent reparenting of existing issues and verify parent/dependency relationships before reporting success
- Search issues and discussions for duplicates, prior art, and planning context, and route substantial proposals to Discussions when required
- Expand the skill trigger to include epics and update the example to demonstrate native parent linkage

## Testing

- `pnpm check:workspace` — 10 passed, 0 failed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill file; no application runtime, auth, or data paths are modified.
> 
> **Overview**
> Updates the **create-issue** agent skill so filing work uses **GitHub native planning** (parent/sub-issues, blocked-by/blocking) instead of duplicating hierarchy in issue bodies.
> 
> The workflow now requires searching **issues and discussions**, verifying a real parent (no guessed parents), routing big proposals to Discussions when templates require it, and choosing **parent vs dependency vs related** links explicitly—with confirmation before reparenting. Drafting rules add **one independently closable outcome**, outcome-oriented acceptance criteria, and a ban on child epics/issues as body checklists (`- [ ] #123`); checkboxes are only for small steps. Creation/verification steps document **`gh issue create` / `gh issue edit`** with `--parent`, `--add-sub-issue`, `--blocked-by`/`--blocking`, and post-create checks via `gh issue view … --json parent,blockedBy,blocking`. The skill description and example now cover **epics** and creating under a known parent (e.g. `--parent 873`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8d840218072aa9ba39f6a63cbaf779f147f7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->