### PR TITLE
docs(site): document quality radio group

### DIFF
--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
@@ -1,4 +1,4 @@
-import { createPlayer, Menu, useQualityOptions } from '@videojs/react';
+import { createPlayer, Menu, QualityRadioGroup } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
@@ -7,34 +7,28 @@ const Player = createPlayer({ features: videoFeatures });
 const src = '{{VJS8_DEMO_VIDEO_HLS}}';
 
 function QualityMenu(): ReactNode {
-  const quality = useQualityOptions();
-  if (quality?.state.availability !== 'available') return null;
-
   return (
     <Menu.Root side="top" align="end">
       <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
         Quality
       </Menu.Trigger>
       <Menu.Content className="menu">
-        <Menu.RadioGroup
+        <QualityRadioGroup
           className="menu-group"
-          value={quality.value}
-          onValueChange={quality.setValue}
           aria-label="Quality"
-        >
-          {quality.options.map((option) => (
-            <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled} className="menu-item">
+          renderItem={(props, item) => (
+            <Menu.RadioItem {...props} className="menu-item">
               <span>
-                {option.label}
-                {option.tier ? <sup className="menu-tier">{option.tier}</sup> : null}
+                {item.label}
+                {item.tier ? <sup className="menu-tier">{item.tier}</sup> : null}
               </span>
-              {option.badge ? <span className="menu-badge">{option.badge}</span> : null}
-              <Menu.ItemIndicator checked={option.value === quality.value} forceMount className="menu-indicator">
+              {item.badge ? <span className="menu-badge">{item.badge}</span> : null}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
                 ✓
               </Menu.ItemIndicator>
             </Menu.RadioItem>
-          ))}
-        </Menu.RadioGroup>
+          )}
+        />
       </Menu.Content>
     </Menu.Root>
   );

--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
@@ -15,7 +15,6 @@ function QualityMenu(): ReactNode {
       <Menu.Content className="menu">
         <QualityRadioGroup
           className="menu-group"
-          aria-label="Quality"
           renderItem={(props, item) => (
             <Menu.RadioItem {...props} className="menu-item">
               <span>

--- a/site/src/content/docs/reference/quality-radio-group.mdx
+++ b/site/src/content/docs/reference/quality-radio-group.mdx
@@ -28,12 +28,14 @@ Creates radio items from the player video rendition state and selects automatic 
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <Menu.RadioGroup>
-    <Menu.GroupLabel />
-    <Menu.RadioItem>
-      <Menu.ItemIndicator />
-    </Menu.RadioItem>
-  </Menu.RadioGroup>
+  <QualityRadioGroup
+    renderItem={(props, item) => (
+      <Menu.RadioItem {...props}>
+        {item.label}
+        <Menu.ItemIndicator checked={item.checked} />
+      </Menu.RadioItem>
+    )}
+  />
   ```
 </FrameworkCase>
 
@@ -57,7 +59,7 @@ Creates radio items from the player video rendition state and selects automatic 
 The group is available when the configured media exposes more than one video rendition. The first generated option is `Auto`; selecting it returns control to adaptive bitrate selection. Pass `formatRendition` to customize visible rendition labels.
 
 <FrameworkCase frameworks={["react"]}>
-<DocsLink slug="reference/use-quality-options">`useQualityOptions`</DocsLink> returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured. Use the returned options with <DocsLink slug="reference/menu">`Menu.RadioGroup`</DocsLink>.
+`QualityRadioGroup` uses <DocsLink slug="reference/use-quality-options">`useQualityOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label`, optional `tier` and `badge`, and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-quality">quality feature</DocsLink> is not configured.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -73,14 +75,14 @@ The group is available when the configured media exposes more than one video ren
 | `data-hidden` | Present / absent | Present when multiple renditions are unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether multiple renditions are available. |
 
-Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
+Unavailable groups receive the native `hidden` attribute.
 
 ## Accessibility
 
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-Give `Menu.RadioGroup` an accessible name with `aria-label` or a nested `Menu.GroupLabel`.
+The component receives an accessible label from the `label` prop or defaults to `Quality`. Override it with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -114,6 +116,4 @@ The element receives an accessible label from the `label` property or defaults t
   </StyleCase>
 </FrameworkCase>
 
-<FrameworkCase frameworks={["html"]}>
-  <ComponentReference component="QualityRadioGroup" />
-</FrameworkCase>
+<ComponentReference component="QualityRadioGroup" />


### PR DESCRIPTION
Refs #2150

## Summary

Document the React `QualityRadioGroup` API alongside the existing HTML component and update the live example to use it.

## Changes

- Add React anatomy, behavior, styling, and accessibility guidance
- Show tier and bitrate badge rendering through `renderItem`
- Replace manual quality hook plumbing in the React demo

## Testing

- `pnpm -F site api-docs`

Depends on #2132.