### PR TITLE
docs(site): document direct player components

### DIFF
--- a/.agents/skills/design-api/references/anti-patterns.md
+++ b/.agents/skills/design-api/references/anti-patterns.md
@@ -76,7 +76,7 @@ const provider = factory.createProvider();
 const player = provider.getInstance();
 
 // Good: Direct API
-const player = createPlayer();
+const { Player } = createPlayer({ features });
 ```
 
 ---

--- a/.agents/skills/write-api-reference/references/demo-patterns.md
+++ b/.agents/skills/write-api-reference/references/demo-patterns.md
@@ -118,17 +118,17 @@ Import registration for:
 ### .tsx (component)
 
 ```tsx
-import { createPlayer, MuteButton } from '@videojs/react';
+import { Container, createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
 import './BasicUsage.css';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="react-mute-button-basic">
+    <Player>
+      <Container className="react-mute-button-basic">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -142,8 +142,8 @@ export default function BasicUsage() {
             <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```

--- a/.agents/skills/write-api-reference/references/mdx-structure.md
+++ b/.agents/skills/write-api-reference/references/mdx-structure.md
@@ -231,7 +231,7 @@ Link generously between related reference pages.
 Same-framework or cross-framework link:
 
 ```mdx
-Within a player provider, <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> is usually simpler.
+Within a `Player`, <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> is usually simpler.
 ```
 
 Selector page linking to framework-specific utils:
@@ -257,7 +257,7 @@ Util pages document React hooks/utilities and HTML controllers/mixins. They are 
 ```yaml
 ---
 title: usePlayer
-description: Hook to access the player store from within a Player Provider
+description: Hook to access the player store from within a Player
 ---
 ```
 

--- a/.agents/skills/write-docs/patterns/code-examples.md
+++ b/.agents/skills/write-docs/patterns/code-examples.md
@@ -16,27 +16,29 @@ How to write effective code examples across documentation — site pages, README
 // ❌ Missing imports — won't work when copied
 function App() {
   return (
-    <Player.Container>
-      <Video src="video.mp4" />
-      <PlayButton />
-    </Player.Container>
+    <Player>
+      <Container>
+        <Video src="video.mp4" />
+        <PlayButton />
+      </Container>
+    </Player>
   );
 }
 
 // ✅ Complete — copy, paste, run
-import { createPlayer, PlayButton } from '@videojs/react';
+import { Container, createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 function App() {
   return (
-    <Player.Provider>
-      <Player.Container>
+    <Player>
+      <Container>
         <Video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4" />
         <PlayButton />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```
@@ -78,15 +80,15 @@ Site pages use `<FrameworkCase>` and `<StyleCase>` to show code per framework. N
 **React:**
 
 ```tsx
-import { createPlayer, PlayButton } from '@videojs/react';
+import { Container, createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="player">
+    <Player>
+      <Container className="player">
         <Video
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"
           autoPlay
@@ -98,8 +100,8 @@ export default function BasicUsage() {
             <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```
@@ -224,20 +226,20 @@ Show which file code belongs to when multiple files are involved:
 
 ````markdown
 ```tsx title="App.tsx"
-import { createPlayer, PlayButton } from '@videojs/react';
+import { Container, createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import './App.css';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function App() {
   return (
-    <Player.Provider>
-      <Player.Container className="player">
+    <Player>
+      <Container className="player">
         <Video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4" />
         <PlayButton />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```

--- a/.agents/skills/write-docs/references/state-tooling.md
+++ b/.agents/skills/write-docs/references/state-tooling.md
@@ -276,11 +276,13 @@ Document common errors:
 **Solution:**
 
 // ❌ Wrong
-const player = createPlayer();
+const { create } = createPlayer({ features: videoFeatures });
+const player = create();
 player.play(); // Error!
 
 // ✅ Correct
-const player = createPlayer();
+const { create } = createPlayer({ features: videoFeatures });
+const player = create();
 await player.attach(videoElement);
 player.play();
 ```

--- a/.agents/skills/write-docs/references/writing-style.md
+++ b/.agents/skills/write-docs/references/writing-style.md
@@ -14,7 +14,7 @@ createPlayer function and pass in a configuration object.
 // ✅ Direct
 Create a player:
 
-const player = createPlayer({ src: 'video.mp4' });
+const { Player } = createPlayer({ features: videoFeatures });
 ```
 
 ## Quick Rules
@@ -162,10 +162,10 @@ For more information about events, please refer to the Events page.
 
 ```markdown
 // ✅ Linked
-Within a player provider, <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> is usually simpler.
+Within a `Player`, <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> is usually simpler.
 
 // ❌ Unlinked
-Within a player provider, `usePlayer` is usually simpler.
+Within a `Player`, `usePlayer` is usually simpler.
 ```
 
 ## Length guidelines

--- a/internal/migrations/plyr.md
+++ b/internal/migrations/plyr.md
@@ -89,31 +89,28 @@ If you're building a React app, the approach is a little different. Firstly, ins
 npm install @videojs/react 
 ```
 
-Create a reusable `VideoPlayer` component in your app:
+Create a reusable player component in your app:
 
-```js
+```tsx
 'use client';
 
 import '@videojs/react/video/minimal-skin.css';
-import { createPlayer } from '@videojs/react';
-import { MinimalVideoSkin, Video, videoFeatures } from '@videojs/react/video';
+import { MinimalVideoSkin, Video, VideoPlayer } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
-
-interface VideoPlayerProps {
+interface AppVideoPlayerProps {
   origin: string;
 }
 
-export function VideoPlayer({ origin }: VideoPlayerProps) {
+export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
   return (
-    <Player.Provider>
+    <VideoPlayer>
       <MinimalVideoSkin poster={`${origin}/poster.jpg`}>
         <Video src={`${origin}/video.mp4`} playsInline>
           <track kind="captions" label="English" src={`${origin}/captions/en.vtt`} srclang="en" default />
           <track kind="metadata" label="thumbnails" src={`${origin}/storyboard.vtt`} default />
         </Video>
       </MinimalVideoSkin>
-    </Player.Provider>
+    </VideoPlayer>
   );
 }
 ```
@@ -220,11 +217,11 @@ import { YouTubeVideo } from '@videojs/react/media/youtube-video';
 ```
 
 ```jsx
-<Player.Provider>
+<VideoPlayer>
   <MinimalVideoSkin>
     <YouTubeVideo src="https://youtu.be/aqz-KE-bpKQ" playsInline />
   </MinimalVideoSkin>
-</Player.Provider>
+</VideoPlayer>
 ```
 
 The component accepts YouTube watch, short, embed, Shorts, live, playlist, and privacy-enhanced URLs, as well as raw 11-character video IDs.
@@ -271,19 +268,16 @@ For package users, same idea but import from @videojs/html/i18n.
 
 Use the React provider when you want scoped overrides:
 
-```js
-'use client'
+```tsx
+'use client';
 
 import '@videojs/react/video/minimal-skin.css';
 import { I18nProvider } from '@videojs/react/i18n';
-import { createPlayer } from '@videojs/react';
-import { MinimalVideoSkin, Video, videoFeatures } from '@videojs/react/video';
-
-const Player = createPlayer({ features: videoFeatures });
+import { MinimalVideoSkin, Video, VideoPlayer } from '@videojs/react/video';
 
 export function MyPlayer() {
   return (
-    <Player.Provider>
+    <VideoPlayer>
       <I18nProvider
         locale="en"
         translations={{
@@ -300,7 +294,7 @@ export function MyPlayer() {
           <Video src="/video.mp4" playsInline />
         </MinimalVideoSkin>
       </I18nProvider>
-    </Player.Provider>
+    </VideoPlayer>
   );
 }
 ```
@@ -352,7 +346,7 @@ Use the media element for standard playback operations:
 | `player.fullscreen.enter()` | Fullscreen feature or fullscreen control |
 | `player.toggleCaptions()` | Text-track feature or captions control |
 
-For custom UI, read and write through the Video.js player store. In React, use `Player.usePlayer()` or selectors. In HTML custom elements, use `PlayerController`.
+For custom UI, read and write through the Video.js player store. In React, import the preset's `usePlayer` hook or use selectors. In HTML custom elements, use `PlayerController`.
 
 ## Rewrite styles
 

--- a/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { AirPlayButton, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <AirPlayButton
           className="media-airplay-button"
@@ -14,7 +14,7 @@ export default function BasicUsage() {
             <button {...props}>{state.state === 'connected' ? 'Stop AirPlay' : 'Start AirPlay'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
@@ -3,7 +3,7 @@ import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
 
 function AudioMenu(): ReactNode {
@@ -31,13 +31,13 @@ function AudioMenu(): ReactNode {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <HlsJsVideo src={src} autoPlay crossOrigin="anonymous" muted playsInline loop />
         <div className="menu-bar">
           <AudioMenu />
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx
@@ -1,18 +1,18 @@
 import { BufferingIndicator, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <BufferingIndicator
           className="media-buffering-indicator"
           render={(props, state) => <div {...props}>{state.visible && <div className="spinner" />}</div>}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { CaptionsButton, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop>
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
         </Video>
@@ -16,7 +16,7 @@ export default function BasicUsage() {
             <button {...props}>{state.subtitlesShowing ? 'Captions Off' : 'Captions On'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
@@ -2,7 +2,7 @@ import { CaptionsRadioGroup, createPlayer, Menu } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 function CaptionsMenu(): ReactNode {
   return (
@@ -29,8 +29,8 @@ function CaptionsMenu(): ReactNode {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop>
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
           <track kind="subtitles" src="/docs/demos/captions-button/captions.vtt" srcLang="es" label="Spanish" />
@@ -38,7 +38,7 @@ export default function BasicUsage() {
         <div className="menu-bar">
           <CaptionsMenu />
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/cast-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/cast-button/react/css/BasicUsage.tsx
@@ -2,12 +2,12 @@ import { CastButton, createPlayer } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <HlsJsVideo src="{{VJS10_DEMO_VIDEO_HLS}}" autoPlay muted playsInline loop />
         <CastButton
           className="media-cast-button"
@@ -15,7 +15,7 @@ export default function BasicUsage() {
             <button {...props}>{state.connection === 'connected' ? 'Stop casting' : 'Start casting'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/controls/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/controls/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { Controls, createPlayer, PlayButton, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
 
         <Controls.Root className="media-controls">
@@ -19,7 +19,7 @@ export default function BasicUsage() {
             <Time.Value type="current" className="time" />
           </Controls.Group>
         </Controls.Root>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/create-player/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/create-player/react/css/BasicUsage.tsx
@@ -1,13 +1,13 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 
 function Controls() {
-  const store = Player.usePlayer();
-  const paused = Player.usePlayer((s) => s.paused);
+  const store = usePlayer();
+  const paused = usePlayer((s) => s.paused);
 
   return (
     <div className="controls">
@@ -20,11 +20,11 @@ function Controls() {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline />
         <Controls />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx
@@ -1,18 +1,18 @@
 import { createPlayer, FullscreenButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <FullscreenButton
           className="media-fullscreen-button"
           render={(props, state) => <button {...props}>{state.fullscreen ? 'Exit Fullscreen' : 'Fullscreen'}</button>}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/i18n/react/css/BuiltIn.tsx
+++ b/site/src/components/docs/demos/i18n/react/css/BuiltIn.tsx
@@ -5,11 +5,11 @@ import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
 import '@videojs/react/video/skin.css';
 import './Sources.css';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BuiltIn() {
   return (
-    <Player.Provider>
+    <Player>
       <I18nProvider locale="es">
         <div className="react-i18n-source">
           <VideoSkin className="react-i18n-source__player">
@@ -17,6 +17,6 @@ export default function BuiltIn() {
           </VideoSkin>
         </div>
       </I18nProvider>
-    </Player.Provider>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/i18n/react/css/Fallback.tsx
+++ b/site/src/components/docs/demos/i18n/react/css/Fallback.tsx
@@ -5,11 +5,11 @@ import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
 import '@videojs/react/video/skin.css';
 import './Sources.css';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function Fallback() {
   return (
-    <Player.Provider>
+    <Player>
       <I18nProvider locale="en">
         <div className="react-i18n-source">
           <VideoSkin className="react-i18n-source__player">
@@ -17,6 +17,6 @@ export default function Fallback() {
           </VideoSkin>
         </div>
       </I18nProvider>
-    </Player.Provider>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/i18n/react/css/Language.tsx
+++ b/site/src/components/docs/demos/i18n/react/css/Language.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import '@videojs/react/video/skin.css';
 import './Language.css';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 const locales = ['en', ...LOCALES] as const;
 type Locale = (typeof locales)[number];
 const languageNames = new Intl.DisplayNames(['en'], { type: 'language' });
@@ -26,13 +26,13 @@ export default function Language() {
           ))}
         </select>
       </label>
-      <Player.Provider>
+      <Player>
         <I18nProvider locale={locale}>
           <VideoSkin className="react-i18n-language__player">
             <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
           </VideoSkin>
         </I18nProvider>
-      </Player.Provider>
+      </Player>
     </div>
   );
 }

--- a/site/src/components/docs/demos/i18n/react/css/Override.tsx
+++ b/site/src/components/docs/demos/i18n/react/css/Override.tsx
@@ -5,11 +5,11 @@ import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
 import '@videojs/react/video/skin.css';
 import './Sources.css';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function Override() {
   return (
-    <Player.Provider>
+    <Player>
       <I18nProvider locale="en" translations={{ buttons: { play: 'Player override' } }}>
         <div className="react-i18n-source">
           <VideoSkin className="react-i18n-source__player">
@@ -17,6 +17,6 @@ export default function Override() {
           </VideoSkin>
         </div>
       </I18nProvider>
-    </Player.Provider>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/i18n/react/css/Registered.tsx
+++ b/site/src/components/docs/demos/i18n/react/css/Registered.tsx
@@ -11,11 +11,11 @@ registerI18n('en-x-demo', {
   },
 });
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function Registered() {
   return (
-    <Player.Provider>
+    <Player>
       <I18nProvider locale="en-x-demo">
         <div className="react-i18n-source">
           <VideoSkin className="react-i18n-source__player">
@@ -23,6 +23,6 @@ export default function Registered() {
           </VideoSkin>
         </div>
       </I18nProvider>
-    </Player.Provider>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
@@ -10,7 +10,7 @@ import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
 
 function SettingsMenu(): ReactNode {
@@ -235,8 +235,8 @@ function SettingsMenu(): ReactNode {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <HlsJsVideo src={src} autoPlay crossOrigin="anonymous" muted playsInline loop>
           <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
           <track kind="subtitles" src="/docs/demos/captions-button/captions.vtt" srcLang="es" label="Spanish" />
@@ -244,7 +244,7 @@ export default function BasicUsage() {
         <div className="menu-bar">
           <SettingsMenu />
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/mute-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/mute-button/react/css/BasicUsage.tsx
@@ -1,18 +1,18 @@
 import { createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <MuteButton
           className="media-mute-button"
           render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.tsx
+++ b/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function VolumeLevels() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <MuteButton
           className="media-mute-button"
@@ -22,7 +22,7 @@ export default function VolumeLevels() {
             </button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/pip-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/pip-button/react/css/BasicUsage.tsx
@@ -1,18 +1,18 @@
 import { createPlayer, PiPButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <PiPButton
           className="media-pip-button"
           render={(props, state) => <button {...props}>{state.pip ? 'Exit PiP' : 'Enter PiP'}</button>}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/play-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/play-button/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline />
         <PlayButton
           className="media-play-button"
@@ -14,7 +14,7 @@ export default function BasicUsage() {
             <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx
@@ -1,18 +1,18 @@
 import { createPlayer, PlaybackRateButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <PlaybackRateButton
           className="media-playback-rate-button"
           render={(props, state) => <button {...props}>{Math.round(state.rate * 10) / 10}&times;</button>}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
@@ -2,7 +2,7 @@ import { createPlayer, Menu, PlaybackRateRadioGroup } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 function SpeedMenu(): ReactNode {
   return (
@@ -29,13 +29,13 @@ function SpeedMenu(): ReactNode {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <div className="menu-bar">
           <SpeedMenu />
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/popover/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/popover/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, Popover } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <div className="bar">
           <Popover.Root>
@@ -17,7 +17,7 @@ export default function BasicUsage() {
             </Popover.Popup>
           </Popover.Root>
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, PlayButton, Poster } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" playsInline />
 
         <Poster className="media-poster" src="{{VJS10_DEMO_POSTER}}" />
@@ -15,7 +15,7 @@ export default function BasicUsage() {
           className="media-play-button"
           render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
@@ -3,7 +3,7 @@ import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 const src = '{{VJS8_DEMO_VIDEO_HLS}}';
 
 function QualityMenu(): ReactNode {
@@ -35,13 +35,13 @@ function QualityMenu(): ReactNode {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <HlsJsVideo src={src} autoPlay crossOrigin="anonymous" muted playsInline loop />
         <div className="menu-bar">
           <QualityMenu />
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/seek-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/seek-button/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, SeekButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <div className="buttons">
           <SeekButton
@@ -28,7 +28,7 @@ export default function BasicUsage() {
             )}
           />
         </div>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, Thumbnail } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function TextTrackUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="demo">
+    <Player>
+      <Container className="demo">
         <Video
           className="media"
           src="{{VJS10_DEMO_VIDEO_MP4}}"
@@ -18,7 +18,7 @@ export default function TextTrackUsage() {
           <track kind="metadata" label="thumbnails" src="/docs/demos/thumbnail/basic.vtt" default />
         </Video>
         <Thumbnail className="media-thumbnail" time={12} />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time-slider/react/css/WithChapters.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithChapters.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, TimeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function WithChapters() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop crossOrigin="anonymous">
           <track kind="chapters" src="/docs/demos/time-slider/chapters.vtt" srcLang="en" default />
         </Video>
@@ -33,7 +33,7 @@ export default function WithChapters() {
             <TimeSlider.Value type="pointer" />
           </TimeSlider.Preview>
         </TimeSlider.Root>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, TimeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function WithParts() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <TimeSlider.Root className="media-time-slider">
           <TimeSlider.Track className="media-slider-track">
@@ -16,7 +16,7 @@ export default function WithParts() {
           <TimeSlider.Thumb className="media-slider-thumb" />
           <TimeSlider.Value type="pointer" className="media-slider-value" />
         </TimeSlider.Root>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time/react/css/CurrentDuration.tsx
+++ b/site/src/components/docs/demos/time/react/css/CurrentDuration.tsx
@@ -1,19 +1,19 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function CurrentDuration() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <Time.Group className="time-group">
           <Time.Value type="current" />
           <Time.Separator />
           <Time.Value type="duration" />
         </Time.Group>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time/react/css/CurrentTime.tsx
+++ b/site/src/components/docs/demos/time/react/css/CurrentTime.tsx
@@ -1,15 +1,15 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function CurrentTime() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <Time.Value type="current" className="media-time" />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time/react/css/CustomNegativeSign.tsx
+++ b/site/src/components/docs/demos/time/react/css/CustomNegativeSign.tsx
@@ -1,15 +1,15 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function CustomNegativeSign() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <Time.Value type="remaining" negativeSign="~" className="media-time" />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time/react/css/CustomSeparator.tsx
+++ b/site/src/components/docs/demos/time/react/css/CustomSeparator.tsx
@@ -1,19 +1,19 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function CustomSeparator() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <Time.Group className="time-group">
           <Time.Value type="current" />
           <Time.Separator> of </Time.Separator>
           <Time.Value type="duration" />
         </Time.Group>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/time/react/css/Remaining.tsx
+++ b/site/src/components/docs/demos/time/react/css/Remaining.tsx
@@ -1,15 +1,15 @@
 import { createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function Remaining() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <Time.Value type="remaining" className="media-time" />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/use-media/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-media/react/css/BasicUsage.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, isMediaSourceCapable, isMediaVideoDimensionsCapable } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, useMedia } = createPlayer({
   features: videoFeatures,
 });
 
 function MediaInfo() {
-  const media = Player.useMedia();
+  const media = useMedia();
 
   if (!media) return null;
 
@@ -36,11 +36,11 @@ function MediaInfo() {
 
 export default function BasicUsage() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <MediaInfo />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/use-player/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/Selector.tsx
@@ -1,12 +1,12 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 
 function StateDisplay() {
-  const state = Player.usePlayer((s) => ({
+  const state = usePlayer((s) => ({
     paused: s.paused,
     currentTime: s.currentTime,
     duration: s.duration,
@@ -30,11 +30,11 @@ function StateDisplay() {
 
 export default function Selector() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <StateDisplay />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/use-player/react/css/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/StoreAccess.tsx
@@ -1,12 +1,12 @@
 import { createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 
 function Controls() {
-  const store = Player.usePlayer();
+  const store = usePlayer();
 
   return (
     <div className="controls">
@@ -22,11 +22,11 @@ function Controls() {
 
 export default function StoreAccess() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <Controls />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/use-store/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/Selector.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, useStore } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 
 function DerivedState() {
-  const store = Player.usePlayer();
+  const store = usePlayer();
   const derived = useStore(store, (s) => ({
     remaining: s.duration - s.currentTime,
     progress: s.duration > 0 ? (s.currentTime / s.duration) * 100 : 0,
@@ -28,11 +28,11 @@ function DerivedState() {
 
 export default function Selector() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <DerivedState />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/use-store/react/css/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/StoreAccess.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, useStore } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 
 function SeekControls() {
-  const store = Player.usePlayer();
+  const store = usePlayer();
   const s = useStore(store);
 
   return (
@@ -23,11 +23,11 @@ function SeekControls() {
 
 export default function StoreAccess() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <SeekControls />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
@@ -1,12 +1,12 @@
 import { createPlayer, MuteButton, VolumeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function WithParts() {
   return (
-    <Player.Provider>
-      <Player.Container className="media-container">
+    <Player>
+      <Container className="media-container">
         <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
         <MuteButton
           className="media-mute-button"
@@ -19,7 +19,7 @@ export default function WithParts() {
           <VolumeSlider.Thumb className="media-slider-thumb" />
           <VolumeSlider.Value type="pointer" className="media-slider-value" />
         </VolumeSlider.Root>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }

--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -20,21 +20,16 @@ export function generateReactCode(skin: Skin): string {
   const skinComponent = skin === 'default' ? 'VideoSkin' : 'MinimalVideoSkin';
   const skinCss = skin === 'default' ? 'skin' : 'minimal-skin';
 
-  return `'use client';
-
-import { createPlayer } from '@videojs/react';
-import { ${skinComponent}, Video, videoFeatures } from '@videojs/react/video';
+  return `import { VideoPlayer as VideoPlayerPreset, ${skinComponent}, Video } from '@videojs/react/video';
 import '@videojs/react/video/${skinCss}.css';
-
-const Player = createPlayer({ features: videoFeatures });
 
 export function VideoPlayer() {
   return (
-    <Player.Provider>
+    <VideoPlayerPreset.Provider>
       <${skinComponent} poster="${VJS10_DEMO_VIDEO.poster}">
         <Video src="${VJS10_DEMO_VIDEO.mp4}" playsInline />
       </${skinComponent}>
-    </Player.Provider>
+    </VideoPlayerPreset.Provider>
   );
 }`;
 }

--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -20,16 +20,16 @@ export function generateReactCode(skin: Skin): string {
   const skinComponent = skin === 'default' ? 'VideoSkin' : 'MinimalVideoSkin';
   const skinCss = skin === 'default' ? 'skin' : 'minimal-skin';
 
-  return `import { VideoPlayer as VideoPlayerPreset, ${skinComponent}, Video } from '@videojs/react/video';
+  return `import { VideoPlayer, ${skinComponent}, Video } from '@videojs/react/video';
 import '@videojs/react/video/${skinCss}.css';
 
-export function VideoPlayer() {
+export function App() {
   return (
-    <VideoPlayerPreset>
+    <VideoPlayer>
       <${skinComponent} poster="${VJS10_DEMO_VIDEO.poster}">
         <Video src="${VJS10_DEMO_VIDEO.mp4}" playsInline />
       </${skinComponent}>
-    </VideoPlayerPreset>
+    </VideoPlayer>
   );
 }`;
 }

--- a/site/src/components/home/Demo/baseCode.ts
+++ b/site/src/components/home/Demo/baseCode.ts
@@ -25,11 +25,11 @@ import '@videojs/react/video/${skinCss}.css';
 
 export function VideoPlayer() {
   return (
-    <VideoPlayerPreset.Provider>
+    <VideoPlayerPreset>
       <${skinComponent} poster="${VJS10_DEMO_VIDEO.poster}">
         <Video src="${VJS10_DEMO_VIDEO.mp4}" playsInline />
       </${skinComponent}>
-    </VideoPlayerPreset.Provider>
+    </VideoPlayerPreset>
   );
 }`;
 }

--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -19,7 +19,7 @@ export default function HeroVideo({
   const SkinComponent = $skin === 'default' ? VideoSkin : MinimalVideoSkin;
 
   return (
-    <VideoPlayer.Provider>
+    <VideoPlayer>
       <SkinComponent
         className={className}
         style={
@@ -40,6 +40,6 @@ export default function HeroVideo({
           />
         </HlsJsVideo>
       </SkinComponent>
-    </VideoPlayer.Provider>
+    </VideoPlayer>
   );
 }

--- a/site/src/components/home/HeroVideo.tsx
+++ b/site/src/components/home/HeroVideo.tsx
@@ -1,13 +1,10 @@
 import { useStore } from '@nanostores/react';
-import { createPlayer } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
-import { MinimalVideoSkin, VideoSkin, videoFeatures } from '@videojs/react/video';
+import { MinimalVideoSkin, VideoPlayer, VideoSkin } from '@videojs/react/video';
 import { VJS10_DEMO_VIDEO } from '@/consts';
 import { skin } from '@/stores/homePageDemos';
 import '@videojs/react/video/skin.css';
 import '@videojs/react/video/minimal-skin.css';
-
-const Player = createPlayer({ features: videoFeatures });
 
 export default function HeroVideo({
   className,
@@ -22,7 +19,7 @@ export default function HeroVideo({
   const SkinComponent = $skin === 'default' ? VideoSkin : MinimalVideoSkin;
 
   return (
-    <Player.Provider>
+    <VideoPlayer.Provider>
       <SkinComponent
         className={className}
         style={
@@ -43,6 +40,6 @@ export default function HeroVideo({
           />
         </HlsJsVideo>
       </SkinComponent>
-    </Player.Provider>
+    </VideoPlayer.Provider>
   );
 }

--- a/site/src/content/blog/2026-03-10-videojs-v10-beta-hello-world-again.mdx
+++ b/site/src/content/blog/2026-03-10-videojs-v10-beta-hello-world-again.mdx
@@ -36,17 +36,17 @@ import '@videojs/react/video/skin.css';
 import { createPlayer } from '@videojs/react';
 import { videoFeatures, VideoSkin, Video } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: videoFeatures,
 });
 
 function App() {
   return (
-    <Player.Provider>
+    <Player>
       <VideoSkin>
         <Video src="video.mp4" />
       </VideoSkin>
-    </Player.Provider>
+    </Player>
   );
 }
 ```
@@ -123,23 +123,23 @@ For example here's a simple React "hello world" with just a video and play butto
 import { createPlayer, features } from '@videojs/react';
 import { Video } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer } = createPlayer({
   features: [features.playback],
 });
 
 function App() {
-  const store = Player.usePlayer();
-  const paused = Player.usePlayer((s) => s.paused);
+  const store = usePlayer();
+  const paused = usePlayer((s) => s.paused);
 
   return (
-    <Player.Provider>
-      <Player.Container>
+    <Player>
+      <Container>
         <Video src="video.mp4" />
         <button onClick={() => (paused ? store.play() : store.pause())}>
           {paused ? 'Play' : 'Pause'}
         </button>
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```
@@ -265,17 +265,17 @@ A default video preset (general website video, the kind of thing you might other
 ```
 
 ```jsx
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: videoFeatures,
 });
 
 function App() {
   return (
-    <Player.Provider>
+    <Player>
       <VideoSkin>
         <Video src="video.mp4" />
       </VideoSkin>
-    </Player.Provider>
+    </Player>
   );
 }
 ```
@@ -291,17 +291,17 @@ A default audio preset (same idea but for the audio tag)
 ```
 
 ```jsx
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: audioFeatures,
 });
 
 function App() {
   return (
-    <Player.Provider>
+    <Player>
       <AudioSkin>
         <Audio src="audio.mp3" />
       </AudioSkin>
-    </Player.Provider>
+    </Player>
   );
 }
 ```
@@ -317,17 +317,17 @@ And a background video preset. Background video is where this concept really sta
 ```
 
 ```jsx
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: backgroundVideoFeatures,
 });
 
 function App() {
   return (
-    <Player.Provider>
+    <Player>
       <BackgroundVideoSkin>
         <BackgroundVideo src="video.mp4" />
       </BackgroundVideoSkin>
-    </Player.Provider>
+    </Player>
   );
 }
 ```

--- a/site/src/content/docs/concepts/cast.mdx
+++ b/site/src/content/docs/concepts/cast.mdx
@@ -17,12 +17,12 @@ import { GoogleCast } from '@videojs/react/media/google-cast';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function App() {
   return (
-    <Player.Provider>
-      <Player.Container>
+    <Player>
+      <Container>
         <HlsJsVideo
           src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
           autoPlay
@@ -32,8 +32,8 @@ export default function App() {
         />
         <GoogleCast />
         <CastButton />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```

--- a/site/src/content/docs/concepts/features.mdx
+++ b/site/src/content/docs/concepts/features.mdx
@@ -22,11 +22,11 @@ For example, the `/video` preset configures `VideoPlayer` with `videoFeatures`, 
 ```tsx
 import { VideoPlayer, Video, VideoSkin } from '@videojs/react/video';
 
-<VideoPlayer.Provider>
+<VideoPlayer>
   <VideoSkin>
     <Video src="movie.mp4" />
   </VideoSkin>
-</VideoPlayer.Provider>
+</VideoPlayer>
 ```
 
 </FrameworkCase>

--- a/site/src/content/docs/concepts/features.mdx
+++ b/site/src/content/docs/concepts/features.mdx
@@ -17,13 +17,16 @@ You probably don't want to hand-pick every feature your player needs. A **featur
 
 <FrameworkCase frameworks={["react"]}>
 
-For example, `videoFeatures` bundles playback, volume, time, fullscreen, and more — everything a general video player needs:
+For example, the `/video` preset configures `VideoPlayer` with `videoFeatures`, which bundles playback, volume, time, fullscreen, and more — everything a general video player needs:
 
 ```tsx
-import { createPlayer } from '@videojs/react';
-import { videoFeatures } from '@videojs/react/video';
+import { VideoPlayer, Video, VideoSkin } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+<VideoPlayer.Provider>
+  <VideoSkin>
+    <Video src="movie.mp4" />
+  </VideoSkin>
+</VideoPlayer.Provider>
 ```
 
 </FrameworkCase>

--- a/site/src/content/docs/concepts/features.mdx
+++ b/site/src/content/docs/concepts/features.mdx
@@ -55,7 +55,7 @@ If you're not using presets, you can create a player that has individual feature
 ```tsx
 import { createPlayer, playbackFeature, volumeFeature, timeFeature, controlsFeature } from '@videojs/react';
 
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: [playbackFeature, volumeFeature, timeFeature, controlsFeature],
 });
 ```
@@ -86,7 +86,7 @@ Since feature bundles are just an array of features under the hood, it doesn't t
 import { createPlayer, playbackFeature } from '@videojs/react';
 import { backgroundFeatures } from '@videojs/react/background';
 
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: [...backgroundFeatures, playbackFeature],
 });
 ```

--- a/site/src/content/docs/concepts/mux-data.mdx
+++ b/site/src/content/docs/concepts/mux-data.mdx
@@ -17,16 +17,16 @@ import { MuxData } from '@videojs/react/media/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 export default function App() {
   return (
-    <Player.Provider>
-      <Player.Container>
+    <Player>
+      <Container>
         <MuxVideo source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }} playsInline />
         <MuxData /> {/* [!code focus] */}
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```

--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -15,15 +15,15 @@ For the reasoning behind this design, see <DocsLink slug="concepts/why-videojs">
 
 ## 1. State management
 <FrameworkCase frameworks={["react"]}>
-State is handled by a preset player provider, which creates a central state store that all components can access. When you wrap your player in `VideoPlayer.Provider`, the components automatically connect to the state.
+State is handled by a preset player provider, which creates a central state store that all components can access. When you wrap your player in `VideoPlayer`, the components automatically connect to the state.
 
 ```tsx
 {/* All components inside automatically connect to state */} {/* [!code focus] */}
-<VideoPlayer.Provider> {/* [!code focus] */}
+<VideoPlayer> {/* [!code focus] */}
   <VideoSkin>
     <Video src="video.mp4" />
   </VideoSkin>
-</VideoPlayer.Provider> {/* [!code focus] */}
+</VideoPlayer> {/* [!code focus] */}
 ```
 
 You can access state and actions from anywhere within the provider with the <DocsLink slug="reference/use-player">`usePlayer` hook</DocsLink>.
@@ -55,11 +55,11 @@ Skins are complete, pre-designed player UIs that package components and styles t
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<VideoPlayer.Provider>
+<VideoPlayer>
   <VideoSkin> {/* [!code focus] */}
     <Video src="video.mp4" />
   </VideoSkin> {/* [!code focus] */}
-</VideoPlayer.Provider>
+</VideoPlayer>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -80,15 +80,15 @@ If you want more control than skins offer you, you can build your own UI from ou
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<VideoPlayer.Provider>
-  <VideoPlayer.Container> {/* [!code focus] */}
+<VideoPlayer>
+  <Container> {/* [!code focus] */}
     <Video src="video.mp4" />
     <Controls.Root> {/* [!code focus] */}
       <PlayButton /> {/* [!code focus] */}
       {/* ... */} {/* [!code focus] */}
     </Controls.Root> {/* [!code focus] */}
-  </VideoPlayer.Container> {/* [!code focus] */}
-</VideoPlayer.Provider>
+  </Container> {/* [!code focus] */}
+</VideoPlayer>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -126,11 +126,11 @@ DASH, YouTube, Vimeo, Mux, and more media elements are currently under developme
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<VideoPlayer.Provider>
+<VideoPlayer>
   <VideoSkin>
     <HlsJsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" /> {/* [!code focus] */}
   </VideoSkin>
-</VideoPlayer.Provider>
+</VideoPlayer>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -163,11 +163,11 @@ import { BackgroundVideo, BackgroundVideoPlayer, BackgroundVideoSkin } from '@vi
 
 function Hero() {
   return (
-    <BackgroundVideoPlayer.Provider>
+    <BackgroundVideoPlayer>
       <BackgroundVideoSkin>
         <BackgroundVideo src="hero.mp4" />
       </BackgroundVideoSkin>
-    </BackgroundVideoPlayer.Provider>
+    </BackgroundVideoPlayer>
   );
 }
 ```

--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -15,7 +15,7 @@ For the reasoning behind this design, see <DocsLink slug="concepts/why-videojs">
 
 ## 1. State management
 <FrameworkCase frameworks={["react"]}>
-State is handled by a preset player provider, which creates a central state store that all components can access. When you wrap your player in `VideoPlayer`, the components automatically connect to the state.
+State is handled by a preset player component, which creates a central state store that all components can access. When you wrap your player in `VideoPlayer`, the components automatically connect to the state.
 
 ```tsx
 {/* All components inside automatically connect to state */} {/* [!code focus] */}
@@ -26,7 +26,7 @@ State is handled by a preset player provider, which creates a central state stor
 </VideoPlayer> {/* [!code focus] */}
 ```
 
-You can access state and actions from anywhere within the provider with the <DocsLink slug="reference/use-player">`usePlayer` hook</DocsLink>.
+You can access state and actions from anywhere within `VideoPlayer` with the <DocsLink slug="reference/use-player">`usePlayer` hook</DocsLink>.
 
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -15,15 +15,15 @@ For the reasoning behind this design, see <DocsLink slug="concepts/why-videojs">
 
 ## 1. State management
 <FrameworkCase frameworks={["react"]}>
-State is handled by a `Player.Provider`, which creates a central state store that all components can access. When you wrap your player in a `Player.Provider`, the components automatically connect to the state.
+State is handled by a preset player provider, which creates a central state store that all components can access. When you wrap your player in `VideoPlayer.Provider`, the components automatically connect to the state.
 
 ```tsx
 {/* All components inside automatically connect to state */} {/* [!code focus] */}
-<Player.Provider> {/* [!code focus] */}
+<VideoPlayer.Provider> {/* [!code focus] */}
   <VideoSkin>
     <Video src="video.mp4" />
   </VideoSkin>
-</Player.Provider> {/* [!code focus] */}
+</VideoPlayer.Provider> {/* [!code focus] */}
 ```
 
 You can access state and actions from anywhere within the provider with the <DocsLink slug="reference/use-player">`usePlayer` hook</DocsLink>.
@@ -55,11 +55,11 @@ Skins are complete, pre-designed player UIs that package components and styles t
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
+<VideoPlayer.Provider>
   <VideoSkin> {/* [!code focus] */}
     <Video src="video.mp4" />
   </VideoSkin> {/* [!code focus] */}
-</Player.Provider>
+</VideoPlayer.Provider>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -80,15 +80,15 @@ If you want more control than skins offer you, you can build your own UI from ou
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
-  <Player.Container> {/* [!code focus] */}
+<VideoPlayer.Provider>
+  <VideoPlayer.Container> {/* [!code focus] */}
     <Video src="video.mp4" />
     <Controls.Root> {/* [!code focus] */}
       <PlayButton /> {/* [!code focus] */}
       {/* ... */} {/* [!code focus] */}
     </Controls.Root> {/* [!code focus] */}
-  </Player.Container> {/* [!code focus] */}
-</Player.Provider>
+  </VideoPlayer.Container> {/* [!code focus] */}
+</VideoPlayer.Provider>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -126,11 +126,11 @@ DASH, YouTube, Vimeo, Mux, and more media elements are currently under developme
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
+<VideoPlayer.Provider>
   <VideoSkin>
     <HlsJsVideo src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8" /> {/* [!code focus] */}
   </VideoSkin>
-</Player.Provider>
+</VideoPlayer.Provider>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -159,18 +159,15 @@ Beyond the defaults, presets target more specific use cases. For example, `/back
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-import { createPlayer } from '@videojs/react';
-import { backgroundFeatures, BackgroundVideo, BackgroundVideoSkin } from '@videojs/react/background';
-
-const Player = createPlayer({ features: backgroundFeatures });
+import { BackgroundVideo, BackgroundVideoPlayer, BackgroundVideoSkin } from '@videojs/react/background';
 
 function Hero() {
   return (
-    <Player.Provider>
+    <BackgroundVideoPlayer.Provider>
       <BackgroundVideoSkin>
         <BackgroundVideo src="hero.mp4" />
       </BackgroundVideoSkin>
-    </Player.Provider>
+    </BackgroundVideoPlayer.Provider>
   );
 }
 ```

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -55,7 +55,7 @@ The default presets are `/video` and `/audio`. These cover the baseline controls
 
 Each React preset exports a named, preconfigured player component and typed `usePlayer` hook, plus the building blocks needed to customize or eject from it:
 
-- **Player** — A provider component named for the preset, such as `VideoPlayer`, already configured with the preset's feature bundle.
+- **Player** — A player component named for the preset, such as `VideoPlayer`, already configured with the preset's feature bundle.
 - **Typed hook** — A `usePlayer` hook whose state and actions match the preset.
 - **Feature bundle** — An array of <DocsLink slug="concepts/features">features</DocsLink> that define the player's state and actions. For example, the video feature bundle includes playback, volume, time, fullscreen, and more.
 - **Skins** — Pre-built UIs designed for that feature bundle. For example, a video skin renders fullscreen and PiP controls because the video feature bundle includes those features. An audio skin doesn't.
@@ -76,18 +76,18 @@ Add features to a preset's feature bundle to enable new functionality. For examp
 import { createPlayer, playbackFeature } from '@videojs/react';
 import { backgroundFeatures, BackgroundVideo } from '@videojs/react/background';
 
-const Player = createPlayer({ // [!code focus]
+const { Player, Container } = createPlayer({ // [!code focus]
   features: [...backgroundFeatures, playbackFeature], // [!code focus]
 }); // [!code focus]
 
 function Hero() {
   return (
-    <Player.Provider>
-      <Player.Container>
+    <Player>
+      <Container>
         <BackgroundVideo src="hero.mp4" />
         <PlayButton />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -14,18 +14,15 @@ A **preset** packages what you need for a specific player use case. It can inclu
 For example, the `@videojs/react/background` preset includes a media element with autoplay, mute, and loop built in, a skin with no controls, and just the features needed to power them:
 
 ```tsx title="App.tsx"
-import { createPlayer } from '@videojs/react';
-import { backgroundFeatures, BackgroundVideo, BackgroundVideoSkin } from '@videojs/react/background'; // [!code focus]
-
-const Player = createPlayer({ features: backgroundFeatures });
+import { BackgroundVideo, BackgroundVideoPlayer, BackgroundVideoSkin } from '@videojs/react/background'; // [!code focus]
 
 function Hero() {
   return (
-    <Player.Provider>
+    <BackgroundVideoPlayer.Provider>
       <BackgroundVideoSkin>
         <BackgroundVideo src="hero.mp4" />
       </BackgroundVideoSkin>
-    </Player.Provider>
+    </BackgroundVideoPlayer.Provider>
   );
 }
 ```
@@ -56,11 +53,21 @@ The default presets are `/video` and `/audio`. These cover the baseline controls
 
 ## What's in a preset
 
-Each preset exports up to three things:
+Each React preset exports a named, preconfigured player and typed `usePlayer` hook, plus the building blocks needed to customize or eject from it:
 
+- **Player** — A `createPlayer` result named for the preset, such as `VideoPlayer`, with a `Provider` already configured with the preset's feature bundle.
+- **Typed hook** — A `usePlayer` hook whose state and actions match the preset.
 - **Feature bundle** — An array of <DocsLink slug="concepts/features">features</DocsLink> that define the player's state and actions. For example, the video feature bundle includes playback, volume, time, fullscreen, and more.
 - **Skins** — Pre-built UIs designed for that feature bundle. For example, a video skin renders fullscreen and PiP controls because the video feature bundle includes those features. An audio skin doesn't.
 - **Media element** — A media component suited to the use case. For example, the background video element bakes in autoplay, mute, and loop.
+
+The convenient hook is the same typed hook available on the player result:
+
+```tsx
+import { usePlayer, VideoPlayer } from '@videojs/react/video';
+
+usePlayer === VideoPlayer.usePlayer;
+```
 
 These parts aren't equally tied together. Skins depend tightly on their feature bundle — a skin expects specific features to exist. Media elements are more interchangeable — you can swap in an HLS or DASH provider without changing your skin or features.
 
@@ -131,11 +138,11 @@ A preset's default media element is just the starting point. You can replace it 
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
+<VideoPlayer.Provider>
   <VideoSkin>
     <HlsJsVideo src="https://example.com/stream.m3u8" /> {/* [!code focus] */}
   </VideoSkin>
-</Player.Provider>
+</VideoPlayer.Provider>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -18,11 +18,11 @@ import { BackgroundVideo, BackgroundVideoPlayer, BackgroundVideoSkin } from '@vi
 
 function Hero() {
   return (
-    <BackgroundVideoPlayer.Provider>
+    <BackgroundVideoPlayer>
       <BackgroundVideoSkin>
         <BackgroundVideo src="hero.mp4" />
       </BackgroundVideoSkin>
-    </BackgroundVideoPlayer.Provider>
+    </BackgroundVideoPlayer>
   );
 }
 ```
@@ -53,21 +53,13 @@ The default presets are `/video` and `/audio`. These cover the baseline controls
 
 ## What's in a preset
 
-Each React preset exports a named, preconfigured player and typed `usePlayer` hook, plus the building blocks needed to customize or eject from it:
+Each React preset exports a named, preconfigured player component and typed `usePlayer` hook, plus the building blocks needed to customize or eject from it:
 
-- **Player** — A `createPlayer` result named for the preset, such as `VideoPlayer`, with a `Provider` already configured with the preset's feature bundle.
+- **Player** — A provider component named for the preset, such as `VideoPlayer`, already configured with the preset's feature bundle.
 - **Typed hook** — A `usePlayer` hook whose state and actions match the preset.
 - **Feature bundle** — An array of <DocsLink slug="concepts/features">features</DocsLink> that define the player's state and actions. For example, the video feature bundle includes playback, volume, time, fullscreen, and more.
 - **Skins** — Pre-built UIs designed for that feature bundle. For example, a video skin renders fullscreen and PiP controls because the video feature bundle includes those features. An audio skin doesn't.
 - **Media element** — A media component suited to the use case. For example, the background video element bakes in autoplay, mute, and loop.
-
-The convenient hook is the same typed hook available on the player result:
-
-```tsx
-import { usePlayer, VideoPlayer } from '@videojs/react/video';
-
-usePlayer === VideoPlayer.usePlayer;
-```
 
 These parts aren't equally tied together. Skins depend tightly on their feature bundle — a skin expects specific features to exist. Media elements are more interchangeable — you can swap in an HLS or DASH provider without changing your skin or features.
 
@@ -138,11 +130,11 @@ A preset's default media element is just the starting point. You can replace it 
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<VideoPlayer.Provider>
+<VideoPlayer>
   <VideoSkin>
     <HlsJsVideo src="https://example.com/stream.m3u8" /> {/* [!code focus] */}
   </VideoSkin>
-</VideoPlayer.Provider>
+</VideoPlayer>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -31,12 +31,12 @@ In prior versions of Video.js, skins were CSS-only themes applied to the same se
 </FrameworkCase>
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
+<VideoPlayer.Provider>
   <VideoSkin> {/* [!code focus] */}
     {/* wraps the Media component */} {/* [!code focus] */}
     <Video src="video.mp4"></Video>
   </VideoSkin> {/* [!code focus] */}
-</Player.Provider>
+</VideoPlayer.Provider>
 ```
 </FrameworkCase>
 
@@ -69,11 +69,11 @@ When you choose a skin you have two options for how you use it: **packaged** or 
 </FrameworkCase>
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-  <Player.Provider>
+  <VideoPlayer.Provider>
     <VideoSkin>
       {/* ...Media... */}
     </VideoSkin>
-  </Player.Provider>
+  </VideoPlayer.Provider>
 ```
 </FrameworkCase>
 
@@ -91,7 +91,7 @@ When you choose a skin you have two options for how you use it: **packaged** or 
 
 Each skin is built with specific <DocsLink slug="concepts/features">features</DocsLink> in mind. For example, a video skin renders fullscreen and picture-in-picture controls. An audio skin doesn't.
 
-You'll find both a skin and the feature bundle it expects exported from the same path. We call these paths **presets**. 
+You'll find a preconfigured player, its typed hook, a skin, and the matching feature bundle exported from the same path. We call these paths **presets**.
 
 <PresetReference />
 

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -31,12 +31,12 @@ In prior versions of Video.js, skins were CSS-only themes applied to the same se
 </FrameworkCase>
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<VideoPlayer.Provider>
+<VideoPlayer>
   <VideoSkin> {/* [!code focus] */}
     {/* wraps the Media component */} {/* [!code focus] */}
     <Video src="video.mp4"></Video>
   </VideoSkin> {/* [!code focus] */}
-</VideoPlayer.Provider>
+</VideoPlayer>
 ```
 </FrameworkCase>
 
@@ -69,11 +69,11 @@ When you choose a skin you have two options for how you use it: **packaged** or 
 </FrameworkCase>
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-  <VideoPlayer.Provider>
+  <VideoPlayer>
     <VideoSkin>
       {/* ...Media... */}
     </VideoSkin>
-  </VideoPlayer.Provider>
+  </VideoPlayer>
 ```
 </FrameworkCase>
 

--- a/site/src/content/docs/concepts/ui-components.mdx
+++ b/site/src/content/docs/concepts/ui-components.mdx
@@ -13,11 +13,11 @@ Every UI component renders exactly one HTML element, taking inspiration from pro
 
 ## Where to put your components
 <FrameworkCase frameworks={["react"]}>
-UI Components can go anywhere inside a <DocsLink slug="reference/player-provider">`<Player.Provider>`</DocsLink>.
+UI Components can go anywhere inside a <DocsLink slug="reference/player-provider">`<Player>`</DocsLink>.
 
-However, you should consider placing your components in `<Player.Container>`. Components in `<Player.Container>` will go fullscreen with the player, respond to user activity, and more.
+However, you should consider placing your components in `<Container>`. Components in `<Container>` will go fullscreen with the player, respond to user activity, and more.
 
-<DocsLinkCard slug="reference/player-container">Read more about `<Player.Container>`</DocsLinkCard>
+<DocsLinkCard slug="reference/player-container">Read more about `<Container>`</DocsLinkCard>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/concepts/why-videojs.mdx
+++ b/site/src/content/docs/concepts/why-videojs.mdx
@@ -124,11 +124,11 @@ The player feels like the rest of your app.
 
     function MyPlayer() {
       return (
-        <VideoPlayer.Provider>
+        <VideoPlayer>
           <VideoSkin>
             <Video src="movie.mp4" />
           </VideoSkin>
-        </VideoPlayer.Provider>
+        </VideoPlayer>
       );
     }
     ```

--- a/site/src/content/docs/concepts/why-videojs.mdx
+++ b/site/src/content/docs/concepts/why-videojs.mdx
@@ -86,7 +86,7 @@ Most player libraries ship every feature in one bundle, so you carry code you do
 ```tsx
 import { createPlayer, playbackFeature, timeFeature } from '@videojs/react';
 
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: [playbackFeature, timeFeature], // [!code focus]
 });
 ```

--- a/site/src/content/docs/concepts/why-videojs.mdx
+++ b/site/src/content/docs/concepts/why-videojs.mdx
@@ -120,15 +120,15 @@ The player feels like the rest of your app.
   </TabsList>
   <TabsPanel client:idle value="react" initial>
     ```tsx
-    import { Player, Video, VideoSkin } from '@videojs/react/video';
+    import { VideoPlayer, Video, VideoSkin } from '@videojs/react/video';
 
     function MyPlayer() {
       return (
-        <Player.Provider>
+        <VideoPlayer.Provider>
           <VideoSkin>
             <Video src="movie.mp4" />
           </VideoSkin>
-        </Player.Provider>
+        </VideoPlayer.Provider>
       );
     }
     ```

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -98,17 +98,17 @@ this.#store.value.setVolume(0.5);
 
 <FrameworkCase frameworks={["react"]}>
 
-Your component needs to be inside <DocsLink slug="reference/player-provider">`<Player.Provider>`</DocsLink> to access state. Place it inside <DocsLink slug="reference/player-container">`<Player.Container>`</DocsLink> if it should also participate in fullscreen and respond to user activity:
+Your component needs to be inside <DocsLink slug="reference/player-provider">`<Player>`</DocsLink> to access state. Place it inside <DocsLink slug="reference/player-container">`<Container>`</DocsLink> if it should also participate in fullscreen and respond to user activity:
 
 ```tsx
-<Player.Provider> // [!code focus]
-  <Player.Container> // [!code focus]
+<Player> // [!code focus]
+  <Container> // [!code focus]
     <VideoSkin>
       <Video src="video.mp4" />
     </VideoSkin>
     <SkipIntroButton /> // [!code focus]
-  </Player.Container> // [!code focus]
-</Player.Provider> // [!code focus]
+  </Container> // [!code focus]
+</Player> // [!code focus]
 ```
 
 </FrameworkCase>

--- a/site/src/content/docs/how-to/i18n-override-translations.mdx
+++ b/site/src/content/docs/how-to/i18n-override-translations.mdx
@@ -46,13 +46,13 @@ Pass `translations` on <DocsLink slug="reference/i18n-provider">`I18nProvider`</
 import { I18nProvider } from '@videojs/react/i18n';
 import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 
-<VideoPlayer.Provider>
+<VideoPlayer>
   <I18nProvider locale="es" translations={{ buttons: { play: 'Comenzar' } }}>
     <VideoSkin>
       <Video src="..." playsInline />
     </VideoSkin>
   </I18nProvider>
-</VideoPlayer.Provider>
+</VideoPlayer>
 ```
 
 Nested providers inherit the parent locale when you only pass `translations`:

--- a/site/src/content/docs/how-to/i18n-override-translations.mdx
+++ b/site/src/content/docs/how-to/i18n-override-translations.mdx
@@ -44,15 +44,15 @@ Pass `translations` on <DocsLink slug="reference/i18n-provider">`I18nProvider`</
 
 ```tsx
 import { I18nProvider } from '@videojs/react/i18n';
-import { Provider, VideoSkin, Video } from '@videojs/react/video';
+import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 
-<Provider>
+<VideoPlayer.Provider>
   <I18nProvider locale="es" translations={{ buttons: { play: 'Comenzar' } }}>
     <VideoSkin>
       <Video src="..." playsInline />
     </VideoSkin>
   </I18nProvider>
-</Provider>
+</VideoPlayer.Provider>
 ```
 
 Nested providers inherit the parent locale when you only pass `translations`:

--- a/site/src/content/docs/how-to/i18n-register-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-register-locale.mdx
@@ -62,13 +62,13 @@ import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 
 export function App() {
   return (
-    <VideoPlayer.Provider>
+    <VideoPlayer>
       <I18nProvider locale="es">
         <VideoSkin>
           <Video src="..." playsInline />
         </VideoSkin>
       </I18nProvider>
-    </VideoPlayer.Provider>
+    </VideoPlayer>
   );
 }
 ```

--- a/site/src/content/docs/how-to/i18n-register-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-register-locale.mdx
@@ -58,17 +58,17 @@ Without the side-effect import, `<media-i18n>` lazy-loads `es` when it resolves 
 ```tsx title="app.tsx"
 import { I18nProvider } from '@videojs/react/i18n';
 import '@videojs/react/i18n/locales/es/register';
-import { Provider, VideoSkin, Video } from '@videojs/react/video';
+import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 
 export function App() {
   return (
-    <Provider>
+    <VideoPlayer.Provider>
       <I18nProvider locale="es">
         <VideoSkin>
           <Video src="..." playsInline />
         </VideoSkin>
       </I18nProvider>
-    </Provider>
+    </VideoPlayer.Provider>
   );
 }
 ```

--- a/site/src/content/docs/how-to/i18n-ssr.mdx
+++ b/site/src/content/docs/how-to/i18n-ssr.mdx
@@ -33,7 +33,7 @@ Import the locale pack on the server (or in a server component) and pass it to <
 
 ```tsx
 import { I18nProvider } from '@videojs/react/i18n';
-import { Provider, VideoSkin, Video } from '@videojs/react/video';
+import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 
 const loaders = {
   es: () => import('@videojs/react/i18n/locales/es'),
@@ -46,13 +46,13 @@ export async function Player({ locale }: { locale: string }) {
   const { default: translations } = await load();
 
   return (
-    <Provider>
+    <VideoPlayer.Provider>
       <I18nProvider locale={locale} translations={translations}>
         <VideoSkin>
           <Video src="..." playsInline />
         </VideoSkin>
       </I18nProvider>
-    </Provider>
+    </VideoPlayer.Provider>
   );
 }
 ```

--- a/site/src/content/docs/how-to/i18n-ssr.mdx
+++ b/site/src/content/docs/how-to/i18n-ssr.mdx
@@ -46,13 +46,13 @@ export async function Player({ locale }: { locale: string }) {
   const { default: translations } = await load();
 
   return (
-    <VideoPlayer.Provider>
+    <VideoPlayer>
       <I18nProvider locale={locale} translations={translations}>
         <VideoSkin>
           <Video src="..." playsInline />
         </VideoSkin>
       </I18nProvider>
-    </VideoPlayer.Provider>
+    </VideoPlayer>
   );
 }
 ```

--- a/site/src/content/docs/how-to/i18n-switch-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-switch-locale.mdx
@@ -54,7 +54,7 @@ An <DocsLink slug="reference/i18n-provider">`I18nProvider`</DocsLink> without `l
 ```tsx
 import { useState } from 'react';
 import { I18nProvider } from '@videojs/react/i18n';
-import { Provider, VideoSkin, Video } from '@videojs/react/video';
+import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 
 function App() {
   const [locale, setLocale] = useState<'en' | 'es' | 'fr'>('en');
@@ -64,13 +64,13 @@ function App() {
       <button type="button" onClick={() => setLocale('es')}>
         Español
       </button>
-      <Provider>
+      <VideoPlayer.Provider>
         <I18nProvider locale={locale}>
           <VideoSkin>
             <Video src="..." playsInline />
           </VideoSkin>
         </I18nProvider>
-      </Provider>
+      </VideoPlayer.Provider>
     </>
   );
 }

--- a/site/src/content/docs/how-to/i18n-switch-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-switch-locale.mdx
@@ -64,13 +64,13 @@ function App() {
       <button type="button" onClick={() => setLocale('es')}>
         Español
       </button>
-      <VideoPlayer.Provider>
+      <VideoPlayer>
         <I18nProvider locale={locale}>
           <VideoSkin>
             <Video src="..." playsInline />
           </VideoSkin>
         </I18nProvider>
-      </VideoPlayer.Provider>
+      </VideoPlayer>
     </>
   );
 }

--- a/site/src/content/docs/reference/create-player.mdx
+++ b/site/src/content/docs/reference/create-player.mdx
@@ -1,6 +1,6 @@
 ---
 title: createPlayer
-description: Factory function that creates a player instance with typed store, Provider component, Container, and hooks
+description: Factory function that creates a typed Player component, Container, and hooks
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
@@ -19,8 +19,9 @@ The hook is typed according to the provided features, giving you full type safet
 import { createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
-// Player.Provider, Player.Container, Player.usePlayer, Player.useMedia
+const { Player, Container, usePlayer, useMedia } = createPlayer({
+  features: videoFeatures,
+});
 ```
 
 ## Examples

--- a/site/src/content/docs/reference/feature-fullscreen.mdx
+++ b/site/src/content/docs/reference/feature-fullscreen.mdx
@@ -61,7 +61,7 @@ By default, the feature locks to `landscape`. Pass a Screen Orientation API type
 import { createPlayer, features } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
 });
 ```

--- a/site/src/content/docs/reference/feature-orientation-lock.mdx
+++ b/site/src/content/docs/reference/feature-orientation-lock.mdx
@@ -30,7 +30,7 @@ export const { Player } = createPlayer({
 import { createPlayer, features } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-const player = createPlayer({
+export const { ProviderMixin } = createPlayer({
   features: [...videoFeatures, features.orientationLock],
 });
 ```
@@ -52,7 +52,7 @@ export const { Player } = createPlayer({
 import { createPlayer, features } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-const player = createPlayer({
+export const { ProviderMixin } = createPlayer({
   features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
 });
 ```

--- a/site/src/content/docs/reference/feature-orientation-lock.mdx
+++ b/site/src/content/docs/reference/feature-orientation-lock.mdx
@@ -19,7 +19,7 @@ By default, the feature locks to `landscape`. Pass a Screen Orientation API type
 import { createPlayer, features } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-export const Player = createPlayer({
+export const { Player } = createPlayer({
   features: [...videoFeatures, features.orientationLock],
 });
 ```
@@ -41,7 +41,7 @@ const player = createPlayer({
 import { createPlayer, features } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-export const Player = createPlayer({
+export const { Player } = createPlayer({
   features: [...videoFeatures, features.orientationLock({ type: 'portrait' })],
 });
 ```

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -1,5 +1,5 @@
 ---
-title: Player.Container
+title: Container
 frameworkTitle:
   html: media-container
 description: The player's interaction surface — handles layout, fullscreen, media attachment, and user activity detection.
@@ -10,7 +10,7 @@ import DocsLink from '@/components/docs/DocsLink.astro';
 import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 
 <FrameworkCase frameworks={["react"]}>
-The `Player.Container` is the player's physical surface. It defines the visual boundary, attaches the media element, and detects user interaction like activity and (eventually) gestures and keyboard input. It lives inside a <DocsLink slug="reference/player-provider">`Player.Provider`</DocsLink>.
+The `Container` is the player's physical surface. It defines the visual boundary, attaches the media element, and detects user interaction like activity and (eventually) gestures and keyboard input. It lives inside a <DocsLink slug="reference/player-provider">`Player`</DocsLink>.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 The `<media-container>` is the player's physical surface. It defines the visual boundary, attaches the media element, and detects user interaction like activity and (eventually) gestures and keyboard input. It lives inside a <DocsLink slug="reference/player-provider">`<video-player>`</DocsLink>.
@@ -18,14 +18,14 @@ The `<media-container>` is the player's physical surface. It defines the visual 
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
-  <Player.Container> {/* [!code focus] */}
+<Player>
+  <Container> {/* [!code focus] */}
     <video src="video.mp4" />
     <Controls.Root>
       {/* ... */}
     </Controls.Root>
-  </Player.Container> {/* [!code focus] */}
-</Player.Provider>
+  </Container> {/* [!code focus] */}
+</Player>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -42,13 +42,13 @@ The `<media-container>` is the player's physical surface. It defines the visual 
 ## How it's created
 
 <FrameworkCase frameworks={["react"]}>
-The `Player.Container` comes from the same `createPlayer()` call that creates the `Player.Provider`. They're a matched pair wired to the same feature set.
+`Container` comes from the same `createPlayer()` call as `Player`.
 
 ```tsx
 import { createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 ```
 
 <DocsLinkCard slug="reference/create-player">`createPlayer` reference</DocsLinkCard>
@@ -89,16 +89,16 @@ customElements.define('my-container', MyContainer);
 
 ### Layout & fullscreen
 
-The container is the visual box around your media and controls. Sizing, aspect ratio, and visual boundaries all go here — on the container, not the provider.
+The container is the visual box around your media and controls. Sizing, aspect ratio, and visual boundaries all go here — on `Container`, not `Player`.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Container style={{ width: 640, aspectRatio: '16/9' }}>
+<Container style={{ width: 640, aspectRatio: '16/9' }}>
   <video src="video.mp4" />
   <Controls.Root>
     {/* ... */}
   </Controls.Root>
-</Player.Container>
+</Container>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -115,7 +115,7 @@ When the user goes fullscreen, the **container** goes fullscreen — not the vid
 ### Media attachment
 
 <FrameworkCase frameworks={["react"]}>
-Media discovery is handled by the provider, not the container. When a media component like `<Video>` registers itself via context, the provider wires it to the store and all of the player's features.
+Media discovery is handled by `Player`, not `Container`. When a media component like `<Video>` registers itself via context, `Player` wires it to the store and all of the player's features.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 Media discovery is handled by the provider, not the container. Custom media elements like `<hlsjs-video>` register themselves via context when they connect. Plain `<video>` and `<audio>` elements are picked up automatically via a `querySelector` fallback. No `slot="media"` attribute is needed.
@@ -136,19 +136,19 @@ A <DocsLink slug="concepts/skins">skin</DocsLink> is a container plus UI control
 <FrameworkCase frameworks={["react"]}>
 ```tsx
 {/* Packaged skin — container is inside VideoSkin */}
-<Player.Provider>
+<Player>
   <VideoSkin>
     <Video src="video.mp4" />
   </VideoSkin>
-</Player.Provider>
+</Player>
 
-{/* Custom UI — you use Player.Container directly */}
-<Player.Provider>
-  <Player.Container>
+{/* Custom UI — you use Container directly */}
+<Player>
+  <Container>
     <video src="video.mp4" />
     <PlayButton />
-  </Player.Container>
-</Player.Provider>
+  </Container>
+</Player>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -172,21 +172,21 @@ A <DocsLink slug="concepts/skins">skin</DocsLink> is a container plus UI control
 
 ## Inside vs. outside the container
 
-The <DocsLink slug="reference/player-provider">provider</DocsLink> gives components access to state and actions. The container layers on physical behaviors — fullscreen, activity detection, gesture handling. Components work in both places; the container just adds those extras.
+<DocsLink slug="reference/player-provider">`Player`</DocsLink> gives components access to state and actions. `Container` layers on physical behaviors — fullscreen, activity detection, and gesture handling. Components work in both places; the container just adds those extras.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
-  <Player.Container>
+<Player>
+  <Container>
     <video src="video.mp4" />
     <Controls.Root>          {/* fullscreen, activity detection, gestures */}
       {/* ... */}
     </Controls.Root>
-  </Player.Container>
+  </Container>
 
   <Transcript />          {/* state & actions, but no container behaviors */}
   <PlaylistSidebar />     {/* state & actions, but no container behaviors */}
-</Player.Provider>
+</Player>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/player-provider.mdx
+++ b/site/src/content/docs/reference/player-provider.mdx
@@ -1,5 +1,5 @@
 ---
-title: Player.Provider
+title: Player
 frameworkTitle:
   html: video-player
 description: The state boundary — creates a store and broadcasts it to all descendants.
@@ -11,7 +11,7 @@ import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
 import Aside from '@/components/Aside.astro';
 
 <FrameworkCase frameworks={["react"]}>
-The `Player.Provider` is the state boundary of your player. It creates a store and makes it available to every component inside it via context. Every player needs exactly one.
+The `Player` is the state boundary of your player. It creates a store and makes it available to every component inside it via context. Every player needs exactly one.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 The `<video-player>` element is the state boundary of your player. It creates a store and makes it available to every element inside it via context. Every player needs exactly one.
@@ -22,16 +22,16 @@ The `<video-player>` element is the state boundary of your player. It creates a 
 import { videoFeatures } from '@videojs/react/video';
 import { createPlayer } from '@videojs/react';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player, Container } = createPlayer({ features: videoFeatures });
 
 function App() {
   return (
-    <Player.Provider>
+    <Player>
       {/* Everything inside can access the player store */}
-      <Player.Container>
+      <Container>
         <video src="video.mp4" />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```
@@ -50,13 +50,13 @@ function App() {
 ## How it's created
 
 <FrameworkCase frameworks={["react"]}>
-Call `createPlayer()` with a `features` array. The returned object contains `Provider`, `Container`, `usePlayer`, and `useMedia` — everything you need for one player instance.
+Call `createPlayer()` with a `features` array. It returns `Player`, `Container`, `usePlayer`, and `useMedia` — everything you need for one player instance.
 
 ```tsx
 import { createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({
+const { Player, Container, usePlayer, useMedia } = createPlayer({
   features: videoFeatures,
 });
 ```
@@ -99,16 +99,16 @@ customElements.define('my-player', MyPlayer);
 
 ## What lives inside it
 
-Everything that needs player state goes inside the provider: skins, containers, UI components, and your own custom components. Anything inside can access the store.
+Everything that needs player state goes inside `Player`: skins, containers, UI components, and your own custom components. Anything inside can access the store.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
+<Player>
   <VideoSkin>           {/* skin — includes container + controls */}
     <Video src="..." /> {/* media element */}
   </VideoSkin>
-  <MyCustomOverlay />   {/* your own component — can use Player.usePlayer() */}
-</Player.Provider>
+  <MyCustomOverlay />   {/* your own component — can use usePlayer() */}
+</Player>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
@@ -125,7 +125,7 @@ Everything that needs player state goes inside the provider: skins, containers, 
 ## No visual presence
 
 <FrameworkCase frameworks={["react"]}>
-The `Provider` renders no visible element of its own — it's purely a state wrapper. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`Container`</DocsLink>, not the Provider.
+`Player` renders no visible element of its own — it's purely a state wrapper. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`Container`</DocsLink>, not `Player`.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
 The `<video-player>` element uses `display: contents`, meaning it has no visual box of its own. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink>, not the provider.
@@ -134,12 +134,12 @@ The `<video-player>` element uses `display: contents`, meaning it has no visual 
 ## Accessing state
 
 <FrameworkCase frameworks={["react"]}>
-Use `Player.usePlayer` to read state or call actions from any component inside the Provider:
+Use `usePlayer` to read state or call actions from any component inside `Player`:
 
 ```tsx title="PlayPauseButton.tsx"
 function PlayPauseButton() {
-  const paused = Player.usePlayer(selectPlayback).paused;
-  const store = Player.usePlayer();
+  const paused = usePlayer(selectPlayback).paused;
+  const store = usePlayer();
 
   return (
     <button onClick={() => store.dispatch('toggle-playback')}>
@@ -174,21 +174,21 @@ class PlayPauseButton extends MediaElement {
 
 ## Extended player layouts
 
-The provider's scope can extend beyond the fullscreen target. Playlists, transcripts, sidebars, and other supplementary UI can live inside the provider but outside the container. They still have full access to the store, they just won't go fullscreen with the video.
+The player's scope can extend beyond the fullscreen target. Playlists, transcripts, sidebars, and other supplementary UI can live inside `Player` but outside `Container`. They still have full access to the store, but they won't go fullscreen with the video.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<Player.Provider>
-  <Player.Container>
+<Player>
+  <Container>
     <video src="video.mp4" />
     <Controls.Root>          {/* goes fullscreen with the video */}
       {/* ... */}
     </Controls.Root>
-  </Player.Container>
+  </Container>
 
   <Transcript />          {/* outside container — still has store access */}
   <PlaylistSidebar />     {/* outside container — still has store access */}
-</Player.Provider>
+</Player>
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -91,7 +91,7 @@ Supported source formats:
 - JSON array: `{ url, startTime, endTime? }[]`
 - JSON sprite array: `{ url, startTime, endTime?, width, height, coords }[]`
 
-In React, text-track mode needs `Player.Provider` because it reads track state from the player store. JSON modes (`thumbnails` prop) work without `Provider`.
+In React, text-track mode needs `Player` because it reads track state from the player store. JSON modes (`thumbnails` prop) work without a player.
 
 The component picks the latest thumbnail whose `startTime` is less than or equal to the current `time`, then scales/clips sprite tiles to fit CSS min/max constraints while preserving aspect ratio.
 

--- a/site/src/content/docs/reference/use-container-attach.mdx
+++ b/site/src/content/docs/reference/use-container-attach.mdx
@@ -5,7 +5,7 @@ description: Hook to register a custom container element with the player context
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
 
-`useContainerAttach` returns a setter function for registering a DOM element as the player's container. The built-in `Player.Container` uses this internally; you only need it when building a custom container element.
+`useContainerAttach` returns a setter function for registering a DOM element as the player's container. The built-in `Container` uses this internally; you only need it when building a custom container element.
 
 ```tsx title="CustomContainer.tsx"
 import { useContainerAttach } from "@videojs/react";
@@ -18,12 +18,12 @@ function CustomContainer({ children }: { children: React.ReactNode }) {
 
 ## Who needs this
 
-You only need `useContainerAttach` if you're replacing the built-in `Player.Container` with a custom element. For example, if you're building a container with custom fullscreen behavior or a non-standard layout boundary.
+You only need `useContainerAttach` if you're replacing the built-in `Container` with a custom element. For example, if you're building a container with custom fullscreen behavior or a non-standard layout boundary.
 
-For standard player layouts, use the built-in `Player.Container`.
+For standard player layouts, use the built-in `Container`.
 
-## Safe outside Provider
+## Safe outside Player
 
-Returns `undefined` when called outside a Player `Provider`. Passing `undefined` to `ref` is harmless in React. Check the return value if your component needs to know whether it's inside a provider.
+Returns `undefined` when called outside `Player`. Passing `undefined` to `ref` is harmless in React. Check the return value if your component needs to know whether it's inside a player.
 
 <UtilReference util="useContainerAttach" />

--- a/site/src/content/docs/reference/use-media-attach.mdx
+++ b/site/src/content/docs/reference/use-media-attach.mdx
@@ -26,8 +26,8 @@ You only need `useMediaAttach` if you're replacing the built-in `<Video>` or `<A
 
 For standard `<video>` and `<audio>` playback, use the built-in components.
 
-## Safe outside Provider
+## Safe outside Player
 
-Returns `undefined` when called outside a Player `Provider`. Check the return value before using it -- this avoids crashes in components that may render outside the player tree.
+Returns `undefined` when called outside `Player`. Check the return value before using it -- this avoids crashes in components that may render outside the player tree.
 
 <UtilReference util="useMediaAttach" />

--- a/site/src/content/docs/reference/use-media.mdx
+++ b/site/src/content/docs/reference/use-media.mdx
@@ -1,6 +1,6 @@
 ---
-title: Player.useMedia
-description: Hook to access the media object from within a Player.Provider
+title: useMedia
+description: Hook to access the media object from within a Player
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
@@ -12,7 +12,11 @@ import BasicUsageDemoReact from "@/components/docs/demos/use-media/react/css/Bas
 import basicUsageReactTsx from "@/components/docs/demos/use-media/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/use-media/react/css/BasicUsage.css?raw";
 
-`Player.useMedia` (from <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>) returns the current `Media` object (or `null` if no media has been registered yet). `Media` is a runtime-agnostic playback interface — any instance that conforms to it, including an `HTMLVideoElement`, can be the media. It exposes capabilities like `play()` and event subscription rather than assuming a native element. It must be called within a `Player.Provider`. The media object becomes available after a `<Video>` or `<Audio>` component mounts inside the provider tree. To attach a custom media element instead of the built-in components, see <DocsLink slug="reference/use-media-attach">`useMediaAttach`</DocsLink>.
+The `useMedia` hook returned by <DocsLink slug="reference/create-player">`createPlayer`</DocsLink> returns the current `Media` object (or `null` if no media has been registered yet). `Media` is a runtime-agnostic playback interface — any instance that conforms to it, including an `HTMLVideoElement`, can be the media. It exposes capabilities like `play()` and event subscription rather than assuming a native element. It must be called within the matching `Player`. The media object becomes available after a `<Video>` or `<Audio>` component mounts inside the player tree. To attach a custom media element instead of the built-in components, see <DocsLink slug="reference/use-media-attach">`useMediaAttach`</DocsLink>.
+
+```tsx
+const { Player, useMedia } = createPlayer({ features: videoFeatures });
+```
 
 ## Examples
 

--- a/site/src/content/docs/reference/use-player.mdx
+++ b/site/src/content/docs/reference/use-player.mdx
@@ -1,6 +1,6 @@
 ---
-title: Player.usePlayer
-description: Hook to access the player store from within a Player.Provider
+title: usePlayer
+description: Hook to access the player store from within a Player
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
@@ -15,7 +15,11 @@ import SelectorDemoReact from "@/components/docs/demos/use-player/react/css/Sele
 import selectorReactTsx from "@/components/docs/demos/use-player/react/css/Selector.tsx?raw";
 import selectorReactCss from "@/components/docs/demos/use-player/react/css/Selector.css?raw";
 
-`Player.usePlayer` (from <DocsLink slug="reference/create-player">`createPlayer`</DocsLink>) gives you access to the player store from any component within a `Player.Provider`. It's typed to the features you passed to `createPlayer`, and has two overloads — without arguments for direct store access, or with a selector for reactive state subscriptions.
+The `usePlayer` hook returned by <DocsLink slug="reference/create-player">`createPlayer`</DocsLink> gives you access to the player store from any component within its `Player`. It's typed to the features you passed to `createPlayer`, and has two overloads — without arguments for direct store access, or with a selector for reactive state subscriptions.
+
+```tsx
+const { Player, usePlayer } = createPlayer({ features: videoFeatures });
+```
 
 `usePlayer` is also available as a standalone import (`import { usePlayer } from '@videojs/react'`), but the standalone version returns an untyped `UnknownStore`. Pass a premade selector to recover typing:
 
@@ -30,7 +34,7 @@ usePlayer(selectPlayback); // PlaybackState | undefined
 
 ### Store Access
 
-Call `Player.usePlayer()` without arguments to get the store instance. Use this for imperative actions like play, pause, and volume changes. The component does not re-render on state changes.
+Call `usePlayer()` without arguments to get the store instance. Use this for imperative actions like play, pause, and volume changes. The component does not re-render on state changes.
 
 <FrameworkCase frameworks={["react"]}>
   <StyleCase styles={["css"]}>

--- a/site/src/content/docs/reference/use-store.mdx
+++ b/site/src/content/docs/reference/use-store.mdx
@@ -15,7 +15,7 @@ import SelectorDemoReact from "@/components/docs/demos/use-store/react/css/Selec
 import selectorReactTsx from "@/components/docs/demos/use-store/react/css/Selector.tsx?raw";
 import selectorReactCss from "@/components/docs/demos/use-store/react/css/Selector.css?raw";
 
-`useStore` subscribes to a store instance directly. It has the same two overloads as <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> — without a selector for store access, or with a selector for reactive state. Within a player provider, `usePlayer` is usually simpler since it reads the store from context. Reach for `useStore` when you have a store instance directly or need to derive computed values from the store.
+`useStore` subscribes to a store instance directly. It has the same two overloads as <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> — without a selector for store access, or with a selector for reactive state. Within `Player`, `usePlayer` is usually simpler since it reads the store from context. Reach for `useStore` when you have a store instance directly or need to derive computed values from the store.
 
 ## Examples
 

--- a/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
+++ b/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
@@ -1,10 +1,7 @@
 
 import { VJS10_DEMO_VIDEO } from '@/consts';
-import { createPlayer } from '@videojs/react';
-import { VideoSkin, Video, videoFeatures } from '@videojs/react/video';
+import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video';
 import '@videojs/react/video/skin.css';
-
-const Player = createPlayer({ features: videoFeatures });
 
 /**
  * Live demo of the (default) frosted video skin design.
@@ -18,10 +15,10 @@ const Player = createPlayer({ features: videoFeatures });
  */
 export function FrostedSkinDemo() {
   return (
-    <Player.Provider>
+    <VideoPlayer.Provider>
       <VideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </VideoSkin>
-    </Player.Provider>
+    </VideoPlayer.Provider>
   );
 }

--- a/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
+++ b/site/src/examples/react/FrostedSkin/FrostedSkinDemo.tsx
@@ -15,10 +15,10 @@ import '@videojs/react/video/skin.css';
  */
 export function FrostedSkinDemo() {
   return (
-    <VideoPlayer.Provider>
+    <VideoPlayer>
       <VideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </VideoSkin>
-    </VideoPlayer.Provider>
+    </VideoPlayer>
   );
 }

--- a/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
+++ b/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
@@ -13,10 +13,10 @@ import '@videojs/react/video/minimal-skin.css';
  */
 export function MinimalSkinDemo() {
   return (
-    <VideoPlayer.Provider>
+    <VideoPlayer>
       <MinimalVideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </MinimalVideoSkin>
-    </VideoPlayer.Provider>
+    </VideoPlayer>
   );
 }

--- a/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
+++ b/site/src/examples/react/MinimalSkin/MinimalSkinDemo.tsx
@@ -1,9 +1,6 @@
 import { VJS10_DEMO_VIDEO } from '@/consts';
-import { createPlayer } from '@videojs/react';
-import { MinimalVideoSkin, Video, videoFeatures } from '@videojs/react/video';
+import { MinimalVideoSkin, VideoPlayer, Video } from '@videojs/react/video';
 import '@videojs/react/video/minimal-skin.css';
-
-const Player = createPlayer({ features: videoFeatures });
 
 /**
  * Live demo of the minimal video skin design.
@@ -16,10 +13,10 @@ const Player = createPlayer({ features: videoFeatures });
  */
 export function MinimalSkinDemo() {
   return (
-    <Player.Provider>
+    <VideoPlayer.Provider>
       <MinimalVideoSkin className="aspect-video" poster={VJS10_DEMO_VIDEO.poster}>
         <Video src={VJS10_DEMO_VIDEO.mp4} playsInline />
       </MinimalVideoSkin>
-    </Player.Provider>
+    </VideoPlayer.Provider>
   );
 }

--- a/site/src/utils/installation/__tests__/codegen.test.ts
+++ b/site/src/utils/installation/__tests__/codegen.test.ts
@@ -199,9 +199,11 @@ describe('generateReactCreateCode', () => {
   it('generates a React player component for default video', () => {
     const result = generateReactCreateCode(baseReact);
     const code = result['MyPlayer.tsx'];
-    expect(code).toContain("'use client'");
-    expect(code).toContain('createPlayer');
-    expect(code).toContain('videoFeatures');
+    expect(code).not.toContain("'use client'");
+    expect(code).not.toContain('createPlayer');
+    expect(code).not.toContain('videoFeatures');
+    expect(code).toContain("import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video'");
+    expect(code).toContain('<VideoPlayer.Provider>');
     expect(code).toContain('<VideoSkin>');
     expect(code).toContain('<Video src={src} playsInline />');
     expect(code).toContain("from '@videojs/react/video'");
@@ -211,7 +213,7 @@ describe('generateReactCreateCode', () => {
   it('uses separate media import for HLS', () => {
     const result = generateReactCreateCode({ ...baseReact, renderer: 'hls' });
     const code = result['MyPlayer.tsx'];
-    expect(code).toContain("import { VideoSkin } from '@videojs/react/video'");
+    expect(code).toContain("import { VideoPlayer, VideoSkin } from '@videojs/react/video'");
     expect(code).toContain("import { HlsJsVideo } from '@videojs/react/media/hlsjs-video'");
     expect(code).toContain('<HlsJsVideo src={src} playsInline />');
   });
@@ -247,7 +249,9 @@ describe('generateReactCreateCode', () => {
     };
     const result = generateReactCreateCode(opts);
     const code = result['MyPlayer.tsx'];
-    expect(code).toContain('audioFeatures');
+    expect(code).not.toContain('audioFeatures');
+    expect(code).toContain("import { AudioPlayer, AudioSkin, Audio } from '@videojs/react/audio'");
+    expect(code).toContain('<AudioPlayer.Provider>');
     expect(code).toContain('<AudioSkin>');
     expect(code).toContain('<Audio src={src} />');
     expect(code).not.toContain('playsInline');
@@ -277,7 +281,11 @@ describe('generateReactCreateCode', () => {
     };
     const result = generateReactCreateCode(opts);
     const code = result['MyPlayer.tsx'];
-    expect(code).toContain('backgroundFeatures');
+    expect(code).not.toContain('backgroundFeatures');
+    expect(code).toContain(
+      "import { BackgroundVideoPlayer, BackgroundVideoSkin, BackgroundVideo } from '@videojs/react/background'"
+    );
+    expect(code).toContain('<BackgroundVideoPlayer.Provider>');
     expect(code).toContain('<BackgroundVideoSkin>');
     expect(code).toContain('<BackgroundVideo');
     expect(code).toContain("import '@videojs/react/background/skin.css'");

--- a/site/src/utils/installation/__tests__/codegen.test.ts
+++ b/site/src/utils/installation/__tests__/codegen.test.ts
@@ -203,7 +203,7 @@ describe('generateReactCreateCode', () => {
     expect(code).not.toContain('createPlayer');
     expect(code).not.toContain('videoFeatures');
     expect(code).toContain("import { VideoPlayer, VideoSkin, Video } from '@videojs/react/video'");
-    expect(code).toContain('<VideoPlayer.Provider>');
+    expect(code).toContain('<VideoPlayer>');
     expect(code).toContain('<VideoSkin>');
     expect(code).toContain('<Video src={src} playsInline />');
     expect(code).toContain("from '@videojs/react/video'");
@@ -251,7 +251,7 @@ describe('generateReactCreateCode', () => {
     const code = result['MyPlayer.tsx'];
     expect(code).not.toContain('audioFeatures');
     expect(code).toContain("import { AudioPlayer, AudioSkin, Audio } from '@videojs/react/audio'");
-    expect(code).toContain('<AudioPlayer.Provider>');
+    expect(code).toContain('<AudioPlayer>');
     expect(code).toContain('<AudioSkin>');
     expect(code).toContain('<Audio src={src} />');
     expect(code).not.toContain('playsInline');
@@ -285,7 +285,7 @@ describe('generateReactCreateCode', () => {
     expect(code).toContain(
       "import { BackgroundVideoPlayer, BackgroundVideoSkin, BackgroundVideo } from '@videojs/react/background'"
     );
-    expect(code).toContain('<BackgroundVideoPlayer.Provider>');
+    expect(code).toContain('<BackgroundVideoPlayer>');
     expect(code).toContain('<BackgroundVideoSkin>');
     expect(code).toContain('<BackgroundVideo');
     expect(code).toContain("import '@videojs/react/background/skin.css'");

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -246,11 +246,11 @@ function getSkinComponent(skin: Exclude<Skin, 'none'>): string {
   return map[skin];
 }
 
-function getUseCaseFeatures(useCase: UseCase): string {
+function getPresetPlayer(useCase: UseCase): string {
   const map: Record<UseCase, string> = {
-    'default-video': 'videoFeatures',
-    'default-audio': 'audioFeatures',
-    'background-video': 'backgroundFeatures',
+    'default-video': 'VideoPlayer',
+    'default-audio': 'AudioPlayer',
+    'background-video': 'BackgroundVideoPlayer',
   };
   return map[useCase];
 }
@@ -264,7 +264,7 @@ export function generateReactCreateCode(
 ): Record<'MyPlayer.tsx', string> {
   const { useCase, skin, renderer } = opts;
   const rendererComponent = getRendererComponent(renderer);
-  const featureType = getUseCaseFeatures(useCase);
+  const playerComponent = getPresetPlayer(useCase);
 
   const isBackgroundVideo = useCase === 'background-video';
   const isNoSkin = skin === 'none';
@@ -285,12 +285,12 @@ export function generateReactCreateCode(
   if (isBackgroundVideo) {
     skinComponent = 'BackgroundVideoSkin';
     skinCssImport = '@videojs/react/background/skin.css';
-    presetImport = `import { ${skinComponent}, ${rendererComponent} } from '@videojs/react/background';`;
+    presetImport = `import { ${playerComponent}, ${skinComponent}, ${rendererComponent} } from '@videojs/react/background';`;
   } else if (isNoSkin) {
     if (isPresetRenderer(renderer)) {
-      presetImport = `import { ${rendererComponent} } from '@videojs/react/${group}';`;
+      presetImport = `import { ${playerComponent}, ${rendererComponent} } from '@videojs/react/${group}';`;
     } else {
-      presetImport = '';
+      presetImport = `import { ${playerComponent} } from '@videojs/react/${group}';`;
       mediaImport = `import { ${rendererComponent} } from '@videojs/react/media/${getMediaSubpath(renderer) ?? renderer}';`;
     }
   } else {
@@ -298,36 +298,31 @@ export function generateReactCreateCode(
     skinComponent = getSkinComponent(skin);
     skinCssImport = `@videojs/react/${group}/${skinFile}.css`;
     if (isPresetRenderer(renderer)) {
-      presetImport = `import { ${skinComponent}, ${rendererComponent} } from '@videojs/react/${group}';`;
+      presetImport = `import { ${playerComponent}, ${skinComponent}, ${rendererComponent} } from '@videojs/react/${group}';`;
     } else {
-      presetImport = `import { ${skinComponent} } from '@videojs/react/${group}';`;
+      presetImport = `import { ${playerComponent}, ${skinComponent} } from '@videojs/react/${group}';`;
       mediaImport = `import { ${rendererComponent} } from '@videojs/react/media/${getMediaSubpath(renderer) ?? renderer}';`;
     }
   }
 
   const playerJsx = skinComponent
-    ? `    <Player.Provider>
+    ? `    <${playerComponent}.Provider>
       <${skinComponent}>
         ${rendererJsx}
       </${skinComponent}>
-    </Player.Provider>`
-    : `    <Player.Provider>
+    </${playerComponent}.Provider>`
+    : `    <${playerComponent}.Provider>
       ${rendererJsx}
-    </Player.Provider>`;
+    </${playerComponent}.Provider>`;
 
   const imports = [
     ...(skinCssImport ? [`import '${skinCssImport}';`] : []),
-    `import { createPlayer, ${featureType} } from '@videojs/react';`,
-    ...(presetImport ? [presetImport] : []),
+    presetImport,
     ...(mediaImport ? [mediaImport] : []),
   ].join('\n');
 
   return {
-    'MyPlayer.tsx': `'use client';
-
-${imports}
-
-const Player = createPlayer({ features: ${featureType} });
+    'MyPlayer.tsx': `${imports}
 
 interface MyPlayerProps {
   src: string;

--- a/site/src/utils/installation/codegen.ts
+++ b/site/src/utils/installation/codegen.ts
@@ -306,14 +306,14 @@ export function generateReactCreateCode(
   }
 
   const playerJsx = skinComponent
-    ? `    <${playerComponent}.Provider>
+    ? `    <${playerComponent}>
       <${skinComponent}>
         ${rendererJsx}
       </${skinComponent}>
-    </${playerComponent}.Provider>`
-    : `    <${playerComponent}.Provider>
+    </${playerComponent}>`
+    : `    <${playerComponent}>
       ${rendererJsx}
-    </${playerComponent}.Provider>`;
+    </${playerComponent}>`;
 
   const imports = [
     ...(skinCssImport ? [`import '${skinCssImport}';`] : []),


### PR DESCRIPTION
Refs #2004

## Summary

- update React guides and examples to use direct preset players such as `<VideoPlayer>` and preset-scoped `usePlayer`
- document the matching custom API: `const { Player, usePlayer } = createPlayer(...)`
- remove React-facing `Provider` and compound-object terminology from guides, references, demos, the v10 blog post, generated-skin snippets, and the Plyr migration guide
- make the installation generator emit preset-first React code without `createPlayer()` boilerplate
- keep custom `createPlayer()` guidance for custom feature compositions

## Stack

- depends on #2116
- followed by standalone containers: #2154

## Verification

- `pnpm -F site api-docs`
- `pnpm -F site test` (532 tests)
- `pnpm -F site build`

The API-design and documentation workflows drove the result-shape naming and the repository-wide terminology audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, examples, and codegen output only—no runtime player API changes in this diff.
> 
> **Overview**
> Aligns site documentation, agent skills, migration guides, and live demos with the **direct preset player** React API introduced upstream.
> 
> **Preset-first usage** is now the default in guides and generated snippets: import and render `<VideoPlayer>`, `<AudioPlayer>`, or `<BackgroundVideoPlayer>` from preset paths instead of calling `createPlayer({ features: videoFeatures })` and wrapping with `<Player.Provider>`. Hero, skin examples, Plyr migration, concept pages, i18n how-tos, and the v10 blog post follow this pattern.
> 
> **Custom compositions** document `createPlayer` as returning named exports: `const { Player, Container, usePlayer, useMedia } = createPlayer({ features })`, with JSX using `<Player>` and `<Container>` rather than compound `Player.Provider` / `Player.Container`. Hook reference pages rename to `usePlayer` / `useMedia` and describe preset-scoped typed hooks where applicable.
> 
> **Reference and terminology** updates retitle the state boundary to **`Player`** (HTML still `video-player`) and the interaction surface to **`Container`**, and presets are described as exporting a preconfigured player component plus typed `usePlayer`, not only feature bundles.
> 
> **Installation codegen** emits preset imports (`VideoPlayer`, skins, media) without `'use client'`, `createPlayer`, or `*Features` boilerplate; tests assert the new output shape.
> 
> Doc demos under `site/src/components/docs/demos/**/react` are updated consistently; custom `createPlayer` examples remain where they teach hooks or custom feature sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c635bbca1c5b02405066d55d6780364cc397d8b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->