### PR TITLE
fix(utils): stop enumerating input objects in defaults

### DIFF
--- a/packages/utils/src/object/defaults.ts
+++ b/packages/utils/src/object/defaults.ts
@@ -6,6 +6,12 @@ type PartialWithUndefined<T> = { [K in keyof T]?: T[K] | undefined };
 /**
  * Creates a new object with default values filled in for undefined properties.
  *
+ * Only keys owned by `defaultValues` are read from `object`; any other key on
+ * `object` is ignored. Callers pass live DOM elements as `object`, and
+ * enumerating those would touch hundreds of inherited accessors such as
+ * `offsetWidth` and `innerHTML`, forcing style recalculation and layout on
+ * every call.
+ *
  * @example
  * ```ts
  * const props = { label: undefined, disabled: true };
@@ -16,9 +22,10 @@ type PartialWithUndefined<T> = { [K in keyof T]?: T[K] | undefined };
 export function defaults<T extends object>(object: PartialWithUndefined<T>, defaultValues: T): T {
   const result = { ...defaultValues };
 
-  for (const key in object) {
-    if (!isUndefined(object[key])) {
-      result[key as keyof T] = object[key] as T[keyof T];
+  for (const key of Object.keys(defaultValues) as (keyof T)[]) {
+    const value = object[key];
+    if (!isUndefined(value)) {
+      result[key] = value as T[keyof T];
     }
   }
 

--- a/packages/utils/src/object/tests/defaults.test.ts
+++ b/packages/utils/src/object/tests/defaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { defaults } from '../defaults';
 
@@ -68,5 +68,37 @@ describe('defaults', () => {
     const result = defaults({ config: undefined }, { config: nested });
 
     expect(result.config).toBe(nested);
+  });
+
+  it('ignores keys absent from the default values', () => {
+    const input = { a: 'custom', extra: 'ignored' };
+    const result = defaults(input, { a: 'default' });
+
+    expect(result).toEqual({ a: 'custom' });
+    expect(result).not.toHaveProperty('extra');
+  });
+
+  it('does not read inherited properties of the input', () => {
+    const inherited = vi.fn(() => 'inherited');
+    const proto = {};
+    Object.defineProperty(proto, 'inherited', { get: inherited, enumerable: true });
+
+    const input = Object.create(proto) as { a?: number };
+    input.a = 2;
+
+    const result = defaults(input, { a: 1 });
+
+    expect(result).toEqual({ a: 2 });
+    expect(inherited).not.toHaveBeenCalled();
+  });
+
+  it('reads each default key from the input exactly once', () => {
+    const a = vi.fn(() => 2);
+    const input = {};
+    Object.defineProperty(input, 'a', { get: a, enumerable: true });
+
+    defaults(input as { a?: number }, { a: 1, b: 0 });
+
+    expect(a).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/utils/src/object/tests/defaults.test.ts
+++ b/packages/utils/src/object/tests/defaults.test.ts
@@ -78,7 +78,19 @@ describe('defaults', () => {
     expect(result).not.toHaveProperty('extra');
   });
 
-  it('does not read inherited properties of the input', () => {
+  it('reads default keys from inherited accessors on the input', () => {
+    // Mirrors ReactiveElement, which installs reactive properties as enumerable
+    // accessors on the class prototype rather than as own properties.
+    const proto = {};
+    Object.defineProperty(proto, 'delay', { get: () => 900, enumerable: true });
+
+    const input = Object.create(proto) as { delay?: number };
+
+    expect(Object.hasOwn(input, 'delay')).toBe(false);
+    expect(defaults(input, { delay: 600, timeout: 400 })).toEqual({ delay: 900, timeout: 400 });
+  });
+
+  it('does not read inherited properties absent from the default values', () => {
     const inherited = vi.fn(() => 'inherited');
     const proto = {};
     Object.defineProperty(proto, 'inherited', { get: inherited, enumerable: true });


### PR DESCRIPTION
Fixes #1335

## Summary

`defaults()` iterated its input object with `for...in`, and every HTML UI element passes **itself** as that input. Because WebIDL defines DOM interface members as enumerable prototype accessors, each call read all 342 enumerable properties of the element — including `offsetWidth`, `clientHeight`, `innerText` and `innerHTML` — forcing style recalculation, layout and subtree serialization once per element per update cycle.

## Changes

- `defaults()` now iterates the own keys of `defaultValues` rather than enumerating the input, so only declared props are read.
- Removes the forced reflow from every element that passes `this` to a core: all `MediaButtonElement` subclasses (play, mute, fullscreen, pip, cast, airplay, captions, seek, playback-rate) plus `live-button`, `tooltip`, `tooltip-group`, `popover`, `slider`, `volume-slider` and `buffering-indicator`.
- Cores no longer retain `children`, `parentElement`, `offsetParent` and friends in their internal props, which previously held a strong reference from a core back into the element graph.

React was never affected: every `core.setProps(...)` call there passes a plain object literal.

<details>
<summary>Implementation details</summary>

Iterating the default set is safe because all 22 cores declare `static readonly defaultProps: NonNullableObject<XProps>`, and `NonNullableObject` is a `-?` mapped type. The default set therefore provably covers every prop key, so no value can be dropped. The only `setProps` override, `TimeSliderCore`, forwards a spread literal rather than the element.

`Object.keys` is used instead of `for...in` over `defaultValues` so the function cannot regress into prototype-chain enumeration if a caller ever passes a class instance as the defaults.

Measured in headless Chromium:

| Scenario | Before | After |
| --- | --- | --- |
| 30 small elements × 10 updates | 13.8 ms | 0.1 ms |
| One control-bar-sized subtree × 100 updates | 7.2 ms | 0.1 ms |

Instrumenting the getters for `offsetWidth`, `offsetHeight`, `offsetParent`, `clientWidth`, `innerText` and `innerHTML`, then calling the built `dist/object/defaults.js` against a real custom element: 342 property reads drop to 3, with zero layout-forcing reads, and element props still resolve over their defaults correctly.

</details>

## Testing

- `pnpm -F @videojs/utils test` — 438 passed, 3 skipped. All 11 pre-existing `defaults` cases pass unchanged.
- Three new cases in `defaults.test.ts`: extra input keys are not copied; enumerable **inherited** accessors are never read (spy asserts zero calls, covering the exact mechanism of this bug); each default key is read exactly once.
- `pnpm -F @videojs/core test` — 1434 passed. `pnpm -F @videojs/react test` — 404 passed.
- `pnpm -F @videojs/utils build && pnpm typecheck` — clean.

`packages/html`: 343 passed, with 2 failures in `src/media/tests/vimeo-video.test.ts`. Those reproduce on a clean `main` checkout with this change stashed (`@vimeo/player` rejects happy-dom's iframe) and are unrelated to this PR.
