### PR TITLE
feat(packages)!: configure orientation lock through providers

### DIFF
--- a/internal/design/store/resolved-feature-state.md
+++ b/internal/design/store/resolved-feature-state.md
@@ -13,7 +13,15 @@ A feature keeps each owned input in private source state and uses `derived` to p
 
 The feature's `config` map connects each provider input to an action and its user-owned state key. This one declaration serves two purposes: provider adapters know which inputs to expose, and the store knows which state survives media detach. Media-owned state resets on detach. Provider and imperative user values persist.
 
+An action accepts its input's own value type plus `null | undefined`, so a narrower union such as a string enum keeps that type on the provider input.
+
 Derived formulas run before a source update is published. Consumers therefore receive one frozen snapshot containing the resolved state.
+
+## Single-owner values
+
+Privacy follows from resolution, not from being configurable. A value with one owner has nothing to resolve, so it is a published source key whose action applies the feature default when input is absent — no symbol, no `derived` formula. `orientationLockType` initialises to `landscape`, and `setOrientationLockType` restores that default for absent input. Absent means nullish *and* the empty string, which is what a valueless HTML attribute delivers.
+
+Publishing the key is also what makes the value observable. `publish` copies string keys only, so a symbol-keyed change produces no public snapshot and notifies nobody. An attached behavior that reacts to its own configuration — orientation lock re-locks the screen when the type changes mid-fullscreen — therefore needs its value on the public snapshot, whether as a published source key or as a `derived` value.
 
 ## Alternatives considered
 
@@ -22,7 +30,7 @@ Derived formulas run before a source update is published. Consumers therefore re
 - **Replay provider props after detach** — loses imperative user writes and can restore stale props.
 - **Resolve inside every setter** — requires each mutation site to repeat the formula.
 
-Each configured value needs private state and an action. Provider adapters apply multi-key changes one action at a time; the design adds no separate batching API.
+Each configured value needs a state key and an action. Provider adapters apply multi-key changes one action at a time; the design adds no separate batching API.
 
 ## Sources of truth
 

--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -1,24 +1,5 @@
-import {
-  type AttachContext,
-  type DerivedContext,
-  defineSlice,
-  type SliceConfig,
-  type StateContext,
-} from '@videojs/store';
-import { isUndefined } from '@videojs/utils/predicate';
+import type { DerivedContext, SliceConfig } from '@videojs/store';
 import type { AnyPlayerFeature, PlayerFeature, PlayerFeatureConfig, PlayerTarget } from './player';
-
-export interface ConfigurablePlayerFeature<Config, State> extends PlayerFeature<State> {
-  (config?: Config): PlayerFeature<State>;
-}
-
-export interface ConfigurablePlayerFeatureConfig<Config, State>
-  extends Omit<SliceConfig<PlayerTarget, State>, 'attach' | 'derived' | 'preserve' | 'state'> {
-  state: (ctx: StateContext<PlayerTarget>, config: Config) => State;
-  attach?: (ctx: AttachContext<PlayerTarget, State>, config: Config) => void;
-}
-
-const definePlayerSlice = defineSlice<PlayerTarget>();
 
 type DerivedFunctions<State> = Record<string, (ctx: DerivedContext<State>) => unknown>;
 
@@ -26,69 +7,36 @@ type DerivedValues<Definitions extends Record<string, (...args: any[]) => unknow
   [Key in keyof Definitions]: ReturnType<Definitions[Key]>;
 };
 
-type StaticPlayerFeatureConfig<State, Derived, Config extends PlayerFeatureConfig> = Omit<
+type PlayerFeatureDefinition<State, Derived, Config extends PlayerFeatureConfig> = Omit<
   SliceConfig<PlayerTarget, State, Derived>,
   'preserve'
 > & {
   config?: Config;
 };
 
