### PR TITLE
fix(store): create abort controllers lazily

### DIFF
--- a/packages/store/src/core/abort-controller-registry.ts
+++ b/packages/store/src/core/abort-controller-registry.ts
@@ -3,12 +3,14 @@ import { anyAbortSignal } from '@videojs/utils/events';
 export type SignalKey = PropertyKey;
 
 export class AbortControllerRegistry {
-  #base = new AbortController();
+  // Created on first read. Runtimes such as Cloudflare Workers forbid constructing I/O-bound
+  // objects during module evaluation, and registries can be created at module scope.
+  #base: AbortController | undefined;
   #keys = new Map<SignalKey, AbortController>();
 
   /** The attach-scoped signal. Aborts on detach or reattach. */
   get base(): AbortSignal {
-    return this.#base.signal;
+    return (this.#base ??= new AbortController()).signal;
   }
 
   /** Clears all keyed signals, leaving base intact. */
@@ -22,8 +24,8 @@ export class AbortControllerRegistry {
   /** Resets base and clears all keyed signals. */
   reset(): void {
     this.clear();
-    this.#base.abort();
-    this.#base = new AbortController();
+    this.#base?.abort();
+    this.#base = undefined;
   }
 
   /** Creates a new signal for the key, superseding any previous signal. */
@@ -31,6 +33,6 @@ export class AbortControllerRegistry {
     this.#keys.get(key)?.abort();
     const controller = new AbortController();
     this.#keys.set(key, controller);
-    return anyAbortSignal([this.#base.signal, controller.signal]);
+    return anyAbortSignal([this.base, controller.signal]);
   }
 }

--- a/packages/store/src/core/tests/abort-controller-registry.test.ts
+++ b/packages/store/src/core/tests/abort-controller-registry.test.ts
@@ -1,7 +1,49 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AbortControllerRegistry } from '../abort-controller-registry';
 
+const NativeAbortController = globalThis.AbortController;
+
+/** Counts controller constructions so lazy creation can be asserted. */
+function countControllers() {
+  const counter = { count: 0 };
+
+  class CountingAbortController extends NativeAbortController {
+    constructor() {
+      super();
+      counter.count++;
+    }
+  }
+
+  vi.stubGlobal('AbortController', CountingAbortController);
+
+  return counter;
+}
+
 describe('AbortControllerRegistry', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('constructor', () => {
+    it('does not construct an AbortController', () => {
+      const controllers = countControllers();
+
+      new AbortControllerRegistry();
+
+      expect(controllers.count).toBe(0);
+    });
+
+    it('constructs an AbortController on first base read', () => {
+      const controllers = countControllers();
+      const signals = new AbortControllerRegistry();
+
+      void signals.base;
+      void signals.base;
+
+      expect(controllers.count).toBe(1);
+    });
+  });
+
   describe('base', () => {
     it('returns an AbortSignal', () => {
       const signals = new AbortControllerRegistry();
@@ -41,6 +83,14 @@ describe('AbortControllerRegistry', () => {
 
       expect(base.aborted).toBe(false);
     });
+
+    it('is not aborted when reset() runs before it is read', () => {
+      const signals = new AbortControllerRegistry();
+
+      signals.reset();
+
+      expect(signals.base.aborted).toBe(false);
+    });
   });
 
   describe('clear', () => {
@@ -76,6 +126,15 @@ describe('AbortControllerRegistry', () => {
   });
 
   describe('reset', () => {
+    it('does not construct an AbortController when base was never read', () => {
+      const controllers = countControllers();
+      const signals = new AbortControllerRegistry();
+
+      signals.reset();
+
+      expect(controllers.count).toBe(0);
+    });
+
     it('aborts base signal', () => {
       const signals = new AbortControllerRegistry();
       const base = signals.base;

--- a/packages/store/src/core/tests/selector.test.ts
+++ b/packages/store/src/core/tests/selector.test.ts
@@ -1,12 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSelector } from '../selector';
 import { defineSlice } from '../slice';
+
+const NativeAbortController = globalThis.AbortController;
 
 interface MockMedia {
   volume: number;
 }
 
 describe('createSelector', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
   const volumeSlice = defineSlice<MockMedia>()({
     name: 'volume',
     state: ({ target }) => ({
@@ -113,5 +120,25 @@ describe('createSelector', () => {
 
     expect(selector({})).toBeUndefined();
     expect(selector.displayName).toBe('empty');
+  });
+
+  // Runtimes such as Cloudflare Workers throw when I/O-bound objects are created during
+  // module evaluation. See https://github.com/videojs/v10/issues/2041.
+  it('does not construct an AbortController on module evaluation', async () => {
+    let constructed = 0;
+
+    class CountingAbortController extends NativeAbortController {
+      constructor() {
+        super();
+        constructed++;
+      }
+    }
+
+    vi.stubGlobal('AbortController', CountingAbortController);
+    vi.resetModules();
+
+    await import('../selector');
+
+    expect(constructed).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #2041

## Summary

`AbortControllerRegistry` built its base `AbortController` in a class field initializer, and the selector state context creates a registry at module scope. Importing `@videojs/store` — and therefore `@videojs/react` — performed I/O-bound work during module evaluation, which runtimes like Cloudflare Workers and Deno Deploy disallow outside a request handler.

## Changes

- The base controller is now created on first read of `base`, so constructing a registry does no work beyond allocating a map.
- `reset()` aborts an existing base controller and drops it, so the next read yields a fresh, unaborted signal. Public behavior is unchanged.

<details>
<summary>Implementation details</summary>

`supersede()` reads through the `base` getter, so keyed signals still combine with the attach-scoped signal and create it lazily at that point. Consumers cannot work around the old behavior themselves, since it ran on import, which is why the fix belongs in the class rather than at the call site.

</details>

## Testing

`pnpm -F @videojs/store test`

New tests assert that constructing a registry creates no `AbortController`, that one is created once on first `base` read, and that importing `core/selector` creates none. All three fail against the previous implementation.

Verified end to end by importing the built `@videojs/react` and `@videojs/react/video` entries in Node with `AbortController`, `setTimeout`, and `Math.random` instrumented: the reported stack reproduces before the change and no module-scope violation remains after it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lifecycle change in cancellation plumbing with regression tests; no auth, data, or API surface changes beyond fixing edge-runtime import behavior.
> 
> **Overview**
> **`AbortControllerRegistry` no longer instantiates a base `AbortController` at construction time**, so importing `@videojs/store` (including the module-scoped registry in `selector`) does not perform I/O-bound work during module evaluation—fixing failures on Cloudflare Workers and similar runtimes ([#2041](https://github.com/videojs/v10/issues/2041)).
> 
> The base controller is created on the first read of `base` (and via `supersede`, which now composes through that getter). **`reset()`** aborts an existing base if one was created, clears it, and leaves the next `base` access to allocate a fresh unaborted signal; behavior for normal attach/detach flows is unchanged.
> 
> Tests count `AbortController` constructions to lock in lazy creation, cover `reset()` before any `base` read, and assert that dynamically importing `selector` does not construct controllers at load time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12788612e09288b52a4a227e207dac1a955bcd7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->