### PR TITLE
feat(packages): hide unavailable radio groups

### DIFF
--- a/packages/core/src/core/ui/audio-track-radio-group/audio-track-radio-group-core.ts
+++ b/packages/core/src/core/ui/audio-track-radio-group/audio-track-radio-group-core.ts
@@ -41,7 +41,8 @@ export class AudioTrackRadioGroupCore {
   readonly state = createState<AudioTrackRadioGroupState>({
     options: [],
     value: '',
-    disabled: false,
+    disabled: true,
+    hidden: true,
     availability: 'unavailable',
     label: '',
   });
@@ -72,6 +73,7 @@ export class AudioTrackRadioGroupCore {
     return {
       'aria-label': this.getLabel(state),
       'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -93,6 +95,7 @@ export class AudioTrackRadioGroupCore {
       options,
       value: enabledIndex === -1 ? '' : getTrackValue(media.audioTrackList[enabledIndex]!, enabledIndex),
       disabled: this.#props.disabled || availability === 'unavailable',
+      hidden: availability === 'unavailable',
       availability,
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });

--- a/packages/core/src/core/ui/audio-track-radio-group/audio-track-radio-group-data-attrs.ts
+++ b/packages/core/src/core/ui/audio-track-radio-group/audio-track-radio-group-data-attrs.ts
@@ -6,6 +6,8 @@ export const AudioTrackRadioGroupDataAttrs = {
   value: 'data-audio-track',
   /** Present when audio track selection is disabled. */
   disabled: 'data-disabled',
+  /** Present when audio track selection is unavailable. */
+  hidden: 'data-hidden',
   /** Indicates audio track availability (`available` or `unavailable`). */
   availability: 'data-availability',
 } as const satisfies StateAttrMap<AudioTrackRadioGroupState>;

--- a/packages/core/src/core/ui/audio-track-radio-group/tests/audio-track-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/audio-track-radio-group/tests/audio-track-radio-group-core.test.ts
@@ -22,6 +22,7 @@ function createState(overrides: Partial<AudioTrackRadioGroupState> = {}): AudioT
     ],
     value: '0',
     disabled: false,
+    hidden: false,
     availability: 'available',
     label: '',
     ...overrides,
@@ -82,8 +83,7 @@ describe('AudioTrackRadioGroupCore', () => {
         createMediaState({ audioTrackList: [{ id: '0', label: 'English', language: 'en', enabled: true }] })
       );
 
-      expect(core.getState().availability).toBe('unavailable');
-      expect(core.getState().disabled).toBe(true);
+      expect(core.getState()).toMatchObject({ availability: 'unavailable', disabled: true, hidden: true });
     });
   });
 

--- a/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
+++ b/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
@@ -51,7 +51,8 @@ export class CaptionsRadioGroupCore {
     options: [{ value: CAPTIONS_OFF_VALUE, label: offText, disabled: false }],
     value: CAPTIONS_OFF_VALUE,
     subtitlesShowing: false,
-    disabled: false,
+    disabled: true,
+    hidden: true,
     availability: 'unavailable',
     label: '',
   });
@@ -82,6 +83,7 @@ export class CaptionsRadioGroupCore {
     return {
       'aria-label': this.getLabel(state),
       'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -110,6 +112,7 @@ export class CaptionsRadioGroupCore {
       value: showingIndex === -1 ? CAPTIONS_OFF_VALUE : captionTracks[showingIndex]!.id || String(showingIndex),
       subtitlesShowing: media.subtitlesShowing,
       disabled: this.#props.disabled || captionTracks.length === 0,
+      hidden: availability === 'unavailable',
       availability,
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });

--- a/packages/core/src/core/ui/captions-radio-group/captions-radio-group-data-attrs.ts
+++ b/packages/core/src/core/ui/captions-radio-group/captions-radio-group-data-attrs.ts
@@ -6,6 +6,8 @@ export const CaptionsRadioGroupDataAttrs = {
   subtitlesShowing: 'data-active',
   /** Present when track selection is disabled. */
   disabled: 'data-disabled',
+  /** Present when track selection is unavailable. */
+  hidden: 'data-hidden',
   /** Indicates captions availability (`available` or `unavailable`). */
   availability: 'data-availability',
 } as const satisfies StateAttrMap<CaptionsRadioGroupState>;

