### PR TITLE
refactor(packages)!: normalize radio group option state

### DIFF
--- a/packages/core/src/core/ui/audio-track-radio-group/audio-track-radio-group-core.ts
+++ b/packages/core/src/core/ui/audio-track-radio-group/audio-track-radio-group-core.ts
@@ -4,7 +4,7 @@ import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
 import { resolveText, type Text } from '../../i18n';
 import { audioText } from '../../i18n/text/menu';
-import type { ButtonState } from '../types';
+import type { RadioOption, RadioOptionsState } from '../types';
 import { resolveLabel } from '../utils/resolve-label';
 
 export interface AudioTrackRadioGroupProps {
@@ -16,17 +16,9 @@ export interface AudioTrackRadioGroupProps {
   disabled?: boolean | undefined;
 }
 
-export interface AudioTrackRadioGroupTrack {
-  value: string;
-  label: Text | string;
-}
+export interface AudioTrackRadioGroupOption extends RadioOption {}
 
-export interface AudioTrackRadioGroupState extends ButtonState {
-  tracks: readonly AudioTrackRadioGroupTrack[];
-  value: string;
-  disabled: boolean;
-  availability: 'available' | 'unavailable';
-}
+export interface AudioTrackRadioGroupState extends RadioOptionsState<AudioTrackRadioGroupOption> {}
 
 function formatTrackLabel(track: MediaAudioTrack): Text | string {
   if (track.label) return track.label;
@@ -47,7 +39,7 @@ export class AudioTrackRadioGroupCore {
   };
 
   readonly state = createState<AudioTrackRadioGroupState>({
-    tracks: [],
+    options: [],
     value: '',
     disabled: false,
     availability: 'unavailable',
@@ -90,14 +82,15 @@ export class AudioTrackRadioGroupCore {
   getState(): AudioTrackRadioGroupState {
     const media = this.#media!;
     const enabledIndex = media.audioTrackList.findIndex((track) => track.enabled);
-    const tracks = media.audioTrackList.map((track, index) => ({
+    const options = media.audioTrackList.map((track, index) => ({
       value: getTrackValue(track, index),
       label: this.getTrackLabel(track),
+      disabled: false,
     }));
-    const availability: AudioTrackRadioGroupState['availability'] = tracks.length > 1 ? 'available' : 'unavailable';
+    const availability: AudioTrackRadioGroupState['availability'] = options.length > 1 ? 'available' : 'unavailable';
 
     this.state.patch({
-      tracks,
+      options,
       value: enabledIndex === -1 ? '' : getTrackValue(media.audioTrackList[enabledIndex]!, enabledIndex),
       disabled: this.#props.disabled || availability === 'unavailable',
       availability,

--- a/packages/core/src/core/ui/audio-track-radio-group/tests/audio-track-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/audio-track-radio-group/tests/audio-track-radio-group-core.test.ts
@@ -16,9 +16,9 @@ function createMediaState(overrides: Partial<MediaAudioTrackState> = {}): MediaA
 
 function createState(overrides: Partial<AudioTrackRadioGroupState> = {}): AudioTrackRadioGroupState {
   return {
-    tracks: [
-      { value: '0', label: 'English' },
-      { value: '1', label: 'Spanish' },
+    options: [
+      { value: '0', label: 'English', disabled: false },
+      { value: '1', label: 'Spanish', disabled: false },
     ],
     value: '0',
     disabled: false,
@@ -37,9 +37,9 @@ describe('AudioTrackRadioGroupCore', () => {
 
       const state = core.getState();
 
-      expect(state.tracks).toEqual([
-        { value: '0', label: 'English' },
-        { value: '1', label: 'Spanish' },
+      expect(state.options).toEqual([
+        { value: '0', label: 'English', disabled: false },
+        { value: '1', label: 'Spanish', disabled: false },
       ]);
       expect(state.value).toBe('0');
     });
@@ -55,10 +55,10 @@ describe('AudioTrackRadioGroupCore', () => {
       });
       core.setMedia(media);
 
-      expect(core.getState().tracks).toEqual([
-        { value: '0', label: 'en' },
-        { value: '1', label: 'commentary' },
-        { value: '2', label: { key: 'menu.audio', text: 'Audio' } },
+      expect(core.getState().options).toEqual([
+        { value: '0', label: 'en', disabled: false },
+        { value: '1', label: 'commentary', disabled: false },
+        { value: '2', label: { key: 'menu.audio', text: 'Audio' }, disabled: false },
       ]);
     });
 
@@ -72,7 +72,7 @@ describe('AudioTrackRadioGroupCore', () => {
       });
       core.setMedia(media);
 
-      expect(core.getState().tracks.map((track) => track.value)).toEqual(['0', '1']);
+      expect(core.getState().options.map((track) => track.value)).toEqual(['0', '1']);
       expect(core.getState().value).toBe('1');
     });
 

--- a/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
+++ b/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
@@ -5,8 +5,8 @@ import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
 import { resolveText, type Text } from '../../i18n';
 import { disableText, enableText } from '../../i18n/text/captions';
-import { captionsText, subtitlesText } from '../../i18n/text/menu';
-import type { ButtonState } from '../types';
+import { captionsText, offText, subtitlesText } from '../../i18n/text/menu';
+import type { RadioOption, RadioOptionsState } from '../types';
 import { resolveLabel } from '../utils/resolve-label';
 
 export interface CaptionsRadioGroupProps {
@@ -18,17 +18,11 @@ export interface CaptionsRadioGroupProps {
   disabled?: boolean | undefined;
 }
 
-export interface CaptionsRadioGroupTrack {
-  value: string;
-  label: Text | string;
-}
+export interface CaptionsRadioGroupOption extends RadioOption {}
 
-export interface CaptionsRadioGroupState extends Pick<MediaTextTrackState, 'subtitlesShowing'>, ButtonState {
-  tracks: readonly CaptionsRadioGroupTrack[];
-  value: string;
-  disabled: boolean;
-  availability: 'available' | 'unavailable';
-}
+export interface CaptionsRadioGroupState
+  extends Pick<MediaTextTrackState, 'subtitlesShowing'>,
+    RadioOptionsState<CaptionsRadioGroupOption> {}
 
 export const CAPTIONS_OFF_VALUE = 'off';
 
@@ -54,7 +48,7 @@ export class CaptionsRadioGroupCore {
   };
 
   readonly state = createState<CaptionsRadioGroupState>({
-    tracks: [],
+    options: [{ value: CAPTIONS_OFF_VALUE, label: offText, disabled: false }],
     value: CAPTIONS_OFF_VALUE,
     subtitlesShowing: false,
     disabled: false,
@@ -99,16 +93,20 @@ export class CaptionsRadioGroupCore {
     const media = this.#media!;
     const captionTracks = getCaptionTracks(media.textTrackList);
     const showingIndex = captionTracks.findIndex((track) => track.mode === 'showing');
-    const tracks = captionTracks.map((track, index) => ({
-      value: track.id || String(index),
-      label: this.getTrackLabel(track),
-    }));
+    const options: CaptionsRadioGroupOption[] = [
+      { value: CAPTIONS_OFF_VALUE, label: offText, disabled: false },
+      ...captionTracks.map((track, index) => ({
+        value: track.id || String(index),
+        label: this.getTrackLabel(track),
+        disabled: false,
+      })),
+    ];
 
     const availability: CaptionsRadioGroupState['availability'] =
       captionTracks.length > 0 ? 'available' : 'unavailable';
 
     this.state.patch({
-      tracks,
+      options,
       value: showingIndex === -1 ? CAPTIONS_OFF_VALUE : captionTracks[showingIndex]!.id || String(showingIndex),
       subtitlesShowing: media.subtitlesShowing,
       disabled: this.#props.disabled || captionTracks.length === 0,

--- a/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
@@ -17,7 +17,7 @@ function createMediaState(overrides: Partial<MediaTextTrackState> = {}): MediaTe
 
 function createState(overrides: Partial<CaptionsRadioGroupState> = {}): CaptionsRadioGroupState {
   return {
-    tracks: [],
+    options: [{ value: CAPTIONS_OFF_VALUE, label: 'Off', disabled: false }],
     value: CAPTIONS_OFF_VALUE,
     subtitlesShowing: false,
     disabled: false,
@@ -42,10 +42,11 @@ describe('CaptionsRadioGroupCore', () => {
       core.setMedia(media);
       const state = core.getState();
 
-      expect(state.tracks).toEqual([
-        { value: 'captions-en', label: 'CC' },
-        { value: 'subtitles-en', label: 'English' },
-        { value: 'subtitles-es', label: 'Spanish' },
+      expect(state.options).toEqual([
+        { value: CAPTIONS_OFF_VALUE, label: { key: 'menu.off', text: 'Off' }, disabled: false },
+        { value: 'captions-en', label: 'CC', disabled: false },
+        { value: 'subtitles-en', label: 'English', disabled: false },
+        { value: 'subtitles-es', label: 'Spanish', disabled: false },
       ]);
       expect(state.value).toBe('subtitles-en');
       expect(state.subtitlesShowing).toBe(true);
@@ -147,9 +148,10 @@ describe('CaptionsRadioGroupCore', () => {
 
       core.setMedia(media);
 
-      expect(core.getState().tracks).toEqual([
-        { value: 'captions-en', label: { key: 'menu.captions', text: 'Captions' } },
-        { value: 'subtitles-en', label: { key: 'menu.subtitles', text: 'Subtitles' } },
+      expect(core.getState().options).toEqual([
+        { value: CAPTIONS_OFF_VALUE, label: { key: 'menu.off', text: 'Off' }, disabled: false },
+        { value: 'captions-en', label: { key: 'menu.captions', text: 'Captions' }, disabled: false },
+        { value: 'subtitles-en', label: { key: 'menu.subtitles', text: 'Subtitles' }, disabled: false },
       ]);
     });
 

--- a/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-core.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-core.ts
@@ -5,7 +5,7 @@ import { isUndefined } from '@videojs/utils/predicate';
 import type { NonNullableObject } from '@videojs/utils/types';
 import { resolveText, type Text } from '../../i18n';
 import { rateText } from '../../i18n/text/playback';
-import type { ButtonState } from '../types';
+import type { RadioOption, RadioOptionsState } from '../types';
 import { resolveLabel } from '../utils/resolve-label';
 
 export interface PlaybackRateRadioGroupProps {
@@ -17,11 +17,12 @@ export interface PlaybackRateRadioGroupProps {
   disabled?: boolean | undefined;
 }
 
-export interface PlaybackRateRadioGroupState extends ButtonState {
+export interface PlaybackRateRadioGroupOption extends RadioOption {
   rate: number;
-  rates: readonly number[];
-  disabled: boolean;
-  availability: 'available' | 'unavailable';
+}
+
+export interface PlaybackRateRadioGroupState extends RadioOptionsState<PlaybackRateRadioGroupOption> {
+  rate: number;
 }
 
 function formatPlaybackRate(rate: number): string {
@@ -37,7 +38,8 @@ export class PlaybackRateRadioGroupCore {
 
   readonly state = createState<PlaybackRateRadioGroupState>({
     rate: 1,
-    rates: [],
+    value: '1',
+    options: [],
     disabled: false,
     availability: 'unavailable',
     label: '',
@@ -92,7 +94,13 @@ export class PlaybackRateRadioGroupCore {
 
     this.state.patch({
       rate: media.playbackRate,
-      rates: media.playbackRates,
+      value: this.getRateValue(media.playbackRate),
+      options: media.playbackRates.map((rate) => ({
+        rate,
+        value: this.getRateValue(rate),
+        label: this.getRateLabel(rate),
+        disabled: false,
+      })),
       disabled: this.#props.disabled || media.playbackRates.length === 0,
       availability,
     });

--- a/packages/core/src/core/ui/playback-rate-radio-group/tests/playback-rate-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/tests/playback-rate-radio-group-core.test.ts
@@ -15,7 +15,8 @@ function createMediaState(overrides: Partial<MediaPlaybackRateState> = {}): Medi
 function createState(overrides: Partial<PlaybackRateRadioGroupState> = {}): PlaybackRateRadioGroupState {
   return {
     rate: 1,
-    rates: [0.5, 1, 1.5, 2],
+    value: '1',
+    options: [0.5, 1, 1.5, 2].map((rate) => ({ rate, value: String(rate), label: `${rate}×`, disabled: false })),
     disabled: false,
     availability: 'available',
     label: '',
@@ -32,7 +33,11 @@ describe('PlaybackRateRadioGroupCore', () => {
       const state = core.getState();
 
       expect(state.rate).toBe(1.5);
-      expect(state.rates).toEqual([1, 1.5]);
+      expect(state.value).toBe('1.5');
+      expect(state.options).toEqual([
+        { rate: 1, value: '1', label: '1×', disabled: false },
+        { rate: 1.5, value: '1.5', label: '1.5×', disabled: false },
+      ]);
     });
 
     it('marks state disabled when no rates are available', () => {

--- a/packages/core/src/core/ui/quality-radio-group/quality-radio-group-core.ts
+++ b/packages/core/src/core/ui/quality-radio-group/quality-radio-group-core.ts
@@ -2,9 +2,9 @@ import type { MediaQualityState, MediaVideoRendition } from '@videojs/media';
 import { createState } from '@videojs/store';
 import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
-import { resolveText, type Text, type TextParams } from '../../i18n';
+import { resolveText, type Text } from '../../i18n';
 import { autoText, autoWithLabelText, qualityText } from '../../i18n/text/menu';
-import type { ButtonState } from '../types';
+import type { RadioOption, RadioOptionsState } from '../types';
 import { resolveLabel } from '../utils/resolve-label';
 
 export interface QualityRadioGroupProps {
@@ -16,21 +16,12 @@ export interface QualityRadioGroupProps {
   disabled?: boolean | undefined;
 }
 
-export interface QualityRadioGroupRendition {
-  value: string;
-  label: Text | string;
+export interface QualityRadioGroupOption extends RadioOption {
   tier?: string | undefined;
   badge?: string | undefined;
 }
 
-export interface QualityRadioGroupState extends ButtonState {
-  renditions: readonly QualityRadioGroupRendition[];
-  autoLabel: Text | string;
-  autoLabelParams?: TextParams;
-  value: string;
-  disabled: boolean;
-  availability: 'available' | 'unavailable';
-}
+export interface QualityRadioGroupState extends RadioOptionsState<QualityRadioGroupOption> {}
 
 export const QUALITY_AUTO_VALUE = 'auto';
 
@@ -116,8 +107,7 @@ export class QualityRadioGroupCore {
   };
 
   readonly state = createState<QualityRadioGroupState>({
-    renditions: [],
-    autoLabel: autoText,
+    options: [{ value: QUALITY_AUTO_VALUE, label: autoText, disabled: false }],
     value: QUALITY_AUTO_VALUE,
     disabled: false,
     availability: 'unavailable',
@@ -185,13 +175,14 @@ export class QualityRadioGroupCore {
     const selectedIndex = media.videoRenditionList.findIndex((rendition) => rendition.selected);
     const availability: QualityRadioGroupState['availability'] =
       media.videoRenditionList.length > 1 ? 'available' : 'unavailable';
-    const toRendition = (rendition: MediaVideoRendition, index: number): QualityRadioGroupRendition => {
+    const toOption = (rendition: MediaVideoRendition, index: number): QualityRadioGroupOption => {
       const tier = this.getRenditionTier(rendition);
       const badge = this.getRenditionBadge(rendition, media.videoRenditionList);
 
       return {
         value: this.getRenditionValue(rendition, index),
         label: this.getRenditionLabel(rendition),
+        disabled: false,
         ...(tier && { tier }),
         ...(badge && { badge }),
       };
@@ -201,14 +192,16 @@ export class QualityRadioGroupCore {
         ? -1
         : media.videoRenditionList.findIndex((rendition) => isSameRendition(rendition, media.activeVideoRendition!));
     const active =
-      media.activeVideoRendition && activeIndex !== -1
-        ? toRendition(media.activeVideoRendition, activeIndex)
-        : undefined;
+      media.activeVideoRendition && activeIndex !== -1 ? toOption(media.activeVideoRendition, activeIndex) : undefined;
+    const autoOption: QualityRadioGroupOption = {
+      value: QUALITY_AUTO_VALUE,
+      label: selectedIndex === -1 && active ? autoWithLabelText : autoText,
+      disabled: false,
+      ...(selectedIndex === -1 && active && { labelParams: { label: resolveText(active.label) } }),
+    };
 
     this.state.patch({
-      renditions: media.videoRenditionList.map(toRendition),
-      autoLabel: selectedIndex === -1 && active ? autoWithLabelText : autoText,
-      ...(selectedIndex === -1 && active && { autoLabelParams: { label: resolveText(active.label) } }),
+      options: [autoOption, ...media.videoRenditionList.map(toOption)],
       value:
         selectedIndex === -1
           ? QUALITY_AUTO_VALUE

--- a/packages/core/src/core/ui/quality-radio-group/tests/quality-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/quality-radio-group/tests/quality-radio-group-core.test.ts
@@ -17,11 +17,11 @@ function createMediaState(overrides: Partial<MediaQualityState> = {}): MediaQual
 
 function createState(overrides: Partial<QualityRadioGroupState> = {}): QualityRadioGroupState {
   return {
-    renditions: [
-      { value: '0', label: '1080p' },
-      { value: '1', label: '720p' },
+    options: [
+      { value: QUALITY_AUTO_VALUE, label: 'Auto', disabled: false },
+      { value: '0', label: '1080p', disabled: false },
+      { value: '1', label: '720p', disabled: false },
     ],
-    autoLabel: 'Auto',
     value: QUALITY_AUTO_VALUE,
     disabled: false,
     availability: 'available',
@@ -39,9 +39,10 @@ describe('QualityRadioGroupCore', () => {
 
       const state = core.getState();
 
-      expect(state.renditions).toEqual([
-        { value: '0', label: '1080p', tier: 'HD' },
-        { value: '1', label: '720p' },
+      expect(state.options).toEqual([
+        { value: QUALITY_AUTO_VALUE, label: { key: 'menu.auto', text: 'Auto' }, disabled: false },
+        { value: '0', label: '1080p', disabled: false, tier: 'HD' },
+        { value: '1', label: '720p', disabled: false },
       ]);
       expect(state.value).toBe(QUALITY_AUTO_VALUE);
     });
@@ -57,10 +58,11 @@ describe('QualityRadioGroupCore', () => {
       });
       core.setMedia(media);
 
-      expect(core.getState().renditions).toEqual([
-        { value: '0', label: '1080p', tier: 'HD', badge: '6 Mbps' },
-        { value: '1', label: '1080p', tier: 'HD', badge: '3 Mbps' },
-        { value: '2', label: '720p' },
+      expect(core.getState().options).toEqual([
+        { value: QUALITY_AUTO_VALUE, label: { key: 'menu.auto', text: 'Auto' }, disabled: false },
+        { value: '0', label: '1080p', disabled: false, tier: 'HD', badge: '6 Mbps' },
+        { value: '1', label: '1080p', disabled: false, tier: 'HD', badge: '3 Mbps' },
+        { value: '2', label: '720p', disabled: false },
       ]);
     });
 
@@ -75,10 +77,11 @@ describe('QualityRadioGroupCore', () => {
       });
       core.setMedia(media);
 
-      expect(core.getState().renditions).toEqual([
-        { value: '0', label: '1080p', tier: 'HD' },
-        { value: '1', label: '2160p', tier: '4K' },
-        { value: '2', label: '4320p', tier: '8K' },
+      expect(core.getState().options).toEqual([
+        { value: QUALITY_AUTO_VALUE, label: { key: 'menu.auto', text: 'Auto' }, disabled: false },
+        { value: '0', label: '1080p', disabled: false, tier: 'HD' },
+        { value: '1', label: '2160p', disabled: false, tier: '4K' },
+        { value: '2', label: '4320p', disabled: false, tier: '8K' },
       ]);
     });
 
@@ -105,8 +108,12 @@ describe('QualityRadioGroupCore', () => {
       const state = core.getState();
 
       expect(state.value).toBe(QUALITY_AUTO_VALUE);
-      expect(state.autoLabel).toMatchObject({ key: 'menu.autoWithLabel', text: 'Auto ({label})' });
-      expect(state.autoLabelParams).toEqual({ label: '720p' });
+      expect(state.options[0]).toEqual({
+        value: QUALITY_AUTO_VALUE,
+        label: { key: 'menu.autoWithLabel', text: 'Auto ({label})' },
+        labelParams: { label: '720p' },
+        disabled: false,
+      });
     });
 
     it('marks availability unavailable with one rendition', () => {

--- a/packages/core/src/core/ui/types.ts
+++ b/packages/core/src/core/ui/types.ts
@@ -1,5 +1,5 @@
 import type { State } from '@videojs/store';
-import type { Text } from '../i18n';
+import type { Text, TextParams } from '../i18n';
 
 export type StateAttrMap<State> = {
   [Key in keyof State]?: string;
@@ -19,6 +19,30 @@ export interface MediaUIComponent<Props = object, State extends object = object>
 
 export interface ButtonState {
   label: Text | string;
+}
+
+/** A normalized radio option produced by a framework-neutral UI core. */
+export interface RadioOption {
+  /** Value passed back to the core when this option is selected. */
+  value: string;
+  /** Visible option label. */
+  label: Text | string;
+  /** Values interpolated into a translated label. */
+  labelParams?: TextParams | undefined;
+  /** Whether this individual option is disabled. */
+  disabled: boolean;
+}
+
+/** Shared state contract for media-backed radio option groups. */
+export interface RadioOptionsState<Option extends RadioOption = RadioOption> extends ButtonState {
+  /** Current radio-group value. */
+  value: string;
+  /** Ordered options displayed by platform adapters. */
+  options: readonly Option[];
+  /** Whether the entire option group is disabled. */
+  disabled: boolean;
+  /** Whether the media exposes a meaningful selection. */
+  availability: 'available' | 'unavailable';
 }
 
 /** Constraint for media button cores that provide a label derived from state. */

--- a/packages/html/src/ui/audio-track-radio-group/audio-track-radio-group-element.ts
+++ b/packages/html/src/ui/audio-track-radio-group/audio-track-radio-group-element.ts
@@ -1,15 +1,17 @@
-import { AudioTrackRadioGroupCore, AudioTrackRadioGroupDataAttrs } from '@videojs/core';
+import {
+  AudioTrackRadioGroupCore,
+  AudioTrackRadioGroupDataAttrs,
+  type AudioTrackRadioGroupOption,
+} from '@videojs/core';
 import { applyStateDataAttrs, logMissingFeature, selectAudioTrack } from '@videojs/core/dom';
-import { type Text, type Translator, translateText } from '@videojs/core/i18n';
+import type { Text } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
-import { cacheKey } from '../../i18n/cache-key';
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
-import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../menu/menu-radio-group-element';
-import { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+import { RadioOptionsController } from '../radio-options/radio-options-controller';
 
 export class AudioTrackRadioGroupElement extends MenuRadioGroupElement {
   static override readonly tagName = 'media-audio-track-radio-group';
@@ -27,27 +29,24 @@ export class AudioTrackRadioGroupElement extends MenuRadioGroupElement {
   readonly #core = new AudioTrackRadioGroupCore();
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectAudioTrack);
-
-  #tracksKey = '';
-  #tracksTranslator: Translator | null = null;
-  #disconnect: AbortController | null = null;
+  readonly #options = new RadioOptionsController<AudioTrackRadioGroupOption>(this, {
+    getTemplate: () => this.getTemplate(),
+    createItem: (template) => this.createRadioItem(template),
+    renderItem: (item, label) => this.setItemLabel(item, label),
+    setItemAttributes: (item, option) => item.setAttribute('data-track', option.value),
+    onValueChange: (value) => {
+      const media = this.#mediaState.value;
+      if (media) this.#core.selectValue(media, value);
+    },
+  });
 
   override connectedCallback(): void {
     super.connectedCallback();
     if (this.destroyed) return;
 
-    this.#disconnect = new AbortController();
-    this.addEventListener('value-change', this.#handleValueChange, { signal: this.#disconnect.signal });
-
     if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   protected override update(changed: PropertyValues): void {
@@ -59,71 +58,14 @@ export class AudioTrackRadioGroupElement extends MenuRadioGroupElement {
       this.#core.setMedia(media);
       state = this.#core.getState();
 
-      this.value = state.value;
       this.applyAriaLabel(this.#i18n.value, this.#core.getLabel(state));
-      if (state.disabled) {
-        this.setAttribute('aria-disabled', 'true');
-      } else {
-        this.removeAttribute('aria-disabled');
-      }
-      this.#syncContent(state);
+      this.#options.sync(state, this.#i18n.value, this.#i18n.locale);
     }
 
     super.update(changed);
 
     if (state) applyStateDataAttrs(this, state, AudioTrackRadioGroupDataAttrs);
   }
-
-  #syncContent(state: AudioTrackRadioGroupCore.State): void {
-    const template = this.getTemplate();
-    const templateKey = template?.innerHTML ?? '';
-    const translator = this.#i18n.value;
-    const tracksKey = `${state.tracks.map((track) => `${track.value}:${cacheKey(track.label)}`).join('|')}::${this.#i18n.locale}::${templateKey}`;
-
-    if (tracksKey !== this.#tracksKey || translator !== this.#tracksTranslator) {
-      this.#tracksKey = tracksKey;
-      this.#tracksTranslator = translator;
-
-      for (const child of [...this.children]) {
-        if (child instanceof HTMLTemplateElement) continue;
-        child.remove();
-      }
-
-      this.append(
-        ...state.tracks.map((track) => this.#createItem(track.value, translateText(track.label, translator), template))
-      );
-    }
-
-    for (const item of this.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)) {
-      const checked = item.value === this.value;
-
-      item.disabled = state.disabled;
-
-      for (const indicator of item.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)) {
-        indicator.checked = checked;
-      }
-    }
-  }
-
-  #createItem(value: string, label: string, template: HTMLTemplateElement | null): MenuRadioItemElement {
-    const item = this.createRadioItem(template);
-
-    item.value = value;
-    item.setAttribute('data-track', value);
-    this.setItemLabel(item, label);
-
-    return item;
-  }
-
-  #handleValueChange = (event: Event): void => {
-    if (event.target !== this) return;
-
-    const media = this.#mediaState.value;
-    if (!media) return;
-
-    const { value } = (event as CustomEvent<{ value: string }>).detail;
-    this.#core.selectValue(media, value);
-  };
 }
 
 export namespace AudioTrackRadioGroupElement {

--- a/packages/html/src/ui/captions-radio-group/captions-radio-group-element.ts
+++ b/packages/html/src/ui/captions-radio-group/captions-radio-group-element.ts
@@ -1,16 +1,13 @@
-import { CAPTIONS_OFF_VALUE, CaptionsRadioGroupCore, CaptionsRadioGroupDataAttrs } from '@videojs/core';
+import { CaptionsRadioGroupCore, CaptionsRadioGroupDataAttrs, type CaptionsRadioGroupOption } from '@videojs/core';
 import { applyStateDataAttrs, logMissingFeature, selectTextTrack } from '@videojs/core/dom';
-import { type Text, type Translator, translateText } from '@videojs/core/i18n';
-import { offText } from '@videojs/core/i18n/text/menu';
+import type { Text } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
-import { cacheKey } from '../../i18n/cache-key';
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
-import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../menu/menu-radio-group-element';
-import { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+import { RadioOptionsController } from '../radio-options/radio-options-controller';
 
 export class CaptionsRadioGroupElement extends MenuRadioGroupElement {
   static override readonly tagName = 'media-captions-radio-group';
@@ -23,31 +20,29 @@ export class CaptionsRadioGroupElement extends MenuRadioGroupElement {
 
   disabled = false;
   label: Text | string = '';
+  formatTrack = CaptionsRadioGroupCore.defaultProps.formatTrack;
 
   readonly #core = new CaptionsRadioGroupCore();
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectTextTrack);
-
-  #tracksKey = '';
-  #tracksTranslator: Translator | null = null;
-  #disconnect: AbortController | null = null;
+  readonly #options = new RadioOptionsController<CaptionsRadioGroupOption>(this, {
+    getTemplate: () => this.getTemplate(),
+    createItem: (template) => this.createRadioItem(template),
+    renderItem: (item, label) => this.setItemLabel(item, label),
+    setItemAttributes: (item, option) => item.setAttribute('data-track', option.value),
+    onValueChange: (value) => {
+      const media = this.#mediaState.value;
+      if (media) this.#core.selectValue(media, value);
+    },
+  });
 
   override connectedCallback(): void {
     super.connectedCallback();
     if (this.destroyed) return;
 
-    this.#disconnect = new AbortController();
-    this.addEventListener('value-change', this.#handleValueChange, { signal: this.#disconnect.signal });
-
     if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   protected override update(changed: PropertyValues): void {
@@ -55,71 +50,18 @@ export class CaptionsRadioGroupElement extends MenuRadioGroupElement {
     let state: CaptionsRadioGroupCore.State | null = null;
 
     if (media) {
-      this.#core.setProps({ disabled: this.disabled, label: this.label });
+      this.#core.setProps({ formatTrack: this.formatTrack, disabled: this.disabled, label: this.label });
       this.#core.setMedia(media);
       state = this.#core.getState();
 
-      this.value = state.value;
       this.applyAriaLabel(this.#i18n.value, this.#core.getLabel(state));
-      this.#syncContent(state);
+      this.#options.sync(state, this.#i18n.value, this.#i18n.locale);
     }
 
     super.update(changed);
 
     if (state) applyStateDataAttrs(this, state, CaptionsRadioGroupDataAttrs);
   }
-
-  #syncContent(state: CaptionsRadioGroupCore.State): void {
-    const template = this.getTemplate();
-    const templateKey = template?.innerHTML ?? '';
-    const translator = this.#i18n.value;
-    const tracksKey = `${state.tracks.map((track) => `${track.value}:${cacheKey(track.label)}`).join('|')}::${this.#i18n.locale}::${templateKey}`;
-
-    if (tracksKey !== this.#tracksKey || translator !== this.#tracksTranslator) {
-      this.#tracksKey = tracksKey;
-      this.#tracksTranslator = translator;
-
-      for (const child of [...this.children]) {
-        if (child instanceof HTMLTemplateElement) continue;
-        child.remove();
-      }
-
-      this.append(this.#createItem(CAPTIONS_OFF_VALUE, translateText(offText, translator), template));
-      this.append(
-        ...state.tracks.map((track) => this.#createItem(track.value, translateText(track.label, translator), template))
-      );
-    }
-
-    for (const item of this.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)) {
-      const checked = item.value === this.value;
-
-      item.disabled = state.disabled;
-
-      for (const indicator of item.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)) {
-        indicator.checked = checked;
-      }
-    }
-  }
-
-  #createItem(value: string, label: string, template: HTMLTemplateElement | null): MenuRadioItemElement {
-    const item = this.createRadioItem(template);
-
-    item.value = value;
-    item.setAttribute('data-track', value);
-    this.setItemLabel(item, label);
-
-    return item;
-  }
-
-  #handleValueChange = (event: Event): void => {
-    if (event.target !== this) return;
-
-    const media = this.#mediaState.value;
-    if (!media) return;
-
-    const { value } = (event as CustomEvent<{ value: string }>).detail;
-    this.#core.selectValue(media, value);
-  };
 }
 
 export namespace CaptionsRadioGroupElement {

--- a/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
+++ b/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
@@ -121,4 +121,40 @@ describe('CaptionsRadioGroupElement', () => {
       expect(items.map((item) => item.textContent)).toEqual(['Desactive', 'Legendes']);
     });
   });
+
+  it('uses a custom track formatter', async () => {
+    const { menu, options } = setup('en', {
+      textTrackList: [{ id: 'es', kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' }],
+    });
+    options.formatTrack = (track) => `${track.language.toUpperCase()} subtitles`;
+    options.requestUpdate();
+
+    await options.updateComplete;
+
+    const items = [...menu.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
+    expect(items.map((item) => item.textContent)).toEqual(['Off', 'ES subtitles']);
+  });
+
+  it('applies group disabled semantics when captions are unavailable', async () => {
+    const { menu, options } = setup('en', { textTrackList: [] });
+
+    await options.updateComplete;
+
+    const items = [...menu.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
+    expect(options.getAttribute('aria-disabled')).toBe('true');
+    expect(items.map((item) => item.disabled)).toEqual([true]);
+  });
+
+  it('selects a captions option by normalized value', async () => {
+    const selectSubtitlesTrack = vi.fn();
+    const { options } = setup('en', {
+      textTrackList: [{ id: 'es', kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' }],
+      selectSubtitlesTrack,
+    });
+
+    await options.updateComplete;
+    options.dispatchEvent(new CustomEvent('value-change', { detail: { value: 'es' } }));
+
+    expect(selectSubtitlesTrack).toHaveBeenCalledWith('es');
+  });
 });

--- a/packages/html/src/ui/menu/get-menu-item-setting-state.ts
+++ b/packages/html/src/ui/menu/get-menu-item-setting-state.ts
@@ -1,10 +1,8 @@
-import {
-  type AudioTrackRadioGroupCore,
-  CAPTIONS_OFF_VALUE,
-  type CaptionsRadioGroupCore,
-  type PlaybackRateRadioGroupCore,
-  QUALITY_AUTO_VALUE,
-  type QualityRadioGroupCore,
+import type {
+  AudioTrackRadioGroupCore,
+  CaptionsRadioGroupCore,
+  PlaybackRateRadioGroupCore,
+  QualityRadioGroupCore,
 } from '@videojs/core';
 import type { Text, TextParams } from '@videojs/core/i18n';
 import { autoText, offText } from '@videojs/core/i18n/text/menu';
@@ -36,9 +34,11 @@ export function getMenuItemSettingState(
   if (type === 'playback-rate') {
     cores.playbackRate.setMedia(media as MediaPlaybackRateState);
     const state = cores.playbackRate.getState();
+    const option = state.options.find((candidate) => candidate.value === state.value);
 
     return {
-      label: cores.playbackRate.getRateLabel(state.rate),
+      label: option?.label ?? cores.playbackRate.getRateLabel(state.rate),
+      labelParams: option?.labelParams,
       availability: state.availability,
     };
   }
@@ -47,18 +47,11 @@ export function getMenuItemSettingState(
     cores.quality.setMedia(media as MediaQualityState);
     const state = cores.quality.getState();
 
-    if (state.value === QUALITY_AUTO_VALUE) {
-      return {
-        label: state.autoLabel,
-        labelParams: state.autoLabelParams,
-        availability: state.availability,
-      };
-    }
-
-    const rendition = state.renditions.find((candidate) => candidate.value === state.value);
+    const option = state.options.find((candidate) => candidate.value === state.value);
 
     return {
-      label: rendition?.label ?? autoText,
+      label: option?.label ?? autoText,
+      labelParams: option?.labelParams,
       availability: state.availability,
     };
   }
@@ -66,10 +59,11 @@ export function getMenuItemSettingState(
   if (type === 'audio-track') {
     cores.audioTrack.setMedia(media as MediaAudioTrackState);
     const state = cores.audioTrack.getState();
-    const track = state.tracks.find((candidate) => candidate.value === state.value);
+    const option = state.options.find((candidate) => candidate.value === state.value);
 
     return {
-      label: track?.label ?? '',
+      label: option?.label ?? '',
+      labelParams: option?.labelParams,
       availability: state.availability,
     };
   }
@@ -77,14 +71,11 @@ export function getMenuItemSettingState(
   cores.captions.setMedia(media as MediaTextTrackState);
   const state = cores.captions.getState();
 
-  if (state.value === CAPTIONS_OFF_VALUE) {
-    return { label: offText, availability: state.availability };
-  }
-
-  const track = state.tracks.find((candidate) => candidate.value === state.value);
+  const option = state.options.find((candidate) => candidate.value === state.value);
 
   return {
-    label: track?.label ?? offText,
+    label: option?.label ?? offText,
+    labelParams: option?.labelParams,
     availability: state.availability,
   };
 }

--- a/packages/html/src/ui/playback-rate-radio-group/playback-rate-radio-group-element.ts
+++ b/packages/html/src/ui/playback-rate-radio-group/playback-rate-radio-group-element.ts
@@ -1,14 +1,17 @@
-import { PlaybackRateRadioGroupCore, PlaybackRateRadioGroupDataAttrs } from '@videojs/core';
-import { applyElementProps, applyStateDataAttrs, logMissingFeature, selectPlaybackRate } from '@videojs/core/dom';
+import {
+  PlaybackRateRadioGroupCore,
+  PlaybackRateRadioGroupDataAttrs,
+  type PlaybackRateRadioGroupOption,
+} from '@videojs/core';
+import { applyStateDataAttrs, logMissingFeature, selectPlaybackRate } from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
-import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../menu/menu-radio-group-element';
-import { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+import { RadioOptionsController } from '../radio-options/radio-options-controller';
 
 export class PlaybackRateRadioGroupElement extends MenuRadioGroupElement {
   static override readonly tagName = 'media-playback-rate-radio-group';
@@ -24,26 +27,24 @@ export class PlaybackRateRadioGroupElement extends MenuRadioGroupElement {
   readonly #core = new PlaybackRateRadioGroupCore();
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectPlaybackRate);
-
-  #ratesKey = '';
-  #disconnect: AbortController | null = null;
+  readonly #options = new RadioOptionsController<PlaybackRateRadioGroupOption>(this, {
+    getTemplate: () => this.getTemplate(),
+    createItem: (template) => this.createRadioItem(template),
+    renderItem: (item, label) => this.setItemLabel(item, label),
+    setItemAttributes: (item, option) => item.setAttribute('data-rate', option.value),
+    onValueChange: (value) => {
+      const media = this.#mediaState.value;
+      if (media) this.#core.selectValue(media, value);
+    },
+  });
 
   override connectedCallback(): void {
     super.connectedCallback();
     if (this.destroyed) return;
 
-    this.#disconnect = new AbortController();
-    this.addEventListener('value-change', this.#handleValueChange, { signal: this.#disconnect.signal });
-
     if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   protected override update(changed: PropertyValues): void {
@@ -55,67 +56,14 @@ export class PlaybackRateRadioGroupElement extends MenuRadioGroupElement {
       this.#core.setMedia(media);
       state = this.#core.getState();
 
-      this.value = this.#core.getRateValue(state.rate);
       this.applyAriaLabel(this.#i18n.value, this.#core.getLabel(state), this.#core.getLabelParams(state));
-      applyElementProps(this, {
-        'aria-disabled': state.disabled ? 'true' : undefined,
-      });
-
-      this.#syncContent(state);
+      this.#options.sync(state, this.#i18n.value, this.#i18n.locale);
     }
 
     super.update(changed);
 
     if (state) applyStateDataAttrs(this, state, PlaybackRateRadioGroupDataAttrs);
   }
-
-  #syncContent(state: PlaybackRateRadioGroupCore.State): void {
-    const template = this.getTemplate();
-    const templateKey = template?.innerHTML ?? '';
-    const ratesKey = `${state.rates.join('|')}::${templateKey}`;
-
-    if (ratesKey !== this.#ratesKey) {
-      this.#ratesKey = ratesKey;
-
-      for (const child of [...this.children]) {
-        if (child instanceof HTMLTemplateElement) continue;
-        child.remove();
-      }
-
-      this.append(...state.rates.map((rate) => this.#createItem(rate, template)));
-    }
-
-    for (const item of this.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)) {
-      const checked = item.value === this.value;
-
-      item.disabled = state.disabled;
-
-      for (const indicator of item.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)) {
-        indicator.checked = checked;
-      }
-    }
-  }
-
-  #createItem(rate: number, template: HTMLTemplateElement | null): MenuRadioItemElement {
-    const item = this.createRadioItem(template);
-    const value = this.#core.getRateValue(rate);
-
-    item.value = value;
-    item.setAttribute('data-rate', value);
-    this.setItemLabel(item, this.#core.getRateLabel(rate));
-
-    return item;
-  }
-
-  #handleValueChange = (event: Event): void => {
-    if (event.target !== this) return;
-
-    const media = this.#mediaState.value;
-    if (!media) return;
-
-    const { value } = (event as CustomEvent<{ value: string }>).detail;
-    this.#core.selectValue(media, value);
-  };
 }
 
 export namespace PlaybackRateRadioGroupElement {

--- a/packages/html/src/ui/quality-radio-group/quality-radio-group-element.ts
+++ b/packages/html/src/ui/quality-radio-group/quality-radio-group-element.ts
@@ -1,15 +1,14 @@
-import { QUALITY_AUTO_VALUE, QualityRadioGroupCore, QualityRadioGroupDataAttrs } from '@videojs/core';
+import { QualityRadioGroupCore, QualityRadioGroupDataAttrs, type QualityRadioGroupOption } from '@videojs/core';
 import { applyStateDataAttrs, logMissingFeature, selectQuality } from '@videojs/core/dom';
-import { type Text, type Translator, translateText } from '@videojs/core/i18n';
+import type { Text } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
-import { cacheKey } from '../../i18n/cache-key';
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
-import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
 import { MenuRadioGroupElement } from '../menu/menu-radio-group-element';
-import { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+import type { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+import { RadioOptionsController } from '../radio-options/radio-options-controller';
 
 export class QualityRadioGroupElement extends MenuRadioGroupElement {
   static override readonly tagName = 'media-quality-radio-group';
@@ -27,27 +26,25 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
   readonly #core = new QualityRadioGroupCore();
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectQuality);
-
-  #renditionsKey = '';
-  #renditionsTranslator: Translator | null = null;
-  #disconnect: AbortController | null = null;
+  readonly #options = new RadioOptionsController<QualityRadioGroupOption>(this, {
+    getTemplate: () => this.getTemplate(),
+    createItem: (template) => this.createRadioItem(template),
+    renderItem: (item, label, option) => this.#setContent(item, label, option.tier, option.badge),
+    setItemAttributes: (item, option) => item.setAttribute('data-rendition', option.value),
+    getOptionCacheKey: (option) => `${option.tier ?? ''}:${option.badge ?? ''}`,
+    onValueChange: (value) => {
+      const media = this.#mediaState.value;
+      if (media) this.#core.selectValue(media, value);
+    },
+  });
 
   override connectedCallback(): void {
     super.connectedCallback();
     if (this.destroyed) return;
 
-    this.#disconnect = new AbortController();
-    this.addEventListener('value-change', this.#handleValueChange, { signal: this.#disconnect.signal });
-
     if (__DEV__ && !this.#mediaState.value && this.#mediaState.displayName) {
       logMissingFeature(this.localName, this.#mediaState.displayName);
     }
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
   }
 
   protected override update(changed: PropertyValues): void {
@@ -59,83 +56,13 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
       this.#core.setMedia(media);
       state = this.#core.getState();
 
-      this.value = state.value;
       this.applyAriaLabel(this.#i18n.value, this.#core.getLabel(state));
-      this.#syncContent(state);
+      this.#options.sync(state, this.#i18n.value, this.#i18n.locale);
     }
 
     super.update(changed);
 
     if (state) applyStateDataAttrs(this, state, QualityRadioGroupDataAttrs);
-  }
-
-  #syncContent(state: QualityRadioGroupCore.State): void {
-    const template = this.getTemplate();
-    const templateKey = template?.innerHTML ?? '';
-    const translator = this.#i18n.value;
-    const renditionsKey = `${state.renditions
-      .map(
-        (rendition) =>
-          `${rendition.value}:${cacheKey(rendition.label)}:${rendition.tier ?? ''}:${rendition.badge ?? ''}`
-      )
-      .join('|')}::${cacheKey(state.autoLabel, state.autoLabelParams)}::${this.#i18n.locale}::${templateKey}`;
-
-    if (renditionsKey !== this.#renditionsKey || translator !== this.#renditionsTranslator) {
-      this.#renditionsKey = renditionsKey;
-      this.#renditionsTranslator = translator;
-
-      for (const child of [...this.children]) {
-        if (child instanceof HTMLTemplateElement) continue;
-        child.remove();
-      }
-
-      this.append(
-        this.#createItem(
-          QUALITY_AUTO_VALUE,
-          translateText(state.autoLabel, translator, state.autoLabelParams),
-          undefined,
-          undefined,
-          template
-        )
-      );
-      this.append(
-        ...state.renditions.map((rendition) =>
-          this.#createItem(
-            rendition.value,
-            translateText(rendition.label, translator),
-            rendition.tier,
-            rendition.badge,
-            template
-          )
-        )
-      );
-    }
-
-    for (const item of this.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)) {
-      const checked = item.value === this.value;
-
-      item.disabled = state.disabled;
-
-      for (const indicator of item.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)) {
-        indicator.checked = checked;
-      }
-    }
-  }
-
-  #createItem(
-    value: string,
-    label: string,
-    tier: string | undefined,
-    badge: string | undefined,
-    template: HTMLTemplateElement | null
-  ): MenuRadioItemElement {
-    const item = this.createRadioItem(template);
-
-    item.value = value;
-    item.setAttribute('data-rendition', value);
-    this.#setContent(item, label, tier, badge);
-
-    return item;
   }
 
   #setContent(item: MenuRadioItemElement, label: string, tier: string | undefined, badge: string | undefined): void {
@@ -161,16 +88,6 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
       item.textContent = [label, tier, badge].filter(Boolean).join(' ');
     }
   }
-
-  #handleValueChange = (event: Event): void => {
-    if (event.target !== this) return;
-
-    const media = this.#mediaState.value;
-    if (!media) return;
-
-    const { value } = (event as CustomEvent<{ value: string }>).detail;
-    this.#core.selectValue(media, value);
-  };
 }
 
 export namespace QualityRadioGroupElement {

--- a/packages/html/src/ui/radio-options/radio-options-controller.ts
+++ b/packages/html/src/ui/radio-options/radio-options-controller.ts
@@ -1,0 +1,107 @@
+import type { RadioOption, RadioOptionsState } from '@videojs/core';
+import { applyElementProps } from '@videojs/core/dom';
+import { type Translator, translateText } from '@videojs/core/i18n';
+import type { ReactiveController, ReactiveControllerHost } from '@videojs/element';
+
+import { cacheKey } from '../../i18n/cache-key';
+import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
+import { MenuRadioItemElement } from '../menu/menu-radio-item-element';
+
+export type RadioOptionsControllerHost = ReactiveControllerHost &
+  HTMLElement & {
+    value: string;
+  };
+
+export interface RadioOptionsControllerConfig<Option extends RadioOption> {
+  getTemplate: () => HTMLTemplateElement | null;
+  createItem: (template: HTMLTemplateElement | null) => MenuRadioItemElement;
+  renderItem: (item: MenuRadioItemElement, label: string, option: Option) => void;
+  setItemAttributes?: ((item: MenuRadioItemElement, option: Option) => void) | undefined;
+  getOptionCacheKey?: ((option: Option) => string) | undefined;
+  onValueChange: (value: string) => void;
+}
+
+/** Renders normalized options into menu radio items and manages their interaction lifecycle. */
+export class RadioOptionsController<Option extends RadioOption> implements ReactiveController {
+  readonly #host: RadioOptionsControllerHost;
+  readonly #config: RadioOptionsControllerConfig<Option>;
+
+  #contentKey = '';
+  #translator: Translator | null = null;
+  #disconnect: AbortController | null = null;
+
+  constructor(host: RadioOptionsControllerHost, config: RadioOptionsControllerConfig<Option>) {
+    this.#host = host;
+    this.#config = config;
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    this.#disconnect = new AbortController();
+    this.#host.addEventListener('value-change', this.#handleValueChange, { signal: this.#disconnect.signal });
+  }
+
+  hostDisconnected(): void {
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+
+  hostDestroyed(): void {
+    this.hostDisconnected();
+  }
+
+  sync(state: RadioOptionsState<Option>, translator: Translator, locale: string): void {
+    this.#host.value = state.value;
+    applyElementProps(this.#host, {
+      'aria-disabled': state.disabled ? 'true' : undefined,
+    });
+
+    const template = this.#config.getTemplate();
+    const contentKey = `${state.options
+      .map(
+        (option) =>
+          `${option.value}:${cacheKey(option.label, option.labelParams)}:${this.#config.getOptionCacheKey?.(option) ?? ''}`
+      )
+      .join('|')}::${locale}::${template?.innerHTML ?? ''}`;
+
+    if (contentKey !== this.#contentKey || translator !== this.#translator) {
+      this.#contentKey = contentKey;
+      this.#translator = translator;
+
+      for (const child of [...this.#host.children]) {
+        if (child instanceof HTMLTemplateElement) continue;
+        child.remove();
+      }
+
+      const items = state.options.map((option) => {
+        const item = this.#config.createItem(template);
+        item.value = option.value;
+        this.#config.setItemAttributes?.(item, option);
+        this.#config.renderItem(item, translateText(option.label, translator, option.labelParams), option);
+        return item;
+      });
+
+      this.#host.append(...items);
+    }
+
+    const optionsByValue = new Map(state.options.map((option) => [option.value, option]));
+
+    for (const item of this.#host.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)) {
+      const checked = item.value === state.value;
+      const option = optionsByValue.get(item.value);
+
+      item.disabled = state.disabled || option?.disabled === true;
+
+      for (const indicator of item.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)) {
+        indicator.checked = checked;
+      }
+    }
+  }
+
+  #handleValueChange = (event: Event): void => {
+    if (event.target !== this.#host) return;
+
+    const { value } = (event as CustomEvent<{ value: string }>).detail;
+    this.#config.onValueChange(value);
+  };
+}

--- a/packages/html/src/ui/radio-options/tests/radio-options-controller.test.ts
+++ b/packages/html/src/ui/radio-options/tests/radio-options-controller.test.ts
@@ -1,0 +1,131 @@
+import type { RadioOption, RadioOptionsState } from '@videojs/core';
+import { createTranslator } from '@videojs/core/i18n';
+import type { PropertyValues } from '@videojs/element';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
+import { MenuRadioGroupElement } from '../../menu/menu-radio-group-element';
+import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
+import { RadioOptionsController } from '../radio-options-controller';
+
+interface TestOption extends RadioOption {
+  badge?: string | undefined;
+}
+
+function defineElement(tagName: string, Base: CustomElementConstructor): void {
+  if (!customElements.get(tagName)) customElements.define(tagName, Base);
+}
+
+class TestRadioOptionsElement extends MenuRadioGroupElement {
+  static override readonly tagName = 'test-radio-options';
+
+  state: RadioOptionsState<TestOption> = {
+    label: '',
+    value: 'one',
+    options: [
+      {
+        value: 'one',
+        label: { key: 'option.one', text: 'One ({detail})' },
+        labelParams: { detail: 'HD' },
+        disabled: false,
+      },
+      { value: 'two', label: 'Two', disabled: true },
+    ],
+    disabled: false,
+    availability: 'available',
+  };
+  translator = createTranslator({ 'option.one': 'First ({detail})' }, 'en');
+  readonly onValueChange = vi.fn();
+
+  readonly #options = new RadioOptionsController<TestOption>(this, {
+    getTemplate: () => this.getTemplate(),
+    createItem: (template) => this.createRadioItem(template),
+    renderItem: (item, label, option) => this.setItemLabel(item, `${label}${option.badge ?? ''}`),
+    setItemAttributes: (item, option) => item.setAttribute('data-option', option.value),
+    getOptionCacheKey: (option) => option.badge ?? '',
+    onValueChange: (value) => this.onValueChange(value),
+  });
+
+  setState(state: RadioOptionsState<TestOption>): void {
+    this.state = state;
+    this.requestUpdate();
+  }
+
+  protected override update(changed: PropertyValues): void {
+    this.#options.sync(this.state, this.translator, 'en');
+    super.update(changed);
+  }
+}
+
+defineElement(MenuRadioItemElement.tagName, MenuRadioItemElement);
+defineElement(MenuItemIndicatorElement.tagName, MenuItemIndicatorElement);
+defineElement(TestRadioOptionsElement.tagName, TestRadioOptionsElement);
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('RadioOptionsController', () => {
+  it('renders translated options from a template and synchronizes item state', async () => {
+    const element = new TestRadioOptionsElement();
+    const template = document.createElement('template');
+    template.innerHTML =
+      '<media-menu-radio-item><span data-part="label"></span><media-menu-item-indicator force-mount></media-menu-item-indicator></media-menu-radio-item>';
+    element.append(template);
+    document.body.append(element);
+
+    await element.updateComplete;
+
+    const items = [...element.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
+    const indicators = [...element.querySelectorAll<MenuItemIndicatorElement>(MenuItemIndicatorElement.tagName)];
+
+    expect(items.map((item) => item.textContent)).toEqual(['First (HD)', 'Two']);
+    expect(items.map((item) => item.getAttribute('data-option'))).toEqual(['one', 'two']);
+    expect(items.map((item) => item.disabled)).toEqual([false, true]);
+    expect(indicators.map((indicator) => indicator.checked)).toEqual([true, false]);
+  });
+
+  it('rebuilds specialized content and applies group disabled semantics', async () => {
+    const element = new TestRadioOptionsElement();
+    document.body.append(element);
+    await element.updateComplete;
+
+    element.setState({
+      ...element.state,
+      value: 'two',
+      disabled: true,
+      options: element.state.options.map((option) => (option.value === 'two' ? { ...option, badge: ' CC' } : option)),
+    });
+    await element.updateComplete;
+
+    const items = [...element.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
+
+    expect(element.getAttribute('aria-disabled')).toBe('true');
+    expect(items.map((item) => item.textContent)).toEqual(['First (HD)', 'Two CC']);
+    expect(items.map((item) => item.disabled)).toEqual([true, true]);
+
+    element.setState({ ...element.state, disabled: false });
+    await element.updateComplete;
+
+    expect(element.hasAttribute('aria-disabled')).toBe(false);
+    expect(items.map((item) => item.disabled)).toEqual([false, true]);
+  });
+
+  it('connects and cleans up value-change handling with the host lifecycle', async () => {
+    const element = new TestRadioOptionsElement();
+    document.body.append(element);
+    await element.updateComplete;
+
+    element.dispatchEvent(new CustomEvent('value-change', { detail: { value: 'two' } }));
+    expect(element.onValueChange).toHaveBeenCalledTimes(1);
+
+    element.remove();
+    element.dispatchEvent(new CustomEvent('value-change', { detail: { value: 'one' } }));
+    expect(element.onValueChange).toHaveBeenCalledTimes(1);
+
+    document.body.append(element);
+    await element.updateComplete;
+    element.dispatchEvent(new CustomEvent('value-change', { detail: { value: 'one' } }));
+    expect(element.onValueChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react/src/ui/audio-track/use-audio-track-options.ts
+++ b/packages/react/src/ui/audio-track/use-audio-track-options.ts
@@ -1,20 +1,13 @@
 'use client';
 
-import { AudioTrackRadioGroupCore } from '@videojs/core';
-import { logMissingFeature, selectAudioTrack } from '@videojs/core/dom';
-import { translateText } from '@videojs/core/i18n';
-import { useCallback, useState } from 'react';
+import { AudioTrackRadioGroupCore, type AudioTrackRadioGroupOption } from '@videojs/core';
+import { selectAudioTrack } from '@videojs/core/dom';
 
-import { useTranslator } from '../../i18n/context';
-import { usePlayer } from '../../player/context';
+import { createRadioOptionsHook, type TranslatedRadioOption } from '../hooks/create-radio-options-hook';
 
 export interface AudioTrackOptionsProps extends AudioTrackRadioGroupCore.Props {}
 
-export interface AudioTrackOption {
-  value: string;
-  label: string;
-  disabled: boolean;
-}
+export type AudioTrackOption = TranslatedRadioOption<AudioTrackRadioGroupOption>;
 
 export interface AudioTrackOptionsResult {
   state: AudioTrackRadioGroupCore.State;
@@ -23,6 +16,13 @@ export interface AudioTrackOptionsResult {
   disabled: boolean;
   setValue: (value: string) => void;
 }
+
+const useAudioTrackRadioOptions = createRadioOptionsHook({
+  name: 'useAudioTrackOptions',
+  feature: 'audioTrack',
+  selector: selectAudioTrack,
+  createCore: () => new AudioTrackRadioGroupCore(),
+});
 
 /**
  * Create audio track menu options from the player audio track state. Returns
@@ -33,33 +33,7 @@ export interface AudioTrackOptionsResult {
 export function useAudioTrackOptions(props?: AudioTrackOptionsProps): AudioTrackOptionsResult | null {
   'use no memo';
 
-  const media = usePlayer(selectAudioTrack);
-  const t = useTranslator();
-  const [core] = useState(() => new AudioTrackRadioGroupCore());
-
-  core.setProps(props ?? {});
-
-  const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
-
-  if (!media) {
-    if (__DEV__) logMissingFeature('useAudioTrackOptions', selectAudioTrack.displayName ?? 'audioTrack');
-    return null;
-  }
-
-  core.setMedia(media);
-  const state = core.getState();
-
-  return {
-    state,
-    value: state.value,
-    options: state.tracks.map((track) => ({
-      value: track.value,
-      label: translateText(track.label, t),
-      disabled: state.disabled,
-    })),
-    disabled: state.disabled,
-    setValue,
-  };
+  return useAudioTrackRadioOptions(props);
 }
 
 export namespace useAudioTrackOptions {

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -1,21 +1,13 @@
 'use client';
 
-import { CAPTIONS_OFF_VALUE, CaptionsRadioGroupCore } from '@videojs/core';
-import { logMissingFeature, selectTextTrack } from '@videojs/core/dom';
-import { translateText } from '@videojs/core/i18n';
-import { offText } from '@videojs/core/i18n/text/menu';
-import { useCallback, useState } from 'react';
+import { CaptionsRadioGroupCore, type CaptionsRadioGroupOption } from '@videojs/core';
+import { selectTextTrack } from '@videojs/core/dom';
 
-import { useTranslator } from '../../i18n/context';
-import { usePlayer } from '../../player/context';
+import { createRadioOptionsHook, type TranslatedRadioOption } from '../hooks/create-radio-options-hook';
 
 export interface CaptionsOptionsProps extends CaptionsRadioGroupCore.Props {}
 
-export interface CaptionsOption {
-  value: string;
-  label: string;
-  disabled: boolean;
-}
+export type CaptionsOption = TranslatedRadioOption<CaptionsRadioGroupOption>;
 
 export interface CaptionsOptionsResult {
   state: CaptionsRadioGroupCore.State;
@@ -25,6 +17,13 @@ export interface CaptionsOptionsResult {
   showMenu: boolean;
   setValue: (value: string) => void;
 }
+
+const useCaptionsRadioOptions = createRadioOptionsHook({
+  name: 'useCaptionsOptions',
+  feature: 'textTrack',
+  selector: selectTextTrack,
+  createCore: () => new CaptionsRadioGroupCore(),
+});
 
 /**
  * Create captions menu options (including an `Off` option) from the player
@@ -36,42 +35,10 @@ export interface CaptionsOptionsResult {
 export function useCaptionsOptions(props?: CaptionsOptionsProps): CaptionsOptionsResult | null {
   'use no memo';
 
-  const media = usePlayer(selectTextTrack);
-  const t = useTranslator();
-  const [core] = useState(() => new CaptionsRadioGroupCore());
+  const result = useCaptionsRadioOptions(props);
+  if (!result) return null;
 
-  core.setProps(props ?? {});
-
-  const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
-
-  if (!media) {
-    if (__DEV__) logMissingFeature('useCaptionsOptions', selectTextTrack.displayName ?? 'textTrack');
-    return null;
-  }
-
-  core.setMedia(media);
-  const state = core.getState();
-  const showMenu = state.tracks.length > 1;
-
-  return {
-    state,
-    value: state.value,
-    options: [
-      {
-        value: CAPTIONS_OFF_VALUE,
-        label: translateText(offText, t),
-        disabled: state.disabled,
-      },
-      ...state.tracks.map((track) => ({
-        value: track.value,
-        label: translateText(track.label, t),
-        disabled: state.disabled,
-      })),
-    ],
-    disabled: state.disabled,
-    showMenu,
-    setValue,
-  };
+  return { ...result, showMenu: result.state.options.length > 2 };
 }
 
 export namespace useCaptionsOptions {

--- a/packages/react/src/ui/hooks/create-radio-options-hook.ts
+++ b/packages/react/src/ui/hooks/create-radio-options-hook.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import type { RadioOption, RadioOptionsState } from '@videojs/core';
+import { logMissingFeature } from '@videojs/core/dom';
+import { translateText } from '@videojs/core/i18n';
+import type { UnknownState } from '@videojs/store';
+import { useCallback, useState } from 'react';
+
+import { useTranslator } from '../../i18n/context';
+import { usePlayer } from '../../player/context';
+
+interface RadioOptionsCore<Props, Media, State extends RadioOptionsState> {
+  setProps(props: Props): void;
+  setMedia(media: Media): void;
+  getState(): State;
+  selectValue(media: Media, value: string): void;
+}
+
+interface RadioOptionsHookConfig<Props, Media, State extends RadioOptionsState> {
+  name: string;
+  feature: string;
+  selector: ((state: UnknownState) => Media | null) & { displayName?: string | undefined };
+  createCore: () => RadioOptionsCore<Props, Media, State>;
+}
+
+type StateOption<State extends RadioOptionsState> = State extends RadioOptionsState<infer Option> ? Option : never;
+
+export type TranslatedRadioOption<Option extends RadioOption> = Omit<Option, 'label' | 'labelParams' | 'disabled'> & {
+  label: string;
+  disabled: boolean;
+};
+
+export interface RadioOptionsHookResult<Option extends RadioOption, State extends RadioOptionsState> {
+  state: State;
+  value: string;
+  options: TranslatedRadioOption<Option>[];
+  disabled: boolean;
+  setValue: (value: string) => void;
+}
+
+/** Creates framework adapter mechanics shared by media-backed radio option hooks. */
+export function createRadioOptionsHook<Props, Media, State extends RadioOptionsState>({
+  name,
+  feature,
+  selector,
+  createCore,
+}: RadioOptionsHookConfig<Props, Media, State>): (
+  props?: Props
+) => RadioOptionsHookResult<StateOption<State>, State> | null {
+  return function useRadioOptions(props?: Props): RadioOptionsHookResult<StateOption<State>, State> | null {
+    'use no memo';
+
+    const media = usePlayer(selector);
+    const t = useTranslator();
+    const [core] = useState(createCore);
+
+    core.setProps(props ?? ({} as Props));
+
+    const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
+
+    if (!media) {
+      if (__DEV__) logMissingFeature(name, selector.displayName ?? feature);
+      return null;
+    }
+
+    core.setMedia(media);
+    const state = core.getState();
+    const options = state.options.map((option) => {
+      const { label, labelParams, disabled, ...rest } = option;
+
+      return {
+        ...rest,
+        label: translateText(label, t, labelParams),
+        disabled: state.disabled || disabled,
+      } as TranslatedRadioOption<StateOption<State>>;
+    });
+
+    return {
+      state,
+      value: state.value,
+      options,
+      disabled: state.disabled,
+      setValue,
+    };
+  };
+}

--- a/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
+++ b/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
@@ -3,20 +3,16 @@
 import {
   type PlaybackRateRadioGroupCore,
   PlaybackRateRadioGroupCore as PlaybackRateRadioGroupCoreClass,
+  type PlaybackRateRadioGroupOption,
 } from '@videojs/core';
-import { logMissingFeature, selectPlaybackRate } from '@videojs/core/dom';
-import { useCallback, useState } from 'react';
+import { selectPlaybackRate } from '@videojs/core/dom';
+import { useCallback } from 'react';
 
-import { usePlayer } from '../../player/context';
+import { createRadioOptionsHook, type TranslatedRadioOption } from '../hooks/create-radio-options-hook';
 
 export interface PlaybackRateOptionsProps extends PlaybackRateRadioGroupCore.Props {}
 
-export interface PlaybackRateOption {
-  rate: number;
-  value: string;
-  label: string;
-  disabled: boolean;
-}
+export type PlaybackRateOption = TranslatedRadioOption<PlaybackRateRadioGroupOption>;
 
 export interface PlaybackRateOptionsResult {
   state: PlaybackRateRadioGroupCore.State;
@@ -28,6 +24,13 @@ export interface PlaybackRateOptionsResult {
   setValue: (value: string) => void;
 }
 
+const usePlaybackRateRadioOptions = createRadioOptionsHook({
+  name: 'usePlaybackRateOptions',
+  feature: 'playbackRate',
+  selector: selectPlaybackRate,
+  createCore: () => new PlaybackRateRadioGroupCoreClass(),
+});
+
 /**
  * Create playback rate menu options from the player playback rate state.
  * Returns `null` when the playback rate feature is not configured.
@@ -35,35 +38,14 @@ export interface PlaybackRateOptionsResult {
  * @param props - Optional `label`, `formatRate`, and `disabled` overrides.
  */
 export function usePlaybackRateOptions(props?: PlaybackRateOptionsProps): PlaybackRateOptionsResult | null {
-  const media = usePlayer(selectPlaybackRate);
-  const [core] = useState(() => new PlaybackRateRadioGroupCoreClass());
-
-  core.setProps(props ?? {});
-
-  const setRate = useCallback((rate: number) => core.select(media!, rate), [core, media]);
-  const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
-
-  if (!media) {
-    if (__DEV__) logMissingFeature('usePlaybackRateOptions', selectPlaybackRate.displayName ?? 'playbackRate');
-    return null;
-  }
-
-  core.setMedia(media);
-  const state = core.getState();
+  const result = usePlaybackRateRadioOptions(props);
+  const setRate = useCallback((rate: number) => result?.setValue(String(rate)), [result?.setValue]);
+  if (!result) return null;
 
   return {
-    state,
-    rate: state.rate,
-    value: core.getRateValue(state.rate),
-    options: state.rates.map((rate) => ({
-      rate,
-      value: core.getRateValue(rate),
-      label: core.getRateLabel(rate),
-      disabled: state.disabled,
-    })),
-    disabled: state.disabled,
+    ...result,
+    rate: result.state.rate,
     setRate,
-    setValue,
   };
 }
 

--- a/packages/react/src/ui/quality/use-quality-options.ts
+++ b/packages/react/src/ui/quality/use-quality-options.ts
@@ -1,22 +1,13 @@
 'use client';
 
-import { QUALITY_AUTO_VALUE, QualityRadioGroupCore } from '@videojs/core';
-import { logMissingFeature, selectQuality } from '@videojs/core/dom';
-import { translateText } from '@videojs/core/i18n';
-import { useCallback, useState } from 'react';
+import { QualityRadioGroupCore, type QualityRadioGroupOption } from '@videojs/core';
+import { selectQuality } from '@videojs/core/dom';
 
-import { useTranslator } from '../../i18n/context';
-import { usePlayer } from '../../player/context';
+import { createRadioOptionsHook, type TranslatedRadioOption } from '../hooks/create-radio-options-hook';
 
 export interface QualityOptionsProps extends QualityRadioGroupCore.Props {}
 
-export interface QualityOption {
-  value: string;
-  label: string;
-  tier?: string | undefined;
-  badge?: string | undefined;
-  disabled: boolean;
-}
+export type QualityOption = TranslatedRadioOption<QualityRadioGroupOption>;
 
 export interface QualityOptionsResult {
   state: QualityRadioGroupCore.State;
@@ -25,6 +16,13 @@ export interface QualityOptionsResult {
   disabled: boolean;
   setValue: (value: string) => void;
 }
+
+const useQualityRadioOptions = createRadioOptionsHook({
+  name: 'useQualityOptions',
+  feature: 'quality',
+  selector: selectQuality,
+  createCore: () => new QualityRadioGroupCore(),
+});
 
 /**
  * Create quality menu options (including an `Auto` option) from the player
@@ -36,42 +34,7 @@ export interface QualityOptionsResult {
 export function useQualityOptions(props?: QualityOptionsProps): QualityOptionsResult | null {
   'use no memo';
 
-  const media = usePlayer(selectQuality);
-  const t = useTranslator();
-  const [core] = useState(() => new QualityRadioGroupCore());
-
-  core.setProps(props ?? {});
-
-  const setValue = useCallback((value: string) => core.selectValue(media!, value), [core, media]);
-
-  if (!media) {
-    if (__DEV__) logMissingFeature('useQualityOptions', selectQuality.displayName ?? 'quality');
-    return null;
-  }
-
-  core.setMedia(media);
-  const state = core.getState();
-
-  return {
-    state,
-    value: state.value,
-    options: [
-      {
-        value: QUALITY_AUTO_VALUE,
-        label: translateText(state.autoLabel, t, state.autoLabelParams),
-        disabled: state.disabled,
-      },
-      ...state.renditions.map((rendition) => ({
-        value: rendition.value,
-        label: translateText(rendition.label, t),
-        ...(rendition.tier && { tier: rendition.tier }),
-        ...(rendition.badge && { badge: rendition.badge }),
-        disabled: state.disabled,
-      })),
-    ],
-    disabled: state.disabled,
-    setValue,
-  };
+  return useQualityRadioOptions(props);
 }
 
 export namespace useQualityOptions {


### PR DESCRIPTION
Closes #2048

## Summary

Normalize the four media-backed radio groups around one framework-neutral option-state contract, then share the repetitive adapter mechanics in React and HTML. Domain-specific calculations remain in their existing cores, and Menu gains no new abstraction.

## Changes

- Return ordered `options` with normalized values, labels, disabled state, and availability from the quality, captions, playback-rate, and audio-track cores
- Keep quality tiers and badges, playback numeric rates, captions Off, and quality Auto as domain-specific option data
- Share translation, missing-feature handling, and `setValue` wiring across the four React hooks
- Share template cloning, item rendering, checked/disabled synchronization, ARIA disabled state, and value-change lifecycle handling across the four HTML elements
- Preserve custom rendering through narrow option attributes, cache keys, and render callbacks

<details>
<summary>Breaking state changes</summary>

Radio group core states now expose `options` instead of the previous domain-specific `tracks`, `rates`, and `renditions` collections. Quality Auto and captions Off are included directly in the normalized option collection.

</details>

## Testing

- 61 focused core tests
- 28 focused HTML tests
- 24 focused React tests
- `pnpm -F @videojs/core build`
- `pnpm -F @videojs/html build`
- `pnpm -F @videojs/react build`
- `pnpm -F site api-docs`
- Biome formatting and `git diff --check`

`pnpm typecheck` currently reports four errors in unchanged HTML media/icon files outside this diff: the two simple-HLS definitions, the HTML icon export test, and the Mux video test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public state shape change across core, React, and HTML radio-group APIs, so consumers reading `tracks`/`rates`/`renditions` or separate Auto/Off handling will need updates. Behavior of media selection itself is largely preserved.
> 
> **Overview**
> **Normalizes** the four media-backed radio groups onto a shared `RadioOption` / `RadioOptionsState` contract.
> 
> Cores now return a single ordered `options` list (with value, label, disabled, and availability) instead of domain-specific `tracks` / `rates` / `renditions`. Captions **Off** and quality **Auto** move into that list, while domain extras like quality tiers/badges and numeric playback rates stay on the option objects.
> 
> React and HTML adapters then share the repetitive wiring: `createRadioOptionsHook` for translation/`setValue`/missing-feature handling, and `RadioOptionsController` for template cloning, item sync, ARIA disabled state, and value-change lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9064b03d0f87f0e753cddd7ad769424a0d222068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->