### PR TITLE
refactor(packages): share dom layout utilities

### DIFF
--- a/packages/core/src/dom/ui/menu/menu-size.ts
+++ b/packages/core/src/dom/ui/menu/menu-size.ts
@@ -1,40 +1,40 @@
-import { resolveCSSLength } from '@videojs/utils/dom';
+import {
+  type AttributeSnapshot,
+  findElementChild,
+  followElementPath,
+  getElementChildren,
+  measureElement,
+  measureElementChildren,
+  observeElements,
+  readCSSLength,
+  restoreAttributes,
+  snapshotAttributes,
+  walkAncestors,
+} from '@videojs/utils/dom';
 import { MenuCSSVars } from '../../../core/ui/menu/menu-css-vars';
 
 const MENU_SUBMENU_ATTR = 'data-submenu';
 const MENU_SUBMENU_EXPANDED_ATTR = 'data-submenu-expanded';
-
-interface CoveredState {
-  ariaHidden: string | null;
-  inert: boolean;
-}
 
 interface MenuSize {
   width: number;
   height: number;
 }
 
-interface StyleSnapshotEntry {
-  property: string;
-  value: string;
-  priority: string;
-}
-
-const measureStyleProperties = ['inset-inline-start', 'inset-inline-end', 'width', 'height', 'min-width', 'max-width'];
-const coveredStates = new WeakMap<HTMLElement, CoveredState>();
+const coveredStates = new WeakMap<HTMLElement, AttributeSnapshot>();
 const rootSizes = new WeakMap<HTMLElement, MenuSize>();
 
 function getActiveSubmenu(content: HTMLElement): HTMLElement | null {
-  return (
-    Array.from(content.children).find(
-      (child): child is HTMLElement =>
-        child instanceof HTMLElement && child.hasAttribute(MENU_SUBMENU_ATTR) && !child.hidden
-    ) ?? null
+  return findElementChild(
+    content,
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && child.hasAttribute(MENU_SUBMENU_ATTR) && !child.hidden
   );
 }
 
 function getRootChildren(content: HTMLElement): HTMLElement[] {
-  return Array.from(content.children).filter(
+  return getElementChildren(
+    content,
     (child): child is HTMLElement => child instanceof HTMLElement && !child.hasAttribute(MENU_SUBMENU_ATTR)
   );
 }
@@ -44,10 +44,7 @@ function setCovered(element: HTMLElement, covered: boolean): void {
 
   if (covered) {
     if (!previous) {
-      coveredStates.set(element, {
-        ariaHidden: element.getAttribute('aria-hidden'),
-        inert: element.hasAttribute('inert'),
-      });
+      coveredStates.set(element, snapshotAttributes(element, ['aria-hidden', 'inert']));
     }
 
     element.setAttribute('aria-hidden', 'true');
@@ -57,144 +54,78 @@ function setCovered(element: HTMLElement, covered: boolean): void {
 
   if (!previous) return;
 
-  if (previous.ariaHidden === null) {
-    element.removeAttribute('aria-hidden');
-  } else {
-    element.setAttribute('aria-hidden', previous.ariaHidden);
-  }
-  element.toggleAttribute('inert', previous.inert);
+  restoreAttributes(element, previous);
   coveredStates.delete(element);
 }
 
-function snapshotInlineStyle(element: HTMLElement): StyleSnapshotEntry[] {
-  return measureStyleProperties.map((property) => ({
-    property,
-    value: element.style.getPropertyValue(property),
-    priority: element.style.getPropertyPriority(property),
-  }));
-}
-
-function restoreInlineStyle(element: HTMLElement, snapshot: StyleSnapshotEntry[]): void {
-  for (const { property, value, priority } of snapshot) {
-    if (value) {
-      element.style.setProperty(property, value, priority);
-    } else {
-      element.style.removeProperty(property);
-    }
-  }
-}
-
-function measureElement(element: HTMLElement, width?: number): MenuSize {
-  const snapshot = snapshotInlineStyle(element);
-
-  try {
-    element.style.setProperty('inset-inline-start', '0px');
-    element.style.setProperty('inset-inline-end', 'auto');
-    element.style.setProperty('width', width === undefined ? 'max-content' : `${width}px`);
-    element.style.setProperty('height', 'auto');
-    element.style.setProperty('min-width', '0px');
-    element.style.setProperty('max-width', 'none');
-
-    const rect = element.getBoundingClientRect();
-
-    return {
-      width: Math.max(rect.width, element.scrollWidth),
-      height: Math.max(rect.height, element.scrollHeight),
-    };
-  } finally {
-    restoreInlineStyle(element, snapshot);
-  }
-}
-
-function getPadding(content: HTMLElement): { inline: number; block: number } {
-  const style = getComputedStyle(content);
-
-  return {
-    inline: (Number.parseFloat(style.paddingInlineStart) || 0) + (Number.parseFloat(style.paddingInlineEnd) || 0),
-    block: (Number.parseFloat(style.paddingBlockStart) || 0) + (Number.parseFloat(style.paddingBlockEnd) || 0),
-  };
+function measureMenuElement(element: HTMLElement, width?: number): MenuSize {
+  return measureElement(element, {
+    overflow: 'both',
+    styles: {
+      insetInlineStart: '0px',
+      insetInlineEnd: 'auto',
+      width: width === undefined ? 'max-content' : `${width}px`,
+      height: 'auto',
+      minWidth: '0px',
+      maxWidth: 'none',
+    },
+  });
 }
 
 function getAvailableWidth(content: HTMLElement): number | null {
-  let current: HTMLElement | null = content;
-
-  while (current) {
-    const value =
-      current.style.getPropertyValue(MenuCSSVars.availableWidth) ||
-      getComputedStyle(current).getPropertyValue(MenuCSSVars.availableWidth);
-    const width = resolveCSSLength(current, value);
-
-    if (Number.isFinite(width) && width > 0) return width;
-    current = current.parentElement;
-  }
-
-  return null;
+  return (
+    walkAncestors(content, (element) => {
+      const width = readCSSLength(element, MenuCSSVars.availableWidth);
+      return width !== null && width > 0 ? width : undefined;
+    }) ?? null
+  );
 }
 
 function constrainWidth(content: HTMLElement, width: number): number {
   const availableWidth = getAvailableWidth(content);
-  return availableWidth ? Math.min(width, availableWidth) : width;
+  return availableWidth === null ? width : Math.min(width, Math.max(0, availableWidth));
 }
 
 function getRootSize(content: HTMLElement, children: HTMLElement[]): MenuSize {
-  const measuredChildren = children.filter((child) => !child.hidden);
-  const padding = getPadding(content);
-
-  if (measuredChildren.length === 0) return { width: padding.inline, height: padding.block };
-
-  let measurements = measuredChildren.map((child) => ({
-    ...measureElement(child),
-    top: child.offsetTop,
-  }));
-  const naturalWidth = Math.max(...measurements.map(({ width }) => width)) + padding.inline;
-  const width = constrainWidth(content, naturalWidth);
-
-  if (width < naturalWidth) {
-    const childWidth = Math.max(0, width - padding.inline);
-    measurements = measuredChildren.map((child) => ({
-      ...measureElement(child, childWidth),
-      top: child.offsetTop,
-    }));
-  }
-
-  const hasPositionedChildren = measurements.some(({ top }) => top !== measurements[0]!.top);
-  const childrenHeight = hasPositionedChildren
-    ? Math.max(...measurements.map(({ height, top }) => top + height))
-    : measurements.reduce((total, { height }) => total + height, 0);
-
-  return { width, height: childrenHeight + padding.block };
+  return measureElementChildren(content, {
+    children,
+    includePadding: true,
+    maxWidth: getAvailableWidth(content),
+    measure: measureMenuElement,
+  });
 }
 
-function getElementSize(content: HTMLElement, element: HTMLElement): MenuSize {
-  const naturalSize = measureElement(element);
+function getConstrainedElementSize(content: HTMLElement, element: HTMLElement): MenuSize {
+  const naturalSize = measureMenuElement(element);
   const width = constrainWidth(content, naturalSize.width);
 
   if (width >= naturalSize.width) return naturalSize;
 
-  const constrainedSize = measureElement(element, width);
+  const constrainedSize = measureMenuElement(element, width);
 
   return { width, height: constrainedSize.height };
 }
 
 function getCurrentSize(content: HTMLElement): MenuSize {
-  const activeSubmenu = getActiveSubmenu(content);
-  const rootChildren = getRootChildren(content);
-  const measuredRootSize = getRootSize(content, rootChildren);
+  const path = followElementPath(content, (current) => {
+    const activeSubmenu = getActiveSubmenu(current);
+    return activeSubmenu?.hasAttribute('data-ending-style') ? null : activeSubmenu;
+  });
+  const current = path[path.length - 1]!;
+  const activeSubmenu = getActiveSubmenu(current);
+  const rootChildren = getRootChildren(current);
+  const measuredRootSize = getRootSize(current, rootChildren);
   const ownRootSize =
-    content.hasAttribute(MENU_SUBMENU_ATTR) && rootChildren.length === 0
-      ? getElementSize(content, content)
+    current.hasAttribute(MENU_SUBMENU_ATTR) && rootChildren.length === 0
+      ? getConstrainedElementSize(current, current)
       : measuredRootSize;
 
-  if (!activeSubmenu) {
-    rootSizes.set(content, ownRootSize);
+  if (!activeSubmenu?.hasAttribute('data-ending-style')) {
+    rootSizes.set(current, ownRootSize);
     return ownRootSize;
   }
 
-  if (activeSubmenu.hasAttribute('data-ending-style')) {
-    return rootSizes.get(content) ?? ownRootSize;
-  }
-
-  return getCurrentSize(activeSubmenu);
+  return rootSizes.get(current) ?? ownRootSize;
 }
 
 /** Synchronize menu size and accessibility to the active submenu, if any. */
@@ -234,29 +165,16 @@ export function syncMenuSizeChain(content: HTMLElement | null): void {
 
 /** Re-measure when the active submenu or ordinary root content changes size. */
 export function observeMenuSize(content: HTMLElement, onResize: () => void): () => void {
-  if (typeof ResizeObserver === 'undefined') return () => {};
+  return observeElements({
+    root: content,
+    getElements: () => {
+      const activeSubmenu = getActiveSubmenu(content);
 
-  const resizeObserver = new ResizeObserver(onResize);
-
-  const observeCurrentElements = () => {
-    resizeObserver.disconnect();
-    const activeSubmenu = getActiveSubmenu(content);
-    const elements =
-      activeSubmenu && !activeSubmenu.hasAttribute('data-ending-style') ? [activeSubmenu] : getRootChildren(content);
-
-    for (const element of elements) resizeObserver.observe(element);
-  };
-
-  observeCurrentElements();
-
-  const mutationObserver = new MutationObserver(() => {
-    observeCurrentElements();
-    onResize();
+      return activeSubmenu && !activeSubmenu.hasAttribute('data-ending-style')
+        ? [activeSubmenu]
+        : getRootChildren(content);
+    },
+    mutations: { childList: true },
+    onChange: onResize,
   });
-  mutationObserver.observe(content, { childList: true });
-
-  return () => {
-    mutationObserver.disconnect();
-    resizeObserver.disconnect();
-  };
 }

--- a/packages/core/src/dom/ui/menu/tests/menu-size.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/menu-size.test.ts
@@ -100,6 +100,18 @@ describe('syncMenuSize', () => {
     expect(content.style.getPropertyValue('--media-menu-width')).toBe('200px');
   });
 
+  it('ignores a non-positive available width before positioning', () => {
+    const content = document.createElement('div');
+    const root = document.createElement('div');
+    content.style.setProperty('--media-menu-available-width', '0px');
+    content.append(root);
+    setSize(root, 180, 120);
+
+    syncMenuSize(content);
+
+    expect(content.style.getPropertyValue('--media-menu-width')).toBe('180px');
+  });
+
   it('propagates the deepest active submenu size through nested menus', () => {
     const root = document.createElement('div');
     const rootItems = document.createElement('div');

--- a/packages/core/src/dom/ui/popover/popover-positioning.ts
+++ b/packages/core/src/dom/ui/popover/popover-positioning.ts
@@ -1,4 +1,4 @@
-import { resolveCSSLength, supportsAnchorPositioning } from '@videojs/utils/dom';
+import { getElementSize, resolveCSSLength, supportsAnchorPositioning } from '@videojs/utils/dom';
 import { clamp } from '@videojs/utils/number';
 import type { PopoverAlign, PopoverSide } from '../../../core/ui/popover/popover-core';
 import { PopoverCSSVars } from '../../../core/ui/popover/popover-css-vars';
@@ -374,13 +374,10 @@ export function resolveOffsets(el: Element, cssVars: PositioningCSSVars = Popove
  */
 export function getPopupPositionRect(el: HTMLElement, side: PopoverSide): DOMRect {
   const rect = el.getBoundingClientRect();
-  const width = el.offsetWidth || rect.width;
-  const height = el.offsetHeight || rect.height;
+  const size = getElementSize(el, {
+    box: 'layout',
+    overflow: side === 'left' || side === 'right' ? 'width' : 'height',
+  });
 
-  return createDOMRect(
-    rect.left,
-    rect.top,
-    side === 'left' || side === 'right' ? Math.max(width, el.scrollWidth) : width,
-    side === 'top' || side === 'bottom' ? Math.max(height, el.scrollHeight) : height
-  );
+  return createDOMRect(rect.left, rect.top, size.width, size.height);
 }

--- a/packages/core/src/dom/ui/popover/popup-positioner.ts
+++ b/packages/core/src/dom/ui/popover/popup-positioner.ts
@@ -2,7 +2,11 @@ import {
   applyStyles,
   getAnchorNames,
   getPositionedSide,
+  type InlineStyleSnapshot,
+  observeResize,
   rafThrottle,
+  restoreInlineStyles,
+  snapshotInlineStyles,
   supportsAnchorPositioning,
 } from '@videojs/utils/dom';
 import { kebabCase } from '@videojs/utils/string';
@@ -57,11 +61,11 @@ export class PopupPositioner {
   #options: PopupPositionerOptions | null = null;
   #boundaryElement: Element | null = null;
   #abort: AbortController | null = null;
-  #observer: ResizeObserver | null = null;
+  #stopObservingResize: (() => void) | null = null;
   #triggerAnchorName: string | null = null;
   #triggerAnchorAdded = false;
   #popupAnchor: InlineStyleValue | null = null;
-  #popupStyles = new Map<string, InlineStyleValue>();
+  #popupStyles: InlineStyleSnapshot | null = null;
   readonly #reposition = rafThrottle(() => this.#position());
 
   sync(options: PopupPositionerOptions): void {
@@ -117,19 +121,16 @@ export class PopupPositioner {
     window.addEventListener('scroll', this.#schedule, { capture: true, passive: true, signal });
     window.addEventListener('resize', this.#schedule, { signal });
 
-    if (typeof ResizeObserver === 'function') {
-      this.#observer = new ResizeObserver(() => this.#schedule());
-      this.#observer.observe(options.trigger);
-      this.#observer.observe(options.popup);
-      if (this.#boundaryElement) this.#observer.observe(this.#boundaryElement);
-    }
+    const resizeTargets: Element[] = [options.trigger, options.popup];
+    if (this.#boundaryElement) resizeTargets.push(this.#boundaryElement);
+    this.#stopObservingResize = observeResize(resizeTargets, () => this.#schedule());
   }
 
   #stopTracking(): void {
     this.#abort?.abort();
     this.#abort = null;
-    this.#observer?.disconnect();
-    this.#observer = null;
+    this.#stopObservingResize?.();
+    this.#stopObservingResize = null;
     this.#reposition.cancel();
     this.#restoreAnchorStyles();
   }
@@ -183,7 +184,7 @@ export class PopupPositioner {
   }
 
   #capturePopupStyles(popup: HTMLElement, cssVars: PositioningCSSVars): void {
-    if (this.#popupStyles.size > 0) return;
+    if (this.#popupStyles) return;
 
     const props = [
       ...POPUP_STYLE_PROPS,
@@ -193,16 +194,13 @@ export class PopupPositioner {
       cssVars.availableHeight,
     ];
 
-    for (const prop of props) {
-      this.#popupStyles.set(prop, this.#readStyle(popup, prop));
-    }
+    this.#popupStyles = snapshotInlineStyles(popup, props);
   }
 
   #restorePopupStyles(popup: HTMLElement): void {
-    for (const [prop, style] of this.#popupStyles) {
-      this.#writeStyle(popup, prop, style);
-    }
-    this.#popupStyles.clear();
+    if (!this.#popupStyles) return;
+    restoreInlineStyles(popup, this.#popupStyles);
+    this.#popupStyles = null;
   }
 
   #applyAnchorStyles(trigger: HTMLElement, popup: HTMLElement, anchorName: string): void {

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -1,4 +1,5 @@
 import { createState, type State } from '@videojs/store';
+import { observeResize } from '@videojs/utils/dom';
 import { throttle } from '@videojs/utils/function';
 import { clamp, roundToStep } from '@videojs/utils/number';
 import { isNull } from '@videojs/utils/predicate';
@@ -331,11 +332,10 @@ export function createSlider(options: SliderOptions): SliderApi {
     return adjusted;
   }
 
-  let resizeObserver: ResizeObserver | null = null;
+  let stopObservingResize: (() => void) | null = null;
 
   if (options.onResize) {
-    resizeObserver = new ResizeObserver(() => options.onResize!());
-    resizeObserver.observe(options.getElement());
+    stopObservingResize = observeResize(options.getElement(), () => options.onResize!());
   }
 
   const rootStyle: SliderRootStyle = { touchAction: 'none', userSelect: 'none' };
@@ -349,7 +349,7 @@ export function createSlider(options: SliderOptions): SliderApi {
     destroy() {
       if (abort.signal.aborted) return;
       abort.abort();
-      resizeObserver?.disconnect();
+      stopObservingResize?.();
       releaseCapture();
       cleanup();
     },

--- a/packages/core/src/dom/ui/thumbnail.ts
+++ b/packages/core/src/dom/ui/thumbnail.ts
@@ -1,4 +1,4 @@
-import { listen } from '@videojs/utils/dom';
+import { listen, observeResize } from '@videojs/utils/dom';
 import { ThumbnailCore } from '../../core/ui/thumbnail/thumbnail-core';
 import type { ThumbnailConstraints } from '../../core/ui/thumbnail/types';
 
@@ -31,7 +31,7 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
   let naturalHeight = 0;
   let lastSrc = '';
   let imgBound = false;
-  let resizeObserver: ResizeObserver | null = null;
+  let stopObservingResize: (() => void) | null = null;
 
   // --- img event listeners ---
 
@@ -71,12 +71,11 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
       }
     }
 
-    if (!resizeObserver) {
+    if (!stopObservingResize) {
       const container = getContainer();
 
       if (container) {
-        resizeObserver = new ResizeObserver(onStateChange);
-        resizeObserver.observe(container);
+        stopObservingResize = observeResize(container, onStateChange);
       }
     }
   }
@@ -129,8 +128,8 @@ export function createThumbnail(options: CreateThumbnailOptions): ThumbnailApi {
 
   function destroy(): void {
     abort.abort();
-    resizeObserver?.disconnect();
-    resizeObserver = null;
+    stopObservingResize?.();
+    stopObservingResize = null;
   }
 
   return {

--- a/packages/html/src/ui/menu/menu-radio-group-element.ts
+++ b/packages/html/src/ui/menu/menu-radio-group-element.ts
@@ -1,5 +1,6 @@
 import type { PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
+import { findElementChild } from '@videojs/utils/dom';
 
 import { RadioGroupElement } from '../radio-group/radio-group-element';
 import { type MenuContextValue, type MenuTriggerMetadata, menuContext } from './context';
@@ -58,7 +59,8 @@ export class MenuRadioGroupElement extends RadioGroupElement {
 
     if (!this.#setTriggerMetadata) return;
 
-    const selectedItem = [...this.children].find(
+    const selectedItem = findElementChild(
+      this,
       (item): item is MenuRadioItemElement => item instanceof MenuRadioItemElement && item.value === this.value
     );
     const label = selectedItem?.querySelector<HTMLElement>('[data-part~="label"]')?.textContent;

--- a/packages/html/src/ui/slider/slider-preview-element.ts
+++ b/packages/html/src/ui/slider/slider-preview-element.ts
@@ -2,7 +2,7 @@ import type { SliderPreviewOverflow } from '@videojs/core/dom';
 import { applyStateDataAttrs, getSliderPreviewStyle } from '@videojs/core/dom';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
-import { applyStyles } from '@videojs/utils/dom';
+import { applyStyles, observeResize } from '@videojs/utils/dom';
 
 import { MediaElement } from '../media-element';
 import { sliderContext } from './context';
@@ -21,24 +21,22 @@ export class SliderPreviewElement extends MediaElement {
     subscribe: true,
   });
 
-  #resizeObserver: ResizeObserver | null = null;
+  #stopObservingResize: (() => void) | null = null;
   #width = 0;
 
   override connectedCallback(): void {
     super.connectedCallback();
 
-    this.#resizeObserver = new ResizeObserver(([entry]) => {
+    this.#stopObservingResize = observeResize(this, ([entry]) => {
       this.#width = entry!.contentRect.width;
       this.#applyPosition();
     });
-
-    this.#resizeObserver.observe(this);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#resizeObserver?.disconnect();
-    this.#resizeObserver = null;
+    this.#stopObservingResize?.();
+    this.#stopObservingResize = null;
   }
 
   #applyPosition(): void {

--- a/packages/react/src/ui/slider/slider-preview.tsx
+++ b/packages/react/src/ui/slider/slider-preview.tsx
@@ -3,6 +3,7 @@
 import type { SliderState } from '@videojs/core';
 import type { SliderPreviewOverflow } from '@videojs/core/dom';
 import { getSliderPreviewStyle } from '@videojs/core/dom';
+import { observeResize } from '@videojs/utils/dom';
 import type { ForwardedRef } from 'react';
 import { forwardRef, useEffect, useRef, useState } from 'react';
 
@@ -32,12 +33,9 @@ export const SliderPreview = forwardRef(function SliderPreview(
     const el = measureRef.current;
     if (!el) return;
 
-    const observer = new ResizeObserver(([entry]) => {
+    return observeResize(el, ([entry]) => {
       setWidth(entry!.contentRect.width);
     });
-
-    observer.observe(el);
-    return () => observer.disconnect();
   }, []);
 
   const positionStyle = getSliderPreviewStyle(width, overflow);

--- a/packages/utils/src/dom/attributes.ts
+++ b/packages/utils/src/dom/attributes.ts
@@ -1,5 +1,28 @@
 import { escapeHtml } from '../string/escape-html';
 
+export interface AttributeSnapshotEntry {
+  name: string;
+  value: string | null;
+}
+
+export type AttributeSnapshot = readonly AttributeSnapshotEntry[];
+
+/** Capture authored values for the selected attributes. */
+export function snapshotAttributes(element: Element, names: Iterable<string>): AttributeSnapshot {
+  return [...names].map((name) => ({ name, value: element.getAttribute(name) }));
+}
+
+/** Restore a snapshot created by `snapshotAttributes`. */
+export function restoreAttributes(element: Element, snapshot: AttributeSnapshot): void {
+  for (const { name, value } of snapshot) {
+    if (value === null) {
+      element.removeAttribute(name);
+    } else {
+      element.setAttribute(name, value);
+    }
+  }
+}
+
 /**
  * Convert a NamedNodeMap to a plain object.
  */

--- a/packages/utils/src/dom/children.ts
+++ b/packages/utils/src/dom/children.ts
@@ -1,0 +1,43 @@
+export type ElementPredicate = (element: Element, index: number) => boolean;
+export type ElementTypePredicate<T extends Element> = (element: Element, index: number) => element is T;
+
+/** Return direct element children accepted by the predicate. */
+export function getElementChildren<T extends Element>(parent: Element, predicate: ElementTypePredicate<T>): T[];
+export function getElementChildren(parent: Element, predicate: ElementPredicate): Element[];
+export function getElementChildren(parent: Element, predicate: ElementPredicate): Element[] {
+  const children: Element[] = [];
+
+  for (let index = 0; index < parent.children.length; index++) {
+    const child = parent.children.item(index);
+    if (child && predicate(child, index)) children.push(child);
+  }
+
+  return children;
+}
+
+/** Find the first direct element child accepted by the predicate. */
+export function findElementChild<T extends Element>(parent: Element, predicate: ElementTypePredicate<T>): T | null;
+export function findElementChild(parent: Element, predicate: ElementPredicate): Element | null;
+export function findElementChild(parent: Element, predicate: ElementPredicate): Element | null {
+  for (let index = 0; index < parent.children.length; index++) {
+    const child = parent.children.item(index);
+    if (child && predicate(child, index)) return child;
+  }
+
+  return null;
+}
+
+/** Follow a single-child relationship from the root until it ends or cycles. */
+export function followElementPath<T extends Element>(root: T, getNext: (element: T) => T | null): T[] {
+  const path: T[] = [];
+  const visited = new Set<T>();
+  let current: T | null = root;
+
+  while (current && !visited.has(current)) {
+    path.push(current);
+    visited.add(current);
+    current = getNext(current);
+  }
+
+  return path;
+}

--- a/packages/utils/src/dom/index.ts
+++ b/packages/utils/src/dom/index.ts
@@ -1,5 +1,19 @@
 export { animationFrame } from './animation-frame';
-export { namedNodeMapToObject, serializeAttributes } from './attributes';
+export {
+  type AttributeSnapshot,
+  type AttributeSnapshotEntry,
+  namedNodeMapToObject,
+  restoreAttributes,
+  serializeAttributes,
+  snapshotAttributes,
+} from './attributes';
+export {
+  type ElementPredicate,
+  type ElementTypePredicate,
+  findElementChild,
+  followElementPath,
+  getElementChildren,
+} from './children';
 export { isRTL } from './direction';
 export { type OnEventOptions, onEvent, resolveEventTarget } from './event';
 export { getDeepActiveElement } from './focus';
@@ -12,12 +26,34 @@ export {
   isInteractiveActivation,
   isInteractiveTarget,
 } from './interactive';
+export {
+  type ChildMeasurement,
+  type ElementOverflowMeasurement,
+  type ElementSize,
+  type ElementSizeBox,
+  type GetElementSizeOptions,
+  getBlockExtent,
+  getElementPadding,
+  getElementSize,
+  getInlineExtent,
+  type LogicalBoxEdges,
+  type MeasureElementChildrenOptions,
+  type MeasureElementOptions,
+  measureElement,
+  measureElementChildren,
+} from './layout';
 export { listen } from './listen';
 export { effectiveLocale } from './locale/effective-locale';
 export { findNearestLang, findNearestLang as nearestLang } from './locale/find-nearest-lang';
 export { mergeLocaleOverlays } from './locale/merge-locale-overlays';
 export { resolveLangAttr } from './locale/resolve-lang-attr';
 export { subscribeAmbientLang } from './locale/subscribe-ambient-lang';
+export {
+  type ObservedElements,
+  type ObserveElementsOptions,
+  observeElements,
+  observeResize,
+} from './observe-elements';
 export { isMacOS } from './platform';
 export {
   getPositionedSide,
@@ -37,7 +73,19 @@ export {
   type ShadowStyle,
 } from './shadow-styles';
 export { getSlottedElement, querySlot } from './slotted';
-export { addAnchorName, applyStyles, getAnchorNames, resolveCSSLength } from './style';
+export {
+  addAnchorName,
+  applyStyles,
+  getAnchorNames,
+  type InlineStyleSnapshot,
+  type InlineStyleSnapshotEntry,
+  type ReadCSSLengthOptions,
+  readCSSLength,
+  resolveCSSLength,
+  restoreInlineStyles,
+  snapshotInlineStyles,
+  withInlineStyles,
+} from './style';
 export { supportsAnchorPositioning, supportsAnimationFrame, supportsIdleCallback } from './supports';
 export { cloneTemplateRoot, createTemplate, getTemplateElement, getTemplateRoot, renderTemplate } from './template';
 export {

--- a/packages/utils/src/dom/layout.ts
+++ b/packages/utils/src/dom/layout.ts
@@ -1,0 +1,147 @@
+import { withInlineStyles } from './style';
+
+export interface ElementSize {
+  width: number;
+  height: number;
+}
+
+export interface LogicalBoxEdges {
+  inlineStart: number;
+  inlineEnd: number;
+  blockStart: number;
+  blockEnd: number;
+}
+
+export type ElementSizeBox = 'bounding' | 'layout';
+export type ElementOverflowMeasurement = 'none' | 'width' | 'height' | 'both';
+
+export interface GetElementSizeOptions {
+  /** Measure the transformed bounding box or the untransformed layout box. */
+  box?: ElementSizeBox | undefined;
+  /** Include overflowing scroll dimensions on the selected axes. */
+  overflow?: ElementOverflowMeasurement | undefined;
+}
+
+/** Read an element's current rendered size. */
+export function getElementSize(
+  element: HTMLElement,
+  { box = 'bounding', overflow = 'none' }: GetElementSizeOptions = {}
+): ElementSize {
+  const rect = element.getBoundingClientRect();
+  let width = box === 'layout' ? element.offsetWidth || rect.width : rect.width;
+  let height = box === 'layout' ? element.offsetHeight || rect.height : rect.height;
+
+  if (overflow === 'width' || overflow === 'both') width = Math.max(width, element.scrollWidth);
+  if (overflow === 'height' || overflow === 'both') height = Math.max(height, element.scrollHeight);
+
+  return { width, height };
+}
+
+export interface MeasureElementOptions extends GetElementSizeOptions {
+  /** Inline styles temporarily applied while measuring. */
+  styles?: Readonly<Record<string, string | undefined>> | undefined;
+}
+
+/** Measure an element with optional temporary inline style overrides. */
+export function measureElement(element: HTMLElement, options: MeasureElementOptions = {}): ElementSize {
+  const { styles, ...sizeOptions } = options;
+  const measure = () => getElementSize(element, sizeOptions);
+
+  return styles ? withInlineStyles(element, styles, measure) : measure();
+}
+
+/** Read logical padding edges in pixels. */
+export function getElementPadding(element: Element): LogicalBoxEdges {
+  const style = getComputedStyle(element);
+
+  return {
+    inlineStart: Number.parseFloat(style.paddingInlineStart) || 0,
+    inlineEnd: Number.parseFloat(style.paddingInlineEnd) || 0,
+    blockStart: Number.parseFloat(style.paddingBlockStart) || 0,
+    blockEnd: Number.parseFloat(style.paddingBlockEnd) || 0,
+  };
+}
+
+export function getInlineExtent(edges: LogicalBoxEdges): number {
+  return edges.inlineStart + edges.inlineEnd;
+}
+
+export function getBlockExtent(edges: LogicalBoxEdges): number {
+  return edges.blockStart + edges.blockEnd;
+}
+
+export interface ChildMeasurement {
+  element: HTMLElement;
+  size: ElementSize;
+  offsetLeft: number;
+  offsetTop: number;
+}
+
+export interface MeasureElementChildrenOptions {
+  /** Children to measure. Defaults to direct HTMLElement children. */
+  children?: Iterable<HTMLElement> | undefined;
+  /** Include the container's logical padding. */
+  includePadding?: boolean | undefined;
+  /** Constrain the resulting width and remeasure children at that width. */
+  maxWidth?: number | null | undefined;
+  /** Child measurement strategy. The optional width is the constrained content width. */
+  measure?: ((element: HTMLElement, width?: number) => ElementSize) | undefined;
+  /** Resolve content size from measurements. Defaults to their layout bounds. */
+  resolveSize?: ((measurements: readonly ChildMeasurement[]) => ElementSize) | undefined;
+}
+
+function defaultResolveChildrenSize(measurements: readonly ChildMeasurement[]): ElementSize {
+  if (measurements.length === 0) return { width: 0, height: 0 };
+
+  const width = Math.max(...measurements.map(({ offsetLeft, size }) => offsetLeft + size.width));
+  const firstTop = measurements[0]!.offsetTop;
+  const hasDistinctOffsets = measurements.some(({ offsetTop }) => offsetTop !== firstTop);
+  const height = hasDistinctOffsets
+    ? Math.max(...measurements.map(({ offsetTop, size }) => offsetTop + size.height))
+    : measurements.reduce((total, { size }) => total + size.height, 0);
+
+  return { width, height };
+}
+
+/** Measure the layout occupied by a collection of child elements. */
+export function measureElementChildren(
+  container: HTMLElement,
+  {
+    children,
+    includePadding = false,
+    maxWidth = null,
+    measure = (element, width) =>
+      measureElement(element, width === undefined ? undefined : { styles: { width: `${width}px` } }),
+    resolveSize = defaultResolveChildrenSize,
+  }: MeasureElementChildrenOptions = {}
+): ElementSize {
+  const elements = [
+    ...(children ?? Array.from(container.children).filter((child) => child instanceof HTMLElement)),
+  ].filter((element) => !element.hidden);
+  const padding = includePadding
+    ? getElementPadding(container)
+    : { inlineStart: 0, inlineEnd: 0, blockStart: 0, blockEnd: 0 };
+  const inlinePadding = getInlineExtent(padding);
+  const blockPadding = getBlockExtent(padding);
+
+  if (elements.length === 0) return { width: inlinePadding, height: blockPadding };
+
+  const collect = (width?: number): ChildMeasurement[] =>
+    elements.map((element) => ({
+      element,
+      size: measure(element, width),
+      offsetLeft: element.offsetLeft,
+      offsetTop: element.offsetTop,
+    }));
+
+  let measurements = collect();
+  const naturalSize = resolveSize(measurements);
+  const naturalWidth = naturalSize.width + inlinePadding;
+  const width = maxWidth === null ? naturalWidth : Math.min(naturalWidth, Math.max(0, maxWidth));
+
+  if (width < naturalWidth) measurements = collect(Math.max(0, width - inlinePadding));
+
+  const size = resolveSize(measurements);
+
+  return { width, height: size.height + blockPadding };
+}

--- a/packages/utils/src/dom/observe-elements.ts
+++ b/packages/utils/src/dom/observe-elements.ts
@@ -1,0 +1,56 @@
+import { noop } from '../function/noop';
+
+export type ObservedElements = Element | Iterable<Element>;
+
+/** Observe one or more elements for size changes and return a cleanup function. */
+export function observeResize(elements: ObservedElements, callback: ResizeObserverCallback): () => void {
+  if (typeof ResizeObserver === 'undefined') return noop;
+
+  const observer = new ResizeObserver(callback);
+  const targets = Symbol.iterator in Object(elements) ? (elements as Iterable<Element>) : [elements as Element];
+
+  for (const element of targets) observer.observe(element);
+
+  return () => observer.disconnect();
+}
+
+export interface ObserveElementsOptions {
+  /** Resolve the current set of elements to resize-observe. */
+  getElements: () => Iterable<Element>;
+  /** Called when an observed element resizes or the configured root mutates. */
+  onChange: () => void;
+  /** Optional root whose mutations can change the observed element set. */
+  root?: Node | undefined;
+  /** Mutation options used to refresh the observed element set. */
+  mutations?: MutationObserverInit | false | undefined;
+}
+
+/**
+ * Observe a dynamically resolved element set. When the optional root mutates,
+ * the set is resolved again before `onChange` is called.
+ */
+export function observeElements({ getElements, onChange, root, mutations }: ObserveElementsOptions): () => void {
+  let stopObservingResize = noop;
+
+  const observeCurrentElements = () => {
+    stopObservingResize();
+    stopObservingResize = observeResize(getElements(), onChange);
+  };
+
+  observeCurrentElements();
+
+  let mutationObserver: MutationObserver | null = null;
+
+  if (root && mutations !== false && typeof MutationObserver !== 'undefined') {
+    mutationObserver = new MutationObserver(() => {
+      observeCurrentElements();
+      onChange();
+    });
+    mutationObserver.observe(root, mutations ?? { childList: true });
+  }
+
+  return () => {
+    mutationObserver?.disconnect();
+    stopObservingResize();
+  };
+}

--- a/packages/utils/src/dom/style.ts
+++ b/packages/utils/src/dom/style.ts
@@ -1,5 +1,17 @@
 import { kebabCase } from '../string/casing';
 
+export interface InlineStyleSnapshotEntry {
+  property: string;
+  value: string;
+  priority: string;
+}
+
+export type InlineStyleSnapshot = readonly InlineStyleSnapshotEntry[];
+
+function normalizeStyleProperty(property: string): string {
+  return property.startsWith('--') ? property : kebabCase(property);
+}
+
 export function getAnchorNames(element: HTMLElement): string[] {
   const value = element.style.getPropertyValue('anchor-name').trim();
 
@@ -36,11 +48,68 @@ export function addAnchorName(element: HTMLElement, name: string): () => void {
 export function applyStyles(element: HTMLElement, styles: Record<string, string | undefined>): void {
   for (const [prop, value] of Object.entries(styles)) {
     if (typeof value === 'string') {
-      // CSS custom properties (--*) are already in the correct format.
-      const key = prop.startsWith('--') ? prop : kebabCase(prop);
-      element.style.setProperty(key, value);
+      element.style.setProperty(normalizeStyleProperty(prop), value);
     }
   }
+}
+
+/** Capture authored inline values and priorities for the selected properties. */
+export function snapshotInlineStyles(element: HTMLElement, properties: Iterable<string>): InlineStyleSnapshot {
+  return [...properties].map((property) => {
+    const normalizedProperty = normalizeStyleProperty(property);
+
+    return {
+      property: normalizedProperty,
+      value: element.style.getPropertyValue(normalizedProperty),
+      priority: element.style.getPropertyPriority(normalizedProperty),
+    };
+  });
+}
+
+/** Restore a snapshot created by `snapshotInlineStyles`. */
+export function restoreInlineStyles(element: HTMLElement, snapshot: InlineStyleSnapshot): void {
+  for (const { property, value, priority } of snapshot) {
+    if (value) {
+      element.style.setProperty(property, value, priority);
+    } else {
+      element.style.removeProperty(property);
+    }
+  }
+}
+
+/** Apply inline styles for a synchronous callback and restore authored styles afterward. */
+export function withInlineStyles<Result>(
+  element: HTMLElement,
+  styles: Readonly<Record<string, string | undefined>>,
+  callback: () => Result
+): Result {
+  const snapshot = snapshotInlineStyles(element, Object.keys(styles));
+
+  try {
+    applyStyles(element, styles);
+    return callback();
+  } finally {
+    restoreInlineStyles(element, snapshot);
+  }
+}
+
+export interface ReadCSSLengthOptions {
+  source?: 'inline' | 'computed' | 'inline-or-computed' | undefined;
+}
+
+/** Read and resolve a CSS property as a pixel length. */
+export function readCSSLength(
+  element: Element,
+  property: string,
+  { source = 'inline-or-computed' }: ReadCSSLengthOptions = {}
+): number | null {
+  const normalizedProperty = normalizeStyleProperty(property);
+  let value =
+    source !== 'computed' && element instanceof HTMLElement ? element.style.getPropertyValue(normalizedProperty) : '';
+
+  if (!value && source !== 'inline') value = getComputedStyle(element).getPropertyValue(normalizedProperty);
+
+  return value.trim() ? resolveCSSLength(element, value) : null;
 }
 
 export function resolveCSSLength(el: Element, value: string): number {

--- a/packages/utils/src/dom/tests/attributes.test.ts
+++ b/packages/utils/src/dom/tests/attributes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { namedNodeMapToObject, serializeAttributes } from '../attributes';
+import { namedNodeMapToObject, restoreAttributes, serializeAttributes, snapshotAttributes } from '../attributes';
 
 describe('serializeAttributes', () => {
   it('serializes a boolean (empty-string) attribute without a value', () => {
@@ -43,6 +43,21 @@ describe('serializeAttributes', () => {
 
   it('returns an empty string for an empty object', () => {
     expect(serializeAttributes({})).toBe('');
+  });
+});
+
+describe('attribute snapshots', () => {
+  it('restores present and absent attributes', () => {
+    const element = document.createElement('div');
+    element.setAttribute('aria-hidden', 'false');
+    const snapshot = snapshotAttributes(element, ['aria-hidden', 'inert']);
+
+    element.setAttribute('aria-hidden', 'true');
+    element.setAttribute('inert', '');
+    restoreAttributes(element, snapshot);
+
+    expect(element.getAttribute('aria-hidden')).toBe('false');
+    expect(element.hasAttribute('inert')).toBe(false);
   });
 });
 

--- a/packages/utils/src/dom/tests/children.test.ts
+++ b/packages/utils/src/dom/tests/children.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { findElementChild, followElementPath, getElementChildren } from '../children';
+
+function isHTMLElement(element: Element): element is HTMLElement {
+  return element instanceof HTMLElement;
+}
+
+describe('element children', () => {
+  it('filters and finds direct children with predicate inference', () => {
+    const parent = document.createElement('div');
+    const first = document.createElement('span');
+    const second = document.createElement('button');
+    const nested = document.createElement('button');
+
+    first.append(nested);
+    parent.append(first, second);
+
+    expect(getElementChildren(parent, isHTMLElement)).toEqual([first, second]);
+    expect(
+      findElementChild(parent, (element): element is HTMLButtonElement => element instanceof HTMLButtonElement)
+    ).toBe(second);
+    expect(getElementChildren(parent, (element) => element.localName === 'button')).toEqual([second]);
+  });
+
+  it('follows a child path and stops cycles', () => {
+    const root = document.createElement('div');
+    const child = document.createElement('div');
+    const leaf = document.createElement('div');
+    const next = new Map<HTMLDivElement, HTMLDivElement>([
+      [root, child],
+      [child, leaf],
+      [leaf, root],
+    ]);
+
+    expect(followElementPath(root, (element) => next.get(element) ?? null)).toEqual([root, child, leaf]);
+  });
+});

--- a/packages/utils/src/dom/tests/layout.test.ts
+++ b/packages/utils/src/dom/tests/layout.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getBlockExtent,
+  getElementPadding,
+  getElementSize,
+  getInlineExtent,
+  measureElement,
+  measureElementChildren,
+} from '../layout';
+
+afterEach(() => vi.restoreAllMocks());
+
+function setDimensions(
+  element: HTMLElement,
+  dimensions: {
+    rectWidth: number;
+    rectHeight: number;
+    offsetWidth?: number;
+    offsetHeight?: number;
+    scrollWidth?: number;
+    scrollHeight?: number;
+  }
+): void {
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    width: dimensions.rectWidth,
+    height: dimensions.rectHeight,
+  } as DOMRect);
+  Object.defineProperties(element, {
+    offsetWidth: { configurable: true, value: dimensions.offsetWidth ?? 0 },
+    offsetHeight: { configurable: true, value: dimensions.offsetHeight ?? 0 },
+    scrollWidth: { configurable: true, value: dimensions.scrollWidth ?? 0 },
+    scrollHeight: { configurable: true, value: dimensions.scrollHeight ?? 0 },
+  });
+}
+
+describe('DOM layout utilities', () => {
+  it('reads bounding, layout, and overflow sizes', () => {
+    const element = document.createElement('div');
+    setDimensions(element, {
+      rectWidth: 120,
+      rectHeight: 80,
+      offsetWidth: 100,
+      offsetHeight: 60,
+      scrollWidth: 140,
+      scrollHeight: 90,
+    });
+
+    expect(getElementSize(element)).toEqual({ width: 120, height: 80 });
+    expect(getElementSize(element, { box: 'layout' })).toEqual({ width: 100, height: 60 });
+    expect(getElementSize(element, { box: 'layout', overflow: 'both' })).toEqual({ width: 140, height: 90 });
+  });
+
+  it('temporarily applies styles while measuring', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('width', '80px', 'important');
+    setDimensions(element, { rectWidth: 160, rectHeight: 90 });
+
+    expect(measureElement(element, { styles: { width: 'max-content', minWidth: '0px' } })).toEqual({
+      width: 160,
+      height: 90,
+    });
+    expect(element.style.getPropertyValue('width')).toBe('80px');
+    expect(element.style.getPropertyPriority('width')).toBe('important');
+    expect(element.style.getPropertyValue('min-width')).toBe('');
+  });
+
+  it('reads logical padding', () => {
+    const element = document.createElement('div');
+    vi.spyOn(globalThis, 'getComputedStyle').mockReturnValue({
+      paddingInlineStart: '4px',
+      paddingInlineEnd: '6px',
+      paddingBlockStart: '8px',
+      paddingBlockEnd: '10px',
+    } as CSSStyleDeclaration);
+
+    const padding = getElementPadding(element);
+    expect(getInlineExtent(padding)).toBe(10);
+    expect(getBlockExtent(padding)).toBe(18);
+  });
+
+  it('measures and remeasures child layouts at a maximum width', () => {
+    const container = document.createElement('div');
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    container.append(first, second);
+    Object.defineProperty(second, 'offsetTop', { configurable: true, value: 40 });
+
+    vi.spyOn(globalThis, 'getComputedStyle').mockReturnValue({
+      paddingInlineStart: '5px',
+      paddingInlineEnd: '5px',
+      paddingBlockStart: '2px',
+      paddingBlockEnd: '3px',
+    } as CSSStyleDeclaration);
+
+    const measure = vi.fn((element: HTMLElement, width?: number) => ({
+      width: width ?? (element === first ? 180 : 140),
+      height: width === undefined ? 40 : element === first ? 60 : 50,
+    }));
+
+    expect(
+      measureElementChildren(container, {
+        children: [first, second],
+        includePadding: true,
+        maxWidth: 150,
+        measure,
+      })
+    ).toEqual({ width: 150, height: 95 });
+    expect(measure).toHaveBeenCalledWith(first, 140);
+    expect(measure).toHaveBeenCalledWith(second, 140);
+  });
+
+  it('preserves a zero maximum width', () => {
+    const container = document.createElement('div');
+    const child = document.createElement('div');
+    container.append(child);
+
+    expect(
+      measureElementChildren(container, {
+        children: [child],
+        maxWidth: 0,
+        measure: (_element, width) => ({ width: width ?? 100, height: 20 }),
+      })
+    ).toEqual({ width: 0, height: 20 });
+  });
+});

--- a/packages/utils/src/dom/tests/observe-elements.test.ts
+++ b/packages/utils/src/dom/tests/observe-elements.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { observeElements, observeResize } from '../observe-elements';
+
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = [];
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+}
+
+class MutationObserverStub {
+  static instances: MutationObserverStub[] = [];
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: MutationCallback) {
+    MutationObserverStub.instances.push(this);
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  ResizeObserverStub.instances.length = 0;
+  MutationObserverStub.instances.length = 0;
+});
+
+describe('observeResize', () => {
+  it('observes multiple elements and returns cleanup', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    const callback = vi.fn();
+    const cleanup = observeResize([first, second], callback);
+    const observer = ResizeObserverStub.instances[0]!;
+
+    expect(observer.observe).toHaveBeenCalledTimes(2);
+    expect(observer.observe).toHaveBeenCalledWith(first);
+    expect(observer.observe).toHaveBeenCalledWith(second);
+
+    observer.callback([], observer as unknown as ResizeObserver);
+    expect(callback).toHaveBeenCalledOnce();
+
+    cleanup();
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when ResizeObserver is unavailable', () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    expect(() => observeResize(document.createElement('div'), vi.fn())()).not.toThrow();
+  });
+});
+
+describe('observeElements', () => {
+  it('refreshes the observed set when the root mutates', () => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal('MutationObserver', MutationObserverStub);
+    const root = document.createElement('div');
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    let elements = [first];
+    const onChange = vi.fn();
+    const cleanup = observeElements({
+      root,
+      getElements: () => elements,
+      mutations: { childList: true },
+      onChange,
+    });
+
+    expect(ResizeObserverStub.instances[0]!.observe).toHaveBeenCalledWith(first);
+
+    elements = [second];
+    MutationObserverStub.instances[0]!.callback([], MutationObserverStub.instances[0] as unknown as MutationObserver);
+
+    expect(ResizeObserverStub.instances[0]!.disconnect).toHaveBeenCalledOnce();
+    expect(ResizeObserverStub.instances[1]!.observe).toHaveBeenCalledWith(second);
+    expect(onChange).toHaveBeenCalledOnce();
+
+    cleanup();
+    expect(MutationObserverStub.instances[0]!.disconnect).toHaveBeenCalledOnce();
+    expect(ResizeObserverStub.instances[1]!.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/utils/src/dom/tests/style.test.ts
+++ b/packages/utils/src/dom/tests/style.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { addAnchorName, getAnchorNames, resolveCSSLength } from '../style';
+import {
+  addAnchorName,
+  getAnchorNames,
+  readCSSLength,
+  resolveCSSLength,
+  restoreInlineStyles,
+  snapshotInlineStyles,
+  withInlineStyles,
+} from '../style';
 
 describe('getAnchorNames', () => {
   it('returns normalized anchor names', () => {
@@ -45,6 +53,45 @@ describe('addAnchorName', () => {
     cleanup();
 
     expect(getAnchorNames(el)).toEqual(['--settings-menu']);
+  });
+});
+
+describe('inline style snapshots', () => {
+  it('normalizes property names and restores values and priorities', () => {
+    const element = document.createElement('div');
+    element.style.setProperty('min-width', '20px', 'important');
+    const snapshot = snapshotInlineStyles(element, ['minWidth', '--custom-size']);
+
+    element.style.setProperty('min-width', '40px');
+    element.style.setProperty('--custom-size', '10px');
+    restoreInlineStyles(element, snapshot);
+
+    expect(element.style.getPropertyValue('min-width')).toBe('20px');
+    expect(element.style.getPropertyValue('--custom-size')).toBe('');
+  });
+
+  it('restores styles when a synchronous callback throws', () => {
+    const element = document.createElement('div');
+    element.style.width = '20px';
+
+    expect(() =>
+      withInlineStyles(element, { width: '40px' }, () => {
+        expect(element.style.width).toBe('40px');
+        throw new Error('stop');
+      })
+    ).toThrow('stop');
+    expect(element.style.width).toBe('20px');
+  });
+});
+
+describe('readCSSLength', () => {
+  it('distinguishes absent values and preserves zero', () => {
+    const element = document.createElement('div');
+
+    expect(readCSSLength(element, '--size', { source: 'inline' })).toBeNull();
+
+    element.style.setProperty('--size', '0px');
+    expect(readCSSLength(element, '--size', { source: 'inline' })).toBe(0);
   });
 });
 


### PR DESCRIPTION
Refs #2089

Refs #2029

## Summary

Extract the reusable DOM traversal, measurement, style preservation, and observation machinery discovered while simplifying menu sizing. The menu module now composes generic utilities while retaining only menu-specific transition, accessibility, and sizing policy.

This PR is stacked on #2029 and should be reviewed after the menu simplification work.

## Changes

- Add typed direct-child traversal and path-following helpers
- Add generic element sizing, temporary measurement, logical padding, and child-layout measurement
- Add inline-style and attribute snapshot/restore helpers plus CSS length reading
- Add `observeResize` and dynamic `observeElements` helpers
- Refactor menu sizing to use the shared primitives without changing submenu transition behavior
- Reuse the utilities in popup positioning, sliders, thumbnails, React/HTML slider previews, and HTML menu radio groups

<details>
<summary>Implementation details</summary>

Menu-specific concepts remain in Core. The shared utilities know only about DOM elements, styles, attributes, layout, and observers; they have no menu, submenu, transition, or settings vocabulary.

Non-positive available menu width remains an unset/pre-positioning state, preserving the behavior of #2029 while generic measurement continues to support an explicit zero maximum.

</details>

## Testing

- `pnpm -F @videojs/utils test`
- `pnpm -F @videojs/core test`
- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/react test src/ui/menu/tests/menu.test.tsx src/ui/slider/tests/slider-preview.test.tsx`
- `pnpm -F @videojs/utils build`
- `pnpm -F @videojs/core build`
- `pnpm -F @videojs/html build`
- `pnpm -F @videojs/react build`
- `pnpm typecheck`
- `pnpm check:workspace`
