### PR TITLE
feat(html): emit source-owned Skin markup

### DIFF
--- a/build/source-ui/output.ts
+++ b/build/source-ui/output.ts
@@ -1,9 +1,15 @@
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { basename, dirname, extname, posix, relative, resolve, sep } from 'node:path';
-import type { ArtifactGraph, ArtifactGraphNode } from '../../packages/compiler/src/artifacts/index.ts';
-import { type CompilerConfig, compile } from '../../packages/compiler/src/index.ts';
-import htmlSourceConfig, { resolveHtmlElementImports } from '../../packages/html/skins.compiler.config.ts';
+import { format } from 'prettier';
+import {
+  type ArtifactGraph,
+  type ArtifactGraphNode,
+  resolveArtifactClosure,
+} from '../../packages/compiler/src/artifacts/index.ts';
+import { compile } from '../../packages/compiler/src/index.ts';
+import { renderSkinSource } from '../../packages/html/scripts/render-skin-source.ts';
+import { resolveHtmlElementImports } from '../../packages/html/skins.compiler.config.ts';
 import { createHtmlIconsSource, createReactIconsSource } from '../../packages/icons/scripts/source.ts';
 import reactSourceConfig from '../../packages/react/skins.compiler.config.ts';
 import { compileVanillaStyles } from '../../packages/skins/scripts/compile-styles.ts';
@@ -38,7 +44,7 @@ export async function createSourceOutput(
   const rootDir = resolve(options.rootDir);
   const registryRoot = options.registryRoot ?? 'registry';
   const targetRoot = options.targetRoot ?? 'components/videojs';
-  const contexts = createArtifactContexts(graph, rootDir, targetRoot, options.target.style);
+  const contexts = createArtifactContexts(graph, rootDir, targetRoot, options.target);
   const entryArtifacts = new Map(
     [...contexts.values()].map((context) => [absoluteGraphPath(rootDir, context.artifact.entry), context])
   );
@@ -52,6 +58,7 @@ export async function createSourceOutput(
       iconSet: options.iconSet ?? 'default',
       registryRoot,
       targetRoot,
+      graph,
       entryArtifacts,
     });
     artifacts[context.artifact.id] = files;
