### PR TITLE
feat(react): add captions radio group

### DIFF
--- a/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
+++ b/packages/core/src/core/ui/captions-radio-group/captions-radio-group-core.ts
@@ -4,13 +4,12 @@ import { isCaptionOrSubtitleTrack } from '@videojs/utils/dom';
 import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
 import { resolveText, type Text } from '../../i18n';
-import { disableText, enableText } from '../../i18n/text/captions';
 import { captionsText, offText, subtitlesText } from '../../i18n/text/menu';
 import type { RadioOption, RadioOptionsState } from '../types';
 import { resolveLabel } from '../utils/resolve-label';
 
 export interface CaptionsRadioGroupProps {
-  /** Custom label for the menu trigger. */
+  /** Custom label for the options group. */
   label?: Text | string | ((state: CaptionsRadioGroupState) => Text | string) | undefined;
   /** Custom formatter for visible track labels. */
   formatTrack?: ((track: MediaTextTrack) => Text | string) | undefined;
@@ -72,7 +71,7 @@ export class CaptionsRadioGroupCore {
     const label = resolveLabel(this.#props.label, state);
     if (label) return label;
 
-    return state.subtitlesShowing ? disableText : enableText;
+    return captionsText;
   }
 
   getTrackLabel(track: MediaTextTrack): Text | string {

--- a/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/captions-radio-group/tests/captions-radio-group-core.test.ts
@@ -95,15 +95,15 @@ describe('CaptionsRadioGroupCore', () => {
   });
 
   describe('getLabel', () => {
-    it('returns default labels based on showing state', () => {
+    it('returns a stable default group label', () => {
       const core = new CaptionsRadioGroupCore();
       expect(core.getLabel(createState({ subtitlesShowing: false }))).toMatchObject({
-        key: 'captions.enable',
-        text: 'Enable captions',
+        key: 'menu.captions',
+        text: 'Captions',
       });
       expect(core.getLabel(createState({ subtitlesShowing: true }))).toMatchObject({
-        key: 'captions.disable',
-        text: 'Disable captions',
+        key: 'menu.captions',
+        text: 'Captions',
       });
     });
 

--- a/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
+++ b/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
@@ -97,16 +97,16 @@ afterEach(() => {
 });
 
 describe('CaptionsRadioGroupElement', () => {
-  it('uses the stateful core label for aria-label', async () => {
+  it('uses the stable core group label for aria-label', async () => {
     const { options } = setup('en');
 
     await options.updateComplete;
-    expect(options.getAttribute('aria-label')).toBe('Enable captions');
+    expect(options.getAttribute('aria-label')).toBe('Captions');
 
     const enabled = setup('en', { subtitlesShowing: true }).options;
 
     await enabled.updateComplete;
-    expect(enabled.getAttribute('aria-label')).toBe('Disable captions');
+    expect(enabled.getAttribute('aria-label')).toBe('Captions');
   });
 
   it('refreshes translated items when registry strings load for the active locale', async () => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -96,6 +96,10 @@ export {
   type CaptionsOption,
   type CaptionsOptionsProps,
   type CaptionsOptionsResult,
+  CaptionsRadioGroup,
+  type CaptionsRadioGroupItemProps,
+  type CaptionsRadioGroupItemState,
+  type CaptionsRadioGroupProps,
   useCaptionsOptions,
 } from './ui/captions-radio-group';
 export { CastButton, type CastButtonProps } from './ui/cast-button/cast-button';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -84,6 +84,12 @@ export {
   type AudioTrackOptionsResult,
   useAudioTrackOptions,
 } from './ui/audio-track';
+export {
+  AudioTrackRadioGroup,
+  type AudioTrackRadioGroupItemProps,
+  type AudioTrackRadioGroupItemState,
+  type AudioTrackRadioGroupProps,
+} from './ui/audio-track-radio-group';
 export { BufferingIndicator, type BufferingIndicatorProps } from './ui/buffering-indicator/buffering-indicator';
 export { CaptionsButton, type CaptionsButtonProps } from './ui/captions-button/captions-button';
 export {

--- a/packages/react/src/ui/audio-track-radio-group/audio-track-radio-group.tsx
+++ b/packages/react/src/ui/audio-track-radio-group/audio-track-radio-group.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { type AudioTrackRadioGroupCore, AudioTrackRadioGroupDataAttrs } from '@videojs/core';
+import { getStateDataAttrs } from '@videojs/core/dom';
+import { isFunction } from '@videojs/utils/predicate';
+import type { ReactElement } from 'react';
+import { Fragment, forwardRef } from 'react';
+
+import type { HTMLProps, UIComponentProps } from '../../utils/types';
+import {
+  type AudioTrackOption,
+  type AudioTrackOptionsProps,
+  useAudioTrackOptions,
+} from '../audio-track/use-audio-track-options';
+import { MenuRadioGroup } from '../menu/menu-radio-group';
+import type { MenuRadioItemProps } from '../menu/menu-radio-item';
+
+export type AudioTrackRadioGroupItemState = AudioTrackOption & {
+  /** Whether this option is the currently enabled audio track. */
+  checked: boolean;
+};
+
+export interface AudioTrackRadioGroupItemProps extends Omit<MenuRadioItemProps, 'ref'> {
+  /** Audio track value represented by the option. */
+  'data-track': string;
+}
+
+export interface AudioTrackRadioGroupProps
+  extends Omit<UIComponentProps<'div', AudioTrackRadioGroupCore.State>, 'children'>,
+    AudioTrackOptionsProps {
+  /** Render one consumer-owned menu radio item for every audio track. */
+  renderItem: (props: AudioTrackRadioGroupItemProps, state: AudioTrackRadioGroupItemState) => ReactElement;
+}
+
+/**
+ * Renders menu radio options for the player's audio tracks.
+ *
+ * @example
+ * ```tsx
+ * <AudioTrackRadioGroup
+ *   renderItem={(props, item) => (
+ *     <Menu.RadioItem {...props}>
+ *       {item.label}
+ *       <Menu.ItemIndicator checked={item.checked} />
+ *     </Menu.RadioItem>
+ *   )}
+ * />
+ * ```
+ */
+export const AudioTrackRadioGroup = forwardRef<HTMLDivElement, AudioTrackRadioGroupProps>(
+  function AudioTrackRadioGroup(componentProps, forwardedRef) {
+    const {
+      renderItem,
+      render,
+      className,
+      style,
+      label,
+      formatTrack,
+      disabled,
+      'aria-label': ariaLabelProp,
+      'aria-labelledby': ariaLabelledBy,
+      ...elementProps
+    } = componentProps;
+    const audioTrack = useAudioTrackOptions({ label, formatTrack, disabled });
+    if (!audioTrack) return null;
+
+    const { state, value, options, setValue } = audioTrack;
+    const ariaLabel = ariaLabelProp ?? (ariaLabelledBy === undefined ? audioTrack.label : undefined);
+
+    return (
+      <MenuRadioGroup
+        {...getStateDataAttrs(state, AudioTrackRadioGroupDataAttrs)}
+        {...elementProps}
+        ref={forwardedRef}
+        className={isFunction(className) ? className(state) : className}
+        style={isFunction(style) ? style(state) : style}
+        render={isFunction(render) ? (props: HTMLProps) => render(props, state) : render}
+        value={value}
+        onValueChange={setValue}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-disabled={state.disabled || undefined}
+        hidden={state.hidden}
+      >
+        {options.map((option) => {
+          const itemState = { ...option, checked: option.value === value };
+
+          return (
+            <Fragment key={option.value}>
+              {renderItem(
+                {
+                  value: option.value,
+                  disabled: option.disabled,
+                  'data-track': option.value,
+                  children: option.label,
+                },
+                itemState
+              )}
+            </Fragment>
+          );
+        })}
+      </MenuRadioGroup>
+    );
+  }
+);
+
+export namespace AudioTrackRadioGroup {
+  export type Props = AudioTrackRadioGroupProps;
+  export type State = AudioTrackRadioGroupCore.State;
+  export type ItemProps = AudioTrackRadioGroupItemProps;
+  export type ItemState = AudioTrackRadioGroupItemState;
+}

--- a/packages/react/src/ui/audio-track-radio-group/index.ts
+++ b/packages/react/src/ui/audio-track-radio-group/index.ts
@@ -1,0 +1,6 @@
+export {
+  AudioTrackRadioGroup,
+  type AudioTrackRadioGroupItemProps,
+  type AudioTrackRadioGroupItemState,
+  type AudioTrackRadioGroupProps,
+} from './audio-track-radio-group';

--- a/packages/react/src/ui/audio-track-radio-group/tests/audio-track-radio-group.test.tsx
+++ b/packages/react/src/ui/audio-track-radio-group/tests/audio-track-radio-group.test.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
+import type { MediaAudioTrack } from '@videojs/media';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '../../../i18n';
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Menu } from '../../menu';
+import { AudioTrackRadioGroup, type AudioTrackRadioGroupItemState } from '../audio-track-radio-group';
+
+afterEach(() => {
+  resetI18nRegistry();
+  cleanup();
+});
+
+const defaultAudioTrackList: MediaAudioTrack[] = [
+  { id: '0', kind: 'main', label: 'English', language: 'en', enabled: true },
+  { id: '1', kind: 'alternative', label: 'Spanish', language: 'es', enabled: false },
+];
+
+function renderAudioTrackRadioGroup({
+  audioTrackList = defaultAudioTrackList,
+  selectAudioTrack = vi.fn(),
+  locale,
+  group,
+}: {
+  audioTrackList?: MediaAudioTrack[];
+  selectAudioTrack?: (value: string) => void;
+  locale?: string;
+  group?: React.ReactNode;
+} = {}) {
+  const { Wrapper } = createPlayerWrapper({ audioTrackList, selectAudioTrack });
+  const content = (
+    <Menu.Root defaultOpen>
+      <Menu.Content>
+        {group ?? <AudioTrackRadioGroup renderItem={(props) => <Menu.RadioItem {...props} />} />}
+      </Menu.Content>
+    </Menu.Root>
+  );
+
+  render(locale ? <I18nProvider locale={locale}>{content}</I18nProvider> : content, { wrapper: Wrapper });
+
+  return { selectAudioTrack };
+}
+
+describe('AudioTrackRadioGroup', () => {
+  it('renders generated radio item props and option state', () => {
+    const states: AudioTrackRadioGroupItemState[] = [];
+    renderAudioTrackRadioGroup({
+      group: (
+        <AudioTrackRadioGroup
+          renderItem={(props, state) => {
+            states.push(state);
+            return <Menu.RadioItem {...props} />;
+          }}
+        />
+      ),
+    });
+
+    const english = screen.getByRole('menuitemradio', { name: 'English' });
+    const spanish = screen.getByRole('menuitemradio', { name: 'Spanish' });
+
+    expect(english.getAttribute('data-track')).toBe('0');
+    expect(english.getAttribute('aria-checked')).toBe('true');
+    expect(spanish.getAttribute('data-track')).toBe('1');
+    expect(spanish.getAttribute('aria-checked')).toBe('false');
+    expect(states.slice(-2)).toEqual([
+      expect.objectContaining({ value: '0', label: 'English', checked: true }),
+      expect.objectContaining({ value: '1', label: 'Spanish', checked: false }),
+    ]);
+  });
+
+  it('selects an audio track', () => {
+    const selectAudioTrack = vi.fn();
+    renderAudioTrackRadioGroup({ selectAudioTrack });
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Spanish' }));
+
+    expect(selectAudioTrack).toHaveBeenCalledWith('1');
+  });
+
+  it('exposes group state through attributes and callbacks', () => {
+    const ref = createRef<HTMLDivElement>();
+    renderAudioTrackRadioGroup({
+      group: (
+        <AudioTrackRadioGroup
+          ref={ref}
+          data-testid="group"
+          className={(state) => `audio-${state.availability}`}
+          renderItem={(props) => <Menu.RadioItem {...props} />}
+        />
+      ),
+    });
+
+    const group = screen.getByTestId('group');
+    expect(ref.current).toBe(group);
+    expect(group.classList.contains('audio-available')).toBe(true);
+    expect(group.getAttribute('aria-label')).toBe('Audio');
+    expect(group.getAttribute('data-audio-track')).toBe('0');
+    expect(group.getAttribute('data-availability')).toBe('available');
+    expect(group.hasAttribute('data-disabled')).toBe(false);
+    expect(group.hidden).toBe(false);
+  });
+
+  it('hides and disables the group when track selection is unavailable', () => {
+    renderAudioTrackRadioGroup({ audioTrackList: [defaultAudioTrackList[0]!] });
+
+    const group = document.querySelector<HTMLElement>('[role="group"]');
+    expect(group).toBeTruthy();
+    expect(group?.hidden).toBe(true);
+    expect(group?.getAttribute('aria-disabled')).toBe('true');
+    expect(group?.hasAttribute('data-disabled')).toBe(true);
+    expect(group?.hasAttribute('data-hidden')).toBe(true);
+    expect(group?.getAttribute('data-availability')).toBe('unavailable');
+  });
+
+  it('supports custom group and item roots', () => {
+    renderAudioTrackRadioGroup({
+      group: (
+        <AudioTrackRadioGroup
+          render={(props, state) => <section {...props} data-value={state.value} />}
+          renderItem={(props, state) => (
+            <Menu.RadioItem {...props}>
+              <span>{state.label}</span>
+              <Menu.ItemIndicator checked={state.checked}>✓</Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      ),
+    });
+
+    const group = screen.getByRole('group', { name: 'Audio' });
+    expect(group.tagName).toBe('SECTION');
+    expect(group.getAttribute('data-value')).toBe('0');
+    expect(screen.getByRole('menuitemradio', { name: 'English' }).querySelector('[aria-hidden="true"]')).toBeTruthy();
+    expect(screen.getByRole('menuitemradio', { name: 'Spanish' })).toBeTruthy();
+  });
+
+  it('translates the default accessible label', () => {
+    registerI18n('xx', { 'menu.audio': 'Audio translated' });
+    renderAudioTrackRadioGroup({ locale: 'xx' });
+
+    expect(screen.getByRole('group', { name: 'Audio translated' })).toBeTruthy();
+  });
+
+  it('lets explicit labeling override the default label', () => {
+    renderAudioTrackRadioGroup({
+      group: (
+        <>
+          <span id="audio-label">Choose audio</span>
+          <AudioTrackRadioGroup aria-labelledby="audio-label" renderItem={(props) => <Menu.RadioItem {...props} />} />
+        </>
+      ),
+    });
+
+    const group = screen.getByRole('group', { name: 'Choose audio' });
+    expect(group.hasAttribute('aria-label')).toBe(false);
+  });
+});

--- a/packages/react/src/ui/audio-track/use-audio-track-options.ts
+++ b/packages/react/src/ui/audio-track/use-audio-track-options.ts
@@ -11,6 +11,7 @@ export type AudioTrackOption = TranslatedRadioOption<AudioTrackRadioGroupOption>
 
 export interface AudioTrackOptionsResult {
   state: AudioTrackRadioGroupCore.State;
+  label: string;
   value: string;
   options: AudioTrackOption[];
   disabled: boolean;

--- a/packages/react/src/ui/captions-radio-group/captions-radio-group.tsx
+++ b/packages/react/src/ui/captions-radio-group/captions-radio-group.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { type CaptionsRadioGroupCore, CaptionsRadioGroupDataAttrs } from '@videojs/core';
+import { getStateDataAttrs } from '@videojs/core/dom';
+import { isFunction } from '@videojs/utils/predicate';
+import type { ReactElement } from 'react';
+import { Fragment, forwardRef } from 'react';
+
+import type { HTMLProps, UIComponentProps } from '../../utils/types';
+import { MenuRadioGroup } from '../menu/menu-radio-group';
+import type { MenuRadioItemProps } from '../menu/menu-radio-item';
+import { type CaptionsOption, type CaptionsOptionsProps, useCaptionsOptions } from './use-captions-options';
+
+export type CaptionsRadioGroupItemState = CaptionsOption & {
+  /** Whether this option is currently selected. */
+  checked: boolean;
+};
+
+export interface CaptionsRadioGroupItemProps extends Omit<MenuRadioItemProps, 'ref'> {
+  /** Text track value represented by the item. */
+  'data-track': string;
+}
+
+export interface CaptionsRadioGroupProps
+  extends Omit<UIComponentProps<'div', CaptionsRadioGroupCore.State>, 'children'>,
+    CaptionsOptionsProps {
+  /** Render one consumer-owned menu radio item for every captions option. */
+  renderItem: (props: CaptionsRadioGroupItemProps, state: CaptionsRadioGroupItemState) => ReactElement;
+}
+
+/**
+ * Renders menu radio items for the player's captions and subtitles tracks.
+ *
+ * @example
+ * ```tsx
+ * <CaptionsRadioGroup
+ *   renderItem={(props, item) => (
+ *     <Menu.RadioItem {...props}>
+ *       {item.label}
+ *       <Menu.ItemIndicator checked={item.checked} />
+ *     </Menu.RadioItem>
+ *   )}
+ * />
+ * ```
+ */
+export const CaptionsRadioGroup = forwardRef<HTMLDivElement, CaptionsRadioGroupProps>(
+  function CaptionsRadioGroup(componentProps, forwardedRef) {
+    const {
+      renderItem,
+      render,
+      className,
+      style,
+      label,
+      formatTrack,
+      disabled,
+      'aria-label': ariaLabelProp,
+      'aria-labelledby': ariaLabelledBy,
+      ...elementProps
+    } = componentProps;
+    const captions = useCaptionsOptions({ label, formatTrack, disabled });
+    if (!captions) return null;
+
+    const { state, value, options, setValue } = captions;
+    const ariaLabel = ariaLabelProp ?? (ariaLabelledBy === undefined ? captions.label : undefined);
+
+    return (
+      <MenuRadioGroup
+        {...getStateDataAttrs(state, CaptionsRadioGroupDataAttrs)}
+        {...elementProps}
+        ref={forwardedRef}
+        className={isFunction(className) ? className(state) : className}
+        style={isFunction(style) ? style(state) : style}
+        render={isFunction(render) ? (props: HTMLProps) => render(props, state) : render}
+        value={value}
+        onValueChange={setValue}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-disabled={state.disabled || undefined}
+        hidden={state.hidden}
+      >
+        {options.map((option) => {
+          const itemState = { ...option, checked: option.value === value };
+
+          return (
+            <Fragment key={option.value}>
+              {renderItem(
+                {
+                  value: option.value,
+                  disabled: option.disabled,
+                  'data-track': option.value,
+                  children: option.label,
+                },
+                itemState
+              )}
+            </Fragment>
+          );
+        })}
+      </MenuRadioGroup>
+    );
+  }
+);
+
+export namespace CaptionsRadioGroup {
+  export type Props = CaptionsRadioGroupProps;
+  export type State = CaptionsRadioGroupCore.State;
+  export type ItemProps = CaptionsRadioGroupItemProps;
+  export type ItemState = CaptionsRadioGroupItemState;
+}

--- a/packages/react/src/ui/captions-radio-group/index.ts
+++ b/packages/react/src/ui/captions-radio-group/index.ts
@@ -1,4 +1,10 @@
 export {
+  CaptionsRadioGroup,
+  type CaptionsRadioGroupItemProps,
+  type CaptionsRadioGroupItemState,
+  type CaptionsRadioGroupProps,
+} from './captions-radio-group';
+export {
   type CaptionsOption,
   type CaptionsOptionsProps,
   type CaptionsOptionsResult,

--- a/packages/react/src/ui/captions-radio-group/tests/captions-radio-group.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/captions-radio-group.test.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '../../../i18n';
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Menu } from '../../menu';
+import { CaptionsRadioGroup, type CaptionsRadioGroupItemState } from '../captions-radio-group';
+
+afterEach(() => {
+  resetI18nRegistry();
+  cleanup();
+});
+
+const defaultTextTrackList = [
+  { kind: 'subtitles', label: 'English', language: 'en', mode: 'disabled' },
+  { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'showing' },
+] as const;
+
+function renderCaptionsRadioGroup({
+  textTrackList = defaultTextTrackList,
+  subtitlesShowing = true,
+  selectSubtitlesTrack = vi.fn(),
+  locale,
+  group,
+}: {
+  textTrackList?: readonly { kind: string; label: string; language: string; mode: string }[];
+  subtitlesShowing?: boolean;
+  selectSubtitlesTrack?: (value: string) => void;
+  locale?: string;
+  group?: React.ReactNode;
+} = {}) {
+  const { Wrapper } = createPlayerWrapper({
+    textTrackList,
+    subtitlesShowing,
+    selectSubtitlesTrack,
+    chaptersCues: [],
+    thumbnailCues: [],
+    thumbnailTrackSrc: null,
+    toggleSubtitles: vi.fn(),
+  });
+  const content = (
+    <Menu.Root defaultOpen>
+      <Menu.Content>
+        {group ?? <CaptionsRadioGroup renderItem={(props) => <Menu.RadioItem {...props} />} />}
+      </Menu.Content>
+    </Menu.Root>
+  );
+
+  render(locale ? <I18nProvider locale={locale}>{content}</I18nProvider> : content, { wrapper: Wrapper });
+
+  return { selectSubtitlesTrack };
+}
+
+describe('CaptionsRadioGroup', () => {
+  it('renders generated radio item props and item state', () => {
+    const states: CaptionsRadioGroupItemState[] = [];
+    renderCaptionsRadioGroup({
+      group: (
+        <CaptionsRadioGroup
+          renderItem={(props, state) => {
+            states.push(state);
+            return <Menu.RadioItem {...props} />;
+          }}
+        />
+      ),
+    });
+
+    expect(screen.getByRole('menuitemradio', { name: 'Off' }).getAttribute('data-track')).toBe('off');
+    expect(screen.getByRole('menuitemradio', { name: 'Spanish' }).getAttribute('aria-checked')).toBe('true');
+    expect(states.slice(-3)).toEqual([
+      expect.objectContaining({ value: 'off', label: 'Off', checked: false }),
+      expect.objectContaining({ value: '0', label: 'English', checked: false }),
+      expect.objectContaining({ value: '1', label: 'Spanish', checked: true }),
+    ]);
+  });
+
+  it('selects a captions track', () => {
+    const selectSubtitlesTrack = vi.fn();
+    renderCaptionsRadioGroup({ selectSubtitlesTrack });
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'English' }));
+
+    expect(selectSubtitlesTrack).toHaveBeenCalledWith('0');
+  });
+
+  it('exposes group state through attributes and callbacks', () => {
+    const ref = createRef<HTMLDivElement>();
+    renderCaptionsRadioGroup({
+      group: (
+        <CaptionsRadioGroup
+          ref={ref}
+          data-testid="group"
+          className={(state) => `captions-${state.availability}`}
+          renderItem={(props) => <Menu.RadioItem {...props} />}
+        />
+      ),
+    });
+
+    const group = screen.getByTestId('group');
+    expect(ref.current).toBe(group);
+    expect(group.classList.contains('captions-available')).toBe(true);
+    expect(group.getAttribute('aria-label')).toBe('Disable captions');
+    expect(group.hasAttribute('data-active')).toBe(true);
+    expect(group.getAttribute('data-availability')).toBe('available');
+  });
+
+  it('hides and disables the group when captions are unavailable', () => {
+    renderCaptionsRadioGroup({ textTrackList: [], subtitlesShowing: false });
+
+    const group = document.querySelector<HTMLElement>('[role="group"]');
+    expect(group).toBeTruthy();
+    expect(group?.hidden).toBe(true);
+    expect(group?.getAttribute('aria-disabled')).toBe('true');
+    expect(group?.hasAttribute('data-disabled')).toBe(true);
+    expect(group?.hasAttribute('data-hidden')).toBe(true);
+  });
+
+  it('supports custom group and item roots', () => {
+    renderCaptionsRadioGroup({
+      group: (
+        <CaptionsRadioGroup
+          render={(props, state) => <section {...props} data-value={state.value} />}
+          renderItem={(props, state) => (
+            <Menu.RadioItem {...props}>
+              <span>{state.label}</span>
+              <Menu.ItemIndicator checked={state.checked}>✓</Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      ),
+    });
+
+    const group = screen.getByRole('group', { name: 'Disable captions' });
+    expect(group.tagName).toBe('SECTION');
+    expect(group.getAttribute('data-value')).toBe('1');
+    expect(screen.getByRole('menuitemradio', { name: 'Spanish' }).querySelector('[aria-hidden="true"]')).toBeTruthy();
+  });
+
+  it('translates the default accessible label', () => {
+    registerI18n('xx', { 'captions.disable': 'Disable translated captions' });
+    renderCaptionsRadioGroup({ locale: 'xx' });
+
+    expect(screen.getByRole('group', { name: 'Disable translated captions' })).toBeTruthy();
+  });
+});

--- a/packages/react/src/ui/captions-radio-group/tests/captions-radio-group.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/captions-radio-group.test.tsx
@@ -103,7 +103,7 @@ describe('CaptionsRadioGroup', () => {
     const group = screen.getByTestId('group');
     expect(ref.current).toBe(group);
     expect(group.classList.contains('captions-available')).toBe(true);
-    expect(group.getAttribute('aria-label')).toBe('Disable captions');
+    expect(group.getAttribute('aria-label')).toBe('Captions');
     expect(group.hasAttribute('data-active')).toBe(true);
     expect(group.getAttribute('data-availability')).toBe('available');
   });
@@ -134,16 +134,16 @@ describe('CaptionsRadioGroup', () => {
       ),
     });
 
-    const group = screen.getByRole('group', { name: 'Disable captions' });
+    const group = screen.getByRole('group', { name: 'Captions' });
     expect(group.tagName).toBe('SECTION');
     expect(group.getAttribute('data-value')).toBe('1');
     expect(screen.getByRole('menuitemradio', { name: 'Spanish' }).querySelector('[aria-hidden="true"]')).toBeTruthy();
   });
 
   it('translates the default accessible label', () => {
-    registerI18n('xx', { 'captions.disable': 'Disable translated captions' });
+    registerI18n('xx', { 'menu.captions': 'Translated captions' });
     renderCaptionsRadioGroup({ locale: 'xx' });
 
-    expect(screen.getByRole('group', { name: 'Disable translated captions' })).toBeTruthy();
+    expect(screen.getByRole('group', { name: 'Translated captions' })).toBeTruthy();
   });
 });

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -11,6 +11,7 @@ export type CaptionsOption = TranslatedRadioOption<CaptionsRadioGroupOption>;
 
 export interface CaptionsOptionsResult {
   state: CaptionsRadioGroupCore.State;
+  label: string;
   value: string;
   options: CaptionsOption[];
   disabled: boolean;

--- a/packages/react/src/ui/hooks/create-radio-options-hook.ts
+++ b/packages/react/src/ui/hooks/create-radio-options-hook.ts
@@ -2,7 +2,7 @@
 
 import type { RadioOption, RadioOptionsState } from '@videojs/core';
 import { logMissingFeature } from '@videojs/core/dom';
-import { translateText } from '@videojs/core/i18n';
+import { type Text, type TextParams, translateText } from '@videojs/core/i18n';
 import type { UnknownState } from '@videojs/store';
 import { useCallback, useState } from 'react';
 
@@ -13,6 +13,8 @@ interface RadioOptionsCore<Props, Media, State extends RadioOptionsState> {
   setProps(props: Props): void;
   setMedia(media: Media): void;
   getState(): State;
+  getLabel(state: State): Text | string;
+  getLabelParams?(state: State): TextParams | undefined;
   selectValue(media: Media, value: string): void;
 }
 
@@ -32,6 +34,7 @@ export type TranslatedRadioOption<Option extends RadioOption> = Omit<Option, 'la
 
 export interface RadioOptionsHookResult<Option extends RadioOption, State extends RadioOptionsState> {
   state: State;
+  label: string;
   value: string;
   options: TranslatedRadioOption<Option>[];
   disabled: boolean;
@@ -78,6 +81,7 @@ export function createRadioOptionsHook<Props, Media, State extends RadioOptionsS
 
     return {
       state,
+      label: translateText(core.getLabel(state), t, core.getLabelParams?.(state)),
       value: state.value,
       options,
       disabled: state.disabled,

--- a/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
+++ b/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
@@ -16,6 +16,7 @@ export type PlaybackRateOption = TranslatedRadioOption<PlaybackRateRadioGroupOpt
 
 export interface PlaybackRateOptionsResult {
   state: PlaybackRateRadioGroupCore.State;
+  label: string;
   rate: number;
   value: string;
   options: PlaybackRateOption[];

--- a/packages/react/src/ui/quality/use-quality-options.ts
+++ b/packages/react/src/ui/quality/use-quality-options.ts
@@ -11,6 +11,7 @@ export type QualityOption = TranslatedRadioOption<QualityRadioGroupOption>;
 
 export interface QualityOptionsResult {
   state: QualityRadioGroupCore.State;
+  label: string;
   value: string;
   options: QualityOption[];
   disabled: boolean;


### PR DESCRIPTION
Refs #2149

## Summary

Add a hook-backed React radio-group component for captions and subtitles, including the generated Off item and consumer-owned item roots.

## Changes

- Add `CaptionsRadioGroup` with required `renderItem` customization
- Forward translated dynamic labels and captions state attributes
- Cover selection, unavailability, custom rendering, translation, and refs

## Testing

- `pnpm -F @videojs/react test src/ui/captions-radio-group/tests/captions-radio-group.test.tsx`
- `pnpm -F @videojs/react build`

Stacked on #2124.