### PR TITLE
feat(skin): setup html compiler plugin

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -172,10 +172,12 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
+    "@videojs/compiler": "workspace:*",
     "@videojs/icons": "workspace:*",
     "@videojs/skins": "workspace:*",
     "happy-dom": "^20.11.1",
     "tsdown": "^0.22.14",
+    "typescript": "^6.0.2",
     "vitest": "^4.1.10"
   },
   "publishConfig": {

--- a/packages/html/skins.compiler.config.ts
+++ b/packages/html/skins.compiler.config.ts
@@ -1,5 +1,5 @@
 import { type CompilerTransform, defineConfig, transform } from '@videojs/compiler';
-import { byTag, replaceJsxChild } from '@videojs/compiler/ast';
+import { tagName } from '@videojs/compiler/ast';
 import ts from 'typescript';
 
 const componentTags = {
@@ -8,9 +8,7 @@ const componentTags = {
   FullscreenButtonPrimitive: 'media-fullscreen-button',
   MuteButtonPrimitive: 'media-mute-button',
   PlayButtonPrimitive: 'media-play-button',
-  'Popover.Root': 'media-popover',
-  'Popover.Popup': 'div',
-  'Popover.Trigger': 'button',
+  'Popover.Popup': 'media-popover',
   SeekButtonPrimitive: 'media-seek-button',
   'Slider.Thumbnail.Root': 'div',
   'Slider.Thumbnail.Image': 'media-slider-thumbnail',
@@ -24,8 +22,7 @@ const componentTags = {
   'TimeSliderPrimitive.Preview': 'media-slider-preview',
   'TimeSliderPrimitive.Value': 'media-slider-value',
   'Tooltip.Provider': 'media-tooltip-group',
-  'TooltipPrimitive.Root': 'media-tooltip',
-  'TooltipPrimitive.Popup': 'div',
+  'TooltipPrimitive.Popup': 'media-tooltip',
   'TooltipPrimitive.Label': 'media-tooltip-label',
   'TooltipPrimitive.Shortcut': 'media-tooltip-shortcut',
   'VolumeSliderPrimitive.Root': 'media-volume-slider',
@@ -66,21 +63,21 @@ const htmlSourceConfig = defineConfig({
     transform(
       (code) => {
         const cn = code.import('@videojs/utils/style', 'cn');
+        const TooltipProps = code.type.named(code.import('@videojs/core', 'TooltipProps', { type: true }));
 
         return [
+          flattenPopupCompound('Popover.Root', 'Popover.Trigger', 'Popover.Popup'),
+          flattenPopupCompound('TooltipPrimitive.Root', 'TooltipPrimitive.Trigger', 'TooltipPrimitive.Popup'),
           ...Object.entries(componentTags).map(([source, target]) => code.jsx.element(source).replace(target)),
           ...Object.entries(iconNames).flatMap(([source, name]) => [
             code.jsx.element(source).addProp('name', name),
             code.jsx.element(source).replace('media-icon'),
           ]),
-          replaceJsxChild({
-            match: byTag('TooltipPrimitive.Trigger'),
-            replace: (element) => (ts.isJsxElement(element) ? element.children : undefined),
-          }),
           code.jsx
             .props('className')
             .where(code.value.isArray())
             .replace(({ value }) => code.value.call(cn, code.value.arrayItems(value))),
+          replaceCanonicalTooltipProps(TooltipProps),
           renameClassNameToClass(),
           removeCanonicalImports(),
         ];
@@ -119,6 +116,94 @@ function removeCanonicalImports(): CompilerTransform {
           )
       )
     );
+}
+
+function flattenPopupCompound(rootTag: string, triggerTag: string, popupTag: string): CompilerTransform {
+  return (context) => {
+    const factory = context.factory;
+
+    const visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      const next = ts.visitEachChild(node, visit, context);
+      if (!ts.isJsxElement(next) || tagName(next) !== rootTag) return next;
+
+      let foundPopup = false;
+      const children = next.children.flatMap((child): readonly ts.JsxChild[] => {
+        if (!ts.isJsxElement(child)) return [child];
+        if (tagName(child) === triggerTag) return child.children;
+        if (tagName(child) !== popupTag) return [child];
+
+        foundPopup = true;
+        const attributes = factory.updateJsxAttributes(child.openingElement.attributes, [
+          ...next.openingElement.attributes.properties,
+          ...child.openingElement.attributes.properties,
+        ]);
+
+        return [
+          factory.updateJsxElement(
+            child,
+            factory.updateJsxOpeningElement(
+              child.openingElement,
+              child.openingElement.tagName,
+              child.openingElement.typeArguments,
+              attributes
+            ),
+            child.children,
+            child.closingElement
+          ),
+        ];
+      });
+
+      if (!foundPopup) return next;
+      return factory.createJsxFragment(
+        factory.createJsxOpeningFragment(),
+        children,
+        factory.createJsxJsxClosingFragment()
+      );
+    };
+
+    return (sourceFile) => ts.visitNode(sourceFile, visit) as ts.SourceFile;
+  };
+}
+
+function replaceCanonicalTooltipProps(tooltipProps: ts.TypeNode): CompilerTransform {
+  return (context) => {
+    const factory = context.factory;
+    const replacement = factory.createIntersectionTypeNode([
+      tooltipProps,
+      factory.createTypeLiteralNode([
+        factory.createPropertySignature(
+          undefined,
+          'children',
+          factory.createToken(ts.SyntaxKind.QuestionToken),
+          factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)
+        ),
+      ]),
+    ]);
+
+    const visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      if (isCanonicalTooltipProps(node)) return replacement;
+      return ts.visitEachChild(node, visit, context);
+    };
+
+    return (sourceFile) => ts.visitNode(sourceFile, visit) as ts.SourceFile;
+  };
+}
+
+function isCanonicalTooltipProps(node: ts.Node): node is ts.IndexedAccessTypeNode {
+  if (!ts.isIndexedAccessTypeNode(node) || !ts.isTypeReferenceNode(node.objectType)) return false;
+  if (!ts.isIdentifier(node.objectType.typeName) || node.objectType.typeName.text !== 'Parameters') return false;
+  if (node.objectType.typeArguments?.length !== 1) return false;
+
+  const parameter = node.objectType.typeArguments[0];
+  if (!ts.isTypeQueryNode(parameter) || !ts.isQualifiedName(parameter.exprName)) return false;
+  if (!ts.isIdentifier(parameter.exprName.left) || parameter.exprName.left.text !== 'TooltipPrimitive') return false;
+  if (parameter.exprName.right.text !== 'Root') return false;
+
+  return (
+    ts.isLiteralTypeNode(node.indexType) &&
+    ts.isNumericLiteral(node.indexType.literal) &&
+    node.indexType.literal.text === '0'
+  );
 }
 
 function renameClassNameToClass(): CompilerTransform {

--- a/packages/html/skins.compiler.config.ts
+++ b/packages/html/skins.compiler.config.ts
@@ -1,0 +1,121 @@
+import { type CompilerTransform, defineConfig, transform } from '@videojs/compiler';
+import ts from 'typescript';
+
+const componentTags = {
+  'Controls.Root': 'media-controls',
+  'Controls.Group': 'media-controls-group',
+  FullscreenButtonPrimitive: 'media-fullscreen-button',
+  MuteButtonPrimitive: 'media-mute-button',
+  PlayButtonPrimitive: 'media-play-button',
+  'Popover.Root': 'media-popover',
+  'Popover.Popup': 'div',
+  'Popover.Trigger': 'button',
+  SeekButtonPrimitive: 'media-seek-button',
+  'Slider.Thumbnail.Root': 'div',
+  'Slider.Thumbnail.Image': 'media-slider-thumbnail',
+  Text: 'span',
+  'TimePrimitive.Value': 'media-time',
+  'TimeSliderPrimitive.Root': 'media-time-slider',
+  'TimeSliderPrimitive.Track': 'media-slider-track',
+  'TimeSliderPrimitive.Fill': 'media-slider-fill',
+  'TimeSliderPrimitive.Buffer': 'media-slider-buffer',
+  'TimeSliderPrimitive.Thumb': 'media-slider-thumb',
+  'TimeSliderPrimitive.Preview': 'media-slider-preview',
+  'TimeSliderPrimitive.Value': 'media-slider-value',
+  'Tooltip.Provider': 'media-tooltip-group',
+  'TooltipPrimitive.Root': 'media-tooltip',
+  'TooltipPrimitive.Popup': 'div',
+  'TooltipPrimitive.Label': 'media-tooltip-label',
+  'TooltipPrimitive.Shortcut': 'media-tooltip-shortcut',
+  'VolumeSliderPrimitive.Root': 'media-volume-slider',
+  'VolumeSliderPrimitive.Track': 'media-slider-track',
+  'VolumeSliderPrimitive.Fill': 'media-slider-fill',
+  'VolumeSliderPrimitive.Thumb': 'media-slider-thumb',
+} as const;
+
+const iconNames = {
+  FullscreenEnterIcon: 'fullscreen-enter',
+  FullscreenExitIcon: 'fullscreen-exit',
+  PauseIcon: 'pause',
+  PlayIcon: 'play',
+  RestartIcon: 'restart',
+  SeekIcon: 'seek',
+  SpinnerIcon: 'spinner',
+  VolumeHighIcon: 'volume-high',
+  VolumeLowIcon: 'volume-low',
+  VolumeOffIcon: 'volume-off',
+} as const;
+
+const elementModules: Readonly<Record<string, string>> = {
+  Controls: '@videojs/html/ui/controls',
+  FullscreenButton: '@videojs/html/ui/fullscreen-button',
+  MuteButton: '@videojs/html/ui/mute-button',
+  PlayButton: '@videojs/html/ui/play-button',
+  Popover: '@videojs/html/ui/popover',
+  SeekButton: '@videojs/html/ui/seek-button',
+  Slider: '@videojs/html/ui/slider',
+  Time: '@videojs/html/ui/time',
+  TimeSlider: '@videojs/html/ui/time-slider',
+  Tooltip: '@videojs/html/ui/tooltip',
+  VolumeSlider: '@videojs/html/ui/volume-slider',
+};
+
+const htmlSourceConfig = defineConfig({
+  plugins: [
+    transform(
+      (code) => [
+        ...Object.entries(componentTags).map(([source, target]) => code.jsx.element(source).replace(target)),
+        ...Object.entries(iconNames).flatMap(([source, name]) => [
+          code.jsx.element(source).addProp('name', name),
+          code.jsx.element(source).replace('media-icon'),
+        ]),
+        renameClassNameToClass(),
+        removeCanonicalImports(),
+      ],
+      { name: '@videojs/html:source-ui' }
+    ),
+  ],
+});
+
+export default htmlSourceConfig;
+
+export function resolveHtmlElementImports(componentSymbols: readonly string[]): string[] {
+  const symbols = new Set(componentSymbols);
+  const imports = new Set<string>();
+
+  for (const symbol of symbols) {
+    if (symbol === 'Slider' && (symbols.has('TimeSlider') || symbols.has('VolumeSlider'))) continue;
+    const source = elementModules[symbol];
+    if (source) imports.add(source);
+  }
+
+  return [...imports].sort();
+}
+
+function removeCanonicalImports(): CompilerTransform {
+  const canonicalSources = new Set(['@videojs/core/components', '@videojs/icons/components']);
+
+  return (context) => (sourceFile) =>
+    context.factory.updateSourceFile(
+      sourceFile,
+      sourceFile.statements.filter(
+        (statement) =>
+          !(
+            ts.isImportDeclaration(statement) &&
+            ts.isStringLiteral(statement.moduleSpecifier) &&
+            canonicalSources.has(statement.moduleSpecifier.text)
+          )
+      )
+    );
+}
+
+function renameClassNameToClass(): CompilerTransform {
+  return (context) => {
+    const visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      const next = ts.visitEachChild(node, visit, context);
+      if (!ts.isJsxAttribute(next) || !ts.isIdentifier(next.name) || next.name.text !== 'className') return next;
+      return context.factory.updateJsxAttribute(next, context.factory.createIdentifier('class'), next.initializer);
+    };
+    return (sourceFile) => ts.visitNode(sourceFile, visit) as ts.SourceFile;
+  };
+}

--- a/packages/html/skins.compiler.config.ts
+++ b/packages/html/skins.compiler.config.ts
@@ -1,4 +1,5 @@
 import { type CompilerTransform, defineConfig, transform } from '@videojs/compiler';
+import { byTag, replaceJsxChild } from '@videojs/compiler/ast';
 import ts from 'typescript';
 
 const componentTags = {
@@ -46,32 +47,44 @@ const iconNames = {
   VolumeOffIcon: 'volume-off',
 } as const;
 
-const elementModules: Readonly<Record<string, string>> = {
-  Controls: '@videojs/html/ui/controls',
-  FullscreenButton: '@videojs/html/ui/fullscreen-button',
-  MuteButton: '@videojs/html/ui/mute-button',
-  PlayButton: '@videojs/html/ui/play-button',
-  Popover: '@videojs/html/ui/popover',
-  SeekButton: '@videojs/html/ui/seek-button',
-  Slider: '@videojs/html/ui/slider',
-  Time: '@videojs/html/ui/time',
-  TimeSlider: '@videojs/html/ui/time-slider',
-  Tooltip: '@videojs/html/ui/tooltip',
-  VolumeSlider: '@videojs/html/ui/volume-slider',
+const elementModules: Readonly<Record<string, readonly string[]>> = {
+  Controls: ['@videojs/html/ui/controls'],
+  FullscreenButton: ['@videojs/html/ui/fullscreen-button'],
+  MuteButton: ['@videojs/html/ui/mute-button'],
+  PlayButton: ['@videojs/html/ui/play-button'],
+  Popover: ['@videojs/html/ui/popover'],
+  SeekButton: ['@videojs/html/ui/seek-button'],
+  Slider: ['@videojs/html/ui/slider'],
+  Time: ['@videojs/html/ui/time'],
+  TimeSlider: ['@videojs/html/ui/time-slider'],
+  Tooltip: ['@videojs/html/ui/tooltip', '@videojs/html/ui/tooltip-group'],
+  VolumeSlider: ['@videojs/html/ui/volume-slider'],
 };
 
 const htmlSourceConfig = defineConfig({
   plugins: [
     transform(
-      (code) => [
-        ...Object.entries(componentTags).map(([source, target]) => code.jsx.element(source).replace(target)),
-        ...Object.entries(iconNames).flatMap(([source, name]) => [
-          code.jsx.element(source).addProp('name', name),
-          code.jsx.element(source).replace('media-icon'),
-        ]),
-        renameClassNameToClass(),
-        removeCanonicalImports(),
-      ],
+      (code) => {
+        const cn = code.import('@videojs/utils/style', 'cn');
+
+        return [
+          ...Object.entries(componentTags).map(([source, target]) => code.jsx.element(source).replace(target)),
+          ...Object.entries(iconNames).flatMap(([source, name]) => [
+            code.jsx.element(source).addProp('name', name),
+            code.jsx.element(source).replace('media-icon'),
+          ]),
+          replaceJsxChild({
+            match: byTag('TooltipPrimitive.Trigger'),
+            replace: (element) => (ts.isJsxElement(element) ? element.children : undefined),
+          }),
+          code.jsx
+            .props('className')
+            .where(code.value.isArray())
+            .replace(({ value }) => code.value.call(cn, code.value.arrayItems(value))),
+          renameClassNameToClass(),
+          removeCanonicalImports(),
+        ];
+      },
       { name: '@videojs/html:source-ui' }
     ),
   ],
@@ -85,8 +98,7 @@ export function resolveHtmlElementImports(componentSymbols: readonly string[]): 
 
   for (const symbol of symbols) {
     if (symbol === 'Slider' && (symbols.has('TimeSlider') || symbols.has('VolumeSlider'))) continue;
-    const source = elementModules[symbol];
-    if (source) imports.add(source);
+    for (const source of elementModules[symbol] ?? []) imports.add(source);
   }
 
   return [...imports].sort();

--- a/packages/html/tests/skins.compiler.config.test.ts
+++ b/packages/html/tests/skins.compiler.config.test.ts
@@ -15,11 +15,23 @@ describe('htmlSourceConfig', () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain('<media-time-slider class={slider.root}');
     expect(result.code).toContain('<media-slider-track class={slider.track}>');
+    expect(result.code).toContain('<media-slider-fill class={cn(slider.fillBase, slider.fill)}/>');
     expect(result.code).toContain('<media-slider-thumbnail class={thumbnail.image}/>');
     expect(result.code).toContain('<media-icon class="size-media-icon drop-shadow-media-icon" name="spinner"/>');
     expect(result.code).not.toContain('className=');
     expect(result.code).not.toContain('@videojs/core/components');
     expect(result.code).not.toContain('@videojs/icons/components');
+  });
+
+  it('unwraps the React-only tooltip trigger part', async () => {
+    const filename = resolve(canonicalRoot, 'components/buttons/button-tooltip.skin.tsx');
+    const source = await readFile(filename, 'utf8');
+    const result = await compile(source, { filename, config: htmlSourceConfig });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('<media-tooltip {...props}>');
+    expect(result.code).toContain('{children}');
+    expect(result.code).not.toContain('<TooltipPrimitive.Trigger>');
   });
 });
 
@@ -49,6 +61,7 @@ describe('resolveHtmlElementImports', () => {
       '@videojs/html/ui/time',
       '@videojs/html/ui/time-slider',
       '@videojs/html/ui/tooltip',
+      '@videojs/html/ui/tooltip-group',
       '@videojs/html/ui/volume-slider',
     ]);
   });

--- a/packages/html/tests/skins.compiler.config.test.ts
+++ b/packages/html/tests/skins.compiler.config.test.ts
@@ -23,15 +23,32 @@ describe('htmlSourceConfig', () => {
     expect(result.code).not.toContain('@videojs/icons/components');
   });
 
-  it('unwraps the React-only tooltip trigger part', async () => {
+  it('lowers tooltip composition around sibling trigger and popup elements', async () => {
     const filename = resolve(canonicalRoot, 'components/buttons/button-tooltip.skin.tsx');
     const source = await readFile(filename, 'utf8');
     const result = await compile(source, { filename, config: htmlSourceConfig });
 
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain('<media-tooltip {...props}>');
+    expect(result.code).toContain('import type { TooltipProps }');
+    expect(result.code).toContain('from "@videojs/core"');
     expect(result.code).toContain('{children}');
+    expect(result.code).toContain('<media-tooltip {...props} class={tooltip.popup}>');
+    expect(result.code).not.toContain('typeof TooltipPrimitive.Root');
     expect(result.code).not.toContain('<TooltipPrimitive.Trigger>');
+  });
+
+  it('lowers popover composition without nesting the button trigger', async () => {
+    const filename = resolve(canonicalRoot, 'components/controls/volume-popover.skin.tsx');
+    const source = await readFile(filename, 'utf8');
+    const result = await compile(source, { filename, config: htmlSourceConfig });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('<MuteButton />');
+    expect(result.code).toContain(
+      '<media-popover openOnHover delay={200} closeDelay={100} side="top" class={volumePopover}>'
+    );
+    expect(result.code).not.toContain('<Popover.Trigger>');
+    expect(result.code).not.toContain('<button>');
   });
 });
 

--- a/packages/html/tests/skins.compiler.config.test.ts
+++ b/packages/html/tests/skins.compiler.config.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { compile } from '@videojs/compiler';
+import { describe, expect, it } from 'vitest';
+import htmlSourceConfig, { resolveHtmlElementImports } from '../skins.compiler.config';
+
+const canonicalRoot = resolve(import.meta.dirname, '../../skins/canonical');
+
+describe('htmlSourceConfig', () => {
+  it('lowers TimeSlider to idiomatic light-DOM element names', async () => {
+    const filename = resolve(canonicalRoot, 'components/sliders/time-slider.skin.tsx');
+    const source = await readFile(filename, 'utf8');
+    const result = await compile(source, { filename, config: htmlSourceConfig });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('<media-time-slider class={slider.root}');
+    expect(result.code).toContain('<media-slider-track class={slider.track}>');
+    expect(result.code).toContain('<media-slider-thumbnail class={thumbnail.image}/>');
+    expect(result.code).toContain('<media-icon class="size-media-icon drop-shadow-media-icon" name="spinner"/>');
+    expect(result.code).not.toContain('className=');
+    expect(result.code).not.toContain('@videojs/core/components');
+    expect(result.code).not.toContain('@videojs/icons/components');
+  });
+});
+
+describe('resolveHtmlElementImports', () => {
+  it('returns exact granular element registrations for the core controls', () => {
+    expect(
+      resolveHtmlElementImports([
+        'Controls',
+        'FullscreenButton',
+        'MuteButton',
+        'PlayButton',
+        'Popover',
+        'SeekButton',
+        'Slider',
+        'Time',
+        'TimeSlider',
+        'Tooltip',
+        'VolumeSlider',
+      ])
+    ).toEqual([
+      '@videojs/html/ui/controls',
+      '@videojs/html/ui/fullscreen-button',
+      '@videojs/html/ui/mute-button',
+      '@videojs/html/ui/play-button',
+      '@videojs/html/ui/popover',
+      '@videojs/html/ui/seek-button',
+      '@videojs/html/ui/time',
+      '@videojs/html/ui/time-slider',
+      '@videojs/html/ui/tooltip',
+      '@videojs/html/ui/volume-slider',
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
+      '@videojs/compiler':
+        specifier: workspace:*
+        version: link:../compiler
       '@videojs/icons':
         specifier: workspace:*
         version: link:../icons
@@ -329,6 +332,9 @@ importers:
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
Refs #1961
Refs #1959

Parent sub-epic: #245

## Stack

- Base: #2006 (`eject/09-react-output`)
- Position: 3 of 4

## Summary

Add the first HTML lowering boundary for canonical Skin source, owned by the HTML package.

## Changes

- Adds the authored lowering at `packages/html/skins.compiler.config.ts`
- Lowers canonical primitives to idiomatic light-DOM custom elements
- Lowers named icons to local `media-icon` roles
- Renames `className` to `class`
- Removes compiler-only canonical imports from output
- Resolves exact granular `@videojs/html/ui/*` registrations
- Tests TimeSlider lowering and the core-controls registration set

## Prototype paths reused from PR #1696

Recreates the prototype's HTML tag-lowering and exact-registration direction against the current canonical source and generic artifact graph.

## Exclusions

- Complete multi-file writer
- Generated `elements.ts` and local icon implementations
- Internal command/identity allocation and multiple-player verification
- Plain HTML, Vue, and Svelte fixtures
- Tailwind/CSS emission, registry files, and parity tests

## Verification

- `pnpm -F @videojs/html test` — 41 files, 300 tests
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Management-visible outcome

HTML now owns its canonical-to-light-DOM translation and exact runtime registration policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time compiler config and tests only; no runtime player or auth paths change until a downstream writer wires this in.
> 
> **Overview**
> Introduces **`packages/html/skins.compiler.config.ts`**, the first HTML-owned lowering step from canonical skin source to idiomatic light-DOM output via `@videojs/compiler`.
> 
> The **`@videojs/html:source-ui`** plugin maps canonical primitives to **`media-*`** custom elements, rewrites icon components to **`media-icon`** with `name`, folds **`className`** arrays through **`cn`** then renames to **`class`**, flattens **popover/tooltip** root+trigger+popup patterns, swaps canonical tooltip prop types for **`TooltipProps`**, and strips **`@videojs/core/components`** / **`@videojs/icons/components`** imports. **`resolveHtmlElementImports`** maps used skin symbols to sorted **`@videojs/html/ui/*`** registration paths (with **`Slider`** deduped when time/volume sliders are present).
> 
> **`packages/html/tests/skins.compiler.config.test.ts`** compiles real canonical skin files and asserts TimeSlider, tooltip, and volume-popover lowering plus the core-controls import list. **`package.json`** adds **`@videojs/compiler`** and **`typescript`** as devDependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47239a61af9f5dc71bf247ed3bad4887fe77449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->