### PR TITLE
refactor(packages)!: redesign video quality options

### DIFF
--- a/packages/core/src/core/ui/quality-radio-group/core.ts
+++ b/packages/core/src/core/ui/quality-radio-group/core.ts
@@ -17,10 +17,30 @@ export interface QualityRadioGroupProps {
   disabled?: boolean | undefined;
 }
 
-export interface QualityRadioGroupOption extends RadioOption {
+export interface QualityRadioGroupOptionParts {
+  /**
+   * Main visible text. Translate it with the option's `labelParams`; the automatic option interpolates the active
+   * rendition.
+   */
+  primary: Text | string;
+  /** Resolution tier such as `HD`, `4K`, or `8K`. */
   tier?: string | undefined;
-  badge?: string | undefined;
+  /** Bitrate text, present only when renditions share a size and need disambiguating. */
+  bitrate?: string | undefined;
 }
+
+export interface QualityRadioGroupAutoOption extends RadioOption {
+  kind: 'auto';
+  parts: QualityRadioGroupOptionParts;
+}
+
+export interface QualityRadioGroupRenditionOption extends RadioOption {
+  kind: 'rendition';
+  rendition: MediaVideoRendition;
+  parts: QualityRadioGroupOptionParts;
+}
+
+export type QualityRadioGroupOption = QualityRadioGroupAutoOption | QualityRadioGroupRenditionOption;
 
 export interface QualityRadioGroupState extends RadioOptionsState<QualityRadioGroupOption> {}
 
@@ -71,7 +91,7 @@ function formatRenditionLabel(rendition: MediaVideoRendition): Text | string {
   return qualityText;
 }
 
-function formatRenditionBadge(
+function formatRenditionBitrateLabel(
   rendition: MediaVideoRendition,
   renditions: readonly MediaVideoRendition[] = []
 ): string | undefined {
@@ -93,8 +113,14 @@ function formatRenditionTier(rendition: MediaVideoRendition): string | undefined
   return undefined;
 }
 
-function getRenditionValue(rendition: MediaVideoRendition, index: number): string {
-  return rendition.id || String(index);
+function getRenditionOptionValue(index: number): string {
+  return `rendition:${index}`;
+}
+
+function formatOptionLabel(primary: Text | string, tier?: string, bitrate?: string): Text | string {
+  if (!tier && !bitrate) return primary;
+
+  return [resolveText(primary), tier, bitrate].filter(Boolean).join(' ');
 }
 
 function isSameRendition(a: MediaVideoRendition, b: MediaVideoRendition): boolean {
@@ -117,7 +143,9 @@ export class QualityRadioGroupCore {
   };
 
   readonly state = createState<QualityRadioGroupState>({
-    options: [{ value: QUALITY_AUTO_VALUE, label: autoText, disabled: false }],
+    options: [
+      { kind: 'auto', value: QUALITY_AUTO_VALUE, label: autoText, disabled: false, parts: { primary: autoText } },
+    ],
     value: QUALITY_AUTO_VALUE,
     disabled: true,
     hidden: true,
@@ -151,13 +179,13 @@ export class QualityRadioGroupCore {
     return formatRenditionLabel(rendition);
   }
 
-  getRenditionBadge(
+  getRenditionBitrateLabel(
     rendition: MediaVideoRendition,
     renditions: readonly MediaVideoRendition[] = []
   ): string | undefined {
     if (this.#props.formatRendition !== QualityRadioGroupCore.defaultProps.formatRendition) return undefined;
 
-    return formatRenditionBadge(rendition, renditions);
+    return formatRenditionBitrateLabel(rendition, renditions);
   }
 
   getRenditionTier(rendition: MediaVideoRendition): string | undefined {
@@ -166,8 +194,8 @@ export class QualityRadioGroupCore {
     return formatRenditionTier(rendition);
   }
 
-  getRenditionValue(rendition: MediaVideoRendition, index: number): string {
-    return getRenditionValue(rendition, index);
+  getRenditionValue(_rendition: MediaVideoRendition, index: number): string {
+    return getRenditionOptionValue(index);
   }
 
   getAttrs(state: QualityRadioGroupState) {
@@ -188,15 +216,21 @@ export class QualityRadioGroupCore {
     const availability: QualityRadioGroupState['availability'] =
       media.videoRenditionList.length > 1 ? 'available' : 'unavailable';
     const toOption = (rendition: MediaVideoRendition, index: number): QualityRadioGroupOption => {
+      const primary = this.getRenditionLabel(rendition);
       const tier = this.getRenditionTier(rendition);
-      const badge = this.getRenditionBadge(rendition, media.videoRenditionList);
+      const bitrate = this.getRenditionBitrateLabel(rendition, media.videoRenditionList);
 
       return {
+        kind: 'rendition',
         value: this.getRenditionValue(rendition, index),
-        label: this.getRenditionLabel(rendition),
+        label: formatOptionLabel(primary, tier, bitrate),
         disabled: false,
-        ...(tier && { tier }),
-        ...(badge && { badge }),
+        rendition,
+        parts: {
+          primary,
+          ...(tier && { tier }),
+          ...(bitrate && { bitrate }),
+        },
       };
     };
     const activeIndex =
@@ -205,10 +239,13 @@ export class QualityRadioGroupCore {
         : media.videoRenditionList.findIndex((rendition) => isSameRendition(rendition, media.activeVideoRendition!));
     const active =
       media.activeVideoRendition && activeIndex !== -1 ? toOption(media.activeVideoRendition, activeIndex) : undefined;
+    const autoLabel = selectedIndex === -1 && active ? autoWithLabelText : autoText;
     const autoOption: QualityRadioGroupOption = {
+      kind: 'auto',
       value: QUALITY_AUTO_VALUE,
-      label: selectedIndex === -1 && active ? autoWithLabelText : autoText,
+      label: autoLabel,
       disabled: false,
+      parts: { primary: autoLabel },
       ...(selectedIndex === -1 && active && { labelParams: { label: resolveText(active.label) } }),
     };
 
@@ -231,16 +268,16 @@ export class QualityRadioGroupCore {
     if (this.#props.disabled) return;
 
     if (value === QUALITY_AUTO_VALUE) {
-      media.selectVideoRendition(value);
+      media.selectVideoRendition(null);
       return;
     }
 
-    const hasValue = media.videoRenditionList.some(
-      (rendition, index) => this.getRenditionValue(rendition, index) === value
+    const index = media.videoRenditionList.findIndex(
+      (rendition, renditionIndex) => this.getRenditionValue(rendition, renditionIndex) === value
     );
-    if (!hasValue) return;
+    if (index === -1) return;
 
-    media.selectVideoRendition(value);
+    media.selectVideoRendition(index);
   }
 
   selectValue(media: MediaQualityState, value: string): void {

--- a/packages/core/src/core/ui/quality-radio-group/tests/core.test.ts
+++ b/packages/core/src/core/ui/quality-radio-group/tests/core.test.ts
@@ -19,9 +19,23 @@ function createMediaState(overrides: Partial<MediaQualityState> = {}): MediaQual
 function createState(overrides: Partial<QualityRadioGroupState> = {}): QualityRadioGroupState {
   return {
     options: [
-      { value: QUALITY_AUTO_VALUE, label: 'Auto', disabled: false },
-      { value: '0', label: '1080p', disabled: false },
-      { value: '1', label: '720p', disabled: false },
+      { kind: 'auto', value: QUALITY_AUTO_VALUE, label: 'Auto', disabled: false, parts: { primary: 'Auto' } },
+      {
+        kind: 'rendition',
+        value: 'rendition:0',
+        label: '1080p HD',
+        disabled: false,
+        rendition: { id: '0', height: 1080, selected: false },
+        parts: { primary: '1080p', tier: 'HD' },
+      },
+      {
+        kind: 'rendition',
+        value: 'rendition:1',
+        label: '720p',
+        disabled: false,
+        rendition: { id: '1', height: 720, selected: false },
+        parts: { primary: '720p' },
+      },
     ],
     value: QUALITY_AUTO_VALUE,
     disabled: false,
@@ -43,9 +57,29 @@ describe('QualityRadioGroupCore', () => {
       const state = core.getState();
 
       expect(state.options).toEqual([
-        { value: QUALITY_AUTO_VALUE, label: { key: 'menu.auto', text: 'Auto' }, disabled: false },
-        { value: '0', label: '1080p', disabled: false, tier: 'HD' },
-        { value: '1', label: '720p', disabled: false },
+        {
+          kind: 'auto',
+          value: QUALITY_AUTO_VALUE,
+          label: { key: 'menu.auto', text: 'Auto' },
+          disabled: false,
+          parts: { primary: { key: 'menu.auto', text: 'Auto' } },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:0',
+          label: '1080p HD',
+          disabled: false,
+          rendition: media.videoRenditionList[0],
+          parts: { primary: '1080p', tier: 'HD' },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:1',
+          label: '720p',
+          disabled: false,
+          rendition: media.videoRenditionList[1],
+          parts: { primary: '720p' },
+        },
       ]);
       expect(state.value).toBe(QUALITY_AUTO_VALUE);
     });
@@ -63,10 +97,37 @@ describe('QualityRadioGroupCore', () => {
       core.setMedia(media);
 
       expect(core.getState().options).toEqual([
-        { value: QUALITY_AUTO_VALUE, label: { key: 'menu.auto', text: 'Auto' }, disabled: false },
-        { value: '0', label: '1080p', disabled: false, tier: 'HD', badge: '6 Mbps' },
-        { value: '1', label: '1080p', disabled: false, tier: 'HD', badge: '3 Mbps' },
-        { value: '2', label: '720p', disabled: false },
+        {
+          kind: 'auto',
+          value: QUALITY_AUTO_VALUE,
+          label: { key: 'menu.auto', text: 'Auto' },
+          disabled: false,
+          parts: { primary: { key: 'menu.auto', text: 'Auto' } },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:0',
+          label: '1080p HD 6 Mbps',
+          disabled: false,
+          rendition: media.videoRenditionList[0],
+          parts: { primary: '1080p', tier: 'HD', bitrate: '6 Mbps' },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:1',
+          label: '1080p HD 3 Mbps',
+          disabled: false,
+          rendition: media.videoRenditionList[1],
+          parts: { primary: '1080p', tier: 'HD', bitrate: '3 Mbps' },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:2',
+          label: '720p',
+          disabled: false,
+          rendition: media.videoRenditionList[2],
+          parts: { primary: '720p' },
+        },
       ]);
     });
 
@@ -83,10 +144,37 @@ describe('QualityRadioGroupCore', () => {
       core.setMedia(media);
 
       expect(core.getState().options).toEqual([
-        { value: QUALITY_AUTO_VALUE, label: { key: 'menu.auto', text: 'Auto' }, disabled: false },
-        { value: '0', label: '1080p', disabled: false, tier: 'HD' },
-        { value: '1', label: '2160p', disabled: false, tier: '4K' },
-        { value: '2', label: '4320p', disabled: false, tier: '8K' },
+        {
+          kind: 'auto',
+          value: QUALITY_AUTO_VALUE,
+          label: { key: 'menu.auto', text: 'Auto' },
+          disabled: false,
+          parts: { primary: { key: 'menu.auto', text: 'Auto' } },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:0',
+          label: '1080p HD',
+          disabled: false,
+          rendition: media.videoRenditionList[0],
+          parts: { primary: '1080p', tier: 'HD' },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:1',
+          label: '2160p 4K',
+          disabled: false,
+          rendition: media.videoRenditionList[1],
+          parts: { primary: '2160p', tier: '4K' },
+        },
+        {
+          kind: 'rendition',
+          value: 'rendition:2',
+          label: '4320p 8K',
+          disabled: false,
+          rendition: media.videoRenditionList[2],
+          parts: { primary: '4320p', tier: '8K' },
+        },
       ]);
     });
 
@@ -101,7 +189,7 @@ describe('QualityRadioGroupCore', () => {
 
       core.setMedia(media);
 
-      expect(core.getState().value).toBe('1');
+      expect(core.getState().value).toBe('rendition:1');
     });
 
     it('labels automatic with the active rendition', () => {
@@ -116,10 +204,12 @@ describe('QualityRadioGroupCore', () => {
 
       expect(state.value).toBe(QUALITY_AUTO_VALUE);
       expect(state.options[0]).toEqual({
+        kind: 'auto',
         value: QUALITY_AUTO_VALUE,
         label: { key: 'menu.autoWithLabel', text: 'Auto ({label})' },
         labelParams: { label: '720p' },
         disabled: false,
+        parts: { primary: { key: 'menu.autoWithLabel', text: 'Auto ({label})' } },
       });
     });
 
@@ -194,16 +284,48 @@ describe('QualityRadioGroupCore', () => {
 
       core.selectValue(media, QUALITY_AUTO_VALUE);
 
-      expect(media.selectVideoRendition).toHaveBeenCalledWith(QUALITY_AUTO_VALUE);
+      expect(media.selectVideoRendition).toHaveBeenCalledWith(null);
     });
 
     it('selects a known rendition', () => {
       const core = new QualityRadioGroupCore();
       const media = createMediaState();
 
-      core.selectValue(media, '1');
+      core.selectValue(media, 'rendition:1');
 
-      expect(media.selectVideoRendition).toHaveBeenCalledWith('1');
+      expect(media.selectVideoRendition).toHaveBeenCalledWith(1);
+    });
+
+    it('keeps automatic selection distinct from a rendition whose id is auto', () => {
+      const core = new QualityRadioGroupCore();
+      const media = createMediaState({
+        videoRenditionList: [
+          { id: 'auto', height: 1080, selected: false },
+          { id: 'other', height: 720, selected: false },
+        ],
+      });
+
+      core.setMedia(media);
+
+      core.selectValue(media, 'rendition:0');
+
+      expect(media.selectVideoRendition).toHaveBeenCalledWith(0);
+    });
+
+    it('selects the correct duplicate rendition without ids', () => {
+      const core = new QualityRadioGroupCore();
+      const media = createMediaState({
+        videoRenditionList: [
+          { height: 1080, bitrate: 6_000_000, selected: false },
+          { height: 1080, bitrate: 6_000_000, selected: false },
+        ],
+      });
+
+      core.setMedia(media);
+
+      core.selectValue(media, 'rendition:1');
+
+      expect(media.selectVideoRendition).toHaveBeenCalledWith(1);
     });
 
     it('does nothing for an unknown rendition', () => {

--- a/packages/core/src/dom/store/features/quality.ts
+++ b/packages/core/src/dom/store/features/quality.ts
@@ -9,12 +9,6 @@ import { listen } from '@videojs/utils/dom';
 
 import { definePlayerFeature } from '../../feature';
 
-const QUALITY_AUTO_VALUE = 'auto';
-
-function getRenditionValue(rendition: VideoRenditionLike, index: number): string {
-  return rendition.id || String(index);
-}
-
 function toMediaRendition(rendition: VideoRenditionLike): MediaVideoRendition {
   return {
     ...(rendition.id !== undefined && { id: rendition.id }),
@@ -38,20 +32,16 @@ export const qualityFeature = definePlayerFeature({
   state: ({ target }): MediaQualityState => ({
     videoRenditionList: [],
     activeVideoRendition: null,
-    selectVideoRendition(value: string) {
+    selectVideoRendition(index: number | null) {
       const { media } = target();
       if (!isMediaVideoRenditionCapable(media)) return;
 
-      if (value === QUALITY_AUTO_VALUE) {
+      if (index === null) {
         media.videoRenditions.selectedIndex = -1;
         return;
       }
 
-      const index = [...media.videoRenditions].findIndex(
-        (rendition, renditionIndex) => getRenditionValue(rendition, renditionIndex) === value
-      );
-
-      if (index !== -1) media.videoRenditions.selectedIndex = index;
+      if (index >= 0 && index < media.videoRenditions.length) media.videoRenditions.selectedIndex = index;
     },
   }),
 

--- a/packages/core/src/dom/store/features/tests/quality.test.ts
+++ b/packages/core/src/dom/store/features/tests/quality.test.ts
@@ -120,20 +120,34 @@ describe('qualityFeature', () => {
 
     store.attach({ media, container: null });
 
-    store.state.selectVideoRendition('auto');
+    store.state.selectVideoRendition(null);
 
     expect((media as any).videoRenditions.selectedIndex).toBe(-1);
   });
 
-  it('selects a rendition by value', () => {
+  it('selects a rendition', () => {
     const media = createMedia([createRendition({ id: '0', height: 1080 }), createRendition({ id: '1', height: 720 })]);
     const store = createStore<PlayerTarget>()(qualityFeature);
 
     store.attach({ media, container: null });
 
-    store.state.selectVideoRendition('1');
+    store.state.selectVideoRendition(1);
 
     expect((media as any).videoRenditions.selectedIndex).toBe(1);
+  });
+
+  it('selects a rendition whose id is auto', () => {
+    const media = createMedia([
+      createRendition({ id: 'auto', height: 1080 }),
+      createRendition({ id: 'other', height: 720 }),
+    ]);
+    const store = createStore<PlayerTarget>()(qualityFeature);
+
+    store.attach({ media, container: null });
+
+    store.state.selectVideoRendition(0);
+
+    expect((media as any).videoRenditions.selectedIndex).toBe(0);
   });
 
   it('resyncs on rendition change', () => {

--- a/packages/html/src/presets/video/minimal-skin.ts
+++ b/packages/html/src/presets/video/minimal-skin.ts
@@ -167,7 +167,7 @@ function getTemplateHTML() {
                           <bdi data-part="label" dir="auto"></bdi>
                           <sup data-part="tier" class="media-menu__tier"></sup>
                         </span>
-                        <span data-part="badge" class="media-badge"></span>
+                        <span data-part="bitrate" class="media-badge"></span>
                         <media-menu-item-indicator force-mount class="media-menu__indicator">
                           ${renderIcon('check', { class: 'media-icon' })}
                         </media-menu-item-indicator>

--- a/packages/html/src/presets/video/skin.ts
+++ b/packages/html/src/presets/video/skin.ts
@@ -160,7 +160,7 @@ function getTemplateHTML() {
                             <bdi data-part="label" dir="auto"></bdi>
                             <sup data-part="tier" class="media-menu__tier"></sup>
                           </span>
-                          <span data-part="badge" class="media-badge"></span>
+                          <span data-part="bitrate" class="media-badge"></span>
                           <media-menu-item-indicator force-mount class="media-menu__indicator">
                             ${renderIcon('check', { class: 'media-icon' })}
                           </media-menu-item-indicator>

--- a/packages/html/src/ui/quality-radio-group/quality-radio-group-element.ts
+++ b/packages/html/src/ui/quality-radio-group/quality-radio-group-element.ts
@@ -28,9 +28,9 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectQuality);
   readonly #options = new RadioOptionsController<QualityRadioGroupOption>(this, {
-    renderItem: (item, label, option) => this.#setContent(item, label, option.tier, option.badge),
+    renderItem: (item, label, option) => this.#setContent(item, label, option),
     setItemAttributes: (item, option) => item.setAttribute('data-rendition', option.value),
-    getOptionCacheKey: (option) => `${option.tier ?? ''}:${option.badge ?? ''}`,
+    getOptionCacheKey: (option) => `${option.parts.tier ?? ''}:${option.parts.bitrate ?? ''}`,
     onValueChange: (value) => {
       const media = this.#mediaState.value;
 
@@ -67,13 +67,15 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
     if (state) applyStateDataAttrs(this, state, QualityRadioGroupDataAttrs);
   }
 
-  #setContent(item: MenuRadioItemElement, label: string, tier: string | undefined, badge: string | undefined): void {
+  #setContent(item: MenuRadioItemElement, label: string, option: QualityRadioGroupOption): void {
     const labelPart = item.querySelector<HTMLElement>('[data-part~="label"]');
     const tierPart = item.querySelector<HTMLElement>('[data-part~="tier"]');
-    const badgePart = item.querySelector<HTMLElement>('[data-part~="badge"]');
+    const bitratePart = item.querySelector<HTMLElement>('[data-part~="bitrate"]');
+    const { tier, bitrate } = option.parts;
+    const primary = translateText(option.parts.primary, this.#i18n.value, option.labelParams);
 
     if (labelPart) {
-      labelPart.textContent = label;
+      labelPart.textContent = primary;
     }
 
     if (tierPart) {
@@ -81,13 +83,13 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
       tierPart.hidden = !tier;
     }
 
-    if (badgePart) {
-      badgePart.textContent = badge ?? '';
-      badgePart.hidden = !badge;
+    if (bitratePart) {
+      bitratePart.textContent = bitrate ?? '';
+      bitratePart.hidden = !bitrate;
     }
 
-    if (!labelPart && !tierPart && !badgePart) {
-      item.textContent = [label, tier, badge].filter(Boolean).join(' ');
+    if (!labelPart && !tierPart && !bitratePart) {
+      item.textContent = label;
     }
   }
 }

--- a/packages/html/src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
+++ b/packages/html/src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
@@ -215,7 +215,7 @@ describe('QualityRadioGroupElement', () => {
     });
   });
 
-  it('renders bitrate badges from a template', async () => {
+  it('renders bitrate parts from a template', async () => {
     const { menu, options } = setup({
       videoRenditionList: [
         { id: '0', height: 1080, bitrate: 6_000_000, selected: false },
@@ -223,14 +223,14 @@ describe('QualityRadioGroupElement', () => {
         { id: '2', height: 720, bitrate: 1_500_000, selected: false },
       ],
       template:
-        '<media-menu-radio-item><span data-part="label"></span><sup data-part="tier"></sup><span data-part="badge"></span><media-menu-item-indicator force-mount></media-menu-item-indicator></media-menu-radio-item>',
+        '<media-menu-radio-item><span data-part="label"></span><sup data-part="tier"></sup><span data-part="bitrate"></span><media-menu-item-indicator force-mount></media-menu-item-indicator></media-menu-radio-item>',
     });
 
     await waitForMenu(menu, options);
 
     const items = [...menu.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
     const tiers = items.map((item) => item.querySelector<HTMLElement>('[data-part~="tier"]'));
-    const badges = items.map((item) => item.querySelector<HTMLElement>('[data-part~="badge"]'));
+    const bitrates = items.map((item) => item.querySelector<HTMLElement>('[data-part~="bitrate"]'));
 
     expect(items.map((item) => item.querySelector('[data-part~="label"]')?.textContent)).toEqual([
       'Auto',
@@ -240,8 +240,8 @@ describe('QualityRadioGroupElement', () => {
     ]);
     expect(tiers.map((tier) => tier?.textContent)).toEqual(['', 'HD', 'HD', '']);
     expect(tiers.map((tier) => tier?.hidden)).toEqual([true, false, false, true]);
-    expect(badges.map((badge) => badge?.textContent)).toEqual(['', '6 Mbps', '3 Mbps', '']);
-    expect(badges.map((badge) => badge?.hidden)).toEqual([true, false, false, true]);
+    expect(bitrates.map((bitrate) => bitrate?.textContent)).toEqual(['', '6 Mbps', '3 Mbps', '']);
+    expect(bitrates.map((bitrate) => bitrate?.hidden)).toEqual([true, false, false, true]);
   });
 
   it('sets the selected rendition', async () => {
@@ -251,11 +251,11 @@ describe('QualityRadioGroupElement', () => {
     await waitForMenu(menu, options);
 
     const item = [...menu.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)].find(
-      (candidate) => candidate.value === '1'
+      (candidate) => candidate.value === 'rendition:1'
     )!;
 
     item.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 
-    expect(selectVideoRendition).toHaveBeenCalledWith('1');
+    expect(selectVideoRendition).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/media/src/core/state.ts
+++ b/packages/media/src/core/state.ts
@@ -268,8 +268,8 @@ export interface MediaQualityState {
   videoRenditionList: MediaVideoRendition[];
   /** Video rendition currently playing, including when automatic ABR is selected. */
   activeVideoRendition: MediaVideoRendition | null;
-  /** Select a video rendition by menu value, or automatic ABR with `"auto"`. */
-  selectVideoRendition(value: string): void;
+  /** Select a video rendition by list index, or use automatic ABR with `null`. */
+  selectVideoRendition(index: number | null): void;
 }
 
 export interface MediaAudioTrack {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -139,9 +139,12 @@ export {
 export { Popover, type PopoverContextValue, usePopoverContext } from './ui/popover';
 export { Poster, type PosterProps } from './ui/poster/poster';
 export {
+  type QualityAutoOption,
   type QualityOption,
+  type QualityOptionParts,
   type QualityOptionsProps,
   type QualityOptionsResult,
+  type QualityRenditionOption,
   useQualityOptions,
 } from './ui/quality';
 export {

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -257,10 +257,10 @@ function SettingsMenu(): ReactNode {
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
                       <bdi dir="auto">
-                        {item.label}
-                        {item.tier ? <sup className={menu.tier}>{item.tier}</sup> : null}
+                        {item.parts.primary}
+                        {item.parts.tier ? <sup className={menu.tier}>{item.parts.tier}</sup> : null}
                       </bdi>
-                      {item.badge ? <span className={badge}>{item.badge}</span> : null}
+                      {item.parts.bitrate ? <span className={badge}>{item.parts.bitrate}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
                       </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -195,10 +195,10 @@ function SettingsMenu(): ReactNode {
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
                       <bdi dir="auto">
-                        {item.label}
-                        {item.tier ? <sup className="media-menu__tier">{item.tier}</sup> : null}
+                        {item.parts.primary}
+                        {item.parts.tier ? <sup className="media-menu__tier">{item.parts.tier}</sup> : null}
                       </bdi>
-                      {item.badge ? <span className="media-badge">{item.badge}</span> : null}
+                      {item.parts.bitrate ? <span className="media-badge">{item.parts.bitrate}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -243,10 +243,10 @@ function SettingsMenu(): ReactNode {
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
                       <bdi dir="auto">
-                        {item.label}
-                        {item.tier ? <sup className={menu.tier}>{item.tier}</sup> : null}
+                        {item.parts.primary}
+                        {item.parts.tier ? <sup className={menu.tier}>{item.parts.tier}</sup> : null}
                       </bdi>
-                      {item.badge ? <span className={badge}>{item.badge}</span> : null}
+                      {item.parts.bitrate ? <span className={badge}>{item.parts.bitrate}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
                       </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -179,10 +179,10 @@ function SettingsMenu(): ReactNode {
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
                       <bdi dir="auto">
-                        {item.label}
-                        {item.tier ? <sup className="media-menu__tier">{item.tier}</sup> : null}
+                        {item.parts.primary}
+                        {item.parts.tier ? <sup className="media-menu__tier">{item.parts.tier}</sup> : null}
                       </bdi>
-                      {item.badge ? <span className="media-badge">{item.badge}</span> : null}
+                      {item.parts.bitrate ? <span className="media-badge">{item.parts.bitrate}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>

--- a/packages/react/src/ui/audio-track/use-audio-track-options.ts
+++ b/packages/react/src/ui/audio-track/use-audio-track-options.ts
@@ -10,6 +10,7 @@ export type AudioTrackOption = TranslatedRadioOption<AudioTrackRadioGroupOption>
 export interface AudioTrackOptionsResult {
   state: AudioTrackRadioGroupCore.State;
   label: string;
+  availability: AudioTrackRadioGroupCore.State['availability'];
   value: string;
   selectedLabel: string;
   options: AudioTrackOption[];

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -10,6 +10,7 @@ export type CaptionsOption = TranslatedRadioOption<CaptionsRadioGroupOption>;
 export interface CaptionsOptionsResult {
   state: CaptionsRadioGroupCore.State;
   label: string;
+  availability: CaptionsRadioGroupCore.State['availability'];
   value: string;
   selectedLabel: string;
   options: CaptionsOption[];

--- a/packages/react/src/ui/hooks/create-radio-options-hook.ts
+++ b/packages/react/src/ui/hooks/create-radio-options-hook.ts
@@ -25,14 +25,17 @@ interface RadioOptionsHookConfig<Props, Media, State extends RadioOptionsState> 
 
 type StateOption<State extends RadioOptionsState> = State extends RadioOptionsState<infer Option> ? Option : never;
 
-export type TranslatedRadioOption<Option extends RadioOption> = Omit<Option, 'label' | 'labelParams' | 'disabled'> & {
-  label: string;
-  disabled: boolean;
-};
+export type TranslatedRadioOption<Option extends RadioOption> = Option extends RadioOption
+  ? Omit<Option, 'label' | 'labelParams' | 'disabled'> & {
+      label: string;
+      disabled: boolean;
+    }
+  : never;
 
 export interface RadioOptionsHookResult<Option extends RadioOption, State extends RadioOptionsState> {
   state: State;
   label: string;
+  availability: State['availability'];
   value: string;
   selectedLabel: string;
   options: TranslatedRadioOption<Option>[];
@@ -82,6 +85,7 @@ export function createRadioOptionsHook<Props, Media, State extends RadioOptionsS
     return {
       state,
       label: translateText(core.getLabel(state), t, core.getLabelParams?.(state)),
+      availability: state.availability,
       value: state.value,
       selectedLabel: options.find((option) => option.value === state.value)?.label ?? '',
       options,

--- a/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
+++ b/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
@@ -15,6 +15,7 @@ export type PlaybackRateOption = TranslatedRadioOption<PlaybackRateRadioGroupOpt
 export interface PlaybackRateOptionsResult {
   state: PlaybackRateRadioGroupCore.State;
   label: string;
+  availability: PlaybackRateRadioGroupCore.State['availability'];
   rate: number;
   value: string;
   selectedLabel: string;

--- a/packages/react/src/ui/quality-radio-group/quality-radio-group.tsx
+++ b/packages/react/src/ui/quality-radio-group/quality-radio-group.tsx
@@ -33,8 +33,8 @@ export interface QualityRadioGroupProps
  *   <QualityRadioGroup
  *     renderItem={(props, item) => (
  *       <Menu.RadioItem {...props}>
- *         {item.label}
- *         {item.tier ? <sup>{item.tier}</sup> : null}
+ *         {item.parts.primary}
+ *         {item.parts.tier ? <sup>{item.parts.tier}</sup> : null}
  *         <Menu.ItemIndicator checked={item.checked} />
  *       </Menu.RadioItem>
  *     )}

--- a/packages/react/src/ui/quality-radio-group/tests/quality-radio-group.test.tsx
+++ b/packages/react/src/ui/quality-radio-group/tests/quality-radio-group.test.tsx
@@ -28,7 +28,7 @@ function renderQualityRadioGroup({
 }: {
   videoRenditionList?: MediaVideoRendition[];
   activeVideoRendition?: MediaVideoRendition | null;
-  selectVideoRendition?: (value: string) => void;
+  selectVideoRendition?: (index: number | null) => void;
   locale?: string;
   group?: React.ReactNode;
 } = {}) {
@@ -58,7 +58,9 @@ describe('QualityRadioGroup', () => {
           renderItem={(props, state) => {
             states.push(state);
             return (
-              <Menu.RadioItem {...props}>{state.tier ? `${state.label} ${state.tier}` : state.label}</Menu.RadioItem>
+              <Menu.RadioItem {...props}>
+                {state.parts.tier ? `${state.parts.primary} ${state.parts.tier}` : state.parts.primary}
+              </Menu.RadioItem>
             );
           }}
         />
@@ -68,9 +70,19 @@ describe('QualityRadioGroup', () => {
     expect(screen.getByRole('menuitemradio', { name: 'Auto' }).getAttribute('data-rendition')).toBe('auto');
     expect(screen.getByRole('menuitemradio', { name: 'Auto' }).getAttribute('aria-checked')).toBe('true');
     expect(states.slice(-3)).toEqual([
-      expect.objectContaining({ value: 'auto', label: 'Auto', checked: true }),
-      expect.objectContaining({ value: '0', label: '1080p', tier: 'HD', checked: false }),
-      expect.objectContaining({ value: '1', label: '720p', checked: false }),
+      expect.objectContaining({ value: 'auto', label: 'Auto', parts: { primary: 'Auto' }, checked: true }),
+      expect.objectContaining({
+        value: 'rendition:0',
+        label: '1080p HD',
+        parts: { primary: '1080p', tier: 'HD' },
+        checked: false,
+      }),
+      expect.objectContaining({
+        value: 'rendition:1',
+        label: '720p',
+        parts: { primary: '720p' },
+        checked: false,
+      }),
     ]);
   });
 
@@ -81,7 +93,7 @@ describe('QualityRadioGroup', () => {
 
     fireEvent.click(screen.getByRole('menuitemradio', { name: '720p' }));
 
-    expect(selectVideoRendition).toHaveBeenCalledWith('1');
+    expect(selectVideoRendition).toHaveBeenCalledWith(1);
   });
 
   it('exposes group state through attributes and callbacks', () => {

--- a/packages/react/src/ui/quality/index.ts
+++ b/packages/react/src/ui/quality/index.ts
@@ -1,6 +1,9 @@
 export {
+  type QualityAutoOption,
   type QualityOption,
+  type QualityOptionParts,
   type QualityOptionsProps,
   type QualityOptionsResult,
+  type QualityRenditionOption,
   useQualityOptions,
 } from './use-quality-options';

--- a/packages/react/src/ui/quality/tests/use-quality-options.test.tsx
+++ b/packages/react/src/ui/quality/tests/use-quality-options.test.tsx
@@ -26,7 +26,7 @@ function renderQualityOptions({
 }: {
   videoRenditionList?: MediaVideoRendition[];
   activeVideoRendition?: MediaVideoRendition | null | undefined;
-  selectVideoRendition?: (value: string) => void;
+  selectVideoRendition?: (index: number | null) => void;
   formatRendition?: ((rendition: MediaVideoRendition) => string) | undefined;
   locale?: string | undefined;
 } = {}) {
@@ -59,12 +59,17 @@ function QualityRadioGroup({
   return (
     <>
       <span data-testid="selected-label">{selectedLabel}</span>
-      <Menu.RadioGroup value={value} onValueChange={setValue} aria-label="Quality">
+      <Menu.RadioGroup
+        value={value}
+        onValueChange={setValue}
+        aria-label={quality.label}
+        data-availability={quality.availability}
+      >
         {options.map((option) => (
-          <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
-            {option.label}
-            {option.tier ? <sup>{option.tier}</sup> : null}
-            {option.badge ? <span>{option.badge}</span> : null}
+          <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled} data-label={option.label}>
+            {option.parts.primary}
+            {option.parts.tier ? <sup>{option.parts.tier}</sup> : null}
+            {option.parts.bitrate ? <span>{option.parts.bitrate}</span> : null}
           </Menu.RadioItem>
         ))}
       </Menu.RadioGroup>
@@ -76,6 +81,7 @@ describe('useQualityOptions', () => {
   it('renders Auto and rendition options', () => {
     renderQualityOptions();
 
+    expect(screen.getByRole('group', { name: 'Quality' }).getAttribute('data-availability')).toBe('available');
     expect(screen.getByRole('menuitemradio', { name: 'Auto' }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByRole('menuitemradio', { name: '1080p HD' }).getAttribute('aria-checked')).toBe('false');
     expect(screen.getByRole('menuitemradio', { name: '720p' }).getAttribute('aria-checked')).toBe('false');
@@ -89,7 +95,7 @@ describe('useQualityOptions', () => {
 
     fireEvent.click(screen.getByRole('menuitemradio', { name: '720p' }));
 
-    expect(selectVideoRendition).toHaveBeenCalledWith('1');
+    expect(selectVideoRendition).toHaveBeenCalledWith(1);
   });
 
   it('renders the active rendition in the Auto option', () => {
@@ -130,8 +136,11 @@ describe('useQualityOptions', () => {
       ],
     });
 
-    expect(screen.getByRole('menuitemradio', { name: '1080p HD 6 Mbps' })).toBeTruthy();
-    expect(screen.getByRole('menuitemradio', { name: '1080p HD 3 Mbps' })).toBeTruthy();
+    const high = screen.getByRole('menuitemradio', { name: '1080p HD 6 Mbps' });
+    const low = screen.getByRole('menuitemradio', { name: '1080p HD 3 Mbps' });
+
+    expect(high.getAttribute('data-label')).toBe('1080p HD 6 Mbps');
+    expect(low.getAttribute('data-label')).toBe('1080p HD 3 Mbps');
     expect(screen.getByRole('menuitemradio', { name: '720p' })).toBeTruthy();
   });
 

--- a/packages/react/src/ui/quality/use-quality-options.ts
+++ b/packages/react/src/ui/quality/use-quality-options.ts
@@ -1,15 +1,40 @@
-import { QualityRadioGroupCore, type QualityRadioGroupOption } from '@videojs/core';
+import {
+  type QualityRadioGroupAutoOption,
+  QualityRadioGroupCore,
+  type QualityRadioGroupRenditionOption,
+} from '@videojs/core';
 import { selectQuality } from '@videojs/core/dom';
+import { translateText } from '@videojs/core/i18n';
 
+import { useTranslator } from '../../i18n/context';
 import { createRadioOptionsHook, type TranslatedRadioOption } from '../hooks/create-radio-options-hook';
 
 export interface QualityOptionsProps extends QualityRadioGroupCore.Props {}
 
-export type QualityOption = TranslatedRadioOption<QualityRadioGroupOption>;
+/** Translated display parts of a quality option, for designs that style the pieces separately. */
+export interface QualityOptionParts {
+  /** Main visible text, such as `1080p` or `Auto (720p)`. */
+  primary: string;
+  /** Resolution tier such as `HD`, `4K`, or `8K`. */
+  tier?: string | undefined;
+  /** Bitrate text, present only when renditions share a size and need disambiguating. */
+  bitrate?: string | undefined;
+}
+
+export interface QualityAutoOption extends Omit<TranslatedRadioOption<QualityRadioGroupAutoOption>, 'parts'> {
+  parts: QualityOptionParts;
+}
+
+export interface QualityRenditionOption extends Omit<TranslatedRadioOption<QualityRadioGroupRenditionOption>, 'parts'> {
+  parts: QualityOptionParts;
+}
+
+export type QualityOption = QualityAutoOption | QualityRenditionOption;
 
 export interface QualityOptionsResult {
   state: QualityRadioGroupCore.State;
   label: string;
+  availability: QualityRadioGroupCore.State['availability'];
   value: string;
   selectedLabel: string;
   options: QualityOption[];
@@ -29,12 +54,34 @@ const useQualityRadioOptions = createRadioOptionsHook({
  * Create quality menu options (including an `Auto` option) from the player video rendition state. Returns `null` when
  * the quality feature is not configured.
  *
+ * Each option's `label` is a complete accessible label. Use `parts` when the design styles the primary text, tier, and
+ * bitrate separately.
+ *
  * @param props - Optional `label`, `formatRendition`, and `disabled` overrides.
  */
 export function useQualityOptions(props?: QualityOptionsProps): QualityOptionsResult | null {
   'use no memo';
 
-  return useQualityRadioOptions(props);
+  const result = useQualityRadioOptions(props);
+  const t = useTranslator();
+
+  if (!result) return null;
+
+  const { options, ...radioGroup } = result;
+
+  return {
+    ...radioGroup,
+    options: options.map(
+      (option): QualityOption => ({
+        ...option,
+        parts: {
+          ...option.parts,
+          // The automatic label interpolates the active rendition, so reuse the fully translated label.
+          primary: option.kind === 'auto' ? option.label : translateText(option.parts.primary, t),
+        },
+      })
+    ),
+  };
 }
 
 export namespace useQualityOptions {

--- a/packages/skins/vjsc/components/menus/quality-menu.tsx
+++ b/packages/skins/vjsc/components/menus/quality-menu.tsx
@@ -27,7 +27,7 @@ export function QualityMenu(props: QualityMenuProps = {}) {
               <Template.Part name="label" />
               <Template.Part name="tier" className={styles.tier} />
             </Text>
-            <Template.Part name="badge" className={styles.badge} />
+            <Template.Part name="bitrate" className={styles.badge} />
           </RadioItem>
         </Template>
       </QualityRadioGroup>

--- a/packages/skins/vjsc/target/html.tsx
+++ b/packages/skins/vjsc/target/html.tsx
@@ -240,7 +240,7 @@ export const htmlComponentTarget: ComponentTarget<CoreSchema> = defineComponentT
           parts: {
             ...optionTemplate.parts,
             tier: ({ props }) => <Sup data-part="tier" {...props} />,
-            badge: ({ props }) => <Span data-part="badge" {...props} />,
+            bitrate: ({ props }) => <Span data-part="bitrate" {...props} />,
           },
         },
         'audio-track-option': optionTemplate,

--- a/packages/skins/vjsc/target/react.tsx
+++ b/packages/skins/vjsc/target/react.tsx
@@ -25,7 +25,7 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
   const Sup = element('sup');
   const I18nText = imported({ from: '@videojs/react', name: 'Text' });
   const renderProps = code.param('props');
-  const item = code.param<{ badge?: unknown; label: unknown; tier?: unknown }>('item');
+  const item = code.param<{ label: unknown; parts: { bitrate?: unknown; primary: unknown; tier?: unknown } }>('item');
   const optionTemplate: TemplateTargetDefinition = {
     render: ({ children }) => <Host renderItem={code.fn([renderProps, item], code.withProps(children, renderProps))} />,
     parts: {
@@ -105,8 +105,9 @@ export const reactComponentTarget: ComponentTarget<CoreSchema> = defineComponent
           ...optionTemplate,
           parts: {
             ...optionTemplate.parts,
-            tier: ({ props }) => code.when(item.tier, <Sup {...props}>{item.tier}</Sup>),
-            badge: ({ props }) => code.when(item.badge, <Span {...props}>{item.badge}</Span>),
+            label: ({ props }) => <Span {...props}>{item.parts.primary}</Span>,
+            tier: ({ props }) => code.when(item.parts.tier, <Sup {...props}>{item.parts.tier}</Sup>),
+            bitrate: ({ props }) => code.when(item.parts.bitrate, <Span {...props}>{item.parts.bitrate}</Span>),
           },
         },
         'audio-track-option': optionTemplate,

--- a/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
+++ b/packages/skins/vjsc/tests/__snapshots__/generated.tsx.snap
@@ -830,10 +830,10 @@ const available = quality?.state.availability === 'available';
     >
       <QualityRadioGroup renderItem={(props, item) => (<RadioItem {...props}>
             <span>
-              <span>{item.label}</span>
-              {item.tier ? <sup className={"media-menu-tier"}>{item.tier}</sup> : null}
+              <span>{item.parts.primary}</span>
+              {item.parts.tier ? <sup className={"media-menu-tier"}>{item.parts.tier}</sup> : null}
             </span>
-            {item.badge ? <span className={"media-menu-badge"}>{item.badge}</span> : null}
+            {item.parts.bitrate ? <span className={"media-menu-badge"}>{item.parts.bitrate}</span> : null}
           </RadioItem>)}>
 
       </QualityRadioGroup>
@@ -2038,10 +2038,10 @@ const available = quality?.state.availability === 'available';
     >
       <QualityRadioGroup renderItem={(props, item) => (<RadioItem {...props}>
             <span>
-              <span>{item.label}</span>
-              {item.tier ? <sup className={"ps-0.5 pt-px text-media-xs font-semibold leading-none text-current/70"}>{item.tier}</sup> : null}
+              <span>{item.parts.primary}</span>
+              {item.parts.tier ? <sup className={"ps-0.5 pt-px text-media-xs font-semibold leading-none text-current/70"}>{item.parts.tier}</sup> : null}
             </span>
-            {item.badge ? <span className={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"}>{item.badge}</span> : null}
+            {item.parts.bitrate ? <span className={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"}>{item.parts.bitrate}</span> : null}
           </RadioItem>)}>
 
       </QualityRadioGroup>
@@ -3295,10 +3295,10 @@ const available = quality?.state.availability === 'available';
     >
       <QualityRadioGroup renderItem={(props, item) => (<RadioItem {...props}>
             <span>
-              <span>{item.label}</span>
-              {item.tier ? <sup className={"media-menu-tier"}>{item.tier}</sup> : null}
+              <span>{item.parts.primary}</span>
+              {item.parts.tier ? <sup className={"media-menu-tier"}>{item.parts.tier}</sup> : null}
             </span>
-            {item.badge ? <span className={"media-menu-badge"}>{item.badge}</span> : null}
+            {item.parts.bitrate ? <span className={"media-menu-badge"}>{item.parts.bitrate}</span> : null}
           </RadioItem>)}>
 
       </QualityRadioGroup>
@@ -4505,10 +4505,10 @@ const available = quality?.state.availability === 'available';
     >
       <QualityRadioGroup renderItem={(props, item) => (<RadioItem {...props}>
             <span>
-              <span>{item.label}</span>
-              {item.tier ? <sup className={"ps-0.5 pt-px text-media-xs font-semibold leading-none text-current/70"}>{item.tier}</sup> : null}
+              <span>{item.parts.primary}</span>
+              {item.parts.tier ? <sup className={"ps-0.5 pt-px text-media-xs font-semibold leading-none text-current/70"}>{item.parts.tier}</sup> : null}
             </span>
-            {item.badge ? <span className={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"}>{item.badge}</span> : null}
+            {item.parts.bitrate ? <span className={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"}>{item.parts.bitrate}</span> : null}
           </RadioItem>)}>
 
       </QualityRadioGroup>
@@ -5683,7 +5683,7 @@ export function QualityMenu(props: QualityMenuProps = {}) {
               <span data-part="label" />
               <sup data-part="tier" class={"media-menu-tier"} />
             </span>
-            <span data-part="badge" class={"media-menu-badge"} />
+            <span data-part="bitrate" class={"media-menu-badge"} />
           </RadioItem>
         </template>
       </QualityRadioGroup>
@@ -6774,7 +6774,7 @@ export function QualityMenu(props: QualityMenuProps = {}) {
               <span data-part="label" />
               <sup data-part="tier" class={"ps-0.5 pt-px text-media-xs font-semibold leading-none text-current/70"} />
             </span>
-            <span data-part="badge" class={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"} />
+            <span data-part="bitrate" class={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"} />
           </RadioItem>
         </template>
       </QualityRadioGroup>
@@ -7914,7 +7914,7 @@ export function QualityMenu(props: QualityMenuProps = {}) {
               <span data-part="label" />
               <sup data-part="tier" class={"media-menu-tier"} />
             </span>
-            <span data-part="badge" class={"media-menu-badge"} />
+            <span data-part="bitrate" class={"media-menu-badge"} />
           </RadioItem>
         </template>
       </QualityRadioGroup>
@@ -9009,7 +9009,7 @@ export function QualityMenu(props: QualityMenuProps = {}) {
               <span data-part="label" />
               <sup data-part="tier" class={"ps-0.5 pt-px text-media-xs font-semibold leading-none text-current/70"} />
             </span>
-            <span data-part="badge" class={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"} />
+            <span data-part="bitrate" class={"rounded-media-control bg-media-control-hover px-1.5 text-media-xs font-semibold"} />
           </RadioItem>
         </template>
       </QualityRadioGroup>

--- a/site/src/components/docs/demos/menu/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/menu/html/css/BasicUsage.html
@@ -58,7 +58,7 @@
                   <span data-part="label"></span>
                   <sup data-part="tier" class="menu-tier"></sup>
                 </span>
-                <span data-part="badge" class="menu-badge"></span>
+                <span data-part="bitrate" class="menu-badge"></span>
                 <media-menu-item-indicator force-mount class="menu-indicator">✓</media-menu-item-indicator>
               </media-menu-radio-item>
             </template>

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
@@ -20,7 +20,7 @@ function SettingsMenu(): ReactNode {
   const audioTrack = useAudioTrackOptions();
   const captions = useCaptionsOptions();
   const hasPlaybackRate = playbackRate?.state.availability === 'available';
-  const hasQuality = quality?.state.availability === 'available';
+  const hasQuality = quality?.availability === 'available';
   const hasAudioTrack = audioTrack?.state.availability === 'available';
   const hasCaptions = captions?.state.availability === 'available';
   if (!hasPlaybackRate && !hasQuality && !hasAudioTrack && !hasCaptions) return null;
@@ -55,7 +55,7 @@ function SettingsMenu(): ReactNode {
                   className="menu-group"
                   value={quality.value}
                   onValueChange={quality.setValue}
-                  aria-label="Quality"
+                  aria-label={quality.label}
                 >
                   {quality.options.map((option) => (
                     <Menu.RadioItem
@@ -65,10 +65,10 @@ function SettingsMenu(): ReactNode {
                       className="menu-item"
                     >
                       <span>
-                        {option.label}
-                        {option.tier ? <sup className="menu-tier">{option.tier}</sup> : null}
+                        {option.parts.primary}
+                        {option.parts.tier ? <sup className="menu-tier">{option.parts.tier}</sup> : null}
                       </span>
-                      {option.badge ? <span className="menu-badge">{option.badge}</span> : null}
+                      {option.parts.bitrate ? <span className="menu-badge">{option.parts.bitrate}</span> : null}
                       <Menu.ItemIndicator
                         checked={option.value === quality.value}
                         forceMount

--- a/site/src/components/docs/demos/quality-radio-group/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/quality-radio-group/html/css/BasicUsage.html
@@ -20,7 +20,7 @@
                   <span data-part="label"></span>
                   <sup data-part="tier" class="menu-tier"></sup>
                 </span>
-                <span data-part="badge" class="menu-badge"></span>
+                <span data-part="bitrate" class="menu-badge"></span>
                 <media-menu-item-indicator force-mount class="menu-indicator">✓</media-menu-item-indicator>
               </media-menu-radio-item>
             </template>

--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
@@ -19,10 +19,10 @@ function QualityMenu(): ReactNode {
             renderItem={(props, item) => (
               <Menu.RadioItem {...props} className="menu-item">
                 <span>
-                  {item.label}
-                  {item.tier ? <sup className="menu-tier">{item.tier}</sup> : null}
+                  {item.parts.primary}
+                  {item.parts.tier ? <sup className="menu-tier">{item.parts.tier}</sup> : null}
                 </span>
-                {item.badge ? <span className="menu-badge">{item.badge}</span> : null}
+                {item.parts.bitrate ? <span className="menu-badge">{item.parts.bitrate}</span> : null}
                 <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
                   ✓
                 </Menu.ItemIndicator>

--- a/site/src/content/docs/how-to/add-quality-selector.mdx
+++ b/site/src/content/docs/how-to/add-quality-selector.mdx
@@ -59,7 +59,7 @@ The <DocsLink slug="reference/feature-quality">quality feature</DocsLink> mirror
 
 - `videoRenditionList` holds each rendition's `id`, `width`, `height`, `bitrate`, `frameRate`, `codec`, and whether it's `selected`.
 - `activeVideoRendition` is the rendition currently playing. When the engine doesn't report one directly, the player matches it from the video's current dimensions.
-- `selectVideoRendition(value)` pins one rendition; pass `'auto'` to return control to the engine's adaptive selection.
+- `selectVideoRendition(index)` pins the rendition at that position in `videoRenditionList`; pass `null` to return control to the engine's adaptive selection. Indexes stay unambiguous when rendition identifiers repeat or are missing.
 
 <FrameworkCase frameworks={["react"]}>
 
@@ -101,9 +101,10 @@ function PinLowestRendition() {
   const renditions = usePlayer((s) => s.videoRenditionList);
 
   const lowest = [...renditions].sort((a, b) => (a.height ?? 0) - (b.height ?? 0))[0];
+  const lowestIndex = lowest ? renditions.indexOf(lowest) : -1;
 
   return (
-    <button type="button" onClick={() => lowest?.id && store.selectVideoRendition(lowest.id)}>
+    <button type="button" disabled={lowestIndex === -1} onClick={() => store.selectVideoRendition(lowestIndex)}>
       Data saver
     </button>
   );
@@ -124,7 +125,7 @@ export default function App() {
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 
-Access the player store through the <DocsLink slug="reference/player-controller">player controller</DocsLink> and call `selectVideoRendition` with a rendition `id` from `videoRenditionList`, or `'auto'` to restore adaptive selection.
+Access the player store through the <DocsLink slug="reference/player-controller">player controller</DocsLink> and call `selectVideoRendition` with the rendition's index in `videoRenditionList`, or `null` to restore adaptive selection.
 
 </FrameworkCase>
 

--- a/site/src/content/docs/reference/quality-radio-group.mdx
+++ b/site/src/content/docs/reference/quality-radio-group.mdx
@@ -64,7 +64,7 @@ Creates radio items from the player video rendition state and selects automatic 
 The group is available when the configured media exposes more than one video rendition. The first generated option is `Auto`; selecting it returns control to adaptive bitrate selection. Pass `formatRendition` to customize visible rendition labels.
 
 <FrameworkCase frameworks={["react"]}>
-`QualityRadioGroup` uses <DocsLink slug="reference/use-quality-options">`useQualityOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label`, optional `tier` and `badge`, and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
+`QualityRadioGroup` uses <DocsLink slug="reference/use-quality-options">`useQualityOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label`, a `kind` of `auto` or `rendition`, display `parts` (`primary`, optional `tier` and `bitrate`), and the current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/use-quality-options.mdx
+++ b/site/src/content/docs/reference/use-quality-options.mdx
@@ -12,20 +12,24 @@ import DocsLink from "@/components/docs/DocsLink.astro";
 import { useQualityOptions } from "@videojs/react";
 ```
 
-`useQualityOptions` returns the current quality value, the available options, and a `setValue` callback for wiring quality selection into a menu. It returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
+`useQualityOptions` returns the current quality value, the available options, the group `label` and `availability`, and a `setValue` callback for wiring quality selection into a menu. It returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
 
 ```tsx title="QualityMenu.tsx"
 import { Menu, useQualityOptions } from "@videojs/react";
 
 function QualityMenu() {
   const quality = useQualityOptions();
-  if (quality?.state.availability !== "available") return null;
+  if (quality?.availability !== "available") return null;
 
   return (
-    <Menu.RadioGroup value={quality.value} onValueChange={quality.setValue} aria-label="Quality">
+    <Menu.RadioGroup value={quality.value} onValueChange={quality.setValue} aria-label={quality.label}>
       {quality.options.map((option) => (
         <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled}>
-          {option.label}
+          <span>
+            {option.parts.primary}
+            {option.parts.tier ? <sup>{option.parts.tier}</sup> : null}
+          </span>
+          {option.parts.bitrate ? <span>{option.parts.bitrate}</span> : null}
           <Menu.ItemIndicator checked={option.value === quality.value} />
         </Menu.RadioItem>
       ))}
@@ -34,8 +38,8 @@ function QualityMenu() {
 }
 ```
 
-The first option is always `Auto`; selecting it returns control to adaptive bitrate selection. Options carry optional `tier` and `badge` fields (e.g. `4K`, `HD`) for richer labels. Pass `formatRendition` to customize the visible rendition labels.
+The first option is always `Auto`; selecting it returns control to adaptive bitrate selection. Each option's `label` is a complete accessible label such as `1080p HD 6 Mbps`. Use `parts.primary`, `parts.tier`, and `parts.bitrate` when the design styles those pieces separately. Rendition options have `kind: "rendition"` and carry the source `rendition`; the automatic option has `kind: "auto"`. Option values are stable menu keys, not rendition identifiers, so they stay unambiguous when identifiers repeat.
 
-See <DocsLink slug="reference/quality-radio-group">QualityRadioGroup</DocsLink> for the component-level pattern, and <DocsLink slug="reference/menu">Menu</DocsLink> for a complete settings menu example.
+Pass `formatRendition` to customize the primary rendition label. See <DocsLink slug="reference/quality-radio-group">QualityRadioGroup</DocsLink> for the component-level pattern, and <DocsLink slug="reference/menu">Menu</DocsLink> for a complete settings menu example.
 
 <UtilReference util="useQualityOptions" />


### PR DESCRIPTION
Closes #2086

## Summary

Redesign the video quality option API so custom menus receive unambiguous values, complete accessible labels, and structured display metadata.

## Changes

- Keep the `useQualityOptions` name (it matches `qualityFeature`, `selectQuality`, and `QualityRadioGroup`) and expose `label` and `availability` directly; the other option hooks expose `availability` too
- Add discriminated `auto` and `rendition` options that both carry `parts` (`primary`, `tier`, `bitrate`) in core, so the HTML and React adapters share one shape
- Select renditions by list index to avoid collisions with automatic mode and duplicate rendition identifiers
- Rename the HTML item part from `badge` to `bitrate` to match `parts.bitrate`
- Update React and HTML skins, the vjsc skin generator and snapshots, tests, demos, the quality how-to, and API reference documentation

## Testing

- pnpm -F @videojs/core test src/core/ui/quality-radio-group/tests/quality-radio-group-core.test.ts src/dom/store/features/tests/quality.test.ts
- pnpm -F @videojs/react test src/ui/quality/tests/use-quality-options.test.tsx
- pnpm -F @videojs/skins test
- pnpm -F @videojs/html test src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
- pnpm typecheck
- pnpm lint
- pnpm check:workspace
- pnpm -F site api-docs
- pnpm -F site astro check

## Review follow-up

- Rebased onto `main`, which had grown the vjsc skin generator and the quality how-to since this branch was cut; both now use the new option shape and the index-based `selectVideoRendition`.
- Fixed the formatting failure in the hook test.
- Dropped the `useVideoQualityOptions` rename; the rest of the quality family does not carry the `Video` prefix.
- Gave the automatic option `parts` in core so HTML consumers do not need a `kind` check before reading them.
- Added `availability` to `usePlaybackRateOptions`, `useAudioTrackOptions`, and `useCaptionsOptions` results so the four hooks stay consistent.