--- a/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
@@ -21,6 +21,7 @@ function createState(overrides: Partial<CaptionsRadioGroupState> = {}): Captions
     value: CAPTIONS_OFF_VALUE,
     subtitlesShowing: false,
     disabled: false,
+    hidden: false,
     availability: 'unavailable',
     label: '',
     ...overrides,
@@ -66,7 +67,7 @@ describe('CaptionsRadioGroupCore', () => {
       const core = new CaptionsRadioGroupCore();
       core.setMedia(createMediaState());
 
-      expect(core.getState().availability).toBe('unavailable');
+      expect(core.getState()).toMatchObject({ availability: 'unavailable', disabled: true, hidden: true });
     });
 
     it('marks availability available when caption tracks exist', () => {
@@ -76,7 +77,7 @@ describe('CaptionsRadioGroupCore', () => {
       });
       core.setMedia(media);
 
-      expect(core.getState().availability).toBe('available');
+      expect(core.getState()).toMatchObject({ availability: 'available', hidden: false });
     });
 
     it('uses off when no track is showing', () => {

--- a/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-core.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-core.ts
@@ -40,7 +40,8 @@ export class PlaybackRateRadioGroupCore {
     rate: 1,
     value: '1',
     options: [],
-    disabled: false,
+    disabled: true,
+    hidden: true,
     availability: 'unavailable',
     label: '',
   });
@@ -79,6 +80,7 @@ export class PlaybackRateRadioGroupCore {
     return {
       'aria-label': this.getLabel(state),
       'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -102,6 +104,7 @@ export class PlaybackRateRadioGroupCore {
         disabled: false,
       })),
       disabled: this.#props.disabled || media.playbackRates.length === 0,
+      hidden: availability === 'unavailable',
       availability,
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });

--- a/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-data-attrs.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-data-attrs.ts
@@ -6,6 +6,8 @@ export const PlaybackRateRadioGroupDataAttrs = {
   rate: 'data-rate',
   /** Present when playback rate selection is disabled. */
   disabled: 'data-disabled',
+  /** Present when playback rate selection is unavailable. */
+  hidden: 'data-hidden',
   /** Indicates playback rate availability (`available` or `unavailable`). */
   availability: 'data-availability',
 } as const satisfies StateAttrMap<PlaybackRateRadioGroupState>;

--- a/packages/core/src/core/ui/playback-rate-radio-group/tests/playback-rate-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/tests/playback-rate-radio-group-core.test.ts
@@ -18,6 +18,7 @@ function createState(overrides: Partial<PlaybackRateRadioGroupState> = {}): Play
     value: '1',
     options: [0.5, 1, 1.5, 2].map((rate) => ({ rate, value: String(rate), label: `${rate}×`, disabled: false })),
     disabled: false,
+    hidden: false,
     availability: 'available',
     label: '',
     ...overrides,
@@ -52,14 +53,14 @@ describe('PlaybackRateRadioGroupCore', () => {
       const core = new PlaybackRateRadioGroupCore();
       core.setMedia(createMediaState({ playbackRates: [] }));
 
-      expect(core.getState().availability).toBe('unavailable');
+      expect(core.getState()).toMatchObject({ availability: 'unavailable', disabled: true, hidden: true });
     });
 
     it('marks availability available when rates exist', () => {
       const core = new PlaybackRateRadioGroupCore();
       core.setMedia(createMediaState());
 
-      expect(core.getState().availability).toBe('available');
+      expect(core.getState()).toMatchObject({ availability: 'available', hidden: false });
     });
   });
 
@@ -123,6 +124,12 @@ describe('PlaybackRateRadioGroupCore', () => {
       const core = new PlaybackRateRadioGroupCore();
       const attrs = core.getAttrs(createState({ disabled: true }));
       expect(attrs['aria-disabled']).toBe('true');
+    });
+
+    it('sets hidden when unavailable', () => {
+      const core = new PlaybackRateRadioGroupCore();
+      const attrs = core.getAttrs(createState({ hidden: true }));
+      expect(attrs.hidden).toBe('');
     });
   });
 

