### PR TITLE
feat(packages)!: add <mux-background-video> over the SPF background-video engine

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -14,6 +14,7 @@ export const PRESETS = [
   'dash-video',
   'audio',
   'background-video',
+  'mux-background-video',
   'vimeo-video',
   'youtube-video',
 ] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -332,6 +332,19 @@ export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';
 
 export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4';
 
+/**
+ * The same clip as {@link BACKGROUND_VIDEO_SRC} over HLS, for the SPF-backed
+ * `<mux-background-video>`. Re-ingested from that asset's `high.mp4` rendition.
+ *
+ * Must be a **CMAF/fMP4** asset: SPF appends fMP4 segments directly and does no
+ * MPEG-TS transmuxing, so a TS-packaged playback ID surfaces the
+ * unsupported-container error instead of playing. Packaging follows the video
+ * quality tier — `premium` yields CMAF, while `plus`/`basic` (legacy
+ * `encoding_tier: smart`) yield MPEG-TS — which is why this is a separate asset
+ * rather than the `.m3u8` of the one above.
+ */
+export const HLS_BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/JsDMLkGisX8lHq01wcVv32kQ2vIYvsrEXx007W15xDKJg.m3u8';
+
 export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 
 export const YOUTUBE_VIDEO_SRC = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -76,6 +76,8 @@ export function App() {
   const hlsPreset = preset === 'hlsjs-video' || preset === 'native-hls-video';
   const muxPreset = preset === 'mux-video' || preset === 'mux-audio';
   const muxSpfPreset = preset === 'mux-video-spf' || preset === 'mux-audio-spf';
+  // Both background presets render a fixed source and have no Tailwind skin.
+  const backgroundPreset = preset === 'background-video' || preset === 'mux-background-video';
   const availableSources =
     preset === 'audio'
       ? MP4_SOURCE_IDS
@@ -168,12 +170,12 @@ export function App() {
   // CDN, background video, and embed (Vimeo/YouTube) videos do not have a Tailwind skin variant.
   useEffect(() => {
     if (
-      (platform === 'cdn' || preset === 'background-video' || preset === 'vimeo-video' || preset === 'youtube-video') &&
+      (platform === 'cdn' || backgroundPreset || preset === 'vimeo-video' || preset === 'youtube-video') &&
       styling === 'tailwind'
     ) {
       setStyling('css');
     }
-  }, [platform, preset, styling]);
+  }, [platform, preset, backgroundPreset, styling]);
 
   const handleSourceChange = useCallback((value: string) => setSource(value as SourceId), []);
 
@@ -201,7 +203,7 @@ export function App() {
         locale={locale}
         onLocaleChange={setLocale}
         availableSources={availableSources}
-        isBackgroundVideo={preset === 'background-video'}
+        isBackgroundVideo={backgroundPreset}
         isSimpleHls={preset.startsWith('simple-hls-')}
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -94,6 +94,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'dash-video': 'DASH Video',
   audio: 'Audio',
   'background-video': 'Background Video',
+  'mux-background-video': 'Mux Background Video (SPF)',
   'vimeo-video': 'Vimeo Video',
   'youtube-video': 'YouTube Video',
 };

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -21,6 +21,7 @@ import {
   getChapters,
   getPosterSrc,
   getStoryboardSrc,
+  HLS_BACKGROUND_VIDEO_SRC,
   isLiveSource,
   SOURCES,
 } from '@app/shared/sources';
@@ -146,6 +147,9 @@ async function loadCdnPreset(preset: Preset, skin: Skin, live: boolean) {
       else await import('@videojs/html/cdn/audio');
       break;
     case 'background-video':
+    case 'mux-background-video':
+      // Player and skin are shared; the element each one renders is what differs,
+      // and that arrives from `loadCdnMedia`.
       await import('@videojs/html/cdn/background');
       break;
   }
@@ -170,6 +174,12 @@ async function loadCdnMedia(preset: Preset) {
       break;
     case 'mux-audio-spf':
       await import('@videojs/html/cdn/media/mux-audio/spf');
+      break;
+    // `<background-video>` rides along inside the `background` bundle above; the
+    // Mux flavor is its own, so the page loads it the way it loads every other
+    // media element.
+    case 'mux-background-video':
+      await import('@videojs/html/cdn/media/mux-background-video');
       break;
     case 'native-hls-video':
       await import('@videojs/html/cdn/media/native-hls-video');
@@ -196,14 +206,18 @@ function isAudioPreset(preset: Preset): boolean {
   );
 }
 
