### PR TITLE
fix(build): make cdn bundles self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,3 +208,8 @@ jobs:
 
       - name: Build CDN bundles
         run: pnpm build:cdn
+
+      # Mirroring cdn/ onto another origin is supported, so the output must not
+      # reference an external CDN or resolve outside the directory.
+      - name: Check CDN bundles are self-contained
+        run: pnpm -F @videojs/html check:cdn

--- a/apps/sandbox/vite.config.ts
+++ b/apps/sandbox/vite.config.ts
@@ -11,7 +11,6 @@ const htmlCdnDir = resolve(__dirname, '../../packages/html/cdn');
 const htmlCdnI18nRegistry = normalizePath(resolve(htmlCdnDir, 'i18n.dev.js'));
 const cdnSandboxMainSrc = resolve(__dirname, 'src/cdn/main.ts');
 const cdnSandboxMainTemplate = resolve(__dirname, 'templates/cdn/main.ts');
-const jsdelivrCdnI18nPattern = /https:\/\/cdn\.jsdelivr\.net\/npm\/@videojs\/html@[^"']+\/cdn\/i18n\.js/g;
 
 /** True when this import should share the single CDN i18n registry module instance. */
 function resolvesToCdnI18nRegistry(source: string, importer?: string): boolean {
@@ -67,18 +66,6 @@ function cdnSandboxI18nPlugin(): Plugin {
         }
 
         return null;
-      },
-    },
-    transform: {
-      filter: {
-        id: /\/packages\/html\/cdn\//,
-        code: /cdn\.jsdelivr\.net\/npm\/@videojs\/html/,
-      },
-      handler(code) {
-        return {
-          code: code.replace(jsdelivrCdnI18nPattern, htmlCdnI18nRegistry),
-          map: null,
-        };
       },
     },
   };

--- a/build/plugins/cdn-i18n-external-plugin.ts
+++ b/build/plugins/cdn-i18n-external-plugin.ts
@@ -6,12 +6,18 @@ export const CDN_I18N_REGISTRY = '@videojs/html/cdn/i18n-registry';
 
 export interface CdnI18nExternalPluginOptions {
   prod: boolean;
-  version: string;
 }
 
