### PR TITLE
fix(media): keep sideloaded track cues through hls.js resets

### DIFF
--- a/apps/e2e/tests/captions.spec.ts
+++ b/apps/e2e/tests/captions.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { MEDIA } from '../fixtures/resources';
 import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
@@ -56,5 +57,67 @@ test.describe('Captions', () => {
     await expect(player.captionsButton).toHaveAttribute(DATA_ATTRS.active, '');
     await player.captionsButton.click();
     await expect(player.captionsButton).not.toHaveAttribute(DATA_ATTRS.active);
+  });
+});
+
+/**
+ * hls.js resets every text track on the media element when it attaches, detaches,
+ * or loads a source, so a `<track>` that loaded before the source was known used
+ * to end up selected but empty — the browser never parses a loaded track again.
+ */
+test.describe('Captions sideloaded before an hls.js source', () => {
+  /** State of the sideloaded track, read from the element the page author sees. */
+  const englishTrack = (page: import('@playwright/test').Page) => {
+    return page.evaluate(() => {
+      const media = document.querySelector('hlsjs-video') as HTMLMediaElement | null;
+      const track = Array.from(media?.textTracks ?? []).find(({ label }) => label === 'English');
+      return { mode: track?.mode ?? 'missing', cues: track?.cues?.length ?? 0 };
+    });
+  };
+
+  const waitForManifest = (page: import('@playwright/test').Page) => {
+    return page.waitForFunction(() => (document.querySelector('hlsjs-video') as HTMLMediaElement).readyState >= 1);
+  };
+
+  test.beforeEach(async ({ page }) => {
+    // Reuse the page's registered elements, but start from a media element that
+    // has caption tracks and no source yet.
+    await page.goto('/pages/html-video-hls.html');
+    await page.evaluate(() => {
+      const vtt = `data:text/vtt,${encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:30.000\nSideloaded caption')}`;
+      document.getElementById('root')!.innerHTML = `
+        <video-player>
+          <video-skin style="max-width: 800px; aspect-ratio: 16/9">
+            <hlsjs-video playsinline>
+              <track default kind="subtitles" label="English" srclang="en" src="${vtt}" />
+            </hlsjs-video>
+          </video-skin>
+        </video-player>`;
+    });
+
+    await expect.poll(() => englishTrack(page)).toEqual({ mode: 'showing', cues: 1 });
+  });
+
+  test('keeps its cues when the source is assigned after connection', async ({ page }) => {
+    await page.evaluate((url) => {
+      (document.querySelector('hlsjs-video') as HTMLMediaElement).src = url;
+    }, MEDIA.hlsTs.url);
+    await waitForManifest(page);
+
+    expect(await englishTrack(page)).toEqual({ mode: 'showing', cues: 1 });
+  });
+
+  test('keeps its cues and selection when the source is replaced', async ({ page }) => {
+    await page.evaluate((url) => {
+      (document.querySelector('hlsjs-video') as HTMLMediaElement).src = url;
+    }, MEDIA.hlsTs.url);
+    await waitForManifest(page);
+
+    await page.evaluate((url) => {
+      (document.querySelector('hlsjs-video') as HTMLMediaElement).src = url;
+    }, MEDIA.hlsFmp4.url);
+    await waitForManifest(page);
+
+    expect(await englishTrack(page)).toEqual({ mode: 'showing', cues: 1 });
   });
 });

--- a/packages/media/src/dom/hls-js/hls-js-only.ts
+++ b/packages/media/src/dom/hls-js/hls-js-only.ts
@@ -17,7 +17,7 @@ import { HlsJsMediaMediaTracksMixin } from './media-tracks';
 import { HlsJsMediaMetadataTracksMixin } from './metadata-tracks';
 import { HlsJsMediaPreloadMixin } from './preload';
 import { HlsJsMediaStreamTypeMixin } from './stream-type';
