### PR TITLE
feat(skin): add registry catalog adapter

### DIFF
--- a/build/source-ui/registry.ts
+++ b/build/source-ui/registry.ts
@@ -1,0 +1,161 @@
+import type { ArtifactGraph, ArtifactGraphNode } from '@videojs/compiler/artifacts';
+
+export type RegistryFramework = 'html' | 'react';
+export type RegistryStyle = 'css' | 'tailwind';
+export type RegistryItemType = 'registry:block' | 'registry:component';
+export type RegistryFileType = 'registry:component' | 'registry:file';
+
+interface RegistryMetadata {
+  title: string;
+  description: string;
+}
+
+export interface RegistryTarget {
+  framework: RegistryFramework;
+  style: RegistryStyle;
+}
+
+export interface RegistryOutputFile {
+  path: string;
+  type: RegistryFileType;
+  target?: string | undefined;
+}
+
+export interface RegistryOutputManifest {
+  artifacts: Readonly<Record<string, readonly RegistryOutputFile[]>>;
+  dependencies?: readonly string[] | undefined;
+}
+
+export interface RegistryCatalogItem {
+  name: string;
+  type: RegistryItemType;
+  title: string;
+  description: string;
+  files: readonly RegistryOutputFile[];
+  dependencies?: readonly string[] | undefined;
+  registryDependencies?: readonly string[] | undefined;
+  meta: {
+    framework: RegistryFramework;
+    style: RegistryStyle;
+    ownership: 'source';
+  };
+}
+
+export interface RegistryCatalog {
+  $schema: 'https://ui.shadcn.com/schema/registry.json';
+  name: 'videojs';
+  homepage: 'https://videojs.org';
+  items: readonly RegistryCatalogItem[];
+}
+
+export interface CreateRegistryCatalogOptions {
+  target: RegistryTarget;
+  output: RegistryOutputManifest;
+  ref?: string | undefined;
+  repository?: `${string}/${string}` | undefined;
+}
+
+export function createRegistryCatalog(
+  graph: ArtifactGraph,
+  { target, output, ref, repository = 'videojs/v10' }: CreateRegistryCatalogOptions
+): RegistryCatalog {
+  const artifacts = new Map(graph.artifacts.map((artifact) => [artifact.id, artifact]));
+  const published = graph.artifacts.filter(hasRegistryMetadata);
+  const publishedIds = new Set(published.map((artifact) => artifact.id));
+
+  return {
+    $schema: 'https://ui.shadcn.com/schema/registry.json',
+    name: 'videojs',
+    homepage: 'https://videojs.org',
+    items: published.map((artifact) => {
+      const { included, dependencies } = partitionDependencies(artifact, artifacts, publishedIds);
+      const files = uniqueFiles(
+        included.flatMap((id) => {
+          const artifactFiles = output.artifacts[id];
+          if (!artifactFiles) throw new Error(`Registry output is missing artifact \`${id}\`.`);
+          return artifactFiles;
+        })
+      );
+      const registry = artifact.metadata.registry;
+
+      return {
+        name: itemName(target, artifact.id),
+        type: artifact.kind === 'skin' ? 'registry:block' : 'registry:component',
+        title: `${registry.title} (${frameworkTitle(target.framework)}, ${styleTitle(target.style)})`,
+        description: `${registry.description} ${frameworkTitle(target.framework)} source with ${styleDescription(target.style)}.`,
+        files,
+        ...(output.dependencies?.length ? { dependencies: [...output.dependencies].sort() } : {}),
+        ...(dependencies.length
+          ? {
+              registryDependencies: dependencies.map(
+                (id) => `${repository}/${itemName(target, id)}${ref ? `#${ref}` : ''}`
+              ),
+            }
+          : {}),
+        meta: {
+          framework: target.framework,
+          style: target.style,
+          ownership: 'source',
+        },
+      };
+    }),
+  };
+}
+
+function hasRegistryMetadata(
+  artifact: ArtifactGraphNode
+): artifact is ArtifactGraphNode & { metadata: { registry: RegistryMetadata } } {
+  const registry = artifact.metadata?.registry;
+  return (
+    typeof registry === 'object' &&
+    registry !== null &&
+    typeof registry.title === 'string' &&
+    typeof registry.description === 'string'
+  );
+}
+
+function partitionDependencies(
+  root: ArtifactGraphNode,
+  artifacts: ReadonlyMap<string, ArtifactGraphNode>,
+  publishedIds: ReadonlySet<string>
+): { included: string[]; dependencies: string[] } {
+  const included = new Set<string>();
+  const dependencies = new Set<string>();
+
+  const visit = (id: string): void => {
+    if (id !== root.id && publishedIds.has(id)) {
+      dependencies.add(id);
+      return;
+    }
+    if (included.has(id)) return;
+    included.add(id);
+
+    const artifact = artifacts.get(id);
+    if (!artifact) throw new Error(`Artifact \`${root.id}\` depends on missing artifact \`${id}\`.`);
+    for (const dependency of artifact.dependencies.artifacts) visit(dependency);
+  };
+
+  visit(root.id);
+  return { included: [...included].sort(), dependencies: [...dependencies].sort() };
+}
+
+function uniqueFiles(files: readonly RegistryOutputFile[]): RegistryOutputFile[] {
+  const unique = new Map(files.map((file) => [`${file.path}\0${file.target ?? ''}`, file]));
+  return [...unique.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function itemName(target: RegistryTarget, artifactId: string): string {
+  return `${target.framework}/${target.style}/${artifactId}`;
+}
+
+function frameworkTitle(framework: RegistryFramework): string {
+  return framework === 'react' ? 'React' : 'HTML';
+}
+
+function styleTitle(style: RegistryStyle): string {
+  return style === 'tailwind' ? 'Tailwind' : 'CSS';
+}
+
+function styleDescription(style: RegistryStyle): string {
+  return style === 'tailwind' ? 'Tailwind styling' : 'vanilla CSS';
+}

--- a/build/source-ui/tests/registry.test.ts
+++ b/build/source-ui/tests/registry.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildSkinArtifactGraph } from '../../../packages/skins/scripts/build-artifact-graph.ts';
+import { createRegistryCatalog, type RegistryOutputManifest, type RegistryTarget } from '../registry.ts';
+
+const targets = [
+  { framework: 'react', style: 'tailwind' },
+  { framework: 'react', style: 'css' },
+  { framework: 'html', style: 'tailwind' },
+  { framework: 'html', style: 'css' },
+] as const satisfies readonly RegistryTarget[];
+
+describe('createRegistryCatalog', () => {
+  for (const target of targets) {
+    it(`creates the ${target.framework}/${target.style} catalog from the artifact graph`, async () => {
+      const { graph } = await buildSkinArtifactGraph();
+      const output = outputManifest(
+        graph.artifacts.map((artifact) => artifact.id),
+        target.framework
+      );
+      const catalog = createRegistryCatalog(graph, { target, output, ref: 'eject/11-registry-catalog' });
+
+      assert.deepEqual(
+        catalog.items.map((item) => item.name),
+        [
+          `${target.framework}/${target.style}/default-video-controls`,
+          `${target.framework}/${target.style}/fullscreen-button`,
+          `${target.framework}/${target.style}/play-button`,
+          `${target.framework}/${target.style}/seek-button`,
+          `${target.framework}/${target.style}/time-slider`,
+          `${target.framework}/${target.style}/volume-popover`,
+          `${target.framework}/${target.style}/volume-slider`,
+        ]
+      );
+      assert.deepEqual(catalog.items[0]?.registryDependencies, [
+        `videojs/v10/${target.framework}/${target.style}/fullscreen-button#eject/11-registry-catalog`,
+        `videojs/v10/${target.framework}/${target.style}/play-button#eject/11-registry-catalog`,
+        `videojs/v10/${target.framework}/${target.style}/seek-button#eject/11-registry-catalog`,
+        `videojs/v10/${target.framework}/${target.style}/time-slider#eject/11-registry-catalog`,
+        `videojs/v10/${target.framework}/${target.style}/volume-popover#eject/11-registry-catalog`,
+      ]);
+      assert.deepEqual(catalog.items[0]?.meta, {
+        framework: target.framework,
+        style: target.style,
+        ownership: 'source',
+      });
+    });
+  }
+
+  it('keeps internal helpers out of the catalog while including their output', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const output = outputManifest(
+      graph.artifacts.map((artifact) => artifact.id),
+      'react'
+    );
+    const catalog = createRegistryCatalog(graph, {
+      target: { framework: 'react', style: 'css' },
+      output,
+    });
+
+    assert.equal(
+      catalog.items.some((item) => item.name.endsWith('/button-tooltip')),
+      false
+    );
+    assert.equal(
+      catalog.items.some((item) => item.name.endsWith('/mute-button')),
+      false
+    );
+    assert.deepEqual(catalog.items.find((item) => item.name.endsWith('/play-button'))?.files, [
+      {
+        path: 'registry/react/button-tooltip.tsx',
+        type: 'registry:component',
+        target: '@ui/videojs/button-tooltip.tsx',
+      },
+      {
+        path: 'registry/react/play-button.tsx',
+        type: 'registry:component',
+        target: '@ui/videojs/play-button.tsx',
+      },
+    ]);
+  });
+});
+
+function outputManifest(artifactIds: readonly string[], framework: 'html' | 'react'): RegistryOutputManifest {
+  const extension = framework === 'react' ? 'tsx' : 'html';
+  return {
+    artifacts: Object.fromEntries(
+      artifactIds.map((id) => [
+        id,
+        [
+          {
+            path: `registry/${framework}/${id}.${extension}`,
+            type: 'registry:component' as const,
+            target: `@ui/videojs/${id}.${extension}`,
+          },
+        ],
+      ])
+    ),
+    dependencies: [framework === 'react' ? '@videojs/react' : '@videojs/html'],
+  };
+}