+function isBackgroundPreset(preset: Preset): boolean {
+  return preset === 'background-video' || preset === 'mux-background-video';
+}
+
 function getPlayerTag(preset: Preset, live: boolean): string {
-  if (preset === 'background-video') return 'background-video-player';
+  if (isBackgroundPreset(preset)) return 'background-video-player';
   if (isAudioPreset(preset)) return live ? 'live-audio-player' : 'audio-player';
   return live ? 'live-video-player' : 'video-player';
 }
 
 function getSkinTag(preset: Preset, skin: Skin, live: boolean): string {
-  if (preset === 'background-video') return 'background-video-skin';
+  if (isBackgroundPreset(preset)) return 'background-video-skin';
   if (isAudioPreset(preset)) return CSS_SKIN_TAGS[skin].audio;
   if (live) return LIVE_VIDEO_CSS_SKIN_TAGS[skin];
   return CSS_SKIN_TAGS[skin].video;
@@ -222,6 +236,7 @@ function getMediaTag(preset: Preset): string {
     'dash-video': 'dash-video',
     audio: 'audio',
     'background-video': 'background-video',
+    'mux-background-video': 'mux-background-video',
   };
 
   return tags[preset] ?? 'video';
@@ -229,7 +244,7 @@ function getMediaTag(preset: Preset): string {
 
 function loadStylesheets(preset: Preset, skin: Skin) {
   if (isAudioPreset(preset)) loadAudioStylesheets(skin);
-  else if (preset !== 'background-video') loadVideoStylesheets(skin);
+  else if (!isBackgroundPreset(preset)) loadVideoStylesheets(skin);
   // Background CSS is loaded via dynamic import in loadCdnPreset.
 }
 
@@ -281,16 +296,21 @@ async function render() {
   const storyboard = isVideoPreset(preset) ? getStoryboardSrc(state.source) : undefined;
   const poster = isVideoPreset(preset) ? getPosterSrc(state.source) : undefined;
 
-  const sourceAttr = preset === 'background-video' ? `src="${BACKGROUND_VIDEO_SRC}"` : `src="${source.url}"`;
+  // Each background preset renders its own fixed source: the native element takes
+  // a progressive MP4, the SPF-backed one needs CMAF/fMP4 over HLS, capped by a
+  // Mux URL param rather than an attribute.
+  const backgroundSrc =
+    preset === 'mux-background-video' ? `${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p` : BACKGROUND_VIDEO_SRC;
+  const sourceAttr = isBackgroundPreset(preset) ? `src="${backgroundSrc}"` : `src="${source.url}"`;
   const mediaAttrs = renderMediaAttrs(state);
 
   // Background video needs viewport dimensions instead of flex centering.
-  if (preset === 'background-video') {
+  if (isBackgroundPreset(preset)) {
     root.className = '';
     root.style.cssText = 'width: 100vw; height: 100vh;';
   }
 
-  if (preset === 'background-video') {
+  if (isBackgroundPreset(preset)) {
     root.innerHTML = wrapCdnPlayerI18n(
       playerTag,
       html`

--- a/apps/sandbox/templates/html-mux-background-video/index.html
+++ b/apps/sandbox/templates/html-mux-background-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Mux Background Video (SPF)</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" style="width: 100vw; height: 100vh"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-mux-background-video/main.ts
+++ b/apps/sandbox/templates/html-mux-background-video/main.ts
@@ -1,0 +1,37 @@
+import '@app/styles.css';
+import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI18n } from '@app/shared/html/i18n';
+import '@videojs/html/background/player';
+import '@videojs/html/background/skin';
+import '@videojs/html/media/mux-background-video';
+import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
+
+// The SPF-backed background video, alongside the natively-played
+// `<background-video>` in `html-background-video`. Same skin and player, same
+// ambient framing — the difference is the engine, which streams HLS and pins one
+// rendition for the session instead of handing a progressive MP4 to the browser.
+//
+// `?max_resolution=720p` is the interesting part: capping which rendition gets
+// fetched is a Mux URL param rather than an attribute, so a hero video shown at
+// 400px tall never has 1080p offered to it in the first place. The source must be
+// CMAF/fMP4 — SPF does no MPEG-TS transmuxing.
+//
+// Deliberately spare: `src` is the element's whole surface, and there is no source
+// picker, matching its sibling page.
+
+const html = String.raw;
+
+async function render() {
+  await prepareSandboxHtmlLocale();
+
+  document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
+    <background-video-player>
+      <background-video-skin>
+        <mux-background-video src="${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p"></mux-background-video>
+      </background-video-skin>
+    </background-video-player>
+  `);
+}
+
+render();
+
+bindSandboxHtmlLocaleChange(render);

--- a/apps/sandbox/templates/react-mux-background-video/index.html
+++ b/apps/sandbox/templates/react-mux-background-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Mux Background Video (SPF)</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" style="width: 100vw; height: 100vh"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-mux-background-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-background-video/main.tsx
@@ -1,0 +1,27 @@
+import '@app/styles.css';
+import '@videojs/react/background/skin.css';
+import { BackgroundVideoProvider } from '@app/shared/react/providers';
+import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
+import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
+import { BackgroundVideoSkin } from '@videojs/react/background';
+import { MuxBackgroundVideo } from '@videojs/react/media/mux-background-video';
+import { createRoot } from 'react-dom/client';
+
+// The SPF-backed counterpart to `react-background-video`. See that page's HTML
+// sibling for what differs: the engine streams HLS and pins one rendition rather
+// than handing a progressive MP4 to the browser, the source must be CMAF/fMP4,
+// and capping the rendition is a Mux URL param rather than a prop.
+
+function App() {
+  return (
+    <SandboxI18nProvider>
+      <BackgroundVideoProvider>
+        <BackgroundVideoSkin>
+          <MuxBackgroundVideo src={`${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p`} />
+        </BackgroundVideoSkin>
+      </BackgroundVideoProvider>
+    </SandboxI18nProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/cdn/media/mux-background-video.ts
+++ b/packages/html/src/cdn/media/mux-background-video.ts
@@ -1,0 +1,1 @@
+import '../../define/media/mux-background-video';

--- a/packages/html/src/define/background/skin.css
+++ b/packages/html/src/define/background/skin.css
@@ -14,14 +14,16 @@ background-video-skin {
 }
 
 /*
- * Every background media the skin can hold. Selected by tag because that is what
- * a background media is here — there is no shared base element or attribute to
- * key on — so a new flavor has to be added to this list or it renders at 0×0:
- * the element gets no box, and the `<video>` inside it is absolutely positioned
- * against that box.
+ * Whatever the skin holds that isn't the placeholder image is the media, and gets
+ * stretched over the host. Matched by what it is *not*, because there is no shared
+ * base element or attribute the media flavors have in common — naming them by tag
+ * meant a new one silently rendered at 0×0, having no box for its inner `<video>`
+ * to be positioned against.
+ *
+ * `:not()` takes the specificity of its most specific argument, so this stays at
+ * (0,0,2) — exactly where the tag-name selectors it replaces were.
  */
-background-video-skin > background-video,
-background-video-skin > mux-background-video {
+background-video-skin > :not(img, picture) {
   position: absolute;
   inset: 0;
   width: 100%;

--- a/packages/html/src/define/background/skin.css
+++ b/packages/html/src/define/background/skin.css
@@ -13,7 +13,15 @@ background-video-skin {
   object-fit: var(--media-object-fit);
 }
 
-background-video-skin > background-video {
+/*
+ * Every background media the skin can hold. Selected by tag because that is what
+ * a background media is here — there is no shared base element or attribute to
+ * key on — so a new flavor has to be added to this list or it renders at 0×0:
+ * the element gets no box, and the `<video>` inside it is absolutely positioned
+ * against that box.
+ */
+background-video-skin > background-video,
+background-video-skin > mux-background-video {
   position: absolute;
   inset: 0;
   width: 100%;

--- a/packages/html/src/define/media/mux-background-video.ts
+++ b/packages/html/src/define/media/mux-background-video.ts
@@ -1,0 +1,14 @@
+import { MuxBackgroundVideo } from '../../media/mux-background-video';
+import { safeDefine } from '../safe-define';
+
+export class MuxBackgroundVideoElement extends MuxBackgroundVideo {
+  static readonly tagName = 'mux-background-video';
+}
+
+safeDefine(MuxBackgroundVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [MuxBackgroundVideoElement.tagName]: MuxBackgroundVideoElement;
+  }
+}

--- a/packages/html/src/media/background-video/media.ts
+++ b/packages/html/src/media/background-video/media.ts
@@ -1,41 +1,7 @@
 import type { Media } from '@videojs/media/dom';
-import { namedNodeMapToObject, serializeAttributes } from '@videojs/utils/dom';
-import { pick } from '@videojs/utils/object';
+import { namedNodeMapToObject } from '@videojs/utils/dom';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
-
-const VideoAttributes = [
-  'autoplay',
-  'controls',
-  'controlslist',
-  'crossorigin',
-  'disablepictureinpicture',
-  'disableremoteplayback',
-  'loop',
-  'muted',
-  'playsinline',
-  'preload',
-] as const;
-
-function getTemplateHTML(attrs: Record<string, string>) {
-  return /*html*/ `
-    <style>
-      :host {
-        position: relative;
-      }
-
-      video {
-        position: absolute;
-        inset: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: var(--media-object-fit, inherit);
-        object-position: var(--media-object-position, 50% 50%);
-      }
-    </style>
-    <slot></slot>
-    <video${serializeAttributes(pick(attrs, [...VideoAttributes]))}></video>
-  `;
-}
+import { getTemplateHTML } from './template';
 
 // Don't extend CustomMediaMixin to save some bytes, background videos don't need the full Media API.
 export class BackgroundVideo extends MediaAttachMixin(HTMLElement) {

--- a/packages/html/src/media/background-video/template.ts
+++ b/packages/html/src/media/background-video/template.ts
@@ -1,0 +1,50 @@
+import { serializeAttributes } from '@videojs/utils/dom';
+import { pick } from '@videojs/utils/object';
+
+/**
+ * Attributes forwarded to the inner `<video>`. `src` is deliberately not one of
+ * them: each element decides what to do with it, whether that is assigning the
+ * inner video or handing it to a playback engine, and serializing it into the
+ * template would start a native load either way.
+ */
+export const VideoAttributes = [
+  'autoplay',
+  'controls',
+  'controlslist',
+  'crossorigin',
+  'disablepictureinpicture',
+  'disableremoteplayback',
+  'loop',
+  'muted',
+  'playsinline',
+  'preload',
+] as const;
+
+/**
+ * The shadow template both background-video elements render: a `<slot>` for a
+ * placeholder image, and a `<video>` stretched over the host.
+ *
+ * Shared so the two can't drift in presentation. `object-fit` and
+ * `object-position` are the only styling hooks — a background video has no
+ * controls to theme.
+ */
+export function getTemplateHTML(attrs: Record<string, string>) {
+  return /*html*/ `
+    <style>
+      :host {
+        position: relative;
+      }
+
+      video {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: var(--media-object-fit, inherit);
+        object-position: var(--media-object-position, 50% 50%);
+      }
+    </style>
+    <slot></slot>
+    <video${serializeAttributes(pick(attrs, [...VideoAttributes]))}></video>
+  `;
+}

--- a/packages/html/src/media/mux-background-video/index.ts
+++ b/packages/html/src/media/mux-background-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/mux-background-video/media.ts
+++ b/packages/html/src/media/mux-background-video/media.ts
@@ -1,0 +1,116 @@
+import type { Media } from '@videojs/media/dom';
+import { MuxBackgroundVideoMedia } from '@videojs/spf/mux-background-video';
+import { type CustomElement, namedNodeMapToObject } from '@videojs/utils/dom';
+import type { Constructor } from '@videojs/utils/types';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+import { getTemplateHTML } from '../background-video/template';
+
+// `MediaAttachMixin` is typed as returning its base, so its `disconnectedCallback`
+// isn't visible for `super` to reach. `CustomElement` declares the lifecycle
+// callbacks this element overrides.
+const MuxBackgroundVideoBase = MediaAttachMixin(HTMLElement) as unknown as Constructor<CustomElement>;
+
+/**
+ * A muted, looping, chrome-less video over the SPF background-video engine.
+ *
+ * The SPF-backed counterpart to `<background-video>`, which plays its source
+ * natively. This one streams HLS through the engine, which pins a single
+ * rendition for the session rather than adapting, and drops audio and text
+ * handling entirely — the shape an ambient hero video actually wants.
+ *
+ * Nearer an image than a player, and `src` is the whole surface. Replaces the
+ * standalone `mux-background-video` package, whose `audio`, `debug`, `preload`,
+ * and `max-resolution` attributes are all deliberately absent. Capping which
+ * rendition is fetched is a Mux URL param, which keeps the renditions it
+ * excludes out of the manifest rather than merely unpicked; `preload` would have
+ * nothing to say, since the engine loads from the moment it has a source. And
+ * unlike `<background-video>` there are no `nomuted` / `noloop` / `noautoplay`
+ * opt-outs: those three are what this element is for, so the adapter fixes them
+ * on at attach.
+ *
+ * Takes no structured `source` — `src` is an HLS URL, as the package it replaces
+ * required. Mux playback-ID identity, poster, and storyboard belong to
+ * `<mux-video>`; none of them mean anything without controls to hang them on.
+ *
+ * @example
+ * ```html
+ * <mux-background-video src="https://stream.mux.com/PLAYBACK_ID.m3u8?max_resolution=720p">
+ *   <img src="https://image.mux.com/PLAYBACK_ID/thumbnail.webp?time=0" alt="" />
+ * </mux-background-video>
+ * ```
+ */
+// Deliberately not `CustomMediaElement`, matching `<background-video>`: a
+// background video needs one property, not the full WHATWG media API.
+export class MuxBackgroundVideo extends MuxBackgroundVideoBase {
+  static shadowRootOptions = { mode: 'open' as ShadowRootMode };
+  static getTemplateHTML = getTemplateHTML;
+
+  static get observedAttributes(): string[] {
+    return ['src'];
+  }
+
+  #media = new MuxBackgroundVideoMedia();
+
+  constructor() {
+    super();
+
+    if (!this.shadowRoot) {
+      this.attachShadow((this.constructor as typeof MuxBackgroundVideo).shadowRootOptions);
+
+      const attrs = {
+        ...namedNodeMapToObject(this.attributes),
+        muted: '',
+        loop: '',
+        autoplay: '',
+        playsinline: '',
+        disableremoteplayback: '',
+        disablepictureinpicture: '',
+      };
+
+      this.shadowRoot!.innerHTML = getTemplateHTML(attrs);
+    }
+
+    // Neither Chrome nor Firefox honor a `muted` attribute set after
+    // `document.createElement`, and autoplay is refused without it. Attaching is
+    // what sets the property — along with the rest of the fixed behavior — so
+    // nothing here needs to repeat it.
+    const video = this.video;
+    if (video) this.#media.attach(video);
+  }
+
+  /** Register the Media (not the inner `<video>`) with the provider. */
+  getMediaTarget(): Media | null {
+    return this.#media as unknown as Media;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback?.();
+    if (this.hasAttribute('keep-alive')) return;
+    // Deferred so a synchronous reparent (remove then insert) doesn't tear down
+    // the engine, matching `CustomMediaElement`.
+    queueMicrotask(() => {
+      if (!this.isConnected) this.#media.destroy();
+    });
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
+    if (oldValue === newValue) return;
+
+    if (name === 'src') this.src = newValue ?? '';
+  }
+
+  /** The inner `<video>` the engine renders into. */
+  get video(): HTMLVideoElement | null {
+    const video = this.shadowRoot?.querySelector('video');
+    return video instanceof HTMLVideoElement ? video : null;
+  }
+
+  /** HLS manifest URL. Assigning a new one restarts playback from scratch. */
+  get src(): string {
+    return this.#media.src;
+  }
+
+  set src(value: string) {
+    this.#media.src = value;
+  }
+}

--- a/packages/html/src/media/mux-background-video/tests/media.test.ts
+++ b/packages/html/src/media/mux-background-video/tests/media.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MuxBackgroundVideo } from '../index';
+
+beforeEach(() => {
+  // The engine seeds `loadActivated: true`, so assigning `src` starts fetching
+  // the manifest at once. Stubbed so these stay offline and leave no request
+  // pending at teardown.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.reject(new Error('offline')))
+  );
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+});
+
+let tagCounter = 0;
+
+function defineElement() {
+  const tag = `test-mux-background-video-${++tagCounter}`;
+  customElements.define(tag, class extends MuxBackgroundVideo {});
+  return tag;
+}
+
+// innerHTML on a connected container so attributes are present when the constructor runs.
+function create(tag: string, attrs: Record<string, string> = {}): MuxBackgroundVideo {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const attrStr = Object.entries(attrs)
+    .map(([k, v]) => ` ${k}="${v.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}"`)
+    .join('');
+  container.innerHTML = `<${tag}${attrStr}></${tag}>`;
+  return container.querySelector(tag) as MuxBackgroundVideo;
+}
+
+describe('MuxBackgroundVideo', () => {
+  it('renders a video into its shadow root', () => {
+    const element = create(defineElement());
+
+    expect(element.video).toBeInstanceOf(HTMLVideoElement);
+  });
+
+  it('forces the ambient playback attributes onto the inner video', () => {
+    // The whole point of the element: no nomuted/noloop/noautoplay opt-outs.
+    const { video } = create(defineElement());
+
+    expect(video?.hasAttribute('muted')).toBe(true);
+    expect(video?.hasAttribute('loop')).toBe(true);
+    expect(video?.hasAttribute('autoplay')).toBe(true);
+    expect(video?.hasAttribute('playsinline')).toBe(true);
+    // Set as a property too — an attribute set post-createElement doesn't take,
+    // and without it autoplay is refused.
+    expect(video?.muted).toBe(true);
+  });
+
+  it('reads src from the attribute', () => {
+    const element = create(defineElement(), { src: 'https://stream.mux.com/abc123.m3u8' });
+
+    expect(element.src).toBe('https://stream.mux.com/abc123.m3u8');
+  });
+
+  it('tracks src when the attribute changes', () => {
+    const element = create(defineElement(), { src: 'https://stream.mux.com/abc123.m3u8' });
+    element.setAttribute('src', 'https://stream.mux.com/def456.m3u8');
+
+    expect(element.src).toBe('https://stream.mux.com/def456.m3u8');
+  });
+
+  it('clears src when the attribute is removed', () => {
+    const element = create(defineElement(), { src: 'https://stream.mux.com/abc123.m3u8' });
+    element.removeAttribute('src');
+
+    expect(element.src).toBe('');
+  });
+
+  it('keeps the Mux params that cap the manifest', () => {
+    // Capping is a query param rather than an attribute, so it has to survive
+    // the round trip through the element untouched.
+    const src = 'https://stream.mux.com/abc123.m3u8?max_resolution=720p';
+    const element = create(defineElement(), { src });
+
+    expect(element.src).toBe(src);
+  });
+
+  it('observes only src', () => {
+    // `max-resolution` is a Mux URL param, `preload` means nothing to an engine
+    // that loads immediately, and `audio` / `debug` from the package this
+    // replaces are gone for good.
+    expect(MuxBackgroundVideo.observedAttributes).toEqual(['src']);
+  });
+});

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -34,6 +34,7 @@ const media = [
   'google-cast',
   'hlsjs-video',
   'mux-audio',
+  'mux-background-video',
   'mux-data',
   'mux-video',
   'native-hls-video',

--- a/packages/react/src/media/mux-background-video/index.ts
+++ b/packages/react/src/media/mux-background-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/mux-background-video/media.tsx
+++ b/packages/react/src/media/mux-background-video/media.tsx
@@ -41,11 +41,25 @@ export const MuxBackgroundVideo = forwardRef<HTMLVideoElement, MuxBackgroundVide
   const htmlProps = useSyncProps(media, props, muxBackgroundVideoMediaDefaultProps);
 
   return (
-    // Applied after the spread rather than before it: unlike the generic
-    // `BackgroundVideo`, these four aren't overridable. They're what the
-    // component is for, and attaching the Media re-applies them anyway, so
-    // letting a caller pass `muted={false}` would only look honored.
-    <video {...htmlProps} ref={composedRef} muted autoPlay loop playsInline>
+    // The same set `<mux-background-video>` forces onto its inner video, so the
+    // two platforms present the same surface: silent looping playback with no
+    // affordance a UA could hang chrome on — AirPlay, Cast, and picture-in-picture
+    // all being things a background video has nowhere to put.
+    //
+    // Applied after the spread rather than before it, unlike the generic
+    // `BackgroundVideo`: they're what the component is for, and attaching the
+    // Media re-applies its own anyway, so honoring `muted={false}` would only
+    // look like it worked.
+    <video
+      {...htmlProps}
+      ref={composedRef}
+      muted
+      autoPlay
+      loop
+      playsInline
+      disableRemotePlayback
+      disablePictureInPicture
+    >
       {children}
     </video>
   );

--- a/packages/react/src/media/mux-background-video/media.tsx
+++ b/packages/react/src/media/mux-background-video/media.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import {
+  MuxBackgroundVideoMedia,
+  type MuxBackgroundVideoMediaProps,
+  muxBackgroundVideoMediaDefaultProps,
+} from '@videojs/spf/mux-background-video';
+import type { VideoHTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+import { useAttachMedia } from '../../utils/use-attach-media';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+// `src` is the only prop the Media owns, taken from the adapter rather than
+// restated here so the two can't disagree about what the surface is.
+export interface MuxBackgroundVideoProps
+  extends Omit<VideoHTMLAttributes<HTMLVideoElement>, keyof MuxBackgroundVideoMediaProps>,
+    Partial<MuxBackgroundVideoMediaProps> {}
+
+/**
+ * A muted, looping, chrome-less video over the SPF background-video engine — the
+ * React counterpart to `<mux-background-video>`, and the replacement for the
+ * standalone `mux-background-video` package's component.
+ *
+ * `src` is an HLS URL and the whole surface. Capping which rendition is fetched
+ * is a Mux URL param (`?max_resolution=720p`) rather than a prop, which keeps
+ * the renditions it excludes out of the manifest instead of merely unpicked.
+ *
+ * There is no structured Mux `source`: playback-ID identity, poster, and
+ * storyboard belong to `MuxVideo`, since none of them mean anything without
+ * controls to hang them on.
+ */
+export const MuxBackgroundVideo = forwardRef<HTMLVideoElement, MuxBackgroundVideoProps>(function MuxBackgroundVideo(
+  { children, ...props },
+  ref
+) {
+  const media = useMediaInstance(MuxBackgroundVideoMedia);
+  const attachRef = useAttachMedia(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const htmlProps = useSyncProps(media, props, muxBackgroundVideoMediaDefaultProps);
+
+  return (
+    // Applied after the spread rather than before it: unlike the generic
+    // `BackgroundVideo`, these four aren't overridable. They're what the
+    // component is for, and attaching the Media re-applies them anyway, so
+    // letting a caller pass `muted={false}` would only look honored.
+    <video {...htmlProps} ref={composedRef} muted autoPlay loop playsInline>
+      {children}
+    </video>
+  );
+});
+
+export namespace MuxBackgroundVideo {
+  export type Props = MuxBackgroundVideoProps;
+}

--- a/packages/spf/package.json
+++ b/packages/spf/package.json
@@ -48,6 +48,11 @@
       "development": "./dist/dev/mux-audio.js",
       "default": "./dist/default/mux-audio.js"
     },
+    "./mux-background-video": {
+      "types": "./dist/dev/mux-background-video.d.ts",
+      "development": "./dist/dev/mux-background-video.js",
+      "default": "./dist/default/mux-background-video.js"
+    },
     "./mux-video": {
       "types": "./dist/dev/mux-video.d.ts",
       "development": "./dist/dev/mux-video.js",

--- a/packages/spf/src/playback/adapters/background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/background-video/adapter.ts
@@ -16,19 +16,11 @@ import {
 
 export interface BackgroundVideoMediaProps {
   src: string;
-  preload: '' | 'none' | 'metadata' | 'auto';
-  loop: boolean;
-  muted: boolean;
-  autoplay: boolean;
   maxResolution: string | number | undefined;
 }
 
 export const backgroundVideoMediaDefaultProps: BackgroundVideoMediaProps = {
   src: '',
-  preload: 'auto',
-  loop: true,
-  muted: true,
-  autoplay: true,
   maxResolution: undefined,
 };
 
@@ -44,15 +36,15 @@ export interface BackgroundVideoMediaAPI extends BackgroundVideoMediaProps {
  * Mixin that adds the background-video SPF playback engine to any
  * base class.
  *
- * Implements the WHATWG HTML media element contract (`src`, `preload`,
- * `loop`, `muted`, `autoplay`, `play()`) so it can be dropped in anywhere a
- * media element API is expected. Compared to `SimpleHlsMediaMixin`, this
- * variant:
+ * Implements the WHATWG HTML media element contract (`src`, `play()`) so it can
+ * be dropped in anywhere a media element API is expected. Compared to
+ * `SimpleHlsMediaMixin`, this variant:
  *
- * - exposes `loop`, `muted`, and `autoplay` as adapter-owned native
- *   passthroughs, all defaulting to `true` — the use case is silent
- *   autoplay-looping video, so muted + autoplay satisfy browser autoplay
- *   policies and loop is the defining behavior;
+ * - fixes silent autoplay-looping playback at `attach` rather than exposing it:
+ *   muted and autoplay are what let it start without a gesture, loop is the
+ *   defining behavior, and `preload` says out loud what the engine does anyway.
+ *   Nothing here declares those four, so a base that has them — a host — keeps
+ *   answering for them, and reads describe the element instead of an intention;
  * - drives the underlying engine with the background-video
  *   composition (single-rendition, video-only, autoplay-from-construction).
  *
@@ -75,10 +67,6 @@ export function BackgroundVideoMediaMixin<Base extends Constructor<any>>(BaseCla
     #engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
     #config: BackgroundVideoEngineConfig;
     #signals!: BackgroundVideoEngineSignals;
-    #preload: '' | 'none' | 'metadata' | 'auto' = backgroundVideoMediaDefaultProps.preload;
-    #loop: boolean = backgroundVideoMediaDefaultProps.loop;
-    #muted: boolean = backgroundVideoMediaDefaultProps.muted;
-    #autoplay: boolean = backgroundVideoMediaDefaultProps.autoplay;
     #maxResolution: string | number | undefined;
 
     /** Pending loadstart listener from a deferred play() retry, if any. */
@@ -104,12 +92,11 @@ export function BackgroundVideoMediaMixin<Base extends Constructor<any>>(BaseCla
 
     attach(mediaElement: HTMLMediaElement): void {
       super.attach?.(mediaElement);
-      // Apply adapter-owned native props before the engine takes over —
-      // the underlying element needs `loop` / `muted` / `autoplay` set for
-      // the use case's autoplay-looping semantics.
-      mediaElement.loop = this.#loop;
-      mediaElement.muted = this.#muted;
-      mediaElement.autoplay = this.#autoplay;
+      // The one place the fixed behavior is stated — see the mixin note.
+      mediaElement.loop = true;
+      mediaElement.muted = true;
+      mediaElement.autoplay = true;
+      mediaElement.preload = 'auto';
 
       this.#signals.context.mediaElement.set(mediaElement);
     }
@@ -123,48 +110,6 @@ export function BackgroundVideoMediaMixin<Base extends Constructor<any>>(BaseCla
     destroy(): void {
       this.#cancelPendingPlay();
       this.#engine.destroy();
-    }
-
-    // -------------------------------------------------------------------------
-    // preload — synchronous IDL attribute (WHATWG §4.8.11.2)
-    // -------------------------------------------------------------------------
-
-    get preload(): '' | 'none' | 'metadata' | 'auto' {
-      return this.#preload;
-    }
-
-    set preload(_value: '' | 'none' | 'metadata' | 'auto') {
-      // Noop for this phase
-    }
-
-    // -------------------------------------------------------------------------
-    // loop / muted / autoplay — adapter-owned IDL attributes mirrored onto
-    // the attached media element. The engine itself has no opinion on any
-    // of them.
-    // -------------------------------------------------------------------------
-
-    get loop(): boolean {
-      return this.#loop;
-    }
-
-    set loop(_value: boolean) {
-      // Noop for this phase
-    }
-
-    get muted(): boolean {
-      return this.#muted;
-    }
-
-    set muted(_value: boolean) {
-      // Noop for this phase
-    }
-
-    get autoplay(): boolean {
-      return this.#autoplay;
-    }
-
-    set autoplay(_value: boolean) {
-      // Noop for this phase
     }
 
     // -------------------------------------------------------------------------

--- a/packages/spf/src/playback/adapters/background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/background-video/adapter.ts
@@ -48,11 +48,10 @@ export interface BackgroundVideoMediaAPI extends BackgroundVideoMediaProps {
  * - drives the underlying engine with the background-video
  *   composition (single-rendition, video-only, autoplay-from-construction).
  *
- * A new engine is created on every src assignment — this fully tears down
- * all state, SourceBuffers, and in-flight requests from the previous
- * source before the next one begins. The media element reference is
- * preserved across src changes and re-applied to the new engine
- * automatically.
+ * A new src re-resolves the presentation, tearing down the state,
+ * SourceBuffers, and in-flight requests the previous one built before the next
+ * begins. The engine instance and the attached media element are both kept, so
+ * neither has to be rewired.
  *
  * @example
  * class BackgroundVideoMedia extends BackgroundVideoMediaMixin(HTMLVideoElementHost) {}
@@ -135,8 +134,6 @@ export function BackgroundVideoMediaMixin<Base extends Constructor<any>>(BaseCla
 
     // -------------------------------------------------------------------------
     // src — synchronous IDL attribute (WHATWG §4.8.11.2)
-    // Each assignment destroys the current engine and starts a fresh one,
-    // matching the browser's load algorithm reset on src change.
     // -------------------------------------------------------------------------
 
     get src(): string {

--- a/packages/spf/src/playback/adapters/background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/background-video/tests/adapter.test.ts
@@ -1,10 +1,10 @@
 /**
  * BackgroundVideoMediaElement adapter tests.
  *
- * Covers the HTMLMediaElement-compatible contract for src, preload, loop,
- * muted, and play(). Adapter-shape parallels SimpleHlsMediaElement; the
- * tests focus on what diverges: the new adapter owns `loop` / `muted`
- * passthroughs and defaults both to true (autoplay-muted, looping).
+ * Covers the HTMLMediaElement-compatible contract for `src` and `play()`.
+ * Adapter-shape parallels SimpleHlsMediaElement; the tests focus on what
+ * diverges: silent autoplay-looping playback is fixed on the element at attach
+ * rather than exposed, and `maxResolution` caps the rendition the engine pins.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MaybeResolvedPresentation } from '../../../../media/types';

--- a/packages/spf/src/playback/adapters/background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/background-video/tests/adapter.test.ts
@@ -104,26 +104,24 @@ describe('BackgroundVideoMediaElement', () => {
     });
   });
 
-  describe('loop / muted defaults', () => {
-    it('defaults loop to true', () => {
-      const media = new BackgroundVideoMediaElement();
-      expect(media.loop).toBe(true);
-    });
-
-    it('defaults muted to true', () => {
-      const media = new BackgroundVideoMediaElement();
-      expect(media.muted).toBe(true);
-    });
-
-    it('applies loop / muted defaults to the media element on attach', () => {
+  // The adapter declares none of these; `attach` is the one place the fixed
+  // behavior is written, so the element is where it is observable.
+  describe('fixed playback behavior', () => {
+    it('fixes loop, muted, autoplay, and preload on the media element at attach', () => {
       const media = new BackgroundVideoMediaElement();
       const el = document.createElement('video');
       // start the element in the opposite state so we can confirm attach overrides it
       el.loop = false;
       el.muted = false;
+      el.autoplay = false;
+      el.preload = 'none';
+
       media.attach(el);
+
       expect(el.loop).toBe(true);
       expect(el.muted).toBe(true);
+      expect(el.autoplay).toBe(true);
+      expect(el.preload).toBe('auto');
     });
 
     // attach modifies native props; changing src doesn't
@@ -134,37 +132,6 @@ describe('BackgroundVideoMediaElement', () => {
       el.loop = false;
       el.muted = false;
       media.src = 'https://example.com/v.m3u8';
-      expect(el.loop).toBe(false);
-      expect(el.muted).toBe(false);
-    });
-
-    // Skipped: `set loop` / `set muted` are noops in Phase 1 (the adapter
-    // pins loop=true / muted=true for the autoplay-looping use case). These
-    // assert functional setters — unskip when the setters are implemented.
-    it.skip('mirrors loop changes onto the attached element', () => {
-      const media = new BackgroundVideoMediaElement();
-      const el = document.createElement('video');
-      media.attach(el);
-      media.loop = false;
-      expect(el.loop).toBe(false);
-      expect(media.loop).toBe(false);
-    });
-
-    it.skip('mirrors muted changes onto the attached element', () => {
-      const media = new BackgroundVideoMediaElement();
-      const el = document.createElement('video');
-      media.attach(el);
-      media.muted = false;
-      expect(el.muted).toBe(false);
-      expect(media.muted).toBe(false);
-    });
-
-    it.skip('stores loop / muted updates made before attach and applies them on attach', () => {
-      const media = new BackgroundVideoMediaElement();
-      media.loop = false;
-      media.muted = false;
-      const el = document.createElement('video');
-      media.attach(el);
       expect(el.loop).toBe(false);
       expect(el.muted).toBe(false);
     });

--- a/packages/spf/src/playback/adapters/mux-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/adapter.ts
@@ -1,0 +1,194 @@
+import type { Constructor, MixinReturn } from '@videojs/utils/types';
+import type { Composition } from '../../../core/composition/create-composition';
+import { pickTrackUnderPixelArea, type TrackPicker } from '../../../media/primitives/select-tracks';
+import type { VideoSelectionSet } from '../../../media/types';
+import {
+  type BackgroundVideoEngineConfig,
+  type BackgroundVideoEngineContext,
+  type BackgroundVideoEngineSignals,
+  type BackgroundVideoEngineState,
+  createBackgroundVideoEngine,
+} from '../../engines/hls/engine-background-video';
+
+export interface MuxBackgroundVideoMediaProps {
+  src: string;
+}
+
+export const muxBackgroundVideoMediaDefaultProps: MuxBackgroundVideoMediaProps = {
+  src: '',
+};
+
+export interface MuxBackgroundVideoMediaAPI extends MuxBackgroundVideoMediaProps {
+  readonly engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
+  attach(mediaElement: HTMLMediaElement): void;
+  detach(): void;
+  destroy(): void;
+  play(): Promise<void>;
+}
+
+/**
+ * Mixin that adds the background-video SPF playback engine to any base class,
+ * for a Mux stream URL.
+ *
+ * `src` is the whole surface. What a consumer would otherwise reach for an
+ * attribute to do — capping which rendition is fetched — is a Mux stream URL
+ * param (`?max_resolution=720p`), so the cap is applied server-side and the
+ * manifest never offers the renditions it excludes. This adapter therefore has
+ * no cap of its own and always pins the top rendition on offer.
+ *
+ * Deliberately a sibling of `../background-video` rather than a layer over it.
+ * They share the engine, not the adapter: that one exposes a client-side
+ * `maxResolution` this one has no use for, and it binds no host. The two are
+ * otherwise line-for-line the same today — **changes to one usually belong in
+ * both** until the Mux flavor grows something of its own, which the screen
+ * resolution and pixel-density capping on the roadmap is expected to be.
+ *
+ * Everything else the use case fixes rather than exposes: video-only, looping,
+ * muted, autoplaying, loading as soon as there is a source. `attach` writes that
+ * onto the element and nothing here declares `loop` / `muted` / `autoplay` /
+ * `preload` of its own — a host-bound Media inherits all four from the host
+ * already, and shadowing them with fixed values would only make reads describe
+ * an intention rather than what the element is doing.
+ *
+ * @example
+ * class MuxBackgroundVideoMedia extends MuxBackgroundVideoMediaMixin(HTMLVideoElementHost) {}
+ *
+ * const media = new MuxBackgroundVideoMedia();
+ * media.attach(document.querySelector('video'));
+ * media.src = 'https://stream.mux.com/PLAYBACK_ID.m3u8?max_resolution=720p';
+ * media.play();
+ */
+export function MuxBackgroundVideoMediaMixin<Base extends Constructor<any>>(BaseClass: Base) {
+  class MuxBackgroundVideoMediaImpl extends BaseClass {
+    #engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
+    #config: BackgroundVideoEngineConfig;
+    #signals!: BackgroundVideoEngineSignals;
+
+    /** Pending loadstart listener from a deferred play() retry, if any. */
+    #loadstartListener: (() => void) | null = null;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const { config } = args?.[0] ?? {};
+      this.#config = config;
+      this.#engine = this.#createEngine();
+    }
+
+    get engine(): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
+      return this.#engine;
+    }
+
+    // -------------------------------------------------------------------------
+    // Media element lifecycle
+    // -------------------------------------------------------------------------
+
+    attach(mediaElement: HTMLMediaElement): void {
+      super.attach?.(mediaElement);
+      // The one place the fixed behavior is stated. Muted and autoplay are what
+      // let it start without a gesture, loop is the defining behavior, and
+      // `preload` says out loud what the engine does regardless — it subtracts
+      // preload monitoring and loads from the moment it has a source.
+      mediaElement.loop = true;
+      mediaElement.muted = true;
+      mediaElement.autoplay = true;
+      mediaElement.preload = 'auto';
+
+      this.#signals.context.mediaElement.set(mediaElement);
+    }
+
+    detach(): void {
+      this.#cancelPendingPlay();
+      this.#signals.context.mediaElement.set(undefined);
+      super.detach?.();
+    }
+
+    destroy(): void {
+      this.#cancelPendingPlay();
+      this.#engine.destroy();
+    }
+
+    // -------------------------------------------------------------------------
+    // src — synchronous IDL attribute (WHATWG §4.8.11.2)
+    // -------------------------------------------------------------------------
+
+    get src(): string {
+      return this.#signals.state.presentation.get()?.url ?? '';
+    }
+
+    set src(value: string) {
+      // Same line the HLS Medias draw: the presentation is set from a fresh
+      // object every time, so re-resolving a URL already playing would restart
+      // it for no reason.
+      if (value === this.src) return;
+
+      this.#cancelPendingPlay();
+      this.#signals.state.presentation.set(value ? { url: value } : undefined);
+    }
+
+    // -------------------------------------------------------------------------
+    // play() — WHATWG §4.8.11.8
+    // Delegates to the attached media element's native play().
+    // -------------------------------------------------------------------------
+
+    async play(): Promise<void> {
+      const mediaElement = this.#signals.context.mediaElement.get();
+      if (!mediaElement) {
+        return Promise.reject(new Error('MuxBackgroundVideoMediaElement: no media element attached'));
+      }
+
+      try {
+        return await mediaElement.play();
+      } catch (err) {
+        // If we have a pending HLS source, the rejection may be because MSE
+        // hasn't attached a blob URL yet. Wait for loadstart (src assigned by
+        // MSE setup) and retry once.
+        if (this.src) {
+          return new Promise<void>((resolve, reject) => {
+            const listener = () => {
+              this.#loadstartListener = null;
+              mediaElement.play().then(resolve, reject);
+            };
+            this.#loadstartListener = listener;
+            mediaElement.addEventListener('loadstart', listener, { once: true });
+          });
+        }
+        throw err;
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private
+    // -------------------------------------------------------------------------
+
+    #createEngine(): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
+      // No cap to apply, so the pick is whichever rendition is largest. Passing
+      // no maximum is what makes that the answer, rather than a rule of its own.
+      const adapterPicker: TrackPicker = (presentation) => {
+        const videoSet = presentation.selectionSets?.find((s) => s.type === 'video') as VideoSelectionSet | undefined;
+        const tracks = videoSet?.switchingSets[0]?.tracks ?? [];
+        return pickTrackUnderPixelArea(tracks)?.id;
+      };
+
+      return createBackgroundVideoEngine({
+        picker: adapterPicker,
+        ...this.#config,
+        onSignalsReady: (signals) => {
+          this.#signals = signals;
+        },
+      });
+    }
+
+    #cancelPendingPlay(): void {
+      if (!this.#loadstartListener) return;
+      const mediaElement = this.#signals.context.mediaElement.get();
+      mediaElement?.removeEventListener('loadstart', this.#loadstartListener);
+      this.#loadstartListener = null;
+    }
+  }
+
+  return MuxBackgroundVideoMediaImpl as unknown as MixinReturn<Base, MuxBackgroundVideoMediaAPI>;
+}
+
+/** Standalone Mux background-video adapter with no base class. */
+export class MuxBackgroundVideoMediaElement extends MuxBackgroundVideoMediaMixin(class {}) {}

--- a/packages/spf/src/playback/adapters/mux-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/adapter.ts
@@ -51,7 +51,7 @@ export interface MuxBackgroundVideoMediaAPI extends MuxBackgroundVideoMediaProps
  * an intention rather than what the element is doing.
  *
  * @example
- * class MuxBackgroundVideoMedia extends MuxBackgroundVideoMediaMixin(HTMLVideoElementHost) {}
+ * class MuxBackgroundVideoMedia extends MuxBackgroundVideoMediaMixin(BackgroundVideoHost) {}
  *
  * const media = new MuxBackgroundVideoMedia();
  * media.attach(document.querySelector('video'));

--- a/packages/spf/src/playback/adapters/mux-background-video/host.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/host.ts
@@ -1,21 +1,19 @@
 /**
- * The `<video>` binding a background video actually uses: somewhere to keep the
- * attached element, and the four properties whose values it fixes.
+ * The `<video>` binding a background video uses: somewhere to keep the attached
+ * element, and the four properties the Media fixes on it.
  *
- * `HTMLVideoElementHost` would do this too, along with the rest of the WHATWG
- * surface — `currentTime`, `play()`, picture-in-picture, fullscreen, event
- * forwarding, media-component registration. None of it is reachable here. The
- * engine drives playback, the element exposes `src` and nothing else, and the
- * background player's store subscribes to no features at all, so every one of
- * those members is weight a consumer downloads to never call. Measured, the full
- * host is 1,644 B gzipped against this one's 234 B, and swapping it takes ~1.2 KB
- * off each of the three published entries.
+ * That is the whole surface anything here reaches. The engine drives playback,
+ * the element exposes `src` and nothing else, and the background player
+ * subscribes to no store features, so nothing asks a background video for
+ * `currentTime`, `play()`, picture-in-picture, fullscreen, forwarded events, or
+ * media components. Holding the host to what is reachable is what keeps this
+ * entry free of `@videojs/media`, and small enough to suit a component whose
+ * whole pitch is its size.
  *
- * ⚠️ The tradeoff is that this is no longer a `Media` structurally, so the layers
- * above cast to reach it, and **a store feature added to `backgroundFeatures`
- * would read properties that aren't here** — silently, as `undefined`. That is
- * the point at which this should become a composition over the shared host
- * rather than a replacement for it.
+ * ⚠️ It implements too little to be a `Media` structurally, which bounds what may
+ * consume it: a store feature reading any property outside this set gets
+ * `undefined` rather than an error. A Media needing more of the media surface
+ * belongs on a host that provides it.
  */
 export class BackgroundVideoHost {
   #target: HTMLVideoElement | null = null;

--- a/packages/spf/src/playback/adapters/mux-background-video/host.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/host.ts
@@ -10,12 +10,16 @@
  * entry free of `@videojs/media`, and small enough to suit a component whose
  * whole pitch is its size.
  *
- * ⚠️ It implements too little to be a `Media` structurally, which bounds what may
- * consume it: a store feature reading any property outside this set gets
- * `undefined` rather than an error. A Media needing more of the media surface
+ * An `EventTarget`, because a Media is one: the store and the element layers
+ * take anything they attach as an event source, and inheriting the three methods
+ * satisfies that for free rather than by stubbing them.
+ *
+ * ⚠️ It still implements too little to carry the rest of the media surface, which
+ * bounds what may consume it: a store feature reading a property outside this set
+ * gets `undefined` rather than an error. A Media needing more of that surface
  * belongs on a host that provides it.
  */
-export class BackgroundVideoHost {
+export class BackgroundVideoHost extends EventTarget {
   #target: HTMLVideoElement | null = null;
 
   attach(target: HTMLVideoElement): void {

--- a/packages/spf/src/playback/adapters/mux-background-video/host.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/host.ts
@@ -1,0 +1,66 @@
+/**
+ * The `<video>` binding a background video actually uses: somewhere to keep the
+ * attached element, and the four properties whose values it fixes.
+ *
+ * `HTMLVideoElementHost` would do this too, along with the rest of the WHATWG
+ * surface — `currentTime`, `play()`, picture-in-picture, fullscreen, event
+ * forwarding, media-component registration. None of it is reachable here. The
+ * engine drives playback, the element exposes `src` and nothing else, and the
+ * background player's store subscribes to no features at all, so every one of
+ * those members is weight a consumer downloads to never call. Measured, the full
+ * host is 1,644 B gzipped against this one's 234 B, and swapping it takes ~1.2 KB
+ * off each of the three published entries.
+ *
+ * ⚠️ The tradeoff is that this is no longer a `Media` structurally, so the layers
+ * above cast to reach it, and **a store feature added to `backgroundFeatures`
+ * would read properties that aren't here** — silently, as `undefined`. That is
+ * the point at which this should become a composition over the shared host
+ * rather than a replacement for it.
+ */
+export class BackgroundVideoHost {
+  #target: HTMLVideoElement | null = null;
+
+  attach(target: HTMLVideoElement): void {
+    if (!target || this.#target === target) return;
+    this.#target = target;
+  }
+
+  detach(): void {
+    this.#target = null;
+  }
+
+  // Read back off the element rather than stored, so they describe what is
+  // playing instead of what was asked for — see the adapter's note on why the
+  // Media declares none of these itself.
+  get loop(): boolean {
+    return this.#target?.loop ?? false;
+  }
+
+  set loop(value: boolean) {
+    if (this.#target) this.#target.loop = value;
+  }
+
+  get muted(): boolean {
+    return this.#target?.muted ?? false;
+  }
+
+  set muted(value: boolean) {
+    if (this.#target) this.#target.muted = value;
+  }
+
+  get autoplay(): boolean {
+    return this.#target?.autoplay ?? false;
+  }
+
+  set autoplay(value: boolean) {
+    if (this.#target) this.#target.autoplay = value;
+  }
+
+  get preload(): HTMLVideoElement['preload'] {
+    return this.#target?.preload ?? 'metadata';
+  }
+
+  set preload(value: HTMLVideoElement['preload']) {
+    if (this.#target) this.#target.preload = value;
+  }
+}

--- a/packages/spf/src/playback/adapters/mux-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/index.ts
@@ -11,8 +11,8 @@
  * no Media to hand an element. Both are the muted-looping case, so a change to
  * one usually belongs in the other.
  *
- * Binding a host here costs nothing this entry was avoiding: its host is local
- * and narrow, so it stays free of `@videojs/media` exactly as its sibling does.
+ * Its host is local and narrow, so this entry carries no `@videojs/media`
+ * dependency either.
  */
 export type { MuxBackgroundVideoMediaAPI, MuxBackgroundVideoMediaProps } from './adapter';
 export {

--- a/packages/spf/src/playback/adapters/mux-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/index.ts
@@ -10,6 +10,9 @@
  * that one exposes a client-side `maxResolution` and binds no host, so it has
  * no Media to hand an element. Both are the muted-looping case, so a change to
  * one usually belongs in the other.
+ *
+ * Binding a host here costs nothing this entry was avoiding: its host is local
+ * and narrow, so it stays free of `@videojs/media` exactly as its sibling does.
  */
 export type { MuxBackgroundVideoMediaAPI, MuxBackgroundVideoMediaProps } from './adapter';
 export {

--- a/packages/spf/src/playback/adapters/mux-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/index.ts
@@ -1,0 +1,20 @@
+/**
+ * The Mux background-video Media over the SPF background-video engine — a
+ * muted, looping, chrome-less video from a Mux stream URL.
+ *
+ * `src` is the whole surface. Capping which rendition is fetched is a Mux URL
+ * param (`?max_resolution=720p`) rather than a property here, which keeps the
+ * excluded renditions out of the manifest instead of merely unpicked.
+ *
+ * Shares the engine with `@videojs/spf/background-video` but not the adapter:
+ * that one exposes a client-side `maxResolution` and binds no host, so it has
+ * no Media to hand an element. Both are the muted-looping case, so a change to
+ * one usually belongs in the other.
+ */
+export type { MuxBackgroundVideoMediaAPI, MuxBackgroundVideoMediaProps } from './adapter';
+export {
+  MuxBackgroundVideoMediaElement,
+  MuxBackgroundVideoMediaMixin,
+  muxBackgroundVideoMediaDefaultProps,
+} from './adapter';
+export { MuxBackgroundVideoMedia } from './media';

--- a/packages/spf/src/playback/adapters/mux-background-video/media.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/media.ts
@@ -1,10 +1,15 @@
-import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
 import { MuxBackgroundVideoMediaMixin } from './adapter';
+import { BackgroundVideoHost } from './host';
 
-const MuxBackgroundVideoMediaBase = MuxBackgroundVideoMediaMixin(HTMLVideoElementHost);
+const MuxBackgroundVideoMediaBase = MuxBackgroundVideoMediaMixin(BackgroundVideoHost);
 
 /**
- * The Mux background-video Media, bound to a `<video>` host.
+ * The Mux background-video Media, bound to a `<video>`.
+ *
+ * Over {@link BackgroundVideoHost} rather than `@videojs/media`'s
+ * `HTMLVideoElementHost`: a background video reaches four of that host's members
+ * and downloads the rest. It also keeps this entry free of `@videojs/media`, the
+ * property `@videojs/spf/background-video` documents for itself.
  *
  * No `MediaTracksMixin`, unlike `SimpleHlsMedia`: the engine subtracts audio and
  * text entirely and pins one video rendition for the session, so there are no

--- a/packages/spf/src/playback/adapters/mux-background-video/media.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/media.ts
@@ -4,12 +4,12 @@ import { BackgroundVideoHost } from './host';
 const MuxBackgroundVideoMediaBase = MuxBackgroundVideoMediaMixin(BackgroundVideoHost);
 
 /**
- * The Mux background-video Media, bound to a `<video>`.
+ * The Mux background-video Media, bound to a `<video>` through
+ * {@link BackgroundVideoHost}.
  *
- * Over {@link BackgroundVideoHost} rather than `@videojs/media`'s
- * `HTMLVideoElementHost`: a background video reaches four of that host's members
- * and downloads the rest. It also keeps this entry free of `@videojs/media`, the
- * property `@videojs/spf/background-video` documents for itself.
+ * That host carries the attached element and the four properties `attach` fixes,
+ * which is all this Media's surface needs, and it is local — so this entry has
+ * no `@videojs/media` dependency.
  *
  * No `MediaTracksMixin`, unlike `SimpleHlsMedia`: the engine subtracts audio and
  * text entirely and pins one video rendition for the session, so there are no

--- a/packages/spf/src/playback/adapters/mux-background-video/media.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/media.ts
@@ -1,0 +1,13 @@
+import { HTMLVideoElementHost } from '@videojs/media/dom/video-host';
+import { MuxBackgroundVideoMediaMixin } from './adapter';
+
+const MuxBackgroundVideoMediaBase = MuxBackgroundVideoMediaMixin(HTMLVideoElementHost);
+
+/**
+ * The Mux background-video Media, bound to a `<video>` host.
+ *
+ * No `MediaTracksMixin`, unlike `SimpleHlsMedia`: the engine subtracts audio and
+ * text entirely and pins one video rendition for the session, so there are no
+ * track lists for a consumer to project or switch between.
+ */
+export class MuxBackgroundVideoMedia extends MuxBackgroundVideoMediaBase {}

--- a/packages/spf/src/playback/adapters/mux-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/tests/adapter.test.ts
@@ -1,0 +1,215 @@
+/**
+ * MuxBackgroundVideoMediaElement adapter tests.
+ *
+ * Mirrors the coverage of `../../background-video`, which shares this adapter's
+ * engine and shape, minus its client-side `maxResolution`. What is asserted here
+ * and not there is the consequence of dropping it: the picker takes the largest
+ * rendition on offer, since capping is a Mux URL param that keeps the rest out
+ * of the manifest to begin with.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MaybeResolvedPresentation } from '../../../../media/types';
+import { MuxBackgroundVideoMediaElement } from '../adapter';
+
+describe('MuxBackgroundVideoMediaElement', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {}))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('src', () => {
+    it('returns empty string before any src is set', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      expect(media.src).toBe('');
+    });
+
+    it('reflects the set value synchronously', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.src = 'https://stream.mux.com/abc123.m3u8';
+      expect(media.src).toBe('https://stream.mux.com/abc123.m3u8');
+    });
+
+    it('synchronously updates engine presentation state when src is set', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.src = 'https://stream.mux.com/abc123.m3u8';
+      expect(media.engine.state.presentation.get()?.url).toBe('https://stream.mux.com/abc123.m3u8');
+    });
+
+    it('keeps the Mux query params that cap the manifest', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.src = 'https://stream.mux.com/abc123.m3u8?max_resolution=720p';
+      expect(media.engine.state.presentation.get()?.url).toBe('https://stream.mux.com/abc123.m3u8?max_resolution=720p');
+    });
+
+    it('clears engine presentation state when src is set to empty string', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.src = 'https://stream.mux.com/abc123.m3u8';
+      media.src = '';
+      expect(media.engine.state.presentation.get()?.url).toBeFalsy();
+    });
+
+    it('leaves engine presentation state alone when src is set to the URL already playing', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.src = 'https://stream.mux.com/abc123.m3u8';
+      const presentation = media.engine.state.presentation.get();
+
+      media.src = 'https://stream.mux.com/abc123.m3u8';
+
+      // The same object, not an equal one: a fresh presentation re-resolves.
+      expect(media.engine.state.presentation.get()).toBe(presentation);
+    });
+  });
+
+  describe('attach / detach', () => {
+    it('exposes the engine immediately (created at construction)', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      expect(media.engine).toBeDefined();
+    });
+
+    it('reuses the same engine instance across attach calls', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      const firstEngine = media.engine;
+      media.attach(document.createElement('video'));
+      media.attach(document.createElement('video'));
+      expect(media.engine).toBe(firstEngine);
+    });
+
+    it('sets mediaElement in context when attached', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      const el = document.createElement('video');
+      media.attach(el);
+      expect(media.engine.context.mediaElement.get()).toBe(el);
+    });
+
+    it('clears mediaElement in context when detached', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.attach(document.createElement('video'));
+      media.detach();
+      expect(media.engine.context.mediaElement.get()).toBeUndefined();
+    });
+  });
+
+  // The adapter declares none of these — a host-bound Media inherits them, and
+  // `attach` is the one place the fixed behavior is written.
+  describe('fixed playback behavior', () => {
+    it('fixes loop, muted, autoplay, and preload on the element at attach', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      const el = document.createElement('video');
+      // Start in the opposite state so attach is what we observe.
+      el.loop = false;
+      el.muted = false;
+      el.autoplay = false;
+      el.preload = 'none';
+
+      media.attach(el);
+
+      expect(el.loop).toBe(true);
+      expect(el.muted).toBe(true);
+      expect(el.autoplay).toBe(true);
+      expect(el.preload).toBe('auto');
+    });
+
+    it('re-applies them to a second element', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.attach(document.createElement('video'));
+
+      const next = document.createElement('video');
+      next.loop = false;
+      media.attach(next);
+
+      expect(next.loop).toBe(true);
+    });
+  });
+
+  describe('rendition selection', () => {
+    // Pre-resolved 4-track presentation. Setting it on `engine.state.presentation`
+    // drives the composition through `presentation-unresolved → resolved`, which
+    // is what fires the picker.
+    const presentationWithFourTracks = (): MaybeResolvedPresentation => ({
+      id: 'p',
+      url: 'https://stream.mux.com/abc123.m3u8',
+      startTime: 0,
+      selectionSets: [
+        {
+          id: 'video-set',
+          type: 'video',
+          switchingSets: [
+            {
+              id: 'video-switching',
+              type: 'video',
+              tracks: [
+                videoTrack('360p', 640, 360, 500_000),
+                videoTrack('720p', 1280, 720, 2_000_000),
+                videoTrack('1080p', 1920, 1080, 4_000_000),
+                videoTrack('1440p', 2560, 1440, 8_000_000),
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    it('picks the largest rendition on offer', async () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      media.engine.state.presentation.set(presentationWithFourTracks());
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      expect(media.engine.state.selectedVideoTrackId.get()).toBe('1440p');
+      media.destroy();
+    });
+
+    it('picks the largest of whatever the manifest offers, which is how a capped URL narrows it', async () => {
+      // What `?max_resolution=720p` produces: the excluded renditions are absent
+      // from the manifest rather than present and skipped.
+      const capped = presentationWithFourTracks();
+      capped.selectionSets![0]!.switchingSets[0]!.tracks = [
+        videoTrack('360p', 640, 360, 500_000),
+        videoTrack('720p', 1280, 720, 2_000_000),
+      ] as never;
+
+      const media = new MuxBackgroundVideoMediaElement();
+      media.engine.state.presentation.set(capped);
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      expect(media.engine.state.selectedVideoTrackId.get()).toBe('720p');
+      media.destroy();
+    });
+  });
+
+  describe('play()', () => {
+    it('rejects when no media element is attached', async () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      await expect(media.play()).rejects.toThrow('no media element attached');
+    });
+  });
+
+  describe('destroy()', () => {
+    it('destroys the underlying engine', () => {
+      const media = new MuxBackgroundVideoMediaElement();
+      const spy = vi.spyOn(media.engine, 'destroy');
+      media.destroy();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});
+
+function videoTrack(id: string, width: number, height: number, bandwidth: number) {
+  return {
+    type: 'video' as const,
+    id,
+    url: `https://stream.mux.com/${id}.m3u8`,
+    bandwidth,
+    mimeType: 'video/mp4',
+    codecs: ['avc1.42E01E'],
+    initialization: { url: 'init', byteRange: { offset: 0, length: 0 } },
+    segments: [],
+    startTime: 0,
+    duration: 0,
+    width,
+    height,
+  } as never;
+}

--- a/packages/spf/src/playback/adapters/mux-background-video/tests/media.test.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/tests/media.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The host-bound Media, covering what binding to a host is what makes true: the
+ * fixed behavior is readable back off the Media because the host forwards to the
+ * element, not because the adapter keeps a parallel copy of it.
+ */
+import { describe, expect, it } from 'vitest';
+import { MuxBackgroundVideoMedia } from '../media';
+
+describe('MuxBackgroundVideoMedia', () => {
+  it('reports the fixed behavior from the attached element', () => {
+    const media = new MuxBackgroundVideoMedia();
+    const el = document.createElement('video');
+
+    media.attach(el);
+
+    expect(media.loop).toBe(true);
+    expect(media.muted).toBe(true);
+    expect(media.autoplay).toBe(true);
+    expect(media.preload).toBe('auto');
+  });
+
+  it('follows the element when it is changed underneath', () => {
+    const media = new MuxBackgroundVideoMedia();
+    const el = document.createElement('video');
+    media.attach(el);
+
+    el.loop = false;
+
+    // The reason for not shadowing these: a stored value would still claim true.
+    expect(media.loop).toBe(false);
+  });
+});

--- a/packages/spf/tsdown.config.ts
+++ b/packages/spf/tsdown.config.ts
@@ -11,6 +11,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'media-tracks': 'src/media/media-tracks/index.ts',
     'background-video': 'src/playback/adapters/background-video/index.ts',
     'mux-audio': 'src/playback/adapters/mux-audio/index.ts',
+    'mux-background-video': 'src/playback/adapters/mux-background-video/index.ts',
     'mux-video': 'src/playback/adapters/mux-video/index.ts',
     'simple-hls': 'src/playback/adapters/simple-hls/index.ts',
     'simple-hls-audio-only': 'src/playback/adapters/simple-hls-audio-only/index.ts',


### PR DESCRIPTION
## Summary

`<mux-background-video>` and `MuxBackgroundVideo`: a muted, looping, chrome-less video from a Mux stream URL, over the SPF background-video engine. `src` is the whole surface — capping which rendition is fetched is a Mux URL param (`?max_resolution=720p`), so the manifest arrives already narrowed and the engine pins the largest track on offer.

## Changes

- **A standalone `mux-background-video` adapter and Media**, behind `@videojs/spf/mux-background-video`. It shares the engine with the generic background-video adapter but not the adapter itself: that one exposes a client-side `maxResolution` this has no use for, and binds no host, so it has no Media to hand an element. The two are otherwise the same today and say so in their docstrings.
- **The element, the React component, sandbox pages, and a CDN bundle**, so every platform the sandbox offers reaches it.
- **Nothing declares `loop` / `muted` / `autoplay` / `preload` any more** — on either background-video adapter. `attach` writes them onto the element instead, which is also what makes them readable back: a host-bound Media inherits all four and forwards to the element, where declaring them meant reads described an intention. The old suite asserted the element going unlooped while `media.loop` still said `true`.
- **The Media binds a narrow, local `<video>` host rather than the shared `HTMLVideoElementHost`.** A background video reaches four of that host's members and would ship the rest; this takes ~1.2 KB gzipped off every published entry and leaves `@videojs/media` out of the graph.
- **Fix: the CDN sandbox page rendered a plain `<video>` for any preset it doesn't claim.** Adding a preset makes it selectable on every platform, and that page falls through `getMediaTag`'s default when its switch has no case, so the element was never defined and no bundle loaded. Both background presets now answer one predicate rather than repeating a comparison in five places.

<details>
<summary>Implementation details</summary>

**Why a separate adapter rather than a layer over the generic one.** With `src`-only and no structured source there is nothing Mux-specific in it yet, so composing would have meant inheriting a `maxResolution` only to override it away. The seam exists for what is coming: screen-resolution and pixel-density capping is the named fast-follow, and it is the first thing that gives this adapter something of its own.

**Why the Media binds a one-off host.** The generic background-video adapter deliberately binds none — its docstring gives the reason as the `@videojs/media` dependency that `HTMLVideoElementHost` would add, which measured 1.26 KB gzipped. But an element needs a host-bound Media, so this one binds a local ~40-line host instead: `attach`, `detach`, and the four properties `attach` fixes.

That is the entire surface reachable here. The engine drives playback, the element exposes `src`, and the background player subscribes to no store features at all (`backgroundFeatures` is `[]`), against a shared host offering `currentTime`, `play()`, picture-in-picture, fullscreen, event forwarding, and media-component registration. Swapping it takes ~1.2 KB gzipped off each of the three published entries — spf 18,159 → 16,891, html 19,144 → 17,918, react 18,637 → 17,390 — and drops `@videojs/media` from the graph entirely. The Mux entry now costs 16,910 B against the generic one's 16,896: **14 bytes for a host-bound Media, where the shared host cost 1,286.**

The tradeoff is written on the host. A feature added to `backgroundFeatures` would read properties that are not there, as `undefined` rather than as a failure — that is the point at which this should compose over the shared host rather than replace it, and the reason the follow-up worth having is making `HTMLVideoElementHost` composable rather than repeating this per Media.

**`<background-video>` is untouched.** Rewiring it onto the engine would have silently broken its `nomuted` / `noloop` / `noautoplay` opt-outs, since `attach` force-writes all three.

</details>

## Breaking changes

- `BackgroundVideoMediaProps` is `src` and `maxResolution` only, and `BackgroundVideoMediaElement` no longer carries `loop` / `muted` / `autoplay` / `preload` at all — its base is a bare object, so nothing backfills them. Composing `BackgroundVideoMediaMixin` over a media host still does.

## Testing

```
pnpm -F @videojs/spf test      # 1485 passed, 11 skipped
pnpm -F @videojs/html test     # 317 passed
pnpm -F @videojs/react test    # 394 passed
pnpm typecheck && pnpm check:workspace
```

Browser smoke on the sandbox, HTML / React / CDN: autoplaying, looping, muted, `preload="auto"`, and `videoHeight` 720 on an asset whose ladder tops out at 1080p — the URL cap narrowed the manifest and the picker took the largest of what remained. The natively-played `<background-video>` was re-checked on both its own page and the CDN page as a regression.



### Smoke test it yourself

Branch preview: **https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app**

- **`<mux-background-video>`** — [HTML](https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app/?platform=html&preset=mux-background-video) · [React](https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app/?platform=react&preset=mux-background-video) · [CDN](https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app/?platform=cdn&preset=mux-background-video)
- **`<background-video>` regressions** — [HTML](https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app/?platform=html&preset=background-video) · [React](https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app/?platform=react&preset=background-video) · [CDN](https://v10-sandbox-git-feat-spf-mux-background-video-mux.vercel.app/?platform=cdn&preset=background-video)

Each background page renders one fixed source and takes no picker, so there is nothing to configure — it either autoplays silently on loop or it doesn't. The thing worth checking is that the Mux pages report `videoHeight` 720 on an asset whose ladder tops out at 1080p, which is the URL cap narrowing the manifest rather than a client-side pick.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `BackgroundVideoMediaProps` and playback-flag semantics on the generic background-video adapter, plus new HLS/SPF playback surface where wrong packaging (non-CMAF) fails at runtime.
> 
> **Overview**
> Adds **`<mux-background-video>`** and **`MuxBackgroundVideo`** for muted, looping hero video from a Mux **HLS** URL via the SPF background-video engine, with **`src` as the only control** (rendition caps via `?max_resolution=` on the URL). Ships HTML custom element, React wrapper, CDN bundle, sandbox presets (HTML/React/CDN), and a dedicated **CMAF/fMP4** demo asset constant.
> 
> Introduces **`@videojs/spf/mux-background-video`** (adapter + **`BackgroundVideoHost`**-bound Media) alongside the generic background-video adapter; the Mux path pins the largest offered rendition because the manifest is already narrowed server-side.
> 
> **Breaking:** both background-video adapters drop **`loop` / `muted` / `autoplay` / `preload`** from their public props/API — **`attach` force-writes** them on the `<video>` instead, and **`BackgroundVideoMediaProps`** is now **`src` + `maxResolution` only** for the standalone element. Shared shadow **template** extraction and **background skin CSS** (`:not(img, picture)`) so native and Mux background elements layout correctly; CDN sandbox treats both background presets uniformly so the new preset loads the right tag/bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adda092f6c878188ef8a4d322c6fd05b8887aa7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

