### PR TITLE
feat(skin): setup react compiler plugin

### DIFF
--- a/packages/compiler/src/jsx/transforms/child-as-prop.ts
+++ b/packages/compiler/src/jsx/transforms/child-as-prop.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { hasJsxAttribute, singleJsxElementChild } from '../../utils/jsx';
+import { hasJsxAttribute, singleJsxChildExpression } from '../../utils/jsx';
 import type { JsxElementLike, Matcher } from '../matchers';
 
 export interface ChildAsPropOptions {
@@ -8,7 +8,7 @@ export interface ChildAsPropOptions {
 }
 
 /**
- * For elements matching `match`, lift the single JSX-element child into the
+ * For elements matching `match`, lift the single JSX element or expression child into the
  * named prop (turning the element into a self-closing form):
  *
  *   <Parent.Trigger><Child/></Parent.Trigger>
@@ -17,7 +17,7 @@ export interface ChildAsPropOptions {
  * Skips no-op cases:
  *   - element is already self-closing
  *   - prop is already set
- *   - children are zero, multiple, or text-only (no single JSX-element child)
+ *   - children are zero, multiple, or text-only
  */
 export function childAsProp(opts: ChildAsPropOptions): ts.TransformerFactory<ts.SourceFile> {
   return (context) => {
@@ -29,16 +29,13 @@ export function childAsProp(opts: ChildAsPropOptions): ts.TransformerFactory<ts.
       const opening = out.openingElement;
       if (hasJsxAttribute(opening.attributes, opts.prop)) return out;
 
-      const elementChild = singleJsxElementChild(out.children);
-      if (!elementChild) return out;
+      const child = singleJsxChildExpression(out.children);
+      if (!child) return out;
 
       const factory = context.factory;
       const newAttrs = factory.createJsxAttributes([
         ...opening.attributes.properties,
-        factory.createJsxAttribute(
-          factory.createIdentifier(opts.prop),
-          factory.createJsxExpression(undefined, elementChild)
-        ),
+        factory.createJsxAttribute(factory.createIdentifier(opts.prop), factory.createJsxExpression(undefined, child)),
       ]);
 
       return factory.createJsxSelfClosingElement(opening.tagName, opening.typeArguments, newAttrs);

--- a/packages/compiler/src/tests/compile.test.ts
+++ b/packages/compiler/src/tests/compile.test.ts
@@ -209,6 +209,14 @@ describe('childAsProp', () => {
     expect(collapse(code)).toContain(collapse(`<T render={<B/>}/>`));
   });
 
+  it('lifts a single JSX expression child into the named prop', async () => {
+    const source = `function App({ child }){ return <T>{child}</T>; }`;
+    const { code } = await compileJsx(source, {
+      transforms: [childAsProp({ match: byTag('T'), prop: 'render' })],
+    });
+    expect(collapse(code)).toContain(collapse(`<T render={child}/>`));
+  });
+
   it('skips when prop is already set', async () => {
     const source = `function App(){ return <T render={<X/>}><B/></T>; }`;
     const { code } = await compileJsx(source, {

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -8,7 +8,7 @@ import {
   hasJsxAttribute,
   hasJsxSpreadAttribute,
   isJsxElementLike as isJsxNodeLike,
-  singleJsxElementChild,
+  singleJsxChildExpression,
 } from './utils/jsx';
 import { insertStatementsAfterImports } from './utils/source-file';
 
@@ -941,7 +941,7 @@ function liftSingleChildToProp(
   const opening = element.openingElement;
   if (hasJsxAttribute(opening.attributes, prop)) return undefined;
 
-  const child = singleJsxElementChild(element.children);
+  const child = singleJsxChildExpression(element.children);
   if (!child) return undefined;
 
   const nextAttrs = factory.createJsxAttributes([

--- a/packages/compiler/src/utils/jsx.ts
+++ b/packages/compiler/src/utils/jsx.ts
@@ -46,6 +46,27 @@ export function singleJsxElementChild(children: readonly ts.JsxChild[]): JsxElem
   return found;
 }
 
+/** Return one meaningful JSX child as an expression, including an expression container. */
+export function singleJsxChildExpression(children: readonly ts.JsxChild[]): ts.Expression | null {
+  let found: ts.Expression | null = null;
+
+  for (const child of children) {
+    if (ts.isJsxText(child) && child.containsOnlyTriviaWhiteSpaces) continue;
+
+    const expression = ts.isJsxExpression(child) ? child.expression : child;
+    if (
+      !expression ||
+      (!isJsxElementLike(expression) && !ts.isJsxFragment(expression) && !ts.isExpression(expression))
+    ) {
+      return null;
+    }
+    if (found) return null;
+    found = expression;
+  }
+
+  return found;
+}
+
 export function jsxExpression(factory: ts.NodeFactory, expression: ts.Expression): ts.JsxExpression {
   return factory.createJsxExpression(undefined, expression);
 }

--- a/packages/compiler/src/utils/tests/jsx.test.ts
+++ b/packages/compiler/src/utils/tests/jsx.test.ts
@@ -7,6 +7,7 @@ import {
   isJsxElementLike,
   propertyAccess,
   readStringAttribute,
+  singleJsxChildExpression,
   singleJsxElementChild,
 } from '../jsx';
 
@@ -22,6 +23,31 @@ describe('JSX attribute utilities', () => {
     expect(readStringAttribute(attributes, 'empty')).toBe('');
     expect(readStringAttribute(attributes, 'dynamic')).toBeNull();
     expect(readStringAttribute(attributes, 'missing')).toBeUndefined();
+  });
+});
+
+describe('singleJsxChildExpression', () => {
+  it('returns element and expression children surrounded by whitespace', () => {
+    const element = firstJsxElement(`<Root>\n  <Child />\n</Root>`) as ts.JsxElement;
+    const expression = firstJsxElement(`<Root>\n  {child}\n</Root>`) as ts.JsxElement;
+
+    expect(singleJsxChildExpression(element.children)).toMatchObject({
+      kind: ts.SyntaxKind.JsxSelfClosingElement,
+    });
+    expect(singleJsxChildExpression(expression.children)).toMatchObject({
+      kind: ts.SyntaxKind.Identifier,
+      text: 'child',
+    });
+  });
+
+  it('rejects text, empty expressions, and multiple children', () => {
+    const text = firstJsxElement(`<Root>text</Root>`) as ts.JsxElement;
+    const empty = firstJsxElement(`<Root>{/* comment */}</Root>`) as ts.JsxElement;
+    const multiple = firstJsxElement(`<Root>{one}{two}</Root>`) as ts.JsxElement;
+
+    expect(singleJsxChildExpression(text.children)).toBeNull();
+    expect(singleJsxChildExpression(empty.children)).toBeNull();
+    expect(singleJsxChildExpression(multiple.children)).toBeNull();
   });
 });
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -130,6 +130,7 @@
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.17",
+    "@videojs/compiler": "workspace:*",
     "@videojs/icons": "workspace:*",
     "@videojs/skins": "workspace:*",
     "jsdom": "^26.1.0",

--- a/packages/react/skins.compiler.config.ts
+++ b/packages/react/skins.compiler.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, jsx, transform } from '@videojs/compiler';
+import { anyTag, childAsProp } from '@videojs/compiler/ast';
+
+const reactSourceConfig = defineConfig({
+  target: jsx({
+    imports: {
+      '@videojs/core': '@videojs/react',
+      '@videojs/core/components': '@videojs/react',
+      '@videojs/icons/components': './icons',
+    },
+    transforms: [
+      childAsProp({
+        match: anyTag(['Popover.Trigger', 'TooltipPrimitive.Trigger']),
+        prop: 'render',
+      }),
+    ],
+  }),
+  plugins: [
+    transform(
+      (code) => {
+        const cn = code.import('@videojs/utils/style', 'cn');
+
+        return [
+          code.jsx.element('Text').replace('span'),
+          code.jsx
+            .props('className')
+            .where(code.value.isArray())
+            .replace(({ value }) => code.value.call(cn, code.value.arrayItems(value))),
+        ];
+      },
+      { name: '@videojs/react:source-ui' }
+    ),
+  ],
+});
+
+export default reactSourceConfig;

--- a/packages/react/tests/skins.compiler.config.test.ts
+++ b/packages/react/tests/skins.compiler.config.test.ts
@@ -1,0 +1,42 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { compile } from '@videojs/compiler';
+import { describe, expect, it } from 'vitest';
+import reactSourceConfig from '../skins.compiler.config';
+
+const canonicalRoot = resolve(import.meta.dirname, '../../skins/canonical');
+const generatedRoot = resolve(import.meta.dirname, '../generated/skins');
+
+async function compileCanonical(relativePath: string) {
+  const filename = resolve(canonicalRoot, relativePath);
+  const source = await readFile(filename, 'utf8');
+  return compile(source, {
+    filename,
+    config: reactSourceConfig,
+    configDir: generatedRoot,
+    outputFile: resolve(generatedRoot, relativePath),
+  });
+}
+
+describe('reactSourceConfig', () => {
+  it('lowers canonical button composition to public React imports', async () => {
+    const result = await compileCanonical('components/buttons/seek-button.skin.tsx');
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('import type { SeekButtonProps } from "@videojs/react"');
+    expect(result.code).toContain('import { SeekButton as SeekButtonPrimitive } from "@videojs/react"');
+    expect(result.code).toContain('import { SeekIcon } from "../../icons"');
+    expect(result.code).toContain('<span className={seekLabel}>');
+    expect(result.code).not.toContain('@videojs/core/components');
+    expect(result.code).not.toContain('@videojs/icons/components');
+  });
+
+  it('lowers button tooltip children to the React render prop', async () => {
+    const result = await compileCanonical('components/buttons/button-tooltip.skin.tsx');
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('from "@videojs/react"');
+    expect(result.code).toContain('<TooltipPrimitive.Trigger render={children}/>');
+    expect(result.code).not.toContain('<TooltipPrimitive.Trigger>{children}</TooltipPrimitive.Trigger>');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@videojs/compiler':
+        specifier: workspace:*
+        version: link:../compiler
       '@videojs/icons':
         specifier: workspace:*
         version: link:../icons


### PR DESCRIPTION
Refs #1960
Refs #1959

Parent sub-epic: #245

## Stack

- Base: #2005 (`eject/08-skin-styles`)
- Position: 2 of 4

## Summary

Add the first production-shaped React lowering boundary for canonical Skin source, owned by the React package rather than the Skin source package or compiler core.

## Changes

- Adds the authored lowering at `packages/react/skins.compiler.config.ts`
- Rewrites canonical Core imports to public `@videojs/react`
- Routes named canonical icons through a local `icons.ts` source boundary
- Lowers `Text` to ordinary React markup
- Converts Tooltip and Popover trigger children to React render props
- Converts canonical class arrays through public `cn`
- Extends the generic compiler child-to-prop transform to support expression children
- Tests the config against real canonical SeekButton and ButtonTooltip source

## Prototype paths reused from PR #1696

Adapts `packages/react/skins.compiler.config.ts`: public component imports, trigger render props, local named icons, `Text` lowering, and class-array normalization. Video.js semantics remain outside compiler core.

## Exclusions

- Complete multi-file writer and checked generated tree
- Tailwind token inlining and vanilla CSS extraction
- Concrete editable icon implementations
- Clean React fixtures
- Registry manifests and parity tests

## Verification

- `pnpm -F @videojs/compiler test` — 12 files, 95 tests
- `pnpm -F @videojs/react test` — 38 files, 393 tests
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Management-visible outcome

React now owns its canonical-to-customer-source translation while `@videojs/compiler` supplies only generic transforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JSX AST transforms used by multiple compiler paths and establishes the first production skin-lowering config; behavior is well covered by tests but wrong transforms would affect generated React skin output.
> 
> **Overview**
> Introduces **`packages/react/skins.compiler.config.ts`** as the React-owned lowering pipeline for canonical skin source: Core imports map to **`@videojs/react`**, icons to a local **`./icons`** boundary, **`Text`** becomes **`span`**, array **`className`** values go through public **`cn`**, and **`Popover.Trigger` / `TooltipPrimitive.Trigger`** children become **`render`** props.
> 
> **`@videojs/compiler`** gains **`singleJsxChildExpression`** and **`childAsProp`** / **`moveChildToProp`** now lift a single **expression** child (e.g. **`{children}`**) as well as element children, with unit and compile tests. **`@videojs/react`** adds **`@videojs/compiler`** as a dev dependency and integration tests compile real canonical **`seek-button`** and **`button-tooltip`** skin files against the new config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b4230a3badde86da627ea2beca843011247027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->