### PR TITLE
refactor(packages): consolidate html template cloning

### DIFF
--- a/packages/html/src/ui/audio-track-radio-group/audio-track-radio-group-element.ts
+++ b/packages/html/src/ui/audio-track-radio-group/audio-track-radio-group-element.ts
@@ -30,9 +30,6 @@ export class AudioTrackRadioGroupElement extends MenuRadioGroupElement {
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectAudioTrack);
   readonly #options = new RadioOptionsController<AudioTrackRadioGroupOption>(this, {
-    getTemplate: () => this.getTemplate(),
-    createItem: (template) => this.createRadioItem(template),
-    renderItem: (item, label) => this.setItemLabel(item, label),
     setItemAttributes: (item, option) => item.setAttribute('data-track', option.value),
     onValueChange: (value) => {
       const media = this.#mediaState.value;

--- a/packages/html/src/ui/captions-radio-group/captions-radio-group-element.ts
+++ b/packages/html/src/ui/captions-radio-group/captions-radio-group-element.ts
@@ -26,9 +26,6 @@ export class CaptionsRadioGroupElement extends MenuRadioGroupElement {
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectTextTrack);
   readonly #options = new RadioOptionsController<CaptionsRadioGroupOption>(this, {
-    getTemplate: () => this.getTemplate(),
-    createItem: (template) => this.createRadioItem(template),
-    renderItem: (item, label) => this.setItemLabel(item, label),
     setItemAttributes: (item, option) => item.setAttribute('data-track', option.value),
     onValueChange: (value) => {
       const media = this.#mediaState.value;

--- a/packages/html/src/ui/menu/menu-radio-group-element.ts
+++ b/packages/html/src/ui/menu/menu-radio-group-element.ts
@@ -1,10 +1,9 @@
 import { type Text, type Translator, translateText } from '@videojs/core/i18n';
 import type { PropertyValues } from '@videojs/element';
-import { cloneTemplateRoot, getTemplateElement, getTemplateRoot } from '@videojs/utils/dom';
 
 import { RadioGroupElement } from '../radio-group/radio-group-element';
 import { MenuGroupController } from './menu-group-controller';
-import { MenuRadioItemElement } from './menu-radio-item-element';
+import type { MenuRadioItemElement } from './menu-radio-item-element';
 
 export class MenuRadioGroupElement extends RadioGroupElement {
   static readonly tagName: string = 'media-menu-radio-group';
@@ -16,20 +15,6 @@ export class MenuRadioGroupElement extends RadioGroupElement {
     super.update(changed);
 
     this.#group.applyProps();
-  }
-
-  protected getTemplate(): HTMLTemplateElement | null {
-    return getTemplateElement(this);
-  }
-
-  protected createRadioItem(template: HTMLTemplateElement | null): MenuRadioItemElement {
-    const root = template ? getTemplateRoot(template) : null;
-
-    if (root?.localName === MenuRadioItemElement.tagName) {
-      return cloneTemplateRoot(root, this.ownerDocument) as MenuRadioItemElement;
-    }
-
-    return this.ownerDocument.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement;
   }
 
   protected setItemLabel(item: MenuRadioItemElement, label: string): void {

--- a/packages/html/src/ui/menu/menu-radio-group-element.ts
+++ b/packages/html/src/ui/menu/menu-radio-group-element.ts
@@ -1,5 +1,6 @@
 import { type Text, type Translator, translateText } from '@videojs/core/i18n';
 import type { PropertyValues } from '@videojs/element';
+import { cloneTemplateRoot, getTemplateElement, getTemplateRoot } from '@videojs/utils/dom';
 
 import { RadioGroupElement } from '../radio-group/radio-group-element';
 import { MenuGroupController } from './menu-group-controller';
@@ -18,24 +19,17 @@ export class MenuRadioGroupElement extends RadioGroupElement {
   }
 
   protected getTemplate(): HTMLTemplateElement | null {
-    for (const child of this.children) {
-      if (child instanceof HTMLTemplateElement) return child;
-    }
-
-    return null;
+    return getTemplateElement(this);
   }
 
   protected createRadioItem(template: HTMLTemplateElement | null): MenuRadioItemElement {
-    if (!template) return document.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement;
+    const root = template ? getTemplateRoot(template) : null;
 
-    const fragment = template.content.cloneNode(true) as DocumentFragment;
-    const root = fragment.firstElementChild;
-
-    if (!root || root.localName !== MenuRadioItemElement.tagName || root.nextElementSibling) {
-      return document.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement;
+    if (root?.localName === MenuRadioItemElement.tagName) {
+      return cloneTemplateRoot(root, this.ownerDocument) as MenuRadioItemElement;
     }
 
-    return root as MenuRadioItemElement;
+    return this.ownerDocument.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement;
   }
 
   protected setItemLabel(item: MenuRadioItemElement, label: string): void {

--- a/packages/html/src/ui/playback-rate-radio-group/playback-rate-radio-group-element.ts
+++ b/packages/html/src/ui/playback-rate-radio-group/playback-rate-radio-group-element.ts
@@ -28,9 +28,6 @@ export class PlaybackRateRadioGroupElement extends MenuRadioGroupElement {
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectPlaybackRate);
   readonly #options = new RadioOptionsController<PlaybackRateRadioGroupOption>(this, {
-    getTemplate: () => this.getTemplate(),
-    createItem: (template) => this.createRadioItem(template),
-    renderItem: (item, label) => this.setItemLabel(item, label),
     setItemAttributes: (item, option) => item.setAttribute('data-rate', option.value),
     onValueChange: (value) => {
       const media = this.#mediaState.value;

--- a/packages/html/src/ui/quality-radio-group/quality-radio-group-element.ts
+++ b/packages/html/src/ui/quality-radio-group/quality-radio-group-element.ts
@@ -27,8 +27,6 @@ export class QualityRadioGroupElement extends MenuRadioGroupElement {
   readonly #i18n = new I18nController(this, i18nContext);
   readonly #mediaState = new PlayerController(this, playerContext, selectQuality);
   readonly #options = new RadioOptionsController<QualityRadioGroupOption>(this, {
-    getTemplate: () => this.getTemplate(),
-    createItem: (template) => this.createRadioItem(template),
     renderItem: (item, label, option) => this.#setContent(item, label, option.tier, option.badge),
     setItemAttributes: (item, option) => item.setAttribute('data-rendition', option.value),
     getOptionCacheKey: (option) => `${option.tier ?? ''}:${option.badge ?? ''}`,

--- a/packages/html/src/ui/radio-options/radio-options-controller.ts
+++ b/packages/html/src/ui/radio-options/radio-options-controller.ts
@@ -2,6 +2,7 @@ import type { RadioOption, RadioOptionsState } from '@videojs/core';
 import { applyElementProps } from '@videojs/core/dom';
 import { type Translator, translateText } from '@videojs/core/i18n';
 import type { ReactiveController, ReactiveControllerHost } from '@videojs/element';
+import { cloneTemplateRoot, getTemplateElement, getTemplateRoot } from '@videojs/utils/dom';
 
 import { cacheKey } from '../../i18n/cache-key';
 import { MenuItemIndicatorElement } from '../menu/menu-item-indicator-element';
@@ -13,9 +14,7 @@ export type RadioOptionsControllerHost = ReactiveControllerHost &
   };
 
 export interface RadioOptionsControllerConfig<Option extends RadioOption> {
-  getTemplate: () => HTMLTemplateElement | null;
-  createItem: (template: HTMLTemplateElement | null) => MenuRadioItemElement;
-  renderItem: (item: MenuRadioItemElement, label: string, option: Option) => void;
+  renderItem?: ((item: MenuRadioItemElement, label: string, option: Option) => void) | undefined;
   setItemAttributes?: ((item: MenuRadioItemElement, option: Option) => void) | undefined;
   getOptionCacheKey?: ((option: Option) => string) | undefined;
   onValueChange: (value: string) => void;
@@ -56,7 +55,9 @@ export class RadioOptionsController<Option extends RadioOption> implements React
       'aria-disabled': state.disabled ? 'true' : undefined,
     });
 
-    const template = this.#config.getTemplate();
+    const template = getTemplateElement(this.#host);
+    const templateRoot = template ? getTemplateRoot(template) : null;
+    const itemRoot = templateRoot?.localName === MenuRadioItemElement.tagName ? templateRoot : null;
     const contentKey = `${state.options
       .map(
         (option) =>
@@ -69,15 +70,19 @@ export class RadioOptionsController<Option extends RadioOption> implements React
       this.#translator = translator;
 
       for (const child of [...this.#host.children]) {
-        if (child instanceof HTMLTemplateElement) continue;
+        if (child === template) continue;
         child.remove();
       }
 
       const items = state.options.map((option) => {
-        const item = this.#config.createItem(template);
+        const item = itemRoot
+          ? (cloneTemplateRoot(itemRoot, this.#host.ownerDocument) as MenuRadioItemElement)
+          : (this.#host.ownerDocument.createElement(MenuRadioItemElement.tagName) as MenuRadioItemElement);
         item.value = option.value;
         this.#config.setItemAttributes?.(item, option);
-        this.#config.renderItem(item, translateText(option.label, translator, option.labelParams), option);
+        const label = translateText(option.label, translator, option.labelParams);
+        if (this.#config.renderItem) this.#config.renderItem(item, label, option);
+        else this.#setItemLabel(item, label);
         return item;
       });
 
@@ -104,4 +109,11 @@ export class RadioOptionsController<Option extends RadioOption> implements React
     const { value } = (event as CustomEvent<{ value: string }>).detail;
     this.#config.onValueChange(value);
   };
+
+  #setItemLabel(item: MenuRadioItemElement, label: string): void {
+    const labelPart = item.querySelector<HTMLElement>('[data-part~="label"]');
+
+    if (labelPart) labelPart.textContent = label;
+    else item.textContent = label;
+  }
 }

--- a/packages/html/src/ui/radio-options/tests/radio-options-controller.test.ts
+++ b/packages/html/src/ui/radio-options/tests/radio-options-controller.test.ts
@@ -38,8 +38,6 @@ class TestRadioOptionsElement extends MenuRadioGroupElement {
   readonly onValueChange = vi.fn();
 
   readonly #options = new RadioOptionsController<TestOption>(this, {
-    getTemplate: () => this.getTemplate(),
-    createItem: (template) => this.createRadioItem(template),
     renderItem: (item, label, option) => this.setItemLabel(item, `${label}${option.badge ?? ''}`),
     setItemAttributes: (item, option) => item.setAttribute('data-option', option.value),
     getOptionCacheKey: (option) => option.badge ?? '',
@@ -83,6 +81,21 @@ describe('RadioOptionsController', () => {
     expect(items.map((item) => item.getAttribute('data-option'))).toEqual(['one', 'two']);
     expect(items.map((item) => item.disabled)).toEqual([false, true]);
     expect(indicators.map((indicator) => indicator.checked)).toEqual([true, false]);
+    expect(element.querySelector('template')).toBe(template);
+  });
+
+  it('falls back to default items for an invalid template', async () => {
+    const element = new TestRadioOptionsElement();
+    const template = document.createElement('template');
+    template.innerHTML = '<div class="invalid"></div><div></div>';
+    element.append(template);
+    document.body.append(element);
+
+    await element.updateComplete;
+
+    expect(element.querySelectorAll(MenuRadioItemElement.tagName)).toHaveLength(2);
+    expect(element.querySelector('.invalid')).toBeNull();
+    expect(element.querySelector('template')).toBe(template);
   });
 
   it('rebuilds specialized content and applies group disabled semantics', async () => {

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -192,14 +192,11 @@ describe('TimeSlider chapter elements', () => {
     await chapters.updateComplete;
 
     expect(chapters.getAttribute('aria-hidden')).toBe('true');
-    expect(chapters.querySelector('template')).toBeNull();
+    expect(chapters.querySelector('template')).toBe(template);
     expect(chapters.querySelectorAll('.chapter')).toHaveLength(1);
-    expect((chapters.firstElementChild as HTMLElement).style.getPropertyValue('--media-slider-chapter-start')).toBe(
-      '0%'
-    );
-    expect((chapters.firstElementChild as HTMLElement).style.getPropertyValue('--media-slider-chapter-end')).toBe(
-      '100%'
-    );
+    const chapter = chapters.querySelector<HTMLElement>('.chapter')!;
+    expect(chapter.style.getPropertyValue('--media-slider-chapter-start')).toBe('0%');
+    expect(chapter.style.getPropertyValue('--media-slider-chapter-end')).toBe('100%');
     expect(chapters.querySelector('svg')).toBeNull();
   });
 

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -213,6 +213,27 @@ describe('TimeSlider chapter elements', () => {
     expect(chapters.querySelector('.fallback')).toBe(fallback);
   });
 
+  it('discovers a template on a later update', async () => {
+    const slider = createElement(TestSliderProviderElement);
+    const chapters = createElement(TimeSliderChaptersElement);
+    const fallback = document.createElement('div');
+    fallback.className = 'fallback';
+    chapters.appendChild(fallback);
+    slider.appendChild(chapters);
+    document.body.appendChild(slider);
+    await chapters.updateComplete;
+
+    const template = document.createElement('template');
+    template.innerHTML = '<div class="chapter"></div>';
+    chapters.appendChild(template);
+    chapters.requestUpdate();
+    await chapters.updateComplete;
+
+    expect(chapters.querySelector('template')).toBe(template);
+    expect(chapters.querySelector('.fallback')).toBeNull();
+    expect(chapters.querySelectorAll('.chapter')).toHaveLength(1);
+  });
+
   for (const [name, content] of [
     ['empty', ''],
     ['multiple-root', '<div></div><div></div>'],

--- a/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
@@ -99,12 +99,14 @@ export class TimeSliderChaptersElement extends MediaElement {
 
   #getTemplateRoot(): HTMLElement | null {
     if (this.#templateChecked) return this.#templateRoot;
-    this.#templateChecked = true;
 
     const template = getTemplateElement(this);
-    const root = template ? getTemplateRoot(template) : null;
+    if (!template) return null;
+
+    this.#templateChecked = true;
+    const root = getTemplateRoot(template);
     if (root?.namespaceURI !== 'http://www.w3.org/1999/xhtml') {
-      if (__DEV__ && template) {
+      if (__DEV__) {
         console.warn(`[${this.localName}] template must contain exactly one HTML root element.`);
       }
       return null;

--- a/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
@@ -7,6 +7,7 @@ import {
 import { applyStateDataAttrs, selectBuffer, selectTextTrack, selectTime } from '@videojs/core/dom';
 import type { PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
+import { cloneTemplateRoot, getTemplateElement, getTemplateRoot } from '@videojs/utils/dom';
 
 import { playerContext } from '../../../player/context';
 import { PlayerController } from '../../../player/player-controller';
@@ -29,7 +30,7 @@ export class TimeSliderChaptersElement extends MediaElement {
   readonly #buffer = new PlayerController(this, playerContext, selectBuffer);
   readonly #time = new PlayerController(this, playerContext, selectTime);
   readonly #rendered = new Map<string, HTMLElement>();
-  #chapterTemplate: HTMLTemplateElement | null = null;
+  #templateRoot: HTMLElement | null = null;
   #templateChecked = false;
 
   override connectedCallback(): void {
@@ -42,11 +43,11 @@ export class TimeSliderChaptersElement extends MediaElement {
 
     const slider = this.#slider.value;
     const duration = this.#time.value?.duration ?? 0;
-    const template = this.#template;
+    const templateRoot = this.#getTemplateRoot();
     if (!slider) return;
 
     applyStateDataAttrs(this, slider.state, slider.stateAttrMap);
-    if (!template) return;
+    if (!templateRoot) return;
 
     const { chapters, ranges, max } = this.#core.getRanges(this.#textTrack.value?.chaptersCues ?? [], 0, duration);
 
@@ -68,12 +69,7 @@ export class TimeSliderChaptersElement extends MediaElement {
       );
       let root = this.#rendered.get(state.key);
 
-      if (!root) {
-        const fragment = template.content.cloneNode(true) as DocumentFragment;
-        const first = fragment.firstElementChild;
-        if (!(first instanceof HTMLElement) || first.nextElementSibling) continue;
-        root = first;
-      }
+      if (!root) root = cloneTemplateRoot(templateRoot, this.ownerDocument);
 
       this.#setStyle(root, 'pointer-events', state.cue ? undefined : 'none');
       this.#setStyle(root, TimeSliderChapterCSSVars.start, state.startPercent);
@@ -101,27 +97,25 @@ export class TimeSliderChaptersElement extends MediaElement {
     for (const [key, rendered] of next) this.#rendered.set(key, rendered);
   }
 
-  get #template(): HTMLTemplateElement | null {
-    if (this.#templateChecked) return this.#chapterTemplate;
+  #getTemplateRoot(): HTMLElement | null {
+    if (this.#templateChecked) return this.#templateRoot;
+    this.#templateChecked = true;
 
-    for (const child of this.children) {
-      if (child instanceof HTMLTemplateElement) {
-        this.#templateChecked = true;
-        const first = child.content.firstElementChild;
-        if (!(first instanceof HTMLElement) || first.nextElementSibling) {
-          if (__DEV__) {
-            console.warn(`[${this.localName}] template must contain exactly one HTML root element.`);
-          }
-          return null;
-        }
-
-        this.#chapterTemplate = child;
-        child.remove();
-        for (const fallback of [...this.childNodes]) fallback.remove();
-        return child;
+    const template = getTemplateElement(this);
+    const root = template ? getTemplateRoot(template) : null;
+    if (root?.namespaceURI !== 'http://www.w3.org/1999/xhtml') {
+      if (__DEV__ && template) {
+        console.warn(`[${this.localName}] template must contain exactly one HTML root element.`);
       }
+      return null;
     }
-    return null;
+
+    this.#templateRoot = root as HTMLElement;
+    for (const node of [...this.childNodes]) {
+      if (node !== template) node.remove();
+    }
+
+    return this.#templateRoot;
   }
 
   #setStyle(element: HTMLElement, name: string, value: string | undefined): void {

--- a/packages/utils/src/dom/index.ts
+++ b/packages/utils/src/dom/index.ts
@@ -39,7 +39,7 @@ export {
 export { getSlottedElement, querySlot } from './slotted';
 export { addAnchorName, applyStyles, getAnchorNames, resolveCSSLength } from './style';
 export { supportsAnchorPositioning, supportsAnimationFrame, supportsIdleCallback } from './supports';
-export { createTemplate, renderTemplate } from './template';
+export { cloneTemplateRoot, createTemplate, getTemplateElement, getTemplateRoot, renderTemplate } from './template';
 export {
   type CaptionOrSubtitleKind,
   findTrackElement,

--- a/packages/utils/src/dom/template.ts
+++ b/packages/utils/src/dom/template.ts
@@ -8,6 +8,29 @@ export function createTemplate(html: string): HTMLTemplateElement | null {
   return template;
 }
 
+/** Return the first direct-child template in a container. */
+export function getTemplateElement(container: Element): HTMLTemplateElement | null {
+  for (const child of container.children) {
+    if (child.localName === 'template' && 'content' in child) return child as HTMLTemplateElement;
+  }
+
+  return null;
+}
+
+/** Return a template's only element root, or `null` when it does not contain exactly one. */
+export function getTemplateRoot(template: HTMLTemplateElement): Element | null {
+  const root = template.content.firstElementChild;
+  return root && !root.nextElementSibling ? root : null;
+}
+
+/** Deep-clone a resolved template root into the target document. */
+export function cloneTemplateRoot<Root extends Element>(
+  root: Root,
+  targetDocument: Document = root.ownerDocument
+): Root {
+  return targetDocument.importNode(root, true) as Root;
+}
+
 /** Deep-clone a template's content into a container. */
 export function renderTemplate(container: Element | ShadowRoot, template: HTMLTemplateElement): void {
   container.appendChild(container.ownerDocument.importNode(template.content, true));

--- a/packages/utils/src/dom/tests/template.test.ts
+++ b/packages/utils/src/dom/tests/template.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createTemplate, renderTemplate } from '../template';
+import { cloneTemplateRoot, createTemplate, getTemplateElement, getTemplateRoot, renderTemplate } from '../template';
 
 describe('createTemplate', () => {
   afterEach(() => {
@@ -41,5 +41,47 @@ describe('renderTemplate', () => {
     expect(container.children).toHaveLength(2);
     expect(container.children[0]!.textContent).toBe('existing');
     expect(container.children[1]!.textContent).toBe('new');
+  });
+});
+
+describe('getTemplateRoot', () => {
+  it('returns the only element root', () => {
+    const template = createTemplate('<div class="root"><span>Hello</span></div>')!;
+    expect(getTemplateRoot(template)).toBe(template.content.firstElementChild);
+  });
+
+  it.each([
+    ['empty', ''],
+    ['multiple roots', '<div></div><div></div>'],
+  ])('returns null for %s templates', (_name, html) => {
+    expect(getTemplateRoot(createTemplate(html)!)).toBeNull();
+  });
+});
+
+describe('getTemplateElement', () => {
+  it('returns the first direct-child template', () => {
+    const container = document.createElement('div');
+    const nested = document.createElement('div');
+    const nestedTemplate = document.createElement('template');
+    const template = document.createElement('template');
+    nested.append(nestedTemplate);
+    container.append(nested, template);
+
+    expect(getTemplateElement(container)).toBe(template);
+  });
+
+  it('returns null when there is no direct-child template', () => {
+    expect(getTemplateElement(document.createElement('div'))).toBeNull();
+  });
+});
+
+describe('cloneTemplateRoot', () => {
+  it('deep-clones a resolved root', () => {
+    const root = getTemplateRoot(createTemplate('<div class="root"><span>Hello</span></div>')!)!;
+    const clone = cloneTemplateRoot(root);
+
+    expect(clone.outerHTML).toBe('<div class="root"><span>Hello</span></div>');
+    expect(clone).not.toBe(root);
+    expect(clone.querySelector('span')).not.toBe(root.querySelector('span'));
   });
 });

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -98,7 +98,7 @@ Add `Chapters` to progressively divide the track when a default `kind="chapters"
   </media-time-slider-chapters>
   ```
 
-  The template must contain exactly one HTML root element. It is cloned for each normalized chapter, including a full-duration range while chapter cues are unavailable. If the template is missing or invalid, non-template fallback content remains in place.
+  The template must contain exactly one HTML root element. It remains in the light DOM and is cloned for each normalized chapter, including a full-duration range while chapter cues are unavailable. If the template is missing or invalid, non-template fallback content remains in place.
 </FrameworkCase>
 
 ## Behavior


### PR DESCRIPTION
Closes #2084

## Summary

Consolidate repeated light-DOM template discovery, validation, and cloning across HTML radio groups and time-slider chapters. This keeps the component implementations small while preserving author-owned templates in the light DOM.

## Changes

- Add focused DOM helpers for finding a direct-child template, resolving its single root, and cloning that root
- Move default radio-item cloning and label rendering into the shared radio options controller
- Reuse the same helpers for chapter templates while retaining keyed chapter elements
- Preserve authored templates and keep existing fallback behavior for missing or invalid roots

## Testing

- `pnpm -F @videojs/utils test`
- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/html build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:workspace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved and expanded tests; no auth, data, or API surface changes beyond internal DOM rendering.
> 
> **Overview**
> Centralizes **light-DOM `<template>` discovery, single-root validation, and cloning** in `@videojs/utils/dom` (`getTemplateElement`, `getTemplateRoot`, `cloneTemplateRoot`), and wires radio groups and time-slider chapters through those helpers instead of duplicating logic per component.
> 
> **Radio options:** `RadioOptionsController` now owns template lookup and menu-radio-item creation; hosts no longer pass `getTemplate` / `createItem`, and default label rendering applies when `renderItem` is omitted. `MenuRadioGroupElement` drops its local template/item factory methods while keeping optional `setItemLabel` overrides where needed.
> 
> **Time slider chapters:** Authored templates **stay in the light DOM** (they are no longer removed after first use). Chapter segments clone from the resolved template root via the shared helpers; invalid templates still fall back to non-template children, with tests for late-added templates and invalid roots.
> 
> Docs note that chapter templates remain in the light DOM when cloned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf9ab039511a954f6013eaaa0d2cb5c6d52cc9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->