### PR TITLE
fix(skin): keep menu scroll position while hovering

### DIFF
--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -57,6 +57,7 @@ export const SELECTORS = {
   ].join(', '),
   playbackRateUncheckedOptions: unchecked(playbackRateOptions),
   activeMenuOptions: `${activeMenu} ${option}`,
+  activeMenuPanel: '.media-menu__panel[data-menu-view-state="active"]',
   activeMenuUncheckedOptions: unchecked(`${activeMenu} ${option}`),
   settingsButton: [
     withinControls('.media-button--settings'),

--- a/apps/e2e/page-objects/player.ts
+++ b/apps/e2e/page-objects/player.ts
@@ -74,6 +74,11 @@ export class PlayerPage {
     return this.page.locator(SELECTORS.settingsSpeedItem).first();
   }
 
+  /** The scrollable panel of the menu view that is currently on screen. */
+  get activeMenuPanel(): Locator {
+    return this.page.locator(SELECTORS.activeMenuPanel).first();
+  }
+
   get poster(): Locator {
     return this.page.locator(SELECTORS.poster).first();
   }

--- a/apps/e2e/tests/menu-scroll.spec.ts
+++ b/apps/e2e/tests/menu-scroll.spec.ts
@@ -1,0 +1,136 @@
+import { type ElementHandle, expect, type Page, test } from '@playwright/test';
+import { VIDEO_PAGES } from '../fixtures/media';
+import { SELECTORS } from '../fixtures/selectors';
+import { PlayerPage } from '../page-objects/player';
+
+const UI_VIDEO_PAGES = VIDEO_PAGES.filter(({ media }) => media === 'video');
+
+type PanelHandle = ElementHandle<HTMLElement>;
+
+/**
+ * Resolve the on-screen menu panel once the submenu view transition settled.
+ *
+ * The transition briefly leaves two panels on screen and clips their overflow,
+ * so the panel is pinned to a handle to keep every later read on one element.
+ */
+async function resolveActiveMenuPanel(page: Page, player: PlayerPage): Promise<PanelHandle> {
+  await expect(page.locator(SELECTORS.activeMenuPanel)).toHaveCount(1);
+  await expect
+    .poll(() => player.activeMenuPanel.evaluate((element) => getComputedStyle(element).overflowY))
+    .toBe('auto');
+
+  const handle = await player.activeMenuPanel.elementHandle();
+  if (!handle) throw new Error('Menu panel is not attached');
+
+  return handle as PanelHandle;
+}
+
+/** Wait for the popover open animation to finish so pointer coordinates are meaningful. */
+async function getStableBox(panel: PanelHandle): Promise<{ x: number; y: number; width: number; height: number }> {
+  let previous = '';
+
+  await expect
+    .poll(async () => {
+      const box = await panel.boundingBox();
+      const key = box
+        ? `${Math.round(box.x)},${Math.round(box.y)},${Math.round(box.width)},${Math.round(box.height)}`
+        : '';
+      const settled = key !== '' && key === previous;
+      previous = key;
+      return settled;
+    })
+    .toBe(true);
+
+  const box = await panel.boundingBox();
+  if (!box) throw new Error('Menu panel is not visible');
+
+  return box;
+}
+
+function getScrollTop(panel: PanelHandle): Promise<number> {
+  return panel.evaluate((element) => Math.round(element.scrollTop));
+}
+
+function getHighlightedOption(panel: PanelHandle): Promise<string> {
+  return panel.evaluate((element) => element.querySelector('[data-highlighted]')?.textContent?.trim() ?? '');
+}
+
+for (const { name, path } of UI_VIDEO_PAGES) {
+  test.describe(`Menu scrolling — ${name} UI`, () => {
+    let player: PlayerPage;
+    let panel: PanelHandle;
+
+    test.beforeEach(async ({ page }) => {
+      player = new PlayerPage(page);
+      await page.goto(path);
+      await player.waitForMediaReady();
+      await player.openPlaybackRateSettings();
+      panel = await resolveActiveMenuPanel(page, player);
+    });
+
+    // Regression: Firefox scroll anchoring latched onto the anchor-positioned
+    // highlight indicator, so every hover scrolled the list by one item.
+    // https://github.com/videojs/v10/issues/2095
+    test('hovering options keeps the scroll position', async ({ page }) => {
+      const overflows = await panel.evaluate((element) => element.scrollHeight > element.clientHeight + 1);
+      expect(overflows, 'speed menu must overflow for this test to be meaningful').toBe(true);
+
+      const box = await getStableBox(panel);
+
+      await panel.evaluate((element) => {
+        element.scrollTop = element.scrollHeight - element.clientHeight;
+      });
+      const scrollTop = await getScrollTop(panel);
+      expect(scrollTop).toBeGreaterThan(0);
+
+      const centerX = box.x + box.width / 2;
+      const bottom = box.height - 2;
+      const middle = box.height / 2;
+
+      /** Walk the pointer across options, recording what each step highlighted and scrolled. */
+      async function walkPointer(from: number, to: number): Promise<{ highlights: Set<string>; scrolls: Set<number> }> {
+        const step = from < to ? 4 : -4;
+        const highlights = new Set<string>();
+        const scrolls = new Set<number>();
+
+        for (let offset = from; step > 0 ? offset <= to : offset >= to; offset += step) {
+          await page.mouse.move(centerX, box.y + offset);
+          await page.waitForTimeout(50);
+          highlights.add(await getHighlightedOption(panel));
+          scrolls.add(await getScrollTop(panel));
+        }
+
+        return { highlights, scrolls };
+      }
+
+      // Enter the list at the bottom and walk up, then back down.
+      for (const walk of [await walkPointer(bottom, middle), await walkPointer(middle, bottom)]) {
+        // The pointer crossed options, so the highlight must have followed it…
+        expect(walk.highlights.size, [...walk.highlights].join(' | ')).toBeGreaterThan(1);
+        // …without moving the list out from under the pointer.
+        expect([...walk.scrolls]).toEqual([scrollTop]);
+      }
+    });
+
+    test('keyboard navigation still scrolls the highlighted option into view', async ({ page }) => {
+      await getStableBox(panel);
+      // Keys only reach the menu once the opened panel owns focus.
+      await expect
+        .poll(() =>
+          panel.evaluate((element) => {
+            const root = element.getRootNode() as Document | ShadowRoot;
+            return element.contains(root.activeElement);
+          })
+        )
+        .toBe(true);
+
+      await panel.evaluate((element) => {
+        element.scrollTop = 0;
+      });
+
+      await page.keyboard.press('End');
+
+      await expect.poll(() => getScrollTop(panel)).toBeGreaterThan(0);
+    });
+  });
+}

--- a/packages/skins/src/default/css/components/menus.css
+++ b/packages/skins/src/default/css/components/menus.css
@@ -95,6 +95,9 @@
         position: absolute;
         position-anchor: --media-menu-item-highlight-anchor;
         inset: anchor(inside);
+        /* Firefox treats the moving highlight as a content shift and re-scrolls
+           the menu while hovering. Exclude it from scroll anchoring. */
+        overflow-anchor: none;
         pointer-events: none;
         content: "";
         background-color: oklch(from currentColor l c h / 0.1);

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -57,6 +57,9 @@ const group = cn(
   'supports-[top:anchor(top)]:before:absolute',
   'supports-[top:anchor(top)]:before:[position-anchor:--media-menu-item-highlight-anchor]',
   'supports-[top:anchor(top)]:before:[inset:anchor(inside)]',
+  // Firefox treats the moving highlight as a content shift and re-scrolls the
+  // menu while hovering. Exclude it from scroll anchoring.
+  'supports-[top:anchor(top)]:before:[overflow-anchor:none]',
   'supports-[top:anchor(top)]:before:pointer-events-none',
   'supports-[top:anchor(top)]:before:bg-current/10',
   'supports-[top:anchor(top)]:before:rounded-(--menu-item-border-radius)',

--- a/packages/skins/src/minimal/css/components/menus.css
+++ b/packages/skins/src/minimal/css/components/menus.css
@@ -100,6 +100,9 @@
         position: absolute;
         position-anchor: --media-menu-item-highlight-anchor;
         inset: anchor(inside);
+        /* Firefox treats the moving highlight as a content shift and re-scrolls
+           the menu while hovering. Exclude it from scroll anchoring. */
+        overflow-anchor: none;
         pointer-events: none;
         content: "";
         background-color: oklch(from currentColor l c h / 0.1);

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -56,6 +56,9 @@ const group = cn(
   'supports-[top:anchor(top)]:before:absolute',
   'supports-[top:anchor(top)]:before:[position-anchor:--media-menu-item-highlight-anchor]',
   'supports-[top:anchor(top)]:before:[inset:anchor(inside)]',
+  // Firefox treats the moving highlight as a content shift and re-scrolls the
+  // menu while hovering. Exclude it from scroll anchoring.
+  'supports-[top:anchor(top)]:before:[overflow-anchor:none]',
   'supports-[top:anchor(top)]:before:pointer-events-none',
   'supports-[top:anchor(top)]:before:bg-current/10',
   'supports-[top:anchor(top)]:before:rounded-(--menu-item-border-radius)',


### PR DESCRIPTION
Closes #2095

## Summary

Scrollable menus (Speed, Quality) jumped in Firefox: scrolling down and then moving the pointer up one option snapped the list back toward the top. The cause is CSS, not the highlight logic — Firefox's scroll anchoring latched onto the anchor-positioned highlight indicator.

## Changes

- Hovering a menu option now highlights it without moving the list, in every browser.
- Keyboard navigation still scrolls the highlighted option into view.
- Applies to the default and minimal skins, in both the CSS and Tailwind token sources.

<details>
<summary>Implementation details</summary>

The skin draws the highlight with an anchor-positioned pseudo-element:

```css
.media-menu__group::before { position: absolute; position-anchor: --media-menu-item-highlight-anchor; inset: anchor(inside); }
.media-menu__item[data-highlighted] { anchor-name: --media-menu-item-highlight-anchor; }
```

When hover moves `data-highlighted`, that absolutely positioned pseudo-element moves inside the scroll container. Firefox picks it as the scroll anchor and compensates by scrolling one option, which puts a new option under the pointer, re-highlights, and repeats until the list hits the top. Chromium excludes such boxes from anchor selection, which is why it was unaffected.

`overflow-anchor: none` on the indicator removes it from anchor selection while leaving scroll anchoring in place for real content shifts. Verified in Firefox 148 that the alternatives — disabling anchoring on the scroll containers, or dropping the indicator — fix it too, and that the reported `tabIndex`/`preventScroll` path is not involved: blocking every `tabIndex` write still reproduces, blocking `data-highlighted` writes does not, and no focus events fire during the jump.

</details>

## Testing

New `apps/e2e/tests/menu-scroll.spec.ts` covers the HTML and React video UIs: it scrolls the Speed list to the bottom, walks the pointer up and back down, and asserts the highlight follows the pointer while `scrollTop` never changes, plus an opposite-direction guard that `End` still scrolls the highlighted option into view.

- `pnpm --dir apps/e2e exec playwright test menu-scroll` on `vite-firefox`, `vite-chromium` and `vite-webkit` — 12/12 pass, stable over repeated runs.
- Reverting the property in the built CSS makes both hover tests fail on Firefox, so the regression test is not vacuous.
- `pnpm -F @videojs/skins test`, `pnpm check:skins`, `pnpm typecheck`, Biome on changed files, and `captions.spec.ts` on Firefox all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CSS on menu highlight styling plus regression e2e; no auth, data, or core playback logic changes.
> 
> **Overview**
> Fixes **Firefox scroll jumping** in long settings menus (e.g. Speed) when moving the pointer over options after scrolling. Firefox was using the anchor-positioned highlight `::before` as a scroll anchor; **`overflow-anchor: none`** on that pseudo-element excludes it while leaving normal scroll-into-view behavior intact.
> 
> The change is mirrored in **default and minimal** skins via both **CSS** and **Tailwind** menu tokens.
> 
> **E2E:** adds `activeMenuPanel` selectors/locators and **`menu-scroll.spec.ts`**, which scrolls the Speed submenu, walks the mouse up/down, asserts highlight changes without `scrollTop` changing, and checks **End** still scrolls for keyboard focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce53e85c9ad10e18656b0a405e02ffcb0d0305f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->