### PR TITLE
feat(packages): resolve the poster from the store, not from markup

### DIFF
--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -39,14 +39,13 @@ async function render() {
   const srcAttr = source ? '' : ` src="${url}"`;
 
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
-    <${playerTag}${posterPlaceholder ? ` poster-placeholder="${posterPlaceholder}"` : ''}>
+    <${playerTag}${poster ? ` poster="${poster}"` : ''}${posterPlaceholder ? ` poster-placeholder="${posterPlaceholder}"` : ''}>
       <${tag} class="aspect-video max-w-4xl mx-auto">
         <!-- The storyboard track is derived automatically from the Mux src. -->
         <mux-video${srcAttr} ${mediaAttrs} playsinline crossorigin="anonymous"></mux-video>
         <!-- Mux Data and Cast are opt-in media components; no env key is needed for Mux-hosted sources. -->
         <mux-data player-software-name="mux-video"></mux-data>
         <google-cast></google-cast>
-        ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
       </${tag}>
     </${playerTag}>
   `);

--- a/apps/sandbox/templates/react-hlsjs-video/main.tsx
+++ b/apps/sandbox/templates/react-hlsjs-video/main.tsx
@@ -39,14 +39,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="aspect-video max-w-4xl mx-auto"
-        >
+      <Provider poster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="aspect-video max-w-4xl mx-auto">
           <HlsJsVideo
             {...(hlsSource ? { source: hlsSource } : { src: url ?? '' })}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -41,14 +41,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider posterPlaceholder={posterPlaceholder}>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="aspect-video max-w-4xl mx-auto"
-        >
+      <Provider poster={poster} posterPlaceholder={posterPlaceholder}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="aspect-video max-w-4xl mx-auto">
           {/* The storyboard track is derived automatically from the Mux src. */}
           <MuxVideo
             {...(muxSource ? { source: muxSource } : { src: url ?? '' })}

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -36,14 +36,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="w-full aspect-video max-w-4xl mx-auto"
-        >
+      <Provider poster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="w-full aspect-video max-w-4xl mx-auto">
           <NativeHlsVideo
             src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-simple-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-simple-hls-video/main.tsx
@@ -36,14 +36,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
-        <VideoSkinComponent
-          poster={poster}
-          skin={skin}
-          styling={styling}
-          live={live}
-          className="aspect-video max-w-4xl mx-auto"
-        >
+      <Provider poster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} live={live} className="aspect-video max-w-4xl mx-auto">
           <SimpleHlsVideo
             src={SOURCES[source].url ?? ''}
             autoPlay={autoplay}

--- a/apps/sandbox/templates/react-video/main.tsx
+++ b/apps/sandbox/templates/react-video/main.tsx
@@ -33,8 +33,8 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <VideoProvider>
-        <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+      <VideoProvider poster={poster}>
+        <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
           <Video
             src={SOURCES[source].url}
             autoPlay={autoplay}

--- a/internal/design/ui/poster.md
+++ b/internal/design/ui/poster.md
@@ -15,16 +15,37 @@ We want a simpler approach: expose minimal state (`data-visible`), let the user 
 
 ## Solution
 
-**HTML:** Wrapper element that accepts `<img>` as child.
+**HTML:** Element that owns an `<img part="img">` in a shadow root, beside a slot for an image of your own.
 **React:** Renders `<img>` directly — no wrapper needed.
+
+The URL comes from the player's resolved `poster`, not from markup here. See [Poster from the store](#poster-from-the-store) below.
 
 Visibility: `visible = !playback.started`. The poster shows until playback starts. `started` persists — pausing doesn't reset it.
 
 ## Accessibility
 
-**Wrapper (`<media-poster>`):** No ARIA role needed. Custom elements have no implicit role, so there's no semantics to hide or override. Do not add `aria-hidden` — the poster image may be informative.
+**HTML element (`<media-poster>`):** No ARIA role needed. Custom elements have no implicit role, so there's no semantics to hide or override. Do not add `aria-hidden` — the poster image may be informative.
 
-**Child (`<img>`):** User provides appropriate `alt` text. Whether a poster is informative or decorative is the author's judgment (per [WAI guidelines](https://www.w3.org/WAI/tutorials/images/decorative/)). This is an advantage over Media Chrome (which forces `aria-hidden="true"` on the internal image) and native `<video poster>` (which has no `alt` equivalent).
+**Image:** The one each binding renders carries `alt=""`. A resolved URL says nothing about what it depicts, and announcing the URL is worse than announcing nothing. Supply your own `alt` — as a prop in React, on your own `<img>` in HTML — to describe a poster that carries meaning. Whether a poster is informative or decorative is the author's judgment (per [WAI guidelines](https://www.w3.org/WAI/tutorials/images/decorative/)). This is an advantage over Media Chrome (which forces `aria-hidden="true"` on the internal image) and native `<video poster>` (which has no `alt` equivalent).
+
+## Poster from the store
+
+*Added 2026-08-08.*
+
+The poster was configured in markup: an `<img slot="poster">` in HTML, a `poster` prop on the React skin. That left content configuration in the skin's hands and made it unreachable from a hand-authored layout, and it left the store's resolved `poster` — user, media, user default — with no reader.
+
+The URL now comes from the metadata feature. The skins pass no arguments, and every consumer inherits the same chain: a packaged skin, an ejected one, a layout you wrote yourself.
+
+Rendering an image is what that requires, and the [decision below](#component-managed-image-src-prop) still holds — so it is a default, not a takeover:
+
+- **React** renders the `<img>` it always did. `src` fills in from the store when you don't pass one; every other image attribute is untouched. `render` receives the resolved `src` in its props, which is the way to hand it to `next/image`.
+- **HTML** owns an `<img part="img">` in a shadow root, beside a `<slot>`. Supply an image and the owned one is hidden and its `src` removed. Removing the `src` is not cosmetic: an image that isn't rendered still downloads.
+
+Detecting a supplied image is `slot.assignedElements({ flatten: true }).length > 0`. Flattening is required, not defensive. A skin forwards its own `<slot name="poster">` into the element, and an empty forwarding slot is itself an assigned node — so counting assigned nodes finds one whether or not the author supplied anything. This is also why the owned image sits *beside* the slot rather than inside it as fallback content: slot fallback renders only when nothing is assigned, and inside a skin something always is.
+
+`data-loaded` is reported on the host rather than the image, because a selector cannot reach past `::part()` to read an attribute. `media-poster:not([data-loaded])::part(img)` is expressible; `::part(img):not([data-loaded])` is not.
+
+An `<img>` cannot host the blur-up placeholder — it is a replaced element and generates no `::before` box — so the placeholder is a separate component. See [Poster placeholder](poster-placeholder.md).
 
 ## Alternatives Considered
 
@@ -42,8 +63,11 @@ Like Media Chrome — component owns the `<img>` internally.
 
 Our approach makes the flexible path the default.
 
+### Wrap React's `Poster` in a container
+
+Considered while looking for somewhere to paint the poster placeholder. Rejected: it changes the React poster's public shape from an `<img>` to a `<div>`, puts `srcset` and friends one element deeper, and breaks the rule that a component adds no elements to the page you style. See [Poster placeholder](poster-placeholder.md), which solved that problem instead.
+
 ## Future
 
 1. **`data-ended`** — Show poster when media ends.
-2. **`data-loaded`** — Set when child image loads, enabling CSS-only poster-placeholder-to-main transitions.
-3. **Transition/animation support** — CSS transition recommendations for fade in/out.
+2. **Transition/animation support** — CSS transition recommendations for fade in/out.

--- a/packages/core/src/core/ui/poster/poster-core.ts
+++ b/packages/core/src/core/ui/poster/poster-core.ts
@@ -1,13 +1,22 @@
-import type { MediaPlaybackState } from '@videojs/media';
+import type { MediaMetadataState, MediaPlaybackState } from '@videojs/media';
+
+/**
+ * The slices the poster composes: `playback` decides whether it shows,
+ * `metadata` resolves what it shows. Composed here rather than in each binding
+ * so the resolution is written and tested once.
+ */
+export type PosterMediaState = Pick<MediaPlaybackState, 'started'> & Pick<MediaMetadataState, 'poster'>;
 
 export interface PosterState {
   visible: boolean;
+  /** Resolved poster URL, empty when nothing supplied one. */
+  src: string;
 }
 
 export class PosterCore {
-  #media: MediaPlaybackState | null = null;
+  #media: PosterMediaState | null = null;
 
-  setMedia(media: MediaPlaybackState): void {
+  setMedia(media: PosterMediaState): void {
     this.#media = media;
   }
 
@@ -15,10 +24,12 @@ export class PosterCore {
     const media = this.#media!;
     return {
       visible: !media.started,
+      src: media.poster,
     };
   }
 }
 
 export namespace PosterCore {
   export type State = PosterState;
+  export type MediaState = PosterMediaState;
 }

--- a/packages/core/src/core/ui/poster/tests/poster-core.test.ts
+++ b/packages/core/src/core/ui/poster/tests/poster-core.test.ts
@@ -1,81 +1,32 @@
-import type { MediaPlaybackState } from '@videojs/media';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { PosterCore } from '../poster-core';
-
-function createMediaState(overrides: Partial<MediaPlaybackState> = {}): MediaPlaybackState {
-  return {
-    paused: true,
-    ended: false,
-    started: false,
-    waiting: false,
-    play: vi.fn(async () => {}),
-    pause: vi.fn(),
-    togglePaused: vi.fn(() => true),
-    ...overrides,
-  };
-}
 
 describe('PosterCore', () => {
   describe('getState', () => {
-    it('returns visible: true when playback has not started', () => {
-      const core = new PosterCore();
-      const media = createMediaState({ started: false });
-
-      core.setMedia(media);
-      const state = core.getState();
-
-      expect(state.visible).toBe(true);
-    });
-
-    it('returns visible: false when playback has started', () => {
-      const core = new PosterCore();
-      const media = createMediaState({ started: true });
-
-      core.setMedia(media);
-      const state = core.getState();
-
-      expect(state.visible).toBe(false);
-    });
-
-    it('returns only primitive values (no methods)', () => {
-      const core = new PosterCore();
-      const media = createMediaState();
-
-      core.setMedia(media);
-      const state = core.getState();
-
-      expect(state).toEqual({ visible: true });
-
-      const functionKeys = Object.entries(state).filter(([, value]) => typeof value === 'function');
-      expect(functionKeys).toHaveLength(0);
-    });
-
-    it('visibility is independent of paused state', () => {
+    it('is visible before playback starts and hidden after', () => {
       const core = new PosterCore();
 
-      // Started but paused - should not be visible
-      core.setMedia(createMediaState({ started: true, paused: true }));
-      expect(core.getState().visible).toBe(false);
-
-      // Started and playing - should not be visible
-      core.setMedia(createMediaState({ started: true, paused: false }));
-      expect(core.getState().visible).toBe(false);
-
-      // Not started and paused - should be visible
-      core.setMedia(createMediaState({ started: false, paused: true }));
+      core.setMedia({ started: false, poster: 'poster.jpg' });
       expect(core.getState().visible).toBe(true);
+
+      core.setMedia({ started: true, poster: 'poster.jpg' });
+      expect(core.getState().visible).toBe(false);
     });
 
-    it('visibility is independent of ended state', () => {
+    it('passes the resolved URL through untouched', () => {
       const core = new PosterCore();
 
-      // Started and ended - should not be visible (started takes precedence)
-      core.setMedia(createMediaState({ started: true, ended: true }));
-      expect(core.getState().visible).toBe(false);
+      core.setMedia({ started: false, poster: 'poster.jpg' });
 
-      // Not started and ended (edge case) - should be visible
-      core.setMedia(createMediaState({ started: false, ended: true }));
-      expect(core.getState().visible).toBe(true);
+      expect(core.getState()).toEqual({ visible: true, src: 'poster.jpg' });
+    });
+
+    it('reports an empty src when nothing supplied a poster', () => {
+      const core = new PosterCore();
+
+      core.setMedia({ started: false, poster: '' });
+
+      expect(core.getState().src).toBe('');
     });
   });
 });

--- a/packages/html/src/ui/poster/poster-element.ts
+++ b/packages/html/src/ui/poster/poster-element.ts
@@ -1,14 +1,149 @@
 import { PosterCore, PosterDataAttrs } from '@videojs/core';
-import { selectPlayback } from '@videojs/core/dom';
+import { applyStateDataAttrs, logMissingFeature, selectMetadata, selectPlayback } from '@videojs/core/dom';
+import type { PropertyValues } from '@videojs/element';
 
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
-import { MediaUIElement } from '../media-ui-element';
+import { MediaElement } from '../media-element';
 
-export class PosterElement extends MediaUIElement<PosterCore> {
+const SHADOW_CSS = `\
+:host {
+  display: block;
+}
+img {
+  display: block;
+}
+img[hidden] {
+  display: none;
+}`;
+
+/**
+ * `<media-poster>` — displays the poster image and hides it once playback starts.
+ *
+ * Owns an `<img part="img">` in a shadow root, alongside a slot for an image of
+ * your own. Supply one and this element's image steps aside, so `srcset`,
+ * `loading`, and `<picture>` stay available. Supply nothing and the resolved
+ * `poster` is rendered for you, which is why the URL is set on the player
+ * rather than here.
+ *
+ * Composes `playback` for visibility and `metadata` for the URL, so it doesn't
+ * extend `MediaUIElement`: that base couples an element to a single feature
+ * selector.
+ */
+export class PosterElement extends MediaElement {
   static readonly tagName = 'media-poster';
 
-  protected readonly core = new PosterCore();
-  protected readonly stateAttrMap = PosterDataAttrs;
-  protected readonly mediaState = new PlayerController(this, playerContext, selectPlayback);
+  readonly #core = new PosterCore();
+  readonly #img = document.createElement('img');
+  readonly #slot = document.createElement('slot');
+
+  readonly #playback = new PlayerController(this, playerContext, selectPlayback);
+  readonly #metadata = new PlayerController(this, playerContext, selectMetadata);
+
+  #disconnect: AbortController | null = null;
+
+  constructor() {
+    super();
+
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const style = document.createElement('style');
+    style.textContent = SHADOW_CSS;
+
+    // The image is decorative: it carries a URL the player resolved, and
+    // nothing here knows what it depicts. Describe a poster that means
+    // something by supplying your own image with an `alt`.
+    this.#img.alt = '';
+    this.#img.setAttribute('part', 'img');
+    this.#img.setAttribute('decoding', 'async');
+
+    shadow.append(style, this.#slot, this.#img);
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (this.destroyed) return;
+
+    this.#disconnect = new AbortController();
+    const { signal } = this.#disconnect;
+
+    // Whether the author has supplied an image can change after connection.
+    // The shadow slot's own `slotchange` doesn't escape the shadow root, and a
+    // change to a skin's forwarding slot bubbles to this host instead, so both
+    // need listening to.
+    this.#slot.addEventListener('slotchange', () => this.requestUpdate(), { signal });
+    this.addEventListener('slotchange', () => this.requestUpdate(), { signal });
+
+    this.#img.addEventListener('load', () => this.#markLoaded(), { signal });
+
+    if (__DEV__ && !this.#playback.value) {
+      logMissingFeature(this.localName, this.#playback.displayName ?? 'playback');
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+
+  protected override update(changed: PropertyValues): void {
+    super.update(changed);
+
+    const playback = this.#playback.value;
+    if (!playback) return;
+
+    // The metadata feature is optional: without it nothing resolves a URL, and
+    // this stays a visibility wrapper around whatever the author supplied.
+    this.#core.setMedia({
+      started: playback.started,
+      poster: this.#metadata.value?.poster ?? '',
+    });
+
+    const state = this.#core.getState();
+    applyStateDataAttrs(this, state, PosterDataAttrs);
+
+    this.#applyImage(state.src);
+  }
+
+  /**
+   * Whether the author supplied an image.
+   *
+   * A skin forwards its own `<slot name="poster">` into this element, and that
+   * empty slot is itself an assigned node — so counting assigned nodes would
+   * always find one. Flattening resolves the chain to what the author actually
+   * put there.
+   */
+  get #hasAuthorImage(): boolean {
+    return this.#slot.assignedElements({ flatten: true }).length > 0;
+  }
+
+  #applyImage(src: string): void {
+    const owned = src !== '' && !this.#hasAuthorImage;
+
+    this.#img.hidden = !owned;
+
+    if (!owned) {
+      // An image that isn't rendered still downloads its `src`.
+      this.#img.removeAttribute('src');
+      this.removeAttribute('data-loaded');
+      return;
+    }
+
+    if (this.#img.getAttribute('src') !== src) {
+      this.removeAttribute('data-loaded');
+      this.#img.setAttribute('src', src);
+    }
+
+    this.#markLoaded();
+  }
+
+  /**
+   * Reported on the host rather than the image, because a selector can't reach
+   * past `::part()` to read an attribute.
+   */
+  #markLoaded(): void {
+    // A cached image can already be complete, in which case `load` never fires.
+    if (this.#img.complete && this.#img.naturalWidth > 0) this.setAttribute('data-loaded', '');
+  }
 }

--- a/packages/html/src/ui/poster/tests/poster-element.test.ts
+++ b/packages/html/src/ui/poster/tests/poster-element.test.ts
@@ -1,0 +1,179 @@
+import type { AnyPlayerStore, PlayerTarget } from '@videojs/core/dom';
+import { metadataFeature, playbackFeature } from '@videojs/core/dom';
+import { ContextProvider } from '@videojs/element/context';
+import { combine, createStore } from '@videojs/store';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { playerContext } from '../../../player/context';
+import { MediaElement } from '../../media-element';
+import { PosterElement } from '../poster-element';
+
+function ensureDefined(ctor: CustomElementConstructor & { readonly tagName: string }): void {
+  if (!customElements.get(ctor.tagName)) customElements.define(ctor.tagName, ctor);
+}
+
+class TestProviderElement extends MediaElement {
+  static readonly tagName = 'test-poster-provider';
+
+  readonly store = createStore<PlayerTarget>()(combine(playbackFeature, metadataFeature)) as unknown as AnyPlayerStore;
+
+  readonly #provider = new ContextProvider(this, { context: playerContext, initialValue: this.store });
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.#provider.setValue(this.store);
+  }
+}
+
+interface Harness {
+  poster: PosterElement;
+  /** The image the element owns, in its shadow root. */
+  owned: HTMLImageElement;
+  setPoster(value: string | null): Promise<void>;
+  start(): Promise<void>;
+  settle(): Promise<void>;
+}
+
+/**
+ * Mounts the poster the way a skin does: inside a shadow root that forwards its
+ * own `<slot name="poster">` into the element.
+ */
+async function mount(options: { authorImage?: boolean } = {}): Promise<Harness> {
+  ensureDefined(TestProviderElement);
+  ensureDefined(PosterElement);
+
+  const provider = document.createElement(TestProviderElement.tagName) as TestProviderElement;
+  document.body.appendChild(provider);
+
+  const skin = provider.attachShadow({ mode: 'open' });
+  skin.innerHTML = `<${PosterElement.tagName}><slot name="poster"></slot></${PosterElement.tagName}>`;
+  const poster = skin.querySelector(PosterElement.tagName) as PosterElement;
+
+  if (options.authorImage) {
+    const image = document.createElement('img');
+    image.slot = 'poster';
+    image.src = 'author.jpg';
+    image.alt = 'Keynote speaker';
+    provider.appendChild(image);
+  }
+
+  const video = document.createElement('video');
+  provider.store.attach({ media: video, container: null });
+
+  await poster.updateComplete;
+
+  const settle = async () => {
+    poster.requestUpdate();
+    await poster.updateComplete;
+  };
+
+  return {
+    poster,
+    owned: poster.shadowRoot!.querySelector('img')!,
+    settle,
+    async setPoster(value) {
+      (provider.store as unknown as { setPoster(value: string | null): void }).setPoster(value);
+      await settle();
+    },
+    async start() {
+      Object.defineProperty(video, 'paused', { value: false, configurable: true });
+      video.dispatchEvent(new Event('play'));
+      await settle();
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('PosterElement', () => {
+  it('renders the resolved poster in an image it owns', async () => {
+    const { owned, setPoster } = await mount();
+
+    await setPoster('poster.jpg');
+
+    expect(owned.getAttribute('src')).toBe('poster.jpg');
+    expect(owned.hidden).toBe(false);
+    expect(owned.getAttribute('part')).toBe('img');
+    expect(owned.alt).toBe('');
+  });
+
+  it('withholds the src until one resolves, so nothing is fetched', async () => {
+    const { owned } = await mount();
+
+    expect(owned.hasAttribute('src')).toBe(false);
+    expect(owned.hidden).toBe(true);
+  });
+
+  it('clears the src when the poster goes away', async () => {
+    const { owned, setPoster } = await mount();
+
+    await setPoster('poster.jpg');
+    await setPoster(null);
+
+    expect(owned.hasAttribute('src')).toBe(false);
+    expect(owned.hidden).toBe(true);
+  });
+
+  it('steps aside for an image the author slotted, and does not fetch its own', async () => {
+    const { owned, setPoster } = await mount({ authorImage: true });
+
+    await setPoster('poster.jpg');
+
+    expect(owned.hidden).toBe(true);
+    expect(owned.hasAttribute('src')).toBe(false);
+  });
+
+  it('takes over when the author removes their image', async () => {
+    const { poster, owned, setPoster, settle } = await mount({ authorImage: true });
+
+    await setPoster('poster.jpg');
+    expect(owned.hidden).toBe(true);
+
+    (poster.getRootNode() as ShadowRoot).host.querySelector('img')!.remove();
+    await settle();
+
+    expect(owned.hidden).toBe(false);
+    expect(owned.getAttribute('src')).toBe('poster.jpg');
+  });
+
+  it('hides once playback starts', async () => {
+    const { poster, setPoster, start } = await mount();
+
+    await setPoster('poster.jpg');
+    expect(poster.hasAttribute('data-visible')).toBe(true);
+
+    await start();
+
+    expect(poster.hasAttribute('data-visible')).toBe(false);
+  });
+
+  it('reports load on the host, where a selector can reach it', async () => {
+    const { poster, owned, setPoster } = await mount();
+
+    await setPoster('poster.jpg');
+    expect(poster.hasAttribute('data-loaded')).toBe(false);
+
+    Object.defineProperty(owned, 'complete', { value: true, configurable: true });
+    Object.defineProperty(owned, 'naturalWidth', { value: 640, configurable: true });
+    owned.dispatchEvent(new Event('load'));
+
+    expect(poster.hasAttribute('data-loaded')).toBe(true);
+  });
+
+  it('drops the load report when the poster changes', async () => {
+    const { poster, owned, setPoster } = await mount();
+
+    await setPoster('poster.jpg');
+    Object.defineProperty(owned, 'complete', { value: true, configurable: true });
+    Object.defineProperty(owned, 'naturalWidth', { value: 640, configurable: true });
+    owned.dispatchEvent(new Event('load'));
+    expect(poster.hasAttribute('data-loaded')).toBe(true);
+
+    Object.defineProperty(owned, 'complete', { value: false, configurable: true });
+    await setPoster('next.jpg');
+
+    expect(poster.hasAttribute('data-loaded')).toBe(false);
+  });
+});

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -18,7 +18,6 @@ import {
   slider,
   spacer,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -67,7 +66,6 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { MinimalLiveVideoSkinProps } from './minimal-skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
@@ -203,7 +201,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn(root(false), className)} style={style} {...rest}>
@@ -211,13 +209,7 @@ export function MinimalLiveVideoSkinTailwind(props: MinimalLiveVideoSkinProps): 
 
       <PosterPlaceholder className={posterPlaceholder} />
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -1,5 +1,4 @@
 import { captionsText } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -48,13 +47,12 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
-import type { BaseVideoSkinProps } from '../types';
+import type { BaseSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
-export type MinimalLiveVideoSkinProps = BaseVideoSkinProps;
+export type MinimalLiveVideoSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
@@ -170,7 +168,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNode {
-  const { children, className, poster, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn('media-minimal-skin media-minimal-skin--video', className)} style={style} {...rest}>
@@ -178,9 +176,7 @@ export function MinimalLiveVideoSkin(props: MinimalLiveVideoSkinProps): ReactNod
 
       <PosterPlaceholder className="media-poster-placeholder" />
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster className="media-poster" />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -19,7 +19,6 @@ import {
   slider,
   spacer,
 } from '@videojs/skins/default/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -68,7 +67,6 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { LiveVideoSkinProps } from './skin';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
@@ -204,7 +202,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn(root(false), className)} style={style} {...rest}>
@@ -212,13 +210,7 @@ export function LiveVideoSkinTailwind(props: LiveVideoSkinProps): ReactNode {
 
       <PosterPlaceholder className={posterPlaceholder} />
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -1,5 +1,4 @@
 import { captionsText } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -48,13 +47,12 @@ import { StatusIndicator } from '@/ui/status-indicator';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
-import type { BaseVideoSkinProps } from '../types';
+import type { BaseSkinProps } from '../types';
 
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
-export type LiveVideoSkinProps = BaseVideoSkinProps;
+export type LiveVideoSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
@@ -167,7 +165,7 @@ function CaptionsTrigger(): ReactNode {
 }
 
 export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
-  const { children, className, poster, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn('media-default-skin media-default-skin--video', className)} style={style} {...rest}>
@@ -175,9 +173,7 @@ export function LiveVideoSkin(props: LiveVideoSkinProps): ReactNode {
 
       <PosterPlaceholder className="media-poster-placeholder" />
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster className="media-poster" />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/types.ts
+++ b/packages/react/src/presets/types.ts
@@ -1,6 +1,4 @@
 import type { CSSProperties, PropsWithChildren } from 'react';
-import type { Poster } from '@/ui/poster';
-import type { RenderProp } from '@/utils/types';
 
 export type BaseSkinProps<T = unknown> = PropsWithChildren<
   T & {
@@ -8,7 +6,3 @@ export type BaseSkinProps<T = unknown> = PropsWithChildren<
     className?: string;
   }
 >;
-
-export type BaseVideoSkinProps<T = unknown> = BaseSkinProps<T> & {
-  poster?: string | RenderProp<Poster.State> | undefined;
-};

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -28,7 +28,6 @@ import {
   thumbnail,
   time,
 } from '@videojs/skins/minimal/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -88,7 +87,6 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { MinimalVideoSkinProps } from './minimal-skin';
 
 const SEEK_TIME = 10;
@@ -422,7 +420,7 @@ function SettingsMenu(): ReactNode {
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn(root(false), className)} style={style} {...rest}>
@@ -430,13 +428,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
 
       <PosterPlaceholder className={posterPlaceholder} />
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -6,7 +6,6 @@ import {
   settingsText,
   speedText,
 } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -66,14 +65,13 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
-import type { BaseVideoSkinProps } from '../types';
+import type { BaseSkinProps } from '../types';
 
 const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
-export type MinimalVideoSkinProps = BaseVideoSkinProps;
+export type MinimalVideoSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
@@ -359,7 +357,7 @@ function SettingsMenu(): ReactNode {
 }
 
 export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
-  const { children, className, poster, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn('media-minimal-skin media-minimal-skin--video', className)} style={style} {...rest}>
@@ -367,9 +365,7 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
 
       <PosterPlaceholder className="media-poster-placeholder" />
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster className="media-poster" />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -30,7 +30,6 @@ import {
   thumbnail,
   time,
 } from '@videojs/skins/default/tailwind/video.tailwind';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -90,7 +89,6 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
 import type { VideoSkinProps } from './skin';
 
 const SEEK_TIME = 10;
@@ -424,7 +422,7 @@ function SettingsMenu(): ReactNode {
 /* ------------------------------------------ Skin ------------------------------------------- */
 
 export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
-  const { children, className, poster: posterProp, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn(root(false), className)} style={style} {...rest}>
@@ -432,13 +430,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
 
       <PosterPlaceholder className={posterPlaceholder} />
 
-      {posterProp && (
-        <Poster
-          src={isString(posterProp) ? posterProp : undefined}
-          render={isRenderProp(posterProp) ? posterProp : undefined}
-          className={poster(false)}
-        />
-      )}
+      <Poster className={poster(false)} />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -6,7 +6,6 @@ import {
   settingsText,
   speedText,
 } from '@videojs/core/i18n/text/menu';
-import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { useTranslator } from '@/i18n/context';
@@ -66,14 +65,13 @@ import { TimeSlider } from '@/ui/time-slider';
 import { Tooltip } from '@/ui/tooltip';
 import { VolumeIndicator } from '@/ui/volume-indicator';
 import { VolumeSlider } from '@/ui/volume-slider';
-import { isRenderProp } from '@/utils/use-render';
-import type { BaseVideoSkinProps } from '../types';
+import type { BaseSkinProps } from '../types';
 
 const SEEK_TIME = 10;
 const TOP_STATUS_ACTIONS = ['toggleSubtitles', 'toggleFullscreen', 'togglePictureInPicture'] as const;
 const CENTER_STATUS_ACTIONS = ['togglePaused'] as const;
 
-export type VideoSkinProps = BaseVideoSkinProps;
+export type VideoSkinProps = BaseSkinProps;
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function Button({ className, ...props }, ref) {
   return (
@@ -434,7 +432,7 @@ function FullscreenControl() {
 }
 
 export function VideoSkin(props: VideoSkinProps): ReactNode {
-  const { children, className, poster, style, ...rest } = props;
+  const { children, className, style, ...rest } = props;
 
   return (
     <Container className={cn('media-default-skin media-default-skin--video', className)} style={style} {...rest}>
@@ -442,9 +440,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
 
       <PosterPlaceholder className="media-poster-placeholder" />
 
-      {poster && (
-        <Poster src={isString(poster) ? poster : undefined} render={isRenderProp(poster) ? poster : undefined} />
-      )}
+      <Poster className="media-poster" />
 
       <BufferingIndicator
         render={(props) => (

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PosterCore, PosterDataAttrs } from '@videojs/core';
-import { logMissingFeature, selectPlayback } from '@videojs/core/dom';
+import { logMissingFeature, selectMetadata, selectPlayback } from '@videojs/core/dom';
 import type { ForwardedRef, SyntheticEvent } from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 
@@ -14,15 +14,23 @@ export interface PosterProps extends UIComponentProps<'img', PosterCore.State> {
 /**
  * Displays the video poster image. Shows before playback starts, hides after.
  *
+ * Renders an `<img>`, so `srcset`, `sizes`, `loading`, and the rest of the
+ * image attributes are yours. Leave `src` off and the player's resolved
+ * `poster` fills it in, which is why the URL is set on the provider rather than
+ * here.
+ *
+ * The image is decorative unless you say otherwise. Describe a poster that
+ * carries meaning by passing your own `alt`.
+ *
  * @example
  * ```tsx
- * <Poster src="poster.jpg" alt="Video description" />
+ * <Player.Provider poster="poster.jpg">
+ *   <Poster />
+ * </Player.Provider>
  *
- * <Poster
- *   src="poster.jpg"
- *   alt="Video description"
- *   className={(state) => state.visible ? 'visible' : 'hidden'}
- * />
+ * <Poster srcSet="poster-480.jpg 480w, poster-1080.jpg 1080w" sizes="100vw" />
+ *
+ * <Poster render={(props) => <Image {...props} alt="" fill />} />
  * ```
  */
 export const Poster = forwardRef(function Poster(
@@ -32,14 +40,26 @@ export const Poster = forwardRef(function Poster(
   const { render, className, style, ...elementProps } = componentProps;
 
   const playback = usePlayer(selectPlayback);
+  const metadata = usePlayer(selectMetadata);
 
   const [core] = useState(() => new PosterCore());
 
-  // Track when the current src has finished loading so the CSS blur-up
-  // sequence can show the poster placeholder first, then crossfade to the full image.
-  const src = (elementProps as { src?: string }).src;
+  // The metadata feature is optional: without it nothing resolves a URL, and
+  // this stays a visibility wrapper around whatever `src` was passed.
+  if (playback) {
+    core.setMedia({ started: playback.started, poster: metadata?.poster ?? '' });
+  }
+
+  const state = playback ? core.getState() : null;
+
+  // An explicit `src` wins over the resolved one, the counterpart of slotting
+  // your own image in HTML.
+  const src = (elementProps as { src?: string }).src ?? state?.src ?? '';
+
+  // Track when the current src has finished loading so the CSS blur-up sequence
+  // can show the poster placeholder first, then crossfade to the full image.
   const [loadedSrc, setLoadedSrc] = useState<string | undefined>(undefined);
-  const loaded = loadedSrc === src;
+  const loaded = src !== '' && loadedSrc === src;
   const imgRef = useRef<HTMLImageElement | null>(null);
 
   // A cached image may already be complete when the element mounts, in which
@@ -55,21 +75,24 @@ export const Poster = forwardRef(function Poster(
     setLoadedSrc(event.currentTarget.getAttribute('src') ?? undefined);
   }, []);
 
-  if (!playback) {
+  if (!playback || !state) {
     if (__DEV__) logMissingFeature('Poster', 'playback');
     return null;
   }
-
-  core.setMedia(playback);
 
   return renderElement(
     'img',
     { render, className, style },
     {
-      state: core.getState(),
+      state,
       stateAttrMap: PosterDataAttrs,
       ref: [forwardedRef, imgRef],
-      props: [elementProps, { 'data-loaded': loaded ? '' : undefined, onLoad: handleLoad }],
+      props: [
+        { alt: '' },
+        elementProps,
+        // An empty `src` requests the document URL, so leave the attribute off.
+        { src: src === '' ? undefined : src, 'data-loaded': loaded ? '' : undefined, onLoad: handleLoad },
+      ],
     }
   );
 });

--- a/packages/react/src/ui/poster/tests/poster.test.tsx
+++ b/packages/react/src/ui/poster/tests/poster.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Poster } from '../poster';
+
+afterEach(cleanup);
+
+function wrapper(state: { started?: boolean; poster?: string } = {}) {
+  const { started = false, poster = '' } = state;
+  return createPlayerWrapper({
+    paused: !started,
+    ended: false,
+    started,
+    waiting: false,
+    play: async () => {},
+    pause: () => {},
+    togglePaused: () => true,
+    contentTitle: '',
+    poster,
+    posterPlaceholder: '',
+    setContentTitle: () => {},
+    setDefaultContentTitle: () => {},
+    setPoster: () => {},
+    setDefaultPoster: () => {},
+    setPosterPlaceholder: () => {},
+    setDefaultPosterPlaceholder: () => {},
+  }).Wrapper;
+}
+
+describe('Poster', () => {
+  it('renders one image carrying the resolved poster', () => {
+    const { getByTestId } = render(<Poster data-testid="poster" />, {
+      wrapper: wrapper({ poster: 'poster.jpg' }),
+    });
+
+    const element = getByTestId('poster');
+    expect(element.tagName).toBe('IMG');
+    expect(element.getAttribute('src')).toBe('poster.jpg');
+  });
+
+  it('leaves the src attribute off when nothing resolved one', () => {
+    const { getByTestId } = render(<Poster data-testid="poster" />, { wrapper: wrapper() });
+
+    // An empty `src` requests the document URL.
+    expect(getByTestId('poster').hasAttribute('src')).toBe(false);
+  });
+
+  it('prefers a src passed to it over the resolved one', () => {
+    const { getByTestId } = render(<Poster data-testid="poster" src="mine.jpg" />, {
+      wrapper: wrapper({ poster: 'poster.jpg' }),
+    });
+
+    expect(getByTestId('poster').getAttribute('src')).toBe('mine.jpg');
+  });
+
+  it('is decorative by default and takes an alt you supply', () => {
+    const { getByTestId, rerender } = render(<Poster data-testid="poster" />, {
+      wrapper: wrapper({ poster: 'poster.jpg' }),
+    });
+
+    expect(getByTestId('poster').getAttribute('alt')).toBe('');
+
+    rerender(<Poster data-testid="poster" alt="Keynote speaker" />);
+
+    expect(getByTestId('poster').getAttribute('alt')).toBe('Keynote speaker');
+  });
+
+  it('keeps the image attributes it does not own', () => {
+    const { getByTestId } = render(
+      <Poster data-testid="poster" srcSet="poster-480.jpg 480w" sizes="100vw" loading="lazy" />,
+      { wrapper: wrapper({ poster: 'poster.jpg' }) }
+    );
+
+    const element = getByTestId('poster');
+    expect(element.getAttribute('srcset')).toBe('poster-480.jpg 480w');
+    expect(element.getAttribute('sizes')).toBe('100vw');
+    expect(element.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('hides once playback starts', () => {
+    const { getByTestId } = render(<Poster data-testid="poster" />, {
+      wrapper: wrapper({ started: true, poster: 'poster.jpg' }),
+    });
+
+    expect(getByTestId('poster').hasAttribute('data-visible')).toBe(false);
+  });
+
+  it('reports when the image has loaded', () => {
+    const { getByTestId } = render(<Poster data-testid="poster" />, {
+      wrapper: wrapper({ poster: 'poster.jpg' }),
+    });
+
+    expect(getByTestId('poster').hasAttribute('data-loaded')).toBe(false);
+
+    fireEvent.load(getByTestId('poster'));
+
+    expect(getByTestId('poster').hasAttribute('data-loaded')).toBe(true);
+  });
+
+  it('hands the resolved src to a render override', () => {
+    const { getByTestId } = render(
+      <Poster render={(props) => <img {...props} data-testid="custom" alt="Keynote speaker" />} />,
+      { wrapper: wrapper({ poster: 'poster.jpg' }) }
+    );
+
+    const element = getByTestId('custom');
+    expect(element.getAttribute('src')).toBe('poster.jpg');
+    expect(element.getAttribute('alt')).toBe('Keynote speaker');
+  });
+});

--- a/packages/skins/src/default/css/components/poster.css
+++ b/packages/skins/src/default/css/components/poster.css
@@ -2,8 +2,12 @@
    Poster Image
    ========================================================================== */
 
+/*
+ * `media-poster` positions an image; React's `.media-poster` is the image, so
+ * it does both jobs itself.
+ */
 .media-default-skin media-poster,
-.media-default-skin > img {
+.media-default-skin .media-poster {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -12,28 +16,49 @@
   transition: opacity 0.25s;
 }
 .media-default-skin media-poster:not([data-visible]),
-.media-default-skin > img:not([data-visible]),
-.media-default-skin > img[data-visible]:not([data-loaded]) {
+.media-default-skin .media-poster:not([data-visible]) {
   opacity: 0;
 }
+
+/*
+ * Three ways an image reaches `media-poster`: the one it owns, reachable only
+ * as a shadow part; one slotted through this skin; and one an ejected skin
+ * inlines where the slot used to be.
+ */
+.media-default-skin media-poster::part(img),
+.media-default-skin media-poster ::slotted(img),
+.media-default-skin media-poster img,
+.media-default-skin .media-poster {
+  object-fit: var(--media-object-fit, contain);
+  object-position: var(--media-object-position, center);
+  border-radius: var(--media-video-border-radius);
+}
+.media-default-skin media-poster::part(img),
 .media-default-skin media-poster ::slotted(img),
 .media-default-skin media-poster img {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: var(--media-object-fit, contain);
-  object-position: var(--media-object-position, center);
-  border-radius: var(--media-video-border-radius);
-}
-.media-default-skin > img {
-  object-fit: var(--media-object-fit, contain);
-  object-position: var(--media-object-position, center);
-  border-radius: inherit;
 }
 
+/*
+ * Hold the image the component owns back until it loads, so the poster
+ * placeholder behind it shows first. An image you supplied reports nothing and
+ * is left alone.
+ */
+.media-default-skin media-poster::part(img),
+.media-default-skin .media-poster {
+  transition: opacity 0.25s;
+}
+.media-default-skin media-poster:not([data-loaded])::part(img),
+.media-default-skin .media-poster[data-visible]:not([data-loaded]) {
+  opacity: 0;
+}
+
+.media-default-skin:fullscreen media-poster::part(img),
 .media-default-skin:fullscreen media-poster ::slotted(img),
 .media-default-skin:fullscreen media-poster img,
-.media-default-skin:fullscreen > img {
+.media-default-skin:fullscreen .media-poster {
   object-fit: contain;
 }

--- a/packages/skins/src/default/tailwind/components/poster.ts
+++ b/packages/skins/src/default/tailwind/components/poster.ts
@@ -1,22 +1,55 @@
 import { cn } from '@videojs/utils/style';
 
+// Class strings stay literal so Tailwind's scanner can see them.
+
+/**
+ * The image `media-poster` owns, reachable only as a shadow part. It is held
+ * back until it loads so the poster placeholder behind it shows first; an image
+ * the author supplied reports nothing and is left alone.
+ */
+const ownedImage = [
+  '[&::part(img)]:absolute',
+  '[&::part(img)]:inset-0',
+  '[&::part(img)]:w-full',
+  '[&::part(img)]:h-full',
+  '[&::part(img)]:[object-fit:var(--media-object-fit,contain)]',
+  '[&::part(img)]:[object-position:var(--media-object-position,center)]',
+  '[&::part(img)]:rounded-(--media-video-border-radius)',
+  '[&::part(img)]:transition-opacity',
+  '[&::part(img)]:duration-250',
+  'not-data-loaded:[&::part(img)]:opacity-0',
+];
+
+/** An image slotted through the skin, which descendant selectors can't reach. */
+const slottedImage = [
+  '[&_::slotted(img)]:absolute',
+  '[&_::slotted(img)]:inset-0',
+  '[&_::slotted(img)]:w-full',
+  '[&_::slotted(img)]:h-full',
+  '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',
+  '[&_::slotted(img)]:[object-position:var(--media-object-position,center)]',
+  '[&_::slotted(img)]:rounded-(--media-video-border-radius)',
+];
+
+/** An image an ejected skin inlines where the slot used to be. */
+const inlinedImage = [
+  '[&_img]:absolute',
+  '[&_img]:inset-0',
+  '[&_img]:w-full',
+  '[&_img]:h-full',
+  '[&_img]:[object-fit:var(--media-object-fit,contain)]',
+  '[&_img]:[object-position:var(--media-object-position,center)]',
+  '[&_img]:rounded-(--media-video-border-radius)',
+];
+
 export const poster = (isShadowDOM: boolean) =>
   cn(
+    // The element — `media-poster` in HTML, the image itself in React.
     'absolute inset-0 w-full h-full pointer-events-none',
-    // Fade in/out with the `data-visible` attribute
     'transition-opacity duration-250',
     'not-data-visible:opacity-0',
-    // In the shadow DOM, the class applies to the parent so we have to set styles on the slotted img.
     isShadowDOM
-      ? [
-          '[&_::slotted(img)]:absolute',
-          '[&_::slotted(img)]:inset-0',
-          '[&_::slotted(img)]:w-full',
-          '[&_::slotted(img)]:h-full',
-          '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',
-          '[&_::slotted(img)]:[object-position:var(--media-object-position,center)]',
-          '[&_::slotted(img)]:rounded-(--media-video-border-radius)',
-        ]
+      ? [...ownedImage, ...slottedImage, ...inlinedImage]
       : [
           'rounded-[inherit] [object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]',
           // Hide until the image has loaded so the poster placeholder shows first

--- a/packages/skins/src/minimal/css/components/poster.css
+++ b/packages/skins/src/minimal/css/components/poster.css
@@ -2,8 +2,12 @@
    Poster Image
    ========================================================================== */
 
+/*
+ * `media-poster` positions an image; React's `.media-poster` is the image, so
+ * it does both jobs itself.
+ */
 .media-minimal-skin media-poster,
-.media-minimal-skin > img {
+.media-minimal-skin .media-poster {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -12,28 +16,49 @@
   transition: opacity 0.25s;
 }
 .media-minimal-skin media-poster:not([data-visible]),
-.media-minimal-skin > img:not([data-visible]),
-.media-minimal-skin > img[data-visible]:not([data-loaded]) {
+.media-minimal-skin .media-poster:not([data-visible]) {
   opacity: 0;
 }
+
+/*
+ * Three ways an image reaches `media-poster`: the one it owns, reachable only
+ * as a shadow part; one slotted through this skin; and one an ejected skin
+ * inlines where the slot used to be.
+ */
+.media-minimal-skin media-poster::part(img),
+.media-minimal-skin media-poster ::slotted(img),
+.media-minimal-skin media-poster img,
+.media-minimal-skin .media-poster {
+  object-fit: var(--media-object-fit, contain);
+  object-position: var(--media-object-position, center);
+  border-radius: var(--media-video-border-radius);
+}
+.media-minimal-skin media-poster::part(img),
 .media-minimal-skin media-poster ::slotted(img),
 .media-minimal-skin media-poster img {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: var(--media-object-fit, contain);
-  object-position: var(--media-object-position, center);
-  border-radius: var(--media-video-border-radius);
-}
-.media-minimal-skin > img {
-  object-fit: var(--media-object-fit, contain);
-  object-position: var(--media-object-position, center);
-  border-radius: inherit;
 }
 
+/*
+ * Hold the image the component owns back until it loads, so the poster
+ * placeholder behind it shows first. An image you supplied reports nothing and
+ * is left alone.
+ */
+.media-minimal-skin media-poster::part(img),
+.media-minimal-skin .media-poster {
+  transition: opacity 0.25s;
+}
+.media-minimal-skin media-poster:not([data-loaded])::part(img),
+.media-minimal-skin .media-poster[data-visible]:not([data-loaded]) {
+  opacity: 0;
+}
+
+.media-minimal-skin:fullscreen media-poster::part(img),
 .media-minimal-skin:fullscreen media-poster ::slotted(img),
 .media-minimal-skin:fullscreen media-poster img,
-.media-minimal-skin:fullscreen > img {
+.media-minimal-skin:fullscreen .media-poster {
   object-fit: contain;
 }

--- a/packages/skins/src/minimal/tailwind/components/poster.ts
+++ b/packages/skins/src/minimal/tailwind/components/poster.ts
@@ -1,22 +1,55 @@
 import { cn } from '@videojs/utils/style';
 
+// Class strings stay literal so Tailwind's scanner can see them.
+
+/**
+ * The image `media-poster` owns, reachable only as a shadow part. It is held
+ * back until it loads so the poster placeholder behind it shows first; an image
+ * the author supplied reports nothing and is left alone.
+ */
+const ownedImage = [
+  '[&::part(img)]:absolute',
+  '[&::part(img)]:inset-0',
+  '[&::part(img)]:w-full',
+  '[&::part(img)]:h-full',
+  '[&::part(img)]:[object-fit:var(--media-object-fit,contain)]',
+  '[&::part(img)]:[object-position:var(--media-object-position,center)]',
+  '[&::part(img)]:rounded-(--media-video-border-radius)',
+  '[&::part(img)]:transition-opacity',
+  '[&::part(img)]:duration-250',
+  'not-data-loaded:[&::part(img)]:opacity-0',
+];
+
+/** An image slotted through the skin, which descendant selectors can't reach. */
+const slottedImage = [
+  '[&_::slotted(img)]:absolute',
+  '[&_::slotted(img)]:inset-0',
+  '[&_::slotted(img)]:w-full',
+  '[&_::slotted(img)]:h-full',
+  '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',
+  '[&_::slotted(img)]:[object-position:var(--media-object-position,center)]',
+  '[&_::slotted(img)]:rounded-(--media-video-border-radius)',
+];
+
+/** An image an ejected skin inlines where the slot used to be. */
+const inlinedImage = [
+  '[&_img]:absolute',
+  '[&_img]:inset-0',
+  '[&_img]:w-full',
+  '[&_img]:h-full',
+  '[&_img]:[object-fit:var(--media-object-fit,contain)]',
+  '[&_img]:[object-position:var(--media-object-position,center)]',
+  '[&_img]:rounded-(--media-video-border-radius)',
+];
+
 export const poster = (isShadowDOM: boolean) =>
   cn(
+    // The element — `media-poster` in HTML, the image itself in React.
     'absolute inset-0 w-full h-full pointer-events-none',
-    // Fade in/out with the `data-visible` attribute
     'transition-opacity duration-250',
     'not-data-visible:opacity-0',
-    // In the shadow DOM, the class applies to the parent so we have to set styles on the slotted img.
     isShadowDOM
-      ? [
-          '[&_::slotted(img)]:absolute',
-          '[&_::slotted(img)]:inset-0',
-          '[&_::slotted(img)]:w-full',
-          '[&_::slotted(img)]:h-full',
-          '[&_::slotted(img)]:[object-fit:var(--media-object-fit,contain)]',
-          '[&_::slotted(img)]:[object-position:var(--media-object-position,center)]',
-          '[&_::slotted(img)]:rounded-(--media-video-border-radius)',
-        ]
+      ? [...ownedImage, ...slottedImage, ...inlinedImage]
       : [
           'rounded-[inherit] [object-fit:var(--media-object-fit,contain)] [object-position:var(--media-object-position,center)]',
           // Hide until the image has loaded so the poster placeholder shows first

--- a/site/src/components/docs/demos/poster-placeholder/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/poster-placeholder/html/css/BasicUsage.css
@@ -33,7 +33,7 @@
   opacity: 0;
 }
 
-.media-poster img {
+.media-poster::part(img) {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/site/src/components/docs/demos/poster-placeholder/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/poster-placeholder/html/css/BasicUsage.html
@@ -1,6 +1,7 @@
 <!-- biome-ignore-all lint/a11y/useMediaCaption: TODO -->
 <video-player
     class="video-player"
+    poster="{{VJS10_DEMO_POSTER}}"
     poster-placeholder="{{VJS10_DEMO_POSTER_PLACEHOLDER}}"
 >
     <media-container>
@@ -11,16 +12,11 @@
 
         <media-poster-placeholder class="media-poster-placeholder"></media-poster-placeholder>
 
-        <media-poster class="media-poster">
-            <img
-                src="{{VJS10_DEMO_POSTER}}"
-                alt="Video thumbnail"
-                />
-            </media-poster>
+        <media-poster class="media-poster"></media-poster>
 
-            <media-play-button class="media-play-button">
-                <span class="paused">Play</span>
-                <span class="playing">Pause</span>
-            </media-play-button>
+        <media-play-button class="media-play-button">
+            <span class="paused">Play</span>
+            <span class="playing">Pause</span>
+        </media-play-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/poster-placeholder/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/poster-placeholder/react/css/BasicUsage.tsx
@@ -5,13 +5,13 @@ const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider posterPlaceholder="{{VJS10_DEMO_POSTER_PLACEHOLDER}}">
+    <Player.Provider poster="{{VJS10_DEMO_POSTER}}" posterPlaceholder="{{VJS10_DEMO_POSTER_PLACEHOLDER}}">
       <Player.Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" playsInline />
 
         <PosterPlaceholder className="media-poster-placeholder" />
 
-        <Poster className="media-poster" src="{{VJS10_DEMO_POSTER}}" />
+        <Poster className="media-poster" />
 
         <PlayButton
           className="media-play-button"

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.css
@@ -18,7 +18,7 @@
   opacity: 0;
 }
 
-.media-poster img {
+.media-poster::part(img) {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/site/src/components/docs/demos/poster/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/poster/html/css/BasicUsage.html
@@ -1,21 +1,16 @@
 <!-- biome-ignore-all lint/a11y/useMediaCaption: TODO -->
-<video-player class="video-player">
+<video-player class="video-player" poster="{{VJS10_DEMO_POSTER}}">
     <media-container>
         <video
             src="{{VJS10_DEMO_VIDEO_MP4}}"
             playsinline
         ></video>
 
-        <media-poster class="media-poster">
-            <img
-                src="{{VJS10_DEMO_POSTER}}"
-                alt="Video thumbnail"
-                />
-            </media-poster>
+        <media-poster class="media-poster"></media-poster>
 
-            <media-play-button class="media-play-button">
-                <span class="paused">Play</span>
-                <span class="playing">Pause</span>
-            </media-play-button>
+        <media-play-button class="media-play-button">
+            <span class="paused">Play</span>
+            <span class="playing">Pause</span>
+        </media-play-button>
     </media-container>
 </video-player>

--- a/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
@@ -5,11 +5,11 @@ const Player = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
+    <Player.Provider poster="{{VJS10_DEMO_POSTER}}">
       <Player.Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" playsInline />
 
-        <Poster className="media-poster" src="{{VJS10_DEMO_POSTER}}" />
+        <Poster className="media-poster" />
 
         <PlayButton
           className="media-play-button"

--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -30,8 +30,8 @@ const Player = createPlayer({ features: videoFeatures });
 
 export function VideoPlayer() {
   return (
-    <Player.Provider>
-      <${skinComponent} poster="${VJS10_DEMO_VIDEO.poster}">
+    <Player.Provider poster="${VJS10_DEMO_VIDEO.poster}">
+      <${skinComponent}>
         <Video src="${VJS10_DEMO_VIDEO.mp4}" playsInline />
       </${skinComponent}>
     </Player.Provider>

--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -22,7 +22,7 @@ export default function HeroVideo({
   const SkinComponent = $skin === 'default' ? VideoSkin : MinimalVideoSkin;
 
   return (
-    <Player.Provider>
+    <Player.Provider poster={poster}>
       <SkinComponent
         className={className}
         style={
@@ -32,7 +32,6 @@ export default function HeroVideo({
             ...style,
           } as React.CSSProperties
         }
-        poster={poster}
       >
         <HlsJsVideo src={VJS10_DEMO_VIDEO.hls} playsInline crossOrigin="anonymous">
           <track

--- a/site/src/content/docs/reference/poster.mdx
+++ b/site/src/content/docs/reference/poster.mdx
@@ -24,19 +24,15 @@ import basicUsageHtmlTs from "@/components/docs/demos/poster/html/css/BasicUsage
 
 ## Anatomy
 
-Import the component:
-
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <Poster src="poster.jpg" alt="Video preview" />
+  <Poster />
   ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
   ```html
-  <media-poster>
-    <img src="poster.jpg" alt="Video preview" />
-  </media-poster>
+  <media-poster></media-poster>
   ```
 </FrameworkCase>
 
@@ -44,35 +40,131 @@ Import the component:
 
 The poster is visible before playback starts. Once the user plays or seeks, the poster hides permanently — pausing does not bring it back. The poster reappears when a new source is loaded.
 
+Set the URL on the player, not on this component:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Player.Provider poster="poster.jpg" />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<video-player poster="poster.jpg"></video-player>
+```
+</FrameworkCase>
+
 A poster is a full-size image, so it takes a moment to arrive. Render a <DocsLink slug="reference/poster-placeholder">`PosterPlaceholder`</DocsLink> behind it and viewers see a blurred stand-in in the meantime.
+
+## Supply your own image
+
+The component renders an image for you, but you never lose control of it. `srcset`, `sizes`, `loading`, `<picture>`, and framework image components all stay available.
+
+<FrameworkCase frameworks={["react"]}>
+The component *is* the `<img>`, so image attributes go straight on it:
+
+```tsx
+<Poster srcSet="poster-480.jpg 480w, poster-1080.jpg 1080w" sizes="100vw" />
+```
+
+To render something else entirely, use `render`. It receives the resolved `src` along with the rest of the props:
+
+```tsx
+<Poster render={(props) => <Image {...props} alt="" fill />} />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+Put an image inside `<media-poster>` and the one it owns steps aside — no request is made for it:
+
+```html
+<media-poster>
+  <img src="poster.jpg" srcset="poster-480.jpg 480w, poster-1080.jpg 1080w" alt="Keynote speaker" />
+</media-poster>
+```
+
+Inside a skin, slot it instead:
+
+```html
+<video-skin>
+  <video src="video.mp4" playsinline></video>
+  <img slot="poster" src="poster.jpg" alt="Keynote speaker" />
+</video-skin>
+```
+</FrameworkCase>
 
 ## Styling
 
-Style the poster with the `[data-visible]` attribute:
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `data-visible` | Present / absent | Present before playback starts |
+| `data-loaded` | Present / absent | Present once the image the component owns has loaded |
 
 <FrameworkCase frameworks={["html"]}>
 ```css
 media-poster:not([data-visible]) {
-  display: none;
+  opacity: 0;
 }
 ```
+
+The image lives in a shadow root, so reach it as a part:
+
+```css
+media-poster::part(img) {
+  object-fit: cover;
+}
+
+/* Fade it in over the poster placeholder rather than popping. */
+media-poster::part(img) {
+  transition: opacity 0.25s;
+}
+media-poster:not([data-loaded])::part(img) {
+  opacity: 0;
+}
+```
+
+An image you supplied yourself is not a part. Style it as a normal descendant, or with `::slotted(img)` from inside a skin's shadow root.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
-React renders an `<img>` element. Add a `className` to style it:
+React renders the `<img>` itself. Add a `className` and use it as the selector:
 
 ```css
-.poster:not([data-visible]) {
-  display: none;
+.media-poster:not([data-visible]) {
+  opacity: 0;
+}
+
+/* Fade it in over the poster placeholder rather than popping. */
+.media-poster {
+  transition: opacity 0.25s;
+}
+.media-poster[data-visible]:not([data-loaded]) {
+  opacity: 0;
 }
 ```
 </FrameworkCase>
 
-You control the child `<img>` — this means `srcset`, `sizes`, `loading="lazy"`, and framework image components all work naturally.
-
 ## Accessibility
 
-Unlike the native `<video poster>` attribute, this component allows you to provide accessible text alternatives for screen readers via the `alt` attribute on your child `<img>`. This means you can describe the poster image (e.g., `alt="Keynote speaker at a conference"`) or mark it as decorative with `alt=""` if it doesn't convey meaningful information. 
+Unlike the native `<video poster>` attribute, this component lets you describe the poster for screen readers.
+
+The image it renders for you carries `alt=""`, which marks it decorative — nothing here knows what a resolved URL depicts, and announcing the URL would be worse than announcing nothing. When the poster carries meaning, say so:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Poster alt="Keynote speaker at a conference" />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<media-poster>
+  <img src="poster.jpg" alt="Keynote speaker at a conference" />
+</media-poster>
+```
+</FrameworkCase>
+
+Whether a poster is informative or decorative is your judgment, per the [WAI guidelines](https://www.w3.org/WAI/tutorials/images/decorative/).
 
 ## Examples
 

--- a/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
+++ b/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
@@ -18,8 +18,8 @@ const Player = createPlayer({ features: videoFeatures });
  */
 export function FrostedSkinDemo() {
   return (
-    <Player.Provider>
-      <VideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
+    <Player.Provider poster={VJS10_DEMO_VIDEO.poster}>
+      <VideoSkin className="aspect-video">
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </VideoSkin>
     </Player.Provider>

--- a/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
+++ b/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
@@ -16,8 +16,8 @@ const Player = createPlayer({ features: videoFeatures });
  */
 export function MinimalSkinDemo() {
   return (
-    <Player.Provider>
-      <MinimalVideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
+    <Player.Provider poster={VJS10_DEMO_VIDEO.poster}>
+      <MinimalVideoSkin className="aspect-video">
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </MinimalVideoSkin>
     </Player.Provider>


### PR DESCRIPTION
Stacked on #2009. Closes #1798.

## The problem

The poster was configured in markup: an `img` carrying `slot="poster"` in HTML, a `poster` prop on the React skin. That put content configuration in the skin's hands, made it unreachable from a hand-authored layout, and left the store's resolved `poster` — user, media, user default — with no reader.

## The change

Before, in HTML:

```html
&lt;video-skin&gt;
  &lt;video src="video.mp4" playsinline&gt;&lt;/video&gt;
  &lt;img slot="poster" src="poster.jpg" alt="Video poster" /&gt;
&lt;/video-skin&gt;
```

After:

```html
&lt;video-player poster="poster.jpg"&gt;
  &lt;video-skin&gt;
    &lt;video src="video.mp4" playsinline&gt;&lt;/video&gt;
  &lt;/video-skin&gt;
&lt;/video-player&gt;
```

Before, in React:

```tsx
&lt;Player.Provider&gt;
  &lt;VideoSkin poster="poster.jpg"&gt;
    &lt;Video src="video.mp4" playsInline /&gt;
  &lt;/VideoSkin&gt;
&lt;/Player.Provider&gt;
```

After:

```tsx
&lt;Player.Provider poster="poster.jpg"&gt;
  &lt;VideoSkin&gt;
    &lt;Video src="video.mp4" playsInline /&gt;
  &lt;/VideoSkin&gt;
&lt;/Player.Provider&gt;
```

`PosterCore` composes `playback` and `metadata`, so the chain is written and tested once and every consumer inherits it: a packaged skin, an ejected one, a layout you wrote yourself. `BaseVideoSkinProps` is gone — the video skins take the same three props the audio ones always did.

## Rendering an image without taking it away

[`internal/design/ui/poster.md`](https://github.com/videojs/v10/blob/claude/poster-store-config-c31gf2/internal/design/ui/poster.md) treats author control of the image as the point of the component, and that still holds. The store supplies a default, it doesn't take over.

**React's `Poster` stays the `img` it was.** `src` fills in from the store when none is passed; every other image attribute is untouched.

```tsx
&lt;Poster /&gt;
&lt;Poster srcSet="poster-480.jpg 480w, poster-1080.jpg 1080w" sizes="100vw" /&gt;
&lt;Poster render={(props) =&gt; &lt;Image {...props} alt="" fill /&gt;} /&gt;
```

It also gains `alt=""` — it had no `alt` at all, so screen readers announced the URL.

**HTML is the harder half**, because `media-poster` never rendered an image; it positioned one you supplied. It now owns an `img` carrying `part="img"` in a shadow root, beside a slot, the same shape `media-thumbnail` already uses. Fill the slot and the owned image steps aside:

```html
&lt;media-poster&gt;
  &lt;img src="poster.jpg" srcset="poster-480.jpg 480w" alt="Keynote speaker" /&gt;
&lt;/media-poster&gt;
```

Hiding it isn't enough on its own: an image that isn't rendered **still downloads**, which is not hypothetical now that Mux and Vimeo donate posters. The `src` is withheld too.

### Why `assignedElements({ flatten: true })`

A skin forwards its own `slot` carrying `name="poster"` into the element, and that empty slot is itself an assigned node — so counting assigned nodes finds one whether or not you supplied anything. Verified in Chromium:

```
author slots an image  →  assigned: 1 (the skin's slot), flattened: [IMG]
author slots nothing   →  assigned: 1 (the skin's slot), flattened: []
```

Same reason the owned image sits *beside* the slot rather than inside it as fallback content: fallback renders only when nothing is assigned, and inside a skin something always is.

### Why `data-loaded` moved to the host

A selector can't reach past `::part()` to read an attribute. `media-poster:not([data-loaded])::part(img)` is expressible; `::part(img):not([data-loaded])` is not. Skins reach the owned image as a part and leave yours alone, which is what held the blur-up sequence together before.

## Fixes that fall out

- **Ejected Tailwind HTML skins rendered an unpositioned poster.** The shadow branch styled only `::slotted(img)`, but `site/scripts/ejected-skins/html.ts` inlines a literal `img` where the slot used to be, which `::slotted` never matches. All three variants — part, slotted, descendant — are emitted now.
- **The React skins' poster was styled through `.media-default-skin > img`.** It's the explicit `.media-poster` now, matching the `.media-poster-placeholder` its sibling uses.

## Testing

Suites green per package: core 1411, react 406, html 311, media 539, utils 419, skins 4, site 530. `pnpm typecheck` reports only the 24 pre-existing `packages/store` test errors; `check:workspace` and `astro check` clean.

New coverage: `PosterCore` resolving the URL; the element rendering it, stepping aside for a slotted image without fetching its own, taking back over when that image is removed, and reporting load on the host; and the React side filling in `src`, preferring one passed to it, defaulting `alt`, and handing the resolved `src` to a `render` override.

Verified in Chromium across both skins and both stylings: the store-resolved poster paints over the poster placeholder, a slotted image replaces it with the owned one hidden and unfetched, and Tailwind compiles the `[&::part(img)]` variants that reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fBNWkGLWPzsP4QK6w7u2L