--- a/packages/skins/artifacts.generated.json
+++ b/packages/skins/artifacts.generated.json
@@ -33,7 +33,7 @@
     },
     {
       "id": "default-video-controls",
-      "kind": "component",
+      "kind": "skin",
       "entry": "./canonical/skins/default/video-controls.skin.tsx",
       "files": [
         {
@@ -62,6 +62,12 @@
         "symbols": {
           "components": ["Controls", "Time", "Tooltip"],
           "icons": []
+        }
+      },
+      "metadata": {
+        "registry": {
+          "description": "Source-owned core controls for a Video.js video player.",
+          "title": "Default Video Controls"
         }
       }
     },
@@ -92,6 +98,12 @@
         "symbols": {
           "components": ["FullscreenButton"],
           "icons": ["FullscreenEnterIcon", "FullscreenExitIcon"]
+        }
+      },
+      "metadata": {
+        "registry": {
+          "description": "A source-owned Video.js fullscreen button with a shared button tooltip.",
+          "title": "Fullscreen Button"
         }
       }
     },
@@ -153,6 +165,12 @@
           "components": ["PlayButton"],
           "icons": ["PauseIcon", "PlayIcon", "RestartIcon"]
         }
+      },
+      "metadata": {
+        "registry": {
+          "description": "A source-owned Video.js play button with play, pause, and replay states.",
+          "title": "Play Button"
+        }
       }
     },
     {
@@ -182,6 +200,12 @@
         "symbols": {
           "components": ["SeekButton", "Text"],
           "icons": ["SeekIcon"]
+        }
+      },
+      "metadata": {
+        "registry": {
+          "description": "A source-owned Video.js button for seeking backward or forward.",
+          "title": "Seek Button"
         }
       }
     },
