### PR TITLE
refactor(utils): simplify css length resolution

### DIFF
--- a/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
@@ -294,18 +294,23 @@ describe('getAnchorPositionStyle', () => {
 describe('resolveOffsets', () => {
   it('resolves non-pixel CSS lengths to pixels', () => {
     const el = document.createElement('div');
-    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation(
-      (target: Element) =>
-        ({
-          fontSize: target === document.documentElement ? '16px' : '14px',
-          getPropertyValue(name: string) {
-            if (name === PopoverCSSVars.sideOffset) return '0.5rem';
-            if (name === PopoverCSSVars.alignOffset) return '1em';
-            if (name === PopoverCSSVars.boundaryOffset) return '2px';
-            return '';
-          },
-        }) as CSSStyleDeclaration
-    );
+    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((target: Element) => {
+      if (target !== el) {
+        return {
+          inlineSize: (target as HTMLElement).style.inlineSize === '0.5rem' ? '8px' : '14px',
+        } as CSSStyleDeclaration;
+      }
+
+      return {
+        fontSize: '14px',
+        getPropertyValue(name: string) {
+          if (name === PopoverCSSVars.sideOffset) return '0.5rem';
+          if (name === PopoverCSSVars.alignOffset) return '1em';
+          if (name === PopoverCSSVars.boundaryOffset) return '2px';
+          return '';
+        },
+      } as CSSStyleDeclaration;
+    });
 
     expect(resolveOffsets(el)).toEqual({ sideOffset: 8, alignOffset: 14, boundaryOffset: 2 });
 

--- a/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
@@ -297,7 +297,7 @@ describe('resolveOffsets', () => {
     const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((target: Element) => {
       if (target !== el) {
         return {
-          inlineSize: (target as HTMLElement).style.inlineSize === '0.5rem' ? '8px' : '14px',
+          insetInlineStart: (target as HTMLElement).style.insetInlineStart === '0.5rem' ? '8px' : '14px',
         } as CSSStyleDeclaration;
       }
 

--- a/packages/utils/src/dom/style.ts
+++ b/packages/utils/src/dom/style.ts
@@ -54,9 +54,9 @@ export function resolveCSSLength(el: Element, value: string): number {
   const probe = doc.createElement('div');
 
   probe.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none';
-  probe.style.inlineSize = length;
+  probe.style.insetInlineStart = length;
 
-  if (!probe.style.inlineSize) return 0;
+  if (!probe.style.insetInlineStart) return 0;
 
   const computed = getComputedStyle(el);
   probe.style.fontSize = computed.fontSize;
@@ -69,7 +69,7 @@ export function resolveCSSLength(el: Element, value: string): number {
   (doc.body ?? doc.documentElement).append(probe);
 
   try {
-    const pixels = Number.parseFloat(getComputedStyle(probe).inlineSize);
+    const pixels = Number.parseFloat(getComputedStyle(probe).insetInlineStart);
     return Number.isFinite(pixels) ? pixels : 0;
   } finally {
     probe.remove();

--- a/packages/utils/src/dom/style.ts
+++ b/packages/utils/src/dom/style.ts
@@ -44,68 +44,34 @@ export function applyStyles(element: HTMLElement, styles: Record<string, string 
 }
 
 export function resolveCSSLength(el: Element, value: string): number {
-  const trimmed = value.trim();
+  const length = value.trim();
 
-  if (!trimmed) return 0;
+  if (!length) return 0;
 
-  const parsed = Number.parseFloat(trimmed);
-
-  if (!Number.isNaN(parsed) && (/^-?\d*\.?\d+$/.test(trimmed) || trimmed.endsWith('px'))) return parsed;
+  if (/^-?(?:\d+(?:\.\d+)?|\.\d+)(?:px)?$/.test(length)) return Number.parseFloat(length);
 
   const doc = el.ownerDocument;
-  const root = doc?.documentElement;
+  const probe = doc.createElement('div');
 
-  if (!Number.isNaN(parsed) && trimmed.endsWith('rem')) {
-    const rootFontSize = root ? Number.parseFloat(getComputedStyle(root).fontSize) || 16 : 16;
-    return parsed * rootFontSize;
-  }
+  probe.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none';
+  probe.style.inlineSize = length;
 
-  if (!Number.isNaN(parsed) && trimmed.endsWith('em')) {
-    const fontSize = el instanceof HTMLElement ? Number.parseFloat(getComputedStyle(el).fontSize) || 16 : 16;
-    return parsed * fontSize;
-  }
-
-  if (!doc) return Number.isNaN(parsed) ? 0 : parsed;
-
-  const measurementEl = doc.createElement('div');
-  measurementEl.style.position = 'absolute';
-  measurementEl.style.visibility = 'hidden';
-  measurementEl.style.pointerEvents = 'none';
-  measurementEl.style.inlineSize = trimmed;
-
-  if (!measurementEl.style.inlineSize) return 0;
-
-  measurementEl.style.blockSize = '0';
-  measurementEl.style.padding = '0';
-  measurementEl.style.border = '0';
-  measurementEl.style.inset = '0';
+  if (!probe.style.inlineSize) return 0;
 
   const computed = getComputedStyle(el);
-  measurementEl.style.fontSize = computed.fontSize;
+  probe.style.fontSize = computed.fontSize;
 
-  for (let i = 0; i < computed.length; i++) {
-    const name = computed.item(i);
-
-    if (name.startsWith('--')) {
-      measurementEl.style.setProperty(name, computed.getPropertyValue(name));
-    }
+  for (const match of length.matchAll(/var\(\s*(--[\w-]+)/g)) {
+    const name = match[1];
+    if (name) probe.style.setProperty(name, computed.getPropertyValue(name));
   }
 
-  const parent = doc.body ?? doc.documentElement;
+  (doc.body ?? doc.documentElement).append(probe);
 
-  if (!parent) return Number.isNaN(parsed) ? 0 : parsed;
-
-  parent.appendChild(measurementEl);
-
-  if (getComputedStyle(measurementEl).inlineSize === 'auto') {
-    measurementEl.remove();
-    return 0;
+  try {
+    const pixels = Number.parseFloat(getComputedStyle(probe).inlineSize);
+    return Number.isFinite(pixels) ? pixels : 0;
+  } finally {
+    probe.remove();
   }
-
-  const pixels = measurementEl.getBoundingClientRect().width;
-  measurementEl.remove();
-
-  if (Number.isFinite(pixels)) return pixels;
-
-  return Number.isNaN(parsed) ? 0 : parsed;
 }

--- a/packages/utils/src/dom/tests/style.test.ts
+++ b/packages/utils/src/dom/tests/style.test.ts
@@ -53,234 +53,60 @@ describe('resolveCSSLength', () => {
     vi.restoreAllMocks();
   });
 
-  it('Returns px values directly', () => {
+  function mockComputedLength(el: Element, inlineSize: string, variables: Record<string, string> = {}) {
+    const getPropertyValue = vi.fn((name: string) => variables[name] ?? '');
+
+    vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((target: Element) =>
+      target === el
+        ? ({ fontSize: '14px', getPropertyValue } as unknown as CSSStyleDeclaration)
+        : ({ inlineSize } as CSSStyleDeclaration)
+    );
+
+    return getPropertyValue;
+  }
+
+  it('returns pixel and unitless values directly', () => {
     const el = document.createElement('div');
 
     expect(resolveCSSLength(el, '8px')).toBe(8);
+    expect(resolveCSSLength(el, '-2.5px')).toBe(-2.5);
+    expect(resolveCSSLength(el, '4')).toBe(4);
   });
 
-  it('Resolves rem values using the root font size', () => {
+  it.each([
+    ['0.5rem', '8px', 8],
+    ['1em', '14px', 14],
+    ['10vw', '24px', 24],
+    ['calc(0.5 * 16px)', '8px', 8],
+    ['calc(1px - 1px)', '0px', 0],
+  ])('resolves %s from its computed inline size', (value, inlineSize, expected) => {
     const el = document.createElement('div');
-    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation(
-      (target: Element) =>
-        ({
-          fontSize: target === document.documentElement ? '16px' : '14px',
-        }) as CSSStyleDeclaration
-    );
+    const appendSpy = vi.spyOn(document.body, 'append');
 
-    expect(resolveCSSLength(el, '0.5rem')).toBe(8);
+    mockComputedLength(el, inlineSize);
 
-    getComputedStyleSpy.mockRestore();
+    expect(resolveCSSLength(el, value)).toBe(expected);
+    expect(appendSpy).toHaveBeenCalledOnce();
+    expect((appendSpy.mock.calls[0]![0] as Element).isConnected).toBe(false);
   });
 
-  it('Resolves em values using the element font size', () => {
+  it('copies referenced custom properties from the source element', () => {
     const el = document.createElement('div');
-    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation(
-      () =>
-        ({
-          fontSize: '14px',
-        }) as CSSStyleDeclaration
-    );
-
-    expect(resolveCSSLength(el, '1em')).toBe(14);
-
-    getComputedStyleSpy.mockRestore();
-  });
-
-  it('Falls back to measurement for other CSS lengths', () => {
-    const el = document.createElement('div');
-    const createElement = document.createElement.bind(document);
-    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const node = createElement(tagName);
-
-      if (tagName === 'div') {
-        vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => {
-          const width = node.style.inlineSize === '10vw' ? 24 : 0;
-          return {
-            x: 0,
-            y: 0,
-            width,
-            height: 0,
-            top: 0,
-            left: 0,
-            right: width,
-            bottom: 0,
-            toJSON() {},
-          };
-        });
-      }
-
-      return node;
-    });
-
-    expect(resolveCSSLength(el, '10vw')).toBe(24);
-    expect(appendChildSpy).toHaveBeenCalled();
-
-    createElementSpy.mockRestore();
-    appendChildSpy.mockRestore();
-  });
-
-  it('Preserves measured zero pixel values', () => {
-    const el = document.createElement('div');
-    const createElement = document.createElement.bind(document);
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const node = createElement(tagName);
-
-      if (tagName === 'div') {
-        vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => ({
-          x: 0,
-          y: 0,
-          width: 0,
-          height: 0,
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          toJSON() {},
-        }));
-      }
-
-      return node;
-    });
-
-    expect(resolveCSSLength(el, 'calc(1px - 1px)')).toBe(0);
-
-    createElementSpy.mockRestore();
-  });
-
-  it('Returns zero for invalid CSS lengths', () => {
-    const el = document.createElement('div');
-    const createElement = document.createElement.bind(document);
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const node = createElement(tagName);
-
-      if (tagName === 'div') {
-        vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => ({
-          x: 0,
-          y: 0,
-          width: 640,
-          height: 0,
-          top: 0,
-          left: 0,
-          right: 640,
-          bottom: 0,
-          toJSON() {},
-        }));
-      }
-
-      return node;
-    });
-
-    expect(resolveCSSLength(el, 'not-a-length')).toBe(0);
-
-    createElementSpy.mockRestore();
-  });
-
-  it('Returns zero when a CSS length resolves to auto', () => {
-    const el = document.createElement('div');
-    const createElement = document.createElement.bind(document);
-    const getComputedStyleSpy = vi
-      .spyOn(globalThis, 'getComputedStyle')
-      .mockImplementation((target: Element) =>
-        target === el
-          ? ({ length: 0, fontSize: '14px' } as CSSStyleDeclaration)
-          : ({ inlineSize: 'auto' } as CSSStyleDeclaration)
-      );
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const node = createElement(tagName);
-
-      if (tagName === 'div') {
-        vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => ({
-          x: 0,
-          y: 0,
-          width: 640,
-          height: 0,
-          top: 0,
-          left: 0,
-          right: 640,
-          bottom: 0,
-          toJSON() {},
-        }));
-      }
-
-      return node;
-    });
-
-    expect(resolveCSSLength(el, 'var(--missing-size)')).toBe(0);
-
-    createElementSpy.mockRestore();
-    getComputedStyleSpy.mockRestore();
-  });
-
-  it('Falls back to measurement for calc values', () => {
-    const el = document.createElement('div');
-    const createElement = document.createElement.bind(document);
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const node = createElement(tagName);
-
-      if (tagName === 'div') {
-        vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => ({
-          x: 0,
-          y: 0,
-          width: node.style.inlineSize.startsWith('calc(') ? 8 : 0,
-          height: 0,
-          top: 0,
-          left: 0,
-          right: 8,
-          bottom: 0,
-          toJSON() {},
-        }));
-      }
-
-      return node;
-    });
-
-    expect(resolveCSSLength(el, 'calc(0.5 * 16px)')).toBe(8);
-
-    createElementSpy.mockRestore();
-  });
-
-  it('Copies custom properties from the source element when measuring', () => {
-    const el = document.createElement('div');
-
-    const createElement = document.createElement.bind(document);
-    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation(
-      () =>
-        ({
-          length: 1,
-          fontSize: '14px',
-          item(index: number) {
-            return index === 0 ? '--size' : '';
-          },
-          getPropertyValue(name: string) {
-            return name === '--size' ? '16px' : '';
-          },
-        }) as CSSStyleDeclaration
-    );
-    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const node = createElement(tagName);
-
-      if (tagName === 'div') {
-        vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => ({
-          x: 0,
-          y: 0,
-          width: node.style.getPropertyValue('--size') === '16px' ? 8 : 0,
-          height: 0,
-          top: 0,
-          left: 0,
-          right: 8,
-          bottom: 0,
-          toJSON() {},
-        }));
-      }
-
-      return node;
-    });
+    const appendSpy = vi.spyOn(document.body, 'append');
+    const getPropertyValue = mockComputedLength(el, '8px', { '--size': '16px' });
 
     expect(resolveCSSLength(el, 'calc(0.5 * var(--size))')).toBe(8);
+    expect(getPropertyValue).toHaveBeenCalledExactlyOnceWith('--size');
+    expect((appendSpy.mock.calls[0]![0] as HTMLElement).style.getPropertyValue('--size')).toBe('16px');
+  });
 
-    createElementSpy.mockRestore();
-    getComputedStyleSpy.mockRestore();
+  it('returns zero for empty, invalid, and unresolved values', () => {
+    const el = document.createElement('div');
+
+    expect(resolveCSSLength(el, '')).toBe(0);
+    expect(resolveCSSLength(el, 'not-a-length')).toBe(0);
+
+    mockComputedLength(el, 'auto');
+    expect(resolveCSSLength(el, 'var(--missing-size)')).toBe(0);
   });
 });

--- a/packages/utils/src/dom/tests/style.test.ts
+++ b/packages/utils/src/dom/tests/style.test.ts
@@ -53,13 +53,13 @@ describe('resolveCSSLength', () => {
     vi.restoreAllMocks();
   });
 
-  function mockComputedLength(el: Element, inlineSize: string, variables: Record<string, string> = {}) {
+  function mockComputedLength(el: Element, insetInlineStart: string, variables: Record<string, string> = {}) {
     const getPropertyValue = vi.fn((name: string) => variables[name] ?? '');
 
     vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((target: Element) =>
       target === el
         ? ({ fontSize: '14px', getPropertyValue } as unknown as CSSStyleDeclaration)
-        : ({ inlineSize } as CSSStyleDeclaration)
+        : ({ insetInlineStart } as CSSStyleDeclaration)
     );
 
     return getPropertyValue;
@@ -75,29 +75,36 @@ describe('resolveCSSLength', () => {
 
   it.each([
     ['0.5rem', '8px', 8],
+    ['-0.5rem', '-8px', -8],
     ['1em', '14px', 14],
+    ['-1em', '-14px', -14],
     ['10vw', '24px', 24],
     ['calc(0.5 * 16px)', '8px', 8],
+    ['calc(0px - 0.5rem)', '-8px', -8],
     ['calc(1px - 1px)', '0px', 0],
-  ])('resolves %s from its computed inline size', (value, inlineSize, expected) => {
+  ])('resolves %s from its computed inset', (value, inset, expected) => {
     const el = document.createElement('div');
     const appendSpy = vi.spyOn(document.body, 'append');
 
-    mockComputedLength(el, inlineSize);
+    mockComputedLength(el, inset);
 
     expect(resolveCSSLength(el, value)).toBe(expected);
     expect(appendSpy).toHaveBeenCalledOnce();
     expect((appendSpy.mock.calls[0]![0] as Element).isConnected).toBe(false);
   });
 
-  it('copies referenced custom properties from the source element', () => {
+  it('copies computed custom properties referenced by the length', () => {
     const el = document.createElement('div');
     const appendSpy = vi.spyOn(document.body, 'append');
-    const getPropertyValue = mockComputedLength(el, '8px', { '--size': '16px' });
+    const getPropertyValue = mockComputedLength(el, '-8px', {
+      '--offset': 'calc(calc(16px / 4) * -2)',
+    });
 
-    expect(resolveCSSLength(el, 'calc(0.5 * var(--size))')).toBe(8);
-    expect(getPropertyValue).toHaveBeenCalledExactlyOnceWith('--size');
-    expect((appendSpy.mock.calls[0]![0] as HTMLElement).style.getPropertyValue('--size')).toBe('16px');
+    expect(resolveCSSLength(el, 'var(--offset)')).toBe(-8);
+    expect(getPropertyValue).toHaveBeenCalledExactlyOnceWith('--offset');
+    expect((appendSpy.mock.calls[0]![0] as HTMLElement).style.getPropertyValue('--offset')).toBe(
+      'calc(calc(16px / 4) * -2)'
+    );
   });
 
   it('returns zero for empty, invalid, and unresolved values', () => {


### PR DESCRIPTION
## Summary

Simplify `resolveCSSLength` while preserving its CSS-based API and responsive behavior. Pixel and unitless values keep a fast path; other valid lengths are resolved by a hidden CSS measurement probe.

## Changes

- remove manual `rem` and `em` conversion branches
- read the probe computed `inline-size` instead of measuring its bounding box
- copy only custom properties referenced by the input expression
- guarantee probe cleanup with `try`/`finally`
- consolidate resolver coverage while retaining pixel, relative, viewport, calculated, variable, zero, invalid, and unresolved cases
- update the popover consumer test to model browser-computed probe sizes

## Impact

- implementation: 51 lines removed, 17 added
- overall diff: 270 lines removed, 67 added (net -203)
- `@videojs/utils/dom`: 3,371 B to 3,261 B Brotli (net -110 B)
- `@videojs/core/dom`: 20,503 B to 20,390 B Brotli (net -113 B)

Bundle entries overlap, so these entry-point deltas are intentionally not summed. Measurements compare clean builds of this commit and its parent with the repository bundle-size script.

## Testing

- `pnpm -F @videojs/utils test`
- `pnpm -F @videojs/core test`
- `pnpm typecheck`
- `pnpm exec turbo run build --filter=@videojs/react... --filter=@videojs/html...`
- Chromium check covering pixel, relative, viewport, calculated, nested custom-property, invalid, unresolved, and cleanup behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Popover and menu layout depend on this helper for offset and available-width pixels; behavior should match prior cases but resolution now relies on computed inset rather than explicit rem/em and box measurement.
> 
> **Overview**
> **`resolveCSSLength`** is simplified: pixel and unitless strings still short-circuit, but everything else is resolved through a hidden probe with **`insetInlineStart`** set to the length and the computed inset read back—replacing separate **`rem`/`em`** math, **`inlineSize`** layout, and **`getBoundingClientRect`** width measurement.
> 
> The probe now copies only **custom properties referenced in the input** (via **`var(--…)`** parsing), uses **`try`/`finally`** so the node is always removed, and drops the old “copy all **`--*`** from computed style” loop. **`style.test.ts`** is tightened around a shared **`mockComputedLength`** helper; the popover **`resolveOffsets`** test mocks probe **`insetInlineStart`** the same way the new resolver behaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40256d2cc084e9f44a27e77be9e04ca593168914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->