--- a/packages/core/src/core/ui/quality-radio-group/quality-radio-group-core.ts
+++ b/packages/core/src/core/ui/quality-radio-group/quality-radio-group-core.ts
@@ -109,7 +109,8 @@ export class QualityRadioGroupCore {
   readonly state = createState<QualityRadioGroupState>({
     options: [{ value: QUALITY_AUTO_VALUE, label: autoText, disabled: false }],
     value: QUALITY_AUTO_VALUE,
-    disabled: false,
+    disabled: true,
+    hidden: true,
     availability: 'unavailable',
     label: '',
   });
@@ -163,6 +164,7 @@ export class QualityRadioGroupCore {
     return {
       'aria-label': this.getLabel(state),
       'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     };
   }
 
@@ -207,6 +209,7 @@ export class QualityRadioGroupCore {
           ? QUALITY_AUTO_VALUE
           : this.getRenditionValue(media.videoRenditionList[selectedIndex]!, selectedIndex),
       disabled: this.#props.disabled || availability === 'unavailable',
+      hidden: availability === 'unavailable',
       availability,
     });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });

--- a/packages/core/src/core/ui/quality-radio-group/quality-radio-group-data-attrs.ts
+++ b/packages/core/src/core/ui/quality-radio-group/quality-radio-group-data-attrs.ts
@@ -6,6 +6,8 @@ export const QualityRadioGroupDataAttrs = {
   value: 'data-quality',
   /** Present when quality selection is disabled. */
   disabled: 'data-disabled',
+  /** Present when quality selection is unavailable. */
+  hidden: 'data-hidden',
   /** Indicates quality availability (`available` or `unavailable`). */
   availability: 'data-availability',
 } as const satisfies StateAttrMap<QualityRadioGroupState>;

--- a/packages/core/src/core/ui/quality-radio-group/tests/quality-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/quality-radio-group/tests/quality-radio-group-core.test.ts
@@ -24,6 +24,7 @@ function createState(overrides: Partial<QualityRadioGroupState> = {}): QualityRa
     ],
     value: QUALITY_AUTO_VALUE,
     disabled: false,
+    hidden: false,
     availability: 'available',
     label: '',
     ...overrides,
@@ -120,8 +121,7 @@ describe('QualityRadioGroupCore', () => {
       const core = new QualityRadioGroupCore();
       core.setMedia(createMediaState({ videoRenditionList: [{ id: '0', height: 1080, selected: false }] }));
 
-      expect(core.getState().availability).toBe('unavailable');
-      expect(core.getState().disabled).toBe(true);
+      expect(core.getState()).toMatchObject({ availability: 'unavailable', disabled: true, hidden: true });
     });
   });
 

--- a/packages/core/src/core/ui/types.ts
+++ b/packages/core/src/core/ui/types.ts
@@ -41,6 +41,8 @@ export interface RadioOptionsState<Option extends RadioOption = RadioOption> ext
   options: readonly Option[];
   /** Whether the entire option group is disabled. */
   disabled: boolean;
+  /** Whether the option group is hidden because no meaningful selection is available. */
+  hidden: boolean;
   /** Whether the media exposes a meaningful selection. */
   availability: 'available' | 'unavailable';
 }

--- a/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
+++ b/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
@@ -142,6 +142,8 @@ describe('CaptionsRadioGroupElement', () => {
 
     const items = [...menu.querySelectorAll<MenuRadioItemElement>(MenuRadioItemElement.tagName)];
     expect(options.getAttribute('aria-disabled')).toBe('true');
+    expect(options.hidden).toBe(true);
+    expect(options.hasAttribute('data-hidden')).toBe(true);
     expect(items.map((item) => item.disabled)).toEqual([true]);
   });
 

--- a/packages/html/src/ui/radio-options/radio-options-controller.ts
+++ b/packages/html/src/ui/radio-options/radio-options-controller.ts
@@ -54,6 +54,7 @@ export class RadioOptionsController<Option extends RadioOption> implements React
     this.#host.value = state.value;
     applyElementProps(this.#host, {
       'aria-disabled': state.disabled ? 'true' : undefined,
+      hidden: state.hidden ? '' : undefined,
     });
 
     const template = this.#config.getTemplate();

--- a/packages/html/src/ui/radio-options/tests/radio-options-controller.test.ts
+++ b/packages/html/src/ui/radio-options/tests/radio-options-controller.test.ts
@@ -32,6 +32,7 @@ class TestRadioOptionsElement extends MenuRadioGroupElement {
       { value: 'two', label: 'Two', disabled: true },
     ],
     disabled: false,
