### PR TITLE
fix(core): skip hidden menu items

### DIFF
--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -129,9 +129,7 @@ export function createMenu(options: MenuOptions): MenuApi {
   const navigationState = createState<NavigationState>({ stack: [], direction: 'forward' });
 
   function isItemHidden(item: HTMLElement): boolean {
-    return (
-      item.hasAttribute('hidden') || item.hasAttribute('data-hidden') || item.getAttribute('aria-hidden') === 'true'
-    );
+    return Boolean(item.hidden || item.hasAttribute('data-hidden') || item.getAttribute('aria-hidden') === 'true');
   }
 
   function getNavigableItems(): HTMLElement[] {

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -128,6 +128,16 @@ export function createMenu(options: MenuOptions): MenuApi {
 
   const navigationState = createState<NavigationState>({ stack: [], direction: 'forward' });
 
+  function isItemHidden(item: HTMLElement): boolean {
+    return (
+      item.hasAttribute('hidden') || item.hasAttribute('data-hidden') || item.getAttribute('aria-hidden') === 'true'
+    );
+  }
+
+  function getNavigableItems(): HTMLElement[] {
+    return items.filter((item) => !isItemHidden(item));
+  }
+
   function push(menuId: string, triggerId: string): void {
     const stack = navigationState.current.stack;
     const topEntry = stack[stack.length - 1];
@@ -154,6 +164,7 @@ export function createMenu(options: MenuOptions): MenuApi {
   // --- Highlight ---
 
   function highlight(element: HTMLElement | null, highlightOptions?: MenuHighlightOptions): void {
+    if (element && isItemHidden(element)) return;
     if (highlightedItem === element) return;
 
     if (highlightedItem) {
@@ -188,13 +199,17 @@ export function createMenu(options: MenuOptions): MenuApi {
   }
 
   function highlightFirstItem(options?: MenuHighlightOptions): void {
-    highlight(items[0] ?? null, options);
+    highlight(getNavigableItems()[0] ?? null, options);
   }
 
   function getInitialHighlightItem(): HTMLElement | null {
+    const navigableItems = getNavigableItems();
+
     return (
-      items.find((item) => item.matches('[role="menuitemradio"][aria-checked="true"], [aria-selected="true"]')) ??
-      items[0] ??
+      navigableItems.find((item) =>
+        item.matches('[role="menuitemradio"][aria-checked="true"], [aria-selected="true"]')
+      ) ??
+      navigableItems[0] ??
       null
     );
   }
@@ -227,11 +242,12 @@ export function createMenu(options: MenuOptions): MenuApi {
     if (typeaheadTimer !== null) clearTimeout(typeaheadTimer);
     typeaheadTimer = setTimeout(clearTypeahead, 500);
 
-    const currentIdx = highlightedItem ? items.indexOf(highlightedItem) : -1;
+    const navigableItems = getNavigableItems();
+    const currentIdx = highlightedItem ? navigableItems.indexOf(highlightedItem) : -1;
 
     // Search from after the current item so repeated chars cycle through matches.
     const searchStart = currentIdx + 1;
-    const candidates = [...items.slice(searchStart), ...items.slice(0, searchStart)];
+    const candidates = [...navigableItems.slice(searchStart), ...navigableItems.slice(0, searchStart)];
 
     const needle = typeaheadBuffer.toLowerCase();
     const match = candidates.find((candidate) => {
@@ -280,40 +296,41 @@ export function createMenu(options: MenuOptions): MenuApi {
     onFocusOut: popover.popupProps.onFocusOut,
     onKeyDown(event) {
       const { key } = event;
+      const navigableItems = getNavigableItems();
 
       if (key !== 'Escape' && isMenuNavigationKey(event) && !event.defaultPrevented) {
         event.preventDefault();
       }
 
-      if (items.length === 0) return;
+      if (navigableItems.length === 0) return;
 
       switch (key) {
         case 'ArrowDown': {
           event.preventDefault();
-          const currentIndex = highlightedItem ? items.indexOf(highlightedItem) : -1;
-          highlight(items[(currentIndex + 1) % items.length] ?? null);
+          const currentIndex = highlightedItem ? navigableItems.indexOf(highlightedItem) : -1;
+          highlight(navigableItems[(currentIndex + 1) % navigableItems.length] ?? null);
           break;
         }
         case 'ArrowUp': {
           event.preventDefault();
-          const currentIndex = highlightedItem ? items.indexOf(highlightedItem) : 0;
-          highlight(items[(currentIndex <= 0 ? items.length : currentIndex) - 1] ?? null);
+          const currentIndex = highlightedItem ? navigableItems.indexOf(highlightedItem) : 0;
+          highlight(navigableItems[(currentIndex <= 0 ? navigableItems.length : currentIndex) - 1] ?? null);
           break;
         }
         case 'Home': {
           event.preventDefault();
-          highlight(items[0] ?? null);
+          highlight(navigableItems[0] ?? null);
           break;
         }
         case 'End': {
           event.preventDefault();
-          highlight(items[items.length - 1] ?? null);
+          highlight(navigableItems[navigableItems.length - 1] ?? null);
           break;
         }
         case 'Enter':
         case ' ': {
           event.preventDefault();
-          highlightedItem?.click();
+          if (highlightedItem && navigableItems.includes(highlightedItem)) highlightedItem.click();
           break;
         }
         default: {

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -118,7 +118,6 @@ export function createMenu(options: MenuOptions): MenuApi {
   // Items are stored in DOM order. Framework/component lifecycle ordering is
   // not always the same as visual order, especially across nested components.
   const items: HTMLElement[] = [];
-  const itemObservers = new Map<HTMLElement, MutationObserver>();
   let highlightedItem: HTMLElement | null = null;
   let triggerElement: HTMLElement | null = null;
   let contentElement: HTMLElement | null = null;
@@ -401,24 +400,11 @@ export function createMenu(options: MenuOptions): MenuApi {
     items.push(element);
     items.sort(compareItems);
 
-    const observer = new MutationObserver(() => {
-      if (highlightedItem === element && isItemHidden(element)) {
-        highlight(getAdjacentNavigableItem(1));
-      }
-    });
-    observer.observe(element, {
-      attributes: true,
-      attributeFilter: ['hidden', 'data-hidden', 'aria-hidden'],
-    });
-    itemObservers.set(element, observer);
-
     if (popover.input.current.active && popover.input.current.status !== 'ending' && !highlightedItem) {
       scheduleInitialHighlight();
     }
 
     return () => {
-      itemObservers.get(element)?.disconnect();
-      itemObservers.delete(element);
       const index = items.indexOf(element);
       if (index !== -1) items.splice(index, 1);
       if (highlightedItem === element) clearHighlight();
@@ -429,8 +415,6 @@ export function createMenu(options: MenuOptions): MenuApi {
     cancelAnimationFrame(openRafId);
     openRafId = 0;
     clearTypeahead();
-    for (const observer of itemObservers.values()) observer.disconnect();
-    itemObservers.clear();
     popover.destroy();
   }
 

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -118,6 +118,7 @@ export function createMenu(options: MenuOptions): MenuApi {
   // Items are stored in DOM order. Framework/component lifecycle ordering is
   // not always the same as visual order, especially across nested components.
   const items: HTMLElement[] = [];
+  const itemObservers = new Map<HTMLElement, MutationObserver>();
   let highlightedItem: HTMLElement | null = null;
   let triggerElement: HTMLElement | null = null;
   let contentElement: HTMLElement | null = null;
@@ -136,6 +137,20 @@ export function createMenu(options: MenuOptions): MenuApi {
 
   function getNavigableItems(): HTMLElement[] {
     return items.filter((item) => !isItemHidden(item));
+  }
+
+  function getAdjacentNavigableItem(direction: 1 | -1): HTMLElement | null {
+    if (items.length === 0) return null;
+
+    const currentIndex = highlightedItem ? items.indexOf(highlightedItem) : direction === 1 ? -1 : 0;
+
+    for (let offset = 1; offset <= items.length; offset++) {
+      const index = (currentIndex + direction * offset + items.length) % items.length;
+      const candidate = items[index];
+      if (candidate && !isItemHidden(candidate)) return candidate;
+    }
+
+    return null;
   }
 
   function push(menuId: string, triggerId: string): void {
@@ -164,7 +179,10 @@ export function createMenu(options: MenuOptions): MenuApi {
   // --- Highlight ---
 
   function highlight(element: HTMLElement | null, highlightOptions?: MenuHighlightOptions): void {
-    if (element && isItemHidden(element)) return;
+    if (element && isItemHidden(element)) {
+      if (element === highlightedItem) highlight(getAdjacentNavigableItem(1), highlightOptions);
+      return;
+    }
     if (highlightedItem === element) return;
 
     if (highlightedItem) {
@@ -307,14 +325,12 @@ export function createMenu(options: MenuOptions): MenuApi {
       switch (key) {
         case 'ArrowDown': {
           event.preventDefault();
-          const currentIndex = highlightedItem ? navigableItems.indexOf(highlightedItem) : -1;
-          highlight(navigableItems[(currentIndex + 1) % navigableItems.length] ?? null);
+          highlight(getAdjacentNavigableItem(1));
           break;
         }
         case 'ArrowUp': {
           event.preventDefault();
-          const currentIndex = highlightedItem ? navigableItems.indexOf(highlightedItem) : 0;
-          highlight(navigableItems[(currentIndex <= 0 ? navigableItems.length : currentIndex) - 1] ?? null);
+          highlight(getAdjacentNavigableItem(-1));
           break;
         }
         case 'Home': {
@@ -385,11 +401,24 @@ export function createMenu(options: MenuOptions): MenuApi {
     items.push(element);
     items.sort(compareItems);
 
+    const observer = new MutationObserver(() => {
+      if (highlightedItem === element && isItemHidden(element)) {
+        highlight(getAdjacentNavigableItem(1));
+      }
+    });
+    observer.observe(element, {
+      attributes: true,
+      attributeFilter: ['hidden', 'data-hidden', 'aria-hidden'],
+    });
+    itemObservers.set(element, observer);
+
     if (popover.input.current.active && popover.input.current.status !== 'ending' && !highlightedItem) {
       scheduleInitialHighlight();
     }
 
     return () => {
+      itemObservers.get(element)?.disconnect();
+      itemObservers.delete(element);
       const index = items.indexOf(element);
       if (index !== -1) items.splice(index, 1);
       if (highlightedItem === element) clearHighlight();
@@ -400,6 +429,8 @@ export function createMenu(options: MenuOptions): MenuApi {
     cancelAnimationFrame(openRafId);
     openRafId = 0;
     clearTypeahead();
+    for (const observer of itemObservers.values()) observer.disconnect();
+    itemObservers.clear();
     popover.destroy();
   }
 

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -550,6 +550,20 @@ describe('createMenu', () => {
       expect(b.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
     });
 
+    it('skips a hidden first item', () => {
+      const { menu } = createTestMenu();
+      const hidden = addItem('Hidden');
+      const visible = addItem('Visible');
+      hidden.hidden = true;
+      menu.registerItem(hidden);
+      menu.registerItem(visible);
+
+      menu.highlightFirstItem();
+
+      expect(hidden.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(visible.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
     it('can highlight the first item without scrolling it into view', () => {
       const { menu } = createTestMenu();
       const element = addItem('Alpha');
@@ -614,6 +628,23 @@ describe('createMenu', () => {
       menu.contentProps.onKeyDown(makeKeyEvent('ArrowDown'));
 
       expect(b.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
+    it('ArrowDown skips items marked data-hidden', () => {
+      const { menu } = createTestMenu();
+      const a = addItem('Alpha');
+      const hidden = addItem('Beta');
+      const c = addItem('Gamma');
+      hidden.setAttribute('data-hidden', '');
+      menu.registerItem(a);
+      menu.registerItem(hidden);
+      menu.registerItem(c);
+      menu.highlight(a);
+
+      menu.contentProps.onKeyDown(makeKeyEvent('ArrowDown'));
+
+      expect(hidden.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(c.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
     });
 
     it('ArrowDown wraps from last to first', () => {
@@ -800,6 +831,20 @@ describe('createMenu', () => {
       menu.contentProps.onKeyDown(makeKeyEvent('b'));
 
       expect(b.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
+    it('ignores aria-hidden type-ahead matches', () => {
+      const { menu } = createTestMenu();
+      const hidden = addItem('Beta');
+      const visible = addItem('Bravo');
+      hidden.setAttribute('aria-hidden', 'true');
+      menu.registerItem(hidden);
+      menu.registerItem(visible);
+
+      menu.contentProps.onKeyDown(makeKeyEvent('b'));
+
+      expect(hidden.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(visible.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
     });
 
     it('cycles through matching items when the same character is pressed repeatedly', () => {

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -647,6 +647,22 @@ describe('createMenu', () => {
       expect(c.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
     });
 
+    it('ArrowDown preserves position when the highlighted item becomes hidden', () => {
+      const { menu } = createTestMenu();
+      const a = addItem('Alpha');
+      const b = addItem('Beta');
+      const c = addItem('Gamma');
+      menu.registerItem(a);
+      menu.registerItem(b);
+      menu.registerItem(c);
+      menu.highlight(b);
+      b.setAttribute('data-hidden', '');
+
+      menu.contentProps.onKeyDown(makeKeyEvent('ArrowDown'));
+
+      expect(c.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
     it('ArrowDown wraps from last to first', () => {
       const { menu } = createTestMenu();
       const a = addItem('Alpha');
@@ -683,6 +699,39 @@ describe('createMenu', () => {
       menu.contentProps.onKeyDown(makeKeyEvent('ArrowUp'));
 
       expect(a.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
+    it('ArrowUp preserves position when the highlighted item becomes hidden', () => {
+      const { menu } = createTestMenu();
+      const a = addItem('Alpha');
+      const b = addItem('Beta');
+      const c = addItem('Gamma');
+      menu.registerItem(a);
+      menu.registerItem(b);
+      menu.registerItem(c);
+      menu.highlight(b);
+      b.hidden = true;
+
+      menu.contentProps.onKeyDown(makeKeyEvent('ArrowUp'));
+
+      expect(a.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
+    it('moves highlight when the current item becomes hidden', async () => {
+      const { menu } = createTestMenu();
+      const a = addItem('Alpha');
+      const b = addItem('Beta');
+      const c = addItem('Gamma');
+      menu.registerItem(a);
+      menu.registerItem(b);
+      menu.registerItem(c);
+      menu.highlight(b);
+
+      b.setAttribute('aria-hidden', 'true');
+      await Promise.resolve();
+
+      expect(b.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(c.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
     });
 
     it('ArrowUp wraps from first to last', () => {

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -717,23 +717,6 @@ describe('createMenu', () => {
       expect(a.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
     });
 
-    it('moves highlight when the current item becomes hidden', async () => {
-      const { menu } = createTestMenu();
-      const a = addItem('Alpha');
-      const b = addItem('Beta');
-      const c = addItem('Gamma');
-      menu.registerItem(a);
-      menu.registerItem(b);
-      menu.registerItem(c);
-      menu.highlight(b);
-
-      b.setAttribute('aria-hidden', 'true');
-      await Promise.resolve();
-
-      expect(b.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
-      expect(c.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
-    });
-
     it('ArrowUp wraps from first to last', () => {
       const { menu } = createTestMenu();
       const a = addItem('Alpha');


### PR DESCRIPTION
Closes #2085

## Summary

- exclude native `hidden`, `data-hidden`, and `aria-hidden="true"` items from roving menu focus
- apply the filtered item set to initial focus, arrow/Home/End navigation, activation, and typeahead
- keep disabled-but-visible menu items navigable to preserve menu accessibility semantics

This is complementary to the typed-setting availability fix, but can be reviewed and merged independently.

## Test plan

- `pnpm build:packages`
- `pnpm typecheck`
- core menu tests: 71 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized DOM menu behavior change with new unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Menu roving focus** now ignores items that are visually hidden via the native `hidden` attribute, `data-hidden`, or `aria-hidden="true"`. Hidden entries stay registered but are excluded from the navigable set used for initial highlight, arrow/Home/End movement, Enter/Space activation, and type-ahead.
> 
> When the currently highlighted item becomes hidden, **arrow navigation** advances to the next visible neighbor as if the hidden row were not in the list (same logical position). Programmatic `highlight()` on a hidden element either no-ops or moves highlight forward if that element was already highlighted.
> 
> Tests cover first-item skip, `data-hidden` during ArrowDown, highlight recovery when an item is hidden mid-navigation, and type-ahead skipping `aria-hidden` matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d922dbe5e84e511b04b1071a68ae0f39e6dce78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->