### PR TITLE
docs(site): document playback rate radio group

### DIFF
--- a/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
@@ -1,34 +1,28 @@
-import { createPlayer, Menu, usePlaybackRateOptions } from '@videojs/react';
+import { createPlayer, Menu, PlaybackRateRadioGroup } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
 const Player = createPlayer({ features: videoFeatures });
 
 function SpeedMenu(): ReactNode {
-  const playbackRate = usePlaybackRateOptions();
-  if (playbackRate?.state.availability !== 'available') return null;
-
   return (
     <Menu.Root side="top" align="end">
       <Menu.Trigger className="settings-trigger" render={<button type="button" />}>
         Speed
       </Menu.Trigger>
       <Menu.Content className="menu">
-        <Menu.RadioGroup
+        <PlaybackRateRadioGroup
           className="menu-group"
-          value={playbackRate.value}
-          onValueChange={playbackRate.setValue}
           aria-label="Speed"
-        >
-          {playbackRate.options.map((option) => (
-            <Menu.RadioItem key={option.value} value={option.value} disabled={option.disabled} className="menu-item">
-              {option.label}
-              <Menu.ItemIndicator checked={option.value === playbackRate.value} forceMount className="menu-indicator">
+          renderItem={(props, item) => (
+            <Menu.RadioItem {...props} className="menu-item">
+              {item.label}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="menu-indicator">
                 ✓
               </Menu.ItemIndicator>
             </Menu.RadioItem>
-          ))}
-        </Menu.RadioGroup>
+          )}
+        />
       </Menu.Content>
     </Menu.Root>
   );

--- a/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
@@ -13,7 +13,6 @@ function SpeedMenu(): ReactNode {
       <Menu.Content className="menu">
         <PlaybackRateRadioGroup
           className="menu-group"
-          aria-label="Speed"
           renderItem={(props, item) => (
             <Menu.RadioItem {...props} className="menu-item">
               {item.label}

--- a/site/src/content/docs/reference/playback-rate-radio-group.mdx
+++ b/site/src/content/docs/reference/playback-rate-radio-group.mdx
@@ -28,12 +28,14 @@ Creates radio items from the player playback rate state and selects the playback
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <Menu.RadioGroup>
-    <Menu.GroupLabel />
-    <Menu.RadioItem>
-      <Menu.ItemIndicator />
-    </Menu.RadioItem>
-  </Menu.RadioGroup>
+  <PlaybackRateRadioGroup
+    renderItem={(props, item) => (
+      <Menu.RadioItem {...props}>
+        {item.label}
+        <Menu.ItemIndicator checked={item.checked} />
+      </Menu.RadioItem>
+    )}
+  />
   ```
 </FrameworkCase>
 
@@ -55,7 +57,7 @@ Creates radio items from the player playback rate state and selects the playback
 The group is available when the configured media exposes playback rates. Option labels default to the rate followed by a multiplication sign (e.g. `1.5×`); pass `formatRate` to customize them.
 
 <FrameworkCase frameworks={["react"]}>
-<DocsLink slug="reference/use-playback-rate-options">`usePlaybackRateOptions`</DocsLink> returns `null` when the <DocsLink slug="reference/feature-playback-rate">playback rate feature</DocsLink> is not configured. Use the returned options with <DocsLink slug="reference/menu">`Menu.RadioGroup`</DocsLink>.
+`PlaybackRateRadioGroup` uses <DocsLink slug="reference/use-playback-rate-options">`usePlaybackRateOptions`</DocsLink> to own selection and generate each item. Its required `renderItem` callback renders the <DocsLink slug="reference/menu">`Menu.RadioItem`</DocsLink> root and receives item state containing the translated `label` and current `checked` value. It returns `null` when the <DocsLink slug="reference/feature-playback-rate">playback rate feature</DocsLink> is not configured.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -71,14 +73,14 @@ The group is available when the configured media exposes playback rates. Option 
 | `data-hidden` | Present / absent | Present when playback-rate selection is unavailable. |
 | `data-availability` | `"available"` / `"unavailable"` | Whether playback rates are available. |
 
-Unavailable groups receive the native `hidden` attribute in HTML. React consumers can use the hook's `hidden` result to omit their group.
+Unavailable groups receive the native `hidden` attribute.
 
 ## Accessibility
 
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-Give `Menu.RadioGroup` an accessible name with `aria-label` or a nested `Menu.GroupLabel`.
+The component defaults to `Playback rate {rate}` (e.g. `Playback rate 1.5`). Override its accessible name with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -112,6 +114,4 @@ The element defaults to `Playback rate {rate}` (e.g. `Playback rate 1.5`). Overr
   </StyleCase>
 </FrameworkCase>
 
-<FrameworkCase frameworks={["html"]}>
-  <ComponentReference component="PlaybackRateRadioGroup" />
-</FrameworkCase>
+<ComponentReference component="PlaybackRateRadioGroup" />

--- a/site/src/content/docs/reference/playback-rate-radio-group.mdx
+++ b/site/src/content/docs/reference/playback-rate-radio-group.mdx
@@ -80,11 +80,11 @@ Unavailable groups receive the native `hidden` attribute.
 The group uses the menu radio group pattern.
 
 <FrameworkCase frameworks={["react"]}>
-The component defaults to `Playback rate {rate}` (e.g. `Playback rate 1.5`). Override its accessible name with `aria-label` or `aria-labelledby`.
+The component receives an accessible label from the `label` prop or defaults to `Playback rate`. Override it with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-The element defaults to `Playback rate {rate}` (e.g. `Playback rate 1.5`). Override its accessible name with `aria-label` or `aria-labelledby`.
+The element receives an accessible label from the `label` property or defaults to `Playback rate`. Override it with `aria-label` or `aria-labelledby`.
 </FrameworkCase>
 
 ## Examples


### PR DESCRIPTION
Refs #2151

## Summary

Document the React `PlaybackRateRadioGroup` API and use it in the playback-rate demo.

## Changes

- Replace manual hook and radio-group wiring in the React demo
- Document the required consumer-owned `renderItem` root
- Describe component availability, accessible labeling, and generated API reference

## Testing

- `pnpm -F site api-docs`

Depends on #2137.