### PR TITLE
fix(i18n): use resolution wording for hindi quality menu

### DIFF
--- a/packages/core/src/core/i18n/locales/hi.ts
+++ b/packages/core/src/core/i18n/locales/hi.ts
@@ -94,7 +94,7 @@ export default {
   },
   menu: {
     settings: 'सेटिंग्स',
-    quality: 'गुणवत्ता',
+    quality: 'रेज़ोल्यूशन',
     audio: 'ऑडियो',
     default: 'डिफ़ॉल्ट',
     speed: 'गति',


### PR DESCRIPTION
Closes #1934

## Summary

Native-speaker feedback on the Hindi review reported that `गुणवत्ता` reads as an unfamiliar literal translation for the quality menu. `रेज़ोल्यूशन` is the term Hindi speakers recognize, largely because YouTube uses it.

## Changes

- Hindi quality menu label now reads `रेज़ोल्यूशन` instead of `गुणवत्ता`

## Testing

`pnpm -F @videojs/core test i18n` (65 passed). No test asserts on the Hindi string, so no test updates were needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Hindi UI string change with no behavior, security, or data impact.
> 
> **Overview**
> Updates the Hindi settings menu label for the quality/resolution picker from **गुणवत्ता** to **रेज़ोल्यूशन**, matching familiar usage (e.g. YouTube) instead of a literal “quality” translation.
> 
> Only `packages/core/src/core/i18n/locales/hi.ts` (`menu.quality`) changes; no logic or other locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a2f8c32cbebd4f1b013091bbe6974894c65764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->