### PR TITLE
feat(media): add maxAutoResolution cap to hls.js sources

### DIFF
--- a/apps/sandbox/app/shared/sandbox-listener.ts
+++ b/apps/sandbox/app/shared/sandbox-listener.ts
@@ -1,11 +1,18 @@
 import { SKINS } from '@app/constants';
 import { DEFAULT_SANDBOX_LOCALE, SANDBOX_LOCALE_TAGS, type SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
 import type { Skin } from '@app/types';
+import type { MediaResolution } from '@videojs/media';
 import { DEFAULT_AUDIO_SOURCE, SOURCES, type SourceId } from './sources';
 
 export const PRELOAD_VALUES = ['none', 'metadata', 'auto'] as const;
 export type PreloadValue = (typeof PRELOAD_VALUES)[number];
 export const DEFAULT_PRELOAD: PreloadValue = 'metadata';
+
+// Any `{height}p`, not just the rungs `MediaResolution` names.
+const MAX_AUTO_RESOLUTION_PATTERN = /^\d+p$/;
+
+export const PREFER_PLAYBACK_VALUES = ['mse', 'native'] as const;
+export type PreferPlaybackValue = (typeof PREFER_PLAYBACK_VALUES)[number];
 
 const params = new URLSearchParams(window.location.search);
 
@@ -30,6 +37,18 @@ function readPreload(): PreloadValue {
   return PRELOAD_VALUES.includes(value as PreloadValue) ? (value as PreloadValue) : DEFAULT_PRELOAD;
 }
 
+function readMaxAutoResolution(): MediaResolution | undefined {
+  const value = params.get('maxAutoResolution');
+  if (!value || !MAX_AUTO_RESOLUTION_PATTERN.test(value) || Number.parseInt(value, 10) <= 0) return undefined;
+
+  return value as MediaResolution;
+}
+
+function readPreferPlayback(): PreferPlaybackValue | undefined {
+  const value = params.get('preferPlayback');
+  return PREFER_PLAYBACK_VALUES.includes(value as PreferPlaybackValue) ? (value as PreferPlaybackValue) : undefined;
+}
+
 let currentSkin = readSkin();
 let currentSource = readSource();
 let currentAutoplay = readBoolean('autoplay');
@@ -37,10 +56,31 @@ let currentMuted = readBoolean('muted');
 let currentLoop = readBoolean('loop');
 let currentPreload = readPreload();
 let currentLocale = readLocale();
+const initialMaxAutoResolution = readMaxAutoResolution();
+const initialPreferPlayback = readPreferPlayback();
 
 function readLocale(): SandboxLocaleTag {
   const value = params.get('locale');
   return SANDBOX_LOCALE_TAGS.includes(value as SandboxLocaleTag) ? (value as SandboxLocaleTag) : DEFAULT_SANDBOX_LOCALE;
+}
+
+/**
+ * Playback options read once from the query string and folded into the *initial*
+ * `source`, so the engine is built with them instead of having them switched in
+ * afterwards. Both keys are absent unless named, leaving the default sandbox
+ * behavior untouched.
+ *
+ * - `?maxAutoResolution=720p` caps automatic rendition selection.
+ * - `?preferPlayback=native` forces the browser's own HLS.
+ */
+export function getInitialPlaybackOverrides(): {
+  maxAutoResolution?: MediaResolution;
+  preferPlayback?: PreferPlaybackValue;
+} {
+  return {
+    ...(initialMaxAutoResolution && { maxAutoResolution: initialMaxAutoResolution }),
+    ...(initialPreferPlayback && { preferPlayback: initialPreferPlayback }),
+  };
 }
 
 export function getInitialSkin(): Skin {

--- a/apps/sandbox/templates/html-hlsjs-video/main.ts
+++ b/apps/sandbox/templates/html-hlsjs-video/main.ts
@@ -7,6 +7,7 @@ import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@a
 import { loadVideoSkinTag } from '@app/shared/html/skins';
 import { renderStoryboard } from '@app/shared/html/storyboard';
 import {
+  getInitialPlaybackOverrides,
   onAutoplayChange,
   onLoopChange,
   onMutedChange,
@@ -34,9 +35,13 @@ async function render() {
   const playerTag = live ? 'live-video-player' : 'video-player';
 
   // A source carrying DRM license servers has no room in the `src` attribute, so
-  // it is assigned as an object below instead.
+  // it is assigned as an object below instead. Query-string playback overrides
+  // need the object for the same reason, and need it before the first load so the
+  // engine is built with them rather than reconfigured afterwards.
+  const overrides = getInitialPlaybackOverrides();
   const { source, url } = SOURCES[state.source];
-  const srcAttr = source ? '' : ` src="${url}"`;
+  const initialSource = source ?? (Object.keys(overrides).length > 0 ? { src: url } : undefined);
+  const srcAttr = initialSource ? '' : ` src="${url}"`;
 
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <${playerTag}>
@@ -50,8 +55,8 @@ async function render() {
     </${playerTag}>
   `);
 
-  if (source) {
-    document.querySelector('hlsjs-video')!.source = source;
+  if (initialSource) {
+    document.querySelector('hlsjs-video')!.source = { ...initialSource, ...overrides };
   }
 }
 

--- a/apps/sandbox/templates/html-mux-video/main.ts
+++ b/apps/sandbox/templates/html-mux-video/main.ts
@@ -8,6 +8,7 @@ import '@videojs/html/media/mux-video';
 import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
 import { loadVideoSkinTag } from '@app/shared/html/skins';
 import {
+  getInitialPlaybackOverrides,
   onAutoplayChange,
   onLoopChange,
   onMutedChange,
@@ -35,9 +36,13 @@ async function render() {
   const playerTag = live ? 'live-video-player' : 'video-player';
 
   // A source carrying signed tokens has no room in the `src` attribute, so it is
-  // assigned as an object below instead.
+  // assigned as an object below instead. Query-string playback overrides need the
+  // object for the same reason, and need it before the first load so the engine is
+  // built with them rather than reconfigured afterwards.
+  const overrides = getInitialPlaybackOverrides();
   const { source, url } = SOURCES[state.source];
-  const srcAttr = source ? '' : ` src="${url}"`;
+  const initialSource = source ?? (Object.keys(overrides).length > 0 ? { src: url } : undefined);
+  const srcAttr = initialSource ? '' : ` src="${url}"`;
 
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <${playerTag}>
@@ -56,8 +61,8 @@ async function render() {
 
   // A Mux `source.drm.token` becomes the FairPlay / Widevine / PlayReady license
   // servers; the playback, poster, and storyboard tokens sign the rest.
-  if (source) {
-    document.querySelector('mux-video')!.source = source;
+  if (initialSource) {
+    document.querySelector('mux-video')!.source = { ...initialSource, ...overrides };
   }
 }
 

--- a/packages/html/src/media/tests/mux-video.test.ts
+++ b/packages/html/src/media/tests/mux-video.test.ts
@@ -23,6 +23,25 @@ describe('MuxVideo', () => {
     expect(el.hasAttribute('source')).toBe(false);
   });
 
+  it('carries maxAutoResolution through the source property', () => {
+    const el = createMuxVideo();
+
+    el.source = { playbackId: 'abc123', preferPlayback: 'native', maxAutoResolution: '720p' };
+
+    expect(el.source?.maxAutoResolution).toBe('720p');
+    // Normalized source options ride the property; no attribute is reflected.
+    expect(el.hasAttribute('maxautoresolution')).toBe(false);
+  });
+
+  it('keeps maxAutoResolution when the src attribute changes', () => {
+    const el = createMuxVideo();
+
+    el.source = { playbackId: 'abc123', preferPlayback: 'native', maxAutoResolution: '720p' };
+    el.setAttribute('src', 'https://stream.mux.com/other.m3u8');
+
+    expect(el.source?.maxAutoResolution).toBe('720p');
+  });
+
   it('keeps engine options when the src attribute changes', () => {
     const el = createMuxVideo();
 

--- a/packages/media/src/core/types.ts
+++ b/packages/media/src/core/types.ts
@@ -28,6 +28,15 @@ export function TypedEventTarget<Events extends { [K in keyof Events]: EventLike
 
 export type MediaFeatureAvailability = 'available' | 'unavailable' | 'unsupported';
 
+/**
+ * Rendition height, as the `{height}p` shorthand streaming providers use.
+ *
+ * Options that accept one match renditions by pixel area rather than by
+ * literal height, so anamorphic variants land in the bucket their source
+ * material belongs to.
+ */
+export type MediaResolution = '270p' | '360p' | '480p' | '540p' | '720p' | '1080p' | '1440p' | '2160p';
+
 // ----------------------------------------
 // Controls
 // ----------------------------------------

--- a/packages/media/src/dom/hls-js/cap-level.ts
+++ b/packages/media/src/dom/hls-js/cap-level.ts
@@ -1,0 +1,184 @@
+import Hls, { type Level } from 'hls.js';
+import type { MediaResolution } from '../../core/types';
+
+/**
+ * Live cap inputs the installed cap-level controller reads on every evaluation.
+ *
+ * hls.js fixes `capLevelController` when the engine is constructed, so the class
+ * cannot carry values that change during playback. The media element owns this
+ * object and mutates it in place instead, which is what lets a cap change skip
+ * rebuilding the engine.
+ */
+export interface RenditionCapPolicy {
+  /** Highest resolution ABR may auto-select, or `undefined` for no cap. */
+  maxAutoResolution: MediaResolution | undefined;
+  /** Registered by the controller's own constructor. */
+  controller?: RenditionCapController | undefined;
+}
+
+export interface RenditionCapController {
+  /** Re-evaluate the policy now rather than on hls.js's next tick. */
+  apply(): void;
+}
+
+/**
+ * Pixel area of a resolution shorthand, assuming 16:9 — `'720p'` is
+ * `1280 × 720`, or `921_600`.
+ *
+ * Renditions are matched on area rather than literal height so anamorphic
+ * variants are judged by how many pixels they actually carry: a 2560×1080
+ * ultrawide rendition costs more than 16:9 1080p and is capped accordingly.
+ *
+ * Mirrors `maxResolutionToPixelArea` in `@videojs/spf`, and agrees with it on
+ * every rung whose 16:9 width is a whole number. It parts company at `'480p'`
+ * on purpose: 16:9 at 480 tall is 853.33 wide, ladders ship the rounded-up
+ * 854×480, and the exact area would put the standard 480p rendition over its
+ * own cap. Rounding the width up admits it while still excluding anything
+ * genuinely wider.
+ */
+export function resolutionToPixelArea(resolution: MediaResolution | undefined): number {
+  if (resolution === undefined) return Number.POSITIVE_INFINITY;
+
+  const height = Number.parseInt(resolution, 10);
+  if (!(Number.isFinite(height) && height > 0)) return Number.POSITIVE_INFINITY;
+
+  return Math.ceil((height * 16) / 9) * height;
+}
+
+/**
+ * Highest level index that keeps automatic selection at or below `resolution`.
+ *
+ * `autoLevelCapping` is a ceiling on the *index*, so every level at or below it
+ * stays eligible. That makes the answer the end of the leading run that fits the
+ * budget, not the single best match: hls.js orders levels by height, so a wider
+ * rendition can exceed the pixel budget from a lower index, and capping at the
+ * best match would leave it selectable.
+ *
+ * Falls back to index `0` when even the lowest rung is over budget — playing
+ * something over-spec beats refusing to adapt.
+ *
+ * Returns `undefined` when there is nothing to cap: no resolution requested, or
+ * no levels to choose from.
+ */
+export function levelIndexAtOrBelow(
+  levels: readonly Level[],
+  resolution: MediaResolution | undefined
+): number | undefined {
+  const maxPixelArea = resolutionToPixelArea(resolution);
+  if (maxPixelArea === Number.POSITIVE_INFINITY || levels.length === 0) return undefined;
+
+  const overBudget = levels.findIndex((level) => (level.width ?? 0) * (level.height ?? 0) > maxPixelArea);
+
+  // Everything fits: the whole ladder is eligible. Otherwise stop one short of
+  // the first level that does not, and never below index 0.
+  return overBudget === -1 ? levels.length - 1 : Math.max(0, overBudget - 1);
+}
+
+type CapLevelControllerClass = typeof Hls.DefaultConfig.capLevelController;
+
+/**
+ * Build the `capLevelController` class to hand to the hls.js constructor.
+ *
+ * `hls.autoLevelCapping` has exactly one writer: hls.js's own
+ * `CapLevelController`, which rewrites it on a one-second interval for as long
+ * as `capLevelToPlayerSize` is on — and it is on by default here. Assigning the
+ * property from outside is undone within a second, so a cap has to be applied
+ * from inside the controller rather than in competition with it.
+ *
+ * The only seam hls.js offers is `getMaxLevel()`, which every value the capping
+ * loop writes passes through. Overriding it makes the requested ceiling part of
+ * the same single-writer computation.
+ *
+ * @param policy - Live cap inputs, re-read on every evaluation.
+ * @param BaseController - Controller to layer on top of, so a controller passed
+ *   through `source.engine.capLevelController` keeps its behavior.
+ */
+export function createCapLevelController(
+  policy: RenditionCapPolicy,
+  BaseController: CapLevelControllerClass = Hls.DefaultConfig.capLevelController
+): CapLevelControllerClass {
+  return class RenditionCapLevelController extends BaseController {
+    #hls: Hls;
+    #capping = false;
+
+    constructor(hls: Hls) {
+      super(hls);
+      this.#hls = hls;
+      policy.controller = this;
+
+      // hls.js re-evaluates on both of these itself, but only while its capping
+      // loop runs. These cover the case where it never starts.
+      hls.on(Hls.Events.MANIFEST_PARSED, this.#onLevelsChanged);
+      hls.on(Hls.Events.LEVELS_UPDATED, this.#onLevelsChanged);
+    }
+
+    destroy() {
+      this.#hls.off(Hls.Events.MANIFEST_PARSED, this.#onLevelsChanged);
+      this.#hls.off(Hls.Events.LEVELS_UPDATED, this.#onLevelsChanged);
+      if (policy.controller === this) policy.controller = undefined;
+      super.destroy();
+    }
+
+    // hls.js keeps the interval handle private, so the loop is tracked through
+    // the public start/stop pair instead of reaching into it.
+    startCapping() {
+      this.#capping = true;
+      super.startCapping();
+    }
+
+    stopCapping() {
+      this.#capping = false;
+      super.stopCapping();
+    }
+
+    /**
+     * Intersect hls.js's player-size ceiling with the requested one. Deferring
+     * to `super` first keeps the behavior it owns — notably the level
+     * restrictions `capLevelOnFPSDrop` accumulates.
+     *
+     * The translation from resolution to level index happens here, not when the
+     * policy is set, because levels arrive after the option does and shift
+     * whenever hls.js drops one.
+     */
+    getMaxLevel(capLevelIndex: number): number {
+      const bySize = super.getMaxLevel(capLevelIndex);
+      const byResolution = levelIndexAtOrBelow(this.#hls.levels, policy.maxAutoResolution);
+
+      return byResolution === undefined ? bySize : Math.min(bySize, byResolution);
+    }
+
+    /**
+     * hls.js measures the element here and writes the ceiling it derives. It
+     * backs out entirely when the element has no measurable size — sensible for
+     * a cap that *is* the element's size, but a requested resolution ceiling
+     * does not depend on layout. A player that is hidden, detached, or not laid
+     * out yet still has to honor it.
+     */
+    detectPlayerSize() {
+      super.detectPlayerSize();
+      if (this.mediaWidth > 0 && this.mediaHeight > 0) return;
+      this.#applyResolutionCap();
+    }
+
+    apply() {
+      // While the loop runs it owns the slot, so go through its own path;
+      // everything it writes already passes through `getMaxLevel()`.
+      if (this.#capping) {
+        this.detectPlayerSize();
+        return;
+      }
+      this.#applyResolutionCap();
+    }
+
+    /** The ceiling on its own, for when the size measurement is unavailable. */
+    #applyResolutionCap() {
+      const { levels } = this.#hls;
+      if (!levels?.length) return;
+
+      // `-1` is how hls.js spells "uncapped".
+      this.#hls.autoLevelCapping = levelIndexAtOrBelow(levels, policy.maxAutoResolution) ?? -1;
+    }
+
+    #onLevelsChanged = () => this.apply();
+  };
+}

--- a/packages/media/src/dom/hls-js/hls-js-only.ts
+++ b/packages/media/src/dom/hls-js/hls-js-only.ts
@@ -5,11 +5,13 @@ import { MediaTracksMixin, type WithMediaTracks } from '../../core/media-tracks'
 import type {
   MediaEngineHost,
   MediaLiveCapability,
+  MediaResolution,
   MediaSourceCapability,
   MediaStreamTypeCapability,
 } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsMediaAirPlayMixin } from './airplay-bridge';
+import { createCapLevelController, type RenditionCapPolicy } from './cap-level';
 import { setupDrm } from './drm';
 import { HlsJsMediaErrorsMixin } from './errors';
 import { HlsJsMediaLiveMixin } from './live';
@@ -35,12 +37,16 @@ export interface HlsJsOnlyMediaParams {
 
 class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost<Hls, HTMLVideoElement> {
   #engine: Hls | null = null;
+  #capPolicy: RenditionCapPolicy = { maxAutoResolution: undefined };
 
   constructor(params: HlsJsOnlyMediaParams) {
     super();
+    const config = { ...defaultHlsConfig, ...params.config };
     this.#engine = new Hls({
-      ...defaultHlsConfig,
-      ...params.config,
+      ...config,
+      // Layered over whatever controller the config already names, so a
+      // `capLevelController` passed through `source.engine` keeps working.
+      capLevelController: createCapLevelController(this.#capPolicy, config.capLevelController),
     });
 
     setupDrm(this.#engine);
@@ -48,6 +54,17 @@ class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost
 
   get engine() {
     return this.#engine;
+  }
+
+  /** Ceiling on automatic rendition selection. See `HlsSource.maxAutoResolution`. */
+  get maxAutoResolution(): MediaResolution | undefined {
+    return this.#capPolicy.maxAutoResolution;
+  }
+
+  set maxAutoResolution(value: MediaResolution | undefined) {
+    if (this.#capPolicy.maxAutoResolution === value) return;
+    this.#capPolicy.maxAutoResolution = value;
+    this.#capPolicy.controller?.apply();
   }
 
   get src() {

--- a/packages/media/src/dom/hls-js/media.ts
+++ b/packages/media/src/dom/hls-js/media.ts
@@ -3,12 +3,14 @@ import Hls, { type HlsConfig as HlsJsConfig } from 'hls.js';
 import { bridgeEvents } from '../../core/bridge-events';
 import { type DrmSystemsConfig, KeySystems } from '../../core/drm';
 
-import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
+import { type MediaResolution, type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { type NativeHlsConfig, NativeHlsMedia, type NativeHlsSource } from '../native-hls';
 import { HTMLVideoElementHost } from '../video-host';
 import { HlsJsOnlyMedia } from './hls-js-only';
 
 export type PreloadType = '' | 'none' | 'metadata' | 'auto';
+
+export type { MediaResolution };
 
 export { Hls };
 
@@ -64,6 +66,22 @@ export interface HlsSource {
    * license server for — which one is used is the browser's choice.
    */
   drm?: DrmSystemsConfig | undefined;
+  /**
+   * Highest resolution adaptive bitrate selection may choose on its own.
+   *
+   * A ceiling on automatic selection, not a filter on what is available:
+   * renditions above it stay in `videoRenditions` and can still be selected by
+   * hand. Matching is by pixel area, so a `'720p'` cap admits any rendition at
+   * or below 1280×720 worth of pixels. When every rendition sits above the cap,
+   * the smallest one is used.
+   *
+   * Applied live — changing it never rebuilds the playback engine. Requires the
+   * hls.js (MSE) engine; native HLS playback ignores it.
+   *
+   * For Mux sources this is distinct from `playback.maxResolution`, which asks
+   * Mux to leave higher renditions out of the manifest altogether.
+   */
+  maxAutoResolution?: MediaResolution | undefined;
   /**
    * Playback options, keyed by the engine that reads them. Only one of the two
    * engines below ends up playing, and each reads only its own key.
@@ -183,12 +201,13 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
   set src(src: string) {
     // `src` says which source to play; every other field says how to play it, so
     // they carry over.
-    const { type, preferPlayback, drm, engine } = this.#source ?? {};
+    const { type, preferPlayback, drm, engine, maxAutoResolution } = this.#source ?? {};
     const next: HlsSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
       ...(drm && { drm }),
       ...(engine && { engine }),
+      ...(maxAutoResolution && { maxAutoResolution }),
       ...(src && { src }),
     };
 
@@ -220,6 +239,10 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
     this.#source = source;
     this.#src = src;
+
+    // Deliberately outside the engine config key below, so it reaches the engine
+    // already running.
+    this.#applyRenditionCaps();
 
     // Assigning is always a source change, so it is always announced.
     this.dispatchEvent(new Event('sourcechange'));
@@ -295,10 +318,16 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       // Read the stored source, not the `source` getter: subclasses override the
       // getter to return what was assigned to them, while the fields below come
       // from what they resolved and handed down (Mux fills in the DRM options).
-      const { type, preferPlayback, drm, engine } = this.#source ?? {};
+      const { type, preferPlayback, drm, engine, maxAutoResolution } = this.#source ?? {};
       const { hlsJs, nativeHls } = engine ?? {};
       const contentType = type ?? inferContentType(this.src);
       const useMse = Hls.isSupported() && contentType === ContentTypes.M3U8 && preferPlayback !== PlaybackTypes.NATIVE;
+
+      if (__DEV__ && !useMse && maxAutoResolution) {
+        console.warn(
+          '[vjs-media] `maxAutoResolution` requires the hls.js (MSE) engine; native HLS playback ignores it.'
+        );
+      }
 
       this.#delegate = useMse
         ? new HlsJsOnlyMedia({ config: withDrmSystems(hlsJs, drm) })
@@ -313,6 +342,7 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
       }
 
       this.#delegate.preload = this.preload;
+      this.#applyRenditionCaps();
 
       if (this.#mediaElement) {
         this.#delegate.attach(this.#mediaElement);
@@ -360,6 +390,13 @@ export class HlsJsMedia extends HTMLVideoElementHost implements HlsMediaProps {
 
     if (Object.keys(source).length > 0) media.source = source;
     return media;
+  }
+
+  /** Push the source's rendition caps down; only the hls.js engine has a lever. */
+  #applyRenditionCaps() {
+    if (this.#delegate instanceof HlsJsOnlyMedia) {
+      this.#delegate.maxAutoResolution = this.#source?.maxAutoResolution;
+    }
   }
 
   #stopTargetLoadStartEvent = (event: Event) => {

--- a/packages/media/src/dom/hls-js/tests/cap-level.test.ts
+++ b/packages/media/src/dom/hls-js/tests/cap-level.test.ts
@@ -1,0 +1,396 @@
+import Hls, { type Level } from 'hls.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MediaResolution } from '../../../core/types';
+import {
+  createCapLevelController,
+  levelIndexAtOrBelow,
+  type RenditionCapPolicy,
+  resolutionToPixelArea,
+} from '../cap-level';
+
+type FakeLevel = { width: number; height: number; bitrate: number };
+
+const level = (width: number, height: number, bitrate: number): FakeLevel => ({ width, height, bitrate });
+
+/** 16:9 ladder, ascending — the shape hls.js hands to `getMaxLevel`. */
+const LADDER: FakeLevel[] = [
+  level(640, 360, 800_000),
+  level(854, 480, 1_400_000),
+  level(1280, 720, 2_800_000),
+  level(1920, 1080, 5_000_000),
+  level(2560, 1440, 9_000_000),
+];
+
+const asLevels = (levels: FakeLevel[]) => levels as unknown as Level[];
+
+function createEngine(levels: FakeLevel[], config: Record<string, unknown> = {}) {
+  const listeners = new Map<string, Set<{ fn: (...args: any[]) => void; ctx: unknown }>>();
+
+  return {
+    levels,
+    autoLevelCapping: -1,
+    autoLevelEnabled: true,
+    logger: { log: () => {} },
+    config: {
+      capLevelToPlayerSize: true,
+      capLevelOnFPSDrop: true,
+      // Pin the scale factor so a retina host does not change the arithmetic.
+      ignoreDevicePixelRatio: true,
+      maxDevicePixelRatio: Number.POSITIVE_INFINITY,
+      ...config,
+    },
+    on(event: string, fn: (...args: any[]) => void, ctx?: unknown) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add({ fn, ctx });
+    },
+    off(event: string, fn: (...args: any[]) => void) {
+      for (const entry of listeners.get(event) ?? []) {
+        if (entry.fn === fn) listeners.get(event)!.delete(entry);
+      }
+    },
+    emit(event: string, data: unknown) {
+      for (const { fn, ctx } of [...(listeners.get(event) ?? [])]) fn.call(ctx, event, data);
+    },
+  } as unknown as Hls;
+}
+
+const emit = (engine: Hls, event: string, data: unknown) => (engine as any).emit(event, data);
+
+const controllers: Array<{ destroy(): void }> = [];
+
+afterEach(() => {
+  // `startCapping()` opens a one-second interval; destroying clears it.
+  while (controllers.length) controllers.pop()!.destroy();
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+interface SetupOptions {
+  maxAutoResolution?: MediaResolution | undefined;
+  levels?: FakeLevel[];
+  config?: Record<string, unknown>;
+  /** Rendered size of the video element; omit to leave it unmeasurable. */
+  playerSize?: { width: number; height: number };
+}
+
+function setup({ maxAutoResolution, levels = LADDER, config, playerSize }: SetupOptions = {}) {
+  const policy: RenditionCapPolicy = { maxAutoResolution };
+  const engine = createEngine(levels, config);
+  const Controller = createCapLevelController(policy);
+  const controller = new Controller(engine) as InstanceType<typeof Controller> & { destroy(): void };
+  controllers.push(controller);
+
+  // hls.js starts its capping loop from here when the manifest signals video.
+  emit(engine, Hls.Events.MANIFEST_PARSED, { levels, firstLevel: 0, video: true });
+
+  if (playerSize) {
+    const video = document.createElement('video');
+    // jsdom reports an empty bounding rect, and hls.js falls back to the
+    // element's width/height attributes when it does.
+    video.width = playerSize.width;
+    video.height = playerSize.height;
+    document.body.appendChild(video);
+    emit(engine, Hls.Events.MEDIA_ATTACHING, { media: video });
+  }
+
+  return { policy, engine, controller, topIndex: levels.length - 1 };
+}
+
+describe('resolutionToPixelArea', () => {
+  it('reads a resolution as its 16:9 pixel area', () => {
+    expect(resolutionToPixelArea('720p')).toBe(1280 * 720);
+    expect(resolutionToPixelArea('1080p')).toBe(1920 * 1080);
+  });
+
+  it('treats an absent cap as unbounded', () => {
+    expect(resolutionToPixelArea(undefined)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('matches the areas `maxResolutionToPixelArea` produces in @videojs/spf', () => {
+    // Pinned rather than imported: the packages do not depend on each other,
+    // and the two ladders have to agree for a cap to mean the same thing across
+    // the hls.js and SPF engines. `'480p'` is excluded here and covered below.
+    const spfArea = (height: number) => (height * height * 16) / 9;
+    const exact: MediaResolution[] = ['270p', '360p', '540p', '720p', '1080p', '1440p', '2160p'];
+
+    for (const resolution of exact) {
+      expect(resolutionToPixelArea(resolution)).toBe(spfArea(Number.parseInt(resolution, 10)));
+    }
+  });
+
+  it('rounds 480p up so the standard 854×480 rendition fits its own cap', () => {
+    // 16:9 at 480 tall is 853.33 wide. SPF's exact area (409_600) sits just
+    // under the 854×480 (409_920) every real ladder ships, which would push
+    // a '480p' cap down to 360p.
+    expect(resolutionToPixelArea('480p')).toBe(854 * 480);
+    expect(resolutionToPixelArea('480p')).toBeGreaterThan((480 * 480 * 16) / 9);
+  });
+});
+
+describe('levelIndexAtOrBelow', () => {
+  it('picks the largest level at or below the cap', () => {
+    expect(levelIndexAtOrBelow(asLevels(LADDER), '720p')).toBe(2);
+    expect(levelIndexAtOrBelow(asLevels(LADDER), '1080p')).toBe(3);
+  });
+
+  it('admits the rendition a cap is named after', () => {
+    // Each rung should select itself rather than the one below it — 854×480 is
+    // the case that a strict 16:9 area would get wrong.
+    expect(levelIndexAtOrBelow(asLevels(LADDER), '360p')).toBe(0);
+    expect(levelIndexAtOrBelow(asLevels(LADDER), '480p')).toBe(1);
+    expect(levelIndexAtOrBelow(asLevels(LADDER), '1440p')).toBe(4);
+  });
+
+  it('has nothing to cap without a resolution', () => {
+    expect(levelIndexAtOrBelow(asLevels(LADDER), undefined)).toBeUndefined();
+  });
+
+  it('has nothing to cap without levels', () => {
+    expect(levelIndexAtOrBelow(asLevels([]), '720p')).toBeUndefined();
+  });
+
+  it('falls back to the smallest level when every rendition is above the cap', () => {
+    // Nothing satisfies a 270p cap here; playing over-spec beats not adapting.
+    expect(levelIndexAtOrBelow(asLevels(LADDER), '270p')).toBe(0);
+  });
+
+  it('measures area rather than height, so an ultrawide rendition counts its full pixels', () => {
+    // 2560×1080 carries more pixels than 16:9 1080p despite being 1080 tall,
+    // so a 1080p cap excludes it and lands on the 16:9 rendition below.
+    const anamorphic = [level(1280, 720, 2_800_000), level(2560, 1080, 8_000_000)];
+
+    expect(levelIndexAtOrBelow(asLevels(anamorphic), '1080p')).toBe(0);
+  });
+
+  it('reaches the top of a run of equally sized levels', () => {
+    const sameSize = [level(1280, 720, 2_000_000), level(1280, 720, 3_500_000)];
+
+    expect(levelIndexAtOrBelow(asLevels(sameSize), '720p')).toBe(1);
+  });
+
+  it('stops below an over-budget level even when a later one fits', () => {
+    // hls.js orders levels by height, so a much wider rendition can blow the
+    // pixel budget from a lower index. `autoLevelCapping` is an index ceiling,
+    // so stopping at the later match would leave index 0 selectable.
+    const mixedAspect = [
+      level(3840, 720, 6_000_000), // 2_764_800 — over a 1080p budget
+      level(1280, 1080, 4_000_000), // 1_382_400 — under it
+    ];
+
+    expect(levelIndexAtOrBelow(asLevels(mixedAspect), '1080p')).toBe(0);
+  });
+
+  it('ignores levels reported without dimensions', () => {
+    const partial = [level(0, 0, 500_000), level(1280, 720, 2_800_000)];
+
+    expect(levelIndexAtOrBelow(asLevels(partial), '720p')).toBe(1);
+  });
+});
+
+describe('createCapLevelController', () => {
+  it('leaves the player-size result alone when no cap is set', () => {
+    const { controller, topIndex } = setup({ playerSize: { width: 1920, height: 1080 } });
+
+    // A 1920-wide player admits the 1080p rendition but not 1440p.
+    expect(controller.getMaxLevel(topIndex)).toBe(3);
+  });
+
+  it('lowers the ceiling to the requested resolution', () => {
+    const { controller, topIndex } = setup({
+      maxAutoResolution: '720p',
+      playerSize: { width: 1920, height: 1080 },
+    });
+
+    expect(controller.getMaxLevel(topIndex)).toBe(2);
+  });
+
+  it('keeps the player-size ceiling when it is the stricter of the two', () => {
+    const { controller, topIndex } = setup({
+      maxAutoResolution: '1440p',
+      playerSize: { width: 1920, height: 1080 },
+    });
+
+    // The caps intersect: 1440p asks for level 4, the player size allows 3.
+    expect(controller.getMaxLevel(topIndex)).toBe(3);
+  });
+
+  it('writes the intersected ceiling to autoLevelCapping', () => {
+    const { engine } = setup({
+      maxAutoResolution: '720p',
+      playerSize: { width: 1920, height: 1080 },
+    });
+
+    expect(engine.autoLevelCapping).toBe(2);
+  });
+
+  it('applies a policy change without waiting for the next tick', () => {
+    const { engine, policy } = setup({ playerSize: { width: 1920, height: 1080 } });
+
+    expect(engine.autoLevelCapping).toBe(3);
+
+    policy.maxAutoResolution = '480p';
+    policy.controller!.apply();
+
+    expect(engine.autoLevelCapping).toBe(1);
+  });
+
+  it('returns to the uncapped ceiling when the policy is cleared', () => {
+    const { engine, policy } = setup({
+      maxAutoResolution: '360p',
+      playerSize: { width: 1920, height: 1080 },
+    });
+
+    expect(engine.autoLevelCapping).toBe(0);
+
+    policy.maxAutoResolution = undefined;
+    policy.controller!.apply();
+
+    expect(engine.autoLevelCapping).toBe(3);
+  });
+
+  it('re-resolves the cap after levels are updated', () => {
+    const { engine } = setup({
+      maxAutoResolution: '720p',
+      playerSize: { width: 1920, height: 1080 },
+    });
+
+    expect(engine.autoLevelCapping).toBe(2);
+
+    // hls.js drops the two lowest renditions; 720p is now index 0.
+    const trimmed = LADDER.slice(2);
+    (engine as any).levels = trimmed;
+    emit(engine, Hls.Events.LEVELS_UPDATED, { levels: trimmed });
+
+    expect(engine.autoLevelCapping).toBe(0);
+  });
+
+  it('registers itself on the policy and steps down on destroy', () => {
+    const { controller, policy } = setup({ playerSize: { width: 1920, height: 1080 } });
+
+    expect(policy.controller).toBe(controller);
+
+    controller.destroy();
+
+    expect(policy.controller).toBeUndefined();
+  });
+
+  it('keeps FPS-drop restrictions, which live behind the base controller', () => {
+    const { engine, controller, topIndex } = setup({
+      maxAutoResolution: '1440p',
+      playerSize: { width: 4096, height: 2160 },
+    });
+
+    // A player this large admits the whole ladder; only the cap holds it to 4.
+    expect(controller.getMaxLevel(topIndex)).toBe(4);
+
+    // hls.js restricts a level after dropped frames. The restriction is applied
+    // inside `super.getMaxLevel()`, so it only survives while we defer to it.
+    emit(engine, Hls.Events.FPS_DROP_LEVEL_CAPPING, { droppedLevel: 4, level: 4 });
+
+    expect(controller.getMaxLevel(topIndex)).toBe(3);
+  });
+
+  it('still caps while the element has no measurable size', () => {
+    // hls.js abandons capping on an unmeasurable element. A requested ceiling
+    // does not depend on layout, so a hidden or not-yet-laid-out player still
+    // gets it — otherwise ABR would climb past the cap until layout settles.
+    const { engine } = setup({ maxAutoResolution: '720p' });
+
+    expect(engine.autoLevelCapping).toBe(2);
+  });
+
+  it('reports uncapped on an unmeasurable element when no resolution is requested', () => {
+    const { engine } = setup();
+
+    expect(engine.autoLevelCapping).toBe(-1);
+  });
+
+  it('hands the slot back to the size measurement once the element can be measured', () => {
+    const { engine, controller } = setup({ maxAutoResolution: '1440p' });
+
+    // Unmeasurable: only the resolution ceiling applies.
+    expect(engine.autoLevelCapping).toBe(4);
+
+    const video = document.createElement('video');
+    video.width = 1920;
+    video.height = 1080;
+    document.body.appendChild(video);
+    emit(engine, Hls.Events.MEDIA_ATTACHING, { media: video });
+    controller.detectPlayerSize();
+
+    // Measurable: the stricter player-size ceiling takes over.
+    expect(engine.autoLevelCapping).toBe(3);
+  });
+
+  describe('with the player-size loop switched off', () => {
+    const noSizeCapping = { config: { capLevelToPlayerSize: false } };
+
+    it('still applies the resolution cap', () => {
+      // hls.js never starts its capping loop here, so nothing else writes the
+      // slot — and a naive implementation would leave the cap inert.
+      const { engine } = setup({ maxAutoResolution: '720p', ...noSizeCapping });
+
+      expect(engine.autoLevelCapping).toBe(2);
+    });
+
+    it('caps without regard to the player size', () => {
+      const { engine } = setup({
+        maxAutoResolution: '1440p',
+        playerSize: { width: 320, height: 180 },
+        ...noSizeCapping,
+      });
+
+      expect(engine.autoLevelCapping).toBe(4);
+    });
+
+    it('reports uncapped when no resolution is requested', () => {
+      const { engine } = setup(noSizeCapping);
+
+      expect(engine.autoLevelCapping).toBe(-1);
+    });
+
+    it('re-resolves the cap after levels are updated', () => {
+      const { engine } = setup({ maxAutoResolution: '720p', ...noSizeCapping });
+
+      const trimmed = LADDER.slice(2);
+      (engine as any).levels = trimmed;
+      emit(engine, Hls.Events.LEVELS_UPDATED, { levels: trimmed });
+
+      expect(engine.autoLevelCapping).toBe(0);
+    });
+  });
+
+  it('layers over a controller supplied through the engine config', () => {
+    const policy: RenditionCapPolicy = { maxAutoResolution: '720p' };
+    const engine = createEngine(LADDER);
+    const seen: number[] = [];
+
+    class CustomController extends Hls.DefaultConfig.capLevelController {
+      getMaxLevel(capLevelIndex: number): number {
+        seen.push(capLevelIndex);
+        // Ignore the player size entirely; allow everything.
+        return capLevelIndex;
+      }
+    }
+
+    const Controller = createCapLevelController(policy, CustomController);
+    const controller = new Controller(engine) as InstanceType<typeof Controller> & { destroy(): void };
+    controllers.push(controller);
+
+    expect(controller.getMaxLevel(4)).toBe(2);
+    expect(seen).toEqual([4]);
+  });
+
+  it('never caps an audio-only stream, whose capping loop never starts', () => {
+    const policy: RenditionCapPolicy = { maxAutoResolution: '720p' };
+    const engine = createEngine([]);
+    const Controller = createCapLevelController(policy);
+    const controller = new Controller(engine) as InstanceType<typeof Controller> & { destroy(): void };
+    controllers.push(controller);
+
+    // No video codec in the manifest, so hls.js defers capping indefinitely.
+    emit(engine, Hls.Events.MANIFEST_PARSED, { levels: [], firstLevel: 0, video: false });
+
+    expect(engine.autoLevelCapping).toBe(-1);
+  });
+});

--- a/packages/media/src/dom/hls-js/tests/hls-media.test.ts
+++ b/packages/media/src/dom/hls-js/tests/hls-media.test.ts
@@ -484,6 +484,159 @@ describe('HlsJsMedia', () => {
     });
   });
 
+  describe('maxAutoResolution', () => {
+    const M3U8 = 'https://example.com/video.m3u8';
+    const built: HlsJsMedia[] = [];
+
+    afterEach(async () => {
+      // Let any queued load settle, then tear the engines down, so no manifest
+      // request outlives the test that started it.
+      await Promise.resolve();
+      while (built.length) built.pop()!.destroy();
+    });
+
+    function setupMse(source: HlsSource = {}) {
+      vi.spyOn(Hls, 'isSupported').mockReturnValue(true);
+
+      const video = document.createElement('video');
+      document.body.appendChild(video);
+
+      const media = new HlsJsMedia();
+      built.push(media);
+      media.attach(video);
+      media.source = { ...source, src: M3U8 };
+      media.load();
+
+      return { media, video };
+    }
+
+    /**
+     * Minimal stand-in for an `Hls` instance, enough to build the controller the
+     * element installed and ask it what the current policy resolves to.
+     */
+    function probeEngine(levels: Array<{ width: number; height: number; bitrate: number }>) {
+      const listeners = new Map<string, Array<{ fn: (...args: any[]) => void; ctx: unknown }>>();
+      return {
+        levels,
+        autoLevelCapping: -1,
+        autoLevelEnabled: true,
+        logger: { log: () => {} },
+        config: { capLevelToPlayerSize: false, ignoreDevicePixelRatio: true, maxDevicePixelRatio: Infinity },
+        on(event: string, fn: (...args: any[]) => void, ctx?: unknown) {
+          listeners.set(event, [...(listeners.get(event) ?? []), { fn, ctx }]);
+        },
+        off: () => {},
+        emit(event: string, data: unknown) {
+          for (const { fn, ctx } of listeners.get(event) ?? []) fn.call(ctx, event, data);
+        },
+      } as unknown as Hls;
+    }
+
+    const LADDER = [
+      { width: 640, height: 360, bitrate: 800_000 },
+      { width: 1280, height: 720, bitrate: 2_800_000 },
+      { width: 1920, height: 1080, bitrate: 5_000_000 },
+    ];
+
+    /** What the engine's installed cap controller resolves the policy to now. */
+    function cappedIndex(media: HlsJsMedia) {
+      const engine = probeEngine(LADDER);
+      const Controller = media.engine!.config.capLevelController;
+      const controller = new Controller(engine);
+
+      // Attach a viewport larger than the whole ladder so the player-size
+      // ceiling never binds and the resolution cap is what is being measured.
+      const probeVideo = document.createElement('video');
+      probeVideo.width = 4096;
+      probeVideo.height = 2160;
+      (engine as any).emit(Hls.Events.MEDIA_ATTACHING, { media: probeVideo });
+
+      const index = controller.getMaxLevel(LADDER.length - 1);
+      controller.destroy();
+      return index;
+    }
+
+    it('installs its own cap-level controller over the hls.js default', () => {
+      const { media } = setupMse();
+
+      expect(media.engine!.config.capLevelController).not.toBe(Hls.DefaultConfig.capLevelController);
+    });
+
+    it('caps automatic selection at the requested resolution', () => {
+      const { media } = setupMse({ maxAutoResolution: '720p' });
+
+      expect(cappedIndex(media)).toBe(1);
+    });
+
+    it('does not recreate the engine when only the cap changes', () => {
+      const { media } = setupMse({ maxAutoResolution: '1080p' });
+      const engine = media.engine;
+
+      media.source = { src: M3U8, maxAutoResolution: '720p' };
+      media.load();
+
+      // Capping is a playback preference, not engine construction: rebuilding
+      // here would tear down the buffer and lose ABR's bandwidth estimate.
+      expect(media.engine).toBe(engine);
+      expect(cappedIndex(media)).toBe(1);
+    });
+
+    it('applies a cap added after playback started', () => {
+      const { media } = setupMse();
+      const engine = media.engine;
+
+      expect(cappedIndex(media)).toBe(2);
+
+      media.source = { src: M3U8, maxAutoResolution: '360p' };
+
+      expect(media.engine).toBe(engine);
+      expect(cappedIndex(media)).toBe(0);
+    });
+
+    it('returns to uncapped selection when the key is removed', () => {
+      const { media } = setupMse({ maxAutoResolution: '360p' });
+
+      media.source = { src: M3U8 };
+
+      expect(cappedIndex(media)).toBe(2);
+    });
+
+    it('keeps the cap when only src changes', () => {
+      const { media } = setupMse({ maxAutoResolution: '720p' });
+
+      media.src = 'https://example.com/other.m3u8';
+
+      expect(media.source).toEqual({ src: 'https://example.com/other.m3u8', maxAutoResolution: '720p' });
+      expect(cappedIndex(media)).toBe(1);
+    });
+
+    it('carries the cap onto an engine rebuilt for new hls.js options', () => {
+      const { media } = setupMse({ maxAutoResolution: '720p' });
+      const engine = media.engine;
+
+      media.source = { src: M3U8, maxAutoResolution: '720p', engine: { hlsJs: { maxBufferLength: 60 } } };
+      media.load();
+
+      expect(media.engine).not.toBe(engine);
+      expect(cappedIndex(media)).toBe(1);
+    });
+
+    it('warns and ignores the cap on native playback', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const media = new HlsJsMedia();
+      built.push(media);
+      media.attach(document.createElement('video'));
+      media.source = { src: M3U8, type: ContentTypes.M3U8, preferPlayback: 'native', maxAutoResolution: '720p' };
+      media.load();
+
+      expect(media.engine).toBeNull();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('`maxAutoResolution` requires the hls.js (MSE) engine')
+      );
+    });
+  });
+
   describe('remote playback load', () => {
     function setupConnected(load: () => Promise<void>) {
       const video = document.createElement('video');

--- a/packages/media/src/dom/mux/media.ts
+++ b/packages/media/src/dom/mux/media.ts
@@ -58,11 +58,12 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
     // params a Mux URL does not carry, such as `poster`.
     if (super.src === value) return;
 
-    const { type, preferPlayback, engine } = this.#source ?? {};
+    const { type, preferPlayback, engine, maxAutoResolution } = this.#source ?? {};
     const source: MuxSource = {
       ...(type && { type }),
       ...(preferPlayback && { preferPlayback }),
       ...(engine && { engine }),
+      ...(maxAutoResolution && { maxAutoResolution }),
       ...(parseMuxVideoURL(value) ?? (value ? { src: value } : null)),
     };
 
@@ -79,6 +80,10 @@ export class MuxMedia extends HlsJsMedia implements MuxMediaProps {
    * PlayReady license servers for this playback ID, so protected media plays
    * whichever path the browser takes. License servers named alongside the token
    * win, key by key, for content Mux does not license.
+   *
+   * `playback.maxResolution` decides which renditions Mux puts in the manifest;
+   * the inherited `maxAutoResolution` caps which of them adaptive selection
+   * picks. The two are independent.
    */
   get source(): MuxSource | null {
     return this.#source;

--- a/packages/media/src/dom/mux/source/source.ts
+++ b/packages/media/src/dom/mux/source/source.ts
@@ -9,11 +9,12 @@ import { parseJwt } from '@videojs/utils/jwt';
 import { isNil } from '@videojs/utils/predicate';
 import { camelCase, snakeCase } from '@videojs/utils/string';
 import type { DrmSystemsConfig } from '../../../core/drm';
-import type { MediaContentData } from '../../../core/types';
+import type { MediaContentData, MediaResolution } from '../../../core/types';
 
 export const MUX_VIDEO_DOMAIN = 'mux.com';
 
-export type MuxResolution = '270p' | '360p' | '480p' | '540p' | '720p' | '1080p' | '1440p' | '2160p';
+/** Mux's rendition-height shorthand. Alias of {@link MediaResolution}. */
+export type MuxResolution = MediaResolution;
 export type MuxRenditionOrder = 'desc';
 export type MuxImageExt = 'webp' | 'jpg' | 'png';
 export type MuxPosterFitMode = 'preserve' | 'stretch' | 'crop' | 'smartcrop' | 'pad';

--- a/packages/media/src/dom/mux/tests/mux-media.test.ts
+++ b/packages/media/src/dom/mux/tests/mux-media.test.ts
@@ -193,6 +193,48 @@ describe('MuxMedia', () => {
     expect(loadstart).not.toHaveBeenCalled();
   });
 
+  it('inherits maxAutoResolution without restarting playback', async () => {
+    vi.spyOn(Hls, 'isSupported').mockReturnValue(true);
+
+    const media = new MuxMedia();
+    media.attach(document.createElement('video'));
+    media.source = { playbackId: 'abc123', maxAutoResolution: '1080p' };
+    await flushLoad();
+
+    const engine = media.engine;
+    const loadstart = vi.fn();
+    media.addEventListener('loadstart', loadstart);
+
+    media.source = { playbackId: 'abc123', maxAutoResolution: '720p' };
+    await flushLoad();
+
+    expect(media.source?.maxAutoResolution).toBe('720p');
+    expect(media.engine).toBe(engine);
+    expect(loadstart).not.toHaveBeenCalled();
+
+    media.destroy();
+  });
+
+  it('keeps the client-side cap separate from the server-side manifest filter', async () => {
+    const media = new MuxMedia();
+    media.attach(document.createElement('video'));
+    // `playback.maxResolution` asks Mux to leave higher renditions out of the
+    // manifest; `maxAutoResolution` caps what ABR picks from the ones that
+    // arrive. Only the former belongs in the URL.
+    media.source = {
+      playbackId: 'abc123',
+      preferPlayback: 'native',
+      playback: { maxResolution: '1080p' },
+      maxAutoResolution: '720p',
+    };
+    await flushLoad();
+
+    expect(media.src).toBe('https://stream.mux.com/abc123.m3u8?max_resolution=1080p');
+    expect(media.source?.maxAutoResolution).toBe('720p');
+
+    media.destroy();
+  });
+
   it('reloads when the playback id changes', async () => {
     const media = new MuxMedia();
     media.attach(document.createElement('video'));

--- a/packages/react/src/media/tests/mux-video.test.tsx
+++ b/packages/react/src/media/tests/mux-video.test.tsx
@@ -74,6 +74,12 @@ describe('MuxVideo', () => {
     expect(media.source?.engine?.hlsJs).toEqual({ maxBufferLength: 60 });
   });
 
+  it('forwards maxAutoResolution from the source prop to the media', () => {
+    const { media } = renderWithMedia(<MuxVideo source={{ playbackId: 'abc123', maxAutoResolution: '720p' }} />);
+
+    expect(media.source?.maxAutoResolution).toBe('720p');
+  });
+
   it('adds a storyboard track inferred from the source prop', () => {
     const { container } = render(<MuxVideo source={{ playbackId: 'abc123' }} />);
 

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -42,7 +42,7 @@ The shape answers one question: does this option describe the source, or how to 
 |---|---|---|
 | Which source to play | `source.src`, or an element's own identity fields | `src`, `MuxVideo`'s `playbackId` |
 | How to interpret it | `source.type` | `'video/mp4'` |
-| How Video.js plays it | `source`, at the top level | `preferPlayback` |
+| How Video.js plays it | `source`, at the top level | `preferPlayback`, `maxAutoResolution` |
 | How a specific engine behaves | `source.engine`, under that engine's name | hls.js's `maxBufferLength`, in `source.engine.hlsJs` |
 | A side-car component's own settings | that component's props | <DocsLink slug="concepts/mux-data">Mux Data</DocsLink>, <DocsLink slug="concepts/cast">Google Cast</DocsLink> |
 
@@ -213,6 +213,26 @@ video.source = { src: 'https://example.com/stream.m3u8', preferPlayback: 'native
 
 It's a preference, not a demand — Video.js falls back to whichever path can actually play the source. `HlsJsVideo`, `MuxVideo`, and `MuxAudio` accept it; DASH and Vimeo have no second playback path.
 
+`maxAutoResolution` caps the highest rendition adaptive bitrate selection reaches for on its own:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<HlsJsVideo source={{ src: 'https://example.com/stream.m3u8', maxAutoResolution: '720p' }} />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+video.source = { src: 'https://example.com/stream.m3u8', maxAutoResolution: '720p' };
+```
+</FrameworkCase>
+
+The cap limits automatic selection without hiding anything. Renditions above it stay in `videoRenditions`, so a viewer can still choose 1080p by hand. Reach for it to hold down bandwidth on a stream that would otherwise climb to 4K, or to keep a background or thumbnail player cheap.
+
+Renditions are matched on pixel area rather than height, which keeps unusual aspect ratios honest: an ultrawide 2560×1080 rendition carries more pixels than 16:9 1080p, so a `'1080p'` cap leaves it out. When every rendition sits above the cap, the smallest one plays.
+
+Changing the cap applies to the running engine, so playback continues uninterrupted. It needs the hls.js engine — native HLS playback ignores it, and audio-only streams have no video renditions to cap.
+
 ## DRM protected sources
 
 Protected content is licensed through `source.drm`, keyed by EME key system id — alongside the URL rather than inside an engine's namespace, because which engine plays the manifest is decided later and both paths read it:
@@ -313,6 +333,8 @@ video.source = {
 };
 ```
 </FrameworkCase>
+
+`playback` params ride along in the URL, so `playback.maxResolution` decides which renditions the manifest carries in the first place. `maxAutoResolution` is the other half of that pair: it caps what adaptive selection picks from the renditions that do arrive. Use `playback.maxResolution` when a viewer should never get 4K, and `maxAutoResolution` when they should be able to ask for it.
 
 Setting a Mux stream URL as `src` works too — the element parses the playback ID and query params back out into `source`. To play something Mux doesn't host, name it with `src` inside `source`; engine options still apply.
 


### PR DESCRIPTION
Closes #1777

## Summary

Adds `source.maxAutoResolution` to hls.js-backed medias, capping the highest rendition ABR selects on its own. Renditions above the cap stay in `videoRenditions` and remain selectable by hand. This is a ceiling on automatic selection, not a filter on availability.

* **Cap controller (`cap-level.ts`)** — `hls.autoLevelCapping` has a single writer: hls.js's own `CapLevelController` rewrites it every second. Setting the property from outside is undone within a second, so the cap is applied from a controller layered over hls.js's, overriding the one method every capped value passes through. Levels are ranked by pixel area rather than height. So an ultrawide rendition is judged on the pixels it actually costs and the largest one at or below the cap wins, falling back to the lowest when nothing fits.
hls.js's own player-size ceiling is kept. The more restrictive of the two wins.

* **Engine wiring** — the controller class is handed to the hls.js constructor, and it reads a mutable policy the media element owns. That split is what lets a cap change reach the running engine instead of rebuilding it: the key is deliberately kept out of `#engineConfigKey()`. A `capLevelController` passed through `source.engine.hlsJs` is extended rather than replaced.

* **`source.maxAutoResolution`** — read in `HlsJsMedia` and pushed down to the hls.js delegate, so `<mux-video>` and `<mux-audio>` inherit it unchanged.
Setting it applies synchronously rather than waiting up to a second for hls.js's next tick.

## Changes

- `MediaResolution` in `core/types.ts`, the `{height}p` union. `MuxResolution` becomes an alias so the two don't drift.
- New `hls-js/cap-level.ts`: the policy, the controller factory, and resolution → level-index resolution. Layers over whatever `capLevelController` the config already names, so a passthrough one keeps working.
- `HlsJsOnlyMedia` owns the policy and exposes `maxAutoResolution` as a live property; the setter asks the controller to re-evaluate instead of waiting for the next tick.
- `<mux-video>` and `<mux-audio>` inherit it; `MuxMedia`'s own `src` setter needed the key added so a URL change keeps the cap.
- Native HLS: no-op plus a `__DEV__` warning, since there is no equivalent lever there.
- Docs: the normalized-options section of `concepts/media-sources.mdx`, plus a note separating this from Mux's `playback.maxResolution` (server side).

## Testing

- `pnpm -F @videojs/media test` — 606 pass (+37: `cap-level.test.ts` for the arithmetic and controller, plus integration in `hls-media.test.ts` and `mux-media.test.ts`).
- `pnpm -F @videojs/html test` — 326 pass. `pnpm -F @videojs/react test` — 401 pass.
- `pnpm typecheck`, `pnpm check:workspace`, `pnpm -F site astro check` — clean.

Verified in the sandbox against a real Mux ladder (270/360/540/720): the cap applies at boot and on live changes without a new `Hls` instance, all four renditions stay listed, and picking 720p by hand while the cap sits at 360p plays 720p. A cap below the whole ladder falls back to the lowest rung; removing the key returns the ceiling to the player-size cap.

The second commit adds `?maxAutoResolution=` and `?preferPlayback=` to the hls.js and Mux sandbox templates, so the engine can be built with the cap already set rather than switched from the console. Both are absent unless named, so default sandbox behavior is unchanged.

For manual test, you can use the new query params in sandbox (local the deploy of this branch):
- [hls.js](https://v10-sandbox-git-fork-r-delfino95-feat-1777-max-auto-86ff39-mux.vercel.app/html-hlsjs-video/index.html?maxAutoResolution=360p)
- [mux-video](https://v10-sandbox-git-fork-r-delfino95-feat-1777-max-auto-86ff39-mux.vercel.app/html-mux-video/index.html?maxAutoResolution=260p)

If you want to test it with an existing player reproducing, you can set it using the console:
```js
const el = document.querySelector('hlsjs-video'); // or mux-video
el.source = { ...el.source, maxAutoResolution: '200p' };
```

## Notes

- hls.js abandons capping when the video element has no measurable size. A requested resolution ceiling doesn't depend on layout, so it's applied anyway — otherwise a hidden or not-yet-laid-out player streams uncapped.
- Audio-only streams never start capping, so the cap is inert there. Asserted rather than assumed.
- No DPR knobs exposed. `ignoreDevicePixelRatio` and `maxDevicePixelRatio` are still reachable through `source.engine.hlsJs`, and a normalized key can be added later without breaking anything. Flagging it so it reads as a decision, not an oversight.
- #1783 (`capRenditionToPlayerSize` and the floor) adds two more inputs to this same `getMaxLevel()` and needs no new plumbing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hls.js ABR/cap-level behavior and source wiring across HLS and Mux media; mistakes could affect rendition selection or engine lifecycle, but changes are well-tested and native HLS is explicitly no-op with a dev warning.
> 
> **Overview**
> Adds **`source.maxAutoResolution`** so hls.js-backed players can cap the highest rendition adaptive bitrate selects automatically, without removing higher renditions from `videoRenditions` or forcing a manual-only ladder.
> 
> The hls.js path installs a **custom cap-level controller** (`cap-level.ts`) that intersects the requested ceiling with hls.js’s player-size cap via `getMaxLevel()`, using **pixel-area** matching (with a deliberate `480p` rounding tweak). The policy is mutated on the media element so cap changes **re-apply on the running engine** and are **excluded from `#engineConfigKey()`** so buffers and ABR state are not torn down. **`MuxMedia` / `<mux-video>`** inherit the option; **`playback.maxResolution`** still only affects the manifest URL.
> 
> Sandbox **hls.js and Mux HTML templates** accept **`?maxAutoResolution=`** and **`?preferPlayback=`** via `getInitialPlaybackOverrides()` so the first load is built with those settings. Docs cover the option and how it differs from Mux’s server-side max resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dcd76001fc4409394d1864f3acefaa2298e8b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->