### PR TITLE
docs(site): repair time slider api reference

### DIFF
--- a/site/scripts/api-docs-builder/src/parts-handler.ts
+++ b/site/scripts/api-docs-builder/src/parts-handler.ts
@@ -88,25 +88,27 @@ export function extractSubPartProps(filePath: string, program: ts.Program, local
   const checker = program.getTypeChecker();
   const props: Record<string, PropDef> = {};
 
-  const SKIP_PROPS = new Set(['children']);
-
   function collectFromMembers(members: ts.NodeArray<ts.TypeElement>) {
     for (const member of members) {
       if (!ts.isPropertySignature(member) || !member.name || !ts.isIdentifier(member.name)) continue;
       const name = member.name.text;
-      if (SKIP_PROPS.has(name) || !member.type) continue;
-
-      let typeStr = checker.typeToString(checker.getTypeFromTypeNode(member.type));
-      if (member.questionToken) typeStr = typeStr.replace(/ \| undefined$/, '');
-
-      const propDef: PropDef = { type: typeStr };
+      if (!member.type) continue;
 
       const symbol = checker.getSymbolAtLocation(member.name);
-      if (symbol) {
-        const docs = symbol.getDocumentationComment(checker);
-        const desc = docs.map((d) => d.text).join('');
-        if (desc) propDef.description = desc;
-      }
+      const docs =
+        symbol
+          ?.getDocumentationComment(checker)
+          .map((part) => part.text)
+          .join('') ?? '';
+      if (name === 'children' && !docs) continue;
+
+      let typeStr = ts.isFunctionTypeNode(member.type)
+        ? member.type.getText(sourceFile)
+        : checker.typeToString(checker.getTypeFromTypeNode(member.type));
+      if (member.questionToken) typeStr = typeStr.replace(/ \| undefined$/, '');
+
+      const propDef: PropDef = { type: typeStr, frameworks: ['react'] };
+      if (docs) propDef.description = docs;
 
       props[name] = propDef;
     }

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -326,10 +326,18 @@ describe('Component pipeline (end-to-end)', () => {
       const fill = findComponent('Gauge')!.reference.parts!.fill!;
 
       expect(fill.name).toBe('Fill');
-      // Sub-part custom React props: extracted from `FillProps` interface.
-      // `children` is auto-excluded by the builder.
-      expect(fill.props.color).toMatchObject({ type: 'string' });
-      expect(fill.props.children).toBeUndefined();
+      // Sub-part custom React props are React-only. Documented `children`
+      // is included because it is an explicit part contract.
+      expect(fill.props.color).toEqual({
+        type: 'string',
+        description: 'The color of the fill bar.',
+        frameworks: ['react'],
+      });
+      expect(fill.props.children).toEqual({
+        type: 'unknown',
+        description: 'Fallback content displayed before the gauge is ready.',
+        frameworks: ['react'],
+      });
       expect(fill.state).toEqual({});
 
       // Fill's React source references `stateAttrMap`, so it gets the

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/gauge/gauge-fill.tsx
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/react/src/ui/gauge/gauge-fill.tsx
@@ -7,7 +7,7 @@
  *      contains "stateAttrMap", the sub-part gets shared data attributes.
  *   2. Sub-part custom React props. The builder extracts own members from the
  *      `{LocalName}Props` interface (must be `interface`, not `type`).
- *      `children` and React DOM attributes are excluded.
+ *      Undocumented `children` and React DOM attributes are excluded.
  */
 
 import type { GaugeDataAttrs } from '../../../../core/src/core/ui/gauge/gauge-data-attrs';
@@ -20,9 +20,9 @@ export function Fill() {
 }
 
 // Must be `interface` (not `type`) for extractSubPartProps to detect it.
-// `children` is auto-excluded by the builder.
 export interface FillProps {
   /** The color of the fill bar. */
   color: string;
+  /** Fallback content displayed before the gauge is ready. */
   children: unknown;
 }

--- a/site/src/components/docs/api-reference/ApiPropsTable.astro
+++ b/site/src/components/docs/api-reference/ApiPropsTable.astro
@@ -10,15 +10,17 @@ import Th from '@/components/typography/Th.astro';
 import Thead from '@/components/typography/Thead.astro';
 import Tr from '@/components/typography/Tr.astro';
 import type { PropDef } from '@/types/component-reference';
+import type { SupportedFramework } from '@/types/docs';
 import PropRow from './PropRow.astro';
 
 interface Props {
   props: Record<string, PropDef>;
   componentName: string;
+  framework: SupportedFramework;
   showAttributeName?: boolean;
 }
 
-const { props, componentName, showAttributeName } = Astro.props;
+const { props, componentName, framework, showAttributeName } = Astro.props;
 ---
 
 <Table maxWidth={false} outerClass="my-6">
@@ -32,18 +34,22 @@ const { props, componentName, showAttributeName } = Astro.props;
   </Thead>
   <Tbody>
     {
-      Object.entries(props).map(([name, prop]) => (
-        <PropRow
-          name={name}
-          type={prop.type}
-          detailedType={prop.detailedType}
-          description={prop.description}
-          defaultValue={prop.default}
-          required={prop.required}
-          showAttributeName={showAttributeName}
-          componentName={componentName}
-        />
-      ))
+      Object.entries(props)
+        .filter(
+          ([, prop]) => !prop.frameworks || prop.frameworks.includes(framework),
+        )
+        .map(([name, prop]) => (
+          <PropRow
+            name={name}
+            type={prop.type}
+            detailedType={prop.detailedType}
+            description={prop.description}
+            defaultValue={prop.default}
+            required={prop.required}
+            showAttributeName={showAttributeName}
+            componentName={componentName}
+          />
+        ))
     }
   </Tbody>
 </Table>

--- a/site/src/components/docs/api-reference/ComponentReference.astro
+++ b/site/src/components/docs/api-reference/ComponentReference.astro
@@ -86,16 +86,19 @@ const singleCssCustomPropertiesSection = !apiReferenceModel.hasParts
               </P>
             )}
 
-            {partPropsSection && (
-              <>
-                <H4 id={partPropsSection.id}>{partPropsSection.title}</H4>
-                <ApiPropsTable
-                  props={part.data.props}
-                  componentName={part.componentName}
-                  showAttributeName={showAttributeName}
-                />
-              </>
-            )}
+            {partPropsSection &&
+              (!partPropsSection.frameworks ||
+                partPropsSection.frameworks.includes(framework)) && (
+                <>
+                  <H4 id={partPropsSection.id}>{partPropsSection.title}</H4>
+                  <ApiPropsTable
+                    props={part.data.props}
+                    componentName={part.componentName}
+                    framework={framework}
+                    showAttributeName={showAttributeName}
+                  />
+                </>
+              )}
 
             {partStateSection && (
               <>
@@ -146,16 +149,19 @@ const singleCssCustomPropertiesSection = !apiReferenceModel.hasParts
       })
     ) : (
       <>
-        {singlePropsSection && (
-          <>
-            <H3 id={singlePropsSection.id}>{singlePropsSection.title}</H3>
-            <ApiPropsTable
-              props={apiReferenceModel.data.props}
-              componentName={component}
-              showAttributeName={showAttributeName}
-            />
-          </>
-        )}
+        {singlePropsSection &&
+          (!singlePropsSection.frameworks ||
+            singlePropsSection.frameworks.includes(framework)) && (
+            <>
+              <H3 id={singlePropsSection.id}>{singlePropsSection.title}</H3>
+              <ApiPropsTable
+                props={apiReferenceModel.data.props}
+                componentName={component}
+                framework={framework}
+                showAttributeName={showAttributeName}
+              />
+            </>
+          )}
 
         {singleStateSection && (
           <>

--- a/site/src/content/docs/reference/feature-text-tracks.mdx
+++ b/site/src/content/docs/reference/feature-text-tracks.mdx
@@ -9,6 +9,8 @@ import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 
 Manages subtitles, captions, chapters, and thumbnail tracks.
 
+A default `kind="chapters"` track can also divide the <DocsLink slug="reference/time-slider">time slider</DocsLink> into chapter ranges and label the chapter at the current interaction position.
+
 <FeatureReference feature="textTrack" />
 
 ### Selector

--- a/site/src/content/docs/reference/slider.mdx
+++ b/site/src/content/docs/reference/slider.mdx
@@ -63,7 +63,7 @@ import withPreviewHtmlTs from "@/components/docs/demos/slider/html/css/WithPrevi
 
 ## Behavior
 
-The base Slider provides a generic range input. It manages value, pointer tracking, and drag interactions. Domain-specific sliders like <DocsLink slug="reference/time-slider">TimeSlider</DocsLink> and <DocsLink slug="reference/volume-slider">VolumeSlider</DocsLink> extend this with media-specific bindings.
+The base Slider provides a generic range input. It manages value, pointer tracking, and drag interactions. Domain-specific sliders like <DocsLink slug="reference/time-slider">TimeSlider</DocsLink> and <DocsLink slug="reference/volume-slider">VolumeSlider</DocsLink> extend this with media-specific bindings. TimeSlider also provides parts for rendering chapter ranges and the chapter at the current interaction position.
 
 The slider supports vertical orientation via the `orientation` prop (defaults to `"horizontal"`).
 

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -39,6 +39,7 @@ import withChaptersHtmlTs from "@/components/docs/demos/time-slider/html/css/Wit
     </TimeSlider.Track>
     <TimeSlider.Thumb />
     <TimeSlider.Preview>
+      <TimeSlider.ChapterTitle />
       <TimeSlider.Value type="pointer" />
     </TimeSlider.Preview>
   </TimeSlider.Root>
@@ -54,6 +55,7 @@ import withChaptersHtmlTs from "@/components/docs/demos/time-slider/html/css/Wit
     </media-slider-track>
     <media-slider-thumb></media-slider-thumb>
     <media-slider-preview>
+      <media-time-slider-chapter-title></media-time-slider-chapter-title>
       <media-slider-value type="pointer"></media-slider-value>
     </media-slider-preview>
   </media-time-slider>

--- a/site/src/types/component-reference.ts
+++ b/site/src/types/component-reference.ts
@@ -12,6 +12,7 @@ export const PropDefSchema = z.object({
   description: z.string().optional(),
   default: z.string().optional(),
   required: z.boolean().optional(),
+  frameworks: z.array(z.enum(['html', 'react'])).optional(),
 });
 
 export const StateDefSchema = z.object({

--- a/site/src/utils/componentReferenceModel.ts
+++ b/site/src/utils/componentReferenceModel.ts
@@ -6,6 +6,7 @@ export interface ApiReferenceSection {
   title: string;
   id: string;
   depth: number;
+  frameworks?: SupportedFramework[];
   tocKind?: string;
 }
 
@@ -84,6 +85,14 @@ function createSections(
       return [];
     }
 
+    const frameworks: SupportedFramework[] | undefined =
+      definition.key === 'props'
+        ? ([
+            ...new Set(Object.values(source.props).flatMap((prop) => prop.frameworks ?? (['html', 'react'] as const))),
+          ] as SupportedFramework[])
+        : undefined;
+    const frameworkRestriction = frameworks?.length === 1 ? { frameworks } : {};
+
     if (options.forPart) {
       return [
         {
@@ -92,6 +101,7 @@ function createSections(
           id: `${options.partId}-${definition.suffix}`,
           depth: 4,
           tocKind: 'api-reference-subsection',
+          ...frameworkRestriction,
         },
       ];
     }
@@ -102,6 +112,7 @@ function createSections(
         title: definition.title,
         id: definition.singleId,
         depth: 3,
+        ...frameworkRestriction,
       },
     ];
   });
@@ -209,12 +220,15 @@ export function buildComponentReferenceTocHeadings(apiReferenceModel: ComponentR
       }
 
       for (const section of part.sections) {
+        const frameworks = section.frameworks
+          ? part.frameworks.filter((framework) => section.frameworks!.includes(framework))
+          : part.frameworks;
         headings.push({
           depth: section.depth,
           text: section.title,
           slug: section.id,
           tocKind: section.tocKind,
-          ...(part.frameworks.length < 2 ? { frameworks: part.frameworks } : {}),
+          ...(frameworks.length < 2 ? { frameworks } : {}),
         });
       }
     }
@@ -227,6 +241,7 @@ export function buildComponentReferenceTocHeadings(apiReferenceModel: ComponentR
       depth: section.depth,
       text: section.title,
       slug: section.id,
+      ...(section.frameworks ? { frameworks: section.frameworks } : {}),
     });
   }
 

--- a/site/src/utils/tests/componentReferenceModel.test.ts
+++ b/site/src/utils/tests/componentReferenceModel.test.ts
@@ -89,7 +89,7 @@ describe('createComponentReferenceModel', () => {
           },
         },
       },
