### PR TITLE
feat(site): document metadata feature

### DIFF
--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -31,6 +31,7 @@ interface MetadataSourceState extends Omit<MediaMetadataState, 'title' | 'poster
 export const metadataFeature = definePlayerFeature({
   name: 'metadata',
   config: {
+    /** The title to display. Takes precedence over the title the media carries. */
     title: {
       action: SET_USER_TITLE,
       state: USER_TITLE,
@@ -38,6 +39,7 @@ export const metadataFeature = definePlayerFeature({
       // another name there.
       html: { attribute: 'content-title' },
     },
+    /** The poster to display. Takes precedence over the poster the media carries. */
     poster: {
       action: SET_USER_POSTER,
       state: USER_POSTER,
@@ -52,7 +54,12 @@ export const metadataFeature = definePlayerFeature({
     [SET_USER_POSTER]: (value) => set({ [USER_POSTER]: value }),
   }),
   derived: {
+    /** The resolved content title. Set it through the player, not through the store. */
     title: ({ get }) => get()[USER_TITLE] ?? get()[MEDIA_TITLE] ?? DEFAULT_TITLE,
+    /**
+     * The resolved poster URL, independent of the media element's own `poster`.
+     * Set it through the player, not through the store.
+     */
     poster: ({ get }) => get()[USER_POSTER] ?? get()[MEDIA_POSTER] ?? DEFAULT_POSTER,
   },
   attach({ target, signal, set }) {

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -232,13 +232,6 @@ function parseConfigEntries(node: ts.Expression, featureName: string): FeatureCo
 }
 
 /**
- * Read the source-state member a config entry points at. An identifier names a
- * symbol constant, so the member is keyed by that symbol; a string names the
- * member itself. Both collapse to the written text, and the lookups that
- * consume it try each shape, since a symbol constant's name and a member name
- * never collide.
- */
-/**
  * Read the attribute name out of a config entry's `html` block.
  *
  * The name is text in markup rather than a reference to a state or action key,
@@ -258,6 +251,13 @@ function htmlAttributeName(node: ts.Expression): string | undefined {
   return undefined;
 }
 
+/**
+ * Read the source-state member a config entry points at. An identifier names a
+ * symbol constant, so the member is keyed by that symbol; a string names the
+ * member itself. Both collapse to the written text, and the lookups that
+ * consume it try each shape, since a symbol constant's name and a member name
+ * never collide.
+ */
 function configKeyReference(node: ts.Expression): string | undefined {
   if (ts.isIdentifier(node)) return node.text;
   if (ts.isStringLiteralLike(node)) return node.text;

--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -14,20 +14,60 @@
  *   - State type: explicit return type annotation on the state() arrow function
  *   - Silent features: state() returns an empty object
  *   - State interfaces: exported from packages/media/src/core/state.ts
+ *
+ * Most features annotate state() with an interface from media/state.ts, which is
+ * also the shape the store publishes. A feature that resolves several inputs
+ * instead keeps them in private, symbol-keyed source state and publishes the
+ * resolved value through `derived`, so its annotation names an interface that
+ * lives in the feature's own file and describes internals.
+ *
+ * When the annotated name isn't in media/state.ts, the published shape is
+ * derived from the feature itself: every non-symbol property of the source
+ * state (inherited members included, with their JSDoc) plus every `derived`
+ * key. Symbol-keyed members are private by construction, so nothing needs to
+ * mark them — TypeScript names them `__@SYMBOL@id`, which is how they're
+ * recognized. No annotation, and nothing for a feature author to remember.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as ts from 'typescript';
-import type { FeatureActionDef, FeatureReference, FeatureStateDef } from './types.js';
+import type { FeatureActionDef, FeatureConfigDef, FeatureReference, FeatureStateDef } from './types.js';
 import { createTypeScriptProgram } from './typescript.js';
-import { getJSDocDescription } from './utils.js';
+import { getJSDocDescription, log, unwrapObjectLiteral } from './utils.js';
+
+/** TypeScript's name prefix for a member keyed by a unique symbol. */
+const SYMBOL_MEMBER_PREFIX = '__@';
 
 const SKIP_FILES = new Set(['index.ts', 'presets.ts', 'feature.parts.ts']);
 
 interface FeatureSource {
   filePath: string;
   name: string;
+  /** The state() annotation. Names a media/state.ts interface, or a local one. */
   stateTypeName?: string;
+  /** `derived` keys, which publish resolved values alongside the source state. */
+  derivedKeys: DerivedKeySource[];
+  config: FeatureConfigSource[];
+  /** JSDoc on the feature export, used when the shape is derived locally. */
+  description?: string;
+}
+
+interface DerivedKeySource {
+  name: string;
+  description?: string;
+}
+
+/**
+ * One `config` entry, resolved to the private source-state keys it drives.
+ * `actionKey` types the input; `stateKey` supplies its initial value.
+ */
+interface FeatureConfigSource {
+  name: string;
+  actionKey: string;
+  stateKey: string;
+  description?: string;
+  defaultValue?: string;
+  attribute?: string;
 }
 
 export interface FeatureResult {
@@ -51,6 +91,8 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
       if (!ts.isVariableStatement(node)) return;
       if (!node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) return;
 
+      const exportDescription = getJSDocDescription(node);
+
       for (const decl of node.declarationList.declarations) {
         if (!ts.isIdentifier(decl.name)) continue;
         const varName = decl.name.text;
@@ -62,6 +104,9 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
 
         let name: string | undefined;
         let stateTypeName: string | undefined;
+        let stateFunction: ts.Expression | undefined;
+        let derivedKeys: DerivedKeySource[] = [];
+        let config: FeatureConfigSource[] = [];
         let silent = false;
 
         for (const prop of arg.properties) {
@@ -71,8 +116,17 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
             name = prop.initializer.text;
           }
 
+          if (prop.name.text === 'config') {
+            config = parseConfigEntries(prop.initializer, name ?? varName);
+          }
+
+          if (prop.name.text === 'derived') {
+            derivedKeys = parseDerivedKeys(prop.initializer);
+          }
+
           if (prop.name.text === 'state') {
             const fn = prop.initializer;
+            stateFunction = fn;
             if ((ts.isArrowFunction(fn) || ts.isFunctionExpression(fn)) && fn.type && ts.isTypeReferenceNode(fn.type)) {
               stateTypeName = fn.type.typeName.getText(sourceFile);
             } else if (isEmptyState(fn)) {
@@ -81,14 +135,205 @@ function discoverFeatureSources(featuresDir: string): FeatureSource[] {
           }
         }
 
+        if (config.length > 0 && stateFunction) {
+          const initialValues = parseStateInitialValues(stateFunction, sourceFile);
+          for (const entry of config) {
+            entry.defaultValue = initialValues.get(entry.stateKey);
+          }
+        }
+
         if (name && (stateTypeName || silent)) {
-          sources.push({ filePath, name, stateTypeName });
+          sources.push({ filePath, name, stateTypeName, derivedKeys, config, description: exportDescription });
         }
       }
     });
   }
 
   return sources;
+}
+
+/** Read the `derived` map, whose keys are published alongside the source state. */
+function parseDerivedKeys(node: ts.Expression): DerivedKeySource[] {
+  const literal = unwrapObjectLiteral(node);
+  if (!literal) return [];
+
+  const keys: DerivedKeySource[] = [];
+
+  for (const prop of literal.properties) {
+    if (!ts.isPropertyAssignment(prop) && !ts.isMethodDeclaration(prop)) continue;
+    if (!ts.isIdentifier(prop.name)) continue;
+
+    const key: DerivedKeySource = { name: prop.name.text };
+    const description = getJSDocDescription(prop);
+    if (description) key.description = description;
+
+    keys.push(key);
+  }
+
+  return keys;
+}
+
+/**
+ * Read the `config` map: `{ contentTitle: { action: 'setContentTitle', state: USER_X } }`.
+ *
+ * Each value names a source-state member either as an identifier bound to a
+ * private symbol or as a string naming the member outright, which is how an
+ * input that forwards to the feature's own public setter is written. An entry
+ * naming anything else is dropped — and warned about, because a silently
+ * missing input reads to a docs reader as "this feature has no such setting".
+ */
+function parseConfigEntries(node: ts.Expression, featureName: string): FeatureConfigSource[] {
+  const literal = unwrapObjectLiteral(node);
+  if (!literal) return [];
+
+  const entries: FeatureConfigSource[] = [];
+
+  for (const prop of literal.properties) {
+    if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+
+    const entryLiteral = unwrapObjectLiteral(prop.initializer);
+    if (!entryLiteral) continue;
+
+    let actionKey: string | undefined;
+    let stateKey: string | undefined;
+    let attribute: string | undefined;
+
+    for (const member of entryLiteral.properties) {
+      if (!ts.isPropertyAssignment(member) || !ts.isIdentifier(member.name)) continue;
+
+      if (member.name.text === 'html') {
+        attribute = htmlAttributeName(member.initializer);
+        continue;
+      }
+
+      const key = configKeyReference(member.initializer);
+      if (!key) continue;
+
+      if (member.name.text === 'action') actionKey = key;
+      if (member.name.text === 'state') stateKey = key;
+    }
+
+    if (!actionKey || !stateKey) {
+      log.warn(
+        `feature "${featureName}": config input "${prop.name.text}" has an unreadable action or state — omitted from the reference.`
+      );
+      continue;
+    }
+
+    const entry: FeatureConfigSource = { name: prop.name.text, actionKey, stateKey };
+    const description = getJSDocDescription(prop);
+    if (description) entry.description = description;
+    if (attribute) entry.attribute = attribute;
+
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+/**
+ * Read the source-state member a config entry points at. An identifier names a
+ * symbol constant, so the member is keyed by that symbol; a string names the
+ * member itself. Both collapse to the written text, and the lookups that
+ * consume it try each shape, since a symbol constant's name and a member name
+ * never collide.
+ */
+/**
+ * Read the attribute name out of a config entry's `html` block.
+ *
+ * The name is text in markup rather than a reference to a state or action key,
+ * so only a literal counts: an identifier here would be a constant this pass
+ * cannot resolve, and guessing at it would put a wrong attribute in the docs.
+ */
+function htmlAttributeName(node: ts.Expression): string | undefined {
+  const literal = unwrapObjectLiteral(node);
+  if (!literal) return undefined;
+
+  for (const member of literal.properties) {
+    if (!ts.isPropertyAssignment(member) || !ts.isIdentifier(member.name)) continue;
+    if (member.name.text !== 'attribute') continue;
+    if (ts.isStringLiteralLike(member.initializer)) return member.initializer.text;
+  }
+
+  return undefined;
+}
+
+function configKeyReference(node: ts.Expression): string | undefined {
+  if (ts.isIdentifier(node)) return node.text;
+  if (ts.isStringLiteralLike(node)) return node.text;
+  return undefined;
+}
+
+/**
+ * Map each computed key in the state() object literal to the value it starts at.
+ *
+ * A named constant is resolved to its literal so the docs show the value rather
+ * than a private identifier; anything else falls back to the written text. A key
+ * that starts at `undefined` is left out, because an unset input is what an
+ * absent default already says — and every other reference omits it rather than
+ * printing "undefined" in the default column.
+ */
+function parseStateInitialValues(node: ts.Expression, sourceFile: ts.SourceFile): Map<string, string> {
+  const values = new Map<string, string>();
+  if (!ts.isArrowFunction(node) && !ts.isFunctionExpression(node)) return values;
+
+  const body = ts.isBlock(node.body) ? findReturnedObjectLiteral(node.body) : unwrapObjectLiteral(node.body);
+  if (!body) return values;
+
+  const constants = collectLiteralConstants(sourceFile);
+
+  for (const prop of body.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    if (!ts.isComputedPropertyName(prop.name) || !ts.isIdentifier(prop.name.expression)) continue;
+
+    const initializer = prop.initializer;
+    if (ts.isIdentifier(initializer) && initializer.text === 'undefined') continue;
+
+    const resolved = ts.isIdentifier(initializer) ? constants.get(initializer.text) : undefined;
+
+    values.set(prop.name.expression.text, resolved ?? initializer.getText(sourceFile));
+  }
+
+  return values;
+}
+
+/** Map file-level `const NAME = <literal>` declarations to their literal text. */
+function collectLiteralConstants(sourceFile: ts.SourceFile): Map<string, string> {
+  const constants = new Map<string, string>();
+
+  ts.forEachChild(sourceFile, (node) => {
+    if (!ts.isVariableStatement(node)) return;
+    if (!(node.declarationList.flags & ts.NodeFlags.Const)) return;
+
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue;
+      if (!isLiteralInitializer(decl.initializer)) continue;
+
+      constants.set(decl.name.text, decl.initializer.getText(sourceFile));
+    }
+  });
+
+  return constants;
+}
+
+function isLiteralInitializer(node: ts.Expression): boolean {
+  return (
+    ts.isStringLiteral(node) ||
+    ts.isNoSubstitutionTemplateLiteral(node) ||
+    ts.isNumericLiteral(node) ||
+    node.kind === ts.SyntaxKind.TrueKeyword ||
+    node.kind === ts.SyntaxKind.FalseKeyword ||
+    node.kind === ts.SyntaxKind.NullKeyword
+  );
+}
+
+function findReturnedObjectLiteral(block: ts.Block): ts.ObjectLiteralExpression | undefined {
+  for (const statement of block.statements) {
+    if (ts.isReturnStatement(statement) && statement.expression) {
+      return unwrapObjectLiteral(statement.expression);
+    }
+  }
+  return undefined;
 }
 
 function isEmptyState(node: ts.Expression): boolean {
@@ -171,6 +416,172 @@ function extractInterfaceMembers(
   return { state, actions };
 }
 
+// ─── Derived Publication ──────────────────────────────────────────
+
+/**
+ * Derive the published shape from the feature itself, for features whose
+ * state() annotation names a private interface rather than a media/state.ts one.
+ *
+ * Every non-symbol property of the source-state type is public — inherited
+ * members included, which is how a `MediaMetadataState`-style base contributes
+ * its members and their JSDoc. Symbol-keyed members are private by
+ * construction. `derived` keys are published on top, typed from what their
+ * function returns.
+ */
+function extractPublishedShape(
+  sourceStateDecl: ts.InterfaceDeclaration,
+  derivedKeys: readonly DerivedKeySource[],
+  derivedLiteral: ts.ObjectLiteralExpression | undefined,
+  checker: ts.TypeChecker
+): { state: Record<string, FeatureStateDef>; actions: Record<string, FeatureActionDef> } {
+  const state: Record<string, FeatureStateDef> = {};
+  const actions: Record<string, FeatureActionDef> = {};
+
+  const declaredType = checker.getTypeAtLocation(sourceStateDecl);
+
+  for (const property of checker.getPropertiesOfType(declaredType)) {
+    const name = property.escapedName as string;
+    if (name.startsWith(SYMBOL_MEMBER_PREFIX)) continue;
+
+    const type = checker.getTypeOfSymbolAtLocation(property, sourceStateDecl);
+    const description = ts.displayPartsToString(property.getDocumentationComment(checker)) || undefined;
+    const callSignature = checker.getSignaturesOfType(type, ts.SignatureKind.Call)[0];
+
+    if (callSignature) {
+      const params = callSignature
+        .getParameters()
+        .map((p) => `${p.name}: ${formatCheckerType(checker.getTypeOfSymbolAtLocation(p, sourceStateDecl), checker)}`)
+        .join(', ');
+      const returnType = formatCheckerType(callSignature.getReturnType(), checker);
+
+      const def: FeatureActionDef = { type: `(${params}) => ${returnType}` };
+      if (description) def.description = description;
+      actions[name] = def;
+    } else {
+      const def: FeatureStateDef = { type: formatCheckerType(type, checker) };
+      if (description) def.description = description;
+      state[name] = def;
+    }
+  }
+
+  for (const key of derivedKeys) {
+    const def: FeatureStateDef = { type: derivedValueType(key.name, derivedLiteral, checker) };
+    if (key.description) def.description = key.description;
+    state[key.name] = def;
+  }
+
+  return { state, actions };
+}
+
+function derivedValueType(
+  name: string,
+  derivedLiteral: ts.ObjectLiteralExpression | undefined,
+  checker: ts.TypeChecker
+): string {
+  const property = derivedLiteral?.properties.find((p) => p.name && ts.isIdentifier(p.name) && p.name.text === name);
+  if (!property) return 'unknown';
+
+  const value = ts.isPropertyAssignment(property) ? property.initializer : property;
+  const signature = checker.getSignaturesOfType(checker.getTypeAtLocation(value), ts.SignatureKind.Call)[0];
+  if (!signature) return 'unknown';
+
+  return formatCheckerType(signature.getReturnType(), checker);
+}
+
+// ─── Configuration Extraction ─────────────────────────────────────
+
+/**
+ * Type each config input from the action it forwards to.
+ *
+ * An input whose action can't be found is still emitted — the prop exists
+ * either way — with its type left unresolved, and warned about so an unresolved
+ * type isn't mistaken for a deliberate one.
+ */
+function extractFeatureConfig(
+  entries: readonly FeatureConfigSource[],
+  sourceStateDecl: ts.InterfaceDeclaration | undefined,
+  checker: ts.TypeChecker,
+  featureName: string
+): Record<string, FeatureConfigDef> {
+  const config: Record<string, FeatureConfigDef> = {};
+
+  for (const entry of entries) {
+    const type = configInputType(entry.actionKey, sourceStateDecl, checker);
+
+    if (type === UNRESOLVED_TYPE) {
+      log.warn(
+        `feature "${featureName}": config input "${entry.name}" points at action "${entry.actionKey}", which has no matching source-state member — type left as "${UNRESOLVED_TYPE}".`
+      );
+    }
+
+    const def: FeatureConfigDef = { type };
+    if (entry.defaultValue) def.default = entry.defaultValue;
+    if (entry.description) def.description = entry.description;
+    if (entry.attribute) def.attribute = entry.attribute;
+
+    config[entry.name] = def;
+  }
+
+  return config;
+}
+
+const UNRESOLVED_TYPE = 'unknown';
+
+function configInputType(
+  actionKey: string,
+  sourceStateDecl: ts.InterfaceDeclaration | undefined,
+  checker: ts.TypeChecker
+): string {
+  if (!sourceStateDecl) return UNRESOLVED_TYPE;
+
+  // A symbol-keyed action is declared in this interface under a computed name,
+  // so it is matched by the identifier inside the brackets.
+  const member = findComputedMember(sourceStateDecl, actionKey);
+  const parameter = member && actionParameter(member);
+  if (parameter?.type) return formatCheckerType(checker.getTypeFromTypeNode(parameter.type), checker);
+
+  return namedActionInputType(actionKey, sourceStateDecl, checker);
+}
+
+/**
+ * Type an action named outright rather than through a symbol. It may be
+ * inherited from the published interface the source state extends, so it is
+ * matched against the resolved type instead of this declaration's own members.
+ */
+function namedActionInputType(
+  actionKey: string,
+  sourceStateDecl: ts.InterfaceDeclaration,
+  checker: ts.TypeChecker
+): string {
+  const declaredType = checker.getTypeAtLocation(sourceStateDecl);
+  const property = checker.getPropertiesOfType(declaredType).find((p) => p.escapedName === actionKey);
+  if (!property) return UNRESOLVED_TYPE;
+
+  const type = checker.getTypeOfSymbolAtLocation(property, sourceStateDecl);
+  const parameter = checker.getSignaturesOfType(type, ts.SignatureKind.Call)[0]?.getParameters()[0];
+  if (!parameter) return UNRESOLVED_TYPE;
+
+  return formatCheckerType(checker.getTypeOfSymbolAtLocation(parameter, sourceStateDecl), checker);
+}
+
+function findComputedMember(decl: ts.InterfaceDeclaration, identifier: string): ts.TypeElement | undefined {
+  return decl.members.find((member) => {
+    const name = member.name;
+    return name && ts.isComputedPropertyName(name) && ts.isIdentifier(name.expression)
+      ? name.expression.text === identifier
+      : false;
+  });
+}
+
+/** Config actions are written as method signatures or as function-typed properties. */
+function actionParameter(member: ts.TypeElement): ts.ParameterDeclaration | undefined {
+  if (ts.isMethodSignature(member)) return member.parameters[0];
+  if (ts.isPropertySignature(member) && member.type && ts.isFunctionTypeNode(member.type)) {
+    return member.type.parameters[0];
+  }
+  return undefined;
+}
+
 // ─── Pipeline ─────────────────────────────────────────────────────
 
 export function generateFeatureReferences(monorepoRoot: string): FeatureResult[] {
@@ -182,8 +593,10 @@ export function generateFeatureReferences(monorepoRoot: string): FeatureResult[]
   const sources = discoverFeatureSources(featuresDir);
   if (sources.length === 0) return [];
 
-  // Create a TS program with the state file for the checker
-  const program = createTypeScriptProgram(monorepoRoot, [stateFilePath]);
+  // The state file supplies published interfaces. A feature's own file is only
+  // needed when it declares config inputs or publishes through `derived`.
+  const localFiles = sources.filter(needsOwnSourceFile).map((source) => source.filePath);
+  const program = createTypeScriptProgram(monorepoRoot, [stateFilePath, ...new Set(localFiles)]);
   const checker = program.getTypeChecker();
   const stateSourceFile = program.getSourceFile(stateFilePath);
   if (!stateSourceFile) return [];
@@ -198,35 +611,122 @@ export function generateFeatureReferences(monorepoRoot: string): FeatureResult[]
 
   const results: FeatureResult[] = [];
   for (const source of sources) {
-    if (!source.stateTypeName) {
-      const ref: FeatureReference = {
-        name: source.name,
-        slug: source.name,
-        state: {},
-        actions: {},
-      };
+    const sourceStateDecl = findSourceStateDecl(program, source);
+    const config = extractFeatureConfig(source.config, sourceStateDecl, checker, source.name);
 
-      results.push({ name: source.name, slug: source.name, reference: ref });
-      continue;
-    }
-
-    const interfaceDecl = interfaces.get(source.stateTypeName);
-    if (!interfaceDecl) continue;
-
-    const description = getJSDocDescription(interfaceDecl);
-    const { state, actions } = extractInterfaceMembers(interfaceDecl, checker, stateSourceFile);
+    const published = resolvePublishedShape(source, interfaces, sourceStateDecl, program, checker, stateSourceFile);
+    if (!published) continue;
 
     const ref: FeatureReference = {
       name: source.name,
       slug: source.name,
-      state,
-      actions,
+      state: published.state,
+      actions: published.actions,
+      config,
     };
 
-    if (description) ref.description = description;
+    if (published.description) ref.description = published.description;
 
     results.push({ name: source.name, slug: source.name, reference: ref });
   }
 
   return results;
+}
+
+/**
+ * A feature file joins the program only when the checker has to read it: to
+ * type a config input's private action, or to derive a published shape the
+ * state file doesn't hold.
+ */
+function needsOwnSourceFile(source: FeatureSource): boolean {
+  return source.config.length > 0 || source.derivedKeys.length > 0;
+}
+
+interface PublishedShape {
+  state: Record<string, FeatureStateDef>;
+  actions: Record<string, FeatureActionDef>;
+  description?: string;
+}
+
+/**
+ * Prefer the media/state.ts interface the annotation names. When it isn't there,
+ * the annotation describes private source state, so derive the published shape
+ * from the feature itself.
+ */
+function resolvePublishedShape(
+  source: FeatureSource,
+  interfaces: ReadonlyMap<string, ts.InterfaceDeclaration>,
+  sourceStateDecl: ts.InterfaceDeclaration | undefined,
+  program: ts.Program,
+  checker: ts.TypeChecker,
+  stateSourceFile: ts.SourceFile
+): PublishedShape | undefined {
+  if (!source.stateTypeName) return { state: {}, actions: {} };
+
+  const interfaceDecl = interfaces.get(source.stateTypeName);
+  if (interfaceDecl) {
+    return {
+      ...extractInterfaceMembers(interfaceDecl, checker, stateSourceFile),
+      description: getJSDocDescription(interfaceDecl),
+    };
+  }
+
+  if (!sourceStateDecl) {
+    log.warn(
+      `feature "${source.name}": state() names "${source.stateTypeName}", which is neither in media/state.ts nor declared in the feature file — no reference generated.`
+    );
+    return undefined;
+  }
+
+  const featureSourceFile = program.getSourceFile(source.filePath);
+  return {
+    ...extractPublishedShape(
+      sourceStateDecl,
+      source.derivedKeys,
+      featureSourceFile && findDerivedLiteral(featureSourceFile),
+      checker
+    ),
+    // No published interface to borrow from, so the feature documents itself.
+    description: source.description,
+  };
+}
+
+/** Locate the interface the feature's state() function annotates, in its own file. */
+function findSourceStateDecl(program: ts.Program, source: FeatureSource): ts.InterfaceDeclaration | undefined {
+  if (!source.stateTypeName) return undefined;
+
+  const featureSourceFile = program.getSourceFile(source.filePath);
+  if (!featureSourceFile) return undefined;
+
+  let found: ts.InterfaceDeclaration | undefined;
+  ts.forEachChild(featureSourceFile, (node) => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === source.stateTypeName) {
+      found = node;
+    }
+  });
+
+  return found;
+}
+
+/** Locate the `derived` object literal in a feature file, for typing its values. */
+function findDerivedLiteral(sourceFile: ts.SourceFile): ts.ObjectLiteralExpression | undefined {
+  let found: ts.ObjectLiteralExpression | undefined;
+
+  ts.forEachChild(sourceFile, (node) => {
+    if (!ts.isVariableStatement(node)) return;
+
+    for (const decl of node.declarationList.declarations) {
+      if (!decl.initializer || !ts.isCallExpression(decl.initializer)) continue;
+      const arg = decl.initializer.arguments[0];
+      if (!arg || !ts.isObjectLiteralExpression(arg)) continue;
+
+      for (const prop of arg.properties) {
+        if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+        if (prop.name.text !== 'derived') continue;
+        found = unwrapObjectLiteral(prop.initializer);
+      }
+    }
+  });
+
+  return found;
 }

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -957,7 +957,7 @@ describe('Feature pipeline (end-to-end)', () => {
   // ─────────────────────────────────────────────────────────────────
   //
   // `fontFamily` is the working named-action shape: public setters are optional
-  // on a feature, and this is the one that still has an inherited one. The two
+  // on a feature, and this is the one that carries an inherited one. The two
   // failures below produce output that looks fine and is wrong, so the warning
   // is part of the contract, not a nicety.
 

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -51,6 +51,10 @@
  *   volume.ts    — Complex feature. Exercises: numeric state, type alias
  *                  (MediaFeatureAvailability), methods with params + returns,
  *                  interface-level JSDoc → feature description.
+ *   metadata.ts  — Resolved + configured feature. Exercises: `@state` tag
+ *                  naming the published interface when state() annotates
+ *                  private source state, and `config` inputs typed from the
+ *                  symbol-keyed private actions they forward to.
  *   presets.ts   — Feature bundles. Exercises: plural *Features naming
  *                  (filtered out of feature discovery), array resolution
  *                  for preset feature lists.
@@ -92,7 +96,7 @@
  *                   without CustomMediaElement. API reference manually maintained.
  */
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { type FeatureResult, generateFeatureReferences } from '../feature-handler';
 import { generateMediaElementReferences, type MediaElementResult } from '../media-element-handler';
 import { generateComponentReferences } from '../pipeline';
@@ -782,6 +786,11 @@ describe('Util pipeline (end-to-end)', () => {
 //   - Filtering: plural *Features (feature bundles) are excluded
 //   - State extraction: interface properties → state record
 //   - Action extraction: interface methods → actions record
+//   - Published state: derived from the feature when state() annotates a
+//     local interface rather than one from media/state.ts
+//   - Config: `config` inputs → provider props, typed from the action they
+//     forward to — a symbol-keyed private one or a public setter named
+//     outright — defaulted from the state() initializer, described by JSDoc
 //   - JSDoc: member descriptions flow through, interface-level JSDoc
 //     becomes the feature description
 //   - Type aliases: expanded in the output (MediaFeatureAvailability →
@@ -802,6 +811,8 @@ describe('Feature pipeline (end-to-end)', () => {
   describe('Discovery', () => {
     it('discovers features from the features index', () => {
       const names = results.map((r) => r.name);
+      expect(names).toContain('captionStyle');
+      expect(names).toContain('metadata');
       expect(names).toContain('orientationLock');
       expect(names).toContain('playback');
       expect(names).toContain('volume');
@@ -819,7 +830,7 @@ describe('Feature pipeline (end-to-end)', () => {
     });
 
     it('produces one result per feature', () => {
-      expect(results.length).toBe(3);
+      expect(results.length).toBe(5);
     });
   });
 
@@ -829,6 +840,180 @@ describe('Feature pipeline (end-to-end)', () => {
 
       expect(ref.state).toEqual({});
       expect(ref.actions).toEqual({});
+    });
+
+    it('has no configuration', () => {
+      expect(findFeature('orientationLock')!.reference.config).toEqual({});
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // METADATA FEATURE (published state + configuration)
+  // ─────────────────────────────────────────────────────────────────
+  //
+  // state() annotates MetadataSourceState, which is local to the feature, so
+  // the published shape is derived. Here the interface omits every member of
+  // the one it extends and keeps the rest behind symbols, so `derived` keys are
+  // the whole published shape and there are no actions at all. `config` maps
+  // two provider inputs onto private state keys and the symbol-keyed actions
+  // that write them.
+
+  describe('metadata (published shape derived from the feature)', () => {
+    it('publishes derived keys with their inferred type and JSDoc', () => {
+      const ref = findFeature('metadata')!.reference;
+
+      expect(ref.state.title).toEqual({
+        type: 'string',
+        description: 'The resolved content title.',
+      });
+      expect(ref.state.poster).toEqual({
+        type: 'string',
+        description: 'The resolved poster URL.',
+      });
+    });
+
+    it('publishes no actions when the source state keeps every writer private', () => {
+      const ref = findFeature('metadata')!.reference;
+
+      // An empty record, not a missing key: the model drops the section on
+      // emptiness, so the reference must say "none" rather than "unknown".
+      expect(ref.actions).toEqual({});
+    });
+
+    it('omits symbol-keyed source state as private', () => {
+      const ref = findFeature('metadata')!.reference;
+
+      expect(Object.keys(ref.state)).toEqual(['title', 'poster']);
+      expect(JSON.stringify(ref)).not.toContain('__@');
+    });
+
+    it('describes itself from the feature export JSDoc', () => {
+      const ref = findFeature('metadata')!.reference;
+
+      expect(ref.description).toBe('Resolves user and media content metadata into player state.');
+    });
+  });
+
+  describe('metadata (configuration)', () => {
+    it('emits one input per config key, in declaration order', () => {
+      const config = findFeature('metadata')!.reference.config;
+
+      expect(Object.keys(config)).toEqual(['title', 'poster']);
+    });
+
+    it('types each input from the symbol-keyed action it forwards to', () => {
+      const config = findFeature('metadata')!.reference.config;
+
+      // MediaContentValue = string | null | undefined, reached through the
+      // computed `[SET_USER_TITLE]` / `[SET_USER_POSTER]` members.
+      for (const input of Object.values(config)) {
+        expect(input.type).toContain('string');
+        expect(input.type).toContain('null');
+        expect(input.type).toContain('undefined');
+      }
+    });
+
+    it('omits the default for an input whose state key starts at undefined', () => {
+      const config = findFeature('metadata')!.reference.config;
+
+      // An unset input is what an absent default already says; printing
+      // "undefined" in the default column would be noise on every row.
+      expect(config.title!.default).toBeUndefined();
+      expect(config.poster!.default).toBeUndefined();
+    });
+
+    it('carries a declared attribute name, and leaves it off when the key is used as-is', () => {
+      const config = findFeature('metadata')!.reference.config;
+
+      // `title` is taken on an element, so the feature declares another name for
+      // markup. `poster` isn't, so it takes the kebab-cased key and the
+      // reference stays silent rather than repeating what the renderer derives.
+      expect(config.title!.attribute).toBe('content-title');
+      expect(config.poster!.attribute).toBeUndefined();
+    });
+
+    it('carries JSDoc from the config entry', () => {
+      const config = findFeature('metadata')!.reference.config;
+
+      expect(config.title!.description).toBe(
+        'The title to display. Takes precedence over the title the media carries.'
+      );
+      expect(config.poster!.description).toBe(
+        'The poster to display. Takes precedence over the poster the media carries.'
+      );
+    });
+
+    it('leaves state and actions untouched by config extraction', () => {
+      const volume = findFeature('volume')!.reference;
+
+      expect(volume.config).toEqual({});
+      expect(Object.keys(volume.state)).toContain('volume');
+      expect(Object.keys(volume.actions)).toContain('setVolume');
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // CAPTION STYLE FEATURE (public setter + config degrade paths)
+  // ─────────────────────────────────────────────────────────────────
+  //
+  // `fontFamily` is the working named-action shape: public setters are optional
+  // on a feature, and this is the one that still has an inherited one. The two
+  // failures below produce output that looks fine and is wrong, so the warning
+  // is part of the contract, not a nicety.
+
+  describe('captionStyle (public setter and config degrade paths)', () => {
+    function generateWithWarnings(): { results: FeatureResult[]; warnings: string[] } {
+      const warnings: string[] = [];
+      const spy = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+        warnings.push(args.map(String).join(' '));
+      });
+
+      try {
+        return { results: generateFeatureReferences(FIXTURE_ROOT), warnings };
+      } finally {
+        spy.mockRestore();
+      }
+    }
+
+    it('types an input from a public setter named outright, following inheritance', () => {
+      const config = findFeature('captionStyle')!.reference.config;
+
+      // `setFontFamily` is declared on MediaCaptionStyleState, not on the
+      // feature's own interface, so the type has to come from the resolved type
+      // rather than the declaration's members.
+      expect(config.fontFamily!.type).toContain('string');
+      expect(config.fontFamily!.type).toContain('null');
+      expect(config.fontFamily!.type).toContain('undefined');
+    });
+
+    it('resolves a named-constant initializer to its literal, not its identifier', () => {
+      const config = findFeature('captionStyle')!.reference.config;
+
+      // state() initializes this key to FALLBACK_FONT; printing that private
+      // identifier into public docs would be meaningless to a reader.
+      expect(config.fontFamily!.default).toBe("'sans-serif'");
+    });
+
+    it('falls back to an unresolved type when the action has no source-state member', () => {
+      const { results: fresh, warnings } = generateWithWarnings();
+      const config = fresh.find((r) => r.name === 'captionStyle')!.reference.config;
+
+      expect(config.fontStretch!.type).toBe('unknown');
+      expect(warnings.some((w) => w.includes('fontStretch') && w.includes('MISSING_ACTION'))).toBe(true);
+    });
+
+    it('drops an input whose action is neither an identifier nor a string, and says so', () => {
+      const { results: fresh, warnings } = generateWithWarnings();
+      const config = fresh.find((r) => r.name === 'captionStyle')!.reference.config;
+
+      expect(config.fontSize).toBeUndefined();
+      expect(warnings.some((w) => w.includes('fontSize') && w.includes('unreadable'))).toBe(true);
+    });
+
+    it('still publishes the feature state around the broken inputs', () => {
+      const ref = findFeature('captionStyle')!.reference;
+
+      expect(ref.state.fontFamily).toMatchObject({ type: 'string' });
     });
   });
 

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/feature.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/feature.ts
@@ -1,9 +1,58 @@
 /**
  * Mock definePlayerFeature — identity function matching the real signature.
  * The builder only needs the TypeScript types to resolve; it never runs this.
+ *
+ * `PlayerFeatureConfig` mirrors the real constraint in
+ * packages/core/src/dom/player.ts rather than loosening it. These fixtures are
+ * inside site/tsconfig.json's program, so `astro check` rejects a fixture
+ * config that production would reject — a loose mock would let the suite pass
+ * on a shape the real API forbids.
  */
-export const definePlayerFeature = <State>(config: {
+
+type ConfigValue = string | null | undefined;
+
+type ActionInput<Action> = Action extends (...args: infer Arguments) => unknown
+  ? Arguments extends [infer Value]
+    ? Value
+    : never
+  : never;
+
+/** State keys whose action accepts exactly `string | null | undefined`. */
+type ConfigActionKey<State> = [State] extends [never]
+  ? PropertyKey
+  : {
+      [Key in keyof State]-?: [ActionInput<State[Key]>] extends [ConfigValue]
+        ? [ConfigValue] extends [ActionInput<State[Key]>]
+          ? Key
+          : never
+        : never;
+    }[keyof State];
+
+type ConfigStateKey<State> = [State] extends [never] ? PropertyKey : keyof State;
+
+export type PlayerFeatureConfig<State = never> = Record<
+  string,
+  {
+    action: ConfigActionKey<State>;
+    state: ConfigStateKey<State>;
+    /** How an HTML provider element names this input, when the key's own name won't do. */
+    html?: {
+      /** Attribute name in markup, kebab-case. Defaults to the kebab-cased key. */
+      attribute: string;
+    };
+  }
+>;
+
+/**
+ * `Config` is a generic constrained to the unparameterized `PlayerFeatureConfig`,
+ * matching the real overload. That keeps the parameter permissive (its keys are
+ * `PropertyKey`) and leaves the narrowing to the author's own
+ * `satisfies PlayerFeatureConfig<SourceState>` clause, exactly as in production.
+ */
+export const definePlayerFeature = <State, Config extends PlayerFeatureConfig = Record<never, never>>(config: {
   name?: string;
+  config?: Config;
   state: (ctx: any) => State;
+  derived?: Record<string, (ctx: any) => unknown>;
   attach?: (ctx: any) => void;
 }) => config;

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/caption-style.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/caption-style.ts
@@ -2,7 +2,7 @@
  * Mock caption-style feature — the paths metadata doesn't use, kept in one place.
  *
  * Exercises: a config input whose action names an inherited public setter
- * outright (public setters are optional, and this is the fixture that still has
+ * outright (public setters are optional, and this is the fixture that carries
  * one), a named constant resolved to its literal in the default column, a state
  * key left at `undefined` and therefore omitted from that column, one input
  * whose action has no matching source-state member (type falls back to

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/caption-style.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/caption-style.ts
@@ -1,0 +1,60 @@
+/**
+ * Mock caption-style feature — the paths metadata doesn't use, kept in one place.
+ *
+ * Exercises: a config input whose action names an inherited public setter
+ * outright (public setters are optional, and this is the fixture that still has
+ * one), a named constant resolved to its literal in the default column, a state
+ * key left at `undefined` and therefore omitted from that column, one input
+ * whose action has no matching source-state member (type falls back to
+ * "unknown" and warns), and one whose action is neither an identifier nor a
+ * string (dropped and warned).
+ *
+ * The last two produce plausible-looking but wrong reference output when they
+ * pass silently, so the suite pins the warnings as well as the output.
+ */
+import type { MediaCaptionStyleState, MediaContentValue } from '../../../../../media/src/core/state';
+import { definePlayerFeature } from '../../feature';
+
+const USER_FONT = Symbol('user-font');
+const USER_SIZE = Symbol('user-size');
+const SET_USER_FONT = Symbol('set-user-font');
+const MISSING_ACTION = Symbol('missing-action');
+
+/** A named constant default, to prove it is resolved rather than printed by name. */
+const FALLBACK_FONT = 'sans-serif';
+
+interface CaptionStyleSourceState extends MediaCaptionStyleState {
+  [USER_FONT]: MediaContentValue;
+  [USER_SIZE]: MediaContentValue;
+  [SET_USER_FONT](value: MediaContentValue): void;
+}
+
+/** Resolves caption styling overrides into player state. */
+export const captionStyleFeature = definePlayerFeature({
+  name: 'captionStyle',
+  // Partly malformed on purpose: the builder must degrade loudly, not silently.
+  config: {
+    /** Forwards to an inherited public setter, named outright. */
+    fontFamily: {
+      action: 'setFontFamily',
+      state: USER_FONT,
+    },
+    /** Points at an action the source state never declares. */
+    fontStretch: {
+      action: MISSING_ACTION,
+      state: USER_SIZE,
+    },
+    /** Uses a computed action, which is neither an identifier nor a string. */
+    fontSize: {
+      action: [SET_USER_FONT][0],
+      state: USER_SIZE,
+    },
+  } as never,
+  state: (): CaptionStyleSourceState => ({
+    [USER_FONT]: FALLBACK_FONT,
+    [USER_SIZE]: undefined,
+    [SET_USER_FONT]: () => {},
+    fontFamily: '',
+    setFontFamily: () => {},
+  }),
+});

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/index.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/index.ts
@@ -7,6 +7,8 @@
  */
 
 export * as features from './feature.parts';
+export * from './caption-style';
+export * from './metadata';
 export * from './orientation-lock';
 export * from './playback';
 export * from './presets';

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/metadata.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/core/src/dom/store/features/metadata.ts
@@ -1,0 +1,69 @@
+/**
+ * Mock metadata feature — mirrors the real one's shape.
+ *
+ * Exercises: a published shape that is `derived` keys alone, since the source
+ * state omits every member of the interface it extends and keeps the rest
+ * behind symbols; symbol-keyed actions typed from their own declarations; an
+ * `html.attribute` that renames the input in markup, alongside an entry that
+ * omits it and falls back to the kebab-cased key; config JSDoc → input
+ * description; and `satisfies` around the config map.
+ *
+ * The feature has no public actions at all, so this fixture also pins that an
+ * empty actions record is what the reference gets.
+ *
+ * Public setters, named-outright actions, and the degrade paths live in the
+ * caption-style fixture, since the real metadata feature uses none of them.
+ */
+import type { MediaContentValue, MediaMetadataState } from '../../../../../media/src/core/state';
+import { definePlayerFeature, type PlayerFeatureConfig } from '../../feature';
+
+const MEDIA_TITLE = Symbol('media-title');
+const USER_TITLE = Symbol('user-title');
+const SET_USER_TITLE = Symbol('set-user-title');
+const DEFAULT_TITLE = '';
+
+const MEDIA_POSTER = Symbol('media-poster');
+const USER_POSTER = Symbol('user-poster');
+const SET_USER_POSTER = Symbol('set-user-poster');
+const DEFAULT_POSTER = '';
+
+interface MetadataSourceState extends Omit<MediaMetadataState, 'title' | 'poster'> {
+  [MEDIA_TITLE]: MediaContentValue;
+  [USER_TITLE]: MediaContentValue;
+  [SET_USER_TITLE](value: MediaContentValue): void;
+  [MEDIA_POSTER]: MediaContentValue;
+  [USER_POSTER]: MediaContentValue;
+  [SET_USER_POSTER](value: MediaContentValue): void;
+}
+
+/** Resolves user and media content metadata into player state. */
+export const metadataFeature = definePlayerFeature({
+  name: 'metadata',
+  config: {
+    /** The title to display. Takes precedence over the title the media carries. */
+    title: {
+      action: SET_USER_TITLE,
+      state: USER_TITLE,
+      html: { attribute: 'content-title' },
+    },
+    /** The poster to display. Takes precedence over the poster the media carries. */
+    poster: {
+      action: SET_USER_POSTER,
+      state: USER_POSTER,
+    },
+  } satisfies PlayerFeatureConfig<MetadataSourceState>,
+  state: (): MetadataSourceState => ({
+    [MEDIA_TITLE]: undefined,
+    [USER_TITLE]: undefined,
+    [SET_USER_TITLE]: () => {},
+    [MEDIA_POSTER]: undefined,
+    [USER_POSTER]: undefined,
+    [SET_USER_POSTER]: () => {},
+  }),
+  derived: {
+    /** The resolved content title. */
+    title: (): string => DEFAULT_TITLE,
+    /** The resolved poster URL. */
+    poster: (): string => DEFAULT_POSTER,
+  },
+});

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/media/src/core/state.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/media/src/core/state.ts
@@ -70,9 +70,9 @@ export interface MediaMetadataState {
  *
  * `setFontFamily` accepts `string | null | undefined` because a config input the
  * author omits arrives as `undefined`, which is what makes it addressable from a
- * feature's `config` by name. Public setters are optional, and the metadata
- * feature no longer has one, so the caption-style fixture is where that path
- * stays covered.
+ * feature's `config` by name. Public setters are optional and the metadata
+ * feature has none, so the caption-style fixture is the one that covers this
+ * path.
  */
 export interface MediaCaptionStyleState {
   /** The font family in use. */

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/media/src/core/state.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/media/src/core/state.ts
@@ -53,3 +53,30 @@ export interface MediaVolumeState {
   /** Toggle mute state. Returns the new muted value. */
   toggleMuted(): boolean;
 }
+
+/** A media-owned content value. `undefined` means the key is absent; `null` means it has no current value. */
+export type MediaContentValue = string | null | undefined;
+
+/** Resolved content metadata exposed by the player store. */
+export interface MediaMetadataState {
+  /** The resolved content title. Set it through the player, not through the store. */
+  title: string;
+  /** The resolved poster URL. Set it through the player, not through the store. */
+  poster: string;
+}
+
+/**
+ * Caption styling exposed by the player store.
+ *
+ * `setFontFamily` accepts `string | null | undefined` because a config input the
+ * author omits arrives as `undefined`, which is what makes it addressable from a
+ * feature's `config` by name. Public setters are optional, and the metadata
+ * feature no longer has one, so the caption-style fixture is where that path
+ * stays covered.
+ */
+export interface MediaCaptionStyleState {
+  /** The font family in use. */
+  fontFamily: string;
+  /** Set or clear the user font family override. */
+  setFontFamily(value: MediaContentValue): void;
+}

--- a/site/scripts/api-docs-builder/src/types.ts
+++ b/site/scripts/api-docs-builder/src/types.ts
@@ -13,7 +13,12 @@ export type {
 
 export { ComponentReferenceSchema, PartReferenceSchema } from '../../../src/types/component-reference.js';
 
-export type { FeatureActionDef, FeatureReference, FeatureStateDef } from '../../../src/types/feature-reference.js';
+export type {
+  FeatureActionDef,
+  FeatureConfigDef,
+  FeatureReference,
+  FeatureStateDef,
+} from '../../../src/types/feature-reference.js';
 export { FeatureReferenceSchema } from '../../../src/types/feature-reference.js';
 export type {
   HostPropertyDef,

--- a/site/src/components/docs/api-reference/ApiPropsTable.astro
+++ b/site/src/components/docs/api-reference/ApiPropsTable.astro
@@ -11,10 +11,11 @@ import Thead from '@/components/typography/Thead.astro';
 import Tr from '@/components/typography/Tr.astro';
 import type { PropDef } from '@/types/component-reference';
 import type { SupportedFramework } from '@/types/docs';
+import type { FeatureConfigDef } from '@/types/feature-reference';
 import PropRow from './PropRow.astro';
 
 interface Props {
-  props: Record<string, PropDef>;
+  props: Record<string, PropDef | FeatureConfigDef>;
   componentName: string;
   framework: SupportedFramework;
   showAttributeName?: boolean;
@@ -47,6 +48,7 @@ const { props, componentName, framework, showAttributeName } = Astro.props;
             defaultValue={prop.default}
             required={prop.required}
             showAttributeName={showAttributeName}
+            attribute={"attribute" in prop ? prop.attribute : undefined}
             componentName={componentName}
           />
         ))

--- a/site/src/components/docs/api-reference/FeatureReference.astro
+++ b/site/src/components/docs/api-reference/FeatureReference.astro
@@ -3,9 +3,12 @@ import { getEntry } from 'astro:content';
 import ContentWidth from '@/components/frames/ContentWidth.astro';
 import H2 from '@/components/typography/H2Markdown.astro';
 import H3 from '@/components/typography/H3Markdown.astro';
+import P from '@/components/typography/P.astro';
+import { isValidFramework } from '@/types/docs';
 import type { FeatureReference } from '@/types/feature-reference';
 import { createFeatureReferenceModel } from '@/utils/featureReferenceModel';
 import ApiActionsTable from './ApiActionsTable.astro';
+import ApiPropsTable from './ApiPropsTable.astro';
 import ApiStateTable from './ApiStateTable.astro';
 
 interface Props {
@@ -13,6 +16,10 @@ interface Props {
 }
 
 const { feature } = Astro.props;
+const { framework } = Astro.params;
+if (!framework || !isValidFramework(framework)) {
+  throw new Error(`Invalid or missing framework param.`);
+}
 
 const entry = await getEntry('featureReference', feature);
 const ref: FeatureReference | null = entry?.data ?? null;
@@ -21,12 +28,35 @@ if (!ref) return;
 const model = createFeatureReferenceModel(feature, ref);
 if (!model) return;
 
+const configSection = model.sections.find((s) => s.key === 'config');
 const stateSection = model.sections.find((s) => s.key === 'state');
 const actionsSection = model.sections.find((s) => s.key === 'actions');
+
+// The runtime derives HTML attribute names from the config keys the same way.
+const isHtml = framework === 'html';
+// `<P>` renders its slot as text, so this copy carries no markdown.
+const configLead = isHtml
+  ? 'Attributes and matching properties the player element accepts. They exist only while this feature is selected.'
+  : 'Props the Player component accepts. They exist only while this feature is selected.';
 ---
 
 <ContentWidth>
   <H2 id={model.heading.id}>{model.heading.text}</H2>
+
+  {
+    configSection && (
+      <>
+        <H3 id={configSection.id}>{configSection.title}</H3>
+        <P>{configLead}</P>
+        <ApiPropsTable
+          props={model.data.config}
+          componentName={`${feature}-config`}
+          framework={framework}
+          showAttributeName={isHtml}
+        />
+      </>
+    )
+  }
 
   {
     stateSection && (

--- a/site/src/components/docs/api-reference/PropRow.astro
+++ b/site/src/components/docs/api-reference/PropRow.astro
@@ -1,8 +1,8 @@
 ---
-import { kebabCase } from 'es-toolkit/string';
 import MarkdownCode from '@/components/typography/MarkdownCode.astro';
 import Td from '@/components/typography/Td.astro';
 import DetailRow from './DetailRow.astro';
+import { getPropReferenceNames } from './prop-reference-names';
 
 interface Props {
   name: string;
@@ -12,18 +12,21 @@ interface Props {
   defaultValue?: string;
   required?: boolean;
   showAttributeName?: boolean;
+  /** Overrides the name derived from the prop, for a feature that declares one. */
+  attribute?: string;
   componentName: string;
 }
 
-const { name, type, detailedType, description, defaultValue, required, showAttributeName, componentName } = Astro.props;
+const { name, type, detailedType, description, defaultValue, required, showAttributeName, attribute, componentName } =
+  Astro.props;
 
 const id = `${componentName}-${name}`;
-const attributeName = showAttributeName ? kebabCase(name) : undefined;
+const { propertyName, attributeName } = getPropReferenceNames(name, attribute, showAttributeName);
 ---
 
 <DetailRow
   id={id}
-  name={name}
+  name={propertyName}
   type={type}
   attributeName={attributeName}
   detailedType={detailedType}
@@ -32,7 +35,7 @@ const attributeName = showAttributeName ? kebabCase(name) : undefined;
 >
   <Td class="align-top">
     <MarkdownCode>
-      {name}
+      {propertyName}
       {required && <span class="text-orange">*</span>}
     </MarkdownCode>
   </Td>

--- a/site/src/components/docs/api-reference/prop-reference-names.test.ts
+++ b/site/src/components/docs/api-reference/prop-reference-names.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getPropReferenceNames } from './prop-reference-names';
+
+describe('getPropReferenceNames', () => {
+  it('maps an overridden HTML attribute without changing the React prop', () => {
+    expect(getPropReferenceNames('title', 'content-title', true)).toEqual({
+      propertyName: 'contentTitle',
+      attributeName: 'content-title',
+    });
+    expect(getPropReferenceNames('title', 'content-title', false)).toEqual({
+      propertyName: 'title',
+      attributeName: undefined,
+    });
+  });
+});

--- a/site/src/components/docs/api-reference/prop-reference-names.ts
+++ b/site/src/components/docs/api-reference/prop-reference-names.ts
@@ -1,0 +1,12 @@
+import { camelCase, kebabCase } from 'es-toolkit/string';
+
+export function getPropReferenceNames(
+  name: string,
+  attribute: string | undefined,
+  showAttributeName = false
+): { propertyName: string; attributeName: string | undefined } {
+  return {
+    propertyName: showAttributeName && attribute ? camelCase(attribute) : name,
+    attributeName: showAttributeName ? (attribute ?? kebabCase(name)) : undefined,
+  };
+}

--- a/site/src/content/docs/reference/feature-metadata.mdx
+++ b/site/src/content/docs/reference/feature-metadata.mdx
@@ -1,0 +1,110 @@
+---
+title: Metadata
+description: Resolved title and poster values for the player store
+---
+
+import FeatureReference from "@/components/docs/api-reference/FeatureReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+import FrameworkCase from "@/components/docs/FrameworkCase.astro";
+
+Resolves what is playing into two values your UI can render: `title` and `poster`.
+
+`title` and `poster` each resolve independently through the same two tiers: the value you set, then the value the media reports. The first tier that holds a value wins; when neither does, the resolved value is an empty string. Because the tiers stay separate, clearing the value you set reveals the media's, and a source that reports a poster but no title contributes to one while leaving the other empty.
+
+An empty string counts as a value and stops the chain: set `title` to `''` and the resolved title is `''`. Pass `null` to clear your value.
+
+The metadata feature is included by the `videoFeatures`, `audioFeatures`, `liveVideoFeatures`, and `liveAudioFeatures` <DocsLink slug="concepts/presets">presets</DocsLink>; apps that build a custom preset can compose it in directly.
+
+<FeatureReference feature="metadata" />
+
+### Selector
+
+<FrameworkCase frameworks={["react"]}>
+Pass `selectMetadata` to <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> to subscribe to metadata state. Returns `undefined` if the metadata feature is not configured.
+
+```tsx title="ContentTitle.tsx"
+import { selectMetadata, usePlayer } from '@videojs/react';
+
+function ContentTitle() {
+  const metadata = usePlayer(selectMetadata);
+  if (!metadata?.title) return null;
+
+  return <h2 className="content-title">{metadata.title}</h2>;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Pass `selectMetadata` to <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> to subscribe to metadata state. Returns `undefined` if the metadata feature is not configured.
+
+```ts title="content-title.ts"
+import { createPlayer, MediaElement, selectMetadata } from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+
+const { PlayerController, context } = createPlayer({ features: videoFeatures });
+
+class ContentTitle extends MediaElement {
+  readonly #metadata = new PlayerController(this, context, selectMetadata);
+}
+```
+</FrameworkCase>
+
+### Player inputs
+
+The store publishes the resolved values and takes no writes. A player input is the only way to set one.
+
+<FrameworkCase frameworks={["react"]}>
+Every input is a prop on <DocsLink slug="reference/player-provider">`Player`</DocsLink>. A player built without the metadata feature has none of them, and none is forwarded.
+
+```tsx title="App.tsx"
+import { Container, createPlayer } from '@videojs/react';
+import { videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+function App({ episode }: { episode: { title: string | null; art: string | null } }) {
+  return (
+    <Player title={episode.title} poster={episode.art}>
+      <Container>
+        <video src="episode.mp4" />
+      </Container>
+    </Player>
+  );
+}
+```
+
+Passing `null` clears your value, so `title={null}` falls through to the title the media reports.
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Every input is an attribute on <DocsLink slug="reference/player-provider">`<video-player>`</DocsLink>, each with a matching property. A player built without the metadata feature observes none of them.
+
+`title` already means the tooltip on an HTML element, so the title input goes by `content-title` in markup, and by `contentTitle` as a property. The other inputs use their own names.
+
+```html
+<video-player content-title="The Pilot" poster="/episode-art.jpg">
+  <media-container>
+    <video src="episode.mp4"></video>
+  </media-container>
+</video-player>
+```
+
+Removing an attribute clears your value, so it falls through to what the media reports.
+
+```ts title="title-controls.ts"
+const player = document.querySelector('video-player');
+
+player?.setAttribute('content-title', 'The Pilot');
+player?.removeAttribute('content-title'); // falls back to the media
+```
+
+The flow between an attribute and its property runs one way: an attribute change writes the property, but setting the property leaves the attribute alone. Read the property for the current value.
+</FrameworkCase>
+
+### Media-reported values
+
+The media tier comes from media that reports content data and announces changes to it, and it covers `title` and `poster`. A media reports only the keys it can vouch for, so either may be absent while the other arrives. A key that never arrives means that tier never contributes, and the resolved value is whatever you set. Detaching the media clears its values; the values you set survive and apply to the next source.
+
+`poster` is the feature's own resolved value, not the media element's `poster` attribute. Setting one does not set the other.
+
+A low-resolution stand-in to show while the poster loads is not part of this feature. The <DocsLink slug="reference/poster">poster</DocsLink> renders an `<img>` you control, so give it a `background-image` and that shows until the poster itself paints over it.

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -152,6 +152,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/feature-error' },
           { slug: 'reference/feature-fullscreen' },
           { slug: 'reference/feature-live' },
+          { slug: 'reference/feature-metadata' },
           { slug: 'reference/feature-orientation-lock' },
           { slug: 'reference/feature-pip', sidebarLabel: 'Picture-in-picture' },
           { slug: 'reference/feature-playback' },

--- a/site/src/types/feature-reference.ts
+++ b/site/src/types/feature-reference.ts
@@ -3,13 +3,22 @@
  *
  * FeatureStateDef and FeatureActionDef reuse StateDefSchema (identical shape)
  * from component-reference.ts, following the same pattern as util-reference.ts.
+ * FeatureConfigDef reuses PropDefSchema for the same reason: a config input is
+ * rendered as a provider prop. Its HTML attribute name is derived from the key,
+ * unless the feature declares one, which it does when the derived name would
+ * collide with a global attribute.
  */
 import { z } from 'astro/zod';
-import { StateDefSchema } from './component-reference';
+import { PropDefSchema, StateDefSchema } from './component-reference';
 
 export const FeatureStateDefSchema = StateDefSchema;
 
 export const FeatureActionDefSchema = StateDefSchema;
+
+export const FeatureConfigDefSchema = PropDefSchema.extend({
+  /** Set only when the feature declares an attribute name instead of taking the kebab-cased key. */
+  attribute: z.string().optional(),
+});
 
 export const FeatureReferenceSchema = z.object({
   name: z.string(),
@@ -17,8 +26,11 @@ export const FeatureReferenceSchema = z.object({
   description: z.string().optional(),
   state: z.record(z.string(), FeatureStateDefSchema),
   actions: z.record(z.string(), FeatureActionDefSchema),
+  /** Provider inputs the feature adds when selected. Empty for unconfigured features. */
+  config: z.record(z.string(), FeatureConfigDefSchema).default({}),
 });
 
 export type FeatureStateDef = z.infer<typeof FeatureStateDefSchema>;
 export type FeatureActionDef = z.infer<typeof FeatureActionDefSchema>;
+export type FeatureConfigDef = z.infer<typeof FeatureConfigDefSchema>;
 export type FeatureReference = z.infer<typeof FeatureReferenceSchema>;

--- a/site/src/utils/featureReferenceModel.js
+++ b/site/src/utils/featureReferenceModel.js
@@ -6,8 +6,12 @@
  *
  * Structure:
  *   ## API Reference (H2)
+ *   ### Configuration (H3) — if feature declares provider inputs
  *   ### State (H3) — if feature has state properties
  *   ### Actions (H3) — if feature has action methods
+ *
+ * Configuration leads, mirroring props-before-state in componentReferenceModel:
+ * inputs first, then what the store publishes back.
  */
 
 function hasEntries(value) {
@@ -18,6 +22,10 @@ export function createFeatureReferenceModel(name, ref) {
   if (!ref) return null;
 
   const sections = [];
+
+  if (hasEntries(ref.config)) {
+    sections.push({ key: 'config', title: 'Configuration', id: 'configuration', depth: 3 });
+  }
 
   if (hasEntries(ref.state)) {
     sections.push({ key: 'state', title: 'State', id: 'state', depth: 3 });


### PR DESCRIPTION
Closes #1940. Closes #2001.

a deeply standard docs metadata page, and some vibe-coded reference generation for the config. Stampable.

https://deploy-preview-2000--vjs10-site.netlify.app/docs/framework/react/reference/feature-metadata


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the TypeScript-based feature reference pipeline and its schemas/UI, so incorrect extraction can ship wrong public API docs. Runtime player behavior is unchanged aside from JSDoc.
> 
> **Overview**
> Documents the **metadata** feature (resolved `title`/`poster`, player inputs, `selectMetadata`) and extends the feature API docs builder so those pages can be generated instead of hand-written.
> 
> The builder now derives published state from local source-state interfaces plus `derived` keys (skipping symbol-keyed internals), and extracts `config` as provider props: types from the forwarded action, defaults from `state()` initializers, JSDoc, and optional HTML `attribute` overrides such as `content-title`. Unreadable or unmatched config entries warn and degrade rather than silently omitting or inventing types.
> 
> Feature reference UI adds a **Configuration** section (framework-aware props vs attributes) and maps declared attribute names through `getPropReferenceNames`. JSDoc on the real `metadataFeature` config/derived keys feeds that table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8ba7ee47b1dbcadf3b593ccd876b3ff742d524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->