### PR TITLE
feat(build): include distribution files as a release asset

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,16 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm build:cdn
 
+      # Fail before publishing rather than ship bundles that reach out to a public
+      # CDN at runtime, which would break self-hosted and archive installs.
+      - name: Check CDN bundles are self-contained
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: pnpm -F @videojs/html check:cdn
+
+      - name: Build distribution archive
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: pnpm -F @videojs/html build:archive
+
       # The site build emits per-framework markdown to site/dist/docs/framework/{html,react}/.
       # The @videojs/html and @videojs/react packages' prepack scripts (fired by `pnpm publish`
       # below) copy that subtree into each package's docs/ directory so it ships in the tarball.
@@ -92,6 +102,21 @@ jobs:
         run: pnpm -r publish --filter "./packages/*" --access public --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Attach the archive to the @videojs/html release so installers outside npm
+      # (Composer, Drupal) have a stable, versioned download. The version comes from
+      # the manifest release-please just bumped, matching release-pr.yml.
+      - name: Upload distribution archive to the release
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: |
+          VERSION=$(jq -r '."packages/html"' .github/release-please/.release-please-manifest.json)
+          gh release upload "@videojs/html@${VERSION}" \
+            "packages/html/archive/videojs-html-${VERSION}.zip" \
+            "packages/html/archive/videojs-html-${VERSION}.tar.gz" \
+            packages/html/archive/SHA256SUMS \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update site/v10 branch
         if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/packages/html/.gitignore
+++ b/packages/html/.gitignore
@@ -1,1 +1,2 @@
 /cdn/
+/archive/

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -167,10 +167,11 @@
     "build": "tsdown",
     "build:cdn": "node --import tsx ./scripts/build-cdn-locales.ts && tsdown --config tsdown.cdn.config.ts",
     "check:cdn": "node --import tsx ./scripts/check-cdn-self-contained.ts",
+    "build:archive": "node --import tsx ./scripts/build-dist-archive.ts",
     "build:watch": "tsdown --watch ./src --no-clean",
     "dev": "pnpm run build:watch",
     "test": "vitest run",