-/** Define a static player feature with derived state and optional configuration inputs. */
+/** Define a player feature with derived state and optional configuration inputs. */
 export function definePlayerFeature<
   State,
   const Definitions extends DerivedFunctions<State>,
   const Config extends PlayerFeatureConfig = Record<never, never>,
 >(
-  definition: Omit<StaticPlayerFeatureConfig<State, DerivedValues<Definitions>, Config>, 'derived'> & {
+  definition: Omit<PlayerFeatureDefinition<State, DerivedValues<Definitions>, Config>, 'derived'> & {
     derived: Definitions;
   }
 ): PlayerFeature<State, DerivedValues<Definitions>, Config>;
-/** Define a static player feature with optional configuration inputs. */
+/** Define a player feature with optional configuration inputs. */
 export function definePlayerFeature<State, const Config extends PlayerFeatureConfig = Record<never, never>>(
-  definition: Omit<StaticPlayerFeatureConfig<State, object, Config>, 'derived'> & { derived?: never }
+  definition: Omit<PlayerFeatureDefinition<State, object, Config>, 'derived'> & { derived?: never }
 ): PlayerFeature<State, object, Config>;
-/**
- * Define the legacy factory-configured form used by static feature variants.
- * Currently used for orientation lock and scheduled for removal in #1942.
- */
-export function definePlayerFeature<Config, State>(
-  definition: ConfigurablePlayerFeatureConfig<Config, State>,
-  defaultConfig: Config
-): ConfigurablePlayerFeature<Config, State>;
-export function definePlayerFeature<Config, State>(
-  definition:
-    | StaticPlayerFeatureConfig<State, object, PlayerFeatureConfig>
-    | ConfigurablePlayerFeatureConfig<Config, State>,
-  defaultConfig?: Config
-): PlayerFeature<State> | ConfigurablePlayerFeature<Config, State> {
-  if (arguments.length === 1) {
-    const feature = definition as StaticPlayerFeatureConfig<State, object, PlayerFeatureConfig>;
-    const preserved = Object.values(feature.config ?? {}).map((entry) => entry.state);
+export function definePlayerFeature<State>(
+  definition: PlayerFeatureDefinition<State, object, PlayerFeatureConfig>
+): PlayerFeature<State> {
+  const preserved = Object.values(definition.config ?? {}).map((entry) => entry.state);
 
-    return {
-      ...feature,
-      ...(preserved.length > 0 ? { preserve: preserved } : {}),
-    } as PlayerFeature<State>;
-  }
-
-  const { name, state, attach } = definition as ConfigurablePlayerFeatureConfig<Config, State>;
-
-  const forConfig = (featureConfig: Config): PlayerFeature<State> =>
-    definePlayerSlice({
-      ...(isUndefined(name) ? {} : { name }),
-      state: (ctx) => state(ctx, featureConfig),
-      ...(attach ? { attach: (ctx) => attach(ctx, featureConfig) } : {}),
-    });
-
-  const defaultFeature = forConfig(defaultConfig as Config);
-  const feature = ((featureConfig?: Config) =>
-    isUndefined(featureConfig) ? defaultFeature : forConfig(featureConfig)) as ConfigurablePlayerFeature<Config, State>;
-
-  feature.state = defaultFeature.state;
-  if (defaultFeature.attach) feature.attach = defaultFeature.attach;
-  if (!isUndefined(name)) Object.defineProperty(feature, 'name', { value: name });
-
-  return feature;
+  return {
+    ...definition,
+    ...(preserved.length > 0 ? { preserve: preserved } : {}),
+  } as PlayerFeature<State>;
 }
 
 /** Merge the configuration declarations from the selected player features. */

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -35,11 +35,16 @@ type ActionInput<Action> = Action extends (...args: infer Arguments) => unknown
     : never
   : never;
 
+/**
+ * Actions accepting text, including narrower unions such as a string enum, so
+ * a feature keeps its own value type on the provider input. `null | undefined`
+ * stays mandatory because that is how a provider clears an absent input.
+ */
 type ConfigActionKey<State> = [State] extends [never]
   ? PropertyKey
   : {
       [Key in keyof State]-?: [ActionInput<State[Key]>] extends [ConfigValue]
-        ? [ConfigValue] extends [ActionInput<State[Key]>]
+        ? [null | undefined] extends [ActionInput<State[Key]>]
           ? Key
           : never
         : never;
@@ -56,10 +61,10 @@ export type PlayerFeatureConfig<State = never> = Record<
   string,
   {
     /**
-     * Source-state action applied when the input changes. It must accept
-     * `string | null | undefined`, since an input the author omits arrives as
-     * `undefined`. A feature's own public setter qualifies when it accepts
-     * that; otherwise point at a private action that does.
+     * Source-state action applied when the input changes. It must accept the
+     * input's own value type plus `null | undefined`, since an input the author
+     * omits arrives as `undefined`. A feature's own public setter qualifies when
+     * it accepts that; otherwise point at a private action that does.
      */
     action: ConfigActionKey<State>;
     /** Provider-owned source-state key whose value survives media detach. */

--- a/packages/core/src/dom/presentation/orientation.ts
+++ b/packages/core/src/dom/presentation/orientation.ts
@@ -1,10 +1,19 @@
-import { isFunction } from '@videojs/utils/predicate';
+import { isFunction, isNull } from '@videojs/utils/predicate';
 
 export interface ScreenOrientationLock {
-  lock(): Promise<void>;
+  /**
+   * Requests `type`, replacing a lock already held for a different type.
+   * Requests never overlap: while one is in flight, a later call only records
+   * the new type and the running request applies it once it settles.
+   */
+  lock(type: ScreenOrientationLockType): Promise<void>;
   unlock(): void;
 }
 
+/**
+ * Orientation types accepted by the Screen Orientation API's
+ * `screen.orientation.lock()`.
+ */
 export type ScreenOrientationLockType =
   | 'any'
   | 'landscape'
@@ -15,20 +24,18 @@ export type ScreenOrientationLockType =
   | 'portrait-primary'
   | 'portrait-secondary';
 
-export interface ScreenOrientationLockConfig {
-  type?: ScreenOrientationLockType | undefined;
-}
-
 interface ScreenOrientation {
   lock?: ((type: ScreenOrientationLockType) => Promise<void>) | undefined;
   unlock?: (() => void) | undefined;
 }
 
-export function createScreenOrientationLock({
-  type = 'landscape',
-}: ScreenOrientationLockConfig = {}): ScreenOrientationLock {
-  let locked = false;
-  let desired = false;
+export function createScreenOrientationLock(): ScreenOrientationLock {
+  /** Type the caller last asked for, or null once released. */
+  let desired: ScreenOrientationLockType | null = null;
+  /** Type the platform accepted, or null while no lock is held. */
+  let held: ScreenOrientationLockType | null = null;
+  /** Set while a platform request is in flight. */
+  let settling = false;
 
   const releaseOrientation = () => {
     const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
@@ -41,36 +48,56 @@ export function createScreenOrientationLock({
     } catch {}
   };
 
+  /**
+   * Drives the platform toward `desired`, one request at a time. A re-entrant
+   * call returns immediately because the running pass re-reads `desired` before
+   * it exits, so the last requested type wins without overlapping requests
+   * whose settle order the platform does not guarantee.
+   */
+  const reconcile = async () => {
+    if (settling) return;
+    settling = true;
+
+    try {
+      while (desired !== held) {
+        const target = desired;
+
+        if (isNull(target)) {
+          releaseOrientation();
+          held = null;
+          continue;
+        }
+
+        const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
+        const lock = orientation?.lock;
+
+        if (!isFunction(lock)) return;
+
+        try {
+          await lock.call(orientation, target);
+        } catch {
+          // Leave `held` alone so it keeps describing the platform. Retrying
+          // the same type here would spin, so wait for the next request.
+          if (desired === target) return;
+          continue;
+        }
+
+        held = target;
+      }
+    } finally {
+      settling = false;
+    }
+  };
+
   return {
-    async lock() {
-      if (locked) return;
-      desired = true;
-
-      const orientation = globalThis.screen?.orientation as ScreenOrientation | undefined;
-      const lock = orientation?.lock;
-
-      if (!isFunction(lock)) return;
-
-      try {
-        await lock.call(orientation, type);
-      } catch {
-        return;
-      }
-
-      if (desired) {
-        locked = true;
-      } else {
-        releaseOrientation();
-      }
+    lock(type) {
+      desired = type;
+      return reconcile();
     },
 
     unlock() {
-      desired = false;
-
-      if (!locked) return;
-
-      locked = false;
-      releaseOrientation();
+      desired = null;
+      void reconcile();
     },
   };
 }

--- a/packages/core/src/dom/presentation/tests/orientation.test.ts
+++ b/packages/core/src/dom/presentation/tests/orientation.test.ts
@@ -10,7 +10,7 @@ describe('createScreenOrientationLock', () => {
     vi.unstubAllGlobals();
   });
 
-  it('locks landscape by default', async () => {
+  it('locks the requested orientation type', async () => {
     const orientation = {
       lock: vi.fn(async () => {}),
       unlock: vi.fn(),
@@ -19,23 +19,26 @@ describe('createScreenOrientationLock', () => {
 
     const screenLock = createScreenOrientationLock();
 
-    await screenLock.lock();
+    await screenLock.lock('portrait');
 
-    expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    expect(orientation.lock).toHaveBeenCalledWith('portrait');
   });
 
-  it('locks the configured orientation type', async () => {
+  it('re-locks when the requested type changes', async () => {
     const orientation = {
       lock: vi.fn(async () => {}),
       unlock: vi.fn(),
     };
     stubOrientation(orientation);
 
-    const screenLock = createScreenOrientationLock({ type: 'portrait' });
+    const screenLock = createScreenOrientationLock();
 
-    await screenLock.lock();
+    await screenLock.lock('landscape');
+    await screenLock.lock('portrait');
 
-    expect(orientation.lock).toHaveBeenCalledWith('portrait');
+    expect(orientation.lock).toHaveBeenNthCalledWith(1, 'landscape');
+    expect(orientation.lock).toHaveBeenNthCalledWith(2, 'portrait');
+    expect(orientation.unlock).not.toHaveBeenCalled();
   });
 
   it('unlocks only after a successful lock', async () => {
@@ -48,8 +51,8 @@ describe('createScreenOrientationLock', () => {
     const screenLock = createScreenOrientationLock();
 
     screenLock.unlock();
-    await screenLock.lock();
-    await screenLock.lock();
+    await screenLock.lock('landscape');
+    await screenLock.lock('landscape');
     screenLock.unlock();
     screenLock.unlock();
 
@@ -62,7 +65,7 @@ describe('createScreenOrientationLock', () => {
 
     const screenLock = createScreenOrientationLock();
 
-    await expect(screenLock.lock()).resolves.toBeUndefined();
+    await expect(screenLock.lock('landscape')).resolves.toBeUndefined();
     expect(() => screenLock.unlock()).not.toThrow();
   });
 
@@ -79,7 +82,7 @@ describe('createScreenOrientationLock', () => {
     stubOrientation(orientation);
 
     const screenLock = createScreenOrientationLock();
-    const lockTask = screenLock.lock();
+    const lockTask = screenLock.lock('landscape');
 
     screenLock.unlock();
     resolveLock();
@@ -88,40 +91,87 @@ describe('createScreenOrientationLock', () => {
     expect(orientation.unlock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not release a newer active lock when an older lock settles', async () => {
-    let resolveFirst!: () => void;
-    let resolveSecond!: () => void;
-
-    const firstLock = new Promise<void>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const secondLock = new Promise<void>((resolve) => {
-      resolveSecond = resolve;
+  it('issues one platform request while an earlier one is in flight', async () => {
+    let resolveLock!: () => void;
+    const lockPromise = new Promise<void>((resolve) => {
+      resolveLock = resolve;
     });
 
     const orientation = {
-      lock: vi.fn<ScreenOrientation['lock']>().mockReturnValueOnce(firstLock).mockReturnValueOnce(secondLock),
+      lock: vi.fn<ScreenOrientation['lock']>().mockReturnValue(lockPromise),
       unlock: vi.fn(),
     };
     stubOrientation(orientation);
 
     const screenLock = createScreenOrientationLock();
-    const firstTask = screenLock.lock();
+    const lockTask = screenLock.lock('landscape');
 
-    screenLock.unlock();
-    const secondTask = screenLock.lock();
+    // A store publishes on every state change, so `sync` can re-request the
+    // type it already asked for while the first request is still pending.
+    await screenLock.lock('landscape');
+    await screenLock.lock('landscape');
 
-    resolveSecond();
-    await secondTask;
+    expect(orientation.lock).toHaveBeenCalledTimes(1);
+
+    resolveLock();
+    await lockTask;
+
+    expect(orientation.lock).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the latest requested type once an in-flight request settles', async () => {
+    let resolveFirst!: () => void;
+    const firstLock = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const orientation = {
+      lock: vi.fn<ScreenOrientation['lock']>().mockReturnValueOnce(firstLock).mockResolvedValue(undefined),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock();
+    const lockTask = screenLock.lock('landscape');
+
+    // Portrait must not reach the platform yet: two overlapping requests can
+    // settle in either order, leaving the screen on whichever landed last.
+    void screenLock.lock('portrait');
+
+    expect(orientation.lock).toHaveBeenCalledTimes(1);
 
     resolveFirst();
-    await firstTask;
+    await lockTask;
 
-    expect(orientation.unlock).not.toHaveBeenCalled();
+    expect(orientation.lock).toHaveBeenNthCalledWith(2, 'portrait');
+    expect(orientation.lock).toHaveBeenCalledTimes(2);
 
+    // Portrait is what the platform actually holds, so one release ends it.
     screenLock.unlock();
 
     expect(orientation.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-requests a type whose earlier request the platform rejected', async () => {
+    const orientation = {
+      lock: vi.fn<ScreenOrientation['lock']>().mockResolvedValue(undefined),
+      unlock: vi.fn(),
+    };
+    stubOrientation(orientation);
+
+    const screenLock = createScreenOrientationLock();
+
+    await screenLock.lock('landscape');
+
+    orientation.lock.mockRejectedValueOnce(new Error('NotSupportedError'));
+    await screenLock.lock('portrait');
+
+    // The rejection must not be recorded as a held portrait lock; the platform
+    // is still on landscape, so asking for portrait again has to reach it.
+    await screenLock.lock('portrait');
+
+    expect(orientation.lock).toHaveBeenNthCalledWith(3, 'portrait');
+    expect(orientation.lock).toHaveBeenCalledTimes(3);
   });
 
   it('ignores rejected locks and thrown unlocks', async () => {
@@ -135,7 +185,7 @@ describe('createScreenOrientationLock', () => {
 
     const rejectedLock = createScreenOrientationLock();
 
-    await expect(rejectedLock.lock()).resolves.toBeUndefined();
+    await expect(rejectedLock.lock('landscape')).resolves.toBeUndefined();
     rejectedLock.unlock();
 
     expect(orientation.unlock).not.toHaveBeenCalled();
@@ -143,7 +193,7 @@ describe('createScreenOrientationLock', () => {
     const acceptedLock = createScreenOrientationLock();
     orientation.lock.mockResolvedValue(undefined);
 
-    await acceptedLock.lock();
+    await acceptedLock.lock('landscape');
 
     expect(() => acceptedLock.unlock()).not.toThrow();
   });

--- a/packages/core/src/dom/store/features/orientation-lock.ts
+++ b/packages/core/src/dom/store/features/orientation-lock.ts
@@ -1,52 +1,112 @@
-import { listen } from '@videojs/utils/dom';
+import { createSelector } from '@videojs/store';
+import { listen, type WebKitVideoElement } from '@videojs/utils/dom';
+import { isNull } from '@videojs/utils/predicate';
 
 import { definePlayerFeature } from '../../feature';
+import type { PlayerFeatureConfig } from '../../player';
 import { isFullscreen } from '../../presentation/fullscreen';
 import { createScreenOrientationLock, type ScreenOrientationLockType } from '../../presentation/orientation';
 
-export interface OrientationLockFeatureConfig {
-  /** Screen orientation type to lock while fullscreen is active. */
-  type?: ScreenOrientationLockType | undefined;
+export type { ScreenOrientationLockType };
+
+const DEFAULT_ORIENTATION_LOCK_TYPE: ScreenOrientationLockType = 'landscape';
+
+/** Orientation lock configuration and its user-config writer. */
+export interface OrientationLockState {
+  /** Screen orientation type locked while fullscreen is active. */
+  orientationLockType: ScreenOrientationLockType;
+  /**
+   * Sets the locked orientation type. Absent input — nullish, or the empty
+   * string a valueless HTML attribute produces — restores the default.
+   */
+  setOrientationLockType(value: ScreenOrientationLockType | null | undefined): void;
 }
 
-interface WebKitPresentationMedia extends HTMLMediaElement {
-  webkitPresentationMode?: string;
-}
-
-export const orientationLockFeature = definePlayerFeature(
-  {
-    name: 'orientationLock',
-    state: () => ({}),
-
-    attach({ target, signal }, config: OrientationLockFeatureConfig) {
-      const { media, container } = target;
-      const orientationLock = createScreenOrientationLock({ type: config.type });
-
-      let wasFullscreen = false;
-      const sync = () => {
-        const fullscreen = isFullscreen(container, media);
-
-        if (!wasFullscreen && fullscreen) {
-          void orientationLock.lock();
-        } else if (wasFullscreen && !fullscreen) {
-          orientationLock.unlock();
-        }
-
-        wasFullscreen = fullscreen;
-      };
-
-      sync();
-
-      listen(document, 'fullscreenchange', sync, { signal });
-      listen(document, 'webkitfullscreenchange', sync, { signal });
-
-      const video = media as WebKitPresentationMedia;
-      if ('webkitPresentationMode' in video) {
-        listen(media, 'webkitpresentationmodechanged', sync, { signal });
-      }
-
-      signal.addEventListener('abort', () => orientationLock.unlock(), { once: true });
+/**
+ * Locks screen orientation while fullscreen is active.
+ *
+ * The orientation type is provider configuration, so it can change during the
+ * player's lifetime. Unsupported browsers and rejected lock requests are
+ * ignored.
+ */
+export const orientationLockFeature = definePlayerFeature({
+  name: 'orientationLock',
+  config: {
+    /** Screen orientation type to lock while fullscreen is active. */
+    orientationLockType: {
+      action: 'setOrientationLockType',
+      state: 'orientationLockType',
     },
+  } satisfies PlayerFeatureConfig<OrientationLockState>,
+  state: ({ set }): OrientationLockState => ({
+    orientationLockType: DEFAULT_ORIENTATION_LOCK_TYPE,
+    // `||` rather than `??`: a valueless HTML attribute arrives as `''`, which
+    // is absent input, not a request to lock to the empty string.
+    setOrientationLockType: (value) => set({ orientationLockType: value || DEFAULT_ORIENTATION_LOCK_TYPE }),
+  }),
+
+  attach({ target, signal, get, store }) {
+    const { media, container } = target;
+    const orientationLock = createScreenOrientationLock();
+
+    // Type that should be held right now, or null when not fullscreen.
+    let synced: ScreenOrientationLockType | null = null;
+
+    // Resolved from current values rather than a fullscreen transition, so the
+    // same handler serves both fullscreen changes and configuration changes.
+    // Comparing the resolved value is what keeps the store subscription below
+    // from re-issuing a platform request on every unrelated state change.
+    const sync = () => {
+      const next = isFullscreen(container, media) ? get().orientationLockType : null;
+
+      if (next === synced) return;
+      synced = next;
+
+      if (isNull(next)) {
+        orientationLock.unlock();
+      } else {
+        void orientationLock.lock(next);
+      }
+    };
+
+    sync();
+
+    listen(document, 'fullscreenchange', sync, { signal });
+    listen(document, 'webkitfullscreenchange', sync, { signal });
+
+    // iOS Safari presentation mode change (covers fullscreen)
+    const video = media as WebKitVideoElement;
+    if ('webkitPresentationMode' in video) {
+      listen(media, 'webkitpresentationmodechanged', sync, { signal });
+    }
+
+    // `orientationLockType` is published source state, so configuration writes
+    // reach this subscription through the normal snapshot notification. It
+    // fires for every published change, which `sync` filters.
+    const unsubscribe = store.subscribe(sync);
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        unsubscribe();
+        orientationLock.unlock();
+      },
+      { once: true }
+    );
   },
-  { type: 'landscape' } satisfies OrientationLockFeatureConfig
-);
+});
+
+// Declared here rather than in `../selectors`, because `createSelector`
+// evaluates its slice at module load and every selector in that module shares
+// one evaluation. An entry there would retain this feature in every bundle
+// importing any selector, and this feature ships in no preset, so that is
+// weight for players that never select it — measured at +290 B per
+// `@videojs/html` UI component and +298 B per React one. `UTIL_ENTRY_POINTS`
+// in the site's api-docs-builder scans this module so the selector still gets
+// a reference page.
+/**
+ * Select the orientation lock state (`orientationLockType`,
+ * `setOrientationLockType`). Returns `undefined` when the feature is not
+ * configured.
+ */
+export const selectOrientationLock = createSelector(orientationLockFeature);

--- a/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
+++ b/packages/core/src/dom/store/features/tests/orientation-lock.test.ts
@@ -1,18 +1,24 @@
-import { createStore } from '@videojs/store';
+import { combine, createStore, defineSlice } from '@videojs/store';
+import type { WebKitVideoElement } from '@videojs/utils/dom';
 import type { Mock } from 'vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../player';
 import { createMockVideo } from '../../../tests/test-helpers';
-import { orientationLockFeature } from '../orientation-lock';
+import type { ScreenOrientationLockType } from '../orientation-lock';
+import { orientationLockFeature, selectOrientationLock } from '../orientation-lock';
+
+/** Stands in for the unrelated features a real player publishes alongside. */
+const noiseSlice = defineSlice<PlayerTarget>()({
+  state: ({ set }): { tick: number; setTick(value: number): void } => ({
+    tick: 0,
+    setTick: (value) => set({ tick: value }),
+  }),
+});
 
 type OrientationMock = {
   lock: Mock<ScreenOrientation['lock']>;
   unlock: Mock<ScreenOrientation['unlock']>;
 };
-
-interface WebKitPresentationVideo extends HTMLVideoElement {
-  webkitPresentationMode?: string;
-}
 
 function stubOrientation(): OrientationMock;
 function stubOrientation<Orientation extends Partial<ScreenOrientation>>(orientation: Orientation): Orientation;
@@ -36,8 +42,19 @@ function setFullscreenElement(value: Element | null) {
   });
 }
 
+// Stores keep document-level fullscreen listeners until destroyed, so an
+// undestroyed store from an earlier test reacts to later dispatches.
+const stores: { destroy(): void }[] = [];
+
+function createOrientationStore() {
+  const store = createStore<PlayerTarget>()(orientationLockFeature);
+  stores.push(store);
+  return store;
+}
+
 describe('orientationLockFeature', () => {
   afterEach(() => {
+    for (const store of stores.splice(0)) store.destroy();
     setFullscreenElement(null);
     vi.unstubAllGlobals();
   });
@@ -47,7 +64,7 @@ describe('orientationLockFeature', () => {
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    const store = createOrientationStore();
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -63,7 +80,8 @@ describe('orientationLockFeature', () => {
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature({ type: 'portrait' }));
+    const store = createOrientationStore();
+    store.setOrientationLockType('portrait');
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -74,12 +92,95 @@ describe('orientationLockFeature', () => {
     });
   });
 
+  it('re-locks when the configured type changes during fullscreen', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createOrientationStore();
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    });
+
+    store.setOrientationLockType('portrait');
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('portrait');
+    });
+
+    expect(orientation.unlock).not.toHaveBeenCalled();
+  });
+
+  it('restores the default type when configuration is cleared', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createOrientationStore();
+    store.setOrientationLockType('portrait');
+    expect(store.orientationLockType).toBe('portrait');
+
+    store.setOrientationLockType(undefined);
+    expect(store.orientationLockType).toBe('landscape');
+
+    store.attach({ media: video, container });
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledWith('landscape');
+    });
+  });
+
+  it('preserves the configured type across detach', () => {
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createOrientationStore();
+    store.setOrientationLockType('portrait');
+
+    const detach = store.attach({ media: video, container });
+    detach();
+
+    expect(store.orientationLockType).toBe('portrait');
+  });
+
+  it('stops responding to configuration changes after detach', async () => {
+    const orientation = stubOrientation();
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createOrientationStore();
+    const detach = store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalled();
+    });
+
+    await Promise.resolve();
+    detach();
+    orientation.lock.mockClear();
+
+    store.setOrientationLockType('portrait');
+    await Promise.resolve();
+
+    expect(orientation.lock).not.toHaveBeenCalled();
+  });
+
   it('unlocks when fullscreen exits', async () => {
     const orientation = stubOrientation();
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    const store = createOrientationStore();
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -103,7 +204,7 @@ describe('orientationLockFeature', () => {
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    const store = createOrientationStore();
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -122,11 +223,11 @@ describe('orientationLockFeature', () => {
 
   it('handles webkit presentation mode changes', async () => {
     const orientation = stubOrientation();
-    const video = createMockVideo() as WebKitPresentationVideo;
+    const video = createMockVideo() as HTMLVideoElement & WebKitVideoElement;
     video.webkitPresentationMode = 'inline';
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    const store = createOrientationStore();
     store.attach({ media: video, container });
 
     video.webkitPresentationMode = 'fullscreen';
@@ -150,7 +251,7 @@ describe('orientationLockFeature', () => {
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    const store = createOrientationStore();
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -169,7 +270,7 @@ describe('orientationLockFeature', () => {
     const video = createMockVideo();
     const container = document.createElement('div');
 
-    const store = createStore<PlayerTarget>()(orientationLockFeature);
+    const store = createOrientationStore();
     store.attach({ media: video, container });
 
     setFullscreenElement(container);
@@ -183,5 +284,67 @@ describe('orientationLockFeature', () => {
     document.dispatchEvent(new Event('fullscreenchange'));
 
     expect(orientation.unlock).not.toHaveBeenCalled();
+  });
+
+  it('restores the default type for an empty configured value', () => {
+    stubOrientation();
+
+    const store = createOrientationStore();
+    store.state.setOrientationLockType('' as ScreenOrientationLockType);
+
+    expect(store.state.orientationLockType).toBe('landscape');
+  });
+
+  it('exposes the orientation lock slice name for selectors', () => {
+    expect(orientationLockFeature.name).toBe('orientationLock');
+    expect(selectOrientationLock.displayName).toBe('orientationLock');
+  });
+
+  it('selects orientation lock state', () => {
+    stubOrientation();
+
+    const store = createOrientationStore();
+
+    expect(selectOrientationLock(store.state)?.orientationLockType).toBe('landscape');
+  });
+
+  it('selects undefined when the feature is not configured', () => {
+    const store = createStore<PlayerTarget>()(noiseSlice);
+
+    expect(selectOrientationLock(store.state)).toBeUndefined();
+  });
+
+  it('does not re-request a rejected lock when unrelated state changes', async () => {
+    // Desktop Chrome rejects `lock()` outside mobile form factors, so `held`
+    // never catches up to the requested type and the primitive cannot dedupe
+    // on its own. Only the resolved-value comparison in `sync` stops a retry
+    // for every published change.
+    const orientation = stubOrientation({
+      lock: vi.fn<ScreenOrientation['lock']>().mockRejectedValue(new Error('NotSupportedError')),
+      unlock: vi.fn<ScreenOrientation['unlock']>(),
+    });
+    const video = createMockVideo();
+    const container = document.createElement('div');
+
+    const store = createStore<PlayerTarget>()(combine(orientationLockFeature, noiseSlice));
+    stores.push(store);
+    store.attach({ media: video, container });
+
+    setFullscreenElement(container);
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await vi.waitFor(() => {
+      expect(orientation.lock).toHaveBeenCalledTimes(1);
+    });
+
+    // The feature subscribes to the whole store, and a real player publishes
+    // constantly during playback (`currentTime` alone runs at several hertz).
+    for (let tick = 1; tick <= 5; tick += 1) store.state.setTick(tick);
+
+    await vi.waitFor(() => {
+      expect(store.state.tick).toBe(5);
+    });
+
+    expect(orientation.lock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -1,11 +1,6 @@
 import { createSelector, createStore, type StateContext } from '@videojs/store';
 import { assertType, describe, expect, it } from 'vitest';
-import {
-  type ConfigurablePlayerFeatureConfig,
-  combinePlayerFeatureConfigs,
-  definePlayerFeature,
-  setPlayerConfigValue,
-} from '../feature';
+import { combinePlayerFeatureConfigs, definePlayerFeature, setPlayerConfigValue } from '../feature';
 import type { PlayerFeatureConfig, PlayerTarget } from '../player';
 
 const stateContext = {
@@ -94,32 +89,45 @@ describe('definePlayerFeature', () => {
     });
   });
 
-  it('defines a configurable player feature', () => {
-    const feature = definePlayerFeature(
-      {
-        name: 'configurable',
-        state: (_ctx, config: { enabled: boolean }) => ({ enabled: config.enabled }),
-      },
-      { enabled: true }
-    );
+  it('accepts config actions narrower than string', () => {
+    type Size = 'small' | 'large';
 
-    expect(feature.name).toBe('configurable');
-    expect(feature.state(stateContext).enabled).toBe(true);
-    expect(feature().state(stateContext).enabled).toBe(true);
-    expect(feature({ enabled: false }).state(stateContext).enabled).toBe(false);
-    expect(createSelector(feature).displayName).toBe('configurable');
-  });
+    interface EnumState {
+      size: Size;
+      setSize(value: Size | null | undefined): void;
+    }
 
-  it('keeps static config declarations out of the legacy feature-factory shape', () => {
-    type LegacyConfig = ConfigurablePlayerFeatureConfig<{ enabled: boolean }, { enabled: boolean }>;
-
-    assertType<LegacyConfig>({
-      state: (_ctx, config: { enabled: boolean }) => ({ enabled: config.enabled }),
+    const feature = definePlayerFeature({
+      name: 'enum',
+      config: {
+        size: {
+          action: 'setSize',
+          state: 'size',
+        },
+      } satisfies PlayerFeatureConfig<EnumState>,
+      state: ({ set }): EnumState => ({
+        size: 'small',
+        setSize: (value) => set({ size: value ?? 'small' }),
+      }),
     });
-    assertType<LegacyConfig>({
-      state: (_ctx, config: { enabled: boolean }) => ({ enabled: config.enabled }),
-      // @ts-expect-error Legacy factory config is fixed when the feature is created.
-      config: { enabled: true },
+
+    const store = createStore<PlayerTarget>()(feature);
+    setPlayerConfigValue(store, feature.config!.size, 'large');
+
+    expect(store.size).toBe('large');
+    expect(createSelector(feature).displayName).toBe('enum');
+
+    interface WidenedState {
+      size: Size;
+      setSize(value: Size): void;
+    }
+
+    assertType<PlayerFeatureConfig<WidenedState>>({
+      size: {
+        // @ts-expect-error Config actions must still accept null and undefined.
+        action: 'setSize',
+        state: 'size',
+      },
     });
   });
 });

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -7,6 +7,7 @@ import {
   metadataFeature,
   type PlayerStore,
   type PlayerTarget,
+  type ScreenOrientationLockType,
   type VideoPlayerStore,
   videoFeatures,
 } from '@videojs/core/dom';
@@ -72,14 +73,19 @@ describe('createPlayer', () => {
     plainProvider.contentTitle;
   });
 
-  it('accepts the orientation lock feature alias with and without config', () => {
-    const configuredOrientationLock = features.orientationLock({ type: 'portrait' });
+  it('exposes orientation lock configuration as a provider property', () => {
+    const withOrientationLock = createPlayer({ features: [features.orientationLock] });
+    const withoutOrientationLock = createPlayer({ features: [features.playback] });
+    const OrientationProvider = withOrientationLock.ProviderMixin(MediaElement);
+    const PlainProvider = withoutOrientationLock.ProviderMixin(MediaElement);
+    const orientationProvider = new OrientationProvider();
+    const plainProvider = new PlainProvider();
 
-    const defaultResult = createPlayer({ features: [features.orientationLock] });
-    const configuredResult = createPlayer({ features: [configuredOrientationLock] });
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(withOrientationLock);
+    assertType<ScreenOrientationLockType | null | undefined>(orientationProvider.orientationLockType);
 
-    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
-    assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
+    // @ts-expect-error orientation lock properties are absent when the feature is absent.
+    plainProvider.orientationLockType;
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -1,4 +1,11 @@
-import { audioFeatures, backgroundFeatures, metadataFeature, type PopupGroup, videoFeatures } from '@videojs/core/dom';
+import {
+  audioFeatures,
+  backgroundFeatures,
+  features,
+  metadataFeature,
+  type PopupGroup,
+  videoFeatures,
+} from '@videojs/core/dom';
 import { ContextConsumer } from '@videojs/element/context';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -164,6 +171,31 @@ describe('createPlayer', () => {
 
     expect(player.getAttribute('title')).toBe('Tooltip');
     expect(player.store.title).toBe('');
+  });
+
+  it('applies orientation lock configuration through attributes and properties', async () => {
+    const { ProviderMixin } = createPlayer({ features: [features.orientationLock] });
+    const ProviderElement = ProviderMixin(MediaElement);
+    const tagName = 'test-orientation-lock-provider';
+    customElements.define(tagName, ProviderElement);
+
+    const player = document.createElement(tagName) as InstanceType<typeof ProviderElement>;
+    player.setAttribute('orientation-lock-type', 'portrait');
+    document.body.append(player);
+
+    expect(player.store.orientationLockType).toBe('portrait');
+
+    player.orientationLockType = 'natural';
+    await player.updateComplete;
+
+    expect(player.store.orientationLockType).toBe('natural');
+
+    player.orientationLockType = undefined;
+    await player.updateComplete;
+
+    expect(player.store.orientationLockType).toBe('landscape');
+
+    player.remove();
   });
 
   it('leaves config attributes inert when their feature is absent', () => {

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -63,14 +63,29 @@ describe('createPlayer', () => {
     </withoutMetadata.Player>;
   });
 
-  it('accepts the orientation lock feature alias with and without config', () => {
-    const configuredOrientationLock = features.orientationLock({ type: 'portrait' });
+  it('exposes orientation lock configuration as a player prop', () => {
+    const withOrientationLock = createPlayer({ features: [features.orientationLock] });
+    const withoutOrientationLock = createPlayer({ features: [features.playback] });
 
-    const defaultResult = createPlayer({ features: [features.orientationLock] });
-    const configuredResult = createPlayer({ features: [configuredOrientationLock] });
+    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(withOrientationLock);
 
-    assertType<CreatePlayerResult<PlayerStore<[typeof features.orientationLock]>>>(defaultResult);
-    assertType<CreatePlayerResult<PlayerStore<[typeof configuredOrientationLock]>>>(configuredResult);
+    <withOrientationLock.Player orientationLockType="portrait">
+      <div />
+    </withOrientationLock.Player>;
+
+    <withOrientationLock.Player orientationLockType={null}>
+      <div />
+    </withOrientationLock.Player>;
+
+    // @ts-expect-error orientation lock props reject values outside the enum.
+    <withOrientationLock.Player orientationLockType="sideways">
+      <div />
+    </withOrientationLock.Player>;
+
+    // @ts-expect-error orientation lock props are absent when the feature is absent.
+    <withoutOrientationLock.Player orientationLockType="portrait">
+      <div />
+    </withoutOrientationLock.Player>;
   });
 
   it('resolves extended video features to generic PlayerStore', () => {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
-import { metadataFeature, type PlayerStore } from '@videojs/core/dom';
+import { features, metadataFeature, type PlayerStore } from '@videojs/core/dom';
 import { defineSlice } from '@videojs/store';
 import { Component, type ErrorInfo, type ReactNode, StrictMode, useState } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -252,6 +252,39 @@ describe('createPlayer', () => {
         </Player>
       );
       expect(store.title).toBe('');
+    });
+
+    it('applies orientation lock configuration through props', () => {
+      const { Player, usePlayer } = createPlayer({ features: [features.orientationLock] });
+
+      let store!: PlayerStore<[typeof features.orientationLock]>;
+
+      function Consumer() {
+        store = usePlayer();
+        return <span>{store.orientationLockType}</span>;
+      }
+
+      const { rerender } = render(
+        <Player orientationLockType="portrait">
+          <Consumer />
+        </Player>
+      );
+
+      expect(screen.getByText('portrait')).toBeTruthy();
+
+      rerender(
+        <Player orientationLockType="natural">
+          <Consumer />
+        </Player>
+      );
+      expect(store.orientationLockType).toBe('natural');
+
+      rerender(
+        <Player>
+          <Consumer />
+        </Player>
+      );
+      expect(store.orientationLockType).toBe('landscape');
     });
 
     it('seeds config inputs during SSR', () => {

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -265,7 +265,9 @@ function configKeyReference(node: ts.Expression): string | undefined {
 }
 
 /**
- * Map each computed key in the state() object literal to the value it starts at.
+ * Map each key in the state() object literal to the value it starts at, under
+ * the same name a config entry uses to reach it: the identifier inside a
+ * computed key, or a published member's own name.
  *
  * A named constant is resolved to its literal so the docs show the value rather
  * than a private identifier; anything else falls back to the written text. A key
@@ -284,14 +286,18 @@ function parseStateInitialValues(node: ts.Expression, sourceFile: ts.SourceFile)
 
   for (const prop of body.properties) {
     if (!ts.isPropertyAssignment(prop)) continue;
-    if (!ts.isComputedPropertyName(prop.name) || !ts.isIdentifier(prop.name.expression)) continue;
+
+    const key = ts.isComputedPropertyName(prop.name)
+      ? ts.isIdentifier(prop.name.expression) && prop.name.expression.text
+      : ts.isIdentifier(prop.name) && prop.name.text;
+    if (!key) continue;
 
     const initializer = prop.initializer;
     if (ts.isIdentifier(initializer) && initializer.text === 'undefined') continue;
 
     const resolved = ts.isIdentifier(initializer) ? constants.get(initializer.text) : undefined;
 
-    values.set(prop.name.expression.text, resolved ?? initializer.getText(sourceFile));
+    values.set(key, resolved ?? initializer.getText(sourceFile));
   }
 
   return values;

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -815,6 +815,7 @@ describe('Feature pipeline (end-to-end)', () => {
       expect(names).toContain('metadata');
       expect(names).toContain('orientationLock');
       expect(names).toContain('playback');
+      expect(names).toContain('poster');
       expect(names).toContain('volume');
     });
 
@@ -830,7 +831,7 @@ describe('Feature pipeline (end-to-end)', () => {
     });
 
     it('produces one result per feature', () => {
-      expect(results.length).toBe(5);
+      expect(results.length).toBe(6);
     });
   });
 
@@ -949,6 +950,32 @@ describe('Feature pipeline (end-to-end)', () => {
       expect(volume.config).toEqual({});
       expect(Object.keys(volume.state)).toContain('volume');
       expect(Object.keys(volume.actions)).toContain('setVolume');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // POSTER FEATURE (published-key defaults and narrow unions)
+  // ─────────────────────────────────────────────────────────────────
+  //
+  // Metadata covers an input that names its action by string. Poster covers the
+  // two steps that still have to follow a published key the rest of the way:
+  // the initial value behind it, and a value type narrower than plain text.
+
+  describe('poster (published-key defaults and narrow unions)', () => {
+    it('reads the default through a plain state key', () => {
+      const config = findFeature('poster')!.reference.config;
+
+      expect(config.poster!.default).toBe("'/poster.jpg'");
+    });
+
+    // The fixture's PlayerFeatureConfig mirrors production, so a constraint that
+    // drifted back to demanding exactly `string | null | undefined` would fail
+    // this file's own type check before it reached the assertion.
+    it('keeps a narrower union as the input type', () => {
+      const config = findFeature('poster')!.reference.config;
+
+      expect(config.posterFit!.type).toBe("undefined | null | 'contain' | 'cover'");
+      expect(config.posterFit!.default).toBe("'contain'");
     });
   });
 

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/feature.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/feature.ts
@@ -17,12 +17,16 @@ type ActionInput<Action> = Action extends (...args: infer Arguments) => unknown
     : never
   : never;
 
-/** State keys whose action accepts exactly `string | null | undefined`. */
+/**
+ * Actions accepting text, including narrower unions such as a string enum, so
+ * a feature keeps its own value type on the provider input. `null | undefined`
+ * stays mandatory because that is how a provider clears an absent input.
+ */
 type ConfigActionKey<State> = [State] extends [never]
   ? PropertyKey
   : {
       [Key in keyof State]-?: [ActionInput<State[Key]>] extends [ConfigValue]
-        ? [ConfigValue] extends [ActionInput<State[Key]>]
+        ? [null | undefined] extends [ActionInput<State[Key]>]
           ? Key
           : never
         : never;

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/index.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/index.ts
@@ -11,5 +11,6 @@ export * from './caption-style';
 export * from './metadata';
 export * from './orientation-lock';
 export * from './playback';
+export * from './poster';
 export * from './presets';
 export * from './volume';

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/poster.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/poster.ts
@@ -1,0 +1,49 @@
+/**
+ * Mock poster feature — what a published config key still has to carry.
+ *
+ * Metadata already covers an input whose action is named by string. This one
+ * covers the rest of that path: the initial value read from state() under a
+ * plain key rather than a computed one, and an input typed by a union narrower
+ * than plain text, which the config constraint has to admit.
+ */
+import { definePlayerFeature, type PlayerFeatureConfig } from '../../feature';
+
+/** A named constant default, reached through a plain rather than computed key. */
+const DEFAULT_POSTER = '/poster.jpg';
+
+type PosterFit = 'contain' | 'cover';
+
+/** Poster configuration and its user-config writers. */
+interface PosterState {
+  /** Image shown before playback starts. */
+  poster: string;
+  /** How the image fills the container. */
+  posterFit: PosterFit;
+  /** Sets the poster image. Absent input restores the default. */
+  setPoster(value: string | null | undefined): void;
+  /** Sets how the image fills the container. Absent input restores the default. */
+  setPosterFit(value: PosterFit | null | undefined): void;
+}
+
+/** Shows a poster image until playback starts. */
+export const posterFeature = definePlayerFeature({
+  name: 'poster',
+  config: {
+    /** Image shown before playback starts. */
+    poster: {
+      action: 'setPoster',
+      state: 'poster',
+    },
+    /** How the image fills the container. */
+    posterFit: {
+      action: 'setPosterFit',
+      state: 'posterFit',
+    },
+  } satisfies PlayerFeatureConfig<PosterState>,
+  state: (): PosterState => ({
+    poster: DEFAULT_POSTER,
+    posterFit: 'contain',
+    setPoster: () => {},
+    setPosterFit: () => {},
+  }),
+});

--- a/site/scripts/api-docs-builder/src/util-handler.ts
+++ b/site/scripts/api-docs-builder/src/util-handler.ts
@@ -68,6 +68,10 @@ const UTIL_ENTRY_POINTS: EntryPoint[] = [
   { index: 'packages/store/src/html/controllers/index.ts', framework: 'html' },
   { index: 'packages/core/src/core/i18n/index.ts', framework: null },
   { index: 'packages/core/src/dom/store/selectors.ts', framework: null },
+  // A selector for a feature that ships in no preset is declared beside its
+  // feature, so importing `selectors.ts` does not retain it. Those modules are
+  // not reachable from the entry points above, so each is scanned directly.
+  { index: 'packages/core/src/dom/store/features/orientation-lock.ts', framework: null },
   { index: 'packages/store/src/core/selector.ts', framework: null },
 ];
 

--- a/site/src/content/docs/reference/feature-fullscreen.mdx
+++ b/site/src/content/docs/reference/feature-fullscreen.mdx
@@ -55,13 +55,24 @@ class FullscreenButton extends MediaElement {
 
 Add <DocsLink slug="reference/feature-orientation-lock">`features.orientationLock`</DocsLink> to lock screen orientation while fullscreen is active. Unsupported browsers and rejected lock requests are ignored, so iOS Safari continues to use its normal fullscreen behavior.
 
-By default, the feature locks to `landscape`. Pass a Screen Orientation API type to customize it:
+The feature locks to `landscape` unless the provider sets another Screen Orientation API type.
 
-```ts
-import { createPlayer, features } from '@videojs/react';
-import { videoFeatures } from '@videojs/react/video';
-
-const { Player } = createPlayer({
-  features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
-});
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Player orientationLockType="portrait">
+  <Container>
+    <video src="/video.mp4" />
+  </Container>
+</Player>
 ```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<my-player orientation-lock-type="portrait">
+  <video src="/video.mp4"></video>
+</my-player>
+```
+</FrameworkCase>
+
+See <DocsLink slug="reference/feature-orientation-lock">Orientation lock</DocsLink> for the player setup.

--- a/site/src/content/docs/reference/feature-orientation-lock.mdx
+++ b/site/src/content/docs/reference/feature-orientation-lock.mdx
@@ -4,6 +4,7 @@ description: Screen orientation locking while fullscreen is active
 ---
 
 import FeatureReference from "@/components/docs/api-reference/FeatureReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 
 Locks screen orientation while fullscreen is active. Add it explicitly to a feature list; it is not included in the default video presets.
@@ -12,11 +13,11 @@ Locks screen orientation while fullscreen is active. Add it explicitly to a feat
 
 ### Usage
 
-By default, the feature locks to `landscape`. Pass a Screen Orientation API type to customize it.
+Selecting the feature adds it to the player.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="player.tsx"
-import { createPlayer, features } from '@videojs/react';
+import { Container, createPlayer, features } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
 export const { Player } = createPlayer({
@@ -27,34 +28,85 @@ export const { Player } = createPlayer({
 
 <FrameworkCase frameworks={["html"]}>
 ```ts title="player.ts"
-import { createPlayer, features } from '@videojs/html';
+import { createPlayer, features, MediaElement } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-export const { ProviderMixin } = createPlayer({
+const { ProviderMixin } = createPlayer({
   features: [...videoFeatures, features.orientationLock],
 });
+
+class MyPlayer extends ProviderMixin(MediaElement) {}
+
+customElements.define('my-player', MyPlayer);
 ```
 </FrameworkCase>
 
-<FrameworkCase frameworks={["react"]}>
-```tsx title="portrait-player.tsx"
-import { createPlayer, features } from '@videojs/react';
-import { videoFeatures } from '@videojs/react/video';
+### Orientation type
 
-export const { Player } = createPlayer({
-  features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
-});
+The feature locks to `landscape` unless the provider sets another Screen Orientation API type. The value can change while the player is running; if the screen is already locked, it re-locks to the new type.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Player orientationLockType="portrait">
+  <Container>
+    <video src="/video.mp4" />
+  </Container>
+</Player>
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-```ts title="portrait-player.ts"
-import { createPlayer, features } from '@videojs/html';
+```html
+<my-player orientation-lock-type="portrait">
+  <video src="/video.mp4"></video>
+</my-player>
+```
+
+The attribute only exists on a player that selected the feature. Setting it on
+an element built from `videoFeatures` alone does nothing.
+</FrameworkCase>
+
+Clearing the value restores `landscape`.
+
+### Selector
+
+<FrameworkCase frameworks={["react"]}>
+Pass `selectOrientationLock` to <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> to subscribe to the lock state. Returns `undefined` if the orientation lock feature is not configured.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Pass `selectOrientationLock` to <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> to subscribe to the lock state. Returns `undefined` if the orientation lock feature is not configured.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="OrientationToggle.tsx"
+import { selectOrientationLock, usePlayer } from '@videojs/react';
+
+function OrientationToggle() {
+  const lock = usePlayer(selectOrientationLock);
+  if (!lock) return null;
+
+  return (
+    <button onClick={() => lock.setOrientationLockType('portrait')}>
+      Lock portrait
+    </button>
+  );
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts title="orientation-toggle.ts"
+import { createPlayer, features, MediaElement, selectOrientationLock } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-export const { ProviderMixin } = createPlayer({
-  features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
+const { PlayerController, context } = createPlayer({
+  features: [...videoFeatures, features.orientationLock],
 });
+
+class OrientationToggle extends MediaElement {
+  readonly #lock = new PlayerController(this, context, selectOrientationLock);
+}
 ```
 </FrameworkCase>
 


### PR DESCRIPTION
Closes #1942.

Last in the stack: #2039 → #2063 → #2000 → this. Merge those first; the base is set to #2000's branch so this diff shows only what's new here.

Moves the orientation lock type from a feature-factory argument to declared provider configuration, and deletes the factory-configured feature form now that its only caller is gone.

## Docs preview

- [Orientation lock](https://deploy-preview-1999--vjs10-site.netlify.app/docs/framework/html/reference/feature-orientation-lock)
- [Fullscreen](https://deploy-preview-1999--vjs10-site.netlify.app/docs/framework/html/reference/feature-fullscreen)

## What is this?

1. `orientationLockType` becomes provider configuration — an attribute in HTML, a prop in React — and can change while the player runs
2. `features.orientationLock({ type })` is gone, along with `ConfigurablePlayerFeature`, `ConfigurablePlayerFeatureConfig`, `OrientationLockFeatureConfig`, `forConfig`, `definePlayerSlice`, and `definePlayerFeature`'s two-argument overload
3. `selectOrientationLock` joins the other feature selectors, declared beside its feature so it stays out of bundles that never select it
4. `createScreenOrientationLock` takes the type per `lock()` call instead of capturing it at construction, and serializes platform requests so the screen cannot desync from the store
5. `ScreenOrientationLockType` is exported, having previously been only structurally reachable
6. A config input may be typed by a union narrower than plain text, so the reference page's Configuration table shows the real orientation types and their `landscape` default

## The API

Select the feature as a value, not a call:

```diff
- features: [...videoFeatures, features.orientationLock({ type: 'portrait' })]
+ features: [...videoFeatures, features.orientationLock]
```

Then set the type on the provider — `orientationLockType="portrait"` as a prop on `Player` in React, `orientation-lock-type="portrait"` as an attribute on the player element in HTML. Clearing the value restores `landscape`. Read it with `selectOrientationLock`, or set it imperatively with `setOrientationLockType`.

The PR title carries the `!` so the squash-merged commit marks the break for release-please.

## What this isn't

- **No feature-owned HTML conversion metadata.** The issue sketched `String` / `Boolean` / `Number` sentinels and a non-string fixture. Orientation lock is string-valued and needs none of it; `Boolean` is unsound under the current model, because a removed boolean attribute converts to `false` rather than absent (`reactive-element.ts:186`), so a `Boolean` key defaulting to `true` could never be cleared through markup; and once the sentinel is checked against the action's parameter type it only restates what the compiler already knows. Worth designing against a feature that actually has a non-string value.
- **No validation.** A typo'd `orientation-lock-type="banana"` reaches `screen.orientation.lock()`, which rejects, and the existing `catch` swallows it — so it silently does not lock rather than falling back to the default. Left out to keep the config API unchanged. The empty string is the exception, since a valueless attribute is ordinary markup rather than a typo; it restores the default.
- **No per-adapter attribute, property, and prop coverage.** `contentTitle` already proves that plumbing, so each adapter gets one wiring test.

## Funny business

- *`ConfigActionKey` required actions to be mutually assignable with `string | null | undefined`,* which rejects `ScreenOrientationLockType | null | undefined`. The reverse clause is dropped so a narrower union keeps its own type on the provider input. Actions must still accept `null | undefined` so providers can clear.

  The builder's mock of that constraint has to move with it. It exists to reject what production rejects, so left stricter it would reject what production now accepts — the fixture declares a union-valued input, which fails its own type check if the constraint drifts back. Two other steps still assumed a private symbol: an input's initial value was read only from a computed key in `state()`, so a published key produced no default. #2000's string-name matching covers the rest, and its checker-based lookup also resolves an inherited action, which is why the syntactic version this branch first wrote is gone.

- *`selectOrientationLock` is declared beside its feature instead of in `selectors.ts`.* `createSelector` evaluates its slice at module load and every selector in that module shares one evaluation, so an entry there retains this feature in every bundle importing any selector. The other features ship in presets, so their cost is already paid; this one is in no preset, and an entry there measured **+290 B per `@videojs/html` UI component and +298 B per React one**. Declared beside the feature, 9 of 291 entries move, all inside compressor noise except `@videojs/core/dom` — the aggregate entry that includes everything — at +34 B. A `/* @__PURE__ */` annotation on the `selectors.ts` form was measured too and does not fix it: 76 entries still grow, by up to 116 B.

  The consequence is that `api-docs-builder` scans `selectors.ts` as a leaf entry point, so a selector declared outside it silently gets no reference page. The feature module is added to `UTIL_ENTRY_POINTS`, which yields `select-orientation-lock.json` and no stray pages. The placement rationale is a plain comment rather than JSDoc, since the extractor publishes JSDoc verbatim to the reference page.

- *Making the type responsive exposed three ways the lock could desync from the screen,* all from one variable standing for both "last requested" and "type we hold" (fixed in d945a1f):
  - A rejected re-lock was recorded as held. After landscape succeeded and a portrait request rejected, the guard suppressed every later portrait request — the screen stayed landscape permanently while the store and the lock both reported portrait.
  - Overlapping requests hit the same problem from the other side. The platform does not guarantee settle order, so whichever request landed last won the screen while the bookkeeping described the other.
  - Where the platform rejects — desktop Chrome, outside mobile form factors — nothing ever converged, so every published store change re-issued a rejected `screen.orientation.lock()`. The store publishes at several hertz during playback.

  The primitive now tracks `desired` and `held` separately and reconciles between them one request at a time. A re-entrant call records the new type and returns; the running pass re-reads `desired` before it exits, so the last request wins and platform requests never overlap. A rejection leaves `held` alone, which keeps it describing the platform and lets a later request for the same type through.

- *`attach` compares a resolved value rather than detecting a fullscreen edge.* Edge detection would not have fired on a config change during steady-state fullscreen, so one `sync` now serves fullscreen events and config changes alike. Comparing the resolved `(fullscreen, type)` value is also what keeps the whole-store subscription from re-requesting a rejected lock.

- *A single-owner value does not need a private symbol.* Nothing in media donates an orientation preference, so there is nothing to resolve: `orientationLockType` is a published source key defaulting to `landscape`, with `setOrientationLockType` restoring that default for absent input — no symbol and no `derived` formula, unlike `contentTitle`, which needs both because three owners compete for it. Publishing the key is also what makes it observable, since `publish` copies string keys only (`store.ts:132`) and a symbol-keyed change notifies nobody — and this behavior reacts to its own configuration. `internal/design/store/resolved-feature-state.md` previously stated config inputs are always symbol-keyed; it now records this case.

- *The HTML docs example was inert.* It set `orientation-lock-type` on a player whose `videoFeatures` preset does not include orientation lock, contradicting the same page's note that the feature is not in the default presets. It now defines an element that selects the feature. The fullscreen page's orientation section keeps a code example, updated from the deleted factory call to the provider input, and framework-gated — the sample it replaced was React-only code shown to HTML readers too.

- *The examples were rewritten again for the `createPlayer` change on main.* `createPlayer` no longer returns `Container`, and the compound `Player.Provider` / `Player.Container` form is gone, so the React samples destructure `Player` and nest a separately imported `Container`. The HTML samples drop `slot="media"`, which the container reference now states is unnecessary.

## Testing

Verified on the merged stack. `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace` (10/10), and `pnpm -F site astro check` (0 errors, 0 warnings) pass. Package suites pass individually — core 1439, html 352, react 422, store 124, and site 551, which includes the api-docs-builder suite.

Coverage added for initial config, updates, clearing to the default, detach preservation, post-detach quiescence, re-lock during fullscreen, selector identity and shape, and one wiring test per adapter. The builder's `poster` fixture covers the two steps a published config key still has to carry: its initial value, and a value type narrower than plain text.

The lock state machine is pinned by exact platform call counts rather than by observing a later `unlock()` — the earlier supersede test passed under a mutation of the branch it claimed to cover. Each new guard was mutation-checked: dropping serialization, recording a rejection as held, `??` for `||`, and dropping the `sync` comparison each fail at least one test.

Also fixes cross-test leakage in `orientation-lock.test.ts`, where stores were never destroyed, so their `document` fullscreen listeners stayed live and reacted to later tests' dispatches.

https://claude.ai/code/session_01DdtP5uKxwgyhrDLEg5T6in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API for orientation lock plus a rewritten lock state machine that talks to `screen.orientation`. Wrong reconciliation could leave the device locked or spam rejected lock() calls during playback.
> 
> **Overview**
> Orientation lock type is now live provider configuration (`orientationLockType` / `orientation-lock-type`) instead of a one-shot `features.orientationLock({ type })` factory argument. Clearing the value restores `landscape`. The type can change while fullscreen is already active.
> 
> Removes the factory-configured feature form (`ConfigurablePlayerFeature` and `definePlayerFeature`'s two-argument overload). Config actions may now be a narrower string union plus `null | undefined`, so the provider input keeps the Screen Orientation enum.
> 
> `createScreenOrientationLock` takes the type on each `lock()` and serializes platform requests (`desired` vs `held`) so overlapping or rejected locks cannot desync the screen. `selectOrientationLock` is declared beside the feature to avoid pulling it into every selector bundle.
> 
> Docs and adapters (React prop, HTML attribute) are updated for the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0538d98875787a53e7ccf22da430023cc2afe0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->