### PR TITLE
docs(site): document captions radio group

### DIFF
--- a/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
@@ -13,7 +13,6 @@ function CaptionsMenu(): ReactNode {
       <Menu.Content className="menu">
         <CaptionsRadioGroup
           className="menu-group"
-          aria-label="Captions"
           renderItem={(props, item) => (
             <Menu.RadioItem {...props} className="menu-item">
               {item.label}

--- a/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
@@ -1,34 +1,28 @@
-import { createPlayer, Menu, useCaptionsOptions } from '@videojs/react';
+import { CaptionsRadioGroup, createPlayer, Menu } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
 const Player = createPlayer({ features: videoFeatures });
 
 function CaptionsMenu(): ReactNode {
-  const captions = useCaptionsOptions();
-  if (captions?.state.availability !== 'available') return null;
-
   return (
     <Menu.Root side="top" align="end">
       <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
         Captions
       </Menu.Trigger>
       <Menu.Content className="menu">
-        <Menu.RadioGroup
+        <CaptionsRadioGroup
           className="menu-group"
-          value={captions.value}
-          onValueChange={captions.setValue}
           aria-label="Captions"
-        >
-          {captions.options.map((option) => (
-            <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled} className="menu-item">
-              {option.label}
-              <Menu.ItemIndicator checked={option.value === captions.value} forceMount className="menu-indicator">
+          renderItem={(props, item) => (
+            <Menu.RadioItem {...props} className="menu-item">
+              {item.label}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
                 ✓
               </Menu.ItemIndicator>
             </Menu.RadioItem>
-          ))}
-        </Menu.RadioGroup>
+          )}
+        />
       </Menu.Content>
     </Menu.Root>
   );

--- a/site/src/content/docs/reference/captions-radio-group.mdx
+++ b/site/src/content/docs/reference/captions-radio-group.mdx
@@ -80,11 +80,11 @@ Unavailable groups receive the native `hidden` attribute.
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-The component receives an accessible label from the `label` prop or defaults to `Enable captions` / `Disable captions` based on the current state. Override it with `aria-label` or `aria-labelledby`.
+The component receives an accessible label from the `label` prop or defaults to `Captions`. Override it with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-The element receives an accessible label from the `label` property or defaults to `Enable captions` / `Disable captions` based on the current state.
+The element receives an accessible label from the `label` property or defaults to `Captions`.
 </FrameworkCase>
 
 ## Examples

--- a/site/src/content/docs/reference/captions-radio-group.mdx
+++ b/site/src/content/docs/reference/captions-radio-group.mdx
@@ -28,12 +28,14 @@ Creates radio items from the player text track state and selects the showing cap
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <Menu.RadioGroup>
-    <Menu.GroupLabel />
-    <Menu.RadioItem>
-      <Menu.ItemIndicator />
-    </Menu.RadioItem>
-  </Menu.RadioGroup>
+  <CaptionsRadioGroup
+    renderItem={(props, item) => (
+      <Menu.RadioItem {...props}>
+        {item.label}
+        <Menu.ItemIndicator checked={item.checked} />
+      </Menu.RadioItem>
+    )}
+  />
   ```
 </FrameworkCase>
 
@@ -55,7 +57,7 @@ Creates radio items from the player text track state and selects the showing cap
 The group is available when the configured media exposes at least one caption or subtitle track. The first generated option is `Off`; selecting it hides captions. Track labels use the track label, then language, then kind. Pass `formatTrack` to customize the visible labels.
 
 <FrameworkCase frameworks={["react"]}>
-<DocsLink slug="reference/use-captions-options">`useCaptionsOptions`</DocsLink> returns `null` when the <DocsLink slug="reference/feature-text-tracks">text tracks feature</DocsLink> is not configured. Use the returned options with <DocsLink slug="reference/menu">`Menu.RadioGroup`</DocsLink>.
+`CaptionsRadioGroup` uses <DocsLink slug="reference/use-captions-options">`useCaptionsOptions`</DocsLink> to own selection and generate each item, including `Off`. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-text-tracks">text tracks feature</DocsLink> is not configured.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -71,14 +73,14 @@ The group is available when the configured media exposes at least one caption or
 | `data-hidden` | Present / absent | Present when caption or subtitle tracks are unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether caption or subtitle tracks are available. |
 
-Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
+Unavailable groups receive the native `hidden` attribute.
 
 ## Accessibility
 
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-Give `Menu.RadioGroup` an accessible name with `aria-label` or a nested `Menu.GroupLabel`.
+The component receives an accessible label from the `label` prop or defaults to `Enable captions` / `Disable captions` based on the current state. Override it with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -112,6 +114,4 @@ The element receives an accessible label from the `label` property or defaults t
   </StyleCase>
 </FrameworkCase>
 
-<FrameworkCase frameworks={["html"]}>
-  <ComponentReference component="CaptionsRadioGroup" />
-</FrameworkCase>
+<ComponentReference component="CaptionsRadioGroup" />


### PR DESCRIPTION
Refs #2149

## Summary

Document the React `CaptionsRadioGroup` API alongside the existing HTML component and update the live example to use it.

## Changes

- Add React anatomy, behavior, styling, and accessibility guidance
- Replace manual captions hook plumbing in the React demo
- Expose the generated React component reference on the shared page

## Testing

- `pnpm -F site api-docs`

Depends on #2127.