### PR TITLE
feat(skin): emit source artifact files

### DIFF
--- a/build/source-ui/output.ts
+++ b/build/source-ui/output.ts
@@ -1,0 +1,244 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, extname, posix, relative, resolve, sep } from 'node:path';
+import type { ArtifactGraph, ArtifactGraphNode } from '../../packages/compiler/src/artifacts/index.ts';
+import { type CompilerConfig, compile } from '../../packages/compiler/src/index.ts';
+import htmlSourceConfig, { resolveHtmlElementImports } from '../../packages/html/skins.compiler.config.ts';
+import { createHtmlIconsSource, createReactIconsSource } from '../../packages/icons/scripts/source.ts';
+import reactSourceConfig from '../../packages/react/skins.compiler.config.ts';
+import type { RegistryOutputFile, RegistryOutputManifest, RegistryTarget } from './registry.ts';
+
+export interface CreateSourceOutputOptions {
+  rootDir: string;
+  target: RegistryTarget;
+  iconSet?: string | undefined;
+  registryRoot?: string | undefined;
+  targetRoot?: string | undefined;
+}
+
+interface ArtifactOutputContext {
+  artifact: ArtifactGraphNode;
+  artifactDir: string;
+  entryFile: string;
+  files: ReadonlyMap<string, string>;
+}
+
+/**
+ * Lowers every artifact entry and materializes its complete source-owned file set.
+ *
+ * The graph decides what belongs to an artifact. Framework packages own lowering,
+ * the icons package owns icon source generation, and this module only orchestrates
+ * those inputs into registry-ready files.
+ */
+export async function createSourceOutput(
+  graph: ArtifactGraph,
+  options: CreateSourceOutputOptions
+): Promise<RegistryOutputManifest> {
+  const rootDir = resolve(options.rootDir);
+  const registryRoot = options.registryRoot ?? 'registry';
+  const targetRoot = options.targetRoot ?? 'components/videojs';
+  const contexts = createArtifactContexts(graph, rootDir, targetRoot);
+  const entryArtifacts = new Map(
+    [...contexts.values()].map((context) => [absoluteGraphPath(rootDir, context.artifact.entry), context])
+  );
+  const artifacts: Record<string, RegistryOutputFile[]> = {};
+  const dependencies: Record<string, string[]> = {};
+
+  for (const context of [...contexts.values()].sort((a, b) => a.artifact.id.localeCompare(b.artifact.id))) {
+    const files = await emitArtifact(context, {
+      rootDir,
+      target: options.target,
+      iconSet: options.iconSet ?? 'default',
+      registryRoot,
+      entryArtifacts,
+    });
+    artifacts[context.artifact.id] = files;
+    dependencies[context.artifact.id] = collectPackageDependencies(files);
+  }
+
+  return { artifacts, dependencies };
+}
+
+async function emitArtifact(
+  context: ArtifactOutputContext,
+  options: {
+    rootDir: string;
+    target: RegistryTarget;
+    iconSet: string;
+    registryRoot: string;
+    entryArtifacts: ReadonlyMap<string, ArtifactOutputContext>;
+  }
+): Promise<RegistryOutputFile[]> {
+  const { artifact } = context;
+  const outputFiles: RegistryOutputFile[] = [];
+  const sourceFiles = artifact.files.filter((file) => file.role === 'source');
+
+  for (const file of sourceFiles) {
+    const inputFile = absoluteGraphPath(options.rootDir, file.path);
+    const target = context.files.get(inputFile);
+    if (!target) throw new Error(`Artifact \`${artifact.id}\` has no output path for \`${file.path}\`.`);
+    const source = await readFile(inputFile, 'utf8');
+    outputFiles.push(outputFile(options, target, rewriteRelativeImports(source, inputFile, context, options)));
+  }
+
+  const inputFile = absoluteGraphPath(options.rootDir, artifact.entry);
+  const canonical = await readFile(inputFile, 'utf8');
+  const config = targetConfig(options.target);
+  const result = await compile(canonical, {
+    filename: inputFile,
+    config,
+    configDir: resolve(options.rootDir, context.artifactDir),
+    outputFile: resolve(options.rootDir, context.entryFile),
+  });
+  if (result.diagnostics.some((diagnostic) => diagnostic.severity === 'error')) {
+    throw new Error(`Artifact \`${artifact.id}\` failed ${options.target.framework} lowering.`);
+  }
+
+  let entrySource = rewriteRelativeImports(result.code, inputFile, context, options);
+  const supportImports: string[] = [];
+  const icons = artifact.dependencies.symbols.icons ?? [];
+  const components = artifact.dependencies.symbols.components ?? [];
+
+  if (icons.length > 0) {
+    const content =
+      options.target.framework === 'react'
+        ? await createReactIconsSource(icons, options.iconSet)
+        : await createHtmlIconsSource(icons, options.iconSet);
+    outputFiles.push(outputFile(options, posix.join(context.artifactDir, 'icons.ts'), content));
+    if (options.target.framework === 'html') supportImports.push(`import './icons';`);
+  }
+
+  if (options.target.framework === 'html') {
+    const elementImports = resolveHtmlElementImports(components);
+    if (elementImports.length > 0) {
+      const content = `${elementImports.map((specifier) => `import '${specifier}';`).join('\n')}\n`;
+      outputFiles.push(outputFile(options, posix.join(context.artifactDir, 'elements.ts'), content));
+      supportImports.push(`import './elements';`);
+    }
+  }
+
+  if (supportImports.length > 0) entrySource = `${supportImports.join('\n')}\n${entrySource}`;
+  outputFiles.push(outputFile(options, context.entryFile, entrySource));
+
+  return outputFiles.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function createArtifactContexts(
+  graph: ArtifactGraph,
+  rootDir: string,
+  targetRoot: string
+): ReadonlyMap<string, ArtifactOutputContext> {
+  return new Map(
+    graph.artifacts.map((artifact) => {
+      const artifactDir = posix.join(targetRoot, artifact.id);
+      const entryFile = posix.join(artifactDir, outputEntryName(artifact.entry));
+      const files = new Map<string, string>();
+
+      for (const file of artifact.files) {
+        const absolute = absoluteGraphPath(rootDir, file.path);
+        files.set(
+          absolute,
+          file.role === 'entry' ? entryFile : posix.join(artifactDir, stripCanonicalPrefix(normalizePath(file.path)))
+        );
+      }
+
+      return [artifact.id, { artifact, artifactDir, entryFile, files }] as const;
+    })
+  );
+}
+
+function rewriteRelativeImports(
+  source: string,
+  inputFile: string,
+  context: ArtifactOutputContext,
+  options: {
+    rootDir: string;
+    entryArtifacts: ReadonlyMap<string, ArtifactOutputContext>;
+  }
+): string {
+  const outputFile = context.files.get(inputFile) ?? context.entryFile;
+  return source.replace(/((?:\bfrom\s*|\bimport\s*)['"])([^'"]+)(['"])/g, (match, prefix, specifier, suffix) => {
+    if (!specifier.startsWith('.')) return match;
+    const importedFile = resolveSourceFile(inputFile, specifier);
+    const dependency = options.entryArtifacts.get(importedFile);
+    const target = dependency?.entryFile ?? context.files.get(importedFile);
+    if (!existsSync(importedFile)) return match;
+    if (!target) {
+      throw new Error(
+        `Artifact \`${context.artifact.id}\` cannot map relative import \`${specifier}\` from \`${normalizePath(
+          relative(options.rootDir, inputFile)
+        )}\`.`
+      );
+    }
+    return `${prefix}${relativeModulePath(dirname(outputFile), withoutTypeScriptExtension(target))}${suffix}`;
+  });
+}
+
+function outputFile(
+  options: { registryRoot: string; target: RegistryTarget },
+  target: string,
+  content: string
+): RegistryOutputFile {
+  return {
+    path: posix.join(options.registryRoot, options.target.framework, options.target.style, target),
+    type: target.endsWith('.css') ? 'registry:file' : 'registry:component',
+    target,
+    content,
+  };
+}
+
+function collectPackageDependencies(files: readonly RegistryOutputFile[]): string[] {
+  const packages = new Set<string>();
+  for (const file of files) {
+    if (file.path.endsWith('.css')) continue;
+    for (const match of file.content.matchAll(/(?:\bfrom\s*|\bimport\s*)['"]([^'"]+)['"]/g)) {
+      const specifier = match[1];
+      if (specifier && !specifier.startsWith('.')) packages.add(packageName(specifier));
+    }
+  }
+  return [...packages].sort();
+}
+
+function targetConfig(target: RegistryTarget): CompilerConfig {
+  return target.framework === 'react' ? reactSourceConfig : htmlSourceConfig;
+}
+
+function outputEntryName(entry: string): string {
+  return basename(entry).replace(/\.skin(?=\.[^.]+$)/, '');
+}
+
+function stripCanonicalPrefix(path: string): string {
+  return path.replace(/^\.\/canonical\//, '');
+}
+
+function absoluteGraphPath(rootDir: string, path: string): string {
+  return resolve(rootDir, path);
+}
+
+function resolveSourceFile(inputFile: string, specifier: string): string {
+  const candidate = resolve(dirname(inputFile), specifier);
+  if (['.ts', '.tsx', '.mts', '.cts'].includes(extname(candidate))) return candidate;
+  for (const extension of ['.ts', '.tsx', '.mts', '.cts']) {
+    const fileName = `${candidate}${extension}`;
+    if (existsSync(fileName)) return fileName;
+  }
+  return candidate;
+}
+
+function withoutTypeScriptExtension(path: string): string {
+  return path.replace(/\.(?:[cm]?ts|tsx)$/, '');
+}
+
+function relativeModulePath(from: string, to: string): string {
+  const path = posix.relative(normalizePath(from), normalizePath(to));
+  return path.startsWith('.') ? path : `./${path}`;
+}
+
+function normalizePath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function packageName(specifier: string): string {
+  if (!specifier.startsWith('@')) return specifier.split('/')[0] ?? specifier;
+  return specifier.split('/').slice(0, 2).join('/');
+}

--- a/build/source-ui/registry.ts
+++ b/build/source-ui/registry.ts
@@ -19,11 +19,12 @@ export interface RegistryOutputFile {
   path: string;
   type: RegistryFileType;
   target?: string | undefined;
+  content: string;
 }
 
 export interface RegistryOutputManifest {
   artifacts: Readonly<Record<string, readonly RegistryOutputFile[]>>;
-  dependencies?: readonly string[] | undefined;
+  dependencies?: Readonly<Record<string, readonly string[]>> | undefined;
 }
 
 export interface RegistryCatalogItem {
@@ -77,6 +78,7 @@ export function createRegistryCatalog(
         })
       );
       const registry = artifact.metadata.registry;
+      const packageDependencies = [...new Set(included.flatMap((id) => output.dependencies?.[id] ?? []))].sort();
 
       return {
         name: itemName(target, artifact.id),
@@ -84,7 +86,7 @@ export function createRegistryCatalog(
         title: `${registry.title} (${frameworkTitle(target.framework)}, ${styleTitle(target.style)})`,
         description: `${registry.description} ${frameworkTitle(target.framework)} source with ${styleDescription(target.style)}.`,
         files,
-        ...(output.dependencies?.length ? { dependencies: [...output.dependencies].sort() } : {}),
+        ...(packageDependencies.length ? { dependencies: packageDependencies } : {}),
         ...(dependencies.length
           ? {
               registryDependencies: dependencies.map(

--- a/build/source-ui/tests/output.test.ts
+++ b/build/source-ui/tests/output.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildSkinArtifactGraph, skinsRoot } from '../../../packages/skins/scripts/build-artifact-graph.ts';
+import { createSourceOutput } from '../output.ts';
+
+describe('createSourceOutput', () => {
+  it('emits complete React component source with local exact icons', async () => {
+    const { graph, diagnostics } = await buildSkinArtifactGraph();
+    assert.deepEqual(diagnostics, []);
+
+    const output = await createSourceOutput(graph, {
+      rootDir: skinsRoot,
+      target: { framework: 'react', style: 'tailwind' },
+    });
+    const files = output.artifacts['play-button'] ?? [];
+    const entry = files.find((file) => file.target?.endsWith('/play-button.tsx'));
+    const icons = files.find((file) => file.target?.endsWith('/icons.ts'));
+
+    assert.deepEqual(
+      files.map((file) => file.target),
+      [
+        'components/videojs/play-button/icons.ts',
+        'components/videojs/play-button/play-button.tsx',
+        'components/videojs/play-button/styles/components/button.tailwind.ts',
+      ]
+    );
+    assert.match(entry?.content ?? '', /from "@videojs\/react"/);
+    assert.match(entry?.content ?? '', /from '\.\.\/button-tooltip\/button-tooltip'/);
+    assert.match(entry?.content ?? '', /from '\.\/styles\/components\/button\.tailwind'/);
+    assert.match(entry?.content ?? '', /className=\{cn\(button\.play\)\}/);
+    assert.match(icons?.content ?? '', /export const PlayIcon/);
+    assert.match(icons?.content ?? '', /export const PauseIcon/);
+    assert.match(icons?.content ?? '', /export const RestartIcon/);
+    assert.doesNotMatch(icons?.content ?? '', /FullscreenEnterIcon|VolumeHighIcon/);
+    assert.deepEqual(output.dependencies?.['play-button'], ['@videojs/react', '@videojs/utils', 'react']);
+    assertNoPrivateImports(files);
+  });
+
+  it('emits HTML source with exact element and icon registration modules', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const output = await createSourceOutput(graph, {
+      rootDir: skinsRoot,
+      target: { framework: 'html', style: 'tailwind' },
+    });
+    const files = output.artifacts['time-slider'] ?? [];
+    const entry = files.find((file) => file.target?.endsWith('/time-slider.tsx'));
+    const elements = files.find((file) => file.target?.endsWith('/elements.ts'));
+    const icons = files.find((file) => file.target?.endsWith('/icons.ts'));
+
+    assert.match(entry?.content ?? '', /^import '\.\/icons';\nimport '\.\/elements';/);
+    assert.match(entry?.content ?? '', /<media-time-slider/);
+    assert.equal(elements?.content, "import '@videojs/html/ui/time-slider';\n");
+    assert.match(icons?.content ?? '', /'spinner': `<svg/);
+    assert.doesNotMatch(icons?.content ?? '', /'play':|'volume-high':/);
+    assert.deepEqual(output.dependencies?.['time-slider'], ['@videojs/html', '@videojs/utils']);
+    assertNoPrivateImports(files);
+  });
+
+  it('rewrites Skin composition imports to sibling artifact directories', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const output = await createSourceOutput(graph, {
+      rootDir: skinsRoot,
+      target: { framework: 'react', style: 'tailwind' },
+    });
+    const entry = output.artifacts['default-video-controls']?.find((file) =>
+      file.target?.endsWith('/video-controls.tsx')
+    );
+
+    assert.match(entry?.content ?? '', /from '\.\.\/play-button\/play-button'/);
+    assert.match(entry?.content ?? '', /from '\.\.\/time-slider\/time-slider'/);
+    assert.match(entry?.content ?? '', /from '\.\/styles\/skins\/default-video-controls\.tailwind'/);
+  });
+
+  it('is deterministic', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const options = {
+      rootDir: skinsRoot,
+      target: { framework: 'react', style: 'tailwind' } as const,
+    };
+
+    assert.deepEqual(await createSourceOutput(graph, options), await createSourceOutput(graph, options));
+  });
+});
+
+function assertNoPrivateImports(files: readonly { content: string }[]): void {
+  const source = files.map((file) => file.content).join('\n');
+  assert.doesNotMatch(source, /@videojs\/(?:core|icons)\/components|@videojs\/jsx/);
+}

--- a/build/source-ui/tests/registry.test.ts
+++ b/build/source-ui/tests/registry.test.ts
@@ -55,7 +55,14 @@ describe('createRegistryCatalog', () => {
     );
     const catalog = createRegistryCatalog(graph, {
       target: { framework: 'react', style: 'css' },
-      output,
+      output: {
+        ...output,
+        dependencies: {
+          ...output.dependencies,
+          'button-tooltip': ['@videojs/utils'],
+          'play-button': ['@videojs/react'],
+        },
+      },
     });
 
     assert.equal(
@@ -71,12 +78,18 @@ describe('createRegistryCatalog', () => {
         path: 'registry/react/button-tooltip.tsx',
         type: 'registry:component',
         target: '@ui/videojs/button-tooltip.tsx',
+        content: '// button-tooltip',
       },
       {
         path: 'registry/react/play-button.tsx',
         type: 'registry:component',
         target: '@ui/videojs/play-button.tsx',
+        content: '// play-button',
       },
+    ]);
+    assert.deepEqual(catalog.items.find((item) => item.name.endsWith('/play-button'))?.dependencies, [
+      '@videojs/react',
+      '@videojs/utils',
     ]);
   });
 });
@@ -92,10 +105,13 @@ function outputManifest(artifactIds: readonly string[], framework: 'html' | 'rea
             path: `registry/${framework}/${id}.${extension}`,
             type: 'registry:component' as const,
             target: `@ui/videojs/${id}.${extension}`,
+            content: `// ${id}`,
           },
         ],
       ])
     ),
-    dependencies: [framework === 'react' ? '@videojs/react' : '@videojs/html'],
+    dependencies: Object.fromEntries(
+      artifactIds.map((id) => [id, [framework === 'react' ? '@videojs/react' : '@videojs/html']])
+    ),
   };
 }

--- a/packages/html/skins.compiler.config.ts
+++ b/packages/html/skins.compiler.config.ts
@@ -73,10 +73,7 @@ const htmlSourceConfig = defineConfig({
             code.jsx.element(source).addProp('name', name),
             code.jsx.element(source).replace('media-icon'),
           ]),
-          code.jsx
-            .props('className')
-            .where(code.value.isArray())
-            .replace(({ value }) => code.value.call(cn, code.value.arrayItems(value))),
+          code.jsx.props('className').replace(({ value }) => code.value.call(cn, [value])),
           replaceCanonicalTooltipProps(TooltipProps),
           renameClassNameToClass(),
           removeCanonicalImports(),
@@ -102,7 +99,7 @@ export function resolveHtmlElementImports(componentSymbols: readonly string[]): 
 }
 
 function removeCanonicalImports(): CompilerTransform {
-  const canonicalSources = new Set(['@videojs/core/components', '@videojs/icons/components']);
+  const canonicalSources = new Set(['@videojs/core/components', '@videojs/icons/components', '@videojs/jsx']);
 
   return (context) => (sourceFile) =>
     context.factory.updateSourceFile(
@@ -182,6 +179,9 @@ function replaceCanonicalTooltipProps(tooltipProps: ts.TypeNode): CompilerTransf
 
     const visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
       if (isCanonicalTooltipProps(node)) return replacement;
+      if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.text === 'ReactElement') {
+        return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
+      }
       return ts.visitEachChild(node, visit, context);
     };
 

--- a/packages/html/tests/skins.compiler.config.test.ts
+++ b/packages/html/tests/skins.compiler.config.test.ts
@@ -13,14 +13,15 @@ describe('htmlSourceConfig', () => {
     const result = await compile(source, { filename, config: htmlSourceConfig });
 
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain('<media-time-slider class={slider.root}');
-    expect(result.code).toContain('<media-slider-track class={slider.track}>');
-    expect(result.code).toContain('<media-slider-fill class={cn(slider.fillBase, slider.fill)}/>');
-    expect(result.code).toContain('<media-slider-thumbnail class={thumbnail.image}/>');
-    expect(result.code).toContain('<media-icon class="size-media-icon drop-shadow-media-icon" name="spinner"/>');
+    expect(result.code).toContain('<media-time-slider class={cn(slider.root)}');
+    expect(result.code).toContain('<media-slider-track class={cn(slider.track)}>');
+    expect(result.code).toContain('<media-slider-fill class={cn([slider.fillBase, slider.fill])}/>');
+    expect(result.code).toContain('<media-slider-thumbnail class={cn(thumbnail.image)}/>');
+    expect(result.code).toContain('<media-icon class={cn("size-media-icon drop-shadow-media-icon")} name="spinner"/>');
     expect(result.code).not.toContain('className=');
     expect(result.code).not.toContain('@videojs/core/components');
     expect(result.code).not.toContain('@videojs/icons/components');
+    expect(result.code).not.toContain('@videojs/jsx');
   });
 
   it('lowers tooltip composition around sibling trigger and popup elements', async () => {
@@ -32,7 +33,10 @@ describe('htmlSourceConfig', () => {
     expect(result.code).toContain('import type { TooltipProps }');
     expect(result.code).toContain('from "@videojs/core"');
     expect(result.code).toContain('{children}');
-    expect(result.code).toContain('<media-tooltip {...props} class={tooltip.popup}>');
+    expect(result.code).toContain('<media-tooltip {...props} class={cn(tooltip.popup)}>');
+    expect(result.code).toContain('children: unknown');
+    expect(result.code).not.toContain('ReactElement');
+    expect(result.code).not.toContain('@videojs/jsx');
     expect(result.code).not.toContain('typeof TooltipPrimitive.Root');
     expect(result.code).not.toContain('<TooltipPrimitive.Trigger>');
   });
@@ -45,7 +49,7 @@ describe('htmlSourceConfig', () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain('<MuteButton />');
     expect(result.code).toContain(
-      '<media-popover openOnHover delay={200} closeDelay={100} side="top" class={volumePopover}>'
+      '<media-popover openOnHover delay={200} closeDelay={100} side="top" class={cn(volumePopover)}>'
     );
     expect(result.code).not.toContain('<Popover.Trigger>');
     expect(result.code).not.toContain('<button>');

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@videojs/icons",
   "type": "module",
-  "private": true,
   "version": "10.0.0-beta.26",
   "description": "SVG icon library for Video.js",
   "license": "Apache-2.0",
@@ -50,6 +49,10 @@
       "types": "./dist/element/index.d.ts",
       "default": "./dist/element/index.js"
     },
+    "./element/base": {
+      "types": "./dist/element/base.d.ts",
+      "default": "./dist/element/base.js"
+    },
     "./element/*": {
       "types": "./dist/element/*/index.d.ts",
       "default": "./dist/element/*/index.js"
@@ -80,7 +83,45 @@
     "vitest": "^4.1.10"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      "./react": {
+        "types": "./dist/react/default/index.d.ts",
+        "default": "./dist/react/default/index.js"
+      },
+      "./react/*": {
+        "types": "./dist/react/*/index.d.ts",
+        "default": "./dist/react/*/index.js"
+      },
+      "./html": {
+        "types": "./dist/html/default/index.d.ts",
+        "default": "./dist/html/default/index.js"
+      },
+      "./html/*": {
+        "types": "./dist/html/*/index.d.ts",
+        "default": "./dist/html/*/index.js"
+      },
+      "./render": {
+        "types": "./dist/render/default/index.d.ts",
+        "default": "./dist/render/default/index.js"
+      },
+      "./render/*": {
+        "types": "./dist/render/*/index.d.ts",
+        "default": "./dist/render/*/index.js"
+      },
+      "./element": {
+        "types": "./dist/element/index.d.ts",
+        "default": "./dist/element/index.js"
+      },
+      "./element/base": {
+        "types": "./dist/element/base.d.ts",
+        "default": "./dist/element/base.js"
+      },
+      "./element/*": {
+        "types": "./dist/element/*/index.d.ts",
+        "default": "./dist/element/*/index.js"
+      }
+    }
   },
   "keywords": [
     "videojs",

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -3,37 +3,11 @@ import { join } from 'node:path';
 
 const isWatch = process.argv.includes('--watch');
 
-import { transform } from '@svgr/core';
-import { transform as esbuildTransform } from 'esbuild';
-import { optimize } from 'svgo';
-
 import { iconBases } from './icon-bases.js';
-import {
-  ASSETS_DIR,
-  createSvgoConfig,
-  DIST_DIR,
-  getIconSets,
-  getSvgFiles,
-  PRESET_DEFAULT_OVERRIDES,
-  REMOVE_ATTRS_PLUGIN,
-  replaceColors,
-} from './shared.js';
+import { ASSETS_DIR, DIST_DIR, getIconSets, getSvgFiles } from './shared.js';
+import { buildHtmlExport, buildReactComponent, optimizeSvg } from './source.js';
 
 const FRAMEWORKS = ['react', 'html'] as const;
-
-const SVGO_CONFIG = createSvgoConfig([
-  {
-    name: 'preset-default',
-    params: { overrides: PRESET_DEFAULT_OVERRIDES },
-  },
-  REMOVE_ATTRS_PLUGIN,
-  {
-    name: 'addAttributesToSVGElement',
-    params: {
-      attributes: [{ 'aria-hidden': 'true' }],
-    },
-  },
-]);
 
 function ensureDir(path: string): void {
   if (!existsSync(path)) mkdirSync(path, { recursive: true });
@@ -41,30 +15,6 @@ function ensureDir(path: string): void {
 
 function cleanDist(): void {
   if (existsSync(DIST_DIR)) rmSync(DIST_DIR, { recursive: true, force: true });
-}
-
-function optimizeSvg(svgContent: string): string {
-  return replaceColors(optimize(svgContent, SVGO_CONFIG).data);
-}
-
-async function buildReactComponent(svgContent: string, componentName: string): Promise<{ js: string; tsx: string }> {
-  const optimized = optimizeSvg(svgContent);
-
-  const transformOpts: Parameters<typeof transform>[1] = {
-    plugins: ['@svgr/plugin-jsx'],
-    jsxRuntime: 'automatic',
-  };
-
-  const tsxCode = await transform(optimized, { ...transformOpts, typescript: true }, { componentName });
-  const jsxCode = await transform(optimized, transformOpts, { componentName });
-
-  const { code } = await esbuildTransform(jsxCode, { loader: 'jsx', jsx: 'automatic' });
-
-  return { js: code, tsx: tsxCode };
-}
-
-function buildHtmlExport(svgContent: string, varName: string): string {
-  return `export const ${varName} = \`${optimizeSvg(svgContent)}\`;\n`;
 }
 
 function buildRenderModule(icons: { name: string; content: string }[]): string {

--- a/packages/icons/scripts/source.ts
+++ b/packages/icons/scripts/source.ts
@@ -1,0 +1,114 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { transform } from '@svgr/core';
+import { transform as esbuildTransform } from 'esbuild';
+import { optimize } from 'svgo';
+import { iconBases } from './icon-bases.js';
+import {
+  ASSETS_DIR,
+  createSvgoConfig,
+  getSvgFiles,
+  PRESET_DEFAULT_OVERRIDES,
+  REMOVE_ATTRS_PLUGIN,
+  replaceColors,
+} from './shared.js';
+
+const SVGO_CONFIG = createSvgoConfig([
+  {
+    name: 'preset-default',
+    params: { overrides: PRESET_DEFAULT_OVERRIDES },
+  },
+  REMOVE_ATTRS_PLUGIN,
+  {
+    name: 'addAttributesToSVGElement',
+    params: {
+      attributes: [{ 'aria-hidden': 'true' }],
+    },
+  },
+]);
+
+export function optimizeSvg(svgContent: string): string {
+  return replaceColors(optimize(svgContent, SVGO_CONFIG).data);
+}
+
+export async function buildReactComponent(
+  svgContent: string,
+  componentName: string
+): Promise<{ js: string; tsx: string }> {
+  const optimized = optimizeSvg(svgContent);
+  const transformOpts: Parameters<typeof transform>[1] = {
+    plugins: ['@svgr/plugin-jsx'],
+    jsxRuntime: 'automatic',
+  };
+  const tsxCode = await transform(optimized, { ...transformOpts, typescript: true }, { componentName });
+  const jsxCode = await transform(optimized, transformOpts, { componentName });
+  const { code } = await esbuildTransform(jsxCode, { loader: 'jsx', jsx: 'automatic' });
+
+  return { js: code, tsx: tsxCode };
+}
+
+export function buildHtmlExport(svgContent: string, varName: string): string {
+  return `export const ${varName} = \`${optimizeSvg(svgContent)}\`;\n`;
+}
+
+export async function createReactIconsSource(componentNames: readonly string[], iconSet = 'default'): Promise<string> {
+  const icons = await resolveIcons(componentNames, iconSet);
+  const components = await Promise.all(
+    icons.map(async ({ componentName, source }) => {
+      const { tsx } = await buildReactComponent(source, componentName);
+      return tsx
+        .replace(/^import type \{ SVGProps \} from ['"]react['"];?\s*/m, '')
+        .replace(`const ${componentName} =`, `export const ${componentName} =`)
+        .replace(new RegExp(`\\s*export default ${componentName};?\\s*$`), '');
+    })
+  );
+
+  return [`import type { SVGProps } from 'react';`, ``, ...components, ``].join('\n');
+}
+
+export async function createHtmlIconsSource(componentNames: readonly string[], iconSet = 'default'): Promise<string> {
+  const icons = await resolveIcons(componentNames, iconSet);
+  const entries = icons.map(({ fileName, source }) => `  '${fileName}': \`${optimizeSvg(source)}\`,`);
+
+  return [
+    `import '@videojs/html/icons/element';`,
+    ``,
+    `interface MediaIconConstructor extends CustomElementConstructor {`,
+    `  register(family: string, icons: Readonly<Record<string, string>>): void;`,
+    `}`,
+    ``,
+    `const icons = {`,
+    ...entries,
+    `};`,
+    ``,
+    `if (typeof customElements !== 'undefined' && typeof HTMLElement !== 'undefined') {`,
+    `  const iconElement = customElements.get('media-icon') as MediaIconConstructor | undefined;`,
+    `  iconElement?.register('${iconSet}', icons);`,
+    `}`,
+    ``,
+  ].join('\n');
+}
+
+async function resolveIcons(
+  componentNames: readonly string[],
+  iconSet: string
+): Promise<Array<{ componentName: string; fileName: string; source: string }>> {
+  const byComponent = new Map(
+    getSvgFiles(iconSet).map((file) => {
+      const fileName = file.slice(0, -'.svg'.length);
+      return [`${iconBases(fileName).pascal}Icon`, fileName] as const;
+    })
+  );
+
+  return Promise.all(
+    [...new Set(componentNames)].sort().map(async (componentName) => {
+      const fileName = byComponent.get(componentName);
+      if (!fileName) throw new Error(`Unknown ${iconSet} icon component \`${componentName}\`.`);
+      return {
+        componentName,
+        fileName,
+        source: await readFile(join(ASSETS_DIR, iconSet, `${fileName}.svg`), 'utf8'),
+      };
+    })
+  );
+}

--- a/packages/icons/tests/source.test.ts
+++ b/packages/icons/tests/source.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createHtmlIconsSource, createReactIconsSource } from '../scripts/source';
+
+describe('createReactIconsSource', () => {
+  it('generates only the requested named icon components', async () => {
+    const source = await createReactIconsSource(['PlayIcon', 'PauseIcon']);
+
+    expect(source).toContain('export const PlayIcon');
+    expect(source).toContain('export const PauseIcon');
+    expect(source).not.toContain('RestartIcon');
+    expect(source).not.toContain('export default');
+  });
+});
+
+describe('createHtmlIconsSource', () => {
+  it('generates an exact local icon registration module', async () => {
+    const source = await createHtmlIconsSource(['SpinnerIcon']);
+
+    expect(source).toContain("import '@videojs/html/icons/element'");
+    expect(source).toContain("iconElement?.register('default', icons)");
+    expect(source).toContain("'spinner': `<svg");
+    expect(source).not.toContain("'play':");
+    expect(source).not.toContain("'volume-high':");
+  });
+});

--- a/packages/react/skins.compiler.config.ts
+++ b/packages/react/skins.compiler.config.ts
@@ -4,9 +4,9 @@ import { anyTag, childAsProp } from '@videojs/compiler/ast';
 const reactSourceConfig = defineConfig({
   target: jsx({
     imports: {
-      '@videojs/core': '@videojs/react',
       '@videojs/core/components': '@videojs/react',
       '@videojs/icons/components': './icons',
+      '@videojs/jsx': (name) => ({ source: 'react', name: name === 'ComponentNode' ? 'ReactElement' : name }),
     },
     transforms: [
       childAsProp({
@@ -22,10 +22,9 @@ const reactSourceConfig = defineConfig({
 
         return [
           code.jsx.element('Text').replace('span'),
-          code.jsx
-            .props('className')
-            .where(code.value.isArray())
-            .replace(({ value }) => code.value.call(cn, code.value.arrayItems(value))),
+          code.jsx.element('Slider.Thumbnail.Root').replace('div'),
+          code.jsx.element('Slider.Thumbnail.Image').replace('Slider.Thumbnail'),
+          code.jsx.props('className').replace(({ value }) => code.value.call(cn, [value])),
         ];
       },
       { name: '@videojs/react:source-ui' }

--- a/packages/react/tests/skins.compiler.config.test.ts
+++ b/packages/react/tests/skins.compiler.config.test.ts
@@ -23,10 +23,10 @@ describe('reactSourceConfig', () => {
     const result = await compileCanonical('components/buttons/seek-button.skin.tsx');
 
     expect(result.diagnostics).toEqual([]);
-    expect(result.code).toContain('import type { SeekButtonProps } from "@videojs/react"');
+    expect(result.code).toMatch(/import type \{ SeekButtonProps \} from ['"]@videojs\/core['"]/);
     expect(result.code).toContain('import { SeekButton as SeekButtonPrimitive } from "@videojs/react"');
     expect(result.code).toContain('import { SeekIcon } from "../../icons"');
-    expect(result.code).toContain('<span className={seekLabel}>');
+    expect(result.code).toContain('<span className={cn(seekLabel)}>');
     expect(result.code).not.toContain('@videojs/core/components');
     expect(result.code).not.toContain('@videojs/icons/components');
   });
@@ -36,7 +36,27 @@ describe('reactSourceConfig', () => {
 
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain('from "@videojs/react"');
+    expect(result.code).toContain('import type { ReactElement } from "react"');
+    expect(result.code).toContain('children: ReactElement');
     expect(result.code).toContain('<TooltipPrimitive.Trigger render={children}/>');
     expect(result.code).not.toContain('<TooltipPrimitive.Trigger>{children}</TooltipPrimitive.Trigger>');
+  });
+
+  it('lowers target-owned thumbnail markup and class values', async () => {
+    const result = await compileCanonical('components/sliders/time-slider.skin.tsx');
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain('<div className={cn(thumbnail.root)}>');
+    expect(result.code).toContain('<Slider.Thumbnail className={cn(thumbnail.image)}/>');
+    expect(result.code).not.toContain('Slider.Thumbnail.Root');
+    expect(result.code).not.toContain('Slider.Thumbnail.Image');
+  });
+
+  it('keeps public core prop types separate from React component imports', async () => {
+    const result = await compileCanonical('components/sliders/volume-slider.skin.tsx');
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toMatch(/import type \{ VolumeSliderProps \} from ['"]@videojs\/core['"]/);
+    expect(result.code).toContain('import { VolumeSlider as VolumeSliderPrimitive } from "@videojs/react"');
   });
 });

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'tests/**/*.test.ts'],
   },
 });

--- a/packages/skins/artifacts.generated.json
+++ b/packages/skins/artifacts.generated.json
@@ -24,7 +24,7 @@
       },
       "dependencies": {
         "artifacts": [],
-        "packages": ["@videojs/core"],
+        "packages": ["@videojs/core", "@videojs/jsx"],
         "symbols": {
           "components": ["Tooltip"],
           "icons": []

--- a/packages/skins/canonical/components/buttons/button-tooltip.skin.tsx
+++ b/packages/skins/canonical/components/buttons/button-tooltip.skin.tsx
@@ -1,7 +1,12 @@
 import { Tooltip as TooltipPrimitive } from '@videojs/core/components';
+import type { ComponentNode as ReactElement } from '@videojs/jsx';
 import { tooltip } from '../../styles/components/popup.tailwind';
 
-export function ButtonTooltip({ children, ...props }: Parameters<typeof TooltipPrimitive.Root>[0]) {
+export type ButtonTooltipProps = Omit<Parameters<typeof TooltipPrimitive.Root>[0], 'children'> & {
+  children: ReactElement;
+};
+
+export function ButtonTooltip({ children, ...props }: ButtonTooltipProps) {
   return (
     <TooltipPrimitive.Root {...props}>
       <TooltipPrimitive.Trigger>{children}</TooltipPrimitive.Trigger>

--- a/packages/skins/scripts/tests/build-artifact-graph.test.ts
+++ b/packages/skins/scripts/tests/build-artifact-graph.test.ts
@@ -12,7 +12,7 @@ describe('buildSkinArtifactGraph', () => {
         id: 'button-tooltip',
         dependencies: {
           artifacts: [],
-          packages: ['@videojs/core'],
+          packages: ['@videojs/core', '@videojs/jsx'],
           symbols: {
             components: ['Tooltip'],
           },
@@ -128,7 +128,7 @@ describe('buildSkinArtifactGraph', () => {
         'volume-slider',
         'volume-popover',
       ],
-      packages: ['@videojs/core', '@videojs/icons'],
+      packages: ['@videojs/core', '@videojs/icons', '@videojs/jsx'],
       resources: {
         styles: [
           './canonical/styles/base.css',


### PR DESCRIPTION
## Outcome

The canonical Skin artifact graph now produces deterministic, registry-ready React and HTML source file sets. Each artifact owns its entry, supporting style modules, exact local icons, exact HTML element registrations, and exact package dependencies.

## Stack

- Position: 1 of the new output stack
- Base: `main`
- Next: Tailwind and vanilla CSS source variants
- Issues: #1956, #1959, #1960, #1961
- Parent epics: #1949 and #245

## Prototype paths reused from #1696

- `packages/icons/scripts/build.ts` and the existing raw SVG asset pipeline
- framework lowering configuration now living in `packages/react/skins.compiler.config.ts` and `packages/html/skins.compiler.config.ts`

The new `build/source-ui/output.ts` orchestration is recreated against the current artifact graph; no prototype commits were cherry-picked.

## Scope

- materialize per-artifact output directories and rewrite relative artifact imports
- emit exact local React `icons.ts` and HTML icon registration modules
- emit exact HTML `elements.ts` registration modules
- derive per-artifact package dependencies from final emitted source
- make `@videojs/icons` publishable while hiding `/components` from public releases through `publishConfig.exports`
- expose the public `@videojs/icons/element/base` entry needed by local HTML icon registration

## Intentionally excluded

- Tailwind resource emission and vanilla CSS compilation
- final declarative HTML serialization and per-player identity wiring
- writing generated registry JSON to disk
- shadcn installation fixtures
- visual or interaction parity claims

## Verification

- `node --import tsx --test build/source-ui/tests/output.test.ts build/source-ui/tests/registry.test.ts`
- `pnpm -F @videojs/icons test`
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Evidence

Focused tests cover deterministic output, sibling artifact import rewriting, public-import validation, exact React icon closure, exact HTML icon/element registration, and dependency union across folded internal helpers.

## Management-visible outcome

The graph is now an actual output input rather than metadata beside synthetic fixtures: a canonical component can become a complete editable source file set without adding Skin policy to `@videojs/compiler`.

## Follow-up

The next stacked draft adds Tailwind and vanilla CSS variants from the same semantic style source.