### PR TITLE
refactor(react)!: simplify createPlayer and preset exports

### DIFF
--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -201,30 +201,27 @@ function reactVideoPage(media: string, resource: string, config: MediaTypeConfig
 
   const isDefaultVideo = media === 'video';
   const mediaImport = isDefaultVideo
-    ? `import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';`
-    : `import { ${reactMedia.component} } from '${reactMedia.importPath}';\nimport { VideoSkin, videoFeatures } from '@videojs/react/video';`;
+    ? `import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';`
+    : `import { ${reactMedia.component} } from '${reactMedia.importPath}';\nimport { VideoPlayer, VideoSkin } from '@videojs/react/video';`;
 
   const posterProp = config.hasPoster ? ` poster={MEDIA.${resource}.poster}` : '';
   const storyboardTrack = config.hasStoryboard
     ? `\n          <track kind="metadata" label="thumbnails" src={MEDIA.${resource}.storyboard} default />`
     : '';
 
-  return `import { createPlayer } from '@videojs/react';
-${mediaImport}
+  return `${mediaImport}
 import '@videojs/react/video/skin.css';
 import { createRoot } from 'react-dom/client';
 import { MEDIA } from '../resources';
 
-const Player = createPlayer({ features: videoFeatures });
-
 function App() {
   return (
-    <Player.Provider>
+    <VideoPlayer.Provider>
       <VideoSkin${posterProp} style={{ maxWidth: 800, aspectRatio: '16/9' }}>
         <${reactMedia.component} src={MEDIA.${resource}.url} playsInline crossOrigin="anonymous">${storyboardTrack}
         </${reactMedia.component}>
       </VideoSkin>
-    </Player.Provider>
+    </VideoPlayer.Provider>
   );
 }
 
@@ -238,24 +235,21 @@ function reactAudioPage(media: string, resource: string): string {
 
   const isDefaultAudio = media === 'audio';
   const mediaImport = isDefaultAudio
-    ? `import { Audio, AudioSkin, audioFeatures } from '@videojs/react/audio';`
-    : `import { ${reactMedia.component} } from '${reactMedia.importPath}';\nimport { AudioSkin, audioFeatures } from '@videojs/react/audio';`;
+    ? `import { Audio, AudioPlayer, AudioSkin } from '@videojs/react/audio';`
+    : `import { ${reactMedia.component} } from '${reactMedia.importPath}';\nimport { AudioPlayer, AudioSkin } from '@videojs/react/audio';`;
 
-  return `import { createPlayer } from '@videojs/react';
-${mediaImport}
+  return `${mediaImport}
 import '@videojs/react/audio/skin.css';
 import { createRoot } from 'react-dom/client';
 import { MEDIA } from '../resources';
 
-const Player = createPlayer({ features: audioFeatures });
-
 function App() {
   return (
-    <Player.Provider>
+    <AudioPlayer.Provider>
       <AudioSkin style={{ maxWidth: 600, margin: '0 auto' }}>
         <${reactMedia.component} src={MEDIA.${resource}.url} />
       </AudioSkin>
-    </Player.Provider>
+    </AudioPlayer.Provider>
   );
 }
 

--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -216,12 +216,12 @@ import { MEDIA } from '../resources';
 
 function App() {
   return (
-    <VideoPlayer.Provider>
+    <VideoPlayer>
       <VideoSkin${posterProp} style={{ maxWidth: 800, aspectRatio: '16/9' }}>
         <${reactMedia.component} src={MEDIA.${resource}.url} playsInline crossOrigin="anonymous">${storyboardTrack}
         </${reactMedia.component}>
       </VideoSkin>
-    </VideoPlayer.Provider>
+    </VideoPlayer>
   );
 }
 
@@ -245,11 +245,11 @@ import { MEDIA } from '../resources';
 
 function App() {
   return (
-    <AudioPlayer.Provider>
+    <AudioPlayer>
       <AudioSkin style={{ maxWidth: 600, margin: '0 auto' }}>
         <${reactMedia.component} src={MEDIA.${resource}.url} />
       </AudioSkin>
-    </AudioPlayer.Provider>
+    </AudioPlayer>
   );
 }
 

--- a/apps/sandbox/app/shared/react/players.ts
+++ b/apps/sandbox/app/shared/react/players.ts
@@ -5,24 +5,24 @@ import { liveAudioFeatures } from '@videojs/react/live-audio';
 import { liveVideoFeatures } from '@videojs/react/live-video';
 import { videoFeatures } from '@videojs/react/video';
 
-export const { Provider: VideoProvider } = createPlayer({
+export const { Player: VideoPlayer } = createPlayer({
   features: [...videoFeatures, features.orientationLock],
 });
 
-export const { Provider: AudioProvider } = createPlayer({
+export const { Player: AudioPlayer } = createPlayer({
   features: audioFeatures,
 });
 
-export const { Provider: BackgroundVideoProvider } = createPlayer({
+export const { Player: BackgroundVideoPlayer } = createPlayer({
   features: backgroundFeatures,
 });
 
-// Live providers register `liveFeature` so the LiveButton can read
+// Live players register `liveFeature` so the LiveButton can read
 // `liveEdgeStart` / `targetLiveWindow` and seek to the live edge.
-export const { Provider: LiveVideoProvider } = createPlayer({
+export const { Player: LiveVideoPlayer } = createPlayer({
   features: liveVideoFeatures,
 });
 
-export const { Provider: LiveAudioProvider } = createPlayer({
+export const { Player: LiveAudioPlayer } = createPlayer({
   features: liveAudioFeatures,
 });

--- a/apps/sandbox/templates/hls-video-react/main.tsx
+++ b/apps/sandbox/templates/hls-video-react/main.tsx
@@ -13,7 +13,7 @@ import { HlsVideo } from '@videojs/react/media/hls-video';
 import { videoFeatures } from '@videojs/react/video';
 import { createRoot } from 'react-dom/client';
 
-const { Provider } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 const buttonStyle: React.CSSProperties = {
   background: 'none',
@@ -28,7 +28,7 @@ const buttonStyle: React.CSSProperties = {
 
 function App() {
   return (
-    <Provider>
+    <Player>
       <div
         style={{
           display: 'inline-flex',
@@ -64,7 +64,7 @@ function App() {
           />
         </div>
       </div>
-    </Provider>
+    </Player>
   );
 }
 

--- a/apps/sandbox/templates/metadata/main.tsx
+++ b/apps/sandbox/templates/metadata/main.tsx
@@ -6,7 +6,7 @@ import { Video } from '@videojs/react/video';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
-const Player = createPlayer({ features: [metadataFeature] });
+const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
 
 type ContentDataVideo = HTMLVideoElement & {
   contentData: Record<string, string | null | undefined>;
@@ -52,7 +52,7 @@ function MetadataVideo({ contentTitle }: { contentTitle: string | null | undefin
 }
 
 function PlayerPreview({ mediaTitle }: { mediaTitle: string | null | undefined }) {
-  const contentTitle = Player.usePlayer((state) => state.contentTitle);
+  const contentTitle = usePlayer((state) => state.contentTitle);
 
   return (
     <div className="relative mt-6 overflow-hidden rounded-lg bg-black shadow-lg">
@@ -127,9 +127,9 @@ function App() {
         ))}
       </fieldset>
 
-      <Player.Provider contentTitle={userTitle} defaultContentTitle={defaultTitle}>
+      <Player contentTitle={userTitle} defaultContentTitle={defaultTitle}>
         <PlayerPreview mediaTitle={mediaTitle} />
-      </Player.Provider>
+      </Player>
 
       <p className="mt-4 font-mono text-sm text-zinc-600">user ?? media ?? userDefault ?? featureDefault</p>
     </main>

--- a/apps/sandbox/templates/react-audio/main.tsx
+++ b/apps/sandbox/templates/react-audio/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { AudioProvider } from '@app/shared/react/providers';
+import { AudioPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { AudioSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -28,11 +28,11 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <AudioProvider>
+      <AudioPlayer>
         <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
           <Audio src={SOURCES[source].url} autoPlay={autoplay} muted={muted} loop={loop} preload={preload} />
         </AudioSkinComponent>
-      </AudioProvider>
+      </AudioPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-background-video/main.tsx
+++ b/apps/sandbox/templates/react-background-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import '@videojs/react/background/skin.css';
-import { BackgroundVideoProvider } from '@app/shared/react/providers';
+import { BackgroundVideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
 import { BackgroundVideo, BackgroundVideoSkin } from '@videojs/react/background';
@@ -9,11 +9,11 @@ import { createRoot } from 'react-dom/client';
 function App() {
   return (
     <SandboxI18nProvider>
-      <BackgroundVideoProvider>
+      <BackgroundVideoPlayer>
         <BackgroundVideoSkin>
           <BackgroundVideo src={BACKGROUND_VIDEO_SRC} />
         </BackgroundVideoSkin>
-      </BackgroundVideoProvider>
+      </BackgroundVideoPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-dash-video/main.tsx
+++ b/apps/sandbox/templates/react-dash-video/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { VideoProvider } from '@app/shared/react/providers';
+import { VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -30,7 +30,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <VideoProvider>
+      <VideoPlayer>
         <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
           <DashVideo
             src={SOURCES[source].url ?? ''}
@@ -45,7 +45,7 @@ function App() {
               sandbox env key is what attributes the views. */}
           <MuxData playerSoftwareName="dash-video" envKey="o9b7ge20gji31ao0rub18505f" />
         </VideoSkinComponent>
-      </VideoProvider>
+      </VideoPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-hls-audio/main.tsx
+++ b/apps/sandbox/templates/react-hls-audio/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { AudioProvider } from '@app/shared/react/providers';
+import { AudioPlayer } from '@app/shared/react/players';
 import { AudioSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
 import { useLoop } from '@app/shared/react/use-loop';
@@ -27,7 +27,7 @@ function App() {
   const preload = usePreload();
 
   return (
-    <AudioProvider>
+    <AudioPlayer>
       <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
         <HlsAudio
           src={SOURCES[source].url ?? ''}
@@ -38,7 +38,7 @@ function App() {
           crossOrigin="anonymous"
         />
       </AudioSkinComponent>
-    </AudioProvider>
+    </AudioPlayer>
   );
 }
 

--- a/apps/sandbox/templates/react-hls-background-video/main.tsx
+++ b/apps/sandbox/templates/react-hls-background-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import '@videojs/react/background/skin.css';
-import { BackgroundVideoProvider } from '@app/shared/react/providers';
+import { BackgroundVideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
 import { BackgroundVideoSkin } from '@videojs/react/background';
@@ -18,11 +18,11 @@ import { createRoot } from 'react-dom/client';
 function App() {
   return (
     <SandboxI18nProvider>
-      <BackgroundVideoProvider>
+      <BackgroundVideoPlayer>
         <BackgroundVideoSkin>
           <HlsBackgroundVideo src={HLS_BACKGROUND_VIDEO_SRC} />
         </BackgroundVideoSkin>
-      </BackgroundVideoProvider>
+      </BackgroundVideoPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-hls-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import { Chapters } from '@app/shared/react/chapters';
-import { LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
+import { LiveVideoPlayer, VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { Storyboard } from '@app/shared/react/storyboard';
@@ -33,11 +33,11 @@ function App() {
   const muted = useMuted();
   const loop = useLoop();
   const preload = usePreload();
-  const Provider = live ? LiveVideoProvider : VideoProvider;
+  const Player = live ? LiveVideoPlayer : VideoPlayer;
 
   return (
     <SandboxI18nProvider>
-      <Provider>
+      <Player>
         <VideoSkinComponent
           poster={poster}
           skin={skin}
@@ -58,7 +58,7 @@ function App() {
             <Storyboard src={storyboard} />
           </HlsVideo>
         </VideoSkinComponent>
-      </Provider>
+      </Player>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-hlsjs-video/main.tsx
+++ b/apps/sandbox/templates/react-hlsjs-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import { Chapters } from '@app/shared/react/chapters';
-import { LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
+import { LiveVideoPlayer, VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { Storyboard } from '@app/shared/react/storyboard';
@@ -33,14 +33,14 @@ function App() {
   const muted = useMuted();
   const loop = useLoop();
   const preload = usePreload();
-  const Provider = live ? LiveVideoProvider : VideoProvider;
+  const Player = live ? LiveVideoPlayer : VideoPlayer;
 
   // A source carrying DRM license servers has no room in a plain `src`.
   const { source: hlsSource, url } = SOURCES[source];
 
   return (
     <SandboxI18nProvider>
-      <Provider>
+      <Player>
         <VideoSkinComponent
           poster={poster}
           skin={skin}
@@ -61,7 +61,7 @@ function App() {
             <Storyboard src={storyboard} />
           </HlsJsVideo>
         </VideoSkinComponent>
-      </Provider>
+      </Player>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-mux-audio-spf/main.tsx
+++ b/apps/sandbox/templates/react-mux-audio-spf/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { AudioProvider } from '@app/shared/react/providers';
+import { AudioPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { AudioSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -40,7 +40,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <AudioProvider>
+      <AudioPlayer>
         <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
           <MuxAudio
             {...(muxSource ? { source: muxSource } : { src: url ?? '' })}
@@ -58,7 +58,7 @@ function App() {
           <MuxData playerSoftwareName="mux-audio" />
           <GoogleCast />
         </AudioSkinComponent>
-      </AudioProvider>
+      </AudioPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-mux-audio/main.tsx
+++ b/apps/sandbox/templates/react-mux-audio/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { AudioProvider } from '@app/shared/react/providers';
+import { AudioPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { AudioSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -35,7 +35,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <AudioProvider>
+      <AudioPlayer>
         <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
           <MuxAudio
             {...(muxSource ? { source: muxSource } : { src: url ?? '' })}
@@ -49,7 +49,7 @@ function App() {
           <MuxData playerSoftwareName="mux-audio" />
           <GoogleCast />
         </AudioSkinComponent>
-      </AudioProvider>
+      </AudioPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-mux-background-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-background-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import '@videojs/react/background/skin.css';
-import { BackgroundVideoProvider } from '@app/shared/react/providers';
+import { BackgroundVideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
 import { BackgroundVideoSkin } from '@videojs/react/background';
@@ -16,11 +16,11 @@ import { createRoot } from 'react-dom/client';
 function App() {
   return (
     <SandboxI18nProvider>
-      <BackgroundVideoProvider>
+      <BackgroundVideoPlayer>
         <BackgroundVideoSkin>
           <MuxBackgroundVideo src={`${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p`} />
         </BackgroundVideoSkin>
-      </BackgroundVideoProvider>
+      </BackgroundVideoPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-mux-video-spf/main.tsx
+++ b/apps/sandbox/templates/react-mux-video-spf/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
+import { LiveVideoPlayer, VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -41,7 +41,7 @@ function App() {
   const muted = useMuted();
   const loop = useLoop();
   const preload = usePreload();
-  const Provider = live ? LiveVideoProvider : VideoProvider;
+  const Player = live ? LiveVideoPlayer : VideoPlayer;
 
   // A source carrying signed tokens has no room in a plain `src`. A `drm.token`
   // is accepted but inert on this flavor.
@@ -49,7 +49,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
+      <Player>
         <VideoSkinComponent
           poster={poster}
           placeholder={placeholder}
@@ -72,7 +72,7 @@ function App() {
           <MuxData playerSoftwareName="mux-video" />
           <GoogleCast />
         </VideoSkinComponent>
-      </Provider>
+      </Player>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-mux-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import { Chapters } from '@app/shared/react/chapters';
-import { LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
+import { LiveVideoPlayer, VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useAutoplay } from '@app/shared/react/use-autoplay';
@@ -34,7 +34,7 @@ function App() {
   const muted = useMuted();
   const loop = useLoop();
   const preload = usePreload();
-  const Provider = live ? LiveVideoProvider : VideoProvider;
+  const Player = live ? LiveVideoPlayer : VideoPlayer;
 
   // A source carrying signed tokens has no room in a plain `src`. A Mux
   // `drm.token` becomes the FairPlay / Widevine / PlayReady license servers.
@@ -42,7 +42,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
+      <Player>
         <VideoSkinComponent
           poster={poster}
           placeholder={placeholder}
@@ -67,7 +67,7 @@ function App() {
           <MuxData playerSoftwareName="mux-video" />
           <GoogleCast />
         </VideoSkinComponent>
-      </Provider>
+      </Player>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-native-hls-video/main.tsx
+++ b/apps/sandbox/templates/react-native-hls-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import { Chapters } from '@app/shared/react/chapters';
-import { LiveVideoProvider, VideoProvider } from '@app/shared/react/providers';
+import { LiveVideoPlayer, VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { Storyboard } from '@app/shared/react/storyboard';
@@ -33,7 +33,7 @@ function App() {
   const muted = useMuted();
   const loop = useLoop();
   const preload = usePreload();
-  const Provider = live ? LiveVideoProvider : VideoProvider;
+  const Player = live ? LiveVideoPlayer : VideoPlayer;
 
   // A source carrying DRM license servers has no room in a plain `src`. Only the
   // FairPlay entry of its `drm` is read here — the systems the same object names
@@ -42,7 +42,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <Provider>
+      <Player>
         <VideoSkinComponent
           poster={poster}
           skin={skin}
@@ -63,7 +63,7 @@ function App() {
             <Storyboard src={storyboard} />
           </NativeHlsVideo>
         </VideoSkinComponent>
-      </Provider>
+      </Player>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-video/main.tsx
+++ b/apps/sandbox/templates/react-video/main.tsx
@@ -1,6 +1,6 @@
 import '@app/styles.css';
 import { Chapters } from '@app/shared/react/chapters';
-import { VideoProvider } from '@app/shared/react/providers';
+import { VideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { Storyboard } from '@app/shared/react/storyboard';
@@ -34,7 +34,7 @@ function App() {
 
   return (
     <SandboxI18nProvider>
-      <VideoProvider>
+      <VideoPlayer>
         <VideoSkinComponent poster={poster} skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
           <Video
             src={SOURCES[source].url}
@@ -49,7 +49,7 @@ function App() {
             <Storyboard src={storyboard} />
           </Video>
         </VideoSkinComponent>
-      </VideoProvider>
+      </VideoPlayer>
     </SandboxI18nProvider>
   );
 }

--- a/apps/sandbox/templates/react-vimeo-video/main.tsx
+++ b/apps/sandbox/templates/react-vimeo-video/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { VideoProvider } from '@app/shared/react/providers';
+import { VideoPlayer } from '@app/shared/react/players';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSkin } from '@app/shared/react/use-skin';
 import { VIMEO_VIDEO_SRC } from '@app/shared/sources';
@@ -17,11 +17,11 @@ function App() {
   const styling = useMemo(readStyling, []);
 
   return (
-    <VideoProvider>
+    <VideoPlayer>
       <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <VimeoVideo className="block w-full h-full" src={VIMEO_VIDEO_SRC} playsInline />
       </VideoSkinComponent>
-    </VideoProvider>
+    </VideoPlayer>
   );
 }
 

--- a/apps/sandbox/templates/react-youtube-video/main.tsx
+++ b/apps/sandbox/templates/react-youtube-video/main.tsx
@@ -1,5 +1,5 @@
 import '@app/styles.css';
-import { VideoProvider } from '@app/shared/react/providers';
+import { VideoPlayer } from '@app/shared/react/players';
 import { VideoSkinComponent } from '@app/shared/react/skins';
 import { useSkin } from '@app/shared/react/use-skin';
 import { YOUTUBE_VIDEO_SRC } from '@app/shared/sources';
@@ -17,11 +17,11 @@ function App() {
   const styling = useMemo(readStyling, []);
 
   return (
-    <VideoProvider>
+    <VideoPlayer>
       <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <YouTubeVideo className="block w-full h-full" src={YOUTUBE_VIDEO_SRC} playsInline />
       </VideoSkinComponent>
-    </VideoProvider>
+    </VideoPlayer>
   );
 }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -73,7 +73,7 @@ export {
   type CreatePlayerConfig,
   type CreatePlayerResult,
   createPlayer,
-  type ProviderProps,
+  type PlayerProps,
 } from './player/create-player';
 // UI
 export { AirPlayButton, type AirPlayButtonProps } from './ui/airplay-button/airplay-button';

--- a/packages/react/src/media/google-cast/google-cast.tsx
+++ b/packages/react/src/media/google-cast/google-cast.tsx
@@ -12,16 +12,16 @@ export type GoogleCastProps = Partial<GoogleCastComponentProps>;
 /**
  * Adds Google Cast support to the surrounding player's media.
  *
- * Renders nothing — place it inside the player provider as a sibling of the
+ * Renders nothing — place it inside the Player as a sibling of the
  * media component (e.g. `<HlsJsVideo />`) and it registers a `GoogleCast`
  * media component with the active media.
  *
  * @example
  * ```tsx
- * <Player.Provider>
+ * <Player>
  *   <HlsJsVideo src="https://example.com/stream.m3u8" />
  *   <GoogleCast receiver="YOUR_APP_ID" />
- * </Player.Provider>
+ * </Player>
  * ```
  */
 export function GoogleCast(props: GoogleCastProps): ReactNode {

--- a/packages/react/src/media/mux-data/mux-data.tsx
+++ b/packages/react/src/media/mux-data/mux-data.tsx
@@ -13,7 +13,7 @@ export type MuxDataProps = Partial<MuxDataComponentProps>;
  * Adds [Mux Data](https://www.mux.com/data) monitoring to the surrounding
  * player's media.
  *
- * Renders nothing — place it inside the player provider as a sibling of the
+ * Renders nothing — place it inside the Player as a sibling of the
  * media component (e.g. `<MuxVideo />`) and it registers a `MuxData` media
  * component with the active media.
  *
@@ -27,10 +27,10 @@ export type MuxDataProps = Partial<MuxDataComponentProps>;
  *
  * @example
  * ```tsx
- * <Player.Provider>
+ * <Player>
  *   <MuxVideo source={{ playbackId: 'abc123' }} />
  *   <MuxData playerSoftwareName="mux-video" />
- * </Player.Provider>
+ * </Player>
  * ```
  */
 export function MuxData(props: MuxDataProps): ReactNode {

--- a/packages/react/src/player/context.tsx
+++ b/packages/react/src/player/context.tsx
@@ -32,15 +32,15 @@ export function PlayerContextProvider({
   return <PlayerContext.Provider value={value}>{children}</PlayerContext.Provider>;
 }
 
-/** Access the full player context value. Throws if used outside a Player Provider. */
+/** Access the full player context value. Throws if used outside a Player. */
 export function usePlayerContext(): PlayerContextValue {
   const ctx = useContext(PlayerContext);
-  if (!ctx) throw new Error('usePlayerContext must be used within a Player Provider');
+  if (!ctx) throw new Error('usePlayerContext must be used within a Player');
   return ctx;
 }
 
 /**
- * Access the player store from within a Player Provider.
+ * Access the player store from within a Player.
  *
  * This standalone hook has no knowledge of your configured features, so it
  * returns an untyped `UnknownStore` whose state properties are typed as
@@ -66,7 +66,7 @@ export function usePlayer<R>(selector?: (state: UnknownState) => R) {
 }
 
 /**
- * Access player state when available, but return `undefined` outside Provider.
+ * Access player state when available, but return `undefined` outside a Player.
  *
  * This is useful for components that can operate without player context
  * (e.g. they accept fully explicit props as a fallback).
@@ -82,19 +82,19 @@ export function useOptionalPlayer<R>(selector?: (state: UnknownState) => R) {
   return ctx ? value : undefined;
 }
 
-/** Access the media element from within a Player Provider. */
+/** Access the media element from within a Player. */
 export function useMedia(): Media | null {
   const { media } = usePlayerContext();
   return media;
 }
 
-/** Access the container element from within a Player Provider. */
+/** Access the container element from within a Player. */
 export function useContainer(): MediaContainer | null {
   const { container } = usePlayerContext();
   return container;
 }
 
-/** Access the container element when a Player Provider is available. */
+/** Access the container element when a Player is available. */
 export function useOptionalContainer(): MediaContainer | null {
   const ctx = useContext(PlayerContext);
   return ctx?.container ?? null;

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -31,14 +31,14 @@ export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
   displayName?: string;
 }
 
-export type ProviderProps<Config = object> = {
+export type PlayerProps<Config = object> = {
   [Key in keyof Config]?: Config[Key] | undefined;
 } & {
   children: ReactNode;
 };
 
 export interface CreatePlayerResult<Store extends PlayerStore> {
-  Provider: FC<ProviderProps<InferPlayerConfig<Store>>>;
+  Player: FC<PlayerProps<InferPlayerConfig<Store>>>;
   Container: typeof Container;
   usePlayer: UsePlayerHook<Store>;
   useMedia: () => Media | null;
@@ -50,7 +50,7 @@ export type UsePlayerHook<Store extends PlayerStore> = {
 };
 
 /**
- * Create a player instance with typed store, Provider component, Container, and hooks.
+ * Create a player instance with a typed Player component, Container, and hooks.
  *
  * @label Video
  * @param config - Player configuration with features and optional display name.
@@ -86,7 +86,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     return store;
   }
 
-  function Provider(props: ProviderProps<any>): ReactNode {
+  function Player(props: PlayerProps<any>): ReactNode {
     const { children } = props;
     // Only inputs declared by selected features are forwarded to store actions.
     const configValues = pick(props, configKeys);
@@ -135,7 +135,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
   }
 
   if (__DEV__ && config.displayName) {
-    Provider.displayName = `${config.displayName}.Provider`;
+    Player.displayName = config.displayName;
   }
 
   function usePlayer<R>(selector?: (state: object) => R): AnyPlayerStore | R {
@@ -144,7 +144,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
   }
 
   return {
-    Provider,
+    Player,
     Container,
     usePlayer,
     useMedia,

--- a/packages/react/src/player/tests/context.test.tsx
+++ b/packages/react/src/player/tests/context.test.tsx
@@ -42,17 +42,17 @@ function createContextValue(overrides?: Partial<PlayerContextValue>): PlayerCont
 }
 
 describe('usePlayerContext', () => {
-  it('throws outside Provider', () => {
+  it('throws outside a Player', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() => {
       renderHook(() => usePlayerContext());
-    }).toThrow('usePlayerContext must be used within a Player Provider');
+    }).toThrow('usePlayerContext must be used within a Player');
 
     consoleSpy.mockRestore();
   });
 
-  it('returns context value inside Provider', () => {
+  it('returns context value inside a Player', () => {
     const store = createMockStore();
     const value = createContextValue({ store: store as any });
 
@@ -67,12 +67,12 @@ describe('usePlayerContext', () => {
 });
 
 describe('useMediaAttach', () => {
-  it('returns undefined outside Provider', () => {
+  it('returns undefined outside a Player', () => {
     const { result } = renderHook(() => useMediaAttach());
     expect(result.current).toBeUndefined();
   });
 
-  it('returns setMedia inside Provider', () => {
+  it('returns setMedia inside a Player', () => {
     const setMedia = vi.fn();
     const value = createContextValue({ setMedia });
 
@@ -108,12 +108,12 @@ describe('useContainer', () => {
 });
 
 describe('useContainerAttach', () => {
-  it('returns undefined outside Provider', () => {
+  it('returns undefined outside a Player', () => {
     const { result } = renderHook(() => useContainerAttach());
     expect(result.current).toBeUndefined();
   });
 
-  it('returns setContainer inside Provider', () => {
+  it('returns setContainer inside a Player', () => {
     const setContainer = vi.fn();
     const value = createContextValue({ setContainer });
 
@@ -126,12 +126,12 @@ describe('useContainerAttach', () => {
 });
 
 describe('useOptionalContainer', () => {
-  it('returns null outside Provider', () => {
+  it('returns null outside a Player', () => {
     const { result } = renderHook(() => useOptionalContainer());
     expect(result.current).toBeNull();
   });
 
-  it('returns container inside Provider', () => {
+  it('returns container inside a Player', () => {
     const container = document.createElement('div');
     const value = createContextValue({ container });
 
@@ -157,24 +157,24 @@ describe('usePlayer', () => {
 });
 
 describe('useOptionalPlayer', () => {
-  it('returns undefined outside Provider', () => {
+  it('returns undefined outside a Player', () => {
     const { result } = renderHook(() => useOptionalPlayer());
     expect(result.current).toBeUndefined();
   });
 
-  it('returns undefined outside Provider with selector', () => {
+  it('returns undefined outside a Player with selector', () => {
     const { result } = renderHook(() => useOptionalPlayer((state: any) => state.paused));
     expect(result.current).toBeUndefined();
   });
 
-  it('does not run selector outside Provider', () => {
+  it('does not run selector outside a Player', () => {
     const selector = vi.fn(() => true);
     const { result } = renderHook(() => useOptionalPlayer(selector));
     expect(result.current).toBeUndefined();
     expect(selector).not.toHaveBeenCalled();
   });
 
-  it('returns store inside Provider', () => {
+  it('returns store inside a Player', () => {
     const store = createMockStore();
     const value = createContextValue({ store: store as any });
 
@@ -185,7 +185,7 @@ describe('useOptionalPlayer', () => {
     expect(result.current).toBe(store);
   });
 
-  it('returns selected state inside Provider', () => {
+  it('returns selected state inside a Player', () => {
     const store = createMockStore({ paused: true });
     const value = createContextValue({ store: store as any });
 

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -51,14 +51,14 @@ describe('createPlayer', () => {
     const withMetadata = createPlayer({ features: [metadataFeature] });
     const withoutMetadata = createPlayer({ features: [features.playback] });
 
-    <withMetadata.Provider contentTitle="Title" defaultContentTitle={null}>
+    <withMetadata.Player contentTitle="Title" defaultContentTitle={null}>
       <div />
-    </withMetadata.Provider>;
+    </withMetadata.Player>;
 
     // @ts-expect-error metadata props are absent when the feature is absent.
-    <withoutMetadata.Provider contentTitle="Title">
+    <withoutMetadata.Player contentTitle="Title">
       <div />
-    </withoutMetadata.Provider>;
+    </withoutMetadata.Player>;
   });
 
   it('accepts the orientation lock feature alias with and without config', () => {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -22,9 +22,9 @@ describe('createPlayer', () => {
     }),
   });
 
-  describe('Provider', () => {
+  describe('Player', () => {
     it('creates store on mount', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
       let store!: PlayerStore;
 
@@ -34,9 +34,9 @@ describe('createPlayer', () => {
       }
 
       render(
-        <Provider>
+        <Player>
           <TestComponent />
-        </Provider>
+        </Player>
       );
 
       expect(store).toBeDefined();
@@ -48,7 +48,7 @@ describe('createPlayer', () => {
     it('destroys store on unmount', () => {
       vi.useFakeTimers();
 
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
       let store!: PlayerStore;
 
@@ -58,9 +58,9 @@ describe('createPlayer', () => {
       }
 
       const { unmount } = render(
-        <Provider>
+        <Player>
           <TestComponent />
-        </Provider>
+        </Player>
       );
 
       const destroySpy = vi.spyOn(store, 'destroy');
@@ -73,7 +73,7 @@ describe('createPlayer', () => {
     });
 
     it('recovers after Activity-style async destroy (React <Activity>)', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
       let store!: PlayerStore;
       // Captured inside TestComponent so we can trigger a media-dep change
@@ -88,9 +88,9 @@ describe('createPlayer', () => {
       }
 
       render(
-        <Provider>
+        <Player>
           <TestComponent />
-        </Provider>
+        </Player>
       );
 
       const originalStore = store;
@@ -114,7 +114,7 @@ describe('createPlayer', () => {
     });
 
     it('seeds current config inputs when replacing a destroyed store', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
+      const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
       let setMedia!: (media: HTMLMediaElement | null) => void;
 
@@ -125,9 +125,9 @@ describe('createPlayer', () => {
       }
 
       render(
-        <Provider contentTitle="Replacement title">
+        <Player contentTitle="Replacement title">
           <Consumer />
-        </Provider>
+        </Player>
       );
 
       const destroyedStore = store;
@@ -140,7 +140,7 @@ describe('createPlayer', () => {
     });
 
     it('survives React StrictMode without StoreError', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
       let store!: PlayerStore;
 
@@ -152,9 +152,9 @@ describe('createPlayer', () => {
       expect(() => {
         render(
           <StrictMode>
-            <Provider>
+            <Player>
               <TestComponent />
-            </Provider>
+            </Player>
           </StrictMode>
         );
       }).not.toThrow();
@@ -166,7 +166,7 @@ describe('createPlayer', () => {
     it('StrictMode: preserves the same store instance and cancels the pending destroy', () => {
       vi.useFakeTimers();
 
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
       // Track every store instance the component sees across all renders.
       const seenStores = new Set<PlayerStore>();
@@ -180,9 +180,9 @@ describe('createPlayer', () => {
 
       render(
         <StrictMode>
-          <Provider>
+          <Player>
             <TestComponent />
-          </Provider>
+          </Player>
         </StrictMode>
       );
 
@@ -200,28 +200,28 @@ describe('createPlayer', () => {
     });
 
     it('uses displayName when provided', () => {
-      const { Provider } = createPlayer({
+      const { Player } = createPlayer({
         features: [mockSlice],
         displayName: 'VideoPlayer',
       });
 
-      expect(Provider.displayName).toBe('VideoPlayer.Provider');
+      expect(Player.displayName).toBe('VideoPlayer');
     });
 
     it('renders children', () => {
-      const { Provider } = createPlayer({ features: [mockSlice] });
+      const { Player } = createPlayer({ features: [mockSlice] });
 
       const { container } = render(
-        <Provider>
+        <Player>
           <span data-testid="child">test</span>
-        </Provider>
+        </Player>
       );
 
       expect(container.querySelector('[data-testid="child"]')).toBeTruthy();
     });
 
     it('seeds config inputs for the first render and syncs only changed props after commit', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
+      const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
 
       function Consumer() {
@@ -230,37 +230,37 @@ describe('createPlayer', () => {
       }
 
       const { rerender } = render(
-        <Provider contentTitle="Initial title">
+        <Player contentTitle="Initial title">
           <Consumer />
-        </Provider>
+        </Player>
       );
 
       expect(screen.getByText('Initial title')).toBeTruthy();
 
       act(() => store.setDefaultContentTitle('Imperative fallback'));
       rerender(
-        <Provider contentTitle="Initial title">
+        <Player contentTitle="Initial title">
           <Consumer />
-        </Provider>
+        </Player>
       );
 
       rerender(
-        <Provider contentTitle="Updated title">
+        <Player contentTitle="Updated title">
           <Consumer />
-        </Provider>
+        </Player>
       );
       expect(store.contentTitle).toBe('Updated title');
 
       rerender(
-        <Provider>
+        <Player>
           <Consumer />
-        </Provider>
+        </Player>
       );
       expect(store.contentTitle).toBe('Imperative fallback');
     });
 
     it('seeds config inputs during SSR', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
+      const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
         return <span>{usePlayer((state) => state.contentTitle)}</span>;
@@ -268,15 +268,15 @@ describe('createPlayer', () => {
 
       expect(
         renderToString(
-          <Provider contentTitle="SSR title">
+          <Player contentTitle="SSR title">
             <Consumer />
-          </Provider>
+          </Player>
         )
       ).toContain('SSR title');
     });
 
     it('hydrates with the same initial config inputs', async () => {
-      const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
+      const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
         return <span>{usePlayer((state) => state.contentTitle)}</span>;
@@ -284,15 +284,15 @@ describe('createPlayer', () => {
 
       const container = document.createElement('div');
       container.innerHTML = renderToString(
-        <Provider contentTitle="Hydrated title">
+        <Player contentTitle="Hydrated title">
           <Consumer />
-        </Provider>
+        </Player>
       );
 
       const view = render(
-        <Provider contentTitle="Hydrated title">
+        <Player contentTitle="Hydrated title">
           <Consumer />
-        </Provider>,
+        </Player>,
         { container, hydrate: true }
       );
 
@@ -304,7 +304,7 @@ describe('createPlayer', () => {
     });
 
     it('does not apply config inputs from an abandoned render', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [metadataFeature] });
+      const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
       let store!: PlayerStore<[typeof metadataFeature]>;
 
       class Boundary extends Component<{ children: ReactNode }, { failed: boolean }> {
@@ -330,18 +330,18 @@ describe('createPlayer', () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
       const { rerender } = render(
         <Boundary>
-          <Provider contentTitle="Committed title">
+          <Player contentTitle="Committed title">
             <Consumer />
-          </Provider>
+          </Player>
         </Boundary>
       );
       const committedStore = store;
 
       rerender(
         <Boundary>
-          <Provider contentTitle="Abandoned title">
+          <Player contentTitle="Abandoned title">
             <Consumer fail />
-          </Provider>
+          </Player>
         </Boundary>
       );
 
@@ -351,7 +351,7 @@ describe('createPlayer', () => {
 
     it('does not derive a locale without an I18nProvider', async () => {
       document.documentElement.lang = 'de';
-      const { Provider, Container } = createPlayer({ features: [mockSlice] });
+      const { Player, Container } = createPlayer({ features: [mockSlice] });
 
       function Locale() {
         const container = useContainer();
@@ -360,11 +360,11 @@ describe('createPlayer', () => {
       }
 
       render(
-        <Provider>
+        <Player>
           <Container>
             <Locale />
           </Container>
-        </Provider>
+        </Player>
       );
 
       await waitFor(() => {
@@ -373,7 +373,7 @@ describe('createPlayer', () => {
     });
 
     it('inherits an explicit I18nProvider', async () => {
-      const { Provider, Container } = createPlayer({ features: [mockSlice] });
+      const { Player, Container } = createPlayer({ features: [mockSlice] });
 
       function Locale() {
         const container = useContainer();
@@ -383,11 +383,11 @@ describe('createPlayer', () => {
 
       render(
         <I18nProvider locale="de">
-          <Provider>
+          <Player>
             <Container>
               <Locale />
             </Container>
-          </Provider>
+          </Player>
         </I18nProvider>
       );
 
@@ -397,7 +397,7 @@ describe('createPlayer', () => {
     });
 
     it('provides a stable context value across parent re-renders (fix for #1296)', () => {
-      const { Provider } = createPlayer({ features: [mockSlice] });
+      const { Player } = createPlayer({ features: [mockSlice] });
 
       const receivedValues: unknown[] = [];
 
@@ -412,9 +412,9 @@ describe('createPlayer', () => {
         const [, setTick] = useState(0);
         forceParentRerender = () => setTick((t) => t + 1);
         return (
-          <Provider>
+          <Player>
             <ContextConsumer />
-          </Provider>
+          </Player>
         );
       }
 
@@ -434,9 +434,9 @@ describe('createPlayer', () => {
 
   describe('usePlayer', () => {
     it('returns store without selector', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
-      const wrapper = ({ children }: { children: ReactNode }) => <Provider>{children}</Provider>;
+      const wrapper = ({ children }: { children: ReactNode }) => <Player>{children}</Player>;
 
       const { result } = renderHook(() => usePlayer(), { wrapper });
 
@@ -446,23 +446,23 @@ describe('createPlayer', () => {
     });
 
     it('returns selected state with selector', () => {
-      const { Provider, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
-      const wrapper = ({ children }: { children: ReactNode }) => <Provider>{children}</Provider>;
+      const wrapper = ({ children }: { children: ReactNode }) => <Player>{children}</Player>;
 
       const { result } = renderHook(() => usePlayer((state: any) => state.volume), { wrapper });
 
       expect(result.current).toBe(1);
     });
 
-    it('throws outside Provider', () => {
+    it('throws outside Player', () => {
       const { usePlayer } = createPlayer({ features: [mockSlice] });
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       expect(() => {
         renderHook(() => usePlayer());
-      }).toThrow('usePlayerContext must be used within a Player Provider');
+      }).toThrow('usePlayerContext must be used within a Player');
 
       consoleSpy.mockRestore();
     });
@@ -476,8 +476,8 @@ describe('createPlayer', () => {
   });
 
   describe('full integration', () => {
-    it('Provider → Container → media attach flow', () => {
-      const { Provider, Container, usePlayer } = createPlayer({ features: [mockSlice] });
+    it('Player → Container → media attach flow', () => {
+      const { Player, Container, usePlayer } = createPlayer({ features: [mockSlice] });
 
       let store!: PlayerStore;
 
@@ -493,9 +493,9 @@ describe('createPlayer', () => {
       }
 
       const { container } = render(
-        <Provider>
+        <Player>
           <TestComponent />
-        </Provider>
+        </Player>
       );
 
       // Store should exist

--- a/packages/react/src/presets/audio/index.ts
+++ b/packages/react/src/presets/audio/index.ts
@@ -1,7 +1,10 @@
 /** Audio-only player preset with playback and volume controls. */
+'use client';
+
 export { audioFeatures } from '@videojs/core/dom';
 export { Audio, type AudioProps } from '@/media/audio';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
+export { AudioPlayer, usePlayer } from './player';
 export * from './skin';
 export * from './skin.tailwind';

--- a/packages/react/src/presets/audio/player.ts
+++ b/packages/react/src/presets/audio/player.ts
@@ -5,10 +5,8 @@ import { createPlayer } from '../../player/create-player';
 
 const player = createPlayer({ features: audioFeatures, displayName: 'AudioPlayer' });
 
-/** Preconfigured player provider with the standard audio features. */
-export const AudioPlayer = player.Provider;
-
-if (__DEV__) AudioPlayer.displayName = 'AudioPlayer';
+/** Preconfigured player with the standard audio features. */
+export const AudioPlayer = player.Player;
 
 /** Access the standard audio player store or select a value from it. */
 export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/audio/player.ts
+++ b/packages/react/src/presets/audio/player.ts
@@ -3,8 +3,12 @@
 import { audioFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-/** Preconfigured player instance with the standard audio features. */
-export const AudioPlayer = createPlayer({ features: audioFeatures, displayName: 'AudioPlayer' });
+const player = createPlayer({ features: audioFeatures, displayName: 'AudioPlayer' });
+
+/** Preconfigured player provider with the standard audio features. */
+export const AudioPlayer = player.Provider;
+
+if (__DEV__) AudioPlayer.displayName = 'AudioPlayer';
 
 /** Access the standard audio player store or select a value from it. */
-export const usePlayer = AudioPlayer.usePlayer;
+export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/audio/player.ts
+++ b/packages/react/src/presets/audio/player.ts
@@ -3,10 +3,9 @@
 import { audioFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-const player = createPlayer({ features: audioFeatures, displayName: 'AudioPlayer' });
-
 /** Preconfigured player with the standard audio features. */
-export const AudioPlayer = player.Player;
-
-/** Access the standard audio player store or select a value from it. */
-export const usePlayer = player.usePlayer;
+export const {
+  Player: AudioPlayer,
+  /** Access the standard audio player store or select a value from it. */
+  usePlayer,
+} = createPlayer({ features: audioFeatures, displayName: 'AudioPlayer' });

--- a/packages/react/src/presets/audio/player.ts
+++ b/packages/react/src/presets/audio/player.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { audioFeatures } from '@videojs/core/dom';
+import { createPlayer } from '../../player/create-player';
+
+/** Preconfigured player instance with the standard audio features. */
+export const AudioPlayer = createPlayer({ features: audioFeatures, displayName: 'AudioPlayer' });
+
+/** Access the standard audio player store or select a value from it. */
+export const usePlayer = AudioPlayer.usePlayer;

--- a/packages/react/src/presets/background/index.ts
+++ b/packages/react/src/presets/background/index.ts
@@ -1,4 +1,7 @@
 /** Ambient background video preset with no user controls. */
+'use client';
+
 export { backgroundFeatures } from '@videojs/core/dom';
 export { BackgroundVideo, type BackgroundVideoProps } from '@/media/background-video';
+export { BackgroundVideoPlayer, usePlayer } from './player';
 export * from './skin';

--- a/packages/react/src/presets/background/player.ts
+++ b/packages/react/src/presets/background/player.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { backgroundFeatures } from '@videojs/core/dom';
+import { createPlayer } from '../../player/create-player';
+
+/** Preconfigured player instance with the background video features. */
+export const BackgroundVideoPlayer = createPlayer({
+  features: backgroundFeatures,
+  displayName: 'BackgroundVideoPlayer',
+});
+
+/** Access the background video player store or select a value from it. */
+export const usePlayer = BackgroundVideoPlayer.usePlayer;

--- a/packages/react/src/presets/background/player.ts
+++ b/packages/react/src/presets/background/player.ts
@@ -8,10 +8,8 @@ const player = createPlayer({
   displayName: 'BackgroundVideoPlayer',
 });
 
-/** Preconfigured player provider with the background video features. */
-export const BackgroundVideoPlayer = player.Provider;
-
-if (__DEV__) BackgroundVideoPlayer.displayName = 'BackgroundVideoPlayer';
+/** Preconfigured player with the background video features. */
+export const BackgroundVideoPlayer = player.Player;
 
 /** Access the background video player store or select a value from it. */
 export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/background/player.ts
+++ b/packages/react/src/presets/background/player.ts
@@ -3,13 +3,9 @@
 import { backgroundFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-const player = createPlayer({
-  features: backgroundFeatures,
-  displayName: 'BackgroundVideoPlayer',
-});
-
 /** Preconfigured player with the background video features. */
-export const BackgroundVideoPlayer = player.Player;
-
-/** Access the background video player store or select a value from it. */
-export const usePlayer = player.usePlayer;
+export const {
+  Player: BackgroundVideoPlayer,
+  /** Access the background video player store or select a value from it. */
+  usePlayer,
+} = createPlayer({ features: backgroundFeatures, displayName: 'BackgroundVideoPlayer' });

--- a/packages/react/src/presets/background/player.ts
+++ b/packages/react/src/presets/background/player.ts
@@ -3,11 +3,15 @@
 import { backgroundFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-/** Preconfigured player instance with the background video features. */
-export const BackgroundVideoPlayer = createPlayer({
+const player = createPlayer({
   features: backgroundFeatures,
   displayName: 'BackgroundVideoPlayer',
 });
 
+/** Preconfigured player provider with the background video features. */
+export const BackgroundVideoPlayer = player.Provider;
+
+if (__DEV__) BackgroundVideoPlayer.displayName = 'BackgroundVideoPlayer';
+
 /** Access the background video player store or select a value from it. */
-export const usePlayer = BackgroundVideoPlayer.usePlayer;
+export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/live-audio/index.ts
+++ b/packages/react/src/presets/live-audio/index.ts
@@ -1,7 +1,10 @@
 /** Live audio player preset — same features as `audio` with a skin that omits duration / current-time displays. */
+'use client';
+
 export { liveAudioFeatures } from '@videojs/core/dom';
 export { Audio, type AudioProps } from '@/media/audio';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
+export { LiveAudioPlayer, usePlayer } from './player';
 export * from './skin';
 export * from './skin.tailwind';

--- a/packages/react/src/presets/live-audio/player.ts
+++ b/packages/react/src/presets/live-audio/player.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { liveAudioFeatures } from '@videojs/core/dom';
+import { createPlayer } from '../../player/create-player';
+
+/** Preconfigured player instance with the live audio features. */
+export const LiveAudioPlayer = createPlayer({ features: liveAudioFeatures, displayName: 'LiveAudioPlayer' });
+
+/** Access the live audio player store or select a value from it. */
+export const usePlayer = LiveAudioPlayer.usePlayer;

--- a/packages/react/src/presets/live-audio/player.ts
+++ b/packages/react/src/presets/live-audio/player.ts
@@ -3,8 +3,12 @@
 import { liveAudioFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-/** Preconfigured player instance with the live audio features. */
-export const LiveAudioPlayer = createPlayer({ features: liveAudioFeatures, displayName: 'LiveAudioPlayer' });
+const player = createPlayer({ features: liveAudioFeatures, displayName: 'LiveAudioPlayer' });
+
+/** Preconfigured player provider with the live audio features. */
+export const LiveAudioPlayer = player.Provider;
+
+if (__DEV__) LiveAudioPlayer.displayName = 'LiveAudioPlayer';
 
 /** Access the live audio player store or select a value from it. */
-export const usePlayer = LiveAudioPlayer.usePlayer;
+export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/live-audio/player.ts
+++ b/packages/react/src/presets/live-audio/player.ts
@@ -3,10 +3,9 @@
 import { liveAudioFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-const player = createPlayer({ features: liveAudioFeatures, displayName: 'LiveAudioPlayer' });
-
 /** Preconfigured player with the live audio features. */
-export const LiveAudioPlayer = player.Player;
-
-/** Access the live audio player store or select a value from it. */
-export const usePlayer = player.usePlayer;
+export const {
+  Player: LiveAudioPlayer,
+  /** Access the live audio player store or select a value from it. */
+  usePlayer,
+} = createPlayer({ features: liveAudioFeatures, displayName: 'LiveAudioPlayer' });

--- a/packages/react/src/presets/live-audio/player.ts
+++ b/packages/react/src/presets/live-audio/player.ts
@@ -5,10 +5,8 @@ import { createPlayer } from '../../player/create-player';
 
 const player = createPlayer({ features: liveAudioFeatures, displayName: 'LiveAudioPlayer' });
 
-/** Preconfigured player provider with the live audio features. */
-export const LiveAudioPlayer = player.Provider;
-
-if (__DEV__) LiveAudioPlayer.displayName = 'LiveAudioPlayer';
+/** Preconfigured player with the live audio features. */
+export const LiveAudioPlayer = player.Player;
 
 /** Access the live audio player store or select a value from it. */
 export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/live-video/index.ts
+++ b/packages/react/src/presets/live-video/index.ts
@@ -1,7 +1,10 @@
 /** Live video player preset — same features as `video` with a skin that omits duration / current-time displays. */
+'use client';
+
 export { liveVideoFeatures } from '@videojs/core/dom';
 export { Video, type VideoProps } from '@/media/video';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
+export { LiveVideoPlayer, usePlayer } from './player';
 export * from './skin';
 export * from './skin.tailwind';

--- a/packages/react/src/presets/live-video/player.ts
+++ b/packages/react/src/presets/live-video/player.ts
@@ -3,10 +3,9 @@
 import { liveVideoFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-const player = createPlayer({ features: liveVideoFeatures, displayName: 'LiveVideoPlayer' });
-
 /** Preconfigured player with the live video features. */
-export const LiveVideoPlayer = player.Player;
-
-/** Access the live video player store or select a value from it. */
-export const usePlayer = player.usePlayer;
+export const {
+  Player: LiveVideoPlayer,
+  /** Access the live video player store or select a value from it. */
+  usePlayer,
+} = createPlayer({ features: liveVideoFeatures, displayName: 'LiveVideoPlayer' });

--- a/packages/react/src/presets/live-video/player.ts
+++ b/packages/react/src/presets/live-video/player.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { liveVideoFeatures } from '@videojs/core/dom';
+import { createPlayer } from '../../player/create-player';
+
+/** Preconfigured player instance with the live video features. */
+export const LiveVideoPlayer = createPlayer({ features: liveVideoFeatures, displayName: 'LiveVideoPlayer' });
+
+/** Access the live video player store or select a value from it. */
+export const usePlayer = LiveVideoPlayer.usePlayer;

--- a/packages/react/src/presets/live-video/player.ts
+++ b/packages/react/src/presets/live-video/player.ts
@@ -3,8 +3,12 @@
 import { liveVideoFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-/** Preconfigured player instance with the live video features. */
-export const LiveVideoPlayer = createPlayer({ features: liveVideoFeatures, displayName: 'LiveVideoPlayer' });
+const player = createPlayer({ features: liveVideoFeatures, displayName: 'LiveVideoPlayer' });
+
+/** Preconfigured player provider with the live video features. */
+export const LiveVideoPlayer = player.Provider;
+
+if (__DEV__) LiveVideoPlayer.displayName = 'LiveVideoPlayer';
 
 /** Access the live video player store or select a value from it. */
-export const usePlayer = LiveVideoPlayer.usePlayer;
+export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/live-video/player.ts
+++ b/packages/react/src/presets/live-video/player.ts
@@ -5,10 +5,8 @@ import { createPlayer } from '../../player/create-player';
 
 const player = createPlayer({ features: liveVideoFeatures, displayName: 'LiveVideoPlayer' });
 
-/** Preconfigured player provider with the live video features. */
-export const LiveVideoPlayer = player.Provider;
-
-if (__DEV__) LiveVideoPlayer.displayName = 'LiveVideoPlayer';
+/** Preconfigured player with the live video features. */
+export const LiveVideoPlayer = player.Player;
 
 /** Access the live video player store or select a value from it. */
 export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/tests/player.test-d.tsx
+++ b/packages/react/src/presets/tests/player.test-d.tsx
@@ -1,0 +1,39 @@
+import type {
+  AudioPlayerStore,
+  BackgroundPlayerStore,
+  LiveAudioPlayerStore,
+  LiveVideoPlayerStore,
+  VideoPlayerStore,
+} from '@videojs/core/dom';
+import { assertType, describe, it } from 'vitest';
+import { AudioPlayer, usePlayer as useAudioPlayer } from '../audio/player';
+import { BackgroundVideoPlayer, usePlayer as useBackgroundVideoPlayer } from '../background/player';
+import { LiveAudioPlayer, usePlayer as useLiveAudioPlayer } from '../live-audio/player';
+import { LiveVideoPlayer, usePlayer as useLiveVideoPlayer } from '../live-video/player';
+import { usePlayer as useVideoPlayer, VideoPlayer } from '../video/player';
+
+describe('preset players', () => {
+  it('exposes each preset provider with its inferred configuration props', () => {
+    <VideoPlayer.Provider contentTitle="Video title">Video</VideoPlayer.Provider>;
+    <AudioPlayer.Provider contentTitle="Audio title">Audio</AudioPlayer.Provider>;
+    <LiveVideoPlayer.Provider contentTitle="Live video title">Live video</LiveVideoPlayer.Provider>;
+    <LiveAudioPlayer.Provider contentTitle="Live audio title">Live audio</LiveAudioPlayer.Provider>;
+    <BackgroundVideoPlayer.Provider>Background video</BackgroundVideoPlayer.Provider>;
+
+    // @ts-expect-error Background video does not include the metadata feature.
+    <BackgroundVideoPlayer.Provider contentTitle="Background title">Background video</BackgroundVideoPlayer.Provider>;
+  });
+
+  it('exposes a typed usePlayer hook for each preset', () => {
+    function Consumers() {
+      assertType<VideoPlayerStore>(useVideoPlayer());
+      assertType<AudioPlayerStore>(useAudioPlayer());
+      assertType<BackgroundPlayerStore>(useBackgroundVideoPlayer());
+      assertType<LiveVideoPlayerStore>(useLiveVideoPlayer());
+      assertType<LiveAudioPlayerStore>(useLiveAudioPlayer());
+      return null;
+    }
+
+    void Consumers;
+  });
+});

--- a/packages/react/src/presets/tests/player.test-d.tsx
+++ b/packages/react/src/presets/tests/player.test-d.tsx
@@ -13,7 +13,7 @@ import { LiveVideoPlayer, usePlayer as useLiveVideoPlayer } from '../live-video/
 import { usePlayer as useVideoPlayer, VideoPlayer } from '../video/player';
 
 describe('preset players', () => {
-  it('exposes each preset provider with its inferred configuration props', () => {
+  it('exposes each preset player with its inferred configuration props', () => {
     <VideoPlayer contentTitle="Video title">Video</VideoPlayer>;
     <AudioPlayer contentTitle="Audio title">Audio</AudioPlayer>;
     <LiveVideoPlayer contentTitle="Live video title">Live video</LiveVideoPlayer>;
@@ -23,7 +23,7 @@ describe('preset players', () => {
     // @ts-expect-error Background video does not include the metadata feature.
     <BackgroundVideoPlayer contentTitle="Background title">Background video</BackgroundVideoPlayer>;
 
-    // @ts-expect-error Preset players are provider components, not createPlayer result objects.
+    // @ts-expect-error Preset players are components, not createPlayer result objects.
     VideoPlayer.Provider;
   });
 

--- a/packages/react/src/presets/tests/player.test-d.tsx
+++ b/packages/react/src/presets/tests/player.test-d.tsx
@@ -14,14 +14,17 @@ import { usePlayer as useVideoPlayer, VideoPlayer } from '../video/player';
 
 describe('preset players', () => {
   it('exposes each preset provider with its inferred configuration props', () => {
-    <VideoPlayer.Provider contentTitle="Video title">Video</VideoPlayer.Provider>;
-    <AudioPlayer.Provider contentTitle="Audio title">Audio</AudioPlayer.Provider>;
-    <LiveVideoPlayer.Provider contentTitle="Live video title">Live video</LiveVideoPlayer.Provider>;
-    <LiveAudioPlayer.Provider contentTitle="Live audio title">Live audio</LiveAudioPlayer.Provider>;
-    <BackgroundVideoPlayer.Provider>Background video</BackgroundVideoPlayer.Provider>;
+    <VideoPlayer contentTitle="Video title">Video</VideoPlayer>;
+    <AudioPlayer contentTitle="Audio title">Audio</AudioPlayer>;
+    <LiveVideoPlayer contentTitle="Live video title">Live video</LiveVideoPlayer>;
+    <LiveAudioPlayer contentTitle="Live audio title">Live audio</LiveAudioPlayer>;
+    <BackgroundVideoPlayer>Background video</BackgroundVideoPlayer>;
 
     // @ts-expect-error Background video does not include the metadata feature.
-    <BackgroundVideoPlayer.Provider contentTitle="Background title">Background video</BackgroundVideoPlayer.Provider>;
+    <BackgroundVideoPlayer contentTitle="Background title">Background video</BackgroundVideoPlayer>;
+
+    // @ts-expect-error Preset players are provider components, not createPlayer result objects.
+    VideoPlayer.Provider;
   });
 
   it('exposes a typed usePlayer hook for each preset', () => {

--- a/packages/react/src/presets/tests/player.test.tsx
+++ b/packages/react/src/presets/tests/player.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AudioPlayer } from '../audio/player';
+import { BackgroundVideoPlayer } from '../background/player';
+import { LiveAudioPlayer } from '../live-audio/player';
+import { LiveVideoPlayer } from '../live-video/player';
+import { usePlayer as useVideoPlayer, VideoPlayer } from '../video/player';
+
+describe('preset players', () => {
+  it.each([
+    ['VideoPlayer.Provider', VideoPlayer.Provider],
+    ['AudioPlayer.Provider', AudioPlayer.Provider],
+    ['BackgroundVideoPlayer.Provider', BackgroundVideoPlayer.Provider],
+    ['LiveVideoPlayer.Provider', LiveVideoPlayer.Provider],
+    ['LiveAudioPlayer.Provider', LiveAudioPlayer.Provider],
+  ])('exports the preconfigured %s component', (displayName, Provider) => {
+    expect(Provider.displayName).toBe(displayName);
+  });
+
+  it('exports the preset hook as the player hook', () => {
+    expect(useVideoPlayer).toBe(VideoPlayer.usePlayer);
+  });
+
+  it('forwards preset configuration props to the player store', () => {
+    function Title() {
+      const title = useVideoPlayer((state) => state.contentTitle);
+      return <span>{title}</span>;
+    }
+
+    render(
+      <VideoPlayer.Provider contentTitle="Preset title">
+        <Title />
+      </VideoPlayer.Provider>
+    );
+
+    expect(screen.getByText('Preset title')).toBeTruthy();
+  });
+});

--- a/packages/react/src/presets/tests/player.test.tsx
+++ b/packages/react/src/presets/tests/player.test.tsx
@@ -8,17 +8,19 @@ import { usePlayer as useVideoPlayer, VideoPlayer } from '../video/player';
 
 describe('preset players', () => {
   it.each([
-    ['VideoPlayer.Provider', VideoPlayer.Provider],
-    ['AudioPlayer.Provider', AudioPlayer.Provider],
-    ['BackgroundVideoPlayer.Provider', BackgroundVideoPlayer.Provider],
-    ['LiveVideoPlayer.Provider', LiveVideoPlayer.Provider],
-    ['LiveAudioPlayer.Provider', LiveAudioPlayer.Provider],
-  ])('exports the preconfigured %s component', (displayName, Provider) => {
-    expect(Provider.displayName).toBe(displayName);
+    ['VideoPlayer', VideoPlayer],
+    ['AudioPlayer', AudioPlayer],
+    ['BackgroundVideoPlayer', BackgroundVideoPlayer],
+    ['LiveVideoPlayer', LiveVideoPlayer],
+    ['LiveAudioPlayer', LiveAudioPlayer],
+  ])('exports the preconfigured %s component', (displayName, Player) => {
+    expect(Player.displayName).toBe(displayName);
   });
 
-  it('exports the preset hook as the player hook', () => {
-    expect(useVideoPlayer).toBe(VideoPlayer.usePlayer);
+  it('exports the provider and hook as separate values', () => {
+    expect(VideoPlayer).not.toHaveProperty('Provider');
+    expect(VideoPlayer).not.toHaveProperty('usePlayer');
+    expect(useVideoPlayer).toBeTypeOf('function');
   });
 
   it('forwards preset configuration props to the player store', () => {
@@ -28,9 +30,9 @@ describe('preset players', () => {
     }
 
     render(
-      <VideoPlayer.Provider contentTitle="Preset title">
+      <VideoPlayer contentTitle="Preset title">
         <Title />
-      </VideoPlayer.Provider>
+      </VideoPlayer>
     );
 
     expect(screen.getByText('Preset title')).toBeTruthy();

--- a/packages/react/src/presets/tests/player.test.tsx
+++ b/packages/react/src/presets/tests/player.test.tsx
@@ -17,7 +17,7 @@ describe('preset players', () => {
     expect(Player.displayName).toBe(displayName);
   });
 
-  it('exports the provider and hook as separate values', () => {
+  it('exports the player and hook as separate values', () => {
     expect(VideoPlayer).not.toHaveProperty('Provider');
     expect(VideoPlayer).not.toHaveProperty('usePlayer');
     expect(useVideoPlayer).toBeTypeOf('function');

--- a/packages/react/src/presets/video/index.ts
+++ b/packages/react/src/presets/video/index.ts
@@ -1,7 +1,10 @@
 /** General-purpose video player preset with full playback controls. */
+'use client';
+
 export { videoFeatures } from '@videojs/core/dom';
 export { Video, type VideoProps } from '@/media/video';
 export * from './minimal-skin';
 export * from './minimal-skin.tailwind';
+export { usePlayer, VideoPlayer } from './player';
 export * from './skin';
 export * from './skin.tailwind';

--- a/packages/react/src/presets/video/player.ts
+++ b/packages/react/src/presets/video/player.ts
@@ -3,10 +3,9 @@
 import { videoFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-const player = createPlayer({ features: videoFeatures, displayName: 'VideoPlayer' });
-
 /** Preconfigured player with the standard video features. */
-export const VideoPlayer = player.Player;
-
-/** Access the standard video player store or select a value from it. */
-export const usePlayer = player.usePlayer;
+export const {
+  Player: VideoPlayer,
+  /** Access the standard video player store or select a value from it. */
+  usePlayer,
+} = createPlayer({ features: videoFeatures, displayName: 'VideoPlayer' });

--- a/packages/react/src/presets/video/player.ts
+++ b/packages/react/src/presets/video/player.ts
@@ -3,8 +3,12 @@
 import { videoFeatures } from '@videojs/core/dom';
 import { createPlayer } from '../../player/create-player';
 
-/** Preconfigured player instance with the standard video features. */
-export const VideoPlayer = createPlayer({ features: videoFeatures, displayName: 'VideoPlayer' });
+const player = createPlayer({ features: videoFeatures, displayName: 'VideoPlayer' });
+
+/** Preconfigured player provider with the standard video features. */
+export const VideoPlayer = player.Provider;
+
+if (__DEV__) VideoPlayer.displayName = 'VideoPlayer';
 
 /** Access the standard video player store or select a value from it. */
-export const usePlayer = VideoPlayer.usePlayer;
+export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/video/player.ts
+++ b/packages/react/src/presets/video/player.ts
@@ -5,10 +5,8 @@ import { createPlayer } from '../../player/create-player';
 
 const player = createPlayer({ features: videoFeatures, displayName: 'VideoPlayer' });
 
-/** Preconfigured player provider with the standard video features. */
-export const VideoPlayer = player.Provider;
-
-if (__DEV__) VideoPlayer.displayName = 'VideoPlayer';
+/** Preconfigured player with the standard video features. */
+export const VideoPlayer = player.Player;
 
 /** Access the standard video player store or select a value from it. */
 export const usePlayer = player.usePlayer;

--- a/packages/react/src/presets/video/player.ts
+++ b/packages/react/src/presets/video/player.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { videoFeatures } from '@videojs/core/dom';
+import { createPlayer } from '../../player/create-player';
+
+/** Preconfigured player instance with the standard video features. */
+export const VideoPlayer = createPlayer({ features: videoFeatures, displayName: 'VideoPlayer' });
+
+/** Access the standard video player store or select a value from it. */
+export const usePlayer = VideoPlayer.usePlayer;

--- a/site/scripts/ejected-skins/react.ts
+++ b/site/scripts/ejected-skins/react.ts
@@ -864,7 +864,7 @@ function destructureSkinProps(source: string): string {
  *     out (a file must export only components for Fast Refresh to apply edits).
  *
  * Also: merges SkinProps into PlayerProps (adding `src`), inlines the skin body
- * into VideoPlayer/AudioPlayer wrapped in `Player.Provider`, and removes the
+ * into VideoPlayer/AudioPlayer wrapped in `Player`, and removes the
  * separate Skin export.
  */
 function flattenSkinIntoPlayer(source: string, mediaType: MediaType): { player: string; component: string } {
@@ -879,7 +879,7 @@ function flattenSkinIntoPlayer(source: string, mediaType: MediaType): { player: 
     `import { createPlayer } from '@videojs/react';`,
     `import { ${features} } from '@videojs/react/${subpath}';`,
     '',
-    `export const Player = createPlayer({ features: ${features} });`,
+    `export const { Player } = createPlayer({ features: ${features} });`,
     '',
   ].join('\n');
 
@@ -896,7 +896,7 @@ function flattenSkinIntoPlayer(source: string, mediaType: MediaType): { player: 
   source = source.replace(/export interface \w+SkinProps/, `export interface ${playerName}Props`);
   source = source.replace(/(\s*)children\?: ReactNode;/, `$1src: string;`);
 
-  // 3. Replace the skin function: rename, swap children→src, wrap in Player.Provider
+  // 3. Replace the skin function: rename, swap children→src, wrap in Player
   //    Match the destructured form: function XSkin({ children, className, poster, ...rest }: XSkinProps): ReactNode {
   source = source.replace(
     /export function \w+Skin\(\{ children, ([^}]+)\}: \w+SkinProps\): ReactNode \{\n([\s\S]*?)\n\}/,
@@ -904,7 +904,7 @@ function flattenSkinIntoPlayer(source: string, mediaType: MediaType): { player: 
       // Replace {children} with <Video/Audio> element inside the body
       let newBody = body.replace(/^\n+/, '').replace(/(\s*)\{children\}/, `$1<${mediaTag} src={src}${playsInline} />`);
 
-      // Wrap the return body in <Player.Provider>, re-indenting everything
+      // Wrap the return body in <Player>, re-indenting everything
       // inside `return (...)` by 2 extra spaces for the new wrapper.
       const returnIdx = newBody.indexOf('return (');
       if (returnIdx !== -1) {
@@ -915,7 +915,7 @@ function flattenSkinIntoPlayer(source: string, mediaType: MediaType): { player: 
           .split('\n')
           .map((line) => (line.trim() === '' ? '' : `  ${line}`))
           .join('\n');
-        newBody = `${newBody.slice(0, returnIdx)}return (\n    <Player.Provider>\n${reindented}\n    </Player.Provider>\n  )${newBody.slice(parenEnd + 1)}`;
+        newBody = `${newBody.slice(0, returnIdx)}return (\n    <Player>\n${reindented}\n    </Player>\n  )${newBody.slice(parenEnd + 1)}`;
       }
 
       const hasPoster = destructuredRest.includes('poster');
@@ -992,7 +992,7 @@ export async function processReactSkin(
   // 10. Destructure skin props in function argument instead of body
   tsx = destructureSkinProps(tsx);
 
-  // 11. Flatten skin into player (split into player.ts + Player.tsx, wrap in Player.Provider)
+  // 11. Flatten skin into player (split into player.ts + Player.tsx, wrap in Player)
   const mediaType = getSkinMediaType(skin);
   const { player, component } = flattenSkinIntoPlayer(tsx, mediaType);
   const componentFile = mediaType === 'video' ? 'VideoPlayer' : 'AudioPlayer';


### PR DESCRIPTION
## Summary

- rename the React `createPlayer()` result from `Provider` to `Player`, alongside its typed `usePlayer` and `useMedia` hooks
- export each preconfigured preset player directly as `VideoPlayer`, `AudioPlayer`, `BackgroundVideoPlayer`, `LiveVideoPlayer`, or `LiveAudioPlayer`
- export a separate typed `usePlayer` hook from every preset path
- keep `createPlayer()` under the hood without turning preset players into runtime namespace objects
- preserve preset feature inference across player props and hooks
- let Next.js Server Components render the direct player component export

## Stack

- this is the base PR
- preset-first docs: #2152
- standalone containers: #2154

## Verification

- `pnpm -F @videojs/react test src/player/tests/create-player.test.tsx src/presets/tests/player.test.tsx`
- `pnpm -F @videojs/react build`
- `pnpm typecheck`
- Next.js 16.3.1 App Router production builds with Turbopack and Webpack, rendering `<VideoPlayer>` from a Server Component and calling preset `usePlayer` from a nested Client Component

Refs #2004

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking public API rename across `@videojs/react` and all preset entry points; consumers must migrate from `Provider` to `Player` and update preset imports, though runtime behavior of the player store should be unchanged.
> 
> **Overview**
> **Breaking API change:** `createPlayer()` now returns a **`Player`** component (not `Provider`), with **`PlayerProps`** replacing `ProviderProps`. Context error messages and JSDoc examples use `<Player>` instead of `<Player.Provider>`.
> 
> Each preset path (`video`, `audio`, `background`, `live-video`, `live-audio`) now ships a dedicated **`VideoPlayer` / `AudioPlayer` / …** component and a separate typed **`usePlayer`** from new `player.ts` modules marked **`'use client'`**, so apps can import a ready-made player without destructuring `createPlayer` themselves.
> 
> Sandbox, e2e page generation, and ejected-skin codegen are updated to wrap skins in **`VideoPlayer`/`AudioPlayer`** (or preset players from `@app/shared/react/players`) instead of `Provider` + manual `createPlayer`. The metadata sandbox uses **`usePlayer`** from `createPlayer`’s return value rather than `Player.usePlayer`.
> 
> Tests and type tests cover the rename, preset exports, and that preset players are plain components (not `.Provider` namespaces).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcb67272e4d2d7d34525707631f981d832f7ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->