### PR TITLE
feat(packages): add canonical skin source boundary

### DIFF
--- a/.agents/plans/eject-prototype-migration.md
+++ b/.agents/plans/eject-prototype-migration.md
@@ -16,19 +16,20 @@ This table is the temporary path-level ledger for moving the prototype into focu
 | `packages/compiler/src/tailwind/**` | PR 5 target/style output | #1962 | Defer Tailwind generation from the generic foundation boundary. |
 | `packages/core/src/jsx-runtime.ts`, `jsx-dev-runtime.ts`, `components.config.js`, `scripts/generate-components.ts`, and `src/core/ui/**/*-component.ts` | PR 2: `eject/02-canonical-source` | #1953 | Reuse constrained JSX, manifest generation, compound-part typing, `Slot`, and `Text` after reconciling against current Core. |
 | `internal/decisions/constrained-jsx-boundaries.md` | PR 2: `eject/02-canonical-source` | #1953 | Restore only if source and tests still support every recorded decision. |
-| `packages/skins/src/default/video.skin.tsx` and `packages/skins/src/index.ts` | PR 2/4 canonical ownership and core Skin source | #1955, #1967, #1968, #1969 | Split the monolith into installable domain components and Skin composition; do not restore as one final artifact. |
-| `packages/skins/package.json`, `tsconfig.json`, `tsdown.config.ts` | PR 2: `eject/02-canonical-source` | #1953, #1955 | Adapt only the canonical authoring dependencies and source layout. |
-| `packages/skins/src/**/{css,tailwind}/**` and prototype `packages/skins/__old__/**` | PR 4/5 style source and output | #1964, #1965, #1962, #1963 | Use as migration evidence; do not restore parked or generated layouts wholesale. |
-| Future `packages/skins/artifacts.ts` plus dependency analysis/output model | PR 3: `eject/03-artifact-graph` | #1958, #1959 | Implement after the first two PR boundaries are reviewed; no artifact-graph work in this pass. |
+| `packages/skins/src/default/video.skin.tsx` and `packages/skins/src/index.ts` | PR 3/5 canonical ownership and core Skin source | #1955, #1967, #1968, #1969 | Split the monolith into installable domain components and Skin composition; do not restore as one final artifact. Stage authored source under isolated `packages/skins/canonical/` while current packaged assets remain the runtime baseline. |
+| `packages/skins/package.json`, `tsconfig.json`, `tsdown.config.ts` | PR 3: `eject/03-canonical-skins` | #1953, #1955 | Add only canonical authoring dependencies and validation; keep the existing `src` build and exports unchanged. |
+| `packages/skins/src/**/{css,tailwind}/**` and prototype `packages/skins/__old__/**` | PR 5/6 style source and output | #1964, #1965, #1962, #1963 | Use as migration evidence; do not restore parked or generated layouts wholesale. |
+| Future `packages/skins/artifacts.ts` plus dependency analysis/output model | PR 4: `eject/04-artifact-graph` | #1958, #1959 | Implement after the canonical workspace boundary is reviewed; keep it out of the canonical-source PR. |
 | `packages/react/skins.compiler.config.ts` | PR 5 React output | #1960 | Reuse target-specific transforms after canonical component boundaries settle. |
 | `packages/react/src/presets/video/__generated__/**` | Later generated package/parity PR | #1972, #1973 | Regenerate from the production graph; never copy prototype output as authored source. |
 | Prototype HTML Skin/template edits | PR 5 HTML output | #1961 | Use as parity evidence; create idiomatic light-DOM output with exact registrations rather than restoring flattened generated files. |
