### PR TITLE
feat(media): add symbol-backed media type guards

### DIFF
--- a/packages/media/src/core/predicate.ts
+++ b/packages/media/src/core/predicate.ts
@@ -23,6 +23,19 @@ export function hasMetadata(media: MediaSourceCapability): boolean {
   return media.readyState >= 1;
 }
 
+/**
+ * Get the playback engine exposed by a Media.
+ *
+ * Returns `undefined` when the value exposes no engine property. An explicit
+ * `null` is preserved because it means the Media supports an engine but none is
+ * currently active.
+ *
+ * @param media - Media value whose engine should be read.
+ */
+export function getMediaEngine(media: unknown): unknown {
+  return isObject(media) && 'engine' in media ? media.engine : undefined;
+}
+
 export function isMediaPauseCapable(value: unknown): value is MediaPauseCapability {
   if (!isObject(value)) return false;
   const media = value as Record<string, unknown>;

--- a/packages/media/src/core/tests/predicate.test.ts
+++ b/packages/media/src/core/tests/predicate.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import { EMPTY_REMOTE, EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../constants';
 import {
+  getMediaEngine,
   isMediaBufferCapable,
   isMediaContentDataCapable,
   isMediaRemotePlaybackCapable,
   isMediaTextTrackCapable,
 } from '../predicate';
+
+describe('getMediaEngine', () => {
+  it('returns the exposed engine', () => {
+    const engine = {};
+
+    expect(getMediaEngine({ engine })).toBe(engine);
+  });
+
+  it('preserves an explicitly inactive engine', () => {
+    expect(getMediaEngine({ engine: null })).toBeNull();
+  });
+
+  it('returns undefined when no engine is exposed', () => {
+    expect(getMediaEngine({})).toBeUndefined();
+    expect(getMediaEngine(null)).toBeUndefined();
+  });
+});
 
 describe('isMediaContentDataCapable', () => {
   it('uses undefined as the unsupported sentinel', () => {

--- a/packages/media/src/dom/dash/index.ts
+++ b/packages/media/src/dom/dash/index.ts
@@ -1,1 +1,2 @@
 export * from './media';
+export { isDashMedia } from './predicate';

--- a/packages/media/src/dom/dash/media.ts
+++ b/packages/media/src/dom/dash/media.ts
@@ -5,6 +5,7 @@ import { MediaTracksMixin } from '../../core/media-tracks';
 import type { MediaEngineHost } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { DashMediaMediaTracksMixin } from './media-tracks';
+import { DASH_MEDIA } from './predicate';
 
 /** Structured DASH source: which source to play, plus how to play it. */
 export interface DashSource {
@@ -39,6 +40,7 @@ class DashMediaBase
   extends DashMediaHost
   implements MediaEngineHost<dashjs.MediaPlayerClass, HTMLVideoElement>, DashMediaProps
 {
+  readonly [DASH_MEDIA] = true;
   #engine: dashjs.MediaPlayerClass;
   #src = dashMediaDefaultProps.src;
   #source: DashSource | null = dashMediaDefaultProps.source;

--- a/packages/media/src/dom/dash/predicate.ts
+++ b/packages/media/src/dom/dash/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { DashMedia } from './media';
+
+export const DASH_MEDIA = Symbol.for('@videojs/media/dash');
+
+/**
+ * Check whether a value is a `DashMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isDashMedia(value: unknown): value is DashMedia {
+  return isObject(value) && DASH_MEDIA in value;
+}

--- a/packages/media/src/dom/dash/tests/predicate.test.ts
+++ b/packages/media/src/dom/dash/tests/predicate.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { DashMedia, isDashMedia } from '..';
+
+describe('isDashMedia', () => {
+  it('recognizes DashMedia by its symbol marker', () => {
+    const media = new DashMedia();
+
+    expect(isDashMedia(media)).toBe(true);
+    expect(isDashMedia({})).toBe(false);
+    expect(isDashMedia(null)).toBe(false);
+  });
+});

--- a/packages/media/src/dom/hls-js/index.ts
+++ b/packages/media/src/dom/hls-js/index.ts
@@ -1,3 +1,4 @@
 export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
 export { KeySystems } from '../../core/drm';
 export * from './media';
+export { isHlsJsMedia } from './predicate';

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -7,6 +7,7 @@ import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { type NativeHlsConfig, NativeHlsMedia, type NativeHlsSource } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsOnlyMedia } from './hls-js-only';
+import { HLS_JS_MEDIA } from './predicate';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
 
@@ -103,6 +104,7 @@ class HlsMediaEvent extends Event {}
  * @fires targetlivewindowchange - Fired when the target live window changes. Read `targetLiveWindow` for the new value.
  */
 export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
+  readonly [HLS_JS_MEDIA] = true;
   #delegate: HlsJsOnlyMedia | NativeHlsMedia | null = null;
   #mediaElement: HTMLVideoElement | null = null;
   #src = hlsMediaDefaultProps.src;

--- a/packages/media/src/dom/hls-js/predicate.ts
+++ b/packages/media/src/dom/hls-js/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { HlsJsMedia } from './media';
+
+export const HLS_JS_MEDIA = Symbol.for('@videojs/media/hls-js');
+
+/**
+ * Check whether a value is an `HlsJsMedia` or one of its subclasses.
+ *
+ * @param value - Value to identify.
+ */
+export function isHlsJsMedia(value: unknown): value is HlsJsMedia {
+  return isObject(value) && HLS_JS_MEDIA in value;
+}

--- a/packages/media/src/dom/hls-js/tests/predicate.test.ts
+++ b/packages/media/src/dom/hls-js/tests/predicate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { HlsJsMedia, isHlsJsMedia } from '..';
+
+describe('isHlsJsMedia', () => {
+  it('recognizes HlsJsMedia by its symbol marker', () => {
+    const media = new HlsJsMedia();
+
+    expect(isHlsJsMedia(media)).toBe(true);
+    expect(isHlsJsMedia({})).toBe(false);
+    expect(isHlsJsMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});

--- a/packages/media/src/dom/mux/index.ts
+++ b/packages/media/src/dom/mux/index.ts
@@ -2,6 +2,7 @@ export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/dr
 export { KeySystems } from '../../core/drm';
 export * from './media';
 export { MuxData, type MuxDataProps, muxDataDefaultProps } from './mux-data';
+export { isMuxMedia } from './predicate';
 // The engine-neutral source layer, re-exported so this stays the one import for
 // the hls.js-backed Media. Its own entry point, `@videojs/media/dom/mux/source`,
 // is what a Media on another engine imports — reaching it through here would

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -1,5 +1,6 @@
 import { HlsJsMedia, type HlsSource } from '../hls-js';
 import { createMuxDrmSystems } from './drm';
+import { MUX_MEDIA } from './predicate';
 import {
   createMuxPosterURL,
   createMuxStoryboardURL,
@@ -37,6 +38,7 @@ export const muxMediaDefaultProps: MuxMediaProps = {
  * @fires sourcechange - Fired when `source` changes, either directly or by parsing a new `src`. Read `source` for the new value.
  */
 export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
+  readonly [MUX_MEDIA] = true;
   #source: MuxSource | null = muxMediaDefaultProps.source;
 
   /**

--- a/packages/media/src/dom/mux/mux-data-engine.ts
+++ b/packages/media/src/dom/mux/mux-data-engine.ts
@@ -1,17 +1,18 @@
-import { hasMethods, isFunction, isObject, isString } from '@videojs/utils/predicate';
+import { isFunction, isObject, isString } from '@videojs/utils/predicate';
+import { getMediaEngine } from '../../core/predicate';
+import { isDashMedia } from '../dash/predicate';
+import { isHlsJsMedia } from '../hls-js/predicate';
 import type { MuxDataOptions } from './types';
 
 /** The `mux-embed` monitor options that hook a playback engine's own telemetry. */
 export type MuxDataEngineOptions = Partial<Pick<MuxDataOptions, 'Hls' | 'hlsjs' | 'dashjs'>>;
 
-type MuxDataHlsJsEngine = NonNullable<MuxDataOptions['hlsjs']>;
 type MuxDataHlsJsClass = NonNullable<MuxDataOptions['Hls']>;
-type MuxDataDashJsEngine = NonNullable<MuxDataOptions['dashjs']>;
 
 const warnedEngines = new WeakSet<object>();
 
 /**
- * Pick the `mux-embed` integration for a media's playback engine.
+ * Pick the `mux-embed` integration for a Media's playback engine.
  *
  * `mux-embed` monitors the media element on its own, and an engine integration
  * is what adds engine-level data on top: rendition switches, request timing and
@@ -19,27 +20,28 @@ const warnedEngines = new WeakSet<object>();
  * one is wired through a different option, so handing a dash.js player to the
  * hls.js option leaves the view with element-level data only.
  *
- * Engines are matched by shape rather than by class so this module imports
- * neither hls.js nor dash.js. Mux Data can be registered with any media without
- * pulling an engine it will never touch into the bundle (dash.js in particular
- * reads `window` on import), and a media whose engine has no integration — a
- * raw `<video>`, native HLS, or an SPF playback engine — is monitored from the
- * element alone instead of through the wrong integration.
+ * Media are identified by their symbol-backed type guards, so this module
+ * imports neither hls.js nor dash.js. Mux Data can be registered with any media
+ * without pulling an engine it will never touch into the bundle (dash.js in
+ * particular reads `window` on import), and a media whose engine has no
+ * integration — a raw `<video>`, native HLS, or an SPF playback engine — is
+ * monitored from the element alone instead of through the wrong integration.
  *
  * @returns Options to spread into a `Mux.monitor()` call. Empty when the engine
  *   has no integration, which leaves element-level monitoring intact.
  */
-export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
-  if (isDashJsEngine(engine)) return { dashjs: engine };
+export function toMuxDataEngineOptions(media: unknown): MuxDataEngineOptions {
+  if (isDashMedia(media)) return { dashjs: media.engine };
 
-  if (isHlsJsEngine(engine)) {
+  if (isHlsJsMedia(media) && media.engine) {
     // `mux-embed` reads hls.js's event names and error details off the class,
     // falling back to `window.Hls` when it isn't given one. Take it from the
     // instance so a bundled hls.js is always found, without importing it here.
-    const Hls = toHlsJsClass(engine);
-    if (Hls) return { hlsjs: engine, Hls };
+    const Hls = toHlsJsClass(media.engine);
+    if (Hls) return { hlsjs: media.engine, Hls };
   }
 
+  const engine = getMediaEngine(media);
   if (__DEV__ && isObject(engine) && !warnedEngines.has(engine)) {
     warnedEngines.add(engine);
     console.warn(
@@ -49,23 +51,6 @@ export function toMuxDataEngineOptions(engine: unknown): MuxDataEngineOptions {
   }
 
   return {};
-}
-
-// Each engine is recognized by what its `mux-embed` monitor reaches for, so a
-// match means the integration has everything it needs. Both monitors subscribe
-// through `on` / `off`; the rendition APIs are what tell the two engines apart.
-
-/** hls.js: its monitor reads renditions from `levels`. */
-function isHlsJsEngine(engine: unknown): engine is MuxDataHlsJsEngine {
-  return hasMethods(engine, ['on', 'off']) && Array.isArray((engine as { levels?: unknown }).levels);
-}
-
-/** dash.js: its monitor reads renditions through the track and rendition-list getters. */
-function isDashJsEngine(engine: unknown): engine is MuxDataDashJsEngine {
-  if (!hasMethods(engine, ['on', 'off', 'getCurrentTrackFor'])) return false;
-  // dash.js v5 replaced `getBitrateInfoListFor` with `getRepresentationsByType`.
-  // `mux-embed` reads whichever the player has, so either one is a match.
-  return hasMethods(engine, ['getRepresentationsByType']) || hasMethods(engine, ['getBitrateInfoListFor']);
 }
 
 /** hls.js's own class, the only place its event names and error details are published. */

--- a/packages/media/src/dom/mux/mux-data.ts
+++ b/packages/media/src/dom/mux/mux-data.ts
@@ -37,9 +37,9 @@ const MUX_VIDEO_DOMAIN = 'mux.com';
  *
  * `engine` is deliberately untyped. Every engine-backed media host exposes one,
  * but they are unrelated types (an hls.js instance, a dash.js player, an SPF
- * composition), and which of them Mux Data can hook is decided by
- * {@link toMuxDataEngineOptions}, not by this contract. Media with no JS engine
- * simply omit it.
+ * composition), and the symbol-backed Media guards in
+ * {@link toMuxDataEngineOptions} decide which of them Mux Data can hook. Media
+ * with no JS engine simply omit it.
  */
 export interface MuxDataMedia extends EventTarget {
   readonly engine?: unknown;
@@ -225,7 +225,7 @@ export class MuxData implements MuxDataProps {
       debug,
       ...(beaconCollectionDomain ? { beaconCollectionDomain } : {}),
       ...(disableCookies ? { disableCookies } : {}),
-      ...toMuxDataEngineOptions(media.engine),
+      ...toMuxDataEngineOptions(media),
       data: {
         ...(env_key ? { env_key } : {}),
         ...(player_software_name ? { player_software_name } : {}),

--- a/packages/media/src/dom/mux/predicate.ts
+++ b/packages/media/src/dom/mux/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { MuxMedia } from './media';
+
+export const MUX_MEDIA = Symbol.for('@videojs/media/mux');
+
+/**
+ * Check whether a value is a `MuxMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isMuxMedia(value: unknown): value is MuxMedia {
+  return isObject(value) && MUX_MEDIA in value;
+}

--- a/packages/media/src/dom/mux/tests/mux-data-engine.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data-engine.test.ts
@@ -1,6 +1,8 @@
 import * as dashjs from 'dashjs';
 import Hls from 'hls.js';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { DASH_MEDIA } from '../../dash/predicate';
+import { HLS_JS_MEDIA } from '../../hls-js/predicate';
 import { toMuxDataEngineOptions } from '../mux-data-engine';
 
 /** Shaped like an hls.js instance, class statics included. */
@@ -25,6 +27,16 @@ class FakeDashJsEngine {
   off() {}
 }
 
+class FakeHlsJsMedia {
+  readonly [HLS_JS_MEDIA] = true;
+  engine: unknown = new FakeHlsJsEngine();
+}
+
+class FakeDashMedia {
+  readonly [DASH_MEDIA] = true;
+  engine: unknown = new FakeDashJsEngine();
+}
+
 let warn: MockInstance<typeof console.warn>;
 
 beforeEach(() => {
@@ -37,23 +49,23 @@ afterEach(() => {
 
 describe('toMuxDataEngineOptions', () => {
   it('wires an hls.js engine and its class into the hls.js integration', () => {
-    const engine = new FakeHlsJsEngine();
+    const media = new FakeHlsJsMedia();
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({ hlsjs: engine, Hls: FakeHlsJsEngine });
+    expect(toMuxDataEngineOptions(media)).toEqual({ hlsjs: media.engine, Hls: FakeHlsJsEngine });
   });
 
   it('wires a dash.js player into the dash.js integration', () => {
-    const engine = new FakeDashJsEngine();
+    const media = new FakeDashMedia();
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
+    expect(toMuxDataEngineOptions(media)).toEqual({ dashjs: media.engine });
   });
 
-  it('wires a pre-v5 dash.js player into the dash.js integration', () => {
-    // v5 replaced `getBitrateInfoListFor` with `getRepresentationsByType`, and
-    // `mux-embed` reads whichever the player has.
-    const engine = { on() {}, off() {}, getCurrentTrackFor() {}, getBitrateInfoListFor() {} };
+  it('does not infer a Media type from its engine shape', () => {
+    const hlsjs = new FakeHlsJsEngine();
+    const dashEngine = new FakeDashJsEngine();
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
+    expect(toMuxDataEngineOptions({ engine: hlsjs })).toEqual({});
+    expect(toMuxDataEngineOptions({ engine: dashEngine })).toEqual({});
   });
 
   it('sends no engine options for media with no engine', () => {
@@ -65,39 +77,44 @@ describe('toMuxDataEngineOptions', () => {
     // An SPF playback engine: a composition, not a handle `mux-embed` can hook.
     const engine = { state: {}, context: {}, destroy: () => Promise.resolve() };
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({});
+    expect(toMuxDataEngineOptions({ engine })).toEqual({});
   });
 
   it('skips the hls.js integration when the engine class publishes no events', () => {
     // `mux-embed` needs the class to hook hls.js events, and reaches for
     // `window.Hls` when it isn't given one — better to monitor the element alone
     // than to let it pick up an unrelated global.
-    const engine = { levels: [], on() {}, off() {} };
+    const media = new FakeHlsJsMedia();
+    media.engine = { levels: [], on() {}, off() {} } as FakeHlsJsEngine;
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({});
+    expect(toMuxDataEngineOptions(media)).toEqual({});
   });
 
-  // The engines are matched by shape, so the real instances are what keeps the
-  // match honest as hls.js and dash.js evolve.
+  // Real instances keep the values handed to mux-embed honest as its engine
+  // integrations and their upstream libraries evolve.
   it('recognizes a real hls.js instance', () => {
+    const media = new FakeHlsJsMedia();
     const engine = new Hls();
+    media.engine = engine;
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({ hlsjs: engine, Hls });
+    expect(toMuxDataEngineOptions(media)).toEqual({ hlsjs: engine, Hls });
 
     engine.destroy();
   });
 
   it('recognizes a real dash.js player', () => {
     const engine = dashjs.MediaPlayer().create();
+    const media = new FakeDashMedia();
+    media.engine = engine;
 
-    expect(toMuxDataEngineOptions(engine)).toEqual({ dashjs: engine });
+    expect(toMuxDataEngineOptions(media)).toEqual({ dashjs: engine });
   });
 
   it('warns once per unrecognized engine in development', () => {
     const engine = { destroy: () => {} };
 
-    toMuxDataEngineOptions(engine);
-    toMuxDataEngineOptions(engine);
+    toMuxDataEngineOptions({ engine });
+    toMuxDataEngineOptions({ engine });
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('could not hook this playback engine'), engine);

--- a/packages/media/src/dom/mux/tests/mux-data.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-data.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DASH_MEDIA } from '../../dash/predicate';
+import { HLS_JS_MEDIA } from '../../hls-js/predicate';
 import { MuxData } from '..';
 import type { MuxDataSdk } from '../types';
 
@@ -36,6 +38,14 @@ class FakeDashJsEngine {
   }
   on() {}
   off() {}
+}
+
+class FakeHlsJsMedia extends FakeMedia {
+  readonly [HLS_JS_MEDIA] = true;
+}
+
+class FakeDashMedia extends FakeMedia {
+  readonly [DASH_MEDIA] = true;
 }
 
 // Initialization is deferred by a microtask so all props settle first.
@@ -90,7 +100,7 @@ describe('MuxData', () => {
     const { sdk, monitor } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
     const video = document.createElement('video');
-    const media = new FakeMedia();
+    const media = new FakeHlsJsMedia();
 
     data.setMedia(media);
     data.attach(video);
@@ -121,7 +131,7 @@ describe('MuxData', () => {
     const { sdk, monitor } = createSdk();
     const data = new MuxData({ MuxDataSdk: sdk, envKey: 'key' });
     const video = document.createElement('video');
-    const media = new FakeMedia();
+    const media = new FakeDashMedia();
     media.engine = new FakeDashJsEngine();
     media.src = 'https://example.com/manifest.mpd';
 

--- a/packages/media/src/dom/mux/tests/predicate.test.ts
+++ b/packages/media/src/dom/mux/tests/predicate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isHlsJsMedia } from '../../hls-js';
+import { isMuxMedia, MuxMedia } from '..';
+
+describe('isMuxMedia', () => {
+  it('recognizes MuxMedia by its own and inherited symbol markers', () => {
+    const media = new MuxMedia();
+
+    expect(isMuxMedia(media)).toBe(true);
+    expect(isHlsJsMedia(media)).toBe(true);
+    expect(isMuxMedia({})).toBe(false);
+    expect(isMuxMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});

--- a/packages/media/src/dom/native-hls/index.ts
+++ b/packages/media/src/dom/native-hls/index.ts
@@ -2,3 +2,4 @@ export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/dr
 export { KeySystems } from '../../core/drm';
 export { type NativeHlsDrmErrorContext, NativeHlsDrmErrors } from './fairplay';
 export * from './media';
+export { isNativeHlsMedia } from './predicate';

--- a/packages/media/src/dom/native-hls/media.ts
+++ b/packages/media/src/dom/native-hls/media.ts
@@ -4,6 +4,7 @@ import { HTMLVideoElementHost } from '../video-host';
 import { NativeHlsMediaDrmMixin } from './drm';
 import { NativeHlsMediaErrorsMixin } from './errors';
 import { NativeHlsMediaLiveMixin } from './live';
+import { NATIVE_HLS_MEDIA } from './predicate';
 import { NativeHlsMediaStreamTypeMixin } from './stream-type';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
@@ -161,4 +162,6 @@ class NativeHlsMediaBase extends HTMLVideoElementHost implements Omit<NativeHlsM
 
 export class NativeHlsMedia extends NativeHlsMediaLiveMixin(
   NativeHlsMediaStreamTypeMixin(NativeHlsMediaDrmMixin(NativeHlsMediaErrorsMixin(NativeHlsMediaBase)))
-) {}
+) {
+  readonly [NATIVE_HLS_MEDIA] = true;
+}

--- a/packages/media/src/dom/native-hls/predicate.ts
+++ b/packages/media/src/dom/native-hls/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { NativeHlsMedia } from './media';
+
+export const NATIVE_HLS_MEDIA = Symbol.for('@videojs/media/native-hls');
+
+/**
+ * Check whether a value is a `NativeHlsMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isNativeHlsMedia(value: unknown): value is NativeHlsMedia {
+  return isObject(value) && NATIVE_HLS_MEDIA in value;
+}

--- a/packages/media/src/dom/native-hls/tests/predicate.test.ts
+++ b/packages/media/src/dom/native-hls/tests/predicate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isNativeHlsMedia, NativeHlsMedia } from '..';
+
+describe('isNativeHlsMedia', () => {
+  it('recognizes NativeHlsMedia by its symbol marker', () => {
+    const media = new NativeHlsMedia();
+
+    expect(isNativeHlsMedia(media)).toBe(true);
+    expect(isNativeHlsMedia({})).toBe(false);
+    expect(isNativeHlsMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});

--- a/packages/media/src/dom/vimeo/index.ts
+++ b/packages/media/src/dom/vimeo/index.ts
@@ -1,1 +1,2 @@
 export * from './media';
+export { isVimeoMedia } from './predicate';

--- a/packages/media/src/dom/vimeo/media.ts
+++ b/packages/media/src/dom/vimeo/media.ts
@@ -8,6 +8,7 @@ import { MediaError } from '../../core/media-error';
 import type { ErrorLike, MediaPreloadType, TextTrackListLike, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
 import { createTimeRange, serializeEmbedParams } from '../utils';
+import { VIMEO_MEDIA } from './predicate';
 
 export type { default as VimeoPlayerApi } from '@vimeo/player';
 
@@ -74,6 +75,7 @@ const VimeoMediaBase = MediaPlayedRangesMixin(EventTarget);
  * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
  */
 export class VimeoMedia extends VimeoMediaBase implements Partial<Video> {
+  readonly [VIMEO_MEDIA] = true;
   #target: HTMLIFrameElement | null = null;
   #player: VimeoPlayer | null = null;
   /**

--- a/packages/media/src/dom/vimeo/predicate.ts
+++ b/packages/media/src/dom/vimeo/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { VimeoMedia } from './media';
+
+export const VIMEO_MEDIA = Symbol.for('@videojs/media/vimeo');
+
+/**
+ * Check whether a value is a `VimeoMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isVimeoMedia(value: unknown): value is VimeoMedia {
+  return isObject(value) && VIMEO_MEDIA in value;
+}

--- a/packages/media/src/dom/vimeo/tests/predicate.test.ts
+++ b/packages/media/src/dom/vimeo/tests/predicate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isVimeoMedia, VimeoMedia } from '..';
+
+describe('isVimeoMedia', () => {
+  it('recognizes VimeoMedia by its symbol marker', () => {
+    const media = new VimeoMedia();
+
+    expect(isVimeoMedia(media)).toBe(true);
+    expect(isVimeoMedia({})).toBe(false);
+    expect(isVimeoMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});

--- a/packages/media/src/dom/youtube/index.ts
+++ b/packages/media/src/dom/youtube/index.ts
@@ -2,5 +2,6 @@
 // `engine` getter surfaces.
 export type { YouTubeApi, YouTubePlayerApi } from './iframe-api';
 export * from './media';
+export { isYouTubeMedia } from './predicate';
 export * from './props';
 export * from './source';

--- a/packages/media/src/dom/youtube/media.ts
+++ b/packages/media/src/dom/youtube/media.ts
@@ -25,12 +25,14 @@ import {
   type YouTubePlayerApi,
   youtubeErrorCodeToMediaErrorCode,
 } from './iframe-api';
+import { YOUTUBE_MEDIA } from './predicate';
 import { youtubeMediaDefaultProps } from './props';
 import { buildYouTubeIframeSrc, parseYouTubeSource, type YouTubeSource } from './source';
 
 const YouTubeMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 export class YouTubeMedia extends YouTubeMediaBase implements Partial<Video> {
+  readonly [YOUTUBE_MEDIA] = true;
   #target: HTMLIFrameElement | null = null;
   #player: YouTubePlayerApi | null = null;
   /** The iframe API rejects `cueVideoById`/`loadVideoById` before `onReady`. */

--- a/packages/media/src/dom/youtube/predicate.ts
+++ b/packages/media/src/dom/youtube/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { YouTubeMedia } from './media';
+
+export const YOUTUBE_MEDIA = Symbol.for('@videojs/media/youtube');
+
+/**
+ * Check whether a value is a `YouTubeMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isYouTubeMedia(value: unknown): value is YouTubeMedia {
+  return isObject(value) && YOUTUBE_MEDIA in value;
+}

--- a/packages/media/src/dom/youtube/tests/predicate.test.ts
+++ b/packages/media/src/dom/youtube/tests/predicate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isYouTubeMedia, YouTubeMedia } from '..';
+
+describe('isYouTubeMedia', () => {
+  it('recognizes YouTubeMedia by its symbol marker', () => {
+    const media = new YouTubeMedia();
+
+    expect(isYouTubeMedia(media)).toBe(true);
+    expect(isYouTubeMedia({})).toBe(false);
+    expect(isYouTubeMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});

--- a/packages/spf/src/playback/adapters/hls-audio/index.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/index.ts
@@ -10,3 +10,4 @@ export {
   hlsAudioMediaDefaultProps,
 } from './adapter';
 export { HlsAudioMedia } from './media';
+export { isHlsAudioMedia } from './predicate';

--- a/packages/spf/src/playback/adapters/hls-audio/media.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/media.ts
@@ -1,6 +1,9 @@
 import { HTMLAudioElementHost } from '@videojs/media/dom/audio-host';
 import { HlsAudioMediaMixin } from './adapter';
+import { HLS_AUDIO_MEDIA } from './predicate';
 
 const HlsAudioMediaBase = HlsAudioMediaMixin(HTMLAudioElementHost);
 
-export class HlsAudioMedia extends HlsAudioMediaBase {}
+export class HlsAudioMedia extends HlsAudioMediaBase {
+  readonly [HLS_AUDIO_MEDIA] = true;
+}

--- a/packages/spf/src/playback/adapters/hls-audio/predicate.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { HlsAudioMedia } from './media';
+
+export const HLS_AUDIO_MEDIA = Symbol.for('@videojs/spf/hls-audio');
+
+/**
+ * Check whether a value is an `HlsAudioMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isHlsAudioMedia(value: unknown): value is HlsAudioMedia {
+  return isObject(value) && HLS_AUDIO_MEDIA in value;
+}

--- a/packages/spf/src/playback/adapters/hls-audio/tests/predicate.test.ts
+++ b/packages/spf/src/playback/adapters/hls-audio/tests/predicate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { HlsAudioMedia, isHlsAudioMedia } from '..';
+
+describe('isHlsAudioMedia', () => {
+  it('recognizes HlsAudioMedia by its symbol marker', () => {
+    const media = new HlsAudioMedia();
+
+    expect(isHlsAudioMedia(media)).toBe(true);
+    expect(isHlsAudioMedia({})).toBe(false);
+    expect(isHlsAudioMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});

--- a/packages/spf/src/playback/adapters/hls-video/index.ts
+++ b/packages/spf/src/playback/adapters/hls-video/index.ts
@@ -16,3 +16,4 @@ export type {
 export { HlsVideoMediaElement, HlsVideoMediaMixin, hlsVideoMediaDefaultProps } from './adapter';
 export { HlsVideoMedia } from './media';
 export { HlsVideoMediaMediaTracksMixin } from './media-tracks';
+export { isHlsVideoMedia } from './predicate';

--- a/packages/spf/src/playback/adapters/hls-video/media.ts
+++ b/packages/spf/src/playback/adapters/hls-video/media.ts
@@ -2,7 +2,10 @@ import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
 import { MediaTracksMixin } from '@videojs/media/media-tracks';
 import { HlsVideoMediaMixin } from './adapter';
 import { HlsVideoMediaMediaTracksMixin } from './media-tracks';
+import { HLS_VIDEO_MEDIA } from './predicate';
 
 const HlsVideoMediaBase = HlsVideoMediaMediaTracksMixin(MediaTracksMixin(HlsVideoMediaMixin(HTMLVideoElementHost)));
 
-export class HlsVideoMedia extends HlsVideoMediaBase {}
+export class HlsVideoMedia extends HlsVideoMediaBase {
+  readonly [HLS_VIDEO_MEDIA] = true;
+}

--- a/packages/spf/src/playback/adapters/hls-video/predicate.ts
+++ b/packages/spf/src/playback/adapters/hls-video/predicate.ts
@@ -1,0 +1,13 @@
+import { isObject } from '@videojs/utils/predicate';
+import type { HlsVideoMedia } from './media';
+
+export const HLS_VIDEO_MEDIA = Symbol.for('@videojs/spf/hls-video');
+
+/**
+ * Check whether a value is an `HlsVideoMedia`.
+ *
+ * @param value - Value to identify.
+ */
+export function isHlsVideoMedia(value: unknown): value is HlsVideoMedia {
+  return isObject(value) && HLS_VIDEO_MEDIA in value;
+}

--- a/packages/spf/src/playback/adapters/hls-video/tests/predicate.test.ts
+++ b/packages/spf/src/playback/adapters/hls-video/tests/predicate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { HlsVideoMedia, isHlsVideoMedia } from '..';
+
+describe('isHlsVideoMedia', () => {
+  it('recognizes HlsVideoMedia by its symbol marker', () => {
+    const media = new HlsVideoMedia();
+
+    expect(isHlsVideoMedia(media)).toBe(true);
+    expect(isHlsVideoMedia({})).toBe(false);
+    expect(isHlsVideoMedia(null)).toBe(false);
+
+    media.destroy();
+  });
+});


### PR DESCRIPTION
Closes #2088

## Summary

Add stable, symbol-backed identity checks for the Media facades so consumers can detect Media types without inferring them from playback-engine shape. Mux Data now chooses its hls.js and dash.js integrations from those Media checks while retaining engine-specific metadata validation where mux-embed requires it.

## Changes

- Add public type guards for Dash, hls.js, Mux, native HLS, Vimeo, YouTube, and the SPF simple-HLS Media facades
- Preserve inherited identities, so `MuxMedia` is also recognized as `HlsJsMedia`
- Add `getMediaEngine()` as the shared safe utility for reading optional Media engines
- Replace Mux Data structural engine detection with Media identity checks and cover branded and unbranded cases
- Remove the now-unused `hasMethods` predicate from Utils

## Testing

- `pnpm -F @videojs/media test` (572 passed)
- `pnpm -F @videojs/spf test` (1,440 passed, 14 skipped)
- `pnpm -F @videojs/utils test` (417 passed, 3 skipped)
- `pnpm -F @videojs/media build`
- `pnpm -F @videojs/spf build`
- `pnpm -F @videojs/utils build`
- `pnpm exec tsgo --noEmit -p packages/media/tsconfig.json`
- `pnpm exec tsgo --noEmit -p packages/spf/tsconfig.json`
- `pnpm exec tsgo --noEmit -p packages/utils/tsconfig.json`
- `pnpm -F site api-docs`

`pnpm typecheck` still reports existing Store/HTML custom-element typing errors outside this diff; the affected Media, SPF, and Utils projects pass their direct typechecks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b18372858eff520ac76ec53a6d905c51eac381c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->