+/**
+ * Keeps the i18n registry out of every CDN bundle by pointing them at the shared `i18n` entry.
+ *
+ * The rewritten specifier is always relative, so a mirrored copy of `cdn/` resolves entirely within
+ * its own origin and works offline. Sharing one registry instance no longer depends on every bundle
+ * naming the same absolute URL — `@videojs/core/i18n` keeps its state on `globalThis`, so duplicate
+ * instances converge on their own.
+ */
 export function cdnI18nExternalPlugin(options: CdnI18nExternalPluginOptions): BuildPlugin {
-  const url = `https://cdn.jsdelivr.net/npm/@videojs/html@${options.version}/cdn/i18n.js`;
-  const devFile = 'i18n.dev.js';
+  const file = options.prod ? 'i18n.js' : 'i18n.dev.js';
 
   function isCdnI18nEntry(importer: string): boolean {
     const normalized = importer.replaceAll('\\', '/');
@@ -34,10 +40,10 @@ export function cdnI18nExternalPlugin(options: CdnI18nExternalPluginOptions): Bu
     renderChunk(code, chunk) {
       if (!code.includes(CDN_I18N_REGISTRY)) return null;
 
-      const rel = chunk.fileName.includes('locales/')
-        ? `../${options.prod ? 'i18n.js' : devFile}`
-        : `./${options.prod ? 'i18n.js' : devFile}`;
-      const target = options.prod ? url : rel;
+      // Resolve against the chunk's own depth: `i18n` sits at the output root, and chunks are
+      // emitted at varying depths (`locales/es.js`, `media/mux-video/spf.js`).
+      const depth = chunk.fileName.split('/').length - 1;
+      const target = depth === 0 ? `./${file}` : `${'../'.repeat(depth)}${file}`;
       const output = new MagicString(code);
 
       for (const quote of ['"', "'"]) {

--- a/packages/core/src/core/i18n/registry.ts
+++ b/packages/core/src/core/i18n/registry.ts
@@ -2,11 +2,42 @@ import { DEFAULT_LOCALE } from '@videojs/utils/i18n';
 import type { FlatTranslations, Locale, Translations } from './params';
 import { flattenTranslations } from './utils';
 
-const registry = new Map<Locale, Partial<FlatTranslations>>();
-const subscribers = new Set<() => void>();
+interface I18nRegistry {
+  readonly layers: Map<Locale, Partial<FlatTranslations>>;
+  readonly subscribers: Set<() => void>;
+}
+
+/**
+ * Well-known key for the shared registry. Its name and value shape are a cross-version contract:
+ * every copy of this module in a realm must agree on them, so change the key when the shape changes.
+ */
+const I18N_REGISTRY_KEY = Symbol.for('@videojs/i18n-registry');
+
+type I18nRegistryHost = { [I18N_REGISTRY_KEY]?: I18nRegistry };
+
+/**
+ * The registry is realm-global rather than module-global so duplicate copies of this module
+ * converge on one set of translations.
+ *
+ * Duplication is normal, not a bug to fix upstream: separately loaded CDN bundles, a pinned and an
+ * unpinned URL for the same file, and two bundlers' output on one page all yield distinct module
+ * instances. With module-scoped state, a `registerI18n` call on one instance is invisible to the
+ * player reading from another, and the locale silently falls back to English.
+ */
+function getRegistry(): I18nRegistry {
+  const host = globalThis as I18nRegistryHost;
+  const existing = host[I18N_REGISTRY_KEY];
+  if (existing) {
+    return existing;
+  }
+
+  const registry: I18nRegistry = { layers: new Map(), subscribers: new Set() };
+  host[I18N_REGISTRY_KEY] = registry;
+  return registry;
+}
 
 function notify(): void {
-  for (const cb of subscribers) {
+  for (const cb of getRegistry().subscribers) {
     cb();
   }
 }
@@ -80,10 +111,11 @@ export function findLocaleKeys(locale: Locale): Locale[] {
 }
 
 function mergeI18nTranslations(chain: Locale[]): FlatTranslations {
+  const { layers } = getRegistry();
   const merged: Partial<FlatTranslations> = {};
   for (let i = chain.length - 1; i >= 0; i--) {
     const tag = chain[i]!;
-    const layer = registry.get(tag);
+    const layer = layers.get(tag);
     if (layer) {
       Object.assign(merged, layer);
     }
@@ -99,9 +131,10 @@ function mergeI18nTranslations(chain: Locale[]): FlatTranslations {
  * @public
  */
 export function registerI18n(locale: Locale, translations: Partial<Translations>): void {
+  const { layers } = getRegistry();
   const tag = getCanonicalLocaleKey(locale);
-  const existing = registry.get(tag) ?? {};
-  registry.set(tag, { ...existing, ...flattenTranslations(translations) });
+  const existing = layers.get(tag) ?? {};
+  layers.set(tag, { ...existing, ...flattenTranslations(translations) });
   notify();
 }
 
@@ -122,6 +155,7 @@ export function getI18nTranslations(locale: Locale): FlatTranslations {
  * @public
  */
 export function onI18nRegistryChange(callback: () => void): () => void {
+  const { subscribers } = getRegistry();
   subscribers.add(callback);
   return () => {
     subscribers.delete(callback);
@@ -135,11 +169,12 @@ export function onI18nRegistryChange(callback: () => void): () => void {
  * @public
  */
 export function hasRegisteredLocale(locale: Locale): boolean {
-  return registry.has(getCanonicalLocaleKey(locale));
+  return getRegistry().layers.has(getCanonicalLocaleKey(locale));
 }
 
 /** Clears registered locale overlays (test isolation). */
 export function resetI18nRegistry(): void {
-  registry.clear();
+  const { layers, subscribers } = getRegistry();
+  layers.clear();
   subscribers.clear();
 }

--- a/packages/core/src/core/i18n/tests/registry.test.ts
+++ b/packages/core/src/core/i18n/tests/registry.test.ts
@@ -95,3 +95,69 @@ describe('i18n registry', () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 });
+
+/**
+ * A page can end up with more than one copy of this module — separately loaded CDN bundles, a
+ * pinned and an unpinned URL for the same file, or two bundlers' output. Registry state is
+ * realm-global so those copies still agree; these tests stand in for that duplication by loading
+ * the module twice through a reset module cache.
+ */
+describe('i18n registry shared across module instances', () => {
+  async function loadTwoInstances() {
+    vi.resetModules();
+    const first = await import('../registry');
+    vi.resetModules();
+    const second = await import('../registry');
+
+    // Guards the premise: same state through genuinely different module objects.
+    expect(first).not.toBe(second);
+
+    return { first, second };
+  }
+
+  beforeEach(() => {
+    resetI18nRegistry();
+  });
+
+  it('reads translations registered through another instance', async () => {
+    const { first, second } = await loadTwoInstances();
+
+    first.registerI18n('es', { buttons: { play: 'Reproducir' } });
+
+    expect(second.getI18nTranslations('es')['buttons.play']).toBe('Reproducir');
+    expect(second.hasRegisteredLocale('es')).toBe(true);
+  });
+
+  it('merges layers for one locale across instances', async () => {
+    const { first, second } = await loadTwoInstances();
+
+    first.registerI18n('es', { buttons: { play: 'Reproducir' } });
+    second.registerI18n('es', { buttons: { pause: 'Pausa' } });
+
+    const es = first.getI18nTranslations('es');
+    expect(es['buttons.play']).toBe('Reproducir');
+    expect(es['buttons.pause']).toBe('Pausa');
+  });
+
+  it('notifies subscribers of another instance', async () => {
+    const { first, second } = await loadTwoInstances();
+    const spy = vi.fn();
+
+    const off = first.onI18nRegistryChange(spy);
+    second.registerI18n('fr', { buttons: { play: 'Lire' } });
+    expect(spy).toHaveBeenCalledOnce();
+
+    off();
+    second.registerI18n('fr', { buttons: { pause: 'Pause' } });
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('resets every instance at once', async () => {
+    const { first, second } = await loadTwoInstances();
+
+    first.registerI18n('es', { buttons: { play: 'Reproducir' } });
+    second.resetI18nRegistry();
+
+    expect(first.hasRegisteredLocale('es')).toBe(false);
+  });
+});

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -166,6 +166,7 @@
   "scripts": {
     "build": "tsdown",
     "build:cdn": "node --import tsx ./scripts/build-cdn-locales.ts && tsdown --config tsdown.cdn.config.ts",
+    "check:cdn": "node --import tsx ./scripts/check-cdn-self-contained.ts",
     "build:watch": "tsdown --watch ./src --no-clean",
     "dev": "pnpm run build:watch",
     "test": "vitest run",

--- a/packages/html/scripts/check-cdn-self-contained.ts
+++ b/packages/html/scripts/check-cdn-self-contained.ts
@@ -1,0 +1,94 @@
+/**
+ * Verify the built CDN output is self-contained.
+ *
+ * Mirroring `cdn/` onto your own origin is a supported way to run the player (see the site's
+ * "Self-host the player" guide), and Drupal-style distributions depend on it. That only holds while
+ * every module specifier in the output is relative and resolves inside the directory — a single
+ * absolute URL silently reintroduces a runtime dependency on a public CDN, which fails closed in
+ * offline, air-gapped, and strict-CSP deployments.
+ *
+ * Prerequisites: `@videojs/html`'s `build:cdn`.
+ */
+
+import { existsSync, globSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CDN_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../cdn');
+
+const PREFIX = '\x1b[35m[check-cdn]\x1b[0m';
+const log = {
+  info: (...args: unknown[]) => console.log(PREFIX, ...args),
+  error: (...args: unknown[]) => console.error(PREFIX, '\x1b[31merror:\x1b[0m', ...args),
+};
+
+/** Static `import`/`export … from`, and dynamic `import()`, specifiers. */
+const SPECIFIER = /(?:\bfrom|\bimport)\s*\(?\s*["']([^"']+)["']/g;
+
+/**
+ * Drop matches that cannot be module specifiers.
+ *
+ * The scan is a regex rather than a parser, so it also sees the words `from` and `import` inside
+ * prose — JSDoc retained in dev bundles, and template literals such as `` `… from "${type}"` ``.
+ * Real specifiers emitted by the bundler are plain paths, so anything carrying whitespace or
+ * template syntax is prose.
+ */
+function isLikelySpecifier(value: string): boolean {
+  return value.length > 0 && !/[\s{}$`]/.test(value);
+}
+
+function collectSpecifiers(code: string): string[] {
+  return [...code.matchAll(SPECIFIER)].map((match) => match[1] as string).filter(isLikelySpecifier);
+}
+
+function main() {
+  if (!existsSync(CDN_DIR)) {
+    log.error(`CDN build not found at ${CDN_DIR}. Run \`pnpm -F @videojs/html build:cdn\` first.`);
+    process.exit(1);
+  }
+
+  const files = globSync('**/*.js', { cwd: CDN_DIR }).sort();
+
+  if (files.length === 0) {
+    log.error(`No JavaScript bundles found in ${CDN_DIR}.`);
+    process.exit(1);
+  }
+
+  const problems: string[] = [];
+  let checked = 0;
+
+  for (const file of files) {
+    const path = resolve(CDN_DIR, file);
+
+    for (const specifier of collectSpecifiers(readFileSync(path, 'utf8'))) {
+      checked++;
+
+      if (/^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(specifier)) {
+        problems.push(`${file}: absolute specifier "${specifier}"`);
+        continue;
+      }
+
+      // A bare specifier has no importer to resolve it in the browser.
+      if (!specifier.startsWith('.')) {
+        problems.push(`${file}: bare specifier "${specifier}"`);
+        continue;
+      }
+
+      if (!existsSync(resolve(dirname(path), specifier))) {
+        problems.push(
+          `${file}: "${specifier}" resolves outside the build (${relative(CDN_DIR, resolve(dirname(path), specifier))})`
+        );
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    log.error(`${problems.length} specifier(s) break self-hosting:`);
+    for (const problem of problems) console.error(`  ${problem}`);
+    process.exit(1);
+  }
+
+  log.info(`✅ ${files.length} bundles, ${checked} specifiers — all resolve inside cdn/`);
+}
+
+main();

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -7,7 +7,6 @@ import { cdnI18nExternalPlugin } from '../../build/plugins/cdn-i18n-external-plu
 import { inlineCssPlugin } from '../../build/plugins/inline-css-plugin.ts';
 import { inlineTemplatePlugin } from '../../build/plugins/inline-template-plugin.ts';
 import { baseConfig } from '../../build/tsdown.ts';
-import pkg from './package.json' with { type: 'json' };
 
 type BuildMode = 'dev' | 'prod';
 
@@ -148,7 +147,7 @@ for (const mode of buildModes) {
       __DEV__: isProd ? 'false' : 'true',
     },
     plugins: [
-      cdnI18nExternalPlugin({ prod: isProd, version: pkg.version }),
+      cdnI18nExternalPlugin({ prod: isProd }),
       inlineCssPlugin({ skinsDir, minify: isProd }),
       inlineTemplatePlugin({ minify: isProd }),
       ...(!isProd ? [dtsStubsPlugin(outDir)] : []),


### PR DESCRIPTION
Refs #828

## Summary

Prod CDN bundles statically imported the i18n registry from a hard-coded `https://cdn.jsdelivr.net/...` URL, so a mirrored copy of `cdn/` still reached out to a public CDN at load. That blocks the offline and self-hosted deployments the "Self-host the player" guide already documents, and it blocks shipping a usable distribution archive for #828.

## Changes

- The i18n registry keeps its layers and subscribers on `globalThis`, so duplicate copies of `@videojs/core/i18n` converge on one set of translations instead of each holding their own. Public API is unchanged.
- CDN bundles now import the shared i18n entry through a relative specifier, so the build resolves entirely within its own origin and works offline.
- `pnpm -F @videojs/html check:cdn` asserts every module specifier in the built output is relative and resolves inside `cdn/`. CI runs it after building the bundles.

<details>
<summary>Implementation details</summary>

The absolute URL was a dedupe mechanism, not an addressing choice: the registry was module-scoped, so sharing one instance depended on every bundle naming the exact same URL. Duplicate instances are normal — separately loaded CDN bundles, a pinned and an unpinned URL for the same file, and two bundlers' output on one page all produce them. Moving the state to a realm-global symbol removes that constraint and lets the specifier stay relative.

The rewritten specifier is now derived from the chunk's own depth rather than special-casing `locales/`, which also corrects any chunk emitted deeper than one level (for example `media/mux-video/spf.js`).

This also fixes a latent hazard on jsDelivr. `how-to/i18n-register-locale` tells users to import the **unpinned** `.../@videojs/html/cdn/i18n.js` while bundles imported the **pinned** URL — different module-map keys, so `registerI18n` could be silently dropped. Those now converge.

The sandbox carried a Vite `transform` hook whose only job was rewriting that URL back to a local module; it is dead code once no bundle emits the URL, so it is removed.

</details>

## Testing

1. `pnpm -F @videojs/core test` (1434 passed) and `pnpm -F @videojs/html test` (343 passed)
2. `pnpm build:cdn && pnpm -F @videojs/html check:cdn` — 392 bundles, 943 specifiers, zero references to jsdelivr (was 59 files)
3. `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace`

The four new registry tests load the module twice through a reset module cache to stand in for real duplication. Verified they are not vacuous: against the previous module-scoped implementation all four fail (`expected undefined to be 'Reproducir'`) while the existing eleven still pass. The `check:cdn` guard was likewise verified in both directions by injecting an absolute URL into a locale bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes i18n runtime state (realm-global registry) and CDN load behavior for all self-hosted deployments; mitigated by unchanged API, new cross-instance tests, and automated CDN self-containment checks in CI.
> 
> **Overview**
> Production CDN bundles no longer pull the shared i18n registry from a hard-coded **jsDelivr** URL. The build rewrites those imports to **relative** paths to `i18n.js` / `i18n.dev.js`, computed from each chunk’s depth so nested outputs like `media/mux-video/spf.js` still resolve correctly. Mirrored or offline copies of `cdn/` can load without reaching an external CDN.
> 
> **`@videojs/core/i18n`** now stores registry layers and subscribers on **`globalThis`** via `Symbol.for('@videojs/i18n-registry')`, so multiple module instances (separate script tags, pinned vs unpinned URLs, mixed bundlers) share one translation store. The public API is unchanged; new tests cover cross-instance register, merge, notify, and reset.
> 
> CI runs **`pnpm -F @videojs/html check:cdn`** after `build:cdn` to fail on absolute URLs, bare specifiers, or imports that resolve outside `cdn/`. The sandbox Vite config drops the transform that rewrote jsDelivr URLs back to local files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2f0439e6f8218de140fd303d639a38c5d9497d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->