-| `packages/icons/components.config.js`, `scripts/build.ts`, generated icon families, and manifest/export changes | PR 2/4 icon contract | #1956 | Reconcile with current icon sources; publish stable exports before source-owned output depends on them. |
+| `packages/icons/components.config.js`, `scripts/build.ts`, generated icon families, and manifest/export changes | Focused icon contract before icon-bearing source | #1956 | Reconcile with current icon sources without importing private cross-package build scripts; publish stable exports before source-owned output depends on them. |
 | Registry adapter/catalog (not implemented as a clean prototype boundary) | PR 6 registry and parity | #1966, #1970, #1971 | Implement outside compiler core from the artifact graph. |
 | Existing `apps/e2e/tests/visual/*-skin.spec.ts` and current ejected-Skin fixtures | Later parity PR | #1972, #1973 | Extend the existing harness; do not create a second parity system. |
 
 ## Stack guardrails
 
 - PR 1 contains no Video.js component names, canonical Skin source, shadcn registry types, public `vjs` binary, Tailwind/CSS generation, or large generated output changes.
-- PR 2 contains constrained JSX/manifests and canonical workspace ownership, but no artifact graph, registry files, or complete target output.
-- Do not begin `eject/03-artifact-graph` until the first two boundaries are reviewed.
+- PR 2 contains constrained JSX/manifests only, with no Skin workspace ownership, artifact graph, registry files, or target output.
+- PR 3 adds isolated canonical Skin ownership without moving or replacing the current packaged `packages/skins/src` assets.
+- Do not begin `eject/04-artifact-graph` until the canonical workspace boundary is reviewed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           - '@videojs/compiler'
           - '@videojs/core'
           - '@videojs/media'
+          - '@videojs/skins'
           - '@videojs/store'
           - '@videojs/utils'
           - '@videojs/element'

--- a/packages/skins/README.md
+++ b/packages/skins/README.md
@@ -8,6 +8,7 @@ The package is private (`"private": true` in `package.json`) and is not publishe
 
 ## Structure
 
+- `canonical/` — isolated target-neutral Skin source; not part of the current packaged build.
 - `src/default/` — default skin tokens and CSS.
 - `src/minimal/` — minimal skin tokens and CSS.
 - `src/shared/` — tokens shared between skins.

--- a/packages/skins/canonical/README.md
+++ b/packages/skins/canonical/README.md
@@ -1,0 +1,19 @@
+# Canonical Skin source
+
+This directory contains target-neutral, authored source for source-owned Video.js UI. It is intentionally isolated from `../src`, which remains the input for the currently packaged React and HTML skins until generated output proves parity.
+
+Canonical source:
+
+- Uses constrained JSX from `@videojs/core`.
+- Imports Video.js primitives only through stable package exports.
+- Keeps independently installable components in role-based directories.
+- Contains semantic structure without React- or HTML-specific markup.
+- Does not copy Media, Store, feature, or SVG implementations.
+
+The initial component paths are:
+
+- `components/buttons/play-button.skin.tsx`
+- `components/sliders/volume-slider.skin.tsx`
+- `components/sliders/time-slider.skin.tsx`
+
+PlayButton source waits for the named canonical icon export owned by #1956. Artifact entries, styles, complete Skin compositions, and generated target output are separate stack boundaries.

--- a/packages/skins/canonical/components/sliders/time-slider.skin.tsx
+++ b/packages/skins/canonical/components/sliders/time-slider.skin.tsx
@@ -1,0 +1,20 @@
+import { Slider, TimeSlider as TimeSliderPrimitive } from '@videojs/core/components';
+
+export function TimeSlider() {
+  return (
+    <TimeSliderPrimitive.Root thumbAlignment="edge">
+      <TimeSliderPrimitive.Track>
+        <TimeSliderPrimitive.Fill />
+        <TimeSliderPrimitive.Buffer />
+      </TimeSliderPrimitive.Track>
+      <TimeSliderPrimitive.Thumb />
+      <Slider.Thumbnail.Root>
+        <Slider.Thumbnail.Image />
+        <TimeSliderPrimitive.Value type="pointer" />
+      </Slider.Thumbnail.Root>
+      <TimeSliderPrimitive.Preview>
+        <TimeSliderPrimitive.Value type="pointer" />
+      </TimeSliderPrimitive.Preview>
+    </TimeSliderPrimitive.Root>
+  );
+}

