### PR TITLE
fix(skin): use pixels for default scale unit

### DIFF
--- a/.agents/skills/migrate-css-to-tailwind/references/migration.md
+++ b/.agents/skills/migrate-css-to-tailwind/references/migration.md
@@ -44,7 +44,7 @@ Tailwind v4 spacing utilities are based on the `--spacing` variable. Translate s
 - `margin-inline: calc(var(--spacing) * 3)` → `mx-3`
 - `gap: var(--spacing)` → `gap-1`
 
-Use built-in responsive or named container variants (`md:`, `@md:`, `@md/media-root:`) for media-query behavior. If a scoped design needs to scale all spacing, overriding `--spacing` at that scope is valid because native utilities inherit it. Ignore `--base-size` and `--size`; resolve font and icon sizes to rem values.
+Use built-in responsive or named container variants (`md:`, `@md:`, `@md/media-root:`) for media-query behavior. If a scoped design needs to scale all spacing, overriding `--spacing` at that scope is valid because native utilities inherit it. Ignore `--scale-unit` and `--size`; resolve font and icon sizes to rem values.
 
 For arbitrary values, Tailwind v4 also provides the build-time `--spacing(N)` function. Use it for literal spacing multipliers that do not map cleanly to a native utility:
 

--- a/packages/skins/src/default/css/components/popup.css
+++ b/packages/skins/src/default/css/components/popup.css
@@ -12,7 +12,7 @@
 
 .media-default-skin .media-popover,
 .media-default-skin .media-tooltip {
-  --popup-translate-distance: calc(0.5 * var(--base-size));
+  --popup-translate-distance: calc(0.5 * var(--scale-unit));
   margin: 0;
   overflow: visible;
   color: inherit;

--- a/packages/skins/src/default/css/components/root.css
+++ b/packages/skins/src/default/css/components/root.css
@@ -7,12 +7,11 @@
   --media-current-shadow-color: oklch(from currentColor 0 0 0 / clamp(0, calc((l - 0.5) * 0.5), 0.15));
   --media-current-shadow-color-subtle: oklch(from var(--media-current-shadow-color) l c h / calc(alpha * 0.4));
   --scrollbar-thumb-color: oklch(from currentColor l c h / 0.3);
-
-  /* Scaling (used in video fullscreen) */
+  /* Scaling - used in video fullscreen to scale the UI. */
   --scale: 1;
-  /* What value and unit to use - 1rem assumes the document font size remains at the default 16px */
-  --base-size: 1rem;
-  --size: calc(var(--base-size) * var(--scale));
+  /* Fixed scaling unit to avoid inheriting the document's root font size. This must be a CSS <length>. */
+  --scale-unit: var(--media-scale-unit, 16px);
+  --size: calc(var(--scale-unit) * var(--scale));
   /* Create a Tailwind-like spacing unit */
   --spacing: calc(var(--size) / 4);
   --font-size-medium: calc(0.9375 * var(--size)); /* 15px */

--- a/packages/skins/src/minimal/css/components/root.css
+++ b/packages/skins/src/minimal/css/components/root.css
@@ -7,11 +7,11 @@
   --media-current-shadow-color: oklch(from currentColor 0 0 0 / clamp(0, calc((l - 0.5) * 0.5), 0.15));
   --media-current-shadow-color-subtle: oklch(from var(--media-current-shadow-color) l c h / calc(alpha * 0.4));
   --scrollbar-thumb-color: oklch(from currentColor l c h / 0.3);
-  /* Scaling (used in video fullscreen) */
+  /* Scaling - used in video fullscreen to scale the UI. */
   --scale: 1;
-  /* What value and unit to use - 1rem assumes the document font size remains at the default 16px */
-  --base-size: 1rem;
-  --size: calc(var(--base-size) * var(--scale));
+  /* Fixed scaling unit to avoid inheriting the document's root font size. This must be a CSS <length>. */
+  --scale-unit: var(--media-scale-unit, 16px);
+  --size: calc(var(--scale-unit) * var(--scale));
   /* Create a Tailwind-like spacing unit. */
   --spacing: calc(var(--size) / 4);
   --font-size-medium: calc(0.9375 * var(--size)); /* 15px */


### PR DESCRIPTION
This change uses a fixed `16px` base unit for the skin’s sizing, preventing the player UI from inheriting unexpected scaling from the document’s root font size. All dimensions continue to derive from the existing scale system, including fullscreen scaling. Consumers who want the player to follow the document’s root font size can opt into `rem`-based sizing by setting `--media-scale-unit: 1rem`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the foundational sizing unit for both skins, which can visually resize all controls for sites with non-default root font sizes. Escape hatch via `--media-scale-unit` mitigates breakage.
> 
> **Overview**
> Switches the default and minimal skins from a rem-based `--base-size` to a fixed **`--scale-unit`** defaulting to `16px`, so player UI sizing no longer inherits the document root font size.
> 
> `--size`, spacing, and font/icon tokens still derive from the existing `--scale` system (including fullscreen). Consumers can opt back into rem-based sizing with `--media-scale-unit: 1rem`. Popup translate distance and the CSS→Tailwind migration notes are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c6ded91e5c37c522bf4e9c1091362e24b5d81ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->