### PR TITLE
fix(html): stabilize ejected element registration

### DIFF
--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -297,7 +297,6 @@ function ejectedHtmlPage(): string {
   const jsonPath = '../../../../../../site/src/content/ejected-skins.json';
 
   return `import '@videojs/html/icons/element';
-import '@videojs/html/video/ui';
 import ejectedSkins from '${jsonPath}';
 
 interface EjectedSkinEntry {
@@ -324,6 +323,8 @@ if (!playerMatch) {
 
 const root = document.getElementById('root')!;
 root.innerHTML = \`<div style="max-width: 800px; aspect-ratio: 16/9">\${playerMatch[0]}</div>\`;
+
+await import('@videojs/html/video/ui');
 `;
 }
 

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -4,6 +4,7 @@ import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 const UI_VIDEO_PAGES = VIDEO_PAGES.filter(({ media }) => media === 'video');
+const EJECTED_HTML_VIDEO_PATH = '/pages/ejected-html-video-mp4.html';
 
 function getMediaVolume(page: Page): Promise<number> {
   return page.evaluate((selector) => {
@@ -181,6 +182,23 @@ for (const { name, path, skipBrowsers } of ALL_VIDEO_PAGES as readonly PageEntry
     });
   });
 }
+
+test.describe('Video Controls — Ejected HTML registration', () => {
+  test('upgrades connected markup before registration', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+
+    const player = new PlayerPage(page);
+    await page.goto(EJECTED_HTML_VIDEO_PATH);
+    await player.waitForMediaReady();
+    await player.showControls();
+    await player.muteButton.hover();
+
+    await expect(player.volumeSlider).toBeVisible();
+    await player.selectAlternativePlaybackRate();
+    expect(errors).toEqual([]);
+  });
+});
 
 for (const { name, path } of UI_VIDEO_PAGES) {
   test.describe(`Video Controls — ${name} UI`, () => {

--- a/packages/html/src/define/tests/video-minimal-ui-ejected.test.ts
+++ b/packages/html/src/define/tests/video-minimal-ui-ejected.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+describe('video/minimal-ui ejected registration', () => {
+  it('upgrades input feedback when light DOM exists before registration', async () => {
+    document.body.innerHTML = /*html*/ `
+      <video-player>
+        <media-container>
+          <video></video>
+          <media-status-announcer></media-status-announcer>
+          <media-volume-indicator></media-volume-indicator>
+          <media-status-indicator></media-status-indicator>
+          <media-seek-indicator></media-seek-indicator>
+        </media-container>
+      </video-player>
+    `;
+
+    await import('../video/minimal-ui');
+
+    const announcer = document.querySelector('media-status-announcer')!;
+    const indicators = [
+      ...document.querySelectorAll('media-volume-indicator, media-status-indicator, media-seek-indicator'),
+    ];
+
+    await (announcer as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+    await Promise.all(
+      indicators.map((indicator) => (indicator as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete)
+    );
+
+    expect(announcer.getAttribute('role')).toBe('status');
+    expect(announcer.querySelector('[data-status-announcer-content]')).not.toBeNull();
+    expect(indicators.every((indicator) => (indicator as HTMLElement).hidden)).toBe(true);
+    expect(customElements.get('media-popover')).toBeDefined();
+    expect(customElements.get('media-menu')).toBeDefined();
+  });
+});

--- a/packages/html/src/ui/input-indicators/input-indicator-element.ts
+++ b/packages/html/src/ui/input-indicators/input-indicator-element.ts
@@ -143,6 +143,9 @@ export abstract class InputIndicatorElement<IndicatorState extends IndicatorLife
   }
 
   #reconnect(): void {
+    // Context can resolve before this field assignment completes.
+    if (!this.container) return;
+
     this.#inputActionUnsubscribe?.();
     this.#visibilityUnsubscribe?.();
     this.#inputActionUnsubscribe = null;

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -124,6 +124,7 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
   getResolvedLabel(): string | undefined {
     const media = this.mediaState.value;
     if (!media) return undefined;
+    this.core.setMedia(media);
     const state = this.core.getState() as InferComponentState<Core>;
     return translateText(this.core.getLabel(state), this.#i18n.value, getLabelParams(this.core, state));
   }

--- a/packages/html/src/ui/status-announcer/status-announcer-element.ts
+++ b/packages/html/src/ui/status-announcer/status-announcer-element.ts
@@ -1,5 +1,5 @@
 import { createStatusAnnouncerLabels, StatusAnnouncerCore } from '@videojs/core';
-import { isSliderFocused, subscribeToStatusAnnouncer } from '@videojs/core/dom';
+import { isSliderFocused, type StatusAnnouncerStore, subscribeToStatusAnnouncer } from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
 
@@ -19,15 +19,16 @@ export class StatusAnnouncerElement extends MediaElement {
 
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #core = new StatusAnnouncerCore();
+  // Context can resolve while connected markup is still upgrading.
+  #storeUnsubscribe: (() => void) | null = null;
   readonly #player = new ContextConsumer(this, {
     context: playerContext,
-    callback: () => this.#reconnect(),
+    callback: (store) => this.#reconnect(store),
     subscribe: true,
   });
   readonly #container = new ContextConsumer(this, { context: containerContext, subscribe: true });
 
   #disconnect: AbortController | null = null;
-  #storeUnsubscribe: (() => void) | null = null;
   #liveText: HTMLElement | null = null;
 
   override connectedCallback(): void {
@@ -79,12 +80,11 @@ export class StatusAnnouncerElement extends MediaElement {
     this.#ensureLiveText().textContent = label ?? '';
   }
 
-  #reconnect(): void {
+  #reconnect(store: StatusAnnouncerStore | undefined = this.#player.value): void {
     this.#storeUnsubscribe?.();
     this.#storeUnsubscribe = null;
     this.#core.resetSnapshot();
 
-    const store = this.#player.value;
     if (!store) return;
 
     this.#storeUnsubscribe = subscribeToStatusAnnouncer(store, this.#core);

--- a/packages/html/src/ui/tests/media-button-element.test.ts
+++ b/packages/html/src/ui/tests/media-button-element.test.ts
@@ -80,6 +80,18 @@ afterEach(() => {
 });
 
 describe('MediaButtonElement', () => {
+  it('resolves its label before the first update', () => {
+    ensureDefined(PlayButtonElement);
+
+    const player = document.createElement(TestPlayerProviderElement.tagName) as TestPlayerProviderElement;
+    const button = document.createElement(PlayButtonElement.tagName) as PlayButtonElement;
+
+    document.body.append(player);
+    player.append(button);
+
+    expect(button.getResolvedLabel()).toBe('Play');
+  });
+
   it('emits shortcut changes before media is attached', async () => {
     const provider = createElement(TestContainerProviderElement);
     const button = createElement(PlayButtonElement);


### PR DESCRIPTION
Closes #1736

## Summary

Fix ejected HTML players when connected light DOM upgrades after deferred UI bundle execution. Context-driven indicators and tooltip labels now tolerate registration-time callbacks, so volume and playback-rate popovers initialize without uncaught errors.

## Changes

- Make status announcer and input indicator context reconnection safe during synchronous upgrades.
- Sync media button cores before tooltip label resolution.
- Exercise production registration order with minimal UI unit coverage and cross-browser ejected interaction coverage.

## Testing

- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/html build`
- `pnpm -F site test scripts/tests/ejected-skins.test.ts`
- Focused ejected registration E2E in Firefox, Chromium, and WebKit.
- Focused Biome checks and `git diff --check`.

`pnpm typecheck` continues to report the existing SPF metadata errors for `id`, `encrypted`, and `lowLatency` outside this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HTML UI lifecycle (context callbacks, indicators, button labels) used by all players; scope is narrow but affects upgrade timing across skins.
> 
> **Overview**
> Fixes **ejected HTML** players when light DOM is connected before the deferred UI bundle runs. Generated ejected pages now inject markup first, then `await import('@videojs/html/video/ui')`, matching production registration order.
> 
> **Context-driven UI** is hardened for synchronous upgrades: input indicators bail out of `#reconnect` if the container consumer is not ready; the status announcer wires the player store from the context callback; media buttons call `setMedia` in `getResolvedLabel()` so tooltips work before the first render.
> 
> Coverage adds a **minimal-ui** unit test for pre-registration markup and a Playwright case on the ejected HTML page (volume popover, playback rate, no page errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d05c20c65321b0beb117352b7160d1fdc704254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->