### PR TITLE
docs(site): restore html sub-part props

### DIFF
--- a/site/scripts/api-docs-builder/src/html-handler.ts
+++ b/site/scripts/api-docs-builder/src/html-handler.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import type { HtmlExtraction } from './types.js';
 
-/** Extract tagName from a Lit element file. */
+/** Extract tagName and reactive properties from a Lit element file. */
 export function extractHtml(
   filePath: string,
   program: ts.Program,
@@ -13,9 +13,11 @@ export function extractHtml(
 
   const className = elementName ?? `${componentName}Element`;
   let tagName = '';
+  let elementClass: ts.ClassDeclaration | undefined;
 
   function visit(node: ts.Node) {
     if (ts.isClassDeclaration(node) && node.name?.text === className) {
+      elementClass = node;
       for (const member of node.members) {
         if (
           ts.isPropertyDeclaration(member) &&
@@ -35,5 +37,77 @@ export function extractHtml(
 
   visit(sourceFile);
 
-  return tagName ? { tagName } : null;
+  if (!tagName || !elementClass) return null;
+
+  const checker = program.getTypeChecker();
+  const properties = new Set<string>();
+  const seen = new Set<ts.ClassDeclaration>();
+
+  function collectProperties(classNode: ts.ClassDeclaration) {
+    if (seen.has(classNode)) return;
+    seen.add(classNode);
+
+    const type = checker.getTypeAtLocation(classNode);
+    for (const baseType of checker.getBaseTypes(type as ts.InterfaceType) ?? []) {
+      const declaration = baseType.getSymbol()?.declarations?.find(ts.isClassDeclaration);
+      if (declaration) collectProperties(declaration);
+    }
+
+    for (const member of classNode.members) {
+      if (
+        !ts.isPropertyDeclaration(member) ||
+        !member.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword) ||
+        !member.name ||
+        !ts.isIdentifier(member.name) ||
+        member.name.text !== 'properties' ||
+        !member.initializer
+      ) {
+        continue;
+      }
+
+      let initializer = member.initializer;
+      while (
+        ts.isSatisfiesExpression(initializer) ||
+        ts.isAsExpression(initializer) ||
+        ts.isParenthesizedExpression(initializer)
+      ) {
+        initializer = initializer.expression;
+      }
+      if (!ts.isObjectLiteralExpression(initializer)) continue;
+
+      for (const property of initializer.properties) {
+        if (!ts.isPropertyAssignment(property) || !property.name) continue;
+        const name =
+          ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : undefined;
+        if (!name) continue;
+
+        let declaration = property.initializer;
+        while (
+          ts.isSatisfiesExpression(declaration) ||
+          ts.isAsExpression(declaration) ||
+          ts.isParenthesizedExpression(declaration)
+        ) {
+          declaration = declaration.expression;
+        }
+        if (
+          ts.isObjectLiteralExpression(declaration) &&
+          declaration.properties.some(
+            (entry) =>
+              ts.isPropertyAssignment(entry) &&
+              ts.isIdentifier(entry.name) &&
+              entry.name.text === 'attribute' &&
+              entry.initializer.kind === ts.SyntaxKind.FalseKeyword
+          )
+        ) {
+          continue;
+        }
+
+        properties.add(name);
+      }
+    }
+  }
+
+  collectProperties(elementClass);
+
+  return { tagName, properties: [...properties] };
 }

--- a/site/scripts/api-docs-builder/src/pipeline.ts
+++ b/site/scripts/api-docs-builder/src/pipeline.ts
@@ -496,6 +496,11 @@ function buildMultiPartReference(
           : null;
 
       const subPartProps = part.reactPath ? extractSubPartProps(part.reactPath, program, part.localName) : {};
+      if (htmlData) {
+        for (const [name, prop] of Object.entries(subPartProps)) {
+          if (htmlData.properties.includes(name)) prop.frameworks = ['html', 'react'];
+        }
+      }
 
       const partRef: PartReference = {
         name: part.name,

--- a/site/scripts/api-docs-builder/src/tests/e2e.test.ts
+++ b/site/scripts/api-docs-builder/src/tests/e2e.test.ts
@@ -326,13 +326,13 @@ describe('Component pipeline (end-to-end)', () => {
       const fill = findComponent('Gauge')!.reference.parts!.fill!;
 
       expect(fill.name).toBe('Fill');
-      // Sub-part custom React props are React-only. Documented `children`
-      // is included because it is an explicit part contract.
+      // Props inherited by the matching custom element are shared with HTML.
       expect(fill.props.color).toEqual({
         type: 'string',
         description: 'The color of the fill bar.',
-        frameworks: ['react'],
+        frameworks: ['html', 'react'],
       });
+      // Documented `children` is included because it is an explicit React contract.
       expect(fill.props.children).toEqual({
         type: 'unknown',
         description: 'Fallback content displayed before the gauge is ready.',

--- a/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/gauge/gauge-fill-element.ts
+++ b/site/scripts/api-docs-builder/src/tests/fixtures/monorepo/packages/html/src/ui/gauge/gauge-fill-element.ts
@@ -2,6 +2,12 @@
  * HTML element fixture for multi-part sub-part.
  */
 
-export class GaugeFillElement {
+class GaugePartElement {
+  static readonly properties = {
+    color: { type: String },
+  };
+}
+
+export class GaugeFillElement extends GaugePartElement {
   static readonly tagName = 'media-gauge-fill';
 }

--- a/site/scripts/api-docs-builder/src/types.ts
+++ b/site/scripts/api-docs-builder/src/types.ts
@@ -119,4 +119,5 @@ export interface CSSVarsExtraction {
 
 export interface HtmlExtraction {
   tagName: string;
+  properties: string[];
 }


### PR DESCRIPTION
Closes #2144

## Summary

Restore HTML API-reference rows for React sub-part props that are also exposed by matching custom elements. The builder now distinguishes shared HTML/React properties from genuinely React-only contracts.

## Changes

- Discover reactive properties on matching custom elements, including inherited declarations
- Mark shared sub-part props for both HTML and React while preserving React-only callbacks and children
- Cover inherited HTML property detection in the API builder E2E fixture

## Testing

- `pnpm -F site test scripts/api-docs-builder/src/tests/e2e.test.ts`
- `pnpm -F site test src/utils/tests/componentReferenceModel.test.ts`
- `pnpm -F site api-docs`
- `pnpm -F site astro check`
- `git diff --check`