### PR TITLE
feat(skin): emit Tailwind and CSS variants

### DIFF
--- a/build/source-ui/output.ts
+++ b/build/source-ui/output.ts
@@ -6,6 +6,7 @@ import { type CompilerConfig, compile } from '../../packages/compiler/src/index.
 import htmlSourceConfig, { resolveHtmlElementImports } from '../../packages/html/skins.compiler.config.ts';
 import { createHtmlIconsSource, createReactIconsSource } from '../../packages/icons/scripts/source.ts';
 import reactSourceConfig from '../../packages/react/skins.compiler.config.ts';
+import { compileVanillaStyles } from '../../packages/skins/scripts/compile-styles.ts';
 import type { RegistryOutputFile, RegistryOutputManifest, RegistryTarget } from './registry.ts';
 
 export interface CreateSourceOutputOptions {
@@ -37,7 +38,7 @@ export async function createSourceOutput(
   const rootDir = resolve(options.rootDir);
   const registryRoot = options.registryRoot ?? 'registry';
   const targetRoot = options.targetRoot ?? 'components/videojs';
-  const contexts = createArtifactContexts(graph, rootDir, targetRoot);
+  const contexts = createArtifactContexts(graph, rootDir, targetRoot, options.target.style);
   const entryArtifacts = new Map(
     [...contexts.values()].map((context) => [absoluteGraphPath(rootDir, context.artifact.entry), context])
   );
@@ -50,6 +51,7 @@ export async function createSourceOutput(
       target: options.target,
       iconSet: options.iconSet ?? 'default',
       registryRoot,
+      targetRoot,
       entryArtifacts,
     });
     artifacts[context.artifact.id] = files;
@@ -66,6 +68,7 @@ async function emitArtifact(
     target: RegistryTarget;
     iconSet: string;
     registryRoot: string;
+    targetRoot: string;
     entryArtifacts: ReadonlyMap<string, ArtifactOutputContext>;
   }
 ): Promise<RegistryOutputFile[]> {
@@ -117,6 +120,17 @@ async function emitArtifact(
     }
   }
 
+  const styleFiles = await emitStyleFiles(
+    artifact,
+    [
+      ...outputFiles.filter((file) => /\.[cm]?[jt]sx?$/.test(file.target ?? '')).map((file) => file.content),
+      entrySource,
+    ],
+    options
+  );
+  outputFiles.push(...styleFiles.files);
+  supportImports.unshift(`import '${styleFiles.entryImport}';`);
+
   if (supportImports.length > 0) entrySource = `${supportImports.join('\n')}\n${entrySource}`;
   outputFiles.push(outputFile(options, context.entryFile, entrySource));
 
