### PR TITLE
feat(packages): normalize volume slider availability

### DIFF
--- a/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
+++ b/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
@@ -121,14 +121,19 @@ describe('VolumeSliderCore', () => {
       const core = new VolumeSliderCore();
       core.setInput(createInput());
       core.setMedia(createMediaState({ volumeAvailability: 'unsupported' }));
-      expect(core.getState().availability).toBe('unsupported');
+      const state = core.getState();
+
+      expect(state.availability).toBe('unsupported');
+      expect(state.disabled).toBe(true);
+      expect(state.hidden).toBe(true);
+      expect(core.getAttrs(state)).toMatchObject({ 'aria-disabled': 'true', tabIndex: -1 });
     });
 
     it('reflects available availability', () => {
       const core = new VolumeSliderCore();
       core.setInput(createInput());
       core.setMedia(createMediaState({ volumeAvailability: 'available' }));
-      expect(core.getState().availability).toBe('available');
+      expect(core.getState()).toMatchObject({ availability: 'available', disabled: false, hidden: false });
     });
   });
 

--- a/packages/core/src/core/ui/volume-slider/volume-slider-core.ts
+++ b/packages/core/src/core/ui/volume-slider/volume-slider-core.ts
@@ -19,6 +19,7 @@ export interface VolumeSliderProps extends SliderProps {
 
 export interface VolumeSliderState extends SliderState, Pick<MediaVolumeState, 'volume' | 'muted'> {
   availability: MediaFeatureAvailability;
+  hidden: boolean;
 }
 
 /** Volume-domain slider: maps media volume/mute state to slider state. */
@@ -58,13 +59,16 @@ export class VolumeSliderCore extends SliderCore {
     const volumePercent = volume * 100;
     const value = dragging ? this.valueFromPercent(dragPercent) : volumePercent;
     const base = super.getSliderState(value);
+    const availability = media.volumeAvailability;
 
     return {
       ...base,
+      disabled: base.disabled || availability !== 'available',
       fillPercent: effectivelyMuted ? 0 : base.fillPercent,
       volume,
       muted: effectivelyMuted,
-      availability: media.volumeAvailability,
+      availability,
+      hidden: availability !== 'available',
     };
   }
 

--- a/packages/core/src/core/ui/volume-slider/volume-slider-data-attrs.ts
+++ b/packages/core/src/core/ui/volume-slider/volume-slider-data-attrs.ts
@@ -5,4 +5,5 @@ import type { VolumeSliderState } from './volume-slider-core';
 export const VolumeSliderDataAttrs = {
   ...SliderDataAttrs,
   availability: 'data-availability',
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<VolumeSliderState>;

--- a/packages/html/src/define/shared.css
+++ b/packages/html/src/define/shared.css
@@ -17,7 +17,7 @@ media-container {
   min-height: 0;
 }
 
-/* Hide volume popover when volume control is unsupported (e.g., iOS Safari). */
-.media-popover--volume:has(media-volume-slider[data-availability="unsupported"]) {
+/* Hide the volume popover when its slider is unavailable. */
+.media-popover--volume:has(media-volume-slider[data-hidden]) {
   display: none;
 }

--- a/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
+++ b/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
@@ -1,5 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import type { AnyPlayerStore } from '@videojs/core/dom';
+import { ContextProvider } from '@videojs/element/context';
+import type { MediaVolumeState } from '@videojs/media';
+import { createStore } from '@videojs/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { playerContext } from '../../../player/context';
+import { MediaElement } from '../../media-element';
 import { SliderThumbElement } from '../../slider/slider-thumb-element';
 import { VolumeSliderElement } from '../volume-slider-element';
 
@@ -13,6 +19,34 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
   const tag = uniqueTag('test-el');
   customElements.define(tag, class extends (Base as unknown as typeof HTMLElement) {});
   return document.createElement(tag) as Element;
+}
+
+function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailability']): AnyPlayerStore {
+  return createStore<unknown>()<MediaVolumeState>({
+    name: 'volume',
+    state: () => ({
+      volume: 1,
+      muted: false,
+      volumeAvailability,
+      setVolume: vi.fn(),
+      toggleMuted: vi.fn(),
+    }),
+  }) as unknown as AnyPlayerStore;
+}
+
+class TestPlayerProviderElement extends MediaElement {
+  store: AnyPlayerStore = createVolumeStore('available');
+
+  readonly #provider = new ContextProvider(this, { context: playerContext });
+
+  override connectedCallback(): void {
+    this.#provider.setValue(this.store);
+    super.connectedCallback();
+  }
+}
+
+if (!customElements.get('test-volume-slider-player')) {
+  customElements.define('test-volume-slider-player', TestPlayerProviderElement);
 }
 
 afterEach(() => {
@@ -84,6 +118,25 @@ describe('VolumeSliderElement', () => {
 
     expect(slider.isConnected).toBe(true);
     expect(thumb.isConnected).toBe(true);
+  });
+
+  it('hides and disables unavailable volume control', async () => {
+    const provider = document.createElement('test-volume-slider-player') as TestPlayerProviderElement;
+    provider.store = createVolumeStore('unsupported');
+    const slider = createElement(VolumeSliderElement);
+    const thumb = createElement(SliderThumbElement);
+
+    document.body.append(provider);
+    slider.append(thumb);
+    provider.append(slider);
+    await slider.updateComplete;
+    await thumb.updateComplete;
+
+    expect(slider.hidden).toBe(true);
+    expect(slider.hasAttribute('data-hidden')).toBe(true);
+    expect(slider.hasAttribute('data-disabled')).toBe(true);
+    expect(thumb.getAttribute('aria-disabled')).toBe('true');
+    expect(thumb.tabIndex).toBe(-1);
   });
 
   it('cleans up on disconnect', async () => {

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -60,7 +60,10 @@ export class VolumeSliderElement extends MediaElement {
     this.#disconnect = new AbortController();
     const signal = this.#disconnect.signal;
 
-    const isDisabled = () => this.disabled || !this.#volumeState.value;
+    const isDisabled = () => {
+      const volume = this.#volumeState.value;
+      return this.disabled || !volume || volume.volumeAvailability !== 'available';
+    };
     const getPercent = () => (this.#volumeState.value?.volume ?? 0) * 100;
     const getStepPercent = () => this.#core.getStepPercent();
     const setVolume = (percent: number) => this.#setVolume(percent);
@@ -147,6 +150,7 @@ export class VolumeSliderElement extends MediaElement {
 
     // Apply data attributes to root.
     applyStateDataAttrs(this, state, VolumeSliderDataAttrs);
+    applyElementProps(this, { hidden: state.hidden ? '' : undefined });
 
     // Provide context to child elements.
     this.#provider.setValue({

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -100,7 +100,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -110,7 +110,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -48,7 +48,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -58,7 +58,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -102,7 +102,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -112,7 +112,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -48,7 +48,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -58,7 +58,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -80,7 +80,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -90,7 +90,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -37,7 +37,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -47,7 +47,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="left" boundary="viewport">

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -72,7 +72,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -82,7 +82,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -29,7 +29,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -39,7 +39,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top" boundary="viewport">

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -117,7 +117,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -127,7 +127,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -67,7 +67,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -77,7 +77,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -118,7 +118,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -128,7 +128,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -67,7 +67,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -77,7 +77,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -142,7 +142,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -152,7 +152,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -86,7 +86,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -96,7 +96,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="right">

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -144,7 +144,7 @@ const SliderThumb = forwardRef<HTMLDivElement, ComponentProps<'div'> & { persist
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className={iconState.mute.button} render={<Button />}>
@@ -154,7 +154,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -86,7 +86,7 @@ const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(function 
 });
 
 function VolumePopover(): ReactNode {
-  const volumeUnsupported = usePlayer((s) => s.volumeAvailability === 'unsupported');
+  const volumeUnavailable = usePlayer((s) => s.volumeAvailability !== 'available');
 
   const muteButton = (
     <MuteButton className="media-button--mute" render={<Button />}>
@@ -96,7 +96,7 @@ function VolumePopover(): ReactNode {
     </MuteButton>
   );
 
-  if (volumeUnsupported) return muteButton;
+  if (volumeUnavailable) return muteButton;
 
   return (
     <Popover.Root openOnHover delay={200} closeDelay={100} side="top">

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -47,7 +47,13 @@ const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
     }),
     mockVolumeState: volumeState,
     // Mutable holder so tests can swap between null and available volume.
-    mutableVolume: { current: volumeState as typeof volumeState | null },
+    mutableVolume: {
+      current: volumeState as
+        | (Omit<typeof volumeState, 'volumeAvailability'> & {
+            volumeAvailability: 'available' | 'unavailable' | 'unsupported';
+          })
+        | null,
+    },
   };
 });
 
@@ -134,6 +140,18 @@ describe('VolumeSliderRoot', () => {
 
     const el = container.querySelector('[data-orientation]');
     expect(el?.getAttribute('data-orientation')).toBe('horizontal');
+  });
+
+  it('does not render when volume control is unavailable', () => {
+    mutableVolume.current = { ...mockVolumeState, volumeAvailability: 'unsupported' };
+    const { Wrapper } = createPlayerWrapper();
+    const { container } = render(
+      <Wrapper>
+        <VolumeSliderRoot data-testid="vol-slider" />
+      </Wrapper>
+    );
+
+    expect(container.querySelector('[data-testid="vol-slider"]')).toBeNull();
   });
 
   it('sets slider CSS custom properties', () => {

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -48,8 +48,8 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
     const volume = usePlayer(selectVolume);
     const translator = useTranslator();
     const locale = useLocale();
-    const unavailable = volume?.volumeAvailability !== 'available';
-    const isDisabled = Boolean(disabled) || unavailable;
+    const isUnavailable = volume?.volumeAvailability !== 'available';
+    const isDisabled = Boolean(disabled) || isUnavailable;
 
     const [core] = useState(() => new VolumeSliderCore());
     core.setProps({ label, orientation, step, largeStep, wheelStep, disabled, thumbAlignment });

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -48,6 +48,8 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
     const volume = usePlayer(selectVolume);
     const translator = useTranslator();
     const locale = useLocale();
+    const unavailable = volume?.volumeAvailability !== 'available';
+    const isDisabled = Boolean(disabled) || unavailable;
 
     const [core] = useState(() => new VolumeSliderCore());
     core.setProps({ label, orientation, step, largeStep, wheelStep, disabled, thumbAlignment });
@@ -55,7 +57,7 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
 
     // Keep refs to the latest dynamic values for stable closures.
     const volumeRef = useLatestRef(volume);
-    const disabledRef = useLatestRef(disabled);
+    const disabledRef = useLatestRef(isDisabled);
 
     const getPercent = () => (volumeRef.current?.volume ?? 0) * 100;
     const getStepPercent = () => core.getStepPercent();
@@ -71,7 +73,7 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
       getStepPercent,
       getLargeStepPercent: () => core.getLargeStepPercent(),
       orientation,
-      disabled,
+      disabled: isDisabled,
       adjustPercent: (rawPercent, thumbSize, trackSize) =>
         core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
       getCSSVars: getSliderCSSVars,
@@ -83,7 +85,7 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
 
     const [wheelHandler] = useState(() =>
       createWheelStep({
-        isDisabled: () => !!disabledRef.current || !volumeRef.current,
+        isDisabled: () => disabledRef.current,
         getPercent: () => (volumeRef.current?.volume ?? 0) * 100,
         getStepPercent: () => core.getWheelStepPercent(),
         onValueChange: (percent) => volumeRef.current?.setVolume(percent / 100),
@@ -108,6 +110,8 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
       if (__DEV__) logMissingFeature('VolumeSlider', 'volume');
       return null;
     }
+
+    if (state.hidden) return null;
 
     return (
       <SliderProvider

--- a/packages/skins/src/default/css/components/popup.css
+++ b/packages/skins/src/default/css/components/popup.css
@@ -97,7 +97,7 @@
   padding: calc(var(--spacing) * 3) 0;
   border-radius: calc(Infinity * 1px);
 
-  &:has(media-volume-slider[data-availability="unsupported"]) {
+  &:has(media-volume-slider[data-hidden]) {
     display: none;
   }
 }

--- a/packages/skins/src/minimal/css/components/popup.css
+++ b/packages/skins/src/minimal/css/components/popup.css
@@ -137,6 +137,6 @@
   }
 }
 
-.media-minimal-skin .media-popover--volume:has(media-volume-slider[data-availability="unsupported"]) {
+.media-minimal-skin .media-popover--volume:has(media-volume-slider[data-hidden]) {
   display: none;
 }

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -37,7 +37,7 @@ import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/With
 
 ## Behavior
 
-Controls the media volume level. The slider maps its 0–100 internal range to the media's 0–1 volume scale. When the media is muted, the fill level drops to 0 regardless of the stored volume value.
+Controls the media volume level. The slider maps its 0–100 internal range to the media's 0–1 volume scale. When the media is muted, the fill level drops to 0 regardless of the stored volume value. When volume control is unavailable, the HTML custom element receives native `hidden`, `data-hidden`, and disabled ARIA semantics; the React component returns `null`.
 
 ## Styling
 


### PR DESCRIPTION
Closes #2074

## Summary

- derive disabled and hidden volume-slider state from volume availability
- expose `data-hidden` and native `hidden` in HTML, and omit unavailable React sliders
- block pointer, keyboard, and wheel interaction while volume control is unavailable
- update volume-popover selectors to use `data-hidden` instead of raw availability values

## Test plan

- `pnpm build:packages`
- `pnpm typecheck`
- core volume-slider tests: 17 passed
- HTML volume-slider tests: 9 passed
- React volume-slider tests: 12 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only volume control gating with consistent tests; behavior widens slightly from `unsupported` only to any non-`available` availability value.
> 
> **Overview**
> **Volume slider availability** is now derived centrally in `VolumeSliderCore`: when `volumeAvailability` is not `available`, state includes `hidden: true`, `disabled: true`, and the usual disabled ARIA/tabIndex behavior.
> 
> **HTML** applies native `hidden` plus `data-hidden`, treats the slider as disabled for pointer/keyboard/wheel when unavailable, and **CSS** hides `.media-popover--volume` via `:has(media-volume-slider[data-hidden])` instead of `data-availability="unsupported"`.
> 
> **React** `VolumeSliderRoot` returns `null` when hidden, wires `isDisabled` through the slider and wheel handler, and **all audio/video skins** show only the mute button (no volume popover) when `volumeAvailability !== 'available'` rather than only `unsupported`.
> 
> Tests and docs are updated for the new semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3616757b8c54e2b98f9b674850b6dfa49b112cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->