### PR TITLE
docs(site): update menu composition demos

### DIFF
--- a/site/src/components/docs/demos/menu/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/menu/html/css/BasicUsage.css
@@ -8,6 +8,30 @@
   width: 100%;
 }
 
+@keyframes media-menu-content-exit {
+  from {
+    filter: none;
+    translate: 0 0;
+  }
+
+  to {
+    filter: blur(8px);
+    translate: -100% 0;
+  }
+}
+
+@keyframes media-menu-content-enter {
+  from {
+    filter: blur(8px);
+    translate: -100% 0;
+  }
+
+  to {
+    filter: none;
+    translate: 0 0;
+  }
+}
+
 .menu-bar {
   position: absolute;
   right: 10px;
@@ -63,39 +87,26 @@
   will-change: translate;
 }
 
-.menu-panel[data-starting-style],
-.menu-panel[data-ending-style] {
-  overflow: hidden;
-}
-
-.menu-panel[data-menu-root-view][data-menu-view-state="inactive"] {
+.menu[data-submenu-expanded="true"] > :not([data-submenu]) {
   filter: blur(8px);
   translate: -100% 0;
+  animation: media-menu-content-exit var(--menu-transition-duration) ease-in-out both;
+}
+
+.menu[data-submenu-expanded="false"] > :not([data-submenu]) {
+  animation: media-menu-content-enter var(--menu-transition-duration) ease-in-out both;
 }
 
 .menu-panel[data-submenu] {
   z-index: 1;
 }
 
-.menu-panel[data-submenu]:not([data-open], [data-ending-style]) {
-  translate: -100% 0;
-  transition-property: none;
-}
-
 .menu-panel[data-submenu][data-starting-style],
 .menu-panel[data-submenu][data-ending-style] {
+  overflow: hidden;
   pointer-events: none;
   filter: blur(8px);
-}
-
-.menu-panel[data-submenu][data-starting-style][data-direction="forward"],
-.menu-panel[data-submenu][data-ending-style][data-direction="back"] {
   translate: 100% 0;
-}
-
-.menu-panel[data-submenu][data-ending-style][data-direction="forward"],
-.menu-panel[data-submenu][data-starting-style][data-direction="back"] {
-  translate: -100% 0;
 }
 
 .menu-item,

--- a/site/src/components/docs/demos/menu/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/menu/html/css/BasicUsage.html
@@ -15,43 +15,43 @@
         <div class="menu-bar">
             <button type="button" commandfor="settings-menu" class="settings-trigger">Settings</button>
             <media-menu id="settings-menu" side="top" align="end" class="menu">
-                <media-menu-view class="menu-panel">
-                    <media-menu-item commandfor="quality-menu" type="quality" class="menu-item">
+                <div class="menu-panel">
+                    <media-menu-item commandfor="quality-menu" class="menu-item">
                         <span>Quality</span>
                         <span class="menu-value">
-                            <media-menu-item-value></media-menu-item-value>
+                            <span data-part="hint"></span>
                             <span aria-hidden="true">›</span>
                         </span>
                     </media-menu-item>
-                    <media-menu-item commandfor="audio-menu" type="audio-track" class="menu-item">
+                    <media-menu-item commandfor="audio-menu" class="menu-item">
                         <span>Audio</span>
                         <span class="menu-value">
-                            <media-menu-item-value></media-menu-item-value>
+                            <span data-part="hint"></span>
                             <span aria-hidden="true">›</span>
                         </span>
                     </media-menu-item>
-                    <media-menu-item commandfor="speed-menu" type="playback-rate" class="menu-item">
+                    <media-menu-item commandfor="speed-menu" class="menu-item">
                         <span>Speed</span>
                         <span class="menu-value">
-                            <media-menu-item-value></media-menu-item-value>
+                            <span data-part="hint"></span>
                             <span aria-hidden="true">›</span>
                         </span>
                     </media-menu-item>
-                    <media-menu-item commandfor="captions-menu" type="captions" class="menu-item">
+                    <media-menu-item commandfor="captions-menu" class="menu-item">
                         <span>Captions</span>
                         <span class="menu-value">
-                            <media-menu-item-value></media-menu-item-value>
+                            <span data-part="hint"></span>
                             <span aria-hidden="true">›</span>
                         </span>
                     </media-menu-item>
                     <media-menu-item class="menu-item">Copy link</media-menu-item>
-                </media-menu-view>
+                </div>
 
                 <media-menu id="quality-menu" class="menu-panel">
-                    <media-menu-back class="menu-back">
+                    <media-menu-item class="menu-back">
                         <span aria-hidden="true">‹</span>
                         Quality
-                    </media-menu-back>
+                    </media-menu-item>
                     <media-quality-radio-group class="menu-group">
                         <template>
                             <media-menu-radio-item class="menu-item">
@@ -67,10 +67,10 @@
                 </media-menu>
 
                 <media-menu id="audio-menu" class="menu-panel">
-                    <media-menu-back class="menu-back">
+                    <media-menu-item class="menu-back">
                         <span aria-hidden="true">‹</span>
                         Audio
-                    </media-menu-back>
+                    </media-menu-item>
                     <media-audio-track-radio-group class="menu-group">
                         <template>
                             <media-menu-radio-item class="menu-item">
@@ -82,10 +82,10 @@
                 </media-menu>
 
                 <media-menu id="speed-menu" class="menu-panel">
-                    <media-menu-back class="menu-back">
+                    <media-menu-item class="menu-back">
                         <span aria-hidden="true">‹</span>
                         Speed
-                    </media-menu-back>
+                    </media-menu-item>
                     <media-playback-rate-radio-group class="menu-group">
                         <template>
                             <media-menu-radio-item class="menu-item">
@@ -97,10 +97,10 @@
                 </media-menu>
 
                 <media-menu id="captions-menu" class="menu-panel">
-                    <media-menu-back class="menu-back">
+                    <media-menu-item class="menu-back">
                         <span aria-hidden="true">‹</span>
                         Captions
-                    </media-menu-back>
+                    </media-menu-item>
                     <media-captions-radio-group class="menu-group">
                         <template>
                             <media-menu-radio-item class="menu-item">

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.css
@@ -6,6 +6,30 @@
   width: 100%;
 }
 
