### PR TITLE
refactor(react): use playback rate radio group in skins

### DIFF
--- a/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-core.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/playback-rate-radio-group-core.ts
@@ -4,7 +4,7 @@ import { defaults } from '@videojs/utils/object';
 import { isUndefined } from '@videojs/utils/predicate';
 import type { NonNullableObject } from '@videojs/utils/types';
 import { resolveText, type Text } from '../../i18n';
-import { rateText } from '../../i18n/text/playback';
+import { playbackRateText } from '../../i18n/text/menu';
 import type { RadioOption, RadioOptionsState } from '../types';
 import { resolveLabel } from '../utils/resolve-label';
 
@@ -60,12 +60,11 @@ export class PlaybackRateRadioGroupCore {
   getLabel(state: PlaybackRateRadioGroupState): Text | string {
     const custom = resolveLabel(this.#props.label, state);
     if (custom !== undefined) return custom;
-    return rateText;
+    return playbackRateText;
   }
 
-  getLabelParams(state: PlaybackRateRadioGroupState): { rate: number } | undefined {
-    if (resolveLabel(this.#props.label, state) !== undefined) return undefined;
-    return { rate: state.rate };
+  getLabelParams(_state: PlaybackRateRadioGroupState): undefined {
+    return undefined;
   }
 
   getRateLabel(rate: number): string {

--- a/packages/core/src/core/ui/playback-rate-radio-group/tests/playback-rate-radio-group-core.test.ts
+++ b/packages/core/src/core/ui/playback-rate-radio-group/tests/playback-rate-radio-group-core.test.ts
@@ -65,11 +65,11 @@ describe('PlaybackRateRadioGroupCore', () => {
   });
 
   describe('getLabel', () => {
-    it('returns default label with rate', () => {
+    it('returns a stable default group label', () => {
       const core = new PlaybackRateRadioGroupCore();
       expect(core.getLabel(createState({ rate: 1.5 }))).toMatchObject({
-        key: 'playback.rate',
-        text: 'Playback rate {rate}',
+        key: 'menu.playbackRate',
+        text: 'Playback rate',
       });
     });
 
@@ -87,14 +87,9 @@ describe('PlaybackRateRadioGroupCore', () => {
   });
 
   describe('getLabelParams', () => {
-    it('returns rate for default label', () => {
+    it('returns no parameters for the stable group label', () => {
       const core = new PlaybackRateRadioGroupCore();
-      expect(core.getLabelParams(createState({ rate: 2 }))).toEqual({ rate: 2 });
-    });
-
-    it('returns undefined when custom label is set', () => {
-      const core = new PlaybackRateRadioGroupCore({ label: 'Speed' });
-      expect(core.getLabelParams(createState())).toBeUndefined();
+      expect(core.getLabelParams(createState({ rate: 2 }))).toBeUndefined();
     });
   });
 
@@ -117,7 +112,7 @@ describe('PlaybackRateRadioGroupCore', () => {
     it('returns aria-label', () => {
       const core = new PlaybackRateRadioGroupCore();
       const attrs = core.getAttrs(createState({ rate: 1.5 }));
-      expect(attrs['aria-label']).toMatchObject({ key: 'playback.rate', text: 'Playback rate {rate}' });
+      expect(attrs['aria-label']).toMatchObject({ key: 'menu.playbackRate', text: 'Playback rate' });
     });
 
     it('sets aria-disabled when disabled', () => {

--- a/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
+++ b/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
@@ -165,7 +165,7 @@ describe('PlaybackRateRadioGroupElement', () => {
     await waitForAssertion(() => {
       expect(items.map((item) => item.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false']);
     });
-    expect(options.getAttribute('aria-label')).toBe('Playback rate 1.25');
+    expect(options.getAttribute('aria-label')).toBe('Playback rate');
     expect(options.getAttribute('data-rate')).toBe('1.25');
   });
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -128,6 +128,12 @@ export {
   usePlaybackRateOptions,
 } from './ui/playback-rate';
 export { PlaybackRateButton, type PlaybackRateButtonProps } from './ui/playback-rate-button/playback-rate-button';
+export {
+  PlaybackRateRadioGroup,
+  type PlaybackRateRadioGroupItemProps,
+  type PlaybackRateRadioGroupItemState,
+  type PlaybackRateRadioGroupProps,
+} from './ui/playback-rate-radio-group';
 export { Popover, type PopoverContextValue, usePopoverContext } from './ui/popover';
 export { Poster, type PosterProps } from './ui/poster/poster';
 export {

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -40,6 +40,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
 import { Time } from '@/ui/time';
@@ -129,22 +130,20 @@ function VolumePopover(): ReactNode {
 
 function PlaybackRateRadioGroup(): ReactNode {
   const t = useTranslator();
-  const state = usePlaybackRateOptions();
-  if (!state) return null;
-
-  const { options, setValue, value } = state;
 
   return (
-    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} aria-label={t(playbackRateText)}>
-      {options.map((option) => (
-        <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
-          <span>{option.label}</span>
-          <Menu.ItemIndicator checked={option.value === value} forceMount className={menu.indicator}>
+    <PlaybackRateRadioGroupComponent
+      className={menu.group}
+      aria-label={t(playbackRateText)}
+      renderItem={(props, item) => (
+        <Menu.RadioItem {...props} className={menu.item}>
+          <span>{item.label}</span>
+          <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
             <CheckIcon className={cn(icon, menu.icon)} />
           </Menu.ItemIndicator>
         </Menu.RadioItem>
-      ))}
-    </Menu.RadioGroup>
+      )}
+    />
   );
 }
 

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -23,6 +23,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -77,27 +78,20 @@ function VolumePopover(): ReactNode {
 
 function PlaybackRateRadioGroup(): ReactNode {
   const t = useTranslator();
-  const state = usePlaybackRateOptions();
-  if (!state) return null;
-
-  const { options, setValue, value } = state;
 
   return (
-    <Menu.RadioGroup
+    <PlaybackRateRadioGroupComponent
       className="media-menu__group"
-      value={value}
-      onValueChange={setValue}
       aria-label={t(playbackRateText)}
-    >
-      {options.map((option) => (
-        <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
-          <span>{option.label}</span>
-          <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
+      renderItem={(props, item) => (
+        <Menu.RadioItem {...props} className="media-menu__item">
+          <span>{item.label}</span>
+          <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
             <CheckIcon className="media-icon" />
           </Menu.ItemIndicator>
         </Menu.RadioItem>
-      ))}
-    </Menu.RadioGroup>
+      )}
+    />
   );
 }
 

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -41,6 +41,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -131,22 +132,20 @@ function VolumePopover(): ReactNode {
 
 function PlaybackRateRadioGroup(): ReactNode {
   const t = useTranslator();
-  const state = usePlaybackRateOptions();
-  if (!state) return null;
-
-  const { options, setValue, value } = state;
 
   return (
-    <Menu.RadioGroup className={menu.group} value={value} onValueChange={setValue} aria-label={t(playbackRateText)}>
-      {options.map((option) => (
-        <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
-          <span>{option.label}</span>
-          <Menu.ItemIndicator checked={option.value === value} forceMount className={menu.indicator}>
+    <PlaybackRateRadioGroupComponent
+      className={menu.group}
+      aria-label={t(playbackRateText)}
+      renderItem={(props, item) => (
+        <Menu.RadioItem {...props} className={menu.item}>
+          <span>{item.label}</span>
+          <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
             <CheckIcon className={cn(icon, menu.icon)} />
           </Menu.ItemIndicator>
         </Menu.RadioItem>
-      ))}
-    </Menu.RadioGroup>
+      )}
+    />
   );
 }
 

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -23,6 +23,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
 import { PlaybackRateButton } from '@/ui/playback-rate-button';
+import { PlaybackRateRadioGroup as PlaybackRateRadioGroupComponent } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { SeekButton } from '@/ui/seek-button';
 import { StatusAnnouncer } from '@/ui/status-announcer';
@@ -77,27 +78,20 @@ function VolumePopover(): ReactNode {
 
 function PlaybackRateRadioGroup(): ReactNode {
   const t = useTranslator();
-  const state = usePlaybackRateOptions();
-  if (!state) return null;
-
-  const { options, setValue, value } = state;
 
   return (
-    <Menu.RadioGroup
+    <PlaybackRateRadioGroupComponent
       className="media-menu__group"
-      value={value}
-      onValueChange={setValue}
       aria-label={t(playbackRateText)}
-    >
-      {options.map((option) => (
-        <Menu.RadioItem key={option.value} className="media-menu__item" value={option.value} disabled={option.disabled}>
-          <span>{option.label}</span>
-          <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
+      renderItem={(props, item) => (
+        <Menu.RadioItem {...props} className="media-menu__item">
+          <span>{item.label}</span>
+          <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
             <CheckIcon className="media-icon" />
           </Menu.ItemIndicator>
         </Menu.RadioItem>
-      ))}
-    </Menu.RadioGroup>
+      )}
+    />
   );
 }
 

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -77,6 +77,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
+import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
@@ -332,30 +333,18 @@ function SettingsMenu(): ReactNode {
                     {t(speedText)}
                   </Menu.Back>
                   <Menu.Separator className={menu.separator} />
-                  <Menu.RadioGroup
+                  <PlaybackRateRadioGroup
                     className={menu.group}
-                    value={playbackRate.value}
-                    onValueChange={playbackRate.setValue}
                     aria-label={t(playbackRateText)}
-                  >
-                    {playbackRate.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className={menu.item}
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
-                        <span>{option.label}</span>
-                        <Menu.ItemIndicator
-                          checked={option.value === playbackRate.value}
-                          forceMount
-                          className={menu.indicator}
-                        >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className={menu.item}>
+                        <span>{item.label}</span>
+                        <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                           <CheckIcon className={cn(icon, menu.icon)} />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -53,6 +53,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
+import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
@@ -273,30 +274,18 @@ function SettingsMenu(): ReactNode {
                     {t(speedText)}
                   </Menu.Back>
                   <Menu.Separator className="media-menu__separator" />
-                  <Menu.RadioGroup
+                  <PlaybackRateRadioGroup
                     className="media-menu__group"
-                    value={playbackRate.value}
-                    onValueChange={playbackRate.setValue}
                     aria-label={t(playbackRateText)}
-                  >
-                    {playbackRate.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className="media-menu__item"
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
-                        <span>{option.label}</span>
-                        <Menu.ItemIndicator
-                          checked={option.value === playbackRate.value}
-                          forceMount
-                          className="media-menu__indicator"
-                        >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className="media-menu__item">
+                        <span>{item.label}</span>
+                        <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                           <CheckIcon className="media-icon" />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -79,6 +79,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
+import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
@@ -334,30 +335,18 @@ function SettingsMenu(): ReactNode {
                     {t(speedText)}
                   </Menu.Back>
                   <Menu.Separator className={menu.separator} />
-                  <Menu.RadioGroup
+                  <PlaybackRateRadioGroup
                     className={menu.group}
-                    value={playbackRate.value}
-                    onValueChange={playbackRate.setValue}
                     aria-label={t(playbackRateText)}
-                  >
-                    {playbackRate.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className={menu.item}
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
-                        <span>{option.label}</span>
-                        <Menu.ItemIndicator
-                          checked={option.value === playbackRate.value}
-                          forceMount
-                          className={menu.indicator}
-                        >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className={menu.item}>
+                        <span>{item.label}</span>
+                        <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                           <CheckIcon className={cn(icon, menu.icon)} />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -53,6 +53,7 @@ import { MuteButton } from '@/ui/mute-button';
 import { PiPButton } from '@/ui/pip-button';
 import { PlayButton } from '@/ui/play-button';
 import { usePlaybackRateOptions } from '@/ui/playback-rate';
+import { PlaybackRateRadioGroup } from '@/ui/playback-rate-radio-group';
 import { Popover } from '@/ui/popover';
 import { Poster } from '@/ui/poster';
 import { useQualityOptions } from '@/ui/quality';
@@ -273,30 +274,18 @@ function SettingsMenu(): ReactNode {
                     {t(speedText)}
                   </Menu.Back>
                   <Menu.Separator className="media-menu__separator" />
-                  <Menu.RadioGroup
+                  <PlaybackRateRadioGroup
                     className="media-menu__group"
-                    value={playbackRate.value}
-                    onValueChange={playbackRate.setValue}
                     aria-label={t(playbackRateText)}
-                  >
-                    {playbackRate.options.map((option) => (
-                      <Menu.RadioItem
-                        key={option.value}
-                        className="media-menu__item"
-                        value={option.value}
-                        disabled={option.disabled}
-                      >
-                        <span>{option.label}</span>
-                        <Menu.ItemIndicator
-                          checked={option.value === playbackRate.value}
-                          forceMount
-                          className="media-menu__indicator"
-                        >
+                    renderItem={(props, item) => (
+                      <Menu.RadioItem {...props} className="media-menu__item">
+                        <span>{item.label}</span>
+                        <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                           <CheckIcon className="media-icon" />
                         </Menu.ItemIndicator>
                       </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
+                    )}
+                  />
                 </Menu.Content>
               </Menu.Root>
             ) : null}

--- a/packages/react/src/ui/playback-rate-radio-group/index.ts
+++ b/packages/react/src/ui/playback-rate-radio-group/index.ts
@@ -1,0 +1,6 @@
+export {
+  PlaybackRateRadioGroup,
+  type PlaybackRateRadioGroupItemProps,
+  type PlaybackRateRadioGroupItemState,
+  type PlaybackRateRadioGroupProps,
+} from './playback-rate-radio-group';

--- a/packages/react/src/ui/playback-rate-radio-group/playback-rate-radio-group.tsx
+++ b/packages/react/src/ui/playback-rate-radio-group/playback-rate-radio-group.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { type PlaybackRateRadioGroupCore, PlaybackRateRadioGroupDataAttrs } from '@videojs/core';
+import { getStateDataAttrs } from '@videojs/core/dom';
+import { isFunction } from '@videojs/utils/predicate';
+import type { ReactElement } from 'react';
+import { Fragment, forwardRef } from 'react';
+
+import type { HTMLProps, UIComponentProps } from '../../utils/types';
+import { MenuRadioGroup } from '../menu/menu-radio-group';
+import type { MenuRadioItemProps } from '../menu/menu-radio-item';
+import {
+  type PlaybackRateOption,
+  type PlaybackRateOptionsProps,
+  usePlaybackRateOptions,
+} from '../playback-rate/use-playback-rate-options';
+
+export type PlaybackRateRadioGroupItemState = PlaybackRateOption & {
+  /** Whether this playback rate is currently selected. */
+  checked: boolean;
+};
+
+export interface PlaybackRateRadioGroupItemProps extends Omit<MenuRadioItemProps, 'ref'> {
+  /** Playback rate represented by the item. */
+  'data-rate': string;
+}
+
+export interface PlaybackRateRadioGroupProps
+  extends Omit<UIComponentProps<'div', PlaybackRateRadioGroupCore.State>, 'children'>,
+    PlaybackRateOptionsProps {
+  /** Render one consumer-owned menu radio item for every playback rate. */
+  renderItem: (props: PlaybackRateRadioGroupItemProps, state: PlaybackRateRadioGroupItemState) => ReactElement;
+}
+
+/**
+ * Renders menu radio items for the player's available playback rates.
+ *
+ * @example
+ * ```tsx
+ * <PlaybackRateRadioGroup
+ *   renderItem={(props, item) => (
+ *     <Menu.RadioItem {...props}>
+ *       {item.label}
+ *       <Menu.ItemIndicator checked={item.checked} />
+ *     </Menu.RadioItem>
+ *   )}
+ * />
+ * ```
+ */
+export const PlaybackRateRadioGroup = forwardRef<HTMLDivElement, PlaybackRateRadioGroupProps>(
+  function PlaybackRateRadioGroup(componentProps, forwardedRef) {
+    const {
+      renderItem,
+      render,
+      className,
+      style,
+      label,
+      formatRate,
+      disabled,
+      'aria-label': ariaLabelProp,
+      'aria-labelledby': ariaLabelledBy,
+      ...elementProps
+    } = componentProps;
+    const playbackRate = usePlaybackRateOptions({ label, formatRate, disabled });
+    if (!playbackRate) return null;
+
+    const { state, value, options, setValue } = playbackRate;
+    const ariaLabel = ariaLabelProp ?? (ariaLabelledBy === undefined ? playbackRate.label : undefined);
+
+    return (
+      <MenuRadioGroup
+        {...getStateDataAttrs(state, PlaybackRateRadioGroupDataAttrs)}
+        {...elementProps}
+        ref={forwardedRef}
+        className={isFunction(className) ? className(state) : className}
+        style={isFunction(style) ? style(state) : style}
+        render={isFunction(render) ? (props: HTMLProps) => render(props, state) : render}
+        value={value}
+        onValueChange={setValue}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-disabled={state.disabled || undefined}
+        hidden={state.hidden}
+      >
+        {options.map((option) => {
+          const itemState = { ...option, checked: option.value === value };
+
+          return (
+            <Fragment key={option.value}>
+              {renderItem(
+                {
+                  value: option.value,
+                  disabled: option.disabled,
+                  'data-rate': option.value,
+                  children: option.label,
+                },
+                itemState
+              )}
+            </Fragment>
+          );
+        })}
+      </MenuRadioGroup>
+    );
+  }
+);
+
+export namespace PlaybackRateRadioGroup {
+  export type Props = PlaybackRateRadioGroupProps;
+  export type State = PlaybackRateRadioGroupCore.State;
+  export type ItemProps = PlaybackRateRadioGroupItemProps;
+  export type ItemState = PlaybackRateRadioGroupItemState;
+}

--- a/packages/react/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group.test.tsx
+++ b/packages/react/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group.test.tsx
@@ -91,7 +91,7 @@ describe('PlaybackRateRadioGroup', () => {
     const group = screen.getByTestId('group');
     expect(ref.current).toBe(group);
     expect(group.classList.contains('rate-available')).toBe(true);
-    expect(group.getAttribute('aria-label')).toBe('Playback rate 1.5');
+    expect(group.getAttribute('aria-label')).toBe('Playback rate');
     expect(group.getAttribute('data-rate')).toBe('1.5');
     expect(group.getAttribute('data-availability')).toBe('available');
   });
@@ -122,16 +122,16 @@ describe('PlaybackRateRadioGroup', () => {
       ),
     });
 
-    const group = screen.getByRole('group', { name: 'Playback rate 1.5' });
+    const group = screen.getByRole('group', { name: 'Playback rate' });
     expect(group.tagName).toBe('SECTION');
     expect(group.getAttribute('data-value')).toBe('1.5');
     expect(screen.getByRole('menuitemradio', { name: '1.5×' }).querySelector('[aria-hidden="true"]')).toBeTruthy();
   });
 
   it('translates the default accessible label', () => {
-    registerI18n('xx', { 'playback.rate': 'Translated rate {rate}' });
+    registerI18n('xx', { 'menu.playbackRate': 'Translated playback rate' });
     renderPlaybackRateRadioGroup({ locale: 'xx' });
 
-    expect(screen.getByRole('group', { name: 'Translated rate 1.5' })).toBeTruthy();
+    expect(screen.getByRole('group', { name: 'Translated playback rate' })).toBeTruthy();
   });
 });

--- a/packages/react/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group.test.tsx
+++ b/packages/react/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group.test.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '../../../i18n';
+import { createPlayerWrapper } from '../../../testing/mocks';
+import { Menu } from '../../menu';
+import { PlaybackRateRadioGroup, type PlaybackRateRadioGroupItemState } from '../playback-rate-radio-group';
+
+afterEach(() => {
+  resetI18nRegistry();
+  cleanup();
+});
+
+function renderPlaybackRateRadioGroup({
+  playbackRates = [0.5, 1, 1.5, 2],
+  playbackRate = 1.5,
+  setPlaybackRate = vi.fn(),
+  locale,
+  group,
+}: {
+  playbackRates?: readonly number[];
+  playbackRate?: number;
+  setPlaybackRate?: (rate: number) => void;
+  locale?: string;
+  group?: React.ReactNode;
+} = {}) {
+  const { Wrapper } = createPlayerWrapper({ playbackRates, playbackRate, setPlaybackRate });
+  const content = (
+    <Menu.Root defaultOpen>
+      <Menu.Content>
+        {group ?? <PlaybackRateRadioGroup renderItem={(props) => <Menu.RadioItem {...props} />} />}
+      </Menu.Content>
+    </Menu.Root>
+  );
+
+  render(locale ? <I18nProvider locale={locale}>{content}</I18nProvider> : content, { wrapper: Wrapper });
+
+  return { setPlaybackRate };
+}
+
+describe('PlaybackRateRadioGroup', () => {
+  it('renders generated radio item props and item state', () => {
+    const states: PlaybackRateRadioGroupItemState[] = [];
+    renderPlaybackRateRadioGroup({
+      group: (
+        <PlaybackRateRadioGroup
+          renderItem={(props, state) => {
+            states.push(state);
+            return <Menu.RadioItem {...props} />;
+          }}
+        />
+      ),
+    });
+
+    expect(screen.getByRole('menuitemradio', { name: '1.5×' }).getAttribute('data-rate')).toBe('1.5');
+    expect(screen.getByRole('menuitemradio', { name: '1.5×' }).getAttribute('aria-checked')).toBe('true');
+    expect(states.slice(-4)).toEqual([
+      expect.objectContaining({ rate: 0.5, value: '0.5', checked: false }),
+      expect.objectContaining({ rate: 1, value: '1', checked: false }),
+      expect.objectContaining({ rate: 1.5, value: '1.5', checked: true }),
+      expect.objectContaining({ rate: 2, value: '2', checked: false }),
+    ]);
+  });
+
+  it('sets the playback rate', () => {
+    const setPlaybackRate = vi.fn();
+    renderPlaybackRateRadioGroup({ setPlaybackRate });
+
+    fireEvent.click(screen.getByRole('menuitemradio', { name: '2×' }));
+
+    expect(setPlaybackRate).toHaveBeenCalledWith(2);
+  });
+
+  it('exposes group state through attributes and callbacks', () => {
+    const ref = createRef<HTMLDivElement>();
+    renderPlaybackRateRadioGroup({
+      group: (
+        <PlaybackRateRadioGroup
+          ref={ref}
+          data-testid="group"
+          className={(state) => `rate-${state.availability}`}
+          renderItem={(props) => <Menu.RadioItem {...props} />}
+        />
+      ),
+    });
+
+    const group = screen.getByTestId('group');
+    expect(ref.current).toBe(group);
+    expect(group.classList.contains('rate-available')).toBe(true);
+    expect(group.getAttribute('aria-label')).toBe('Playback rate 1.5');
+    expect(group.getAttribute('data-rate')).toBe('1.5');
+    expect(group.getAttribute('data-availability')).toBe('available');
+  });
+
+  it('hides and disables the group when playback rates are unavailable', () => {
+    renderPlaybackRateRadioGroup({ playbackRates: [] });
+
+    const group = document.querySelector<HTMLElement>('[role="group"]');
+    expect(group).toBeTruthy();
+    expect(group?.hidden).toBe(true);
+    expect(group?.getAttribute('aria-disabled')).toBe('true');
+    expect(group?.hasAttribute('data-disabled')).toBe(true);
+    expect(group?.hasAttribute('data-hidden')).toBe(true);
+  });
+
+  it('supports custom group and item roots', () => {
+    renderPlaybackRateRadioGroup({
+      group: (
+        <PlaybackRateRadioGroup
+          render={(props, state) => <section {...props} data-value={state.value} />}
+          renderItem={(props, state) => (
+            <Menu.RadioItem {...props}>
+              <span>{state.label}</span>
+              <Menu.ItemIndicator checked={state.checked}>✓</Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      ),
+    });
+
+    const group = screen.getByRole('group', { name: 'Playback rate 1.5' });
+    expect(group.tagName).toBe('SECTION');
+    expect(group.getAttribute('data-value')).toBe('1.5');
+    expect(screen.getByRole('menuitemradio', { name: '1.5×' }).querySelector('[aria-hidden="true"]')).toBeTruthy();
+  });
+
+  it('translates the default accessible label', () => {
+    registerI18n('xx', { 'playback.rate': 'Translated rate {rate}' });
+    renderPlaybackRateRadioGroup({ locale: 'xx' });
+
+    expect(screen.getByRole('group', { name: 'Translated rate 1.5' })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Refs #2151

## Summary

Adopt `PlaybackRateRadioGroup` across React audio and video skins while preserving their existing speed menu presentation.

## Changes

- Replace manual playback-rate option mapping in audio and video presets
- Update default, minimal, CSS, and Tailwind variants
- Keep skin-owned radio item content, indicators, and classes

## Testing

- `pnpm -F @videojs/react build`

Depends on #2137.