@@ -69,12 +76,14 @@ async function emitArtifact(
     iconSet: string;
     registryRoot: string;
     targetRoot: string;
+    graph: ArtifactGraph;
     entryArtifacts: ReadonlyMap<string, ArtifactOutputContext>;
   }
 ): Promise<RegistryOutputFile[]> {
   const { artifact } = context;
   const outputFiles: RegistryOutputFile[] = [];
-  const sourceFiles = artifact.files.filter((file) => file.role === 'source');
+  const sourceFiles =
+    options.target.framework === 'react' ? artifact.files.filter((file) => file.role === 'source') : [];
 
   for (const file of sourceFiles) {
     const inputFile = absoluteGraphPath(options.rootDir, file.path);
@@ -85,22 +94,34 @@ async function emitArtifact(
   }
 
   const inputFile = absoluteGraphPath(options.rootDir, artifact.entry);
-  const canonical = await readFile(inputFile, 'utf8');
-  const config = targetConfig(options.target);
-  const result = await compile(canonical, {
-    filename: inputFile,
-    config,
-    configDir: resolve(options.rootDir, context.artifactDir),
-    outputFile: resolve(options.rootDir, context.entryFile),
-  });
-  if (result.diagnostics.some((diagnostic) => diagnostic.severity === 'error')) {
-    throw new Error(`Artifact \`${artifact.id}\` failed ${options.target.framework} lowering.`);
+  let entrySource: string;
+  if (options.target.framework === 'html') {
+    entrySource = await format(await renderSkinSource(inputFile), {
+      parser: 'html',
+      printWidth: 120,
+      htmlWhitespaceSensitivity: 'ignore',
+    });
+  } else {
+    const canonical = await readFile(inputFile, 'utf8');
+    const result = await compile(canonical, {
+      filename: inputFile,
+      config: reactSourceConfig,
+      configDir: resolve(options.rootDir, context.artifactDir),
+      outputFile: resolve(options.rootDir, context.entryFile),
+    });
+    if (result.diagnostics.some((diagnostic) => diagnostic.severity === 'error')) {
+      throw new Error(`Artifact \`${artifact.id}\` failed ${options.target.framework} lowering.`);
+    }
+    entrySource = rewriteRelativeImports(result.code, inputFile, context, options);
   }
 
-  let entrySource = rewriteRelativeImports(result.code, inputFile, context, options);
   const supportImports: string[] = [];
-  const icons = artifact.dependencies.symbols.icons ?? [];
-  const components = artifact.dependencies.symbols.components ?? [];
+  const symbols =
+    options.target.framework === 'html'
+      ? resolveArtifactClosure(options.graph, artifact.id).symbols
+      : artifact.dependencies.symbols;
+  const icons = symbols.icons ?? [];
+  const components = symbols.components ?? [];
 
   if (icons.length > 0) {
     const content =
@@ -108,7 +129,6 @@ async function emitArtifact(
         ? await createReactIconsSource(icons, options.iconSet)
         : await createHtmlIconsSource(icons, options.iconSet);
     outputFiles.push(outputFile(options, posix.join(context.artifactDir, 'icons.ts'), content));
-    if (options.target.framework === 'html') supportImports.push(`import './icons';`);
   }
 
   if (options.target.framework === 'html') {
@@ -116,7 +136,6 @@ async function emitArtifact(
     if (elementImports.length > 0) {
       const content = `${elementImports.map((specifier) => `import '${specifier}';`).join('\n')}\n`;
       outputFiles.push(outputFile(options, posix.join(context.artifactDir, 'elements.ts'), content));
-      supportImports.push(`import './elements';`);
     }
   }
 
@@ -129,7 +148,7 @@ async function emitArtifact(
     options
   );
   outputFiles.push(...styleFiles.files);
-  supportImports.unshift(`import '${styleFiles.entryImport}';`);
+  if (styleFiles.entryImport) supportImports.unshift(`import '${styleFiles.entryImport}';`);
 
   if (supportImports.length > 0) entrySource = `${supportImports.join('\n')}\n${entrySource}`;
   outputFiles.push(outputFile(options, context.entryFile, entrySource));
@@ -141,12 +160,12 @@ function createArtifactContexts(
   graph: ArtifactGraph,
   rootDir: string,
   targetRoot: string,
-  style: RegistryTarget['style']
+  target: RegistryTarget
 ): ReadonlyMap<string, ArtifactOutputContext> {
   return new Map(
     graph.artifacts.map((artifact) => {
       const artifactDir = posix.join(targetRoot, artifact.id);
-      const entryFile = posix.join(artifactDir, outputEntryName(artifact.entry));
+      const entryFile = posix.join(artifactDir, outputEntryName(artifact.entry, target.framework));
       const files = new Map<string, string>();
 
       for (const file of artifact.files) {
@@ -155,7 +174,7 @@ function createArtifactContexts(
           absolute,
           file.role === 'entry'
             ? entryFile
-            : styleSourceTarget(posix.join(targetRoot, stripCanonicalPrefix(normalizePath(file.path))), style)
+            : styleSourceTarget(posix.join(targetRoot, stripCanonicalPrefix(normalizePath(file.path))), target.style)
         );
       }
 
@@ -173,7 +192,7 @@ async function emitStyleFiles(
     targetRoot: string;
     registryRoot: string;
   }
-): Promise<{ files: RegistryOutputFile[]; entryImport: string }> {
+): Promise<{ files: RegistryOutputFile[]; entryImport?: string | undefined }> {
   const resources = artifact.resources.styles ?? [];
   const files: RegistryOutputFile[] = [];
   let tailwindSource: string | undefined;
@@ -200,7 +219,10 @@ async function emitStyleFiles(
 
   if (!tailwindSource) throw new Error(`Artifact \`${artifact.id}\` has no Tailwind style resource.`);
   if (options.target.style === 'tailwind') {
-    return { files, entryImport: '../styles/tailwind.css' };
+    return {
+      files,
+      ...(options.target.framework === 'react' ? { entryImport: '../styles/tailwind.css' } : {}),
+    };
   }
 
   const artifactStyles = posix.join(options.targetRoot, artifact.id, 'styles.css');
@@ -209,7 +231,10 @@ async function emitStyleFiles(
     '\n'
   );
   files.push(outputFile(options, artifactStyles, content));
-  return { files, entryImport: './styles.css' };
+  return {
+    files,
+    ...(options.target.framework === 'react' ? { entryImport: './styles.css' } : {}),
+  };
 }
 
 function rewriteRelativeImports(
@@ -264,12 +289,9 @@ function collectPackageDependencies(files: readonly RegistryOutputFile[]): strin
   return [...packages].sort();
 }
 
-function targetConfig(target: RegistryTarget): CompilerConfig {
-  return target.framework === 'react' ? reactSourceConfig : htmlSourceConfig;
-}
-
-function outputEntryName(entry: string): string {
-  return basename(entry).replace(/\.skin(?=\.[^.]+$)/, '');
+function outputEntryName(entry: string, framework: RegistryTarget['framework']): string {
+  const base = basename(entry).replace(/\.skin(?=\.[^.]+$)/, '');
+  return framework === 'html' ? base.replace(/\.[^.]+$/, '.html') : base;
 }
 
 function stripCanonicalPrefix(path: string): string {

--- a/build/source-ui/registry.ts
+++ b/build/source-ui/registry.ts
@@ -69,7 +69,7 @@ export function createRegistryCatalog(
     name: 'videojs',
     homepage: 'https://videojs.org',
     items: published.map((artifact) => {
-      const { included, dependencies } = partitionDependencies(artifact, artifacts, publishedIds);
+      const { included, dependencies } = partitionDependencies(artifact, artifacts, publishedIds, target.framework);
       const files = uniqueFiles(
         included.flatMap((id) => {
           const artifactFiles = output.artifacts[id];
@@ -119,8 +119,10 @@ function hasRegistryMetadata(
 function partitionDependencies(
   root: ArtifactGraphNode,
   artifacts: ReadonlyMap<string, ArtifactGraphNode>,
-  publishedIds: ReadonlySet<string>
+  publishedIds: ReadonlySet<string>,
+  framework: RegistryFramework
 ): { included: string[]; dependencies: string[] } {
+  if (framework === 'html') return { included: [root.id], dependencies: [] };
   const included = new Set<string>();
   const dependencies = new Set<string>();
 

--- a/build/source-ui/tests/output.test.ts
+++ b/build/source-ui/tests/output.test.ts
@@ -55,19 +55,18 @@ describe('createSourceOutput', () => {
       target: { framework: 'html', style: 'tailwind' },
     });
     const files = output.artifacts['time-slider'] ?? [];
-    const entry = files.find((file) => file.target?.endsWith('/time-slider.tsx'));
+    const entry = files.find((file) => file.target?.endsWith('/time-slider.html'));
     const elements = files.find((file) => file.target?.endsWith('/elements.ts'));
     const icons = files.find((file) => file.target?.endsWith('/icons.ts'));
 
-    assert.match(
-      entry?.content ?? '',
-      /^import '\.\.\/styles\/tailwind\.css';\nimport '\.\/icons';\nimport '\.\/elements';/
-    );
+    assert.doesNotMatch(entry?.content ?? '', /\bimport\b|\bexport\b/);
     assert.match(entry?.content ?? '', /<media-time-slider/);
+    assert.match(entry?.content ?? '', /thumb-alignment="edge"/);
+    assert.doesNotMatch(entry?.content ?? '', /thumbAlignment|class="[^"]*,/);
     assert.equal(elements?.content, "import '@videojs/html/ui/time-slider';\n");
     assert.match(icons?.content ?? '', /'spinner': `<svg/);
     assert.doesNotMatch(icons?.content ?? '', /'play':|'volume-high':/);
-    assert.deepEqual(output.dependencies?.['time-slider'], ['@videojs/html', '@videojs/utils']);
+    assert.deepEqual(output.dependencies?.['time-slider'], ['@videojs/html']);
     assertNoPrivateImports(files);
   });
 
@@ -98,6 +97,27 @@ describe('createSourceOutput', () => {
     assert.match(tailwind?.content ?? '', /@source "\.\.\/\*\*\/\*\.\{ts,tsx,html\}";/);
     assert.match(tailwind?.content ?? '', /@theme inline/);
     assert.doesNotMatch(tailwind?.content ?? '', /\.skin\.tsx/);
+  });
+
+  it('inlines complete HTML Skin composition with transitive registrations', async () => {
+    const { graph } = await buildSkinArtifactGraph();
+    const output = await createSourceOutput(graph, {
+      rootDir: skinsRoot,
+      target: { framework: 'html', style: 'tailwind' },
+    });
+    const files = output.artifacts['default-video-controls'] ?? [];
+    const entry = files.find((file) => file.target?.endsWith('/video-controls.html'));
+    const elements = files.find((file) => file.target?.endsWith('/elements.ts'));
+    const icons = files.find((file) => file.target?.endsWith('/icons.ts'));
+
+    assert.match(entry?.content ?? '', /<media-play-button/);
+    assert.match(entry?.content ?? '', /<media-seek-button[^>]+seconds="-10"/);
+    assert.match(entry?.content ?? '', /<media-volume-slider[^>]+orientation="vertical"/);
+    assert.match(entry?.content ?? '', /<media-fullscreen-button/);
+    assert.match(elements?.content ?? '', /@videojs\/html\/ui\/play-button/);
+    assert.match(elements?.content ?? '', /@videojs\/html\/ui\/volume-slider/);
+    assert.match(icons?.content ?? '', /'play': `<svg/);
+    assert.match(icons?.content ?? '', /'volume-high': `<svg/);
   });
 
   it('emits ordinary CSS from the artifact style-module candidates', async () => {

--- a/build/source-ui/tests/registry.test.ts
+++ b/build/source-ui/tests/registry.test.ts
@@ -32,13 +32,18 @@ describe('createRegistryCatalog', () => {
           `${target.framework}/${target.style}/volume-slider`,
         ]
       );
-      assert.deepEqual(catalog.items[0]?.registryDependencies, [
-        `videojs/v10/${target.framework}/${target.style}/fullscreen-button#eject/11-registry-catalog`,
-        `videojs/v10/${target.framework}/${target.style}/play-button#eject/11-registry-catalog`,
-        `videojs/v10/${target.framework}/${target.style}/seek-button#eject/11-registry-catalog`,
-        `videojs/v10/${target.framework}/${target.style}/time-slider#eject/11-registry-catalog`,
-        `videojs/v10/${target.framework}/${target.style}/volume-popover#eject/11-registry-catalog`,
-      ]);
+      assert.deepEqual(
+        catalog.items[0]?.registryDependencies,
+        target.framework === 'react'
+          ? [
+              `videojs/v10/${target.framework}/${target.style}/fullscreen-button#eject/11-registry-catalog`,
+              `videojs/v10/${target.framework}/${target.style}/play-button#eject/11-registry-catalog`,
+              `videojs/v10/${target.framework}/${target.style}/seek-button#eject/11-registry-catalog`,
+              `videojs/v10/${target.framework}/${target.style}/time-slider#eject/11-registry-catalog`,
+              `videojs/v10/${target.framework}/${target.style}/volume-popover#eject/11-registry-catalog`,
+            ]
+          : undefined
+      );
       assert.deepEqual(catalog.items[0]?.meta, {
         framework: target.framework,
         style: target.style,

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -175,6 +175,7 @@
     "@videojs/compiler": "workspace:*",
     "@videojs/icons": "workspace:*",
     "@videojs/skins": "workspace:*",
+    "esbuild": "^0.28.1",
     "happy-dom": "^20.11.1",
     "tsdown": "^0.22.14",
     "typescript": "^6.0.2",

--- a/packages/html/scripts/render-skin-source.ts
+++ b/packages/html/scripts/render-skin-source.ts
@@ -1,0 +1,102 @@
+import { readFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { compile } from '@videojs/compiler';
+import { build, type Plugin } from 'esbuild';
+import htmlSourceConfig from '../skins.compiler.config.ts';
+
+/** Render one canonical Skin artifact entry to static light-DOM HTML. */
+export async function renderSkinSource(entryFile: string): Promise<string> {
+  const result = await build({
+    entryPoints: [entryFile],
+    bundle: true,
+    format: 'cjs',
+    platform: 'neutral',
+    write: false,
+    jsx: 'automatic',
+    jsxImportSource: 'source-ui-html',
+    plugins: [canonicalHtmlPlugin()],
+  });
+  const code = result.outputFiles[0]?.text;
+  if (!code) throw new Error(`HTML source rendering produced no output for \`${entryFile}\`.`);
+
+  const module = { exports: {} as Record<string, unknown> };
+  runInNewContext(code, { module, exports: module.exports });
+  const render = Object.values(module.exports).find(
+    (value): value is (props: Record<string, never>) => unknown => typeof value === 'function'
+  );
+  if (!render) throw new Error(`HTML source rendering found no component export in \`${entryFile}\`.`);
+
+  return String(render({})).trim();
+}
+
+function canonicalHtmlPlugin(): Plugin {
+  return {
+    name: 'videojs-source-html',
+    setup(build) {
+      build.onResolve({ filter: /^source-ui-html\/jsx-runtime$/ }, () => ({
+        path: 'jsx-runtime',
+        namespace: 'videojs-source-html',
+      }));
+      build.onResolve({ filter: /^@videojs\/utils\/style$/ }, () => ({
+        path: 'style',
+        namespace: 'videojs-source-html',
+      }));
+      build.onLoad({ filter: /.*/, namespace: 'videojs-source-html' }, ({ path }) => ({
+        contents: path === 'style' ? classNamesRuntime : jsxRuntime,
+        loader: 'js',
+      }));
+      build.onLoad({ filter: /\.skin\.tsx$/ }, async ({ path }) => {
+        const source = await readFile(path, 'utf8');
+        const result = await compile(source, { filename: path, config: htmlSourceConfig });
+        return { contents: result.code, loader: 'tsx', resolveDir: dirname(path) };
+      });
+    },
+  };
+}
+
+const classNamesRuntime = `
+export function cn(...values) {
+  return values.flat(Infinity).filter(Boolean).join(' ');
+}
+`;
+
+const jsxRuntime = `
+export const Fragment = Symbol('Fragment');
+const raw = Symbol('raw-html');
+
+export function jsx(type, props) {
+  if (type === Fragment) return html(renderChildren(props?.children));
+  if (typeof type === 'function') return type(props ?? {});
+
+  const { children, ...attributes } = props ?? {};
+  return html('<' + type + renderAttributes(attributes) + '>' + renderChildren(children) + '</' + type + '>');
+}
+
+export const jsxs = jsx;
+
+function renderAttributes(attributes) {
+  let output = '';
+  for (const [name, value] of Object.entries(attributes)) {
+    if (value == null || value === false || typeof value === 'function') continue;
+    const attribute = name === 'className' ? 'class' : name.replace(/[A-Z]/g, (letter) => '-' + letter.toLowerCase());
+    const normalized = attribute === 'class' ? [value].flat(Infinity).filter(Boolean).join(' ') : value;
+    output += normalized === true ? ' ' + attribute : ' ' + attribute + '="' + escape(normalized) + '"';
+  }
+  return output;
+}
+
+function renderChildren(children) {
+  return [children].flat(Infinity).filter((value) => value != null && value !== false).map((value) => {
+    return value && typeof value === 'object' && raw in value ? value[raw] : escape(value);
+  }).join('');
+}
+
+function escape(value) {
+  return String(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function html(value) {
+  return { [raw]: value, toString() { return value; } };
+}
+`;

--- a/packages/html/src/ui/popover/tests/popover-element.test.ts
+++ b/packages/html/src/ui/popover/tests/popover-element.test.ts
@@ -20,6 +20,22 @@ afterEach(() => {
 });
 
 describe('PopoverElement', () => {
+  it('assigns safe identity to an adjacent source-owned trigger', async () => {
+    const firstTrigger = document.createElement('button');
+    const firstPopover = createPopover();
+    const secondTrigger = document.createElement('button');
+    const secondPopover = createPopover();
+
+    document.body.append(firstTrigger, firstPopover, secondTrigger, secondPopover);
+    await Promise.all([firstPopover.updateComplete, secondPopover.updateComplete]);
+
+    expect(firstPopover.id).toMatch(/^vjs-popup-/);
+    expect(secondPopover.id).toMatch(/^vjs-popup-/);
+    expect(firstPopover.id).not.toBe(secondPopover.id);
+    expect(firstTrigger.getAttribute('commandfor')).toBe(firstPopover.id);
+    expect(secondTrigger.getAttribute('commandfor')).toBe(secondPopover.id);
+  });
+
   it('exposes the positioned side on the popup', async () => {
     const trigger = document.createElement('button');
     const popover = createPopover();

--- a/packages/html/src/ui/position-controller.ts
+++ b/packages/html/src/ui/position-controller.ts
@@ -5,6 +5,8 @@ export type PositionControllerHost = ReactiveControllerHost & HTMLElement;
 
 export type PositionControllerOptions = Omit<PopupPositionerOptions, 'popup'>;
 
+let popupId = 0;
+
 /** Connects a popup element to the shared positioning lifecycle. */
 export class PositionController implements ReactiveController {
   readonly #host: PositionControllerHost;
@@ -21,8 +23,16 @@ export class PositionController implements ReactiveController {
     if (trigger) {
       return root.getElementById(trigger);
     }
-    if (!this.#host.id) return null;
-    return root.querySelector<HTMLElement>(`[commandfor="${this.#host.id}"]`);
+    if (this.#host.id) {
+      return root.querySelector<HTMLElement>(`[commandfor="${this.#host.id}"]`);
+    }
+
+    const adjacent = this.#host.previousElementSibling;
+    if (!(adjacent instanceof HTMLElement)) return null;
+
+    this.#host.id = nextPopupId(root);
+    adjacent.setAttribute('commandfor', this.#host.id);
+    return adjacent;
   }
 
   sync(options: PositionControllerOptions): void {
@@ -40,4 +50,11 @@ export class PositionController implements ReactiveController {
   hostDestroyed(): void {
     this.cleanup();
   }
+}
+
+function nextPopupId(root: Document | ShadowRoot): string {
+  let id: string;
+  do id = `vjs-popup-${++popupId}`;
+  while (root.getElementById(id));
+  return id;
 }

--- a/packages/html/tests/render-skin-source.test.ts
+++ b/packages/html/tests/render-skin-source.test.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { renderSkinSource } from '../scripts/render-skin-source';
+
+const canonicalRoot = resolve(import.meta.dirname, '../../skins/canonical');
+
+describe('renderSkinSource', () => {
+  it('renders canonical composition to static light-DOM custom elements', async () => {
+    const html = await renderSkinSource(resolve(canonicalRoot, 'skins/default/video-controls.skin.tsx'));
+
+    expect(html).toContain('<media-controls');
+    expect(html).toContain('<media-play-button');
+    expect(html).toContain('<media-seek-button');
+    expect(html).toContain('seconds="-10"');
+    expect(html).toContain('seconds="10"');
+    expect(html).toContain('thumb-alignment="edge"');
+    expect(html).not.toContain('thumbAlignment');
+    expect(html).not.toMatch(/class="[^"]*,/);
+    expect(html).not.toContain('commandfor=');
+    expect(html).not.toMatch(/ id=/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       '@videojs/skins':
         specifier: workspace:*
         version: link:../skins
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1


### PR DESCRIPTION
## Outcome

Canonical Skin composition now emits formatted, static light-DOM custom-element markup for HTML consumers, with exact transitive registrations and no fixed authored popup IDs.

## Stack

- Position: 3
- Base: #2016 (`eject/13-style-variants`)
- Issue: #1961
- Parent epic: #245

## Scope

- render constrained canonical JSX to self-contained `.html` component and Skin snippets
- inline HTML component composition while React remains module-composed
- normalize component properties to idiomatic kebab-case custom-element attributes
- aggregate exact transitive `elements.ts` and local `icons.ts` registration
- remove HTML registry dependencies where composition is already inlined
- assign adjacent tooltip/popover pairs unique runtime IDs instead of authoring duplicate IDs
- test two independent popup pairs and run the complete HTML package suite

## Intentionally excluded

- writing registry JSON and generated files to disk
- shadcn branch/SHA installation fixtures
- full browser visual and interaction parity
- Vue/Svelte smoke projects

## Verification

- `node --import tsx --test build/source-ui/tests/output.test.ts build/source-ui/tests/registry.test.ts`
- `pnpm -F @videojs/html test`
- `pnpm typecheck`
- `pnpm check:workspace`
- `git diff --check`

## Evidence

Output tests assert real expanded play/seek/time-slider/volume/fullscreen markup, kebab-case attributes, exact closure registrations, public imports, and all four framework/style catalogs. The HTML suite passes 304 tests, including two-instance identity coverage.

## Management-visible outcome

The HTML target is now genuinely HTML source rather than React-shaped TSX with renamed tags, and copied players no longer rely on duplicated authored IDs for tooltips or popovers.

## Follow-up

The next stacked draft writes the four registries, adds drift validation, and proves branch/SHA installation in clean fixtures.