### PR TITLE
feat(media): support DRM protected native HLS playback

### DIFF
--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -40,8 +40,9 @@ const DRM_TOKENS = {
 
 /**
  * License servers for the DRM asset below, named outright rather than derived
- * from a Mux token. Both engines take the same shape, so one object configures
- * either — native HLS reads the FairPlay entry and ignores the rest.
+ * from a Mux token. `source.drm` is engine neutral, so naming every system here
+ * licenses whichever path the browser takes — native HLS reads the FairPlay
+ * entry and leaves the rest to hls.js.
  */
 const DRM_SYSTEMS = {
   'com.apple.fps': {
@@ -124,26 +125,16 @@ const SOURCE_MAP = {
     },
   },
   'hls-drm': {
-    // The same asset, licensed the generic way: each engine's own configuration,
-    // naming the license servers outright. Works on any hls.js-backed element,
-    // and shows what the per-engine source options still reach.
-    label: 'HLS - DRM protected (engine config)',
+    // The same asset, licensed the generic way: `source.drm` naming the license
+    // servers outright. Works on any HLS element, whichever path it takes.
+    label: 'HLS - DRM protected (license servers)',
     type: 'hls',
     subType: 'mp4',
     drm: true,
     poster: `https://image.mux.com/${DRM_PLAYBACK_ID}/thumbnail.webp?token=${DRM_TOKENS.thumbnail}`,
     source: {
       src: `https://stream.mux.com/${DRM_PLAYBACK_ID}.m3u8?token=${DRM_TOKENS.playback}`,
-      engine: {
-        hlsJs: {
-          // hls.js only listens for `encrypted` when EME is switched on.
-          emeEnabled: true,
-          drmSystems: DRM_SYSTEMS,
-        },
-        // Safari negotiates FairPlay itself when it plays the manifest, and never
-        // sees the hls.js configuration above, so the native path is named too.
-        nativeHls: { drmSystems: DRM_SYSTEMS },
-      },
+      drm: DRM_SYSTEMS,
     },
   },
   'hls-live': {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -108,7 +108,7 @@ const SOURCE_MAP = {
   'hls-drm': {
     // The same asset, licensed the generic way: hls.js's own `drmSystems`, keyed
     // by EME key system id and naming each license server outright. Works on any
-    // hls.js-backed element, and shows what `source.engine` still reaches.
+    // hls.js-backed element, and shows what `source.hlsJs` still reaches.
     label: 'HLS - DRM protected (engine config)',
     type: 'hls',
     subType: 'mp4',
@@ -116,7 +116,7 @@ const SOURCE_MAP = {
     poster: `https://image.mux.com/${DRM_PLAYBACK_ID}/thumbnail.webp?token=${DRM_TOKENS.thumbnail}`,
     source: {
       src: `https://stream.mux.com/${DRM_PLAYBACK_ID}.m3u8?token=${DRM_TOKENS.playback}`,
-      engine: {
+      hlsJs: {
         // hls.js only listens for `encrypted` when EME is switched on.
         emeEnabled: true,
         drmSystems: {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -106,9 +106,9 @@ const SOURCE_MAP = {
     },
   },
   'hls-drm': {
-    // The same asset, licensed the generic way: hls.js's own `drmSystems`, keyed
-    // by EME key system id and naming each license server outright. Works on any
-    // hls.js-backed element, and shows what `source.hlsJs` still reaches.
+    // The same asset, licensed the generic way: each engine's own configuration,
+    // naming the license servers outright. Works on any hls.js-backed element,
+    // and shows what the per-engine source options still reach.
     label: 'HLS - DRM protected (engine config)',
     type: 'hls',
     subType: 'mp4',
@@ -130,6 +130,14 @@ const SOURCE_MAP = {
           'com.microsoft.playready': {
             licenseUrl: `https://license.mux.com/license/playready/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
           },
+        },
+      },
+      // Safari negotiates FairPlay itself when it plays the manifest, and never
+      // sees the hls.js configuration above, so the native path is named too.
+      nativeHls: {
+        drm: {
+          licenseUrl: `https://license.mux.com/license/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+          serverCertificateUrl: `https://license.mux.com/appcert/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
         },
       },
     },

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -134,14 +134,16 @@ const SOURCE_MAP = {
     poster: `https://image.mux.com/${DRM_PLAYBACK_ID}/thumbnail.webp?token=${DRM_TOKENS.thumbnail}`,
     source: {
       src: `https://stream.mux.com/${DRM_PLAYBACK_ID}.m3u8?token=${DRM_TOKENS.playback}`,
-      hlsJs: {
-        // hls.js only listens for `encrypted` when EME is switched on.
-        emeEnabled: true,
-        drmSystems: DRM_SYSTEMS,
+      engine: {
+        hlsJs: {
+          // hls.js only listens for `encrypted` when EME is switched on.
+          emeEnabled: true,
+          drmSystems: DRM_SYSTEMS,
+        },
+        // Safari negotiates FairPlay itself when it plays the manifest, and never
+        // sees the hls.js configuration above, so the native path is named too.
+        nativeHls: { drmSystems: DRM_SYSTEMS },
       },
-      // Safari negotiates FairPlay itself when it plays the manifest, and never
-      // sees the hls.js configuration above, so the native path is named too.
-      nativeHls: { drmSystems: DRM_SYSTEMS },
     },
   },
   'hls-live': {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -38,6 +38,24 @@ const DRM_TOKENS = {
     'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InMiLCJleHAiOjIxNDc0ODM2NDd9.Eh5a51KEYRbwWIvX7M3Z-9hMwmydt2XC9kq0m-oCmnSegnN0l-GOQoUvzFMOOCKJHbfVRTuLkEvoCjCgo1JEmTHKRDo7u_V5JDZbQf6xKjtJXlTEibNEi_wD3M_3DiuYYv3R5sNol97j-yGbJQ8_16HTv7muJhr7qI8S9sKr_zJgp_E0PyFBm6plaigWcDBMcXfcvK4I9IwTKBehlXw2sVy6eUarhmS_wtA6sNXJk8f2RG2fUnt6jq8HWQlpkrXTqJCDcQ69dwDzl_TOdDWWLN3dNBlmGyEjEZyHJD2podRdddV4Yu78_bq7ImCH05JpJqY_caX9seXS6uJh38HuIA',
 } as const;
 
+/**
+ * License servers for the DRM asset below, named outright rather than derived
+ * from a Mux token. Both engines take the same shape, so one object configures
+ * either — native HLS reads the FairPlay entry and ignores the rest.
+ */
+const DRM_SYSTEMS = {
+  'com.apple.fps': {
+    licenseUrl: `https://license.mux.com/license/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+    serverCertificateUrl: `https://license.mux.com/appcert/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+  },
+  'com.widevine.alpha': {
+    licenseUrl: `https://license.mux.com/license/widevine/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+  },
+  'com.microsoft.playready': {
+    licenseUrl: `https://license.mux.com/license/playready/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
+  },
+} as const;
+
 const SOURCE_MAP = {
   'hls-1': {
     label: 'HLS - Big Buck Bunny',
@@ -119,27 +137,11 @@ const SOURCE_MAP = {
       hlsJs: {
         // hls.js only listens for `encrypted` when EME is switched on.
         emeEnabled: true,
-        drmSystems: {
-          'com.apple.fps': {
-            licenseUrl: `https://license.mux.com/license/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
-            serverCertificateUrl: `https://license.mux.com/appcert/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
-          },
-          'com.widevine.alpha': {
-            licenseUrl: `https://license.mux.com/license/widevine/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
-          },
-          'com.microsoft.playready': {
-            licenseUrl: `https://license.mux.com/license/playready/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
-          },
-        },
+        drmSystems: DRM_SYSTEMS,
       },
       // Safari negotiates FairPlay itself when it plays the manifest, and never
       // sees the hls.js configuration above, so the native path is named too.
-      nativeHls: {
-        drm: {
-          licenseUrl: `https://license.mux.com/license/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
-          serverCertificateUrl: `https://license.mux.com/appcert/fairplay/${DRM_PLAYBACK_ID}?token=${DRM_TOKENS.drm}`,
-        },
-      },
+      nativeHls: { drmSystems: DRM_SYSTEMS },
     },
   },
   'hls-live': {

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -214,8 +214,12 @@ export const SOURCES: Record<SourceId, SandboxSource> = SOURCE_MAP;
 
 export const SOURCE_IDS = Object.keys(SOURCES) as SourceId[];
 export const NON_DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type !== 'dash' && !isDrmSource(id));
-/** hls.js-backed presets add the DRM asset that names its license servers outright. */
-export const HLSJS_SOURCE_IDS = SOURCE_IDS.filter(
+/**
+ * HLS presets add the DRM asset that names its license servers outright. Both
+ * hls.js and native HLS read it, each from its own half of the source — which
+ * half depends on the path the browser ends up taking.
+ */
+export const HLS_SOURCE_IDS = SOURCE_IDS.filter(
   (id) => SOURCES[id].type !== 'dash' && id !== 'mux-drm' && id !== 'hls-drm-unlicensed'
 );
 /** Mux presets add the DRM asset licensed by a Mux token, which only they can read. */

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -67,7 +67,7 @@ export function App() {
   const pagePath = getPagePath(platform, preset);
 
   // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs;
-  // any hls.js-backed one can take license servers through `source.engine`. The
+  // any hls.js-backed one can take license servers through `source.hlsJs`. The
   // CDN sandbox builds elements from attributes alone, so neither reaches it.
   const structuredSource = platform !== 'cdn';
   const availableSources =

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -67,9 +67,9 @@ export function App() {
   const pagePath = getPagePath(platform, preset);
 
   // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs;
-  // the HLS presets take license servers through `source.hlsJs` (hls.js) and
-  // `source.nativeHls` (the browser). The CDN sandbox builds elements from
-  // attributes alone, so neither reaches it.
+  // the HLS presets take license servers through `source.engine.hlsJs` (hls.js)
+  // and `source.engine.nativeHls` (the browser). The CDN sandbox builds elements
+  // from attributes alone, so neither reaches it.
   const structuredSource = platform !== 'cdn';
   const hlsPreset = preset === 'hlsjs-video' || preset === 'native-hls-video';
   const availableSources =

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -67,8 +67,9 @@ export function App() {
   const pagePath = getPagePath(platform, preset);
 
   // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs;
-  // any hls.js-backed one can take license servers through `source.hlsJs`. The
-  // CDN sandbox builds elements from attributes alone, so neither reaches it.
+  // any hls.js-backed one can take license servers through the per-engine source
+  // options. The CDN sandbox builds elements from attributes alone, so neither
+  // reaches it.
   const structuredSource = platform !== 'cdn';
   const availableSources =
     preset === 'audio'

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -67,9 +67,9 @@ export function App() {
   const pagePath = getPagePath(platform, preset);
 
   // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs;
-  // the HLS presets take license servers through `source.engine.hlsJs` (hls.js)
-  // and `source.engine.nativeHls` (the browser). The CDN sandbox builds elements
-  // from attributes alone, so neither reaches it.
+  // the HLS presets take license servers through `source.drm`, whichever path
+  // they play. The CDN sandbox builds elements from attributes alone, so neither
+  // reaches it.
   const structuredSource = platform !== 'cdn';
   const hlsPreset = preset === 'hlsjs-video' || preset === 'native-hls-video';
   const availableSources =

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -7,7 +7,7 @@ import {
   DEFAULT_AUDIO_SOURCE,
   DEFAULT_DASH_SOURCE,
   DEFAULT_SOURCE,
-  HLSJS_SOURCE_IDS,
+  HLS_SOURCE_IDS,
   isDrmSource,
   MP4_SOURCE_IDS,
   MUX_SOURCE_IDS,
@@ -67,10 +67,11 @@ export function App() {
   const pagePath = getPagePath(platform, preset);
 
   // `MuxVideo` is the only preset that turns a Mux DRM token into license URLs;
-  // any hls.js-backed one can take license servers through the per-engine source
-  // options. The CDN sandbox builds elements from attributes alone, so neither
-  // reaches it.
+  // the HLS presets take license servers through `source.hlsJs` (hls.js) and
+  // `source.nativeHls` (the browser). The CDN sandbox builds elements from
+  // attributes alone, so neither reaches it.
   const structuredSource = platform !== 'cdn';
+  const hlsPreset = preset === 'hlsjs-video' || preset === 'native-hls-video';
   const availableSources =
     preset === 'audio'
       ? MP4_SOURCE_IDS
@@ -78,8 +79,8 @@ export function App() {
         ? DASH_SOURCE_IDS
         : structuredSource && preset === 'mux-video'
           ? MUX_SOURCE_IDS
-          : structuredSource && preset === 'hlsjs-video'
-            ? HLSJS_SOURCE_IDS
+          : structuredSource && hlsPreset
+            ? HLS_SOURCE_IDS
             : preset.startsWith('simple-hls-')
               ? SIMPLE_HLS_SOURCE_IDS
               : NON_DASH_SOURCE_IDS;

--- a/apps/sandbox/templates/html-native-hls-video/main.ts
+++ b/apps/sandbox/templates/html-native-hls-video/main.ts
@@ -32,16 +32,26 @@ async function render() {
   const mediaAttrs = renderMediaAttrs(state);
   const playerTag = live ? 'live-video-player' : 'video-player';
 
+  // A source carrying DRM license servers has no room in the `src` attribute, so
+  // it is assigned as an object below instead. Only `nativeHls` is read here —
+  // the same object also names the hls.js servers, which this element ignores.
+  const { source, url } = SOURCES[state.source];
+  const srcAttr = source ? '' : ` src="${url}"`;
+
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <${playerTag}>
       <${tag} class="w-full aspect-video max-w-4xl mx-auto">
-        <native-hls-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline crossorigin="anonymous">
+        <native-hls-video${srcAttr} ${mediaAttrs} playsinline crossorigin="anonymous">
           ${renderStoryboard(storyboard)}
         </native-hls-video>
         ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
       </${tag}>
     </${playerTag}>
   `);
+
+  if (source) {
+    document.querySelector('native-hls-video')!.source = source;
+  }
 }
 
 render();

--- a/apps/sandbox/templates/html-native-hls-video/main.ts
+++ b/apps/sandbox/templates/html-native-hls-video/main.ts
@@ -33,8 +33,9 @@ async function render() {
   const playerTag = live ? 'live-video-player' : 'video-player';
 
   // A source carrying DRM license servers has no room in the `src` attribute, so
-  // it is assigned as an object below instead. Only `nativeHls` is read here —
-  // the same object also names the hls.js servers, which this element ignores.
+  // it is assigned as an object below instead. Only `engine.nativeHls` is read
+  // here — the same object also names the hls.js servers, which this element
+  // ignores.
   const { source, url } = SOURCES[state.source];
   const srcAttr = source ? '' : ` src="${url}"`;
 

--- a/apps/sandbox/templates/html-native-hls-video/main.ts
+++ b/apps/sandbox/templates/html-native-hls-video/main.ts
@@ -33,9 +33,9 @@ async function render() {
   const playerTag = live ? 'live-video-player' : 'video-player';
 
   // A source carrying DRM license servers has no room in the `src` attribute, so
-  // it is assigned as an object below instead. Only `engine.nativeHls` is read
-  // here — the same object also names the hls.js servers, which this element
-  // ignores.
+  // it is assigned as an object below instead. Only the FairPlay entry of its
+  // `drm` is read here — the systems the same object names for hls.js are
+  // ignored.
   const { source, url } = SOURCES[state.source];
   const srcAttr = source ? '' : ` src="${url}"`;
 

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -34,6 +34,11 @@ function App() {
   const preload = usePreload();
   const Provider = live ? LiveVideoProvider : VideoProvider;
 
+  // A source carrying DRM license servers has no room in a plain `src`. Only
+  // `nativeHls` is read here — the same object also names the hls.js servers,
+  // which this element ignores.
+  const { source: hlsSource, url } = SOURCES[source];
+
   return (
     <SandboxI18nProvider>
       <Provider>
@@ -45,7 +50,7 @@ function App() {
           className="w-full aspect-video max-w-4xl mx-auto"
         >
           <NativeHlsVideo
-            src={SOURCES[source].url ?? ''}
+            {...(hlsSource ? { source: hlsSource } : { src: url ?? '' })}
             autoPlay={autoplay}
             muted={muted}
             loop={loop}

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -34,9 +34,9 @@ function App() {
   const preload = usePreload();
   const Provider = live ? LiveVideoProvider : VideoProvider;
 
-  // A source carrying DRM license servers has no room in a plain `src`. Only
-  // `engine.nativeHls` is read here — the same object also names the hls.js
-  // servers, which this element ignores.
+  // A source carrying DRM license servers has no room in a plain `src`. Only the
+  // FairPlay entry of its `drm` is read here — the systems the same object names
+  // for hls.js are ignored.
   const { source: hlsSource, url } = SOURCES[source];
 
   return (

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -35,8 +35,8 @@ function App() {
   const Provider = live ? LiveVideoProvider : VideoProvider;
 
   // A source carrying DRM license servers has no room in a plain `src`. Only
-  // `nativeHls` is read here — the same object also names the hls.js servers,
-  // which this element ignores.
+  // `engine.nativeHls` is read here — the same object also names the hls.js
+  // servers, which this element ignores.
   const { source: hlsSource, url } = SOURCES[source];
 
   return (

--- a/packages/html/src/media/tests/mux-video.test.ts
+++ b/packages/html/src/media/tests/mux-video.test.ts
@@ -26,13 +26,13 @@ describe('MuxVideo', () => {
   it('keeps engine options when the src attribute changes', () => {
     const el = createMuxVideo();
 
-    el.source = { playbackId: 'abc123', preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
+    el.source = { playbackId: 'abc123', preferPlayback: 'native', engine: { hlsJs: { maxBufferLength: 60 } } };
     el.setAttribute('src', 'https://stream.mux.com/other.m3u8');
 
     expect(el.source).toEqual({
       playbackId: 'other',
       preferPlayback: 'native',
-      hlsJs: { maxBufferLength: 60 },
+      engine: { hlsJs: { maxBufferLength: 60 } },
     });
   });
 

--- a/packages/html/src/media/tests/mux-video.test.ts
+++ b/packages/html/src/media/tests/mux-video.test.ts
@@ -26,13 +26,13 @@ describe('MuxVideo', () => {
   it('keeps engine options when the src attribute changes', () => {
     const el = createMuxVideo();
 
-    el.source = { playbackId: 'abc123', preferPlayback: 'native', engine: { maxBufferLength: 60 } };
+    el.source = { playbackId: 'abc123', preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
     el.setAttribute('src', 'https://stream.mux.com/other.m3u8');
 
     expect(el.source).toEqual({
       playbackId: 'other',
       preferPlayback: 'native',
-      engine: { maxBufferLength: 60 },
+      hlsJs: { maxBufferLength: 60 },
     });
   });
 

--- a/packages/media/src/core/drm.ts
+++ b/packages/media/src/core/drm.ts
@@ -1,0 +1,35 @@
+/**
+ * EME key system identifiers. The value is what a CDM is asked for, and what
+ * `source.drm` — and each engine's own DRM configuration — is keyed by.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMediaKeySystemAccess
+ */
+export const KeySystems = {
+  FAIRPLAY: 'com.apple.fps',
+  WIDEVINE: 'com.widevine.alpha',
+  PLAYREADY: 'com.microsoft.playready',
+  CLEARKEY: 'org.w3.clearkey',
+} as const;
+
+export type KeySystem = (typeof KeySystems)[keyof typeof KeySystems];
+
+/** Where one key system's licenses come from. */
+export interface DrmSystemConfig {
+  /** License server the CDM's license request is POSTed to. */
+  licenseUrl: string;
+  /**
+   * URL of the DRM server (application) certificate. FairPlay needs one unless
+   * its CDM is pre-provisioned; Widevine and PlayReady ignore it.
+   */
+  serverCertificateUrl?: string | undefined;
+}
+
+/**
+ * License servers keyed by EME key system id — the shape of `source.drm`.
+ *
+ * Name every system you hold a license server for: which one is negotiated is
+ * the browser's choice, and each playback path reads the systems it can reach.
+ * hls.js's own `drmSystems` takes the same shape, so a single object describes
+ * DRM for either engine.
+ */
+export type DrmSystemsConfig = Partial<Record<KeySystem, DrmSystemConfig>>;

--- a/packages/media/src/core/index.ts
+++ b/packages/media/src/core/index.ts
@@ -1,4 +1,6 @@
 export { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from './constants';
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from './drm';
+export { KeySystems } from './drm';
 export { MediaError } from './media-error';
 
 export * from './predicate';

--- a/packages/media/src/dom/dash/media.ts
+++ b/packages/media/src/dom/dash/media.ts
@@ -9,6 +9,12 @@ import { HTMLVideoElementHost } from '../video-host';
 export interface DashSource {
   /** MPD URL. Mirrors the host's `src` property. */
   src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: DashEngineConfig | undefined;
+}
+
+/** The engines a DASH source can configure. */
+export interface DashEngineConfig {
   /**
    * dash.js's own settings, passed through untouched. Replacing them resets any
    * previously applied settings.
@@ -77,8 +83,8 @@ export class DashMedia
 
   /** MPD URL. Setting it re-derives `source`, carrying its settings over. */
   set src(value) {
-    const { dashJs } = this.#source ?? {};
-    const next: DashSource = { ...(dashJs && { dashJs }), ...(value && { src: value }) };
+    const { engine } = this.#source ?? {};
+    const next: DashSource = { ...(engine && { engine }), ...(value && { src: value }) };
 
     // Everything happens in the `source` setter, so there is one path for
     // storing it, telling the engine, and dispatching `sourcechange`.
@@ -86,11 +92,11 @@ export class DashMedia
   }
 
   /**
-   * Structured source: the MPD URL in `src`, plus dash.js settings in `dashJs`.
-   * Replacing it re-derives `src`.
+   * Structured source: the MPD URL in `src`, plus dash.js settings in
+   * `engine.dashJs`. Replacing it re-derives `src`.
    *
-   * dash.js takes settings on a live player, so changing `dashJs` re-applies
-   * them in place instead of recreating the engine.
+   * dash.js takes settings on a live player, so changing `engine.dashJs`
+   * re-applies them in place instead of recreating the engine.
    */
   get source(): DashSource | null {
     return this.#source;
@@ -107,19 +113,19 @@ export class DashMedia
     // Assigning is always a source change, so it is always announced. Only the
     // engine calls are guarded, so re-assigning an equivalent source — an inline
     // React prop, say — never disturbs what is already playing.
-    const configChanged = !deepEqual(this.#source?.dashJs ?? null, source?.dashJs ?? null);
+    const configChanged = !deepEqual(this.#source?.engine?.dashJs ?? null, source?.engine?.dashJs ?? null);
     const srcChanged = this.#src !== src;
 
     this.#source = source;
     this.#src = src;
 
-    if (configChanged) this.#applyEngineConfig(source?.dashJs);
+    if (configChanged) this.#applyEngineConfig(source?.engine?.dashJs);
     if (srcChanged) this.#engine.attachSource(src);
 
     this.dispatchEvent(new Event('sourcechange'));
   }
 
-  // `dashJs` is replaced, not merged, but dash.js merges every
+  // `engine.dashJs` is replaced, not merged, but dash.js merges every
   // `updateSettings()` call into the current settings — reset first so dropping
   // a key clears it instead of leaving the previous value behind.
   #applyEngineConfig(settings?: dashjs.MediaPlayerSettingClass) {

--- a/packages/media/src/dom/dash/media.ts
+++ b/packages/media/src/dom/dash/media.ts
@@ -13,7 +13,7 @@ export interface DashSource {
    * dash.js's own settings, passed through untouched. Replacing them resets any
    * previously applied settings.
    */
-  engine?: dashjs.MediaPlayerSettingClass | undefined;
+  dashJs?: dashjs.MediaPlayerSettingClass | undefined;
 }
 
 export interface DashMediaProps {
@@ -77,8 +77,8 @@ export class DashMedia
 
   /** MPD URL. Setting it re-derives `source`, carrying its settings over. */
   set src(value) {
-    const { engine } = this.#source ?? {};
-    const next: DashSource = { ...(engine && { engine }), ...(value && { src: value }) };
+    const { dashJs } = this.#source ?? {};
+    const next: DashSource = { ...(dashJs && { dashJs }), ...(value && { src: value }) };
 
     // Everything happens in the `source` setter, so there is one path for
     // storing it, telling the engine, and dispatching `sourcechange`.
@@ -86,10 +86,10 @@ export class DashMedia
   }
 
   /**
-   * Structured source: the MPD URL in `src`, plus dash.js settings in `engine`.
+   * Structured source: the MPD URL in `src`, plus dash.js settings in `dashJs`.
    * Replacing it re-derives `src`.
    *
-   * dash.js takes settings on a live player, so changing `engine` re-applies
+   * dash.js takes settings on a live player, so changing `dashJs` re-applies
    * them in place instead of recreating the engine.
    */
   get source(): DashSource | null {
@@ -107,23 +107,23 @@ export class DashMedia
     // Assigning is always a source change, so it is always announced. Only the
     // engine calls are guarded, so re-assigning an equivalent source — an inline
     // React prop, say — never disturbs what is already playing.
-    const configChanged = !deepEqual(this.#source?.engine ?? null, source?.engine ?? null);
+    const configChanged = !deepEqual(this.#source?.dashJs ?? null, source?.dashJs ?? null);
     const srcChanged = this.#src !== src;
 
     this.#source = source;
     this.#src = src;
 
-    if (configChanged) this.#applyEngineConfig(source?.engine);
+    if (configChanged) this.#applyEngineConfig(source?.dashJs);
     if (srcChanged) this.#engine.attachSource(src);
 
     this.dispatchEvent(new Event('sourcechange'));
   }
 
-  // `engine` is replaced, not merged, but dash.js merges every
+  // `dashJs` is replaced, not merged, but dash.js merges every
   // `updateSettings()` call into the current settings — reset first so dropping
   // a key clears it instead of leaving the previous value behind.
-  #applyEngineConfig(engine?: dashjs.MediaPlayerSettingClass) {
+  #applyEngineConfig(settings?: dashjs.MediaPlayerSettingClass) {
     this.#engine.resetSettings();
-    if (engine) this.#engine.updateSettings(engine);
+    if (settings) this.#engine.updateSettings(settings);
   }
 }

--- a/packages/media/src/dom/dash/tests/dash-media.test.ts
+++ b/packages/media/src/dom/dash/tests/dash-media.test.ts
@@ -72,10 +72,10 @@ describe('DashMedia', () => {
   });
 
   describe('source', () => {
-    it('forwards engine settings to the dash.js player', () => {
+    it('forwards dash.js settings to the dash.js player', () => {
       const { media, engine } = setup();
 
-      media.source = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
 
       expect(engine.updateSettings).toHaveBeenCalledWith({ streaming: { abandonLoadTimeout: 1000 } });
     });
@@ -94,7 +94,7 @@ describe('DashMedia', () => {
 
     it('leaves the engine alone for a structurally equal source', () => {
       const { media, engine } = setup();
-      const source: DashSource = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 1000 } } };
+      const source: DashSource = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
       media.source = source;
 
       const sourcechange = vi.fn();
@@ -103,7 +103,7 @@ describe('DashMedia', () => {
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
-      media.source = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
 
       // Assigning is always announced, but nothing reaches dash.js, so an inline
       // React prop cannot disturb what is already playing.
@@ -114,27 +114,27 @@ describe('DashMedia', () => {
       expect(media.source).toEqual(source);
     });
 
-    it('does not re-attach the manifest when only engine options change', () => {
+    it('does not re-attach the manifest when only dash.js settings change', () => {
       const { media, engine } = setup();
-      media.source = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
       engine.attachSource.mockClear();
 
-      media.source = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 2000 } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 2000 } } };
 
       expect(engine.attachSource).not.toHaveBeenCalled();
       expect(engine.updateSettings).toHaveBeenLastCalledWith({ streaming: { abandonLoadTimeout: 2000 } });
     });
 
-    it('resets settings instead of merging when an engine option is dropped', () => {
+    it('resets settings instead of merging when a dash.js setting is dropped', () => {
       const { media, engine } = setup();
       media.source = {
         src: MANIFEST,
-        engine: { streaming: { abandonLoadTimeout: 1000, cacheInitSegments: true } },
+        dashJs: { streaming: { abandonLoadTimeout: 1000, cacheInitSegments: true } },
       };
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
-      media.source = { src: MANIFEST, engine: { streaming: { cacheInitSegments: true } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { cacheInitSegments: true } } };
 
       expect(engine.resetSettings).toHaveBeenCalledOnce();
       expect(engine.resetSettings.mock.invocationCallOrder[0]!).toBeLessThan(
@@ -143,9 +143,9 @@ describe('DashMedia', () => {
       expect(engine.updateSettings).toHaveBeenCalledExactlyOnceWith({ streaming: { cacheInitSegments: true } });
     });
 
-    it('resets settings when engine options are removed entirely', () => {
+    it('resets settings when dash.js settings are removed entirely', () => {
       const { media, engine } = setup();
-      media.source = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
@@ -169,9 +169,9 @@ describe('DashMedia', () => {
   });
 
   describe('src', () => {
-    it('preserves source engine options across a src change', () => {
+    it('preserves source dash.js settings across a src change', () => {
       const { media, engine } = setup();
-      media.source = { src: MANIFEST, engine: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
@@ -179,7 +179,7 @@ describe('DashMedia', () => {
 
       expect(media.source).toEqual({
         src: 'https://example.com/other.mpd',
-        engine: { streaming: { abandonLoadTimeout: 1000 } },
+        dashJs: { streaming: { abandonLoadTimeout: 1000 } },
       });
       expect(engine.attachSource).toHaveBeenLastCalledWith('https://example.com/other.mpd');
       // Carried-over options are already applied to the live player.

--- a/packages/media/src/dom/dash/tests/dash-media.test.ts
+++ b/packages/media/src/dom/dash/tests/dash-media.test.ts
@@ -75,7 +75,7 @@ describe('DashMedia', () => {
     it('forwards dash.js settings to the dash.js player', () => {
       const { media, engine } = setup();
 
-      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
 
       expect(engine.updateSettings).toHaveBeenCalledWith({ streaming: { abandonLoadTimeout: 1000 } });
     });
@@ -94,7 +94,7 @@ describe('DashMedia', () => {
 
     it('leaves the engine alone for a structurally equal source', () => {
       const { media, engine } = setup();
-      const source: DashSource = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
+      const source: DashSource = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
       media.source = source;
 
       const sourcechange = vi.fn();
@@ -103,7 +103,7 @@ describe('DashMedia', () => {
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
-      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
 
       // Assigning is always announced, but nothing reaches dash.js, so an inline
       // React prop cannot disturb what is already playing.
@@ -116,10 +116,10 @@ describe('DashMedia', () => {
 
     it('does not re-attach the manifest when only dash.js settings change', () => {
       const { media, engine } = setup();
-      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
       engine.attachSource.mockClear();
 
-      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 2000 } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 2000 } } } };
 
       expect(engine.attachSource).not.toHaveBeenCalled();
       expect(engine.updateSettings).toHaveBeenLastCalledWith({ streaming: { abandonLoadTimeout: 2000 } });
@@ -129,12 +129,12 @@ describe('DashMedia', () => {
       const { media, engine } = setup();
       media.source = {
         src: MANIFEST,
-        dashJs: { streaming: { abandonLoadTimeout: 1000, cacheInitSegments: true } },
+        engine: { dashJs: { streaming: { abandonLoadTimeout: 1000, cacheInitSegments: true } } },
       };
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
-      media.source = { src: MANIFEST, dashJs: { streaming: { cacheInitSegments: true } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { cacheInitSegments: true } } } };
 
       expect(engine.resetSettings).toHaveBeenCalledOnce();
       expect(engine.resetSettings.mock.invocationCallOrder[0]!).toBeLessThan(
@@ -145,7 +145,7 @@ describe('DashMedia', () => {
 
     it('resets settings when dash.js settings are removed entirely', () => {
       const { media, engine } = setup();
-      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
@@ -171,7 +171,7 @@ describe('DashMedia', () => {
   describe('src', () => {
     it('preserves source dash.js settings across a src change', () => {
       const { media, engine } = setup();
-      media.source = { src: MANIFEST, dashJs: { streaming: { abandonLoadTimeout: 1000 } } };
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
       engine.updateSettings.mockClear();
       engine.resetSettings.mockClear();
 
@@ -179,7 +179,7 @@ describe('DashMedia', () => {
 
       expect(media.source).toEqual({
         src: 'https://example.com/other.mpd',
-        dashJs: { streaming: { abandonLoadTimeout: 1000 } },
+        engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } },
       });
       expect(engine.attachSource).toHaveBeenLastCalledWith('https://example.com/other.mpd');
       // Carried-over options are already applied to the live player.

--- a/packages/media/src/dom/hls-js/index.ts
+++ b/packages/media/src/dom/hls-js/index.ts
@@ -1,1 +1,3 @@
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
+export { KeySystems } from '../../core/drm';
 export * from './media';

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -3,7 +3,7 @@ import Hls, { type HlsConfig as HlsJsConfig } from 'hls.js';
 import { bridgeEvents } from '../../core/bridge-events';
 
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
-import { NativeHlsMedia } from '../native-hls';
+import { type NativeHlsConfig, NativeHlsMedia } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsOnlyMedia } from './hls-js-only';
 
@@ -37,11 +37,12 @@ export interface HlsMediaProps {
 /**
  * Structured HLS source: which source to play, plus how to play it.
  *
- * Engine options are namespaced by engine, so an element with more than one
- * playback path to choose from keeps their configurations apart.
+ * Playback options are namespaced by engine. There are two paths here — hls.js
+ * and the browser's own HLS support — and only one of them runs, so a source
+ * describes both without either engine reading the other's options.
  *
- * `preferPlayback` and `hlsJs` are both read when the engine is constructed, so
- * changing either recreates it.
+ * `preferPlayback` and the engine options are all read when the engine is
+ * constructed, so changing any of them recreates it.
  */
 export interface HlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
@@ -54,10 +55,16 @@ export interface HlsSource {
    */
   preferPlayback?: PlaybackType | undefined;
   /**
-   * hls.js's own configuration, passed through untouched. DRM-protected
+   * hls.js's own configuration, passed through untouched. DRM-protected MSE
    * playback is configured here, through `emeEnabled` and `drmSystems`.
    */
   hlsJs?: Partial<HlsJsConfig> | undefined;
+  /**
+   * Options for the browser's own HLS playback, used whenever the native path
+   * is the one taken. DRM lives here too: Safari negotiates FairPlay itself and
+   * never sees the hls.js configuration.
+   */
+  nativeHls?: NativeHlsConfig | undefined;
 }
 
 export const hlsMediaDefaultProps: HlsMediaProps = {
@@ -145,8 +152,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `type` and `hlsJs` intact, so changing the URL never disturbs engine
-   * configuration.
+   * leaves `type` and the engine options intact, so changing the URL never
+   * disturbs engine configuration.
    */
   get src() {
     return this.#src;
@@ -155,11 +162,12 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, hlsJs } = this.#source ?? {};
+    const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
       ...(hlsJs && { hlsJs }),
+      ...(nativeHls && { nativeHls }),
       ...(src && { src }),
     };
 
@@ -170,11 +178,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Structured source: what to play (`src`, an optional `type`) plus how to play
-   * it (`preferPlayback`, `hlsJs`). Assigning it derives `src`.
+   * it (`preferPlayback`, `hlsJs`, `nativeHls`). Assigning it derives `src`.
    *
    * Sources are compared structurally, so reassigning an equivalent object — an
-   * inline React prop, for instance — is a no-op. Only a change under `hlsJs`
-   * (or a change to the resolved content type) recreates the playback engine.
+   * inline React prop, for instance — is a no-op. Only a change to the engine
+   * options (or to the resolved content type) recreates the playback engine.
    */
   get source(): HlsSource | null {
     return this.#source;
@@ -265,16 +273,14 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
       // Read the stored source, not the `source` getter: subclasses override the
       // getter to return what was assigned to them, while the fields below come
-      // from what they resolved and handed down (Mux fills in `hlsJs` here).
-      const { type, preferPlayback, hlsJs } = this.#source ?? {};
+      // from what they resolved and handed down (Mux fills in the DRM options).
+      const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
-      if (__DEV__ && !useMse && hlsJs?.emeEnabled) {
-        console.warn('[vjs-drm] DRM playback requires the hls.js (MSE) engine; native HLS playback ignores it.');
-      }
-
-      this.#delegate = useMse ? new HlsJsOnlyMedia({ config: { ...hlsJs } }) : new NativeHlsMedia();
+      this.#delegate = useMse
+        ? new HlsJsOnlyMedia({ config: { ...hlsJs } })
+        : this.#createNativeDelegate(nativeHls, hlsJs);
 
       bridgeEvents(this.#delegate, this);
 
@@ -297,6 +303,23 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
     }
   }
 
+  /**
+   * A native delegate carrying the native half of the source. Its `src` is
+   * assigned separately, once the delegate is wired up, and carries what is
+   * set here forward.
+   */
+  #createNativeDelegate(nativeHls: NativeHlsConfig | undefined, hlsJs: Partial<HlsJsConfig> | undefined) {
+    if (__DEV__ && hlsJs?.emeEnabled && !nativeHls?.drm) {
+      console.warn(
+        '[vjs-drm] Native HLS playback reads `source.nativeHls.drm` rather than the hls.js `drmSystems`, and none is configured. DRM-protected media will not play.'
+      );
+    }
+
+    const media = new NativeHlsMedia();
+    if (nativeHls) media.source = { nativeHls };
+    return media;
+  }
+
   #stopTargetLoadStartEvent = (event: Event) => {
     if (!(event instanceof HlsMediaEvent)) event.stopImmediatePropagation();
   };
@@ -313,14 +336,14 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * Every value the engine is constructed from. Compared structurally, so an
-   * equivalent `source.hlsJs` never triggers a rebuild — including nested
-   * options like `drmSystems`, which a flat comparison would see as changed
-   * whenever the object identity did.
+   * Every value the engine is constructed from. Compared structurally, so
+   * equivalent engine options never trigger a rebuild — including nested ones
+   * like `drmSystems`, which a flat comparison would see as changed whenever
+   * the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, hlsJs } = this.#source ?? {};
-    return { hlsJs, preferPlayback, contentType: type ?? inferContentType(this.src) };
+    const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
+    return { hlsJs, nativeHls, preferPlayback, contentType: type ?? inferContentType(this.src) };
   }
 
   #engineDestroy() {

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -37,7 +37,10 @@ export interface HlsMediaProps {
 /**
  * Structured HLS source: which source to play, plus how to play it.
  *
- * `preferPlayback` and `engine` are both read when the engine is constructed, so
+ * Engine options are namespaced by engine, so an element with more than one
+ * playback path to choose from keeps their configurations apart.
+ *
+ * `preferPlayback` and `hlsJs` are both read when the engine is constructed, so
  * changing either recreates it.
  */
 export interface HlsSource {
@@ -54,7 +57,7 @@ export interface HlsSource {
    * hls.js's own configuration, passed through untouched. DRM-protected
    * playback is configured here, through `emeEnabled` and `drmSystems`.
    */
-  engine?: Partial<HlsJsConfig> | undefined;
+  hlsJs?: Partial<HlsJsConfig> | undefined;
 }
 
 export const hlsMediaDefaultProps: HlsMediaProps = {
@@ -142,7 +145,7 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `type` and `engine` intact, so changing the URL never disturbs engine
+   * leaves `type` and `hlsJs` intact, so changing the URL never disturbs engine
    * configuration.
    */
   get src() {
@@ -152,11 +155,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, engine } = this.#source ?? {};
+    const { type, preferPlayback, hlsJs } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
-      ...(engine && { engine }),
+      ...(hlsJs && { hlsJs }),
       ...(src && { src }),
     };
 
@@ -167,10 +170,10 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Structured source: what to play (`src`, an optional `type`) plus how to play
-   * it (`preferPlayback`, `engine`). Assigning it derives `src`.
+   * it (`preferPlayback`, `hlsJs`). Assigning it derives `src`.
    *
    * Sources are compared structurally, so reassigning an equivalent object — an
-   * inline React prop, for instance — is a no-op. Only a change under `engine`
+   * inline React prop, for instance — is a no-op. Only a change under `hlsJs`
    * (or a change to the resolved content type) recreates the playback engine.
    */
   get source(): HlsSource | null {
@@ -262,16 +265,16 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
       // Read the stored source, not the `source` getter: subclasses override the
       // getter to return what was assigned to them, while the fields below come
-      // from what they resolved and handed down (Mux fills in `engine` here).
-      const { type, preferPlayback, engine } = this.#source ?? {};
+      // from what they resolved and handed down (Mux fills in `hlsJs` here).
+      const { type, preferPlayback, hlsJs } = this.#source ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
-      if (__DEV__ && !useMse && engine?.emeEnabled) {
+      if (__DEV__ && !useMse && hlsJs?.emeEnabled) {
         console.warn('[vjs-drm] DRM playback requires the hls.js (MSE) engine; native HLS playback ignores it.');
       }
 
-      this.#delegate = useMse ? new HlsJsOnlyMedia({ config: { ...engine } }) : new NativeHlsMedia();
+      this.#delegate = useMse ? new HlsJsOnlyMedia({ config: { ...hlsJs } }) : new NativeHlsMedia();
 
       bridgeEvents(this.#delegate, this);
 
@@ -311,13 +314,13 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Every value the engine is constructed from. Compared structurally, so an
-   * equivalent `source.engine` never triggers a rebuild — including nested
+   * equivalent `source.hlsJs` never triggers a rebuild — including nested
    * options like `drmSystems`, which a flat comparison would see as changed
    * whenever the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, engine } = this.#source ?? {};
-    return { engine, preferPlayback, contentType: type ?? inferContentType(this.src) };
+    const { type, preferPlayback, hlsJs } = this.#source ?? {};
+    return { hlsJs, preferPlayback, contentType: type ?? inferContentType(this.src) };
   }
 
   #engineDestroy() {

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -3,7 +3,7 @@ import Hls, { type HlsConfig as HlsJsConfig } from 'hls.js';
 import { bridgeEvents } from '../../core/bridge-events';
 
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
-import { type NativeHlsConfig, NativeHlsMedia } from '../native-hls';
+import { FAIRPLAY_KEY_SYSTEM, type NativeHlsConfig, NativeHlsMedia } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsOnlyMedia } from './hls-js-only';
 
@@ -62,7 +62,8 @@ export interface HlsSource {
   /**
    * Options for the browser's own HLS playback, used whenever the native path
    * is the one taken. DRM lives here too: Safari negotiates FairPlay itself and
-   * never sees the hls.js configuration.
+   * never sees the hls.js configuration. `nativeHls.drmSystems` takes the same
+   * shape as the hls.js one, so both paths can share a single object.
    */
   nativeHls?: NativeHlsConfig | undefined;
 }
@@ -309,9 +310,9 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
    * set here forward.
    */
   #createNativeDelegate(nativeHls: NativeHlsConfig | undefined, hlsJs: Partial<HlsJsConfig> | undefined) {
-    if (__DEV__ && hlsJs?.emeEnabled && !nativeHls?.drm) {
+    if (__DEV__ && hlsJs?.emeEnabled && !nativeHls?.drmSystems?.[FAIRPLAY_KEY_SYSTEM]) {
       console.warn(
-        '[vjs-drm] Native HLS playback reads `source.nativeHls.drm` rather than the hls.js `drmSystems`, and none is configured. DRM-protected media will not play.'
+        `[vjs-drm] Native HLS playback reads \`source.nativeHls.drmSystems\` rather than the hls.js one, and no \`${FAIRPLAY_KEY_SYSTEM}\` license server is configured there. DRM-protected media will not play.`
       );
     }
 

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -55,6 +55,15 @@ export interface HlsSource {
    */
   preferPlayback?: PlaybackType | undefined;
   /**
+   * Playback options, keyed by the engine that reads them. Only one of the two
+   * engines below ends up playing, and each reads only its own key.
+   */
+  engine?: HlsEngineConfig | undefined;
+}
+
+/** The engines an HLS source can configure. */
+export interface HlsEngineConfig {
+  /**
    * hls.js's own configuration, passed through untouched. DRM-protected MSE
    * playback is configured here, through `emeEnabled` and `drmSystems`.
    */
@@ -163,12 +172,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
+    const { type, preferPlayback, engine } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
-      ...(hlsJs && { hlsJs }),
-      ...(nativeHls && { nativeHls }),
+      ...(engine && { engine }),
       ...(src && { src }),
     };
 
@@ -179,7 +187,7 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
   /**
    * Structured source: what to play (`src`, an optional `type`) plus how to play
-   * it (`preferPlayback`, `hlsJs`, `nativeHls`). Assigning it derives `src`.
+   * it (`preferPlayback`, `engine`). Assigning it derives `src`.
    *
    * Sources are compared structurally, so reassigning an equivalent object — an
    * inline React prop, for instance — is a no-op. Only a change to the engine
@@ -275,7 +283,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       // Read the stored source, not the `source` getter: subclasses override the
       // getter to return what was assigned to them, while the fields below come
       // from what they resolved and handed down (Mux fills in the DRM options).
-      const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
+      const { type, preferPlayback, engine } = this.#source ?? {};
+      const { hlsJs, nativeHls } = engine ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
@@ -312,12 +321,12 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   #createNativeDelegate(nativeHls: NativeHlsConfig | undefined, hlsJs: Partial<HlsJsConfig> | undefined) {
     if (__DEV__ && hlsJs?.emeEnabled && !nativeHls?.drmSystems?.[FAIRPLAY_KEY_SYSTEM]) {
       console.warn(
-        `[vjs-drm] Native HLS playback reads \`source.nativeHls.drmSystems\` rather than the hls.js one, and no \`${FAIRPLAY_KEY_SYSTEM}\` license server is configured there. DRM-protected media will not play.`
+        `[vjs-drm] Native HLS playback reads \`source.engine.nativeHls.drmSystems\` rather than the hls.js one, and no \`${FAIRPLAY_KEY_SYSTEM}\` license server is configured there. DRM-protected media will not play.`
       );
     }
 
     const media = new NativeHlsMedia();
-    if (nativeHls) media.source = { nativeHls };
+    if (nativeHls) media.source = { engine: { nativeHls } };
     return media;
   }
 
@@ -343,8 +352,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
    * the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
-    return { hlsJs, nativeHls, preferPlayback, contentType: type ?? inferContentType(this.src) };
+    const { type, preferPlayback, engine } = this.#source ?? {};
+    return { engine, preferPlayback, contentType: type ?? inferContentType(this.src) };
   }
 
   #engineDestroy() {

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -336,15 +336,20 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
     nativeHls: NativeHlsConfig | undefined,
     hlsJs: Partial<HlsJsConfig> | undefined
   ) {
-    // The delegate applies the same precedence, so the warning has to read what
-    // it will end up licensing against.
-    const drmSystems = nativeHls?.drmSystems ?? drm;
-    const isProtected = hlsJs?.emeEnabled || hlsJs?.drmSystems || Object.keys(drmSystems ?? {}).length > 0;
+    if (__DEV__) {
+      // The delegate applies the same precedence, so the warning has to read — and
+      // name — whatever it will end up licensing against. An escape hatch replaces
+      // `source.drm` rather than adding to it, so pointing at the wrong one of the
+      // two would send a reader looking in a field that is already correct.
+      const drmSystems = nativeHls?.drmSystems ?? drm;
+      const field = nativeHls?.drmSystems ? 'source.engine.nativeHls.drmSystems' : 'source.drm';
+      const isProtected = hlsJs?.emeEnabled || hlsJs?.drmSystems || Object.keys(drmSystems ?? {}).length > 0;
 
-    if (__DEV__ && isProtected && !drmSystems?.[KeySystems.FAIRPLAY]) {
-      console.warn(
-        `[vjs-drm] Native HLS playback negotiates FairPlay itself and never sees the hls.js DRM configuration, and no \`${KeySystems.FAIRPLAY}\` license server is named in \`source.drm\`. DRM-protected media will not play.`
-      );
+      if (isProtected && !drmSystems?.[KeySystems.FAIRPLAY]) {
+        console.warn(
+          `[vjs-drm] Native HLS playback negotiates FairPlay itself and never sees the hls.js DRM configuration, and no \`${KeySystems.FAIRPLAY}\` license server is named in \`${field}\`. DRM-protected media will not play.`
+        );
+      }
     }
 
     const media = new NativeHlsMedia();

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -1,9 +1,10 @@
 import { deepEqual } from '@videojs/utils/object';
 import Hls, { type HlsConfig as HlsJsConfig } from 'hls.js';
 import { bridgeEvents } from '../../core/bridge-events';
+import { type DrmSystemsConfig, KeySystems } from '../../core/drm';
 
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
-import { FAIRPLAY_KEY_SYSTEM, type NativeHlsConfig, NativeHlsMedia } from '../native-hls';
+import { type NativeHlsConfig, NativeHlsMedia, type NativeHlsSource } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsOnlyMedia } from './hls-js-only';
 
@@ -55,6 +56,15 @@ export interface HlsSource {
    */
   preferPlayback?: PlaybackType | undefined;
   /**
+   * License servers for protected content, keyed by EME key system id.
+   *
+   * Engine neutral, because which engine plays is decided later: hls.js is
+   * handed every system named here (with EME switched on), and native playback
+   * negotiates the `com.apple.fps` entry itself. Name every system you hold a
+   * license server for — which one is used is the browser's choice.
+   */
+  drm?: DrmSystemsConfig | undefined;
+  /**
    * Playback options, keyed by the engine that reads them. Only one of the two
    * engines below ends up playing, and each reads only its own key.
    */
@@ -64,15 +74,16 @@ export interface HlsSource {
 /** The engines an HLS source can configure. */
 export interface HlsEngineConfig {
   /**
-   * hls.js's own configuration, passed through untouched. DRM-protected MSE
-   * playback is configured here, through `emeEnabled` and `drmSystems`.
+   * hls.js's own configuration, passed through untouched. A `drmSystems` of its
+   * own replaces `source.drm` for hls.js — an escape hatch for licensing MSE
+   * playback differently, or for the parts of hls.js's DRM configuration
+   * `source.drm` does not cover.
    */
   hlsJs?: Partial<HlsJsConfig> | undefined;
   /**
    * Options for the browser's own HLS playback, used whenever the native path
-   * is the one taken. DRM lives here too: Safari negotiates FairPlay itself and
-   * never sees the hls.js configuration. `nativeHls.drmSystems` takes the same
-   * shape as the hls.js one, so both paths can share a single object.
+   * is the one taken. Its `drmSystems` replaces `source.drm` for that path in
+   * the same way.
    */
   nativeHls?: NativeHlsConfig | undefined;
 }
@@ -172,10 +183,11 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, engine } = this.#source ?? {};
+    const { type, preferPlayback, drm, engine } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
+      ...(drm && { drm }),
       ...(engine && { engine }),
       ...(src && { src }),
     };
@@ -283,14 +295,14 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       // Read the stored source, not the `source` getter: subclasses override the
       // getter to return what was assigned to them, while the fields below come
       // from what they resolved and handed down (Mux fills in the DRM options).
-      const { type, preferPlayback, engine } = this.#source ?? {};
+      const { type, preferPlayback, drm, engine } = this.#source ?? {};
       const { hlsJs, nativeHls } = engine ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
 
       this.#delegate = useMse
-        ? new HlsJsOnlyMedia({ config: { ...hlsJs } })
-        : this.#createNativeDelegate(nativeHls, hlsJs);
+        ? new HlsJsOnlyMedia({ config: withDrmSystems(hlsJs, drm) })
+        : this.#createNativeDelegate(drm, nativeHls, hlsJs);
 
       bridgeEvents(this.#delegate, this);
 
@@ -314,19 +326,34 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   }
 
   /**
-   * A native delegate carrying the native half of the source. Its `src` is
-   * assigned separately, once the delegate is wired up, and carries what is
-   * set here forward.
+   * A native delegate carrying the native half of the source — the DRM
+   * configuration and the native engine options, which it applies the same
+   * precedence to. Its `src` is assigned separately, once the delegate is wired
+   * up, and carries what is set here forward.
    */
-  #createNativeDelegate(nativeHls: NativeHlsConfig | undefined, hlsJs: Partial<HlsJsConfig> | undefined) {
-    if (__DEV__ && hlsJs?.emeEnabled && !nativeHls?.drmSystems?.[FAIRPLAY_KEY_SYSTEM]) {
+  #createNativeDelegate(
+    drm: DrmSystemsConfig | undefined,
+    nativeHls: NativeHlsConfig | undefined,
+    hlsJs: Partial<HlsJsConfig> | undefined
+  ) {
+    // The delegate applies the same precedence, so the warning has to read what
+    // it will end up licensing against.
+    const drmSystems = nativeHls?.drmSystems ?? drm;
+    const isProtected = hlsJs?.emeEnabled || hlsJs?.drmSystems || Object.keys(drmSystems ?? {}).length > 0;
+
+    if (__DEV__ && isProtected && !drmSystems?.[KeySystems.FAIRPLAY]) {
       console.warn(
-        `[vjs-drm] Native HLS playback reads \`source.engine.nativeHls.drmSystems\` rather than the hls.js one, and no \`${FAIRPLAY_KEY_SYSTEM}\` license server is configured there. DRM-protected media will not play.`
+        `[vjs-drm] Native HLS playback negotiates FairPlay itself and never sees the hls.js DRM configuration, and no \`${KeySystems.FAIRPLAY}\` license server is named in \`source.drm\`. DRM-protected media will not play.`
       );
     }
 
     const media = new NativeHlsMedia();
-    if (nativeHls) media.source = { engine: { nativeHls } };
+    const source: NativeHlsSource = {
+      ...(drm && { drm }),
+      ...(nativeHls && { engine: { nativeHls } }),
+    };
+
+    if (Object.keys(source).length > 0) media.source = source;
     return media;
   }
 
@@ -352,8 +379,8 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
    * the object identity did.
    */
   #engineConfigKey() {
-    const { type, preferPlayback, engine } = this.#source ?? {};
-    return { engine, preferPlayback, contentType: type ?? inferContentType(this.src) };
+    const { type, preferPlayback, drm, engine } = this.#source ?? {};
+    return { drm, engine, preferPlayback, contentType: type ?? inferContentType(this.src) };
   }
 
   #engineDestroy() {
@@ -364,6 +391,27 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
     // Delegate teardown already emits `streamtypechange` (bridged); only sync cache.
     if (!this.#isUserStreamType) this.#streamType = StreamTypes.UNKNOWN;
   }
+}
+
+/**
+ * hls.js configuration with the source's DRM licensing folded in. hls.js takes
+ * `drmSystems` in the same shape as `source.drm`, so the standardized config is
+ * what it plays from unless `engine.hlsJs` names servers of its own.
+ *
+ * hls.js runs key exchange only while `emeEnabled` is set, so configured DRM
+ * switches it on — short of an explicit `emeEnabled: false`, which stays a way
+ * to describe a source's licensing without acting on it.
+ */
+function withDrmSystems(
+  hlsJs: Partial<HlsJsConfig> | undefined,
+  drm: DrmSystemsConfig | undefined
+): Partial<HlsJsConfig> {
+  const drmSystems = hlsJs?.drmSystems ?? drm;
+  if (!drmSystems || Object.keys(drmSystems).length === 0) return { ...hlsJs };
+
+  // hls.js declares `serverCertificateUrl` without `undefined`, which an
+  // omittable property here is allowed to carry. The values are the same.
+  return { emeEnabled: true, ...hlsJs, drmSystems: drmSystems as HlsJsConfig['drmSystems'] };
 }
 
 function inferContentType(src: string): SourceType {

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -251,6 +251,53 @@ describe('HlsJsMedia', () => {
     }
 
     const drmEngine = { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } };
+    const drm = {
+      'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE, serverCertificateUrl: 'https://license.test/appcert' },
+      'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE },
+    };
+
+    it('licenses the hls.js engine from `source.drm`', () => {
+      const { media } = setupMse({ drm });
+
+      // hls.js takes the same shape, and only negotiates keys while EME is on.
+      expect(media.engine!.config.emeEnabled).toBe(true);
+      expect(media.engine!.config.drmSystems).toEqual(drm);
+    });
+
+    it('leaves EME alone when `source.drm` names nothing', () => {
+      const { media } = setupMse({ drm: {} });
+      expect(media.engine!.config.emeEnabled).toBe(false);
+    });
+
+    it('describes licensing without acting on it for an explicit `emeEnabled: false`', () => {
+      const { media } = setupMse({ drm, engine: { hlsJs: { emeEnabled: false } } });
+
+      expect(media.engine!.config.emeEnabled).toBe(false);
+      expect(media.engine!.config.drmSystems).toEqual(drm);
+    });
+
+    it('lets `engine.hlsJs.drmSystems` replace `source.drm`', () => {
+      const { media } = setupMse({ drm, engine: { hlsJs: { drmSystems: drmEngine.drmSystems } } });
+
+      // An escape hatch replaces what it is an escape from, rather than merging:
+      // the FairPlay server named in `drm` is gone.
+      expect(media.engine!.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } });
+      expect(media.engine!.config.emeEnabled).toBe(true);
+    });
+
+    it('recreates the engine when a `source.drm` license server changes', () => {
+      const { media } = setupMse({ drm });
+      const engine = media.engine;
+
+      // Same license servers in a new object (e.g. an inline React prop).
+      media.source = { src: media.src, drm: { ...drm } };
+      media.load();
+      expect(media.engine).toBe(engine);
+
+      media.source = { src: media.src, drm: { 'com.widevine.alpha': { licenseUrl: 'https://other.test/widevine' } } };
+      media.load();
+      expect(media.engine).not.toBe(engine);
+    });
 
     it('hands DRM options straight to the hls.js engine', () => {
       const { media } = setupMse({ engine: { hlsJs: drmEngine } });
@@ -301,7 +348,7 @@ describe('HlsJsMedia', () => {
       });
     });
 
-    it('warns when native playback is taken and only hls.js DRM is configured', () => {
+    it('warns when native playback is taken and no FairPlay server is named', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { media } = setup();
@@ -309,7 +356,50 @@ describe('HlsJsMedia', () => {
       media.load();
 
       expect(media.engine).toBeNull();
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.engine.nativeHls.drmSystems`'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.drm`'));
+    });
+
+    it('hands `source.drm` to the native delegate', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const requestMediaKeySystemAccess = vi.fn(() => new Promise<never>(() => {}));
+      vi.stubGlobal('navigator', { ...navigator, requestMediaKeySystemAccess });
+
+      const { media, video } = setup();
+      // Every system named, as a source describing both paths would: the native
+      // delegate takes the FairPlay entry and leaves the rest to an MSE engine.
+      media.source = { ...media.source, drm };
+      media.load();
+
+      // jsdom has no `MediaEncryptedEvent`; only these two fields are read.
+      video.dispatchEvent(Object.assign(new Event('encrypted'), { initDataType: 'skd', initData: new ArrayBuffer(8) }));
+      await Promise.resolve();
+
+      expect(media.engine).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+      expect(requestMediaKeySystemAccess).toHaveBeenCalledWith('com.apple.fps', expect.any(Array));
+    });
+
+    it('recreates the native delegate when `source.drm` changes', () => {
+      const { media, video } = setup();
+      media.source = { ...media.source, drm };
+      media.load();
+
+      fireDurationChange(video, Infinity);
+      expect(media.streamType).toBe('live');
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      media.source = { ...media.source, drm: { ...drm } };
+      media.load();
+      // Structurally equal, so the delegate playing it is left alone.
+      expect(handler).not.toHaveBeenCalled();
+
+      media.source = { ...media.source, drm: { 'com.apple.fps': { licenseUrl: 'https://other.test/fairplay' } } };
+      media.load();
+
+      // Teardown `live` → `unknown`, then the new delegate re-detects `live`.
+      expect(handler).toHaveBeenCalledTimes(2);
     });
 
     it('hands `nativeHls` to the native delegate', async () => {

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -137,7 +137,11 @@ describe('HlsJsMedia', () => {
       media.addEventListener('streamtypechange', handler);
 
       // New hls.js option values must recreate the engine to take effect.
-      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
+      media.source = {
+        type: ContentTypes.M3U8,
+        preferPlayback: 'native',
+        engine: { hlsJs: { maxBufferLength: 60 } },
+      };
       media.load();
 
       // Teardown `live` → `unknown`, then the new delegate re-detects `live`.
@@ -151,7 +155,7 @@ describe('HlsJsMedia', () => {
       const source = {
         type: ContentTypes.M3U8,
         preferPlayback: 'native',
-        hlsJs: { maxBufferLength: 60 },
+        engine: { hlsJs: { maxBufferLength: 60 } },
       } as const;
 
       media.source = { ...source };
@@ -220,11 +224,11 @@ describe('HlsJsMedia', () => {
     it('replaces the source rather than merging it', () => {
       const { media } = setup();
 
-      media.source = { hlsJs: { maxBufferLength: 60 } };
+      media.source = { engine: { hlsJs: { maxBufferLength: 60 } } };
 
       // A new source object signals a fresh start: options set in `setup()` are
       // dropped rather than merged.
-      expect(media.source).toEqual({ hlsJs: { maxBufferLength: 60 } });
+      expect(media.source).toEqual({ engine: { hlsJs: { maxBufferLength: 60 } } });
     });
   });
 
@@ -249,7 +253,7 @@ describe('HlsJsMedia', () => {
     const drmEngine = { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } };
 
     it('hands DRM options straight to the hls.js engine', () => {
-      const { media } = setupMse({ hlsJs: drmEngine });
+      const { media } = setupMse({ engine: { hlsJs: drmEngine } });
 
       expect(media.engine!.config.emeEnabled).toBe(true);
       expect(media.engine!.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } });
@@ -261,13 +265,15 @@ describe('HlsJsMedia', () => {
     });
 
     it('reuses the engine for an equivalent DRM config', () => {
-      const { media } = setupMse({ hlsJs: drmEngine });
+      const { media } = setupMse({ engine: { hlsJs: drmEngine } });
       const engine = media.engine;
 
       // Same license servers in a new object (e.g. an inline React prop).
       media.source = {
         src: media.src,
-        hlsJs: { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } },
+        engine: {
+          hlsJs: { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } },
+        },
       };
       media.load();
 
@@ -275,14 +281,16 @@ describe('HlsJsMedia', () => {
     });
 
     it('recreates the engine when a license server changes', () => {
-      const { media } = setupMse({ hlsJs: drmEngine });
+      const { media } = setupMse({ engine: { hlsJs: drmEngine } });
       const engine = media.engine;
 
       media.source = {
         src: media.src,
-        hlsJs: {
-          emeEnabled: true,
-          drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://other.test/widevine' } },
+        engine: {
+          hlsJs: {
+            emeEnabled: true,
+            drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://other.test/widevine' } },
+          },
         },
       };
       media.load();
@@ -297,11 +305,11 @@ describe('HlsJsMedia', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { media } = setup();
-      media.source = { ...media.source, hlsJs: drmEngine };
+      media.source = { ...media.source, engine: { hlsJs: drmEngine } };
       media.load();
 
       expect(media.engine).toBeNull();
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.nativeHls.drmSystems`'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.engine.nativeHls.drmSystems`'));
     });
 
     it('hands `nativeHls` to the native delegate', async () => {
@@ -312,8 +320,10 @@ describe('HlsJsMedia', () => {
       const { media, video } = setup();
       media.source = {
         ...media.source,
-        hlsJs: drmEngine,
-        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } },
+        engine: {
+          hlsJs: drmEngine,
+          nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } },
+        },
       };
       media.load();
 
@@ -330,7 +340,7 @@ describe('HlsJsMedia', () => {
       const { media, video } = setup();
       media.source = {
         ...media.source,
-        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } },
+        engine: { nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } } },
       };
       media.load();
 
@@ -342,7 +352,7 @@ describe('HlsJsMedia', () => {
 
       media.source = {
         ...media.source,
-        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://other.test/fairplay' } } },
+        engine: { nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://other.test/fairplay' } } } },
       };
       media.load();
 
@@ -354,14 +364,14 @@ describe('HlsJsMedia', () => {
       const { media, video } = setup();
       const nativeHls = { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } };
 
-      media.source = { ...media.source, nativeHls: { ...nativeHls } };
+      media.source = { ...media.source, engine: { nativeHls: { ...nativeHls } } };
       media.load();
 
       fireDurationChange(video, Infinity);
       const handler = vi.fn();
       media.addEventListener('streamtypechange', handler);
 
-      media.source = { ...media.source, nativeHls: { ...nativeHls } };
+      media.source = { ...media.source, engine: { nativeHls: { ...nativeHls } } };
       media.load();
 
       expect(handler).not.toHaveBeenCalled();
@@ -496,9 +506,9 @@ describe('HlsJsMedia', () => {
       expect(media.streamType).toBe('live');
 
       handler.mockClear();
-      // `engine.debug` is part of `HlsJsMedia`'s engine key — toggling it
+      // `engine.hlsJs.debug` is part of `HlsJsMedia`'s engine key — toggling it
       // recreates the native delegate without switching playback engines.
-      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', hlsJs: { debug: true } };
+      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', engine: { hlsJs: { debug: true } } };
       media.load();
 
       // Teardown: a single `live` → `unknown`, then the new delegate re-detects
@@ -520,7 +530,7 @@ describe('HlsJsMedia', () => {
       });
 
       // Recreates the native delegate; duration would otherwise sync-detect as `on-demand`.
-      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', hlsJs: { debug: true } };
+      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', engine: { hlsJs: { debug: true } } };
       media.load();
 
       expect(seen).not.toContain('on-demand');

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -301,7 +301,7 @@ describe('HlsJsMedia', () => {
       media.load();
 
       expect(media.engine).toBeNull();
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.nativeHls.drm`'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.nativeHls.drmSystems`'));
     });
 
     it('hands `nativeHls` to the native delegate', async () => {
@@ -313,7 +313,7 @@ describe('HlsJsMedia', () => {
       media.source = {
         ...media.source,
         hlsJs: drmEngine,
-        nativeHls: { drm: { licenseUrl: FAIRPLAY_LICENSE } },
+        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } },
       };
       media.load();
 
@@ -328,7 +328,10 @@ describe('HlsJsMedia', () => {
 
     it('recreates the native delegate when `nativeHls` changes', () => {
       const { media, video } = setup();
-      media.source = { ...media.source, nativeHls: { drm: { licenseUrl: FAIRPLAY_LICENSE } } };
+      media.source = {
+        ...media.source,
+        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } },
+      };
       media.load();
 
       fireDurationChange(video, Infinity);
@@ -337,7 +340,10 @@ describe('HlsJsMedia', () => {
       const handler = vi.fn();
       media.addEventListener('streamtypechange', handler);
 
-      media.source = { ...media.source, nativeHls: { drm: { licenseUrl: 'https://other.test/fairplay' } } };
+      media.source = {
+        ...media.source,
+        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://other.test/fairplay' } } },
+      };
       media.load();
 
       // Teardown `live` → `unknown`, then the new delegate re-detects `live`.
@@ -346,7 +352,7 @@ describe('HlsJsMedia', () => {
 
     it('leaves the native delegate alone for a structurally equal `nativeHls`', () => {
       const { media, video } = setup();
-      const nativeHls = { drm: { licenseUrl: FAIRPLAY_LICENSE } };
+      const nativeHls = { drmSystems: { 'com.apple.fps': { licenseUrl: FAIRPLAY_LICENSE } } };
 
       media.source = { ...media.source, nativeHls: { ...nativeHls } };
       media.load();

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -8,6 +8,7 @@ import { ContentTypes, Hls, HlsJsMedia, type HlsSource } from '../index';
 afterEach(() => {
   document.body.innerHTML = '';
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 function fireDurationChange(video: HTMLVideoElement, duration: number) {
@@ -229,6 +230,7 @@ describe('HlsJsMedia', () => {
 
   describe('drm', () => {
     const WIDEVINE_LICENSE = 'https://license.test/widevine';
+    const FAIRPLAY_LICENSE = 'https://license.test/fairplay';
 
     function setupMse(source: HlsSource) {
       vi.spyOn(Hls, 'isSupported').mockReturnValue(true);
@@ -291,7 +293,7 @@ describe('HlsJsMedia', () => {
       });
     });
 
-    it('warns and builds no engine for native playback', () => {
+    it('warns when native playback is taken and only hls.js DRM is configured', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { media } = setup();
@@ -299,7 +301,64 @@ describe('HlsJsMedia', () => {
       media.load();
 
       expect(media.engine).toBeNull();
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('DRM playback requires the hls.js (MSE) engine'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.nativeHls.drm`'));
+    });
+
+    it('hands `nativeHls` to the native delegate', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const requestMediaKeySystemAccess = vi.fn(() => new Promise<never>(() => {}));
+      vi.stubGlobal('navigator', { ...navigator, requestMediaKeySystemAccess });
+
+      const { media, video } = setup();
+      media.source = {
+        ...media.source,
+        hlsJs: drmEngine,
+        nativeHls: { drm: { licenseUrl: FAIRPLAY_LICENSE } },
+      };
+      media.load();
+
+      // jsdom has no `MediaEncryptedEvent`; only these two fields are read.
+      video.dispatchEvent(Object.assign(new Event('encrypted'), { initDataType: 'skd', initData: new ArrayBuffer(8) }));
+      await Promise.resolve();
+
+      expect(media.engine).toBeNull();
+      expect(warn).not.toHaveBeenCalled();
+      expect(requestMediaKeySystemAccess).toHaveBeenCalledWith('com.apple.fps', expect.any(Array));
+    });
+
+    it('recreates the native delegate when `nativeHls` changes', () => {
+      const { media, video } = setup();
+      media.source = { ...media.source, nativeHls: { drm: { licenseUrl: FAIRPLAY_LICENSE } } };
+      media.load();
+
+      fireDurationChange(video, Infinity);
+      expect(media.streamType).toBe('live');
+
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      media.source = { ...media.source, nativeHls: { drm: { licenseUrl: 'https://other.test/fairplay' } } };
+      media.load();
+
+      // Teardown `live` → `unknown`, then the new delegate re-detects `live`.
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('leaves the native delegate alone for a structurally equal `nativeHls`', () => {
+      const { media, video } = setup();
+      const nativeHls = { drm: { licenseUrl: FAIRPLAY_LICENSE } };
+
+      media.source = { ...media.source, nativeHls: { ...nativeHls } };
+      media.load();
+
+      fireDurationChange(video, Infinity);
+      const handler = vi.fn();
+      media.addEventListener('streamtypechange', handler);
+
+      media.source = { ...media.source, nativeHls: { ...nativeHls } };
+      media.load();
+
+      expect(handler).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -136,7 +136,7 @@ describe('HlsJsMedia', () => {
       media.addEventListener('streamtypechange', handler);
 
       // New hls.js option values must recreate the engine to take effect.
-      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', engine: { maxBufferLength: 60 } };
+      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
       media.load();
 
       // Teardown `live` → `unknown`, then the new delegate re-detects `live`.
@@ -150,7 +150,7 @@ describe('HlsJsMedia', () => {
       const source = {
         type: ContentTypes.M3U8,
         preferPlayback: 'native',
-        engine: { maxBufferLength: 60 },
+        hlsJs: { maxBufferLength: 60 },
       } as const;
 
       media.source = { ...source };
@@ -219,11 +219,11 @@ describe('HlsJsMedia', () => {
     it('replaces the source rather than merging it', () => {
       const { media } = setup();
 
-      media.source = { engine: { maxBufferLength: 60 } };
+      media.source = { hlsJs: { maxBufferLength: 60 } };
 
       // A new source object signals a fresh start: options set in `setup()` are
       // dropped rather than merged.
-      expect(media.source).toEqual({ engine: { maxBufferLength: 60 } });
+      expect(media.source).toEqual({ hlsJs: { maxBufferLength: 60 } });
     });
   });
 
@@ -247,7 +247,7 @@ describe('HlsJsMedia', () => {
     const drmEngine = { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } };
 
     it('hands DRM options straight to the hls.js engine', () => {
-      const { media } = setupMse({ engine: drmEngine });
+      const { media } = setupMse({ hlsJs: drmEngine });
 
       expect(media.engine!.config.emeEnabled).toBe(true);
       expect(media.engine!.config.drmSystems).toEqual({ 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } });
@@ -259,13 +259,13 @@ describe('HlsJsMedia', () => {
     });
 
     it('reuses the engine for an equivalent DRM config', () => {
-      const { media } = setupMse({ engine: drmEngine });
+      const { media } = setupMse({ hlsJs: drmEngine });
       const engine = media.engine;
 
       // Same license servers in a new object (e.g. an inline React prop).
       media.source = {
         src: media.src,
-        engine: { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } },
+        hlsJs: { emeEnabled: true, drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } },
       };
       media.load();
 
@@ -273,12 +273,12 @@ describe('HlsJsMedia', () => {
     });
 
     it('recreates the engine when a license server changes', () => {
-      const { media } = setupMse({ engine: drmEngine });
+      const { media } = setupMse({ hlsJs: drmEngine });
       const engine = media.engine;
 
       media.source = {
         src: media.src,
-        engine: {
+        hlsJs: {
           emeEnabled: true,
           drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://other.test/widevine' } },
         },
@@ -295,7 +295,7 @@ describe('HlsJsMedia', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const { media } = setup();
-      media.source = { ...media.source, engine: drmEngine };
+      media.source = { ...media.source, hlsJs: drmEngine };
       media.load();
 
       expect(media.engine).toBeNull();
@@ -433,7 +433,7 @@ describe('HlsJsMedia', () => {
       handler.mockClear();
       // `engine.debug` is part of `HlsJsMedia`'s engine key — toggling it
       // recreates the native delegate without switching playback engines.
-      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', engine: { debug: true } };
+      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', hlsJs: { debug: true } };
       media.load();
 
       // Teardown: a single `live` → `unknown`, then the new delegate re-detects
@@ -455,7 +455,7 @@ describe('HlsJsMedia', () => {
       });
 
       // Recreates the native delegate; duration would otherwise sync-detect as `on-demand`.
-      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', engine: { debug: true } };
+      media.source = { type: ContentTypes.M3U8, preferPlayback: 'native', hlsJs: { debug: true } };
       media.load();
 
       expect(seen).not.toContain('on-demand');

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -359,6 +359,22 @@ describe('HlsJsMedia', () => {
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.drm`'));
     });
 
+    it('names the configuration it is licensing against when it warns', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { media } = setup();
+      // `source.drm` names FairPlay, but the escape hatch replaces it and does
+      // not — so the field to go and look at is the escape hatch.
+      media.source = {
+        ...media.source,
+        drm,
+        engine: { nativeHls: { drmSystems: { 'com.widevine.alpha': { licenseUrl: WIDEVINE_LICENSE } } } },
+      };
+      media.load();
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`source.engine.nativeHls.drmSystems`'));
+    });
+
     it('hands `source.drm` to the native delegate', async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const requestMediaKeySystemAccess = vi.fn(() => new Promise<never>(() => {}));

--- a/packages/media/src/dom/mux/drm.ts
+++ b/packages/media/src/dom/mux/drm.ts
@@ -1,12 +1,15 @@
 import { parseJwt } from '@videojs/utils/jwt';
 import type { DRMSystemsConfiguration } from 'hls.js';
-import type { NativeHlsDrmConfig } from '../native-hls';
 import { createMuxQuery, MUX_VIDEO_DOMAIN, type MuxJWT, type MuxSourceBase } from './source';
 
 /**
- * Build the hls.js `drmSystems` a source describes, keyed by EME key system id.
- * Mux signs one license token per playback ID and serves every system from a
- * URL derived from it, so `drm.token` is all a caller provides.
+ * Build the `drmSystems` a source describes, keyed by EME key system id. Mux
+ * signs one license token per playback ID and serves every system from a URL
+ * derived from it, so `drm.token` is all a caller provides.
+ *
+ * Both engines take this shape, so the result configures either: hls.js
+ * negotiates whichever system the browser offers, and native HLS reads the
+ * FairPlay entry.
  *
  * Returns `undefined` when no license token is present, or when the token is
  * not scoped to DRM — an unsigned license request is always rejected, so there
@@ -37,19 +40,4 @@ export function createMuxDrmSystems(source?: MuxSourceBase | null): DRMSystemsCo
     'com.widevine.alpha': { licenseUrl: url('license/widevine') },
     'com.microsoft.playready': { licenseUrl: url('license/playready') },
   };
-}
-
-/**
- * Build the FairPlay configuration native HLS takes. Safari negotiates keys
- * itself when the browser plays the manifest, so the same license token that
- * fills `drmSystems` describes the native path too — it just reaches a
- * different engine, and only FairPlay is on offer there.
- *
- * @internal
- */
-export function createMuxDrmConfig(source?: MuxSourceBase | null): NativeHlsDrmConfig | undefined {
-  const fairplay = createMuxDrmSystems(source)?.['com.apple.fps'];
-  if (!fairplay) return undefined;
-
-  return { licenseUrl: fairplay.licenseUrl, serverCertificateUrl: fairplay.serverCertificateUrl };
 }

--- a/packages/media/src/dom/mux/drm.ts
+++ b/packages/media/src/dom/mux/drm.ts
@@ -1,28 +1,24 @@
 import { parseJwt } from '@videojs/utils/jwt';
-import type { DRMSystemsConfiguration } from 'hls.js';
+import type { DrmSystemsConfig } from '../../core/drm';
 import { createMuxQuery, MUX_VIDEO_DOMAIN, type MuxJWT, type MuxSourceBase } from './source';
 
 /**
- * Build the `drmSystems` a source describes, keyed by EME key system id. Mux
- * signs one license token per playback ID and serves every system from a URL
- * derived from it, so `drm.token` is all a caller provides.
- *
- * Both engines take this shape, so the result configures either: hls.js
- * negotiates whichever system the browser offers, and native HLS reads the
- * FairPlay entry.
+ * Build the license servers a source describes, keyed by EME key system id —
+ * `source.drm` as any other source would name it. Mux signs one license token
+ * per playback ID and serves every system from a URL derived from it, so
+ * `drm.token` is all a caller provides.
  *
  * Returns `undefined` when no license token is present, or when the token is
  * not scoped to DRM — an unsigned license request is always rejected, so there
  * is nothing useful to configure.
  *
- * Separate from `./source` because the return shape is hls.js's: this is the
- * one part of the Mux source that can't be shared with an engine that
- * configures DRM differently, or — like SPF today — doesn't configure it at
- * all.
+ * Separate from `./source` because it is the one part of the Mux source an
+ * engine that licenses differently — or, like SPF today, doesn't license at
+ * all — has nothing to do with.
  *
  * @internal
  */
-export function createMuxDrmSystems(source?: MuxSourceBase | null): DRMSystemsConfiguration | undefined {
+export function createMuxDrmSystems(source?: MuxSourceBase | null): DrmSystemsConfig | undefined {
   if (!source?.playbackId) return undefined;
   const { playbackId, customDomain = MUX_VIDEO_DOMAIN, drm } = source;
   const { token } = drm ?? {};

--- a/packages/media/src/dom/mux/drm.ts
+++ b/packages/media/src/dom/mux/drm.ts
@@ -1,5 +1,6 @@
 import { parseJwt } from '@videojs/utils/jwt';
 import type { DRMSystemsConfiguration } from 'hls.js';
+import type { NativeHlsDrmConfig } from '../native-hls';
 import { createMuxQuery, MUX_VIDEO_DOMAIN, type MuxJWT, type MuxSourceBase } from './source';
 
 /**
@@ -36,4 +37,19 @@ export function createMuxDrmSystems(source?: MuxSourceBase | null): DRMSystemsCo
     'com.widevine.alpha': { licenseUrl: url('license/widevine') },
     'com.microsoft.playready': { licenseUrl: url('license/playready') },
   };
+}
+
+/**
+ * Build the FairPlay configuration native HLS takes. Safari negotiates keys
+ * itself when the browser plays the manifest, so the same license token that
+ * fills `drmSystems` describes the native path too — it just reaches a
+ * different engine, and only FairPlay is on offer there.
+ *
+ * @internal
+ */
+export function createMuxDrmConfig(source?: MuxSourceBase | null): NativeHlsDrmConfig | undefined {
+  const fairplay = createMuxDrmSystems(source)?.['com.apple.fps'];
+  if (!fairplay) return undefined;
+
+  return { licenseUrl: fairplay.licenseUrl, serverCertificateUrl: fairplay.serverCertificateUrl };
 }

--- a/packages/media/src/dom/mux/index.ts
+++ b/packages/media/src/dom/mux/index.ts
@@ -1,3 +1,5 @@
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
+export { KeySystems } from '../../core/drm';
 export * from './media';
 export { MuxData, type MuxDataProps, muxDataDefaultProps } from './mux-data';
 // The engine-neutral source layer, re-exported so this stays the one import for

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -50,12 +50,11 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
     // params a Mux URL does not carry, such as `poster`.
     if (super.src === value) return;
 
-    const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
+    const { type, preferPlayback, engine } = this.#source ?? {};
     const source: MuxSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
-      ...(hlsJs && { hlsJs }),
-      ...(nativeHls && { nativeHls }),
+      ...(engine && { engine }),
       ...(parseMuxVideoURL(value) ?? (value ? { src: value } : null)),
     };
 
@@ -66,12 +65,13 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * Structured Mux source. Setting it derives `src` from the playback ID,
    * custom domain, and `playback` params (appended as `snake_case` query
    * params). A `playback.token` replaces all other params — signed URLs bake
-   * them into the token. Engine options live under `hlsJs` and `nativeHls`.
+   * them into the token. Engine options live under `engine`.
    *
-   * A `drm.token` fills in both: `hlsJs.drmSystems` and `nativeHls.drmSystems`
-   * get Mux's FairPlay, Widevine, and PlayReady license servers for this
-   * playback ID, so protected media plays whichever path the browser takes.
-   * Naming either yourself overrides that, for content Mux does not license.
+   * A `drm.token` fills in both: `engine.hlsJs.drmSystems` and
+   * `engine.nativeHls.drmSystems` get Mux's FairPlay, Widevine, and PlayReady
+   * license servers for this playback ID, so protected media plays whichever
+   * path the browser takes. Naming either yourself overrides that, for content
+   * Mux does not license.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -128,12 +128,14 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
  * Whatever the caller set wins, key by key, so license servers of their own
  * replace the derived ones.
  */
-function withMuxDrm(source: MuxSource): Pick<MuxSource, 'hlsJs' | 'nativeHls'> {
+function withMuxDrm(source: MuxSource): Pick<MuxSource, 'engine'> {
   const drmSystems = createMuxDrmSystems(source);
-  if (!drmSystems) return { hlsJs: source.hlsJs, nativeHls: source.nativeHls };
+  if (!drmSystems) return { engine: source.engine };
 
   return {
-    hlsJs: { emeEnabled: true, drmSystems, ...source.hlsJs },
-    nativeHls: { drmSystems, ...source.nativeHls },
+    engine: {
+      hlsJs: { emeEnabled: true, drmSystems, ...source.engine?.hlsJs },
+      nativeHls: { drmSystems, ...source.engine?.nativeHls },
+    },
   };
 }

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -11,7 +11,7 @@ import {
 /**
  * Structured Mux source for the hls.js-backed Media: Mux identity and params
  * from {@link MuxSourceBase}, plus everything hls.js takes — `type`,
- * `preferPlayback`, and its own `engine` config.
+ * `preferPlayback`, and its own `hlsJs` config.
  */
 export interface MuxSource extends HlsSource, MuxSourceBase {}
 
@@ -50,11 +50,11 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
     // params a Mux URL does not carry, such as `poster`.
     if (super.src === value) return;
 
-    const { type, preferPlayback, engine } = this.#source ?? {};
+    const { type, preferPlayback, hlsJs } = this.#source ?? {};
     const source: MuxSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
-      ...(engine && { engine }),
+      ...(hlsJs && { hlsJs }),
       ...(parseMuxVideoURL(value) ?? (value ? { src: value } : null)),
     };
 
@@ -65,11 +65,11 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * Structured Mux source. Setting it derives `src` from the playback ID,
    * custom domain, and `playback` params (appended as `snake_case` query
    * params). A `playback.token` replaces all other params — signed URLs bake
-   * them into the token. Engine options live under `engine`.
+   * them into the token. Engine options live under `hlsJs`.
    *
-   * A `drm.token` fills in the inherited `engine.drmSystems` with Mux's
+   * A `drm.token` fills in the inherited `hlsJs.drmSystems` with Mux's
    * FairPlay, Widevine, and PlayReady license servers for this playback ID.
-   * Naming `engine.drmSystems` yourself overrides that, for content Mux does
+   * Naming `hlsJs.drmSystems` yourself overrides that, for content Mux does
    * not license.
    */
   get source(): MuxSource | null {
@@ -90,7 +90,7 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
     super.source = source && {
       ...source,
       src: createMuxVideoURL(source) ?? source.src ?? '',
-      engine: withMuxDrm(source),
+      hlsJs: withMuxDrm(source),
     };
   }
 
@@ -117,12 +117,12 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
 
 /**
  * Fold Mux's derived license servers into the engine config, switching EME on
- * so hls.js listens for `encrypted`. Whatever the caller set under `engine`
+ * so hls.js listens for `encrypted`. Whatever the caller set under `hlsJs`
  * wins, key by key, so `drmSystems` of their own replaces the derived set.
  */
-function withMuxDrm(source: MuxSource): MuxSource['engine'] {
+function withMuxDrm(source: MuxSource): MuxSource['hlsJs'] {
   const drmSystems = createMuxDrmSystems(source);
-  if (!drmSystems) return source.engine;
+  if (!drmSystems) return source.hlsJs;
 
-  return { emeEnabled: true, drmSystems, ...source.engine };
+  return { emeEnabled: true, drmSystems, ...source.hlsJs };
 }

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -4,16 +4,23 @@ import {
   createMuxPosterURL,
   createMuxStoryboardURL,
   createMuxVideoURL,
+  type MuxDrmParams,
   type MuxSourceBase,
   parseMuxVideoURL,
 } from './source';
 
 /**
  * Structured Mux source for the hls.js-backed Media: Mux identity and params
- * from {@link MuxSourceBase}, plus everything hls.js takes — `type`,
- * `preferPlayback`, and its own `hlsJs` and `nativeHls` config.
+ * from {@link MuxSourceBase}, plus everything the HLS layer takes — `type`,
+ * `preferPlayback`, and its `engine` config.
  */
-export interface MuxSource extends HlsSource, MuxSourceBase {}
+export interface MuxSource extends HlsSource, MuxSourceBase {
+  /**
+   * The inherited license servers, or a Mux license `token` to derive them from.
+   * Redeclared because both halves name `drm`, and Mux's is the wider of the two.
+   */
+  drm?: MuxDrmParams | undefined;
+}
 
 export interface MuxMediaProps {
   src: string;
@@ -67,11 +74,10 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * params). A `playback.token` replaces all other params — signed URLs bake
    * them into the token. Engine options live under `engine`.
    *
-   * A `drm.token` fills in both: `engine.hlsJs.drmSystems` and
-   * `engine.nativeHls.drmSystems` get Mux's FairPlay, Widevine, and PlayReady
-   * license servers for this playback ID, so protected media plays whichever
-   * path the browser takes. Naming either yourself overrides that, for content
-   * Mux does not license.
+   * A `drm.token` fills in `drm` itself: Mux's FairPlay, Widevine, and
+   * PlayReady license servers for this playback ID, so protected media plays
+   * whichever path the browser takes. License servers named alongside the token
+   * win, key by key, for content Mux does not license.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -117,25 +123,17 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
 }
 
 /**
- * Fold Mux's derived license servers into both engine configurations, switching
- * EME on so hls.js listens for `encrypted`. Which engine ends up playing is
- * decided later, and a signed Mux source should play either way.
+ * Resolve Mux's DRM authoring input into the license servers the HLS layer
+ * licenses from. Which engine ends up playing is decided later, and both read
+ * `drm`, so a signed Mux source plays either way.
  *
- * The same `drmSystems` object serves both: native HLS takes the hls.js shape
- * and reads the FairPlay entry out of it, ignoring the systems only MSE can
- * negotiate.
- *
- * Whatever the caller set wins, key by key, so license servers of their own
- * replace the derived ones.
+ * `token` is Mux's own input and stops here — it names no license server, and a
+ * key system is what everything downstream expects to find. Servers the caller
+ * named win, key by key, so their own licensing replaces the derived URLs.
  */
-function withMuxDrm(source: MuxSource): Pick<MuxSource, 'engine'> {
-  const drmSystems = createMuxDrmSystems(source);
-  if (!drmSystems) return { engine: source.engine };
+function withMuxDrm(source: MuxSource): Pick<HlsSource, 'drm'> {
+  const { token: _token, ...systems } = source.drm ?? {};
+  const drm = { ...createMuxDrmSystems(source), ...systems };
 
-  return {
-    engine: {
-      hlsJs: { emeEnabled: true, drmSystems, ...source.engine?.hlsJs },
-      nativeHls: { drmSystems, ...source.engine?.nativeHls },
-    },
-  };
+  return { drm: Object.keys(drm).length > 0 ? drm : undefined };
 }

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -1,5 +1,5 @@
 import { HlsJsMedia, type HlsSource } from '../hls-js';
-import { createMuxDrmSystems } from './drm';
+import { createMuxDrmConfig, createMuxDrmSystems } from './drm';
 import {
   createMuxPosterURL,
   createMuxStoryboardURL,
@@ -11,7 +11,7 @@ import {
 /**
  * Structured Mux source for the hls.js-backed Media: Mux identity and params
  * from {@link MuxSourceBase}, plus everything hls.js takes — `type`,
- * `preferPlayback`, and its own `hlsJs` config.
+ * `preferPlayback`, and its own `hlsJs` and `nativeHls` config.
  */
 export interface MuxSource extends HlsSource, MuxSourceBase {}
 
@@ -50,11 +50,12 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
     // params a Mux URL does not carry, such as `poster`.
     if (super.src === value) return;
 
-    const { type, preferPlayback, hlsJs } = this.#source ?? {};
+    const { type, preferPlayback, hlsJs, nativeHls } = this.#source ?? {};
     const source: MuxSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
       ...(hlsJs && { hlsJs }),
+      ...(nativeHls && { nativeHls }),
       ...(parseMuxVideoURL(value) ?? (value ? { src: value } : null)),
     };
 
@@ -65,12 +66,13 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * Structured Mux source. Setting it derives `src` from the playback ID,
    * custom domain, and `playback` params (appended as `snake_case` query
    * params). A `playback.token` replaces all other params — signed URLs bake
-   * them into the token. Engine options live under `hlsJs`.
+   * them into the token. Engine options live under `hlsJs` and `nativeHls`.
    *
-   * A `drm.token` fills in the inherited `hlsJs.drmSystems` with Mux's
-   * FairPlay, Widevine, and PlayReady license servers for this playback ID.
-   * Naming `hlsJs.drmSystems` yourself overrides that, for content Mux does
-   * not license.
+   * A `drm.token` fills in both: the inherited `hlsJs.drmSystems` with Mux's
+   * FairPlay, Widevine, and PlayReady license servers for this playback ID, and
+   * `nativeHls.drm` with the FairPlay half, so protected media plays whichever
+   * path the browser takes. Naming either yourself overrides that, for content
+   * Mux does not license.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -90,7 +92,7 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
     super.source = source && {
       ...source,
       src: createMuxVideoURL(source) ?? source.src ?? '',
-      hlsJs: withMuxDrm(source),
+      ...withMuxDrm(source),
     };
   }
 
@@ -116,13 +118,21 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
 }
 
 /**
- * Fold Mux's derived license servers into the engine config, switching EME on
- * so hls.js listens for `encrypted`. Whatever the caller set under `hlsJs`
- * wins, key by key, so `drmSystems` of their own replaces the derived set.
+ * Fold Mux's derived license servers into both engine configurations, switching
+ * EME on so hls.js listens for `encrypted`. Which engine ends up playing is
+ * decided later, and a signed Mux source should play either way.
+ *
+ * Whatever the caller set wins, key by key, so license servers of their own
+ * replace the derived ones.
  */
-function withMuxDrm(source: MuxSource): MuxSource['hlsJs'] {
+function withMuxDrm(source: MuxSource): Pick<MuxSource, 'hlsJs' | 'nativeHls'> {
   const drmSystems = createMuxDrmSystems(source);
-  if (!drmSystems) return source.hlsJs;
+  if (!drmSystems) return { hlsJs: source.hlsJs, nativeHls: source.nativeHls };
 
-  return { emeEnabled: true, drmSystems, ...source.hlsJs };
+  const drm = createMuxDrmConfig(source);
+
+  return {
+    hlsJs: { emeEnabled: true, drmSystems, ...source.hlsJs },
+    nativeHls: { ...(drm && { drm }), ...source.nativeHls },
+  };
 }

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -1,5 +1,5 @@
 import { HlsJsMedia, type HlsSource } from '../hls-js';
-import { createMuxDrmConfig, createMuxDrmSystems } from './drm';
+import { createMuxDrmSystems } from './drm';
 import {
   createMuxPosterURL,
   createMuxStoryboardURL,
@@ -68,11 +68,10 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * params). A `playback.token` replaces all other params — signed URLs bake
    * them into the token. Engine options live under `hlsJs` and `nativeHls`.
    *
-   * A `drm.token` fills in both: the inherited `hlsJs.drmSystems` with Mux's
-   * FairPlay, Widevine, and PlayReady license servers for this playback ID, and
-   * `nativeHls.drm` with the FairPlay half, so protected media plays whichever
-   * path the browser takes. Naming either yourself overrides that, for content
-   * Mux does not license.
+   * A `drm.token` fills in both: `hlsJs.drmSystems` and `nativeHls.drmSystems`
+   * get Mux's FairPlay, Widevine, and PlayReady license servers for this
+   * playback ID, so protected media plays whichever path the browser takes.
+   * Naming either yourself overrides that, for content Mux does not license.
    */
   get source(): MuxSource | null {
     return this.#source;
@@ -122,6 +121,10 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
  * EME on so hls.js listens for `encrypted`. Which engine ends up playing is
  * decided later, and a signed Mux source should play either way.
  *
+ * The same `drmSystems` object serves both: native HLS takes the hls.js shape
+ * and reads the FairPlay entry out of it, ignoring the systems only MSE can
+ * negotiate.
+ *
  * Whatever the caller set wins, key by key, so license servers of their own
  * replace the derived ones.
  */
@@ -129,10 +132,8 @@ function withMuxDrm(source: MuxSource): Pick<MuxSource, 'hlsJs' | 'nativeHls'> {
   const drmSystems = createMuxDrmSystems(source);
   if (!drmSystems) return { hlsJs: source.hlsJs, nativeHls: source.nativeHls };
 
-  const drm = createMuxDrmConfig(source);
-
   return {
     hlsJs: { emeEnabled: true, drmSystems, ...source.hlsJs },
-    nativeHls: { ...(drm && { drm }), ...source.nativeHls },
+    nativeHls: { drmSystems, ...source.nativeHls },
   };
 }

--- a/packages/media/src/dom/mux/source/source.ts
+++ b/packages/media/src/dom/mux/source/source.ts
@@ -2,12 +2,13 @@
  * The Mux source: playback identity, the params that modify it, and the URLs
  * derived from both. Engine-neutral on purpose — every Mux Media needs it, and
  * they don't share an engine. Nothing here may reach for a specific one
- * (hls.js's license-server shaping lives in `../drm.ts`), because
- * `@videojs/spf` imports this module for its own Mux Media.
+ * (license-server derivation lives in `../drm.ts`, for the engines that
+ * license), because `@videojs/spf` imports this module for its own Mux Media.
  */
 import { parseJwt } from '@videojs/utils/jwt';
 import { isNil } from '@videojs/utils/predicate';
 import { camelCase, snakeCase } from '@videojs/utils/string';
+import type { DrmSystemsConfig } from '../../../core/drm';
 
 export const MUX_VIDEO_DOMAIN = 'mux.com';
 
@@ -84,7 +85,12 @@ export interface MuxStoryboardParams {
   [param: string]: string | number | undefined;
 }
 
-export interface MuxDrmParams {
+/**
+ * Mux's DRM authoring input: a license token, in place of the license servers
+ * `source.drm` normally names. Servers named outright alongside it still win,
+ * key by key, for content Mux does not license.
+ */
+export interface MuxDrmParams extends DrmSystemsConfig {
   /**
    * DRM license token: a JWT signed for the playback ID with the DRM (`d`)
    * audience. Mux derives every license server URL from it, so it is the only
@@ -110,6 +116,7 @@ export interface MuxSourceBase {
   playback?: MuxPlaybackParams | undefined;
   poster?: MuxPosterParams | undefined;
   storyboard?: MuxStoryboardParams | undefined;
+  /** License servers keyed by key system, or a Mux license `token` to derive them from. */
   drm?: MuxDrmParams | undefined;
 }
 

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Hls, HlsJsMedia } from '../../hls-js';
-import { MuxMedia } from '..';
+import { MuxMedia, type MuxSource } from '..';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 // Header `{"alg":"HS256"}`, body sets `aud`, empty signature. Unpadded base64url,
 // like a real JWT, so it survives a query string untouched.
@@ -382,6 +387,36 @@ describe('MuxMedia', () => {
       return media;
     }
 
+    /** A CDM that grants access, so key exchange gets as far as the certificate. */
+    function stubNativeKeySystem() {
+      const session = { addEventListener() {}, generateRequest: async () => {}, close: async () => {} };
+      const mediaKeys = { createSession: () => session, setServerCertificate: async () => true };
+
+      vi.stubGlobal('navigator', {
+        ...navigator,
+        requestMediaKeySystemAccess: async () => ({ createMediaKeys: async () => mediaKeys }),
+      });
+
+      const fetchMock = vi.fn(async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(4) }) as Response);
+      vi.stubGlobal('fetch', fetchMock);
+      return fetchMock;
+    }
+
+    async function setupNative(source: MuxSource) {
+      const media = new MuxMedia();
+      const video = document.createElement('video');
+      video.setMediaKeys = async () => {};
+      media.attach(video);
+      media.source = { playbackId: 'abc123', preferPlayback: 'native', ...source };
+      await flushLoad();
+      return { media, video };
+    }
+
+    /** jsdom has no `MediaEncryptedEvent`; only these two fields are read. */
+    function fireEncrypted(video: HTMLVideoElement) {
+      video.dispatchEvent(Object.assign(new Event('encrypted'), { initDataType: 'skd', initData: new ArrayBuffer(8) }));
+    }
+
     it('configures the hls.js engine from a DRM token', async () => {
       const media = setupMse();
       media.source = { playbackId: 'abc123', playback: { token: PLAYBACK_TOKEN }, drm: { token: DRM_TOKEN } };
@@ -416,6 +451,36 @@ describe('MuxMedia', () => {
       // `drm` stays Mux's own authoring input; only the derived license servers
       // reach the HLS layer.
       expect(media.source).toEqual({ playbackId: 'abc123', drm: { token: DRM_TOKEN } });
+    });
+
+    it('configures native FairPlay from the same DRM token', async () => {
+      const fetchMock = stubNativeKeySystem();
+      const { video } = await setupNative({ drm: { token: DRM_TOKEN }, playback: { token: PLAYBACK_TOKEN } });
+
+      fireEncrypted(video);
+      await flushLoad();
+
+      // Which engine plays is decided later, so one token configures both paths:
+      // the native one reaches Mux's servers rather than failing for want of them.
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://license.mux.com/appcert/fairplay/abc123?token=${DRM_TOKEN}`,
+        expect.anything()
+      );
+    });
+
+    it('lets an explicit nativeHls.drm override the derived one', async () => {
+      const fetchMock = stubNativeKeySystem();
+      const { video } = await setupNative({
+        drm: { token: DRM_TOKEN },
+        nativeHls: { drm: { licenseUrl: 'https://drm.example/fairplay' } },
+      });
+
+      fireEncrypted(video);
+      await flushLoad();
+
+      // The caller named no certificate URL, so nothing is fetched — least of all
+      // from the servers the token would have derived.
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('lets an explicit hlsJs.drmSystems override the derived one', async () => {

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -483,6 +483,28 @@ describe('MuxMedia', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
+    it('lets a license server named alongside the token replace the derived one', async () => {
+      const media = setupMse();
+      media.source = {
+        playbackId: 'abc123',
+        drm: { token: DRM_TOKEN, 'com.widevine.alpha': { licenseUrl: 'https://drm.example/widevine' } },
+      };
+      await flushLoad();
+
+      // `drm` is the standard shape with a Mux token folded in, so the two mix:
+      // Widevine is licensed by the caller, the rest by Mux.
+      expect(media.engine!.config.drmSystems).toEqual({
+        'com.apple.fps': {
+          licenseUrl: `https://license.mux.com/license/fairplay/abc123?token=${DRM_TOKEN}`,
+          serverCertificateUrl: `https://license.mux.com/appcert/fairplay/abc123?token=${DRM_TOKEN}`,
+        },
+        'com.widevine.alpha': { licenseUrl: 'https://drm.example/widevine' },
+        'com.microsoft.playready': {
+          licenseUrl: `https://license.mux.com/license/playready/abc123?token=${DRM_TOKEN}`,
+        },
+      });
+    });
+
     it('lets an explicit hlsJs.drmSystems override the derived one', async () => {
       const media = setupMse();
       media.source = {

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -207,7 +207,7 @@ describe('MuxMedia', () => {
     const media = new MuxMedia();
     media.attach(document.createElement('video'));
     const engine = { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } };
-    media.source = { playbackId: 'abc123', preferPlayback: 'native', engine };
+    media.source = { playbackId: 'abc123', preferPlayback: 'native', hlsJs: engine };
     await flushLoad();
 
     const loadstart = vi.fn();
@@ -218,7 +218,7 @@ describe('MuxMedia', () => {
     media.source = {
       playbackId: 'abc123',
       preferPlayback: 'native',
-      engine: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
+      hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
       poster: { time: 5 },
     };
     await flushLoad();
@@ -232,7 +232,7 @@ describe('MuxMedia', () => {
     media.source = {
       playbackId: 'abc123',
       preferPlayback: 'native',
-      engine: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
+      hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
     };
     await flushLoad();
 
@@ -242,7 +242,7 @@ describe('MuxMedia', () => {
     media.source = {
       playbackId: 'abc123',
       preferPlayback: 'native',
-      engine: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/other' } } },
+      hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/other' } } },
     };
     await flushLoad();
 
@@ -258,7 +258,7 @@ describe('MuxMedia', () => {
     const loadstart = vi.fn();
     media.addEventListener('loadstart', loadstart);
 
-    media.source = { playbackId: 'abc123', preferPlayback: 'native', engine: { maxBufferLength: 60 } };
+    media.source = { playbackId: 'abc123', preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
     await flushLoad();
 
     expect(loadstart).toHaveBeenCalled();
@@ -418,12 +418,12 @@ describe('MuxMedia', () => {
       expect(media.source).toEqual({ playbackId: 'abc123', drm: { token: DRM_TOKEN } });
     });
 
-    it('lets an explicit engine.drmSystems override the derived one', async () => {
+    it('lets an explicit hlsJs.drmSystems override the derived one', async () => {
       const media = setupMse();
       media.source = {
         playbackId: 'abc123',
         drm: { token: DRM_TOKEN },
-        engine: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
+        hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
       };
       await flushLoad();
 

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -211,8 +211,8 @@ describe('MuxMedia', () => {
   it('does not reload for an equivalent nested engine option', async () => {
     const media = new MuxMedia();
     media.attach(document.createElement('video'));
-    const engine = { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } };
-    media.source = { playbackId: 'abc123', preferPlayback: 'native', hlsJs: engine };
+    const hlsJs = { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } };
+    media.source = { playbackId: 'abc123', preferPlayback: 'native', engine: { hlsJs } };
     await flushLoad();
 
     const loadstart = vi.fn();
@@ -223,7 +223,7 @@ describe('MuxMedia', () => {
     media.source = {
       playbackId: 'abc123',
       preferPlayback: 'native',
-      hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
+      engine: { hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } } },
       poster: { time: 5 },
     };
     await flushLoad();
@@ -237,7 +237,7 @@ describe('MuxMedia', () => {
     media.source = {
       playbackId: 'abc123',
       preferPlayback: 'native',
-      hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
+      engine: { hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } } },
     };
     await flushLoad();
 
@@ -247,7 +247,7 @@ describe('MuxMedia', () => {
     media.source = {
       playbackId: 'abc123',
       preferPlayback: 'native',
-      hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/other' } } },
+      engine: { hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/other' } } } },
     };
     await flushLoad();
 
@@ -263,7 +263,7 @@ describe('MuxMedia', () => {
     const loadstart = vi.fn();
     media.addEventListener('loadstart', loadstart);
 
-    media.source = { playbackId: 'abc123', preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
+    media.source = { playbackId: 'abc123', preferPlayback: 'native', engine: { hlsJs: { maxBufferLength: 60 } } };
     await flushLoad();
 
     expect(loadstart).toHaveBeenCalled();
@@ -472,7 +472,7 @@ describe('MuxMedia', () => {
       const fetchMock = stubNativeKeySystem();
       const { video } = await setupNative({
         drm: { token: DRM_TOKEN },
-        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://drm.example/fairplay' } } },
+        engine: { nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://drm.example/fairplay' } } } },
       });
 
       fireEncrypted(video);
@@ -488,7 +488,7 @@ describe('MuxMedia', () => {
       media.source = {
         playbackId: 'abc123',
         drm: { token: DRM_TOKEN },
-        hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } },
+        engine: { hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: 'https://drm.example/license' } } } },
       };
       await flushLoad();
 

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -468,11 +468,11 @@ describe('MuxMedia', () => {
       );
     });
 
-    it('lets an explicit nativeHls.drm override the derived one', async () => {
+    it('lets an explicit nativeHls.drmSystems override the derived one', async () => {
       const fetchMock = stubNativeKeySystem();
       const { video } = await setupNative({
         drm: { token: DRM_TOKEN },
-        nativeHls: { drm: { licenseUrl: 'https://drm.example/fairplay' } },
+        nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://drm.example/fairplay' } } },
       });
 
       fireEncrypted(video);

--- a/packages/media/src/dom/native-hls/drm.ts
+++ b/packages/media/src/dom/native-hls/drm.ts
@@ -1,0 +1,170 @@
+import { isWebKitAirPlayCapable } from '@videojs/utils/dom';
+import type { Constructor } from '@videojs/utils/types';
+
+import { MediaError } from '../../core/media-error';
+import type { NativeMediaHost } from './errors';
+import {
+  createDrmError,
+  type FairPlayContext,
+  type FairPlayKeySystem,
+  type NativeHlsDrmConfig,
+  NativeHlsDrmErrors,
+  NativeHlsDrmMessages,
+} from './fairplay';
+import { createFairPlayEme } from './fairplay-eme';
+import { createFairPlayWebKit } from './fairplay-webkit';
+
+/**
+ * What the mixin needs from whatever it is composed onto: the DRM half of the
+ * source, and somewhere to put an error the media element never reports.
+ */
+export type NativeHlsDrmHost = NativeMediaHost & {
+  readonly source: { nativeHls?: { drm?: NativeHlsDrmConfig | undefined } | undefined } | null;
+  setError(error: MediaError): void;
+};
+
+/**
+ * Play DRM-protected HLS natively, configured by `source.nativeHls.drm`.
+ *
+ * Native HLS has no JS engine to hand key exchange to, so this mixin does it
+ * against the media element directly: it answers the element's key requests by
+ * fetching an application certificate and trading the CDM's SPC for a CKC at
+ * the license server. Only FairPlay is reachable this way — Widevine and
+ * PlayReady content needs the hls.js (MSE) engine.
+ *
+ * The configuration is read when a key request arrives rather than up front,
+ * so assigning `source` and letting the element load are independent; state is
+ * released on `emptied`, when the element starts on a new resource.
+ *
+ * Encrypted content with nothing configured fails loudly. Safari otherwise
+ * stalls without explanation, which is indistinguishable from a slow network.
+ */
+export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost>>(BaseClass: Base) {
+  class NativeHlsMediaDrm extends (BaseClass as Constructor<NativeHlsDrmHost>) {
+    #disconnect: AbortController | null = null;
+    #active: { keySystem: FairPlayKeySystem; disconnect: AbortController } | null = null;
+    #useWebKit = false;
+
+    attach(target: HTMLVideoElement): void {
+      super.attach(target);
+      this.#init(target);
+    }
+
+    detach(): void {
+      this.#destroy();
+      super.detach?.();
+    }
+
+    destroy(): void {
+      this.#destroy();
+      super.destroy?.();
+    }
+
+    #destroy(): void {
+      this.#disconnect?.abort();
+      this.#disconnect = null;
+      this.#useWebKit = false;
+      void this.#reset();
+    }
+
+    #init(target: HTMLVideoElement): void {
+      this.#destroy();
+      this.#disconnect = new AbortController();
+      const { signal } = this.#disconnect;
+
+      // Both events are always observed, and each is served only by the
+      // implementation that owns it — Safari can fire both, and only one of
+      // them describes the keys the active CDM is holding.
+      target.addEventListener('encrypted', (event) => this.#serve(event as MediaEncryptedEvent, false), { signal });
+      target.addEventListener('webkitneedkey', (event) => this.#serve(event as MediaEncryptedEvent, true), { signal });
+
+      // Fired when the element starts on a new resource, so the keys and
+      // sessions held for the previous one are no longer good for anything.
+      target.addEventListener('emptied', () => void this.#reset(), { signal });
+
+      if (isWebKitAirPlayCapable(target)) {
+        // A new receiver needs a new session, and EME is worth preferring
+        // again the moment playback comes back to this device.
+        target.addEventListener(
+          'webkitcurrentplaybacktargetiswirelesschanged',
+          () => {
+            this.#useWebKit = false;
+            void this.#reset();
+          },
+          { signal }
+        );
+      }
+    }
+
+    #serve(event: MediaEncryptedEvent, fromWebKit: boolean): void {
+      if (fromWebKit !== this.#useWebKit) return;
+
+      const media = this.target as HTMLVideoElement | null;
+      const config = this.source?.nativeHls?.drm;
+      if (!media) return;
+
+      if (!config?.licenseUrl) {
+        this.setError(
+          createDrmError(NativeHlsDrmMessages.MISSING_CONFIGURATION, NativeHlsDrmErrors.MISSING_CONFIGURATION)
+        );
+        return;
+      }
+
+      const active = (this.#active ??= this.#createKeySystem(media, config));
+
+      void active.keySystem.request(event).catch((cause) => {
+        // What raised this has since been torn down, so it is about a source
+        // that is no longer playing.
+        if (active.disconnect.signal.aborted) return;
+        this.setError(
+          cause instanceof MediaError
+            ? cause
+            : createDrmError(NativeHlsDrmMessages.CDM_ERROR, NativeHlsDrmErrors.CDM_ERROR)
+        );
+      });
+    }
+
+    #createKeySystem(media: HTMLVideoElement, config: NativeHlsDrmConfig) {
+      const disconnect = new AbortController();
+
+      const context: FairPlayContext = {
+        media,
+        config,
+        signal: disconnect.signal,
+        reportError: (error) => this.setError(error),
+      };
+
+      const keySystem = this.#useWebKit
+        ? createFairPlayWebKit(context)
+        : createFairPlayEme(context, { onUnsupported: () => void this.#fallBackToWebKit(media) });
+
+      return { keySystem, disconnect };
+    }
+
+    #reset(): Promise<void> {
+      const active = this.#active;
+      this.#active = null;
+
+      active?.disconnect.abort();
+      return active?.keySystem.close() ?? Promise.resolve();
+    }
+
+    async #fallBackToWebKit(media: HTMLVideoElement): Promise<void> {
+      if (this.#useWebKit) return;
+      this.#useWebKit = true;
+
+      // EME has to release the element's media keys before the legacy API can
+      // claim them, so the switch waits for teardown to finish.
+      await this.#reset();
+      if (!this.#disconnect || this.#disconnect.signal.aborted) return;
+
+      // WebKit does not re-issue the key request the EME session failed on, so
+      // the resource is reloaded to have it delivered to the legacy listener.
+      // Playback restarts; the AirPlay handoff that got us here is already an
+      // interruption.
+      media.load();
+    }
+  }
+
+  return NativeHlsMediaDrm as unknown as Base;
+}

--- a/packages/media/src/dom/native-hls/drm.ts
+++ b/packages/media/src/dom/native-hls/drm.ts
@@ -21,12 +21,15 @@ import { createFairPlayWebKit } from './fairplay-webkit';
  * source, and somewhere to put an error the media element never reports.
  */
 export type NativeHlsDrmHost = NativeMediaHost & {
-  readonly source: { nativeHls?: { drmSystems?: NativeHlsDrmSystemsConfig | undefined } | undefined } | null;
+  readonly source: {
+    engine?: { nativeHls?: { drmSystems?: NativeHlsDrmSystemsConfig | undefined } | undefined } | undefined;
+  } | null;
   setError(error: MediaError): void;
 };
 
 /**
- * Play DRM-protected HLS natively, configured by `source.nativeHls.drmSystems`.
+ * Play DRM-protected HLS natively, configured by
+ * `source.engine.nativeHls.drmSystems`.
  *
  * Native HLS has no JS engine to hand key exchange to, so this mixin does it
  * against the media element directly: it answers the element's key requests by
@@ -102,7 +105,7 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
       if (fromWebKit !== this.#useWebKit) return;
 
       const media = this.target as HTMLVideoElement | null;
-      const drmSystems = this.source?.nativeHls?.drmSystems;
+      const drmSystems = this.source?.engine?.nativeHls?.drmSystems;
       const config = drmSystems?.[FAIRPLAY_KEY_SYSTEM];
       if (!media) return;
 
@@ -112,7 +115,7 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
           // shape, so a config naming only the systems MSE reaches is an easy
           // mistake to make and looks configured from the outside.
           console.warn(
-            `[vjs-drm] Native HLS negotiates FairPlay only, and \`source.nativeHls.drmSystems\` names no \`${FAIRPLAY_KEY_SYSTEM}\` license server.`
+            `[vjs-drm] Native HLS negotiates FairPlay only, and \`source.engine.nativeHls.drmSystems\` names no \`${FAIRPLAY_KEY_SYSTEM}\` license server.`
           );
         }
 

--- a/packages/media/src/dom/native-hls/drm.ts
+++ b/packages/media/src/dom/native-hls/drm.ts
@@ -5,11 +5,13 @@ import { MediaError } from '../../core/media-error';
 import type { NativeMediaHost } from './errors';
 import {
   createDrmError,
+  FAIRPLAY_KEY_SYSTEM,
   type FairPlayContext,
   type FairPlayKeySystem,
-  type NativeHlsDrmConfig,
   NativeHlsDrmErrors,
   NativeHlsDrmMessages,
+  type NativeHlsDrmSystemConfig,
+  type NativeHlsDrmSystemsConfig,
 } from './fairplay';
 import { createFairPlayEme } from './fairplay-eme';
 import { createFairPlayWebKit } from './fairplay-webkit';
@@ -19,12 +21,12 @@ import { createFairPlayWebKit } from './fairplay-webkit';
  * source, and somewhere to put an error the media element never reports.
  */
 export type NativeHlsDrmHost = NativeMediaHost & {
-  readonly source: { nativeHls?: { drm?: NativeHlsDrmConfig | undefined } | undefined } | null;
+  readonly source: { nativeHls?: { drmSystems?: NativeHlsDrmSystemsConfig | undefined } | undefined } | null;
   setError(error: MediaError): void;
 };
 
 /**
- * Play DRM-protected HLS natively, configured by `source.nativeHls.drm`.
+ * Play DRM-protected HLS natively, configured by `source.nativeHls.drmSystems`.
  *
  * Native HLS has no JS engine to hand key exchange to, so this mixin does it
  * against the media element directly: it answers the element's key requests by
@@ -100,10 +102,20 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
       if (fromWebKit !== this.#useWebKit) return;
 
       const media = this.target as HTMLVideoElement | null;
-      const config = this.source?.nativeHls?.drm;
+      const drmSystems = this.source?.nativeHls?.drmSystems;
+      const config = drmSystems?.[FAIRPLAY_KEY_SYSTEM];
       if (!media) return;
 
       if (!config?.licenseUrl) {
+        if (__DEV__ && drmSystems && Object.keys(drmSystems).length > 0) {
+          // Sharing one `drmSystems` object with hls.js is the point of the
+          // shape, so a config naming only the systems MSE reaches is an easy
+          // mistake to make and looks configured from the outside.
+          console.warn(
+            `[vjs-drm] Native HLS negotiates FairPlay only, and \`source.nativeHls.drmSystems\` names no \`${FAIRPLAY_KEY_SYSTEM}\` license server.`
+          );
+        }
+
         this.setError(
           createDrmError(NativeHlsDrmMessages.MISSING_CONFIGURATION, NativeHlsDrmErrors.MISSING_CONFIGURATION)
         );
@@ -124,7 +136,7 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
       });
     }
 
-    #createKeySystem(media: HTMLVideoElement, config: NativeHlsDrmConfig) {
+    #createKeySystem(media: HTMLVideoElement, config: NativeHlsDrmSystemConfig) {
       const disconnect = new AbortController();
 
       const context: FairPlayContext = {

--- a/packages/media/src/dom/native-hls/drm.ts
+++ b/packages/media/src/dom/native-hls/drm.ts
@@ -1,17 +1,15 @@
 import { isWebKitAirPlayCapable } from '@videojs/utils/dom';
 import type { Constructor } from '@videojs/utils/types';
 
+import { type DrmSystemConfig, type DrmSystemsConfig, KeySystems } from '../../core/drm';
 import { MediaError } from '../../core/media-error';
 import type { NativeMediaHost } from './errors';
 import {
   createDrmError,
-  FAIRPLAY_KEY_SYSTEM,
   type FairPlayContext,
   type FairPlayKeySystem,
   NativeHlsDrmErrors,
   NativeHlsDrmMessages,
-  type NativeHlsDrmSystemConfig,
-  type NativeHlsDrmSystemsConfig,
 } from './fairplay';
 import { createFairPlayEme } from './fairplay-eme';
 import { createFairPlayWebKit } from './fairplay-webkit';
@@ -22,14 +20,15 @@ import { createFairPlayWebKit } from './fairplay-webkit';
  */
 export type NativeHlsDrmHost = NativeMediaHost & {
   readonly source: {
-    engine?: { nativeHls?: { drmSystems?: NativeHlsDrmSystemsConfig | undefined } | undefined } | undefined;
+    drm?: DrmSystemsConfig | undefined;
+    engine?: { nativeHls?: { drmSystems?: DrmSystemsConfig | undefined } | undefined } | undefined;
   } | null;
   setError(error: MediaError): void;
 };
 
 /**
- * Play DRM-protected HLS natively, configured by
- * `source.engine.nativeHls.drmSystems`.
+ * Play DRM-protected HLS natively, configured by `source.drm` (or, where the
+ * native path needs licensing of its own, `source.engine.nativeHls.drmSystems`).
  *
  * Native HLS has no JS engine to hand key exchange to, so this mixin does it
  * against the media element directly: it answers the element's key requests by
@@ -102,21 +101,31 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
       }
     }
 
+    /**
+     * The license servers in effect: `source.drm`, or the native engine's own
+     * `drmSystems` where one is named — an escape hatch replaces what it is an
+     * escape from rather than merging with it.
+     */
+    #drmSystems(): DrmSystemsConfig {
+      const { drm, engine } = this.source ?? {};
+      return engine?.nativeHls?.drmSystems ?? drm ?? {};
+    }
+
     #serve(event: MediaEncryptedEvent, fromWebKit: boolean): void {
       if (fromWebKit !== this.#useWebKit) return;
 
       const media = this.target as HTMLVideoElement | null;
-      const drmSystems = this.source?.engine?.nativeHls?.drmSystems;
-      const config = drmSystems?.[FAIRPLAY_KEY_SYSTEM];
+      const drmSystems = this.#drmSystems();
+      const config = drmSystems[KeySystems.FAIRPLAY];
       if (!media) return;
 
       if (!config?.licenseUrl) {
-        if (__DEV__ && drmSystems && Object.keys(drmSystems).length > 0) {
-          // Sharing one `drmSystems` object with hls.js is the point of the
-          // shape, so a config naming only the systems MSE reaches is an easy
+        if (__DEV__ && Object.keys(drmSystems).length > 0) {
+          // One DRM configuration describing every system is the point of the
+          // shape, so a source naming only the systems MSE reaches is an easy
           // mistake to make and looks configured from the outside.
           console.warn(
-            `[vjs-drm] Native HLS negotiates FairPlay only, and \`source.engine.nativeHls.drmSystems\` names no \`${FAIRPLAY_KEY_SYSTEM}\` license server.`
+            `[vjs-drm] Native HLS negotiates FairPlay only, and this source names no \`${KeySystems.FAIRPLAY}\` license server.`
           );
         }
 
@@ -140,7 +149,7 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
       });
     }
 
-    #createKeySystem(media: HTMLVideoElement, config: NativeHlsDrmSystemConfig) {
+    #createKeySystem(media: HTMLVideoElement, config: DrmSystemConfig) {
       const disconnect = new AbortController();
 
       // The key system outlives the object the source was assigned as, so the
@@ -148,7 +157,7 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
       // server updated on a playing source reaches the next request. Dropping it
       // altogether falls back to what key exchange started with, since requests
       // already in flight still have to finish.
-      const readConfig = () => this.source?.engine?.nativeHls?.drmSystems?.[FAIRPLAY_KEY_SYSTEM] ?? config;
+      const readConfig = () => this.#drmSystems()[KeySystems.FAIRPLAY] ?? config;
 
       const context: FairPlayContext = {
         media,

--- a/packages/media/src/dom/native-hls/drm.ts
+++ b/packages/media/src/dom/native-hls/drm.ts
@@ -38,8 +38,9 @@ export type NativeHlsDrmHost = NativeMediaHost & {
  * PlayReady content needs the hls.js (MSE) engine.
  *
  * The configuration is read when a key request arrives rather than up front,
- * so assigning `source` and letting the element load are independent; state is
- * released on `emptied`, when the element starts on a new resource.
+ * so assigning `source` and letting the element load are independent, and a
+ * license server updated on a playing source is picked up without a reload;
+ * state is released on `emptied`, when the element starts on a new resource.
  *
  * Encrypted content with nothing configured fails loudly. Safari otherwise
  * stalls without explanation, which is indistinguishable from a slow network.
@@ -142,9 +143,18 @@ export function NativeHlsMediaDrmMixin<Base extends Constructor<NativeHlsDrmHost
     #createKeySystem(media: HTMLVideoElement, config: NativeHlsDrmSystemConfig) {
       const disconnect = new AbortController();
 
+      // The key system outlives the object the source was assigned as, so the
+      // configuration is resolved on every use rather than captured: a license
+      // server updated on a playing source reaches the next request. Dropping it
+      // altogether falls back to what key exchange started with, since requests
+      // already in flight still have to finish.
+      const readConfig = () => this.source?.engine?.nativeHls?.drmSystems?.[FAIRPLAY_KEY_SYSTEM] ?? config;
+
       const context: FairPlayContext = {
         media,
-        config,
+        get config() {
+          return readConfig();
+        },
         signal: disconnect.signal,
         reportError: (error) => this.setError(error),
       };

--- a/packages/media/src/dom/native-hls/errors.ts
+++ b/packages/media/src/dom/native-hls/errors.ts
@@ -14,6 +14,21 @@ export function NativeHlsMediaErrorsMixin<Base extends Constructor<NativeMediaHo
       return this.#error;
     }
 
+    /**
+     * Announce `error` as coming from this media, latching it as the current
+     * error when it is fatal. Non-fatal errors are announced only — playback
+     * continues, so they must not stand in for whatever fails next.
+     *
+     * For siblings producing errors the media element never reports itself:
+     * DRM key exchange, notably, which fails entirely outside the element.
+     *
+     * @internal
+     */
+    setError(error: MediaError): void {
+      if (error.fatal) this.#error = error;
+      this.dispatchEvent(new ErrorEvent('error', { error, message: error.message }));
+    }
+
     attach(target: HTMLVideoElement): void {
       super.attach(target);
       this.#init(target);
@@ -51,10 +66,7 @@ export function NativeHlsMediaErrorsMixin<Base extends Constructor<NativeMediaHo
 
           const code = native.code;
           const useCanonicalMessage = code >= MediaError.MEDIA_ERR_ABORTED && code <= MediaError.MEDIA_ERR_ENCRYPTED;
-          const error = new MediaError(useCanonicalMessage ? undefined : native.message, code, true);
-          this.#error = error;
-
-          this.dispatchEvent(new ErrorEvent('error', { error, message: error.message }));
+          this.setError(new MediaError(useCanonicalMessage ? undefined : native.message, code, true));
         },
         { signal, capture: true }
       );
@@ -69,5 +81,6 @@ export function NativeHlsMediaErrorsMixin<Base extends Constructor<NativeMediaHo
     }
   }
 
-  return NativeHlsMediaErrors as unknown as Base & Constructor<{ readonly error: MediaError | null }>;
+  return NativeHlsMediaErrors as unknown as Base &
+    Constructor<{ readonly error: MediaError | null; setError(error: MediaError): void }>;
 }

--- a/packages/media/src/dom/native-hls/fairplay-eme.ts
+++ b/packages/media/src/dom/native-hls/fairplay-eme.ts
@@ -1,0 +1,181 @@
+import type { WebKitVideoElement } from '@videojs/utils/dom';
+import {
+  createDrmError,
+  FAIRPLAY_CONTENT_TYPE,
+  FAIRPLAY_INIT_DATA_TYPE,
+  FAIRPLAY_KEY_SYSTEM,
+  type FairPlayContext,
+  type FairPlayKeySystem,
+  NativeHlsDrmErrors,
+  NativeHlsDrmMessages,
+  requestAppCertificate,
+  requestLicenseKey,
+  toDrmError,
+} from './fairplay';
+
+/**
+ * FairPlay negotiates against the manifest rather than a codec, holds no
+ * persistent state, and needs no device identifier — the narrowest
+ * configuration Safari will grant.
+ */
+const FAIRPLAY_CONFIGURATION: MediaKeySystemConfiguration = {
+  initDataTypes: [FAIRPLAY_INIT_DATA_TYPE],
+  videoCapabilities: [{ contentType: FAIRPLAY_CONTENT_TYPE, robustness: '' }],
+  distinctiveIdentifier: 'not-allowed',
+  persistentState: 'not-allowed',
+  sessionTypes: ['temporary'],
+};
+
+export interface FairPlayEmeOptions {
+  /**
+   * Called when the CDM refuses to create a session in the one situation the
+   * legacy WebKit API still serves: an AirPlay receiver on an affected OS.
+   */
+  onUnsupported?: (() => void) | undefined;
+}
+
+/**
+ * Standard EME FairPlay, driven by the media element's `encrypted` event.
+ *
+ * Key exchange is the documented three-step dance: negotiate access to the key
+ * system and give the CDM its application certificate, open a session and let
+ * it generate an SPC, then trade that SPC for a CKC at the license server. Key
+ * system access and the certificate are shared by every session on the source,
+ * so they are resolved once and reused.
+ */
+export function createFairPlayEme(context: FairPlayContext, options: FairPlayEmeOptions = {}): FairPlayKeySystem {
+  const { media, signal, reportError } = context;
+  const sessions = new Set<MediaKeySession>();
+
+  let keys: Promise<MediaKeys> | null = null;
+  let certificate: Promise<ArrayBuffer | null> | null = null;
+
+  async function createKeys(): Promise<MediaKeys> {
+    let access: MediaKeySystemAccess;
+    try {
+      access = await navigator.requestMediaKeySystemAccess(FAIRPLAY_KEY_SYSTEM, [FAIRPLAY_CONFIGURATION]);
+    } catch (cause) {
+      throw toDrmError(cause, NativeHlsDrmMessages.UNSUPPORTED_KEY_SYSTEM, NativeHlsDrmErrors.UNSUPPORTED_KEY_SYSTEM);
+    }
+
+    const mediaKeys = await access.createMediaKeys();
+    const appCertificate = await (certificate ??= requestAppCertificate(context));
+
+    // A pre-provisioned CDM can go without one, so an absent certificate is
+    // only a configuration choice — a rejected one is a real failure.
+    if (appCertificate) {
+      const accepted = await mediaKeys.setServerCertificate(appCertificate).catch(() => false);
+      if (!accepted) {
+        throw createDrmError(
+          NativeHlsDrmMessages.SERVER_CERTIFICATE_FAILED,
+          NativeHlsDrmErrors.SERVER_CERTIFICATE_FAILED
+        );
+      }
+    }
+
+    await media.setMediaKeys(mediaKeys);
+    return mediaKeys;
+  }
+
+  async function onMessage(session: MediaKeySession, event: MediaKeyMessageEvent): Promise<void> {
+    try {
+      const ckc = await requestLicenseKey(context, event.message);
+      if (signal.aborted) return;
+
+      await session.update(ckc).catch((cause) => {
+        throw toDrmError(cause, NativeHlsDrmMessages.UPDATE_LICENSE_FAILED, NativeHlsDrmErrors.UPDATE_LICENSE_FAILED);
+      });
+    } catch (cause) {
+      if (signal.aborted) return;
+      // Both steps raise errors that describe themselves; this only covers what
+      // neither anticipated.
+      reportError(toDrmError(cause, NativeHlsDrmMessages.CDM_ERROR, NativeHlsDrmErrors.CDM_ERROR));
+    }
+  }
+
+  function onKeyStatusesChange(session: MediaKeySession): void {
+    session.keyStatuses.forEach((status) => {
+      if (status === 'internal-error') {
+        reportError(createDrmError(NativeHlsDrmMessages.CDM_ERROR, NativeHlsDrmErrors.CDM_ERROR));
+      } else if (status === 'output-restricted' || status === 'output-downscaled') {
+        // Playback continues — often as a black frame — so this is announced
+        // without failing the source.
+        reportError(
+          createDrmError(NativeHlsDrmMessages.OUTPUT_RESTRICTED, NativeHlsDrmErrors.OUTPUT_RESTRICTED, false)
+        );
+      }
+    });
+  }
+
+  async function createSession(mediaKeys: MediaKeys, initDataType: string, initData: ArrayBuffer): Promise<void> {
+    const session = mediaKeys.createSession();
+    sessions.add(session);
+
+    session.addEventListener('message', (event) => void onMessage(session, event as MediaKeyMessageEvent), { signal });
+    session.addEventListener('keystatuseschange', () => onKeyStatusesChange(session), { signal });
+
+    try {
+      await session.generateRequest(initDataType, initData);
+    } catch (cause) {
+      sessions.delete(session);
+      await session.close().catch(() => {});
+
+      // Some OS versions cannot generate a request while the playback target is
+      // an AirPlay receiver. Legacy WebKit FairPlay still can, so hand over
+      // rather than failing the source.
+      if (isAirPlayUnsupported(media, cause)) {
+        options.onUnsupported?.();
+        return;
+      }
+
+      throw toDrmError(cause, NativeHlsDrmMessages.GENERATE_REQUEST_FAILED, NativeHlsDrmErrors.GENERATE_REQUEST_FAILED);
+    }
+  }
+
+  return {
+    async request(event: MediaEncryptedEvent): Promise<void> {
+      if (event.initDataType !== FAIRPLAY_INIT_DATA_TYPE) {
+        if (__DEV__) {
+          console.warn(`[vjs-drm] Ignoring unexpected initialization data type "${event.initDataType}".`);
+        }
+        return;
+      }
+
+      if (!event.initData) {
+        if (__DEV__) console.warn('[vjs-drm] Ignoring an `encrypted` event carrying no initialization data.');
+        return;
+      }
+
+      const mediaKeys = await (keys ??= createKeys());
+      if (signal.aborted) return;
+
+      await createSession(mediaKeys, event.initDataType, event.initData);
+    },
+
+    async close(): Promise<void> {
+      const closing = [...sessions].map((session) => session.close().catch(() => {}));
+      sessions.clear();
+
+      const pending = keys;
+      keys = null;
+      certificate = null;
+
+      await Promise.all(closing);
+
+      // Only release keys still ours: a source that replaced this one may
+      // already have set its own while these sessions were closing.
+      const mediaKeys = await pending?.catch(() => null);
+      if (mediaKeys && media.mediaKeys === mediaKeys) {
+        await media.setMediaKeys(null).catch(() => {});
+      }
+    },
+  };
+}
+
+function isAirPlayUnsupported(media: HTMLMediaElement, cause: unknown): boolean {
+  return (
+    cause instanceof DOMException &&
+    cause.name === 'NotSupportedError' &&
+    !!(media as WebKitVideoElement).webkitCurrentPlaybackTargetIsWireless
+  );
+}

--- a/packages/media/src/dom/native-hls/fairplay-eme.ts
+++ b/packages/media/src/dom/native-hls/fairplay-eme.ts
@@ -73,6 +73,12 @@ export function createFairPlayEme(context: FairPlayContext, options: FairPlayEme
       }
     }
 
+    // The element outlives this key system, so keys the teardown has already
+    // abandoned must not reach it. `close()` releases only keys it still owns,
+    // and cannot un-install what lands after that check — which would leave the
+    // source that replaced this one holding a CDM configured for the last one.
+    if (signal.aborted) return mediaKeys;
+
     await media.setMediaKeys(mediaKeys);
     return mediaKeys;
   }

--- a/packages/media/src/dom/native-hls/fairplay-eme.ts
+++ b/packages/media/src/dom/native-hls/fairplay-eme.ts
@@ -1,9 +1,9 @@
 import type { WebKitVideoElement } from '@videojs/utils/dom';
+import { KeySystems } from '../../core/drm';
 import {
   createDrmError,
   FAIRPLAY_CONTENT_TYPE,
   FAIRPLAY_INIT_DATA_TYPE,
-  FAIRPLAY_KEY_SYSTEM,
   type FairPlayContext,
   type FairPlayKeySystem,
   NativeHlsDrmErrors,
@@ -53,7 +53,7 @@ export function createFairPlayEme(context: FairPlayContext, options: FairPlayEme
   async function createKeys(): Promise<MediaKeys> {
     let access: MediaKeySystemAccess;
     try {
-      access = await navigator.requestMediaKeySystemAccess(FAIRPLAY_KEY_SYSTEM, [FAIRPLAY_CONFIGURATION]);
+      access = await navigator.requestMediaKeySystemAccess(KeySystems.FAIRPLAY, [FAIRPLAY_CONFIGURATION]);
     } catch (cause) {
       throw toDrmError(cause, NativeHlsDrmMessages.UNSUPPORTED_KEY_SYSTEM, NativeHlsDrmErrors.UNSUPPORTED_KEY_SYSTEM);
     }

--- a/packages/media/src/dom/native-hls/fairplay-webkit.ts
+++ b/packages/media/src/dom/native-hls/fairplay-webkit.ts
@@ -1,0 +1,208 @@
+import {
+  createDrmError,
+  FAIRPLAY_CONTENT_TYPE,
+  FAIRPLAY_LEGACY_KEY_SYSTEM,
+  type FairPlayContext,
+  type FairPlayKeySystem,
+  NativeHlsDrmErrors,
+  NativeHlsDrmMessages,
+  requestAppCertificate,
+  requestLicenseKey,
+  toDrmError,
+} from './fairplay';
+
+/**
+ * The pre-EME WebKit key API. Still shipped by Safari, undeclared in
+ * `lib.dom`, and only reachable through `window.WebKitMediaKeys`.
+ */
+interface WebKitMediaKeySession extends EventTarget {
+  readonly error: { code: number; systemCode: number } | null;
+  update(response: BufferSource): void;
+  close(): void;
+}
+
+interface WebKitMediaKeys {
+  createSession(mimeType: string, initData: BufferSource): WebKitMediaKeySession;
+}
+
+interface WebKitMediaKeysConstructor {
+  new (keySystem: string): WebKitMediaKeys;
+  isTypeSupported(keySystem: string, mimeType?: string): boolean;
+}
+
+interface WebKitEncryptedMediaElement extends HTMLMediaElement {
+  readonly webkitKeys: WebKitMediaKeys | null;
+  webkitSetMediaKeys(keys: WebKitMediaKeys | null): void;
+}
+
+interface WebKitKeyMessageEvent extends Event {
+  readonly message: ArrayBuffer;
+}
+
+/** Whether this realm still exposes the legacy WebKit key API for `media`. */
+export function supportsWebKitFairPlay(media: HTMLMediaElement): boolean {
+  return 'WebKitMediaKeys' in globalThis && 'webkitSetMediaKeys' in media;
+}
+
+/**
+ * Legacy WebKit FairPlay, driven by `webkitneedkey`.
+ *
+ * This exists for one reason: on some OS versions EME cannot generate a
+ * license request while the playback target is an AirPlay receiver, and the
+ * pre-EME API can. It mirrors the EME flow with the older calls, and differs
+ * in two ways — the application certificate is mandatory (it is packed into
+ * the session's initialization data rather than handed to the CDM), and
+ * `webkitSetMediaKeys` / `update` are synchronous.
+ *
+ * Remove this once the underlying WebKit issue is fixed.
+ *
+ * @see https://developer.apple.com/streaming/fps/
+ */
+export function createFairPlayWebKit(context: FairPlayContext): FairPlayKeySystem {
+  const { media, signal, reportError } = context;
+  const element = media as WebKitEncryptedMediaElement;
+  const sessions = new Set<WebKitMediaKeySession>();
+
+  let certificate: Promise<ArrayBuffer | null> | null = null;
+
+  function setupKeys(): void {
+    if (element.webkitKeys) return;
+
+    const MediaKeysConstructor = (globalThis as { WebKitMediaKeys?: WebKitMediaKeysConstructor }).WebKitMediaKeys;
+    if (!MediaKeysConstructor || !supportsWebKitFairPlay(media)) {
+      throw createDrmError(NativeHlsDrmMessages.UNSUPPORTED_KEY_SYSTEM, NativeHlsDrmErrors.UNSUPPORTED_KEY_SYSTEM);
+    }
+
+    try {
+      element.webkitSetMediaKeys(new MediaKeysConstructor(FAIRPLAY_LEGACY_KEY_SYSTEM));
+    } catch (cause) {
+      throw toDrmError(cause, NativeHlsDrmMessages.UNSUPPORTED_KEY_SYSTEM, NativeHlsDrmErrors.UNSUPPORTED_KEY_SYSTEM);
+    }
+  }
+
+  async function onMessage(session: WebKitMediaKeySession, event: WebKitKeyMessageEvent): Promise<void> {
+    try {
+      const ckc = await requestLicenseKey(context, event.message);
+      if (signal.aborted) return;
+      session.update(ckc);
+    } catch (cause) {
+      if (signal.aborted) return;
+      reportError(
+        toDrmError(cause, NativeHlsDrmMessages.UPDATE_LICENSE_FAILED, NativeHlsDrmErrors.UPDATE_LICENSE_FAILED)
+      );
+    }
+  }
+
+  function onKeyError(session: WebKitMediaKeySession): void {
+    const error = createDrmError(NativeHlsDrmMessages.CDM_ERROR, NativeHlsDrmErrors.CDM_ERROR);
+    error.data = session.error;
+    reportError(error);
+  }
+
+  return {
+    async request(event: MediaEncryptedEvent): Promise<void> {
+      if (!event.initData) {
+        if (__DEV__) console.warn('[vjs-drm] Ignoring a `webkitneedkey` event carrying no initialization data.');
+        return;
+      }
+
+      setupKeys();
+
+      const appCertificate = await (certificate ??= requestAppCertificate(context));
+      if (signal.aborted) return;
+
+      // Unlike EME, the certificate is packed into the session's data rather
+      // than handed to the CDM, so there is no going without one.
+      if (!appCertificate) {
+        throw createDrmError(NativeHlsDrmMessages.MISSING_CERTIFICATE_URL, NativeHlsDrmErrors.MISSING_CONFIGURATION);
+      }
+
+      // `webkitKeys` is set by `setupKeys()` above, or it threw.
+      const session = element.webkitKeys!.createSession(
+        FAIRPLAY_CONTENT_TYPE,
+        packInitData(event.initData, appCertificate)
+      );
+      sessions.add(session);
+
+      session.addEventListener(
+        'webkitkeymessage',
+        (message) => void onMessage(session, message as WebKitKeyMessageEvent),
+        {
+          signal,
+        }
+      );
+      session.addEventListener('webkitkeyerror', () => onKeyError(session), { signal });
+    },
+
+    async close(): Promise<void> {
+      for (const session of sessions) {
+        // Throws when the session is already in a closed state.
+        try {
+          session.close();
+        } catch {}
+      }
+      sessions.clear();
+      certificate = null;
+
+      try {
+        element.webkitSetMediaKeys(null);
+      } catch {}
+    },
+  };
+}
+
+/**
+ * Repack `webkitneedkey` initialization data into what
+ * `WebKitMediaKeys.createSession()` expects.
+ *
+ * In:  the raw event data — a `skd://` URI as UTF-16LE, in newer WebKit builds
+ *      behind a 4-byte little-endian byte count.
+ * Out: that data verbatim, then the content ID and the application
+ *      certificate, each behind their own 4-byte little-endian byte count.
+ */
+function packInitData(initData: ArrayBuffer, certificate: ArrayBuffer): Uint8Array<ArrayBuffer> {
+  const source = new Uint8Array(initData);
+  const contentId = toUtf16LE(getContentId(initData));
+  const appCertificate = new Uint8Array(certificate);
+
+  const packed = new Uint8Array(source.byteLength + 4 + contentId.byteLength + 4 + appCertificate.byteLength);
+  const view = new DataView(packed.buffer);
+  let offset = 0;
+
+  const append = (bytes: Uint8Array) => {
+    packed.set(bytes, offset);
+    offset += bytes.byteLength;
+  };
+
+  const appendWithLength = (bytes: Uint8Array) => {
+    view.setUint32(offset, bytes.byteLength, true);
+    offset += 4;
+    append(bytes);
+  };
+
+  append(source);
+  appendWithLength(contentId);
+  appendWithLength(appCertificate);
+
+  return packed;
+}
+
+/**
+ * The content ID FairPlay keys the session on: everything after the scheme in
+ * the `skd://` URI. Locating the scheme rather than skipping a fixed prefix
+ * covers both the bare URI older WebKit sends and the length-prefixed form.
+ */
+function getContentId(initData: ArrayBuffer): string {
+  const decoded = new TextDecoder('utf-16le').decode(initData);
+  const start = decoded.indexOf('skd://');
+  return start === -1 ? decoded : decoded.slice(start + 'skd://'.length);
+}
+
+function toUtf16LE(value: string): Uint8Array<ArrayBuffer> {
+  const bytes = new Uint8Array(value.length * 2);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < value.length; i++) {
+    view.setUint16(i * 2, value.charCodeAt(i), true);
+  }
+  return bytes;
+}

--- a/packages/media/src/dom/native-hls/fairplay.ts
+++ b/packages/media/src/dom/native-hls/fairplay.ts
@@ -1,0 +1,163 @@
+import { MediaError } from '../../core/media-error';
+
+/** EME key system identifier for FairPlay Streaming. */
+export const FAIRPLAY_KEY_SYSTEM = 'com.apple.fps';
+
+/** Key system identifier the legacy `WebKitMediaKeys` API answers to. */
+export const FAIRPLAY_LEGACY_KEY_SYSTEM = 'com.apple.fps.1_0';
+
+/** Initialization data type Safari reports for an `EXT-X-KEY` `skd://` URI. */
+export const FAIRPLAY_INIT_DATA_TYPE = 'skd';
+
+/** What FairPlay negotiates capabilities against — the manifest, not a codec. */
+export const FAIRPLAY_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
+
+/**
+ * FairPlay Streaming configuration for native HLS playback.
+ *
+ * Native HLS leaves key exchange to Safari's own CDM, which negotiates
+ * FairPlay and nothing else — Widevine and PlayReady need the hls.js (MSE)
+ * engine. The fields mirror the `com.apple.fps` entry of hls.js's `drmSystems`
+ * so one source description covers both engines.
+ */
+export interface NativeHlsDrmConfig {
+  /** License server the SPC is POSTed to; answers with the CKC. */
+  licenseUrl: string;
+  /**
+   * URL of the FairPlay application certificate (DER). Every FairPlay
+   * deployment issues one; the legacy WebKit path cannot run without it.
+   */
+  serverCertificateUrl?: string | undefined;
+}
+
+/**
+ * `context` values carried by the `MediaError`s key exchange produces. The
+ * message is prose meant for a person; this is the part to branch on.
+ */
+export const NativeHlsDrmErrors = {
+  /** The content is encrypted but `source.nativeHls.drm` is missing something required. */
+  MISSING_CONFIGURATION: 'drmMissingConfiguration',
+  /** No FairPlay CDM here, or it refused the requested configuration. */
+  UNSUPPORTED_KEY_SYSTEM: 'drmUnsupportedKeySystem',
+  /** The application certificate could not be fetched. */
+  CERTIFICATE_REQUEST_FAILED: 'drmCertificateRequestFailed',
+  /** The CDM rejected the application certificate. */
+  SERVER_CERTIFICATE_FAILED: 'drmServerCertificateFailed',
+  /** The CDM could not produce a license request (SPC). */
+  GENERATE_REQUEST_FAILED: 'drmGenerateRequestFailed',
+  /** The license server could not be reached, or answered with an error. */
+  LICENSE_REQUEST_FAILED: 'drmLicenseRequestFailed',
+  /** The CDM rejected the license (CKC). */
+  UPDATE_LICENSE_FAILED: 'drmUpdateLicenseFailed',
+  /** The CDM failed internally and cannot decrypt. */
+  CDM_ERROR: 'drmCdmError',
+  /** Non-fatal: this output is not secure enough for full-quality rendering. */
+  OUTPUT_RESTRICTED: 'drmOutputRestricted',
+} as const;
+
+export type NativeHlsDrmErrorContext = (typeof NativeHlsDrmErrors)[keyof typeof NativeHlsDrmErrors];
+
+export const NativeHlsDrmMessages = {
+  MISSING_CONFIGURATION: 'This media is DRM-protected, but no DRM license server was configured for it.',
+  MISSING_CERTIFICATE_URL: 'This media is DRM-protected, but no DRM application certificate was configured for it.',
+  UNSUPPORTED_KEY_SYSTEM:
+    'This browser cannot play DRM-protected content with its current security configuration. Try another browser.',
+  CERTIFICATE_REQUEST_FAILED: 'The DRM application certificate could not be loaded.',
+  SERVER_CERTIFICATE_FAILED: 'The DRM application certificate was rejected. It may no longer be valid.',
+  GENERATE_REQUEST_FAILED: 'A DRM license could not be requested for this media.',
+  LICENSE_REQUEST_FAILED: 'The DRM license could not be loaded.',
+  UPDATE_LICENSE_FAILED: 'The DRM license was rejected for this media.',
+  CDM_ERROR:
+    'The DRM Content Decryption Module failed. Try reloading the page, updating your browser, or another browser.',
+  OUTPUT_RESTRICTED: 'This output is not secure enough for DRM playback. The video may render as a black screen.',
+} as const;
+
+/**
+ * One FairPlay implementation, driven by the DRM mixin: it hands over each key
+ * request the media element makes and closes everything down between sources.
+ */
+export interface FairPlayKeySystem {
+  /** Serve a single key request (`encrypted` or `webkitneedkey`). */
+  request(event: MediaEncryptedEvent): Promise<void>;
+  /** Close every open session and release the element's media keys. */
+  close(): Promise<void>;
+}
+
+/** Everything a FairPlay implementation is given to work with. */
+export interface FairPlayContext {
+  /** The element the CDM is bound to. */
+  media: HTMLMediaElement;
+  config: NativeHlsDrmConfig;
+  /** Aborted when the source is replaced or the media detaches. */
+  signal: AbortSignal;
+  /** Surface an error on the media host. Non-fatal ones are announced only. */
+  reportError(error: MediaError): void;
+}
+
+/** Build an encrypted-media `MediaError` tagged with a {@link NativeHlsDrmErrors} context. */
+export function createDrmError(message: string, context: NativeHlsDrmErrorContext, fatal = true): MediaError {
+  return new MediaError(message, MediaError.MEDIA_ERR_ENCRYPTED, fatal, context);
+}
+
+/**
+ * Coerce anything thrown during key exchange into a reportable error. An error
+ * raised further down already describes what failed, so it passes through
+ * rather than being flattened into the caller's more general message.
+ */
+export function toDrmError(cause: unknown, message: string, context: NativeHlsDrmErrorContext): MediaError {
+  if (cause instanceof MediaError) return cause;
+  const error = createDrmError(message, context);
+  error.data = cause;
+  return error;
+}
+
+/**
+ * Fetch the FairPlay application certificate. Resolves `null` when the source
+ * names no certificate URL — EME can still negotiate with a pre-provisioned
+ * CDM, so whether that is fatal is the caller's call.
+ */
+export async function requestAppCertificate({ config, signal }: FairPlayContext): Promise<ArrayBuffer | null> {
+  const { serverCertificateUrl } = config;
+  if (!serverCertificateUrl) return null;
+
+  const response = await fetch(serverCertificateUrl, { signal }).catch((cause) => {
+    throw toDrmError(
+      cause,
+      NativeHlsDrmMessages.CERTIFICATE_REQUEST_FAILED,
+      NativeHlsDrmErrors.CERTIFICATE_REQUEST_FAILED
+    );
+  });
+
+  if (!response.ok) {
+    throw createDrmError(
+      NativeHlsDrmMessages.CERTIFICATE_REQUEST_FAILED,
+      NativeHlsDrmErrors.CERTIFICATE_REQUEST_FAILED
+    );
+  }
+
+  return response.arrayBuffer();
+}
+
+/**
+ * Exchange a server playback context (SPC) for a content key context (CKC).
+ * FairPlay license servers take the raw SPC bytes as the request body.
+ */
+export async function requestLicenseKey(
+  { config, signal }: FairPlayContext,
+  spc: BufferSource
+): Promise<Uint8Array<ArrayBuffer>> {
+  const response = await fetch(config.licenseUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: spc,
+    signal,
+  }).catch((cause) => {
+    throw toDrmError(cause, NativeHlsDrmMessages.LICENSE_REQUEST_FAILED, NativeHlsDrmErrors.LICENSE_REQUEST_FAILED);
+  });
+
+  if (!response.ok) {
+    throw createDrmError(NativeHlsDrmMessages.LICENSE_REQUEST_FAILED, NativeHlsDrmErrors.LICENSE_REQUEST_FAILED);
+  }
+
+  return new Uint8Array(await response.arrayBuffer());
+}

--- a/packages/media/src/dom/native-hls/fairplay.ts
+++ b/packages/media/src/dom/native-hls/fairplay.ts
@@ -13,14 +13,10 @@ export const FAIRPLAY_INIT_DATA_TYPE = 'skd';
 export const FAIRPLAY_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 
 /**
- * FairPlay Streaming configuration for native HLS playback.
- *
- * Native HLS leaves key exchange to Safari's own CDM, which negotiates
- * FairPlay and nothing else — Widevine and PlayReady need the hls.js (MSE)
- * engine. The fields mirror the `com.apple.fps` entry of hls.js's `drmSystems`
- * so one source description covers both engines.
+ * License servers for one key system. The fields mirror hls.js's
+ * `DRMSystemConfiguration`, minus the parts only an MSE engine can act on.
  */
-export interface NativeHlsDrmConfig {
+export interface NativeHlsDrmSystemConfig {
   /** License server the SPC is POSTed to; answers with the CKC. */
   licenseUrl: string;
   /**
@@ -31,11 +27,23 @@ export interface NativeHlsDrmConfig {
 }
 
 /**
+ * DRM configuration for native HLS playback, keyed by key system id — the same
+ * shape as the hls.js `drmSystems` configuration, so one object can describe
+ * both engines.
+ *
+ * Only `com.apple.fps` is typed: key exchange is left to Safari's own CDM,
+ * which negotiates FairPlay and nothing else. An hls.js `drmSystems` naming
+ * Widevine or PlayReady can still be shared with this; the systems only MSE
+ * reaches are ignored.
+ */
+export type NativeHlsDrmSystemsConfig = Partial<Record<typeof FAIRPLAY_KEY_SYSTEM, NativeHlsDrmSystemConfig>>;
+
+/**
  * `context` values carried by the `MediaError`s key exchange produces. The
  * message is prose meant for a person; this is the part to branch on.
  */
 export const NativeHlsDrmErrors = {
-  /** The content is encrypted but `source.nativeHls.drm` is missing something required. */
+  /** The content is encrypted but `source.nativeHls.drmSystems` is missing something required. */
   MISSING_CONFIGURATION: 'drmMissingConfiguration',
   /** No FairPlay CDM here, or it refused the requested configuration. */
   UNSUPPORTED_KEY_SYSTEM: 'drmUnsupportedKeySystem',
@@ -87,7 +95,7 @@ export interface FairPlayKeySystem {
 export interface FairPlayContext {
   /** The element the CDM is bound to. */
   media: HTMLMediaElement;
-  config: NativeHlsDrmConfig;
+  config: NativeHlsDrmSystemConfig;
   /** Aborted when the source is replaced or the media detaches. */
   signal: AbortSignal;
   /** Surface an error on the media host. Non-fatal ones are announced only. */

--- a/packages/media/src/dom/native-hls/fairplay.ts
+++ b/packages/media/src/dom/native-hls/fairplay.ts
@@ -95,7 +95,12 @@ export interface FairPlayKeySystem {
 export interface FairPlayContext {
   /** The element the CDM is bound to. */
   media: HTMLMediaElement;
-  config: NativeHlsDrmSystemConfig;
+  /**
+   * The FairPlay half of `source.engine.nativeHls.drmSystems`, read on every
+   * use rather than captured — a license server updated on a playing source
+   * (a rotated token, say) has to reach the next request.
+   */
+  readonly config: NativeHlsDrmSystemConfig;
   /** Aborted when the source is replaced or the media detaches. */
   signal: AbortSignal;
   /** Surface an error on the media host. Non-fatal ones are announced only. */

--- a/packages/media/src/dom/native-hls/fairplay.ts
+++ b/packages/media/src/dom/native-hls/fairplay.ts
@@ -1,7 +1,5 @@
+import type { DrmSystemConfig } from '../../core/drm';
 import { MediaError } from '../../core/media-error';
-
-/** EME key system identifier for FairPlay Streaming. */
-export const FAIRPLAY_KEY_SYSTEM = 'com.apple.fps';
 
 /** Key system identifier the legacy `WebKitMediaKeys` API answers to. */
 export const FAIRPLAY_LEGACY_KEY_SYSTEM = 'com.apple.fps.1_0';
@@ -11,32 +9,6 @@ export const FAIRPLAY_INIT_DATA_TYPE = 'skd';
 
 /** What FairPlay negotiates capabilities against — the manifest, not a codec. */
 export const FAIRPLAY_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
-
-/**
- * License servers for one key system. The fields mirror hls.js's
- * `DRMSystemConfiguration`, minus the parts only an MSE engine can act on.
- */
-export interface NativeHlsDrmSystemConfig {
-  /** License server the SPC is POSTed to; answers with the CKC. */
-  licenseUrl: string;
-  /**
-   * URL of the FairPlay application certificate (DER). Every FairPlay
-   * deployment issues one; the legacy WebKit path cannot run without it.
-   */
-  serverCertificateUrl?: string | undefined;
-}
-
-/**
- * DRM configuration for native HLS playback, keyed by key system id — the same
- * shape as the hls.js `drmSystems` configuration, so one object can describe
- * both engines.
- *
- * Only `com.apple.fps` is typed: key exchange is left to Safari's own CDM,
- * which negotiates FairPlay and nothing else. An hls.js `drmSystems` naming
- * Widevine or PlayReady can still be shared with this; the systems only MSE
- * reaches are ignored.
- */
-export type NativeHlsDrmSystemsConfig = Partial<Record<typeof FAIRPLAY_KEY_SYSTEM, NativeHlsDrmSystemConfig>>;
 
 /**
  * `context` values carried by the `MediaError`s key exchange produces. The
@@ -96,11 +68,11 @@ export interface FairPlayContext {
   /** The element the CDM is bound to. */
   media: HTMLMediaElement;
   /**
-   * The FairPlay half of `source.engine.nativeHls.drmSystems`, read on every
-   * use rather than captured — a license server updated on a playing source
-   * (a rotated token, say) has to reach the next request.
+   * The FairPlay entry of the source's DRM configuration, read on every use
+   * rather than captured — a license server updated on a playing source (a
+   * rotated token, say) has to reach the next request.
    */
-  readonly config: NativeHlsDrmSystemConfig;
+  readonly config: DrmSystemConfig;
   /** Aborted when the source is replaced or the media detaches. */
   signal: AbortSignal;
   /** Surface an error on the media host. Non-fatal ones are announced only. */

--- a/packages/media/src/dom/native-hls/fairplay.ts
+++ b/packages/media/src/dom/native-hls/fairplay.ts
@@ -43,7 +43,7 @@ export type NativeHlsDrmSystemsConfig = Partial<Record<typeof FAIRPLAY_KEY_SYSTE
  * message is prose meant for a person; this is the part to branch on.
  */
 export const NativeHlsDrmErrors = {
-  /** The content is encrypted but `source.nativeHls.drmSystems` is missing something required. */
+  /** The content is encrypted but `source.engine.nativeHls.drmSystems` is missing something required. */
   MISSING_CONFIGURATION: 'drmMissingConfiguration',
   /** No FairPlay CDM here, or it refused the requested configuration. */
   UNSUPPORTED_KEY_SYSTEM: 'drmUnsupportedKeySystem',

--- a/packages/media/src/dom/native-hls/index.ts
+++ b/packages/media/src/dom/native-hls/index.ts
@@ -1,1 +1,2 @@
+export { type NativeHlsDrmConfig, type NativeHlsDrmErrorContext, NativeHlsDrmErrors } from './fairplay';
 export * from './media';

--- a/packages/media/src/dom/native-hls/index.ts
+++ b/packages/media/src/dom/native-hls/index.ts
@@ -1,8 +1,4 @@
-export {
-  FAIRPLAY_KEY_SYSTEM,
-  type NativeHlsDrmErrorContext,
-  NativeHlsDrmErrors,
-  type NativeHlsDrmSystemConfig,
-  type NativeHlsDrmSystemsConfig,
-} from './fairplay';
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
+export { KeySystems } from '../../core/drm';
+export { type NativeHlsDrmErrorContext, NativeHlsDrmErrors } from './fairplay';
 export * from './media';

--- a/packages/media/src/dom/native-hls/index.ts
+++ b/packages/media/src/dom/native-hls/index.ts
@@ -1,2 +1,8 @@
-export { type NativeHlsDrmConfig, type NativeHlsDrmErrorContext, NativeHlsDrmErrors } from './fairplay';
+export {
+  FAIRPLAY_KEY_SYSTEM,
+  type NativeHlsDrmErrorContext,
+  NativeHlsDrmErrors,
+  type NativeHlsDrmSystemConfig,
+  type NativeHlsDrmSystemsConfig,
+} from './fairplay';
 export * from './media';

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -21,13 +21,20 @@ export interface NativeHlsMediaProps {
 /**
  * Structured native HLS source: which source to play, plus how to play it.
  *
- * Playback options sit under `nativeHls` rather than at the top level. Native
- * HLS is one of two paths `HlsJsVideo` can take, and namespacing by engine lets
- * a single source describe both without either reading the other's options.
+ * Playback options sit under `engine`, keyed by engine, rather than at the top
+ * level. Native HLS is one of two paths `HlsJsVideo` can take, and namespacing
+ * by engine lets a single source describe both without either reading the
+ * other's options.
  */
 export interface NativeHlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
   src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: NativeHlsEngineConfig | undefined;
+}
+
+/** The engines a native HLS source can configure. */
+export interface NativeHlsEngineConfig {
   /** Options for the browser's own HLS playback. */
   nativeHls?: NativeHlsConfig | undefined;
 }
@@ -67,7 +74,7 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
 
   /**
    * Media source URL. Assigning it replaces the identity half of `source` and
-   * leaves `nativeHls` intact, so changing the URL never disturbs key exchange.
+   * leaves `engine` intact, so changing the URL never disturbs key exchange.
    */
   get src() {
     return this.#src;
@@ -76,9 +83,9 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
   set src(src: string) {
     // `src` says which source to play; everything else says how to play it, so
     // it carries over.
-    const { nativeHls } = this.#source ?? {};
+    const { engine } = this.#source ?? {};
     const next: NativeHlsSource = {
-      ...(nativeHls && { nativeHls }),
+      ...(engine && { engine }),
       ...(src && { src }),
     };
 
@@ -88,8 +95,8 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
   }
 
   /**
-   * Structured source: what to play (`src`) plus how to play it (`nativeHls`).
-   * Assigning it derives `src`.
+   * Structured source: what to play (`src`) plus how to play it
+   * (`engine.nativeHls`). Assigning it derives `src`.
    *
    * Unlike `HlsJsMedia`, this does not announce a `sourcechange`. It is also
    * the delegate `HlsJsMedia` plays native sources through, and every event it

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -1,6 +1,8 @@
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
+import { NativeHlsMediaDrmMixin } from './drm';
 import { NativeHlsMediaErrorsMixin } from './errors';
+import type { NativeHlsDrmConfig } from './fairplay';
 import { NativeHlsMediaLiveMixin } from './live';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
@@ -11,18 +13,47 @@ export const StreamTypes = MediaStreamTypes;
 
 export interface NativeHlsMediaProps {
   src: string;
+  source: NativeHlsSource | null;
   preload: PreloadType;
   streamType: StreamType;
 }
 
+/**
+ * Structured native HLS source: which source to play, plus how to play it.
+ *
+ * Playback options sit under `nativeHls` rather than at the top level. Native
+ * HLS is one of two paths `HlsJsVideo` can take, and namespacing by engine lets
+ * a single source describe both without either reading the other's options.
+ */
+export interface NativeHlsSource {
+  /** Manifest URL. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** Options for the browser's own HLS playback. */
+  nativeHls?: NativeHlsConfig | undefined;
+}
+
+/**
+ * Native HLS playback options. There is no JS engine to configure here — the
+ * browser plays the manifest itself — so this is what Video.js does around it.
+ */
+export interface NativeHlsConfig {
+  /**
+   * FairPlay Streaming configuration for protected content. Safari negotiates
+   * keys itself; this names the servers it negotiates with.
+   */
+  drm?: NativeHlsDrmConfig | undefined;
+}
+
 export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {
   src: '',
+  source: null,
   preload: 'metadata',
   streamType: MediaStreamTypes.UNKNOWN,
 };
 
 class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsMediaProps, 'streamType'> {
   #src = nativeHlsMediaDefaultProps.src;
+  #source: NativeHlsSource | null = nativeHlsMediaDefaultProps.source;
   #preload = nativeHlsMediaDefaultProps.preload;
 
   /**
@@ -33,13 +64,49 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
     return null;
   }
 
+  /**
+   * Media source URL. Assigning it replaces the identity half of `source` and
+   * leaves `nativeHls` intact, so changing the URL never disturbs key exchange.
+   */
   get src() {
     return this.#src;
   }
 
   set src(src: string) {
-    this.#src = src;
-    if (this.target) this.target.src = src;
+    // `src` says which source to play; everything else says how to play it, so
+    // it carries over.
+    const { nativeHls } = this.#source ?? {};
+    const next: NativeHlsSource = {
+      ...(nativeHls && { nativeHls }),
+      ...(src && { src }),
+    };
+
+    // Everything happens in the `source` setter, so there is one path for
+    // storing it and loading.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  /**
+   * Structured source: what to play (`src`) plus how to play it (`nativeHls`).
+   * Assigning it derives `src`.
+   *
+   * Unlike `HlsJsMedia`, this does not announce a `sourcechange`. It is also
+   * the delegate `HlsJsMedia` plays native sources through, and every event it
+   * dispatches is re-dispatched there — which already announces its own.
+   */
+  get source(): NativeHlsSource | null {
+    return this.#source;
+  }
+
+  set source(value: NativeHlsSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    this.#source = source;
+    this.#src = source?.src ?? '';
+    if (this.target) this.target.src = this.#src;
   }
 
   /** Preload type (`'none'` / `'metadata'` / `'auto'`). */
@@ -61,5 +128,5 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
 }
 
 export class NativeHlsMedia extends NativeHlsMediaLiveMixin(
-  NativeHlsMediaStreamTypeMixin(NativeHlsMediaErrorsMixin(NativeHlsMediaBase))
+  NativeHlsMediaStreamTypeMixin(NativeHlsMediaDrmMixin(NativeHlsMediaErrorsMixin(NativeHlsMediaBase)))
 ) {}

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -1,8 +1,8 @@
+import type { DrmSystemsConfig } from '../../core/drm';
 import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { NativeHlsMediaDrmMixin } from './drm';
 import { NativeHlsMediaErrorsMixin } from './errors';
-import type { NativeHlsDrmSystemsConfig } from './fairplay';
 import { NativeHlsMediaLiveMixin } from './live';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
@@ -29,6 +29,13 @@ export interface NativeHlsMediaProps {
 export interface NativeHlsSource {
   /** Manifest URL. Mirrors the host's `src` property. */
   src?: string | undefined;
+  /**
+   * License servers for protected content, keyed by EME key system id. Safari
+   * negotiates keys itself and reaches FairPlay only, so the `com.apple.fps`
+   * entry is the one read here — the rest can ride along for an engine that can
+   * negotiate them.
+   */
+  drm?: DrmSystemsConfig | undefined;
   /** Playback options, keyed by the engine that reads them. */
   engine?: NativeHlsEngineConfig | undefined;
 }
@@ -45,11 +52,11 @@ export interface NativeHlsEngineConfig {
  */
 export interface NativeHlsConfig {
   /**
-   * License servers for protected content, keyed by key system id, in the same
-   * shape hls.js takes. Safari negotiates keys itself; this names the servers
-   * it negotiates with, so only the `com.apple.fps` entry is read.
+   * License servers for protected content, keyed by EME key system id. An
+   * escape hatch for licensing native playback differently from every other
+   * path: naming it replaces `source.drm` here, and nowhere else.
    */
-  drmSystems?: NativeHlsDrmSystemsConfig | undefined;
+  drmSystems?: DrmSystemsConfig | undefined;
 }
 
 export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {
@@ -87,8 +94,9 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
   set src(src: string) {
     // `src` says which source to play; everything else says how to play it, so
     // it carries over.
-    const { engine } = this.#source ?? {};
+    const { drm, engine } = this.#source ?? {};
     const next: NativeHlsSource = {
+      ...(drm && { drm }),
       ...(engine && { engine }),
       ...(src && { src }),
     };

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -2,7 +2,7 @@ import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { NativeHlsMediaDrmMixin } from './drm';
 import { NativeHlsMediaErrorsMixin } from './errors';
-import type { NativeHlsDrmConfig } from './fairplay';
+import type { NativeHlsDrmSystemsConfig } from './fairplay';
 import { NativeHlsMediaLiveMixin } from './live';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
@@ -38,10 +38,11 @@ export interface NativeHlsSource {
  */
 export interface NativeHlsConfig {
   /**
-   * FairPlay Streaming configuration for protected content. Safari negotiates
-   * keys itself; this names the servers it negotiates with.
+   * License servers for protected content, keyed by key system id, in the same
+   * shape hls.js takes. Safari negotiates keys itself; this names the servers
+   * it negotiates with, so only the `com.apple.fps` entry is read.
    */
-  drm?: NativeHlsDrmConfig | undefined;
+  drmSystems?: NativeHlsDrmSystemsConfig | undefined;
 }
 
 export const nativeHlsMediaDefaultProps: NativeHlsMediaProps = {

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -75,6 +75,10 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
   /**
    * Media source URL. Assigning it replaces the identity half of `source` and
    * leaves `engine` intact, so changing the URL never disturbs key exchange.
+   *
+   * Like the element's own `src`, assigning it always loads — including the URL
+   * already playing. This is the imperative half of the API, and what
+   * `HlsJsMedia` loads its native delegate through.
    */
   get src() {
     return this.#src;
@@ -89,14 +93,18 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
       ...(src && { src }),
     };
 
-    // Everything happens in the `source` setter, so there is one path for
-    // storing it and loading.
-    this.source = Object.keys(next).length > 0 ? next : null;
+    this.#source = Object.keys(next).length > 0 ? next : null;
+    this.#src = src;
+    if (this.target) this.target.src = src;
   }
 
   /**
    * Structured source: what to play (`src`) plus how to play it
    * (`engine.nativeHls`). Assigning it derives `src`.
+   *
+   * Only a new URL reaches the element, so reassigning an equivalent source —
+   * an inline React prop, for instance — neither reloads nor disturbs key
+   * exchange. Use `src` or `load()` to reload what is already playing.
    *
    * Unlike `HlsJsMedia`, this does not announce a `sourcechange`. It is also
    * the delegate `HlsJsMedia` plays native sources through, and every event it
@@ -112,9 +120,17 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
     // nothing.
     if (source === this.#source) return;
 
+    const src = source?.src ?? '';
+    // Assigning the element's `src` restarts the media load algorithm, even for
+    // the URL it already holds, so only a different one reaches it. Nothing else
+    // here is read up front — the DRM options are read when a key request
+    // arrives — so an equivalent source cannot interrupt playback.
+    const srcChanged = this.#src !== src;
+
     this.#source = source;
-    this.#src = source?.src ?? '';
-    if (this.target) this.target.src = this.#src;
+    this.#src = src;
+
+    if (srcChanged && this.target) this.target.src = src;
   }
 
   /** Preload type (`'none'` / `'metadata'` / `'auto'`). */

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -139,10 +139,14 @@ function stubFetch() {
   });
 }
 
+/**
+ * Only FairPlay is typed, since it is the only system Safari negotiates, but an
+ * hls.js `drmSystems` naming the rest can be shared with a native source — so
+ * the helper takes what reaches the mixin at runtime.
+ */
 function setup(
-  drm: { licenseUrl: string; serverCertificateUrl?: string } | null = {
-    licenseUrl: LICENSE_URL,
-    serverCertificateUrl: CERTIFICATE_URL,
+  drmSystems: Record<string, { licenseUrl: string; serverCertificateUrl?: string }> | null = {
+    'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL },
   }
 ) {
   const video = document.createElement('video');
@@ -150,7 +154,7 @@ function setup(
 
   const media = new NativeHlsMedia();
   media.attach(video);
-  media.source = { src: 'https://example.test/protected.m3u8', ...(drm && { nativeHls: { drm } }) };
+  media.source = { src: 'https://example.test/protected.m3u8', ...(drmSystems && { nativeHls: { drmSystems } }) };
 
   const errors = vi.fn();
   media.addEventListener('error', errors);
@@ -186,7 +190,9 @@ describe('NativeHlsMediaDrmMixin', () => {
     media.src = 'https://example.test/other.m3u8';
 
     expect(media.source).toEqual({
-      nativeHls: { drm: { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
+      nativeHls: {
+        drmSystems: { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
+      },
       src: 'https://example.test/other.m3u8',
     });
   });
@@ -241,6 +247,17 @@ describe('NativeHlsMediaDrmMixin', () => {
     expect(media.error).toBeInstanceOf(MediaError);
     expect(media.error!.code).toBe(MediaError.MEDIA_ERR_ENCRYPTED);
     expect(media.error!.context).toBe(NativeHlsDrmErrors.MISSING_CONFIGURATION);
+  });
+
+  it('fails when only key systems native playback cannot negotiate are configured', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubKeySystem();
+    const { media, video } = setup({ 'com.widevine.alpha': { licenseUrl: 'https://license.test/widevine' } });
+
+    fireKeyRequest(video);
+
+    expect(media.error!.context).toBe(NativeHlsDrmErrors.MISSING_CONFIGURATION);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('com.apple.fps'));
   });
 
   it('ignores initialization data it cannot act on', async () => {

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -225,6 +225,29 @@ describe('NativeHlsMediaDrmMixin', () => {
     expect(session.update).toHaveBeenCalledWith(CKC);
   });
 
+  it('follows a license server updated on the playing source', async () => {
+    const rotated = 'https://license.test/fairplay?token=rotated';
+    const { session } = stubKeySystem();
+    const { media, video } = setup();
+    video.setMediaKeys = vi.fn(async () => {});
+
+    fireKeyRequest(video);
+    await settle();
+
+    // Same manifest, new license server: nothing reloads, so the key system the
+    // CDM is holding has to pick the change up on its own.
+    media.source = {
+      src: media.src,
+      engine: { nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: rotated } } } },
+    };
+
+    session.dispatch(Object.assign(new Event('message'), { message: new Uint8Array([5, 5]).buffer }));
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith(rotated, expect.objectContaining({ method: 'POST' }));
+    expect(session.update).toHaveBeenCalledWith(CKC);
+  });
+
   it('negotiates FairPlay against the manifest, without persistent state', async () => {
     const { requestMediaKeySystemAccess } = stubKeySystem();
     const { video } = setup();

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -154,7 +154,10 @@ function setup(
 
   const media = new NativeHlsMedia();
   media.attach(video);
-  media.source = { src: 'https://example.test/protected.m3u8', ...(drmSystems && { nativeHls: { drmSystems } }) };
+  media.source = {
+    src: 'https://example.test/protected.m3u8',
+    ...(drmSystems && { engine: { nativeHls: { drmSystems } } }),
+  };
 
   const errors = vi.fn();
   media.addEventListener('error', errors);
@@ -184,14 +187,16 @@ afterEach(() => {
 });
 
 describe('NativeHlsMediaDrmMixin', () => {
-  it('carries `source.nativeHls` across an `src` assignment', () => {
+  it('carries `source.engine` across an `src` assignment', () => {
     const { media } = setup();
 
     media.src = 'https://example.test/other.m3u8';
 
     expect(media.source).toEqual({
-      nativeHls: {
-        drmSystems: { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
+      engine: {
+        nativeHls: {
+          drmSystems: { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
+        },
       },
       src: 'https://example.test/other.m3u8',
     });

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -1,0 +1,444 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
+import { NativeHlsDrmErrors } from '../fairplay';
+import { NativeHlsMedia } from '../index';
+
+const LICENSE_URL = 'https://license.test/fairplay';
+const CERTIFICATE_URL = 'https://license.test/appcert';
+
+/** A CKC the license server hands back. */
+const CKC = new Uint8Array([1, 2, 3, 4]);
+/** The DER application certificate. */
+const CERTIFICATE = new Uint8Array([9, 8, 7, 6]);
+
+/** The `skd://` URI WebKit reports, encoded the way it arrives: UTF-16LE. */
+function skdInitData(contentId: string): ArrayBuffer {
+  const uri = `skd://${contentId}`;
+  const bytes = new Uint8Array(uri.length * 2);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < uri.length; i++) view.setUint16(i * 2, uri.charCodeAt(i), true);
+  return bytes.buffer;
+}
+
+/** jsdom implements neither `MediaEncryptedEvent` nor `webkitneedkey`. */
+function fireKeyRequest(
+  video: HTMLVideoElement,
+  type: 'encrypted' | 'webkitneedkey' = 'encrypted',
+  initData?: unknown
+) {
+  video.dispatchEvent(
+    Object.assign(new Event(type), {
+      initDataType: 'skd',
+      initData: initData === undefined ? skdInitData('abc123') : initData,
+    })
+  );
+}
+
+interface KeySystemStubs {
+  session: {
+    generateRequest: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    keyStatuses: Map<string, MediaKeyStatus>;
+    dispatch(event: Event): void;
+  };
+  mediaKeys: { createSession: ReturnType<typeof vi.fn>; setServerCertificate: ReturnType<typeof vi.fn> };
+  requestMediaKeySystemAccess: ReturnType<typeof vi.fn>;
+}
+
+/** A CDM that grants access, accepts the certificate, and opens sessions. */
+function stubKeySystem(): KeySystemStubs {
+  const listeners = new Map<string, Set<EventListener>>();
+
+  const session = {
+    generateRequest: vi.fn(async () => {}),
+    update: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    keyStatuses: new Map<string, MediaKeyStatus>(),
+    addEventListener(type: string, listener: EventListener, options?: AddEventListenerOptions) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+      options?.signal?.addEventListener('abort', () => listeners.get(type)!.delete(listener));
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(event: Event) {
+      for (const listener of listeners.get(event.type) ?? []) listener(event);
+    },
+  };
+
+  const mediaKeys = {
+    createSession: vi.fn(() => session),
+    setServerCertificate: vi.fn(async () => true),
+  };
+
+  const requestMediaKeySystemAccess = vi.fn(async () => ({ createMediaKeys: async () => mediaKeys }));
+
+  Object.defineProperty(navigator, 'requestMediaKeySystemAccess', {
+    value: requestMediaKeySystemAccess,
+    configurable: true,
+    writable: true,
+  });
+
+  return { session, mediaKeys, requestMediaKeySystemAccess } as unknown as KeySystemStubs;
+}
+
+/** The pre-EME WebKit key API, which jsdom has no notion of. */
+function stubWebKitKeySystem() {
+  const listeners = new Map<string, Set<EventListener>>();
+
+  const session = {
+    error: null as { code: number; systemCode: number } | null,
+    update: vi.fn(),
+    close: vi.fn(),
+    addEventListener(type: string, listener: EventListener, options?: AddEventListenerOptions) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+      options?.signal?.addEventListener('abort', () => listeners.get(type)!.delete(listener));
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(event: Event) {
+      for (const listener of listeners.get(event.type) ?? []) listener(event);
+    },
+  };
+
+  const createSession = vi.fn((_mimeType: string, _initData: BufferSource) => session);
+  const setMediaKeys = vi.fn((_keys: unknown) => {});
+
+  vi.stubGlobal(
+    'WebKitMediaKeys',
+    class {
+      createSession = createSession;
+    }
+  );
+
+  return {
+    session,
+    createSession,
+    setMediaKeys,
+    install(video: HTMLVideoElement) {
+      let current: unknown = null;
+      setMediaKeys.mockImplementation((value) => {
+        current = value;
+      });
+      Object.defineProperty(video, 'webkitKeys', { get: () => current, configurable: true });
+      Object.defineProperty(video, 'webkitSetMediaKeys', { value: setMediaKeys, configurable: true });
+    },
+  };
+}
+
+/** Certificate and license responses, both keyed off the request URL. */
+function stubFetch() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const body = url === CERTIFICATE_URL ? CERTIFICATE : CKC;
+    return { ok: true, arrayBuffer: async () => body.buffer.slice(0) } as Response;
+  });
+}
+
+function setup(
+  drm: { licenseUrl: string; serverCertificateUrl?: string } | null = {
+    licenseUrl: LICENSE_URL,
+    serverCertificateUrl: CERTIFICATE_URL,
+  }
+) {
+  const video = document.createElement('video');
+  document.body.append(video);
+
+  const media = new NativeHlsMedia();
+  media.attach(video);
+  media.source = { src: 'https://example.test/protected.m3u8', ...(drm && { nativeHls: { drm } }) };
+
+  const errors = vi.fn();
+  media.addEventListener('error', errors);
+
+  return { media, video, errors };
+}
+
+/**
+ * Let the setup chain (key access → certificate → session → license) settle.
+ * Yielding to the macrotask queue drains every microtask in between.
+ */
+async function settle() {
+  for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let fetchMock: ReturnType<typeof stubFetch>;
+
+beforeEach(() => {
+  fetchMock = stubFetch();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('NativeHlsMediaDrmMixin', () => {
+  it('carries `source.nativeHls` across an `src` assignment', () => {
+    const { media } = setup();
+
+    media.src = 'https://example.test/other.m3u8';
+
+    expect(media.source).toEqual({
+      nativeHls: { drm: { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
+      src: 'https://example.test/other.m3u8',
+    });
+  });
+
+  it('exchanges the SPC for a license and updates the session', async () => {
+    const { session } = stubKeySystem();
+    const setMediaKeys = vi.fn(async () => {});
+    const { video } = setup();
+    video.setMediaKeys = setMediaKeys;
+
+    fireKeyRequest(video);
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith(CERTIFICATE_URL, expect.anything());
+    expect(setMediaKeys).toHaveBeenCalled();
+    expect(session.generateRequest).toHaveBeenCalledWith('skd', expect.any(ArrayBuffer));
+
+    session.dispatch(Object.assign(new Event('message'), { message: new Uint8Array([5, 5]).buffer }));
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      LICENSE_URL,
+      expect.objectContaining({ method: 'POST', body: expect.anything() })
+    );
+    expect(session.update).toHaveBeenCalledWith(CKC);
+  });
+
+  it('negotiates FairPlay against the manifest, without persistent state', async () => {
+    const { requestMediaKeySystemAccess } = stubKeySystem();
+    const { video } = setup();
+    video.setMediaKeys = vi.fn(async () => {});
+
+    fireKeyRequest(video);
+    await settle();
+
+    expect(requestMediaKeySystemAccess).toHaveBeenCalledWith('com.apple.fps', [
+      expect.objectContaining({
+        initDataTypes: ['skd'],
+        persistentState: 'not-allowed',
+        distinctiveIdentifier: 'not-allowed',
+      }),
+    ]);
+  });
+
+  it('fails loudly when protected content has no DRM configuration', () => {
+    stubKeySystem();
+    const { media, video, errors } = setup(null);
+
+    fireKeyRequest(video);
+
+    expect(errors).toHaveBeenCalledOnce();
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error!.code).toBe(MediaError.MEDIA_ERR_ENCRYPTED);
+    expect(media.error!.context).toBe(NativeHlsDrmErrors.MISSING_CONFIGURATION);
+  });
+
+  it('ignores initialization data it cannot act on', async () => {
+    const { requestMediaKeySystemAccess } = stubKeySystem();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { video, errors } = setup();
+
+    video.dispatchEvent(Object.assign(new Event('encrypted'), { initDataType: 'cenc', initData: new ArrayBuffer(8) }));
+    await settle();
+
+    expect(requestMediaKeySystemAccess).not.toHaveBeenCalled();
+    expect(errors).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejected key system as a fatal encrypted error', async () => {
+    const { requestMediaKeySystemAccess } = stubKeySystem();
+    requestMediaKeySystemAccess.mockRejectedValue(new Error('unsupported'));
+
+    const { media, video } = setup();
+
+    fireKeyRequest(video);
+    await settle();
+
+    expect(media.error!.context).toBe(NativeHlsDrmErrors.UNSUPPORTED_KEY_SYSTEM);
+    expect(media.error!.fatal).toBe(true);
+  });
+
+  it('reports a rejected application certificate', async () => {
+    const { mediaKeys } = stubKeySystem();
+    mediaKeys.setServerCertificate.mockResolvedValue(false);
+
+    const { media, video } = setup();
+    video.setMediaKeys = vi.fn(async () => {});
+
+    fireKeyRequest(video);
+    await settle();
+
+    expect(media.error!.context).toBe(NativeHlsDrmErrors.SERVER_CERTIFICATE_FAILED);
+  });
+
+  it('reports a license server that answers with an error', async () => {
+    const { session } = stubKeySystem();
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) =>
+      String(input) === CERTIFICATE_URL
+        ? ({ ok: true, arrayBuffer: async () => CERTIFICATE.buffer.slice(0) } as Response)
+        : ({ ok: false, arrayBuffer: async () => new ArrayBuffer(0) } as Response)
+    );
+
+    const { media, video } = setup();
+    video.setMediaKeys = vi.fn(async () => {});
+
+    fireKeyRequest(video);
+    await settle();
+
+    session.dispatch(Object.assign(new Event('message'), { message: new ArrayBuffer(2) }));
+    await settle();
+
+    expect(media.error!.context).toBe(NativeHlsDrmErrors.LICENSE_REQUEST_FAILED);
+    expect(session.update).not.toHaveBeenCalled();
+  });
+
+  it('announces an insecure output without latching it as the error', async () => {
+    const { session } = stubKeySystem();
+    const { media, video, errors } = setup();
+    video.setMediaKeys = vi.fn(async () => {});
+
+    fireKeyRequest(video);
+    await settle();
+
+    session.keyStatuses.set('key', 'output-restricted');
+    session.dispatch(new Event('keystatuseschange'));
+
+    const event = errors.mock.calls[0]![0] as ErrorEvent;
+    expect(event.error.context).toBe(NativeHlsDrmErrors.OUTPUT_RESTRICTED);
+    expect(event.error.fatal).toBe(false);
+    // Playback continues, so it must not stand in for whatever fails next.
+    expect(media.error).toBeNull();
+  });
+
+  it('closes sessions and releases keys on `emptied`', async () => {
+    const { session } = stubKeySystem();
+    const setMediaKeys = vi.fn(async (_keys: MediaKeys | null) => {});
+    const { video } = setup();
+    video.setMediaKeys = setMediaKeys;
+
+    fireKeyRequest(video);
+    await settle();
+
+    Object.defineProperty(video, 'mediaKeys', { value: setMediaKeys.mock.calls[0]![0], configurable: true });
+    video.dispatchEvent(new Event('emptied'));
+    await settle();
+
+    expect(session.close).toHaveBeenCalled();
+    expect(setMediaKeys).toHaveBeenLastCalledWith(null);
+  });
+
+  it('stops answering key requests after detach', async () => {
+    const { requestMediaKeySystemAccess } = stubKeySystem();
+    const { media, video } = setup();
+
+    media.detach();
+    fireKeyRequest(video);
+    await settle();
+
+    expect(requestMediaKeySystemAccess).not.toHaveBeenCalled();
+  });
+
+  it('leaves `webkitneedkey` alone while EME is in charge', async () => {
+    const { requestMediaKeySystemAccess } = stubKeySystem();
+    const { video, errors } = setup();
+
+    fireKeyRequest(video, 'webkitneedkey');
+    await settle();
+
+    expect(requestMediaKeySystemAccess).not.toHaveBeenCalled();
+    expect(errors).not.toHaveBeenCalled();
+  });
+
+  describe('legacy WebKit fallback', () => {
+    /**
+     * Drive the one handover the legacy path exists for: EME cannot generate a
+     * request while the playback target is an AirPlay receiver.
+     */
+    async function setupFallback() {
+      const eme = stubKeySystem();
+      eme.session.generateRequest.mockRejectedValue(new DOMException('nope', 'NotSupportedError'));
+
+      const webkit = stubWebKitKeySystem();
+      const { media, video, errors } = setup();
+      video.setMediaKeys = vi.fn(async () => {});
+      video.load = vi.fn();
+      webkit.install(video);
+      Object.defineProperty(video, 'webkitCurrentPlaybackTargetIsWireless', { value: true, configurable: true });
+
+      fireKeyRequest(video);
+      await settle();
+
+      return { media, video, errors, eme, webkit };
+    }
+
+    it('hands over to the legacy API and reloads to have the key request re-issued', async () => {
+      const { video, errors } = await setupFallback();
+
+      expect(video.load).toHaveBeenCalled();
+      // The handover is not a failure, so nothing is surfaced.
+      expect(errors).not.toHaveBeenCalled();
+    });
+
+    it('serves `webkitneedkey` once it has taken over', async () => {
+      const { video, webkit } = await setupFallback();
+
+      fireKeyRequest(video, 'webkitneedkey');
+      await settle();
+
+      expect(webkit.setMediaKeys).toHaveBeenCalledWith(expect.any(Object));
+      expect(webkit.createSession).toHaveBeenCalledWith('application/vnd.apple.mpegurl', expect.any(Uint8Array));
+
+      webkit.session.dispatch(Object.assign(new Event('webkitkeymessage'), { message: new ArrayBuffer(2) }));
+      await settle();
+
+      expect(webkit.session.update).toHaveBeenCalledWith(CKC);
+    });
+
+    it('packs the content id and certificate into the session initialization data', async () => {
+      const { video, webkit } = await setupFallback();
+
+      fireKeyRequest(video, 'webkitneedkey');
+      await settle();
+
+      const packed = webkit.createSession.mock.calls[0]![1] as Uint8Array;
+      const initData = skdInitData('abc123');
+      const view = new DataView(packed.buffer);
+
+      expect(packed.slice(0, initData.byteLength)).toEqual(new Uint8Array(initData));
+
+      let offset = initData.byteLength;
+      const contentIdLength = view.getUint32(offset, true);
+      offset += 4;
+      expect(new TextDecoder('utf-16le').decode(packed.slice(offset, offset + contentIdLength))).toBe('abc123');
+
+      offset += contentIdLength;
+      const certificateLength = view.getUint32(offset, true);
+      offset += 4;
+      expect(certificateLength).toBe(CERTIFICATE.byteLength);
+      expect(packed.slice(offset, offset + certificateLength)).toEqual(CERTIFICATE);
+    });
+
+    it('reports a CDM failure reported through `webkitkeyerror`', async () => {
+      const { media, video, webkit } = await setupFallback();
+
+      fireKeyRequest(video, 'webkitneedkey');
+      await settle();
+
+      webkit.session.error = { code: 1, systemCode: 42 };
+      webkit.session.dispatch(new Event('webkitkeyerror'));
+
+      expect(media.error!.context).toBe(NativeHlsDrmErrors.CDM_ERROR);
+      expect(media.error!.data).toEqual({ code: 1, systemCode: 42 });
+    });
+  });
+});

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -401,6 +401,36 @@ describe('NativeHlsMediaDrmMixin', () => {
     expect(setMediaKeys).toHaveBeenLastCalledWith(null);
   });
 
+  it('installs no keys when the source is replaced mid key exchange', async () => {
+    const { mediaKeys, requestMediaKeySystemAccess } = stubKeySystem();
+
+    // Hold the CDM negotiation open so teardown lands in the middle of it.
+    let grantAccess: (() => void) | undefined;
+    const granted = new Promise<void>((resolve) => {
+      grantAccess = resolve;
+    });
+    requestMediaKeySystemAccess.mockImplementation(async () => {
+      await granted;
+      return { createMediaKeys: async () => mediaKeys };
+    });
+
+    const setMediaKeys = vi.fn(async (_keys: MediaKeys | null) => {});
+    const { video } = setup();
+    video.setMediaKeys = setMediaKeys;
+
+    fireKeyRequest(video);
+    await settle();
+
+    // A new resource abandons this exchange, then the CDM answers anyway. The
+    // element is shared with whatever plays next, so nothing may be installed on
+    // it this late.
+    video.dispatchEvent(new Event('emptied'));
+    grantAccess?.();
+    await settle();
+
+    expect(setMediaKeys).not.toHaveBeenCalled();
+  });
+
   it('stops answering key requests after detach', async () => {
     const { requestMediaKeySystemAccess } = stubKeySystem();
     const { media, video } = setup();

--- a/packages/media/src/dom/native-hls/tests/drm.test.ts
+++ b/packages/media/src/dom/native-hls/tests/drm.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DrmSystemsConfig } from '../../../core/drm';
 import { MediaError } from '../../../core/media-error';
 import { NativeHlsDrmErrors } from '../fairplay';
 import { NativeHlsMedia } from '../index';
@@ -140,14 +141,12 @@ function stubFetch() {
 }
 
 /**
- * Only FairPlay is typed, since it is the only system Safari negotiates, but an
- * hls.js `drmSystems` naming the rest can be shared with a native source — so
- * the helper takes what reaches the mixin at runtime.
+ * Licensed the standard way, through `source.drm`. Systems only an MSE engine
+ * can negotiate are welcome there — one source describes every path — so the
+ * helper takes whatever a caller would name.
  */
 function setup(
-  drmSystems: Record<string, { licenseUrl: string; serverCertificateUrl?: string }> | null = {
-    'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL },
-  }
+  drm: DrmSystemsConfig | null = { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } }
 ) {
   const video = document.createElement('video');
   document.body.append(video);
@@ -156,7 +155,7 @@ function setup(
   media.attach(video);
   media.source = {
     src: 'https://example.test/protected.m3u8',
-    ...(drmSystems && { engine: { nativeHls: { drmSystems } } }),
+    ...(drm && { drm }),
   };
 
   const errors = vi.fn();
@@ -187,19 +186,42 @@ afterEach(() => {
 });
 
 describe('NativeHlsMediaDrmMixin', () => {
-  it('carries `source.engine` across an `src` assignment', () => {
+  it('carries the DRM configuration across an `src` assignment', () => {
     const { media } = setup();
 
     media.src = 'https://example.test/other.m3u8';
 
     expect(media.source).toEqual({
-      engine: {
-        nativeHls: {
-          drmSystems: { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
-        },
-      },
+      drm: { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
       src: 'https://example.test/other.m3u8',
     });
+  });
+
+  it('licenses from `engine.nativeHls.drmSystems` where the native path names its own', async () => {
+    const nativeLicense = 'https://license.test/native-fairplay';
+    const { session } = stubKeySystem();
+    const video = document.createElement('video');
+    document.body.append(video);
+
+    const media = new NativeHlsMedia();
+    media.attach(video);
+    video.setMediaKeys = vi.fn(async () => {});
+    media.source = {
+      src: 'https://example.test/protected.m3u8',
+      drm: { 'com.apple.fps': { licenseUrl: LICENSE_URL, serverCertificateUrl: CERTIFICATE_URL } },
+      engine: { nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: nativeLicense } } } },
+    };
+
+    fireKeyRequest(video);
+    await settle();
+
+    session.dispatch(Object.assign(new Event('message'), { message: new Uint8Array([5, 5]).buffer }));
+    await settle();
+
+    // The escape hatch replaces `source.drm` rather than merging with it, so no
+    // certificate is fetched either.
+    expect(fetchMock).not.toHaveBeenCalledWith(CERTIFICATE_URL, expect.anything());
+    expect(fetchMock).toHaveBeenCalledWith(nativeLicense, expect.objectContaining({ method: 'POST' }));
   });
 
   it('exchanges the SPC for a license and updates the session', async () => {
@@ -236,10 +258,7 @@ describe('NativeHlsMediaDrmMixin', () => {
 
     // Same manifest, new license server: nothing reloads, so the key system the
     // CDM is holding has to pick the change up on its own.
-    media.source = {
-      src: media.src,
-      engine: { nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: rotated } } } },
-    };
+    media.source = { src: media.src, drm: { 'com.apple.fps': { licenseUrl: rotated } } };
 
     session.dispatch(Object.assign(new Event('message'), { message: new Uint8Array([5, 5]).buffer }));
     await settle();

--- a/packages/media/src/dom/native-hls/tests/media.test.ts
+++ b/packages/media/src/dom/native-hls/tests/media.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { NativeHlsMedia, type NativeHlsSource } from '../index';
+
+const MANIFEST = 'https://example.test/video.m3u8';
+const DRM: NativeHlsSource['engine'] = {
+  nativeHls: { drmSystems: { 'com.apple.fps': { licenseUrl: 'https://license.test/fairplay' } } },
+};
+
+/**
+ * jsdom implements neither the media load algorithm nor its events, so what
+ * reaches the element is observed through the assignments themselves.
+ */
+function setup() {
+  const video = document.createElement('video');
+  document.body.append(video);
+
+  const loads: string[] = [];
+  let src = '';
+  Object.defineProperty(video, 'src', {
+    configurable: true,
+    get: () => src,
+    set: (value: string) => {
+      src = value;
+      loads.push(value);
+    },
+  });
+
+  const media = new NativeHlsMedia();
+  media.attach(video);
+
+  return { media, video, loads };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('NativeHlsMedia', () => {
+  describe('source', () => {
+    it('derives src and loads the manifest', () => {
+      const { media, loads } = setup();
+
+      media.source = { src: MANIFEST, engine: DRM };
+
+      expect(media.src).toBe(MANIFEST);
+      expect(loads).toEqual([MANIFEST]);
+    });
+
+    it('leaves the element alone for a source naming the same URL', () => {
+      const { media, loads } = setup();
+
+      media.source = { src: MANIFEST, engine: DRM };
+      // Same values in a new object (e.g. an inline React prop). Reloading here
+      // would restart playback, mid key exchange included.
+      media.source = { src: MANIFEST, engine: DRM };
+
+      expect(loads).toEqual([MANIFEST]);
+      expect(media.source).toEqual({ src: MANIFEST, engine: DRM });
+    });
+
+    it('loads a new URL and carries the engine options over', () => {
+      const { media, loads } = setup();
+
+      media.source = { src: MANIFEST, engine: DRM };
+      media.src = 'https://example.test/other.m3u8';
+
+      expect(loads).toEqual([MANIFEST, 'https://example.test/other.m3u8']);
+      expect(media.source).toEqual({ src: 'https://example.test/other.m3u8', engine: DRM });
+    });
+
+    it('reloads when `src` is assigned the URL already playing', () => {
+      const { media, loads } = setup();
+
+      media.source = { src: MANIFEST };
+      // `src` mirrors the element, where assigning it always loads — it is how
+      // `HlsJsMedia` loads a native delegate, and how a failed source is retried.
+      media.src = MANIFEST;
+
+      expect(loads).toEqual([MANIFEST, MANIFEST]);
+    });
+  });
+});

--- a/packages/media/src/dom/types.ts
+++ b/packages/media/src/dom/types.ts
@@ -1,1 +1,3 @@
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../core/drm';
+export { KeySystems } from '../core/drm';
 export type { Media, MediaFeatureAvailability } from '../core/types';

--- a/packages/media/src/dom/vimeo/media.ts
+++ b/packages/media/src/dom/vimeo/media.ts
@@ -22,6 +22,12 @@ export interface VimeoEngineConfig extends VimeoEmbedParameters {
 export interface VimeoSource {
   /** Vimeo URL or id. Mirrors the host's `src` property. */
   src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: VimeoSourceEngineConfig | undefined;
+}
+
+/** The engines a Vimeo source can configure. */
+export interface VimeoSourceEngineConfig {
   /** Vimeo's own embed parameters, passed through untouched. */
   vimeo?: VimeoEngineConfig | undefined;
 }
@@ -154,8 +160,8 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
   }
   /** Vimeo URL or id. Setting it re-derives `source`, carrying its embed options over. */
   set src(value) {
-    const { vimeo } = this.#source ?? {};
-    const next: VimeoSource = { ...(vimeo && { vimeo }), ...(value && { src: value }) };
+    const { engine } = this.#source ?? {};
+    const next: VimeoSource = { ...(engine && { engine }), ...(value && { src: value }) };
 
     // Everything happens in the `source` setter, so there is one path for storing
     // it, deciding on a load, and dispatching `sourcechange`.
@@ -186,7 +192,7 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
     }
     this.dispatchEvent(new Event('emptied'));
     this.dispatchEvent(new Event('loadstart'));
-    const loadOptions = toLoadVideoOptions(this.#src, this.#source?.vimeo);
+    const loadOptions = toLoadVideoOptions(this.#src, this.#source?.engine?.vimeo);
     // An unparsable src never reaches the player, so no `loaded` will ever settle
     // this load.
     if (!loadOptions) {
@@ -321,8 +327,8 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
 
   /**
    * Structured source: the Vimeo URL or ID in `src`, plus embed options under
-   * `vimeo`. Replacing it re-derives `src`; assigning an equivalent source is
-   * a no-op.
+   * `engine.vimeo`. Replacing it re-derives `src`; assigning an equivalent
+   * source is a no-op.
    */
   get source(): VimeoSource | null {
     return this.#source;
@@ -337,7 +343,7 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
     const srcChanged = this.#src !== src;
     // Embed options are read when the video is loaded, so a change to them needs
     // a reload of its own even though the URL is the same.
-    const engineChanged = !deepEqual(this.#source?.vimeo ?? null, source?.vimeo ?? null);
+    const engineChanged = !deepEqual(this.#source?.engine?.vimeo ?? null, source?.engine?.vimeo ?? null);
 
     this.#source = source;
     this.#src = src;
@@ -646,7 +652,7 @@ export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps>
     transparent: false,
     h: parsed.hash,
     // Vimeo-specific knobs (`autopause`, `byline`, `dnt`, …) flow through here.
-    ...(props.source?.vimeo ?? undefined),
+    ...(props.source?.engine?.vimeo ?? undefined),
   };
   if (parsed.kind === 'event') {
     const hashPath = parsed.hash ? `/${parsed.hash}` : '';

--- a/packages/media/src/dom/vimeo/media.ts
+++ b/packages/media/src/dom/vimeo/media.ts
@@ -23,7 +23,7 @@ export interface VimeoSource {
   /** Vimeo URL or id. Mirrors the host's `src` property. */
   src?: string | undefined;
   /** Vimeo's own embed parameters, passed through untouched. */
-  engine?: VimeoEngineConfig | undefined;
+  vimeo?: VimeoEngineConfig | undefined;
 }
 
 /** Parsed pieces of a Vimeo source URL. */
@@ -154,8 +154,8 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
   }
   /** Vimeo URL or id. Setting it re-derives `source`, carrying its embed options over. */
   set src(value) {
-    const { engine } = this.#source ?? {};
-    const next: VimeoSource = { ...(engine && { engine }), ...(value && { src: value }) };
+    const { vimeo } = this.#source ?? {};
+    const next: VimeoSource = { ...(vimeo && { vimeo }), ...(value && { src: value }) };
 
     // Everything happens in the `source` setter, so there is one path for storing
     // it, deciding on a load, and dispatching `sourcechange`.
@@ -186,7 +186,7 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
     }
     this.dispatchEvent(new Event('emptied'));
     this.dispatchEvent(new Event('loadstart'));
-    const loadOptions = toLoadVideoOptions(this.#src, this.#source?.engine);
+    const loadOptions = toLoadVideoOptions(this.#src, this.#source?.vimeo);
     // An unparsable src never reaches the player, so no `loaded` will ever settle
     // this load.
     if (!loadOptions) {
@@ -321,7 +321,7 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
 
   /**
    * Structured source: the Vimeo URL or ID in `src`, plus embed options under
-   * `engine`. Replacing it re-derives `src`; assigning an equivalent source is
+   * `vimeo`. Replacing it re-derives `src`; assigning an equivalent source is
    * a no-op.
    */
   get source(): VimeoSource | null {
@@ -337,7 +337,7 @@ export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
     const srcChanged = this.#src !== src;
     // Embed options are read when the video is loaded, so a change to them needs
     // a reload of its own even though the URL is the same.
-    const engineChanged = !deepEqual(this.#source?.engine ?? null, source?.engine ?? null);
+    const engineChanged = !deepEqual(this.#source?.vimeo ?? null, source?.vimeo ?? null);
 
     this.#source = source;
     this.#src = src;
@@ -646,7 +646,7 @@ export function buildVimeoIframeSrc(src: string, props: Partial<VimeoMediaProps>
     transparent: false,
     h: parsed.hash,
     // Vimeo-specific knobs (`autopause`, `byline`, `dnt`, …) flow through here.
-    ...(props.source?.engine ?? undefined),
+    ...(props.source?.vimeo ?? undefined),
   };
   if (parsed.kind === 'event') {
     const hashPath = parsed.hash ? `/${parsed.hash}` : '';
@@ -664,10 +664,10 @@ const READY_STATE_HAVE_NOTHING = 0;
 const READY_STATE_HAVE_METADATA = 1;
 const READY_STATE_HAVE_FUTURE_DATA = 3;
 
-function toLoadVideoOptions(src: string, engine?: VimeoEngineConfig) {
+function toLoadVideoOptions(src: string, vimeo?: VimeoEngineConfig) {
   const parsed = parseVimeoSource(src);
   if (!parsed) return null;
   const base = parsed.kind === 'event' ? `${EMBED_EVENT_BASE}/${parsed.id}/embed` : `${EMBED_VIDEO_BASE}/${parsed.id}`;
   const url = `${base}${parsed.hash ? `?h=${parsed.hash}` : ''}` as VimeoUrl;
-  return { url, ...engine } as LoadVideoOptions;
+  return { url, ...vimeo } as LoadVideoOptions;
 }

--- a/packages/media/src/dom/vimeo/tests/media.test.ts
+++ b/packages/media/src/dom/vimeo/tests/media.test.ts
@@ -167,7 +167,10 @@ describe('buildVimeoIframeSrc', () => {
   });
 
   it('forwards preload and Vimeo-specific knobs', () => {
-    const src = buildVimeoIframeSrc('76979871', { preload: 'auto', source: { vimeo: { autopause: true } } });
+    const src = buildVimeoIframeSrc('76979871', {
+      preload: 'auto',
+      source: { engine: { vimeo: { autopause: true } } },
+    });
     expect(src).toContain('preload=auto');
     expect(src).toContain('autopause=1');
   });
@@ -183,13 +186,13 @@ describe('buildVimeoIframeSrc', () => {
   });
 
   it('merges arbitrary Vimeo options into params', () => {
-    const src = buildVimeoIframeSrc('76979871', { source: { vimeo: { background: true, byline: false } } });
+    const src = buildVimeoIframeSrc('76979871', { source: { engine: { vimeo: { background: true, byline: false } } } });
     expect(src).toContain('background=1');
     expect(src).toContain('byline=0');
   });
 
   it('lets Vimeo options override derived params', () => {
-    const src = buildVimeoIframeSrc('76979871', { controls: false, source: { vimeo: { controls: true } } });
+    const src = buildVimeoIframeSrc('76979871', { controls: false, source: { engine: { vimeo: { controls: true } } } });
     expect(src).toContain('controls=1');
     expect(src).not.toContain('controls=0');
   });
@@ -469,23 +472,23 @@ describe('VimeoMedia', () => {
 
   it('preserves source Vimeo options across a src change', () => {
     const media = new VimeoMedia();
-    media.source = { src: '76979871', vimeo: { autopause: true } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: true } } };
 
     media.src = 'https://vimeo.com/12345';
-    expect(media.source).toEqual({ src: 'https://vimeo.com/12345', vimeo: { autopause: true } });
+    expect(media.source).toEqual({ src: 'https://vimeo.com/12345', engine: { vimeo: { autopause: true } } });
   });
 
   it('does not reload for a structurally equal source', async () => {
     const media = new VimeoMedia();
     const { player } = await attachAndLoad(media);
-    media.source = { src: '76979871', vimeo: { autopause: true } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: true } } };
     await Promise.resolve();
 
     const sourcechange = vi.fn();
     media.addEventListener('sourcechange', sourcechange);
     player.loadVideo.mockClear();
 
-    media.source = { src: '76979871', vimeo: { autopause: true } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: true } } };
     await Promise.resolve();
 
     // Assigning is always announced, but nothing reaches the Vimeo player.
@@ -505,7 +508,7 @@ describe('VimeoMedia', () => {
 
   it('carries Vimeo options into the initial embed URL', () => {
     const media = new VimeoMedia();
-    media.source = { src: '76979871', vimeo: { autopause: true } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: true } } };
 
     const iframe = createIframe();
     media.attach(iframe);
@@ -516,13 +519,13 @@ describe('VimeoMedia', () => {
   it('reloads when only Vimeo options change', async () => {
     const media = new VimeoMedia();
     const { player } = await attachAndLoad(media);
-    media.source = { src: '76979871', vimeo: { autopause: true } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: true } } };
     await Promise.resolve();
     player.loadVideo.mockClear();
 
     // Same video, new embed options. They are read at load time, so the video
     // has to be loaded again for them to take effect.
-    media.source = { src: '76979871', vimeo: { autopause: false } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: false } } };
     await Promise.resolve();
 
     expect(player.loadVideo).toHaveBeenCalledWith({
@@ -536,7 +539,7 @@ describe('VimeoMedia', () => {
     const { player } = await attachAndLoad(media);
     player.loadVideo.mockClear();
 
-    media.source = { src: '76979871', vimeo: { autopause: false } };
+    media.source = { src: '76979871', engine: { vimeo: { autopause: false } } };
     await Promise.resolve();
     expect(player.loadVideo).toHaveBeenCalledWith({
       url: 'https://player.vimeo.com/video/76979871',

--- a/packages/media/src/dom/vimeo/tests/media.test.ts
+++ b/packages/media/src/dom/vimeo/tests/media.test.ts
@@ -166,8 +166,8 @@ describe('buildVimeoIframeSrc', () => {
     expect(src).not.toContain('controls=0');
   });
 
-  it('forwards preload and Vimeo-specific engine knobs', () => {
-    const src = buildVimeoIframeSrc('76979871', { preload: 'auto', source: { engine: { autopause: true } } });
+  it('forwards preload and Vimeo-specific knobs', () => {
+    const src = buildVimeoIframeSrc('76979871', { preload: 'auto', source: { vimeo: { autopause: true } } });
     expect(src).toContain('preload=auto');
     expect(src).toContain('autopause=1');
   });
@@ -182,14 +182,14 @@ describe('buildVimeoIframeSrc', () => {
     expect(src).not.toContain('h=');
   });
 
-  it('merges arbitrary engine options into params', () => {
-    const src = buildVimeoIframeSrc('76979871', { source: { engine: { background: true, byline: false } } });
+  it('merges arbitrary Vimeo options into params', () => {
+    const src = buildVimeoIframeSrc('76979871', { source: { vimeo: { background: true, byline: false } } });
     expect(src).toContain('background=1');
     expect(src).toContain('byline=0');
   });
 
-  it('lets engine options override derived params', () => {
-    const src = buildVimeoIframeSrc('76979871', { controls: false, source: { engine: { controls: true } } });
+  it('lets Vimeo options override derived params', () => {
+    const src = buildVimeoIframeSrc('76979871', { controls: false, source: { vimeo: { controls: true } } });
     expect(src).toContain('controls=1');
     expect(src).not.toContain('controls=0');
   });
@@ -467,25 +467,25 @@ describe('VimeoMedia', () => {
     expect(sourcechange).toHaveBeenCalledTimes(1);
   });
 
-  it('preserves source engine options across a src change', () => {
+  it('preserves source Vimeo options across a src change', () => {
     const media = new VimeoMedia();
-    media.source = { src: '76979871', engine: { autopause: true } };
+    media.source = { src: '76979871', vimeo: { autopause: true } };
 
     media.src = 'https://vimeo.com/12345';
-    expect(media.source).toEqual({ src: 'https://vimeo.com/12345', engine: { autopause: true } });
+    expect(media.source).toEqual({ src: 'https://vimeo.com/12345', vimeo: { autopause: true } });
   });
 
   it('does not reload for a structurally equal source', async () => {
     const media = new VimeoMedia();
     const { player } = await attachAndLoad(media);
-    media.source = { src: '76979871', engine: { autopause: true } };
+    media.source = { src: '76979871', vimeo: { autopause: true } };
     await Promise.resolve();
 
     const sourcechange = vi.fn();
     media.addEventListener('sourcechange', sourcechange);
     player.loadVideo.mockClear();
 
-    media.source = { src: '76979871', engine: { autopause: true } };
+    media.source = { src: '76979871', vimeo: { autopause: true } };
     await Promise.resolve();
 
     // Assigning is always announced, but nothing reaches the Vimeo player.
@@ -503,9 +503,9 @@ describe('VimeoMedia', () => {
     expect(media.src).toBe('');
   });
 
-  it('carries engine options into the initial embed URL', () => {
+  it('carries Vimeo options into the initial embed URL', () => {
     const media = new VimeoMedia();
-    media.source = { src: '76979871', engine: { autopause: true } };
+    media.source = { src: '76979871', vimeo: { autopause: true } };
 
     const iframe = createIframe();
     media.attach(iframe);
@@ -513,16 +513,16 @@ describe('VimeoMedia', () => {
     expect(iframe.src).toContain('autopause=1');
   });
 
-  it('reloads when only engine options change', async () => {
+  it('reloads when only Vimeo options change', async () => {
     const media = new VimeoMedia();
     const { player } = await attachAndLoad(media);
-    media.source = { src: '76979871', engine: { autopause: true } };
+    media.source = { src: '76979871', vimeo: { autopause: true } };
     await Promise.resolve();
     player.loadVideo.mockClear();
 
     // Same video, new embed options. They are read at load time, so the video
     // has to be loaded again for them to take effect.
-    media.source = { src: '76979871', engine: { autopause: false } };
+    media.source = { src: '76979871', vimeo: { autopause: false } };
     await Promise.resolve();
 
     expect(player.loadVideo).toHaveBeenCalledWith({
@@ -531,12 +531,12 @@ describe('VimeoMedia', () => {
     });
   });
 
-  it('carries engine options into loadVideo options', async () => {
+  it('carries Vimeo options into loadVideo options', async () => {
     const media = new VimeoMedia();
     const { player } = await attachAndLoad(media);
     player.loadVideo.mockClear();
 
-    media.source = { src: '76979871', engine: { autopause: false } };
+    media.source = { src: '76979871', vimeo: { autopause: false } };
     await Promise.resolve();
     expect(player.loadVideo).toHaveBeenCalledWith({
       url: 'https://player.vimeo.com/video/76979871',

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -123,8 +123,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   }
   /** YouTube URL or id. Setting it re-derives `source`, carrying its player parameters over. */
   set src(value) {
-    const { youtube } = this.#source ?? {};
-    const next: YouTubeSource = { ...(youtube && { youtube }), ...(value && { src: value }) };
+    const { engine } = this.#source ?? {};
+    const next: YouTubeSource = { ...(engine && { engine }), ...(value && { src: value }) };
 
     // Everything happens in the `source` setter, so there is one path for storing
     // it, deciding on a load, and dispatching `sourcechange`.
@@ -313,8 +313,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
 
   /**
    * Structured source: the YouTube URL or ID in `src`, plus player parameters
-   * under `youtube`. Replacing it re-derives `src`; assigning an equivalent
-   * source is a no-op.
+   * under `engine.youtube`. Replacing it re-derives `src`; assigning an
+   * equivalent source is a no-op.
    */
   get source(): YouTubeSource | null {
     return this.#source;
@@ -329,7 +329,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     const srcChanged = this.#src !== src;
     // Player parameters are read when the embed is built, so a change to them
     // needs a reload of its own even though the URL is the same.
-    const engineChanged = !deepEqual(this.#source?.youtube ?? null, source?.youtube ?? null);
+    const engineChanged = !deepEqual(this.#source?.engine?.youtube ?? null, source?.engine?.youtube ?? null);
 
     this.#source = source;
     this.#src = src;

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -123,8 +123,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
   }
   /** YouTube URL or id. Setting it re-derives `source`, carrying its player parameters over. */
   set src(value) {
-    const { engine } = this.#source ?? {};
-    const next: YouTubeSource = { ...(engine && { engine }), ...(value && { src: value }) };
+    const { youtube } = this.#source ?? {};
+    const next: YouTubeSource = { ...(youtube && { youtube }), ...(value && { src: value }) };
 
     // Everything happens in the `source` setter, so there is one path for storing
     // it, deciding on a load, and dispatching `sourcechange`.
@@ -313,8 +313,8 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
 
   /**
    * Structured source: the YouTube URL or ID in `src`, plus player parameters
-   * under `engine`. Replacing it re-derives `src`; assigning an equivalent source
-   * is a no-op.
+   * under `youtube`. Replacing it re-derives `src`; assigning an equivalent
+   * source is a no-op.
    */
   get source(): YouTubeSource | null {
     return this.#source;
@@ -329,7 +329,7 @@ export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
     const srcChanged = this.#src !== src;
     // Player parameters are read when the embed is built, so a change to them
     // needs a reload of its own even though the URL is the same.
-    const engineChanged = !deepEqual(this.#source?.engine ?? null, source?.engine ?? null);
+    const engineChanged = !deepEqual(this.#source?.youtube ?? null, source?.youtube ?? null);
 
     this.#source = source;
     this.#src = src;

--- a/packages/media/src/dom/youtube/source.ts
+++ b/packages/media/src/dom/youtube/source.ts
@@ -57,7 +57,7 @@ export interface YouTubeSource {
   /** YouTube URL or id. Mirrors the host's `src` property. */
   src?: string | undefined;
   /** YouTube's own player parameters, passed through untouched. */
-  engine?: YouTubeEngineConfig | undefined;
+  youtube?: YouTubeEngineConfig | undefined;
 }
 
 /** Parsed pieces of a YouTube source URL. */
@@ -125,7 +125,7 @@ export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaPr
     iv_load_policy: 3,
     start: parsed.startTime,
     // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
-    ...(props.source?.engine ?? undefined),
+    ...(props.source?.youtube ?? undefined),
   };
   if (parsed.kind === 'playlist' && parsed.listId) {
     return `${embedBase}?${serializeEmbedParams({ listType: 'playlist', list: parsed.listId, ...params })}`;

--- a/packages/media/src/dom/youtube/source.ts
+++ b/packages/media/src/dom/youtube/source.ts
@@ -56,6 +56,12 @@ export interface YouTubeEngineConfig extends Record<string, unknown> {
 export interface YouTubeSource {
   /** YouTube URL or id. Mirrors the host's `src` property. */
   src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: YouTubeSourceEngineConfig | undefined;
+}
+
+/** The engines a YouTube source can configure. */
+export interface YouTubeSourceEngineConfig {
   /** YouTube's own player parameters, passed through untouched. */
   youtube?: YouTubeEngineConfig | undefined;
 }
@@ -125,7 +131,7 @@ export function buildYouTubeIframeSrc(src: string, props: Partial<YouTubeMediaPr
     iv_load_policy: 3,
     start: parsed.startTime,
     // YouTube-specific knobs (`cc_load_policy`, `hl`, `color`, …) flow through here.
-    ...(props.source?.youtube ?? undefined),
+    ...(props.source?.engine?.youtube ?? undefined),
   };
   if (parsed.kind === 'playlist' && parsed.listId) {
     return `${embedBase}?${serializeEmbedParams({ listType: 'playlist', list: parsed.listId, ...params })}`;

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -214,16 +214,16 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).not.toContain('controls=0');
   });
 
-  it('forwards preload and YouTube-specific engine knobs', () => {
-    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { preload: 'auto', source: { engine: { cc_load_policy: 1 } } });
+  it('forwards preload and YouTube-specific knobs', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { preload: 'auto', source: { youtube: { cc_load_policy: 1 } } });
     expect(src).toContain('preload=auto');
     expect(src).toContain('cc_load_policy=1');
   });
 
-  it('serializes engine options verbatim', () => {
+  it('serializes YouTube player parameters verbatim', () => {
     const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
       source: {
-        engine: {
+        youtube: {
           cc_lang_pref: 'fr',
           color: 'white',
           disablekb: 1,
@@ -247,16 +247,16 @@ describe('buildYouTubeIframeSrc', () => {
     expect(src).toContain(`widget_referrer=${encodeURIComponent('https://widgets.example.com')}`);
   });
 
-  it('carries undeclared engine options through', () => {
+  it('carries undeclared YouTube player parameters through', () => {
     const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
       // Undocumented knobs and whatever YouTube adds next stay usable.
-      source: { engine: { some_future_param: 'x' } },
+      source: { youtube: { some_future_param: 'x' } },
     });
     expect(src).toContain('some_future_param=x');
   });
 
-  it('lets engine options override the defaults the host sets', () => {
-    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { source: { engine: { rel: 1, iv_load_policy: 1 } } });
+  it('lets YouTube player parameters override the defaults the host sets', () => {
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { source: { youtube: { rel: 1, iv_load_policy: 1 } } });
     expect(src).toContain('rel=1');
     expect(src).toContain('iv_load_policy=1');
   });
@@ -649,31 +649,31 @@ describe('YouTubeMedia source', () => {
     expect(sourceChange).toHaveBeenCalledTimes(1);
   });
 
-  it('re-derives source from src, carrying engine options over', () => {
+  it('re-derives source from src, carrying YouTube player parameters over', () => {
     const media = new YouTubeMedia();
-    media.source = { src: 'aqz-KE-bpKQ', engine: { cc_load_policy: 1 } };
+    media.source = { src: 'aqz-KE-bpKQ', youtube: { cc_load_policy: 1 } };
 
     media.src = 'dQw4w9WgXcQ';
 
-    expect(media.source).toEqual({ engine: { cc_load_policy: 1 }, src: 'dQw4w9WgXcQ' });
+    expect(media.source).toEqual({ youtube: { cc_load_policy: 1 }, src: 'dQw4w9WgXcQ' });
   });
 
-  it('reloads when only engine options change', async () => {
+  it('reloads when only YouTube player parameters change', async () => {
     const media = new YouTubeMedia();
     media.src = 'aqz-KE-bpKQ';
     const { player } = await attachAndLoad(media);
     player.cueVideoById.mockClear();
 
-    media.source = { src: 'aqz-KE-bpKQ', engine: { cc_load_policy: 1 } };
+    media.source = { src: 'aqz-KE-bpKQ', youtube: { cc_load_policy: 1 } };
     await Promise.resolve();
 
     expect(player.cueVideoById).toHaveBeenCalledWith({ videoId: 'aqz-KE-bpKQ' });
     media.detach();
   });
 
-  it('serializes engine options onto the initial iframe src', () => {
+  it('serializes YouTube player parameters onto the initial iframe src', () => {
     const media = new YouTubeMedia();
-    media.source = { src: 'aqz-KE-bpKQ', engine: { hl: 'fr' } };
+    media.source = { src: 'aqz-KE-bpKQ', youtube: { hl: 'fr' } };
     const iframe = createIframe();
     media.attach(iframe);
 

--- a/packages/media/src/dom/youtube/tests/media.test.ts
+++ b/packages/media/src/dom/youtube/tests/media.test.ts
@@ -215,7 +215,10 @@ describe('buildYouTubeIframeSrc', () => {
   });
 
   it('forwards preload and YouTube-specific knobs', () => {
-    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { preload: 'auto', source: { youtube: { cc_load_policy: 1 } } });
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
+      preload: 'auto',
+      source: { engine: { youtube: { cc_load_policy: 1 } } },
+    });
     expect(src).toContain('preload=auto');
     expect(src).toContain('cc_load_policy=1');
   });
@@ -223,16 +226,18 @@ describe('buildYouTubeIframeSrc', () => {
   it('serializes YouTube player parameters verbatim', () => {
     const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
       source: {
-        youtube: {
-          cc_lang_pref: 'fr',
-          color: 'white',
-          disablekb: 1,
-          end: 90,
-          fs: 0,
-          hl: 'fr-ca',
-          origin: 'https://example.com',
-          playlist: 'aqz-KE-bpKQ',
-          widget_referrer: 'https://widgets.example.com',
+        engine: {
+          youtube: {
+            cc_lang_pref: 'fr',
+            color: 'white',
+            disablekb: 1,
+            end: 90,
+            fs: 0,
+            hl: 'fr-ca',
+            origin: 'https://example.com',
+            playlist: 'aqz-KE-bpKQ',
+            widget_referrer: 'https://widgets.example.com',
+          },
         },
       },
     });
@@ -250,13 +255,15 @@ describe('buildYouTubeIframeSrc', () => {
   it('carries undeclared YouTube player parameters through', () => {
     const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
       // Undocumented knobs and whatever YouTube adds next stay usable.
-      source: { youtube: { some_future_param: 'x' } },
+      source: { engine: { youtube: { some_future_param: 'x' } } },
     });
     expect(src).toContain('some_future_param=x');
   });
 
   it('lets YouTube player parameters override the defaults the host sets', () => {
-    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', { source: { youtube: { rel: 1, iv_load_policy: 1 } } });
+    const src = buildYouTubeIframeSrc('aqz-KE-bpKQ', {
+      source: { engine: { youtube: { rel: 1, iv_load_policy: 1 } } },
+    });
     expect(src).toContain('rel=1');
     expect(src).toContain('iv_load_policy=1');
   });
@@ -651,11 +658,11 @@ describe('YouTubeMedia source', () => {
 
   it('re-derives source from src, carrying YouTube player parameters over', () => {
     const media = new YouTubeMedia();
-    media.source = { src: 'aqz-KE-bpKQ', youtube: { cc_load_policy: 1 } };
+    media.source = { src: 'aqz-KE-bpKQ', engine: { youtube: { cc_load_policy: 1 } } };
 
     media.src = 'dQw4w9WgXcQ';
 
-    expect(media.source).toEqual({ youtube: { cc_load_policy: 1 }, src: 'dQw4w9WgXcQ' });
+    expect(media.source).toEqual({ engine: { youtube: { cc_load_policy: 1 } }, src: 'dQw4w9WgXcQ' });
   });
 
   it('reloads when only YouTube player parameters change', async () => {
@@ -664,7 +671,7 @@ describe('YouTubeMedia source', () => {
     const { player } = await attachAndLoad(media);
     player.cueVideoById.mockClear();
 
-    media.source = { src: 'aqz-KE-bpKQ', youtube: { cc_load_policy: 1 } };
+    media.source = { src: 'aqz-KE-bpKQ', engine: { youtube: { cc_load_policy: 1 } } };
     await Promise.resolve();
 
     expect(player.cueVideoById).toHaveBeenCalledWith({ videoId: 'aqz-KE-bpKQ' });
@@ -673,7 +680,7 @@ describe('YouTubeMedia source', () => {
 
   it('serializes YouTube player parameters onto the initial iframe src', () => {
     const media = new YouTubeMedia();
-    media.source = { src: 'aqz-KE-bpKQ', youtube: { hl: 'fr' } };
+    media.source = { src: 'aqz-KE-bpKQ', engine: { youtube: { hl: 'fr' } } };
     const iframe = createIframe();
     media.attach(iframe);
 

--- a/packages/react/src/media/tests/mux-video.test.tsx
+++ b/packages/react/src/media/tests/mux-video.test.tsx
@@ -67,9 +67,11 @@ describe('MuxVideo', () => {
   });
 
   it('forwards engine options from the source prop to the media', () => {
-    const { media } = renderWithMedia(<MuxVideo source={{ playbackId: 'abc123', hlsJs: { maxBufferLength: 60 } }} />);
+    const { media } = renderWithMedia(
+      <MuxVideo source={{ playbackId: 'abc123', engine: { hlsJs: { maxBufferLength: 60 } } }} />
+    );
 
-    expect(media.source?.hlsJs).toEqual({ maxBufferLength: 60 });
+    expect(media.source?.engine?.hlsJs).toEqual({ maxBufferLength: 60 });
   });
 
   it('adds a storyboard track inferred from the source prop', () => {

--- a/packages/react/src/media/tests/mux-video.test.tsx
+++ b/packages/react/src/media/tests/mux-video.test.tsx
@@ -67,9 +67,9 @@ describe('MuxVideo', () => {
   });
 
   it('forwards engine options from the source prop to the media', () => {
-    const { media } = renderWithMedia(<MuxVideo source={{ playbackId: 'abc123', engine: { maxBufferLength: 60 } }} />);
+    const { media } = renderWithMedia(<MuxVideo source={{ playbackId: 'abc123', hlsJs: { maxBufferLength: 60 } }} />);
 
-    expect(media.source?.engine).toEqual({ maxBufferLength: 60 });
+    expect(media.source?.hlsJs).toEqual({ maxBufferLength: 60 });
   });
 
   it('adds a storyboard track inferred from the source prop', () => {

--- a/packages/react/src/media/vimeo-video/media.tsx
+++ b/packages/react/src/media/vimeo-video/media.tsx
@@ -37,7 +37,7 @@ export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(functio
       frameBorder={0}
       width="100%"
       height="100%"
-      referrerPolicy={props.source?.engine?.referrerPolicy}
+      referrerPolicy={props.source?.vimeo?.referrerPolicy}
       {...iframeProps}
       ref={composedRef}
     >

--- a/packages/react/src/media/vimeo-video/media.tsx
+++ b/packages/react/src/media/vimeo-video/media.tsx
@@ -37,7 +37,7 @@ export const VimeoVideo = forwardRef<HTMLIFrameElement, VimeoVideoProps>(functio
       frameBorder={0}
       width="100%"
       height="100%"
-      referrerPolicy={props.source?.vimeo?.referrerPolicy}
+      referrerPolicy={props.source?.engine?.vimeo?.referrerPolicy}
       {...iframeProps}
       ref={composedRef}
     >

--- a/packages/react/src/media/youtube-video/media.tsx
+++ b/packages/react/src/media/youtube-video/media.tsx
@@ -37,7 +37,7 @@ export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(fun
       frameBorder={0}
       width="100%"
       height="100%"
-      referrerPolicy={props.source?.engine?.referrerPolicy}
+      referrerPolicy={props.source?.youtube?.referrerPolicy}
       {...iframeProps}
       ref={composedRef}
     >

--- a/packages/react/src/media/youtube-video/media.tsx
+++ b/packages/react/src/media/youtube-video/media.tsx
@@ -37,7 +37,7 @@ export const YouTubeVideo = forwardRef<HTMLIFrameElement, YouTubeVideoProps>(fun
       frameBorder={0}
       width="100%"
       height="100%"
-      referrerPolicy={props.source?.youtube?.referrerPolicy}
+      referrerPolicy={props.source?.engine?.youtube?.referrerPolicy}
       {...iframeProps}
       ref={composedRef}
     >

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -263,7 +263,7 @@ Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM f
 
 ### Native HLS negotiates FairPlay itself
 
-When the browser plays the manifest — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element that takes the native path — there is no hls.js instance, and Safari never sees the configuration above. Name the license servers under `nativeHls` instead. FairPlay is the only system reachable this way:
+When the browser plays the manifest — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element that takes the native path — there is no hls.js instance, and Safari never sees the configuration above. Name the license servers under `nativeHls.drmSystems` instead. It takes the same shape as the hls.js one, keyed by key system, but only the `com.apple.fps` entry is read: FairPlay is the only system reachable this way.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -271,9 +271,11 @@ When the browser plays the manifest — <DocsLink slug="reference/native-hls-vid
   source={{
     src: 'https://example.com/protected.m3u8',
     nativeHls: {
-      drm: {
-        licenseUrl: 'https://license.example.com/fairplay',
-        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+      drmSystems: {
+        'com.apple.fps': {
+          licenseUrl: 'https://license.example.com/fairplay',
+          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+        },
       },
     },
   }}
@@ -289,9 +291,11 @@ const video = document.querySelector('native-hls-video');
 video.source = {
   src: 'https://example.com/protected.m3u8',
   nativeHls: {
-    drm: {
-      licenseUrl: 'https://license.example.com/fairplay',
-      serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+    drmSystems: {
+      'com.apple.fps': {
+        licenseUrl: 'https://license.example.com/fairplay',
+        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+      },
     },
   },
 };
@@ -300,19 +304,25 @@ video.source = {
 
 Video.js POSTs the CDM's license request to `licenseUrl` and hands the response back, so any FairPlay server that speaks the standard SPC/CKC exchange works as-is.
 
-Both halves can sit on one source, which is what the namespaces are for. `HlsJsVideo` reads only the one belonging to the engine it ends up using:
+Both halves can sit on one source, which is what the namespaces are for. `HlsJsVideo` reads only the one belonging to the engine it ends up using — and since the shapes match, one `drmSystems` object describes both:
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
+const drmSystems = {
+  'com.apple.fps': { licenseUrl, serverCertificateUrl },
+  'com.widevine.alpha': { licenseUrl: widevineLicenseUrl },
+  'com.microsoft.playready': { licenseUrl: playreadyLicenseUrl },
+};
+
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  hlsJs: { emeEnabled: true, drmSystems: { /* Widevine, PlayReady, FairPlay */ } },
-  nativeHls: { drm: { licenseUrl, serverCertificateUrl } },
+  hlsJs: { emeEnabled: true, drmSystems },
+  nativeHls: { drmSystems },
 };
 ```
 </FrameworkCase>
 
-Taking the native path with EME configured for hls.js and nothing under `nativeHls` warns in development — protected media would otherwise stall with no explanation. Encrypted media that reaches the native path with no `nativeHls.drm` at all fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
+Taking the native path with EME configured for hls.js and no FairPlay server under `nativeHls` warns in development — protected media would otherwise stall with no explanation. Encrypted media that reaches the native path with no `nativeHls.drmSystems['com.apple.fps']` fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
 
 ## Mux sources name a playback ID
 
@@ -363,7 +373,7 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 ### Mux signs DRM with a token
 
-Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in both halves above for you — `hlsJs.drmSystems` with EME switched on, and `nativeHls.drm` with the FairPlay server — so protected media plays whichever path the browser takes:
+Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in both halves above for you — `hlsJs.drmSystems` with EME switched on, and `nativeHls.drmSystems` — so protected media plays whichever path the browser takes:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -390,7 +400,7 @@ video.source = {
 
 DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
 
-A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `hlsJs.drmSystems` or `nativeHls.drm` yourself takes precedence, for content Mux doesn't license.
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `hlsJs.drmSystems` or `nativeHls.drmSystems` yourself takes precedence, for content Mux doesn't license.
 
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -138,11 +138,12 @@ Engine options are **namespaced by engine**. Each key holds that engine's own co
 | Key | Elements that read it | It holds |
 |---|---|---|
 | `hlsJs` | <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> | an [hls.js config](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning) |
+| `nativeHls` | <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, and the three above whenever the browser plays the manifest | options for the browser's own HLS support |
 | `dashJs` | <DocsLink slug="reference/dash-video">DashVideo</DocsLink> | [dash.js settings](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html) |
 | `vimeo` | `VimeoVideo` | [Vimeo embed parameters](https://developer.vimeo.com/player/sdk/embed) |
 | `youtube` | `YouTubeVideo` | [YouTube player parameters](https://developer.chrome.com/docs/youtube/iframe_api_reference#Parameters) |
 
-Naming the engine rather than using one generic key keeps configurations apart where an element has more than one engine to choose from, and leaves room for options that come to mean the same thing across all of them.
+Naming the engine rather than using one generic key matters where an element has more than one to choose from. `HlsJsVideo` plays through hls.js or through the browser depending on the platform and `preferPlayback`, and only one of them runs — so a single source can describe both paths without either engine reading the other's options.
 
 hls.js reads its options when the engine is constructed, so changing them tears down the engine and builds a new one:
 
@@ -214,7 +215,9 @@ It's a preference, not a demand — Video.js falls back to whichever path can ac
 
 ## DRM protected sources
 
-DRM is engine configuration like any other, so it goes under the engine that performs key exchange. For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
+DRM is engine configuration like any other, so it goes under whichever engine performs key exchange.
+
+For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -256,9 +259,60 @@ video.source = {
 
 Name every system you hold a license server for — which one gets used is the browser's choice. `serverCertificateUrl` is the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it.
 
-Only the hls.js (MSE) engine plays DRM-protected media, so native HLS playback ignores all of this and warns in development.
-
 Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM first, falling back to whatever robustness the browser offers, so content restricted to L1 devices plays where it can. Supplying your own `requestMediaKeySystemAccessFunc` replaces that entirely.
+
+### Native HLS negotiates FairPlay itself
+
+When the browser plays the manifest — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element that takes the native path — there is no hls.js instance, and Safari never sees the configuration above. Name the license servers under `nativeHls` instead. FairPlay is the only system reachable this way:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<NativeHlsVideo
+  source={{
+    src: 'https://example.com/protected.m3u8',
+    nativeHls: {
+      drm: {
+        licenseUrl: 'https://license.example.com/fairplay',
+        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+      },
+    },
+  }}
+  playsInline
+/>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+const video = document.querySelector('native-hls-video');
+
+video.source = {
+  src: 'https://example.com/protected.m3u8',
+  nativeHls: {
+    drm: {
+      licenseUrl: 'https://license.example.com/fairplay',
+      serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+    },
+  },
+};
+```
+</FrameworkCase>
+
+Video.js POSTs the CDM's license request to `licenseUrl` and hands the response back, so any FairPlay server that speaks the standard SPC/CKC exchange works as-is.
+
+Both halves can sit on one source, which is what the namespaces are for. `HlsJsVideo` reads only the one belonging to the engine it ends up using:
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+video.source = {
+  src: 'https://example.com/protected.m3u8',
+  hlsJs: { emeEnabled: true, drmSystems: { /* Widevine, PlayReady, FairPlay */ } },
+  nativeHls: { drm: { licenseUrl, serverCertificateUrl } },
+};
+```
+</FrameworkCase>
+
+Taking the native path with EME configured for hls.js and nothing under `nativeHls` warns in development — protected media would otherwise stall with no explanation. Encrypted media that reaches the native path with no `nativeHls.drm` at all fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
 
 ## Mux sources name a playback ID
 
@@ -309,7 +363,7 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 ### Mux signs DRM with a token
 
-Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in the `hlsJs.drmSystems` above for you, EME included:
+Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in both halves above for you — `hlsJs.drmSystems` with EME switched on, and `nativeHls.drm` with the FairPlay server — so protected media plays whichever path the browser takes:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -336,7 +390,7 @@ video.source = {
 
 DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
 
-A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `hlsJs.drmSystems` yourself takes precedence, for content Mux doesn't license.
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `hlsJs.drmSystems` or `nativeHls.drm` yourself takes precedence, for content Mux doesn't license.
 
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 
@@ -391,10 +445,7 @@ It survives a `src` change, so swapping the source keeps the frame you asked for
 
 ## Elements without engine options
 
-Two elements take `src` and the usual media attributes, but expose no `source`:
-
-- <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink> hands playback to the browser, so there is no engine to configure.
-- <DocsLink slug="reference/simple-hls-video">SimpleHlsVideo</DocsLink> and <DocsLink slug="reference/simple-hls-audio-only">SimpleHlsAudioOnly</DocsLink> run on our own playback engine, which does not accept configuration from the element yet.
+<DocsLink slug="reference/simple-hls-video">SimpleHlsVideo</DocsLink> and <DocsLink slug="reference/simple-hls-audio-only">SimpleHlsAudioOnly</DocsLink> take `src` and the usual media attributes but expose no `source`. They run on our own playback engine, which does not accept configuration from the element yet.
 
 ## Migrate from `config`
 
@@ -432,7 +483,7 @@ video.source = { src, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } }
 ```
 </FrameworkCase>
 
-`<native-hls-video>`, `<simple-hls-video>`, and `<simple-hls-audio-only>` accepted a `config` that nothing read. Remove it — those elements never applied it.
+`<simple-hls-video>` and `<simple-hls-audio-only>` accepted a `config` that nothing read. Remove it — those elements never applied it.
 
 ## See also
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -16,7 +16,7 @@ Every media element takes a `src`. Elements that drive a playback engine also ta
   source={{
     src: 'https://example.com/stream.m3u8',
     preferPlayback: 'mse',
-    engine: { maxBufferLength: 60 },
+    hlsJs: { maxBufferLength: 60 },
   }}
 />
 ```
@@ -29,7 +29,7 @@ const video = document.querySelector('hlsjs-video');
 video.source = {
   src: 'https://example.com/stream.m3u8',
   preferPlayback: 'mse',
-  engine: { maxBufferLength: 60 },
+  hlsJs: { maxBufferLength: 60 },
 };
 ```
 </FrameworkCase>
@@ -42,8 +42,8 @@ The shape answers one question: does this option describe the source, or how to 
 |---|---|---|
 | Which source to play | `source.src`, or an element's own identity fields | `src`, `MuxVideo`'s `playbackId` |
 | How to interpret it | `source.type` | `'video/mp4'` |
-| How Video.js plays it | `source`, alongside `engine` | `preferPlayback` |
-| How the engine behaves | `source.engine` | hls.js's `maxBufferLength` |
+| How Video.js plays it | `source`, at the top level | `preferPlayback` |
+| How a specific engine behaves | `source`, under that engine's name | hls.js's `maxBufferLength`, in `source.hlsJs` |
 | A side-car component's own settings | that component's props | <DocsLink slug="concepts/mux-data">Mux Data</DocsLink>, <DocsLink slug="concepts/cast">Google Cast</DocsLink> |
 
 `type` is worth reaching for when the URL lies about its contents. Video.js infers the content type from the file extension, so a manifest served from an extensionless or signed URL may need to say so explicitly:
@@ -62,7 +62,7 @@ video.source = { src: 'https://example.com/asset?id=42', type: 'application/vnd.
 
 ## `src` and `source` stay in sync
 
-They are two views of the same thing, and writing either updates the other. Setting `source` derives `src`. Setting `src` replaces only the identity half and **keeps the rest, such as `type` and `engine`, intact**:
+They are two views of the same thing, and writing either updates the other. Setting `source` derives `src`. Setting `src` replaces only the identity half and **keeps the rest, such as `type` and the engine options, intact**:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -112,7 +112,7 @@ Sources are compared **structurally**, not by reference. Reassigning an object w
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 // A fresh object literal on every render. Nothing reloads.
-<HlsJsVideo source={{ src, engine: { maxBufferLength: 60 } }} />
+<HlsJsVideo source={{ src, hlsJs: { maxBufferLength: 60 } }} />
 ```
 
 This is why you can write `source` inline. React hands the element a brand new object every render, and the element recognizes it as the same source. There's no need to memoize it or spread the previous value to avoid clobbering anything.
@@ -120,12 +120,12 @@ This is why you can write `source` inline. React hands the element a brand new o
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
-video.source = { src, engine: { maxBufferLength: 60 } };
-video.source = { src, engine: { maxBufferLength: 60 } }; // no-op
+video.source = { src, hlsJs: { maxBufferLength: 60 } };
+video.source = { src, hlsJs: { maxBufferLength: 60 } }; // no-op
 ```
 </FrameworkCase>
 
-Only a change to `engine`, `preferPlayback`, or the resolved content type recreates the playback engine.
+Only a change to the engine options, `preferPlayback`, or the resolved content type recreates the playback engine.
 
 <Aside type="note">
 `source` holds an object, so it's a property, not an attribute — there is no `source=""` in HTML. `src` remains the attribute, and it's the one to reach for when your markup only names a URL.
@@ -133,13 +133,16 @@ Only a change to `engine`, `preferPlayback`, or the resolved content type recrea
 
 ## Engine options
 
-`engine` is the playback engine's own configuration object, handed over untouched. There's no Video.js wrapper around it, so whatever the engine documents works:
+Engine options are **namespaced by engine**. Each key holds that engine's own configuration object, handed over untouched — there's no Video.js wrapper around it, so whatever the engine documents works:
 
-| Element | `engine` is |
-|---|---|
-| <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> | an [hls.js config](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning) |
-| <DocsLink slug="reference/dash-video">DashVideo</DocsLink> | [dash.js settings](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html) |
-| `VimeoVideo` | [Vimeo embed parameters](https://developer.vimeo.com/player/sdk/embed) |
+| Key | Elements that read it | It holds |
+|---|---|---|
+| `hlsJs` | <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> | an [hls.js config](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning) |
+| `dashJs` | <DocsLink slug="reference/dash-video">DashVideo</DocsLink> | [dash.js settings](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html) |
+| `vimeo` | `VimeoVideo` | [Vimeo embed parameters](https://developer.vimeo.com/player/sdk/embed) |
+| `youtube` | `YouTubeVideo` | [YouTube player parameters](https://developer.chrome.com/docs/youtube/iframe_api_reference#Parameters) |
+
+Naming the engine rather than using one generic key keeps configurations apart where an element has more than one engine to choose from, and leaves room for options that come to mean the same thing across all of them.
 
 hls.js reads its options when the engine is constructed, so changing them tears down the engine and builds a new one:
 
@@ -148,7 +151,7 @@ hls.js reads its options when the engine is constructed, so changing them tears 
 <HlsJsVideo
   source={{
     src: 'https://example.com/stream.m3u8',
-    engine: { maxBufferLength: 60, enableWorker: false },
+    hlsJs: { maxBufferLength: 60, enableWorker: false },
   }}
 />
 ```
@@ -158,19 +161,19 @@ hls.js reads its options when the engine is constructed, so changing them tears 
 ```ts
 video.source = {
   src: 'https://example.com/stream.m3u8',
-  engine: { maxBufferLength: 60, enableWorker: false },
+  hlsJs: { maxBufferLength: 60, enableWorker: false },
 };
 ```
 </FrameworkCase>
 
-dash.js takes settings on a running player, so `engine` is applied in place and playback continues uninterrupted:
+dash.js takes settings on a running player, so `dashJs` is applied in place and playback continues uninterrupted:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <DashVideo
   source={{
     src: 'https://example.com/manifest.mpd',
-    engine: { streaming: { abr: { maxBitrate: { video: 2000 } } } },
+    dashJs: { streaming: { abr: { maxBitrate: { video: 2000 } } } },
   }}
 />
 ```
@@ -182,16 +185,16 @@ const video = document.querySelector('dash-video');
 
 video.source = {
   src: 'https://example.com/manifest.mpd',
-  engine: { streaming: { abr: { maxBitrate: { video: 2000 } } } },
+  dashJs: { streaming: { abr: { maxBitrate: { video: 2000 } } } },
 };
 ```
 </FrameworkCase>
 
-Because `engine` replaces rather than merges, dropping a key restores the dash.js default instead of leaving the old value behind.
+Because `dashJs` replaces rather than merges, dropping a key restores the dash.js default instead of leaving the old value behind.
 
 ### Options Video.js normalizes
 
-Where an option means the same thing across engines, it sits on `source` itself rather than inside `engine`.
+Where an option means the same thing across engines, it sits on `source` itself rather than inside an engine's namespace.
 
 `preferPlayback` picks between [hls.js](https://github.com/video-dev/hls.js/) and the browser's own HLS support:
 
@@ -211,14 +214,14 @@ It's a preference, not a demand — Video.js falls back to whichever path can ac
 
 ## DRM protected sources
 
-DRM is engine configuration like any other, so it goes under `engine` — for hls.js, that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
+DRM is engine configuration like any other, so it goes under the engine that performs key exchange. For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <HlsJsVideo
   source={{
     src: 'https://example.com/protected.m3u8',
-    engine: {
+    hlsJs: {
       emeEnabled: true,
       drmSystems: {
         'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
@@ -237,7 +240,7 @@ DRM is engine configuration like any other, so it goes under `engine` — for hl
 ```ts
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  engine: {
+  hlsJs: {
     emeEnabled: true,
     drmSystems: {
       'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
@@ -259,7 +262,7 @@ Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM f
 
 ## Mux sources name a playback ID
 
-<DocsLink slug="reference/mux-video">MuxVideo</DocsLink> and <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> identify a source by `playbackId` rather than a URL, and derive `src` from it. Everything else works the same, `engine` included:
+<DocsLink slug="reference/mux-video">MuxVideo</DocsLink> and <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> identify a source by `playbackId` rather than a URL, and derive `src` from it. Everything else works the same, engine options included:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -267,7 +270,7 @@ Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM f
   source={{
     playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
     playback: { maxResolution: '1080p' },
-    engine: { maxBufferLength: 60 },
+    hlsJs: { maxBufferLength: 60 },
   }}
   playsInline
 />
@@ -281,7 +284,7 @@ const video = document.querySelector('mux-video');
 video.source = {
   playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
   playback: { maxResolution: '1080p' },
-  engine: { maxBufferLength: 60 },
+  hlsJs: { maxBufferLength: 60 },
 };
 ```
 </FrameworkCase>
@@ -306,7 +309,7 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 ### Mux signs DRM with a token
 
-Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in the `engine.drmSystems` above for you, EME included:
+Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in the `hlsJs.drmSystems` above for you, EME included:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -333,7 +336,7 @@ video.source = {
 
 DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
 
-A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `engine.drmSystems` yourself takes precedence, for content Mux doesn't license.
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `hlsJs.drmSystems` yourself takes precedence, for content Mux doesn't license.
 
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 
@@ -401,12 +404,13 @@ Media elements used to take a `config` object: one untyped bag holding engine op
 |---|---|
 | `config.preferPlayback` | `source.preferPlayback` |
 | `config.contentType` | `source.type` |
-| `config.hlsJs` | `source.engine` |
+| `config.hlsJs` | `source.hlsJs` |
+| `config.dashJs` | `source.dashJs` |
 | `config.muxData` | the <DocsLink slug="concepts/mux-data">Mux Data</DocsLink> component's own props |
 | `config.googleCast` | the <DocsLink slug="concepts/cast">Google Cast</DocsLink> component's own props |
-| `config` on VimeoVideo | `source.engine` |
+| `config` on VimeoVideo | `source.vimeo` |
 
-The `hlsJs` and `dashJs` nesting is gone: `engine` *is* the engine's config object now, so its options sit one level shallower than they did under `config`.
+The engine keys keep their names, so their contents move across unchanged — what moves is the object they sit in.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -414,7 +418,7 @@ The `hlsJs` and `dashJs` nesting is gone: `engine` *is* the engine's config obje
 <HlsJsVideo src={src} config={{ preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } }} />
 
 // After
-<HlsJsVideo source={{ src, preferPlayback: 'native', engine: { maxBufferLength: 60 } }} />
+<HlsJsVideo source={{ src, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } }} />
 ```
 </FrameworkCase>
 
@@ -424,7 +428,7 @@ The `hlsJs` and `dashJs` nesting is gone: `engine` *is* the engine's config obje
 video.config = { preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
 
 // After
-video.source = { src, preferPlayback: 'native', engine: { maxBufferLength: 60 } };
+video.source = { src, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
 ```
 </FrameworkCase>
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -16,7 +16,7 @@ Every media element takes a `src`. Elements that drive a playback engine also ta
   source={{
     src: 'https://example.com/stream.m3u8',
     preferPlayback: 'mse',
-    hlsJs: { maxBufferLength: 60 },
+    engine: { hlsJs: { maxBufferLength: 60 } },
   }}
 />
 ```
@@ -29,7 +29,7 @@ const video = document.querySelector('hlsjs-video');
 video.source = {
   src: 'https://example.com/stream.m3u8',
   preferPlayback: 'mse',
-  hlsJs: { maxBufferLength: 60 },
+  engine: { hlsJs: { maxBufferLength: 60 } },
 };
 ```
 </FrameworkCase>
@@ -43,7 +43,7 @@ The shape answers one question: does this option describe the source, or how to 
 | Which source to play | `source.src`, or an element's own identity fields | `src`, `MuxVideo`'s `playbackId` |
 | How to interpret it | `source.type` | `'video/mp4'` |
 | How Video.js plays it | `source`, at the top level | `preferPlayback` |
-| How a specific engine behaves | `source`, under that engine's name | hls.js's `maxBufferLength`, in `source.hlsJs` |
+| How a specific engine behaves | `source.engine`, under that engine's name | hls.js's `maxBufferLength`, in `source.engine.hlsJs` |
 | A side-car component's own settings | that component's props | <DocsLink slug="concepts/mux-data">Mux Data</DocsLink>, <DocsLink slug="concepts/cast">Google Cast</DocsLink> |
 
 `type` is worth reaching for when the URL lies about its contents. Video.js infers the content type from the file extension, so a manifest served from an extensionless or signed URL may need to say so explicitly:
@@ -112,7 +112,7 @@ Sources are compared **structurally**, not by reference. Reassigning an object w
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 // A fresh object literal on every render. Nothing reloads.
-<HlsJsVideo source={{ src, hlsJs: { maxBufferLength: 60 } }} />
+<HlsJsVideo source={{ src, engine: { hlsJs: { maxBufferLength: 60 } } }} />
 ```
 
 This is why you can write `source` inline. React hands the element a brand new object every render, and the element recognizes it as the same source. There's no need to memoize it or spread the previous value to avoid clobbering anything.
@@ -120,8 +120,8 @@ This is why you can write `source` inline. React hands the element a brand new o
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
-video.source = { src, hlsJs: { maxBufferLength: 60 } };
-video.source = { src, hlsJs: { maxBufferLength: 60 } }; // no-op
+video.source = { src, engine: { hlsJs: { maxBufferLength: 60 } } };
+video.source = { src, engine: { hlsJs: { maxBufferLength: 60 } } }; // no-op
 ```
 </FrameworkCase>
 
@@ -133,15 +133,15 @@ Only a change to the engine options, `preferPlayback`, or the resolved content t
 
 ## Engine options
 
-Engine options are **namespaced by engine**. Each key holds that engine's own configuration object, handed over untouched — there's no Video.js wrapper around it, so whatever the engine documents works:
+Engine options live under `source.engine`, **namespaced by engine**. Each key there holds that engine's own configuration object, handed over untouched — there's no Video.js wrapper around it, so whatever the engine documents works:
 
 | Key | Elements that read it | It holds |
 |---|---|---|
-| `hlsJs` | <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> | an [hls.js config](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning) |
-| `nativeHls` | <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, and the three above whenever the browser plays the manifest | options for the browser's own HLS support |
-| `dashJs` | <DocsLink slug="reference/dash-video">DashVideo</DocsLink> | [dash.js settings](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html) |
-| `vimeo` | `VimeoVideo` | [Vimeo embed parameters](https://developer.vimeo.com/player/sdk/embed) |
-| `youtube` | `YouTubeVideo` | [YouTube player parameters](https://developer.chrome.com/docs/youtube/iframe_api_reference#Parameters) |
+| `engine.hlsJs` | <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> | an [hls.js config](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning) |
+| `engine.nativeHls` | <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, and the three above whenever the browser plays the manifest | options for the browser's own HLS support |
+| `engine.dashJs` | <DocsLink slug="reference/dash-video">DashVideo</DocsLink> | [dash.js settings](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html) |
+| `engine.vimeo` | `VimeoVideo` | [Vimeo embed parameters](https://developer.vimeo.com/player/sdk/embed) |
+| `engine.youtube` | `YouTubeVideo` | [YouTube player parameters](https://developer.chrome.com/docs/youtube/iframe_api_reference#Parameters) |
 
 Naming the engine rather than using one generic key matters where an element has more than one to choose from. `HlsJsVideo` plays through hls.js or through the browser depending on the platform and `preferPlayback`, and only one of them runs — so a single source can describe both paths without either engine reading the other's options.
 
@@ -152,7 +152,7 @@ hls.js reads its options when the engine is constructed, so changing them tears 
 <HlsJsVideo
   source={{
     src: 'https://example.com/stream.m3u8',
-    hlsJs: { maxBufferLength: 60, enableWorker: false },
+    engine: { hlsJs: { maxBufferLength: 60, enableWorker: false } },
   }}
 />
 ```
@@ -162,19 +162,19 @@ hls.js reads its options when the engine is constructed, so changing them tears 
 ```ts
 video.source = {
   src: 'https://example.com/stream.m3u8',
-  hlsJs: { maxBufferLength: 60, enableWorker: false },
+  engine: { hlsJs: { maxBufferLength: 60, enableWorker: false } },
 };
 ```
 </FrameworkCase>
 
-dash.js takes settings on a running player, so `dashJs` is applied in place and playback continues uninterrupted:
+dash.js takes settings on a running player, so `engine.dashJs` is applied in place and playback continues uninterrupted:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <DashVideo
   source={{
     src: 'https://example.com/manifest.mpd',
-    dashJs: { streaming: { abr: { maxBitrate: { video: 2000 } } } },
+    engine: { dashJs: { streaming: { abr: { maxBitrate: { video: 2000 } } } } },
   }}
 />
 ```
@@ -186,12 +186,12 @@ const video = document.querySelector('dash-video');
 
 video.source = {
   src: 'https://example.com/manifest.mpd',
-  dashJs: { streaming: { abr: { maxBitrate: { video: 2000 } } } },
+  engine: { dashJs: { streaming: { abr: { maxBitrate: { video: 2000 } } } } },
 };
 ```
 </FrameworkCase>
 
-Because `dashJs` replaces rather than merges, dropping a key restores the dash.js default instead of leaving the old value behind.
+Because `engine.dashJs` replaces rather than merges, dropping a key restores the dash.js default instead of leaving the old value behind.
 
 ### Options Video.js normalizes
 
@@ -224,13 +224,15 @@ For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
 <HlsJsVideo
   source={{
     src: 'https://example.com/protected.m3u8',
-    hlsJs: {
-      emeEnabled: true,
-      drmSystems: {
-        'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
-        'com.apple.fps': {
-          licenseUrl: 'https://license.example.com/fairplay',
-          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+    engine: {
+      hlsJs: {
+        emeEnabled: true,
+        drmSystems: {
+          'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
+          'com.apple.fps': {
+            licenseUrl: 'https://license.example.com/fairplay',
+            serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+          },
         },
       },
     },
@@ -243,13 +245,15 @@ For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
 ```ts
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  hlsJs: {
-    emeEnabled: true,
-    drmSystems: {
-      'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
-      'com.apple.fps': {
-        licenseUrl: 'https://license.example.com/fairplay',
-        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+  engine: {
+    hlsJs: {
+      emeEnabled: true,
+      drmSystems: {
+        'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
+        'com.apple.fps': {
+          licenseUrl: 'https://license.example.com/fairplay',
+          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+        },
       },
     },
   },
@@ -263,18 +267,20 @@ Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM f
 
 ### Native HLS negotiates FairPlay itself
 
-When the browser plays the manifest — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element that takes the native path — there is no hls.js instance, and Safari never sees the configuration above. Name the license servers under `nativeHls.drmSystems` instead. It takes the same shape as the hls.js one, keyed by key system, but only the `com.apple.fps` entry is read: FairPlay is the only system reachable this way.
+When the browser plays the manifest — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element that takes the native path — there is no hls.js instance, and Safari never sees the configuration above. Name the license servers under `engine.nativeHls.drmSystems` instead. It takes the same shape as the hls.js one, keyed by key system, but only the `com.apple.fps` entry is read: FairPlay is the only system reachable this way.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <NativeHlsVideo
   source={{
     src: 'https://example.com/protected.m3u8',
-    nativeHls: {
-      drmSystems: {
-        'com.apple.fps': {
-          licenseUrl: 'https://license.example.com/fairplay',
-          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+    engine: {
+      nativeHls: {
+        drmSystems: {
+          'com.apple.fps': {
+            licenseUrl: 'https://license.example.com/fairplay',
+            serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+          },
         },
       },
     },
@@ -290,11 +296,13 @@ const video = document.querySelector('native-hls-video');
 
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  nativeHls: {
-    drmSystems: {
-      'com.apple.fps': {
-        licenseUrl: 'https://license.example.com/fairplay',
-        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+  engine: {
+    nativeHls: {
+      drmSystems: {
+        'com.apple.fps': {
+          licenseUrl: 'https://license.example.com/fairplay',
+          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
+        },
       },
     },
   },
@@ -316,13 +324,15 @@ const drmSystems = {
 
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  hlsJs: { emeEnabled: true, drmSystems },
-  nativeHls: { drmSystems },
+  engine: {
+    hlsJs: { emeEnabled: true, drmSystems },
+    nativeHls: { drmSystems },
+  },
 };
 ```
 </FrameworkCase>
 
-Taking the native path with EME configured for hls.js and no FairPlay server under `nativeHls` warns in development — protected media would otherwise stall with no explanation. Encrypted media that reaches the native path with no `nativeHls.drmSystems['com.apple.fps']` fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
+Taking the native path with EME configured for hls.js and no FairPlay server under `engine.nativeHls` warns in development — protected media would otherwise stall with no explanation. Encrypted media that reaches the native path with no `engine.nativeHls.drmSystems['com.apple.fps']` fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
 
 ## Mux sources name a playback ID
 
@@ -334,7 +344,7 @@ Taking the native path with EME configured for hls.js and no FairPlay server und
   source={{
     playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
     playback: { maxResolution: '1080p' },
-    hlsJs: { maxBufferLength: 60 },
+    engine: { hlsJs: { maxBufferLength: 60 } },
   }}
   playsInline
 />
@@ -348,7 +358,7 @@ const video = document.querySelector('mux-video');
 video.source = {
   playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM',
   playback: { maxResolution: '1080p' },
-  hlsJs: { maxBufferLength: 60 },
+  engine: { hlsJs: { maxBufferLength: 60 } },
 };
 ```
 </FrameworkCase>
@@ -373,7 +383,7 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 ### Mux signs DRM with a token
 
-Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in both halves above for you — `hlsJs.drmSystems` with EME switched on, and `nativeHls.drmSystems` — so protected media plays whichever path the browser takes:
+Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in both halves above for you — `engine.hlsJs.drmSystems` with EME switched on, and `engine.nativeHls.drmSystems` — so protected media plays whichever path the browser takes:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -400,7 +410,7 @@ video.source = {
 
 DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
 
-A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `hlsJs.drmSystems` or `nativeHls.drmSystems` yourself takes precedence, for content Mux doesn't license.
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `engine.hlsJs.drmSystems` or `engine.nativeHls.drmSystems` yourself takes precedence, for content Mux doesn't license.
 
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 
@@ -465,11 +475,11 @@ Media elements used to take a `config` object: one untyped bag holding engine op
 |---|---|
 | `config.preferPlayback` | `source.preferPlayback` |
 | `config.contentType` | `source.type` |
-| `config.hlsJs` | `source.hlsJs` |
-| `config.dashJs` | `source.dashJs` |
+| `config.hlsJs` | `source.engine.hlsJs` |
+| `config.dashJs` | `source.engine.dashJs` |
 | `config.muxData` | the <DocsLink slug="concepts/mux-data">Mux Data</DocsLink> component's own props |
 | `config.googleCast` | the <DocsLink slug="concepts/cast">Google Cast</DocsLink> component's own props |
-| `config` on VimeoVideo | `source.vimeo` |
+| `config` on VimeoVideo | `source.engine.vimeo` |
 
 The engine keys keep their names, so their contents move across unchanged — what moves is the object they sit in.
 
@@ -479,7 +489,7 @@ The engine keys keep their names, so their contents move across unchanged — wh
 <HlsJsVideo src={src} config={{ preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } }} />
 
 // After
-<HlsJsVideo source={{ src, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } }} />
+<HlsJsVideo source={{ src, preferPlayback: 'native', engine: { hlsJs: { maxBufferLength: 60 } } }} />
 ```
 </FrameworkCase>
 
@@ -489,7 +499,7 @@ The engine keys keep their names, so their contents move across unchanged — wh
 video.config = { preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
 
 // After
-video.source = { src, preferPlayback: 'native', hlsJs: { maxBufferLength: 60 } };
+video.source = { src, preferPlayback: 'native', engine: { hlsJs: { maxBufferLength: 60 } } };
 ```
 </FrameworkCase>
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -138,7 +138,7 @@ Engine options live under `source.engine`, **namespaced by engine**. Each key th
 | Key | Elements that read it | It holds |
 |---|---|---|
 | `engine.hlsJs` | <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/mux-audio">MuxAudio</DocsLink> | an [hls.js config](https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning) |
-| `engine.nativeHls` | <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, and the three above whenever the browser plays the manifest | options for the browser's own HLS support |
+| `engine.nativeHls` | <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, and the three above whenever the browser plays the manifest | options for the browser's own HLS support (today, [DRM](#licensing-one-engine-differently)) |
 | `engine.dashJs` | <DocsLink slug="reference/dash-video">DashVideo</DocsLink> | [dash.js settings](https://cdn.dashjs.org/latest/jsdoc/module-Settings.html) |
 | `engine.vimeo` | `VimeoVideo` | [Vimeo embed parameters](https://developer.vimeo.com/player/sdk/embed) |
 | `engine.youtube` | `YouTubeVideo` | [YouTube player parameters](https://developer.chrome.com/docs/youtube/iframe_api_reference#Parameters) |
@@ -215,26 +215,20 @@ It's a preference, not a demand — Video.js falls back to whichever path can ac
 
 ## DRM protected sources
 
-DRM is engine configuration like any other, so it goes under whichever engine performs key exchange.
-
-For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
+Protected content is licensed through `source.drm`, keyed by EME key system id — alongside the URL rather than inside an engine's namespace, because which engine plays the manifest is decided later and both paths read it:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 <HlsJsVideo
   source={{
     src: 'https://example.com/protected.m3u8',
-    engine: {
-      hlsJs: {
-        emeEnabled: true,
-        drmSystems: {
-          'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
-          'com.apple.fps': {
-            licenseUrl: 'https://license.example.com/fairplay',
-            serverCertificateUrl: 'https://license.example.com/fairplay-cert',
-          },
-        },
+    drm: {
+      'com.apple.fps': {
+        licenseUrl: 'https://license.example.com/fairplay',
+        serverCertificateUrl: 'https://license.example.com/fairplay-cert',
       },
+      'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
+      'com.microsoft.playready': { licenseUrl: 'https://license.example.com/playready' },
     },
   }}
 />
@@ -245,94 +239,51 @@ For hls.js that's `emeEnabled` and `drmSystems`, keyed by EME key system id:
 ```ts
 video.source = {
   src: 'https://example.com/protected.m3u8',
-  engine: {
-    hlsJs: {
-      emeEnabled: true,
-      drmSystems: {
-        'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
-        'com.apple.fps': {
-          licenseUrl: 'https://license.example.com/fairplay',
-          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
-        },
-      },
+  drm: {
+    'com.apple.fps': {
+      licenseUrl: 'https://license.example.com/fairplay',
+      serverCertificateUrl: 'https://license.example.com/fairplay-cert',
     },
+    'com.widevine.alpha': { licenseUrl: 'https://license.example.com/widevine' },
+    'com.microsoft.playready': { licenseUrl: 'https://license.example.com/playready' },
   },
 };
 ```
 </FrameworkCase>
 
-Name every system you hold a license server for — which one gets used is the browser's choice. `serverCertificateUrl` is the server (application) certificate FairPlay requires; Widevine and PlayReady ignore it.
+Name every system you hold a license server for — which one gets used is the browser's choice. `serverCertificateUrl` is the DRM server (application) certificate FairPlay requires; Widevine and PlayReady ignore it.
 
-Video.js adds one thing on top: for Widevine it asks for a hardware-backed CDM first, falling back to whatever robustness the browser offers, so content restricted to L1 devices plays where it can. Supplying your own `requestMediaKeySystemAccessFunc` replaces that entirely.
+### What each path can license
 
-### Native HLS negotiates FairPlay itself
+The same `drm` reaches both playback paths, and how far it gets is the one thing worth knowing about each:
 
-When the browser plays the manifest — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element that takes the native path — there is no hls.js instance, and Safari never sees the configuration above. Name the license servers under `engine.nativeHls.drmSystems` instead. It takes the same shape as the hls.js one, keyed by key system, but only the `com.apple.fps` entry is read: FairPlay is the only system reachable this way.
+| Path | Key systems it negotiates | What Video.js does with `drm` |
+|---|---|---|
+| hls.js (MSE) | FairPlay, Widevine, PlayReady | Hands it to hls.js as `drmSystems`, with `emeEnabled` switched on |
+| The browser's own HLS | FairPlay | Answers the element's key requests itself: POSTs the CDM's license request to `licenseUrl` and hands the response back |
 
-<FrameworkCase frameworks={["react"]}>
-```tsx
-<NativeHlsVideo
-  source={{
-    src: 'https://example.com/protected.m3u8',
-    engine: {
-      nativeHls: {
-        drmSystems: {
-          'com.apple.fps': {
-            licenseUrl: 'https://license.example.com/fairplay',
-            serverCertificateUrl: 'https://license.example.com/fairplay-cert',
-          },
-        },
-      },
-    },
-  }}
-  playsInline
-/>
-```
-</FrameworkCase>
+So a source naming only Widevine plays through hls.js and cannot play on the native path — <DocsLink slug="reference/native-hls-video">NativeHlsVideo</DocsLink>, or any HLS element the browser ends up playing the manifest for. Video.js says so in development, and encrypted media that gets there with no `com.apple.fps` license server fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
+
+For Widevine on hls.js, Video.js asks for a hardware-backed CDM first, falling back to whatever robustness the browser offers, so content restricted to L1 devices plays where it can. Supplying your own `requestMediaKeySystemAccessFunc` replaces that entirely.
+
+### Licensing one engine differently
+
+An engine's own `drmSystems` **replaces** `source.drm`, for that engine alone. Reach for it when one path licenses differently, or when you need more of [hls.js's DRM configuration](https://github.com/video-dev/hls.js/blob/master/docs/API.md#drmsystems) than `drm` covers:
 
 <FrameworkCase frameworks={["html"]}>
 ```ts
-const video = document.querySelector('native-hls-video');
-
 video.source = {
   src: 'https://example.com/protected.m3u8',
+  drm: { 'com.apple.fps': { licenseUrl, serverCertificateUrl } },
   engine: {
-    nativeHls: {
-      drmSystems: {
-        'com.apple.fps': {
-          licenseUrl: 'https://license.example.com/fairplay',
-          serverCertificateUrl: 'https://license.example.com/fairplay-cert',
-        },
-      },
-    },
+    // hls.js licenses from here instead, and the native path still from `drm`.
+    hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: widevineLicenseUrl } } },
   },
 };
 ```
 </FrameworkCase>
 
-Video.js POSTs the CDM's license request to `licenseUrl` and hands the response back, so any FairPlay server that speaks the standard SPC/CKC exchange works as-is.
-
-Both halves can sit on one source, which is what the namespaces are for. `HlsJsVideo` reads only the one belonging to the engine it ends up using — and since the shapes match, one `drmSystems` object describes both:
-
-<FrameworkCase frameworks={["html"]}>
-```ts
-const drmSystems = {
-  'com.apple.fps': { licenseUrl, serverCertificateUrl },
-  'com.widevine.alpha': { licenseUrl: widevineLicenseUrl },
-  'com.microsoft.playready': { licenseUrl: playreadyLicenseUrl },
-};
-
-video.source = {
-  src: 'https://example.com/protected.m3u8',
-  engine: {
-    hlsJs: { emeEnabled: true, drmSystems },
-    nativeHls: { drmSystems },
-  },
-};
-```
-</FrameworkCase>
-
-Taking the native path with EME configured for hls.js and no FairPlay server under `engine.nativeHls` warns in development — protected media would otherwise stall with no explanation. Encrypted media that reaches the native path with no `engine.nativeHls.drmSystems['com.apple.fps']` fails with a `MEDIA_ERR_ENCRYPTED` error rather than hanging.
+It replaces rather than merges, so the FairPlay server above is gone as far as hls.js is concerned. `engine.nativeHls.drmSystems` does the same for the native path.
 
 ## Mux sources name a playback ID
 
@@ -383,7 +334,7 @@ video.source = { playbackId, storyboard: { format: 'jpg' }, poster: { time: 12 }
 
 ### Mux signs DRM with a token
 
-Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token and nothing else. It fills in both halves above for you — `engine.hlsJs.drmSystems` with EME switched on, and `engine.nativeHls.drmSystems` — so protected media plays whichever path the browser takes:
+Mux serves FairPlay, Widevine, and PlayReady from URLs derived from a single license token, so `source.drm` takes that token in place of the license servers it would otherwise name. Mux fills the rest in for you, so protected media plays whichever path the browser takes:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -410,7 +361,18 @@ video.source = {
 
 DRM playback is always signed, so a `playback.token` belongs alongside it — and `poster.token` / `storyboard.token` for the images. Each is scoped to a different audience, so they are four separate tokens rather than one reused four times. Sign them on your server; see [Mux's DRM guide](https://www.mux.com/docs/guides/protect-videos-with-drm) for how.
 
-A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. Naming `engine.hlsJs.drmSystems` or `engine.nativeHls.drmSystems` yourself takes precedence, for content Mux doesn't license.
+A `drm.token` that isn't scoped to DRM is ignored rather than sent, since the license request would be rejected. License servers named alongside the token win, key by key, for the systems Mux doesn't license:
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+video.source = {
+  playbackId,
+  playback: { token: playbackToken },
+  // FairPlay and PlayReady from Mux, Widevine from your own server.
+  drm: { token: drmToken, 'com.widevine.alpha': { licenseUrl: widevineLicenseUrl } },
+};
+```
+</FrameworkCase>
 
 `source.poster` gets no such treatment — it's only data, and nothing applies it to the media. Both URLs are readable from `contentData`, keyed by what each one describes:
 


### PR DESCRIPTION
Refs #1775 · follows #1948 (hls.js DRM), #1903 (source restructure)

Native HLS can play DRM-protected content, and every element licenses protected sources the same way: `source.drm`, keyed by EME key system id. Engine options are grouped under `source.engine` and namespaced by engine to get there.

## Breaking — engine options move to `source.engine`

```diff
-<HlsJsVideo source={{ src, engine: { maxBufferLength: 60 } }} />
+<HlsJsVideo source={{ src, engine: { hlsJs: { maxBufferLength: 60 } } }} />
```

| Element | Before | After |
|---|---|---|
| `HlsJsVideo`, `MuxVideo`, `MuxAudio` | `source.engine` | `source.engine.hlsJs`, `source.engine.nativeHls` |
| `NativeHlsVideo` | — | `source.drm`, `source.engine.nativeHls` |
| `DashVideo` | `source.engine` | `source.engine.dashJs` |
| `VimeoVideo` | `source.engine` | `source.engine.vimeo` |
| `YouTubeVideo` | `source.engine` | `source.engine.youtube` |

Contents move across unchanged; what changes is that `engine` is now keyed by engine rather than holding one engine's config directly. `src`, `type`, `preferPlayback`, `drm`, and Mux's identity params stay at the top level, so what describes the source stays apart from what configures an engine — and one source can carry two engines without either reading the other's options, per [this review](https://github.com/videojs/v10/pull/1903#discussion_r3701915674).

## New — DRM lives on the source, not the engine

Which engine plays a manifest is decided at load time, so licensing was the one "engine option" a protected source had to state twice to play everywhere. `source.drm` names the license servers once, keyed by key system:

```ts
hlsJsVideo.source = {
  src: 'https://example.com/protected.m3u8',
  drm: {
    'com.apple.fps': { licenseUrl, serverCertificateUrl },
    'com.widevine.alpha': { licenseUrl: widevineLicenseUrl },
  },
};
```

The same object works on `NativeHlsVideo`, `HlsJsVideo`, `MuxVideo`, and `MuxAudio`. What each path does with it is the only difference:

| Path | Key systems it negotiates | What it does with `drm` |
|---|---|---|
| hls.js (MSE) | FairPlay, Widevine, PlayReady | Handed to hls.js as `drmSystems`, with `emeEnabled` switched on |
| The browser's own HLS | FairPlay | Video.js answers the element's key requests itself: POSTs the CDM's request to `licenseUrl`, hands the response back |

An engine's own `drmSystems` still works, and now reads as what it is: an escape hatch that **replaces** `source.drm` for that engine alone — for a path that licenses differently, or for the parts of hls.js's DRM configuration `source.drm` does not cover.

```ts
hlsJsVideo.source = {
  src,
  drm: { 'com.apple.fps': { licenseUrl, serverCertificateUrl } },
  // hls.js licenses from here instead; the native path still from `drm`.
  engine: { hlsJs: { drmSystems: { 'com.widevine.alpha': { licenseUrl: widevineLicenseUrl } } } },
};
```

Mux still derives everything from one token, into `drm` rather than into both engine configs. Servers named alongside the token win key by key, so a source can mix Mux-licensed and self-licensed systems:

```ts
muxVideo.source = { playbackId, playback: { token: playbackToken }, drm: { token: drmToken } };
```

## New — DRM on the native path

`NativeHlsVideo` gains a structured `source`, and FairPlay key exchange against the media element: fetch the application certificate, trade the CDM's SPC for a CKC at the license server, release everything between sources. FairPlay is the only system Safari negotiates, so a `drm` naming Widevine or PlayReady is carried but unused.

Encrypted media that reaches this path with no `com.apple.fps` license server **fails loudly** with a `MEDIA_ERR_ENCRYPTED` error, rather than stalling the way Safari does. A development warning covers the near miss the shared shape invites: licensing configured for hls.js only, or a `drm` that names only the systems MSE can reach.

## Exports

`@videojs/media`, and every engine entry (`/dom/hls-js`, `/dom/native-hls`, `/dom/mux`):

```ts
interface DrmSystemConfig { licenseUrl: string; serverCertificateUrl?: string }
type DrmSystemsConfig = Partial<Record<KeySystem, DrmSystemConfig>>;

const KeySystems = { FAIRPLAY, WIDEVINE, PLAYREADY, CLEARKEY };
type KeySystem // the union of those values
```

`@videojs/media/dom/native-hls`:

```ts
interface NativeHlsSource       { src?: string; drm?: DrmSystemsConfig; engine?: NativeHlsEngineConfig }
interface NativeHlsEngineConfig { nativeHls?: NativeHlsConfig }
interface NativeHlsConfig       { drmSystems?: DrmSystemsConfig }

const NativeHlsDrmErrors: {
  MISSING_CONFIGURATION      // 'drmMissingConfiguration'
  UNSUPPORTED_KEY_SYSTEM     // 'drmUnsupportedKeySystem'
  CERTIFICATE_REQUEST_FAILED // 'drmCertificateRequestFailed'
  SERVER_CERTIFICATE_FAILED  // 'drmServerCertificateFailed'
  GENERATE_REQUEST_FAILED    // 'drmGenerateRequestFailed'
  LICENSE_REQUEST_FAILED     // 'drmLicenseRequestFailed'
  UPDATE_LICENSE_FAILED      // 'drmUpdateLicenseFailed'
  CDM_ERROR                  // 'drmCdmError'
  OUTPUT_RESTRICTED          // 'drmOutputRestricted'
}
type NativeHlsDrmErrorContext // the union of those values
```

Key exchange failures dispatch `error` with a `MEDIA_ERR_ENCRYPTED` `MediaError` carrying one of those contexts:

```ts
media.addEventListener('error', (event) => {
  if (event.error.context === NativeHlsDrmErrors.MISSING_CONFIGURATION) { /* … */ }
});
```

`OUTPUT_RESTRICTED` is non-fatal — announced, but not latched into `media.error`, since playback continues.

The other source modules name their engine container too: `HlsEngineConfig`, `DashEngineConfig`, `VimeoSourceEngineConfig`, `YouTubeSourceEngineConfig`.

<details>
<summary>Behavior notes</summary>

- **Licensing is read per key request, not at load.** Assigning `source` and letting the element load stay independent, and a license server updated on a playing source — a rotated token, say — reaches the next request without a reload. Nothing is captured when the key system is created.
- **An equivalent source never reloads native playback.** `NativeHlsMedia.source` only reaches the element when the URL changes; assigning `src` still loads unconditionally, like the element's own `src`, which is how `HlsJsMedia` reloads its native delegate and how a failed source is retried. Nothing else in a native source is read up front, so an inline React `source` cannot interrupt playback or key exchange.
- **A changed `source.drm` recreates the engine**, structurally compared like the rest of `source.engine`, so an equivalent object is a no-op.
- **hls.js DRM switches EME on.** hls.js negotiates keys only while `emeEnabled` is set, so configured licensing enables it — short of an explicit `emeEnabled: false`, which stays a way to describe a source's licensing without acting on it.
- **Legacy WebKit fallback** (`webkitneedkey` / `WebKitMediaKeys`) covers OS versions that cannot generate a license request while an AirPlay receiver is the playback target. Gated on `NotSupportedError` + wireless; removable when Apple fixes it.
- **`NativeHlsMedia` does not dispatch `sourcechange`** — it is also `HlsJsMedia`'s native delegate, and `bridgeEvents` re-dispatches everything it fires onto a host that already announces its own.
- Adapted from [`muxinc/elements`](https://github.com/muxinc/elements/tree/main/packages/playback-core/src), split into `fairplay.ts` (shared), `fairplay-eme.ts`, `fairplay-webkit.ts`, `drm.ts` (mixin).

</details>

## Testing

```
pnpm -F @videojs/media test           # 32 files, 554 tests
pnpm -F @videojs/html test src/media  # 54 tests
pnpm -F @videojs/react test src/media # 38 tests
pnpm typecheck && pnpm check:workspace && pnpm -F site build
```

19 tests in `native-hls/tests/drm.test.ts` cover both key-exchange paths, every error context, a rotated license server on a playing source, the engine-level override, teardown, and the AirPlay handover; 4 in `native-hls/tests/media.test.ts` cover what does and does not reload. `hls-media.test.ts` and `mux-media.test.ts` cover `source.drm` reaching either engine, `engine.*.drmSystems` replacing it, and Mux mixing derived and caller-named servers.

FairPlay needs Safari and a licensed asset; the AirPlay fallback needs an affected OS. For a manual pass: sandbox → `Native HLS Video` → `HLS - DRM protected (license servers)`, which the `HLS Video` preset also offers for comparison.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API change to `source.engine` shape plus new encrypted-media paths (FairPlay EME/WebKit, license fetch, Mux DRM derivation) that affect playback and auth-sensitive licensing behavior across HLS, DASH, and embed players.
> 
> **Overview**
> **Breaking:** Engine-specific options move under `source.engine` keyed by engine (`hlsJs`, `nativeHls`, `dashJs`, `vimeo`, `youtube`) instead of living directly on `source.engine`. Call sites and docs are updated accordingly.
> 
> **DRM:** Protected playback is configured once via **`source.drm`** (license servers per EME key system). hls.js gets `drmSystems` + `emeEnabled`; native HLS runs new FairPlay key exchange (certificate + license POST) with EME and a **WebKit `webkitneedkey` fallback** for AirPlay. Per-engine `engine.*.drmSystems` still **replaces** `source.drm` for that path only. **Mux** maps `drm.token` into derived `drm` URLs instead of folding into hls.js `engine`.
> 
> **Native HLS:** `NativeHlsVideo` gains structured `source` (object assign when DRM is present). Sandbox renames `HLSJS_SOURCE_IDS` → `HLS_SOURCE_IDS` for both hls.js and native presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8ed7b409dc07c994fd8ecdd1ca6cc6132417ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

