### PR TITLE
fix(media): hook the media's actual playback engine in mux data

### DIFF
--- a/apps/sandbox/templates/html-dash-video/main.ts
+++ b/apps/sandbox/templates/html-dash-video/main.ts
@@ -2,6 +2,7 @@ import '@app/styles.css';
 import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI18n } from '@app/shared/html/i18n';
 import '@videojs/html/video/player';
 import '@videojs/html/media/dash-video';
+import '@videojs/html/media/mux-data';
 import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
 import { loadVideoSkinTag } from '@app/shared/html/skins';
 import { renderStoryboard } from '@app/shared/html/storyboard';
@@ -36,6 +37,10 @@ async function render() {
         <dash-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline>
           ${renderStoryboard(storyboard)}
         </dash-video>
+        <!-- Mux Data is an opt-in media component. It hands the dash.js engine to the Mux Data
+             SDK, so views carry stream-level detail. These streams aren't Mux-hosted, so the
+             sandbox env key is what attributes the views. -->
+        <mux-data player-software-name="dash-video" env-key="o9b7ge20gji31ao0rub18505f"></mux-data>
         ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
       </${tag}>
     </video-player>

--- a/apps/sandbox/templates/react-dash-video/main.tsx
+++ b/apps/sandbox/templates/react-dash-video/main.tsx
@@ -11,6 +11,7 @@ import { useSource } from '@app/shared/react/use-source';
 import { SOURCES } from '@app/shared/sources';
 import type { Styling } from '@app/types';
 import { DashVideo } from '@videojs/react/media/dash-video';
+import { MuxData } from '@videojs/react/media/mux-data';
 import { useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 
@@ -39,6 +40,10 @@ function App() {
             preload={preload}
             playsInline
           />
+          {/* Mux Data is an opt-in media component. It hands the dash.js engine to the Mux Data
+              SDK, so views carry stream-level detail. These streams aren't Mux-hosted, so the
+              sandbox env key is what attributes the views. */}
+          <MuxData playerSoftwareName="dash-video" envKey="o9b7ge20gji31ao0rub18505f" />
         </VideoSkinComponent>
       </VideoProvider>
     </SandboxI18nProvider>

--- a/packages/html/src/media/mux-data/mux-data-element.ts
+++ b/packages/html/src/media/mux-data/mux-data-element.ts
@@ -15,6 +15,10 @@ import { MediaComponentElement } from '../media-component-element';
  * as its `video_id`, which Mux attributes to the owning environment. Set
  * `env-key` to monitor sources Mux doesn't host.
  *
+ * Any media element works. When the media plays through an hls.js or dash.js
+ * engine, that engine is handed to the Mux Data SDK so the view also carries
+ * stream-level detail such as rendition switches and request timing.
+ *
  * @example
  * ```html
  * <video-player>

--- a/packages/media/src/dom/mux/mux-data-engine.ts
+++ b/packages/media/src/dom/mux/mux-data-engine.ts
@@ -1,0 +1,75 @@
+import { isFunction, isObject } from '@videojs/utils/predicate';
+import type { MuxDataOptions } from './types';
+
+/** The `mux-embed` monitor options that hook a playback engine's own telemetry. */
+export type MuxDataEngineOptions = Partial<Pick<MuxDataOptions, 'Hls' | 'hlsjs' | 'dashjs'>>;
+
+type MuxDataHlsJsEngine = NonNullable<MuxDataOptions['hlsjs']>;
+type MuxDataHlsJsClass = NonNullable<MuxDataOptions['Hls']>;
+type MuxDataDashJsEngine = NonNullable<MuxDataOptions['dashjs']>;
+
+const warnedEngines = new WeakSet<object>();
+
+/**
+ * Pick the `mux-embed` integration for a media's playback engine.
+ *
+ * `mux-embed` monitors the media element on its own, and an engine integration
+ * is what adds engine-level data on top: rendition switches, request timing and
+ * throughput, and engine errors. It ships two — hls.js and dash.js — and each
+ * one is wired through a different option, so handing a dash.js player to the
+ * hls.js option leaves the view with element-level data only.
+ *
+ * Engines are matched by shape rather than by class so this module imports
+ * neither hls.js nor dash.js. Mux Data can be registered with any media without
+ * pulling an engine it will never touch into the bundle (dash.js in particular
+ * reads `window` on import), and a media whose engine has no integration — a
+ * raw `<video>`, native HLS, or an SPF playback engine — is monitored from the
+ * element alone instead of through the wrong integration.
+ *
+ * @returns Options to spread into a `Mux.monitor()` call. Empty when the engine
+ *   has no integration, which leaves element-level monitoring intact.
+ */
+export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
+  if (isDashJsEngine(engine)) return { dashjs: engine };
+
+  if (isHlsJsEngine(engine)) {
+    // `mux-embed` reads hls.js's event names off the class, falling back to
+    // `window.Hls` when it isn't given one. Take it from the instance so a
+    // bundled hls.js is always found, without importing hls.js here.
+    const Hls = toHlsJsClass(engine);
+    if (Hls) return { hlsjs: engine, Hls };
+  }
+
+  if (__DEV__ && isObject(engine) && !warnedEngines.has(engine)) {
+    warnedEngines.add(engine);
+    console.warn(
+      '[vjs-mux] Mux Data could not hook this playback engine, so the view is monitored from the media element alone. Engine-level data (rendition switches, request timing, engine errors) will be missing.',
+      engine
+    );
+  }
+
+  return {};
+}
+
+/** hls.js: loads a source into a media element and emits its own events. */
+function isHlsJsEngine(engine: unknown): engine is MuxDataHlsJsEngine {
+  return hasMethods(engine, ['loadSource', 'attachMedia', 'on', 'off']);
+}
+
+/** dash.js: attaches a source and a view, and exposes the metrics `mux-embed` reads. */
+function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
+  return hasMethods(engine, ['attachSource', 'attachView', 'getDashMetrics', 'on', 'off']);
+}
+
+function hasMethods(value: unknown, methods: string[]): boolean {
+  if (!isObject(value)) return false;
+  return methods.every((method) => isFunction((value as Record<string, unknown>)[method]));
+}
+
+/** hls.js's own class, the only place its event names are published. */
+function toHlsJsClass(engine: object): MuxDataHlsJsClass | undefined {
+  const engineClass: unknown = engine.constructor;
+  if (!isFunction(engineClass)) return undefined;
+  const statics = engineClass as unknown as MuxDataHlsJsClass;
+  return isObject(statics.Events) ? statics : undefined;
+}

--- a/packages/media/src/dom/mux/mux-data-engine.ts
+++ b/packages/media/src/dom/mux/mux-data-engine.ts
@@ -1,4 +1,4 @@
-import { isFunction, isObject } from '@videojs/utils/predicate';
+import { hasMethods, isFunction, isObject, isString } from '@videojs/utils/predicate';
 import type { MuxDataOptions } from './types';
 
 /** The `mux-embed` monitor options that hook a playback engine's own telemetry. */
@@ -33,9 +33,9 @@ export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
   if (isDashJsEngine(engine)) return { dashjs: engine };
 
   if (isHlsJsEngine(engine)) {
-    // `mux-embed` reads hls.js's event names off the class, falling back to
-    // `window.Hls` when it isn't given one. Take it from the instance so a
-    // bundled hls.js is always found, without importing hls.js here.
+    // `mux-embed` reads hls.js's event names and error details off the class,
+    // falling back to `window.Hls` when it isn't given one. Take it from the
+    // instance so a bundled hls.js is always found, without importing it here.
     const Hls = toHlsJsClass(engine);
     if (Hls) return { hlsjs: engine, Hls };
   }
@@ -51,25 +51,27 @@ export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
   return {};
 }
 
-/** hls.js: loads a source into a media element and emits its own events. */
+// Each engine is recognized by what its `mux-embed` monitor reaches for, so a
+// match means the integration has everything it needs. Both monitors subscribe
+// through `on` / `off`; the rendition APIs are what tell the two engines apart.
+
+/** hls.js: its monitor reads renditions from `levels`. */
 function isHlsJsEngine(engine: unknown): engine is MuxDataHlsJsEngine {
-  return hasMethods(engine, ['loadSource', 'attachMedia', 'on', 'off']);
+  return hasMethods(engine, ['on', 'off']) && Array.isArray((engine as { levels?: unknown }).levels);
 }
 
-/** dash.js: attaches a source and a view, and exposes the metrics `mux-embed` reads. */
+/** dash.js: its monitor reads renditions through the track and rendition-list getters. */
 function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
-  return hasMethods(engine, ['attachSource', 'attachView', 'getDashMetrics', 'on', 'off']);
+  if (!hasMethods(engine, ['on', 'off', 'getCurrentTrackFor'])) return false;
+  // dash.js v5 replaced `getBitrateInfoListFor` with `getRepresentationsByType`.
+  // `mux-embed` reads whichever the player has, so either one is a match.
+  return hasMethods(engine, ['getRepresentationsByType']) || hasMethods(engine, ['getBitrateInfoListFor']);
 }
 
-function hasMethods(value: unknown, methods: string[]): boolean {
-  if (!isObject(value)) return false;
-  return methods.every((method) => isFunction((value as Record<string, unknown>)[method]));
-}
-
-/** hls.js's own class, the only place its event names are published. */
+/** hls.js's own class, the only place its event names and error details are published. */
 function toHlsJsClass(engine: object): MuxDataHlsJsClass | undefined {
   const engineClass: unknown = engine.constructor;
   if (!isFunction(engineClass)) return undefined;
   const statics = engineClass as unknown as MuxDataHlsJsClass;
-  return isObject(statics.Events) ? statics : undefined;
+  return isObject(statics.Events) && isObject(statics.ErrorDetails) && isString(statics.version) ? statics : undefined;
 }

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -1,6 +1,6 @@
 import Mux from 'mux-embed';
-import { Hls, type HlsJsMedia } from '../hls-js';
 import { getPlayerVersion } from './env';
+import { toMuxDataEngineOptions } from './mux-data-engine';
 import type { MuxDataOptions, MuxDataSdk } from './types';
 
 export interface MuxDataProps {
@@ -30,8 +30,19 @@ export const muxDataDefaultProps: MuxDataProps = {
 
 const MUX_VIDEO_DOMAIN = 'mux.com';
 
+/**
+ * What Mux Data needs from the media it monitors: the source being played, a
+ * `loadstart` to re-monitor on, and — for engine-backed playback — the engine
+ * itself.
+ *
+ * `engine` is deliberately untyped. Every engine-backed media host exposes one,
+ * but they are unrelated types (an hls.js instance, a dash.js player, an SPF
+ * composition), and which of them Mux Data can hook is decided by
+ * {@link toMuxDataEngineOptions}, not by this contract. Media with no JS engine
+ * simply omit it.
+ */
 export interface MuxDataMedia extends EventTarget {
-  readonly engine?: HlsJsMedia['engine'];
+  readonly engine?: unknown;
   readonly src: string;
 }
 
@@ -204,7 +215,6 @@ export class MuxData implements MuxDataProps {
       playerInitTime: player_init_time,
       metadata = {},
     } = this;
-    const { engine: hlsjs } = media;
 
     const { view_session_id = this.MuxDataSdk?.utils.generateUUID() } = metadata;
     const video_id = toVideoId({ metadata, src: media.src });
@@ -215,8 +225,7 @@ export class MuxData implements MuxDataProps {
       debug,
       ...(beaconCollectionDomain ? { beaconCollectionDomain } : {}),
       ...(disableCookies ? { disableCookies } : {}),
-      ...(hlsjs ? { hlsjs } : {}),
-      Hls,
+      ...toMuxDataEngineOptions(media.engine),
       data: {
         ...(env_key ? { env_key } : {}),
         ...(player_software_name ? { player_software_name } : {}),

--- a/packages/media/src/dom/mux/tests/mux-data-engine.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data-engine.test.ts
@@ -3,21 +3,23 @@ import Hls from 'hls.js';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { toMuxDataEngineOptions } from '../mux-data-engine';
 
-/** Shaped like an hls.js instance: its class carries the event names `mux-embed` reads. */
+/** Shaped like an hls.js instance, class statics included. */
 class FakeHlsJsEngine {
   static Events = { MANIFEST_LOADED: 'hlsManifestLoaded' };
-  loadSource() {}
-  attachMedia() {}
+  static ErrorDetails = { MANIFEST_LOAD_ERROR: 'manifestLoadError' };
+  static version = '1.6.15';
+  levels: unknown[] = [];
   on() {}
   off() {}
 }
 
-/** Shaped like a dash.js `MediaPlayerClass`. */
+/** Shaped like a dash.js v5 `MediaPlayerClass`. */
 class FakeDashJsEngine {
-  attachSource() {}
-  attachView() {}
-  getDashMetrics() {
-    return {};
+  getCurrentTrackFor() {
+    return null;
+  }
+  getRepresentationsByType() {
+    return [];
   }
   on() {}
   off() {}
@@ -46,6 +48,14 @@ describe('toMuxDataEngineOptions', () => {
     expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
   });
 
+  it('wires a pre-v5 dash.js player into the dash.js integration', () => {
+    // v5 replaced `getBitrateInfoListFor` with `getRepresentationsByType`, and
+    // `mux-embed` reads whichever the player has.
+    const engine = { on() {}, off() {}, getCurrentTrackFor() {}, getBitrateInfoListFor() {} };
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
+  });
+
   it('sends no engine options for media with no engine', () => {
     expect(toMuxDataEngineOptions(null)).toEqual({});
     expect(toMuxDataEngineOptions(undefined)).toEqual({});
@@ -58,11 +68,11 @@ describe('toMuxDataEngineOptions', () => {
     expect(toMuxDataEngineOptions(engine)).toEqual({});
   });
 
-  it('skips the hls.js integration when the engine class carries no events', () => {
+  it('skips the hls.js integration when the engine class publishes no events', () => {
     // `mux-embed` needs the class to hook hls.js events, and reaches for
     // `window.Hls` when it isn't given one — better to monitor the element alone
     // than to let it pick up an unrelated global.
-    const engine = { loadSource() {}, attachMedia() {}, on() {}, off() {} };
+    const engine = { levels: [], on() {}, off() {} };
 
     expect(toMuxDataEngineOptions(engine)).toEqual({});
   });

--- a/packages/media/src/dom/mux/tests/mux-data-engine.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data-engine.test.ts
@@ -1,0 +1,95 @@
+import * as dashjs from 'dashjs';
+import Hls from 'hls.js';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { toMuxDataEngineOptions } from '../mux-data-engine';
+
+/** Shaped like an hls.js instance: its class carries the event names `mux-embed` reads. */
+class FakeHlsJsEngine {
+  static Events = { MANIFEST_LOADED: 'hlsManifestLoaded' };
+  loadSource() {}
+  attachMedia() {}
+  on() {}
+  off() {}
+}
+
+/** Shaped like a dash.js `MediaPlayerClass`. */
+class FakeDashJsEngine {
+  attachSource() {}
+  attachView() {}
+  getDashMetrics() {
+    return {};
+  }
+  on() {}
+  off() {}
+}
+
+let warn: MockInstance<typeof console.warn>;
+
+beforeEach(() => {
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('toMuxDataEngineOptions', () => {
+  it('wires an hls.js engine and its class into the hls.js integration', () => {
+    const engine = new FakeHlsJsEngine();
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({ hlsjs: engine, Hls: FakeHlsJsEngine });
+  });
+
+  it('wires a dash.js player into the dash.js integration', () => {
+    const engine = new FakeDashJsEngine();
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
+  });
+
+  it('sends no engine options for media with no engine', () => {
+    expect(toMuxDataEngineOptions(null)).toEqual({});
+    expect(toMuxDataEngineOptions(undefined)).toEqual({});
+  });
+
+  it('sends no engine options for an engine it has no integration for', () => {
+    // An SPF playback engine: a composition, not a handle `mux-embed` can hook.
+    const engine = { state: {}, context: {}, destroy: () => Promise.resolve() };
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({});
+  });
+
+  it('skips the hls.js integration when the engine class carries no events', () => {
+    // `mux-embed` needs the class to hook hls.js events, and reaches for
+    // `window.Hls` when it isn't given one — better to monitor the element alone
+    // than to let it pick up an unrelated global.
+    const engine = { loadSource() {}, attachMedia() {}, on() {}, off() {} };
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({});
+  });
+
+  // The engines are matched by shape, so the real instances are what keeps the
+  // match honest as hls.js and dash.js evolve.
+  it('recognizes a real hls.js instance', () => {
+    const engine = new Hls();
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({ hlsjs: engine, Hls });
+
+    engine.destroy();
+  });
+
+  it('recognizes a real dash.js player', () => {
+    const engine = dashjs.MediaPlayer().create();
+
+    expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
+  });
+
+  it('warns once per unrecognized engine in development', () => {
+    const engine = { destroy: () => {} };
+
+    toMuxDataEngineOptions(engine);
+    toMuxDataEngineOptions(engine);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('could not hook this playback engine'), engine);
+  });
+});

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -16,21 +16,23 @@ class FakeMedia extends EventTarget {
   src = '';
 }
 
-/** Shaped like an hls.js instance: its class carries the event names `mux-embed` reads. */
+/** Shaped like an hls.js instance, class statics included. */
 class FakeHlsJsEngine {
   static Events = { MANIFEST_LOADED: 'hlsManifestLoaded' };
-  loadSource() {}
-  attachMedia() {}
+  static ErrorDetails = { MANIFEST_LOAD_ERROR: 'manifestLoadError' };
+  static version = '1.6.15';
+  levels: unknown[] = [];
   on() {}
   off() {}
 }
 
 /** Shaped like a dash.js `MediaPlayerClass`. */
 class FakeDashJsEngine {
-  attachSource() {}
-  attachView() {}
-  getDashMetrics() {
-    return {};
+  getCurrentTrackFor() {
+    return null;
+  }
+  getRepresentationsByType() {
+    return [];
   }
   on() {}
   off() {}

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { HlsJsMedia } from '../../hls-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MuxData } from '..';
 import type { MuxDataSdk } from '../types';
 
@@ -13,8 +12,28 @@ function createSdk() {
 }
 
 class FakeMedia extends EventTarget {
-  engine: HlsJsMedia['engine'] = null;
+  engine: unknown = null;
   src = '';
+}
+
+/** Shaped like an hls.js instance: its class carries the event names `mux-embed` reads. */
+class FakeHlsJsEngine {
+  static Events = { MANIFEST_LOADED: 'hlsManifestLoaded' };
+  loadSource() {}
+  attachMedia() {}
+  on() {}
+  off() {}
+}
+
+/** Shaped like a dash.js `MediaPlayerClass`. */
+class FakeDashJsEngine {
+  attachSource() {}
+  attachView() {}
+  getDashMetrics() {
+    return {};
+  }
+  on() {}
+  off() {}
 }
 
 // Initialization is deferred by a microtask so all props settle first.
@@ -22,6 +41,10 @@ async function settle() {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
 
 describe('MuxData', () => {
   it('accepts a player software name', () => {
@@ -74,7 +97,7 @@ describe('MuxData', () => {
 
     expect(monitor).toHaveBeenCalledTimes(1);
 
-    const engine = {} as NonNullable<HlsJsMedia['engine']>;
+    const engine = new FakeHlsJsEngine();
     media.engine = engine;
     media.src = 'https://stream.mux.com/abc123.m3u8';
     media.dispatchEvent(new Event('loadstart'));
@@ -86,9 +109,47 @@ describe('MuxData', () => {
       video,
       expect.objectContaining({
         hlsjs: engine,
+        Hls: FakeHlsJsEngine,
         data: expect.objectContaining({ video_id: 'abc123' }),
       })
     );
+  });
+
+  it('monitors a dash.js engine through the dash.js integration', async () => {
+    const { sdk, monitor } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+    media.engine = new FakeDashJsEngine();
+    media.src = 'https://example.com/manifest.mpd';
+
+    data.setMedia(media);
+    data.attach(video);
+
+    await settle();
+
+    const [, options] = monitor.mock.lastCall!;
+    expect(options.dashjs).toBe(media.engine);
+    expect(options).not.toHaveProperty('hlsjs');
+    expect(options).not.toHaveProperty('Hls');
+  });
+
+  it('monitors media with no engine from the media element alone', async () => {
+    const { sdk, monitor } = createSdk();
+    const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
+    const video = document.createElement('video');
+    const media = new FakeMedia();
+    media.src = 'https://example.com/video.mp4';
+
+    data.setMedia(media);
+    data.attach(video);
+
+    await settle();
+
+    const [, options] = monitor.mock.lastCall!;
+    expect(options).not.toHaveProperty('hlsjs');
+    expect(options).not.toHaveProperty('Hls');
+    expect(options).not.toHaveProperty('dashjs');
   });
 
   it('moves its media listener when registered with another host', async () => {

--- a/packages/react/src/media/mux-data/mux-data.tsx
+++ b/packages/react/src/media/mux-data/mux-data.tsx
@@ -21,6 +21,10 @@ export type MuxDataProps = Partial<MuxDataComponentProps>;
  * as its `video_id`, which Mux attributes to the owning environment. Set
  * `envKey` to monitor sources Mux doesn't host.
  *
+ * Any media component works. When the media plays through an hls.js or dash.js
+ * engine, that engine is handed to the Mux Data SDK so the view also carries
+ * stream-level detail such as rendition switches and request timing.
+ *
  * @example
  * ```tsx
  * <Player.Provider>

--- a/packages/utils/src/predicate/predicate.ts
+++ b/packages/utils/src/predicate/predicate.ts
@@ -38,6 +38,20 @@ export function isObject(value: unknown): value is object {
 }
 
 /**
+ * Check if a value is an object carrying a callable method for every given name.
+ *
+ * Recognizes a foreign object by the shape a caller needs from it, without
+ * importing the library that defines it or testing against its class.
+ */
+export function hasMethods<K extends string>(
+  value: unknown,
+  methods: readonly K[]
+): value is Record<K, (...args: any[]) => any> {
+  if (!isObject(value)) return false;
+  return methods.every((method) => isFunction((value as Record<string, unknown>)[method]));
+}
+
+/**
  * Check if a value is a plain object (not a class instance like Date, Map, etc).
  */
 export function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/utils/src/predicate/tests/predicate.test.ts
+++ b/packages/utils/src/predicate/tests/predicate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  hasMethods,
   isAbortError,
   isBoolean,
   isFunction,
@@ -208,6 +209,38 @@ describe('predicate', () => {
     it('returns false for functions', () => {
       expect(isPlainObject(() => {})).toBe(false);
       expect(isPlainObject(() => {})).toBe(false);
+    });
+  });
+
+  describe('hasMethods', () => {
+    it('returns true when every name is a callable method', () => {
+      expect(hasMethods({ play: () => {}, pause: () => {} }, ['play', 'pause'])).toBe(true);
+      expect(hasMethods(new Map(), ['get', 'set'])).toBe(true);
+    });
+
+    it('finds methods inherited from a prototype', () => {
+      class Engine {
+        on() {}
+        off() {}
+      }
+      expect(hasMethods(new Engine(), ['on', 'off'])).toBe(true);
+    });
+
+    it('returns true for an empty list of methods', () => {
+      expect(hasMethods({}, [])).toBe(true);
+    });
+
+    it('returns false when a name is missing or not callable', () => {
+      expect(hasMethods({ play: () => {} }, ['play', 'pause'])).toBe(false);
+      expect(hasMethods({ play: 'nope' }, ['play'])).toBe(false);
+    });
+
+    it('returns false for non-objects', () => {
+      expect(hasMethods(null, ['play'])).toBe(false);
+      expect(hasMethods(undefined, ['play'])).toBe(false);
+      expect(hasMethods('play', ['play'])).toBe(false);
+      // A function can carry methods, but callers here are matching object shapes.
+      expect(hasMethods(() => {}, [])).toBe(false);
     });
   });
 

--- a/site/src/content/docs/concepts/mux-data.mdx
+++ b/site/src/content/docs/concepts/mux-data.mdx
@@ -75,7 +75,9 @@ An explicit key always wins, so set one to send Mux-hosted views to a specific e
 
 ## Any media element works
 
-The component attaches to the media the player is using, not to a specific element type, so it monitors <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/dash-video">DashVideo</DocsLink>, and the rest alike. When the media exposes an [hls.js](https://github.com/video-dev/hls.js/) engine, the component hands that engine to the Mux Data SDK so it can report stream-level detail alongside the playback metrics.
+The component attaches to the media the player is using, not to a specific element type, so it monitors <DocsLink slug="reference/mux-video">MuxVideo</DocsLink>, <DocsLink slug="reference/hlsjs-video">HlsJsVideo</DocsLink>, <DocsLink slug="reference/dash-video">DashVideo</DocsLink>, and the rest alike.
+
+How much it reports depends on the engine playing the stream. Every media gets the playback metrics the media element itself can tell us. On top of that, the component recognizes [hls.js](https://github.com/video-dev/hls.js/) and [dash.js](https://github.com/Dash-Industry-Forum/dash.js) engines and hands them to the Mux Data SDK, which adds stream-level detail: rendition switches, segment request timing and throughput, and engine errors. Media with no JavaScript engine, like native HLS or a plain `<video>`, report the element-level metrics alone.
 
 The `video_id` it reports is the Mux playback ID for streams served from `stream.mux.com`, and the source URL otherwise. Each view also gets a generated `view_session_id`. Override either through `metadata`.
 


### PR DESCRIPTION
Closes #2038
Refs #1845

## Summary

Mux Data assumed `media.engine` was an hls.js instance. It handed that engine to `mux-embed` as `hlsjs` and always sent the hls.js constructor along with it, so DASH playback was monitored through the hls.js integration and lost every engine-level signal. Engines are now matched by shape and routed to the integration that understands them.

## Changes

- hls.js engines keep the `hlsjs` path; dash.js players go through `mux-embed`'s own `dashjs` path, which was never being used.
- Media with no JavaScript engine (native HLS, a plain `<video>`) or an engine Mux Data cannot hook (an SPF composition) are monitored from the media element alone, with a one-time dev warning naming the data that will be missing. Previously an unrelated engine was passed to the hls.js option.
- Mux Data no longer imports hls.js. A `MuxData`-only import drops from **1,239,192 to 123,410 bytes**, and the DASH sandbox pages now bundle Mux Data with no hls.js chunk at all.
- `MuxDataMedia.engine` is typed `unknown`, since engine selection belongs to the resolver rather than the media contract.
- Both DASH sandbox templates compose `<mux-data>` / `<MuxData>` so the dash.js path is easy to exercise in a browser.

<details>
<summary>Implementation details</summary>

`toMuxDataEngineOptions()` recognizes engines structurally rather than with `instanceof`, so the module imports neither hls.js nor dash.js. That is what removes the bundle cost, and it also keeps dash.js's top-level `window` access (#1343) away from SSR. Two tests match against real `new Hls()` and `dashjs.MediaPlayer().create()` instances so library drift breaks the match loudly.

`mux-embed` reads hls.js's event names off the class and falls back to `window.Hls` when it is not given one. The class is taken from `engine.constructor`, which finds the bundled hls.js without importing it. If that class carries no `Events`, Mux Data monitors the element alone rather than letting `mux-embed` pick up an unrelated global.

SPF stays out of scope; #1845 still owns its telemetry. It now falls back to element-only monitoring instead of misreporting.

</details>

## Testing

1. `pnpm -F @videojs/media test` (565 passed, including new `toMuxDataEngineOptions` coverage for hls.js, dash.js, engine-less, and unrecognized engines)
2. `pnpm -F @videojs/html test src/media`, `pnpm -F @videojs/react test src/media`, `pnpm typecheck`, `pnpm check:workspace`
3. Manual: run the sandbox `dash-video` preset for HTML and React, and confirm Mux Data reports the view with dash.js data attached.

Note for reviewers: the sandbox templates carry a Mux Data environment key, which is client-visible by design, so the Akamai test streams can be attributed. `apps/sandbox` build currently also fails on unrelated stale scratch directories in the gitignored `src/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics/telemetry wiring for all engine-backed playback; behavior is more correct but affects what Mux receives in production views.
> 
> **Overview**
> Fixes **Mux Data** treating every `media.engine` as hls.js, which meant DASH playback was wired through `mux-embed`'s hls.js integration and lost engine-level telemetry (renditions, segment timing, engine errors).
> 
> Monitoring now goes through **`toMuxDataEngineOptions()`**, which picks the right `mux-embed` hook by engine shape: dash.js → `dashjs`, hls.js → `hlsjs` + constructor from `engine.constructor` (no hls.js import), and everything else → element-only monitoring with a one-time dev warning. **`MuxDataMedia.engine`** is **`unknown`** to match that model.
> 
> **`hasMethods`** was added in `@videojs/utils/predicate` for structural checks. DASH HTML/React **sandbox** templates compose **`<mux-data>` / `<MuxData>`** with a sandbox env key so the dash path is easy to verify. Docs now describe hls.js and dash.js engine support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8febac5affe7afbf0a70a4a8b1d0d188a4a229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->