@@ -217,6 +241,12 @@
           "components": ["Slider", "TimeSlider"],
           "icons": ["SpinnerIcon"]
         }
+      },
+      "metadata": {
+        "registry": {
+          "description": "A source-owned Video.js timeline with seek preview and thumbnails.",
+          "title": "Time Slider"
+        }
       }
     },
     {
@@ -246,6 +276,12 @@
         "symbols": {
           "components": ["Popover"],
           "icons": []
+        }
+      },
+      "metadata": {
+        "registry": {
+          "description": "Source-owned Video.js mute and volume controls in a popover.",
+          "title": "Volume Popover"
         }
       }
     },
@@ -280,6 +316,12 @@
         "symbols": {
           "components": ["VolumeSlider"],
           "icons": []
+        }
+      },
+      "metadata": {
+        "registry": {
+          "description": "A source-owned Video.js volume slider.",
+          "title": "Volume Slider"
         }
       }
     }

--- a/packages/skins/artifacts.generated.json
+++ b/packages/skins/artifacts.generated.json
@@ -66,8 +66,8 @@
       },
       "metadata": {
         "registry": {
-          "description": "Source-owned core controls for a Video.js video player.",
-          "title": "Default Video Controls"
+          "description": "A video control bar with play, seek, current and remaining time, volume, fullscreen, tooltips, and thumbnail previews.",
+          "title": "Core Video Controls"
         }
       }
     },
