### PR TITLE
feat(media): support the video renditions api in dash media

### DIFF
--- a/packages/media/src/core/media-tracks/mixin.ts
+++ b/packages/media/src/core/media-tracks/mixin.ts
@@ -1,3 +1,4 @@
+import { hasMethods } from '@videojs/utils/predicate';
 import type { AnyConstructor, MixinReturn } from '@videojs/utils/types';
 import type {
   MediaAudioRenditionCapability,
@@ -148,6 +149,15 @@ function getBaseMediaTracksFn(MediaElementClass: any, type: string): (() => any)
   return undefined;
 }
 
+// Native track lists are event targets wherever they are implemented (Safari).
+// Environments that stub them out as plain arrays (jsdom) publish no changes, so
+// there is nothing to mirror and the list stays local.
+function isNativeTrackList(
+  value: unknown
+): value is Iterable<any> & Record<'addEventListener' | 'removeEventListener', (...args: any[]) => void> {
+  return hasMethods(value, ['addEventListener', 'removeEventListener']);
+}
+
 function getVideoTracks(media: any) {
   let tracks = getPrivate(media).videoTracks as VideoTrackList | undefined;
   if (!tracks) {
@@ -155,10 +165,10 @@ function getVideoTracks(media: any) {
     getPrivate(media).videoTracks = tracks;
 
     const nativeEl = media.target;
+    const nativeTracks = nativeVideoTracksFn && nativeEl ? nativeVideoTracksFn.call(nativeEl) : undefined;
 
-    if (nativeVideoTracksFn && nativeEl) {
+    if (isNativeTrackList(nativeTracks)) {
       const currentTracks = tracks;
-      const nativeTracks = nativeVideoTracksFn.call(nativeEl);
 
       for (const nativeTrack of nativeTracks) {
         addVideoTrack(media, nativeTrack);
@@ -205,10 +215,10 @@ function getAudioTracks(media: any) {
     getPrivate(media).audioTracks = tracks;
 
     const nativeEl = media.target;
+    const nativeTracks = nativeAudioTracksFn && nativeEl ? nativeAudioTracksFn.call(nativeEl) : undefined;
 
-    if (nativeAudioTracksFn && nativeEl) {
+    if (isNativeTrackList(nativeTracks)) {
       const currentTracks = tracks;
-      const nativeTracks = nativeAudioTracksFn.call(nativeEl);
 
       for (const nativeTrack of nativeTracks) {
         addAudioTrack(media, nativeTrack);

--- a/packages/media/src/core/media-tracks/tests/mixin-native.test.ts
+++ b/packages/media/src/core/media-tracks/tests/mixin-native.test.ts
@@ -16,15 +16,22 @@ class FakeNativeTrackList extends EventTarget {
 }
 
 class FakeHTMLMediaElement {
-  #videoTracks = new FakeNativeTrackList();
-  #audioTracks = new FakeNativeTrackList();
+  #videoTracks: unknown;
+  #audioTracks: unknown;
+
+  // Native lists are event targets where they are implemented, and stubbed out
+  // as plain arrays where they are not (jsdom), so both are constructible here.
+  constructor(videoTracks: unknown = new FakeNativeTrackList(), audioTracks: unknown = new FakeNativeTrackList()) {
+    this.#videoTracks = videoTracks;
+    this.#audioTracks = audioTracks;
+  }
 
   get videoTracks() {
-    return this.#videoTracks;
+    return this.#videoTracks as FakeNativeTrackList;
   }
 
   get audioTracks() {
-    return this.#audioTracks;
+    return this.#audioTracks as FakeNativeTrackList;
   }
 }
 
@@ -44,6 +51,12 @@ class NativeMedia extends EventTarget {
 }
 
 const NativeMediaWithTracks = MediaTracksMixin(NativeMedia);
+
+class StubbedNativeMedia extends EventTarget {
+  target = new FakeHTMLMediaElement([{ kind: 'main' }], [{ kind: 'main' }]);
+}
+
+const StubbedNativeMediaWithTracks = MediaTracksMixin(StubbedNativeMedia);
 
 describe('MediaTracksMixin', () => {
   it('mirrors native tracks into the custom lists', () => {
@@ -80,6 +93,20 @@ describe('MediaTracksMixin', () => {
 
     expect(media.audioTracks.length).toBe(1);
     expect([...media.audioTracks]).toEqual([custom]);
+  });
+
+  it('keeps the lists local when native tracks publish no changes', () => {
+    const media = new StubbedNativeMediaWithTracks();
+
+    // Nothing to mirror and nothing to subscribe to, so only authored tracks show.
+    expect(media.videoTracks.length).toBe(0);
+    expect(media.audioTracks.length).toBe(0);
+
+    const videoTrack = media.addVideoTrack('main');
+    const audioTrack = media.addAudioTrack('main');
+
+    expect([...media.videoTracks]).toEqual([videoTrack]);
+    expect([...media.audioTracks]).toEqual([audioTrack]);
   });
 
   it('removes native track listeners when the target is detached', () => {

--- a/packages/media/src/dom/dash/media-tracks.ts
+++ b/packages/media/src/dom/dash/media-tracks.ts
@@ -127,8 +127,17 @@ export function DashMediaMediaTracksMixin<Base extends Constructor<MediaTracksHo
 
       // Applying `engine.dashJs` resets dash.js settings wholesale, which drops
       // the switching this mixin turned off; re-apply the selection it was for.
-      if (this.#isBitrateSwitchingOff) this.#switchRendition();
+      if (this.#isBitrateSwitchingOff && this.#isEngineBitrateSwitchingOn()) this.#switchRendition();
     };
+
+    // dash.js's own reading rather than what this mixin last asked for: settings
+    // are reset out from under it, and only the engine knows whether that
+    // happened. Announcing a source that changed nothing must leave the pinned
+    // representation alone, or an inline React `source` prop would interrupt
+    // playback on every render.
+    #isEngineBitrateSwitchingOn() {
+      return this.engine?.getSettings().streaming?.abr?.autoSwitchBitrate?.video !== false;
+    }
 
     #setActiveRendition(id: string | undefined) {
       for (const rendition of this.videoRenditions) {

--- a/packages/media/src/dom/dash/media-tracks.ts
+++ b/packages/media/src/dom/dash/media-tracks.ts
@@ -1,0 +1,179 @@
+import type { Constructor } from '@videojs/utils/types';
+import * as dashjs from 'dashjs';
+
+import type { MediaVideoRenditionCapability, MediaVideoTrackCapability } from '../../core/types';
+import type { HTMLVideoElementHost } from '../video-host';
+
+type DashEngineHost = HTMLVideoElementHost & {
+  readonly engine?: dashjs.MediaPlayerClass | null;
+};
+
+type MediaTracksHost = DashEngineHost & MediaVideoTrackCapability & MediaVideoRenditionCapability;
+
+/**
+ * Mirrors the dash.js video representations of the active stream into the
+ * media element's `videoRenditions` list, and wires user selection back to
+ * `engine.setRepresentationForTypeById()`.
+ *
+ * DASH representations belong to an adaptation set rather than to a flat list,
+ * so they are hung off a single `'main'` video track — the one the renditions of
+ * the stream that is playing are read from.
+ *
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied
+ * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
+ * and friends.
+ */
+export function DashMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
+  class DashMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
+    // The source is announced as a whole, so the URL it resolved to last is what
+    // tells a new stream apart from a settings-only change.
+    #src = '';
+    #isBitrateSwitchingOff = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const { engine } = this;
+      if (!engine) return;
+
+      engine.on(dashjs.MediaPlayer.events.STREAM_INITIALIZED, this.#onStreamInitialized);
+      engine.on(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, this.#onQualityChangeRendered);
+
+      this.addEventListener('sourcechange', this.#onSourceChange);
+      this.videoRenditions.addEventListener('change', this.#switchRendition);
+    }
+
+    destroy() {
+      const { engine } = this;
+
+      engine?.off(dashjs.MediaPlayer.events.STREAM_INITIALIZED, this.#onStreamInitialized);
+      engine?.off(dashjs.MediaPlayer.events.QUALITY_CHANGE_RENDERED, this.#onQualityChangeRendered);
+
+      this.removeEventListener('sourcechange', this.#onSourceChange);
+      this.videoRenditions.removeEventListener('change', this.#switchRendition);
+
+      this.#removeVideoTracks();
+
+      super.destroy();
+    }
+
+    // Every stream — a new source, and every period of a multi-period manifest —
+    // announces the representations that are playable from here on, so the list
+    // is rebuilt rather than added to.
+    #onStreamInitialized = (event: dashjs.StreamInitializedEvent) => {
+      const { engine } = this;
+      if (!engine || event.error) return;
+
+      this.#reset();
+
+      const videoTrack = this.addVideoTrack('main');
+      // Selecting the track is what puts its renditions in `videoRenditions`, so
+      // it happens before any is added and their `addrendition` events land.
+      videoTrack.selected = true;
+
+      for (const representation of engine.getRepresentationsByType('video')) {
+        const rendition = videoTrack.addRendition(
+          // DASH representations are segment templates rather than a single
+          // playable URL, so they are identified by their manifest id alone.
+          '',
+          representation.width || undefined,
+          representation.height || undefined,
+          representation.codecs ?? undefined,
+          toBitrate(representation),
+          representation.frameRate || undefined
+        );
+
+        rendition.id = representation.id;
+      }
+
+      // dash.js reports a switch only once it renders one, so the representation
+      // the stream starts on comes from the engine.
+      this.#setActiveRendition(engine.getCurrentRepresentationForType('video')?.id);
+    };
+
+    #onQualityChangeRendered = (event: dashjs.QualityChangeRenderedEvent) => {
+      if (event.mediaType !== 'video') return;
+      this.#setActiveRendition(event.newRepresentation?.id);
+    };
+
+    #switchRendition = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      // Multiple renditions can be selected, but dash.js plays exactly one
+      // representation at a time, so the first one wins.
+      const selected = [...this.videoRenditions].find((rendition) => rendition.selected);
+
+      if (!selected?.id) {
+        this.#restoreBitrateSwitching();
+        return;
+      }
+
+      this.#isBitrateSwitchingOff = true;
+      engine.updateSettings(autoSwitchBitrate(false));
+      engine.setRepresentationForTypeById('video', selected.id, true);
+    };
+
+    #onSourceChange = () => {
+      const srcChanged = this.src !== this.#src;
+      this.#src = this.src;
+
+      // A new stream announces renditions of its own, and the one that is going
+      // away leaves nothing to select from.
+      if (srcChanged) {
+        this.#reset();
+        return;
+      }
+
+      // Applying `engine.dashJs` resets dash.js settings wholesale, which drops
+      // the switching this mixin turned off; re-apply the selection it was for.
+      if (this.#isBitrateSwitchingOff) this.#switchRendition();
+    };
+
+    #setActiveRendition(id: string | undefined) {
+      for (const rendition of this.videoRenditions) {
+        rendition.active = id !== undefined && rendition.id === id;
+      }
+    }
+
+    #reset() {
+      this.#removeVideoTracks();
+      this.#restoreBitrateSwitching();
+    }
+
+    // Only ever undoes what a selection turned off, so dash.js settings that
+    // switch bitrates manually on purpose are left as configured.
+    #restoreBitrateSwitching() {
+      if (!this.#isBitrateSwitchingOff) return;
+      this.#isBitrateSwitchingOff = false;
+      this.engine?.updateSettings(autoSwitchBitrate(true));
+    }
+
+    #removeVideoTracks() {
+      for (const videoTrack of this.videoTracks) {
+        this.removeVideoTrack(videoTrack);
+      }
+    }
+  }
+
+  return DashMediaMediaTracks as unknown as Base;
+}
+
+/**
+ * dash.js plays a pinned representation only while its own bitrate switching is
+ * off, so selecting a rendition takes this setting alongside the representation.
+ */
+function autoSwitchBitrate(video: boolean): dashjs.MediaPlayerSettingClass {
+  return { streaming: { abr: { autoSwitchBitrate: { video } } } };
+}
+
+/**
+ * Representation bitrate in bits per second. `bandwidth` is what the manifest
+ * declares; the kbit reading is dash.js's own derived value, kept as a fallback
+ * for representations that carry one without the other.
+ */
+function toBitrate(representation: dashjs.Representation): number | undefined {
+  const { bandwidth, bitrateInKbit } = representation;
+  if (bandwidth) return bandwidth;
+  return bitrateInKbit ? bitrateInKbit * 1000 : undefined;
+}

--- a/packages/media/src/dom/dash/media.ts
+++ b/packages/media/src/dom/dash/media.ts
@@ -4,6 +4,7 @@ import * as dashjs from 'dashjs';
 import { MediaTracksMixin } from '../../core/media-tracks';
 import type { MediaEngineHost } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
+import { DashMediaMediaTracksMixin } from './media-tracks';
 
 /** Structured DASH source: which source to play, plus how to play it. */
 export interface DashSource {
@@ -32,13 +33,10 @@ export const dashMediaDefaultProps: DashMediaProps = {
   source: null,
 };
 
-const DashMediaBase = MediaTracksMixin(HTMLVideoElementHost);
+const DashMediaHost = MediaTracksMixin(HTMLVideoElementHost);
 
-/**
- * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
- */
-export class DashMedia
-  extends DashMediaBase
+class DashMediaBase
+  extends DashMediaHost
   implements MediaEngineHost<dashjs.MediaPlayerClass, HTMLVideoElement>, DashMediaProps
 {
   #engine: dashjs.MediaPlayerClass;
@@ -133,3 +131,8 @@ export class DashMedia
     if (settings) this.#engine.updateSettings(settings);
   }
 }
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ */
+export class DashMedia extends DashMediaMediaTracksMixin(DashMediaBase) {}

--- a/packages/media/src/dom/dash/tests/dash-media.test.ts
+++ b/packages/media/src/dom/dash/tests/dash-media.test.ts
@@ -6,17 +6,32 @@ vi.mock('dashjs', () => {
     QUALITY_CHANGE_RENDERED: 'qualityChangeRendered',
   };
 
+  /** dash.js merges every `updateSettings()` call into the current settings. */
+  function merge(target: Record<string, any>, source: Record<string, any>) {
+    for (const [key, value] of Object.entries(source)) {
+      const isPlainObject = typeof value === 'object' && value !== null && !Array.isArray(value);
+      target[key] = isPlainObject ? merge({ ...target[key] }, value) : value;
+    }
+    return target;
+  }
+
   function create() {
     const listeners = new Map<string, Set<(event: any) => void>>();
 
     const player = {
       representations: [] as any[],
       currentRepresentation: null as any,
+      settings: {} as Record<string, any>,
       initialize: vi.fn(),
       attachView: vi.fn(),
       attachSource: vi.fn(),
-      updateSettings: vi.fn(),
-      resetSettings: vi.fn(),
+      updateSettings: vi.fn((settings: Record<string, any>) => {
+        player.settings = merge(player.settings, settings);
+      }),
+      resetSettings: vi.fn(() => {
+        player.settings = {};
+      }),
+      getSettings: vi.fn(() => player.settings),
       destroy: vi.fn(),
       on: vi.fn((type: string, listener: (event: any) => void) => {
         const typeListeners = listeners.get(type) ?? new Set();
@@ -56,6 +71,7 @@ type MockEngine = {
   attachSource: ReturnType<typeof vi.fn>;
   updateSettings: ReturnType<typeof vi.fn>;
   resetSettings: ReturnType<typeof vi.fn>;
+  getSettings: ReturnType<typeof vi.fn>;
   setRepresentationForTypeById: ReturnType<typeof vi.fn>;
   emit(type: string, event?: Record<string, unknown>): void;
 };
@@ -359,6 +375,26 @@ describe('DashMedia', () => {
 
       expect(engine.updateSettings).toHaveBeenLastCalledWith(AUTO_SWITCH_OFF);
       expect(engine.setRepresentationForTypeById).toHaveBeenCalledWith('video', '1', true);
+    });
+
+    it('leaves the pinned representation alone when an equivalent source is re-assigned', async () => {
+      const { media, engine } = setup();
+      const source: DashSource = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
+      media.source = source;
+      initStream(engine, REPRESENTATIONS);
+
+      media.videoRenditions.selectedIndex = 1;
+      await flush();
+      engine.updateSettings.mockClear();
+      engine.setRepresentationForTypeById.mockClear();
+
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
+
+      // Settings were never reset, so the pin still holds — re-pinning would
+      // interrupt playback on every render of an inline React `source` prop.
+      expect(engine.updateSettings).not.toHaveBeenCalled();
+      expect(engine.setRepresentationForTypeById).not.toHaveBeenCalled();
+      expect(media.videoRenditions.selectedIndex).toBe(1);
     });
 
     it('drops renditions and restores switching when the source changes', async () => {

--- a/packages/media/src/dom/dash/tests/dash-media.test.ts
+++ b/packages/media/src/dom/dash/tests/dash-media.test.ts
@@ -1,17 +1,45 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('dashjs', () => {
+  const events = {
+    STREAM_INITIALIZED: 'streamInitialized',
+    QUALITY_CHANGE_RENDERED: 'qualityChangeRendered',
+  };
+
   function create() {
-    return {
+    const listeners = new Map<string, Set<(event: any) => void>>();
+
+    const player = {
+      representations: [] as any[],
+      currentRepresentation: null as any,
       initialize: vi.fn(),
       attachView: vi.fn(),
       attachSource: vi.fn(),
       updateSettings: vi.fn(),
       resetSettings: vi.fn(),
       destroy: vi.fn(),
+      on: vi.fn((type: string, listener: (event: any) => void) => {
+        const typeListeners = listeners.get(type) ?? new Set();
+        typeListeners.add(listener);
+        listeners.set(type, typeListeners);
+      }),
+      off: vi.fn((type: string, listener: (event: any) => void) => {
+        listeners.get(type)?.delete(listener);
+      }),
+      getRepresentationsByType: vi.fn((type: string) => (type === 'video' ? player.representations : [])),
+      getCurrentRepresentationForType: vi.fn(() => player.currentRepresentation),
+      setRepresentationForTypeById: vi.fn(),
+      /** Test-only: dispatch a dash.js player event to its listeners. */
+      emit(type: string, event: Record<string, unknown> = {}) {
+        for (const listener of [...(listeners.get(type) ?? [])]) listener({ type, ...event });
+      },
     };
+
+    return player;
   }
-  return { MediaPlayer: () => ({ create }), default: { MediaPlayer: () => ({ create }) } };
+
+  const MediaPlayer = Object.assign(() => ({ create }), { events });
+  return { MediaPlayer, default: { MediaPlayer } };
 });
 
 import type { DashSource } from '../index';
@@ -21,6 +49,27 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
+type MockEngine = {
+  representations: MockRepresentation[];
+  currentRepresentation: MockRepresentation | null;
+  attachView: ReturnType<typeof vi.fn>;
+  attachSource: ReturnType<typeof vi.fn>;
+  updateSettings: ReturnType<typeof vi.fn>;
+  resetSettings: ReturnType<typeof vi.fn>;
+  setRepresentationForTypeById: ReturnType<typeof vi.fn>;
+  emit(type: string, event?: Record<string, unknown>): void;
+};
+
+type MockRepresentation = {
+  id: string;
+  width?: number;
+  height?: number;
+  bandwidth?: number;
+  bitrateInKbit?: number;
+  codecs?: string | null;
+  frameRate?: number;
+};
+
 function setup() {
   const video = document.createElement('video');
   document.body.appendChild(video);
@@ -28,19 +77,29 @@ function setup() {
   const media = new DashMedia();
   media.attach(video);
 
-  return { media, video, engine: spies(media) };
+  return { media, video, engine: media.engine as unknown as MockEngine };
 }
 
-function spies(media: DashMedia) {
-  const engine = media.engine as unknown as Record<string, ReturnType<typeof vi.fn>>;
-  return {
-    attachSource: engine.attachSource!,
-    updateSettings: engine.updateSettings!,
-    resetSettings: engine.resetSettings!,
-  };
+/** dash.js announces a stream with the video representations it can play. */
+function initStream(engine: MockEngine, representations: MockRepresentation[]) {
+  engine.representations = representations;
+  engine.emit('streamInitialized', { error: null });
+}
+
+/** Rendition list events are queued, so selection reaches dash.js a microtask later. */
+async function flush() {
+  await Promise.resolve();
 }
 
 const MANIFEST = 'https://example.com/manifest.mpd';
+const OTHER_MANIFEST = 'https://example.com/other.mpd';
+const AUTO_SWITCH_OFF = { streaming: { abr: { autoSwitchBitrate: { video: false } } } };
+const AUTO_SWITCH_ON = { streaming: { abr: { autoSwitchBitrate: { video: true } } } };
+
+const REPRESENTATIONS: MockRepresentation[] = [
+  { id: '0', width: 1920, height: 1080, bandwidth: 6_000_000, codecs: 'avc1.640028', frameRate: 30 },
+  { id: '1', width: 1280, height: 720, bitrateInKbit: 3000, codecs: 'avc1.64001f', frameRate: 30 },
+];
 
 describe('DashMedia', () => {
   describe('destroy', () => {
@@ -61,13 +120,12 @@ describe('DashMedia', () => {
     });
 
     it('detaches the dash view from the target on destroy', () => {
-      const { media } = setup();
-      const attachView = media.engine!.attachView as ReturnType<typeof vi.fn>;
-      attachView.mockClear();
+      const { media, engine } = setup();
+      engine.attachView.mockClear();
 
       media.destroy();
 
-      expect(attachView).toHaveBeenCalledWith(null);
+      expect(engine.attachView).toHaveBeenCalledWith(null);
     });
   });
 
@@ -203,6 +261,157 @@ describe('DashMedia', () => {
       // Every assignment is announced, but the same URL is not re-attached.
       expect(sourcechange).toHaveBeenCalledTimes(2);
       expect(engine.attachSource).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('videoRenditions', () => {
+    it('mirrors the video representations of the initialized stream', () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+
+      initStream(engine, REPRESENTATIONS);
+
+      // Renditions hang off a single selected `main` track.
+      expect(media.videoTracks.length).toBe(1);
+      expect(media.videoTracks[0]!.selected).toBe(true);
+
+      expect([...media.videoRenditions]).toMatchObject([
+        { id: '0', width: 1920, height: 1080, bitrate: 6_000_000, codec: 'avc1.640028', frameRate: 30 },
+        // Only a kbit reading: converted to bits per second like `bandwidth`.
+        { id: '1', width: 1280, height: 720, bitrate: 3_000_000, codec: 'avc1.64001f', frameRate: 30 },
+      ]);
+    });
+
+    it('rebuilds the list for every stream it is told about', () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+
+      initStream(engine, [{ id: '2', width: 640, height: 360, bandwidth: 800_000 }]);
+
+      expect(media.videoTracks.length).toBe(1);
+      expect([...media.videoRenditions].map((rendition) => rendition.id)).toEqual(['2']);
+    });
+
+    it('ignores a stream that failed to initialize', () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+
+      engine.representations = REPRESENTATIONS;
+      engine.emit('streamInitialized', { error: new Error('nope') });
+
+      expect(media.videoRenditions.length).toBe(0);
+    });
+
+    it('pins the selected representation and turns dash.js bitrate switching off', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+      engine.updateSettings.mockClear();
+
+      media.videoRenditions.selectedIndex = 1;
+      await flush();
+
+      expect(engine.updateSettings).toHaveBeenCalledWith(AUTO_SWITCH_OFF);
+      expect(engine.setRepresentationForTypeById).toHaveBeenCalledWith('video', '1', true);
+    });
+
+    it('hands switching back to dash.js when the selection is cleared', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+
+      media.videoRenditions.selectedIndex = 1;
+      await flush();
+      engine.updateSettings.mockClear();
+
+      media.videoRenditions.selectedIndex = -1;
+      await flush();
+
+      expect(engine.updateSettings).toHaveBeenCalledExactlyOnceWith(AUTO_SWITCH_ON);
+    });
+
+    it('leaves dash.js settings alone when nothing was ever pinned', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+      engine.updateSettings.mockClear();
+
+      media.videoRenditions.selectedIndex = -1;
+      await flush();
+
+      // Switching was never turned off, so configured settings are not overruled.
+      expect(engine.updateSettings).not.toHaveBeenCalled();
+    });
+
+    it('re-pins the selected representation when dash.js settings are re-applied', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+
+      media.videoRenditions.selectedIndex = 1;
+      await flush();
+      engine.setRepresentationForTypeById.mockClear();
+
+      // Applying new settings resets them wholesale, which would otherwise leave
+      // dash.js switching bitrates again behind the user's back.
+      media.source = { src: MANIFEST, engine: { dashJs: { streaming: { abandonLoadTimeout: 1000 } } } };
+
+      expect(engine.updateSettings).toHaveBeenLastCalledWith(AUTO_SWITCH_OFF);
+      expect(engine.setRepresentationForTypeById).toHaveBeenCalledWith('video', '1', true);
+    });
+
+    it('drops renditions and restores switching when the source changes', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+
+      media.videoRenditions.selectedIndex = 1;
+      await flush();
+      engine.updateSettings.mockClear();
+
+      media.src = OTHER_MANIFEST;
+
+      expect(media.videoRenditions.length).toBe(0);
+      expect(engine.updateSettings).toHaveBeenCalledExactlyOnceWith(AUTO_SWITCH_ON);
+    });
+
+    it('marks the representation dash.js renders active', () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      engine.currentRepresentation = REPRESENTATIONS[0]!;
+      initStream(engine, REPRESENTATIONS);
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([true, false]);
+
+      engine.emit('qualityChangeRendered', { mediaType: 'video', newRepresentation: { id: '1' } });
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+    });
+
+    it('ignores rendered switches for other media types', () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      engine.currentRepresentation = REPRESENTATIONS[0]!;
+      initStream(engine, REPRESENTATIONS);
+
+      engine.emit('qualityChangeRendered', { mediaType: 'audio', newRepresentation: { id: '1' } });
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([true, false]);
+    });
+
+    it('stops mirroring representations once destroyed', () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      initStream(engine, REPRESENTATIONS);
+
+      media.destroy();
+
+      expect(media.videoRenditions.length).toBe(0);
+
+      initStream(engine, REPRESENTATIONS);
+
+      expect(media.videoRenditions.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Refs #1262

## Summary

DASH media now populates the standard video renditions API, so quality menus work with `<dash-video>` / `<DashVideo>` the same way they already do with hls.js. Previously `videoRenditions` was always empty for DASH, which left the quality menu unavailable.

## Changes

- DASH video representations of the active stream are mirrored into `videoRenditions` (id, width, height, codec, bitrate, frame rate), hung off a single selected `main` video track.
- Selecting a rendition pins that representation in dash.js and turns dash.js bitrate switching off; clearing the selection hands switching back. Bitrate switching that was configured deliberately is never overruled.
- The rendition dash.js actually renders is reported as `active`, which is what the quality menu shows while playback is automatic.
- The list is rebuilt per stream, dropped when the source changes, and a pinned rendition survives a `source.engine.dashJs` update (applying settings resets them wholesale in dash.js).
- Fix: native `videoTracks` / `audioTracks` were assumed to be event targets. Environments that stub them out as plain arrays (jsdom) threw on the first track-list access of an attached media host — silently, inside a dispatched event. This affected hls.js media too.

<details>
<summary>Implementation details</summary>

`DashMediaMediaTracksMixin` is the dash.js counterpart to `hls-js/media-tracks.ts`: it reads `getRepresentationsByType('video')` on `streamInitialized`, writes selection back through `setRepresentationForTypeById('video', id, true)`, and tracks the rendered representation via `qualityChangeRendered`.

dash.js honors a pinned representation only while `streaming.abr.autoSwitchBitrate.video` is `false`, so selection owns that setting — but only undoes what it turned on itself. The `source` setter resets dash.js settings wholesale when `engine.dashJs` changes, so the mixin re-applies a live pin on `sourcechange` when the URL did not change.

`DashMedia` is now composed (`class DashMedia extends DashMediaMediaTracksMixin(DashMediaBase) {}`), matching how `HlsJsOnlyMedia` layers its behaviors. `MediaTracksMixin` is still applied to `HTMLVideoElementHost` exactly as before, so track-list detach cleanup and the generated API reference are unchanged (`pnpm -F site api-docs:generate` produces a byte-identical `dash-video.json`).

Based on the approach in [muxinc/media-elements' `dash-video-element`](https://github.com/muxinc/media-elements/blob/b5221eee9c52dfa7ddcbc8260f8b079e87d1e12c/packages/dash-video-element/dash-video-element.js). Thumbnail/storyboard extraction from DASH `image` representations is not part of this change.

</details>

## Testing

1. `pnpm -F @videojs/media test` — 11 new `DashMedia > videoRenditions` cases plus a `MediaTracksMixin` case for stubbed native lists.
2. `pnpm -F @videojs/core test`, `pnpm -F @videojs/html test`, `pnpm -F @videojs/react test`, `pnpm typecheck`, `pnpm check:workspace`.
3. Manual: `pnpm dev`, open the HTML or React `dash-video` sandbox template, and use the quality menu — renditions should list, a picked quality should stick, and `auto` should return to adaptive switching. Not yet verified in a real browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New dash.js ABR/representation wiring and source-change edge cases affect playback quality selection; the native track-list guard touches shared `MediaTracksMixin` used by multiple media hosts.
> 
> **Overview**
> **DASH playback now exposes `videoRenditions`** so quality menus work on `<dash-video>` / `<DashVideo>` like they already do for HLS. On `streamInitialized`, dash.js video representations are mirrored onto a single selected `main` track; user picks call `setRepresentationForTypeById`, disable ABR only while a quality is pinned, and `qualityChangeRendered` drives the `active` rendition.
> 
> **`DashMedia` is composed** with a new `DashMediaMediaTracksMixin` layered on `DashMediaBase`, matching the HLS mixin pattern. Source handling is careful about React-style re-assignments: equivalent `source` objects do not re-pin or interrupt playback; a new `src` clears renditions and restores ABR; re-applied `engine.dashJs` settings re-pin an existing selection when dash.js resets settings.
> 
> **`MediaTracksMixin` no longer assumes native `videoTracks` / `audioTracks` are event targets.** Mirroring and listeners run only when `isNativeTrackList` passes (e.g. Safari); jsdom-style plain arrays stay local-only, fixing silent failures on first track access for DASH and HLS hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e3d8b107f8f9abd8a2a9bba79a1ca391105de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->