+@keyframes media-menu-content-exit {
+  from {
+    filter: none;
+    translate: 0 0;
+  }
+
+  to {
+    filter: blur(8px);
+    translate: -100% 0;
+  }
+}
+
+@keyframes media-menu-content-enter {
+  from {
+    filter: blur(8px);
+    translate: -100% 0;
+  }
+
+  to {
+    filter: none;
+    translate: 0 0;
+  }
+}
+
 .menu-bar {
   position: absolute;
   right: 10px;
@@ -63,39 +87,26 @@
   will-change: translate;
 }
 
-.menu-panel[data-starting-style],
-.menu-panel[data-ending-style] {
-  overflow: hidden;
-}
-
-.menu-panel[data-menu-root-view][data-menu-view-state="inactive"] {
+.menu[data-submenu-expanded="true"] > :not([data-submenu]) {
   filter: blur(8px);
   translate: -100% 0;
+  animation: media-menu-content-exit var(--menu-transition-duration) ease-in-out both;
+}
+
+.menu[data-submenu-expanded="false"] > :not([data-submenu]) {
+  animation: media-menu-content-enter var(--menu-transition-duration) ease-in-out both;
 }
 
 .menu-panel[data-submenu] {
   z-index: 1;
 }
 
-.menu-panel[data-submenu]:not([data-open], [data-ending-style]) {
-  translate: -100% 0;
-  transition-property: none;
-}
-
 .menu-panel[data-submenu][data-starting-style],
 .menu-panel[data-submenu][data-ending-style] {
+  overflow: hidden;
   pointer-events: none;
   filter: blur(8px);
-}
-
-.menu-panel[data-submenu][data-starting-style][data-direction="forward"],
-.menu-panel[data-submenu][data-ending-style][data-direction="back"] {
   translate: 100% 0;
-}
-
-.menu-panel[data-submenu][data-ending-style][data-direction="forward"],
-.menu-panel[data-submenu][data-starting-style][data-direction="back"] {
-  translate: -100% 0;
 }
 
 .menu-item,

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
@@ -31,27 +31,26 @@ function SettingsMenu(): ReactNode {
         Settings
       </Menu.Trigger>
       <Menu.Content className="menu">
-        <Menu.View className="menu-panel">
+        <div className="menu-panel">
           {hasQuality ? (
             <Menu.Root>
               <Menu.Trigger
-                type="quality"
                 className="menu-item"
                 render={(props) => (
                   <div {...props}>
                     <span>Quality</span>
                     <span className="menu-value">
-                      <Menu.ItemValue />
+                      {quality.selectedLabel}
                       <span aria-hidden="true">›</span>
                     </span>
                   </div>
                 )}
               />
               <Menu.Content className="menu-panel">
-                <Menu.Back className="menu-back">
+                <Menu.Item className="menu-back">
                   <span aria-hidden="true">‹</span>
                   Quality
-                </Menu.Back>
+                </Menu.Item>
                 <Menu.RadioGroup
                   className="menu-group"
                   value={quality.value}
@@ -87,23 +86,22 @@ function SettingsMenu(): ReactNode {
           {hasAudioTrack ? (
             <Menu.Root>
               <Menu.Trigger
-                type="audio-track"
                 className="menu-item"
                 render={(props) => (
                   <div {...props}>
                     <span>Audio</span>
                     <span className="menu-value">
-                      <Menu.ItemValue />
+                      {audioTrack.selectedLabel}
                       <span aria-hidden="true">›</span>
                     </span>
                   </div>
                 )}
               />
               <Menu.Content className="menu-panel">
-                <Menu.Back className="menu-back">
+                <Menu.Item className="menu-back">
                   <span aria-hidden="true">‹</span>
                   Audio
-                </Menu.Back>
+                </Menu.Item>
                 <Menu.RadioGroup
                   className="menu-group"
                   value={audioTrack.value}
@@ -135,23 +133,22 @@ function SettingsMenu(): ReactNode {
           {hasPlaybackRate ? (
             <Menu.Root>
               <Menu.Trigger
-                type="playback-rate"
                 className="menu-item"
                 render={(props) => (
                   <div {...props}>
                     <span>Speed</span>
                     <span className="menu-value">
-                      <Menu.ItemValue />
+                      {playbackRate.selectedLabel}
                       <span aria-hidden="true">›</span>
                     </span>
                   </div>
                 )}
               />
               <Menu.Content className="menu-panel">
-                <Menu.Back className="menu-back">
+                <Menu.Item className="menu-back">
                   <span aria-hidden="true">‹</span>
                   Speed
-                </Menu.Back>
+                </Menu.Item>
                 <Menu.RadioGroup
                   className="menu-group"
                   value={playbackRate.value}
@@ -183,23 +180,22 @@ function SettingsMenu(): ReactNode {
           {hasCaptions ? (
             <Menu.Root>
               <Menu.Trigger
-                type="captions"
                 className="menu-item"
                 render={(props) => (
                   <div {...props}>
                     <span>Captions</span>
                     <span className="menu-value">
-                      <Menu.ItemValue />
+                      {captions.selectedLabel}
                       <span aria-hidden="true">›</span>
                     </span>
                   </div>
                 )}
               />
               <Menu.Content className="menu-panel">
-                <Menu.Back className="menu-back">
+                <Menu.Item className="menu-back">
                   <span aria-hidden="true">‹</span>
                   Captions
-                </Menu.Back>
+                </Menu.Item>
                 <Menu.RadioGroup
                   className="menu-group"
                   value={captions.value}
@@ -231,7 +227,7 @@ function SettingsMenu(): ReactNode {
           <Menu.Item className="menu-item" onSelect={() => navigator.clipboard?.writeText(window.location.href)}>
             Copy link
           </Menu.Item>
-        </Menu.View>
+        </div>
       </Menu.Content>
     </Menu.Root>
   );


### PR DESCRIPTION
Refs #2029
Closes #2155 

## Summary

Update the HTML and React menu demos to compose the simplified menu primitives introduced by #2029. Values now come from radio-option state and ordinary items provide submenu back behavior.

This PR is stacked on #2029 and is required for the site to typecheck after the removed menu APIs land.

## Changes

- Replace menu view and back components with ordinary markup and menu items
- Render selected setting labels from option state and light-DOM hint outlets
- Remove the menu item setting `type` API from both demos
- Update demo transitions for the new submenu lifecycle data attributes

## Testing

- `pnpm -F site astro check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and demo-only changes with no production runtime or security impact.
> 
> **Overview**
> Aligns the **HTML** and **React** settings-menu demos with the simplified menu API from #2029 so the site typechecks after removed menu components land.
> 
> **Markup & API:** Replaces `media-menu-view` / `Menu.View` with a plain `div.menu-panel`, swaps `media-menu-back` / `Menu.Back` for `media-menu-item` / `Menu.Item`, and drops setting-specific `type` on triggers. Selected values now come from **`selectedLabel`** (React) or **`data-part="hint"`** (HTML) instead of `Menu.ItemValue` / `media-menu-item-value`.
> 
> **Animations:** Submenu motion no longer relies on `data-menu-root-view`, `data-menu-view-state`, or `data-direction`. Root content uses **`data-submenu-expanded`** on `.menu` with enter/exit keyframes; submenu panels keep blur/slide via `data-starting-style` / `data-ending-style` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf79c17f9f6761c665cde3b0d4e04437389a904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->