@@ -102,7 +102,7 @@
       },
       "metadata": {
         "registry": {
-          "description": "A source-owned Video.js fullscreen button with a shared button tooltip.",
+          "description": "A button that enters and exits fullscreen with state-aware icons and an accessible tooltip.",
           "title": "Fullscreen Button"
         }
       }
@@ -168,7 +168,7 @@
       },
       "metadata": {
         "registry": {
-          "description": "A source-owned Video.js play button with play, pause, and replay states.",
+          "description": "A three-state button that plays, pauses, or restarts media with matching icons and an accessible tooltip.",
           "title": "Play Button"
         }
       }
@@ -204,7 +204,7 @@
       },
       "metadata": {
         "registry": {
-          "description": "A source-owned Video.js button for seeking backward or forward.",
+          "description": "A button that skips playback forward or backward by a configurable number of seconds, with a direction-aware icon and accessible tooltip.",
           "title": "Seek Button"
         }
       }
@@ -244,7 +244,7 @@
       },
       "metadata": {
         "registry": {
-          "description": "A source-owned Video.js timeline with seek preview and thumbnails.",
+          "description": "A playback timeline for seeking, with current and buffered progress plus time and thumbnail previews.",
           "title": "Time Slider"
         }
       }
@@ -280,8 +280,8 @@
       },
       "metadata": {
         "registry": {
-          "description": "Source-owned Video.js mute and volume controls in a popover.",
-          "title": "Volume Popover"
+          "description": "A mute toggle with a vertical slider for adjusting playback volume in a popover.",
+          "title": "Volume Control"
         }
       }
     },
@@ -320,7 +320,7 @@
       },
       "metadata": {
         "registry": {
-          "description": "A source-owned Video.js volume slider.",
+          "description": "A horizontal or vertical slider for adjusting playback volume by dragging, using the keyboard, or scrolling.",
           "title": "Volume Slider"
         }
       }

--- a/packages/skins/artifacts.ts
+++ b/packages/skins/artifacts.ts
@@ -3,8 +3,14 @@ import { type ArtifactDefinition, defineArtifact } from '@videojs/compiler/artif
 export type SkinArtifactKind = 'component' | 'skin' | 'preset' | 'utility' | 'theme';
 export type SkinArtifactResourceKind = 'styles';
 export type SkinArtifactSymbolKind = 'components' | 'icons' | 'elements';
