### PR TITLE
docs(site): document audio track radio group

### DIFF
--- a/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
@@ -1,4 +1,4 @@
-import { createPlayer, Menu, useAudioTrackOptions } from '@videojs/react';
+import { AudioTrackRadioGroup, createPlayer, Menu } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
@@ -7,30 +7,23 @@ const Player = createPlayer({ features: videoFeatures });
 const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
 
 function AudioMenu(): ReactNode {
-  const audioTrack = useAudioTrackOptions();
-  if (audioTrack?.state.availability !== 'available') return null;
-
   return (
     <Menu.Root side="top" align="end">
       <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
         Audio
       </Menu.Trigger>
       <Menu.Content className="menu">
-        <Menu.RadioGroup
+        <AudioTrackRadioGroup
           className="menu-group"
-          value={audioTrack.value}
-          onValueChange={audioTrack.setValue}
-          aria-label="Audio tracks"
-        >
-          {audioTrack.options.map((option) => (
-            <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled} className="menu-item">
-              {option.label}
-              <Menu.ItemIndicator checked={option.value === audioTrack.value} forceMount className="menu-indicator">
+          renderItem={(props, item) => (
+            <Menu.RadioItem {...props} className="menu-item">
+              {item.label}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
                 ✓
               </Menu.ItemIndicator>
             </Menu.RadioItem>
-          ))}
-        </Menu.RadioGroup>
+          )}
+        />
       </Menu.Content>
     </Menu.Root>
   );

--- a/site/src/content/docs/reference/audio-track-radio-group.mdx
+++ b/site/src/content/docs/reference/audio-track-radio-group.mdx
@@ -28,12 +28,14 @@ Creates radio items from the player audio track state and selects the enabled tr
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <Menu.RadioGroup>
-    <Menu.GroupLabel />
-    <Menu.RadioItem>
-      <Menu.ItemIndicator />
-    </Menu.RadioItem>
-  </Menu.RadioGroup>
+  <AudioTrackRadioGroup
+    renderItem={(props, item) => (
+      <Menu.RadioItem {...props}>
+        {item.label}
+        <Menu.ItemIndicator checked={item.checked} />
+      </Menu.RadioItem>
+    )}
+  />
   ```
 </FrameworkCase>
 
@@ -55,7 +57,7 @@ Creates radio items from the player audio track state and selects the enabled tr
 The group is available when the configured media exposes more than one audio track. Labels use the track label, then language, then kind. Pass `formatTrack` to customize the visible labels.
 
 <FrameworkCase frameworks={["react"]}>
-<DocsLink slug="reference/use-audio-track-options">`useAudioTrackOptions`</DocsLink> returns `null` when the <DocsLink slug="reference/feature-audio-track">audio track feature</DocsLink> is not configured. Use the returned options with <DocsLink slug="reference/menu">`Menu.RadioGroup`</DocsLink>.
+`AudioTrackRadioGroup` uses <DocsLink slug="reference/use-audio-track-options">`useAudioTrackOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-audio-track">audio track feature</DocsLink> is not configured.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -71,14 +73,14 @@ The group is available when the configured media exposes more than one audio tra
 | `data-hidden` | Present / absent | Present when multiple audio tracks are unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether multiple audio tracks are available. |
 
-Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
+Unavailable groups receive the native `hidden` attribute.
 
 ## Accessibility
 
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-Give `Menu.RadioGroup` an accessible name with `aria-label` or a nested `Menu.GroupLabel`.
+The component receives an accessible label from the `label` prop or defaults to `Audio`. Override it with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -112,6 +114,4 @@ The element receives an accessible label from the `label` property or defaults t
   </StyleCase>
 </FrameworkCase>
 
-<FrameworkCase frameworks={["html"]}>
-  <ComponentReference component="AudioTrackRadioGroup" />
-</FrameworkCase>
+<ComponentReference component="AudioTrackRadioGroup" />


### PR DESCRIPTION
Refs #2148

## Summary

Document the React `AudioTrackRadioGroup` API alongside the existing HTML component and update the live example to use the specialized component.

## Changes

- Add React anatomy, behavior, styling, and accessibility guidance
- Replace manual hook plumbing in the React demo
- Expose the generated React component reference on the shared page

## Testing

- `pnpm -F site api-docs`

Depends on #2124.