### PR TITLE
fix(core): restore the last selected subtitles track on toggle

### DIFF
--- a/packages/core/src/dom/store/features/tests/text-track.test.ts
+++ b/packages/core/src/dom/store/features/tests/text-track.test.ts
@@ -183,7 +183,7 @@ describe('textTrackFeature', () => {
       ]);
     });
 
-    it('toggleSubtitles() enables and disables caption/subtitle tracks', () => {
+    it('toggleSubtitles() enables a single caption/subtitle track and disables them all', () => {
       const video = createVideo();
       const subtitlesTrack = createMockTrack('subtitles');
       const captionsTrack = createMockTrack('captions');
@@ -194,13 +194,82 @@ describe('textTrackFeature', () => {
 
       const enabled = store.state.toggleSubtitles();
       expect(enabled).toBe(true);
-      expect(subtitlesTrack.mode).toBe('showing');
+      // Captions sort before subtitles, matching the captions menu order.
       expect(captionsTrack.mode).toBe('showing');
+      expect(subtitlesTrack.mode).toBe('disabled');
 
       const disabled = store.state.toggleSubtitles(false);
       expect(disabled).toBe(false);
       expect(subtitlesTrack.mode).toBe('disabled');
       expect(captionsTrack.mode).toBe('disabled');
+    });
+
+    it('toggleSubtitles() restores the track that was showing', () => {
+      const video = createVideo();
+      const englishTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-en', language: 'en' });
+      const germanTrack = createMockTrack('subtitles', 'showing', { id: 'subtitles-de', language: 'de' });
+      mockTextTracks(video, [englishTrack, germanTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.toggleSubtitles()).toBe(false);
+      expect(englishTrack.mode).toBe('disabled');
+      expect(germanTrack.mode).toBe('disabled');
+
+      expect(store.state.toggleSubtitles()).toBe(true);
+      expect(englishTrack.mode).toBe('disabled');
+      expect(germanTrack.mode).toBe('showing');
+    });
+
+    it('toggleSubtitles() restores the track selected through selectSubtitlesTrack()', () => {
+      const video = createVideo();
+      const englishTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-en', language: 'en' });
+      const germanTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-de', language: 'de' });
+      mockTextTracks(video, [englishTrack, germanTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      store.state.selectSubtitlesTrack('subtitles-de');
+      store.state.selectSubtitlesTrack('off');
+
+      expect(store.state.toggleSubtitles()).toBe(true);
+      expect(englishTrack.mode).toBe('disabled');
+      expect(germanTrack.mode).toBe('showing');
+    });
+
+    it('toggleSubtitles(true) keeps the showing track instead of enabling every track', () => {
+      const video = createVideo();
+      const englishTrack = createMockTrack('subtitles', 'showing', { id: 'subtitles-en', language: 'en' });
+      const germanTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-de', language: 'de' });
+      mockTextTracks(video, [englishTrack, germanTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.toggleSubtitles(true)).toBe(true);
+      expect(englishTrack.mode).toBe('showing');
+      expect(germanTrack.mode).toBe('disabled');
+    });
+
+    it('toggleSubtitles() falls back to the first track when the remembered track is gone', () => {
+      const video = createVideo();
+      const germanTrack = createMockTrack('subtitles', 'showing', { id: 'subtitles-de', language: 'de' });
+      mockTextTracks(video, [germanTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      store.state.toggleSubtitles(false);
+
+      const frenchTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-fr', language: 'fr' });
+      const spanishTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-es', language: 'es' });
+      mockTextTracks(video, [frenchTrack, spanishTrack]);
+
+      expect(store.state.toggleSubtitles()).toBe(true);
+      expect(frenchTrack.mode).toBe('showing');
+      expect(spanishTrack.mode).toBe('disabled');
     });
 
     it('toggleSubtitles() returns false when no subtitle tracks exist', () => {

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -1,61 +1,102 @@
-import type { MediaTextCue, MediaTextTrack, MediaTextTrackState, TextTrackLike } from '@videojs/media';
+import type {
+  MediaTextCue,
+  MediaTextTrack,
+  MediaTextTrackCapability,
+  MediaTextTrackState,
+  TextTrackLike,
+} from '@videojs/media';
 import { isMediaTextTrackCapable, isQuerySelectorAllCapable } from '@videojs/media';
-import { findTrackElement, getTextTrackList, isCaptionOrSubtitleTrack, listen } from '@videojs/utils/dom';
+import { findTrackElement, isCaptionOrSubtitleTrack, listen } from '@videojs/utils/dom';
 import { definePlayerFeature } from '../../feature';
+
+interface IdentifiedTrack {
+  id: string;
+  track: TextTrackLike;
+}
 
 function getTrackId(track: TextTrackLike, index: number): string {
   return track.id || `track:${index}:${track.kind}:${track.language}:${track.label}`;
 }
 
+/**
+ * Caption/subtitle tracks paired with the ids exposed through `textTrackList`,
+ * ordered like the captions menu so index-based fallbacks agree with the UI.
+ */
+function getSubtitlesTracks(media: MediaTextTrackCapability): IdentifiedTrack[] {
+  return Array.from(media.textTracks)
+    .map((track, index) => ({ id: getTrackId(track, index), track }))
+    .filter(({ track }) => isCaptionOrSubtitleTrack(track))
+    .sort((a, b) => (a.track.kind > b.track.kind ? 1 : a.track.kind < b.track.kind ? -1 : 0));
+}
+
+/** Show at most one caption/subtitle track; passing `null` disables them all. */
+function showOnly(tracks: IdentifiedTrack[], active: TextTrackLike | null): void {
+  for (const { track } of tracks) {
+    const mode = track === active ? 'showing' : 'disabled';
+    if (track.mode !== mode) track.mode = mode;
+  }
+}
+
 export const textTrackFeature = definePlayerFeature({
   name: 'textTrack',
-  state: ({ target }): MediaTextTrackState => ({
-    chaptersCues: [],
-    thumbnailCues: [],
-    thumbnailTrackSrc: null,
-    textTrackList: [],
-    subtitlesShowing: false,
-    toggleSubtitles(forceShow?: boolean) {
-      const { media } = target();
-      if (!isMediaTextTrackCapable(media)) return false;
+  state: ({ target }): MediaTextTrackState => {
+    // The track the user last had showing. Remembered so `toggleSubtitles()`
+    // restores that one selection instead of enabling every language at once.
+    let lastShownId: string | null = null;
 
-      const subtitlesTracks = getTextTrackList(media, isCaptionOrSubtitleTrack);
-      if (!subtitlesTracks.length) return false;
+    return {
+      chaptersCues: [],
+      thumbnailCues: [],
+      thumbnailTrackSrc: null,
+      textTrackList: [],
+      subtitlesShowing: false,
+      toggleSubtitles(forceShow?: boolean) {
+        const { media } = target();
+        if (!isMediaTextTrackCapable(media)) return false;
 
-      const showing = subtitlesTracks.some((track) => track.mode === 'showing');
-      const nextShowing = forceShow ?? !showing;
+        const subtitlesTracks = getSubtitlesTracks(media);
+        if (!subtitlesTracks.length) return false;
 
-      for (const track of subtitlesTracks) {
-        track.mode = nextShowing ? 'showing' : 'disabled';
-      }
+        const showing = subtitlesTracks.find(({ track }) => track.mode === 'showing');
+        const nextShowing = forceShow ?? !showing;
 
-      return nextShowing;
-    },
-    selectSubtitlesTrack(value: string) {
-      const { media } = target();
-      if (!isMediaTextTrackCapable(media)) return;
+        if (showing) lastShownId = showing.id;
 
-      const subtitlesTracks = Array.from(media.textTracks)
-        .map((track, index) => ({ index, track }))
-        .filter(({ track }) => isCaptionOrSubtitleTrack(track));
-      if (!subtitlesTracks.length) return;
-
-      if (value === 'off') {
-        for (const { track } of subtitlesTracks) {
-          track.mode = 'disabled';
+        if (!nextShowing) {
+          showOnly(subtitlesTracks, null);
+          return false;
         }
-        return;
-      }
 
-      const active = subtitlesTracks.find(({ index, track }) => getTrackId(track, index) === value);
-      const track = active?.track;
-      if (!track) return;
+        // Restore the remembered track, falling back to the first one the
+        // captions menu offers when there is nothing to restore.
+        const next = showing ?? subtitlesTracks.find(({ id }) => id === lastShownId) ?? subtitlesTracks[0]!;
+        lastShownId = next.id;
+        showOnly(subtitlesTracks, next.track);
 
-      for (const { track: candidate } of subtitlesTracks) {
-        candidate.mode = candidate === track ? 'showing' : 'disabled';
-      }
-    },
-  }),
+        return true;
+      },
+      selectSubtitlesTrack(value: string) {
+        const { media } = target();
+        if (!isMediaTextTrackCapable(media)) return;
+
+        const subtitlesTracks = getSubtitlesTracks(media);
+        if (!subtitlesTracks.length) return;
+
+        if (value === 'off') {
+          const showing = subtitlesTracks.find(({ track }) => track.mode === 'showing');
+          if (showing) lastShownId = showing.id;
+          showOnly(subtitlesTracks, null);
+          return;
+        }
+
+        const active = subtitlesTracks.find(({ id }) => id === value);
+        if (!active) return;
+
+        lastShownId = active.id;
+        showOnly(subtitlesTracks, active.track);
+      },
+    };
+  },
 
   attach({ target, signal, set }) {
     const { media } = target;

--- a/packages/media/src/core/state.ts
+++ b/packages/media/src/core/state.ts
@@ -323,7 +323,11 @@ export interface MediaTextTrackState {
   textTrackList: MediaTextTrack[];
   /** Whether captions/subtitles are currently enabled. */
   subtitlesShowing: boolean;
-  /** Toggle captions/subtitles visibility. Returns the new enabled value. */
+  /**
+   * Toggle captions/subtitles visibility. Showing restores the track that was
+   * last showing, or the first caption/subtitle track when there is none.
+   * Returns the new enabled value.
+   */
   toggleSubtitles(forceShow?: boolean): boolean;
   /** Select a captions/subtitles track by menu value, or disable with `"off"`. */
   selectSubtitlesTrack(value: string): void;


### PR DESCRIPTION
Fixes #2032

## Summary

Toggling captions on a source with multiple subtitle/caption tracks turned on every language at once. `toggleSubtitles()` now remembers the track the user last had showing and restores just that one.

## Changes

- `toggleSubtitles()` shows at most one caption/subtitle track. Turning captions off records the track that was showing; turning them back on restores it.
- With nothing remembered (first toggle on a fresh source), it falls back to the first track in captions-menu order instead of enabling all of them.
- `toggleSubtitles(true)` while a track is already showing is now a no-op rather than enabling every other language, and it normalizes a multi-showing state down to one track.
- Selecting a track through the captions menu (`selectSubtitlesTrack`) updates the remembered track, so `c` off/on restores the menu choice.
- Documented the restore semantics on the `MediaTextTrackState.toggleSubtitles` contract.

<details>
<summary>Implementation details</summary>

The remembered track id lives in the `textTrack` feature state closure, so it is per player store and needs no new public state field. Both actions now share one helper that pairs caption/subtitle tracks with the same stable ids exposed through `textTrackList` (keeping `selectSubtitlesTrack` values valid) and orders them like the captions menu, plus a `showOnly()` helper that enables one track and disables the rest.

This also improves the hls.js path: `HlsJsMediaTextTracksMixin` resolves the active hls.js subtitle track from the first `showing` text track, which was ambiguous while every track was showing.

</details>

## Testing

`pnpm -F @videojs/core test` — new cases cover restoring the previously showing track, restoring a menu selection after `off`, `toggleSubtitles(true)` not enabling extra tracks, and the fallback when the remembered track is gone after a source change. Also ran the `@videojs/media`, `@videojs/html`, and `@videojs/react` suites plus `pnpm typecheck`.

Manual: load a source with two caption languages, select one, press `c` twice — only the selected language returns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core caption toggle and track-selection behavior used by keyboard shortcuts and the captions UI; logic is well-tested but affects hls.js active-subtitle resolution when multiple tracks were previously showing.
> 
> **Overview**
> Fixes **multi-language captions turning on at once** when using the `c` shortcut or `toggleSubtitles()`. The text-track feature now keeps **at most one** caption/subtitle track in `showing` mode and stores the last active track id in feature closure state.
> 
> **`toggleSubtitles()`** turns all caption/subtitle tracks off when disabling; when enabling, it restores the track that was showing, the one chosen via **`selectSubtitlesTrack()`**, or the **first track in captions-menu order** (captions before subtitles). **`toggleSubtitles(true)`** no longer enables every language—it leaves the current track alone or collapses a bad multi-showing state to a single track. If the remembered track disappears after a source change, it falls back to the first available track.
> 
> Shared helpers **`getSubtitlesTracks`** and **`showOnly`** align track ids with `textTrackList` and menu ordering. The **`MediaTextTrackState.toggleSubtitles`** contract documents the restore behavior. Tests cover restore, menu selection, forced show, and stale-track fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0752e6941abecf9a699f51b206398ffaeec58ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->