-export type SkinArtifactDefinition = Omit<ArtifactDefinition<SkinArtifactKind>, 'resources'> & {
+export interface SkinRegistryMetadata {
+  title: string;
+  description: string;
+}
+
+export type SkinArtifactDefinition = Omit<ArtifactDefinition<SkinArtifactKind>, 'resources' | 'metadata'> & {
   resources?: Readonly<Partial<Record<SkinArtifactResourceKind, readonly string[]>>> | undefined;
+  metadata?: { readonly registry?: SkinRegistryMetadata | undefined } | undefined;
 };
 
 const coreStyleResources = {
@@ -14,15 +20,27 @@ const coreStyleResources = {
 export const skinArtifacts = [
   defineArtifact({
     id: 'default-video-controls',
-    kind: 'component',
+    kind: 'skin',
     entry: './canonical/skins/default/video-controls.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Default Video Controls',
+        description: 'Source-owned core controls for a Video.js video player.',
+      },
+    },
   }),
   defineArtifact({
     id: 'fullscreen-button',
     kind: 'component',
     entry: './canonical/components/buttons/fullscreen-button.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Fullscreen Button',
+        description: 'A source-owned Video.js fullscreen button with a shared button tooltip.',
+      },
+    },
   }),
   defineArtifact({
     id: 'mute-button',
@@ -35,18 +53,36 @@ export const skinArtifacts = [
     kind: 'component',
     entry: './canonical/components/buttons/play-button.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Play Button',
+        description: 'A source-owned Video.js play button with play, pause, and replay states.',
+      },
+    },
   }),
   defineArtifact({
     id: 'seek-button',
     kind: 'component',
     entry: './canonical/components/buttons/seek-button.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Seek Button',
+        description: 'A source-owned Video.js button for seeking backward or forward.',
+      },
+    },
   }),
   defineArtifact({
     id: 'time-slider',
     kind: 'component',
     entry: './canonical/components/sliders/time-slider.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Time Slider',
+        description: 'A source-owned Video.js timeline with seek preview and thumbnails.',
+      },
+    },
   }),
   defineArtifact({
     id: 'button-tooltip',
@@ -59,11 +95,23 @@ export const skinArtifacts = [
     kind: 'component',
     entry: './canonical/components/sliders/volume-slider.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Volume Slider',
+        description: 'A source-owned Video.js volume slider.',
+      },
+    },
   }),
   defineArtifact({
     id: 'volume-popover',
     kind: 'component',
     entry: './canonical/components/controls/volume-popover.skin.tsx',
     resources: coreStyleResources,
+    metadata: {
+      registry: {
+        title: 'Volume Popover',
+        description: 'Source-owned Video.js mute and volume controls in a popover.',
+      },
+    },
   }),
 ] as const satisfies readonly SkinArtifactDefinition[];

--- a/packages/skins/artifacts.ts
+++ b/packages/skins/artifacts.ts
@@ -25,8 +25,9 @@ export const skinArtifacts = [
     resources: coreStyleResources,
     metadata: {
       registry: {
-        title: 'Default Video Controls',
-        description: 'Source-owned core controls for a Video.js video player.',
+        title: 'Core Video Controls',
+        description:
+          'A video control bar with play, seek, current and remaining time, volume, fullscreen, tooltips, and thumbnail previews.',
       },
     },
   }),
@@ -38,7 +39,7 @@ export const skinArtifacts = [
     metadata: {
       registry: {
         title: 'Fullscreen Button',
-        description: 'A source-owned Video.js fullscreen button with a shared button tooltip.',
+        description: 'A button that enters and exits fullscreen with state-aware icons and an accessible tooltip.',
       },
     },
   }),
@@ -56,7 +57,8 @@ export const skinArtifacts = [
     metadata: {
       registry: {
         title: 'Play Button',
-        description: 'A source-owned Video.js play button with play, pause, and replay states.',
+        description:
+          'A three-state button that plays, pauses, or restarts media with matching icons and an accessible tooltip.',
       },
     },
   }),
@@ -68,7 +70,8 @@ export const skinArtifacts = [
     metadata: {
       registry: {
         title: 'Seek Button',
-        description: 'A source-owned Video.js button for seeking backward or forward.',
+        description:
+          'A button that skips playback forward or backward by a configurable number of seconds, with a direction-aware icon and accessible tooltip.',
       },
     },
   }),