-    "clean": "rimraf --glob dist cdn docs types '*.tsbuildinfo'",
+    "clean": "rimraf --glob dist cdn archive docs types '*.tsbuildinfo'",
     "prepack": "node --import tsx ../../site/scripts/copy-package-docs.ts html"
   },
   "dependencies": {

--- a/packages/html/scripts/build-dist-archive.ts
+++ b/packages/html/scripts/build-dist-archive.ts
@@ -1,0 +1,112 @@
+/**
+ * Build the distribution archives attached to each `@videojs/html` GitHub release.
+ *
+ * Package managers outside npm — Composer for Drupal, and anything vendoring a versioned
+ * tarball — need a downloadable, browser-ready copy of the player. This assembles one from the
+ * production CDN bundles: entry points, the shared chunks they import, and nothing else.
+ *
+ * Everything is copied out of the existing `build:cdn` output rather than rebuilt, so the archive
+ * ships the same bundles the CDN serves. Sourcemaps are left out to keep the download small, and
+ * their now-dangling `sourceMappingURL` comments are stripped so browsers do not request them.
+ *
+ * Prerequisites: `@videojs/html`'s `build:cdn`. Requires `zip` and `tar` on PATH.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findUnresolvableSpecifiers, resolveClosure } from './cdn-graph.ts';
+
+const PACKAGE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = resolve(PACKAGE_DIR, '../..');
+const CDN_DIR = resolve(PACKAGE_DIR, 'cdn');
+const OUT_DIR = resolve(PACKAGE_DIR, 'archive');
+
+const PREFIX = '\x1b[35m[dist-archive]\x1b[0m';
+const log = {
+  info: (...args: unknown[]) => console.log(PREFIX, ...args),
+  error: (...args: unknown[]) => console.error(PREFIX, '\x1b[31merror:\x1b[0m', ...args),
+};
+
+const SOURCE_MAPPING_URL = /\n?\/\/# sourceMappingURL=.*$/;
+
+function run(command: string, args: string[], cwd: string): void {
+  const result = spawnSync(command, args, { cwd, stdio: 'inherit' });
+
+  if (result.error) {
+    throw new Error(`\`${command}\` is required to build the archive but could not be run: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`\`${command} ${args.join(' ')}\` exited with ${result.status}`);
+  }
+}
+
+function sha256(path: string): string {
+  const result = spawnSync('shasum', ['-a', '256', path], { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(`Could not checksum ${path}`);
+  return (result.stdout.split(' ')[0] as string).trim();
+}
+
+async function main() {
+  if (!existsSync(CDN_DIR)) {
+    log.error(`CDN build not found at ${CDN_DIR}. Run \`pnpm -F @videojs/html build:cdn\` first.`);
+    process.exit(1);
+  }
+
+  // The build config resolves its entry globs against the working directory.
+  process.chdir(PACKAGE_DIR);
+  const [{ entries }, pkg] = await Promise.all([
+    import('../tsdown.cdn.config.ts'),
+    import('../package.json', { with: { type: 'json' } }).then((module) => module.default),
+  ]);
+
+  const name = `videojs-html-${pkg.version}`;
+  const stageDir = resolve(OUT_DIR, name);
+
+  rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(stageDir, { recursive: true });
+
+  // Production entries only: dev bundles carry a `.dev` suffix and are not part of a distribution.
+  const roots = entries.map(({ name: entry }) => `${entry}.js`);
+  const files = [...resolveClosure(CDN_DIR, roots)].sort();
+
+  for (const file of files) {
+    const target = join(stageDir, file);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, readFileSync(resolve(CDN_DIR, file), 'utf8').replace(SOURCE_MAPPING_URL, '\n'));
+  }
+
+  // The archive is what self-hosters actually run, so verify the copy rather than trusting that
+  // the reachable set stayed self-contained.
+  const problems = findUnresolvableSpecifiers(stageDir, files);
+  if (problems.length > 0) {
+    log.error(`${problems.length} specifier(s) would break the archive:`);
+    for (const problem of problems) console.error(`  ${problem}`);
+    process.exit(1);
+  }
+
+  cpSync(resolve(REPO_ROOT, 'LICENSE'), resolve(stageDir, 'LICENSE'));
+  cpSync(resolve(PACKAGE_DIR, 'README.md'), resolve(stageDir, 'README.md'));
+  writeFileSync(resolve(stageDir, 'VERSION'), `${pkg.version}\n`);
+
+  run('zip', ['--quiet', '--recurse-paths', `${name}.zip`, name], OUT_DIR);
+  run('tar', ['--create', '--gzip', '--file', `${name}.tar.gz`, name], OUT_DIR);
+
+  const archives = [`${name}.zip`, `${name}.tar.gz`];
+  writeFileSync(
+    resolve(OUT_DIR, 'SHA256SUMS'),
+    `${archives.map((archive) => `${sha256(resolve(OUT_DIR, archive))}  ${archive}`).join('\n')}\n`
+  );
+
+  log.info(`✅ ${files.length} bundles from ${roots.length} entries`);
+  for (const archive of archives) {
+    const size = (statSync(resolve(OUT_DIR, archive)).size / 1024).toFixed(0);
+    log.info(`   archive/${archive} (${size} KB)`);
+  }
+}
+
+main().catch((error: unknown) => {
+  log.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/html/scripts/cdn-graph.ts
+++ b/packages/html/scripts/cdn-graph.ts
@@ -1,0 +1,94 @@
+/**
+ * Module-graph helpers for the built CDN output.
+ *
+ * Shared by `check-cdn-self-contained.ts` and `build-dist-archive.ts` so the definition of
+ * "reachable from an entry" stays identical between the guard and the archive it guards.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+/** Static `import`/`export … from`, and dynamic `import()`, specifiers. */
+const SPECIFIER = /(?:\bfrom|\bimport)\s*\(?\s*["']([^"']+)["']/g;
+
+/**
+ * Drop matches that cannot be module specifiers.
+ *
+ * The scan is a regex rather than a parser, so it also sees the words `from` and `import` inside
+ * prose — JSDoc retained in dev bundles, and template literals such as `` `… from "${type}"` ``.
+ * Real specifiers emitted by the bundler are plain paths, so anything carrying whitespace or
+ * template syntax is prose.
+ */
+function isLikelySpecifier(value: string): boolean {
+  return value.length > 0 && !/[\s{}$`]/.test(value);
+}
+
+export function collectSpecifiers(code: string): string[] {
+  return [...code.matchAll(SPECIFIER)].map((match) => match[1] as string).filter(isLikelySpecifier);
+}
+
+function isAbsoluteSpecifier(specifier: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(specifier);
+}
+
+/**
+ * Every file reachable from `roots` by following relative specifiers, as paths relative to `dir`.
+ *
+ * The CDN build emits plain ES modules with no `import.meta.url` asset references, workers, or
+ * non-JavaScript files, so the static import graph is the complete set of files an entry needs.
+ */
+export function resolveClosure(dir: string, roots: readonly string[]): Set<string> {
+  const seen = new Set<string>();
+  const queue = [...roots];
+
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (seen.has(file)) continue;
+
+    const path = resolve(dir, file);
+    if (!existsSync(path)) {
+      throw new Error(`Expected bundle is missing from the build: ${file}`);
+    }
+
+    seen.add(file);
+
+    for (const specifier of collectSpecifiers(readFileSync(path, 'utf8'))) {
+      if (!specifier.startsWith('.')) continue;
+      queue.push(relative(dir, resolve(dirname(path), specifier)));
+    }
+  }
+
+  return seen;
+}
+
+/**
+ * Report specifiers that would break a copy of `dir` served from an arbitrary origin: anything
+ * absolute, bare, or resolving outside the directory.
+ */
+export function findUnresolvableSpecifiers(dir: string, files: Iterable<string>): string[] {
+  const problems: string[] = [];
+
+  for (const file of files) {
+    const path = resolve(dir, file);
+
+    for (const specifier of collectSpecifiers(readFileSync(path, 'utf8'))) {
+      if (isAbsoluteSpecifier(specifier)) {
+        problems.push(`${file}: absolute specifier "${specifier}"`);
+        continue;
+      }
+
+      // A bare specifier has no importer to resolve it in the browser.
+      if (!specifier.startsWith('.')) {
+        problems.push(`${file}: bare specifier "${specifier}"`);
+        continue;
+      }
+
+      const target = resolve(dirname(path), specifier);
+      if (!existsSync(target)) {
+        problems.push(`${file}: "${specifier}" resolves outside the build (${relative(dir, target)})`);
+      }
+    }
+  }
+
+  return problems;
+}

--- a/packages/html/scripts/check-cdn-self-contained.ts
+++ b/packages/html/scripts/check-cdn-self-contained.ts
@@ -2,17 +2,18 @@
  * Verify the built CDN output is self-contained.
  *
  * Mirroring `cdn/` onto your own origin is a supported way to run the player (see the site's
- * "Self-host the player" guide), and Drupal-style distributions depend on it. That only holds while
- * every module specifier in the output is relative and resolves inside the directory — a single
- * absolute URL silently reintroduces a runtime dependency on a public CDN, which fails closed in
- * offline, air-gapped, and strict-CSP deployments.
+ * "Self-host the player" guide), and the release distribution archive is cut from this output.
+ * That only holds while every module specifier is relative and resolves inside the directory — a
+ * single absolute URL silently reintroduces a runtime dependency on a public CDN, which fails
+ * closed in offline, air-gapped, and strict-CSP deployments.
  *
  * Prerequisites: `@videojs/html`'s `build:cdn`.
  */
 
-import { existsSync, globSync, readFileSync } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
+import { existsSync, globSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { findUnresolvableSpecifiers } from './cdn-graph.ts';
 
 const CDN_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../cdn');
 
@@ -21,25 +22,6 @@ const log = {
   info: (...args: unknown[]) => console.log(PREFIX, ...args),
   error: (...args: unknown[]) => console.error(PREFIX, '\x1b[31merror:\x1b[0m', ...args),
 };
-
-/** Static `import`/`export … from`, and dynamic `import()`, specifiers. */
-const SPECIFIER = /(?:\bfrom|\bimport)\s*\(?\s*["']([^"']+)["']/g;
-
-/**
- * Drop matches that cannot be module specifiers.
- *
- * The scan is a regex rather than a parser, so it also sees the words `from` and `import` inside
- * prose — JSDoc retained in dev bundles, and template literals such as `` `… from "${type}"` ``.
- * Real specifiers emitted by the bundler are plain paths, so anything carrying whitespace or
- * template syntax is prose.
- */
-function isLikelySpecifier(value: string): boolean {
-  return value.length > 0 && !/[\s{}$`]/.test(value);
-}
-
-function collectSpecifiers(code: string): string[] {
-  return [...code.matchAll(SPECIFIER)].map((match) => match[1] as string).filter(isLikelySpecifier);
-}
 
 function main() {
   if (!existsSync(CDN_DIR)) {
@@ -54,33 +36,7 @@ function main() {
     process.exit(1);
   }
 
-  const problems: string[] = [];
-  let checked = 0;
-
-  for (const file of files) {
-    const path = resolve(CDN_DIR, file);
-
-    for (const specifier of collectSpecifiers(readFileSync(path, 'utf8'))) {
-      checked++;
-
-      if (/^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(specifier)) {
-        problems.push(`${file}: absolute specifier "${specifier}"`);
-        continue;
-      }
-
-      // A bare specifier has no importer to resolve it in the browser.
-      if (!specifier.startsWith('.')) {
-        problems.push(`${file}: bare specifier "${specifier}"`);
-        continue;
-      }
-
-      if (!existsSync(resolve(dirname(path), specifier))) {
-        problems.push(
-          `${file}: "${specifier}" resolves outside the build (${relative(CDN_DIR, resolve(dirname(path), specifier))})`
-        );
-      }
-    }
-  }
+  const problems = findUnresolvableSpecifiers(CDN_DIR, files);
 
   if (problems.length > 0) {
     log.error(`${problems.length} specifier(s) break self-hosting:`);
@@ -88,7 +44,7 @@ function main() {
     process.exit(1);
   }
 
-  log.info(`✅ ${files.length} bundles, ${checked} specifiers — all resolve inside cdn/`);
+  log.info(`✅ ${files.length} bundles — every specifier resolves inside cdn/`);
 }
 
 main();

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -75,7 +75,14 @@ const localeEntries = globSync('src/cdn/locales/*.ts').map((file) => ({
   name: `locales/${basename(file, '.ts')}`,
 }));
 
-const entries = [
+/**
+ * Every CDN bundle the build emits, as `{ src, name }` where `name` is the output path without
+ * its extension. Exported so the distribution archive can take its entry points from the build
+ * definition rather than guessing which built files are entries and which are shared chunks.
+ *
+ * The `src` paths are relative to this package, so importers must run from the package root.
+ */
+export const entries = [
   { src: 'src/cdn/i18n.ts', name: 'i18n' },
   ...localeEntries,
   ...presets.map((name) => ({ src: `src/cdn/${name}.ts`, name })),

--- a/site/src/content/docs/how-to/self-host-the-player.mdx
+++ b/site/src/content/docs/how-to/self-host-the-player.mdx
@@ -8,6 +8,10 @@ import DocsLink from '@/components/docs/DocsLink.astro';
 
 By default, the <DocsLink slug="how-to/installation">installation</DocsLink> flow loads the player from a public CDN. For offline, air-gapped, or locked-down deployments, you can serve everything from your own origin instead. Pick one of the options below.
 
+<Aside type="tip" title="Which option?">
+Bundle a single file when you already build your front end. Download the release archive when you install outside npm, like Composer or Drupal. Mirror the CDN files when you want the published layout as-is.
+</Aside>
+
 ## Bundle a single file (recommended)
 
 Install the package, put the player's imports into an entry file, then let any bundler produce one self-contained module you can host anywhere. For the default video player, that's:
@@ -29,6 +33,51 @@ Load the output with `type="module"`:
 ```
 
 You get one file (plus a sourcemap), no runtime requests to a CDN, and only the features you import. Any bundler works (Vite, Rollup, webpack) as long as the output stays ESM.
+
+## Download the release archive
+
+Every [release](https://github.com/videojs/v10/releases) ships a `videojs-html-<version>.zip` (and a `.tar.gz`) holding the prebuilt player. Use it when your deployment installs dependencies outside npm, or when you want a versioned artifact to vendor into your own repository.
+
+Unpack it into whatever your server treats as static files:
+
+```bash
+curl -LO https://github.com/videojs/v10/releases/download/@videojs/html@10.0.0-beta.26/videojs-html-10.0.0-beta.26.zip
+unzip videojs-html-10.0.0-beta.26.zip -d public/
+```
+
+Then point a script tag at the player you want:
+
+```html
+<script type="module" src="/videojs-html-10.0.0-beta.26/video.js"></script>
+```
+
+The archive holds the same production bundles the CDN serves, minus sourcemaps and development builds. Every path inside it is relative, so it runs from any origin with no outbound requests. `SHA256SUMS` on the release verifies the download.
+
+For Composer-based projects such as Drupal, declare the archive as a package:
+
+```json title="composer.json"
+{
+  "repositories": [
+    {
+      "type": "package",
+      "package": {
+        "name": "videojs/html",
+        "version": "10.0.0-beta.26",
+        "type": "drupal-library",
+        "dist": {
+          "type": "zip",
+          "url": "https://github.com/videojs/v10/releases/download/@videojs/html@10.0.0-beta.26/videojs-html-10.0.0-beta.26.zip"
+        }
+      }
+    }
+  ],
+  "require": {
+    "videojs/html": "10.0.0-beta.26"
+  }
+}
+```
+
+Composer strips the archive's top-level directory, so the player lands directly in your libraries path.
 
 ## Mirror the prebuilt CDN files
 


### PR DESCRIPTION
Closes #828
Stacked on #2121 — review that first, and this diff will shrink to its own commits once #2121 merges.

## Summary

v8 shipped a `video-js-<version>.zip` release asset; v10 shipped no equivalent, so Composer-based projects such as [Drupal](https://www.drupal.org/project/videojs) had no way to install a browser-ready player. Each `@videojs/html` release now carries `videojs-html-<version>.zip` and `.tar.gz`.

## Changes

- `pnpm -F @videojs/html build:archive` assembles the archive from the production CDN bundles: every entry point, the shared chunks it imports, and nothing else. Sourcemaps and development builds stay out, so the zip is ~700 KB.
- The release workflow builds the archive and uploads it to the `@videojs/html` release, alongside a `SHA256SUMS` file.
- The release run verifies the CDN bundles are self-contained before publishing, so a regression fails the release instead of shipping an archive that cannot work offline.
- "Self-host the player" documents the archive and the Composer package declaration Drupal projects need.

<details>
<summary>Implementation details</summary>

Files are copied out of the existing `build:cdn` output rather than rebuilt, so the archive ships the same bundles the CDN serves and the release gains no extra build step.

Entry points come from the build config's exported entry list rather than a filename heuristic. `cdn/` holds the development and production builds side by side, and their content-hashed shared chunks are indistinguishable by name — 110 of the 280 non-`.dev.js` files there belong to the development build, so any glob-based filter silently ships them.

Excluding sourcemaps leaves dangling `sourceMappingURL` comments, so those are stripped and browsers do not request maps that are not there.

The archive is what self-hosters actually run, so the staged copy is re-verified before packing rather than trusting that the reachable set stayed self-contained. That check shares its graph traversal with `check:cdn`.

Archive layout, with one top-level directory because Composer strips it on extraction:

```
videojs-html-<version>/
  video.js  audio.js  background.js  …
  media/*.js  locales/*.js  i18n.js
  <shared chunks>
  LICENSE  README.md  VERSION
```

</details>

## Testing

1. `pnpm build:cdn && pnpm -F @videojs/html build:archive` — 194 bundles from 82 entries, 702 KB zip, 651 KB tar.gz
2. Verified the extracted archive in a real browser: served it over a local static server with **every off-origin request aborted**, loaded `video.js` and `locales/es.js` as separate module scripts, and got a booted player with `aria-label="Reproducir"` — zero blocked requests, zero page errors. That exercises both offline operation and the shared i18n registry across separately loaded bundles.
3. Confirmed the archive contains no sourcemaps, no development bundles, no `sourceMappingURL` comments, and no references to a public CDN.
4. `pnpm build:site` renders the updated guide; `pnpm lint`, `pnpm check:workspace`, and workflow YAML parsing all pass.

Note that the download URL contains the tag verbatim (`.../releases/download/@videojs/html@<version>/…`). Worth a sanity check on the first release that publishes an asset, since Composer will depend on that shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release pipeline and artifact upload paths; mistakes could break Composer/Drupal installs or ship non-offline bundles, mitigated by check:cdn and archive verification.
> 
> **Overview**
> Restores a **v8-style downloadable player** for non-npm installs (Composer/Drupal): each `@videojs/html` release gets `videojs-html-<version>.zip`/`.tar.gz` plus `SHA256SUMS`, uploaded from CI after npm publish.
> 
> **`pnpm -F @videojs/html build:archive`** stages production CDN entry bundles and their shared chunks (from exported `entries` in `tsdown.cdn.config.ts`, not globs), strips `sourceMappingURL`, adds LICENSE/README/VERSION, and re-runs the self-contained import check on the staged tree. **`cdn-graph.ts`** centralizes specifier scanning so **`check:cdn`** and the archive use the same rules.
> 
> Release CD now runs **`check:cdn`** before publish and **`build:archive`** before **`gh release upload`**. Docs add a **“Download the release archive”** path and a Composer `drupal-library` example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fce2873ef46a983e5d70ec63b5005de900643e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->