### PR TITLE
refactor(packages): simplify status announcer

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -57,6 +57,7 @@ export * from './ui/slider/slider-data-attrs';
 export * from './ui/slider/slider-segments-core';
 export * from './ui/status-announcer/status-announcer-core';
 export * from './ui/status-announcer/status-announcer-labels';
+export * from './ui/status-announcer/status-announcer-status';
 export * from './ui/status-indicator/status-indicator-core';
 export * from './ui/status-indicator/status-indicator-data-attrs';
 export * from './ui/status-indicator/status-indicator-status';

--- a/packages/core/src/core/ui/status-announcer/status-announcer-core.ts
+++ b/packages/core/src/core/ui/status-announcer/status-announcer-core.ts
@@ -3,28 +3,24 @@ import { createState } from '@videojs/store';
 import type { IndicatorCoreProps } from '../indicator/indicator-lifecycle';
 import { getIndicatorCloseDelay, IndicatorCloseController } from '../indicator/indicator-lifecycle';
 import type { MediaSnapshot } from '../input-action/input-action';
-import { formatVolumeValue } from '../volume-indicator/volume-indicator-status';
-import {
-  DEFAULT_STATUS_ANNOUNCER_LABELS,
-  formatPlaybackRateAnnouncerLabel,
-  formatSeekAnnouncerLabel,
-  type StatusAnnouncerLabels,
-} from './status-announcer-labels';
+import { DEFAULT_STATUS_ANNOUNCER_LABELS, type StatusAnnouncerLabels } from './status-announcer-labels';
+import { deriveStatusAnnouncement, deriveVolumeAnnouncement } from './status-announcer-status';
 
 const ANNOUNCEMENT_DEBOUNCE = 200;
 
 export interface StatusAnnouncerProps extends IndicatorCoreProps {
   labels?: Partial<StatusAnnouncerLabels> | undefined;
-  shouldAnnounceSeek?: ((snapshot: MediaSnapshot) => boolean) | undefined;
-  shouldAnnounceVolume?: ((snapshot: MediaSnapshot) => boolean) | undefined;
+  /** Whether debounced seek and volume changes should be announced. */
+  shouldAnnounce?: (() => boolean) | undefined;
 }
 
 export interface StatusAnnouncerState {
+  generation: number;
   label: string | null;
 }
 
 export class StatusAnnouncerCore {
-  readonly state = createState<StatusAnnouncerState>({ label: null });
+  readonly state = createState<StatusAnnouncerState>({ generation: 0, label: null });
 
   #props: StatusAnnouncerProps = {};
   #snapshot: MediaSnapshot | null = null;
@@ -60,42 +56,12 @@ export class StatusAnnouncerCore {
     if (!previous) return false;
 
     const labels = this.#getLabels();
-    let handled = false;
-    const queue: string[] = [];
+    const statusLabel = deriveStatusAnnouncement(previous, snapshot, labels);
+    const statusHandled = statusLabel !== null && this.#announce(statusLabel);
+    const seekHandled = this.#processSeekSnapshot(previous, snapshot, labels, statusHandled);
+    const volumeHandled = this.#processVolumeSnapshot(previous, snapshot, labels, statusHandled || seekHandled);
 
-    if (hasChanged(previous.paused, snapshot.paused)) {
-      queue.push(snapshot.paused ? labels.paused : labels.playing);
-    }
-
-    if (hasChanged(previous.subtitlesShowing, snapshot.subtitlesShowing) && snapshot.subtitlesAvailable !== false) {
-      queue.push(snapshot.subtitlesShowing ? labels.captionsOn : labels.captionsOff);
-    }
-
-    if (hasChanged(previous.fullscreen, snapshot.fullscreen)) {
-      queue.push(snapshot.fullscreen ? labels.fullscreen : labels.exitFullscreen);
-    }
-
-    if (hasChanged(previous.pip, snapshot.pip)) {
-      queue.push(snapshot.pip ? labels.pictureInPicture : labels.exitPictureInPicture);
-    }
-
-    if (hasChanged(previous.playbackRate, snapshot.playbackRate)) {
-      queue.push(formatPlaybackRateAnnouncerLabel(snapshot.playbackRate, labels));
-    }
-
-    if (queue.length > 0) {
-      handled = this.#announce(queue.join('. '));
-    }
-
-    if (this.#processSeekSnapshot(previous, snapshot, labels, handled)) {
-      handled = true;
-    }
-
-    if (this.#processVolumeSnapshot(previous, snapshot, labels, handled)) {
-      handled = true;
-    }
-
-    return handled;
+    return statusHandled || seekHandled || volumeHandled;
   }
 
   #getLabels(): StatusAnnouncerLabels {
@@ -107,7 +73,7 @@ export class StatusAnnouncerCore {
 
   #announce(label: string): boolean {
     this.#clearTimer();
-    this.state.patch({ label });
+    this.state.patch({ generation: this.state.current.generation + 1, label });
     this.#close.arm();
     return true;
   }
@@ -118,17 +84,10 @@ export class StatusAnnouncerCore {
     labels: StatusAnnouncerLabels,
     alreadyHandled: boolean
   ): boolean {
-    if (!hasChanged(previous.volume, snapshot.volume) && !hasChanged(previous.muted, snapshot.muted)) return false;
-    if (this.#props.shouldAnnounceVolume?.(snapshot) === false) return false;
-    if (alreadyHandled) return false;
+    const label = deriveVolumeAnnouncement(previous, snapshot, labels);
+    if (label === null || alreadyHandled || !this.#shouldAnnounce()) return false;
 
-    const volume = snapshot.volume ?? previous.volume;
-    const muted = snapshot.muted ?? previous.muted;
-
-    if (volume === undefined && muted === undefined) return false;
-
-    const label = muted || (volume ?? 0) <= 0 ? labels.muted : labels.volumeWithValue(formatVolumeValue(volume ?? 0));
-    this.#schedule(label, () => this.#props.shouldAnnounceVolume?.(snapshot) !== false);
+    this.#schedule(label);
     return true;
   }
 
@@ -158,27 +117,27 @@ export class StatusAnnouncerCore {
     this.#seekTargetTime = null;
 
     if (targetTime === undefined || targetTime === null || Object.is(targetTime, startTime)) return false;
-    if (this.#props.shouldAnnounceSeek?.(snapshot) === false) return false;
-    if (alreadyHandled) return false;
+    if (alreadyHandled || !this.#shouldAnnounce()) return false;
 
-    this.#schedule(
-      formatSeekAnnouncerLabel(targetTime, labels),
-      () => this.#props.shouldAnnounceSeek?.(snapshot) !== false
-    );
+    this.#schedule(labels.seekedTo(targetTime));
     return true;
   }
 
-  #schedule(label: string, shouldAnnounce: () => boolean): void {
+  #schedule(label: string): void {
     this.#clearTimer();
     this.#timer = setTimeout(() => {
       this.#timer = null;
-      if (!shouldAnnounce()) return;
+      if (!this.#shouldAnnounce()) return;
       this.#announce(label);
     }, ANNOUNCEMENT_DEBOUNCE);
   }
 
+  #shouldAnnounce(): boolean {
+    return this.#props.shouldAnnounce?.() !== false;
+  }
+
   #clearTimer(): void {
-    if (!this.#timer) return;
+    if (this.#timer === null) return;
     clearTimeout(this.#timer);
     this.#timer = null;
   }
@@ -187,8 +146,4 @@ export class StatusAnnouncerCore {
 export namespace StatusAnnouncerCore {
   export type Props = StatusAnnouncerProps;
   export type State = StatusAnnouncerState;
-}
-
-function hasChanged<Value>(previous: Value | undefined, next: Value | undefined): next is Value {
-  return previous !== undefined && next !== undefined && !Object.is(previous, next);
 }

--- a/packages/core/src/core/ui/status-announcer/status-announcer-labels.ts
+++ b/packages/core/src/core/ui/status-announcer/status-announcer-labels.ts
@@ -34,11 +34,3 @@ export function createStatusAnnouncerLabels(translator: Translator, locale = DEF
     playbackRate: (rate) => translator(rateText, { rate }),
   };
 }
-
-export function formatSeekAnnouncerLabel(time: number, labels: StatusAnnouncerLabels): string {
-  return labels.seekedTo(time);
-}
-
-export function formatPlaybackRateAnnouncerLabel(rate: number, labels: StatusAnnouncerLabels): string {
-  return labels.playbackRate(`${rate}×`);
-}

--- a/packages/core/src/core/ui/status-announcer/status-announcer-status.ts
+++ b/packages/core/src/core/ui/status-announcer/status-announcer-status.ts
@@ -1,0 +1,51 @@
+import type { MediaSnapshot } from '../input-action/input-action';
+import { formatVolumeValue } from '../volume-indicator/volume-indicator-status';
+import { DEFAULT_STATUS_ANNOUNCER_LABELS, type StatusAnnouncerLabels } from './status-announcer-labels';
+
+export function deriveStatusAnnouncement(
+  previous: MediaSnapshot,
+  snapshot: MediaSnapshot,
+  labels: StatusAnnouncerLabels = DEFAULT_STATUS_ANNOUNCER_LABELS
+): string | null {
+  const announcements: string[] = [];
+
+  if (hasChanged(previous.paused, snapshot.paused)) {
+    announcements.push(snapshot.paused ? labels.paused : labels.playing);
+  }
+
+  if (hasChanged(previous.subtitlesShowing, snapshot.subtitlesShowing) && snapshot.subtitlesAvailable !== false) {
+    announcements.push(snapshot.subtitlesShowing ? labels.captionsOn : labels.captionsOff);
+  }
+
+  if (hasChanged(previous.fullscreen, snapshot.fullscreen)) {
+    announcements.push(snapshot.fullscreen ? labels.fullscreen : labels.exitFullscreen);
+  }
+
+  if (hasChanged(previous.pip, snapshot.pip)) {
+    announcements.push(snapshot.pip ? labels.pictureInPicture : labels.exitPictureInPicture);
+  }
+
+  if (hasChanged(previous.playbackRate, snapshot.playbackRate)) {
+    announcements.push(labels.playbackRate(`${snapshot.playbackRate}×`));
+  }
+
+  return announcements.length > 0 ? announcements.join('. ') : null;
+}
+
+export function deriveVolumeAnnouncement(
+  previous: MediaSnapshot,
+  snapshot: MediaSnapshot,
+  labels: StatusAnnouncerLabels = DEFAULT_STATUS_ANNOUNCER_LABELS
+): string | null {
+  if (!hasChanged(previous.volume, snapshot.volume) && !hasChanged(previous.muted, snapshot.muted)) return null;
+
+  const volume = snapshot.volume ?? previous.volume;
+  const muted = snapshot.muted ?? previous.muted;
+
+  if (volume === undefined && muted === undefined) return null;
+  return muted || (volume ?? 0) <= 0 ? labels.muted : labels.volumeWithValue(formatVolumeValue(volume ?? 0));
+}
+
+function hasChanged<Value>(previous: Value | undefined, next: Value | undefined): next is Value {
+  return previous !== undefined && next !== undefined && !Object.is(previous, next);
+}

--- a/packages/core/src/core/ui/status-announcer/tests/status-announcer-core.test.ts
+++ b/packages/core/src/core/ui/status-announcer/tests/status-announcer-core.test.ts
@@ -71,7 +71,7 @@ describe('StatusAnnouncerCore', () => {
   it('rechecks volume suppression when the debounced announcement fires', () => {
     let shouldAnnounce = true;
     const core = new StatusAnnouncerCore();
-    core.setProps({ shouldAnnounceVolume: () => shouldAnnounce });
+    core.setProps({ shouldAnnounce: () => shouldAnnounce });
 
     core.processSnapshot({ volume: 0.5, muted: false });
     expect(core.processSnapshot({ volume: 0.75, muted: false })).toBe(true);
@@ -85,7 +85,7 @@ describe('StatusAnnouncerCore', () => {
   it('rechecks seek suppression when the debounced announcement fires', () => {
     let shouldAnnounce = true;
     const core = new StatusAnnouncerCore();
-    core.setProps({ shouldAnnounceSeek: () => shouldAnnounce });
+    core.setProps({ shouldAnnounce: () => shouldAnnounce });
 
     core.processSnapshot({ currentTime: 10, duration: 120, seeking: false });
     core.processSnapshot({ currentTime: 45, duration: 120, seeking: true });
@@ -95,30 +95,6 @@ describe('StatusAnnouncerCore', () => {
     vi.advanceTimersByTime(200);
 
     expect(core.state.current.label).toBeNull();
-  });
-
-  it('combines multiple immediate snapshot announcements', () => {
-    const core = new StatusAnnouncerCore();
-
-    core.processSnapshot({
-      paused: true,
-      subtitlesShowing: false,
-      subtitlesAvailable: true,
-      fullscreen: false,
-      playbackRate: 1,
-    });
-
-    expect(
-      core.processSnapshot({
-        paused: false,
-        subtitlesShowing: true,
-        subtitlesAvailable: true,
-        fullscreen: true,
-        playbackRate: 1.25,
-      })
-    ).toBe(true);
-
-    expect(core.state.current.label).toBe('Playing. Captions on. Fullscreen. Playback rate 1.25×');
   });
 
   it('announces confirmed playback, captions, fullscreen, pip, and playback-rate changes', () => {
@@ -144,15 +120,6 @@ describe('StatusAnnouncerCore', () => {
     }
   });
 
-  it('does not announce captions when captions are unavailable', () => {
-    const core = new StatusAnnouncerCore();
-
-    core.processSnapshot({ subtitlesShowing: false, subtitlesAvailable: false });
-
-    expect(core.processSnapshot({ subtitlesShowing: true, subtitlesAvailable: false })).toBe(false);
-    expect(core.state.current.label).toBeNull();
-  });
-
   it('debounces volume snapshot announcements to the final value', () => {
     const core = new StatusAnnouncerCore();
     const process = createSnapshotProcessor(core, { volume: 0.5, muted: false });
@@ -166,17 +133,6 @@ describe('StatusAnnouncerCore', () => {
 
     vi.advanceTimersByTime(1);
     expect(core.state.current.label).toBe('Volume 60%');
-  });
-
-  it('uses the translated volume phrase order', () => {
-    const core = new StatusAnnouncerCore();
-    core.setProps({ labels: { volumeWithValue: (value) => `${value} volume` } });
-    const process = createSnapshotProcessor(core, { volume: 0.5, muted: false });
-
-    process({ volume: 0.75 });
-    vi.advanceTimersByTime(200);
-
-    expect(core.state.current.label).toBe('75% volume');
   });
 
   it('replaces a pending volume announcement with a completed seek', () => {
@@ -232,6 +188,21 @@ describe('StatusAnnouncerCore', () => {
     expect(core.state.current.label).toBe('Muted');
   });
 
+  it('increments the generation for repeated announcement labels', () => {
+    const core = new StatusAnnouncerCore();
+    const process = createSnapshotProcessor(core, { volume: 0.5, muted: false });
+
+    process({ volume: 0 });
+    vi.advanceTimersByTime(200);
+    const firstGeneration = core.state.current.generation;
+
+    process({ muted: true });
+    vi.advanceTimersByTime(200);
+
+    expect(core.state.current.label).toBe('Muted');
+    expect(core.state.current.generation).toBe(firstGeneration + 1);
+  });
+
   it('ignores regular currentTime updates and announces completed seeks once', () => {
     const core = new StatusAnnouncerCore();
     const process = createSnapshotProcessor(core, { currentTime: 10, duration: 120, seeking: false });
@@ -269,7 +240,7 @@ describe('StatusAnnouncerCore', () => {
 
   it('allows seek announcements to be suppressed by callers', () => {
     const core = new StatusAnnouncerCore();
-    core.setProps({ shouldAnnounceSeek: () => false });
+    core.setProps({ shouldAnnounce: () => false });
     const process = createSnapshotProcessor(core, { currentTime: 10, duration: 120, seeking: false });
 
     process({ currentTime: 45, seeking: true });
@@ -282,7 +253,7 @@ describe('StatusAnnouncerCore', () => {
 
   it('allows volume announcements to be suppressed by callers', () => {
     const core = new StatusAnnouncerCore();
-    core.setProps({ shouldAnnounceVolume: () => false });
+    core.setProps({ shouldAnnounce: () => false });
     const process = createSnapshotProcessor(core, { volume: 0.5, muted: false });
 
     expect(process({ volume: 0.75 })).toBe(false);

--- a/packages/core/src/core/ui/status-announcer/tests/status-announcer-status.test.ts
+++ b/packages/core/src/core/ui/status-announcer/tests/status-announcer-status.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_STATUS_ANNOUNCER_LABELS } from '../status-announcer-labels';
+import { deriveStatusAnnouncement, deriveVolumeAnnouncement } from '../status-announcer-status';
+
+describe('deriveStatusAnnouncement', () => {
+  it('combines confirmed status changes', () => {
+    expect(
+      deriveStatusAnnouncement(
+        {
+          paused: true,
+          subtitlesShowing: false,
+          subtitlesAvailable: true,
+          fullscreen: false,
+          pip: false,
+          playbackRate: 1,
+        },
+        {
+          paused: false,
+          subtitlesShowing: true,
+          subtitlesAvailable: true,
+          fullscreen: true,
+          pip: true,
+          playbackRate: 1.25,
+        }
+      )
+    ).toBe('Playing. Captions on. Fullscreen. Picture in picture. Playback rate 1.25×');
+  });
+
+  it('ignores captions changes when captions are unavailable', () => {
+    expect(
+      deriveStatusAnnouncement(
+        { subtitlesShowing: false, subtitlesAvailable: false },
+        { subtitlesShowing: true, subtitlesAvailable: false }
+      )
+    ).toBeNull();
+  });
+});
+
+describe('deriveVolumeAnnouncement', () => {
+  it('formats changed volume and mute state', () => {
+    const labels = {
+      ...DEFAULT_STATUS_ANNOUNCER_LABELS,
+      volumeWithValue: (value: string) => `${value} volume`,
+    };
+
+    expect(deriveVolumeAnnouncement({ volume: 0.5, muted: false }, { volume: 0.75, muted: false }, labels)).toBe(
+      '75% volume'
+    );
+    expect(deriveVolumeAnnouncement({ volume: 0.75, muted: false }, { volume: 0.75, muted: true }, labels)).toBe(
+      'Muted'
+    );
+  });
+
+  it('ignores unchanged volume state', () => {
+    expect(deriveVolumeAnnouncement({ volume: 0.5, muted: false }, { volume: 0.5, muted: false })).toBeNull();
+  });
+});

--- a/packages/core/src/dom/ui/status-announcer.ts
+++ b/packages/core/src/dom/ui/status-announcer.ts
@@ -1,5 +1,6 @@
 import type { StatusAnnouncerCore } from '../../core/ui/status-announcer/status-announcer-core';
 import { getMediaSnapshot, type MediaSnapshotStore } from './input-action';
+import { isSliderFocused } from './slider-focus';
 
 export interface StatusAnnouncerStore extends MediaSnapshotStore {
   readonly target: unknown | null;
@@ -13,15 +14,16 @@ export function subscribeToStatusAnnouncer(store: StatusAnnouncerStore, core: St
   let revision = 0;
 
   const baseline = () => {
+    target = store.target;
     pending = true;
     const current = ++revision;
+    core.resetSnapshot();
 
     queueMicrotask(() => {
       if (!active || current !== revision) return;
 
       pending = false;
       target = store.target;
-      core.resetSnapshot();
       if (target) core.processSnapshot(getMediaSnapshot(store));
     });
   };
@@ -30,8 +32,6 @@ export function subscribeToStatusAnnouncer(store: StatusAnnouncerStore, core: St
     const nextTarget = store.target;
 
     if (nextTarget !== target) {
-      target = nextTarget;
-      core.resetSnapshot();
       baseline();
       return;
     }
@@ -40,11 +40,14 @@ export function subscribeToStatusAnnouncer(store: StatusAnnouncerStore, core: St
     core.processSnapshot(getMediaSnapshot(store));
   });
 
-  core.resetSnapshot();
   baseline();
 
   return () => {
     active = false;
     unsubscribe();
   };
+}
+
+export function shouldAnnounceStatusChange(container: HTMLElement | null | undefined): boolean {
+  return !container || !isSliderFocused(container);
 }

--- a/packages/core/src/dom/ui/tests/status-announcer.test.ts
+++ b/packages/core/src/dom/ui/tests/status-announcer.test.ts
@@ -1,15 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { StatusAnnouncerCore } from '../../../core/ui/status-announcer/status-announcer-core';
 import { type StatusAnnouncerStore, subscribeToStatusAnnouncer } from '../status-announcer';
 
 describe('subscribeToStatusAnnouncer', () => {
   it('uses attach updates as the snapshot baseline', async () => {
     const core = new StatusAnnouncerCore();
+    const resetSnapshot = vi.spyOn(core, 'resetSnapshot');
     const { attach, setState, store } = createStore({ paused: true });
     const unsubscribe = subscribeToStatusAnnouncer(store, core);
 
+    expect(resetSnapshot).toHaveBeenCalledTimes(1);
+
     attach({ paused: false });
+    expect(resetSnapshot).toHaveBeenCalledTimes(2);
     await Promise.resolve();
+
+    expect(resetSnapshot).toHaveBeenCalledTimes(2);
 
     expect(core.state.current.label).toBeNull();
 

--- a/packages/html/src/ui/status-announcer/status-announcer-element.ts
+++ b/packages/html/src/ui/status-announcer/status-announcer-element.ts
@@ -1,5 +1,5 @@
 import { createStatusAnnouncerLabels, StatusAnnouncerCore } from '@videojs/core';
-import { isSliderFocused, type StatusAnnouncerStore, subscribeToStatusAnnouncer } from '@videojs/core/dom';
+import { type StatusAnnouncerStore, shouldAnnounceStatusChange, subscribeToStatusAnnouncer } from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
 
@@ -62,14 +62,7 @@ export class StatusAnnouncerElement extends MediaElement {
     this.#core.setProps({
       closeDelay: this.closeDelay,
       labels: createStatusAnnouncerLabels(this.#i18n.value, this.#i18n.locale),
-      shouldAnnounceSeek: () => {
-        const container = this.#container.value?.container;
-        return !container || !isSliderFocused(container);
-      },
-      shouldAnnounceVolume: () => {
-        const container = this.#container.value?.container;
-        return !container || !isSliderFocused(container);
-      },
+      shouldAnnounce: () => shouldAnnounceStatusChange(this.#container.value?.container),
     });
   }
 
@@ -77,15 +70,22 @@ export class StatusAnnouncerElement extends MediaElement {
     super.update(changed);
 
     const label = this.#core.state.current.label;
-    this.#ensureLiveText().textContent = label ?? '';
+    const liveText = this.#ensureLiveText();
+
+    if (label === null) {
+      liveText.replaceChildren();
+    } else {
+      liveText.replaceChildren(document.createTextNode(label));
+    }
   }
 
   #reconnect(store: StatusAnnouncerStore | undefined = this.#player.value): void {
     this.#storeUnsubscribe?.();
     this.#storeUnsubscribe = null;
-    this.#core.resetSnapshot();
-
-    if (!store) return;
+    if (!store) {
+      this.#core.resetSnapshot();
+      return;
+    }
 
     this.#storeUnsubscribe = subscribeToStatusAnnouncer(store, this.#core);
   }

--- a/packages/html/src/ui/status-announcer/tests/status-announcer-element.test.ts
+++ b/packages/html/src/ui/status-announcer/tests/status-announcer-element.test.ts
@@ -95,6 +95,32 @@ describe('StatusAnnouncerElement', () => {
     expect(announcer.textContent).toBe('Playing');
   });
 
+  it('replaces live content for repeated announcement labels', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { store, setState } = createTestStore({ volume: 0.5, muted: false });
+      const { announcer } = await renderStatusAnnouncerElement(store);
+      const content = announcer.querySelector('[data-status-announcer-content]')!;
+
+      setState({ volume: 0 });
+      await Promise.resolve();
+      vi.advanceTimersByTime(200);
+      await (announcer as StatusAnnouncerElement).updateComplete;
+      const firstContent = content.firstChild;
+
+      setState({ muted: true });
+      await Promise.resolve();
+      vi.advanceTimersByTime(200);
+      await (announcer as StatusAnnouncerElement).updateComplete;
+
+      expect(announcer.textContent).toBe('Muted');
+      expect(content.firstChild).not.toBe(firstContent);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('uses the next store snapshot as baseline when the store changes', async () => {
     const first = createTestStore({ paused: false });
     const second = createTestStore({ paused: false });

--- a/packages/react/src/ui/status-announcer/status-announcer.tsx
+++ b/packages/react/src/ui/status-announcer/status-announcer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createStatusAnnouncerLabels, StatusAnnouncerCore } from '@videojs/core';
-import { isSliderFocused, subscribeToStatusAnnouncer } from '@videojs/core/dom';
+import { shouldAnnounceStatusChange, subscribeToStatusAnnouncer } from '@videojs/core/dom';
 import type { ForwardedRef } from 'react';
 import { forwardRef, useEffect, useState, useSyncExternalStore } from 'react';
 import { useLocale, useTranslator } from '../../i18n/context';
@@ -31,8 +31,7 @@ export const StatusAnnouncer = forwardRef(function StatusAnnouncer(
       ...createStatusAnnouncerLabels(translator, locale),
       ...labels,
     },
-    shouldAnnounceSeek: () => !container || !isSliderFocused(container),
-    shouldAnnounceVolume: () => !container || !isSliderFocused(container),
+    shouldAnnounce: () => shouldAnnounceStatusChange(container),
   });
 
   useEffect(() => subscribeToStatusAnnouncer(store, core), [core, store]);
@@ -53,7 +52,11 @@ export const StatusAnnouncer = forwardRef(function StatusAnnouncer(
         elementProps,
         {
           role: 'status',
-          children: state.label ?? '',
+          children: (
+            <span key={state.generation} data-status-announcer-content="">
+              {state.label ?? ''}
+            </span>
+          ),
         },
       ],
     }

--- a/packages/react/src/ui/status-announcer/tests/status-announcer.test.tsx
+++ b/packages/react/src/ui/status-announcer/tests/status-announcer.test.tsx
@@ -29,6 +29,29 @@ describe('StatusAnnouncer', () => {
     expect(getByRole('status').textContent).toBe('Playing');
   });
 
+  it('replaces live content for repeated announcement labels', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { store, setState } = createTestStore({ volume: 0.5, muted: false });
+      const { getByRole } = renderWithPlayer(<StatusAnnouncer />, store);
+      await act(async () => {});
+
+      setState({ volume: 0 });
+      await act(async () => vi.advanceTimersByTime(200));
+      const firstContent = getByRole('status').querySelector('[data-status-announcer-content]');
+
+      setState({ muted: true });
+      await act(async () => vi.advanceTimersByTime(200));
+      const nextContent = getByRole('status').querySelector('[data-status-announcer-content]');
+
+      expect(getByRole('status').textContent).toBe('Muted');
+      expect(nextContent).not.toBe(firstContent);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('uses custom labels', async () => {
     const { store, setState } = createTestStore({ paused: true });
     const { getByRole } = renderWithPlayer(<StatusAnnouncer labels={{ playing: 'Custom playing' }} />, store);


### PR DESCRIPTION
Closes #2076

## Summary

Simplify the snapshot-driven status announcer and make consecutive announcements observable even when their translated labels are identical. This keeps the HTML and React adapters aligned while reducing duplicated suppression and baseline-reset logic.

## Changes

- Extract pure status and volume announcement derivation from the stateful core
- Consolidate seek and volume suppression behind one shared player-slider focus policy
- Increment an announcement generation so repeated labels replace live-region content
- Remove duplicate snapshot resets when stores attach or change
- Add focused core, DOM, HTML, and React regression coverage

## Testing

- pnpm -F @videojs/core test src/core/ui/status-announcer/tests/status-announcer-core.test.ts src/core/ui/status-announcer/tests/status-announcer-status.test.ts src/dom/ui/tests/status-announcer.test.ts
- pnpm -F @videojs/html test src/ui/status-announcer/tests/status-announcer-element.test.ts
- pnpm -F @videojs/react test src/ui/status-announcer/tests/status-announcer.test.tsx
- pnpm typecheck
- Manual sandbox verification for repeated Muted announcements and focused-slider suppression

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches screen-reader live regions and debounced seek/volume announcement timing; behavior is well covered by tests but a11y regressions are possible if generation or suppression wiring is wrong.
> 
> **Overview**
> **Refactors the snapshot-driven status announcer** so announcement text is derived in pure helpers and HTML/React stay aligned on suppression and live-region updates.
> 
> **Core:** Immediate status and debounced volume/seek copy move into `status-announcer-status` (`deriveStatusAnnouncement`, `deriveVolumeAnnouncement`). `StatusAnnouncerCore` delegates to those helpers; `shouldAnnounceSeek` / `shouldAnnounceVolume` become a single optional `shouldAnnounce`. State gains a **`generation`** counter incremented on each announce so adapters can force DOM updates when the label string repeats (e.g. back-to-back “Muted”).
> 
> **DOM/adapters:** `shouldAnnounceStatusChange` centralizes “don’t announce while a player slider is focused.” `subscribeToStatusAnnouncer` resets the snapshot baseline once per attach/target change (no duplicate resets). HTML replaces live text via `replaceChildren`; React keys the content span on `generation`.
> 
> **Tests:** New unit tests for derivation; core/DOM/HTML/React coverage for generation, suppression, and baseline behavior. Removed label formatter exports from `status-announcer-labels`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290c1846109547b6af74c60bd67a395f1b54549a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->