-    };
+    } satisfies ComponentReference;
 
     const model = createComponentReferenceModel('Controls', apiReference);
 
@@ -223,7 +223,7 @@ describe('buildComponentReferenceTocHeadings', () => {
         trigger: {
           name: 'Trigger',
           props: {
-            onClick: { type: '() => void' },
+            onClick: { type: '() => void', frameworks: ['react'] },
           },
           state: {},
           dataAttributes: {},
@@ -233,7 +233,7 @@ describe('buildComponentReferenceTocHeadings', () => {
           },
         },
       },
-    };
+    } satisfies ComponentReference;
 
     const model = createComponentReferenceModel('Popover', apiReference);
     const headings = buildComponentReferenceTocHeadings(model);
@@ -258,5 +258,47 @@ describe('buildComponentReferenceTocHeadings', () => {
         frameworks: ['react'],
       },
     ]);
+  });
+
+  it('restricts a shared part props section to its prop frameworks', () => {
+    const apiReference = {
+      name: 'TimeSlider',
+      props: {},
+      state: {},
+      dataAttributes: {},
+      cssCustomProperties: {},
+      platforms: {},
+      parts: {
+        chapters: {
+          name: 'Chapters',
+          props: {
+            renderChapter: { type: '() => ReactElement', frameworks: ['react'] },
+          },
+          state: {},
+          dataAttributes: {},
+          cssCustomProperties: {},
+          platforms: {
+            html: { tagName: 'media-time-slider-chapters' },
+            react: {},
+          },
+        },
+      },
+    } satisfies ComponentReference;
+
+    const model = createComponentReferenceModel('TimeSlider', apiReference);
+
+    expect(model?.parts[0]?.sections).toMatchObject([
+      {
+        key: 'props',
+        frameworks: ['react'],
+      },
+    ]);
+    expect(buildComponentReferenceTocHeadings(model)).toContainEqual({
+      depth: 4,
+      text: 'Props',
+      slug: 'chapters-props',
+      tocKind: 'api-reference-subsection',
+      frameworks: ['react'],
+    });
   });
 });


### PR DESCRIPTION
Closes #2053

## Summary

Repair stale generated and hand-authored TimeSlider documentation introduced by the chaptered slider API. React-only sub-part props now stay out of HTML reference tables, while authored prop signatures and meaningful fallback children remain readable.

## Changes

- Mark generated React sub-part props with their framework and filter reference sections and rows accordingly
- Preserve authored function signatures and include documented children contracts
- Add ChapterTitle to both anatomy variants and cross-link chapter tracks with the TimeSlider reference

## Testing

- pnpm -F site test scripts/api-docs-builder/src/tests/e2e.test.ts src/utils/tests/componentReferenceModel.test.ts
- pnpm -F site api-docs
- pnpm -F site astro check
- Biome and git diff checks
- Rendered React and HTML TimeSlider reference pages locally