### PR TITLE
feat(spf)!: cap renditions to the screen and surface unplayable sources

### DIFF
--- a/apps/e2e/fixtures/resources.ts
+++ b/apps/e2e/fixtures/resources.ts
@@ -17,6 +17,38 @@ export const MEDIA = {
     poster: 'https://image.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/thumbnail.jpg',
     storyboard: 'https://image.mux.com/lhnU49l1VGi3zrTAZhDm9LUUxSjpaPW9BL4jY25Kwo4/storyboard.vtt',
   },
+  /**
+   * HLS/CMAF with a 4K ladder — rungs from 640x360 up to 3838x2160, so a screen
+   * emulated below the top rung has something smaller to cap to. Video-only.
+   *
+   * The off-by-two widths are the source's near-square pixel aspect ratio rather
+   * than a typo, which is why the cap compares pixel areas instead of matching
+   * `1920x1080`-style tiers.
+   */
+  hls4k: {
+    url: 'https://stream.mux.com/SfAaZ9InpM8FMfky7DkNBuTpxEDqU8Jchpa49urOWcs.m3u8',
+  },
+  /**
+   * HLS/CMAF carrying **no video renditions at all** — the one failure shape with
+   * no per-rendition cause behind it, since nothing resolves and so nothing
+   * reports. A video-only composition can never play it.
+   */
+  hlsAudioOnly: {
+    url: 'https://stream.mux.com/2NEjLyf6ETnskbfAtbM00Vdzb97B00OKUUQcRD6LZpBRw.m3u8',
+  },
+  /**
+   * DRM-protected HLS, deliberately left unlicensed: the video renditions carry
+   * `EXT-X-KEY` for all three key systems and no license path is supplied, so an
+   * engine with no EME pipeline reports the source as protected. Here to be
+   * refused, not played.
+   *
+   * The playback token is signed to `exp: 2147483647` (January 2038), so this
+   * doesn't rot out from under CI. Same asset the sandbox offers as
+   * `hls-drm-unlicensed`.
+   */
+  hlsDrm: {
+    url: 'https://stream.mux.com/FefhWnSMzDqz5z9yxssihdRx8dV6srhYJ8301uQBhRak.m3u8?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IndGcXlSYlRjZDZSaEJkMDJ3Wnd6YTAwR0htNnFVOUlQZTFJS1kwMHgzMDE2dUhBIn0.eyJzdWIiOiJGZWZoV25TTXpEcXo1ejl5eHNzaWhkUng4ZFY2c3JoWUo4MzAxdVFCaFJhayIsImF1ZCI6InYiLCJleHAiOjIxNDc0ODM2NDd9.jXIpJZPB7diM5M6jMVRQ6dELY5YnONzC8jJClm7CT1nm-q25F5PiCvHcdLGqerjN1V_7T9cjhSX02p1i0UiABaKX2Wa4HCf6H6ZSKbY3MiCiRJHnfZzr_cVHCuBRXJlMzXesK_VzgP4kVrVi9-Sj8fGaeQmt4mB0sgtGGM7LpGV1IJdv_9aWnqQpQK7IeWi9ivNwa9Vw-PeppfOFdyQbqYJScIAY-_k6fzGaQucONyIolFGJZuBcan3nDRvCUpSFi0vPO87jf5Zbp6kn-HeARmUTYDPBLoeVSjttxYhoeDQYtNeqbuJ3Tj6S1_9TsE_SNSNZm3lxHoJCz5Wp_YcusQ',
+  },
   /** DASH (Big Buck Bunny 30fps via Akamai). */
   dash: {
     url: 'https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd',

--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -2,8 +2,9 @@
  * Generates Vite test pages from PageEntry definitions.
  *
  * Reads the media type configs and page arrays, then writes .ts/.tsx + .html
- * files to `apps/vite/src/pages/`. Special pages (ejected skins, captions) are
- * hand-written and not generated.
+ * files to `apps/vite/src/pages/`, which is gitignored — every page there comes
+ * from this script, including the special ones (ejected skins, captions,
+ * background video), which take their own templates rather than the player shell.
  *
  * Run: `pnpm --dir apps/e2e generate-pages`
  */
@@ -99,6 +100,17 @@ const MEDIA_TYPES: Record<string, MediaTypeConfig> = {
     hasPoster: false,
     isAudio: true,
   },
+  // Rendered by the `background` category templates rather than the player ones:
+  // this element has no controls to hang on a skin. The entry exists because
+  // every page looks its media type up here.
+  'hls-background-video': {
+    element: 'hls-background-video',
+    imports: ['@videojs/html/media/hls-background-video'],
+    attrs: '',
+    hasStoryboard: false,
+    hasPoster: false,
+    isAudio: false,
+  },
 };
 
 // React component names for media elements
@@ -106,6 +118,10 @@ const REACT_MEDIA: Record<string, { component: string; importPath: string }> = {
   video: { component: 'Video', importPath: '@videojs/react/video' },
   'hlsjs-video': { component: 'HlsJsVideo', importPath: '@videojs/react/media/hlsjs-video' },
   audio: { component: 'Audio', importPath: '@videojs/react/audio' },
+  'hls-background-video': {
+    component: 'HlsBackgroundVideo',
+    importPath: '@videojs/react/media/hls-background-video',
+  },
 };
 
 // CDN import paths (override standard imports)
@@ -124,7 +140,7 @@ interface PageDef {
   framework: 'html' | 'react';
   media: string;
   resource: string;
-  category?: 'cdn' | 'ejected-html' | 'ejected-react' | 'captions' | 'source-html' | 'source-react';
+  category?: 'cdn' | 'ejected-html' | 'ejected-react' | 'captions' | 'background' | 'source-html' | 'source-react';
 }
 
 // ---------------------------------------------------------------------------
@@ -258,8 +274,78 @@ createRoot(document.getElementById('root')!).render(<App />);
 }
 
 // ---------------------------------------------------------------------------
-// Special page templates (captions, ejected skins)
+// Special page templates (captions, ejected skins, background video)
 // ---------------------------------------------------------------------------
+
+/**
+ * The SPF background-video Media, alone rather than inside a player: the
+ * composition subscribes to no store features and has no controls, so a skin
+ * would only add moving parts to what the spec is measuring.
+ *
+ * `?src=` picks the source, so one page serves every shape
+ * `spf-background-video.spec.ts` drives — playable, MPEG-TS, encrypted,
+ * audio-only — and a test can compare two of them without a page each. Assigned
+ * as a property rather than interpolated into markup, since the DRM source
+ * carries a signed-URL query string.
+ */
+function backgroundVideoPage(config: MediaTypeConfig, resource: string): string {
+  return `${config.imports.map((imp) => `import '${imp}';`).join('\n')}
+import { MEDIA } from '../resources';
+
+const src = new URLSearchParams(window.location.search).get('src') ?? MEDIA.${resource}.url;
+
+const media = document.createElement('${config.element}') as HTMLElement & { src: string };
+media.src = src;
+// Viewport units rather than percentages: the shared page shell's #root has no
+// height of its own, and a background video that lays out at zero is one an
+// engine may treat as offscreen.
+media.style.width = '100vw';
+media.style.height = '100vh';
+
+document.getElementById('root')!.append(media);
+`;
+}
+
+/**
+ * The React counterpart, and the only place `onError` can be observed: the
+ * component hands out no reference to its Media, so what a consumer sees is
+ * whatever React's own event plumbing delivers. Failures are counted onto
+ * `window` rather than rendered — the assertion is that the prop fired at all,
+ * since the condition behind it isn't reachable from here by design.
+ */
+function reactBackgroundVideoPage(media: string, resource: string): string {
+  const reactMedia = REACT_MEDIA[media];
+  if (!reactMedia) throw new Error(`No React component mapping for media type: ${media}`);
+
+  return `import { ${reactMedia.component} } from '${reactMedia.importPath}';
+import { createRoot } from 'react-dom/client';
+import { MEDIA } from '../resources';
+
+declare global {
+  interface Window {
+    __backgroundVideoErrors: number;
+  }
+}
+
+window.__backgroundVideoErrors = 0;
+
+const src = new URLSearchParams(window.location.search).get('src') ?? MEDIA.${resource}.url;
+
+function App() {
+  return (
+    <${reactMedia.component}
+      src={src}
+      style={{ width: '100vw', height: '100vh' }}
+      onError={() => {
+        window.__backgroundVideoErrors += 1;
+      }}
+    />
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);
+`;
+}
 
 function captionsPage(resource: string): string {
   const captionVtt = 'WEBVTT\\n\\n00:00:00.000 --> 00:00:30.000\\nThis is a test caption';
@@ -445,6 +531,26 @@ const PAGES: PageDef[] = [
     media: 'hls-video',
     resource: 'hlsTs',
   },
+  // The SPF background-video composition, driven by `spf-background-video.spec.ts`
+  // alone: `?src=` swaps the source per test, so these carry a playable default
+  // and stay out of `fixtures/media.ts`'s page arrays — the parameterized
+  // playback suites all assume a player with controls.
+  {
+    name: 'HTML HLS Background Video',
+    path: 'html-hls-background-video',
+    framework: 'html',
+    media: 'hls-background-video',
+    resource: 'hlsFmp4',
+    category: 'background',
+  },
+  {
+    name: 'React HLS Background Video',
+    path: 'react-hls-background-video',
+    framework: 'react',
+    media: 'hls-background-video',
+    resource: 'hlsFmp4',
+    category: 'background',
+  },
   { name: 'HTML DASH Video', path: 'html-dash-video', framework: 'html', media: 'dash-video', resource: 'dash' },
   {
     name: 'HTML Native HLS Video',
@@ -554,7 +660,12 @@ function generatePage(page: PageDef): { ts: string; html: string; ext: string } 
   let ts: string;
 
   // Special category pages
-  if (page.category === 'captions') {
+  if (page.category === 'background') {
+    ts =
+      page.framework === 'react'
+        ? reactBackgroundVideoPage(page.media, page.resource)
+        : backgroundVideoPage(config, page.resource);
+  } else if (page.category === 'captions') {
     ts = captionsPage(page.resource);
   } else if (page.category === 'ejected-html') {
     ts = ejectedHtmlPage(page.resource);

--- a/apps/e2e/tests/spf-background-video.spec.ts
+++ b/apps/e2e/tests/spf-background-video.spec.ts
@@ -1,0 +1,290 @@
+import { expect, type Page, test } from '@playwright/test';
+import { MEDIA } from '../fixtures/resources';
+
+/**
+ * The SPF background-video composition end to end: a real manifest through the
+ * engine, onto the Media's `error`, and out to whichever surface the platform
+ * gives a consumer.
+ *
+ * What only a browser can establish, and so what this file is for: **nothing
+ * about an unplayable source reaches the media element here.** The unit tests
+ * write `state.errors` directly and assert the promotion; they cannot show that
+ * the engine derives that sequence from a real playlist, and they cannot show
+ * that `HTMLMediaElement.error` stays null while it does. That claim is the
+ * premise the whole surface rests on — if a browser ever starts reporting these
+ * itself, this is where we find out.
+ *
+ * The pinned variant's own shape is the other thing pinned down here. Only the
+ * *selected* rendition's playlist is ever resolved, so an unplayable pick
+ * produces a **cause with no verdict behind it** — nothing prunes the renditions
+ * that were never probed, so the candidate set never empties. A source offering
+ * no video at all is the mirror case: a verdict with no cause. Both are fatal,
+ * and asserting the sequence (not just the surfaced code) is what would catch a
+ * `select-tracks` refactor quietly changing which.
+ *
+ * @see internal/design/spf/features/errors.md
+ * @see internal/design/spf/features/rendition-selection-caps.md
+ */
+
+/** SVTA 99 [Custom] 001 — the engine has no pipeline for what the source needs. */
+const SVTA_UNSUPPORTED_PLAYBACK_FEATURE = 99001;
+
+/** SVTA 2 [Playback] 011 — no video track this environment can play. */
+const SVTA_NO_SUPPORTED_VIDEO_TRACK = 2011;
+
+/** SVTA 1 [Media Content] 004 — the per-rendition container cause. */
+const SVTA_UNSUPPORTED_VIDEO_FORMAT = 1004;
+
+/** SVTA 4 [Content Protection] 008 — encrypted, with no decryption pipeline. */
+const SVTA_UNSUPPORTED_DRM_SYSTEM = 4008;
+
+const HTML_PAGE = '/pages/html-hls-background-video.html';
+const REACT_PAGE = '/pages/react-hls-background-video.html';
+
+const pageFor = (base: string, url: string) => `${base}?src=${encodeURIComponent(url)}`;
+
+interface SurfacedError {
+  code: number;
+  message: string;
+}
+
+type BackgroundVideoElement = HTMLElement & {
+  error?: SurfacedError | null;
+  video?: HTMLVideoElement | null;
+  src?: string;
+  getMediaTarget?(): { engine?: { state?: { errors?: { get(): Array<{ code: number }> | undefined } } } };
+};
+
+// Each of these runs in the page, where `page.evaluate` serializes the function
+// without its module scope — so every one looks the element up for itself rather
+// than sharing a helper.
+
+/** The error the Media surfaces, or null while none has. */
+function readSurfacedError(): SurfacedError | null {
+  const media = document.querySelector('hls-background-video') as BackgroundVideoElement | null;
+  return media?.error ?? null;
+}
+
+/** Every SVTA code in the engine's reported sequence, causes included. */
+function readReportedCodes(): number[] {
+  const media = document.querySelector('hls-background-video') as BackgroundVideoElement | null;
+  const errors = media?.getMediaTarget?.()?.engine?.state?.errors?.get() ?? [];
+  return errors.map((error) => error.code);
+}
+
+/** What the inner `<video>` itself knows about the failure. Expected: nothing. */
+function readInnerVideoState(): { error: number | null; readyState: number } | null {
+  const media = document.querySelector('hls-background-video') as BackgroundVideoElement | null;
+  const video = media?.video;
+  return video ? { error: video.error?.code ?? null, readyState: video.readyState } : null;
+}
+
+function readPlaybackState(): { readyState: number; currentTime: number; width: number; height: number } | null {
+  const media = document.querySelector('hls-background-video') as BackgroundVideoElement | null;
+  const video = media?.video;
+  return video
+    ? {
+        readyState: video.readyState,
+        currentTime: video.currentTime,
+        width: video.videoWidth,
+        height: video.videoHeight,
+      }
+    : null;
+}
+
+async function waitForSurfacedError(page: Page): Promise<SurfacedError> {
+  await page.waitForFunction(
+    () => !!(document.querySelector('hls-background-video') as (HTMLElement & { error?: unknown }) | null)?.error,
+    undefined,
+    { timeout: 20_000 }
+  );
+
+  const error = await page.evaluate(readSurfacedError);
+  expect(error).not.toBeNull();
+  return error as SurfacedError;
+}
+
+/** Wait for frames to exist and the clock to move — playing, not merely loaded. */
+async function waitForPlayback(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const video = (document.querySelector('hls-background-video') as { video?: HTMLVideoElement | null } | null)
+        ?.video;
+      return !!video && video.readyState >= 3 && video.currentTime > 0;
+    },
+    undefined,
+    { timeout: 30_000 }
+  );
+}
+
+test.describe('SPF background video', () => {
+  test('a playable fMP4 source plays and surfaces no error', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsFmp4.url));
+    await waitForPlayback(page);
+
+    // The control. Without it, a spec that always reported fatal would pass —
+    // and autoplay is the composition's own contract, since nothing here offers
+    // a play button to fall back on.
+    expect(await page.evaluate(readSurfacedError)).toBeNull();
+    expect(await page.evaluate(readReportedCodes)).toEqual([]);
+  });
+
+  test('an MPEG-TS source surfaces a fatal unsupported-playback-feature error', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsTs.url));
+
+    const error = await waitForSurfacedError(page);
+
+    expect(error.code).toBe(SVTA_UNSUPPORTED_PLAYBACK_FEATURE);
+    // Deliberately empty: viewer-facing copy is the consumer's to localize from
+    // the code, and the engine's own explanation goes to the console.
+    expect(error.message).toBe('');
+  });
+
+  test('the MPEG-TS sequence holds the cause with no verdict behind it', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsTs.url));
+    await waitForSurfacedError(page);
+
+    const codes = await page.evaluate(readReportedCodes);
+
+    // The pinned variant's defining asymmetry, and the reason its fatal set is
+    // wider than the other adapters'. `hls-video` reaches a 2011 verdict on this
+    // same source because its ABR path prunes and re-picks until the type
+    // empties; here the pick is dropped and never replaced, so the cause is all
+    // there is. A verdict appearing would mean selection changed shape.
+    expect(codes).toContain(SVTA_UNSUPPORTED_VIDEO_FORMAT);
+    expect(codes).not.toContain(SVTA_NO_SUPPORTED_VIDEO_TRACK);
+  });
+
+  test('the inner video learns nothing — no error, still at readyState 0', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsTs.url));
+    await waitForSurfacedError(page);
+
+    // The measured premise this whole surface exists for. Nothing in MSE reports
+    // an unplayable source here: Chromium accepts MPEG-TS appends into a
+    // `video/mp4` SourceBuffer and buffers nothing, WebKit demuxes the TS
+    // outright, and neither produces a SourceBuffer, MediaSource, or element
+    // error. If this assertion ever fails, the browser started doing the work
+    // itself and the composition should be reconsidered — that is a finding, not
+    // a flake.
+    expect(await page.evaluate(readInnerVideoState)).toEqual({ error: null, readyState: 0 });
+  });
+
+  test('an encrypted source with no license path surfaces the same fatal code', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsDrm.url));
+
+    const error = await waitForSurfacedError(page);
+    const codes = await page.evaluate(readReportedCodes);
+
+    // One surfaced code for both failures, because the consumer's situation is
+    // identical: this player cannot play this source, and no retry or CDN helps.
+    // The sequence is where the two stay distinguishable.
+    expect(error.code).toBe(SVTA_UNSUPPORTED_PLAYBACK_FEATURE);
+    expect(codes).toContain(SVTA_UNSUPPORTED_DRM_SYSTEM);
+  });
+
+  test('a source with no video renditions surfaces the verdict itself', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsAudioOnly.url));
+
+    const error = await waitForSurfacedError(page);
+    const codes = await page.evaluate(readReportedCodes);
+
+    // The mirror of the MPEG-TS case: nothing resolves, so no cause exists to be
+    // more specific than the verdict, and with nothing unsupported in the
+    // sequence the code is not substituted. This is `reportAbsentTrackType`
+    // firing from the head of the constraint chain, where an empty input still
+    // means "the source offers none" rather than "the constraints pruned them".
+    expect(error.code).toBe(SVTA_NO_SUPPORTED_VIDEO_TRACK);
+    expect(codes).toEqual([SVTA_NO_SUPPORTED_VIDEO_TRACK]);
+  });
+
+  test('changing to a playable source clears the error and plays', async ({ page }) => {
+    await page.goto(pageFor(HTML_PAGE, MEDIA.hlsTs.url));
+    await waitForSurfacedError(page);
+
+    await page.evaluate((url) => {
+      const media = document.querySelector('hls-background-video') as (HTMLElement & { src?: string }) | null;
+      if (media) media.src = url;
+    }, MEDIA.hlsFmp4.url);
+
+    // Per-source reset through the whole chain: `collectErrors` clears the
+    // sequence on source change and the adapter's `error` follows, with no
+    // source-change hook of its own. Recovery, not just a cleared flag over a
+    // dead engine — so playback is asserted too.
+    await page.waitForFunction(
+      () => {
+        const media = document.querySelector('hls-background-video') as (HTMLElement & { error?: unknown }) | null;
+        return !!media && !media.error;
+      },
+      undefined,
+      { timeout: 20_000 }
+    );
+    await waitForPlayback(page);
+  });
+
+  test("React's onError fires for a source the <video> never learns about", async ({ page }) => {
+    await page.goto(pageFor(REACT_PAGE, MEDIA.hlsTs.url));
+
+    // The component exposes no Media, so the prop firing at all is the contract.
+    // It can only fire because the component re-dispatches on the `<video>`,
+    // whose own `error` stays null throughout.
+    await page.waitForFunction(() => window.__backgroundVideoErrors > 0, undefined, { timeout: 20_000 });
+
+    const videoError = await page.evaluate(() => document.querySelector('video')?.error?.code ?? null);
+    expect(videoError).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Screen-size rendition cap
+  // ---------------------------------------------------------------------------
+  // `getScreenResolution` reads `screen.width/height × devicePixelRatio`. Measured
+  // in both projects: `window.screen` follows the *emulated viewport* rather than
+  // the `screen` context option, so the reading is driven here through viewport
+  // and `deviceScaleFactor`, which are emulated reliably. That makes the pick
+  // deterministic; it also means this file can't distinguish "reads the screen"
+  // from "reads the window", which stays a unit-level concern.
+  //
+  // Assertions are about *fit* rather than exact rungs, so a ladder change at the
+  // source doesn't break them.
+  test.describe('screen-size cap', () => {
+    const readPickedSize = async (page: Page) => {
+      await waitForPlayback(page);
+      const state = await page.evaluate(readPlaybackState);
+      expect(state).not.toBeNull();
+      return state as NonNullable<typeof state>;
+    };
+
+    test.describe('on a small screen', () => {
+      test.use({ viewport: { width: 800, height: 600 }, deviceScaleFactor: 1 });
+
+      test('caps the pinned rendition to what the screen can show', async ({ page }) => {
+        await page.goto(pageFor(HTML_PAGE, MEDIA.hls4k.url));
+        const { width, height } = await readPickedSize(page);
+
+        // The cap's whole claim: a 4K ladder on an 800x600 screen must not pin a
+        // rendition the screen cannot show. Area rather than per-axis, matching
+        // the rule — an anamorphic rendition isn't measured by matching tiers.
+        expect(width * height).toBeLessThanOrEqual(800 * 600);
+        expect(width).toBeGreaterThan(0);
+      });
+    });
+
+    test.describe('on a 4K screen', () => {
+      // 1920x1080 at 2x — a 4K budget reached through the device pixel ratio, so
+      // this also covers `useDevicePixelRatio`: in CSS pixels alone the same
+      // viewport could never justify a 2160-line rendition.
+      test.use({ viewport: { width: 1920, height: 1080 }, deviceScaleFactor: 2 });
+
+      test('takes the largest rendition when the screen can show it', async ({ page }) => {
+        await page.goto(pageFor(HTML_PAGE, MEDIA.hls4k.url));
+        const { width, height } = await readPickedSize(page);
+
+        // The other half of the rule, and what stops the cap from being a
+        // constant: the same source on a screen with room pins something the
+        // small-screen case could not. Bounded rather than pinned to an exact
+        // rung, so the assertions survive a ladder change at the source.
+        expect(height).toBeGreaterThan(1080);
+        expect(width * height).toBeLessThanOrEqual(3840 * 2160);
+      });
+    });
+  });
+});

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -333,18 +333,25 @@ export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';
 export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4';
 
 /**
- * The same clip as {@link BACKGROUND_VIDEO_SRC} over HLS, for the SPF-backed
- * `<hls-background-video>` and its `<mux-background-video>` alias. Re-ingested
- * from that asset's `high.mp4` rendition.
+ * A 4K clip over HLS, for the SPF-backed `<hls-background-video>` and its
+ * `<mux-background-video>` alias.
+ *
+ * Deliberately *not* the clip {@link BACKGROUND_VIDEO_SRC} plays: the rendition
+ * ladder has to straddle a real screen for the screen-resolution cap to have
+ * anything to choose between. Its rungs run 640x360 → 3838x2160, so a display
+ * under the top rung caps to 2558x1440 instead. (Those off-by-two widths are the
+ * source's near-square pixel aspect ratio, not a typo, and they are the reason
+ * the cap compares pixel areas rather than matching `1920x1080`-style tiers.)
+ * Video-only — the source carries no audio track.
  *
  * Must be a **CMAF/fMP4** asset: SPF appends fMP4 segments directly and does no
  * MPEG-TS transmuxing, so a TS-packaged playback ID surfaces the
  * unsupported-container error instead of playing. Packaging follows the video
  * quality tier — `premium` yields CMAF, while `plus`/`basic` (legacy
- * `encoding_tier: smart`) yield MPEG-TS — which is why this is a separate asset
- * rather than the `.m3u8` of the one above.
+ * `encoding_tier: smart`) yield MPEG-TS — which is also why a 4K ladder needs
+ * `max_resolution_tier: '2160p'` alongside `video_quality: 'premium'`.
  */
-export const HLS_BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/JsDMLkGisX8lHq01wcVv32kQ2vIYvsrEXx007W15xDKJg.m3u8';
+export const HLS_BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/SfAaZ9InpM8FMfky7DkNBuTpxEDqU8Jchpa49urOWcs.m3u8';
 
 export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -232,6 +232,29 @@ const SOURCE_MAP = {
     subType: 'mp4',
     live: true,
   },
+  /**
+   * A 4K ladder over HLS, and the default source for the SPF background presets.
+   *
+   * Deliberately *not* the clip {@link BACKGROUND_VIDEO_SRC} plays: the rendition
+   * ladder has to straddle a real screen for the screen-resolution cap to have
+   * anything to choose between. Its rungs run 640x360 → 3838x2160, so a display
+   * under the top rung caps to 2558x1440 instead. (Those off-by-two widths are the
+   * source's near-square pixel aspect ratio, not a typo, and they are the reason
+   * the cap compares pixel areas rather than matching `1920x1080`-style tiers.)
+   * Video-only — the source carries no audio track.
+   *
+   * CMAF/fMP4, because SPF appends fMP4 segments directly and does no MPEG-TS
+   * transmuxing. Packaging follows the video quality tier — `premium` yields CMAF,
+   * while `plus`/`basic` (legacy `encoding_tier: smart`) yield MPEG-TS — which is
+   * also why a 4K ladder needs `max_resolution_tier: '2160p'` alongside
+   * `video_quality: 'premium'`.
+   */
+  'hls-4k': {
+    label: 'HLS - Short 4K UHD 2160p',
+    url: 'https://stream.mux.com/SfAaZ9InpM8FMfky7DkNBuTpxEDqU8Jchpa49urOWcs.m3u8',
+    type: 'hls',
+    subType: 'mp4',
+  },
   'hls-audio-only-cmaf': {
     label: 'HLS - Audio only (CMAF/fmp4)',
     url: 'https://stream.mux.com/2NEjLyf6ETnskbfAtbM00Vdzb97B00OKUUQcRD6LZpBRw.m3u8',
@@ -329,29 +352,31 @@ export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'd
 export const DEFAULT_SOURCE: SourceId = 'hls-1';
 export const DEFAULT_AUDIO_SOURCE: SourceId = 'mp4-1';
 export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';
+/**
+ * Where the SPF background presets land when entered. The 4K ladder rather than
+ * {@link DEFAULT_SOURCE}, which is MPEG-TS and so is a failure case for this
+ * engine rather than a demo of it.
+ */
+export const DEFAULT_BACKGROUND_SOURCE: SourceId = 'hls-4k';
 
 export const BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008/low.mp4';
 
 /**
- * A 4K clip over HLS, for the SPF-backed `<hls-background-video>` and its
- * `<mux-background-video>` alias.
+ * Add Mux's rendition cap to a stream URL, the param `<mux-background-video>`
+ * exists to demonstrate. Merged rather than appended, since a sandbox source may
+ * already carry params of its own (clip bounds, a playback token).
  *
- * Deliberately *not* the clip {@link BACKGROUND_VIDEO_SRC} plays: the rendition
- * ladder has to straddle a real screen for the screen-resolution cap to have
- * anything to choose between. Its rungs run 640x360 → 3838x2160, so a display
- * under the top rung caps to 2558x1440 instead. (Those off-by-two widths are the
- * source's near-square pixel aspect ratio, not a typo, and they are the reason
- * the cap compares pixel areas rather than matching `1920x1080`-style tiers.)
- * Video-only — the source carries no audio track.
- *
- * Must be a **CMAF/fMP4** asset: SPF appends fMP4 segments directly and does no
- * MPEG-TS transmuxing, so a TS-packaged playback ID surfaces the
- * unsupported-container error instead of playing. Packaging follows the video
- * quality tier — `premium` yields CMAF, while `plus`/`basic` (legacy
- * `encoding_tier: smart`) yield MPEG-TS — which is also why a 4K ladder needs
- * `max_resolution_tier: '2160p'` alongside `video_quality: 'premium'`.
+ * Left alone when the URL is signed: Mux validates the whole query against the
+ * token, so a param added beside one answers 403 instead of capping — which would
+ * replace whatever failure that source was chosen to reach.
  */
-export const HLS_BACKGROUND_VIDEO_SRC = 'https://stream.mux.com/SfAaZ9InpM8FMfky7DkNBuTpxEDqU8Jchpa49urOWcs.m3u8';
+export function withMuxMaxResolution(url: string, maxResolution: string): string {
+  if (!url || url.includes('token=')) return url;
+
+  const capped = new URL(url);
+  capped.searchParams.set('max_resolution', maxResolution);
+  return capped.href;
+}
 
 export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -5,6 +5,7 @@ import type { SourceId } from '@app/shared/sources';
 import {
   DASH_SOURCE_IDS,
   DEFAULT_AUDIO_SOURCE,
+  DEFAULT_BACKGROUND_SOURCE,
   DEFAULT_DASH_SOURCE,
   DEFAULT_SOURCE,
   HLS_SOURCE_IDS,
@@ -27,15 +28,27 @@ function getPagePath(platform: Platform, preset: Preset): string {
   return `/${platform}-${preset}/`;
 }
 
+/**
+ * The SPF background presets default to their own source rather than the global
+ * one, which is MPEG-TS and so is a failure case for that engine rather than a
+ * demo of it. Only when nothing was asked for — an explicit `?source=` still wins,
+ * so a shared link reaches the source it names.
+ */
+function isSpfBackgroundPreset(preset: Preset): boolean {
+  return preset === 'hls-background-video' || preset === 'mux-background-video';
+}
+
 function readParams() {
   const params = new URLSearchParams(location.search);
   const preload = params.get('preload');
+  const preset = (params.get('preset') ?? 'video') as Preset;
   return {
     platform: (params.get('platform') ?? 'html') as Platform,
     styling: (params.get('styling') ?? 'css') as Styling,
-    preset: (params.get('preset') ?? 'video') as Preset,
+    preset,
     skin: (params.get('skin') ?? 'default') as 'default' | 'minimal',
-    source: (params.get('source') ?? 'hls-1') as SourceId,
+    source: (params.get('source') ??
+      (isSpfBackgroundPreset(preset) ? DEFAULT_BACKGROUND_SOURCE : DEFAULT_SOURCE)) as SourceId,
     autoplay: params.get('autoplay') === '1',
     muted: params.get('muted') === '1',
     loop: params.get('loop') === '1',
@@ -76,9 +89,12 @@ export function App() {
   const muxPreset = preset === 'mux-video' || preset === 'mux-audio';
   const muxSpfPreset = preset === 'mux-video-spf' || preset === 'mux-audio-spf';
   const spfHlsPreset = preset === 'hls-video' || preset === 'hls-audio';
-  // Every background preset renders a fixed source and has no Tailwind skin.
-  const backgroundPreset =
-    preset === 'background-video' || preset === 'hls-background-video' || preset === 'mux-background-video';
+  // The SPF-backed background presets take the same HLS sources the plain HLS
+  // presets do — `<background-video>` is the one that stays fixed, since it hands a
+  // progressive MP4 to the browser rather than streaming a manifest.
+  const spfBackgroundPreset = isSpfBackgroundPreset(preset);
+  // No background preset has a Tailwind skin or a skin choice.
+  const backgroundPreset = preset === 'background-video' || spfBackgroundPreset;
   const embedPreset = (EMBED_PRESETS as readonly Preset[]).includes(preset);
   const availableSources =
     preset === 'audio'
@@ -91,7 +107,7 @@ export function App() {
             ? HLS_SOURCE_IDS
             : structuredSource && muxSpfPreset
               ? MUX_SPF_SOURCE_IDS
-              : spfHlsPreset || muxSpfPreset
+              : spfHlsPreset || muxSpfPreset || spfBackgroundPreset
                 ? SPF_HLS_SOURCE_IDS
                 : NON_DASH_SOURCE_IDS;
 
@@ -166,6 +182,17 @@ export function App() {
     }
   }, [preset, source]);
 
+  // Land the SPF background presets on their own default when *switched into*,
+  // rather than inheriting whatever the previous preset was showing —
+  // `readParams` covers the first-mount half. Keyed on entry, so a source picked
+  // afterwards sticks.
+  const previousPreset = useRef(preset);
+  useEffect(() => {
+    const entered = spfBackgroundPreset && previousPreset.current !== preset;
+    previousPreset.current = preset;
+    if (entered) setSource(DEFAULT_BACKGROUND_SOURCE);
+  }, [preset, spfBackgroundPreset]);
+
   // Constrain source away from DRM the preset cannot license, and away from a
   // playback ID a non-Mux preset has no URL for.
   useEffect(() => {
@@ -210,6 +237,7 @@ export function App() {
         onAccentColorChange={setAccentColor}
         availableSources={availableSources}
         isBackgroundVideo={backgroundPreset}
+        isSpfBackgroundVideo={spfBackgroundPreset}
         isSpfHls={spfHlsPreset}
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -30,6 +30,7 @@ type NavbarProps = {
   onAccentColorChange: (value: string) => void;
   availableSources: readonly SourceId[];
   isBackgroundVideo: boolean;
+  isSpfBackgroundVideo: boolean;
   isSpfHls: boolean;
   isMuxVideo: boolean;
   isMuxAudio: boolean;
@@ -47,9 +48,9 @@ type NavbarProps = {
  * protection. Derived from the pair rather than stored on the source, since every
  * source here plays fine under some other media.
  *
- * Keyed on the *preset*, not a single is-SPF-HLS flag, because the two
- * variants answer differently and a note promising the wrong outcome is worse
- * than none — a reviewer would file the difference as a bug:
+ * Keyed on the *preset*, not a single is-SPF-HLS flag, because the variants answer
+ * differently and a note promising the wrong outcome is worse than none — a
+ * reviewer would file the difference as a bug:
  *
  * - **DRM.** Mux encrypts video renditions and leaves audio clear. The audio-only
  *   engine resolves only the audio rendition, so it never fetches an encrypted
@@ -62,6 +63,16 @@ type NavbarProps = {
  *   only appears for one of them.
  */
 function expectedOutcomeNote(source: SandboxSource, preset: Preset): string | undefined {
+  // The background presets are the same engine again, minus every error surface:
+  // they compose no `collectErrors`, put no capability constraints on their
+  // one-shot selection, and have no adapter mapping. Nothing reaches the media
+  // element either — MPEG-TS and encryption both leave `error === null`, measured
+  // on Chromium and WebKit — so the note promises a stall rather than a verdict.
+  if (preset === 'hls-background-video' || preset === 'mux-background-video') {
+    if (source.drm || (source.subType && source.subType !== 'mp4')) return 'expects silent stall, no error';
+    return undefined;
+  }
+
   if (preset !== 'hls-video' && preset !== 'hls-audio') return undefined;
   const audioOnlyPreset = preset === 'hls-audio';
 
@@ -130,6 +141,7 @@ export function Navbar({
   onAccentColorChange,
   availableSources,
   isBackgroundVideo,
+  isSpfBackgroundVideo,
   isSpfHls,
   isMuxVideo,
   isMuxAudio,
@@ -192,7 +204,7 @@ export function Navbar({
               if (sources[id].type === 'none') return true;
               // Any HLS source, including formats the SPF engine can't play — reaching
               // those failures on purpose is how the error paths get smoke-tested.
-              if (isSpfHls) return sources[id].type === 'hls';
+              if (isSpfHls || isSpfBackgroundVideo) return sources[id].type === 'hls';
               if (isMuxVideo || isMuxAudio) return sources[id].type !== 'dash';
               return true;
             })
@@ -200,7 +212,10 @@ export function Navbar({
               const note = expectedOutcomeNote(sources[id], preset);
               return { value: id, label: note ? `${sources[id].label} — ${note}` : sources[id].label };
             })}
-          disabled={isBackgroundVideo || isEmbedMedia}
+          // `<background-video>` is the one background preset with a fixed source:
+          // it hands a progressive MP4 to the browser, where the SPF-backed pair
+          // stream whatever manifest they're pointed at.
+          disabled={(isBackgroundVideo && !isSpfBackgroundVideo) || isEmbedMedia}
         />
       </div>
 

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -63,13 +63,17 @@ type NavbarProps = {
  *   only appears for one of them.
  */
 function expectedOutcomeNote(source: SandboxSource, preset: Preset): string | undefined {
-  // The background presets are the same engine again, minus every error surface:
-  // they compose no `collectErrors`, put no capability constraints on their
-  // one-shot selection, and have no adapter mapping. Nothing reaches the media
-  // element either — MPEG-TS and encryption both leave `error === null`, measured
-  // on Chromium and WebKit — so the note promises a stall rather than a verdict.
+  // The background presets are the same engine again, error surface included:
+  // `collectErrors` is composed, the one-shot selection carries capability
+  // constraints, and the adapter promotes the first fatal condition. Nothing
+  // reaches the media element even so — MPEG-TS and encryption both leave
+  // `HTMLMediaElement.error` null, measured on Chromium and WebKit — so that
+  // promoted condition is the only signal there is. Kept separate from the plain
+  // HLS branch below because this composition's fatal set is wider: it is
+  // video-only, so an absent video type is fatal here too.
   if (preset === 'hls-background-video' || preset === 'mux-background-video') {
-    if (source.drm || (source.subType && source.subType !== 'mp4')) return 'expects silent stall, no error';
+    if (source.drm) return 'expects protected error';
+    if (source.subType && source.subType !== 'mp4') return 'expects unsupported-format error';
     return undefined;
   }
 

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -23,13 +23,13 @@ import {
   getChapters,
   getPosterSrc,
   getStoryboardSrc,
-  HLS_BACKGROUND_VIDEO_SRC,
   isLiveSource,
   SOURCES,
   SPOTIFY_AUDIO_SRC,
   TIKTOK_VIDEO_SRC,
   TWITCH_VIDEO_SRC,
   VIMEO_VIDEO_SRC,
+  withMuxMaxResolution,
   YOUTUBE_VIDEO_SRC,
 } from '@app/shared/sources';
 import type { Preset, Skin } from '@app/types';
@@ -371,15 +371,16 @@ async function render() {
   const storyboard = isVideoPreset(preset) ? getStoryboardSrc(state.source) : undefined;
   const poster = isVideoPreset(preset) ? getPosterSrc(state.source) : undefined;
 
-  // Each background preset renders its own fixed source: the native element takes
-  // a progressive MP4, the SPF-backed tags need CMAF/fMP4 over HLS. The Mux tag
-  // gets the capped URL, which is the whole reason that name is worth keeping —
-  // `hls-background-video` is the same element pinning the top rendition on offer.
+  // `<background-video>` renders a fixed progressive MP4, since a native element
+  // has no manifest to pick renditions from. The SPF-backed tags take the picked
+  // HLS source instead, and the Mux one adds the cap param that is the whole reason
+  // that name is worth keeping — `hls-background-video` is the same element against
+  // an uncapped manifest.
   const backgroundSrc =
     preset === 'mux-background-video'
-      ? `${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p`
+      ? withMuxMaxResolution(source.url ?? '', '720p')
       : preset === 'hls-background-video'
-        ? HLS_BACKGROUND_VIDEO_SRC
+        ? (source.url ?? '')
         : BACKGROUND_VIDEO_SRC;
   const sourceAttr = isBackgroundPreset(preset)
     ? `src="${backgroundSrc}"`

--- a/apps/sandbox/templates/html-hls-background-video/main.ts
+++ b/apps/sandbox/templates/html-hls-background-video/main.ts
@@ -3,22 +3,26 @@ import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI
 import '@videojs/html/background/player';
 import '@videojs/html/background/skin';
 import '@videojs/html/media/hls-background-video';
-import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
+import { getInitialSource, onSourceChange } from '@app/shared/sandbox-listener';
+import { SOURCES, type SourceId } from '@app/shared/sources';
 
 // The SPF-backed background video, alongside the natively-played
 // `<background-video>` in `html-background-video`. Same skin and player, same
 // ambient framing — the difference is the engine, which streams HLS and pins one
 // rendition for the session instead of handing a progressive MP4 to the browser.
-// The source must be CMAF/fMP4; SPF does no MPEG-TS transmuxing.
 //
-// No cap here, so the pinned rendition is the largest the manifest offers.
+// Unlike its native sibling this one takes the source picker, because `src` is an
+// ordinary HLS URL and the engine's answer to a given manifest is the thing worth
+// smoke-testing: CMAF plays, MPEG-TS has no transmuxer, encrypted renditions have
+// no EME, and an audio-only ladder has no video for a video-only engine to resolve.
+//
+// No cap here, so the pinned rendition is the largest that fits the screen.
 // `html-mux-background-video` is the same element under its Mux-flavored tag,
 // pointed at a URL that caps the manifest instead — see that page for the pair.
-//
-// Deliberately spare: `src` is the element's whole surface, and there is no source
-// picker, matching its sibling pages.
 
 const html = String.raw;
+
+let source: SourceId = getInitialSource();
 
 async function render() {
   await prepareSandboxHtmlLocale();
@@ -26,12 +30,17 @@ async function render() {
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <background-video-player>
       <background-video-skin>
-        <hls-background-video src="${HLS_BACKGROUND_VIDEO_SRC}"></hls-background-video>
+        <hls-background-video src="${SOURCES[source].url ?? ''}"></hls-background-video>
       </background-video-skin>
     </background-video-player>
   `);
 }
 
 render();
+
+onSourceChange((next) => {
+  source = next;
+  render();
+});
 
 bindSandboxHtmlLocaleChange(render);

--- a/apps/sandbox/templates/html-mux-background-video/main.ts
+++ b/apps/sandbox/templates/html-mux-background-video/main.ts
@@ -3,35 +3,45 @@ import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI
 import '@videojs/html/background/player';
 import '@videojs/html/background/skin';
 import '@videojs/html/media/mux-background-video';
-import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
+import { getInitialSource, onSourceChange } from '@app/shared/sandbox-listener';
+import { SOURCES, type SourceId, withMuxMaxResolution } from '@app/shared/sources';
 
 // `<mux-background-video>` is `<hls-background-video>` under its Mux-flavored tag
 // — the same element, so `html-hls-background-video` is the same page with the
 // other name. What this one adds is the reason the name is worth keeping.
 //
 // `?max_resolution=720p` is that reason: capping which rendition gets fetched is a
-// Mux URL param rather than an attribute, so a hero video shown at 400px tall
-// never has 1080p offered to it in the first place. The element pins the largest
-// rendition the manifest offers either way; the URL is what decides what that is.
-// The source must be CMAF/fMP4 — SPF does no MPEG-TS transmuxing.
+// Mux URL param rather than an attribute, so a hero video shown at 400px tall never
+// has 1080p offered to it in the first place. Both pages narrow to what fits the
+// screen; only this one narrows the manifest, so the renditions it excludes are
+// absent rather than present and unpicked.
 //
-// Deliberately spare: `src` is the element's whole surface, and there is no source
-// picker, matching its sibling pages.
+// Takes the same source picker as its HLS-named sibling — see that page for what
+// each source shape is there to reach.
 
 const html = String.raw;
+
+let source: SourceId = getInitialSource();
 
 async function render() {
   await prepareSandboxHtmlLocale();
 
+  const src = withMuxMaxResolution(SOURCES[source].url ?? '', '720p');
+
   document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
     <background-video-player>
       <background-video-skin>
-        <mux-background-video src="${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p"></mux-background-video>
+        <mux-background-video src="${src}"></mux-background-video>
       </background-video-skin>
     </background-video-player>
   `);
 }
 
 render();
+
+onSourceChange((next) => {
+  source = next;
+  render();
+});
 
 bindSandboxHtmlLocaleChange(render);

--- a/apps/sandbox/templates/react-hls-background-video/main.tsx
+++ b/apps/sandbox/templates/react-hls-background-video/main.tsx
@@ -2,25 +2,32 @@ import '@app/styles.css';
 import '@videojs/react/background/skin.css';
 import { BackgroundVideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
-import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
+import { useSource } from '@app/shared/react/use-source';
+import { SOURCES } from '@app/shared/sources';
 import { BackgroundVideoSkin } from '@videojs/react/background';
 import { HlsBackgroundVideo } from '@videojs/react/media/hls-background-video';
 import { createRoot } from 'react-dom/client';
 
 // The SPF-backed counterpart to `react-background-video`. See that page's HTML
 // sibling for what differs: the engine streams HLS and pins one rendition rather
-// than handing a progressive MP4 to the browser, and the source must be CMAF/fMP4.
+// than handing a progressive MP4 to the browser.
 //
-// No cap, so the pinned rendition is the largest the manifest offers.
+// Unlike that native sibling this one takes the source picker, since `src` is an
+// ordinary HLS URL — see `html-hls-background-video` for what each source shape is
+// there to reach.
+//
+// No cap, so the pinned rendition is the largest that fits the screen.
 // `react-mux-background-video` is this same component under its Mux-flavored name,
 // pointed at a URL that caps the manifest instead.
 
 function App() {
+  const source = useSource();
+
   return (
     <SandboxI18nProvider>
       <BackgroundVideoPlayer>
         <BackgroundVideoSkin>
-          <HlsBackgroundVideo src={HLS_BACKGROUND_VIDEO_SRC} />
+          <HlsBackgroundVideo src={SOURCES[source].url ?? ''} />
         </BackgroundVideoSkin>
       </BackgroundVideoPlayer>
     </SandboxI18nProvider>

--- a/apps/sandbox/templates/react-mux-background-video/main.tsx
+++ b/apps/sandbox/templates/react-mux-background-video/main.tsx
@@ -2,7 +2,8 @@ import '@app/styles.css';
 import '@videojs/react/background/skin.css';
 import { BackgroundVideoPlayer } from '@app/shared/react/players';
 import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
-import { HLS_BACKGROUND_VIDEO_SRC } from '@app/shared/sources';
+import { useSource } from '@app/shared/react/use-source';
+import { SOURCES, withMuxMaxResolution } from '@app/shared/sources';
 import { BackgroundVideoSkin } from '@videojs/react/background';
 import { MuxBackgroundVideo } from '@videojs/react/media/mux-background-video';
 import { createRoot } from 'react-dom/client';
@@ -14,11 +15,13 @@ import { createRoot } from 'react-dom/client';
 // manifest rather than present and unpicked.
 
 function App() {
+  const source = useSource();
+
   return (
     <SandboxI18nProvider>
       <BackgroundVideoPlayer>
         <BackgroundVideoSkin>
-          <MuxBackgroundVideo src={`${HLS_BACKGROUND_VIDEO_SRC}?max_resolution=720p`} />
+          <MuxBackgroundVideo src={withMuxMaxResolution(SOURCES[source].url ?? '', '720p')} />
         </BackgroundVideoSkin>
       </BackgroundVideoPlayer>
     </SandboxI18nProvider>

--- a/internal/design/spf/features/capability-probing.md
+++ b/internal/design/spf/features/capability-probing.md
@@ -106,10 +106,11 @@ layer onto specific phases per the
 
 | Piece | Role |
 |---|---|
-| `excludeUnplayableTracks` | Hard-constraint in the `applyConstraints` pre-pass; reads `config.canPlayTrack`, drops undecodable renditions before the rule chain. Shared by `switchVideoTrack` / `switchAudioTrack`, pooled with `excludeFailedCdns`. When it prunes a type that *has* tracks to empty, the selection clears (no pick) so a pick made before a relabel can't linger as unplayable |
+| `excludeUnplayableTracks` | Hard-constraint in the `applyConstraints` pre-pass; reads `config.canPlayTrack`, drops undecodable renditions before the rule chain. Lives in `playback/primitives/selection-rules.ts` rather than beside `switchVideoTrack`, for the reason that module exists: the pinned `selectVideoTrack` applies it too, and reaching it through `behaviors/track-switching.ts` would drag the ABR path into a composition that deliberately omits it. `track-switching` re-exports it, so its public surface is unchanged. Applied by `switchVideoTrack` / `switchAudioTrack` (pooled with `excludeFailedCdns`) and by `selectVideoTrack` (alone — its compositions run no failover monitor, so `failedCdns` has no writer). When it prunes a type that *has* tracks to empty, the selection clears (no pick) so a pick made before a relabel can't linger as unplayable |
 
-**Engine wiring (`playback/engines/hls/engine.ts` + `engine-audio-only.ts`):**
-- `canPlayTrack` config — both engine factories default it to the DOM `canPlayTrack` in `finalConfig` (the audio-only variant too, so filtering isn't inert there); override to force-exclude a codec (the Tier 2 seam). Adapters forward it via `...config`.
+**Engine wiring (`playback/engines/hls/engine.ts`, `engine-audio-only.ts`, `engine-background-video.ts`):**
+- `canPlayTrack` config — all three engine factories default it to the DOM `canPlayTrack` in `finalConfig` (the audio-only and background variants too, so filtering isn't inert there); override to force-exclude a codec (the Tier 2 seam). Adapters forward it via `...config`.
+- The background variant is the one where the pre-pass runs under a *pinned* selection: `selectVideoTrack` picks once, so the constraint is re-applied by a sibling effect rather than by the picking reaction, and its only outcome is to unpin — never to choose a different rendition.
 
 **State slots:**
 - **Reads (constraint):** `presentation` candidates' `mimeType` + `codecs`, via `config.canPlayTrack`.

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -238,30 +238,46 @@ DOM-free, so the codes are usable from any layer: `SvtaError`
 | `canPlayTrack` | `media/dom/capabilities.ts` | Prunes non-fMP4 containers and encrypted renditions, so every reported cause has a corresponding exclusion |
 | `parseMediaPlaylist` → `MediaPlaylistMetadata.encrypted` | `media/hls/parse-media-playlist.ts` | `EXT-X-KEY` detection. `METHOD=NONE` is not encryption; a clear lead followed by a real key is. Deliberately not a CMAF-HAM `Protection` model — set-level `defaultKid` can't express a clear lead or key rotation, and CML never populates it from HLS |
 | `parseMediaPlaylist` → `MediaPlaylistMetadata.lowLatency` | `media/hls/parse-media-playlist.ts` | LL-HLS detection for the phase-5 notice — any of `EXT-X-PART`, `EXT-X-PART-INF`, or `PART-HOLD-BACK`. Records that the publisher configured LL-HLS, not that we honour it; partial segments are still skipped |
-| `firstFatal` / `hasUnsupportedFeatureCause` | `playback/adapters/hls-video/error-surface.ts` | The shared half of both adapters' promotion step, plus the `HlsVideoMediaError` type. Only the *policy* — which codes are fatal — stays per adapter |
+| `firstFatal` / `hasUnsupportedFeatureCause` | `playback/adapters/hls-video/error-surface.ts` | The shared half of the promotion step, plus the `HlsVideoMediaError` type. Only the *policy* — which codes are fatal — stays per adapter. All three adapters share `firstFatal`; the `ErrorLike` mapping and its 99001 substitution are the video and audio ones only |
 | `UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE` and the two notice strings | `playback/primitives/error-messages.ts` | **Console-only** copy, plain constants. Nothing here is viewer-facing; separate exports so a composition that logs neither notice doesn't carry the bytes |
 
-**Adapters** — `playback/adapters/hls-video/adapter.ts` and
-`hls-audio/adapter.ts`. Each owns `FATAL_SVTA_CODES` (its fatality
-allow-list — the audio-only set is narrower, since it composes no video
-selection and so can never report 2011), the `error` getter, and the
-`'error'` dispatch.
+**Adapters** — `playback/adapters/hls-video/adapter.ts`,
+`hls-audio/adapter.ts`, and `hls-background-video/adapter.ts`. Each owns
+`FATAL_SVTA_CODES` (its fatality allow-list — the audio-only set is
+narrower, since it composes no video selection and so can never report
+2011; the background set is narrower still, at 2011 alone), the `error`
+getter, and the `'error'` dispatch. First fatal wins, latched so a later
+append doesn't re-fire, and clearing rides `collectErrors`' per-source
+reset rather than a source-change hook of its own.
 
-**The background-video composition deliberately has no adapter surface.** It
-reports onto `state.errors` and logs, and stops there: `src` is that Media's whole
-surface, and every failure it can meet already reports a specific cause. Worth
-recording because the measurement says the stakes are real — on Chromium and
-WebKit (2026-08-14) every unplayable source there is a *silent stall* with
-`HTMLMediaElement.error` null at `readyState 0`, since nothing in MSE reports it
-either. Chromium accepts MPEG-TS appends into a `video/mp4` SourceBuffer, fires
-`update` (not `error`), and buffers nothing; WebKit demuxes the TS outright. No
-SourceBuffer error, no MediaSource error, no element error on either. So the
-reported sequence plus its console output is the only failure signal that exists
-for that composition. First fatal wins, latched on the *reported* code so a
-later append doesn't re-fire. Where the sequence holds an
+The two HLS adapters latch on the *reported* code rather than the
+surfaced one, because the two can differ: where the sequence holds an
 unimplemented-capability cause, the surfaced code becomes 99001 and the
 condition is logged with the sequence attached; the `message` stays
 empty either way.
+
+**The background-video adapter surfaces the reported `SvtaError` itself, with
+no mapping.** The `ErrorLike` translation the other two perform exists for the
+store's error feature and the dialog above it, and this composition has
+neither — no store features, no chrome, nothing to localize copy into — so the
+reported code is more use to a consumer than a translation of it, and 99001
+substitution would buy nothing. Having *a* surface at all matters more here than
+elsewhere: on Chromium and WebKit (2026-08-14) every unplayable source in this
+composition is a *silent stall* with `HTMLMediaElement.error` null at
+`readyState 0`, since nothing in MSE reports it either. Chromium accepts MPEG-TS
+appends into a `video/mp4` SourceBuffer, fires `update` (not `error`), and
+buffers nothing; WebKit demuxes the TS outright. No SourceBuffer error, no
+MediaSource error, no element error on either. The reported sequence, its console
+output, and this surface are the only failure signals that exist.
+
+Both platform components forward it, since a consumer of either holds the element
+rather than the Media. `<hls-background-video>` re-fires `'error'` on itself and
+delegates an `error` getter — one eager listener on a Media it owns for life,
+rather than `CustomMediaElement`'s bridge-on-first-`addEventListener`, which is
+more machinery than a single event is worth. The React component re-dispatches on
+the `<video>` node instead, so React's own event plumbing invokes `onError` with
+the synthetic event it is typed for; a handler there learns *that* the source
+won't play, and the console and `engine.state.errors` hold which condition it was.
 
 `alternativeMediaSuggestion` is a static seam on the video adapter: a
 Media with a better-equipped sibling to point at (a Mux Video whose
@@ -357,6 +373,18 @@ limitations*).
     once, with the conditions attached, silent for a verdict with no
     unsupported cause, and the alternative-Media sentence appended when
     the class names one
+  - `packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts`
+    → *error surface* — nothing before a report; the verdict surfaces as
+    the reported `SvtaError` (no mapping, no `message` invented) and fires
+    `'error'`; a cause on its own stays in the sequence; fires once per
+    distinct condition; clears on per-source reset without announcing the
+    clear
+  - `packages/html/src/media/hls-background-video/tests/media.test.ts` and
+    `packages/react/src/media/hls-background-video/tests/media.test.tsx`
+    → the forward — the element re-fires `'error'` on itself and exposes
+    the condition while the inner `<video>`'s own `error` stays null; the
+    React component's `onError` fires with the `<video>` as target, and
+    stays quiet for a non-fatal report
 - **E2E:**
   - `apps/e2e/tests/spf-unsupported-source.spec.ts` (Chromium and WebKit —
     the two the CI matrix and `test:all` run; a `vite-firefox` project

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -250,18 +250,23 @@ getter, and the `'error'` dispatch. First fatal wins, latched so a later
 append doesn't re-fire, and clearing rides `collectErrors`' per-source
 reset rather than a source-change hook of its own.
 
-The two HLS adapters latch on the *reported* code rather than the
-surfaced one, because the two can differ: where the sequence holds an
+All three latch on the *reported* code rather than the surfaced one,
+because the two can differ: where the sequence holds an
 unimplemented-capability cause, the surfaced code becomes 99001 and the
 condition is logged with the sequence attached; the `message` stays
-empty either way.
+empty either way. One `HlsVideoMediaError` shape across all three, kept
+under the name `hls-video` publishes it as rather than copied per adapter.
 
-**The background-video adapter surfaces the reported `SvtaError` itself, with
-no mapping.** The `ErrorLike` translation the other two perform exists for the
-store's error feature and the dialog above it, and this composition has
-neither — no store features, no chrome, nothing to localize copy into — so the
-reported code is more use to a consumer than a translation of it, and 99001
-substitution would buy nothing. Having *a* surface at all matters more here than
+**The background-video adapter maps identically, and deliberately so.** It has
+no store feature or dialog above it to localize copy from a code — the argument
+for leaving the condition unmapped — but an SVTA code alone is something a
+consumer has to go and look up, where 99001 plus the logged sentence says the
+actionable thing: this player has no pipeline for what the source needs, and no
+retry or CDN changes that. The one thing it doesn't take is
+`alternativeMediaSuggestion`; nothing in this repo plays an HLS background video
+that this engine can't, so there is no sibling to name.
+
+Having *a* surface at all matters more here than
 elsewhere: on Chromium and WebKit (2026-08-14) every unplayable source in this
 composition is a *silent stall* with `HTMLMediaElement.error` null at
 `readyState 0`, since nothing in MSE reports it either. Chromium accepts MPEG-TS
@@ -280,9 +285,10 @@ in the sandbox on Chromium (2026-08-17): an MPEG-TS source reports 1004 alone an
 an encrypted one 4008 alone — no verdict behind either, because the *other*
 renditions were never resolved and so were never pruned, leaving the candidate set
 non-empty while the pick is gone. A verdict-only allow-list left both as silent
-stalls, which is exactly what this surface exists to prevent. First-fatal-wins then
-surfaces the cause over the verdict when a source produces both, which is the more
-specific of the two. Reporting a verdict from the deselect instead was the
+stalls, which is exactly what this surface exists to prevent. Both then map to
+99001 through the same substitution the other adapters use, so what a consumer
+reads is "unplayable here", with the container-vs-encryption specifics on the
+console. Reporting a verdict from the deselect instead was the
 alternative; it stays rejected because selection there deliberately reports
 nothing (the cause is more specific and already logged), and because fatality is
 the adapter's to decide.
@@ -391,13 +397,14 @@ limitations*).
     unsupported cause, and the alternative-Media sentence appended when
     the class names one
   - `packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts`
-    → *error surface* — nothing before a report; the verdict surfaces as
-    the reported `SvtaError` (no mapping, no `message` invented) and fires
-    `'error'`; a *cause* with no verdict behind it surfaces too, for
-    container and encryption alike (the pinned-variant rule above); 2039
-    stays out of it; the cause wins over the verdict when both are present;
-    fires once per distinct condition; clears on per-source reset without
-    announcing the clear
+    → *error surface* — nothing before a report; a verdict with no cause
+    behind it keeps its own code and fires `'error'`; a *cause* with no
+    verdict behind it surfaces too, for container and encryption alike (the
+    pinned-variant rule above), substituted to 99001 with the reporter's
+    context carried through; 2039 stays out of it; the explanation is logged
+    once, with the conditions attached and no prose on `message`; fires once
+    per distinct condition; clears on per-source reset without announcing
+    the clear
   - `packages/html/src/media/hls-background-video/tests/media.test.ts` and
     `packages/react/src/media/hls-background-video/tests/media.test.tsx`
     → the forward — the element re-fires `'error'` on itself and exposes

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -423,6 +423,22 @@ limitations*).
     and an fMP4 control reports nothing. Driven by the
     `html-hls-video-ts` page, deliberately absent from
     `fixtures/media.ts`'s page arrays
+  - `apps/e2e/tests/spf-background-video.spec.ts` (same two projects) —
+    the background composition against real manifests: a playable fMP4
+    source reports nothing; MPEG-TS surfaces 99001 with an empty
+    `message`; **the sequence holds 1004 with no 2011 behind it**, the
+    pinned-variant shape a `select-tracks` refactor would otherwise change
+    unnoticed; the *encrypted* source surfaces the same 99001 over a 4008;
+    an audio-only ladder keeps its own 2011 with no substitution; a source
+    change back to fMP4 clears the error and plays; and React's `onError`
+    fires. The load-bearing one is **the inner `<video>` staying at
+    `readyState 0` with `error` null** while all of that happens — the
+    measured premise the surface exists for, now asserted rather than
+    recorded. Driven by `html-` and `react-hls-background-video`, a
+    `background` category in `generate-pages.ts` whose template skips the
+    player shell every other page uses — this composition has no controls
+    to hang on a skin — and takes a `?src=` param, so one page per platform
+    serves every source shape
 - **Manual:** the sandbox offers both failing shapes to the plain HLS
   presets — `hls-audio-only-ts` (MPEG-TS) and `hls-drm-unlicensed` (the
   DRM asset with no license path), each labelled with the error it should
@@ -440,9 +456,11 @@ limitations*).
   source. That walk is what found the verdict-only gap the fatal set now
   covers.
 - **Out of scope / deferred:**
-  - **No E2E for the encrypted path** — no encrypted source is wired into
-    the e2e fixtures, so 4008 → 99001 is unit-verified plus manually
-    reachable in the sandbox, not automated
+  - **The encrypted path is E2E-covered on the background composition
+    only** — `MEDIA.hlsDrm` (the sandbox's unlicensed DRM asset, its token
+    signed to 2038 so it can't rot) proves 4008 → 99001 there. The same
+    path through `hls-video` and into the dialog is still unit-verified
+    plus manually reachable, since its pages take one source each
   - **The audio verdict (2012) is unit-covered only** — the e2e TS
     source has muxed audio and therefore no separate audio track
 

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -143,24 +143,6 @@ retry-exhaustion, pipeline producers) are not.
   through unresolved carries the prior source's errors forward.
   `resolve-track` guards the same transition with a commit-time id
   check; doing likewise here is a follow-up.
-- **A type absent entirely is silent, which is wrong for a composition
-  that needs it.** `hasTracksOfType` correctly treats "no tracks of this
-  type" as legitimate — a video-only source must not report 2012 — but
-  the audio-only engine composes *only* audio, so a source with no audio
-  rendition is unplayable and reports nothing at all. Observed on a
-  muxed-audio MPEG-TS source (`hls-1` in the sandbox): no cause, since
-  `reportUnsupportedTrackConditions` runs per resolved track and none resolves; no
-  verdict, since the guard returns first; the element sits at
-  `readyState 0` with `error === null`. `track-switching` can't tell the
-  two apart — it's per-type and composition-agnostic, and per §Open
-  questions producers must not assert fatality — so the fix likely mirrors
-  the causes/verdicts split: report "this type has no renditions" as a
-  distinct non-fatal-by-default condition and let each adapter's
-  `FATAL_SVTA_CODES` decide, which the audio-only adapter's narrower set
-  already demonstrates. No existing code fits (1004/1005 and 2011/2012 all
-  presuppose renditions that *were* there), so this needs a code chosen
-  against the spec. A source with no tracks of **any** type is the same
-  gap, wider: every type takes the silent path.
 - **Manifest fetch/parse failure never reaches `errors`.**
   `resolve-presentation` carries a `TODO(error-management)` and only
   `console.error`s. Notably the path a 403 takes, so an expired signed or
@@ -243,6 +225,8 @@ DOM-free, so the codes are usable from any layer: `SvtaError`
 |---|---|---|
 | `collectErrors` | `playback/behaviors/collect-errors.ts` | Owns the `errors` slot and its per-source lifecycle. No effects, no policy — a lifecycle owner, not an error handler. Same slot-owner-vs-writer split as `setupFailoverMonitor` / `failedCdns` |
 | `switchVideoTrack` / `switchAudioTrack` / `switchTextTrack` | `playback/behaviors/track-switching.ts` | Report the **verdict** (2011 / 2012) when a type has renditions but constraints pruned every one. Per-variant `noSupportedTrackCode`; text supplies none, since absent subtitles aren't a failure. Reports generically — it never reads a constraint's state, so it doesn't know *why* the set emptied |
+| `selectVideoTrack` | `playback/behaviors/select-tracks.ts` | The *pinned* variant. `entry` stays the only thing that ever **selects**; a sibling `effects` entry on the same `presentation-resolved` state only ever **de**selects, dropping a pick the constraints turned against. Keeping selection out of the reaction is what separates this from `switchVideoTrack` — a re-pick here would make it that behavior with extra steps — but it must *be* a reaction, since container and encryption are only known once a media playlist resolves, after `entry` ran. It reports nothing itself: whatever made the pick unplayable already reported its own cause (1004 / 4008), more specific than a verdict and already logged. A pick naming a track the manifest never offered is left alone, preserving the module's external-writes contract |
+| `reportAbsentTrackType` | `playback/behaviors/collect-errors.ts` | The one failure with no cause behind it: a source offering **no** renditions of a type the composition needs. Nothing resolves, so `reportUnsupportedTrackConditions` never runs and no cause exists to be more specific than a verdict. Shaped as a *constraint* rather than config so a composition opts in by adding it to `constraints` and one that doesn't pays nothing — it never actually constrains, returning its input untouched. Belongs at the head of the chain, where an empty input still means "the source offers none" rather than "the constraints ahead pruned them all." Idempotent, because the chain runs inside a `computed` that re-derives on every `presentation` write while the sequence keeps duplicates |
 | `resolveVideoTrack` / `resolveAudioTrack` / `resolveTextTrack` | `playback/behaviors/resolve-track.ts` | Call the `reportUnsupportedTrackConditions` seam post-parse, reporting **causes** per rendition as it resolves — before committing the parsed track |
 
 **Helpers and seams:**
@@ -261,7 +245,19 @@ DOM-free, so the codes are usable from any layer: `SvtaError`
 `hls-audio/adapter.ts`. Each owns `FATAL_SVTA_CODES` (its fatality
 allow-list — the audio-only set is narrower, since it composes no video
 selection and so can never report 2011), the `error` getter, and the
-`'error'` dispatch. First fatal wins, latched on the *reported* code so a
+`'error'` dispatch.
+
+**The background-video composition deliberately has no adapter surface.** It
+reports onto `state.errors` and logs, and stops there: `src` is that Media's whole
+surface, and every failure it can meet already reports a specific cause. Worth
+recording because the measurement says the stakes are real — on Chromium and
+WebKit (2026-08-14) every unplayable source there is a *silent stall* with
+`HTMLMediaElement.error` null at `readyState 0`, since nothing in MSE reports it
+either. Chromium accepts MPEG-TS appends into a `video/mp4` SourceBuffer, fires
+`update` (not `error`), and buffers nothing; WebKit demuxes the TS outright. No
+SourceBuffer error, no MediaSource error, no element error on either. So the
+reported sequence plus its console output is the only failure signal that exists
+for that composition. First fatal wins, latched on the *reported* code so a
 later append doesn't re-fire. Where the sequence holds an
 unimplemented-capability cause, the surfaced code becomes 99001 and the
 condition is logged with the sequence attached; the `message` stays
@@ -323,6 +319,19 @@ limitations*).
     regardless of which constraint emptied the set** (all-CDN cooldown
     reads the same as capability rejection); nothing for a type with no
     tracks; 2012 for the audio variant; nothing for text
+  - `packages/spf/src/playback/behaviors/tests/select-tracks.test.ts` →
+    *capability constraint + verdict* — prunes an undecodable rendition
+    before the chain picks; no pick plus 2011 when every rendition is
+    undecodable; **clears a pick already made when a later container
+    relabel prunes every rendition** (the warm path the pinned variant
+    exists to survive); does not re-pick after unpinning (the pinning
+    contract); nothing reported for a presentation with no video tracks;
+    passes everything through with no probe wired
+  - `packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts`
+    → *errors* — declares the slot; makes no pick for an unplayable
+    container *without* reporting a verdict (the 1004 cause covers it);
+    reports 2011 for a source with no video renditions at all; reports that
+    **once**, not per presentation write; clears on src unload
   - `packages/spf/src/media/dom/tests/capabilities.test.ts` — encrypted
     renditions asserted unplayable without consulting `isTypeSupported`;
     clear renditions still fall through to the codec probe (the other
@@ -365,7 +374,9 @@ limitations*).
   DRM asset with no license path), each labelled with the error it should
   produce. `SPF_HLS_SOURCE_IDS` is what keeps the unlicensed DRM
   source reachable there while the presets that *can* license DRM get the
-  playable variants instead.
+  playable variants instead. The two SPF background presets
+  (`hls-background-video`, `mux-background-video`) take the same source
+  list, so the same failing shapes reach the pinned variant.
 - **Out of scope / deferred:**
   - **No E2E for the encrypted path** — no encrypted source is wired into
     the e2e fixtures, so 4008 → 99001 is unit-verified plus manually

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -245,7 +245,7 @@ DOM-free, so the codes are usable from any layer: `SvtaError`
 `hls-audio/adapter.ts`, and `hls-background-video/adapter.ts`. Each owns
 `FATAL_SVTA_CODES` (its fatality allow-list — the audio-only set is
 narrower, since it composes no video selection and so can never report
-2011; the background set is narrower still, at 2011 alone), the `error`
+2011; the background set is *wider*, and § below says why), the `error`
 getter, and the `'error'` dispatch. First fatal wins, latched so a later
 append doesn't re-fire, and clearing rides `collectErrors`' per-source
 reset rather than a source-change hook of its own.
@@ -269,6 +269,23 @@ appends into a `video/mp4` SourceBuffer, fires `update` (not `error`), and
 buffers nothing; WebKit demuxes the TS outright. No SourceBuffer error, no
 MediaSource error, no element error on either. The reported sequence, its console
 output, and this surface are the only failure signals that exist.
+
+**And in the pinned variant a cause *is* a verdict**, which is why 1004 and 4008
+join 2011 in its fatal set. Elsewhere a cause is context — one unplayable
+rendition doesn't fail a source whose others still play, and a verdict follows if
+the type empties. Here only the *pinned* rendition's playlist is ever resolved, so
+a cause can only be about the pick itself, and dropping that pick is final:
+`selectVideoTrack` never re-picks, and `switchVideoTrack` isn't composed. Measured
+in the sandbox on Chromium (2026-08-17): an MPEG-TS source reports 1004 alone and
+an encrypted one 4008 alone — no verdict behind either, because the *other*
+renditions were never resolved and so were never pruned, leaving the candidate set
+non-empty while the pick is gone. A verdict-only allow-list left both as silent
+stalls, which is exactly what this surface exists to prevent. First-fatal-wins then
+surfaces the cause over the verdict when a source produces both, which is the more
+specific of the two. Reporting a verdict from the deselect instead was the
+alternative; it stays rejected because selection there deliberately reports
+nothing (the cause is more specific and already logged), and because fatality is
+the adapter's to decide.
 
 Both platform components forward it, since a consumer of either holds the element
 rather than the Media. `<hls-background-video>` re-fires `'error'` on itself and
@@ -376,9 +393,11 @@ limitations*).
   - `packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts`
     → *error surface* — nothing before a report; the verdict surfaces as
     the reported `SvtaError` (no mapping, no `message` invented) and fires
-    `'error'`; a cause on its own stays in the sequence; fires once per
-    distinct condition; clears on per-source reset without announcing the
-    clear
+    `'error'`; a *cause* with no verdict behind it surfaces too, for
+    container and encryption alike (the pinned-variant rule above); 2039
+    stays out of it; the cause wins over the verdict when both are present;
+    fires once per distinct condition; clears on per-source reset without
+    announcing the clear
   - `packages/html/src/media/hls-background-video/tests/media.test.ts` and
     `packages/react/src/media/hls-background-video/tests/media.test.tsx`
     → the forward — the element re-fires `'error'` on itself and exposes
@@ -404,7 +423,15 @@ limitations*).
   source reachable there while the presets that *can* license DRM get the
   playable variants instead. The two SPF background presets
   (`hls-background-video`, `mux-background-video`) take the same source
-  list, so the same failing shapes reach the pinned variant.
+  list, so the same failing shapes reach the pinned variant. Walked on
+  Chromium 2026-08-17 against `html-hls-background-video` and
+  `react-hls-background-video`: `hls-4k` plays and pins 2558x1440 against a
+  3456x2234 screen with an empty sequence and `error` null; `hls-1` (TS)
+  surfaces 1004 and `hls-drm-unlicensed` surfaces 4008, each from a cause
+  with no verdict behind it; `hls-audio-only-cmaf` surfaces 2011; and the
+  event fires once, clears on a new `src`, and re-fires for the next bad
+  source. That walk is what found the verdict-only gap the fatal set now
+  covers.
 - **Out of scope / deferred:**
   - **No E2E for the encrypted path** — no encrypted source is wired into
     the e2e fixtures, so 4008 → 99001 is unit-verified plus manually

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -239,7 +239,7 @@ DOM-free, so the codes are usable from any layer: `SvtaError`
 | `parseMediaPlaylist` → `MediaPlaylistMetadata.encrypted` | `media/hls/parse-media-playlist.ts` | `EXT-X-KEY` detection. `METHOD=NONE` is not encryption; a clear lead followed by a real key is. Deliberately not a CMAF-HAM `Protection` model — set-level `defaultKid` can't express a clear lead or key rotation, and CML never populates it from HLS |
 | `parseMediaPlaylist` → `MediaPlaylistMetadata.lowLatency` | `media/hls/parse-media-playlist.ts` | LL-HLS detection for the phase-5 notice — any of `EXT-X-PART`, `EXT-X-PART-INF`, or `PART-HOLD-BACK`. Records that the publisher configured LL-HLS, not that we honour it; partial segments are still skipped |
 | `firstFatal` / `hasUnsupportedFeatureCause` | `playback/adapters/hls-video/error-surface.ts` | The shared half of the promotion step, plus the `HlsVideoMediaError` type. Only the *policy* — which codes are fatal — stays per adapter. All three adapters share `firstFatal`; the `ErrorLike` mapping and its 99001 substitution are the video and audio ones only |
-| `UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE` and the two notice strings | `playback/primitives/error-messages.ts` | **Console-only** copy, plain constants. Nothing here is viewer-facing; separate exports so a composition that logs neither notice doesn't carry the bytes |
+| `UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE`, `UNPLAYABLE_SOURCE_MESSAGE`, and the two notice strings | `playback/primitives/error-messages.ts` | **Console-only** copy, plain constants. Nothing here is viewer-facing; separate exports so a composition that logs neither notice doesn't carry the bytes. The generic one exists for a composition whose failures don't all reduce to a missing feature — see the background adapter below |
 
 **Adapters** — `playback/adapters/hls-video/adapter.ts`,
 `hls-audio/adapter.ts`, and `hls-background-video/adapter.ts`. Each owns
@@ -265,6 +265,17 @@ actionable thing: this player has no pipeline for what the source needs, and no
 retry or CDN changes that. The one thing it doesn't take is
 `alternativeMediaSuggestion`; nothing in this repo plays an HLS background video
 that this engine can't, so there is no sibling to name.
+
+**The console half diverges, though: it logs on every fatal condition, not only
+a substituted one, and logs the generic sentence.** Both follow from causes being
+fatal here. The other two adapters log only when they substitute 99001, which is
+sound where every fatal condition *is* a verdict about a missing feature; here a
+verdict can instead mean the source carries no video at all, which would otherwise
+reach a developer as a bare 2011 with nothing said about it. And a message naming
+a missing feature would be wrong for exactly that case, so
+`UNPLAYABLE_SOURCE_MESSAGE` names none: the structured conditions logged beside it
+already carry track type, id, and container. One unconditional log also costs a
+branch less than one per case.
 
 Having *a* surface at all matters more here than
 elsewhere: on Chromium and WebKit (2026-08-14) every unplayable source in this
@@ -402,9 +413,9 @@ limitations*).
     verdict behind it surfaces too, for container and encryption alike (the
     pinned-variant rule above), substituted to 99001 with the reporter's
     context carried through; 2039 stays out of it; the explanation is logged
-    once, with the conditions attached and no prose on `message`; fires once
-    per distinct condition; clears on per-source reset without announcing
-    the clear
+    once, with the conditions attached and no prose on `message`, **including
+    for a verdict that substitutes nothing**; fires once per distinct
+    condition; clears on per-source reset without announcing the clear
   - `packages/html/src/media/hls-background-video/tests/media.test.ts` and
     `packages/react/src/media/hls-background-video/tests/media.test.tsx`
     → the forward — the element re-fires `'error'` on itself and exposes

--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -272,10 +272,12 @@ fatal here. The other two adapters log only when they substitute 99001, which is
 sound where every fatal condition *is* a verdict about a missing feature; here a
 verdict can instead mean the source carries no video at all, which would otherwise
 reach a developer as a bare 2011 with nothing said about it. And a message naming
-a missing feature would be wrong for exactly that case, so
-`UNPLAYABLE_SOURCE_MESSAGE` names none: the structured conditions logged beside it
-already carry track type, id, and container. One unconditional log also costs a
-branch less than one per case.
+one missing feature would be wrong for exactly that case, so
+`UNPLAYABLE_SOURCE_MESSAGE` names all three broadly instead. Nor does it defer the
+*why* to the conditions: an `SvtaError` is a code and its context, and nothing on
+this path sets `message`, so pointing a developer at them for prose they don't
+carry is what made the earlier wording confusing. One unconditional log also costs
+a branch less than one per case.
 
 Having *a* surface at all matters more here than
 elsewhere: on Chromium and WebKit (2026-08-14) every unplayable source in this

--- a/internal/design/spf/features/rendition-selection-caps.md
+++ b/internal/design/spf/features/rendition-selection-caps.md
@@ -135,6 +135,17 @@ from the config-driven ones above.
   and the `hls-background-video` adapter tests — the composed default.
   Note these write `screenResolution` explicitly; a test that leaves it
   ambient makes its expected pick depend on the runner's display.
+- `apps/e2e/tests/spf-background-video.spec.ts` → *screen-size cap* —
+  the same 4K ladder through a real browser on both projects: an
+  800x600 screen pins a rendition inside that area, and 1920x1080 at
+  `deviceScaleFactor: 2` pins one above 1080 lines, which also covers
+  `useDevicePixelRatio` (in CSS pixels alone that viewport could never
+  justify a 2160-line rendition). Bounded rather than pinned to an exact
+  rung, so a ladder change at the source doesn't break it. **Driven
+  through the viewport, not the `screen` context option:** measured in
+  both projects, `window.screen` follows the emulated viewport and the
+  `screen` option has no effect, so an e2e test cannot distinguish
+  "reads the screen" from "reads the window" — that stays unit-level.
 - Manual, Chromium on a 3456x2234 display against a 3840x2160 ladder:
   the pick moves from 3838x2160 (8.29 Mpx, over the 7.72 Mpx screen) to
   2558x1440. The sandbox page is `html-hls-background-video`, whose

--- a/internal/design/spf/features/rendition-selection-caps.md
+++ b/internal/design/spf/features/rendition-selection-caps.md
@@ -1,18 +1,17 @@
 ---
-status: draft
-date: 2026-05-20
-definition: technical
+status: partial
+date: 2026-08-14
+definition: sketched
 ---
 
 # Rendition selection caps
 
-Policy-driven constraints that narrow the candidate set of video
-renditions before quality selection runs. Each cap is a separate
-constraint slot read by `selectQuality` (or the ABR equivalent) and
-applied as a filter on `presentation.videoTracks` before selection.
-The selection slot itself (`selectedVideoTrackId`) remains
-single-writer; caps participate as constraints, not as competing
-selectors.
+Policy-driven narrowing of the candidate set of video renditions before
+the pick is taken. Each cap is a **selection rule** — a soft filter in
+the chain described by
+[track-switching-model.md](../track-switching-model.md) — so the
+selection slot (`selectedVideoTrackId`) stays single-writer and caps
+bias the candidates rather than competing to write it.
 
 A **Player feature** in the framing from
 [clusters.md § Feature classification axes](./clusters.md#feature-classification-axes):
@@ -22,53 +21,135 @@ other consumer-side reasons.
 
 ## Status
 
-- **Composition:** not implemented in `createHlsVideoEngine`. Today
-  `selectQuality` operates over all `presentation.videoTracks` with
-  no candidate-set narrowing beyond `userVideoTrackSelection`
-  (single-track manual override) and bandwidth-driven safety
-  margins.
-- **Definition depth:** technical — scope and constraints
-  articulated; no implementation. Source material: [SPF Epics
+- **Composition:** the **screen-size cap** is implemented and composed
+  by `createBackgroundVideoEngine`, whose default rule chain is
+  `[screenResolutionCap, preferHighestResolution]` — narrow to the
+  renditions that fit the screen, then take the largest. Not composed
+  by `createHlsVideoEngine`, where `selectQuality` still operates over
+  all video tracks with no narrowing beyond `userVideoTrackSelection`.
+  The config-driven caps (max-height, max-bitrate, max-FPS), the
+  player-element cap, and the cap floor are all unimplemented.
+- **Definition depth:** sketched for the screen-size cap
+  (implementation surface below); the remaining phases stay technical —
+  scope articulated, no implementation. Source material: [SPF Epics
   Working Doc](https://www.notion.so/35f97a7f89d08123a13fecab1ca1cac4)
   Cluster E entries #13 (1080p+ Resolution Cap, eng S, validation S)
   and NEW-C (Screen-Size / Player-Size Resolution Cap, eng S–M,
   validation S), unified per that doc's "Resolution-cap
   unification" open question.
 
+  Note NEW-C bundles *screen*-size and *player*-size into one entry.
+  Only the screen-size half shipped; they are separate phase rows below
+  because they differ in both signal source and layer.
+
 ## Phases of complexity
 
-Phases. The first four are motivation slices — different signal
-sources (config / `ResizeObserver`) feeding the same constraint+filter
-mechanism (a per-cap state slot read by `selectQuality` as a filter on
-the candidate set before selection). The fifth is meta-policy on top:
-it modifies how the combination of caps resolves, not a cap of its
+The first five are motivation slices — different signal sources
+(config / `screen` / `ResizeObserver`) feeding the same mechanism, a
+soft-filter rule in the selection chain. The sixth is meta-policy on
+top: it modifies how the combination of caps resolves, not a cap of its
 own.
 
-| Phase | What | Mechanism |
+| Phase | What | Status / mechanism |
 |---|---|---|
-| Billing-driven max-height cap | Config-driven `maxHeight` (e.g., 1080) excludes higher-resolution variants from the candidate set. Drives the Mux billing use case (cap delivery at 1080p+ for tier-pricing alignment) | **Policy** — config field consumed by `selectQuality`'s filter step; no new behavior. Matching axis is configurable: height (default, simpler) or total pixels (e.g., for exact alignment with resolution-based pricing tiers — `1080p = 2,073,600 pixels` ensures anamorphic / non-standard-aspect variants are matched correctly) |
-| Viewport-driven height cap | Cap the candidate set to renditions that fit the player element's rendered dimensions. Avoids serving higher-resolution variants the viewer can't perceive | **Middle pattern** — `ResizeObserver` monitor writes cap state on player-element size changes; `selectQuality` reads. New behavior. Pairs with the cap-floor phase below — the floor counters this phase's tendency to over-aggressively downgrade on small players |
-| Max-bitrate cap | Config-driven `maxBitrate` excludes variants above the threshold. Useful for bandwidth-constrained delivery contexts (mobile, billing) | **Policy** — same shape as max-height cap |
-| Max-FPS cap | Config-driven `maxFps` excludes high-frame-rate variants. Less common motivation but mentioned in [video-abr.md](./video-abr.md)'s "What's not implemented" | **Policy** — same shape |
-| Cap floor (minimum effective cap) | Counter-pressure to other caps: when the combination of upper-bound caps (viewport, max-bitrate, etc.) would narrow the effective candidate set below a configured floor (e.g., 720p), the floor wins — the effective cap is `max(otherCaps, floor)`. Motivation: viewport-driven caps over-aggressively downgrade quality on small players; the floor prevents perceptual quality from dropping too far when the player is small | **Meta-policy** — not a cap of its own. New constraint slot (e.g., `videoMinMaxHeight`) read by `selectQuality`'s filter step alongside the other cap slots; combination takes the `max` over the other caps' effective bounds. Mux Player's [`MinCapLevelController.minMaxResolution = 720`](https://github.com/muxinc/elements/blob/main/packages/playback-core/src/min-cap-level-controller.ts) is the reference implementation |
+| Screen-size cap | Narrow the candidates to renditions whose pixel area fits the screen. Avoids delivering more pixels than the display has | **Implemented** — `screenResolutionCap`, a soft-filter rule reading `state.screenResolution`. See *Implementation surface* |
+| Billing-driven max-height cap | Config-driven `maxHeight` (e.g., 1080) excludes higher-resolution variants from the candidate set. Drives the Mux billing use case (cap delivery at 1080p+ for tier-pricing alignment) | **Not implemented.** Policy — a config-reading rule, no new behavior. Matching axis is configurable: height (simpler) or total pixels (for exact alignment with resolution-based pricing tiers — `1080p = 2,073,600 pixels` matches anamorphic / non-standard-aspect variants correctly). The screen cap chose pixel area for the same reason |
+| Player-element cap | Narrow to renditions that fit the *player element's* rendered dimensions rather than the screen's. Strictly tighter than the screen cap, and the one that matters for a small embed on a large display | **Not implemented.** Middle pattern — a `ResizeObserver` monitor writes element dimensions; a rule reads them. New behavior. The half of Epics NEW-C that did not ship. Pairs with the cap floor below, which counters its tendency to over-aggressively downgrade on small players |
+| Max-bitrate cap | Config-driven `maxBitrate` excludes variants above the threshold. Useful for bandwidth-constrained delivery contexts (mobile, billing) | **Not implemented.** Policy — same shape as max-height cap |
+| Max-FPS cap | Config-driven `maxFps` excludes high-frame-rate variants. Less common motivation but mentioned in [video-abr.md](./video-abr.md)'s "What's not implemented" | **Not implemented.** Policy — same shape |
+| Cap floor (minimum effective cap) | Counter-pressure to other caps: when the combination of upper-bound caps would narrow the effective candidate set below a configured floor (e.g., 720p), the floor wins — the effective cap is `max(otherCaps, floor)`. Motivation: element- and screen-driven caps downgrade too aggressively on small surfaces | **Not implemented.** Meta-policy — not a cap of its own; it modifies how the caps combine. Mux Player's [`MinCapLevelController.minMaxResolution = 720`](https://github.com/muxinc/elements/blob/main/packages/playback-core/src/min-cap-level-controller.ts) is the reference implementation. Also the answer to the screen cap's no-fit behavior (see below) if that ever needs changing |
 
-The first four phases share a single mechanism: a constraint slot +
-filter step before `selectQuality` consumes the candidates. They
-differ in signal source (one-shot config vs reactive `ResizeObserver`)
-and constraint axis (height / bitrate / FPS). The cap-floor phase is
-meta-policy on top — it modifies how the combination of caps resolves,
-not a cap of its own. Per-phase implementation is small (S / S-M per
-the Epics doc).
+The upper-bound caps share one mechanism: a soft-filter rule in the
+chain, ahead of the ranker. They differ in signal source (one-shot
+config vs reactive `screen` / `ResizeObserver`) and constraint axis
+(area / height / bitrate / FPS). Because soft filters compose by
+narrowing one after another, adding a cap is additive — no combination
+logic is needed for the upper bounds, and *intersection* falls out of
+applying them in sequence. Only the floor needs real combination
+semantics, which is what makes it meta-policy. Per-phase implementation
+is small (S / S-M per the Epics doc).
+
+### How the shipped cap behaves
+
+Three properties of `screenResolutionCap` worth stating, because each
+was a decision rather than a detail:
+
+- **Pixel area, not height.** A `"1080p"`-style tier only describes a
+  rendition once you assume its aspect ratio, which mis-measures an
+  anamorphic ladder. `state.screenResolution` is therefore a width and
+  a height, and the comparison is on area.
+- **It declines to cap rather than guessing.** No `screenResolution`
+  signal at all (the composition omitted `trackScreenResolution`) or a
+  reading of `undefined` (no screen) both leave the candidates
+  unnarrowed. "Unknown" has to mean "don't cap": treating it as an area
+  of zero would pin every source to its smallest rendition on exactly
+  the environments we know least about.
+- **When no rendition fits, it falls through.** The cap is a plain soft
+  filter, and `applyRules` skips a rule that matches nothing, so the
+  chain proceeds unnarrowed and the ranker behind the cap decides —
+  which for `preferHighestResolution` means the largest rendition. This
+  is unreachable at the default `useDevicePixelRatio: true`, since any
+  real screen measured in device pixels exceeds a 640x360 rung, but it
+  is reachable with `useDevicePixelRatio: false` on a small phone. The
+  fix, if it ever matters, is the cap floor — not a special case inside
+  the cap.
+
+## Implementation surface
+
+| Piece | Path | Role |
+|---|---|---|
+| `getScreenResolution` / `watchScreenResolution` | `packages/spf/src/media/dom/screen.ts` | Read the screen's pixel dimensions, and re-read on every signal that implies a change (`resize`, `screen`'s own `change`, orientation, a `dppx` media query). Returns `undefined` where there is no screen |
+| `trackScreenResolution` | `packages/spf/src/playback/behaviors/dom/track-screen-resolution.ts` | Behavior that owns `state.screenResolution`, subscribing the watcher for the composition's lifetime |
+| `screenResolutionCap` | `packages/spf/src/playback/behaviors/select-tracks.ts` | The cap itself: a soft-filter `SelectionRule` reading `state.screenResolution` |
+| `preferHighestResolution` | `packages/spf/src/playback/behaviors/select-tracks.ts` | The ranker composed behind it — a sort, so the chain's head is the largest surviving rendition |
+| `tracksUnderPixelArea` / `byDescendingResolution` | `packages/spf/src/media/primitives/select-tracks.ts` | The geometry the two rules are built from: one filter, one comparator |
+| `applyRules` / `applyConstraints` | `packages/spf/src/playback/primitives/selection-rules.ts` | The composers. `applyRules` supplies the fall-through and the head-is-the-pick semantics the cap relies on |
+| `createBackgroundVideoEngine` | `packages/spf/src/playback/engines/hls/engine-background-video.ts` | Composes `trackScreenResolution` and the default chain |
+
+`screenResolutionCap`, `preferHighestResolution`, and `SelectTrackRule`
+are exported from `@videojs/spf/hls`, so a consumer can pass
+`rules: [preferHighestResolution]` to drop the cap, or compose its own
+rule alongside it, rather than only replacing the chain wholesale.
+
+## Config surface
+
+| Option | Where | Effect |
+|---|---|---|
+| `rules` | `BackgroundVideoEngineConfig` | Replaces the default chain. Omit for `[screenResolutionCap, preferHighestResolution]` |
+| `useDevicePixelRatio` | `BackgroundVideoEngineConfig`, read by `trackScreenResolution` | Whether the screen is measured in device pixels (default `true`) or CSS pixels. ⚠️ Chromium and Gecko fold page zoom into `devicePixelRatio`, so with this on, zooming moves the cap; WebKit does not |
+
+There is no cap-value config option. The cap is derived from a measured
+screen rather than configured, which is what distinguishes this phase
+from the config-driven ones above.
+
+## Verification
+
+- `packages/spf/src/media/primitives/tests/select-tracks.test.ts` —
+  the filter and the comparator, including the anamorphic case and
+  order preservation.
+- `packages/spf/src/playback/behaviors/tests/select-tracks.test.ts` —
+  the rule: narrowing, both decline-to-cap paths, the no-fit
+  fall-through, and that the chain reaches the same pick with the cap
+  on either side of the ranker.
+- `packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts`
+  and the `hls-background-video` adapter tests — the composed default.
+  Note these write `screenResolution` explicitly; a test that leaves it
+  ambient makes its expected pick depend on the runner's display.
+- Manual, Chromium on a 3456x2234 display against a 3840x2160 ladder:
+  the pick moves from 3838x2160 (8.29 Mpx, over the 7.72 Mpx screen) to
+  2558x1440. The sandbox page is `html-hls-background-video`, whose
+  source is a deliberately 4K asset for this reason.
 
 ## What's in scope vs out of scope
 
 **In scope:**
-- All five phases above for video renditions
-- Constraint+filter pattern: per-cap state slots + filter step in
-  `selectQuality` before bandwidth-based selection runs
-- Config surface under existing `quality?: {…}` engine config
-- Edge case handling: empty candidate set after cap filtering (open
-  question — fallback policy)
+- All six phases above for video renditions
+- Each cap as a soft-filter rule in the selection chain, ahead of the
+  ranker. Observed inputs (screen, player element) get a state slot
+  holding the measurement; configured inputs need none, since a rule
+  reads `config` directly
+- Empty candidate set after cap filtering — resolved: fall through,
+  see *How the shipped cap behaves*
 
 **Out of scope (separate candidate features):**
 - **[multi-signal-abr](./multi-signal-abr.md)** — incorporates non-
@@ -88,10 +169,10 @@ the Epics doc).
 **Out of scope (different architectural layer):**
 - Above-engine consumers that write cap state from React / HTML
   observers (e.g., a React hook that observes the player container
-  and writes a cap value). This feature owns the SPF-side state
-  slots and filter logic; *where* the writer lives (engine-side
-  `ResizeObserver` behavior vs adapter-level observation writing to
-  the slot) is partly an open question (see below).
+  and writes a cap value). This feature owns the SPF-side state slots
+  and the rules; *where* the writer lives is settled for the screen cap
+  (engine-side, `trackScreenResolution`) and still open for the
+  player-element cap.
 - The Mux Video element's customer-facing attributes
   (`max-resolution`, `cap-rendition-to-player-size`) — those are
   adapter-layer API surfaces that *consume* this feature's config /
@@ -101,75 +182,57 @@ the Epics doc).
 
 Things this feature probably forces decisions on, not just additions:
 
-- **`selectQuality` filter-then-select shape.** Today's `selectQuality`
-  takes `(candidates, bandwidth, config)` and returns a track.
-  Adding caps means either (a) pre-filtering candidates outside
-  `selectQuality` and passing the filtered set in, or (b) extending
-  `selectQuality`'s signature to take the constraint slots and
-  filter internally. Option (a) keeps `selectQuality` pure and
-  matches the `userVideoTrackSelection` precedent (where the
-  filtering happens in `switchVideoQuality` before invoking
-  `selectQuality`). Option (b) bakes caps into the ABR module
-  directly.
-- **State-slot granularity.** Per-cap slots (`videoMaxHeight`,
-  `videoMaxBitrate`, `videoMaxFps`, `videoViewportHeight`) vs a
-  unified slot (`videoRenditionConstraints: { maxHeight?,
-  maxBitrate?, maxFps?, viewportHeight? }`). Per-cap slots align
-  with the constraint+filter pattern's "one writer per slot"
-  shape; a unified slot complicates multi-writer semantics if
-  different caps have different writers (config-driven for some,
-  `ResizeObserver`-driven for others).
-- **Viewport-driven cap signal-source location.** The cap state is
-  SPF-side, but the player-element dimensions are DOM-side. A new
-  engine-side behavior could read `mediaSource.media` (the
-  `<video>` element) and `ResizeObserver` it, or adapter-level code
-  could observe the player container and write the cap state slot.
-  Affects which layer owns the DOM dependency.
-- **Empty-candidate-set fallback.** If caps narrow candidates to
-  zero (e.g., `maxHeight: 480` on a source with only 720p+
-  variants), `selectQuality` has nothing to return. Fallback
-  options: ignore the cap entirely, pick lowest available
-  rendition above the cap, or surface an engine error.
-  Configurable behavior or engine-level decision.
-- **Cap-combination semantics.** When multiple caps are active
-  (viewport + max-bitrate, or viewport + cap-floor), they combine
-  via *intersection* on the candidate set — each upper-bound cap
-  narrows independently. The cap-floor inverts: it computes the
-  most restrictive other-cap result and enforces a lower bound on
-  it (`max()`). Where this combination lives is part of the
-  filter-then-select shape question above: option (a) puts it in
-  the dispatcher (`switchVideoQuality`) before `selectQuality` is
-  invoked; option (b) bakes it into `selectQuality` itself.
+- **~~`selectQuality` filter-then-select shape.~~ Resolved by the rule
+  model, as neither option originally posed.** The question assumed caps
+  would either pre-filter outside `selectQuality` or be baked into its
+  signature. Instead the picker was replaced wholesale by an ordered
+  rule chain, so a cap is simply a rule in it — no filter step, and
+  `selectQuality` keeps its shape. See
+  [track-switching-model.md](../track-switching-model.md).
+- **State-slot granularity, for the *config-driven* caps.** Per-cap
+  slots (`videoMaxHeight`, `videoMaxBitrate`, `videoMaxFps`) vs a
+  unified slot. Still open, but the screen cap sets a precedent that
+  reframes it: its slot holds a **measurement** (`screenResolution`),
+  not a cap value, and the rule derives the bound. A config-driven cap
+  needs no state slot at all — a rule can read `config` directly, as
+  the audio language policy already does. So the question may only be
+  live for caps whose input is observed rather than configured.
+- **Player-element cap signal-source location.** The screen cap answered
+  this for itself — an engine-side behavior reading `screen`, no adapter
+  involvement — but the element cap is the harder case, since the
+  element is DOM-side and the engine only holds `mediaSource.media`.
+  Still open, and still decides which layer owns the DOM dependency.
+- **Cap-combination semantics.** Upper-bound caps combine by
+  *intersection*, which now falls out for free: soft filters narrow one
+  after another, so applying two caps in sequence is their
+  intersection, and no combination logic exists to write. The cap floor
+  still inverts this (`max()` over the other caps' bounds) and is the
+  one phase that needs real combination semantics — which is why it is
+  meta-policy rather than a cap.
 
 ## Open questions
 
-- **Per-cap slots vs unified constraint slot.** See cross-cutting
-  bullet above. Open until the second cap lands and the multi-writer
-  shape becomes concrete.
-- **Viewport-driven cap signal-source location.** Engine-side
-  `ResizeObserver` on `mediaSource.media`, or adapter-side observation
-  writing to the cap slot? Affects feature shape (one behavior vs
-  one slot) and DOM dependency placement.
-- **Empty-candidate-set fallback policy.** Ignore / pick-lowest /
-  error? Config-driven or engine-fixed?
 - **max-FPS cap inclusion.** Listed in video-abr.md's "What's not
   implemented" but lower priority than max-height / max-bitrate.
-  Document as Phase 4 or defer?
+  Document as a phase or defer?
 - **Audio caps.** Audio renditions don't have height analogs but
   could have max-bitrate or max-channels caps. Extend this feature
   to cover audio or carry audio caps separately?
-- **Interaction with [capability-probing](./capability-probing.md).**
-  Capability filtering narrows candidates to "what the browser can
-  play"; caps narrow to "what the player chooses to deliver." Apply
-  capability filter first, then policy caps (per current cluster
-  framing). Confirm ordering when both land.
+- **~~Interaction with [capability-probing](./capability-probing.md).~~
+  Resolved structurally by the rule model.** Capability exclusions are
+  **constraints** (hard: never attempt an unplayable track) and caps are
+  **rules** (soft), and `applyConstraints` runs before `applyRules` by
+  construction. So capability filtering precedes policy caps with no
+  coordination between the two features. Retained here because the
+  ordering was an open question and the answer is now load-bearing for
+  both docs.
 - **Cap-floor scope: policy caps only, or all candidate-narrowing
-  signals?** The floor counters the viewport-driven cap (and
+  signals?** The floor counters the element- and screen-driven caps (and
   potentially max-bitrate / max-FPS caps), but should not override
-  capability-filter physics. If [capability-probing](./capability-probing.md)
-  removes unsupported renditions, the floor can't add them back.
-  Confirm the boundary: floor operates over the policy-cap-narrowed
-  set, not over the capability-filtered set.
+  capability-filter physics. The constraints-before-rules split above
+  makes this mostly self-enforcing — a floor written as a rule cannot
+  re-add what a constraint removed, because the constraint pass has
+  already run. Confirm the boundary when the floor lands.
 - **Cap-floor default value.** Mux Player hardcodes 720p as
   `MinCapLevelController.minMaxResolution`. For SPF, should the
   floor default to a value, or require explicit opt-in? Defaulting
@@ -179,10 +242,11 @@ Things this feature probably forces decisions on, not just additions:
 
 ## Related features
 
-- **[video-abr](./video-abr.md)** — primary consumer. `selectQuality`
-  is the read-side; `userVideoTrackSelection` is the existing
-  constraint+filter precedent. Cap slots layer on top of the same
-  pattern.
+- **[video-abr](./video-abr.md)** — the consumer for the caps that have
+  yet to land in `createHlsVideoEngine`. Its ranker is what a cap
+  narrows *for*: the cap decides which renditions are admissible and the
+  ranker picks within them. `userVideoTrackSelection` is the existing
+  constraint+filter precedent.
 - **[multi-signal-abr](./multi-signal-abr.md)** — different concern
   (ABR algorithm extension) but caps could feed it as inputs.
 - **[audio-abr](./audio-abr.md)** — audio quality switching that
@@ -211,10 +275,15 @@ Things this feature probably forces decisions on, not just additions:
 - [clusters.md § Feature classification axes](./clusters.md#feature-classification-axes)
   — the Player-feature framing this doc instantiates; mixes
   Policy mechanism (config-driven caps) and Middle-pattern
-  mechanism (viewport-driven cap)
+  mechanism (the screen and player-element caps)
 - [clusters.md § Constraint + filter](./clusters.md#constraint--filter)
   — cross-cluster pattern this feature instantiates; `video-abr`'s
   `userVideoTrackSelection` is the precedent
+- [track-switching-model.md](../track-switching-model.md) — the rule
+  model the shipped cap is built on: a hard constraints pre-pass, then
+  an ordered chain of soft filters and one ranker, with the pick as the
+  head. Its "scope" kind is what a cap is, and its `applyRules`
+  fall-through is what the cap relies on when nothing fits
 - [video-abr.md](./video-abr.md) — primary consumer; `selectQuality`
   is the read-side, `userVideoTrackSelection` the constraint
   precedent

--- a/internal/design/spf/track-switching-model.md
+++ b/internal/design/spf/track-switching-model.md
@@ -110,7 +110,7 @@ a runtime signal):
 | `multi-language-audio` | scope | Prefer the default/selected language. |
 | `5.1-surround-selection` | scope | Prefer the requested channel layout. |
 | `hevc-variant-selection` | scope | Prefer (or force) a codec, e.g. AVC over HEVC. |
-| `rendition-selection-caps` | scope (likely several) | Stay within an upper cap (player/screen size, cost tier) and/or above a floor. |
+| `rendition-selection-caps` | scope (likely several) | Stay within an upper cap (player/screen size, cost tier) and/or above a floor. **The screen-size cap has since shipped as `screenResolutionCap`** — the first rule written against this model, and the one that exercises the soft-filter fall-through. See [rendition-selection-caps.md](./features/rendition-selection-caps.md). |
 
 This set is already long, and it will grow as features land. That breadth — not any single entry — is
 the backdrop for the model.

--- a/packages/html/src/media/hls-background-video/media.ts
+++ b/packages/html/src/media/hls-background-video/media.ts
@@ -1,5 +1,5 @@
 import type { Media } from '@videojs/media/dom';
-import { HlsBackgroundVideoMedia, type SvtaError } from '@videojs/spf/hls-background-video';
+import { HlsBackgroundVideoMedia, type HlsVideoMediaError } from '@videojs/spf/hls-background-video';
 import { type CustomElement, namedNodeMapToObject } from '@videojs/utils/dom';
 import type { Constructor } from '@videojs/utils/types';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
@@ -123,11 +123,12 @@ export class HlsBackgroundVideo extends HlsBackgroundVideoBase {
   }
 
   /**
-   * The condition that made the current source unplayable, or `null` — the
-   * engine's reported {@link SvtaError}, not a `MediaError`. Reset by a new
-   * source. Not on the inner `<video>`, which never learns of it.
+   * What made the current source unplayable, or `null`. An SVTA code rather than
+   * a `MediaError` one — 99001 where this player has no pipeline for what the
+   * source needs, with the specifics logged. Reset by a new source, and not on
+   * the inner `<video>`, which never learns of it.
    */
-  get error(): SvtaError | null {
+  get error(): HlsVideoMediaError | null {
     return this.#media.error;
   }
 

--- a/packages/html/src/media/hls-background-video/media.ts
+++ b/packages/html/src/media/hls-background-video/media.ts
@@ -33,6 +33,11 @@ const HlsBackgroundVideoBase = MediaAttachMixin(HTMLElement) as unknown as Const
  * required. Mux playback-ID identity, poster, and storyboard belong to
  * `<mux-video>`; none of them mean anything without controls to hang them on.
  *
+ * Nothing about an unplayable source reaches the inner `<video>` on its own, so
+ * `error` on it stays null and the element sits at `readyState 0`. The engine
+ * reports and logs each condition instead, which keeps a source that never appears
+ * diagnosable from the console without widening this element's surface.
+ *
  * `<mux-background-video>` is this element under the name the package it replaces
  * used. Same class, so the tag is a naming choice and nothing more.
  *

--- a/packages/html/src/media/hls-background-video/media.ts
+++ b/packages/html/src/media/hls-background-video/media.ts
@@ -1,5 +1,5 @@
 import type { Media } from '@videojs/media/dom';
-import { HlsBackgroundVideoMedia } from '@videojs/spf/hls-background-video';
+import { HlsBackgroundVideoMedia, type SvtaError } from '@videojs/spf/hls-background-video';
 import { type CustomElement, namedNodeMapToObject } from '@videojs/utils/dom';
 import type { Constructor } from '@videojs/utils/types';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
@@ -35,8 +35,11 @@ const HlsBackgroundVideoBase = MediaAttachMixin(HTMLElement) as unknown as Const
  *
  * Nothing about an unplayable source reaches the inner `<video>` on its own, so
  * `error` on it stays null and the element sits at `readyState 0`. The engine
- * reports and logs each condition instead, which keeps a source that never appears
- * diagnosable from the console without widening this element's surface.
+ * reports each condition and logs it, the Media promotes the fatal one, and this
+ * element re-fires it as its own `error` / `'error'` — the one place a consumer
+ * holding the element can see a source that never appears.
+ *
+ * @fires error - Fired when a fatal condition is reported. Read `error` for it.
  *
  * `<mux-background-video>` is this element under the name the package it replaces
  * used. Same class, so the tag is a naming choice and nothing more.
@@ -85,6 +88,11 @@ export class HlsBackgroundVideo extends HlsBackgroundVideoBase {
     // nothing here needs to repeat it.
     const video = this.video;
     if (video) this.#media.attach(video);
+
+    // Re-fired rather than bridged on demand the way `CustomMediaElement` does
+    // it: one listener for the one event this element has, on a Media it owns
+    // for its whole life, is less than the machinery to defer it would cost.
+    this.#media.addEventListener('error', () => this.dispatchEvent(new Event('error')));
   }
 
   /** Register the Media (not the inner `<video>`) with the provider. */
@@ -112,6 +120,15 @@ export class HlsBackgroundVideo extends HlsBackgroundVideoBase {
   get video(): HTMLVideoElement | null {
     const video = this.shadowRoot?.querySelector('video');
     return video instanceof HTMLVideoElement ? video : null;
+  }
+
+  /**
+   * The condition that made the current source unplayable, or `null` — the
+   * engine's reported {@link SvtaError}, not a `MediaError`. Reset by a new
+   * source. Not on the inner `<video>`, which never learns of it.
+   */
+  get error(): SvtaError | null {
+    return this.#media.error;
   }
 
   /** HLS manifest URL. Assigning a new one restarts playback from scratch. */

--- a/packages/html/src/media/hls-background-video/tests/media.test.ts
+++ b/packages/html/src/media/hls-background-video/tests/media.test.ts
@@ -1,7 +1,11 @@
+import type { HlsBackgroundVideoMedia } from '@videojs/spf/hls-background-video';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MuxBackgroundVideo } from '../../mux-background-video';
 import { HlsBackgroundVideo } from '../index';
+
+/** SVTA 2011 — no video track this environment can play. */
+const NO_SUPPORTED_VIDEO_TRACK = 2011;
 
 beforeEach(() => {
   // The engine seeds `loadActivated: true`, so assigning `src` starts fetching
@@ -36,6 +40,13 @@ function create(tag: string, attrs: Record<string, string> = {}): HlsBackgroundV
   container.innerHTML = `<${tag}${attrStr}></${tag}>`;
   return container.querySelector(tag) as HlsBackgroundVideo;
 }
+
+/** The Media the element registers, which is what the engine hangs off. */
+function mediaOf(element: HlsBackgroundVideo) {
+  return element.getMediaTarget() as unknown as HlsBackgroundVideoMedia;
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('HlsBackgroundVideo', () => {
   it('renders a video into its shadow root', () => {
@@ -91,6 +102,43 @@ describe('HlsBackgroundVideo', () => {
     // loads immediately, and `audio` / `debug` from the package this replaces are
     // gone for good.
     expect(HlsBackgroundVideo.observedAttributes).toEqual(['src']);
+  });
+
+  // The engine's reported sequence is the only failure signal this composition
+  // has: an unplayable source leaves the inner <video> at readyState 0 with
+  // `error` null, so nothing here can be read off the element it renders into.
+  describe('error surface', () => {
+    it('exposes no error before anything is reported', () => {
+      expect(create(defineElement()).error).toBeNull();
+    });
+
+    it('re-fires the Media error as its own, and exposes the condition', async () => {
+      const element = create(defineElement());
+      const fired: Event[] = [];
+      element.addEventListener('error', (event) => fired.push(event));
+
+      mediaOf(element).engine.state.errors.set([{ code: NO_SUPPORTED_VIDEO_TRACK }]);
+      await flush();
+
+      expect(fired).toHaveLength(1);
+      expect(fired[0]?.target).toBe(element);
+      expect(element.error?.code).toBe(NO_SUPPORTED_VIDEO_TRACK);
+      // The condition never reached the inner video, which is why the element
+      // has a surface of its own.
+      expect(element.video?.error).toBeFalsy();
+    });
+
+    it('clears when a new source resets the sequence', async () => {
+      const element = create(defineElement());
+      mediaOf(element).engine.state.errors.set([{ code: NO_SUPPORTED_VIDEO_TRACK }]);
+      await flush();
+
+      // collectErrors clears the slot on source change.
+      mediaOf(element).engine.state.errors.set(undefined);
+      await flush();
+
+      expect(element.error).toBeNull();
+    });
   });
 
   it('is what <mux-background-video> resolves to', () => {

--- a/packages/react/src/media/hls-background-video/media.tsx
+++ b/packages/react/src/media/hls-background-video/media.tsx
@@ -6,7 +6,7 @@ import {
   hlsBackgroundVideoMediaDefaultProps,
 } from '@videojs/spf/hls-background-video';
 import type { VideoHTMLAttributes } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useEffect, useRef } from 'react';
 import { useAttachMedia } from '../../utils/use-attach-media';
 import { useComposedRefs } from '../../utils/use-composed-refs';
 import { useMediaInstance } from '../../utils/use-media-instance';
@@ -32,10 +32,13 @@ export interface HlsBackgroundVideoProps
  * storyboard belong to `MuxVideo`, since none of them mean anything without
  * controls to hang them on.
  *
- * `onError` on the underlying `<video>` will not fire for an unplayable source:
- * nothing about one reaches the media element on its own. The engine reports and
- * logs each condition instead, so a source that never appears is diagnosable from
- * the console without a prop for it.
+ * `onError` fires for an unplayable source, which it could not do on its own:
+ * nothing about one reaches the media element, so the `<video>`'s own `error`
+ * stays null at `readyState 0`. The engine reports the condition, the Media
+ * promotes the fatal one, and this component re-fires it on the `<video>` — where
+ * a handler already listening for a failed source receives it. Which condition it
+ * was is on the console and `engine.state.errors`; the handler gets "this source
+ * won't play", which is the decision a background video actually has to make.
  *
  * `MuxBackgroundVideo` is this same component under the name the package it
  * replaces used — an alias, not a variant.
@@ -45,9 +48,20 @@ export const HlsBackgroundVideo = forwardRef<HTMLVideoElement, HlsBackgroundVide
   ref
 ) {
   const media = useMediaInstance(HlsBackgroundVideoMedia);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const attachRef = useAttachMedia(media);
-  const composedRef = useComposedRefs(attachRef, ref);
+  const composedRef = useComposedRefs(attachRef, videoRef, ref);
   const htmlProps = useSyncProps(media, props, hlsBackgroundVideoMediaDefaultProps);
+
+  // Re-fired on the element rather than handed to `onError` directly, so React's
+  // own event plumbing delivers it: the handler gets the synthetic event it is
+  // typed for, and anything else listening on the node — the consumer's own
+  // `addEventListener`, a testing-library assertion — sees the same failure.
+  useEffect(() => {
+    const forward = () => videoRef.current?.dispatchEvent(new Event('error'));
+    media.addEventListener('error', forward);
+    return () => media.removeEventListener('error', forward);
+  }, [media]);
 
   return (
     // The same set `<hls-background-video>` forces onto its inner video, so the

--- a/packages/react/src/media/hls-background-video/media.tsx
+++ b/packages/react/src/media/hls-background-video/media.tsx
@@ -32,6 +32,11 @@ export interface HlsBackgroundVideoProps
  * storyboard belong to `MuxVideo`, since none of them mean anything without
  * controls to hang them on.
  *
+ * `onError` on the underlying `<video>` will not fire for an unplayable source:
+ * nothing about one reaches the media element on its own. The engine reports and
+ * logs each condition instead, so a source that never appears is diagnosable from
+ * the console without a prop for it.
+ *
  * `MuxBackgroundVideo` is this same component under the name the package it
  * replaces used — an alias, not a variant.
  */

--- a/packages/react/src/media/hls-background-video/tests/media.test.tsx
+++ b/packages/react/src/media/hls-background-video/tests/media.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** SVTA 2011 — no video track this environment can play. */
+const NO_SUPPORTED_VIDEO_TRACK = 2011;
+/** SVTA 1004 — one rendition's container is unplayable; not a failed source. */
+const UNSUPPORTED_VIDEO_FORMAT = 1004;
+
+/**
+ * The component owns its Media and hands out no reference to it, so the engine
+ * is reached by tracking what it constructs. Everything else about the entry is
+ * the real thing.
+ */
+const instances: { engine: { state: { errors: { set(value: unknown): void } } } }[] = vi.hoisted(() => []);
+
+vi.mock('@videojs/spf/hls-background-video', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@videojs/spf/hls-background-video')>();
+  return {
+    ...actual,
+    HlsBackgroundVideoMedia: class extends actual.HlsBackgroundVideoMedia {
+      constructor(...args: unknown[]) {
+        super(...args);
+        instances.push(this as never);
+      }
+    },
+  };
+});
+
+const { HlsBackgroundVideo } = await import('../media');
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  instances.length = 0;
+  // The engine seeds `loadActivated: true`, so a rendered `src` starts fetching
+  // the manifest at once. Stubbed so these stay offline and leave no request
+  // pending at teardown.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.reject(new Error('offline')))
+  );
+});
+
+afterEach(() => {
+  // Unmount explicitly: this package wires no auto-cleanup, and a mounted
+  // component here keeps a live engine — whose in-flight manifest request can
+  // land after the environment is gone.
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('HlsBackgroundVideo', () => {
+  // An unplayable source never reaches the <video>, so `onError` can only fire
+  // because the component re-fires what the engine reported.
+  describe('error forwarding', () => {
+    it('calls onError when a fatal condition is reported', async () => {
+      const onError = vi.fn();
+      const { container } = render(<HlsBackgroundVideo src="https://example.com/v.m3u8" onError={onError} />);
+
+      instances[0]?.engine.state.errors.set([{ code: NO_SUPPORTED_VIDEO_TRACK }]);
+      await flush();
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      // Delivered through React's own plumbing, on the node the consumer holds.
+      expect(onError.mock.calls[0]?.[0]?.target).toBe(container.querySelector('video'));
+    });
+
+    it('stays quiet for a condition the Media does not treat as fatal', async () => {
+      const onError = vi.fn();
+      render(<HlsBackgroundVideo src="https://example.com/v.m3u8" onError={onError} />);
+
+      // One unplayable rendition is context, not a failed source.
+      instances[0]?.engine.state.errors.set([{ code: UNSUPPORTED_VIDEO_FORMAT }]);
+      await flush();
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/media/hls-background-video/tests/media.test.tsx
+++ b/packages/react/src/media/hls-background-video/tests/media.test.tsx
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /** SVTA 2011 — no video track this environment can play. */
 const NO_SUPPORTED_VIDEO_TRACK = 2011;
-/** SVTA 1004 — one rendition's container is unplayable; not a failed source. */
-const UNSUPPORTED_VIDEO_FORMAT = 1004;
+/** SVTA 2039 — a manifest feature went unhonored; degraded but still playable. */
+const MANIFEST_FEATURE_UNSUPPORTED = 2039;
 
 /**
  * The component owns its Media and hands out no reference to it, so the engine
@@ -69,8 +69,8 @@ describe('HlsBackgroundVideo', () => {
       const onError = vi.fn();
       render(<HlsBackgroundVideo src="https://example.com/v.m3u8" onError={onError} />);
 
-      // One unplayable rendition is context, not a failed source.
-      instances[0]?.engine.state.errors.set([{ code: UNSUPPORTED_VIDEO_FORMAT }]);
+      // A degraded-but-playable notice must not reach the surface.
+      instances[0]?.engine.state.errors.set([{ code: MANIFEST_FEATURE_UNSUPPORTED }]);
       await flush();
 
       expect(onError).not.toHaveBeenCalled();

--- a/packages/spf/src/media/dom/screen.ts
+++ b/packages/spf/src/media/dom/screen.ts
@@ -18,6 +18,8 @@
  */
 
 import { listen } from '@videojs/utils/dom';
+import { shallowEqual } from '@videojs/utils/object';
+import { isFunction } from '@videojs/utils/predicate';
 
 /** A screen's pixel dimensions. */
 export interface ScreenResolution {
@@ -34,8 +36,13 @@ export interface ScreenResolutionOptions {
    * Opt out for CSS pixels. Note that derating — a 3x phone rarely wanting 3x the
    * pixels of its layout — is a scale applied over this reading rather than a
    * reason to turn it off.
+   *
+   * ⚠️ Chromium and Gecko fold page zoom into `devicePixelRatio`, so with this on,
+   * zooming moves the reading even though the screen didn't change. WebKit holds
+   * the ratio independent of zoom and is unaffected. Whether a cap should track
+   * zoom is the cap's call; this flag is only what puts zoom in scope.
    */
-  useDevicePixelRatio?: boolean | undefined;
+  useDevicePixelRatio: boolean;
 }
 
 /**
@@ -52,13 +59,14 @@ export interface ScreenResolutionOptions {
  * cap should flap on rotation, or hold the larger budget across both — and
  * belongs to the cap rather than to the reading.
  */
-export function getScreenResolution(options: ScreenResolutionOptions = {}): ScreenResolution | undefined {
+export function getScreenResolution(
+  { useDevicePixelRatio }: ScreenResolutionOptions = { useDevicePixelRatio: true }
+): ScreenResolution | undefined {
   const screen = globalThis.screen;
   if (!screen) return undefined;
 
   // `|| 1` covers a missing or nonsense ratio: a CSS-pixel reading is still true
   // and still cappable, so it isn't worth failing the whole answer over.
-  const { useDevicePixelRatio = true } = options;
   const ratio = useDevicePixelRatio ? globalThis.devicePixelRatio || 1 : 1;
 
   // Rounded because device pixels are whole and a fractional ratio doesn't divide
@@ -78,8 +86,12 @@ export function getScreenResolution(options: ScreenResolutionOptions = {}): Scre
  * signal that implies one and compares readings to decide whether anything
  * actually moved. Comparing is what makes that safe: the signals overlap and
  * `resize` in particular is noisy, so over-subscribing costs a discarded read
- * rather than a spurious call. `onChange` fires only on a genuine change, and
- * never on subscribe — call {@link getScreenResolution} for the starting value.
+ * rather than a spurious call.
+ *
+ * `onChange` is called once on subscribe with the starting value — including
+ * `undefined` where there is no screen — and after that only on a genuine change.
+ * So a consumer gets its initial state from the watcher and never has to pair it
+ * with a separate {@link getScreenResolution} call.
  *
  * The signals, and what each one is here for:
  *
@@ -95,9 +107,16 @@ export function getScreenResolution(options: ScreenResolutionOptions = {}): Scre
  * - **`screen.orientation` change** — rotation, which swaps the axes without
  *   necessarily resizing the window.
  * - **a `(resolution: <ratio>dppx)` media query** — the device pixel ratio
- *   changing under a window that kept its size, from zoom or from moving to a
- *   display with a different ratio. Armed against the current ratio and re-armed
- *   when it moves, since the query only reports on the ratio it was built for.
+ *   changing under a window that kept its size, which is the cross-display drag
+ *   between displays of different density. Each query only answers about the ratio
+ *   it was built for, so it reports one change and its handler arms the next.
+ *
+ *   Worth keeping despite looking redundant, because it is the only coverage that
+ *   case has in WebKit and Firefox: neither implements `screen`'s change event,
+ *   and the drag doesn't resize the window. It is also a cleaner signal in Safari
+ *   than elsewhere — WebKit holds `devicePixelRatio` independent of page zoom, so
+ *   there it moves only on a real density change, where Chromium and Gecko fold
+ *   zoom into it as well.
  *
  * ⚠️ Known gap, on engines without `screen`'s change event: dragging a window
  * between two different-size displays that share a ratio, without the window
@@ -107,74 +126,72 @@ export function getScreenResolution(options: ScreenResolutionOptions = {}): Scre
  */
 export function watchScreenResolution(
   onChange: (resolution: ScreenResolution | undefined) => void,
-  options: ScreenResolutionOptions = {}
+  options: ScreenResolutionOptions = { useDevicePixelRatio: true }
 ): () => void {
+  // One signal for every listener, so stopping is one call rather than a handle
+  // per subscription. Also makes a late `watchRatio` inert: `addEventListener`
+  // drops a listener whose signal has already aborted.
+  const disconnect = new AbortController();
+  const { signal } = disconnect;
   let current = getScreenResolution(options);
-  let armedRatio: number | undefined;
-  let stopRatioQuery: (() => void) | undefined;
 
   const check = () => {
-    armRatioQuery();
-
     const next = getScreenResolution(options);
-    if (isSameResolution(current, next)) return;
+    if (shallowEqual(current, next)) return;
 
     current = next;
     onChange(next);
   };
 
-  // Re-armed rather than armed once: a `dppx` query only answers about the ratio
-  // it was built for, so after the ratio moves the old query goes quiet.
-  const armRatioQuery = () => {
-    const ratio = globalThis.devicePixelRatio;
-    if (ratio === armedRatio) return;
+  // Deliver the starting value up front, so a consumer gets its initial state from
+  // the watcher rather than having to pair it with a separate read. Unconditional,
+  // rather than falling out of comparing against an empty `current`: an unknown
+  // reading is a value too, and a consumer that only ever heard from us about a
+  // *known* screen couldn't tell "there is no screen" from "not called yet".
+  //
+  // Before the listeners rather than after, so a callback that throws takes
+  // nothing with it — there is no subscription yet to strand.
+  onChange(current);
 
-    stopRatioQuery?.();
-    stopRatioQuery = undefined;
-    armedRatio = ratio;
+  // A `dppx` query only answers about the ratio it was built for, so each one
+  // reports a single change and the handler builds the next. `once: true` is what
+  // keeps that from accumulating listeners: the fired one is gone before the
+  // replacement is armed, with no handle to track. Same shape as MDN's snippet
+  // for this, whose earlier non-re-arming version fired exactly once and stopped.
+  const watchRatio = () => {
+    const query = globalThis.matchMedia?.(`(resolution: ${globalThis.devicePixelRatio}dppx)`);
+    if (!query) return;
 
-    if (!(typeof ratio === 'number' && Number.isFinite(ratio) && ratio > 0)) return;
-
-    const query = globalThis.matchMedia?.(`(resolution: ${ratio}dppx)`);
-    if (query) stopRatioQuery = listen(query, 'change', check);
+    listen(
+      query,
+      'change',
+      () => {
+        watchRatio();
+        check();
+      },
+      { once: true, signal }
+    );
   };
 
-  armRatioQuery();
+  watchRatio();
 
   // Each signal is optional for the same reason the reading is: an environment
   // missing one has nothing to report from it, which is not a reason to fail.
-  // `screen`'s own change event is subscribed unconditionally rather than
-  // feature-detected — where it isn't implemented it simply never fires, and a
-  // signal that never fires costs nothing under comparison.
+  // `screen`'s own change event is subscribed without feature-detecting — where
+  // it isn't implemented it simply never fires, and a signal that never fires
+  // costs nothing under comparison.
   const screen = globalThis.screen;
-  const screenEvents = asEventTarget(screen);
-  const stopResize = globalThis.window ? listen(globalThis.window, 'resize', check) : undefined;
-  const stopScreen = screenEvents ? listen(screenEvents, 'change', check) : undefined;
-  const stopOrientation = screen?.orientation ? listen(screen.orientation, 'change', check) : undefined;
+  const orientation = screen?.orientation;
 
-  return () => {
-    stopResize?.();
-    stopScreen?.();
-    stopOrientation?.();
-    stopRatioQuery?.();
-    stopRatioQuery = undefined;
-  };
+  if (globalThis.window) listen(globalThis.window, 'resize', check, { signal });
+  // NOTE: Chromium browsers support screen change event.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Screen/change_event
+  if (isEventTarget(screen)) listen(screen, 'change', check, { signal });
+  if (orientation) listen(orientation, 'change', check, { signal });
+
+  return () => disconnect.abort();
 }
 
-/**
- * `Screen` as something subscribable.
- *
- * It is an `EventTarget` at runtime, and dispatches `change` where the Window
- * Management API is implemented, but `lib.dom.d.ts` types neither — so the shape
- * gets checked rather than declared. Same approach `@videojs/core` takes to
- * `screen.orientation`'s lock methods, which that lib under-types too.
- */
-function asEventTarget(value: object | undefined): EventTarget | undefined {
-  return value && 'addEventListener' in value ? (value as EventTarget) : undefined;
-}
-
-/** Whether two readings say the same thing, counting two unknowns as agreeing. */
-function isSameResolution(a: ScreenResolution | undefined, b: ScreenResolution | undefined): boolean {
-  if (!a || !b) return a === b;
-  return a.width === b.width && a.height === b.height;
+function isEventTarget(value: any): value is EventTarget {
+  return isFunction(value?.addEventListener);
 }

--- a/packages/spf/src/media/dom/screen.ts
+++ b/packages/spf/src/media/dom/screen.ts
@@ -7,16 +7,17 @@
  * `maxResolutionToPixelArea` has to make, and the one that mis-measures an
  * anamorphic or otherwise non-16:9 rendition.
  *
- * This is the first slice of the screen-size cap in
- * `internal/design/spf/features/rendition-selection-caps.md`. What it leaves out
- * is reacting to change: this is a one-shot read, and the screen underneath a
- * window is not stable. Rotating a device swaps the axes; unplugging or
- * reattaching a monitor, or dragging the window to a different display, changes
- * the numbers *and* which physical screen they describe. So a live cap has to
- * re-read rather than cache — which is why this reads the ambient screen at call
- * time, with no subscription and no memoization of its own. A watcher belongs
- * over this function, not inside it.
+ * The signal source for the screen-size cap in
+ * `internal/design/spf/features/rendition-selection-caps.md`.
+ *
+ * The screen underneath a window is not stable: rotating a device swaps the axes,
+ * and unplugging a monitor or dragging the window to another display changes the
+ * numbers *and* which physical screen they describe. So `getScreenResolution`
+ * reads at call time and caches nothing, and `watchScreenResolution` layers the
+ * reacting on top rather than the reader holding state of its own.
  */
+
+import { listen } from '@videojs/utils/dom';
 
 /** A screen's pixel dimensions. */
 export interface ScreenResolution {
@@ -67,4 +68,89 @@ export function getScreenResolution(options: ScreenResolutionOptions = {}): Scre
   const height = Math.round(screen.height * ratio);
 
   return width > 0 && height > 0 ? { width, height } : undefined;
+}
+
+/**
+ * Call `onChange` whenever {@link getScreenResolution} would start answering
+ * differently. Returns a function that stops watching.
+ *
+ * There is no single event for "the screen changed", so this subscribes to every
+ * signal that implies one and compares readings to decide whether anything
+ * actually moved. Comparing is what makes that safe: the signals overlap and
+ * `resize` in particular is noisy, so over-subscribing costs a discarded read
+ * rather than a spurious call. `onChange` fires only on a genuine change, and
+ * never on subscribe — call {@link getScreenResolution} for the starting value.
+ *
+ * The signals, and what each one is here for:
+ *
+ * - **`resize`** — the window changing size, which is also what the OS does to it
+ *   when the display it was on goes away.
+ * - **`screen.orientation` change** — rotation, which swaps the axes without
+ *   necessarily resizing the window.
+ * - **a `(resolution: <ratio>dppx)` media query** — the device pixel ratio
+ *   changing under a window that kept its size, from zoom or from moving to a
+ *   display with a different ratio. Armed against the current ratio and re-armed
+ *   when it moves, since the query only reports on the ratio it was built for.
+ *
+ * ⚠️ Known gap: dragging a window between two same-ratio displays of different
+ * sizes, without the window resizing, changes the reading with none of the above
+ * firing. Closing it needs the Window Management API's screen-change events,
+ * which are permission-gated and not broadly available — so it is deliberately
+ * out of this slice rather than approximated with polling, whose interval and
+ * battery cost are a policy decision this function shouldn't be making.
+ */
+export function watchScreenResolution(
+  onChange: (resolution: ScreenResolution | undefined) => void,
+  options: ScreenResolutionOptions = {}
+): () => void {
+  let current = getScreenResolution(options);
+  let armedRatio: number | undefined;
+  let stopRatioQuery: (() => void) | undefined;
+
+  const check = () => {
+    armRatioQuery();
+
+    const next = getScreenResolution(options);
+    if (isSameResolution(current, next)) return;
+
+    current = next;
+    onChange(next);
+  };
+
+  // Re-armed rather than armed once: a `dppx` query only answers about the ratio
+  // it was built for, so after the ratio moves the old query goes quiet.
+  const armRatioQuery = () => {
+    const ratio = globalThis.devicePixelRatio;
+    if (ratio === armedRatio) return;
+
+    stopRatioQuery?.();
+    stopRatioQuery = undefined;
+    armedRatio = ratio;
+
+    if (!(typeof ratio === 'number' && Number.isFinite(ratio) && ratio > 0)) return;
+
+    const query = globalThis.matchMedia?.(`(resolution: ${ratio}dppx)`);
+    if (query) stopRatioQuery = listen(query, 'change', check);
+  };
+
+  armRatioQuery();
+
+  // Each signal is optional for the same reason the reading is: an environment
+  // missing one has nothing to report from it, which is not a reason to fail.
+  const stopResize = globalThis.window ? listen(globalThis.window, 'resize', check) : undefined;
+  const orientation = globalThis.screen?.orientation;
+  const stopOrientation = orientation ? listen(orientation, 'change', check) : undefined;
+
+  return () => {
+    stopResize?.();
+    stopOrientation?.();
+    stopRatioQuery?.();
+    stopRatioQuery = undefined;
+  };
+}
+
+/** Whether two readings say the same thing, counting two unknowns as agreeing. */
+function isSameResolution(a: ScreenResolution | undefined, b: ScreenResolution | undefined): boolean {
+  if (!a || !b) return a === b;
+  return a.width === b.width && a.height === b.height;
 }

--- a/packages/spf/src/media/dom/screen.ts
+++ b/packages/spf/src/media/dom/screen.ts
@@ -3,9 +3,8 @@
  *
  * Reported as a width and a height rather than a `"720p"`-style tier, because
  * the cap that consumes it compares against real track dimensions. A tier only
- * describes a track once you assume its aspect ratio — the assumption
- * `maxResolutionToPixelArea` has to make, and the one that mis-measures an
- * anamorphic or otherwise non-16:9 rendition.
+ * describes a track once you assume its aspect ratio, and that assumption
+ * mis-measures an anamorphic or otherwise non-16:9 rendition.
  *
  * The signal source for the screen-size cap in
  * `internal/design/spf/features/rendition-selection-caps.md`.
@@ -49,10 +48,10 @@ export interface ScreenResolutionOptions {
  * Read the screen's resolution, or `undefined` where there isn't one to read.
  *
  * `undefined` means "unknown", which is the answer a cap needs in order to not
- * cap. That lines up with `maxResolutionToPixelArea(undefined)` returning
- * `+Infinity`, so an unknown screen is a cap of "no cap" rather than a cap of
- * zero — the reading a naive `?? 0` would produce, which would pin every source
- * to its smallest rendition on exactly the environments we know least about.
+ * cap. `screenResolutionCap` reads it that way and declines to narrow, so an
+ * unknown screen is "no cap" rather than a cap of zero — the reading a naive
+ * `?? 0` would produce, which would pin every source to its smallest rendition on
+ * exactly the environments we know least about.
  *
  * Dimensions are reported as-is, including the axis swap a rotated device
  * applies to them. Normalizing orientation away is a policy question — whether a

--- a/packages/spf/src/media/dom/screen.ts
+++ b/packages/spf/src/media/dom/screen.ts
@@ -83,6 +83,13 @@ export function getScreenResolution(options: ScreenResolutionOptions = {}): Scre
  *
  * The signals, and what each one is here for:
  *
+ * - **`screen`'s own `change`** — the screen itself being reconfigured, or the
+ *   window landing on a different one. The direct signal, and the only one that
+ *   catches a window moving between two same-size, same-ratio displays. From the
+ *   Window Management API, but on the base `Screen` rather than behind
+ *   `getScreenDetails()`, so it needs no permission — only a secure context.
+ *   Measured present in Chromium and absent in WebKit and Firefox, hence the
+ *   three below rather than this alone.
  * - **`resize`** — the window changing size, which is also what the OS does to it
  *   when the display it was on goes away.
  * - **`screen.orientation` change** — rotation, which swaps the axes without
@@ -92,12 +99,11 @@ export function getScreenResolution(options: ScreenResolutionOptions = {}): Scre
  *   display with a different ratio. Armed against the current ratio and re-armed
  *   when it moves, since the query only reports on the ratio it was built for.
  *
- * ⚠️ Known gap: dragging a window between two same-ratio displays of different
- * sizes, without the window resizing, changes the reading with none of the above
- * firing. Closing it needs the Window Management API's screen-change events,
- * which are permission-gated and not broadly available — so it is deliberately
- * out of this slice rather than approximated with polling, whose interval and
- * battery cost are a policy decision this function shouldn't be making.
+ * ⚠️ Known gap, on engines without `screen`'s change event: dragging a window
+ * between two different-size displays that share a ratio, without the window
+ * resizing, changes the reading with nothing firing. Closing it there would mean
+ * polling, whose interval and battery cost are a policy decision this function
+ * shouldn't be making.
  */
 export function watchScreenResolution(
   onChange: (resolution: ScreenResolution | undefined) => void,
@@ -137,16 +143,34 @@ export function watchScreenResolution(
 
   // Each signal is optional for the same reason the reading is: an environment
   // missing one has nothing to report from it, which is not a reason to fail.
+  // `screen`'s own change event is subscribed unconditionally rather than
+  // feature-detected — where it isn't implemented it simply never fires, and a
+  // signal that never fires costs nothing under comparison.
+  const screen = globalThis.screen;
+  const screenEvents = asEventTarget(screen);
   const stopResize = globalThis.window ? listen(globalThis.window, 'resize', check) : undefined;
-  const orientation = globalThis.screen?.orientation;
-  const stopOrientation = orientation ? listen(orientation, 'change', check) : undefined;
+  const stopScreen = screenEvents ? listen(screenEvents, 'change', check) : undefined;
+  const stopOrientation = screen?.orientation ? listen(screen.orientation, 'change', check) : undefined;
 
   return () => {
     stopResize?.();
+    stopScreen?.();
     stopOrientation?.();
     stopRatioQuery?.();
     stopRatioQuery = undefined;
   };
+}
+
+/**
+ * `Screen` as something subscribable.
+ *
+ * It is an `EventTarget` at runtime, and dispatches `change` where the Window
+ * Management API is implemented, but `lib.dom.d.ts` types neither — so the shape
+ * gets checked rather than declared. Same approach `@videojs/core` takes to
+ * `screen.orientation`'s lock methods, which that lib under-types too.
+ */
+function asEventTarget(value: object | undefined): EventTarget | undefined {
+  return value && 'addEventListener' in value ? (value as EventTarget) : undefined;
 }
 
 /** Whether two readings say the same thing, counting two unknowns as agreeing. */

--- a/packages/spf/src/media/dom/screen.ts
+++ b/packages/spf/src/media/dom/screen.ts
@@ -1,0 +1,70 @@
+/**
+ * Screen resolution, as the signal source for a screen-size rendition cap.
+ *
+ * Reported as a width and a height rather than a `"720p"`-style tier, because
+ * the cap that consumes it compares against real track dimensions. A tier only
+ * describes a track once you assume its aspect ratio — the assumption
+ * `maxResolutionToPixelArea` has to make, and the one that mis-measures an
+ * anamorphic or otherwise non-16:9 rendition.
+ *
+ * This is the first slice of the screen-size cap in
+ * `internal/design/spf/features/rendition-selection-caps.md`. What it leaves out
+ * is reacting to change: this is a one-shot read, and the screen underneath a
+ * window is not stable. Rotating a device swaps the axes; unplugging or
+ * reattaching a monitor, or dragging the window to a different display, changes
+ * the numbers *and* which physical screen they describe. So a live cap has to
+ * re-read rather than cache — which is why this reads the ambient screen at call
+ * time, with no subscription and no memoization of its own. A watcher belongs
+ * over this function, not inside it.
+ */
+
+/** A screen's pixel dimensions. */
+export interface ScreenResolution {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface ScreenResolutionOptions {
+  /**
+   * Scale the reading from CSS pixels into device pixels. On by default, since
+   * device pixels are what the screen actually has, and a rendition's dimensions
+   * are in the same units.
+   *
+   * Opt out for CSS pixels. Note that derating — a 3x phone rarely wanting 3x the
+   * pixels of its layout — is a scale applied over this reading rather than a
+   * reason to turn it off.
+   */
+  useDevicePixelRatio?: boolean | undefined;
+}
+
+/**
+ * Read the screen's resolution, or `undefined` where there isn't one to read.
+ *
+ * `undefined` means "unknown", which is the answer a cap needs in order to not
+ * cap. That lines up with `maxResolutionToPixelArea(undefined)` returning
+ * `+Infinity`, so an unknown screen is a cap of "no cap" rather than a cap of
+ * zero — the reading a naive `?? 0` would produce, which would pin every source
+ * to its smallest rendition on exactly the environments we know least about.
+ *
+ * Dimensions are reported as-is, including the axis swap a rotated device
+ * applies to them. Normalizing orientation away is a policy question — whether a
+ * cap should flap on rotation, or hold the larger budget across both — and
+ * belongs to the cap rather than to the reading.
+ */
+export function getScreenResolution(options: ScreenResolutionOptions = {}): ScreenResolution | undefined {
+  const screen = globalThis.screen;
+  if (!screen) return undefined;
+
+  // `|| 1` covers a missing or nonsense ratio: a CSS-pixel reading is still true
+  // and still cappable, so it isn't worth failing the whole answer over.
+  const { useDevicePixelRatio = true } = options;
+  const ratio = useDevicePixelRatio ? globalThis.devicePixelRatio || 1 : 1;
+
+  // Rounded because device pixels are whole and a fractional ratio doesn't divide
+  // a screen evenly. `NaN` from a nonsense dimension fails the check below, since
+  // no comparison against it holds.
+  const width = Math.round(screen.width * ratio);
+  const height = Math.round(screen.height * ratio);
+
+  return width > 0 && height > 0 ? { width, height } : undefined;
+}

--- a/packages/spf/src/media/dom/tests/screen.test.ts
+++ b/packages/spf/src/media/dom/tests/screen.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getScreenResolution } from '../screen';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getScreenResolution', () => {
+  it('reads the ambient screen', () => {
+    // The real browser screen — its size is the environment's to decide, so
+    // assert the shape rather than the numbers.
+    const resolution = getScreenResolution();
+
+    expect(resolution).toBeDefined();
+    expect(resolution!.width).toBeGreaterThan(0);
+    expect(resolution!.height).toBeGreaterThan(0);
+  });
+
+  it('reports a portrait screen with its axes as given', () => {
+    // Not normalized to landscape: whether a cap should flap on rotation is the
+    // cap's question, so the reading stays literal.
+    vi.stubGlobal('screen', { width: 390, height: 844 });
+    vi.stubGlobal('devicePixelRatio', 1);
+
+    expect(getScreenResolution()).toEqual({ width: 390, height: 844 });
+  });
+
+  it('returns undefined when there is no screen', () => {
+    // The answer a cap needs in order to not cap.
+    vi.stubGlobal('screen', undefined);
+
+    expect(getScreenResolution()).toBeUndefined();
+  });
+
+  describe('useDevicePixelRatio', () => {
+    it('scales into device pixels by default', () => {
+      vi.stubGlobal('screen', { width: 1440, height: 900 });
+      vi.stubGlobal('devicePixelRatio', 2);
+
+      expect(getScreenResolution()).toEqual({ width: 2880, height: 1800 });
+      expect(getScreenResolution({ useDevicePixelRatio: true })).toEqual({ width: 2880, height: 1800 });
+    });
+
+    it('reports CSS pixels when opted out', () => {
+      vi.stubGlobal('screen', { width: 1440, height: 900 });
+      vi.stubGlobal('devicePixelRatio', 2);
+
+      expect(getScreenResolution({ useDevicePixelRatio: false })).toEqual({ width: 1440, height: 900 });
+    });
+
+    it('rounds to whole device pixels on a fractional ratio', () => {
+      // 390 * 2.75 = 1072.5 → nearest; 844 * 2.75 = 2321 exactly.
+      vi.stubGlobal('screen', { width: 390, height: 844 });
+      vi.stubGlobal('devicePixelRatio', 2.75);
+
+      expect(getScreenResolution()).toEqual({ width: 1073, height: 2321 });
+    });
+
+    it('falls back to CSS pixels for an unusable ratio rather than failing the reading', () => {
+      // A CSS-pixel reading is still true and still cappable, so an unusable
+      // ratio costs the refinement, not the whole answer.
+      vi.stubGlobal('screen', { width: 1440, height: 900 });
+
+      for (const devicePixelRatio of [0, Number.NaN, undefined]) {
+        vi.stubGlobal('devicePixelRatio', devicePixelRatio);
+
+        expect(getScreenResolution()).toEqual({ width: 1440, height: 900 });
+      }
+    });
+  });
+});

--- a/packages/spf/src/media/dom/tests/screen.test.ts
+++ b/packages/spf/src/media/dom/tests/screen.test.ts
@@ -94,9 +94,12 @@ describe('watchScreenResolution', () => {
     return queries;
   }
 
-  /** A mutable screen, so a test can move it the way the environment would. */
+  /**
+   * A mutable screen, so a test can move it the way the environment would. An
+   * `EventTarget` because the real one is: `screen` dispatches its own `change`.
+   */
   function stubScreen(width: number, height: number, ratio = 1) {
-    const screen = { width, height, orientation: new EventTarget() };
+    const screen = Object.assign(new EventTarget(), { width, height, orientation: new EventTarget() });
     vi.stubGlobal('screen', screen);
     vi.stubGlobal('devicePixelRatio', ratio);
     return screen;
@@ -133,6 +136,21 @@ describe('watchScreenResolution', () => {
     const stop = watchScreenResolution(onChange);
 
     expect(onChange).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("reports on the screen's own change event", () => {
+    // The direct signal, and the only one that catches a window moving between
+    // two same-size, same-ratio displays. Chromium-only, so the others stay.
+    const screen = stubScreen(1440, 900);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    screen.width = 3840;
+    screen.height = 2160;
+    screen.dispatchEvent(new Event('change'));
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 3840, height: 2160 });
     stop();
   });
 
@@ -238,7 +256,7 @@ describe('watchScreenResolution', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('stops the ratio query and the orientation listener too', () => {
+  it('stops every signal, not just resize', () => {
     const queries = stubMatchMedia();
     const screen = stubScreen(1440, 900, 1);
     const onChange = vi.fn();
@@ -248,6 +266,7 @@ describe('watchScreenResolution', () => {
 
     screen.width = 1920;
     queries[0]!.fire();
+    screen.dispatchEvent(new Event('change'));
     screen.orientation.dispatchEvent(new Event('change'));
 
     expect(onChange).not.toHaveBeenCalled();

--- a/packages/spf/src/media/dom/tests/screen.test.ts
+++ b/packages/spf/src/media/dom/tests/screen.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getScreenResolution } from '../screen';
+import { getScreenResolution, watchScreenResolution } from '../screen';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -67,5 +67,189 @@ describe('getScreenResolution', () => {
         expect(getScreenResolution()).toEqual({ width: 1440, height: 900 });
       }
     });
+  });
+});
+
+describe('watchScreenResolution', () => {
+  /**
+   * A `matchMedia` stand-in whose queries can be told to fire. The real one only
+   * reports on ratios the environment actually has, so driving a ratio change
+   * means driving the query.
+   */
+  function stubMatchMedia() {
+    const queries: Array<{ query: string; fire: () => void }> = [];
+
+    vi.stubGlobal('matchMedia', (query: string) => {
+      const listeners = new Set<() => void>();
+      queries.push({ query, fire: () => listeners.forEach((listener) => listener()) });
+
+      return {
+        matches: true,
+        media: query,
+        addEventListener: (_: string, listener: () => void) => listeners.add(listener),
+        removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
+      };
+    });
+
+    return queries;
+  }
+
+  /** A mutable screen, so a test can move it the way the environment would. */
+  function stubScreen(width: number, height: number, ratio = 1) {
+    const screen = { width, height, orientation: new EventTarget() };
+    vi.stubGlobal('screen', screen);
+    vi.stubGlobal('devicePixelRatio', ratio);
+    return screen;
+  }
+
+  it('reports a new reading on resize', () => {
+    const screen = stubScreen(1440, 900);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    screen.width = 1920;
+    screen.height = 1080;
+    globalThis.dispatchEvent(new Event('resize'));
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 1920, height: 1080 });
+    stop();
+  });
+
+  it('does not report when nothing moved', () => {
+    // `resize` is noisy, so comparing readings is what keeps it from firing.
+    stubScreen(1440, 900);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    globalThis.dispatchEvent(new Event('resize'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('does not report on subscribe', () => {
+    stubScreen(1440, 900);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    expect(onChange).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('reports rotation, which swaps the axes without a resize', () => {
+    const screen = stubScreen(390, 844);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    screen.width = 844;
+    screen.height = 390;
+    screen.orientation.dispatchEvent(new Event('change'));
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 844, height: 390 });
+    stop();
+  });
+
+  it('reports a device pixel ratio change under a window that kept its size', () => {
+    const queries = stubMatchMedia();
+    stubScreen(1440, 900, 1);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    expect(queries[0]?.query).toBe('(resolution: 1dppx)');
+
+    vi.stubGlobal('devicePixelRatio', 2);
+    queries[0]!.fire();
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 2880, height: 1800 });
+    stop();
+  });
+
+  it('re-arms the ratio query against the new ratio', () => {
+    // A `dppx` query only answers about the ratio it was built for, so the old
+    // one goes quiet once the ratio moves.
+    const queries = stubMatchMedia();
+    stubScreen(1440, 900, 1);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    vi.stubGlobal('devicePixelRatio', 2);
+    queries[0]!.fire();
+
+    expect(queries[1]?.query).toBe('(resolution: 2dppx)');
+
+    vi.stubGlobal('devicePixelRatio', 3);
+    queries[1]!.fire();
+
+    expect(onChange).toHaveBeenLastCalledWith({ width: 4320, height: 2700 });
+    stop();
+  });
+
+  it('reports the reading becoming unknown, then known again', () => {
+    const screen = stubScreen(1440, 900);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    screen.width = 0;
+    globalThis.dispatchEvent(new Event('resize'));
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+
+    screen.width = 1440;
+    globalThis.dispatchEvent(new Event('resize'));
+    expect(onChange).toHaveBeenLastCalledWith({ width: 1440, height: 900 });
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    stop();
+  });
+
+  it('honors the reader options', () => {
+    const screen = stubScreen(1440, 900, 2);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange, { useDevicePixelRatio: false });
+
+    screen.width = 1920;
+    globalThis.dispatchEvent(new Event('resize'));
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 1920, height: 900 });
+    stop();
+  });
+
+  it('watches harmlessly where there is no screen to read', () => {
+    // Nothing to report from a signal an environment doesn't have, which is not a
+    // reason to fail — same line the reading draws.
+    vi.stubGlobal('screen', undefined);
+    const onChange = vi.fn();
+
+    const stop = watchScreenResolution(onChange);
+    globalThis.dispatchEvent(new Event('resize'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(stop).not.toThrow();
+  });
+
+  it('stops reporting once stopped', () => {
+    const screen = stubScreen(1440, 900);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    stop();
+    screen.width = 1920;
+    globalThis.dispatchEvent(new Event('resize'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('stops the ratio query and the orientation listener too', () => {
+    const queries = stubMatchMedia();
+    const screen = stubScreen(1440, 900, 1);
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange);
+
+    stop();
+
+    screen.width = 1920;
+    queries[0]!.fire();
+    screen.orientation.dispatchEvent(new Event('change'));
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/spf/src/media/dom/tests/screen.test.ts
+++ b/packages/spf/src/media/dom/tests/screen.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getScreenResolution, watchScreenResolution } from '../screen';
+import { getScreenResolution, type ScreenResolutionOptions, watchScreenResolution } from '../screen';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -80,15 +80,12 @@ describe('watchScreenResolution', () => {
     const queries: Array<{ query: string; fire: () => void }> = [];
 
     vi.stubGlobal('matchMedia', (query: string) => {
-      const listeners = new Set<() => void>();
-      queries.push({ query, fire: () => listeners.forEach((listener) => listener()) });
+      // A real `EventTarget`, so `once` and `signal` come from the platform rather
+      // than from a stub that could model them wrongly — the watcher leans on both.
+      const target = new EventTarget();
+      queries.push({ query, fire: () => target.dispatchEvent(new Event('change')) });
 
-      return {
-        matches: true,
-        media: query,
-        addEventListener: (_: string, listener: () => void) => listeners.add(listener),
-        removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
-      };
+      return Object.assign(target, { matches: true, media: query });
     });
 
     return queries;
@@ -105,10 +102,54 @@ describe('watchScreenResolution', () => {
     return screen;
   }
 
+  /**
+   * Subscribe, then forget the call the subscribe itself makes, so a test can
+   * assert on changes alone.
+   */
+  function watchChanges(options?: ScreenResolutionOptions) {
+    const onChange = vi.fn();
+    const stop = watchScreenResolution(onChange, options);
+    onChange.mockClear();
+    return { onChange, stop };
+  }
+
+  describe('on subscribe', () => {
+    it('reports the starting value, so a consumer needs no separate read', () => {
+      stubScreen(1440, 900);
+      const onChange = vi.fn();
+
+      const stop = watchScreenResolution(onChange);
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 1440, height: 900 });
+      stop();
+    });
+
+    it('reports undefined where there is no screen', () => {
+      // Unconditional, so a consumer can tell "there is no screen" from "not
+      // called yet". Comparing against an empty starting value would stay silent.
+      vi.stubGlobal('screen', undefined);
+      const onChange = vi.fn();
+
+      const stop = watchScreenResolution(onChange);
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith(undefined);
+      stop();
+    });
+
+    it('honors the reader options', () => {
+      stubScreen(1440, 900, 2);
+      const onChange = vi.fn();
+
+      const stop = watchScreenResolution(onChange, { useDevicePixelRatio: false });
+
+      expect(onChange).toHaveBeenCalledExactlyOnceWith({ width: 1440, height: 900 });
+      stop();
+    });
+  });
+
   it('reports a new reading on resize', () => {
     const screen = stubScreen(1440, 900);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     screen.width = 1920;
     screen.height = 1080;
@@ -121,19 +162,9 @@ describe('watchScreenResolution', () => {
   it('does not report when nothing moved', () => {
     // `resize` is noisy, so comparing readings is what keeps it from firing.
     stubScreen(1440, 900);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     globalThis.dispatchEvent(new Event('resize'));
-
-    expect(onChange).not.toHaveBeenCalled();
-    stop();
-  });
-
-  it('does not report on subscribe', () => {
-    stubScreen(1440, 900);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
 
     expect(onChange).not.toHaveBeenCalled();
     stop();
@@ -143,8 +174,7 @@ describe('watchScreenResolution', () => {
     // The direct signal, and the only one that catches a window moving between
     // two same-size, same-ratio displays. Chromium-only, so the others stay.
     const screen = stubScreen(1440, 900);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     screen.width = 3840;
     screen.height = 2160;
@@ -156,8 +186,7 @@ describe('watchScreenResolution', () => {
 
   it('reports rotation, which swaps the axes without a resize', () => {
     const screen = stubScreen(390, 844);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     screen.width = 844;
     screen.height = 390;
@@ -168,10 +197,10 @@ describe('watchScreenResolution', () => {
   });
 
   it('reports a device pixel ratio change under a window that kept its size', () => {
+    // The cross-display drag: the only coverage that case has in WebKit and Gecko.
     const queries = stubMatchMedia();
     stubScreen(1440, 900, 1);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     expect(queries[0]?.query).toBe('(resolution: 1dppx)');
 
@@ -187,8 +216,7 @@ describe('watchScreenResolution', () => {
     // one goes quiet once the ratio moves.
     const queries = stubMatchMedia();
     stubScreen(1440, 900, 1);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     vi.stubGlobal('devicePixelRatio', 2);
     queries[0]!.fire();
@@ -202,10 +230,41 @@ describe('watchScreenResolution', () => {
     stop();
   });
 
+  it('arms one ratio query, no matter how much else fires', () => {
+    // Only the query's own handler re-arms, so noisy signals can't accumulate
+    // queries. This is what `once: true` replaces the old ratio bookkeeping with.
+    const queries = stubMatchMedia();
+    stubScreen(1440, 900, 1);
+    const { stop } = watchChanges();
+
+    globalThis.dispatchEvent(new Event('resize'));
+    globalThis.dispatchEvent(new Event('resize'));
+
+    expect(queries).toHaveLength(1);
+    stop();
+  });
+
+  it('retires each ratio query once it has fired', () => {
+    // `once: true`, so re-firing the spent query is inert — the live one is the
+    // replacement, armed against the ratio that is now current.
+    const queries = stubMatchMedia();
+    stubScreen(1440, 900, 1);
+    const { onChange, stop } = watchChanges();
+
+    vi.stubGlobal('devicePixelRatio', 2);
+    queries[0]!.fire();
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    queries[0]!.fire();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(queries).toHaveLength(2);
+    stop();
+  });
+
   it('reports the reading becoming unknown, then known again', () => {
     const screen = stubScreen(1440, 900);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     screen.width = 0;
     globalThis.dispatchEvent(new Event('resize'));
@@ -219,10 +278,9 @@ describe('watchScreenResolution', () => {
     stop();
   });
 
-  it('honors the reader options', () => {
+  it('reports changes in CSS pixels when the ratio is opted out', () => {
     const screen = stubScreen(1440, 900, 2);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange, { useDevicePixelRatio: false });
+    const { onChange, stop } = watchChanges({ useDevicePixelRatio: false });
 
     screen.width = 1920;
     globalThis.dispatchEvent(new Event('resize'));
@@ -235,9 +293,8 @@ describe('watchScreenResolution', () => {
     // Nothing to report from a signal an environment doesn't have, which is not a
     // reason to fail — same line the reading draws.
     vi.stubGlobal('screen', undefined);
-    const onChange = vi.fn();
+    const { onChange, stop } = watchChanges();
 
-    const stop = watchScreenResolution(onChange);
     globalThis.dispatchEvent(new Event('resize'));
 
     expect(onChange).not.toHaveBeenCalled();
@@ -246,8 +303,7 @@ describe('watchScreenResolution', () => {
 
   it('stops reporting once stopped', () => {
     const screen = stubScreen(1440, 900);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     stop();
     screen.width = 1920;
@@ -257,10 +313,10 @@ describe('watchScreenResolution', () => {
   });
 
   it('stops every signal, not just resize', () => {
+    // One abort signal behind all of them, so none can outlive the watcher.
     const queries = stubMatchMedia();
     const screen = stubScreen(1440, 900, 1);
-    const onChange = vi.fn();
-    const stop = watchScreenResolution(onChange);
+    const { onChange, stop } = watchChanges();
 
     stop();
 

--- a/packages/spf/src/media/errors.ts
+++ b/packages/spf/src/media/errors.ts
@@ -56,8 +56,15 @@ export const SVTA_UNSUPPORTED_AUDIO_FORMAT = 1005;
 export const SVTA_UNSUPPORTED_DRM_SYSTEM = 4008;
 
 /**
- * SVTA 2 [Playback] 011 — no video track the environment can play. For a source
- * that *has* video renditions where every one was excluded as unplayable.
+ * SVTA 2 [Playback] 011 — no video track the environment can play.
+ *
+ * Covers both ways a composition can end up with nothing to select: renditions
+ * that existed and were all excluded as unplayable, and — where the composition
+ * composes `reportAbsentTrackType` to say it needs the type — a source carrying
+ * none to begin with. Deliberately one code for both, because they are the same
+ * answer to a viewer, and because the alternative is a code the SVTA spec doesn't
+ * define. Whether an absent type is a failure is the composition's to state,
+ * which is why it opts in rather than being read off the source.
  */
 export const SVTA_NO_SUPPORTED_VIDEO_TRACK = 2011;
 

--- a/packages/spf/src/media/primitives/select-tracks.ts
+++ b/packages/spf/src/media/primitives/select-tracks.ts
@@ -1,19 +1,4 @@
-import { DEFAULT_QUALITY_CONFIG, selectQuality } from '../abr/quality-selection';
-import type {
-  AudioSelectionSet,
-  MaybeResolvedPresentation,
-  PartiallyResolvedTextTrack,
-  TextTrack,
-  TrackType,
-  VideoSelectionSet,
-} from '../types';
-import { SelectedTrackIdKeyByType } from '../utils/track-selection';
-
-/**
- * Default initial bandwidth estimate for cold start (bits per second).
- * Conservative 1 Mbps to avoid over-selecting on slow connections.
- */
-export const DEFAULT_INITIAL_BANDWIDTH = 1_000_000;
+import type { MaybeResolvedPresentation, PartiallyResolvedTextTrack, TextTrack } from '../types';
 
 /**
  * State shape for track selection.
@@ -23,36 +8,6 @@ export interface TrackSelectionState {
   selectedVideoTrackId?: string;
   selectedAudioTrackId?: string;
   selectedTextTrackId?: string;
-}
-
-/**
- * Context shape for track selection.
- * Currently empty - reserved for future use (e.g., bandwidth estimator).
- */
-export type TrackSelectionContext = Record<string, never>;
-
-/**
- * Action types for track selection.
- * Reserved for future event-driven selection triggers.
- */
-export type TrackSelectionAction = { type: 'presentation-loaded' };
-
-/**
- * Configuration for video track selection.
- */
-export interface VideoSelectionConfig {
-  /**
-   * Initial bandwidth estimate for cold start (bits per second).
-   * Used to select video quality before we have real measurements.
-   * Default: 1 Mbps (conservative).
-   */
-  initialBandwidth?: number;
-
-  /**
-   * Safety margin for quality selection (0-1).
-   * Default: 0.85 (15% headroom).
-   */
-  safetyMargin?: number;
 }
 
 /**
@@ -99,25 +54,13 @@ export interface TextSelectionConfig {
 
 // =============================================================================
 // Helper Functions (Pure Selection Logic)
+//
+// Candidate-list policies and track geometry, for the selection rules in
+// `playback/behaviors/select-tracks.ts` and `playback/behaviors/track-switching.ts`
+// to compose. Nothing here consults a whole presentation or returns a single id:
+// narrowing a list and ordering a list are the two shapes a rule can take, and the
+// rule chain takes the head of what they leave.
 // =============================================================================
-
-/**
- * Contract for a track picker — a pure function that consults a
- * presentation (and optional config) and returns the id of the track to
- * select, or `undefined` to leave the slot unset.
- *
- * Behaviors that own a track-selection slot (`selectAudioTrack`,
- * `selectVideoTrack`, `switchVideoTrack`) accept a
- * `TrackPicker` via config. The behavior passes its own config straight
- * through as the picker's second argument — pickers that need richer
- * options (language preferences, default-track filtering, bandwidth-aware
- * selection) read from `config`; pickers that don't (e.g., first-track)
- * ignore it.
- */
-export type TrackPicker<Config = unknown> = (
-  presentation: MaybeResolvedPresentation,
-  config?: Config
-) => string | undefined;
 
 /**
  * Test whether a track matches a partial-track description: every present,
@@ -137,143 +80,48 @@ export function matchesPartialTrack<T>(track: T, filter: Partial<T>): boolean {
   return true;
 }
 
-/**
- * Pick the first track of the given type from a presentation.
- *
- * Returns the first track in the first switching set of the matching
- * selection set, or `undefined` if either is missing. POC-shaped
- * default-pick — `pickVideoTrack` / `pickAudioTrack` honor bandwidth +
- * language preferences and will replace this once selection callers are
- * ready.
- */
-export function pickFirstTrackId(presentation: MaybeResolvedPresentation, type: TrackType): string | undefined {
-  return presentation.selectionSets?.find((set) => set.type === type)?.switchingSets[0]?.tracks[0]?.id;
-}
-
-/**
- * Pick video track using quality selection algorithm.
- *
- * Uses bandwidth-based selection with safety margin to pick
- * the highest quality track that fits available bandwidth.
- *
- * @param presentation - Presentation with video tracks
- * @param config - Selection configuration (bandwidth, safety margin)
- * @returns Selected video track ID, or undefined if no video tracks
- */
-export function pickVideoTrack(
-  presentation: MaybeResolvedPresentation,
-  config?: VideoSelectionConfig
-): string | undefined {
-  const videoSet = presentation.selectionSets?.find((set) => set.type === 'video') as VideoSelectionSet | undefined;
-
-  if (!videoSet || videoSet.switchingSets.length === 0) {
-    return undefined;
-  }
-
-  // Get first switching set's tracks (HLS typically has one switching set per type)
-  const switchingSet = videoSet.switchingSets[0];
-  if (!switchingSet || switchingSet.tracks.length === 0) {
-    return undefined;
-  }
-
-  const initialBandwidth = config?.initialBandwidth ?? DEFAULT_INITIAL_BANDWIDTH;
-  const safetyMargin = config?.safetyMargin ?? DEFAULT_QUALITY_CONFIG.safetyMargin;
-
-  // selectQuality works with both partially resolved and resolved tracks
-  const selected = selectQuality(switchingSet.tracks as any, { bandwidth: initialBandwidth, safetyMargin });
-
-  return selected?.id;
-}
-
-/**
- * Translates a "max resolution" into a total total pixel area
- * for comparisons with video track resolutions with an assumed
- * 16:9 ratio.
- *
- * Example: "720p" translates to a 921600 pixel area.
- *
- * Because 720 * 1280 = 720 * (720 * (16/9) ) = 921_600
- *
- * Accepts:
- * - string with the format '{height}p'. ('720p')
- * - bare number, interpreted as pixel area. (921_600)
- * - anything else will translate to `+Infinity`, meaning no cap specified
- */
-export function maxResolutionToPixelArea(value: string | number | undefined): number {
-  if (value === undefined || value === null) return Number.POSITIVE_INFINITY;
-  if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? value : Number.POSITIVE_INFINITY;
-  const match = value.trim().match(/^(\d+)p?$/i);
-  if (!match) return Number.POSITIVE_INFINITY;
-  const height = Number(match[1]);
-  if (!(Number.isFinite(height) && height > 0)) return Number.POSITIVE_INFINITY;
-  return (height * height * 16) / 9;
-}
-
 type RankableTrack = { id: string; width?: number; height?: number; bandwidth?: number };
 
+/** Missing dimensions are treated as area `0`, so a track without them ranks last. */
+function pixelArea(track: RankableTrack): number {
+  return (track.width ?? 0) * (track.height ?? 0);
+}
+
 /**
- * Pick the track with the highest pixel area at or below `maxPixelArea`.
- * Falls back to the lowest track when nothing satisfies the cap (the
- * lowest of the above-cap set is the closest to the cap from above).
- * Tiebreak on bandwidth. Missing dimensions are treated as area `0`.
+ * Narrow to the tracks at or below `maxPixelArea`, and nothing else: no ordering,
+ * no fallback. Survivors keep their incoming order, and an empty result is a real
+ * answer — "none of these fit".
+ *
+ * Deliberately only the filter, because as a selection rule this composes under
+ * `applyRules`, which already owns both halves a caller might expect here: an empty
+ * result is skipped, so a preference can never narrow the candidate set to nothing;
+ * and ordering the survivors is a separate rule's job
+ * ({@link byDescendingResolution}, bandwidth ABR). Doing either here would duplicate
+ * the composer and give one rule two responsibilities.
  */
-export function pickTrackUnderPixelArea<T extends RankableTrack>(
+export function tracksUnderPixelArea<T extends RankableTrack>(
   tracks: readonly T[],
   maxPixelArea: number = Number.POSITIVE_INFINITY
-): T | undefined {
-  if (tracks.length === 0) return undefined;
-
-  // Sort descending by pixel area, bandwidth as tiebreaker. List sizes
-  // are small (HLS variant counts) — no need to optimize past a sort.
-  const sorted = [...tracks].sort(
-    (a, b) =>
-      (b.width ?? 0) * (b.height ?? 0) - (a.width ?? 0) * (a.height ?? 0) || (b.bandwidth ?? 0) - (a.bandwidth ?? 0)
-  );
-
-  return sorted.find((t) => (t.width ?? 0) * (t.height ?? 0) <= maxPixelArea) ?? sorted[sorted.length - 1];
+): readonly T[] {
+  return tracks.filter((track) => pixelArea(track) <= maxPixelArea);
 }
 
 /**
- * Pick the video track with the highest pixel area.
+ * Compare two tracks by resolution, largest first, with bandwidth as the tiebreak
+ * for renditions of identical dimensions. Missing dimensions are treated as area
+ * `0`, so a track without them sorts last.
  *
- * Pair with `selectVideoTrack`; compose `switchVideoQuality` instead
- * for runtime-adapted quality.
+ * A comparator rather than a "highest track" function: the selection-rule chain
+ * takes the head of the list it produces, so ranking never has to collapse to a
+ * single track. `preferHighestResolution` is `sort` over this and nothing more.
  */
-export function pickHighestResolutionVideoTrack(presentation: MaybeResolvedPresentation): string | undefined {
-  const videoSet = presentation.selectionSets?.find((set) => set.type === 'video') as VideoSelectionSet | undefined;
-  const tracks = videoSet?.switchingSets[0]?.tracks;
-  if (!tracks?.length) return undefined;
-  return pickTrackUnderPixelArea(tracks)?.id;
+export function byDescendingResolution(a: RankableTrack, b: RankableTrack): number {
+  return pixelArea(b) - pixelArea(a) || (b.bandwidth ?? 0) - (a.bandwidth ?? 0);
 }
 
 /**
- * Pick audio track.
- *
- * Selection priority:
- * 1. First track matching preferred language (if specified)
- * 2. First default track
- * 3. First audio track
- *
- * @param presentation - Presentation with audio tracks
- * @param config - Selection configuration (preferred language)
- * @returns Selected audio track ID, or undefined if no audio tracks
- */
-export function pickAudioTrack(
-  presentation: MaybeResolvedPresentation,
-  config?: AudioSelectionConfig
-): string | undefined {
-  const audioSet = presentation.selectionSets?.find((set) => set.type === 'audio') as AudioSelectionSet | undefined;
-  const tracks = audioSet?.switchingSets[0]?.tracks;
-  if (!tracks?.length) return undefined;
-  return pickAudioTrackFromTracks(tracks, config);
-}
-
-/**
- * Default audio policy over an explicit candidate list rather than a whole
- * presentation: the three-tier pick `pickAudioTrack` delegates to, factored out
- * for the same reason `pickTextTrackFromTracks` was — a caller that has already
- * narrowed the candidates (a selection-rule chain) applies the same policy
- * without re-deriving from the presentation.
+ * Default audio policy over a candidate list: the three-tier pick a selection-rule
+ * chain applies once it has narrowed the candidates.
  *
  * Priority: `preferredAudioLanguage` match → `DEFAULT=YES` → first track.
  */
@@ -300,33 +148,9 @@ export function pickAudioTrackFromTracks(
 }
 
 /**
- * Pick text track to activate from a presentation. Conforms to the
- * `TrackPicker` contract. The candidate-list core (`pickTextTrackFromTracks`)
- * is the opt-in default policy `switchTextTrack`'s terminal applies once it has
- * narrowed the renditions.
- *
- * Selection priority (if enabled):
- * 1. User preference (preferredSubtitleLanguage)
- * 2. DEFAULT track (if enableDefaultTrack is true and track has DEFAULT=YES + AUTOSELECT=YES)
- * 3. No auto-selection (user opt-in)
- *
- * By default, FORCED tracks are excluded per Apple's HLS spec.
- */
-export function pickTextTrack(
-  presentation: MaybeResolvedPresentation,
-  config?: TextSelectionConfig
-): string | undefined {
-  const tracks = presentation.selectionSets?.find((set) => set.type === 'text')?.switchingSets?.[0]?.tracks;
-  if (!tracks?.length) return undefined;
-  return pickTextTrackFromTracks(tracks, config);
-}
-
-/**
- * Default text-track policy over an explicit candidate list (rather than a whole
- * presentation): the opt-in three-tier pick `pickTextTrack` delegates to, factored
- * out so a caller that has already narrowed the candidates — a constrained,
- * CDN-scoped track-switching chain — applies the same policy without re-deriving
- * from the presentation.
+ * Default text-track policy over a candidate list: the opt-in three-tier pick
+ * `switchTextTrack`'s terminal applies once it has narrowed the renditions to the
+ * constrained, CDN-scoped set.
  *
  * Priority: `preferredSubtitleLanguage` match → `DEFAULT=YES + AUTOSELECT=YES`
  * (only when `enableDefaultTrack`) → `undefined` (opt-in). FORCED tracks are
@@ -353,32 +177,4 @@ export function pickTextTrackFromTracks(
   }
 
   return undefined;
-}
-
-/**
- * Check if we can select a track of the given type.
- *
- * Returns true when:
- * - Presentation exists
- * - Has tracks of the specified type
- *
- * Generic over track type - works for video, audio, or text.
- */
-export function canSelectTrack(state: TrackSelectionState, type: TrackType): boolean {
-  return !!state?.presentation?.selectionSets?.find((set) => set.type === type)?.switchingSets?.[0]?.tracks.length;
-}
-
-/**
- * Check if we should select a track of the given type.
- *
- * Returns true when:
- * - Track of this type is not already selected
- *
- * Generic over track type - works for video, audio, or text.
- *
- * @TODO figure out reactive model for ABR cases - right now we're only selecting
- * if we have nothing selected (CJP)
- */
-export function shouldSelectTrack(state: TrackSelectionState, type: TrackType): boolean {
-  return !state[SelectedTrackIdKeyByType[type]];
 }

--- a/packages/spf/src/media/primitives/select-tracks.ts
+++ b/packages/spf/src/media/primitives/select-tracks.ts
@@ -263,19 +263,24 @@ export function pickAudioTrack(
   config?: AudioSelectionConfig
 ): string | undefined {
   const audioSet = presentation.selectionSets?.find((set) => set.type === 'audio') as AudioSelectionSet | undefined;
+  const tracks = audioSet?.switchingSets[0]?.tracks;
+  if (!tracks?.length) return undefined;
+  return pickAudioTrackFromTracks(tracks, config);
+}
 
-  if (!audioSet || audioSet.switchingSets.length === 0) {
-    return undefined;
-  }
-
-  // Get first switching set's tracks
-  const switchingSet = audioSet.switchingSets[0];
-  if (!switchingSet || switchingSet.tracks.length === 0) {
-    return undefined;
-  }
-
-  const tracks = switchingSet.tracks;
-
+/**
+ * Default audio policy over an explicit candidate list rather than a whole
+ * presentation: the three-tier pick `pickAudioTrack` delegates to, factored out
+ * for the same reason `pickTextTrackFromTracks` was — a caller that has already
+ * narrowed the candidates (a selection-rule chain) applies the same policy
+ * without re-deriving from the presentation.
+ *
+ * Priority: `preferredAudioLanguage` match → `DEFAULT=YES` → first track.
+ */
+export function pickAudioTrackFromTracks(
+  tracks: readonly { id: string; language?: string | undefined; default?: boolean | undefined }[],
+  config?: AudioSelectionConfig
+): string | undefined {
   // Try preferred language first
   if (config?.preferredAudioLanguage) {
     const languageMatch = tracks.find((track) => track.language === config.preferredAudioLanguage);

--- a/packages/spf/src/media/primitives/tests/select-tracks.test.ts
+++ b/packages/spf/src/media/primitives/tests/select-tracks.test.ts
@@ -1,310 +1,16 @@
+/**
+ * Track geometry for the video selection rules: one filter, one comparator.
+ *
+ * The candidate-list policies alongside them (`pickAudioTrackFromTracks`,
+ * `pickTextTrackFromTracks`) are covered through the behaviors that compose them —
+ * `selectAudioTrack` in `playback/behaviors/tests/select-tracks.test.ts`, and
+ * `switchTextTrack` in `playback/behaviors/tests/track-switching.test.ts` — since
+ * the policy and its lifecycle are only meaningful together.
+ */
 import { describe, expect, it } from 'vitest';
-import type {
-  AudioSelectionSet,
-  PartiallyResolvedAudioTrack,
-  PartiallyResolvedVideoTrack,
-  Presentation,
-  TextSelectionSet,
-  VideoSelectionSet,
-} from '../../types';
-import {
-  maxResolutionToPixelArea,
-  pickAudioTrack,
-  pickHighestResolutionVideoTrack,
-  pickTextTrack,
-  pickTrackUnderPixelArea,
-  pickVideoTrack,
-} from '../select-tracks';
+import { byDescendingResolution, tracksUnderPixelArea } from '../select-tracks';
 
-// Helper to create a minimal presentation
-function createPresentation(config: {
-  video?: PartiallyResolvedVideoTrack[];
-  audio?: PartiallyResolvedAudioTrack[];
-  text?: any[];
-}): Presentation {
-  const selectionSets = [];
-
-  if (config.video && config.video.length > 0) {
-    selectionSets.push({
-      id: 'video-set',
-      type: 'video' as const,
-      switchingSets: [
-        {
-          id: 'video-switching',
-          type: 'video' as const,
-          tracks: config.video,
-        },
-      ],
-    } as VideoSelectionSet);
-  }
-
-  if (config.audio && config.audio.length > 0) {
-    selectionSets.push({
-      id: 'audio-set',
-      type: 'audio' as const,
-      switchingSets: [
-        {
-          id: 'audio-switching',
-          type: 'audio' as const,
-          tracks: config.audio,
-        },
-      ],
-    } as AudioSelectionSet);
-  }
-
-  if (config.text && config.text.length > 0) {
-    selectionSets.push({
-      id: 'text-set',
-      type: 'text' as const,
-      switchingSets: [
-        {
-          id: 'text-switching',
-          type: 'text' as const,
-          tracks: config.text,
-        },
-      ],
-    } as TextSelectionSet);
-  }
-
-  return {
-    id: 'pres-1',
-    url: 'http://example.com/playlist.m3u8',
-    selectionSets,
-    startTime: 0,
-  };
-}
-
-describe('pickVideoTrack', () => {
-  it('selects appropriate quality based on initial bandwidth', () => {
-    const tracks: PartiallyResolvedVideoTrack[] = [
-      {
-        type: 'video',
-        id: '360p',
-        url: 'http://example.com/360p.m3u8',
-        bandwidth: 500_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 640,
-        height: 360,
-      },
-      {
-        type: 'video',
-        id: '720p',
-        url: 'http://example.com/720p.m3u8',
-        bandwidth: 2_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 1280,
-        height: 720,
-      },
-      {
-        type: 'video',
-        id: '1080p',
-        url: 'http://example.com/1080p.m3u8',
-        bandwidth: 4_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 1920,
-        height: 1080,
-      },
-    ];
-
-    const presentation = createPresentation({ video: tracks });
-
-    // With default 1 Mbps, should select 360p (500k fits with margin)
-    const selected = pickVideoTrack(presentation);
-    expect(selected).toBe('360p');
-
-    // With 3 Mbps, should select 720p (2M fits, 4M doesn't with 0.85 margin)
-    const selected2 = pickVideoTrack(presentation, { initialBandwidth: 3_000_000 });
-    expect(selected2).toBe('720p');
-
-    // With 5 Mbps, should select 1080p (4M fits with margin)
-    const selected3 = pickVideoTrack(presentation, { initialBandwidth: 5_000_000 });
-    expect(selected3).toBe('1080p');
-  });
-
-  it('returns undefined when no video tracks', () => {
-    const presentation = createPresentation({ audio: [] });
-
-    const selected = pickVideoTrack(presentation);
-    expect(selected).toBeUndefined();
-  });
-
-  it('falls back to lowest quality when bandwidth is very low', () => {
-    const tracks: PartiallyResolvedVideoTrack[] = [
-      {
-        type: 'video',
-        id: '720p',
-        url: 'http://example.com/720p.m3u8',
-        bandwidth: 2_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-      },
-      {
-        type: 'video',
-        id: '1080p',
-        url: 'http://example.com/1080p.m3u8',
-        bandwidth: 4_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-      },
-    ];
-
-    const presentation = createPresentation({ video: tracks });
-
-    // With 100 kbps (very low), should fall back to lowest (720p)
-    const selected = pickVideoTrack(presentation, { initialBandwidth: 100_000 });
-    expect(selected).toBe('720p');
-  });
-
-  it('uses custom safety margin when provided', () => {
-    const tracks: PartiallyResolvedVideoTrack[] = [
-      {
-        type: 'video',
-        id: '720p',
-        url: 'http://example.com/720p.m3u8',
-        bandwidth: 2_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-      },
-    ];
-
-    const presentation = createPresentation({ video: tracks });
-
-    // With 2.1 Mbps and 0.95 margin, should NOT select 720p (needs 2.1M)
-    // Falls back to lowest
-    const selected = pickVideoTrack(presentation, {
-      initialBandwidth: 2_050_000,
-      safetyMargin: 0.95,
-    });
-    expect(selected).toBe('720p'); // Falls back since it's the only/lowest option
-  });
-});
-
-describe('pickHighestResolutionVideoTrack', () => {
-  it('selects the track with the highest width × height area', () => {
-    const tracks: PartiallyResolvedVideoTrack[] = [
-      {
-        type: 'video',
-        id: '360p',
-        url: 'http://example.com/360p.m3u8',
-        bandwidth: 500_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 640,
-        height: 360,
-      },
-      {
-        type: 'video',
-        id: '1080p',
-        url: 'http://example.com/1080p.m3u8',
-        bandwidth: 4_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 1920,
-        height: 1080,
-      },
-      {
-        type: 'video',
-        id: '720p',
-        url: 'http://example.com/720p.m3u8',
-        bandwidth: 2_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 1280,
-        height: 720,
-      },
-    ];
-
-    const presentation = createPresentation({ video: tracks });
-    expect(pickHighestResolutionVideoTrack(presentation)).toBe('1080p');
-  });
-
-  it('falls back to bandwidth when resolution metadata is missing', () => {
-    const tracks: PartiallyResolvedVideoTrack[] = [
-      {
-        type: 'video',
-        id: 'low',
-        url: 'http://example.com/low.m3u8',
-        bandwidth: 500_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-      },
-      {
-        type: 'video',
-        id: 'high',
-        url: 'http://example.com/high.m3u8',
-        bandwidth: 4_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-      },
-    ];
-
-    const presentation = createPresentation({ video: tracks });
-    expect(pickHighestResolutionVideoTrack(presentation)).toBe('high');
-  });
-
-  it('breaks ties on equal resolution by bandwidth', () => {
-    const tracks: PartiallyResolvedVideoTrack[] = [
-      {
-        type: 'video',
-        id: '1080p-low',
-        url: 'http://example.com/1080p-low.m3u8',
-        bandwidth: 3_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 1920,
-        height: 1080,
-      },
-      {
-        type: 'video',
-        id: '1080p-high',
-        url: 'http://example.com/1080p-high.m3u8',
-        bandwidth: 6_000_000,
-        mimeType: 'video/mp4',
-        codecs: ['avc1.42E01E'],
-        width: 1920,
-        height: 1080,
-      },
-    ];
-
-    const presentation = createPresentation({ video: tracks });
-    expect(pickHighestResolutionVideoTrack(presentation)).toBe('1080p-high');
-  });
-
-  it('returns undefined when no video tracks exist', () => {
-    const presentation = createPresentation({ audio: [] });
-    expect(pickHighestResolutionVideoTrack(presentation)).toBeUndefined();
-  });
-});
-
-describe('maxResolutionToPixelArea', () => {
-  it('translates `"<n>p"` strings to 16:9 pixel area', () => {
-    expect(maxResolutionToPixelArea('720p')).toBe(720 * 1280);
-    expect(maxResolutionToPixelArea('1080P')).toBe(1080 * 1920);
-    expect(maxResolutionToPixelArea('1440p')).toBe(1440 * 2560);
-    expect(maxResolutionToPixelArea('2160p')).toBe(2160 * 3840);
-  });
-
-  it('treats bare numeric strings as height (16:9 area)', () => {
-    expect(maxResolutionToPixelArea('720')).toBe(720 * 1280);
-  });
-
-  it('treats bare numbers as a pixel-area cap', () => {
-    expect(maxResolutionToPixelArea(921_600)).toBe(921_600);
-  });
-
-  it('returns +Infinity for unrecognized inputs (no cap)', () => {
-    expect(maxResolutionToPixelArea(undefined)).toBe(Number.POSITIVE_INFINITY);
-    expect(maxResolutionToPixelArea('garbage')).toBe(Number.POSITIVE_INFINITY);
-    expect(maxResolutionToPixelArea('-720')).toBe(Number.POSITIVE_INFINITY);
-    expect(maxResolutionToPixelArea(0)).toBe(Number.POSITIVE_INFINITY);
-    expect(maxResolutionToPixelArea(-1)).toBe(Number.POSITIVE_INFINITY);
-  });
-});
-
-describe('pickTrackUnderPixelArea', () => {
+describe('tracksUnderPixelArea', () => {
   const tracks = [
     { id: '360p', width: 640, height: 360, bandwidth: 500_000 },
     { id: '720p', width: 1280, height: 720, bandwidth: 2_000_000 },
@@ -312,465 +18,86 @@ describe('pickTrackUnderPixelArea', () => {
     { id: '1440p', width: 2560, height: 1440, bandwidth: 8_000_000 },
   ];
 
-  it('returns undefined for an empty list', () => {
-    expect(pickTrackUnderPixelArea([])).toBeUndefined();
+  it('returns nothing for an empty list', () => {
+    expect(tracksUnderPixelArea([], 1920 * 1080)).toEqual([]);
   });
 
-  it('picks the highest-area track when no cap is provided', () => {
-    expect(pickTrackUnderPixelArea(tracks)?.id).toBe('1440p');
+  it('keeps every track at or below the cap', () => {
+    expect(tracksUnderPixelArea(tracks, 1920 * 1080).map((track) => track.id)).toEqual(['360p', '720p', '1080p']);
   });
 
-  it('picks the highest track at or below the cap', () => {
-    expect(pickTrackUnderPixelArea(tracks, 1280 * 720)?.id).toBe('720p');
-    expect(pickTrackUnderPixelArea(tracks, 1920 * 1080)?.id).toBe('1080p');
+  it('keeps the whole set when no cap is provided', () => {
+    expect(tracksUnderPixelArea(tracks).map((track) => track.id)).toEqual(['360p', '720p', '1080p', '1440p']);
   });
 
-  it('falls back to the lowest track when the cap excludes everything', () => {
-    expect(pickTrackUnderPixelArea(tracks, 100)?.id).toBe('360p');
+  // Ordering is `byDescendingResolution`'s job, not the filter's — a cap only decides
+  // which tracks are admissible. Given a shuffled ladder it filters and nothing else.
+  it('preserves the incoming order rather than ranking', () => {
+    const shuffled = [tracks[2], tracks[0], tracks[3], tracks[1]] as typeof tracks;
+    expect(tracksUnderPixelArea(shuffled, 1920 * 1080).map((track) => track.id)).toEqual(['1080p', '360p', '720p']);
   });
 
-  it('tiebreaks on bandwidth at equal pixel area', () => {
-    const ties = [
-      { id: '1080p-low', width: 1920, height: 1080, bandwidth: 3_000_000 },
-      { id: '1080p-high', width: 1920, height: 1080, bandwidth: 6_000_000 },
+  // No fallback of its own: an empty result is the honest answer, and `applyRules`
+  // is what turns it into "the cap expressed no opinion" by skipping the rule.
+  it('returns nothing when the cap excludes everything', () => {
+    expect(tracksUnderPixelArea(tracks, 100)).toEqual([]);
+  });
+
+  it('admits a track whose area exactly equals the cap', () => {
+    expect(tracksUnderPixelArea(tracks, 640 * 360).map((track) => track.id)).toEqual(['360p']);
+  });
+
+  // Anamorphic ladders are the reason the cap compares areas rather than heights:
+  // 3840x1714 is 6.58 Mpx, so it fits a 7.72 Mpx screen even though 2160 > 1714.
+  it('compares area, not height', () => {
+    const anamorphic = [
+      { id: 'wide-2160', width: 3840, height: 1714, bandwidth: 12_000_000 },
+      { id: 'uhd', width: 3840, height: 2160, bandwidth: 15_000_000 },
     ];
-    expect(pickTrackUnderPixelArea(ties)?.id).toBe('1080p-high');
-  });
-
-  it('treats missing dimensions as area 0', () => {
-    const mixed = [
-      { id: 'unknown', bandwidth: 1_000_000 },
-      { id: '720p', width: 1280, height: 720, bandwidth: 2_000_000 },
-    ];
-    expect(pickTrackUnderPixelArea(mixed)?.id).toBe('720p');
+    expect(tracksUnderPixelArea(anamorphic, 3456 * 2234).map((track) => track.id)).toEqual(['wide-2160']);
   });
 });
 
-describe('pickAudioTrack', () => {
-  it('selects first track when no preferences', () => {
-    const tracks: PartiallyResolvedAudioTrack[] = [
-      {
-        type: 'audio',
-        id: 'audio-en',
-        url: 'http://example.com/audio-en.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'English',
-        language: 'en',
-        sampleRate: 48000,
-        channels: 2,
-      },
-      {
-        type: 'audio',
-        id: 'audio-es',
-        url: 'http://example.com/audio-es.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'Spanish',
-        language: 'es',
-        sampleRate: 48000,
-        channels: 2,
-      },
-    ];
+describe('byDescendingResolution', () => {
+  const sortedIds = (tracks: readonly { id: string; width?: number; height?: number; bandwidth?: number }[]) =>
+    [...tracks].sort(byDescendingResolution).map((track) => track.id);
 
-    const presentation = createPresentation({ audio: tracks });
-
-    const selected = pickAudioTrack(presentation);
-    expect(selected).toBe('audio-en');
+  it('orders by pixel area, largest first', () => {
+    expect(
+      sortedIds([
+        { id: '720p', width: 1280, height: 720, bandwidth: 2_000_000 },
+        { id: '1440p', width: 2560, height: 1440, bandwidth: 8_000_000 },
+        { id: '360p', width: 640, height: 360, bandwidth: 500_000 },
+        { id: '1080p', width: 1920, height: 1080, bandwidth: 4_000_000 },
+      ])
+    ).toEqual(['1440p', '1080p', '720p', '360p']);
   });
 
-  it('selects preferred language when specified', () => {
-    const tracks: PartiallyResolvedAudioTrack[] = [
-      {
-        type: 'audio',
-        id: 'audio-en',
-        url: 'http://example.com/audio-en.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'English',
-        language: 'en',
-        sampleRate: 48000,
-        channels: 2,
-      },
-      {
-        type: 'audio',
-        id: 'audio-es',
-        url: 'http://example.com/audio-es.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'Spanish',
-        language: 'es',
-        sampleRate: 48000,
-        channels: 2,
-      },
-    ];
-
-    const presentation = createPresentation({ audio: tracks });
-
-    const selected = pickAudioTrack(presentation, { preferredAudioLanguage: 'es' });
-    expect(selected).toBe('audio-es');
+  it('tiebreaks on bandwidth for identical dimensions, highest first', () => {
+    expect(
+      sortedIds([
+        { id: '1080p-low', width: 1920, height: 1080, bandwidth: 3_000_000 },
+        { id: '1080p-high', width: 1920, height: 1080, bandwidth: 6_000_000 },
+      ])
+    ).toEqual(['1080p-high', '1080p-low']);
   });
 
-  it('selects default track when available', () => {
-    const tracks: PartiallyResolvedAudioTrack[] = [
-      {
-        type: 'audio',
-        id: 'audio-en',
-        url: 'http://example.com/audio-en.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'English',
-        sampleRate: 48000,
-        channels: 2,
-      },
-      {
-        type: 'audio',
-        id: 'audio-es',
-        url: 'http://example.com/audio-es.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'Spanish',
-        default: true,
-        sampleRate: 48000,
-        channels: 2,
-      },
-    ];
-
-    const presentation = createPresentation({ audio: tracks });
-
-    const selected = pickAudioTrack(presentation);
-    expect(selected).toBe('audio-es');
+  it('sorts a track with unknown dimensions last, since its area reads as 0', () => {
+    expect(
+      sortedIds([
+        { id: 'unknown', bandwidth: 9_000_000 },
+        { id: '360p', width: 640, height: 360, bandwidth: 500_000 },
+      ])
+    ).toEqual(['360p', 'unknown']);
   });
 
-  it('prefers language match over default flag', () => {
-    const tracks: PartiallyResolvedAudioTrack[] = [
-      {
-        type: 'audio',
-        id: 'audio-en',
-        url: 'http://example.com/audio-en.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'English',
-        language: 'en',
-        sampleRate: 48000,
-        channels: 2,
-      },
-      {
-        type: 'audio',
-        id: 'audio-es',
-        url: 'http://example.com/audio-es.m3u8',
-        bandwidth: 128_000,
-        mimeType: 'audio/mp4',
-        codecs: ['mp4a.40.2'],
-        groupId: 'audio',
-        name: 'Spanish',
-        language: 'es',
-        default: true,
-        sampleRate: 48000,
-        channels: 2,
-      },
-    ];
-
-    const presentation = createPresentation({ audio: tracks });
-
-    const selected = pickAudioTrack(presentation, { preferredAudioLanguage: 'en' });
-    expect(selected).toBe('audio-en');
-  });
-
-  it('returns undefined when no audio tracks', () => {
-    const presentation = createPresentation({ video: [] });
-
-    const selected = pickAudioTrack(presentation);
-    expect(selected).toBeUndefined();
-  });
-});
-
-describe('pickTextTrack', () => {
-  it('returns undefined by default (user opt-in)', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    const selected = pickTextTrack(presentation);
-    expect(selected).toBeUndefined();
-  });
-
-  it('returns undefined when no text tracks', () => {
-    const presentation = createPresentation({ video: [] });
-
-    const selected = pickTextTrack(presentation);
-    expect(selected).toBeUndefined();
-  });
-
-  it('excludes FORCED tracks by default', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-      {
-        type: 'text' as const,
-        id: 'text-en-forced',
-        url: 'http://example.com/text-en-forced.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English (Forced)',
-        kind: 'subtitles' as const,
-        language: 'en',
-        forced: true,
-        default: true,
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    // FORCED track excluded by default, even with DEFAULT=YES
-    const selected = pickTextTrack(presentation, { enableDefaultTrack: true });
-    expect(selected).toBeUndefined();
-  });
-
-  it('includes FORCED tracks when includeForcedTracks enabled', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-      {
-        type: 'text' as const,
-        id: 'text-en-forced',
-        url: 'http://example.com/text-en-forced.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English (Forced)',
-        kind: 'subtitles' as const,
-        language: 'en',
-        forced: true,
-        default: true,
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    // FORCED track included and selected when enabled
-    const selected = pickTextTrack(presentation, {
-      includeForcedTracks: true,
-      enableDefaultTrack: true,
-    });
-    expect(selected).toBe('text-en-forced');
-  });
-
-  it('selects preferred language when specified', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-      {
-        type: 'text' as const,
-        id: 'text-es',
-        url: 'http://example.com/text-es.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'Spanish',
-        kind: 'subtitles' as const,
-        language: 'es',
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    const selected = pickTextTrack(presentation, { preferredSubtitleLanguage: 'es' });
-    expect(selected).toBe('text-es');
-  });
-
-  it('selects DEFAULT track when enableDefaultTrack is true', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-      {
-        type: 'text' as const,
-        id: 'text-es',
-        url: 'http://example.com/text-es.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'Spanish',
-        kind: 'subtitles' as const,
-        language: 'es',
-        default: true,
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    const selected = pickTextTrack(presentation, { enableDefaultTrack: true });
-    expect(selected).toBe('text-es');
-  });
-
-  it('does NOT select DEFAULT track when enableDefaultTrack is false', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-      {
-        type: 'text' as const,
-        id: 'text-es',
-        url: 'http://example.com/text-es.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'Spanish',
-        kind: 'subtitles' as const,
-        language: 'es',
-        default: true,
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    // enableDefaultTrack defaults to false
-    const selected = pickTextTrack(presentation);
-    expect(selected).toBeUndefined();
-  });
-
-  it('prefers language match over DEFAULT flag', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en',
-        url: 'http://example.com/text-en.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English',
-        kind: 'subtitles' as const,
-        language: 'en',
-      },
-      {
-        type: 'text' as const,
-        id: 'text-es',
-        url: 'http://example.com/text-es.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'Spanish',
-        kind: 'subtitles' as const,
-        language: 'es',
-        default: true,
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    // Preferred language trumps DEFAULT
-    const selected = pickTextTrack(presentation, {
-      preferredSubtitleLanguage: 'en',
-      enableDefaultTrack: true,
-    });
-    expect(selected).toBe('text-en');
-  });
-
-  it('returns undefined when all tracks are FORCED and includeForcedTracks is false', () => {
-    const tracks = [
-      {
-        type: 'text' as const,
-        id: 'text-en-forced',
-        url: 'http://example.com/text-en-forced.m3u8',
-        bandwidth: 256,
-        mimeType: 'application/mp4',
-        codecs: [],
-        groupId: 'text',
-        label: 'English (Forced)',
-        kind: 'subtitles' as const,
-        language: 'en',
-        forced: true,
-      },
-    ];
-
-    const presentation = createPresentation({ text: tracks });
-
-    // All tracks filtered out - no selection
-    const selected = pickTextTrack(presentation, { enableDefaultTrack: true });
-    expect(selected).toBeUndefined();
+  // Anamorphic again, from the ranking side: fewer pixels loses despite more height.
+  it('ranks by area rather than height', () => {
+    expect(
+      sortedIds([
+        { id: 'wide', width: 3840, height: 1714, bandwidth: 12_000_000 },
+        { id: 'uhd', width: 3840, height: 2160, bandwidth: 15_000_000 },
+      ])
+    ).toEqual(['uhd', 'wide']);
   });
 });

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -4,6 +4,7 @@ import { effect } from '../../../core/signals/effect';
 import {
   SVTA_NO_SUPPORTED_VIDEO_TRACK,
   SVTA_UNSUPPORTED_DRM_SYSTEM,
+  SVTA_UNSUPPORTED_PLAYBACK_FEATURE,
   SVTA_UNSUPPORTED_VIDEO_FORMAT,
   type SvtaError,
 } from '../../../media/errors';
@@ -14,11 +15,13 @@ import {
   type BackgroundVideoEngineState,
   createBackgroundVideoEngine,
 } from '../../engines/hls/engine-background-video';
-import { firstFatal } from '../hls-video/error-surface';
+import { UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE } from '../../primitives/error-messages';
+import { firstFatal, type HlsVideoMediaError, hasUnsupportedFeatureCause } from '../hls-video/error-surface';
 
-// What `error` is: the reported condition itself, so a consumer can name the type
-// it reads without importing from an engine-level path.
-export type { SvtaError } from '../../../media/errors';
+// The same error shape the video and audio Medias expose, under the name they
+// publish it as — one type for all three surfaces rather than a background-flavored
+// copy of it.
+export type { HlsVideoMediaError } from '../hls-video/error-surface';
 
 export interface HlsBackgroundVideoMediaProps {
   src: string;
@@ -30,7 +33,7 @@ export const hlsBackgroundVideoMediaDefaultProps: HlsBackgroundVideoMediaProps =
 
 export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps {
   readonly engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
-  readonly error: SvtaError | null;
+  readonly error: HlsVideoMediaError | null;
   attach(mediaElement: HTMLMediaElement): void;
   detach(): void;
   destroy(): void;
@@ -77,7 +80,8 @@ const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([
  * (measured on Chromium and WebKit) — so a consumer that watched only the
  * `<video>` would see a source that never appears and never says why. The engine
  * reports each condition onto `engine.state.errors` and logs it; this adapter
- * promotes the first fatal one. See `internal/design/spf/features/errors.md`.
+ * promotes the first fatal one, mapping it the same way the video and audio Medias
+ * map theirs. See `internal/design/spf/features/errors.md`.
  *
  * Selection pins the largest rendition that *fits the screen*, and holds it for
  * the session. The manifest is still the better place to narrow further: a
@@ -121,7 +125,13 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
     #engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
     #config: BackgroundVideoEngineConfig;
     #signals!: BackgroundVideoEngineSignals;
-    #error: SvtaError | null = null;
+    #error: HlsVideoMediaError | null = null;
+    /**
+     * The *reported* condition currently surfaced, which is what the re-fire latch
+     * keys on. Not `#error.code`: that's the code this adapter chose to surface,
+     * and the substitution below can make the two differ.
+     */
+    #reportedCode: number | null = null;
     #stopErrorSync: () => void;
 
     /** Pending loadstart listener from a deferred play() retry, if any. */
@@ -139,7 +149,8 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
       // the slot per source, so a new source starts with no error without this
       // needing its own source-change hook.
       this.#stopErrorSync = effect(() => {
-        this.#setError(firstFatal(this.#signals.state.errors.get(), FATAL_SVTA_CODES));
+        const errors = this.#signals.state.errors.get();
+        this.#setError(firstFatal(errors, FATAL_SVTA_CODES), errors);
       });
     }
 
@@ -154,29 +165,46 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
      * fatal is wider here than on the video and audio Medias; see
      * {@link FATAL_SVTA_CODES}. Resets per source. Fires `'error'` when set.
      *
-     * The reported {@link SvtaError} itself, unmapped: the video and audio Medias
-     * translate a condition into an `ErrorLike` for the store's error feature and
-     * the dialog above it, and a background video has neither — no store features,
-     * no chrome, nothing to localize copy into. So the code the engine reported is
-     * more use to a consumer here than a translation of it would be.
+     * Mapped the same way theirs are: a sequence holding an
+     * unimplemented-capability cause surfaces as
+     * {@link SVTA_UNSUPPORTED_PLAYBACK_FEATURE} (99001) with the specifics logged,
+     * because "this player can't play this source" is what a consumer can act on,
+     * where a raw container or DRM code only says what to go and look up.
      */
-    get error(): SvtaError | null {
+    get error(): HlsVideoMediaError | null {
       return this.#error;
     }
 
-    #setError(reported: SvtaError | undefined): void {
+    #setError(reported: SvtaError | undefined, errors: readonly SvtaError[] | undefined): void {
       if (!reported) {
         // Cleared (new source). No event: `'error'` announces a failure, and
         // consumers reset their own copy on source change.
         this.#error = null;
+        this.#reportedCode = null;
         return;
       }
       // Keyed on the code, not the object: a later append re-runs this effect
       // with an equal-but-new array, and re-firing `'error'` for a condition
       // already surfaced would look like a second failure.
-      if (this.#error?.code === reported.code) return;
+      if (this.#reportedCode === reported.code) return;
+      this.#reportedCode = reported.code;
 
-      this.#error = reported;
+      const unsupported = hasUnsupportedFeatureCause(errors);
+      if (unsupported) {
+        // The prose lives here rather than on `error.message`, matching the other
+        // two: viewer-facing copy is the consumer's to localize from the code, and
+        // a background video has no chrome to put it in anyway. No
+        // alternative-Media sentence, unlike the Mux Medias — nothing in this repo
+        // plays an HLS background video that this engine can't, so there is no
+        // sibling to name.
+        console.error(UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE, { conditions: errors });
+      }
+
+      this.#error = {
+        code: unsupported ? SVTA_UNSUPPORTED_PLAYBACK_FEATURE : reported.code,
+        message: reported.message ?? '',
+        ...(reported.data === undefined ? {} : { data: reported.data }),
+      };
       // Optional-chained: with an EventTarget-less base (`HlsBackgroundVideoMediaElement`
       // standalone) there's nowhere to dispatch.
       this.dispatchEvent?.(new Event('error'));

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -1,7 +1,5 @@
 import type { Constructor, MixinReturn } from '@videojs/utils/types';
 import type { Composition } from '../../../core/composition/create-composition';
-import { pickTrackUnderPixelArea, type TrackPicker } from '../../../media/primitives/select-tracks';
-import type { VideoSelectionSet } from '../../../media/types';
 import {
   type BackgroundVideoEngineConfig,
   type BackgroundVideoEngineContext,
@@ -30,7 +28,7 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
  * Mixin that adds the background-video SPF playback engine to any base class,
  * for an HLS URL.
  *
- * `src` is the whole surface, and the picker always pins the top rendition on
+ * `src` is the whole surface, and selection always pins the top rendition on
  * offer. There is no cap of its own because the manifest is the better place to
  * narrow one: a delivery param — `?max_resolution=720p` on a Mux stream URL, for
  * one — keeps the renditions it excludes out of the manifest entirely, rather
@@ -165,16 +163,10 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
     // -------------------------------------------------------------------------
 
     #createEngine(): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
-      // No cap to apply, so the pick is whichever rendition is largest. Passing
-      // no maximum is what makes that the answer, rather than a rule of its own.
-      const adapterPicker: TrackPicker = (presentation) => {
-        const videoSet = presentation.selectionSets?.find((s) => s.type === 'video') as VideoSelectionSet | undefined;
-        const tracks = videoSet?.switchingSets[0]?.tracks ?? [];
-        return pickTrackUnderPixelArea(tracks)?.id;
-      };
-
+      // No selection config of its own: the engine's default rule chain already
+      // narrows to the largest rendition on offer, which is exactly what this
+      // adapter used to hand over as a bespoke picker.
       return createBackgroundVideoEngine({
-        picker: adapterPicker,
         ...this.#config,
         onSignalsReady: (signals) => {
           this.#signals = signals;

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -1,7 +1,12 @@
 import type { Constructor, MixinReturn } from '@videojs/utils/types';
 import type { Composition } from '../../../core/composition/create-composition';
 import { effect } from '../../../core/signals/effect';
-import { SVTA_NO_SUPPORTED_VIDEO_TRACK, type SvtaError } from '../../../media/errors';
+import {
+  SVTA_NO_SUPPORTED_VIDEO_TRACK,
+  SVTA_UNSUPPORTED_DRM_SYSTEM,
+  SVTA_UNSUPPORTED_VIDEO_FORMAT,
+  type SvtaError,
+} from '../../../media/errors';
 import {
   type BackgroundVideoEngineConfig,
   type BackgroundVideoEngineContext,
@@ -38,13 +43,28 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
  * (§Approach: "impact varies with player implementation"), so it's decided at
  * this boundary rather than by the reporter.
  *
- * One code, where the video adapter's list has two: this engine composes video
- * selection alone, so the video verdict is the only verdict it can ever report.
- * The per-rendition causes (unsupported format, unsupported DRM) stay in the
- * sequence as context — one unplayable rendition doesn't fail a source that goes
- * on to play the rest.
+ * **Causes are fatal here, unlike on the other two adapters.** There, a cause is
+ * context — one unplayable rendition doesn't fail a source whose others still
+ * play, and a verdict follows if the type empties. In the pinned variant a cause
+ * *is* the verdict: only the pinned rendition's playlist is ever resolved, so a
+ * cause can only be about the pick itself, and dropping that pick is final —
+ * nothing here re-picks (that is what `switchVideoTrack` exists for, and this
+ * engine doesn't compose it). Measured on Chromium: an MPEG-TS source reports
+ * 1004 and an encrypted one 4008, each with no verdict behind it, and the element
+ * then sits at `readyState 0` with `error` null forever.
+ *
+ * The verdict is still listed, for the one shape that reports nothing else: a
+ * source offering no video renditions at all, which `reportAbsentTrackType`
+ * reports from the head of the constraint chain.
+ *
+ * First-fatal-wins then surfaces the cause rather than the verdict when both are
+ * present, which is the more specific of the two.
  */
-const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([SVTA_NO_SUPPORTED_VIDEO_TRACK]);
+const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([
+  SVTA_NO_SUPPORTED_VIDEO_TRACK,
+  SVTA_UNSUPPORTED_VIDEO_FORMAT,
+  SVTA_UNSUPPORTED_DRM_SYSTEM,
+]);
 
 /**
  * Mixin that adds the background-video SPF playback engine to any base class,
@@ -130,8 +150,9 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
     /**
      * The current fatal condition, or `null`. Only *fatal* ones appear here — the
      * engine reports non-fatal ones too (they stay in `engine.state.errors`), and
-     * promoting them would say playback had failed when it hadn't. Resets per
-     * source. Fires `'error'` when set.
+     * promoting them would say playback had failed when it hadn't. Which ones are
+     * fatal is wider here than on the video and audio Medias; see
+     * {@link FATAL_SVTA_CODES}. Resets per source. Fires `'error'` when set.
      *
      * The reported {@link SvtaError} itself, unmapped: the video and audio Medias
      * translate a condition into an `ErrorLike` for the store's error feature and

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -28,12 +28,24 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
  * Mixin that adds the background-video SPF playback engine to any base class,
  * for an HLS URL.
  *
- * `src` is the whole surface, and selection always pins the top rendition on
- * offer. There is no cap of its own because the manifest is the better place to
- * narrow one: a delivery param — `?max_resolution=720p` on a Mux stream URL, for
- * one — keeps the renditions it excludes out of the manifest entirely, rather
- * than fetched-then-unpicked. Deriving a cap from the screen instead is on the
- * roadmap, and lands here when it does.
+ * `src` is the whole surface. Failures are deliberately not on it: nothing about
+ * an unplayable source reaches the media element on its own here — an unsupported
+ * container, encryption with no EME, and an undecodable codec all leave
+ * `HTMLMediaElement.error` null with the element stalled at `readyState 0`
+ * (measured on Chromium and WebKit) — so the engine reports them onto
+ * `engine.state.errors` and logs each one instead. See
+ * `internal/design/spf/features/errors.md`.
+ *
+ * Selection pins the largest rendition that *fits the screen*, and holds it for
+ * the session. The manifest is still the better place to narrow further: a
+ * delivery param — `?max_resolution=720p` on a Mux stream URL, for one — keeps
+ * the renditions it excludes out of the manifest entirely, rather than
+ * fetched-then-unpicked.
+ *
+ * The pin is given up, never moved, if the pick turns out to be unplayable: the
+ * container is only known once a media playlist resolves, which is after the pick
+ * is made, so the selection clears rather than quietly appending bytes nothing can
+ * decode.
  *
  * `@videojs/spf/mux-background-video` is this same Media under a Mux-flavored
  * name — an alias, not a variant. Nothing about the surface changes with the
@@ -164,8 +176,8 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
 
     #createEngine(): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
       // No selection config of its own: the engine's default rule chain already
-      // narrows to the largest rendition on offer, which is exactly what this
-      // adapter used to hand over as a bespoke picker.
+      // narrows to the largest rendition that fits the screen, which is exactly
+      // what this adapter used to hand over as a bespoke picker.
       return createBackgroundVideoEngine({
         ...this.#config,
         onSignalsReady: (signals) => {

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -1,5 +1,7 @@
 import type { Constructor, MixinReturn } from '@videojs/utils/types';
 import type { Composition } from '../../../core/composition/create-composition';
+import { effect } from '../../../core/signals/effect';
+import { SVTA_NO_SUPPORTED_VIDEO_TRACK, type SvtaError } from '../../../media/errors';
 import {
   type BackgroundVideoEngineConfig,
   type BackgroundVideoEngineContext,
@@ -7,6 +9,11 @@ import {
   type BackgroundVideoEngineState,
   createBackgroundVideoEngine,
 } from '../../engines/hls/engine-background-video';
+import { firstFatal } from '../hls-video/error-surface';
+
+// What `error` is: the reported condition itself, so a consumer can name the type
+// it reads without importing from an engine-level path.
+export type { SvtaError } from '../../../media/errors';
 
 export interface HlsBackgroundVideoMediaProps {
   src: string;
@@ -18,6 +25,7 @@ export const hlsBackgroundVideoMediaDefaultProps: HlsBackgroundVideoMediaProps =
 
 export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps {
   readonly engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
+  readonly error: SvtaError | null;
   attach(mediaElement: HTMLMediaElement): void;
   detach(): void;
   destroy(): void;
@@ -25,16 +33,31 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
 }
 
 /**
+ * Which reported conditions this composition treats as **fatal** — the ones that
+ * reach `error` and fire `'error'`. Severity isn't part of an SVTA code
+ * (§Approach: "impact varies with player implementation"), so it's decided at
+ * this boundary rather than by the reporter.
+ *
+ * One code, where the video adapter's list has two: this engine composes video
+ * selection alone, so the video verdict is the only verdict it can ever report.
+ * The per-rendition causes (unsupported format, unsupported DRM) stay in the
+ * sequence as context — one unplayable rendition doesn't fail a source that goes
+ * on to play the rest.
+ */
+const FATAL_SVTA_CODES: ReadonlySet<number> = new Set<number>([SVTA_NO_SUPPORTED_VIDEO_TRACK]);
+
+/**
  * Mixin that adds the background-video SPF playback engine to any base class,
  * for an HLS URL.
  *
- * `src` is the whole surface. Failures are deliberately not on it: nothing about
+ * `src` is the whole input surface, and `error` is the one output: nothing about
  * an unplayable source reaches the media element on its own here — an unsupported
  * container, encryption with no EME, and an undecodable codec all leave
  * `HTMLMediaElement.error` null with the element stalled at `readyState 0`
- * (measured on Chromium and WebKit) — so the engine reports them onto
- * `engine.state.errors` and logs each one instead. See
- * `internal/design/spf/features/errors.md`.
+ * (measured on Chromium and WebKit) — so a consumer that watched only the
+ * `<video>` would see a source that never appears and never says why. The engine
+ * reports each condition onto `engine.state.errors` and logs it; this adapter
+ * promotes the first fatal one. See `internal/design/spf/features/errors.md`.
  *
  * Selection pins the largest rendition that *fits the screen*, and holds it for
  * the session. The manifest is still the better place to narrow further: a
@@ -63,6 +86,8 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
  * engine instance and the attached media element are both kept, so neither has to
  * be rewired.
  *
+ * @fires error - Fired when a fatal condition is reported. Read `error` for it.
+ *
  * @example
  * class HlsBackgroundVideoMedia extends HlsBackgroundVideoMediaMixin(BackgroundVideoHost) {}
  *
@@ -76,6 +101,8 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
     #engine: Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext>;
     #config: BackgroundVideoEngineConfig;
     #signals!: BackgroundVideoEngineSignals;
+    #error: SvtaError | null = null;
+    #stopErrorSync: () => void;
 
     /** Pending loadstart listener from a deferred play() retry, if any. */
     #loadstartListener: (() => void) | null = null;
@@ -86,10 +113,52 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
       const { config } = args?.[0] ?? {};
       this.#config = config;
       this.#engine = this.#createEngine();
+
+      // Promote the first fatal condition out of the engine's reported sequence
+      // onto this surface. Clearing rides the same signal: `collectErrors` resets
+      // the slot per source, so a new source starts with no error without this
+      // needing its own source-change hook.
+      this.#stopErrorSync = effect(() => {
+        this.#setError(firstFatal(this.#signals.state.errors.get(), FATAL_SVTA_CODES));
+      });
     }
 
     get engine(): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
       return this.#engine;
+    }
+
+    /**
+     * The current fatal condition, or `null`. Only *fatal* ones appear here — the
+     * engine reports non-fatal ones too (they stay in `engine.state.errors`), and
+     * promoting them would say playback had failed when it hadn't. Resets per
+     * source. Fires `'error'` when set.
+     *
+     * The reported {@link SvtaError} itself, unmapped: the video and audio Medias
+     * translate a condition into an `ErrorLike` for the store's error feature and
+     * the dialog above it, and a background video has neither — no store features,
+     * no chrome, nothing to localize copy into. So the code the engine reported is
+     * more use to a consumer here than a translation of it would be.
+     */
+    get error(): SvtaError | null {
+      return this.#error;
+    }
+
+    #setError(reported: SvtaError | undefined): void {
+      if (!reported) {
+        // Cleared (new source). No event: `'error'` announces a failure, and
+        // consumers reset their own copy on source change.
+        this.#error = null;
+        return;
+      }
+      // Keyed on the code, not the object: a later append re-runs this effect
+      // with an equal-but-new array, and re-firing `'error'` for a condition
+      // already surfaced would look like a second failure.
+      if (this.#error?.code === reported.code) return;
+
+      this.#error = reported;
+      // Optional-chained: with an EventTarget-less base (`HlsBackgroundVideoMediaElement`
+      // standalone) there's nowhere to dispatch.
+      this.dispatchEvent?.(new Event('error'));
     }
 
     // -------------------------------------------------------------------------
@@ -118,6 +187,7 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
 
     destroy(): void {
       this.#cancelPendingPlay();
+      this.#stopErrorSync();
       this.#engine.destroy();
     }
 

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -15,7 +15,7 @@ import {
   type BackgroundVideoEngineState,
   createBackgroundVideoEngine,
 } from '../../engines/hls/engine-background-video';
-import { UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE } from '../../primitives/error-messages';
+import { UNPLAYABLE_SOURCE_MESSAGE } from '../../primitives/error-messages';
 import { firstFatal, type HlsVideoMediaError, hasUnsupportedFeatureCause } from '../hls-video/error-surface';
 
 // The same error shape the video and audio Medias expose, under the name they
@@ -189,19 +189,18 @@ export function HlsBackgroundVideoMediaMixin<Base extends Constructor<any>>(Base
       if (this.#reportedCode === reported.code) return;
       this.#reportedCode = reported.code;
 
-      const unsupported = hasUnsupportedFeatureCause(errors);
-      if (unsupported) {
-        // The prose lives here rather than on `error.message`, matching the other
-        // two: viewer-facing copy is the consumer's to localize from the code, and
-        // a background video has no chrome to put it in anyway. No
-        // alternative-Media sentence, unlike the Mux Medias — nothing in this repo
-        // plays an HLS background video that this engine can't, so there is no
-        // sibling to name.
-        console.error(UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE, { conditions: errors });
-      }
+      // Logged for every fatal condition, not just the substituted ones: a source
+      // with no video renditions is as dead as an unplayable container, and it
+      // would otherwise reach a developer as a bare code. One generic sentence
+      // rather than one per case — the conditions beside it carry the specifics.
+      //
+      // Prose stays here rather than on `error.message`, matching the other two:
+      // viewer-facing copy is the consumer's to localize, and a background video
+      // has no chrome to put it in anyway.
+      console.error(UNPLAYABLE_SOURCE_MESSAGE, { conditions: errors });
 
       this.#error = {
-        code: unsupported ? SVTA_UNSUPPORTED_PLAYBACK_FEATURE : reported.code,
+        code: hasUnsupportedFeatureCause(errors) ? SVTA_UNSUPPORTED_PLAYBACK_FEATURE : reported.code,
         message: reported.message ?? '',
         ...(reported.data === undefined ? {} : { data: reported.data }),
       };

--- a/packages/spf/src/playback/adapters/hls-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/index.ts
@@ -17,7 +17,7 @@
  * Mux-flavored names. Same classes, so the import path is a naming choice and
  * nothing more.
  */
-export type { HlsBackgroundVideoMediaAPI, HlsBackgroundVideoMediaProps, SvtaError } from './adapter';
+export type { HlsBackgroundVideoMediaAPI, HlsBackgroundVideoMediaProps, HlsVideoMediaError } from './adapter';
 export {
   HlsBackgroundVideoMediaElement,
   HlsBackgroundVideoMediaMixin,

--- a/packages/spf/src/playback/adapters/hls-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/index.ts
@@ -2,10 +2,11 @@
  * The Media over the background-video engine — SPF's public playback surface for
  * the muted, looping, chrome-less case, from an HLS URL.
  *
- * `src` is the whole surface, and the picker pins the top rendition the manifest
- * offers. Narrowing that set is a delivery concern rather than a property here —
- * a Mux stream URL's `?max_resolution=720p`, for one, keeps the renditions it
- * excludes out of the manifest instead of merely unpicked.
+ * `src` is the whole input surface and `error` the one output; selection pins the
+ * largest rendition that fits the screen and holds it for the session. Narrowing
+ * further is a delivery concern rather than a property here — a Mux stream URL's
+ * `?max_resolution=720p`, for one, keeps the renditions it excludes out of the
+ * manifest instead of merely unpicked.
  *
  * Separate from `@videojs/spf/hls`, where the engine itself ships beside the
  * other HLS engines, for the same reason the HLS Medias are: wiring an engine
@@ -16,7 +17,7 @@
  * Mux-flavored names. Same classes, so the import path is a naming choice and
  * nothing more.
  */
-export type { HlsBackgroundVideoMediaAPI, HlsBackgroundVideoMediaProps } from './adapter';
+export type { HlsBackgroundVideoMediaAPI, HlsBackgroundVideoMediaProps, SvtaError } from './adapter';
 export {
   HlsBackgroundVideoMediaElement,
   HlsBackgroundVideoMediaMixin,

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -14,9 +14,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   SVTA_NO_SUPPORTED_VIDEO_TRACK,
   SVTA_UNSUPPORTED_DRM_SYSTEM,
+  SVTA_UNSUPPORTED_PLAYBACK_FEATURE,
   SVTA_UNSUPPORTED_VIDEO_FORMAT,
 } from '../../../../media/errors';
 import type { MaybeResolvedPresentation } from '../../../../media/types';
+import { UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE } from '../../../primitives/error-messages';
 import { HlsBackgroundVideoMediaElement, HlsBackgroundVideoMediaMixin } from '../adapter';
 
 describe('HlsBackgroundVideoMediaElement', () => {
@@ -275,9 +277,9 @@ describe('HlsBackgroundVideoMediaElement', () => {
       media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
       await flush();
 
-      // The condition as reported: nothing here maps it onto a generic media
-      // error, since this Media has no dialog above it to localize copy for.
-      expect(media.error).toEqual({ code: SVTA_NO_SUPPORTED_VIDEO_TRACK });
+      // A verdict with nothing unsupported behind it keeps its own code. No
+      // message: viewer-facing copy is the consumer's to localize from the code.
+      expect(media.error).toEqual({ code: SVTA_NO_SUPPORTED_VIDEO_TRACK, message: '' });
       expect(fired).toHaveLength(1);
       media.destroy();
     });
@@ -291,25 +293,53 @@ describe('HlsBackgroundVideoMediaElement', () => {
       // cause against the pinned rendition and nothing else, because only the
       // pick's playlist resolves and dropping it is final. Verdict-only fatality
       // would leave this a silent stall.
-      media.engine.state.errors.set([
-        { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video', trackId: 'v1', mimeType: 'video/mp2t' } },
-      ]);
+      const data = { trackType: 'video', trackId: 'v1', mimeType: 'video/mp2t' };
+      media.engine.state.errors.set([{ code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data }]);
       await flush();
 
-      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_VIDEO_FORMAT);
+      // Surfaced as the unimplemented-capability code, like the other two Medias:
+      // no retry, CDN, or rendition fixes it. The reporter's context rides along.
+      expect(media.error).toEqual({ code: SVTA_UNSUPPORTED_PLAYBACK_FEATURE, message: '', data });
       expect(fired).toHaveLength(1);
       media.destroy();
     });
 
-    it('surfaces the same way for an encrypted pick', async () => {
+    it('surfaces the same code for an encrypted pick', async () => {
       const media = new TestMedia();
       media.engine.state.errors.set([
         { code: SVTA_UNSUPPORTED_DRM_SYSTEM, data: { trackType: 'video', trackId: 'v1' } },
       ]);
       await flush();
 
-      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_DRM_SYSTEM);
+      // One code for both: the consumer's situation is identical either way, and
+      // the specifics stay on `engine.state.errors` and the console.
+      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_PLAYBACK_FEATURE);
       media.destroy();
+    });
+
+    it('logs the unsupported-feature explanation once, with the conditions attached', async () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const media = new TestMedia();
+        media.engine.state.errors.set([{ code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video' } }]);
+        await flush();
+        media.engine.state.errors.set([
+          { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video' } },
+          { code: SVTA_NO_SUPPORTED_VIDEO_TRACK },
+        ]);
+        await flush();
+
+        // The prose is console-only — `error.message` stays empty — and a later
+        // append must not repeat it.
+        const logged = spy.mock.calls.filter(([message]) => message === UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE);
+        expect(logged).toHaveLength(1);
+        expect(logged[0]?.[1]).toEqual({
+          conditions: [{ code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video' } }],
+        });
+        media.destroy();
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('ignores a condition outside the fatal set', async () => {
@@ -326,18 +356,18 @@ describe('HlsBackgroundVideoMediaElement', () => {
       media.destroy();
     });
 
-    it('surfaces the cause rather than the verdict when the sequence carries both', async () => {
+    it('carries the first fatal condition data even when the code is substituted', async () => {
       const media = new TestMedia();
-      // Sequence order is causal, and first-fatal-wins picks the more specific of
-      // the two — 1004 says what about the source is unplayable, 2011 only that
-      // nothing was selectable.
+      // Sequence order is causal, so the cause is the one whose context rides
+      // along, while both conditions collapse to the same surfaced code.
       media.engine.state.errors.set([
         { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video', trackId: 'v1' } },
         { code: SVTA_NO_SUPPORTED_VIDEO_TRACK },
       ]);
       await flush();
 
-      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_VIDEO_FORMAT);
+      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_PLAYBACK_FEATURE);
+      expect(media.error?.data).toEqual({ trackType: 'video', trackId: 'v1' });
       media.destroy();
     });
 

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -11,8 +11,9 @@
  * test asserts identity and leans on this file for behavior.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SVTA_NO_SUPPORTED_VIDEO_TRACK, SVTA_UNSUPPORTED_VIDEO_FORMAT } from '../../../../media/errors';
 import type { MaybeResolvedPresentation } from '../../../../media/types';
-import { HlsBackgroundVideoMediaElement } from '../adapter';
+import { HlsBackgroundVideoMediaElement, HlsBackgroundVideoMediaMixin } from '../adapter';
 
 describe('HlsBackgroundVideoMediaElement', () => {
   beforeEach(() => {
@@ -243,6 +244,89 @@ describe('HlsBackgroundVideoMediaElement', () => {
       media.engine.state.presentation.set(presentationWithFourTracks());
       await new Promise<void>((resolve) => queueMicrotask(resolve));
       expect(media.engine.state.selectedVideoTrackId.get()).toBe('360p');
+      media.destroy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error surface — error / 'error' event. The only signal an unplayable source
+  // produces here: the inner <video> stays at readyState 0 with `error` null.
+  // ---------------------------------------------------------------------------
+  describe('error surface', () => {
+    class TestMedia extends HlsBackgroundVideoMediaMixin(EventTarget) {}
+
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    it('exposes no error before anything is reported', () => {
+      const media = new TestMedia();
+      expect(media.error).toBeNull();
+      media.destroy();
+    });
+
+    it('surfaces a reported fatal condition and fires error', async () => {
+      const media = new TestMedia();
+      const fired: Event[] = [];
+      media.addEventListener('error', (event) => fired.push(event));
+
+      media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
+      await flush();
+
+      // The condition as reported: nothing here maps it onto a generic media
+      // error, since this Media has no dialog above it to localize copy for.
+      expect(media.error).toEqual({ code: SVTA_NO_SUPPORTED_VIDEO_TRACK });
+      expect(fired).toHaveLength(1);
+      media.destroy();
+    });
+
+    it('leaves the causes in the sequence — only the verdict is fatal', async () => {
+      const media = new TestMedia();
+      const fired: Event[] = [];
+      media.addEventListener('error', (event) => fired.push(event));
+
+      // One unplayable rendition doesn't fail a source whose others still play,
+      // so a cause on its own stays context.
+      media.engine.state.errors.set([
+        { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video', trackId: 'v1' } },
+      ]);
+      await flush();
+
+      expect(media.error).toBeNull();
+      expect(fired).toHaveLength(0);
+      media.destroy();
+    });
+
+    it('fires once per distinct condition, not per re-report', async () => {
+      const media = new TestMedia();
+      const fired: Event[] = [];
+      media.addEventListener('error', (event) => fired.push(event));
+
+      media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
+      await flush();
+      // A later append leaves the first fatal in place; the surface must not
+      // re-fire for the condition it already announced.
+      media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }, { code: SVTA_UNSUPPORTED_VIDEO_FORMAT }]);
+      await flush();
+
+      expect(fired).toHaveLength(1);
+      media.destroy();
+    });
+
+    it('clears when the sequence resets for a new source', async () => {
+      const media = new TestMedia();
+      const fired: Event[] = [];
+      media.addEventListener('error', (event) => fired.push(event));
+
+      media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
+      await flush();
+      expect(media.error).not.toBeNull();
+
+      // collectErrors clears the slot on source change. Clearing is not itself a
+      // failure, so it announces nothing.
+      media.engine.state.errors.set(undefined);
+      await flush();
+
+      expect(media.error).toBeNull();
+      expect(fired).toHaveLength(1);
       media.destroy();
     });
   });

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -219,9 +219,12 @@ describe('HlsBackgroundVideoMediaElement', () => {
       media.destroy();
     });
 
-    it('honors a config-supplied picker, overriding the adapter default', async () => {
-      // The adapter's own picker is spread first, so a consumer-supplied one wins.
-      const media = new HlsBackgroundVideoMediaElement({ config: { picker: () => '360p' } });
+    it('honors a config-supplied rule chain, overriding the engine default', async () => {
+      // The adapter supplies no selection config of its own, so a consumer's chain
+      // replaces the engine's `preferHighestResolution` default outright.
+      const media = new HlsBackgroundVideoMediaElement({
+        config: { rules: [(tracks: readonly { id: string }[]) => tracks.filter((track) => track.id === '360p')] },
+      });
       media.engine.state.presentation.set(presentationWithFourTracks());
       await new Promise<void>((resolve) => queueMicrotask(resolve));
       expect(media.engine.state.selectedVideoTrackId.get()).toBe('360p');

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -197,9 +197,22 @@ describe('HlsBackgroundVideoMediaElement', () => {
 
     it('picks the largest rendition on offer', async () => {
       const media = new HlsBackgroundVideoMediaElement();
+      // The default chain caps to the screen, so this is written explicitly —
+      // left ambient, the expected pick would vary with the runner's display.
+      media.engine.state.screenResolution.set({ width: 3840, height: 2160 });
       media.engine.state.presentation.set(presentationWithFourTracks());
       await new Promise<void>((resolve) => queueMicrotask(resolve));
       expect(media.engine.state.selectedVideoTrackId.get()).toBe('1440p');
+      media.destroy();
+    });
+
+    it('caps the pick to the screen when the manifest offers more than it can show', async () => {
+      const media = new HlsBackgroundVideoMediaElement();
+      // 1080p (2,073,600) is over a 1,555,200 px screen; 720p (921,600) fits.
+      media.engine.state.screenResolution.set({ width: 1440, height: 1080 });
+      media.engine.state.presentation.set(presentationWithFourTracks());
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      expect(media.engine.state.selectedVideoTrackId.get()).toBe('720p');
       media.destroy();
     });
 
@@ -213,6 +226,7 @@ describe('HlsBackgroundVideoMediaElement', () => {
       ] as never;
 
       const media = new HlsBackgroundVideoMediaElement();
+      media.engine.state.screenResolution.set({ width: 3840, height: 2160 });
       media.engine.state.presentation.set(capped);
       await new Promise<void>((resolve) => queueMicrotask(resolve));
       expect(media.engine.state.selectedVideoTrackId.get()).toBe('720p');
@@ -221,7 +235,8 @@ describe('HlsBackgroundVideoMediaElement', () => {
 
     it('honors a config-supplied rule chain, overriding the engine default', async () => {
       // The adapter supplies no selection config of its own, so a consumer's chain
-      // replaces the engine's `preferHighestResolution` default outright.
+      // replaces the engine's `[screenResolutionCap, preferHighestResolution]`
+      // default outright — screen cap included, hence no screen written here.
       const media = new HlsBackgroundVideoMediaElement({
         config: { rules: [(tracks: readonly { id: string }[]) => tracks.filter((track) => track.id === '360p')] },
       });

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -11,7 +11,11 @@
  * test asserts identity and leans on this file for behavior.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { SVTA_NO_SUPPORTED_VIDEO_TRACK, SVTA_UNSUPPORTED_VIDEO_FORMAT } from '../../../../media/errors';
+import {
+  SVTA_NO_SUPPORTED_VIDEO_TRACK,
+  SVTA_UNSUPPORTED_DRM_SYSTEM,
+  SVTA_UNSUPPORTED_VIDEO_FORMAT,
+} from '../../../../media/errors';
 import type { MaybeResolvedPresentation } from '../../../../media/types';
 import { HlsBackgroundVideoMediaElement, HlsBackgroundVideoMediaMixin } from '../adapter';
 
@@ -278,20 +282,62 @@ describe('HlsBackgroundVideoMediaElement', () => {
       media.destroy();
     });
 
-    it('leaves the causes in the sequence — only the verdict is fatal', async () => {
+    it('surfaces a cause with no verdict behind it — the pinned variant never re-picks', async () => {
       const media = new TestMedia();
       const fired: Event[] = [];
       media.addEventListener('error', (event) => fired.push(event));
 
-      // One unplayable rendition doesn't fail a source whose others still play,
-      // so a cause on its own stays context.
+      // What an MPEG-TS source actually produces here (measured on Chromium): a
+      // cause against the pinned rendition and nothing else, because only the
+      // pick's playlist resolves and dropping it is final. Verdict-only fatality
+      // would leave this a silent stall.
       media.engine.state.errors.set([
-        { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video', trackId: 'v1' } },
+        { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video', trackId: 'v1', mimeType: 'video/mp2t' } },
       ]);
+      await flush();
+
+      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_VIDEO_FORMAT);
+      expect(fired).toHaveLength(1);
+      media.destroy();
+    });
+
+    it('surfaces the same way for an encrypted pick', async () => {
+      const media = new TestMedia();
+      media.engine.state.errors.set([
+        { code: SVTA_UNSUPPORTED_DRM_SYSTEM, data: { trackType: 'video', trackId: 'v1' } },
+      ]);
+      await flush();
+
+      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_DRM_SYSTEM);
+      media.destroy();
+    });
+
+    it('ignores a condition outside the fatal set', async () => {
+      const media = new TestMedia();
+      const fired: Event[] = [];
+      media.addEventListener('error', (event) => fired.push(event));
+
+      // 2039 (manifest feature unsupported) is the degraded-but-playable tier.
+      media.engine.state.errors.set([{ code: 2039 }]);
       await flush();
 
       expect(media.error).toBeNull();
       expect(fired).toHaveLength(0);
+      media.destroy();
+    });
+
+    it('surfaces the cause rather than the verdict when the sequence carries both', async () => {
+      const media = new TestMedia();
+      // Sequence order is causal, and first-fatal-wins picks the more specific of
+      // the two — 1004 says what about the source is unplayable, 2011 only that
+      // nothing was selectable.
+      media.engine.state.errors.set([
+        { code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video', trackId: 'v1' } },
+        { code: SVTA_NO_SUPPORTED_VIDEO_TRACK },
+      ]);
+      await flush();
+
+      expect(media.error?.code).toBe(SVTA_UNSUPPORTED_VIDEO_FORMAT);
       media.destroy();
     });
 
@@ -304,7 +350,7 @@ describe('HlsBackgroundVideoMediaElement', () => {
       await flush();
       // A later append leaves the first fatal in place; the surface must not
       // re-fire for the condition it already announced.
-      media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }, { code: SVTA_UNSUPPORTED_VIDEO_FORMAT }]);
+      media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }, { code: 2039 }]);
       await flush();
 
       expect(fired).toHaveLength(1);

--- a/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/tests/adapter.test.ts
@@ -18,7 +18,7 @@ import {
   SVTA_UNSUPPORTED_VIDEO_FORMAT,
 } from '../../../../media/errors';
 import type { MaybeResolvedPresentation } from '../../../../media/types';
-import { UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE } from '../../../primitives/error-messages';
+import { UNPLAYABLE_SOURCE_MESSAGE } from '../../../primitives/error-messages';
 import { HlsBackgroundVideoMediaElement, HlsBackgroundVideoMediaMixin } from '../adapter';
 
 describe('HlsBackgroundVideoMediaElement', () => {
@@ -317,7 +317,7 @@ describe('HlsBackgroundVideoMediaElement', () => {
       media.destroy();
     });
 
-    it('logs the unsupported-feature explanation once, with the conditions attached', async () => {
+    it('logs the explanation once, with the conditions attached', async () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       try {
         const media = new TestMedia();
@@ -331,11 +331,28 @@ describe('HlsBackgroundVideoMediaElement', () => {
 
         // The prose is console-only — `error.message` stays empty — and a later
         // append must not repeat it.
-        const logged = spy.mock.calls.filter(([message]) => message === UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE);
+        const logged = spy.mock.calls.filter(([message]) => message === UNPLAYABLE_SOURCE_MESSAGE);
         expect(logged).toHaveLength(1);
         expect(logged[0]?.[1]).toEqual({
           conditions: [{ code: SVTA_UNSUPPORTED_VIDEO_FORMAT, data: { trackType: 'video' } }],
         });
+        media.destroy();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('explains a source with no video renditions too, not only a substituted code', async () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const media = new TestMedia();
+        // The shape that used to reach a developer as a bare 2011: a verdict with
+        // no cause behind it, so nothing was substituted and nothing was said.
+        media.engine.state.errors.set([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
+        await flush();
+
+        expect(spy.mock.calls.filter(([message]) => message === UNPLAYABLE_SOURCE_MESSAGE)).toHaveLength(1);
+        expect(media.error?.code).toBe(SVTA_NO_SUPPORTED_VIDEO_TRACK);
         media.destroy();
       } finally {
         spy.mockRestore();

--- a/packages/spf/src/playback/adapters/hls-video/error-surface.ts
+++ b/packages/spf/src/playback/adapters/hls-video/error-surface.ts
@@ -1,11 +1,16 @@
 /**
  * The shared half of promoting reported conditions onto a media surface.
  *
- * Both HLS adapters do the same things: pick the first condition they treat as
- * fatal, latch it so a later append doesn't re-fire, and name a better-equipped
- * Media when their own class points at one. Only the *policy* differs — which
- * codes are fatal, which the video adapter and the audio-only adapter answer
- * differently — so that stays with each adapter and everything else lives here.
+ * Every adapter that has one does the same things: pick the first condition it
+ * treats as fatal, latch it so a later append doesn't re-fire, and name a
+ * better-equipped Media when its own class points at one. Only the *policy*
+ * differs — which codes are fatal, which the video, audio-only, and background
+ * adapters each answer differently — so that stays with each adapter and
+ * everything else lives here.
+ *
+ * `firstFatal` is the part all three share. The `ErrorLike` mapping below it is
+ * for the two that feed a store and a dialog; the background adapter surfaces the
+ * reported condition unmapped, so it takes the picker and nothing else.
  *
  * See `internal/design/spf/features/errors.md` for the causes-vs-verdicts split
  * this rests on.

--- a/packages/spf/src/playback/adapters/mux-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/index.ts
@@ -16,6 +16,8 @@
 export type {
   HlsBackgroundVideoMediaAPI as MuxBackgroundVideoMediaAPI,
   HlsBackgroundVideoMediaProps as MuxBackgroundVideoMediaProps,
+  // Not renamed: the SVTA vocabulary is neither Mux- nor adapter-flavored.
+  SvtaError,
 } from '../hls-background-video/adapter';
 export {
   HlsBackgroundVideoMediaElement as MuxBackgroundVideoMediaElement,

--- a/packages/spf/src/playback/adapters/mux-background-video/index.ts
+++ b/packages/spf/src/playback/adapters/mux-background-video/index.ts
@@ -16,8 +16,9 @@
 export type {
   HlsBackgroundVideoMediaAPI as MuxBackgroundVideoMediaAPI,
   HlsBackgroundVideoMediaProps as MuxBackgroundVideoMediaProps,
-  // Not renamed: the SVTA vocabulary is neither Mux- nor adapter-flavored.
-  SvtaError,
+  // Not renamed: one error shape is shared by every SPF Media, so a Mux-flavored
+  // alias of it would imply a variant that doesn't exist.
+  HlsVideoMediaError,
 } from '../hls-background-video/adapter';
 export {
   HlsBackgroundVideoMediaElement as MuxBackgroundVideoMediaElement,

--- a/packages/spf/src/playback/behaviors/collect-errors.ts
+++ b/packages/spf/src/playback/behaviors/collect-errors.ts
@@ -25,9 +25,10 @@
 
 import { defineBehavior } from '../../core/composition/create-composition';
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
-import { computed, type ReadonlySignal, type Signal, update } from '../../core/signals/primitives';
+import { computed, peek, type ReadonlySignal, type Signal, update } from '../../core/signals/primitives';
 import type { SvtaError } from '../../media/errors';
 import { isResolvedPresentation, type MaybeResolvedPresentation } from '../../media/types';
+import type { SelectionRule } from '../primitives/selection-rules';
 
 export interface CollectErrorsState {
   presentation?: MaybeResolvedPresentation;
@@ -66,6 +67,43 @@ export function emitError(state: ErrorEmitterState, error: SvtaError): void {
   console.error('[spf] reported condition', error);
   if (!state.errors) return;
   update(state.errors, (errors) => [...(errors ?? []), error]);
+}
+
+/**
+ * A "constraint" that reports a type the source carries **no** renditions of, for
+ * a composition that can't play without it.
+ *
+ * Strange on purpose, and the strangeness is the point: it never constrains
+ * anything, always returning its input untouched. It is shaped as a rule so a
+ * composition opts in by adding it to `constraints` — nothing to thread through
+ * config, and no cost at all to a composition that leaves it out.
+ *
+ * **Belongs first in the chain.** A constraint sees the list as it stands at its
+ * own position, so only at the head does an empty input mean "the source offers
+ * none of this type" rather than "the constraints ahead of me pruned them all."
+ *
+ * This is the one failure no per-rendition cause can report: causes come from
+ * `reportUnsupportedTrackConditions` as each media playlist resolves, and here
+ * nothing resolves, because there is nothing to resolve. Everything else already
+ * reports something more specific than a verdict.
+ *
+ * Idempotent because the constraint chain runs inside a `computed` that re-derives
+ * on every `presentation` write — segment appends and live reloads included — and
+ * the sequence deliberately keeps duplicates. `peek` is what keeps that computed
+ * from subscribing to the slot this writes.
+ *
+ * @example
+ * // engine-background-video.ts — video-only, so a source with none can't play
+ * constraints: [reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK), excludeUnplayableTracks]
+ */
+export function reportAbsentTrackType<T>(code: number): SelectionRule<T, ErrorEmitterState> {
+  return (tracks, { state }) => {
+    const reported = state.errors && peek(state.errors);
+    if (!tracks.length && !reported?.some((error) => error.code === code)) {
+      emitError(state, { code });
+    }
+    return tracks;
+  };
 }
 
 /**

--- a/packages/spf/src/playback/behaviors/dom/tests/track-screen-resolution.test.ts
+++ b/packages/spf/src/playback/behaviors/dom/tests/track-screen-resolution.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { StateSignals } from '../../../../core/composition/create-composition';
+import { signal } from '../../../../core/signals/primitives';
+import type { ScreenResolution } from '../../../../media/dom/screen';
+import {
+  type ScreenResolutionState,
+  type TrackScreenResolutionConfig,
+  trackScreenResolution,
+} from '../track-screen-resolution';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** A mutable screen, so a test can move it the way the environment would. */
+function stubScreen(width: number, height: number, ratio = 1) {
+  const screen = Object.assign(new EventTarget(), { width, height, orientation: new EventTarget() });
+  vi.stubGlobal('screen', screen);
+  vi.stubGlobal('devicePixelRatio', ratio);
+  return screen;
+}
+
+function setupTrackScreenResolution(config?: TrackScreenResolutionConfig) {
+  const state: StateSignals<ScreenResolutionState> = {
+    screenResolution: signal<ScreenResolution | undefined>(undefined),
+  };
+  const cleanup = trackScreenResolution.setup({ state, context: {}, config });
+  return { state, cleanup };
+}
+
+describe('trackScreenResolution', () => {
+  it('populates the slot at setup, not on the first change', () => {
+    // The watcher reports its starting value, so nothing downstream sees
+    // `undefined` while waiting for a screen that may never change.
+    stubScreen(1440, 900);
+
+    const { state, cleanup } = setupTrackScreenResolution();
+
+    expect(state.screenResolution.get()).toEqual({ width: 1440, height: 900 });
+    cleanup();
+  });
+
+  it('reports device pixels by default', () => {
+    stubScreen(1440, 900, 2);
+
+    const { state, cleanup } = setupTrackScreenResolution();
+
+    expect(state.screenResolution.get()).toEqual({ width: 2880, height: 1800 });
+    cleanup();
+  });
+
+  it('reports CSS pixels when useDevicePixelRatio is off', () => {
+    stubScreen(1440, 900, 2);
+
+    const { state, cleanup } = setupTrackScreenResolution({ useDevicePixelRatio: false });
+
+    expect(state.screenResolution.get()).toEqual({ width: 1440, height: 900 });
+    cleanup();
+  });
+
+  it('tracks the screen changing under the window', () => {
+    const screen = stubScreen(1440, 900);
+    const { state, cleanup } = setupTrackScreenResolution();
+
+    screen.width = 3840;
+    screen.height = 2160;
+    screen.dispatchEvent(new Event('change'));
+
+    expect(state.screenResolution.get()).toEqual({ width: 3840, height: 2160 });
+    cleanup();
+  });
+
+  it('writes undefined where there is no screen to read', () => {
+    // The value a cap reads as "no cap", rather than leaving the slot unwritten.
+    vi.stubGlobal('screen', undefined);
+
+    const { state, cleanup } = setupTrackScreenResolution();
+
+    expect(state.screenResolution.get()).toBeUndefined();
+    cleanup();
+  });
+
+  it('stops writing after cleanup', () => {
+    const screen = stubScreen(1440, 900);
+    const { state, cleanup } = setupTrackScreenResolution();
+
+    cleanup();
+
+    screen.width = 3840;
+    screen.dispatchEvent(new Event('change'));
+
+    expect(state.screenResolution.get()).toEqual({ width: 1440, height: 900 });
+  });
+});

--- a/packages/spf/src/playback/behaviors/dom/track-screen-resolution.ts
+++ b/packages/spf/src/playback/behaviors/dom/track-screen-resolution.ts
@@ -1,0 +1,51 @@
+/**
+ * Mirror the screen's pixel dimensions into reactive state, so a rendition cap
+ * can narrow candidates to what the screen can actually show without reading the
+ * environment at pick time — which would make the picker impure, and would never
+ * re-pick when the screen changed.
+ *
+ * Populated at setup rather than on the first change: `watchScreenResolution`
+ * reports its starting value, so nothing downstream waits on a screen that may
+ * never move. `undefined` where there is no screen to read, which is the value a
+ * cap reads as "no cap" — see `getScreenResolution` on why that beats a zero.
+ *
+ * Reads no other slot, and has no source-identity reset: the screen is
+ * independent of the presentation, so a new `src` doesn't invalidate the reading.
+ */
+import { defineBehavior } from '../../../core/composition/create-composition';
+import type { Signal } from '../../../core/signals/primitives';
+import { type ScreenResolution, watchScreenResolution } from '../../../media/dom/screen';
+
+export interface ScreenResolutionState {
+  screenResolution?: ScreenResolution;
+}
+
+export interface TrackScreenResolutionConfig {
+  /**
+   * Whether the reading is scaled into device pixels. Defaults to `true` — see
+   * `ScreenResolutionOptions.useDevicePixelRatio`, including its note on page
+   * zoom being folded into the ratio outside WebKit.
+   */
+  useDevicePixelRatio?: boolean;
+}
+
+function trackScreenResolutionSetup({
+  state,
+  config,
+}: {
+  state: { screenResolution: Signal<ScreenResolutionState['screenResolution']> };
+  config?: TrackScreenResolutionConfig;
+}): () => void {
+  const useDevicePixelRatio = config?.useDevicePixelRatio ?? true;
+
+  // No `effect` wrapper, unlike its `track*` siblings: they re-subscribe when
+  // `context.mediaElement` changes, and this behavior has no reactive dependency
+  // to re-run on. The watcher's own teardown is the whole cleanup.
+  return watchScreenResolution((resolution) => state.screenResolution.set(resolution), { useDevicePixelRatio });
+}
+
+export const trackScreenResolution = defineBehavior({
+  stateKeys: ['screenResolution'],
+  contextKeys: [],
+  setup: trackScreenResolutionSetup,
+});

--- a/packages/spf/src/playback/behaviors/select-tracks.ts
+++ b/packages/spf/src/playback/behaviors/select-tracks.ts
@@ -1,20 +1,31 @@
 /**
  * **Default audio/video track selection on src load / unselect on src unload.**
  * When a presentation is resolved, sets `selectedVideoTrackId` /
- * `selectedAudioTrackId` to a per-type-picker default if no selection already
- * exists. When the presentation is unset/reset (transitions back to unresolved),
+ * `selectedAudioTrackId` from a per-type default rule chain if no selection
+ * already exists. When the presentation is unset/reset (transitions back to unresolved),
  * clears the selection so a stale id from the previous source doesn't persist.
  *
  * Lifecycle-driven: each transition fires its work once. Does not police the
  * selection between transitions; external writes (user picks, ABR, programmatic
  * filter-driven re-picks) are left alone.
  *
- * Picker is config-driven: each per-type export wires a sensible default
- * (`pickAudioTrack` for audio — three-tier language-aware; `pickFirstTrackId`
- * for video) and the caller can supply their own via `config.picker` for custom
- * selection logic. The behavior's `config` is forwarded to the picker as its
- * second argument, so options like `preferredAudioLanguage` reach the picker
- * without an intermediate wrapping layer.
+ * Selection runs the same rule model `switchVideoTrack` does — a hard
+ * `constraints` pre-pass, then an ordered `rules` chain, with the pick as the
+ * head (see `internal/design/spf/track-switching-model.md`). What differs is
+ * reactivity, not the rules: this evaluates the chain once on resolve and pins
+ * the result, where `switchVideoTrack` re-evaluates inside an effect so its rules
+ * subscribe to bandwidth and user selection. A rule written for one therefore
+ * composes into the other unchanged.
+ *
+ * Both are config-driven, each per-type export wiring a sensible default: audio's
+ * three-tier language policy, and for video the *empty* chain — with nothing
+ * narrowing or reordering, the head is the first candidate. The behavior's
+ * `config` is forwarded to the rules, so options like `preferredAudioLanguage`
+ * reach them without an intermediate layer.
+ *
+ * Note a rule can only pick among real candidates, where the picker it replaced
+ * could return any id at all. An id absent from the manifest was never
+ * selectable, so that narrowing is the point rather than a limitation.
  *
  * Compose `selectVideoTrack` for the simple "pick a default video track"
  * behavior, or `switchVideoTrack` (`./track-switching.ts`) for the
@@ -37,13 +48,14 @@ import { createMachineReactor } from '../../core/reactors/create-machine-reactor
 import { computed, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
 import {
   type AudioSelectionConfig,
-  pickAudioTrack,
-  pickFirstTrackId,
-  type TrackPicker,
+  pickAudioTrackFromTracks,
+  pickTrackUnderPixelArea,
   type TrackSelectionState,
   type VideoSelectionConfig,
 } from '../../media/primitives/select-tracks';
-import { isResolvedPresentation } from '../../media/types';
+import { isResolvedPresentation, type TrackType } from '../../media/types';
+import { getTracksByType } from '../../media/utils/tracks';
+import { applyConstraints, applyRules, type SelectionRule } from '../primitives/selection-rules';
 import { AUDIO_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../primitives/track-types';
 
 // ============================================================================
@@ -52,7 +64,7 @@ import { AUDIO_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../primitives/track-types'
 // `setupTrackSelection` has the same shape as a Behavior `setup` function:
 // `({ state, config }) => Reactor`. Each `selectXTrack` export below calls
 // it from inside its own `defineBehavior` setup, supplying its per-type
-// `selectedKey`, default picker, and forwarded picker config. The lifecycle
+// `selectedKey`, track type, default rule chain, and forwarded config. The lifecycle
 // — pick on entering 'presentation-resolved' if not already selected; clear
 // on entering 'presentation-unresolved' — is shared.
 // ============================================================================
@@ -63,18 +75,26 @@ type SelectStateMap<K extends SelectedTrackKey> = {
   presentation: ReadonlySignal<TrackSelectionState['presentation']>;
 } & { [P in K]: Signal<TrackSelectionState[P]> };
 
-interface TrackSelectionSetupConfig<K extends SelectedTrackKey, PickerConfig> {
+/** A selection rule over this behavior's candidate tracks. */
+export type SelectTrackRule<Config> = SelectionRule<SelectableTrack, unknown, unknown, Config | undefined>;
+
+/** What a rule here needs off a candidate: the id it may become the pick by. */
+type SelectableTrack = { id: string };
+
+interface TrackSelectionSetupConfig<K extends SelectedTrackKey, RuleConfig> {
   selectedKey: K;
-  picker: TrackPicker<PickerConfig>;
-  pickerConfig?: PickerConfig;
+  trackType: TrackType;
+  constraints: readonly SelectTrackRule<RuleConfig>[];
+  rules: readonly SelectTrackRule<RuleConfig>[];
+  ruleConfig?: RuleConfig;
 }
 
-function setupTrackSelection<K extends SelectedTrackKey, PickerConfig>({
+function setupTrackSelection<K extends SelectedTrackKey, RuleConfig>({
   state,
-  config: { selectedKey, picker, pickerConfig },
+  config: { selectedKey, trackType, constraints, rules, ruleConfig },
 }: {
   state: SelectStateMap<K>;
-  config: TrackSelectionSetupConfig<K, PickerConfig>;
+  config: TrackSelectionSetupConfig<K, RuleConfig>;
 }) {
   const derivedStateSignal = computed(() =>
     isResolvedPresentation(state.presentation.get())
@@ -105,7 +125,14 @@ function setupTrackSelection<K extends SelectedTrackKey, PickerConfig>({
             // the reactor's `'presentation-resolved'` gate is exactly
             // `isResolvedPresentation(state.presentation.get())`, which
             // requires a truthy Presentation.
-            const id = picker(state.presentation.get()!, pickerConfig);
+            const deps = { state, config: ruleConfig };
+            const candidates = getTracksByType(state.presentation.get()!, trackType);
+            // Constraints prune the unplayable, then the chain narrows and ranks;
+            // the pick is the head. An empty `rules` chain therefore selects the
+            // first candidate — the same answer `pickFirstTrackId` gave, now a
+            // consequence of the model rather than a separate code path.
+            const survivors = applyRules(rules, applyConstraints(constraints, candidates, deps), deps);
+            const id = survivors[0]?.id;
             if (id) state[selectedKey].set(id);
           }
           return () => state[selectedKey].set(undefined);
@@ -116,28 +143,59 @@ function setupTrackSelection<K extends SelectedTrackKey, PickerConfig>({
 }
 
 // ============================================================================
-// Default pickers
+// Default rules
 //
-// Each variant resolves its picker as `config?.picker ?? <default>` and
-// forwards the whole engine config as `pickerConfig`, so a rich picker
-// (`pickAudioTrack`) reads its options directly. Audio uses its primitive
-// picker as-is; video adapts `pickFirstTrackId` (positional `type` arg) into
-// the `TrackPicker` shape.
+// Each variant resolves its chain as `config?.rules ?? <default>`. The whole
+// behavior config is forwarded as the rules' `config`, so a policy rule reads
+// its own options (`preferredAudioLanguage`) directly off it.
+//
+// Video's default is the *empty* chain: with no rule narrowing or reordering the
+// candidates, the head is the first track — exactly what `pickFirstTrackId` used
+// to return, now falling out of the model instead of being its own code path.
 // ============================================================================
 
-/** Default video picker: first track in the video selection set. */
-const defaultVideoPicker: TrackPicker = (presentation) => pickFirstTrackId(presentation, 'video');
+/** Default video chain: none. The first candidate is the pick. */
+const DEFAULT_VIDEO_RULES: readonly SelectTrackRule<SelectVideoTrackConfig>[] = [];
+
+/**
+ * Default audio chain: the three-tier policy (`preferredAudioLanguage` →
+ * `DEFAULT=YES` → first) as a single narrowing rule. Returning `[]` when nothing
+ * is picked lets `applyRules` fall through to the unnarrowed candidates, so the
+ * head stays the first track — the same last tier the policy itself ends on.
+ */
+const preferAudioPolicy: SelectTrackRule<SelectAudioTrackConfig> = (tracks, { config }) => {
+  const id = pickAudioTrackFromTracks(tracks as readonly { id: string }[], config);
+  const pick = tracks.find((track) => track.id === id);
+  return pick ? [pick] : [];
+};
+
+const DEFAULT_AUDIO_RULES: readonly SelectTrackRule<SelectAudioTrackConfig>[] = [preferAudioPolicy];
+
+/**
+ * Narrow to the largest rendition on offer, by pixel area. The background-video
+ * default — that variant pins one rendition for the session, and absent a cap the
+ * largest is the pick.
+ *
+ * Exported because it is a *rule*, not a variant's private policy: the same one
+ * composes into `switchVideoTrack`'s chain when a ranker is wanted there.
+ */
+export const preferHighestResolution: SelectTrackRule<unknown> = (tracks) => {
+  const pick = pickTrackUnderPixelArea(tracks as readonly { id: string }[]);
+  return pick ? [pick] : [];
+};
 
 // ============================================================================
 // Specialized exports — one per track type
 // ============================================================================
 
 /**
- * Config for `selectVideoTrack`. Pass `picker` to fully override selection
- * logic; otherwise the default `pickFirstTrackId` is used.
+ * Config for `selectVideoTrack`. Pass `rules` to replace the selection chain, or
+ * `constraints` to prune candidates before it runs; otherwise the chain is empty
+ * and the first candidate is the pick.
  */
 export interface SelectVideoTrackConfig extends VideoSelectionConfig {
-  picker?: TrackPicker<SelectVideoTrackConfig>;
+  constraints?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
+  rules?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
 }
 
 /**
@@ -162,19 +220,22 @@ export const selectVideoTrack = defineBehavior({
       state,
       config: {
         selectedKey: VIDEO_TYPE_CONFIG.selectedKey,
-        picker: config?.picker ?? defaultVideoPicker,
-        pickerConfig: config,
+        trackType: 'video',
+        constraints: config?.constraints ?? [],
+        rules: config?.rules ?? DEFAULT_VIDEO_RULES,
+        ruleConfig: config,
       },
     }),
 });
 
 /**
- * Config for `selectAudioTrack`. Pass `picker` to fully override selection
- * logic; otherwise the default `pickAudioTrack` is used (three-tier:
- * `preferredAudioLanguage` → `DEFAULT=YES` → first track).
+ * Config for `selectAudioTrack`. Pass `rules` to replace the selection chain, or
+ * `constraints` to prune candidates before it runs; otherwise the default
+ * three-tier policy applies (`preferredAudioLanguage` → `DEFAULT=YES` → first).
  */
 export interface SelectAudioTrackConfig extends AudioSelectionConfig {
-  picker?: TrackPicker<SelectAudioTrackConfig>;
+  constraints?: readonly SelectTrackRule<SelectAudioTrackConfig>[];
+  rules?: readonly SelectTrackRule<SelectAudioTrackConfig>[];
 }
 
 /**
@@ -194,10 +255,10 @@ export interface SelectAudioTrackConfig extends AudioSelectionConfig {
  * const reactor = selectAudioTrack.setup({ state });
  *
  * @example
- * // Custom picker with language preference
+ * // Language preference, honored by the default audio policy rule
  * const reactor = selectAudioTrack.setup({
  *   state,
- *   config: { preferredAudioLanguage: 'en', picker: myLanguageAwarePicker },
+ *   config: { preferredAudioLanguage: 'en' },
  * });
  */
 export const selectAudioTrack = defineBehavior({
@@ -208,8 +269,10 @@ export const selectAudioTrack = defineBehavior({
       state,
       config: {
         selectedKey: AUDIO_TYPE_CONFIG.selectedKey,
-        picker: config?.picker ?? pickAudioTrack,
-        pickerConfig: config,
+        trackType: 'audio',
+        constraints: config?.constraints ?? [],
+        rules: config?.rules ?? DEFAULT_AUDIO_RULES,
+        ruleConfig: config,
       },
     }),
 });

--- a/packages/spf/src/playback/behaviors/select-tracks.ts
+++ b/packages/spf/src/playback/behaviors/select-tracks.ts
@@ -5,9 +5,17 @@
  * already exists. When the presentation is unset/reset (transitions back to unresolved),
  * clears the selection so a stale id from the previous source doesn't persist.
  *
- * Lifecycle-driven: each transition fires its work once. Does not police the
- * selection between transitions; external writes (user picks, ABR, programmatic
- * filter-driven re-picks) are left alone.
+ * Lifecycle-driven: the pick fires once per transition, and nothing re-picks —
+ * that is what separates these from the `switch*` variants. External writes (user
+ * picks, ABR, programmatic filter-driven re-picks) are left alone, including a
+ * write naming a track the manifest never offered.
+ *
+ * The one thing policed between transitions is a pick the *constraints* turn
+ * against: a rendition's container and encryption are only known once its media
+ * playlist resolves, which is after the pick was made, so a selection that becomes
+ * unplayable is dropped. Dropped, never moved — re-picking is exactly the behavior
+ * `switchVideoTrack` exists to provide. Dropping reports nothing on its own, since
+ * whatever made the pick unplayable already reported its own, more specific cause.
  *
  * Selection runs the same rule model `switchVideoTrack` does — a hard
  * `constraints` pre-pass, then an ordered `rules` chain, with the pick as the
@@ -45,7 +53,7 @@
 
 import { defineBehavior } from '../../core/composition/create-composition';
 import { createMachineReactor } from '../../core/reactors/create-machine-reactor';
-import { computed, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
+import { computed, peek, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
 import {
   type AudioSelectionConfig,
   byDescendingResolution,
@@ -55,7 +63,14 @@ import {
 } from '../../media/primitives/select-tracks';
 import { isResolvedPresentation, type TrackType } from '../../media/types';
 import { getTracksByType } from '../../media/utils/tracks';
-import { applyConstraints, applyRules, type SelectionRule } from '../primitives/selection-rules';
+import {
+  applyConstraints,
+  applyRules,
+  type CapabilityConstraintConfig,
+  excludeUnplayableTracks,
+  type SelectionRule,
+  sameCandidateSet,
+} from '../primitives/selection-rules';
 import { AUDIO_TYPE_CONFIG, VIDEO_TYPE_CONFIG } from '../primitives/track-types';
 
 // ============================================================================
@@ -102,6 +117,27 @@ function setupTrackSelection<K extends SelectedTrackKey, RuleConfig>({
       : ('presentation-unresolved' as const)
   );
 
+  const deps = { state, config: ruleConfig };
+
+  // The playable candidate set — the type's tracks after the hard-constraints
+  // pre-pass. A `computed` so it re-evaluates when its inputs change, which is what
+  // lets a *pinned* selection still notice it has gone unplayable: `resolve-track`
+  // relabels the whole type's container from the first resolved media playlist,
+  // long after `entry` made its pick under the fMP4 default.
+  //
+  // The `equals` gates notification on the set of track ids rather than array
+  // identity, matching `setupTrackSwitching`'s. Segment appends and live reloads
+  // both swap in a new presentation object carrying the same variants; without
+  // this the effect below would re-run on every one of them.
+  const candidateSet = computed(
+    () => {
+      const presentation = state.presentation.get();
+      if (!isResolvedPresentation(presentation)) return [];
+      return applyConstraints(constraints, getTracksByType(presentation, trackType), deps);
+    },
+    { equals: sameCandidateSet }
+  );
+
   return createMachineReactor({
     initial: 'presentation-unresolved',
     monitor: () => derivedStateSignal.get(),
@@ -125,18 +161,50 @@ function setupTrackSelection<K extends SelectedTrackKey, RuleConfig>({
             // the reactor's `'presentation-resolved'` gate is exactly
             // `isResolvedPresentation(state.presentation.get())`, which
             // requires a truthy Presentation.
-            const deps = { state, config: ruleConfig };
-            const candidates = getTracksByType(state.presentation.get()!, trackType);
+            //
             // Constraints prune the unplayable, then the chain narrows and ranks;
             // the pick is the head. An empty `rules` chain therefore selects the
             // first candidate, which falls out of the model rather than needing a
             // first-track code path of its own.
-            const survivors = applyRules(rules, applyConstraints(constraints, candidates, deps), deps);
+            const survivors = applyRules(rules, peek(candidateSet), deps);
             const id = survivors[0]?.id;
             if (id) state[selectedKey].set(id);
           }
           return () => state[selectedKey].set(undefined);
         },
+        effects: [
+          // Selection is `entry`'s alone — this only ever *de*selects. Keeping the
+          // pick out of a reaction is what makes this the pinned variant rather
+          // than a worse-spelled `switchVideoTrack`: nothing here re-ranks or moves
+          // the pin. It has to be a reaction all the same, because what it watches
+          // for is learned late — container and encryption come from a rendition's
+          // media playlist, which resolves after the pick was made.
+          //
+          // Deliberately does *not* report why. Whatever made the pick unplayable
+          // reported its own cause as the playlist resolved (1004 container, 4008
+          // encryption, via `reportUnsupportedTrackConditions`), which is both more
+          // specific than a verdict and already logged. The one condition no cause
+          // covers is nothing being playable at all — no rendition resolved, so
+          // none reported — which is why that alone emits here. See
+          // `internal/design/spf/features/errors.md`.
+          () => {
+            // Untracked: writing the slot below must not re-enter this reaction.
+            const selectedId = peek(state[selectedKey]);
+            if (!selectedId) return;
+            if (candidateSet.get().some((track) => track.id === selectedId)) return;
+
+            // Only a pick the source actually offers is this behavior's to drop. An
+            // id absent from the manifest was never selectable, and external writes
+            // are left alone — see this module's header.
+            const presentation = peek(state.presentation);
+            if (
+              isResolvedPresentation(presentation) &&
+              getTracksByType(presentation, trackType).some((track) => track.id === selectedId)
+            ) {
+              state[selectedKey].set(undefined);
+            }
+          },
+        ],
       },
     },
   });
@@ -245,13 +313,20 @@ export const screenResolutionCap: SelectTrackRule<unknown> = (tracks, { state })
 
 /**
  * Config for `selectVideoTrack`. Pass `rules` to replace the selection chain, or
- * `constraints` to prune candidates before it runs; otherwise the chain is empty
- * and the first candidate is the pick.
+ * `constraints` to replace the capability pre-pass; otherwise the chain is empty
+ * and the first playable candidate is the pick.
  */
-export interface SelectVideoTrackConfig {
+export interface SelectVideoTrackConfig extends CapabilityConstraintConfig {
   constraints?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
   rules?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
 }
+
+/**
+ * Default video constraints: the capability pre-pass alone. No
+ * `excludeFailedCdns` — this variant's compositions run no failover monitor, so
+ * `failedCdns` has no writer and the constraint would always pass through.
+ */
+const DEFAULT_VIDEO_CONSTRAINTS: readonly SelectTrackRule<SelectVideoTrackConfig>[] = [excludeUnplayableTracks];
 
 /**
  * Select a video track when a presentation loads. Clears the selection on
@@ -276,7 +351,7 @@ export const selectVideoTrack = defineBehavior({
       config: {
         selectedKey: VIDEO_TYPE_CONFIG.selectedKey,
         trackType: 'video',
-        constraints: config?.constraints ?? [],
+        constraints: config?.constraints ?? DEFAULT_VIDEO_CONSTRAINTS,
         rules: config?.rules ?? DEFAULT_VIDEO_RULES,
         ruleConfig: config,
       },

--- a/packages/spf/src/playback/behaviors/select-tracks.ts
+++ b/packages/spf/src/playback/behaviors/select-tracks.ts
@@ -48,10 +48,10 @@ import { createMachineReactor } from '../../core/reactors/create-machine-reactor
 import { computed, type ReadonlySignal, type Signal } from '../../core/signals/primitives';
 import {
   type AudioSelectionConfig,
+  byDescendingResolution,
   pickAudioTrackFromTracks,
-  pickTrackUnderPixelArea,
   type TrackSelectionState,
-  type VideoSelectionConfig,
+  tracksUnderPixelArea,
 } from '../../media/primitives/select-tracks';
 import { isResolvedPresentation, type TrackType } from '../../media/types';
 import { getTracksByType } from '../../media/utils/tracks';
@@ -129,8 +129,8 @@ function setupTrackSelection<K extends SelectedTrackKey, RuleConfig>({
             const candidates = getTracksByType(state.presentation.get()!, trackType);
             // Constraints prune the unplayable, then the chain narrows and ranks;
             // the pick is the head. An empty `rules` chain therefore selects the
-            // first candidate — the same answer `pickFirstTrackId` gave, now a
-            // consequence of the model rather than a separate code path.
+            // first candidate, which falls out of the model rather than needing a
+            // first-track code path of its own.
             const survivors = applyRules(rules, applyConstraints(constraints, candidates, deps), deps);
             const id = survivors[0]?.id;
             if (id) state[selectedKey].set(id);
@@ -150,8 +150,8 @@ function setupTrackSelection<K extends SelectedTrackKey, RuleConfig>({
 // its own options (`preferredAudioLanguage`) directly off it.
 //
 // Video's default is the *empty* chain: with no rule narrowing or reordering the
-// candidates, the head is the first track — exactly what `pickFirstTrackId` used
-// to return, now falling out of the model instead of being its own code path.
+// candidates, the head is the first track — a consequence of the model rather than
+// a first-track code path of its own.
 // ============================================================================
 
 /** Default video chain: none. The first candidate is the pick. */
@@ -172,16 +172,71 @@ const preferAudioPolicy: SelectTrackRule<SelectAudioTrackConfig> = (tracks, { co
 const DEFAULT_AUDIO_RULES: readonly SelectTrackRule<SelectAudioTrackConfig>[] = [preferAudioPolicy];
 
 /**
- * Narrow to the largest rendition on offer, by pixel area. The background-video
- * default — that variant pins one rendition for the session, and absent a cap the
- * largest is the pick.
+ * Order the candidates by resolution, largest first, with bandwidth breaking ties
+ * between renditions of identical dimensions. The background-video default — that
+ * variant pins one rendition for the session, and absent a cap the largest is the
+ * head.
+ *
+ * A ranker, so it reorders rather than narrowing: the chain's pick is the head of
+ * what it returns, which means ranking never has to collapse to one track. Belongs
+ * last in a chain — a sort only reorders what survived the filters ahead of it, and
+ * leaving it last is what lets `applyRules` early-bail before it runs.
  *
  * Exported because it is a *rule*, not a variant's private policy: the same one
  * composes into `switchVideoTrack`'s chain when a ranker is wanted there.
  */
-export const preferHighestResolution: SelectTrackRule<unknown> = (tracks) => {
-  const pick = pickTrackUnderPixelArea(tracks as readonly { id: string }[]);
-  return pick ? [pick] : [];
+export const preferHighestResolution: SelectTrackRule<unknown> = (tracks) => [...tracks].sort(byDescendingResolution);
+
+/**
+ * What {@link screenResolutionCap} reads off the composition state.
+ *
+ * Structurally compatible with `media/dom/screen`'s `ScreenResolution` rather than
+ * importing it: this module sits outside the DOM layer (project references enforce
+ * that), and a rule comparing pixel areas needs two numbers, not a screen.
+ */
+type ScreenResolutionRuleState = {
+  screenResolution?: ReadonlySignal<{ readonly width: number; readonly height: number } | undefined>;
+};
+
+/**
+ * Narrow to the renditions that fit the screen, by pixel area — the screen-size
+ * cap from `internal/design/spf/features/rendition-selection-caps.md`, as a scope
+ * (soft filter) rather than a constraint: an over-cap rendition is wasteful, not
+ * unplayable, so nothing here may make a source unplayable.
+ *
+ * Narrows only — it neither orders the survivors nor resolves the case where none
+ * survive, because `applyRules` owns both. So it needs a ranker behind it to pick
+ * within the cap: `[screenResolutionCap, preferHighestResolution]` yields the
+ * largest rendition that fits. Composed *last*, the pick would instead be whichever
+ * fitting rendition the manifest happened to list first.
+ *
+ * Reading `state.screenResolution` through its signal is what subscribes a
+ * re-evaluating chain (`switchVideoTrack`) to screen changes; `selectVideoTrack`
+ * pins the first answer instead, by design.
+ *
+ * Compares areas rather than matching a `"1080p"`-style tier because a tier only
+ * describes a rendition once you assume its aspect ratio — the assumption that
+ * mis-measures an anamorphic ladder. See `media/dom/screen.ts`.
+ *
+ * Three ways the cap ends up not applying, all of them fall-through:
+ *
+ * - **No `screenResolution` signal at all**, because the composition omits
+ *   `trackScreenResolution`. So composing the cap without its signal source is
+ *   inert rather than broken.
+ * - **A `screenResolution` of `undefined`**, meaning no screen to read. "Unknown"
+ *   has to mean "don't cap": treating it as an area of zero would pin every source
+ *   to its smallest rendition on exactly the environments we know least about.
+ * - **No rendition fits**, on a screen smaller than the whole ladder. `applyRules`
+ *   skips the empty result and the chain proceeds unnarrowed, so the ranker behind
+ *   the cap decides — for `preferHighestResolution`, the largest rendition. A floor
+ *   is the fix if that ever matters (`rendition-selection-caps.md` carries one), not
+ *   a special case here.
+ */
+export const screenResolutionCap: SelectTrackRule<unknown> = (tracks, { state }) => {
+  const screenResolution = (state as ScreenResolutionRuleState | undefined)?.screenResolution?.get();
+  if (!screenResolution) return [];
+
+  return tracksUnderPixelArea(tracks, screenResolution.width * screenResolution.height);
 };
 
 // ============================================================================
@@ -193,7 +248,7 @@ export const preferHighestResolution: SelectTrackRule<unknown> = (tracks) => {
  * `constraints` to prune candidates before it runs; otherwise the chain is empty
  * and the first candidate is the pick.
  */
-export interface SelectVideoTrackConfig extends VideoSelectionConfig {
+export interface SelectVideoTrackConfig {
   constraints?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
   rules?: readonly SelectTrackRule<SelectVideoTrackConfig>[];
 }

--- a/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
@@ -144,7 +144,7 @@ describe('selectVideoTrack', () => {
     reactor.destroy();
   });
 
-  it('honors a caller-supplied picker', async () => {
+  it('honors a caller-supplied rule chain', async () => {
     const videoTracks: PartiallyResolvedVideoTrack[] = [
       {
         type: 'video',
@@ -167,11 +167,11 @@ describe('selectVideoTrack', () => {
     const presentation = createPresentation({ video: videoTracks });
     const state = makeState({ presentation });
 
-    // Custom picker bypasses the default first-track rule and pins to a
-    // specific id; the behavior should honor it.
+    // A narrowing rule replaces the default empty chain, so the pick is the
+    // survivor rather than the first candidate.
     const reactor = selectVideoTrack.setup({
       state,
-      config: { picker: () => 'video-high' },
+      config: { rules: [(tracks: readonly { id: string }[]) => tracks.filter((track) => track.id === 'video-high')] },
     });
 
     await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { StateSignals } from '../../../core/composition/create-composition';
 import { signal } from '../../../core/signals/primitives';
+import type { SvtaError } from '../../../media/errors';
 import type { TrackSelectionState } from '../../../media/primitives/select-tracks';
 import type {
   AudioSelectionSet,
@@ -178,6 +179,154 @@ describe('selectVideoTrack', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(state.selectedVideoTrackId.get()).toBe('video-high');
+
+    reactor.destroy();
+  });
+});
+
+// The capability pre-pass and the verdict it produces. This is what lets a
+// *pinned* selection notice it has gone unplayable: `resolve-track` relabels the
+// whole type's container from the first resolved media playlist, long after the
+// pick was made under the fMP4 default.
+describe('selectVideoTrack — capability constraint + verdict', () => {
+  const playable: PartiallyResolvedVideoTrack = {
+    type: 'video',
+    id: 'video-mp4',
+    url: 'http://example.com/video-mp4.m3u8',
+    bandwidth: 1_000_000,
+    mimeType: 'video/mp4',
+    codecs: ['avc1.4d401f'],
+  };
+  const undecodable: PartiallyResolvedVideoTrack = {
+    type: 'video',
+    id: 'video-hevc',
+    url: 'http://example.com/video-hevc.m3u8',
+    bandwidth: 4_000_000,
+    mimeType: 'video/mp4',
+    codecs: ['hvc1.2.4.L153.B0'],
+  };
+
+  /** Rejects anything whose codec list names HEVC — stands in for the DOM probe. */
+  const noHevc = (track: { codecs?: string[] }) => !track.codecs?.some((codec) => codec.startsWith('hvc1'));
+
+  function makeErrorState(presentation: MaybeResolvedPresentation) {
+    return { ...makeState({ presentation }), errors: signal<SvtaError[] | undefined>(undefined) };
+  }
+
+  it('prunes an undecodable rendition before the chain picks', async () => {
+    const state = makeErrorState(createPresentation({ video: [undecodable, playable] }));
+
+    const reactor = selectVideoTrack.setup({ state, config: { canPlayTrack: noHevc } });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(state.selectedVideoTrackId.get()).toBe('video-mp4');
+    expect(state.errors.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  it('makes no pick when every rendition is undecodable', async () => {
+    const state = makeErrorState(createPresentation({ video: [undecodable] }));
+
+    const reactor = selectVideoTrack.setup({ state, config: { canPlayTrack: noHevc } });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(state.selectedVideoTrackId.get()).toBeUndefined();
+    // No verdict without `requireVideoTrack`: this behavior reports only the
+    // condition no per-rendition cause covers, and it isn't this composition's
+    // place to say an absent type is fatal.
+    expect(state.errors.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  // The warm path, and the reason this behavior needed an effect rather than
+  // entry alone: the pick is made while the type still carries the fMP4 default,
+  // and only the later relabel reveals it as MPEG-TS.
+  it('clears a pick already made when a later container relabel prunes every rendition', async () => {
+    const fmp4Labelled = createPresentation({ video: [{ ...playable, id: 'video-1' }] });
+    const state = makeErrorState(fmp4Labelled);
+
+    // The DOM probe's real answer: a non-fMP4 container is unplayable outright.
+    const reactor = selectVideoTrack.setup({
+      state,
+      config: {
+        canPlayTrack: (track: { mimeType?: string }) => track.mimeType !== 'video/mp2t',
+        requireVideoTrack: true,
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(state.selectedVideoTrackId.get()).toBe('video-1');
+
+    // What `applyContainerMimeType` does once the media playlist resolves with no
+    // EXT-X-MAP: relabel every rendition of the type, in a new presentation object.
+    state.presentation.set(
+      createPresentation({ video: [{ ...playable, id: 'video-1', mimeType: 'video/mp2t' }] }) as Presentation
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(state.selectedVideoTrackId.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  // The partially-unplayable case, which is how encryption presents: it is detected
+  // per media playlist, so a pruned pick can sit beside renditions that still look
+  // playable. The pin is dropped rather than moved — moving it would make this
+  // `switchVideoTrack` with extra steps — and losing it is the failure, because
+  // `entry` has already run and nothing will choose again.
+  it('deselects when the pick alone is constrained away', async () => {
+    const encrypted = { ...playable, id: 'video-encrypted' };
+    const clear = { ...playable, id: 'video-clear' };
+    const state = makeErrorState(createPresentation({ video: [encrypted, clear] }));
+
+    // Unplayable only *after* the pick, which is the real sequence: encryption is
+    // read off a media playlist, and only the selected rendition's is fetched.
+    // Pruning it up front would let `entry` avoid it and never exercise this path.
+    let pruneEncrypted = false;
+    const reactor = selectVideoTrack.setup({
+      state,
+      config: { canPlayTrack: (track: { id?: string }) => !(pruneEncrypted && track.id === 'video-encrypted') },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(state.selectedVideoTrackId.get()).toBe('video-encrypted');
+
+    pruneEncrypted = true;
+    // Re-notify the candidate set the way committing a resolved track does.
+    state.presentation.set(createPresentation({ video: [encrypted, clear] }) as Presentation);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Dropped, not moved to `video-clear`.
+    expect(state.selectedVideoTrackId.get()).toBeUndefined();
+    // No verdict: a sibling still looks playable, so nothing here can claim the
+    // type is unplayable. What made the pick unplayable reported its own cause as
+    // the playlist resolved — 4008 for the real encryption case.
+    expect(state.errors.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  it('passes every rendition through when no probe is wired', async () => {
+    const state = makeErrorState(createPresentation({ video: [undecodable] }));
+
+    const reactor = selectVideoTrack.setup({ state });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(state.selectedVideoTrackId.get()).toBe('video-hevc');
+    expect(state.errors.get()).toBeUndefined();
+
+    reactor.destroy();
+  });
+
+  // The optional-slot contract: reporting goes through a seam that no-ops when
+  // `collectErrors` isn't composed, so the clear still happens either way.
+  it('still clears the pick when no errors slot is composed', async () => {
+    const state = makeState({ presentation: createPresentation({ video: [undecodable] }) });
+
+    const reactor = selectVideoTrack.setup({ state, config: { canPlayTrack: noHevc } });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(state.selectedVideoTrackId.get()).toBeUndefined();
 
     reactor.destroy();
   });

--- a/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
@@ -11,7 +11,8 @@ import type {
   TextSelectionSet,
   VideoSelectionSet,
 } from '../../../media/types';
-import { selectAudioTrack, selectVideoTrack } from '../select-tracks';
+import { applyRules } from '../../primitives/selection-rules';
+import { preferHighestResolution, screenResolutionCap, selectAudioTrack, selectVideoTrack } from '../select-tracks';
 
 function makeState(initial: TrackSelectionState = {}): StateSignals<TrackSelectionState> {
   return {
@@ -351,5 +352,100 @@ describe('selectAudioTrack', () => {
     expect(state.selectedAudioTrackId.get()).toBe('audio-en');
 
     reactor.destroy();
+  });
+});
+
+// ============================================================================
+// screenResolutionCap — tested as the pure rule it is, no behavior in the way.
+// The composed-chain case at the bottom is the one that matters in practice.
+// ============================================================================
+
+describe('preferHighestResolution', () => {
+  const noDeps = { state: {}, config: undefined };
+
+  // A ranker, not a picker: it returns the whole reordered set and lets the chain
+  // take the head. Returning one track would early-bail `applyRules` and block any
+  // rule behind it.
+  it('returns every candidate, reordered, rather than a single pick', () => {
+    const tracks = [
+      { id: '720p', width: 1280, height: 720, bandwidth: 2_000_000 },
+      { id: '1440p', width: 2560, height: 1440, bandwidth: 8_000_000 },
+      { id: '360p', width: 640, height: 360, bandwidth: 500_000 },
+    ];
+    expect(preferHighestResolution(tracks, noDeps).map((track) => track.id)).toEqual(['1440p', '720p', '360p']);
+  });
+
+  it('does not mutate the candidate list it was given', () => {
+    const tracks = [
+      { id: '360p', width: 640, height: 360, bandwidth: 500_000 },
+      { id: '1080p', width: 1920, height: 1080, bandwidth: 4_000_000 },
+    ];
+    preferHighestResolution(tracks, noDeps);
+    expect(tracks.map((track) => track.id)).toEqual(['360p', '1080p']);
+  });
+});
+
+describe('screenResolutionCap', () => {
+  const ladder = [
+    { id: '360p', width: 640, height: 360, bandwidth: 500_000 },
+    { id: '1080p', width: 1920, height: 1080, bandwidth: 4_000_000 },
+    { id: '1440p', width: 2560, height: 1440, bandwidth: 8_000_000 },
+    { id: '2160p', width: 3840, height: 2160, bandwidth: 15_000_000 },
+  ];
+
+  // A 16" MBP in its default scaled mode: 3456x2234 device px = 7,720,704.
+  const laptopScreen = { width: 3456, height: 2234 };
+
+  function depsWith(screenResolution: { width: number; height: number } | undefined) {
+    return { state: { screenResolution: signal(screenResolution) }, config: undefined };
+  }
+
+  // Narrows only — the surviving order is the manifest's. Choosing among the
+  // survivors is the following ranker's job, exercised at the bottom of this block.
+  it('narrows to the renditions that fit the screen', () => {
+    const survivors = screenResolutionCap(ladder, depsWith(laptopScreen));
+    expect(survivors.map((track) => track.id)).toEqual(['360p', '1080p', '1440p']);
+  });
+
+  it('falls through when there is no screen to read', () => {
+    expect(screenResolutionCap(ladder, depsWith(undefined))).toEqual([]);
+  });
+
+  // Composing the cap without `trackScreenResolution` leaves the slot absent
+  // entirely — inert rather than broken, and notably not a cap of zero.
+  it('falls through when the composition declares no screenResolution signal', () => {
+    expect(screenResolutionCap(ladder, { state: {}, config: undefined })).toEqual([]);
+  });
+
+  // No fallback here either — `applyRules` skips an empty result, which is what
+  // keeps a cap from ever narrowing the candidates to nothing.
+  it('falls through when the screen fits no rendition at all', () => {
+    expect(screenResolutionCap(ladder, depsWith({ width: 320, height: 240 }))).toEqual([]);
+  });
+
+  it('leaves the chain unnarrowed when nothing fits, so the ranker still decides', () => {
+    const deps = depsWith({ width: 320, height: 240 });
+    const survivors = applyRules([screenResolutionCap, preferHighestResolution], ladder, deps);
+    expect(survivors[0]?.id).toBe('2160p');
+  });
+
+  it('picks the largest rendition that fits when composed ahead of the ranker', () => {
+    const deps = depsWith(laptopScreen);
+    const survivors = applyRules([screenResolutionCap, preferHighestResolution], ladder, deps);
+    expect(survivors[0]?.id).toBe('1440p');
+  });
+
+  // Order-independent, per the model: a sort reorders whatever survived, and a
+  // filter preserves order, so the head is the same either way round.
+  it('reaches the same pick with the cap after the ranker', () => {
+    const deps = depsWith(laptopScreen);
+    expect(applyRules([preferHighestResolution, screenResolutionCap], ladder, deps)[0]?.id).toBe('1440p');
+  });
+
+  // Without the cap the same ladder pins the top rung — the difference the rule makes.
+  it('is what pulls the pick below the top rung', () => {
+    const deps = depsWith(laptopScreen);
+    expect(applyRules([preferHighestResolution], ladder, deps)[0]?.id).toBe('2160p');
+    expect(applyRules([screenResolutionCap, preferHighestResolution], ladder, deps)[0]?.id).toBe('1440p');
   });
 });

--- a/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/select-tracks.test.ts
@@ -232,9 +232,10 @@ describe('selectVideoTrack — capability constraint + verdict', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(state.selectedVideoTrackId.get()).toBeUndefined();
-    // No verdict without `requireVideoTrack`: this behavior reports only the
-    // condition no per-rendition cause covers, and it isn't this composition's
-    // place to say an absent type is fatal.
+    // No verdict from the behavior itself: reporting an absent type is a
+    // constraint a composition opts into — `reportAbsentTrackType`, as the
+    // background-video engine does — and the default video constraints are
+    // `excludeUnplayableTracks` alone.
     expect(state.errors.get()).toBeUndefined();
 
     reactor.destroy();
@@ -250,10 +251,7 @@ describe('selectVideoTrack — capability constraint + verdict', () => {
     // The DOM probe's real answer: a non-fMP4 container is unplayable outright.
     const reactor = selectVideoTrack.setup({
       state,
-      config: {
-        canPlayTrack: (track: { mimeType?: string }) => track.mimeType !== 'video/mp2t',
-        requireVideoTrack: true,
-      },
+      config: { canPlayTrack: (track: { mimeType?: string }) => track.mimeType !== 'video/mp2t' },
     });
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(state.selectedVideoTrackId.get()).toBe('video-1');

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -17,9 +17,6 @@ import type {
 import { applyContainerMimeType } from '../../../media/utils/tracks';
 import type { BandwidthState } from '../../../network/bandwidth-estimator';
 import {
-  applyConstraints,
-  applyRules,
-  type SelectionRule,
   type SwitchVideoTrackConfig,
   setupTrackSwitching,
   switchAudioTrack,
@@ -691,93 +688,6 @@ describe('switchAudioTrack — userAudioTrackSelection filter', () => {
     expect(state.selectedAudioTrackId.get()).toBe('audio-en');
 
     reactor.destroy();
-  });
-});
-
-// ============================================================================
-// applyRules — the rule-chain composer (pure; no signals)
-// ============================================================================
-
-describe('applyRules', () => {
-  const track = (id: string) => ({ id });
-  const all = [track('a'), track('b'), track('c')];
-
-  const noDeps = { state: {}, context: {}, config: {} };
-
-  it('applies rules in order; the pick is the first survivor', () => {
-    const dropA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'a');
-    const reverse: SelectionRule<{ id: string }> = (tracks) => [...tracks].reverse();
-    const result = applyRules([dropA, reverse], all, noDeps);
-    expect(result.map((t) => t.id)).toEqual(['c', 'b']);
-  });
-
-  it('skips a rule that returns nothing (fall-through), keeping the prior set', () => {
-    const matchNone: SelectionRule<{ id: string }> = () => [];
-    const result = applyRules([matchNone], all, noDeps);
-    expect(result.map((t) => t.id)).toEqual(['a', 'b', 'c']);
-  });
-
-  it('stops at one survivor and does not run later rules (early-bail)', () => {
-    const toA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id === 'a');
-    let laterCalled = false;
-    const later: SelectionRule<{ id: string }> = (tracks) => {
-      laterCalled = true;
-      return tracks;
-    };
-    const result = applyRules([toA, later], all, noDeps);
-    expect(result.map((t) => t.id)).toEqual(['a']);
-    expect(laterCalled).toBe(false);
-  });
-
-  it('passes the candidate list and deps (state, context, config) through to each rule', () => {
-    const deps = { state: { marker: 1 }, context: { other: 2 }, config: { tuning: 3 } };
-    let received: unknown[] = [];
-    const rule: SelectionRule<{ id: string }, typeof deps.state, typeof deps.context, typeof deps.config> = (
-      tracks,
-      ruleDeps
-    ) => {
-      received = [tracks, ruleDeps];
-      return tracks;
-    };
-    applyRules([rule], all, deps);
-    expect(received).toEqual([all, deps]);
-  });
-});
-
-// ============================================================================
-// applyConstraints — the hard-constraints pre-pass (pure; no signals)
-// ============================================================================
-
-describe('applyConstraints', () => {
-  const track = (id: string) => ({ id });
-  const all = [track('a'), track('b'), track('c')];
-  const noDeps = { state: {}, context: {}, config: {} };
-
-  const noA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'a');
-  const noC: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'c');
-
-  it('removes what each constraint excludes (pooled)', () => {
-    expect(applyConstraints([noA, noC], all, noDeps).map((t) => t.id)).toEqual(['b']);
-  });
-
-  it('is order-independent', () => {
-    expect(applyConstraints([noA, noC], all, noDeps)).toEqual(applyConstraints([noC, noA], all, noDeps));
-  });
-
-  it('preserves an empty result — no fall-through, unlike applyRules', () => {
-    const none: SelectionRule<{ id: string }> = () => [];
-    expect(applyConstraints([none], all, noDeps)).toEqual([]);
-  });
-
-  it('runs every constraint — no early-bail at a single survivor', () => {
-    const toA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id === 'a');
-    let laterCalled = false;
-    const later: SelectionRule<{ id: string }> = (tracks) => {
-      laterCalled = true;
-      return tracks;
-    };
-    applyConstraints([toA, later], all, noDeps);
-    expect(laterCalled).toBe(true);
   });
 });
 

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -86,7 +86,7 @@ import { getTracksByType } from '../../media/utils/tracks';
 import type { BandwidthConfig, BandwidthState } from '../../network/bandwidth-estimator';
 import { DEFAULT_BANDWIDTH_CONFIG, getBandwidthEstimate } from '../../network/bandwidth-estimator';
 import type { SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
-import { applyConstraints, applyRules } from '../primitives/selection-rules';
+import { applyConstraints, applyRules, excludeUnplayableTracks, sameCandidateSet } from '../primitives/selection-rules';
 import { type ErrorEmitterState, emitError } from './collect-errors';
 
 // ============================================================================
@@ -145,7 +145,7 @@ export const DEFAULT_INITIAL_BANDWIDTH = 5_000_000;
 // simple `selectVideoTrack` variant can share them without pulling the ABR path
 // in with them. See that module's note.
 export type { SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
-export { applyConstraints, applyRules } from '../primitives/selection-rules';
+export { applyConstraints, applyRules, excludeUnplayableTracks } from '../primitives/selection-rules';
 
 // ============================================================================
 // Specialization helper
@@ -353,17 +353,6 @@ type CdnRuleConfig<S extends SelectionKey, T extends SwitchableTrack> = TrackSwi
   getCdnId?: GetCdnId;
 };
 
-/**
- * Config the capability constraint reads: the base config plus an *optional*
- * `canPlayTrack` codec probe. Optional → an unwired probe means "no codec
- * filtering" and the constraint passes everything through, so the base config
- * (without it) stays assignable. The engine defaults it to the DOM-bound
- * `canPlayTrack`.
- */
-type CapabilityConstraintConfig<S extends SelectionKey, T extends SwitchableTrack> = TrackSwitchingConfig<S, T> & {
-  canPlayTrack?: CanPlayTrack;
-};
-
 type VideoTrackCandidate = PartiallyResolvedVideoTrack | VideoTrack;
 type AudioTrackCandidate = PartiallyResolvedAudioTrack | AudioTrack;
 type TextTrackCandidate = PartiallyResolvedTextTrack | TextTrack;
@@ -411,31 +400,6 @@ function excludeFailedCdns<S extends SelectionKey, T extends SwitchableTrack>(
   const getCdnId = config.getCdnId ?? defaultGetCdnId;
   const failedSet = new Set(failed);
   return tracks.filter((track) => !failedSet.has(getCdnId(track.url)));
-}
-
-/**
- * Capability constraint — a *hard* filter (constraints pre-pass), shared by
- * video and audio. Removes renditions this environment can't decode, probed via
- * the injected `canPlayTrack` (codec → `MediaSource.isTypeSupported`). Moving
- * the check here — before selection — means an unplayable variant (e.g. HEVC on
- * a browser without HEVC) is pruned upstream and never picked, instead of
- * surviving into the pipeline to fail late at `createSourceBuffer`. That late
- * throw stays as a defensive structural guarantee; with this constraint it
- * should rarely fire.
- *
- * Passes everything through when there's no `canPlayTrack` probe (a composition
- * that didn't wire it, or DOM-free tests). When it prunes *every* track (no
- * decodable rendition), the empty result is preserved (per `applyConstraints`)
- * — "nothing playable," so the behavior clears the selection (no pick) and the
- * late `createSourceBuffer` check stays as the backstop.
- */
-function excludeUnplayableTracks<S extends SelectionKey, T extends SwitchableTrack>(
-  tracks: readonly T[],
-  { config }: SelectionRuleDeps<TrackSwitchingStateMap<S>, AnySlotMap, CapabilityConstraintConfig<S, T>>
-): readonly T[] {
-  const canPlay = config.canPlayTrack;
-  if (!canPlay) return tracks;
-  return tracks.filter((track) => canPlay(track));
 }
 
 /**
@@ -627,7 +591,7 @@ export function setupTrackSwitching<
       if (!isResolvedPresentation(presentation)) return [];
       return applyConstraints(config.constraints ?? [], getTracks(presentation), deps);
     },
-    { equals: (a, b) => a.length === b.length && a.every((track) => b.some((other) => other.id === track.id)) }
+    { equals: sameCandidateSet }
   );
 
   return createMachineReactor({

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -564,7 +564,7 @@ type TextTerminalConfig = TrackSwitchingConfig<'selectedTextTrackId', TextTrackC
  *     stale pick whose match is gone (e.g. the language dropped on a source
  *     change) falls through to the default policy.
  *   - auto (`undefined`) → the opt-in default policy (`preferredSubtitleLanguage`
- *     → `DEFAULT=YES + AUTOSELECT=YES` → none), shared with `pickTextTrack`.
+ *     → `DEFAULT=YES + AUTOSELECT=YES` → none), via `pickTextTrackFromTracks`.
  *
  * Returning `undefined` is a real outcome (captions are opt-in), which is why the
  * text variant relies on `setupTrackSwitching`'s no-selection seam.

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -85,6 +85,8 @@ import { getCdnId as defaultGetCdnId, type GetCdnId } from '../../media/utils/cd
 import { getTracksByType } from '../../media/utils/tracks';
 import type { BandwidthConfig, BandwidthState } from '../../network/bandwidth-estimator';
 import { DEFAULT_BANDWIDTH_CONFIG, getBandwidthEstimate } from '../../network/bandwidth-estimator';
+import type { SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
+import { applyConstraints, applyRules } from '../primitives/selection-rules';
 import { type ErrorEmitterState, emitError } from './collect-errors';
 
 // ============================================================================
@@ -138,83 +140,12 @@ export const DEFAULT_INITIAL_BANDWIDTH = 5_000_000;
 // Rule chain
 // ============================================================================
 
-/**
- * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
- * deps so a rule reads from the same surfaces a behavior does. `context` is
- * optional — it's threaded through but absent on direct setup calls (and
- * unread by today's rules), so the whole deps object can pass straight through.
- */
-export interface SelectionRuleDeps<State = unknown, Context = unknown, Config = unknown> {
-  state: State;
-  context?: Context;
-  config: Config;
-}
-
-/**
- * A selection rule narrows or reorders the candidate list. It reads the state,
- * context, and config it needs at apply time (tightly-coupled reads), so a
- * rule's `.get()`s subscribe the running effect to exactly what it consulted.
- * Returning an empty list means "no match" — the composer skips it, so a soft
- * filter never narrows the set to nothing. A ranker returns the list with its
- * pick at the head.
- */
-export type SelectionRule<T, State = unknown, Context = unknown, Config = unknown> = (
-  tracks: readonly T[],
-  deps: SelectionRuleDeps<State, Context, Config>
-) => readonly T[];
-
-/**
- * Apply rules to a candidate list in order; the pick is the first survivor.
- * Two responsibilities the rules don't carry: a rule that returns nothing is
- * skipped (fall-through — a preference never empties the set), and once one
- * survivor remains the chain stops (early-bail — later rules, including the
- * bandwidth ranker, never run, so the effect doesn't subscribe to their
- * signals while the choice is fixed).
- *
- * @param rules - Rules to apply, most authoritative first
- * @param tracks - Candidate tracks
- * @param deps - The behavior's `{ state, context, config }`, passed through to each rule
- * @returns The surviving candidates, pick first
- */
-export function applyRules<T, State, Context, Config>(
-  rules: readonly SelectionRule<T, State, Context, Config>[],
-  tracks: readonly T[],
-  deps: SelectionRuleDeps<State, Context, Config>
-): readonly T[] {
-  let current = tracks;
-  for (const rule of rules) {
-    const remaining = rule(current, deps);
-    if (remaining.length === 0) continue;
-    current = remaining;
-    if (current.length === 1) break;
-  }
-  return current;
-}
-
-/**
- * Apply hard constraints to a candidate list — the pre-pass that runs before the
- * rule chain. A constraint shares a rule's signature but its exclusion is
- * *hard*: it removes the unplayable (a codec the environment can't decode, a CDN
- * in failover cooldown) and a removed track is never attempted. Unlike
- * `applyRules`, this never skips an empty result and never early-bails — every
- * constraint always applies, and an empty survivor set is a real outcome
- * ("nothing playable here"), not a fall-through. Because each constraint only
- * removes, the order they run in can't change the result.
- *
- * @param constraints - Constraints to apply (pooled, order-independent)
- * @param tracks - Candidate tracks
- * @param deps - The behavior's `{ state, context, config }`, passed to each constraint
- * @returns The playable survivors (possibly empty)
- */
-export function applyConstraints<T, State, Context, Config>(
-  constraints: readonly SelectionRule<T, State, Context, Config>[],
-  tracks: readonly T[],
-  deps: SelectionRuleDeps<State, Context, Config>
-): readonly T[] {
-  let current = tracks;
-  for (const constraint of constraints) current = constraint(current, deps);
-  return current;
-}
+// Re-exported so a consumer typing against this module's rules doesn't need a
+// second import; the definitions live in `../primitives/selection-rules` so the
+// simple `selectVideoTrack` variant can share them without pulling the ABR path
+// in with them. See that module's note.
+export type { SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
+export { applyConstraints, applyRules } from '../primitives/selection-rules';
 
 // ============================================================================
 // Specialization helper

--- a/packages/spf/src/playback/engines/hls/engine-background-video.ts
+++ b/packages/spf/src/playback/engines/hls/engine-background-video.ts
@@ -7,7 +7,6 @@ import {
 import { makeShareSignals, type ShareSignalsConfig } from '../../../core/composition/share-signals';
 import type { ScreenResolution } from '../../../media/dom/screen';
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
-import { pickHighestResolutionVideoTrack, type TrackPicker } from '../../../media/primitives/select-tracks';
 import type { MaybeResolvedPresentation } from '../../../media/types';
 import { getResolvedSelectedTrackDuration } from '../../../media/utils/track-selection';
 import type { SegmentLoaderActor } from '../../actors/dom/segment-loader';
@@ -22,7 +21,7 @@ import { trackScreenResolution } from '../../behaviors/dom/track-screen-resoluti
 import { updateMediaSourceDuration } from '../../behaviors/dom/update-mediasource-duration';
 import { type ParsePresentation, resolvePresentation } from '../../behaviors/resolve-presentation';
 import { resolveVideoTrack } from '../../behaviors/resolve-track';
-import { type SelectVideoTrackConfig, selectVideoTrack } from '../../behaviors/select-tracks';
+import { preferHighestResolution, type SelectVideoTrackConfig, selectVideoTrack } from '../../behaviors/select-tracks';
 
 // ============================================================================
 // Background-video engine state & context
@@ -91,15 +90,15 @@ export type BackgroundVideoEngineSignals = {
 export interface BackgroundVideoEngineConfig
   extends ShareSignalsConfig<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   /**
-   * Track picker handed to `selectVideoTrack`. Default:
-   * `pickHighestResolutionVideoTrack` — picks the highest-resolution variant on
-   * presentation resolve and pins it for the session. Override for
-   * mobile-aware or content-aware caps.
+   * Selection-rule chain handed to `selectVideoTrack`. Defaults to
+   * `[preferHighestResolution]` — narrows to the largest rendition on offer and
+   * pins it for the session.
    *
-   * Adapters (e.g. `HlsBackgroundVideoMediaElement`) install their own
-   * picker; this default applies when the engine is constructed directly.
+   * A cap composes as another rule ahead of it, which is how the screen-size cap
+   * will arrive; nothing about this variant's selection is a bespoke picker any
+   * more.
    */
-  picker?: TrackPicker<SelectVideoTrackConfig>;
+  rules?: readonly NonNullable<SelectVideoTrackConfig['rules']>[number][];
   /**
    * Manifest parser handed to `resolvePresentation`. Defaults to the HLS
    * multivariant-playlist parser.
@@ -124,7 +123,7 @@ const shareSignals = makeShareSignals<BackgroundVideoEngineState, BackgroundVide
  * Subtractive composition over the HLS engine baseline:
  * audio-side, text-side, ABR-driven, preload-monitoring, and play/seek
  * load-trigger behaviors are removed. `selectVideoTrack` (with a
- * max-resolution picker by default) replaces `switchVideoQuality`, pinning
+ * highest-resolution rule by default) replaces `switchVideoQuality`, pinning
  * a single rendition for the session. The initial state seeds
  * `loadActivated: true` so the composition behaves as if preload has
  * already been activated — appropriate for ambient / hero / GIF-replacement
@@ -153,7 +152,7 @@ export function createBackgroundVideoEngine(
 ): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   const finalConfig = {
     ...config,
-    picker: config.picker ?? pickHighestResolutionVideoTrack,
+    rules: config.rules ?? [preferHighestResolution],
     parsePresentation: config.parsePresentation ?? parseMultivariantPlaylist,
     resolveDuration: getResolvedSelectedTrackDuration,
   };

--- a/packages/spf/src/playback/engines/hls/engine-background-video.ts
+++ b/packages/spf/src/playback/engines/hls/engine-background-video.ts
@@ -5,6 +5,7 @@ import {
   type StateSignals,
 } from '../../../core/composition/create-composition';
 import { makeShareSignals, type ShareSignalsConfig } from '../../../core/composition/share-signals';
+import type { ScreenResolution } from '../../../media/dom/screen';
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
 import { pickHighestResolutionVideoTrack, type TrackPicker } from '../../../media/primitives/select-tracks';
 import type { MaybeResolvedPresentation } from '../../../media/types';
@@ -17,6 +18,7 @@ import { loadVideoSegments } from '../../behaviors/dom/load-segments';
 import { setupVideoBufferActors } from '../../behaviors/dom/setup-buffer-actors';
 import { setupMediaSource } from '../../behaviors/dom/setup-mediasource';
 import { trackCurrentTime } from '../../behaviors/dom/track-current-time';
+import { trackScreenResolution } from '../../behaviors/dom/track-screen-resolution';
 import { updateMediaSourceDuration } from '../../behaviors/dom/update-mediasource-duration';
 import { type ParsePresentation, resolvePresentation } from '../../behaviors/resolve-presentation';
 import { resolveVideoTrack } from '../../behaviors/resolve-track';
@@ -29,11 +31,16 @@ import { type SelectVideoTrackConfig, selectVideoTrack } from '../../behaviors/s
 /**
  * State shape for the background-video playback engine.
  *
- * Narrower than `HlsVideoEngineState`: audio/text track slots are absent
+ * Mostly narrower than `HlsVideoEngineState`: audio/text track slots are absent
  * because their selection/resolution behaviors are subtracted. `bandwidthState`
  * is present because `setupVideoBufferActors` declares it and `loadVideoSegments`
  * samples into it (wasted work in this variant — a Phase 3 alt-impl will skip
  * sampling).
+ *
+ * `screenResolution` is the one slot this variant has and the HLS video engine
+ * doesn't, because the screen-size cap is being built here first. It generalizes
+ * — the cap is a selection rule both engines can compose — so expect the slot to
+ * appear there too rather than staying variant-specific.
  */
 export interface BackgroundVideoEngineState {
   /**
@@ -44,6 +51,12 @@ export interface BackgroundVideoEngineState {
   preload?: 'auto' | 'metadata' | 'none';
   selectedVideoTrackId?: string;
   loadActivated?: boolean;
+  /**
+   * The screen's pixel dimensions, or `undefined` where there is none to read.
+   * Written by `trackScreenResolution`; nothing reads it yet — the screen-size
+   * rendition cap that will is the next step.
+   */
+  screenResolution?: ScreenResolution;
 }
 
 /**
@@ -92,6 +105,11 @@ export interface BackgroundVideoEngineConfig
    * multivariant-playlist parser.
    */
   parsePresentation?: ParsePresentation;
+  /**
+   * Whether `state.screenResolution` is reported in device pixels. Read by
+   * `trackScreenResolution`; defaults to `true`.
+   */
+  useDevicePixelRatio?: boolean;
 }
 
 // ============================================================================
@@ -160,6 +178,11 @@ export function createBackgroundVideoEngine(
 
       // Playback tracking
       trackCurrentTime,
+
+      // Environment tracking — the signal source for a screen-size rendition
+      // cap. Independent of the presentation, so it sits outside the
+      // resolve/select/load sequence above.
+      trackScreenResolution,
 
       // End of stream coordination
       endOfStream,

--- a/packages/spf/src/playback/engines/hls/engine-background-video.ts
+++ b/packages/spf/src/playback/engines/hls/engine-background-video.ts
@@ -5,13 +5,16 @@ import {
   type StateSignals,
 } from '../../../core/composition/create-composition';
 import { makeShareSignals, type ShareSignalsConfig } from '../../../core/composition/share-signals';
+import { canPlayTrack } from '../../../media/dom/capabilities';
 import type { ScreenResolution } from '../../../media/dom/screen';
+import { SVTA_NO_SUPPORTED_VIDEO_TRACK, type SvtaError } from '../../../media/errors';
 import { parseMultivariantPlaylist } from '../../../media/hls/parse-multivariant';
-import type { MaybeResolvedPresentation } from '../../../media/types';
+import type { CanPlayTrack, MaybeResolvedPresentation } from '../../../media/types';
 import { getResolvedSelectedTrackDuration } from '../../../media/utils/track-selection';
 import type { SegmentLoaderActor } from '../../actors/dom/segment-loader';
 import type { SourceBufferActor } from '../../actors/dom/source-buffer';
 import { calculatePresentationDuration } from '../../behaviors/calculate-presentation-duration';
+import { collectErrors, reportAbsentTrackType } from '../../behaviors/collect-errors';
 import { endOfStream } from '../../behaviors/dom/end-of-stream';
 import { loadVideoSegments } from '../../behaviors/dom/load-segments';
 import { setupVideoBufferActors } from '../../behaviors/dom/setup-buffer-actors';
@@ -27,6 +30,11 @@ import {
   screenResolutionCap,
   selectVideoTrack,
 } from '../../behaviors/select-tracks';
+import {
+  type ReportUnsupportedTrackConditions,
+  reportUnsupportedTrackConditions,
+} from '../../primitives/report-track-conditions';
+import { excludeUnplayableTracks } from '../../primitives/selection-rules';
 
 // ============================================================================
 // Background-video engine state & context
@@ -61,6 +69,13 @@ export interface BackgroundVideoEngineState {
    * selection rule — which treats `undefined` as "don't cap".
    */
   screenResolution?: ScreenResolution;
+  /**
+   * Conditions reported while this source is loaded — the per-rendition causes
+   * `resolveVideoTrack` reports and the verdict `selectVideoTrack` reports when
+   * the constraints prune every rendition. Owned and cleared per source by
+   * `collectErrors`; the adapter derives which are fatal.
+   */
+  errors?: SvtaError[];
 }
 
 /**
@@ -95,6 +110,13 @@ export type BackgroundVideoEngineSignals = {
 export interface BackgroundVideoEngineConfig
   extends ShareSignalsConfig<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   /**
+   * Hard-constraint pre-pass handed to `selectVideoTrack`. Defaults to
+   * `[reportAbsentTrackType(2011), excludeUnplayableTracks]` — report a source
+   * offering no video at all (this engine composes only video, so it can never
+   * play one), then prune the renditions this environment can't decode.
+   */
+  constraints?: SelectVideoTrackConfig['constraints'];
+  /**
    * Selection-rule chain handed to `selectVideoTrack`. Defaults to
    * `[screenResolutionCap, preferHighestResolution]` — narrows to the renditions
    * that fit the screen, takes the largest of those, and pins it for the session.
@@ -114,6 +136,19 @@ export interface BackgroundVideoEngineConfig
    * `trackScreenResolution`; defaults to `true`.
    */
   useDevicePixelRatio?: boolean;
+  /**
+   * Codec/container capability probe read by `selectVideoTrack`'s constraint
+   * pre-pass. Defaults to the DOM `canPlayTrack`; override to force-exclude a
+   * codec.
+   */
+  canPlayTrack?: CanPlayTrack;
+  /**
+   * Per-rendition condition reporting, called by `resolveVideoTrack` once a
+   * media playlist parses. Defaults to
+   * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers
+   * (1004) and encryption (4008).
+   */
+  reportUnsupportedTrackConditions?: ReportUnsupportedTrackConditions;
 }
 
 // ============================================================================
@@ -133,6 +168,13 @@ const shareSignals = makeShareSignals<BackgroundVideoEngineState, BackgroundVide
  * `loadActivated: true` so the composition behaves as if preload has
  * already been activated — appropriate for ambient / hero / GIF-replacement
  * surfaces that should start loading the moment a src is set.
+ *
+ * Error reporting is *not* subtracted: `collectErrors` owns the sequence,
+ * `resolveVideoTrack` reports per-rendition causes, and `selectVideoTrack`
+ * reports the video verdict when nothing survives its constraints. Without them
+ * every unplayable source here is a silent stall — an unsupported container,
+ * encryption this engine can't decrypt, and an undecodable codec all leave
+ * `HTMLMediaElement.error` null on both Chromium and WebKit.
  *
  * Native `loop` / `muted` / `autoplay` are adapter concerns and live on
  * `HlsBackgroundVideoMediaElement` rather than the engine.
@@ -157,9 +199,12 @@ export function createBackgroundVideoEngine(
 ): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   const finalConfig = {
     ...config,
+    constraints: config.constraints ?? [reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK), excludeUnplayableTracks],
     rules: config.rules ?? [screenResolutionCap, preferHighestResolution],
     parsePresentation: config.parsePresentation ?? parseMultivariantPlaylist,
     resolveDuration: getResolvedSelectedTrackDuration,
+    canPlayTrack: config.canPlayTrack ?? canPlayTrack,
+    reportUnsupportedTrackConditions: config.reportUnsupportedTrackConditions ?? reportUnsupportedTrackConditions,
   };
 
   return createComposition(
@@ -168,7 +213,12 @@ export function createBackgroundVideoEngine(
       // Presentation duration
       calculatePresentationDuration,
 
-      // Track selection - pinned single-rendition pick on presentation resolve.
+      // Owns `errors` and its per-source lifecycle; reporters append into it.
+      collectErrors,
+
+      // Track selection - pinned single-rendition pick on presentation resolve,
+      // unpinned again if the constraint pre-pass later prunes every rendition
+      // (which is how a container relabel reaches a pick already made).
       selectVideoTrack,
       // Resolve selected video track (fetch its media playlist)
       resolveVideoTrack,

--- a/packages/spf/src/playback/engines/hls/engine-background-video.ts
+++ b/packages/spf/src/playback/engines/hls/engine-background-video.ts
@@ -21,7 +21,12 @@ import { trackScreenResolution } from '../../behaviors/dom/track-screen-resoluti
 import { updateMediaSourceDuration } from '../../behaviors/dom/update-mediasource-duration';
 import { type ParsePresentation, resolvePresentation } from '../../behaviors/resolve-presentation';
 import { resolveVideoTrack } from '../../behaviors/resolve-track';
-import { preferHighestResolution, type SelectVideoTrackConfig, selectVideoTrack } from '../../behaviors/select-tracks';
+import {
+  preferHighestResolution,
+  type SelectVideoTrackConfig,
+  screenResolutionCap,
+  selectVideoTrack,
+} from '../../behaviors/select-tracks';
 
 // ============================================================================
 // Background-video engine state & context
@@ -52,8 +57,8 @@ export interface BackgroundVideoEngineState {
   loadActivated?: boolean;
   /**
    * The screen's pixel dimensions, or `undefined` where there is none to read.
-   * Written by `trackScreenResolution`; nothing reads it yet — the screen-size
-   * rendition cap that will is the next step.
+   * Written by `trackScreenResolution`, read by the `screenResolutionCap`
+   * selection rule — which treats `undefined` as "don't cap".
    */
   screenResolution?: ScreenResolution;
 }
@@ -91,12 +96,12 @@ export interface BackgroundVideoEngineConfig
   extends ShareSignalsConfig<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   /**
    * Selection-rule chain handed to `selectVideoTrack`. Defaults to
-   * `[preferHighestResolution]` — narrows to the largest rendition on offer and
-   * pins it for the session.
+   * `[screenResolutionCap, preferHighestResolution]` — narrows to the renditions
+   * that fit the screen, takes the largest of those, and pins it for the session.
    *
-   * A cap composes as another rule ahead of it, which is how the screen-size cap
-   * will arrive; nothing about this variant's selection is a bespoke picker any
-   * more.
+   * The cap sits ahead of the ranker because a scope that narrows first wins over
+   * one applied later; pass `[preferHighestResolution]` alone to opt out and always
+   * pin the largest rendition on offer.
    */
   rules?: readonly NonNullable<SelectVideoTrackConfig['rules']>[number][];
   /**
@@ -152,7 +157,7 @@ export function createBackgroundVideoEngine(
 ): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   const finalConfig = {
     ...config,
-    rules: config.rules ?? [preferHighestResolution],
+    rules: config.rules ?? [screenResolutionCap, preferHighestResolution],
     parsePresentation: config.parsePresentation ?? parseMultivariantPlaylist,
     resolveDuration: getResolvedSelectedTrackDuration,
   };

--- a/packages/spf/src/playback/engines/hls/index.ts
+++ b/packages/spf/src/playback/engines/hls/index.ts
@@ -15,6 +15,12 @@ export {
   derivePerTypeStartMediaTime,
   deriveSharedMinStartMediaTime,
 } from '../../behaviors/establish-start-media-time';
+// The video selection rules the engines compose by default, plus the rule shape
+// itself. `config.rules` is public, so without these a consumer can override the
+// chain but cannot reconstruct or partially opt out of the default it replaces —
+// `[preferHighestResolution]` alone drops the screen-size cap, for one.
+export type { SelectTrackRule } from '../../behaviors/select-tracks';
+export { preferHighestResolution, screenResolutionCap } from '../../behaviors/select-tracks';
 // The Medias over these engines are not here: they live behind
 // `@videojs/spf/hls-video`, `@videojs/spf/hls-audio`, and
 // `@videojs/spf/hls-background-video` so that driving an engine directly doesn't pull

--- a/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
@@ -179,4 +179,55 @@ describe('createBackgroundVideoEngine', () => {
     expect(engine.state.selectedVideoTrackId.get()).toBe('forced-pick');
     engine.destroy();
   });
+
+  describe('screenResolution', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function stubScreen(width: number, height: number, ratio = 1) {
+      const screen = Object.assign(new EventTarget(), { width, height, orientation: new EventTarget() });
+      vi.stubGlobal('screen', screen);
+      vi.stubGlobal('devicePixelRatio', ratio);
+      return screen;
+    }
+
+    it('is populated in device pixels before any presentation is set', () => {
+      // The cap needs the screen from frame 0, not once a source arrives — the
+      // slot is independent of the presentation lifecycle.
+      stubScreen(1440, 900, 2);
+      const engine = createBackgroundVideoEngine();
+
+      expect(engine.state.screenResolution.get()).toEqual({ width: 2880, height: 1800 });
+
+      engine.destroy();
+    });
+
+    it('honors useDevicePixelRatio from engine config', () => {
+      stubScreen(1440, 900, 2);
+      const engine = createBackgroundVideoEngine({ useDevicePixelRatio: false });
+
+      expect(engine.state.screenResolution.get()).toEqual({ width: 1440, height: 900 });
+
+      engine.destroy();
+    });
+
+    it('tracks the screen changing under the window', () => {
+      const screen = stubScreen(1440, 900);
+      const engine = createBackgroundVideoEngine();
+
+      screen.width = 3840;
+      screen.height = 2160;
+      screen.dispatchEvent(new Event('change'));
+
+      expect(engine.state.screenResolution.get()).toEqual({ width: 3840, height: 2160 });
+
+      engine.destroy();
+    });
+
+    // Teardown is asserted at the behavior level instead — see
+    // `behaviors/dom/tests/track-screen-resolution.test.ts`. Reading the slot
+    // after `destroy()` returns `undefined` regardless, so an engine-level
+    // assertion here couldn't tell a removed listener from torn-down state.
+  });
 });

--- a/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
@@ -4,8 +4,8 @@
  * The variant subtracts audio, text, ABR, and preload-monitoring behaviors
  * from the HLS video engine, then seeds `loadActivated: true` so the
  * composition behaves as if preload has already been activated. These tests
- * confirm the seed, the absence of subtracted state slots, and the picker
- * configurability.
+ * confirm the seed, the absence of subtracted state slots, and the selection
+ * rule chain — its screen-size cap and its configurability.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { snapshot } from '../../../../core/signals/primitives';
@@ -78,8 +78,13 @@ describe('createBackgroundVideoEngine', () => {
     engine.destroy();
   });
 
-  it('defaults the picker to pickHighestResolutionVideoTrack', async () => {
+  // The screen is written explicitly in both tests below rather than left to
+  // whatever the test runner's screen happens to be: the default chain caps to it,
+  // so an ambient reading would make the expected pick machine-dependent.
+  it('defaults the rule chain to the largest rendition that fits the screen', async () => {
     const engine = createBackgroundVideoEngine();
+    // Roomy enough that the cap admits both, leaving the ranker to decide.
+    engine.state.screenResolution.set({ width: 3840, height: 2160 });
 
     const presentation: MaybeResolvedPresentation = {
       id: 'p',
@@ -135,9 +140,55 @@ describe('createBackgroundVideoEngine', () => {
     engine.destroy();
   });
 
+  it('caps the default pick to the screen', async () => {
+    const engine = createBackgroundVideoEngine();
+    // 921,600 px: the 1080p rung's 2,073,600 is over it, the 480p rung's 409,920 fits.
+    engine.state.screenResolution.set({ width: 1280, height: 720 });
+
+    const videoTrack = (id: string, width: number, height: number, bandwidth: number) =>
+      ({
+        type: 'video',
+        id,
+        url: `https://example.com/${id}.m3u8`,
+        bandwidth,
+        mimeType: 'video/mp4',
+        codecs: ['avc1.42E01E'],
+        initialization: { url: 'init', byteRange: { offset: 0, length: 0 } },
+        segments: [],
+        startTime: 0,
+        duration: 0,
+        width,
+        height,
+      }) as never;
+
+    engine.state.presentation.set({
+      id: 'p',
+      url: 'https://example.com/manifest.m3u8',
+      startTime: 0,
+      selectionSets: [
+        {
+          id: 'video-set',
+          type: 'video',
+          switchingSets: [
+            {
+              id: 'video-switching',
+              type: 'video',
+              tracks: [videoTrack('480p', 854, 480, 1_000_000), videoTrack('1080p', 1920, 1080, 4_000_000)],
+            },
+          ],
+        },
+      ],
+    } as MaybeResolvedPresentation);
+
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    expect(engine.state.selectedVideoTrackId.get()).toBe('480p');
+    engine.destroy();
+  });
+
   it('honors a custom rule chain from config', async () => {
     // Two tracks, so overriding is observable: the default chain
-    // (`preferHighestResolution`) would take 720p, and this rule takes 480p.
+    // (`[screenResolutionCap, preferHighestResolution]`) would take 720p on any
+    // screen that fits it, and this rule takes 480p regardless.
     const engine = createBackgroundVideoEngine({
       rules: [(tracks) => tracks.filter((track) => track.id === '480p')],
     });

--- a/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
@@ -9,6 +9,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { snapshot } from '../../../../core/signals/primitives';
+import { SVTA_NO_SUPPORTED_VIDEO_TRACK } from '../../../../media/errors';
 import type { MaybeResolvedPresentation } from '../../../../media/types';
 import { createBackgroundVideoEngine } from '../engine-background-video';
 
@@ -58,6 +59,133 @@ describe('createBackgroundVideoEngine', () => {
     expect('userVideoTrackSelection' in state).toBe(false);
 
     engine.destroy();
+  });
+
+  // Error reporting is deliberately *not* subtracted: nothing about an unplayable
+  // source reaches the media element on its own, so without the sequence a
+  // background video fails invisibly.
+  describe('errors', () => {
+    const unplayablePresentation = (): MaybeResolvedPresentation => ({
+      id: 'p',
+      url: 'https://example.com/v.m3u8',
+      startTime: 0,
+      selectionSets: [
+        {
+          id: 'video-set',
+          type: 'video',
+          switchingSets: [
+            {
+              id: 'video-switching',
+              type: 'video',
+              tracks: [
+                {
+                  type: 'video',
+                  id: '720p-ts',
+                  url: 'https://example.com/720p.m3u8',
+                  bandwidth: 2_000_000,
+                  // Already relabeled, as `resolve-track` leaves the whole type
+                  // once a media playlist resolves without an EXT-X-MAP.
+                  mimeType: 'video/mp2t',
+                  codecs: ['avc1.42E01E'],
+                  width: 1280,
+                  height: 720,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    it('declares the errors slot', () => {
+      const engine = createBackgroundVideoEngine();
+      expect('errors' in (snapshot(engine.state) as Record<string, unknown>)).toBe(true);
+      engine.destroy();
+    });
+
+    // MPEG-TS: the capability constraint prunes it, so nothing is selected. No
+    // verdict — the cause (1004) is reported by `resolveVideoTrack` as the playlist
+    // resolves, which is more specific and needs no manifest fetch here.
+    it('makes no pick for an unplayable container', async () => {
+      const engine = createBackgroundVideoEngine();
+      engine.state.presentation.set(unplayablePresentation());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(engine.state.selectedVideoTrackId.get()).toBeUndefined();
+      expect(engine.state.errors.get()).toBeUndefined();
+      engine.destroy();
+    });
+
+    // The one failure with no per-rendition cause behind it: nothing resolves, so
+    // nothing reports. `reportAbsentTrackType` at the head of the constraint chain
+    // is what covers it, composed because this engine is video-only.
+    it('reports for a source with no video renditions at all', async () => {
+      const engine = createBackgroundVideoEngine();
+      engine.state.presentation.set(audioOnlyPresentation());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(engine.state.errors.get()).toEqual([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
+      engine.destroy();
+    });
+
+    const audioOnlyPresentation = (): MaybeResolvedPresentation =>
+      ({
+        id: 'p',
+        url: 'https://example.com/audio-only.m3u8',
+        startTime: 0,
+        selectionSets: [
+          {
+            id: 'audio-set',
+            type: 'audio',
+            switchingSets: [
+              {
+                id: 'audio-switching',
+                type: 'audio',
+                tracks: [
+                  {
+                    type: 'audio',
+                    id: 'audio-1',
+                    url: 'https://example.com/audio.m3u8',
+                    bandwidth: 128_000,
+                    mimeType: 'audio/mp4',
+                    codecs: ['mp4a.40.2'],
+                    groupId: 'g',
+                    name: 'English',
+                    sampleRate: 48_000,
+                    channels: 2,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }) as never;
+
+    it('reports the absent type once, not on every presentation write', async () => {
+      // The constraint chain runs inside a `computed` that re-derives on every
+      // write, and the sequence keeps duplicates, so the guard is load-bearing.
+      const engine = createBackgroundVideoEngine();
+      engine.state.presentation.set(audioOnlyPresentation());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      engine.state.presentation.set(audioOnlyPresentation());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(engine.state.errors.get()).toHaveLength(1);
+      engine.destroy();
+    });
+
+    it('clears the sequence on src unload so the next source starts clean', async () => {
+      const engine = createBackgroundVideoEngine();
+      engine.state.presentation.set(audioOnlyPresentation());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(engine.state.errors.get()).toHaveLength(1);
+
+      engine.state.presentation.set(undefined);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(engine.state.errors.get()).toBeUndefined();
+      engine.destroy();
+    });
   });
 
   it('omits subtracted context slots — no audio segment loader / text actors', () => {

--- a/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
@@ -135,9 +135,11 @@ describe('createBackgroundVideoEngine', () => {
     engine.destroy();
   });
 
-  it('honors a custom picker override from config', async () => {
+  it('honors a custom rule chain from config', async () => {
+    // Two tracks, so overriding is observable: the default chain
+    // (`preferHighestResolution`) would take 720p, and this rule takes 480p.
     const engine = createBackgroundVideoEngine({
-      picker: () => 'forced-pick',
+      rules: [(tracks) => tracks.filter((track) => track.id === '480p')],
     });
 
     const presentation: MaybeResolvedPresentation = {
@@ -167,6 +169,20 @@ describe('createBackgroundVideoEngine', () => {
                   width: 854,
                   height: 480,
                 } as never,
+                {
+                  type: 'video',
+                  id: '720p',
+                  url: 'https://example.com/720p.m3u8',
+                  bandwidth: 2_500_000,
+                  mimeType: 'video/mp4',
+                  codecs: ['avc1.42E01E'],
+                  initialization: { url: 'init', byteRange: { offset: 0, length: 0 } },
+                  segments: [],
+                  startTime: 0,
+                  duration: 0,
+                  width: 1280,
+                  height: 720,
+                } as never,
               ],
             },
           ],
@@ -176,7 +192,7 @@ describe('createBackgroundVideoEngine', () => {
 
     engine.state.presentation.set(presentation);
     await new Promise<void>((resolve) => queueMicrotask(resolve));
-    expect(engine.state.selectedVideoTrackId.get()).toBe('forced-pick');
+    expect(engine.state.selectedVideoTrackId.get()).toBe('480p');
     engine.destroy();
   });
 

--- a/packages/spf/src/playback/primitives/error-messages.ts
+++ b/packages/spf/src/playback/primitives/error-messages.ts
@@ -24,6 +24,20 @@ export const UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE =
   "Can't play this source: it requires an unsupported playback feature.";
 
 /**
+ * Logged for **any** fatal condition, by a composition whose failures don't all
+ * reduce to a missing feature.
+ *
+ * The background variant is the case: it treats a per-rendition cause as fatal on
+ * its own, so what reaches its surface can be an unsupported container, DRM it
+ * can't decrypt, or a source carrying no video at all. One sentence covers every
+ * one of those, and the conditions logged beside it — already structured, already
+ * carrying track type, id, and container — say which. Naming a feature instead
+ * would be wrong for the last case and would send a developer looking in the
+ * wrong place.
+ */
+export const UNPLAYABLE_SOURCE_MESSAGE = "Can't play this source. The conditions logged with this message say why.";
+
+/**
  * LL-HLS delivery, played as standard live. The parser ignores partial segments
  * and the loader fetches whole ones, so latency lands wherever `HOLD-BACK` puts
  * it — the stream plays, just not at the latency it was published for.

--- a/packages/spf/src/playback/primitives/error-messages.ts
+++ b/packages/spf/src/playback/primitives/error-messages.ts
@@ -29,13 +29,13 @@ export const UNSUPPORTED_PLAYBACK_FEATURE_MESSAGE =
  *
  * The background variant is the case: it treats a per-rendition cause as fatal on
  * its own, so what reaches its surface can be an unsupported container, DRM it
- * can't decrypt, or a source carrying no video at all. One sentence covers every
- * one of those, and the conditions logged beside it — already structured, already
- * carrying track type, id, and container — say which. Naming a feature instead
- * would be wrong for the last case and would send a developer looking in the
- * wrong place.
+ * can't decrypt, or a source carrying no video at all. Naming one feature would be
+ * wrong for the last of those, so all three are named broadly. Deferring the *why*
+ * to the conditions instead would promise prose they don't carry — an `SvtaError`
+ * is a code and its context, and nothing on this path sets `message`.
  */
-export const UNPLAYABLE_SOURCE_MESSAGE = "Can't play this source. The conditions logged with this message say why.";
+export const UNPLAYABLE_SOURCE_MESSAGE =
+  "Can't play this source — unsupported container, encryption, or no usable video track.";
 
 /**
  * LL-HLS delivery, played as standard live. The parser ignores partial segments

--- a/packages/spf/src/playback/primitives/selection-rules.ts
+++ b/packages/spf/src/playback/primitives/selection-rules.ts
@@ -1,0 +1,93 @@
+/**
+ * The selection-rule substrate: the shape of a rule, and the two composers that
+ * turn a list of them into a pick.
+ *
+ * Lives here rather than beside `switchVideoTrack` so both track-selection
+ * behaviors can share rules. The simple `selectVideoTrack` variant exists
+ * specifically to tree-shake the ABR path out, so importing a composer from
+ * `behaviors/track-switching.ts` would drag the bandwidth estimator and quality
+ * selection back in with it. These four have no dependencies at all — pure
+ * generics over a candidate list — so either side can reach them freely.
+ *
+ * See `internal/design/spf/track-switching-model.md` for the model these
+ * implement: a hard constraints pre-pass, then an ordered chain of soft
+ * narrowing rules and rankers, with the pick as the first survivor.
+ */
+
+/**
+ * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
+ * deps so a rule reads from the same surfaces a behavior does. `context` is
+ * optional — it's threaded through but absent on direct setup calls (and
+ * unread by today's rules), so the whole deps object can pass straight through.
+ */
+export interface SelectionRuleDeps<State = unknown, Context = unknown, Config = unknown> {
+  state: State;
+  context?: Context;
+  config: Config;
+}
+
+/**
+ * A selection rule narrows or reorders the candidate list. It reads the state,
+ * context, and config it needs at apply time (tightly-coupled reads), so a
+ * rule's `.get()`s subscribe the running effect to exactly what it consulted.
+ * Returning an empty list means "no match" — the composer skips it, so a soft
+ * filter never narrows the set to nothing. A ranker returns the list with its
+ * pick at the head.
+ */
+export type SelectionRule<T, State = unknown, Context = unknown, Config = unknown> = (
+  tracks: readonly T[],
+  deps: SelectionRuleDeps<State, Context, Config>
+) => readonly T[];
+
+/**
+ * Apply rules to a candidate list in order; the pick is the first survivor.
+ * Two responsibilities the rules don't carry: a rule that returns nothing is
+ * skipped (fall-through — a preference never empties the set), and once one
+ * survivor remains the chain stops (early-bail — later rules, including the
+ * bandwidth ranker, never run, so the effect doesn't subscribe to their
+ * signals while the choice is fixed).
+ *
+ * @param rules - Rules to apply, most authoritative first
+ * @param tracks - Candidate tracks
+ * @param deps - The behavior's `{ state, context, config }`, passed through to each rule
+ * @returns The surviving candidates, pick first
+ */
+export function applyRules<T, State, Context, Config>(
+  rules: readonly SelectionRule<T, State, Context, Config>[],
+  tracks: readonly T[],
+  deps: SelectionRuleDeps<State, Context, Config>
+): readonly T[] {
+  let current = tracks;
+  for (const rule of rules) {
+    const remaining = rule(current, deps);
+    if (remaining.length === 0) continue;
+    current = remaining;
+    if (current.length === 1) break;
+  }
+  return current;
+}
+
+/**
+ * Apply hard constraints to a candidate list — the pre-pass that runs before the
+ * rule chain. A constraint shares a rule's signature but its exclusion is
+ * *hard*: it removes the unplayable (a codec the environment can't decode, a CDN
+ * in failover cooldown) and a removed track is never attempted. Unlike
+ * `applyRules`, this never skips an empty result and never early-bails — every
+ * constraint always applies, and an empty survivor set is a real outcome
+ * ("nothing playable here"), not a fall-through. Because each constraint only
+ * removes, the order they run in can't change the result.
+ *
+ * @param constraints - Constraints to apply (pooled, order-independent)
+ * @param tracks - Candidate tracks
+ * @param deps - The behavior's `{ state, context, config }`, passed to each constraint
+ * @returns The playable survivors (possibly empty)
+ */
+export function applyConstraints<T, State, Context, Config>(
+  constraints: readonly SelectionRule<T, State, Context, Config>[],
+  tracks: readonly T[],
+  deps: SelectionRuleDeps<State, Context, Config>
+): readonly T[] {
+  let current = tracks;
+  for (const constraint of constraints) current = constraint(current, deps);
+  return current;
+}

--- a/packages/spf/src/playback/primitives/selection-rules.ts
+++ b/packages/spf/src/playback/primitives/selection-rules.ts
@@ -14,6 +14,8 @@
  * narrowing rules and rankers, with the pick as the first survivor.
  */
 
+import type { CanPlayTrack } from '../../media/types';
+
 /**
  * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
  * deps so a rule reads from the same surfaces a behavior does. `context` is
@@ -90,4 +92,60 @@ export function applyConstraints<T, State, Context, Config>(
   let current = tracks;
   for (const constraint of constraints) current = constraint(current, deps);
   return current;
+}
+
+/**
+ * Whether two candidate sets hold the same tracks, by id.
+ *
+ * The `equals` both selection behaviors give their candidate-set `computed`. A
+ * live playlist refresh swaps in a new presentation object carrying the same
+ * variants, and a constraint's own inputs can churn without changing which
+ * tracks survive; in both cases the set is unchanged and the reaction must not
+ * re-fire. Compares by id rather than array identity for exactly that.
+ */
+export function sameCandidateSet<T extends { id: string }>(a: readonly T[], b: readonly T[]): boolean {
+  return a.length === b.length && a.every((track) => b.some((other) => other.id === track.id));
+}
+
+/**
+ * What {@link excludeUnplayableTracks} reads off the config it is handed.
+ *
+ * Read through a cast rather than constraining the rule's `Config` generic, the
+ * same way `screenResolutionCap` reads `screenResolution` off its state: a rule
+ * composes into chains whose config types have nothing else in common, and
+ * constraining the generic would make every one of those a weak-type mismatch.
+ * Each engine defaults `canPlayTrack` to the DOM-bound probe; unwired means "no
+ * capability filtering" and the constraint passes everything through.
+ */
+export interface CapabilityConstraintConfig {
+  canPlayTrack?: CanPlayTrack;
+}
+
+/**
+ * Capability constraint — a *hard* filter for the {@link applyConstraints}
+ * pre-pass. Removes renditions this environment can't decode, probed via the
+ * injected `canPlayTrack` (codec → `MediaSource.isTypeSupported`, plus the
+ * container and encryption assertions that probe can't make). Constraining here
+ * — before selection — means an unplayable variant is pruned upstream and never
+ * picked, instead of surviving into the pipeline to fail late at
+ * `createSourceBuffer`. That late throw stays as a defensive structural
+ * guarantee; with this constraint it should rarely fire.
+ *
+ * Lives here rather than beside `switchVideoTrack` for the reason this module
+ * exists: both the re-evaluating variant and the pinned `selectVideoTrack` apply
+ * it, and reaching it through `behaviors/track-switching.ts` would drag the ABR
+ * path into a composition that deliberately omits it.
+ *
+ * Passes everything through when there's no probe (a composition that didn't
+ * wire one, or DOM-free tests). When it prunes *every* track, the empty result is
+ * preserved (per `applyConstraints`) — "nothing playable" — which each consuming
+ * behavior answers by clearing its selection and reporting the type's verdict.
+ */
+export function excludeUnplayableTracks<T, State, Context, Config>(
+  tracks: readonly T[],
+  { config }: SelectionRuleDeps<State, Context, Config>
+): readonly T[] {
+  const canPlay = (config as CapabilityConstraintConfig | undefined)?.canPlayTrack;
+  if (!canPlay) return tracks;
+  return tracks.filter((track) => canPlay(track as Parameters<CanPlayTrack>[0]));
 }

--- a/packages/spf/src/playback/primitives/tests/selection-rules.test.ts
+++ b/packages/spf/src/playback/primitives/tests/selection-rules.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The rule-chain composers, tested pure — no signals, no behavior, no engine.
+ *
+ * The two differ in exactly three ways, and each is asserted here: a rule that
+ * matches nothing falls through while a constraint's empty result stands, a rule
+ * chain bails at one survivor while every constraint always runs, and constraint
+ * order can't change the outcome while rule order can.
+ */
+import { describe, expect, it } from 'vitest';
+import { applyConstraints, applyRules, type SelectionRule } from '../selection-rules';
+
+// ============================================================================
+// applyRules — the rule-chain composer (pure; no signals)
+// ============================================================================
+
+describe('applyRules', () => {
+  const track = (id: string) => ({ id });
+  const all = [track('a'), track('b'), track('c')];
+
+  const noDeps = { state: {}, context: {}, config: {} };
+
+  it('applies rules in order; the pick is the first survivor', () => {
+    const dropA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'a');
+    const reverse: SelectionRule<{ id: string }> = (tracks) => [...tracks].reverse();
+    const result = applyRules([dropA, reverse], all, noDeps);
+    expect(result.map((t) => t.id)).toEqual(['c', 'b']);
+  });
+
+  it('skips a rule that returns nothing (fall-through), keeping the prior set', () => {
+    const matchNone: SelectionRule<{ id: string }> = () => [];
+    const result = applyRules([matchNone], all, noDeps);
+    expect(result.map((t) => t.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('stops at one survivor and does not run later rules (early-bail)', () => {
+    const toA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id === 'a');
+    let laterCalled = false;
+    const later: SelectionRule<{ id: string }> = (tracks) => {
+      laterCalled = true;
+      return tracks;
+    };
+    const result = applyRules([toA, later], all, noDeps);
+    expect(result.map((t) => t.id)).toEqual(['a']);
+    expect(laterCalled).toBe(false);
+  });
+
+  it('passes the candidate list and deps (state, context, config) through to each rule', () => {
+    const deps = { state: { marker: 1 }, context: { other: 2 }, config: { tuning: 3 } };
+    let received: unknown[] = [];
+    const rule: SelectionRule<{ id: string }, typeof deps.state, typeof deps.context, typeof deps.config> = (
+      tracks,
+      ruleDeps
+    ) => {
+      received = [tracks, ruleDeps];
+      return tracks;
+    };
+    applyRules([rule], all, deps);
+    expect(received).toEqual([all, deps]);
+  });
+});
+
+// ============================================================================
+// applyConstraints — the hard-constraints pre-pass (pure; no signals)
+// ============================================================================
+
+describe('applyConstraints', () => {
+  const track = (id: string) => ({ id });
+  const all = [track('a'), track('b'), track('c')];
+  const noDeps = { state: {}, context: {}, config: {} };
+
+  const noA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'a');
+  const noC: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id !== 'c');
+
+  it('removes what each constraint excludes (pooled)', () => {
+    expect(applyConstraints([noA, noC], all, noDeps).map((t) => t.id)).toEqual(['b']);
+  });
+
+  it('is order-independent', () => {
+    expect(applyConstraints([noA, noC], all, noDeps)).toEqual(applyConstraints([noC, noA], all, noDeps));
+  });
+
+  it('preserves an empty result — no fall-through, unlike applyRules', () => {
+    const none: SelectionRule<{ id: string }> = () => [];
+    expect(applyConstraints([none], all, noDeps)).toEqual([]);
+  });
+
+  it('runs every constraint — no early-bail at a single survivor', () => {
+    const toA: SelectionRule<{ id: string }> = (tracks) => tracks.filter((t) => t.id === 'a');
+    let laterCalled = false;
+    const later: SelectionRule<{ id: string }> = (tracks) => {
+      laterCalled = true;
+      return tracks;
+    };
+    applyConstraints([toA, later], all, noDeps);
+    expect(laterCalled).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #1785

## Summary

Two things the SPF background-video composition lacked: a rendition pick that respects the screen it will be shown on, and any way to say a source can't be played. Both arrive as composable pieces rather than variant-private logic — track selection is now the same rule chain the ABR path uses, which is a **breaking** change for anyone configuring `selectVideoTrack` / `selectAudioTrack` directly.

## Changes

**Selection by rule chain (breaking)**

- `SelectVideoTrackConfig.picker` / `SelectAudioTrackConfig.picker` / `BackgroundVideoEngineConfig.picker` are replaced by `rules` plus an optional `constraints` pre-pass — the model `switchVideoTrack` already ran. A rule written for one composes into the other unchanged; the two behaviors differ in *reactivity*, not in what a rule is.
- A rule now selects among real candidates, where a picker could return any id. An id the manifest never offered was never selectable, so that's the point rather than a limitation.
- `preferHighestResolution` ships as a shared rule, and the dead picker cluster it orphans is deleted (~230 lines from `media/primitives/select-tracks.ts`, none of it reachable from an entry point).

**Screen-size rendition cap**

- `screenResolutionCap` narrows candidates to the renditions whose *pixel area* fits the screen, composed ahead of the ranker in the background-video engine's default chain. Areas rather than `"1080p"`-style tiers, because a tier only describes a rendition once you assume its aspect ratio — the assumption that mis-measures an anamorphic ladder.
- Fed by `trackScreenResolution`, a new behavior over a new `media/dom/screen` reader/watcher. Device pixels by default; `undefined` where there's no screen to read, which the cap treats as "don't cap" rather than a cap of zero.
- A soft filter, never a constraint: an over-cap rendition is wasteful, not unplayable, so the cap can't make a source fail. Three fall-through paths (no signal composed, no screen, nothing fits) are all intentional.
- Player-size capping — the other half of #1785 — is **not** in this PR. Different signal source (`ResizeObserver`), different owning layer; `rendition-selection-caps.md` records the split.

**Unplayable sources stop being silent**

- Nothing about an unplayable source reaches the media element in this composition. Measured on Chromium and WebKit: an unsupported container, encryption with no EME, and an undecodable codec all leave `HTMLMediaElement.error` null with the element stalled at `readyState 0`, because nothing in MSE reports them either.
- The engine now reports SVTA-coded conditions onto `engine.state.errors` (owned per-source by `collectErrors`), and the Media promotes the first fatal one to `error` + an `'error'` event — the same surface, shape, and 99001 mapping the video and audio Medias already have.
- `<hls-background-video>` re-fires it as its own event and exposes `error`; the React component re-dispatches on the `<video>` so `onError` fires. A consumer of either holds the element, not the Media.
- Fatality is wider here than on the other adapters, and deliberately: only the *pinned* rendition's playlist is ever resolved, so a cause (1004 / 4008) can only concern the pick, and dropping the pick is final. A verdict-only list left MPEG-TS and DRM as silent stalls.
- Every fatal condition is explained on the console, not only the ones that substitute 99001 — otherwise a source with no video renditions arrives as a bare 2011. The sentence names no cause, since naming a missing feature would be wrong for that case; the structured conditions beside it carry the specifics.

<details>
<summary>Implementation details</summary>

- `applyRules` / `applyConstraints` / `SelectionRule` moved to `playback/primitives/selection-rules.ts` so both selection behaviors can share them. `selectVideoTrack` exists to tree-shake the ABR path out, so importing a composer from `track-switching.ts` would have dragged the bandwidth estimator back in.
- `selectVideoTrack` still *selects* only in `entry`. A sibling effect only ever **de**selects a pick the constraints later turn against — container and encryption are known only once a media playlist resolves, after the pick was made. Re-picking is what `switchVideoTrack` is for; doing it here would make this that behavior with extra steps.
- `reportAbsentTrackType` is a "constraint" that never constrains, composed at the *head* of the chain, where an empty input still means "the source offers none" rather than "the constraints ahead pruned them all". Opt-in per composition, so one that doesn't need it pays nothing.
- The screen watcher subscribes to four signals (`screen`'s own `change`, `resize`, orientation, and a `dppx` media query) and compares readings, so over-subscribing costs a discarded read rather than a spurious call. `Screen.prototype.onchange` is Chromium-only in a secure context — measured across all three engines — so it joins the others rather than replacing them.
- Bundle: `@videojs/spf/hls` sits at 19.99 KB gzipped against a 20 KB target. Composing `trackScreenResolution` is what consumed most of the remaining headroom.

</details>

## Preview

Sandbox on this branch — [v10-sandbox](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app). The SPF background presets take the full HLS source list, so every shape below is reachable from the picker; these link straight to it.

| Source | Link | What to expect |
| :-- | :-- | :-- |
| 4K CMAF | [HTML](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=html&preset=hls-background-video&source=hls-4k) · [React](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=react&preset=hls-background-video&source=hls-4k) | Plays. The cap picks the largest rung at or under your screen — on a 3456x2234 display that's 2558x1440, not the 3838x2160 top rung |
| MPEG-TS | [HTML](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=html&preset=hls-background-video&source=hls-1) · [React](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=react&preset=hls-background-video&source=hls-1) | No video. `error.code === 99001`, console explains it with the 1004 condition attached, `video.error` stays null |
| DRM, unlicensed | [HTML](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=html&preset=hls-background-video&source=hls-drm-unlicensed) · [React](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=react&preset=hls-background-video&source=hls-drm-unlicensed) | Same 99001, over a 4008 in `engine.state.errors` |
| Audio-only | [HTML](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=html&preset=hls-background-video&source=hls-audio-only-cmaf) · [React](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=react&preset=hls-background-video&source=hls-audio-only-cmaf) | 2011, kept as-is — no cause behind it to substitute for. Still explained on the console, which is what makes a bare verdict actionable |

`preset=mux-background-video` is the same element and component under their Mux-flavored names, and should behave identically — [worth one pass](https://v10-sandbox-git-feat-screen-resolution-cap-mux.vercel.app/?platform=html&preset=mux-background-video&source=hls-4k) to confirm the alias.

To read the surfaced error from the console on either platform:

```js
// HTML
document.querySelector('hls-background-video').error
// engine sequence, both platforms (HTML shown)
document.querySelector('hls-background-video').getMediaTarget().engine.state.errors.get()
```

## Testing

```bash
pnpm -F @videojs/spf test          # 1512 passing
pnpm -F @videojs/html test
pnpm -F @videojs/react test
pnpm --dir apps/e2e exec playwright test spf-background-video \
  --project=vite-chromium --project=vite-webkit   # 20 passing
```

New e2e (`apps/e2e/tests/spf-background-video.spec.ts`) drives real manifests on both browser projects: fMP4 plays with nothing reported; MPEG-TS surfaces 99001 with the sequence holding a cause and *no* verdict behind it; the unlicensed DRM asset lands on the same code; an audio-only ladder keeps its own 2011; a source change back to fMP4 clears and plays; React's `onError` fires. The load-bearing one asserts the inner `<video>` stays at `readyState 0` with `error` null throughout — if a browser ever starts reporting these itself, that test is how we find out. The cap is covered through viewport × `deviceScaleFactor` (Playwright's `screen` option turns out not to apply — `window.screen` follows the emulated viewport in both projects).

Manual, Chromium against the sandbox's 4K preset on a 3456x2234 display: the pick moves from 3838x2160 to 2558x1440, playing at `readyState 4`. The sandbox's SPF background presets take the full HLS source list, so every failing shape is reachable there.

**Not verified on real Safari.** `vite-webkit` is Playwright's WebKit build, not the shipped Safari media stack; a `safaridriver` pass is still worth doing before release, since a CMAF rendition Safari's `isTypeSupported` rejects would now surface a fatal error rather than stalling quietly.

Found and filed along the way: #2162 (an empty `EXT-X-MAP` init URL fetches and appends the hosting page).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking SPF selection config and wider fatal-error semantics for background video affect playback and consumer error handling; large cross-package change with real-network e2e.
> 
> **Overview**
> **Breaking:** track selection moves from `picker` callbacks to composable **`rules`** and optional **`constraints`**, shared with the ABR path; legacy pickers and related primitives are removed.
> 
> For **SPF background video**, the default chain **`[screenResolutionCap, preferHighestResolution]`** pins the largest rendition whose pixel area fits the screen, fed by new **`getScreenResolution` / `watchScreenResolution`** and **`trackScreenResolution`**. **`selectVideoTrack`** can deselect a pick when capability info arrives later; **`reportAbsentTrackType`** covers sources with no video renditions.
> 
> **Unplayable sources** are no longer silent: the background adapter promotes fatal SVTA conditions (including per-rendition causes in the pinned model) to **`error`** and **`'error'`**, with console logging. **`<hls-background-video>`** and the React wrapper forward that to consumers while the inner **`<video>`** stays at **`readyState 0`** with **`error` null**.
> 
> **Sandbox / e2e:** SPF background presets use a selectable HLS source list and **`withMuxMaxResolution`**; new fixtures and **`spf-background-video.spec.ts`** plus generated **`?src=`** background pages exercise playback, errors, recovery, and viewport caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8b47e6d6e3a9bdcd3c4a3ea25b73a9a3f5f0061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->