### PR TITLE
feat(skin): setup basic tailwind styles for new skin system

### DIFF
--- a/packages/skins/artifacts.generated.json
+++ b/packages/skins/artifacts.generated.json
@@ -9,9 +9,19 @@
         {
           "path": "./canonical/components/buttons/button-tooltip.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/popup.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": [],
         "packages": ["@videojs/core"],
@@ -29,9 +39,23 @@
         {
           "path": "./canonical/skins/default/video-controls.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/popup.tailwind.ts",
+          "role": "source"
+        },
+        {
+          "path": "./canonical/styles/skins/default-video-controls.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": ["fullscreen-button", "play-button", "seek-button", "time-slider", "volume-popover"],
         "packages": ["@videojs/core"],
@@ -49,9 +73,19 @@
         {
           "path": "./canonical/components/buttons/fullscreen-button.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/button.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": ["button-tooltip"],
         "packages": ["@videojs/core", "@videojs/icons"],
@@ -69,9 +103,19 @@
         {
           "path": "./canonical/components/buttons/mute-button.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/button.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": [],
         "packages": ["@videojs/core", "@videojs/icons"],
@@ -89,9 +133,19 @@
         {
           "path": "./canonical/components/buttons/play-button.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/button.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": ["button-tooltip"],
         "packages": ["@videojs/core", "@videojs/icons"],
@@ -109,9 +163,19 @@
         {
           "path": "./canonical/components/buttons/seek-button.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/button.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": ["button-tooltip"],
         "packages": ["@videojs/core", "@videojs/icons"],
@@ -129,9 +193,23 @@
         {
           "path": "./canonical/components/sliders/time-slider.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/popup.tailwind.ts",
+          "role": "source"
+        },
+        {
+          "path": "./canonical/styles/components/slider.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": [],
         "packages": ["@videojs/core", "@videojs/icons"],
@@ -149,9 +227,19 @@
         {
           "path": "./canonical/components/controls/volume-popover.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/popup.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": ["mute-button", "volume-slider"],
         "packages": ["@videojs/core"],
@@ -169,9 +257,23 @@
         {
           "path": "./canonical/components/sliders/volume-slider.skin.tsx",
           "role": "entry"
+        },
+        {
+          "path": "./canonical/styles/components/popup.tailwind.ts",
+          "role": "source"
+        },
+        {
+          "path": "./canonical/styles/components/slider.tailwind.ts",
+          "role": "source"
         }
       ],
-      "resources": {},
+      "resources": {
+        "styles": [
+          "./canonical/styles/base.css",
+          "./canonical/styles/tailwind.css",
+          "./canonical/styles/themes/default.css"
+        ]
+      },
       "dependencies": {
         "artifacts": [],
         "packages": ["@videojs/core"],

--- a/packages/skins/artifacts.ts
+++ b/packages/skins/artifacts.ts
@@ -7,50 +7,63 @@ export type SkinArtifactDefinition = Omit<ArtifactDefinition<SkinArtifactKind>, 
   resources?: Readonly<Partial<Record<SkinArtifactResourceKind, readonly string[]>>> | undefined;
 };
 
+const coreStyleResources = {
+  styles: ['./canonical/styles/tailwind.css', './canonical/styles/base.css', './canonical/styles/themes/default.css'],
+} as const;
+
 export const skinArtifacts = [
   defineArtifact({
     id: 'default-video-controls',
     kind: 'component',
     entry: './canonical/skins/default/video-controls.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'fullscreen-button',
     kind: 'component',
     entry: './canonical/components/buttons/fullscreen-button.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'mute-button',
     kind: 'component',
     entry: './canonical/components/buttons/mute-button.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'play-button',
     kind: 'component',
     entry: './canonical/components/buttons/play-button.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'seek-button',
     kind: 'component',
     entry: './canonical/components/buttons/seek-button.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'time-slider',
     kind: 'component',
     entry: './canonical/components/sliders/time-slider.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'button-tooltip',
     kind: 'component',
     entry: './canonical/components/buttons/button-tooltip.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'volume-slider',
     kind: 'component',
     entry: './canonical/components/sliders/volume-slider.skin.tsx',
+    resources: coreStyleResources,
   }),
   defineArtifact({
     id: 'volume-popover',
     kind: 'component',
     entry: './canonical/components/controls/volume-popover.skin.tsx',
+    resources: coreStyleResources,
   }),
 ] as const satisfies readonly SkinArtifactDefinition[];

--- a/packages/skins/canonical/README.md
+++ b/packages/skins/canonical/README.md
@@ -8,6 +8,7 @@ Canonical source:
 - Imports Video.js primitives only through stable package exports.
 - Keeps independently installable components in role-based directories.
 - Contains semantic structure without React- or HTML-specific markup.
+- Imports named Tailwind utility tokens from locally owned style modules.
 - Does not copy Media, Store, feature, or SVG implementations.
 
 The current canonical paths are:
@@ -22,4 +23,4 @@ The current canonical paths are:
 - `components/sliders/volume-slider.skin.tsx`
 - `components/sliders/time-slider.skin.tsx`
 
-Canonical components import icon roles from `@videojs/icons/components`; target lowering replaces that compiler-only source contract with local named React exports or exact HTML registrations. Artifact entries are authored in `../artifacts.ts`; styles, complete Skin compositions, and generated target output remain separate stack boundaries.
+Canonical components import icon roles from `@videojs/icons/components`; target lowering replaces that compiler-only source contract with local named React exports or exact HTML registrations. The Tailwind v4 input in `styles/tailwind.css` maps semantic utilities to scoped media variables, so Tailwind source can be preserved or lowered into vanilla CSS from the same authored utilities. Artifact entries are authored in `../artifacts.ts`; generated target output remains a separate stack boundary.

--- a/packages/skins/canonical/components/buttons/button-tooltip.skin.tsx
+++ b/packages/skins/canonical/components/buttons/button-tooltip.skin.tsx
@@ -1,12 +1,13 @@
 import { Tooltip as TooltipPrimitive } from '@videojs/core/components';
+import { tooltip } from '../../styles/components/popup.tailwind';
 
 export function ButtonTooltip({ children, ...props }: Parameters<typeof TooltipPrimitive.Root>[0]) {
   return (
     <TooltipPrimitive.Root {...props}>
       <TooltipPrimitive.Trigger>{children}</TooltipPrimitive.Trigger>
-      <TooltipPrimitive.Popup>
+      <TooltipPrimitive.Popup className={tooltip.popup}>
         <TooltipPrimitive.Label />
-        <TooltipPrimitive.Shortcut />
+        <TooltipPrimitive.Shortcut className={tooltip.shortcut} />
       </TooltipPrimitive.Popup>
     </TooltipPrimitive.Root>
   );

--- a/packages/skins/canonical/components/buttons/fullscreen-button.skin.tsx
+++ b/packages/skins/canonical/components/buttons/fullscreen-button.skin.tsx
@@ -1,13 +1,14 @@
 import { FullscreenButton as FullscreenButtonPrimitive } from '@videojs/core/components';
 import { FullscreenEnterIcon, FullscreenExitIcon } from '@videojs/icons/components';
+import { button, buttonIcon } from '../../styles/components/button.tailwind';
 import { ButtonTooltip } from './button-tooltip.skin';
 
 export function FullscreenButton() {
   return (
     <ButtonTooltip>
-      <FullscreenButtonPrimitive>
-        <FullscreenEnterIcon />
-        <FullscreenExitIcon />
+      <FullscreenButtonPrimitive className={button.fullscreen}>
+        <FullscreenEnterIcon className={buttonIcon.fullscreenEnter} />
+        <FullscreenExitIcon className={buttonIcon.fullscreenExit} />
       </FullscreenButtonPrimitive>
     </ButtonTooltip>
   );

--- a/packages/skins/canonical/components/buttons/mute-button.skin.tsx
+++ b/packages/skins/canonical/components/buttons/mute-button.skin.tsx
@@ -1,12 +1,13 @@
 import { MuteButton as MuteButtonPrimitive } from '@videojs/core/components';
 import { VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@videojs/icons/components';
+import { button, buttonIcon } from '../../styles/components/button.tailwind';
 
 export function MuteButton() {
   return (
-    <MuteButtonPrimitive>
-      <VolumeOffIcon />
-      <VolumeLowIcon />
-      <VolumeHighIcon />
+    <MuteButtonPrimitive className={button.mute}>
+      <VolumeOffIcon className={buttonIcon.volumeOff} />
+      <VolumeLowIcon className={buttonIcon.volumeLow} />
+      <VolumeHighIcon className={buttonIcon.volumeHigh} />
     </MuteButtonPrimitive>
   );
 }

--- a/packages/skins/canonical/components/buttons/play-button.skin.tsx
+++ b/packages/skins/canonical/components/buttons/play-button.skin.tsx
@@ -1,14 +1,15 @@
 import { PlayButton as PlayButtonPrimitive } from '@videojs/core/components';
 import { PauseIcon, PlayIcon, RestartIcon } from '@videojs/icons/components';
+import { button, buttonIcon } from '../../styles/components/button.tailwind';
 import { ButtonTooltip } from './button-tooltip.skin';
 
 export function PlayButton() {
   return (
     <ButtonTooltip>
-      <PlayButtonPrimitive>
-        <RestartIcon />
-        <PlayIcon />
-        <PauseIcon />
+      <PlayButtonPrimitive className={button.play}>
+        <RestartIcon className={buttonIcon.restart} />
+        <PlayIcon className={buttonIcon.play} />
+        <PauseIcon className={buttonIcon.pause} />
       </PlayButtonPrimitive>
     </ButtonTooltip>
   );

--- a/packages/skins/canonical/components/buttons/seek-button.skin.tsx
+++ b/packages/skins/canonical/components/buttons/seek-button.skin.tsx
@@ -1,6 +1,7 @@
 import type { SeekButtonProps } from '@videojs/core';
 import { SeekButton as SeekButtonPrimitive, Text } from '@videojs/core/components';
 import { SeekIcon } from '@videojs/icons/components';
+import { button, buttonIcon, seekLabel } from '../../styles/components/button.tailwind';
 import { ButtonTooltip } from './button-tooltip.skin';
 
 export function SeekButton(props: SeekButtonProps = {}) {
@@ -8,9 +9,9 @@ export function SeekButton(props: SeekButtonProps = {}) {
 
   return (
     <ButtonTooltip>
-      <SeekButtonPrimitive {...props} seconds={seconds}>
-        <SeekIcon />
-        <Text>{Math.abs(seconds)}</Text>
+      <SeekButtonPrimitive className={button.seek} {...props} seconds={seconds}>
+        <SeekIcon className={seconds < 0 ? buttonIcon.seekBackward : buttonIcon.base} />
+        <Text className={seekLabel}>{Math.abs(seconds)}</Text>
       </SeekButtonPrimitive>
     </ButtonTooltip>
   );

--- a/packages/skins/canonical/components/controls/volume-popover.skin.tsx
+++ b/packages/skins/canonical/components/controls/volume-popover.skin.tsx
@@ -1,4 +1,5 @@
 import { Popover } from '@videojs/core/components';
+import { volumePopover } from '../../styles/components/popup.tailwind';
 import { MuteButton } from '../buttons/mute-button.skin';
 import { VolumeSlider } from '../sliders/volume-slider.skin';
 
@@ -8,7 +9,7 @@ export function VolumePopover() {
       <Popover.Trigger>
         <MuteButton />
       </Popover.Trigger>
-      <Popover.Popup>
+      <Popover.Popup className={volumePopover}>
         <VolumeSlider orientation="vertical" />
       </Popover.Popup>
     </Popover.Root>

--- a/packages/skins/canonical/components/sliders/time-slider.skin.tsx
+++ b/packages/skins/canonical/components/sliders/time-slider.skin.tsx
@@ -1,21 +1,22 @@
 import { Slider, TimeSlider as TimeSliderPrimitive } from '@videojs/core/components';
 import { SpinnerIcon } from '@videojs/icons/components';
+import { slider, thumbnail } from '../../styles/components/slider.tailwind';
 
 export function TimeSlider() {
   return (
-    <TimeSliderPrimitive.Root thumbAlignment="edge">
-      <TimeSliderPrimitive.Track>
-        <TimeSliderPrimitive.Fill />
-        <TimeSliderPrimitive.Buffer />
+    <TimeSliderPrimitive.Root className={slider.root} thumbAlignment="edge">
+      <TimeSliderPrimitive.Track className={slider.track}>
+        <TimeSliderPrimitive.Fill className={[slider.fillBase, slider.fill]} />
+        <TimeSliderPrimitive.Buffer className={[slider.fillBase, slider.buffer]} />
       </TimeSliderPrimitive.Track>
-      <TimeSliderPrimitive.Thumb />
-      <Slider.Thumbnail.Root>
-        <Slider.Thumbnail.Image />
-        <TimeSliderPrimitive.Value type="pointer" />
-        <SpinnerIcon />
+      <TimeSliderPrimitive.Thumb className={slider.thumb} />
+      <Slider.Thumbnail.Root className={thumbnail.root}>
+        <Slider.Thumbnail.Image className={thumbnail.image} />
+        <TimeSliderPrimitive.Value className={slider.value} type="pointer" />
+        <SpinnerIcon className="size-media-icon drop-shadow-media-icon" />
       </Slider.Thumbnail.Root>
-      <TimeSliderPrimitive.Preview>
-        <TimeSliderPrimitive.Value type="pointer" />
+      <TimeSliderPrimitive.Preview className={slider.preview}>
+        <TimeSliderPrimitive.Value className={slider.value} type="pointer" />
       </TimeSliderPrimitive.Preview>
     </TimeSliderPrimitive.Root>
   );

--- a/packages/skins/canonical/components/sliders/volume-slider.skin.tsx
+++ b/packages/skins/canonical/components/sliders/volume-slider.skin.tsx
@@ -1,13 +1,14 @@
 import type { VolumeSliderProps } from '@videojs/core';
 import { VolumeSlider as VolumeSliderPrimitive } from '@videojs/core/components';
+import { slider } from '../../styles/components/slider.tailwind';
 
 export function VolumeSlider(props: VolumeSliderProps = {}) {
   return (
-    <VolumeSliderPrimitive.Root thumbAlignment="edge" {...props}>
-      <VolumeSliderPrimitive.Track>
-        <VolumeSliderPrimitive.Fill />
+    <VolumeSliderPrimitive.Root className={slider.root} thumbAlignment="edge" {...props}>
+      <VolumeSliderPrimitive.Track className={slider.track}>
+        <VolumeSliderPrimitive.Fill className={[slider.fillBase, slider.fill]} />
       </VolumeSliderPrimitive.Track>
-      <VolumeSliderPrimitive.Thumb />
+      <VolumeSliderPrimitive.Thumb className={slider.thumb} />
     </VolumeSliderPrimitive.Root>
   );
 }

--- a/packages/skins/canonical/skins/default/video-controls.skin.tsx
+++ b/packages/skins/canonical/skins/default/video-controls.skin.tsx
@@ -4,26 +4,27 @@ import { PlayButton } from '../../components/buttons/play-button.skin';
 import { SeekButton } from '../../components/buttons/seek-button.skin';
 import { VolumePopover } from '../../components/controls/volume-popover.skin';
 import { TimeSlider } from '../../components/sliders/time-slider.skin';
+import { controlsGroup, time, videoControls } from '../../styles/skins/default-video-controls.tailwind';
 
 const SEEK_SECONDS = 10;
 
 export function DefaultVideoControls() {
   return (
-    <Controls.Root>
+    <Controls.Root className={videoControls}>
       <Tooltip.Provider>
-        <Controls.Group>
+        <Controls.Group className={controlsGroup.base}>
           <PlayButton />
           <SeekButton seconds={-SEEK_SECONDS} />
           <SeekButton seconds={SEEK_SECONDS} />
         </Controls.Group>
 
-        <Controls.Group>
-          <TimePrimitive.Value type="current" />
+        <Controls.Group className={controlsGroup.time}>
+          <TimePrimitive.Value className={time} type="current" />
           <TimeSlider />
-          <TimePrimitive.Value type="remaining" toggle />
+          <TimePrimitive.Value className={time} type="remaining" toggle />
         </Controls.Group>
 
-        <Controls.Group>
+        <Controls.Group className={controlsGroup.base}>
           <VolumePopover />
           <FullscreenButton />
         </Controls.Group>

--- a/packages/skins/canonical/styles/base.css
+++ b/packages/skins/canonical/styles/base.css
@@ -1,0 +1,8 @@
+@layer videojs.base {
+  .vjs-skin,
+  .vjs-skin *,
+  .vjs-skin *::before,
+  .vjs-skin *::after {
+    box-sizing: border-box;
+  }
+}

--- a/packages/skins/canonical/styles/components/button.tailwind.ts
+++ b/packages/skins/canonical/styles/components/button.tailwind.ts
@@ -1,0 +1,56 @@
+const base = [
+  'grid size-media-control shrink-0 place-items-center rounded-media-pill border-0 bg-transparent p-0 text-inherit',
+  'cursor-pointer outline-2 outline-transparent -outline-offset-2',
+  'hover:bg-media-control-hover focus-visible:bg-media-control-hover aria-expanded:bg-media-control-hover',
+  'focus-visible:outline-current focus-visible:outline-offset-2',
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+];
+
+const icon = 'size-media-icon drop-shadow-media-icon';
+
+export const button = {
+  base,
+  fullscreen: [base, 'group/fullscreen'],
+  mute: [base, 'group/mute'],
+  play: [base, 'group/play'],
+  seek: base,
+};
+
+export const buttonIcon = {
+  base: icon,
+  fullscreenEnter: [
+    icon,
+    'hidden opacity-0 group-not-data-fullscreen/fullscreen:block group-not-data-fullscreen/fullscreen:opacity-100',
+  ],
+  fullscreenExit: [
+    icon,
+    'hidden opacity-0 group-data-fullscreen/fullscreen:block group-data-fullscreen/fullscreen:opacity-100',
+  ],
+  pause: [
+    icon,
+    'hidden opacity-0 group-data-started/play:group-not-data-paused/play:group-not-data-ended/play:block',
+    'group-data-started/play:group-not-data-paused/play:group-not-data-ended/play:opacity-100',
+  ],
+  play: [
+    icon,
+    'hidden opacity-0 group-not-data-ended/play:group-data-paused/play:block',
+    'group-not-data-ended/play:group-data-paused/play:opacity-100',
+    'group-not-data-ended/play:group-not-data-started/play:block',
+    'group-not-data-ended/play:group-not-data-started/play:opacity-100',
+  ],
+  restart: [icon, 'hidden opacity-0 group-data-ended/play:block group-data-ended/play:opacity-100'],
+  seekBackward: [icon, '-scale-x-100'],
+  volumeHigh: [
+    icon,
+    'hidden opacity-0 group-not-data-muted/mute:group-not-data-[volume-level=low]/mute:block',
+    'group-not-data-muted/mute:group-not-data-[volume-level=low]/mute:opacity-100',
+  ],
+  volumeLow: [
+    icon,
+    'hidden opacity-0 group-not-data-muted/mute:group-data-[volume-level=low]/mute:block',
+    'group-not-data-muted/mute:group-data-[volume-level=low]/mute:opacity-100',
+  ],
+  volumeOff: [icon, 'hidden opacity-0 group-data-muted/mute:block group-data-muted/mute:opacity-100'],
+};
+
+export const seekLabel = 'tabular-nums';

--- a/packages/skins/canonical/styles/components/popup.tailwind.ts
+++ b/packages/skins/canonical/styles/components/popup.tailwind.ts
@@ -1,0 +1,12 @@
+export const surface = 'bg-media-surface text-media-controls shadow-media-surface backdrop-blur-media-surface';
+
+export const tooltip = {
+  popup: [
+    surface,
+    'm-0 whitespace-nowrap rounded-media-pill border-0 px-2.5 py-[0.35rem]',
+    'data-open:flex data-open:items-center data-open:gap-1',
+  ],
+  shortcut: 'text-[0.75em] font-semibold',
+};
+
+export const volumePopover = [surface, 'm-0 rounded-media-pill border-0 py-3'];

--- a/packages/skins/canonical/styles/components/slider.tailwind.ts
+++ b/packages/skins/canonical/styles/components/slider.tailwind.ts
@@ -1,0 +1,29 @@
+import { surface } from './popup.tailwind';
+
+export const slider = {
+  root: [
+    'group/slider relative flex min-h-media-control min-w-20 flex-1 cursor-pointer items-center justify-center outline-none',
+    'data-[orientation=vertical]:h-20 data-[orientation=vertical]:w-media-control data-[orientation=vertical]:min-w-0',
+  ],
+  track: [
+    'relative h-media-slider-track w-full overflow-hidden rounded-media-pill bg-media-slider-track',
+    'data-[orientation=vertical]:h-full data-[orientation=vertical]:w-media-slider-track',
+  ],
+  fillBase: [
+    'absolute inset-y-0 left-0 rounded-[inherit]',
+    'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:top-auto data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:w-auto',
+  ],
+  fill: 'w-(--media-slider-fill) bg-current data-[orientation=vertical]:h-(--media-slider-fill)',
+  buffer: ['w-(--media-slider-buffer) bg-media-slider-buffer', 'data-[orientation=vertical]:h-(--media-slider-buffer)'],
+  thumb: [
+    'absolute top-1/2 left-(--media-slider-fill) size-media-slider-thumb -translate-x-1/2 -translate-y-1/2 rounded-media-pill bg-current',
+    'data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill))] data-[orientation=vertical]:left-1/2',
+  ],
+  preview: 'relative',
+  value: 'tabular-nums',
+};
+
+export const thumbnail = {
+  root: [surface, 'absolute bottom-[calc(100%+0.75rem)] overflow-hidden rounded-media-surface'],
+  image: 'block max-h-28 max-w-48',
+};

--- a/packages/skins/canonical/styles/skins/default-video-controls.tailwind.ts
+++ b/packages/skins/canonical/styles/skins/default-video-controls.tailwind.ts
@@ -1,0 +1,14 @@
+import { surface } from '../components/popup.tailwind';
+
+export const videoControls = [
+  surface,
+  'vjs-skin vjs-theme-default flex items-center gap-media-controls-gap rounded-media-pill p-media-controls-padding',
+  'font-media text-media leading-none text-media-controls',
+];
+
+export const controlsGroup = {
+  base: 'flex items-center gap-media-controls-gap',
+  time: 'flex flex-1 items-center gap-media-controls-gap',
+};
+
+export const time = 'tabular-nums';

--- a/packages/skins/canonical/styles/tailwind.css
+++ b/packages/skins/canonical/styles/tailwind.css
@@ -1,0 +1,26 @@
+@import "tailwindcss";
+@import "./base.css";
+@import "./themes/default.css";
+
+@source "../**/*.skin.tsx";
+
+@theme inline {
+  --color-media-controls: var(--media-controls-color);
+  --color-media-control-hover: var(--media-control-hover-background);
+  --color-media-slider-buffer: var(--media-slider-buffer-background);
+  --color-media-slider-track: var(--media-slider-track-background);
+  --color-media-surface: var(--media-surface-background);
+  --font-media: var(--media-font-family);
+  --text-media: var(--media-font-size);
+  --spacing-media-control: var(--media-control-size);
+  --spacing-media-controls-gap: var(--media-controls-gap);
+  --spacing-media-controls-padding: var(--media-controls-padding);
+  --spacing-media-icon: var(--media-icon-size);
+  --spacing-media-slider-thumb: var(--media-slider-thumb-size);
+  --spacing-media-slider-track: var(--media-slider-track-size);
+  --radius-media-pill: var(--media-radius-pill);
+  --radius-media-surface: var(--media-radius-surface);
+  --shadow-media-surface: 0 0 0 1px var(--media-surface-border), 0 2px 8px var(--media-shadow-color);
+  --drop-shadow-media-icon: 0 1px 0 var(--media-shadow-color);
+  --backdrop-blur-media-surface: var(--media-surface-backdrop-filter);
+}

--- a/packages/skins/canonical/styles/tailwind.css
+++ b/packages/skins/canonical/styles/tailwind.css
@@ -3,6 +3,7 @@
 @import "./themes/default.css";
 
 @source "../**/*.skin.tsx";
+@source "./**/*.tailwind.ts";
 
 @theme inline {
   --color-media-controls: var(--media-controls-color);
@@ -22,5 +23,5 @@
   --radius-media-surface: var(--media-radius-surface);
   --shadow-media-surface: 0 0 0 1px var(--media-surface-border), 0 2px 8px var(--media-shadow-color);
   --drop-shadow-media-icon: 0 1px 0 var(--media-shadow-color);
-  --backdrop-blur-media-surface: var(--media-surface-backdrop-filter);
+  --blur-media-surface: var(--media-surface-backdrop-blur);
 }

--- a/packages/skins/canonical/styles/themes/default.css
+++ b/packages/skins/canonical/styles/themes/default.css
@@ -15,7 +15,7 @@
     --media-slider-thumb-size: 0.75rem;
     --media-slider-track-background: oklch(1 0 0 / 0.2);
     --media-slider-track-size: 0.25rem;
-    --media-surface-backdrop-filter: blur(12px);
+    --media-surface-backdrop-blur: 12px;
     --media-surface-background: oklch(0.2 0 0 / 0.72);
     --media-surface-border: oklch(1 0 0 / 0.16);
   }

--- a/packages/skins/canonical/styles/themes/default.css
+++ b/packages/skins/canonical/styles/themes/default.css
@@ -1,0 +1,22 @@
+@layer videojs.theme {
+  .vjs-theme-default {
+    --media-controls-color: oklch(1 0 0);
+    --media-controls-gap: 0.25rem;
+    --media-controls-padding: 0.25rem;
+    --media-control-size: 2.25rem;
+    --media-control-hover-background: oklch(1 0 0 / 0.12);
+    --media-font-family: ui-sans-serif, system-ui, sans-serif;
+    --media-font-size: 0.875rem;
+    --media-icon-size: 1.125rem;
+    --media-radius-pill: 9999px;
+    --media-radius-surface: 0.5rem;
+    --media-shadow-color: oklch(0 0 0 / 0.35);
+    --media-slider-buffer-background: oklch(1 0 0 / 0.3);
+    --media-slider-thumb-size: 0.75rem;
+    --media-slider-track-background: oklch(1 0 0 / 0.2);
+    --media-slider-track-size: 0.25rem;
+    --media-surface-backdrop-filter: blur(12px);
+    --media-surface-background: oklch(0.2 0 0 / 0.72);
+    --media-surface-border: oklch(1 0 0 / 0.16);
+  }
+}

--- a/packages/skins/scripts/tests/build-artifact-graph.test.ts
+++ b/packages/skins/scripts/tests/build-artifact-graph.test.ts
@@ -129,6 +129,13 @@ describe('buildSkinArtifactGraph', () => {
         'volume-popover',
       ],
       packages: ['@videojs/core', '@videojs/icons'],
+      resources: {
+        styles: [
+          './canonical/styles/base.css',
+          './canonical/styles/tailwind.css',
+          './canonical/styles/themes/default.css',
+        ],
+      },
       symbols: {
         components: [
           'Controls',


### PR DESCRIPTION
Refs #1962
Refs #1964
Refs #1965

Parent sub-epic: #1950

## Stack

- Base: `main` after #1993
- Position: 1 of 4

## Summary

Make the canonical core controls Tailwind-first. Canonical JSX now consumes locally owned utility tokens, while a Tailwind v4 CSS-first theme input maps semantic utilities to scoped media variables. Vanilla CSS remains a later lowering of this same source.

## Changes

- Adds named `*.tailwind.ts` style tokens under `packages/skins/canonical/styles`
- Adds `styles/tailwind.css` with `@theme inline` semantic mappings and canonical source discovery
- Keeps reset and Default-theme values as scoped CSS layers
- Replaces the temporary hand-authored component CSS and BEM-style classes
- Adds Tailwind-driven icon state, button, slider, surface, tooltip, thumbnail, controls, and time styles
- Records exact style-token and CSS resource closure in the artifact graph

## Prototype paths reused from PR #1696

Reuses the proven canonical-token direction from `packages/skins/src/default/tailwind/**` and the prototype compiler style inputs. This PR recreates only the authored Skin boundary; it does not restore target style compilation.

## Exclusions

- Tailwind preserve/inline target projection
- Vanilla CSS extraction
- Generated React or HTML files
- Registry manifests and installation
- Full packaged-Skin parity

## Verification

- `pnpm -F @videojs/skins test` — 2 files, 4 tests
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Management-visible outcome

The core source graph now has one editable Tailwind-first style source and a scoped semantic theme contract that both Tailwind and future vanilla-CSS output can consume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and build-metadata changes only; no runtime security or data paths, with tests updated for the new style resources.
> 
> **Overview**
> Canonical skin JSX now pulls **named utility tokens** from local `*.tailwind.ts` modules instead of unstyled or hand-authored BEM/CSS, covering buttons, sliders, tooltips, popovers, and the default video controls layout.
> 
> Adds a **Tailwind v4 CSS entry** (`tailwind.css`) with `@theme inline` mappings to scoped `--media-*` variables, plus `base.css` reset and a **default theme** layer. The **artifact graph** records each component’s style-token sources and shared CSS resources (`base`, `tailwind`, `default` theme) so builds know the full style closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1bfd3a922f9c09866664a0e1bc1fb26e201ace5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->