@@ -126,7 +140,8 @@ async function emitArtifact(
 function createArtifactContexts(
   graph: ArtifactGraph,
   rootDir: string,
-  targetRoot: string
+  targetRoot: string,
+  style: RegistryTarget['style']
 ): ReadonlyMap<string, ArtifactOutputContext> {
   return new Map(
     graph.artifacts.map((artifact) => {
@@ -138,13 +153,63 @@ function createArtifactContexts(
         const absolute = absoluteGraphPath(rootDir, file.path);
         files.set(
           absolute,
-          file.role === 'entry' ? entryFile : posix.join(artifactDir, stripCanonicalPrefix(normalizePath(file.path)))
+          file.role === 'entry'
+            ? entryFile
+            : styleSourceTarget(posix.join(targetRoot, stripCanonicalPrefix(normalizePath(file.path))), style)
         );
       }
 
       return [artifact.id, { artifact, artifactDir, entryFile, files }] as const;
     })
   );
+}
+
+async function emitStyleFiles(
+  artifact: ArtifactGraphNode,
+  sourceFiles: readonly string[],
+  options: {
+    rootDir: string;
+    target: RegistryTarget;
+    targetRoot: string;
+    registryRoot: string;
+  }
+): Promise<{ files: RegistryOutputFile[]; entryImport: string }> {
+  const resources = artifact.resources.styles ?? [];
+  const files: RegistryOutputFile[] = [];
+  let tailwindSource: string | undefined;
+
+  for (const resource of resources) {
+    const inputFile = absoluteGraphPath(options.rootDir, resource);
+    const source = await readFile(inputFile, 'utf8');
+    if (resource.endsWith('/tailwind.css')) {
+      tailwindSource = source;
+      if (options.target.style === 'css') continue;
+    }
+
+    const target = posix.join(options.targetRoot, stripCanonicalPrefix(normalizePath(resource)));
+    const content = resource.endsWith('/tailwind.css')
+      ? source
+          .replace(/^@source .*;\s*$/gm, '')
+          .replace(
+            '@import "./themes/default.css";',
+            '@import "./themes/default.css";\n\n@source "../**/*.{ts,tsx,html}";'
+          )
+      : source;
+    files.push(outputFile(options, target, content));
+  }
+
+  if (!tailwindSource) throw new Error(`Artifact \`${artifact.id}\` has no Tailwind style resource.`);
+  if (options.target.style === 'tailwind') {
+    return { files, entryImport: '../styles/tailwind.css' };
+  }
+
+  const artifactStyles = posix.join(options.targetRoot, artifact.id, 'styles.css');
+  const utilityCss = await compileVanillaStyles(tailwindSource, sourceFiles);
+  const content = [`@import '../styles/base.css';`, `@import '../styles/themes/default.css';`, ``, utilityCss].join(
+    '\n'
+  );
+  files.push(outputFile(options, artifactStyles, content));
+  return { files, entryImport: './styles.css' };
 }
 
 function rewriteRelativeImports(
@@ -209,6 +274,10 @@ function outputEntryName(entry: string): string {
 
 function stripCanonicalPrefix(path: string): string {
   return path.replace(/^\.\/canonical\//, '');
+}
+
+function styleSourceTarget(path: string, style: RegistryTarget['style']): string {
+  return style === 'css' ? path.replace(/\.tailwind(?=\.[^.]+$)/, '.styles') : path;
 }
 
 function absoluteGraphPath(rootDir: string, path: string): string {

--- a/build/source-ui/registry.ts
+++ b/build/source-ui/registry.ts
@@ -142,7 +142,15 @@ function partitionDependencies(
 }
 
 function uniqueFiles(files: readonly RegistryOutputFile[]): RegistryOutputFile[] {
-  const unique = new Map(files.map((file) => [`${file.path}\0${file.target ?? ''}`, file]));
+  const unique = new Map<string, RegistryOutputFile>();
+  for (const file of files) {
+    const key = `${file.path}\0${file.target ?? ''}`;
+    const existing = unique.get(key);
+    if (existing && existing.content !== file.content) {
+      throw new Error(`Registry output collision: ${file.path}`);
+    }
+    unique.set(key, file);
+  }
   return [...unique.values()].sort((a, b) => a.path.localeCompare(b.path));
 }
 

--- a/build/source-ui/tests/output.test.ts
+++ b/build/source-ui/tests/output.test.ts
@@ -2,6 +2,14 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { buildSkinArtifactGraph, skinsRoot } from '../../../packages/skins/scripts/build-artifact-graph.ts';
 import { createSourceOutput } from '../output.ts';
+import { createRegistryCatalog, type RegistryTarget } from '../registry.ts';
+
+const targets = [
+  { framework: 'react', style: 'tailwind' },
+  { framework: 'react', style: 'css' },
+  { framework: 'html', style: 'tailwind' },
+  { framework: 'html', style: 'css' },
+] as const satisfies readonly RegistryTarget[];
 
 describe('createSourceOutput', () => {
   it('emits complete React component source with local exact icons', async () => {
@@ -21,12 +29,16 @@ describe('createSourceOutput', () => {
       [
         'components/videojs/play-button/icons.ts',
         'components/videojs/play-button/play-button.tsx',
-        'components/videojs/play-button/styles/components/button.tailwind.ts',
+        'components/videojs/styles/base.css',
+        'components/videojs/styles/components/button.tailwind.ts',
+        'components/videojs/styles/tailwind.css',
+        'components/videojs/styles/themes/default.css',
       ]
     );
+    assert.match(entry?.content ?? '', /^import '\.\.\/styles\/tailwind\.css';/);
     assert.match(entry?.content ?? '', /from "@videojs\/react"/);
     assert.match(entry?.content ?? '', /from '\.\.\/button-tooltip\/button-tooltip'/);
-    assert.match(entry?.content ?? '', /from '\.\/styles\/components\/button\.tailwind'/);
+    assert.match(entry?.content ?? '', /from '\.\.\/styles\/components\/button\.tailwind'/);
     assert.match(entry?.content ?? '', /className=\{cn\(button\.play\)\}/);
     assert.match(icons?.content ?? '', /export const PlayIcon/);
     assert.match(icons?.content ?? '', /export const PauseIcon/);
@@ -47,7 +59,10 @@ describe('createSourceOutput', () => {
     const elements = files.find((file) => file.target?.endsWith('/elements.ts'));
     const icons = files.find((file) => file.target?.endsWith('/icons.ts'));
 
-    assert.match(entry?.content ?? '', /^import '\.\/icons';\nimport '\.\/elements';/);
+    assert.match(
+      entry?.content ?? '',
+      /^import '\.\.\/styles\/tailwind\.css';\nimport '\.\/icons';\nimport '\.\/elements';/
+    );
     assert.match(entry?.content ?? '', /<media-time-slider/);
     assert.equal(elements?.content, "import '@videojs/html/ui/time-slider';\n");
     assert.match(icons?.content ?? '', /'spinner': `<svg/);
@@ -68,7 +83,43 @@ describe('createSourceOutput', () => {
 
     assert.match(entry?.content ?? '', /from '\.\.\/play-button\/play-button'/);
     assert.match(entry?.content ?? '', /from '\.\.\/time-slider\/time-slider'/);
-    assert.match(entry?.content ?? '', /from '\.\/styles\/skins\/default-video-controls\.tailwind'/);
+    assert.match(entry?.content ?? '', /from '\.\.\/styles\/skins\/default-video-controls\.tailwind'/);
+  });
+
+  it('emits Tailwind source entrypoints and semantic theme configuration', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const output = await createSourceOutput(graph, {
+      rootDir: skinsRoot,
+      target: { framework: 'react', style: 'tailwind' },
+    });
+    const tailwind = output.artifacts['play-button']?.find((file) => file.target?.endsWith('/styles/tailwind.css'));
+
+    assert.match(tailwind?.content ?? '', /@import "tailwindcss";/);
+    assert.match(tailwind?.content ?? '', /@source "\.\.\/\*\*\/\*\.\{ts,tsx,html\}";/);
+    assert.match(tailwind?.content ?? '', /@theme inline/);
+    assert.doesNotMatch(tailwind?.content ?? '', /\.skin\.tsx/);
+  });
+
+  it('emits ordinary CSS from the artifact style-module candidates', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const output = await createSourceOutput(graph, {
+      rootDir: skinsRoot,
+      target: { framework: 'react', style: 'css' },
+    });
+    const files = output.artifacts['play-button'] ?? [];
+    const entry = files.find((file) => file.target?.endsWith('/play-button.tsx'));
+    const styles = files.find((file) => file.target?.endsWith('/play-button/styles.css'));
+
+    assert.match(entry?.content ?? '', /^import '\.\/styles\.css';/);
+    assert.match(entry?.content ?? '', /from '\.\.\/styles\/components\/button\.styles'/);
+    assert.match(styles?.content ?? '', /@import '\.\.\/styles\/base\.css';/);
+    assert.match(styles?.content ?? '', /\.size-media-control/);
+    assert.match(styles?.content ?? '', /\.group-data-started\\\/play/);
+    assert.doesNotMatch(styles?.content ?? '', /media-slider-track/);
+    assert.equal(
+      files.some((file) => file.target?.endsWith('/tailwind.css')),
+      false
+    );
   });
 
   it('is deterministic', async () => {
@@ -80,6 +131,21 @@ describe('createSourceOutput', () => {
 
     assert.deepEqual(await createSourceOutput(graph, options), await createSourceOutput(graph, options));
   });
+
+  for (const target of targets) {
+    it(`builds the complete ${target.framework}/${target.style} registry catalog`, async () => {
+      const { graph } = await buildSkinArtifactGraph();
+      const output = await createSourceOutput(graph, { rootDir: skinsRoot, target });
+      const catalog = createRegistryCatalog(graph, { target, output });
+
+      assert.equal(catalog.items.length, 7);
+      assert.equal(
+        catalog.items.every((item) => item.files.every((file) => file.content.length > 0)),
+        true
+      );
+      assertNoPrivateImports(catalog.items.flatMap((item) => item.files));
+    });
+  }
 });
 
 function assertNoPrivateImports(files: readonly { content: string }[]): void {

--- a/packages/html/tests/skins.compiler.config.test.ts
+++ b/packages/html/tests/skins.compiler.config.test.ts
@@ -15,7 +15,7 @@ describe('htmlSourceConfig', () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.code).toContain('<media-time-slider class={cn(slider.root)}');
     expect(result.code).toContain('<media-slider-track class={cn(slider.track)}>');
-    expect(result.code).toContain('<media-slider-fill class={cn([slider.fillBase, slider.fill])}/>');
+    expect(result.code).toContain('<media-slider-fill class={cn(slider.fill)}/>');
     expect(result.code).toContain('<media-slider-thumbnail class={cn(thumbnail.image)}/>');
     expect(result.code).toContain('<media-icon class={cn("size-media-icon drop-shadow-media-icon")} name="spinner"/>');
     expect(result.code).not.toContain('className=');

--- a/packages/skins/canonical/components/sliders/time-slider.skin.tsx
+++ b/packages/skins/canonical/components/sliders/time-slider.skin.tsx
@@ -6,8 +6,8 @@ export function TimeSlider() {
   return (
     <TimeSliderPrimitive.Root className={slider.root} thumbAlignment="edge">
       <TimeSliderPrimitive.Track className={slider.track}>
-        <TimeSliderPrimitive.Fill className={[slider.fillBase, slider.fill]} />
-        <TimeSliderPrimitive.Buffer className={[slider.fillBase, slider.buffer]} />
+        <TimeSliderPrimitive.Fill className={slider.fill} />
+        <TimeSliderPrimitive.Buffer className={slider.buffer} />
       </TimeSliderPrimitive.Track>
       <TimeSliderPrimitive.Thumb className={slider.thumb} />
       <Slider.Thumbnail.Root className={thumbnail.root}>

--- a/packages/skins/canonical/components/sliders/volume-slider.skin.tsx
+++ b/packages/skins/canonical/components/sliders/volume-slider.skin.tsx
@@ -6,7 +6,7 @@ export function VolumeSlider(props: VolumeSliderProps = {}) {
   return (
     <VolumeSliderPrimitive.Root className={slider.root} thumbAlignment="edge" {...props}>
       <VolumeSliderPrimitive.Track className={slider.track}>
-        <VolumeSliderPrimitive.Fill className={[slider.fillBase, slider.fill]} />
+        <VolumeSliderPrimitive.Fill className={slider.fill} />
       </VolumeSliderPrimitive.Track>
       <VolumeSliderPrimitive.Thumb className={slider.thumb} />
     </VolumeSliderPrimitive.Root>

--- a/packages/skins/canonical/styles/components/button.tailwind.ts
+++ b/packages/skins/canonical/styles/components/button.tailwind.ts
@@ -10,9 +10,9 @@ const icon = 'size-media-icon drop-shadow-media-icon';
 
 export const button = {
   base,
-  fullscreen: [base, 'group/fullscreen'],
-  mute: [base, 'group/mute'],
-  play: [base, 'group/play'],
+  fullscreen: [...base, 'group/fullscreen'],
+  mute: [...base, 'group/mute'],
+  play: [...base, 'group/play'],
   seek: base,
 };
 

--- a/packages/skins/canonical/styles/components/slider.tailwind.ts
+++ b/packages/skins/canonical/styles/components/slider.tailwind.ts
@@ -1,5 +1,10 @@
 import { surface } from './popup.tailwind';
 
+const fillBase = [
+  'absolute inset-y-0 left-0 rounded-[inherit]',
+  'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:top-auto data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:w-auto',
+];
+
 export const slider = {
   root: [
     'group/slider relative flex min-h-media-control min-w-20 flex-1 cursor-pointer items-center justify-center outline-none',
@@ -9,12 +14,12 @@ export const slider = {
     'relative h-media-slider-track w-full overflow-hidden rounded-media-pill bg-media-slider-track',
     'data-[orientation=vertical]:h-full data-[orientation=vertical]:w-media-slider-track',
   ],
-  fillBase: [
-    'absolute inset-y-0 left-0 rounded-[inherit]',
-    'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:top-auto data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:w-auto',
+  fill: [...fillBase, 'w-(--media-slider-fill) bg-current data-[orientation=vertical]:h-(--media-slider-fill)'],
+  buffer: [
+    ...fillBase,
+    'w-(--media-slider-buffer) bg-media-slider-buffer',
+    'data-[orientation=vertical]:h-(--media-slider-buffer)',
   ],
-  fill: 'w-(--media-slider-fill) bg-current data-[orientation=vertical]:h-(--media-slider-fill)',
-  buffer: ['w-(--media-slider-buffer) bg-media-slider-buffer', 'data-[orientation=vertical]:h-(--media-slider-buffer)'],
   thumb: [
     'absolute top-1/2 left-(--media-slider-fill) size-media-slider-thumb -translate-x-1/2 -translate-y-1/2 rounded-media-pill bg-current',
     'data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill))] data-[orientation=vertical]:left-1/2',

--- a/packages/skins/package.json
+++ b/packages/skins/package.json
@@ -44,6 +44,7 @@
     "@videojs/core": "workspace:*",
     "@videojs/icons": "workspace:*",
     "@videojs/jsx": "workspace:*",
+    "tailwindcss": "^4.3.3",
     "tsx": "^4.23.1",
     "tsdown": "^0.22.14",
     "typescript": "^6.0.2",

--- a/packages/skins/scripts/compile-styles.ts
+++ b/packages/skins/scripts/compile-styles.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { compile } from 'tailwindcss';
+
+const tailwindRoot = resolve(dirname(fileURLToPath(import.meta.resolve('tailwindcss'))), '..');
+
+/** Compile the utility candidates used by one artifact into ordinary CSS. */
+export async function compileVanillaStyles(tailwindSource: string, sourceFiles: readonly string[]): Promise<string> {
+  const compiler = await compile(vanillaCompilerSource(tailwindSource), {
+    base: process.cwd(),
+    loadStylesheet: async (id, base) => {
+      const path = id.startsWith('tailwindcss/')
+        ? resolve(tailwindRoot, id.slice('tailwindcss/'.length))
+        : resolve(base, id);
+      return { path, base: dirname(path), content: await readFile(path, 'utf8') };
+    },
+  });
+
+  return compiler.build(collectCandidates(sourceFiles));
+}
+
+function vanillaCompilerSource(source: string): string {
+  return source
+    .replace(
+      '@import "tailwindcss";',
+      [
+        '@layer theme, base, components, utilities;',
+        '@import "tailwindcss/theme.css" layer(theme) reference;',
+        '@import "tailwindcss/utilities.css" layer(utilities);',
+      ].join('\n')
+    )
+    .replace(/^@import "\.\/base\.css";\s*$/m, '')
+    .replace(/^@import "\.\/themes\/default\.css";\s*$/m, '')
+    .replace(/^@source .*;\s*$/gm, '');
+}
+
+function collectCandidates(sourceFiles: readonly string[]): string[] {
+  const candidates = new Set<string>();
+  for (const source of sourceFiles) {
+    for (const match of source.matchAll(/(['"])(.*?)\1/gs)) {
+      for (const candidate of match[2]?.split(/\s+/) ?? []) {
+        if (candidate) candidates.add(candidate);
+      }
+    }
+  }
+  return [...candidates].sort();
+}

--- a/packages/skins/tests/compile-styles.test.ts
+++ b/packages/skins/tests/compile-styles.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { compileVanillaStyles } from '../scripts/compile-styles';
+
+const tailwindSource = `
+@import "tailwindcss";
+@import "./base.css";
+@import "./themes/default.css";
+@source "../**/*.skin.tsx";
+
+@theme inline {
+  --spacing-media-control: var(--media-control-size);
+}
+`;
+
+describe('compileVanillaStyles', () => {
+  it('compiles only supplied utility candidates without Tailwind imports', async () => {
+    const css = await compileVanillaStyles(tailwindSource, [
+      `export const button = 'grid size-media-control hover:opacity-50';`,
+    ]);
+
+    expect(css).toContain('.grid');
+    expect(css).toContain('.size-media-control');
+    expect(css).toContain('.hover\\:opacity-50:hover');
+    expect(css).not.toContain('.flex');
+    expect(css).not.toContain('@import "tailwindcss"');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       '@videojs/jsx':
         specifier: workspace:*
         version: link:../jsx
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)


### PR DESCRIPTION
## Outcome

Every emitted React and HTML artifact now has a usable Tailwind v4 or vanilla CSS source variant from the same canonical semantic style source.

## Stack

- Position: 2
- Base: #2015 (`eject/12-source-emission`)
- Issues: #1962 and #1963
- Parent epics: #245 and #1950

## Scope

- emit shared base, default-theme, and semantic style-token source
- emit a Tailwind v4 CSS-first configuration with output-correct `@source` paths
- compile artifact style-module candidates to ordinary CSS for the CSS variant
- rename CSS-variant token modules from `.tailwind.ts` to `.styles.ts`
- add artifact entry style imports and collision validation
- verify all four React/HTML × Tailwind/CSS catalogs against real output

## Intentionally excluded

- final declarative HTML serialization and per-player identity wiring
- generated registry files on disk
- shadcn installation fixtures
- browser visual and interaction parity
- property-level pruning inside a shared canonical style module; CSS is currently minimal at the owned module boundary

## Verification

- `node --import tsx --test build/source-ui/tests/output.test.ts build/source-ui/tests/registry.test.ts`
- `pnpm -F @videojs/skins test`
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Evidence

The matrix test builds seven catalog items in each of the four variants with non-empty files, public imports only, exact closure, and no conflicting shared output. Focused CSS tests verify candidate compilation without a Tailwind runtime import.

## Management-visible outcome

One canonical Skin graph now produces both editable Tailwind source and build-tool-independent CSS source without maintaining separate component markup.

## Follow-up

The next stacked draft replaces intermediate HTML TSX with idiomatic source-owned HTML output and validates multiple-player-safe identity.