@@ -80,7 +83,8 @@ export const skinArtifacts = [
     metadata: {
       registry: {
         title: 'Time Slider',
-        description: 'A source-owned Video.js timeline with seek preview and thumbnails.',
+        description:
+          'A playback timeline for seeking, with current and buffered progress plus time and thumbnail previews.',
       },
     },
   }),
@@ -98,7 +102,8 @@ export const skinArtifacts = [
     metadata: {
       registry: {
         title: 'Volume Slider',
-        description: 'A source-owned Video.js volume slider.',
+        description:
+          'A horizontal or vertical slider for adjusting playback volume by dragging, using the keyboard, or scrolling.',
       },
     },
   }),
@@ -109,8 +114,8 @@ export const skinArtifacts = [
     resources: coreStyleResources,
     metadata: {
       registry: {
-        title: 'Volume Popover',
-        description: 'Source-owned Video.js mute and volume controls in a popover.',
+        title: 'Volume Control',
+        description: 'A mute toggle with a vertical slider for adjusting playback volume in a popover.',
       },
     },
   }),


### PR DESCRIPTION
Refs #1966
Refs #1970
Refs #1971

Parent sub-epics: #245, #1951

## Stack

- Base: #2007 (`eject/10-html-output`)
- Position: 4 of 4

## Summary

Adapt the generic Skin artifact graph into the four source-owned registry catalog variants without coupling shadcn or catalog policy into `@videojs/compiler` or `packages/skins`.

## Changes

- Adds the repository-owned adapter at `build/source-ui/registry.ts`
- Keeps artifact titles, descriptions, and public catalog membership with authored Skin metadata
- Produces React/HTML and Tailwind/CSS item naming
- Maps the partial `default-video-controls` milestone to `registry:block`
- Includes internal helper output without promoting helpers to public items
- Produces branch/SHA-pinned same-repository registry dependencies
- Consumes target output manifests so only customer-owned files enter catalog items
- Tests all four variants and internal-helper closure

## Prototype paths reused from PR #1696

Recreates the prototype registry-adapter boundary while consuming `@videojs/compiler/artifacts` as a generic graph. Registry-specific types and behavior remain repository build tooling.

## Exclusions

- Checked-in root and nested `registry.json` files
- Complete target output writer and generated source tree
- shadcn CLI validation and branch/SHA installation
- Drift command and CI integration
- CLI list/search/view/add/eject behavior
- Clean fixtures and parity tests

The partial block remains `default-video-controls`; it is not the final Default Skin catalog item.

## Verification

- `node --import tsx --test build/source-ui/tests/registry.test.ts` — 5 tests
- `pnpm -F @videojs/skins test` — 2 files, 4 tests
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Management-visible outcome

The generic graph is now cleanly separated from Video.js registry policy, and the repository has a testable adapter for all four planned source-owned catalog variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time catalog generation and skin metadata only; no runtime auth, data, or player behavior changes.
> 
> **Overview**
> Adds a **repository-owned shadcn registry adapter** at `build/source-ui/registry.ts` that turns the generic skin artifact graph plus per-target output manifests into a `registry.json` catalog for React/HTML and Tailwind/CSS variants.
> 
> **Skin metadata** now carries optional `metadata.registry` title/description on public controls; `default-video-controls` is reclassified as **`kind: 'skin'`** so the adapter can emit it as `registry:block`. Helpers without registry metadata (e.g. `button-tooltip`, `mute-button`) stay out of the catalog but their generated files are still folded into parent items via dependency closure.
> 
> Catalog items get framework/style-scoped names, shared npm `dependencies` from the manifest, and **same-repo `registryDependencies`** pinned with an optional ref. Tests cover all four targets and helper inclusion behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcddf06e5c3d672d4cfd9818da0b9e949e265e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->