--- a/packages/skins/canonical/components/sliders/volume-slider.skin.tsx
+++ b/packages/skins/canonical/components/sliders/volume-slider.skin.tsx
@@ -1,0 +1,16 @@
+import { VolumeSlider as VolumeSliderPrimitive } from '@videojs/core/components';
+
+export interface VolumeSliderProps {
+  orientation?: 'horizontal' | 'vertical' | undefined;
+}
+
+export function VolumeSlider({ orientation = 'horizontal' }: VolumeSliderProps = {}) {
+  return (
+    <VolumeSliderPrimitive.Root orientation={orientation} thumbAlignment="edge">
+      <VolumeSliderPrimitive.Track>
+        <VolumeSliderPrimitive.Fill />
+      </VolumeSliderPrimitive.Track>
+      <VolumeSliderPrimitive.Thumb />
+    </VolumeSliderPrimitive.Root>
+  );
+}

--- a/packages/skins/package.json
+++ b/packages/skins/package.json
@@ -28,14 +28,21 @@
   "scripts": {
     "build": "tsdown",
     "build:watch": "tsdown --watch ./src --no-clean",
+    "check:canonical": "node --import tsx ./scripts/check-canonical-imports.ts",
     "dev": "pnpm run build:watch",
+    "test": "pnpm run check:canonical && pnpm run test:types && vitest run",
+    "test:types": "tsgo --project ./tsconfig.canonical.json",
     "clean": "rimraf --glob dist types '*.tsbuildinfo'"
   },
   "dependencies": {
     "@videojs/utils": "workspace:*"
   },
   "devDependencies": {
-    "tsdown": "^0.22.14"
+    "@videojs/core": "workspace:*",
+    "tsx": "^4.23.1",
+    "tsdown": "^0.22.14",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.10"
   },
   "keywords": [
     "media",

--- a/packages/skins/scripts/check-canonical-imports.ts
+++ b/packages/skins/scripts/check-canonical-imports.ts
@@ -1,0 +1,118 @@
+import { globSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const DEFAULT_CANONICAL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../canonical');
+
+export const CANONICAL_PACKAGE_IMPORTS: ReadonlySet<string> = new Set([
+  '@videojs/core/components',
+  '@videojs/core/jsx-runtime',
+]);
+
+export interface CanonicalImportViolation {
+  file: string;
+  line: number;
+  column: number;
+  source: string;
+  reason: 'outside-canonical-root' | 'package-not-allowed';
+}
+
+export interface CanonicalImportCheckResult {
+  files: number;
+  violations: readonly CanonicalImportViolation[];
+}
+
+function isWithinRoot(root: string, target: string): boolean {
+  const path = relative(root, target);
+  return path === '' || (!path.startsWith(`..${sep}`) && path !== '..' && !isAbsolute(path));
+}
+
+function moduleSpecifier(node: ts.Node): ts.StringLiteralLike | null {
+  if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier) {
+    return ts.isStringLiteralLike(node.moduleSpecifier) ? node.moduleSpecifier : null;
+  }
+
+  if (
+    ts.isCallExpression(node) &&
+    node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+    node.arguments.length === 1 &&
+    ts.isStringLiteralLike(node.arguments[0]!)
+  ) {
+    return node.arguments[0]!;
+  }
+
+  if (
+    ts.isImportTypeNode(node) &&
+    ts.isLiteralTypeNode(node.argument) &&
+    ts.isStringLiteralLike(node.argument.literal)
+  ) {
+    return node.argument.literal;
+  }
+
+  return null;
+}
+
+function violationForSource(
+  canonicalRoot: string,
+  file: string,
+  source: string
+): CanonicalImportViolation['reason'] | null {
+  if (source.startsWith('.')) {
+    return isWithinRoot(canonicalRoot, resolve(dirname(file), source)) ? null : 'outside-canonical-root';
+  }
+
+  return CANONICAL_PACKAGE_IMPORTS.has(source) ? null : 'package-not-allowed';
+}
+
+export function checkCanonicalImports(canonicalRoot = DEFAULT_CANONICAL_ROOT): CanonicalImportCheckResult {
+  const files = globSync('**/*.{ts,tsx}', { cwd: canonicalRoot })
+    .map((file) => resolve(canonicalRoot, file))
+    .sort();
+  const violations: CanonicalImportViolation[] = [];
+
+  for (const file of files) {
+    const sourceText = readFileSync(file, 'utf8');
+    const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+    const visit = (node: ts.Node): void => {
+      const specifier = moduleSpecifier(node);
+      if (specifier) {
+        const reason = violationForSource(canonicalRoot, file, specifier.text);
+        if (reason) {
+          const location = sourceFile.getLineAndCharacterOfPosition(specifier.getStart(sourceFile));
+          violations.push({
+            file,
+            line: location.line + 1,
+            column: location.character + 1,
+            source: specifier.text,
+            reason,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+  }
+
+  return { files: files.length, violations };
+}
+
+function run(): void {
+  const result = checkCanonicalImports();
+  if (result.violations.length === 0) {
+    process.stdout.write(`Checked ${result.files} canonical source files.\n`);
+    return;
+  }
+
+  for (const violation of result.violations) {
+    process.stderr.write(
+      `${relative(process.cwd(), violation.file)}:${violation.line}:${violation.column} ${violation.source}: ${violation.reason}\n`
+    );
+  }
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) run();

--- a/packages/skins/scripts/tests/check-canonical-imports.test.ts
+++ b/packages/skins/scripts/tests/check-canonical-imports.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { checkCanonicalImports } from '../check-canonical-imports';
+
+const roots: string[] = [];
+
+function setup(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'videojs-canonical-imports-'));
+  roots.push(root);
+
+  for (const [file, source] of Object.entries(files)) {
+    const path = join(root, file);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, source);
+  }
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('checkCanonicalImports', () => {
+  it('accepts stable Video.js exports and local imports', () => {
+    const root = setup({
+      'components/control.tsx': `
+        import { Controls } from '@videojs/core/components';
+        import type { ComponentNode } from '@videojs/core/jsx-runtime';
+        export { helper } from './helper';
+        export const value: ComponentNode | typeof Controls = Controls;
+      `,
+      'components/helper.ts': 'export const helper = true;',
+    });
+
+    expect(checkCanonicalImports(root).violations).toEqual([]);
+  });
+
+  it('rejects private and target-specific package imports', () => {
+    const root = setup({
+      'component.tsx': `
+        import { PlayButton } from '@videojs/core/src/core/ui/play-button';
+        import { useState } from 'react';
+        export const load = () => import('@videojs/react/ui/play-button');
+        export type Internal = import('@videojs/core/src/core/ui/manifest').ComponentManifest;
+        export const value = [PlayButton, useState, load];
+      `,
+    });
+
+    expect(checkCanonicalImports(root).violations.map(({ source, reason }) => ({ source, reason }))).toEqual([
+      { source: '@videojs/core/src/core/ui/play-button', reason: 'package-not-allowed' },
+      { source: 'react', reason: 'package-not-allowed' },
+      { source: '@videojs/react/ui/play-button', reason: 'package-not-allowed' },
+      { source: '@videojs/core/src/core/ui/manifest', reason: 'package-not-allowed' },
+    ]);
+  });
+
+  it('rejects relative imports that escape the canonical root', () => {
+    const root = setup({
+      'components/control.tsx': `import { legacy } from '../../src/default/tailwind/video.tailwind';`,
+    });
+
+    expect(checkCanonicalImports(root).violations).toMatchObject([
+      {
+        source: '../../src/default/tailwind/video.tailwind',
+        reason: 'outside-canonical-root',
+      },
+    ]);
+  });
+});

--- a/packages/skins/tsconfig.canonical.json
+++ b/packages/skins/tsconfig.canonical.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "isolatedDeclarations": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@videojs/core",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  "include": ["canonical/**/*.ts", "canonical/**/*.tsx"]
+}

--- a/packages/skins/vitest.config.ts
+++ b/packages/skins/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['scripts/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,9 +441,21 @@ importers:
         specifier: workspace:*
         version: link:../utils
     devDependencies:
+      '@videojs/core':
+        specifier: workspace:*
+        version: link:../core
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/spf:
     dependencies:


### PR DESCRIPTION
## Stack

- **Position:** 3 — canonical Skin workspace boundary
- **Base:** #1986 (`eject/02-canonical-source`)
- **Owning issues:** Refs #1953, #1955, #1968, #1969
- **Parent epic:** #1949

## Management-visible outcome

Canonical source-owned Skin work can now proceed in `@videojs/skins` without moving, renaming, or compiling the current packaged Skin assets.

## What changed

- adds isolated target-neutral source under `packages/skins/canonical/`
- adds independently owned `TimeSlider` and `VolumeSlider` source components
- enforces public/stable package imports and prevents relative imports from escaping the canonical tree
- adds isolated canonical JSX type-checking and focused checker tests
- adds `@videojs/skins` to the package CI test matrix
- updates the prototype migration ledger for the revised stack

The existing `packages/skins/src/**` build inputs, exports, and runtime output are unchanged.

## Layout decision for review

The TDD's original recommended layout places canonical authoring under `packages/skins/src/**`. This draft deliberately stages it under `packages/skins/canonical/**` so new source-owned work stays visibly and mechanically separate from today's packaged Skin implementation during parity work.

If this durable boundary is accepted in review, the TDD should be updated before merge. It is not being changed silently in this draft.

## Prototype paths reused from #1696

- `packages/skins/src/default/video.skin.tsx` as semantic composition evidence
- the prototype's constrained JSX package wiring and authoring dependency shape
- the slider compound structures for TimeSlider/thumbnail preview and VolumeSlider

Not reused:

- the monolithic default Skin file
- `packages/skins/__old__/**`
- private cross-package icon build imports
- generated React/HTML output

## Intentionally excluded

- PlayButton and other icon-bearing source until #1956 provides the named public icon contract
- styles and themes
- complete core Skin composition
- artifact graph and multi-file closure
- React/HTML lowering
- registry output and packaged Skin cutover

## Verification

- `pnpm -F @videojs/skins test` — pass (checker, canonical type-check, 3 focused tests)
- `pnpm -F @videojs/skins build` — pass; build entries remain under `src/**` and no `canonical/**` output is emitted
- `pnpm build:packages` — pass (11/11 packages)
- `pnpm check:workspace` — pass (10/10 checks)
- `git diff --check` — pass
- GitHub CI — 23 successful, 1 intentionally skipped E2E matrix placeholder
- `pnpm typecheck` — clean-checkout GitHub CI passes; this shared local worktree separately reported Store/React test-type errors outside the diff

## Follow-up

- #1956 unblocks named canonical icons and PlayButton source
- artifact graph remains the next stack boundary after this layout is reviewed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive (new tree, scripts, docs, CI matrix); runtime skin packaging and exports stay the same.
> 
> **Overview**
> Introduces **`packages/skins/canonical/`** as a separate authoring area for target-neutral, constrained JSX skin components, without changing the existing **`src/**`** build, exports, or shipped assets.
> 
> Adds initial **`TimeSlider`** and **`VolumeSlider`** canonical components (PlayButton is documented but deferred until #1956). Validation includes a **`check:canonical`** import guard (only `@videojs/core/components`, `@videojs/core/jsx-runtime`, and in-tree relative imports), **`tsconfig.canonical.json`** type-checking, Vitest coverage for the checker, and wiring **`@videojs/skins`** into the CI package test matrix. The eject migration ledger is updated to treat canonical skins as **PR 3** and push artifact-graph work to **PR 4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a8af018cdd26338d261a467acb92164327c443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->