### PR TITLE
fix(media): raise hls.js preload buffer limits without restarting the load

### DIFF
--- a/packages/media/src/dom/hls-js/preload.ts
+++ b/packages/media/src/dom/hls-js/preload.ts
@@ -9,8 +9,11 @@ export type PreloadType = '' | 'none' | 'metadata' | 'auto';
  * attribute to hls.js `startLoad` / buffer-limit configuration.
  *
  * - `'auto'` or already playing → full buffer limits, immediate start.
- * - `'metadata'` → minimal buffer (1 byte / 1 second), deferred full load on play.
- * - `'none'` / `''` → no start, deferred full load on play.
+ * - `'metadata'` → minimal buffer (1 byte / 1 second), limits raised on play.
+ * - `'none'` / `''` → no start, deferred load on play.
+ *
+ * Loading is started at most once per source. Widening the limits afterwards is
+ * a plain config write, never a second `startLoad()`.
  */
 export function HlsJsMediaPreloadMixin<Base extends Constructor<HlsEngineHost>>(BaseClass: Base) {
   class HlsJsMediaPreload extends (BaseClass as Constructor<HlsEngineHost>) {
@@ -18,11 +21,17 @@ export function HlsJsMediaPreloadMixin<Base extends Constructor<HlsEngineHost>>(
     #preload: PreloadType = 'metadata';
     #defaultMaxBufferLength: number | undefined;
     #defaultMaxBufferSize: number | undefined;
+    #loadStarted = false;
 
     constructor(...args: any[]) {
       super(...args);
 
-      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => this.#init());
+      this.engine?.on(Hls.Events.MANIFEST_LOADING, () => {
+        // `loadSource()` stops loading before announcing the manifest, so the
+        // next start for this source has to be a real `startLoad()` again.
+        this.#loadStarted = false;
+        this.#init();
+      });
       this.engine?.on(Hls.Events.MEDIA_ATTACHED, () => this.#init());
       this.engine?.on(Hls.Events.MEDIA_DETACHED, () => this.#destroy());
       this.engine?.on(Hls.Events.DESTROYING, () => this.#destroy());
@@ -40,6 +49,7 @@ export function HlsJsMediaPreloadMixin<Base extends Constructor<HlsEngineHost>>(
     #destroy(): void {
       this.#preloadAbort?.abort();
       this.#preloadAbort = null;
+      this.#loadStarted = false;
     }
 
     #init(): void {
@@ -62,25 +72,45 @@ export function HlsJsMediaPreloadMixin<Base extends Constructor<HlsEngineHost>>(
       const defaultLength = this.#defaultMaxBufferLength;
       const defaultSize = this.#defaultMaxBufferSize;
 
-      const startLoad = (length?: number, size?: number) => {
+      /**
+       * Applies buffer limits, and starts loading only if this source has not
+       * been started yet.
+       *
+       * Once loading is under way, writing the limits is enough: hls.js reads
+       * both off `config` on every tick and its ticker is already armed. A
+       * second `startLoad()` would open with hls.js's own `stopLoad()`, which
+       * aborts the in-flight segment — and that abort resets the controller to
+       * IDLE a task later, so the next tick re-requests and re-aborts, forever.
+       */
+      const load = (length?: number, size?: number) => {
         const { engine } = this;
         if (!engine) return;
+
         engine.config.maxBufferLength = length ?? defaultLength;
         engine.config.maxBufferSize = size ?? defaultSize;
+
+        if (this.#loadStarted) {
+          // No-op unless something paused buffering; ManagedMediaSource does,
+          // on `endstreaming`.
+          engine.resumeBuffering?.();
+          return;
+        }
+
+        this.#loadStarted = true;
         engine.startLoad();
       };
 
       if (this.preload === 'auto' || !target.paused) {
-        startLoad();
+        load();
         return;
       }
 
       if (this.preload === 'metadata') {
-        startLoad(1, 1);
+        load(1, 1);
       }
 
       this.#preloadAbort = new AbortController();
-      target.addEventListener('play', () => startLoad(), {
+      target.addEventListener('play', () => load(), {
         signal: this.#preloadAbort.signal,
         once: true,
       });

--- a/packages/media/src/dom/hls-js/tests/preload.test.ts
+++ b/packages/media/src/dom/hls-js/tests/preload.test.ts
@@ -22,6 +22,7 @@ function createEngine(): Hls {
       for (const fn of listeners.get(event) ?? []) fn(event, ...args);
     },
     startLoad: vi.fn(),
+    resumeBuffering: vi.fn(),
     media: null,
   } as unknown as Hls;
 }
@@ -114,7 +115,9 @@ describe('HlsJsMediaPreloadMixin', () => {
     expect(engine.config.maxBufferSize).toBe(1);
   });
 
-  it('defers full load to play event when preload=metadata', () => {
+  it('raises buffer limits in place on play when preload=metadata', () => {
+    // A second `startLoad()` would abort the in-flight segment and leave hls.js
+    // cancelling and re-requesting on every tick, forever. See #1979.
     const engine = createEngine();
     const host = new PreloadHost(engine);
 
@@ -128,9 +131,61 @@ describe('HlsJsMediaPreloadMixin', () => {
 
     video.dispatchEvent(new Event('play'));
 
-    expect(engine.startLoad).toHaveBeenCalled();
+    expect(engine.startLoad).not.toHaveBeenCalled();
+    expect(engine.resumeBuffering).toHaveBeenCalled();
     expect(engine.config.maxBufferLength).toBe(30);
     expect(engine.config.maxBufferSize).toBe(60_000_000);
+  });
+
+  it('starts loading on play when preload=none', () => {
+    const engine = createEngine();
+    const host = new PreloadHost(engine);
+
+    host.preload = 'none';
+
+    const video = document.createElement('video');
+    host.attach(video);
+    (engine as any).emit(Hls.Events.MEDIA_ATTACHED);
+
+    expect(engine.startLoad).not.toHaveBeenCalled();
+
+    video.dispatchEvent(new Event('play'));
+
+    expect(engine.startLoad).toHaveBeenCalledTimes(1);
+    expect(engine.config.maxBufferLength).toBe(30);
+    expect(engine.config.maxBufferSize).toBe(60_000_000);
+  });
+
+  it('starts loading once across repeated engine events', () => {
+    const engine = createEngine();
+    const host = new PreloadHost(engine);
+
+    host.preload = 'metadata';
+
+    const video = document.createElement('video');
+    host.attach(video);
+    (engine as any).emit(Hls.Events.MANIFEST_LOADING);
+    (engine as any).emit(Hls.Events.MEDIA_ATTACHED);
+
+    expect(engine.startLoad).toHaveBeenCalledTimes(1);
+    expect(engine.config.maxBufferLength).toBe(1);
+  });
+
+  it('starts loading again for a new source', () => {
+    const engine = createEngine();
+    const host = new PreloadHost(engine);
+
+    host.preload = 'metadata';
+
+    const video = document.createElement('video');
+    host.attach(video);
+    (engine as any).emit(Hls.Events.MEDIA_ATTACHED);
+    (engine.startLoad as ReturnType<typeof vi.fn>).mockClear();
+
+    // `loadSource()` stops loading before announcing the manifest.
+    (engine as any).emit(Hls.Events.MANIFEST_LOADING);
+
+    expect(engine.startLoad).toHaveBeenCalledTimes(1);
   });
 
   it('applies preload to native element immediately when target exists', () => {


### PR DESCRIPTION
Fixes #1979

## Summary

With `preload="metadata"`, pressing play while the first init segment is still in flight put hls.js into an unbounded request/abort loop and playback never started. The preload mixin restored its clamped buffer limits by calling `startLoad()` a second time, and `Hls.startLoad()` opens with `stopLoad()` — aborting the segment that was already loading.

The abort's rejection lands a task later and resets the stream controller to `IDLE`, by which point a replacement request is open; the next 100ms tick then cancels that one too. Nothing bounds it, because no retry counter is involved. Any origin with TTFB above one tick reproduces it — a cold CDN is enough.

## Changes

- Buffer limits are now raised in place on `play` instead of restarting the load, so nothing in flight is aborted.
- Loading is started at most once per source. `preload="none"` still calls `startLoad()` on play, since `autoStartLoad` is off and nothing else would begin a load.
- `resumeBuffering()` is called when the limits are widened, which matters under ManagedMediaSource where `buffer-controller` pauses buffering on `endstreaming`.
- Initialization is idempotent: it runs on both `MANIFEST_LOADING` and `MEDIA_ATTACHED`, and previously every run started a load.

<details>
<summary>Implementation details</summary>

`getMaxBufferLength()` reads `config.maxBufferLength` / `config.maxBufferSize` on every tick, and the ticker is already armed once loading has begun, so writing the two values is all that is needed to lift the metadata clamp — no `stopLoad`, nothing to cancel.

A `#loadStarted` flag distinguishes "clamped and running" from "never started". It resets on `MANIFEST_LOADING`, since `loadSource()` stops loading before announcing the new manifest, so the next start for that source is a real `startLoad()` again, and on detach/destroy.

The second `MEDIA_ATTACHED` case is worth calling out separately from the issue: `loadSource()` re-attaches media on a source change and `MEDIA_ATTACHED` is async, so a run landing after fragment loading had begun could trigger the same abort loop with no user gesture involved — including on `preload="auto"`, which has no `play` listener at all.

</details>

## Testing

`pnpm -F @videojs/media test` (582 passing) and `pnpm typecheck`.

`preload.test.ts` now asserts that `play` under `preload="metadata"` widens the limits without a second `startLoad()`, that `preload="none"` still starts on play, that repeated engine events start loading once, and that a new source starts again.

Not covered automatically: the network-level reproduction needs an origin that holds init segments past one tick, and `apps/e2e` has no request-interception harness today. Manual check — serve an fMP4 ladder with ~300ms TTFB on segments, press play mid-request, and confirm there are no canceled 0-byte segment requests and that the ABR ladder still climbs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core HLS loading and buffering behavior, but the change is narrowly scoped to avoid duplicate startLoad() and is covered by expanded unit tests.
> 
> **Overview**
> Fixes **#1979**: with `preload="metadata"`, pressing play while the first segment was still loading could trap hls.js in an endless request/abort loop because widening buffers called **`startLoad()` again**, which internally **`stopLoad()`**s and cancels the in-flight fetch.
> 
> The HLS preload mixin now calls **`startLoad()` at most once per source**. On play (or when limits need widening), it only updates **`maxBufferLength` / `maxBufferSize`** and optionally **`resumeBuffering()`**—no second start. **`#loadStarted`** resets on **`MANIFEST_LOADING`** (new source) and detach/destroy so idempotent **`MANIFEST_LOADING` + `MEDIA_ATTACHED`** init does not double-start.
> 
> Tests assert metadata play widens limits without a second **`startLoad()`**, **`preload="none"`** still starts on play, repeated events start once, and a new manifest triggers a fresh start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7050a304a6c1b3a8e7eaab7089b7284a4a388d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->