### PR TITLE
fix(skin): increase time hidden threshold in default skin

### DIFF
--- a/packages/skins/src/default/css/components/time.css
+++ b/packages/skins/src/default/css/components/time.css
@@ -10,7 +10,7 @@
   container: media-time-controls / inline-size;
 
   & .media-time:last-child {
-    @container media-time-controls (width < 10rem) {
+    @container media-time-controls (width < 16rem) {
       display: none;
     }
   }

--- a/packages/skins/src/default/tailwind/components/time.ts
+++ b/packages/skins/src/default/tailwind/components/time.ts
@@ -1,5 +1,5 @@
 export const time = {
-  group: '@container/media-time flex items-center flex-1 gap-2.5 @max-[10rem]/media-time:[&>*:last-child]:hidden',
+  group: '@container/media-time flex items-center flex-1 gap-2.5 @max-[16rem]/media-time:[&>*:last-child]:hidden',
   current: 'tabular-nums',
   duration:
     'tabular-nums cursor-pointer rounded-[--spacing(1)] outline-2 outline-transparent -outline-offset-2 transition-[outline-color,outline-offset] duration-100 ease-out focus-visible:outline-current focus-visible:outline-offset-2',


### PR DESCRIPTION
Closes #1947 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive tweak in the default skin with no logic or data changes.
> 
> **Overview**
> Raises the default skin’s **container-query breakpoint** for hiding the last time label (typically duration) from **10rem to 16rem**, so both current time and duration stay visible on slightly narrower control bars.
> 
> The same threshold is updated in **`time.css`** (`@container media-time-controls`) and the matching **Tailwind** `time.group` utility (`@max-[16rem]/media-time`), keeping the CSS and Tailwind skin paths aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37658564815d2794d0e13253c9ff5aa46030da74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->