-import { HlsJsMediaTextTracksMixin } from './text-tracks';
+import { HlsJsMediaTextTracksMixin, withPreservedTextTracks } from './text-tracks';
 
 export const defaultHlsConfig: Partial<HlsConfig> = {
   backBufferLength: 30,
@@ -55,16 +55,18 @@ class HlsJsOnlyMediaBase extends HTMLVideoElementHost implements MediaEngineHost
   }
 
   set src(src: string) {
-    this.#engine?.loadSource(src);
+    // Attaching, detaching, and loading a source each reset every text track on
+    // the element, sideloaded ones included. See `withPreservedTextTracks`.
+    withPreservedTextTracks(this.target as HTMLVideoElement | null, () => this.#engine?.loadSource(src));
   }
 
   attach(target: HTMLVideoElement) {
     super.attach(target);
-    this.#engine?.attachMedia(target);
+    withPreservedTextTracks(target, () => this.#engine?.attachMedia(target));
   }
 
   detach() {
-    this.#engine?.detachMedia();
+    withPreservedTextTracks(this.target as HTMLVideoElement | null, () => this.#engine?.detachMedia());
     super.detach();
   }
 

--- a/packages/media/src/dom/hls-js/tests/text-tracks.test.ts
+++ b/packages/media/src/dom/hls-js/tests/text-tracks.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withPreservedTextTracks } from '../text-tracks';
+
+/**
+ * jsdom has no text track implementation, so the media element and its tracks
+ * are stubbed with the parts the helper touches: `cues` reads as `null` while a
+ * track is disabled, exactly as the spec requires.
+ */
+class FakeTextTrack {
+  mode: TextTrackMode = 'disabled';
+  #cues: TextTrackCue[] = [];
+
+  get cues(): TextTrackCue[] | null {
+    return this.mode === 'disabled' ? null : this.#cues;
+  }
+
+  addCue(cue: TextTrackCue) {
+    this.#cues.push(cue);
+  }
+
+  /** Mirrors hls.js's `clearCurrentCues()`, which reads cues through `hidden`. */
+  clearCues() {
+    const { mode } = this;
+    if (mode === 'disabled') this.mode = 'hidden';
+    this.#cues = [];
+    if (mode === 'disabled') this.mode = mode;
+  }
+}
+
+interface FakeTrackElementInit {
+  mode?: TextTrackMode;
+  cues?: string[];
+  readyState?: number;
+  hlsOwned?: boolean;
+}
+
+function fakeTrackElement({ mode = 'showing', cues = [], readyState = 2, hlsOwned = false }: FakeTrackElementInit) {
+  const track = new FakeTextTrack();
+  track.mode = 'hidden';
+  for (const id of cues) track.addCue({ id } as TextTrackCue);
+  track.mode = mode;
+
+  return {
+    track,
+    readyState,
+    hasAttribute: (name: string) => hlsOwned && name === 'data-removeondestroy',
+  };
+}
+
+function fakeMedia(...trackEls: ReturnType<typeof fakeTrackElement>[]) {
+  return { querySelectorAll: () => trackEls } as unknown as HTMLMediaElement;
+}
+
+function cueIds(track: FakeTextTrack): string[] {
+  const { mode } = track;
+  if (mode === 'disabled') track.mode = 'hidden';
+  const ids = (track.cues ?? []).map((cue) => cue.id);
+  track.mode = mode;
+  return ids;
+}
+
+describe('withPreservedTextTracks', () => {
+  it('returns the action result', () => {
+    expect(withPreservedTextTracks(fakeMedia(), () => 'loaded')).toBe('loaded');
+  });
+
+  it('puts back cues the action removed from a sideloaded track', () => {
+    const trackEl = fakeTrackElement({ mode: 'showing', cues: ['one', 'two'] });
+
+    withPreservedTextTracks(fakeMedia(trackEl), () => trackEl.track.clearCues());
+
+    expect(cueIds(trackEl.track)).toEqual(['one', 'two']);
+  });
+
+  it('puts back the mode the action changed', () => {
+    const trackEl = fakeTrackElement({ mode: 'showing', cues: ['one'] });
+
+    withPreservedTextTracks(fakeMedia(trackEl), () => {
+      trackEl.track.clearCues();
+      trackEl.track.mode = 'disabled';
+    });
+
+    expect(trackEl.track.mode).toBe('showing');
+    expect(cueIds(trackEl.track)).toEqual(['one']);
+  });
+
+  it('keeps cues the action left alone from being added twice', () => {
+    const trackEl = fakeTrackElement({ mode: 'showing', cues: ['one'] });
+
+    withPreservedTextTracks(fakeMedia(trackEl), () => {
+      trackEl.track.addCue({ id: 'two' } as TextTrackCue);
+    });
+
+    expect(cueIds(trackEl.track)).toEqual(['one', 'two']);
+  });
+
+  it('restores a disabled track that already loaded its cues', () => {
+    const trackEl = fakeTrackElement({ mode: 'disabled', cues: ['one'], readyState: 2 });
+
+    withPreservedTextTracks(fakeMedia(trackEl), () => trackEl.track.clearCues());
+
+    expect(trackEl.track.mode).toBe('disabled');
+    expect(cueIds(trackEl.track)).toEqual(['one']);
+  });
+
+  it('does not touch the mode of a disabled track that never loaded', () => {
+    const trackEl = fakeTrackElement({ mode: 'disabled', readyState: 0 });
+    const setMode = vi.spyOn(trackEl.track, 'mode', 'set');
+
+    withPreservedTextTracks(fakeMedia(trackEl), () => {});
+
+    expect(setMode).not.toHaveBeenCalled();
+  });
+
+  it('leaves the tracks hls.js owns to hls.js', () => {
+    const trackEl = fakeTrackElement({ mode: 'showing', cues: ['one'], hlsOwned: true });
+
+    withPreservedTextTracks(fakeMedia(trackEl), () => {
+      trackEl.track.clearCues();
+      trackEl.track.mode = 'disabled';
+    });
+
+    expect(trackEl.track.mode).toBe('disabled');
+    expect(cueIds(trackEl.track)).toEqual([]);
+  });
+
+  it('restores when the action throws', () => {
+    const trackEl = fakeTrackElement({ mode: 'showing', cues: ['one'] });
+
+    expect(() =>
+      withPreservedTextTracks(fakeMedia(trackEl), () => {
+        trackEl.track.clearCues();
+        throw new Error('attach failed');
+      })
+    ).toThrow('attach failed');
+
+    expect(cueIds(trackEl.track)).toEqual(['one']);
+  });
+
+  it('runs the action without a media element', () => {
+    const action = vi.fn();
+
+    withPreservedTextTracks(null, action);
+
+    expect(action).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/media/src/dom/hls-js/text-tracks.ts
+++ b/packages/media/src/dom/hls-js/text-tracks.ts
@@ -4,6 +4,91 @@ import type { CuesParsedData, NonNativeTextTracksData } from 'hls.js';
 import Hls from 'hls.js';
 import type { HlsEngineHost } from './types';
 
+/** Marks the `<track>` elements created here for hls.js's own text tracks. */
+const HLS_TRACK_ATTR = 'data-removeondestroy';
+
+/** `HTMLTrackElement.LOADED` — the element parsed its resource and will not parse it again. */
+const TRACK_LOADED = 2;
+
+interface TextTrackSnapshot {
+  track: TextTrack;
+  mode: TextTrackMode;
+  cues: TextTrackCue[];
+}
+
+/**
+ * Runs an hls.js call that attaches, detaches, or loads a source, leaving the
+ * `<track>` children hls.js does not own the way it found them.
+ *
+ * hls.js resets *every* text track on the media element at those points: it
+ * clears the cues of all of them and disables the ones it takes for subtitles,
+ * without checking which tracks it created. Tracks sideloaded from `<track>`
+ * elements are collateral damage, and losing their cues is permanent — an
+ * element that finished loading is never parsed again, so the track keeps
+ * reporting `showing` while rendering nothing. It surfaces whenever a `<track>`
+ * outlives a source assignment, most visibly when `src` arrives after the
+ * element connected and its default track already loaded.
+ *
+ * Cues are the objects the browser parsed, so putting back the ones hls.js took
+ * restores the track without refetching its resource.
+ */
+export function withPreservedTextTracks<T>(media: HTMLMediaElement | null, action: () => T): T {
+  const snapshots = media ? snapshotTextTracks(media) : [];
+
+  try {
+    return action();
+  } finally {
+    for (const snapshot of snapshots) restoreTextTrack(snapshot);
+  }
+}
+
+function snapshotTextTracks(media: HTMLMediaElement): TextTrackSnapshot[] {
+  const snapshots: TextTrackSnapshot[] = [];
+
+  for (const trackEl of media.querySelectorAll('track')) {
+    // Tracks created for hls.js are rebuilt from the manifest on every load.
+    if (trackEl.hasAttribute(HLS_TRACK_ATTR)) continue;
+
+    const { track } = trackEl;
+    // A disabled track stays disabled through anything hls.js does, and only
+    // holds cues if it was enabled long enough to load them. Skipping the rest
+    // keeps the mode juggling below off the common path.
+    if (track.mode === 'disabled' && trackEl.readyState !== TRACK_LOADED) continue;
+
+    snapshots.push({
+      track,
+      mode: track.mode,
+      cues: withReadableCues(track, () => Array.from(track.cues ?? [])),
+    });
+  }
+
+  return snapshots;
+}
+
+function restoreTextTrack({ track, mode, cues }: TextTrackSnapshot): void {
+  if (track.mode !== mode) track.mode = mode;
+  if (!cues.length) return;
+
+  withReadableCues(track, () => {
+    const present = new Set<TextTrackCue>(track.cues ?? []);
+    for (const cue of cues) {
+      if (!present.has(cue)) track.addCue(cue);
+    }
+  });
+}
+
+/** Reads or writes cues through a mode that exposes them, leaving the track's own mode intact. */
+function withReadableCues<T>(track: TextTrack, action: () => T): T {
+  const { mode } = track;
+  if (mode === 'disabled') track.mode = 'hidden';
+
+  try {
+    return action();
+  } finally {
+    if (mode === 'disabled') track.mode = mode;
+  }
+}
+
 /**
  * Bridges hls.js non-native text tracks to native `<track>` elements so the
  * rest of the player can treat them like any other text track.
@@ -137,7 +222,7 @@ export function HlsJsMediaTextTracksMixin<Base extends Constructor<HlsEngineHost
     }
 
     #clearTracks(): void {
-      const trackEls = this.target?.querySelectorAll?.('track[data-removeondestroy]') ?? [];
+      const trackEls = this.target?.querySelectorAll?.(`track[${HLS_TRACK_ATTR}]`) ?? [];
       trackEls.forEach((trackEl) => trackEl.remove());
     }
   }
@@ -169,7 +254,7 @@ function addTextTrack(
   trackEl.track.mode = isCaptionOrSubtitleTrack({ kind }) ? 'disabled' : 'hidden';
 
   // Add data attribute to identify tracks that should be removed when switching sources/destroying hls.js instance.
-  trackEl.setAttribute('data-removeondestroy', '');
+  trackEl.setAttribute(HLS_TRACK_ATTR, '');
   mediaEl.append(trackEl);
 
   return trackEl.track as TextTrack;


### PR DESCRIPTION
Fixes #1859

## Summary

A `<track>` child that finished loading before hls.js got a source ended up selected but empty: hls.js clears the cues of *every* text track on the media element when it attaches, detaches, or loads a source, and no browser parses a loaded `<track>` element a second time.

## Changes

- Sideloaded `<track>` cues and their selected mode now survive an hls.js attach, detach, or source load, so a `src` assigned after the element connects (or replaced later) no longer empties the default caption track.
- Tracks hls.js created for the manifest are left to hls.js, which still rebuilds them per source.

<details>
<summary>Implementation details</summary>

`hls.js`'s `TimelineController._cleanTracks()` runs on `MEDIA_ATTACHING` and `MANIFEST_LOADING`, and `SubtitleTrackController.onMediaDetaching()` disables every subtitle track it finds and clears their cues. Neither checks which tracks hls.js created, and `loadSource()` internally detaches and re-attaches, so one source assignment hits all three paths.

Recovery after the fact is not possible: a track element at `readyState: LOADED` never re-parses. Re-assigning `src`, toggling `mode`, and re-appending the element were all verified as no-ops in Chromium, WebKit, and Firefox. So `withPreservedTextTracks()` snapshots the mode and cues of the non-hls.js `<track>` children immediately before each engine call and puts back whatever was removed. The cues are the objects the browser already parsed, so the resource is not refetched.

Disabled tracks are skipped unless they previously loaded, which keeps the temporary `mode` switch — needed because `cues` reads `null` while a track is disabled — off the common path.

</details>

## Testing

- `pnpm -F @videojs/media test` — new unit coverage for `withPreservedTextTracks` (jsdom has no text track implementation, so the tracks are stubbed).
- `pnpm -F @videojs/e2e e2e captions.spec` — two hls.js regression tests: cues survive a source assigned after connection, and survive a source replacement. Both fail without this change and pass in Chromium, WebKit, and Firefox.

Note: `Captions › captions button toggles captions` fails on WebKit before and after this change. The fixture combines `crossorigin="anonymous"` with a `data:text/vtt` track, which WebKit refuses; unrelated to this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hls.js lifecycle and text-track DOM behavior on every source change; mistakes could affect manifest subtitles or duplicate cues, but hls-owned tracks are explicitly excluded and tests cover edge cases.
> 
> **Overview**
> Fixes sideloaded `<track>` captions going **empty but still `showing`** when hls.js attaches, detaches, or loads a source—because hls.js clears cues on every text track and a loaded `<track>` never re-parses.
> 
> Adds **`withPreservedTextTracks`**, which snapshots mode and cue objects for author `<track>` elements (skipping hls-owned `data-removeondestroy` tracks) and restores them after each engine call. **`HlsJsOnlyMedia`** now wraps `loadSource`, `attachMedia`, and `detachMedia` with that helper.
> 
> Adds **Vitest** coverage for the helper (stubbed tracks) and **Playwright** regressions for hls.js: cues survive late `src` assignment and source replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcdbf44b000d22cf3498f3a0b9cf8d2ab94874a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->