+    hidden: false,
     availability: 'available',
   };
   translator = createTranslator({ 'option.one': 'First ({detail})' }, 'en');
@@ -109,6 +110,22 @@ describe('RadioOptionsController', () => {
 
     expect(element.hasAttribute('aria-disabled')).toBe(false);
     expect(items.map((item) => item.disabled)).toEqual([false, true]);
+  });
+
+  it('applies native hidden semantics to unavailable groups', async () => {
+    const element = new TestRadioOptionsElement();
+    document.body.append(element);
+    await element.updateComplete;
+
+    element.setState({ ...element.state, hidden: true, availability: 'unavailable' });
+    await element.updateComplete;
+
+    expect(element.hidden).toBe(true);
+
+    element.setState({ ...element.state, hidden: false, availability: 'available' });
+    await element.updateComplete;
+
+    expect(element.hidden).toBe(false);
   });
 
   it('connects and cleans up value-change handling with the host lifecycle', async () => {

--- a/packages/react/src/ui/audio-track/use-audio-track-options.ts
+++ b/packages/react/src/ui/audio-track/use-audio-track-options.ts
@@ -14,6 +14,7 @@ export interface AudioTrackOptionsResult {
   value: string;
   options: AudioTrackOption[];
   disabled: boolean;
+  hidden: boolean;
   setValue: (value: string) => void;
 }
 

--- a/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
@@ -86,7 +86,11 @@ function createReactiveTextTrackWrapper(initialState: Record<string, unknown>) {
 
 function CaptionsAvailability(): ReactNode {
   const captions = useCaptionsOptions();
-  return <div data-testid="availability">{captions?.state.availability ?? 'missing'}</div>;
+  return (
+    <div data-testid="availability">
+      {captions ? `${captions.state.availability}:${captions.hidden ? 'hidden' : 'visible'}` : 'missing'}
+    </div>
+  );
 }
 
 function CaptionsRadioGroup(): ReactNode {
@@ -168,7 +172,7 @@ describe('useCaptionsOptions', () => {
 
     render(<CaptionsAvailability />, { wrapper: Wrapper });
 
-    expect(screen.getByTestId('availability').textContent).toBe('unavailable');
+    expect(screen.getByTestId('availability').textContent).toBe('unavailable:hidden');
 
     act(() => {
       updateState({
@@ -185,6 +189,6 @@ describe('useCaptionsOptions', () => {
       });
     });
 
-    expect(screen.getByTestId('availability').textContent).toBe('available');
+    expect(screen.getByTestId('availability').textContent).toBe('available:visible');
   });
 });

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -14,6 +14,7 @@ export interface CaptionsOptionsResult {
   value: string;
   options: CaptionsOption[];
   disabled: boolean;
+  hidden: boolean;
   showMenu: boolean;
   setValue: (value: string) => void;
 }

--- a/packages/react/src/ui/hooks/create-radio-options-hook.ts
+++ b/packages/react/src/ui/hooks/create-radio-options-hook.ts
@@ -35,6 +35,7 @@ export interface RadioOptionsHookResult<Option extends RadioOption, State extend
   value: string;
   options: TranslatedRadioOption<Option>[];
   disabled: boolean;
+  hidden: boolean;
   setValue: (value: string) => void;
 }
 
@@ -80,6 +81,7 @@ export function createRadioOptionsHook<Props, Media, State extends RadioOptionsS
       value: state.value,
       options,
       disabled: state.disabled,
+      hidden: state.hidden,
       setValue,
     };
   };

--- a/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
+++ b/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
@@ -20,6 +20,7 @@ export interface PlaybackRateOptionsResult {
   value: string;
   options: PlaybackRateOption[];
   disabled: boolean;
+  hidden: boolean;
   setRate: (rate: number) => void;
   setValue: (value: string) => void;
 }

--- a/packages/react/src/ui/quality/use-quality-options.ts
+++ b/packages/react/src/ui/quality/use-quality-options.ts
@@ -14,6 +14,7 @@ export interface QualityOptionsResult {
   value: string;
   options: QualityOption[];
   disabled: boolean;
+  hidden: boolean;
   setValue: (value: string) => void;
 }
 

--- a/site/src/content/docs/reference/audio-track-radio-group.mdx
+++ b/site/src/content/docs/reference/audio-track-radio-group.mdx
@@ -68,15 +68,10 @@ The group is available when the configured media exposes more than one audio tra
 | --- | --- | --- |
 | `data-audio-track` | `string` | Current audio track value. |
 | `data-disabled` | Present / absent | Present when audio track selection is disabled. |
+| `data-hidden` | Present / absent | Present when multiple audio tracks are unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether multiple audio tracks are available. |
 
-<FrameworkCase frameworks={["html"]}>
-  ```css
-  media-audio-track-radio-group[data-availability="unavailable"] {
-    display: none;
-  }
-  ```
-</FrameworkCase>
+Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/captions-radio-group.mdx
+++ b/site/src/content/docs/reference/captions-radio-group.mdx
@@ -68,15 +68,10 @@ The group is available when the configured media exposes at least one caption or
 | --- | --- | --- |
 | `data-active` | Present / absent | Present when captions are enabled. |
 | `data-disabled` | Present / absent | Present when track selection is disabled. |
+| `data-hidden` | Present / absent | Present when caption or subtitle tracks are unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether caption or subtitle tracks are available. |
 
-<FrameworkCase frameworks={["html"]}>
-  ```css
-  media-captions-radio-group[data-availability="unavailable"] {
-    display: none;
-  }
-  ```
-</FrameworkCase>
+Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/playback-rate-radio-group.mdx
+++ b/site/src/content/docs/reference/playback-rate-radio-group.mdx
@@ -68,15 +68,10 @@ The group is available when the configured media exposes playback rates. Option 
 | --- | --- | --- |
 | `data-rate` | `number` | Current playback rate. |
 | `data-disabled` | Present / absent | Present when playback rate selection is disabled. |
+| `data-hidden` | Present / absent | Present when playback-rate selection is unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether playback rates are available. |
 
-<FrameworkCase frameworks={["html"]}>
-  ```css
-  media-playback-rate-radio-group[data-availability="unavailable"] {
-    display: none;
-  }
-  ```
-</FrameworkCase>
+Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/quality-radio-group.mdx
+++ b/site/src/content/docs/reference/quality-radio-group.mdx
@@ -70,15 +70,10 @@ The group is available when the configured media exposes more than one video ren
 | --- | --- | --- |
 | `data-quality` | `string` | Current quality value. |
 | `data-disabled` | Present / absent | Present when quality selection is disabled. |
+| `data-hidden` | Present / absent | Present when multiple renditions are unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether multiple renditions are available. |
 
-<FrameworkCase frameworks={["html"]}>
-  ```css
-  media-quality-radio-group[data-availability="unavailable"] {
-    display: none;
-  }
-  ```
-</FrameworkCase>
+Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
 
 ## Accessibility
 


### PR DESCRIPTION
Closes #2075

## Summary

- derive a shared `hidden` state for audio track, captions, playback rate, and quality radio groups
- expose `data-hidden` plus native `hidden` in HTML and a `hidden` hook result in React
- document the availability contract and cover state transitions in core, HTML, and React tests

## Test plan

- `pnpm build:packages`
- `pnpm typecheck`
- core radio-group tests: 62 passed
- HTML radio-group tests: 9 passed
- React captions-options tests: 6 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility and adapter plumbing only; selection logic and availability rules are unchanged aside from the new hidden surface.
> 
> **Overview**
> Adds a shared **`hidden`** flag on media-backed menu radio groups (audio track, captions, playback rate, quality) so UI can drop groups when there is nothing meaningful to choose.
> 
> **Core** sets `hidden` when `availability` is `unavailable` (same rules as before: e.g. ≤1 audio track, no caption tracks, empty playback rates, ≤1 rendition). Initial state defaults to hidden/disabled until media is applied. **`getAttrs`** and **`data-hidden`** mirror that state; HTML **`RadioOptionsController`** applies the native **`hidden`** attribute.
> 
> **React** option hooks expose **`hidden`** from the shared **`createRadioOptionsHook`**. Docs no longer recommend CSS on `data-availability="unavailable"`; they document **`data-hidden`**, native **`hidden`** in HTML, and the hook for React.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e501ee2b5afdd4c6f1b363fedb4a37ce4b82fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->