### PR TITLE
refactor(react): use quality radio group in skins

### DIFF
--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -80,6 +80,7 @@ import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
+import { QualityRadioGroup } from '@/ui/quality-radio-group';
 import { SeekIndicator } from '@/ui/seek-indicator';
 import { Slider } from '@/ui/slider';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -228,34 +229,22 @@ function SettingsMenu(): ReactNode {
                     {t(qualityText)}
                   </Menu.Back>
                   <Menu.Separator className={menu.separator} />
-                  <Menu.RadioGroup
+                  <QualityRadioGroup
                     className={menu.group}
-                    value={quality.value}
-                    onValueChange={quality.setValue}
                     aria-label={t(qualityText)}
-                  >
-                    {quality.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className={menu.item}
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className={menu.item}>
                         <span>
-                          {option.label}
-                          {option.tier ? <sup className={menu.tier}>{option.tier}</sup> : null}
+                          {item.label}
+                          {item.tier ? <sup className={menu.tier}>{item.tier}</sup> : null}
                         </span>
-                        {option.badge ? <span className={badge}>{option.badge}</span> : null}
-                        <Menu.ItemIndicator
-                          checked={option.value === quality.value}
-                          forceMount
-                          className={menu.indicator}
-                        >
+                        {item.badge ? <span className={badge}>{item.badge}</span> : null}
+                        <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                           <CheckIcon className={cn(icon, menu.icon)} />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -56,6 +56,7 @@ import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
+import { QualityRadioGroup } from '@/ui/quality-radio-group';
 import { SeekIndicator } from '@/ui/seek-indicator';
 import { Slider } from '@/ui/slider';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -169,34 +170,22 @@ function SettingsMenu(): ReactNode {
                     {t(qualityText)}
                   </Menu.Back>
                   <Menu.Separator className="media-menu__separator" />
-                  <Menu.RadioGroup
+                  <QualityRadioGroup
                     className="media-menu__group"
-                    value={quality.value}
-                    onValueChange={quality.setValue}
                     aria-label={t(qualityText)}
-                  >
-                    {quality.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className="media-menu__item"
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className="media-menu__item">
                         <span>
-                          {option.label}
-                          {option.tier ? <sup className="media-menu__tier">{option.tier}</sup> : null}
+                          {item.label}
+                          {item.tier ? <sup className="media-menu__tier">{item.tier}</sup> : null}
                         </span>
-                        {option.badge ? <span className="media-badge">{option.badge}</span> : null}
-                        <Menu.ItemIndicator
-                          checked={option.value === quality.value}
-                          forceMount
-                          className="media-menu__indicator"
-                        >
+                        {item.badge ? <span className="media-badge">{item.badge}</span> : null}
+                        <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                           <CheckIcon className="media-icon" />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -82,6 +82,7 @@ import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
+import { QualityRadioGroup } from '@/ui/quality-radio-group';
 import { SeekIndicator } from '@/ui/seek-indicator';
 import { Slider } from '@/ui/slider';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -230,34 +231,22 @@ function SettingsMenu(): ReactNode {
                     {t(qualityText)}
                   </Menu.Back>
                   <Menu.Separator className={menu.separator} />
-                  <Menu.RadioGroup
+                  <QualityRadioGroup
                     className={menu.group}
-                    value={quality.value}
-                    onValueChange={quality.setValue}
                     aria-label={t(qualityText)}
-                  >
-                    {quality.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className={menu.item}
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className={menu.item}>
                         <span>
-                          {option.label}
-                          {option.tier ? <sup className={menu.tier}>{option.tier}</sup> : null}
+                          {item.label}
+                          {item.tier ? <sup className={menu.tier}>{item.tier}</sup> : null}
                         </span>
-                        {option.badge ? <span className={badge}>{option.badge}</span> : null}
-                        <Menu.ItemIndicator
-                          checked={option.value === quality.value}
-                          forceMount
-                          className={menu.indicator}
-                        >
+                        {item.badge ? <span className={badge}>{item.badge}</span> : null}
+                        <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                           <CheckIcon className={cn(icon, menu.icon)} />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -56,6 +56,7 @@ import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
+import { QualityRadioGroup } from '@/ui/quality-radio-group';
 import { SeekIndicator } from '@/ui/seek-indicator';
 import { Slider } from '@/ui/slider';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -169,34 +170,22 @@ function SettingsMenu(): ReactNode {
                     {t(qualityText)}
                   </Menu.Back>
                   <Menu.Separator className="media-menu__separator" />
-                  <Menu.RadioGroup
+                  <QualityRadioGroup
                     className="media-menu__group"
-                    value={quality.value}
-                    onValueChange={quality.setValue}
                     aria-label={t(qualityText)}
-                  >
-                    {quality.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className="media-menu__item"
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className="media-menu__item">
                         <span>
-                          {option.label}
-                          {option.tier ? <sup className="media-menu__tier">{option.tier}</sup> : null}
+                          {item.label}
+                          {item.tier ? <sup className="media-menu__tier">{item.tier}</sup> : null}
                         </span>
-                        {option.badge ? <span className="media-badge">{option.badge}</span> : null}
-                        <Menu.ItemIndicator
-                          checked={option.value === quality.value}
-                          forceMount
-                          className="media-menu__indicator"
-                        >
+                        {item.badge ? <span className="media-badge">{item.badge}</span> : null}
+                        <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                           <CheckIcon className="media-icon" />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}


### PR DESCRIPTION
Refs #2150

## Summary

Adopt `QualityRadioGroup` in every React video skin while preserving rendition labels, tiers, bitrate badges, and indicators.

## Changes

- Replace manual quality option mapping in default and minimal skins
- Update both CSS and Tailwind skin variants
- Keep all skin-owned quality item presentation

## Testing

- `pnpm -F @videojs/react build`

Depends on #2132.