### PR TITLE
fix(media): keep the hls audio selection across group switches

### DIFF
--- a/packages/media/src/dom/hls-js/media-tracks.ts
+++ b/packages/media/src/dom/hls-js/media-tracks.ts
@@ -34,6 +34,10 @@ function getLevelKey(level: HlsJsMediaTrackLevel): string {
   return `${level.url[0] ?? ''}|${level.width}x${level.height}|${level.videoCodec}|${level.bitrate}`;
 }
 
+function getAudioTrackKind(audioTrack: HlsJsMediaAudioTrack): string {
+  return audioTrack.default ? 'main' : 'alternative';
+}
+
 /**
  * Mirrors hls.js manifest levels and alternate audio into the media element's
  * `videoRenditions` / `audioTracks` lists, and wires user selection back to
@@ -56,6 +60,8 @@ export function HlsJsMediaMediaTracksMixin<Base extends Constructor<MediaTracksH
 
       engine.on(Hls.Events.MANIFEST_PARSED, this.#onManifestParsed);
       engine.on(Hls.Events.AUDIO_TRACKS_UPDATED, this.#onAudioTracksUpdated);
+      engine.on(Hls.Events.AUDIO_TRACK_SWITCHING, this.#onAudioTrackSwitch);
+      engine.on(Hls.Events.AUDIO_TRACK_SWITCHED, this.#onAudioTrackSwitch);
       engine.on(Hls.Events.LEVELS_UPDATED, this.#onLevelsUpdated);
       engine.on(Hls.Events.LEVEL_SWITCHED, this.#onLevelSwitched);
       engine.once(Hls.Events.DESTROYING, this.#teardown);
@@ -86,16 +92,47 @@ export function HlsJsMediaMediaTracksMixin<Base extends Constructor<MediaTracksH
       }
     };
 
+    // hls.js re-emits this whenever the active audio group changes, which a
+    // rendition switch can trigger mid-playback. Skip the rebuild when the set
+    // is unchanged so the list (and its selection) survives the group switch.
     #onAudioTracksUpdated = (_event: string, data: { audioTracks: HlsJsMediaAudioTrack[] }) => {
+      if (this.#audioTracksMatch(data.audioTracks)) return;
+
       this.#removeAudioTracks();
 
       for (const hlsAudioTrack of data.audioTracks) {
-        const kind = hlsAudioTrack.default ? 'main' : 'alternative';
-        const audioTrack = this.addAudioTrack(kind, hlsAudioTrack.name, hlsAudioTrack.lang);
+        const audioTrack = this.addAudioTrack(getAudioTrackKind(hlsAudioTrack), hlsAudioTrack.name, hlsAudioTrack.lang);
         audioTrack.id = `${hlsAudioTrack.id}`;
-        audioTrack.enabled = Boolean(hlsAudioTrack.default);
       }
     };
+
+    // `enabled` is owned by the engine's switch events rather than seeded from
+    // `.default`, because hls.js already carries a selection across audio groups
+    // and re-announces it here.
+    #onAudioTrackSwitch = (_event: string, data: { id: number }) => {
+      const selectedId = `${data.id}`;
+
+      for (const audioTrack of this.audioTracks) {
+        audioTrack.enabled = audioTrack.id === selectedId;
+      }
+    };
+
+    // hls.js reindexes track ids per audio group, so compare the identifying
+    // attributes rather than relying on object identity or ids alone.
+    #audioTracksMatch(hlsAudioTracks: HlsJsMediaAudioTrack[]): boolean {
+      const currentTracks = [...this.audioTracks];
+      if (currentTracks.length !== hlsAudioTracks.length) return false;
+
+      return hlsAudioTracks.every((hlsAudioTrack, index) => {
+        const audioTrack = currentTracks[index];
+        return (
+          audioTrack?.id === `${hlsAudioTrack.id}` &&
+          audioTrack.kind === getAudioTrackKind(hlsAudioTrack) &&
+          audioTrack.label === (hlsAudioTrack.name ?? '') &&
+          audioTrack.language === (hlsAudioTrack.lang ?? '')
+        );
+      });
+    }
 
     #switchAudioTrack = () => {
       const { engine } = this;
@@ -153,6 +190,8 @@ export function HlsJsMediaMediaTracksMixin<Base extends Constructor<MediaTracksH
 
       engine?.off(Hls.Events.MANIFEST_PARSED, this.#onManifestParsed);
       engine?.off(Hls.Events.AUDIO_TRACKS_UPDATED, this.#onAudioTracksUpdated);
+      engine?.off(Hls.Events.AUDIO_TRACK_SWITCHING, this.#onAudioTrackSwitch);
+      engine?.off(Hls.Events.AUDIO_TRACK_SWITCHED, this.#onAudioTrackSwitch);
       engine?.off(Hls.Events.LEVELS_UPDATED, this.#onLevelsUpdated);
       engine?.off(Hls.Events.LEVEL_SWITCHED, this.#onLevelSwitched);
       engine?.off(Hls.Events.DESTROYING, this.#teardown);

--- a/packages/media/src/dom/hls-js/tests/media-tracks.test.ts
+++ b/packages/media/src/dom/hls-js/tests/media-tracks.test.ts
@@ -48,6 +48,12 @@ const manifestParsed = (engine: Hls, levels: Array<Record<string, unknown>>) =>
 const audioTracksUpdated = (engine: Hls, audioTracks: Array<Record<string, unknown>>) =>
   (engine as any).emit(Hls.Events.AUDIO_TRACKS_UPDATED, { audioTracks });
 
+const audioTrackSwitching = (engine: Hls, audioTrack: Record<string, unknown>) =>
+  (engine as any).emit(Hls.Events.AUDIO_TRACK_SWITCHING, audioTrack);
+
+const audioTrackSwitched = (engine: Hls, audioTrack: Record<string, unknown>) =>
+  (engine as any).emit(Hls.Events.AUDIO_TRACK_SWITCHED, audioTrack);
+
 function flush() {
   return Promise.resolve();
 }
@@ -69,7 +75,7 @@ describe('HlsJsMediaMediaTracksMixin', () => {
     expect([...host.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 360]);
   });
 
-  it('mirrors alternate audio tracks and enables the default', () => {
+  it('mirrors alternate audio tracks', () => {
     const engine = createEngine();
     const host = new HlsJsMediaMediaTracks(engine);
 
@@ -79,9 +85,28 @@ describe('HlsJsMediaMediaTracksMixin', () => {
     ]);
 
     expect(host.audioTracks.length).toBe(2);
-    expect(host.audioTracks[0]?.enabled).toBe(true);
-    expect(host.audioTracks[1]?.enabled).toBe(false);
-    expect(host.audioTracks[1]?.label).toBe('Spanish');
+    expect([...host.audioTracks].map((track) => track.id)).toEqual(['0', '1']);
+    expect([...host.audioTracks].map((track) => track.kind)).toEqual(['main', 'alternative']);
+    expect([...host.audioTracks].map((track) => track.label)).toEqual(['English', 'Spanish']);
+    expect([...host.audioTracks].map((track) => track.language)).toEqual(['en', 'es']);
+  });
+
+  it('enables the audio track announced by the engine', () => {
+    const engine = createEngine();
+    const host = new HlsJsMediaMediaTracks(engine);
+
+    audioTracksUpdated(engine, [
+      { id: 0, default: true, name: 'English', lang: 'en' },
+      { id: 1, name: 'Spanish', lang: 'es' },
+    ]);
+    audioTrackSwitching(engine, { id: 0, default: true, name: 'English', lang: 'en' });
+
+    expect([...host.audioTracks].map((track) => track.enabled)).toEqual([true, false]);
+
+    // hls.js can pick a non-default track on its own (e.g. `audioPreference`).
+    audioTrackSwitched(engine, { id: 1, name: 'Spanish', lang: 'es' });
+
+    expect([...host.audioTracks].map((track) => track.enabled)).toEqual([false, true]);
   });
 
   it('forwards a rendition selection to engine.nextLevel', async () => {
@@ -168,6 +193,56 @@ describe('HlsJsMediaMediaTracksMixin', () => {
     expect(engine.audioTrack).toBe(1);
     expect(english!.enabled).toBe(false);
     expect(spanish!.enabled).toBe(true);
+  });
+
+  it('keeps the audio selection when a group switch re-emits the same track set', async () => {
+    const engine = createEngine();
+    const host = new HlsJsMediaMediaTracks(engine);
+
+    const audioTracks = [
+      { id: 0, default: true, name: 'English', lang: 'en' },
+      { id: 1, name: 'Spanish', lang: 'es' },
+    ];
+    audioTracksUpdated(engine, audioTracks);
+    audioTrackSwitching(engine, audioTracks[0]!);
+
+    const [english, spanish] = [...host.audioTracks];
+    english!.enabled = false;
+    spanish!.enabled = true;
+    await flush();
+    expect(engine.audioTrack).toBe(1);
+
+    // A rendition switch moves to another audio group: hls.js clears its
+    // selection, re-announces the same languages, then re-applies the match.
+    (engine as any).audioTrack = -1;
+    audioTracksUpdated(
+      engine,
+      audioTracks.map((audioTrack) => ({ ...audioTrack }))
+    );
+    (engine as any).audioTrack = 1;
+    audioTrackSwitching(engine, audioTracks[1]!);
+    await flush();
+
+    expect([...host.audioTracks].map((track) => track.enabled)).toEqual([false, true]);
+    expect(engine.audioTrack).toBe(1);
+  });
+
+  it('rebuilds the audio track list when the track set changes', () => {
+    const engine = createEngine();
+    const host = new HlsJsMediaMediaTracks(engine);
+
+    audioTracksUpdated(engine, [
+      { id: 0, default: true, name: 'English', lang: 'en' },
+      { id: 1, name: 'Spanish', lang: 'es' },
+    ]);
+
+    audioTracksUpdated(engine, [
+      { id: 0, default: true, name: 'English', lang: 'en' },
+      { id: 1, name: 'French', lang: 'fr' },
+    ]);
+
+    expect(host.audioTracks.length).toBe(2);
+    expect([...host.audioTracks].map((track) => track.label)).toEqual(['English', 'French']);
   });
 
   it('clears all media tracks on DESTROYING', () => {


### PR DESCRIPTION
Fixes #1856

## Summary

hls.js emits `AUDIO_TRACKS_UPDATED` every time the active audio group changes, which a rendition switch can trigger mid-playback. The mixin rebuilt `audioTracks` on that event and seeded `enabled` from the manifest's `default` flag, so any quality change (manual or ABR) snapped the viewer's audio language back to the default.

## Changes

- Skip the `audioTracks` rebuild when hls.js re-announces the same track set, so the list and its selection survive an audio group switch
- Derive `enabled` from `AUDIO_TRACK_SWITCHING` / `AUDIO_TRACK_SWITCHED` instead of the manifest `default` flag; hls.js already matches the current track into the new group and re-announces it

<details>
<summary>Implementation details</summary>

hls.js reindexes `track.id` per audio group, so the "same set" check compares id, kind, label, and language positionally rather than object identity. When the set genuinely differs the list is rebuilt with nothing enabled, and the `AUDIO_TRACK_SWITCHING` that hls.js fires in the same tick supplies the selection. Because `change` events on the track list are coalesced per microtask, the reflection never round-trips a stale selection back into `engine.audioTrack`.

</details>

## Testing

`pnpm -F @videojs/media test` (582 passing) and `pnpm typecheck`. New cases in `packages/media/src/dom/hls-js/tests/media-tracks.test.ts` cover the group-switch sequence, engine-announced selection, and list rebuilds; both new selection tests fail against the previous implementation.

Manual: load a multi-quality, multi-language HLS stream, pick a non-default audio language, then change quality and confirm the language sticks.

---

Original fix by @zoriya in https://github.com/videojs/v10/issues/1856, adapted with the same-set guard and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes playback-facing audio track mirroring and selection during live HLS events; behavior is localized to the hls.js mixin with new unit tests but affects user-visible language during ABR/rendition changes.
> 
> **Overview**
> Fixes audio language snapping back to the manifest default when quality changes during HLS playback.
> 
> The hls.js `HlsJsMediaMediaTracksMixin` no longer rebuilds `audioTracks` on every `AUDIO_TRACKS_UPDATED` if the announced set matches the current list (id, kind, label, language), so rendition-driven audio group switches preserve the user's language. **`enabled`** is now driven by `AUDIO_TRACK_SWITCHING` / `AUDIO_TRACK_SWITCHED` instead of seeding from the manifest **`default`** flag, aligning the DOM track list with hls.js's cross-group selection.
> 
> Tests cover engine-announced selection, same-set group switches, and full list rebuilds when tracks actually change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b156a76543d74e4e2d4940d9f8564817c674aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->