### PR TITLE
refactor(packages)!: remove containers from createPlayer

### DIFF
--- a/internal/decisions/player/player-container-separation.md
+++ b/internal/decisions/player/player-container-separation.md
@@ -9,14 +9,14 @@ date: 2026-02-25
 
 The HTML player element (`<video-player>`) is a **provider only** — it owns the store and provides state context to descendants. A separate `<media-container>` element handles layout, media attachment, and acts as the fullscreen target. The `PlayerElement` no longer combines `ProviderMixin` and `ContainerMixin` by default.
 
-This mirrors the React architecture where `Provider`, `Container`, and media components (`Video`, `Audio`) are distinct:
+This mirrors the React architecture where `Player`, `Container`, and media components (`Video`, `Audio`) are distinct:
 
 ```tsx
-<Provider>
+<Player>
   <VideoSkin> {/* Container + UI */}
     <Video src="..." />
   </VideoSkin>
-</Provider>
+</Player>
 ```
 
 The HTML equivalent:
@@ -31,24 +31,24 @@ The HTML equivalent:
 
 ## Context
 
-On the React side, the separation between `Provider` (state), `Container` (layout/media attachment), and `Video` (media element) is natural — React's component model encourages composition through nesting.
+On the React side, the separation between `Player` (state), `Container` (layout/media attachment), and `Video` (media element) is natural — React's component model encourages composition through nesting.
 
 On the HTML side, there was temptation to combine the provider and container into a single `<video-player>` element. This would make the wrapping element feel more "functional" as a traditional HTML element that handles both state and layout. However, combining them means:
 
-- **Skins diverge across platforms.** In React, a skin is `Container` + UI controls — the provider wraps outside. If the HTML player element _is_ the container, then HTML skins don't include a container (it's already baked in), while React skins do. "Skin" means different things on each platform.
+- **Skins diverge across platforms.** In React, a skin is `Container` + UI controls — `Player` wraps outside. If the HTML player element _is_ the container, then HTML skins don't include a container (it's already baked in), while React skins do. "Skin" means different things on each platform.
 - **Features outside the fullscreen target lose state access.** The container is the fullscreen target. If it's also the provider, then anything outside it (playlist, transcript, sidebar) is also outside the player's state scope and can't use `PlayerController` or context to access player state.
 
-The current architecture already exposes `ProviderMixin` and `ContainerMixin` separately via `createPlayer()`. This decision formalizes the separation as the default — `PlayerElement` becomes provider-only rather than a combined provider+container.
+The current architecture exposes `ProviderMixin` through `createPlayer()` and `ContainerMixin` independently from the main package. This decision formalizes the separation as the default — `PlayerElement` becomes provider-only rather than a combined provider+container.
 
 ## Alternatives Considered
 
 - **Combined provider+container as `<video-player>`** — Bundles state management and layout into a single element. Feels more natural in HTML at first, but forces anything outside the fullscreen target to also be outside the player's state scope. Skins would mean different things on each platform: in React, a skin wraps a container; in HTML, the skin _is_ the player. Rejected because of the parity and extensibility problems described in the rationale.
 
-- **Naming the element `<video-provider>`** — Directly mirrors the React `Provider` component. Rejected because it breaks HTML naming conventions. In HTML, the parent element of a domain is named after the domain: `<form>` wraps a form, `<table>` wraps a table. A video player's parent element should be called "player", not "provider".
+- **Naming the element `<video-provider>`** — Names the state-boundary implementation detail. Rejected because it breaks HTML naming conventions. In HTML, the parent element of a domain is named after the domain: `<form>` wraps a form, `<table>` wraps a table. A video player's parent element should be called "player", not "provider".
 
 ## Rationale
 
-**Cross-platform skin parity.** Skins should mean the same thing on both platforms. In React, a skin is a `Container` plus UI controls — it doesn't include the provider. If the HTML player element combines provider and container, then HTML skins would exclude the container (it's already baked into `<video-player>`), breaking parity. Keeping them separate means a skin on both platforms is: container + UI.
+**Cross-platform skin parity.** Skins should mean the same thing on both platforms. In React, a skin is a `Container` plus UI controls — it doesn't include `Player`. If the HTML player element combines provider and container, then HTML skins would exclude the container (it's already baked into `<video-player>`), breaking parity. Keeping them separate means a skin on both platforms is: container + UI.
 
 ```tsx
 // React: Skin = Container + UI
@@ -94,9 +94,9 @@ If the container is bundled into `<video-player>`, these features must live _out
 **Programmatic composition remains available.** For developers building non-declarative players who want a single combined element, `ProviderMixin` and `ContainerMixin` can still be composed together:
 
 ```ts
-import { createPlayer } from '@videojs/html';
+import { ContainerMixin, createPlayer } from '@videojs/html';
 
-const { ProviderMixin, ContainerMixin } = createPlayer({ features });
+const { ProviderMixin } = createPlayer({ features });
 
 // Combine into a single element if desired
 class MyPlayer extends ProviderMixin(ContainerMixin(MediaElement)) {

--- a/internal/migrations/media-chrome.md
+++ b/internal/migrations/media-chrome.md
@@ -127,26 +127,26 @@ Media Chrome `<template>`-based themes (`media-theme`) become Video.js **skins**
 
 ## React
 
-Media Chrome's React package wraps the custom elements. `@videojs/react` ships native components composed under a `createPlayer` provider, customized with the `render` prop and hooks (`usePlayer`, `useMedia`, `useStore`).
+Media Chrome's React package wraps the custom elements. `@videojs/react` ships native components composed with `createPlayer`, customized with the `render` prop and hooks (`usePlayer`, `useMedia`, `useStore`).
 
 ```tsx
-import { createPlayer, PlayButton } from '@videojs/react';
+import { Container, createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const Player = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export function MyPlayer() {
   return (
-    <Player.Provider>
-      <Player.Container>
+    <Player>
+      <Container>
         <Video src="video.mp4" />
         <PlayButton
           render={(props, state) => (
             <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>
           )}
         />
-      </Player.Container>
-    </Player.Provider>
+      </Container>
+    </Player>
   );
 }
 ```
@@ -185,7 +185,7 @@ The skin hides controls by removing `data-visible` from `<media-controls>`. Keep
 To change the *delay* rather than disable it, note the idle timer is a constant inside `controlsFeature`. Fork that feature and swap it into a custom feature list:
 
 ```ts
-const Player = createPlayer({
+const { Player } = createPlayer({
   features: videoFeatures.map((f) => (f.name === 'controls' ? myControlsFeature : f)),
 });
 ```

--- a/internal/migrations/plyr.md
+++ b/internal/migrations/plyr.md
@@ -346,7 +346,7 @@ Use the media element for standard playback operations:
 | `player.fullscreen.enter()` | Fullscreen feature or fullscreen control |
 | `player.toggleCaptions()` | Text-track feature or captions control |
 
-For custom UI, read and write through the Video.js player store. In React, import the preset's `usePlayer` hook or use selectors. In HTML custom elements, use `PlayerController`.
+For custom UI, read and write through the Video.js player store. In React, import `usePlayer` from the preset and call it directly or with a selector. In HTML custom elements, use `PlayerController`.
 
 ## Rewrite styles
 

--- a/packages/html/src/media/container-element.ts
+++ b/packages/html/src/media/container-element.ts
@@ -5,11 +5,8 @@ import { listen } from '@videojs/utils/dom';
 
 import { i18nContext } from '../i18n/context';
 import { I18nController } from '../i18n/controller';
-import { containerContext, playerContext } from '../player/context';
-import { createContainerMixin } from '../store/container-mixin';
+import { ContainerMixin } from '../store/container-mixin';
 import { MediaElement } from '../ui/media-element';
-
-const ContainerMixin = createContainerMixin({ playerContext, containerContext });
 
 export class MediaContainerElement extends ContainerMixin(MediaElement) {
   static readonly tagName = 'media-container';

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -10,7 +10,6 @@ import {
 } from '@videojs/core/dom';
 import { combine, createStore } from '@videojs/store';
 
-import { type ContainerMixin, createContainerMixin } from '../store/container-mixin';
 import { createProviderMixin, type ProviderMixin } from '../store/provider-mixin';
 import { containerContext, mediaContext, type PlayerContext, playerContext } from './context';
 import { PlayerController } from './player-controller';
@@ -31,20 +30,17 @@ export interface CreatePlayerResult<Store extends PlayerStore> {
 
   /** Mixin that provides player context to descendants. */
   ProviderMixin: ProviderMixin<Store>;
-
-  /** Mixin that consumes player context and registers as the container element. */
-  ContainerMixin: ContainerMixin<Store>;
 }
 
 /**
- * Creates a player factory with typed store, mixins, and controller.
+ * Creates a player factory with a typed store, provider mixin, and controller.
  *
  * @example
  * ```ts
  * import { createPlayer, MediaElement, selectPlayback } from '@videojs/html';
  * import { videoFeatures } from '@videojs/html/video';
  *
- * const { ProviderMixin, ContainerMixin, PlayerController, context } = createPlayer({
+ * const { ProviderMixin, PlayerController, context } = createPlayer({
  *   features: videoFeatures,
  * });
  *
@@ -97,16 +93,10 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
     config: featureConfig,
   });
 
-  const ContainerMixin = createContainerMixin<PlayerStore>({
-    playerContext,
-    containerContext,
-  });
-
   return {
     context: playerContext,
     create,
     PlayerController,
     ProviderMixin,
-    ContainerMixin,
   };
 }

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -21,6 +21,8 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: videoFeatures });
 
     assertType<CreatePlayerResult<VideoPlayerStore>>(result);
+    // @ts-expect-error ContainerMixin is imported from the package root, not created per player.
+    result.ContainerMixin;
   });
 
   it('resolves audio features to AudioPlayerStore', () => {

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -2,6 +2,7 @@ import { audioFeatures, backgroundFeatures, metadataFeature, type PopupGroup, vi
 import { ContextConsumer } from '@videojs/element/context';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { ContainerMixin } from '../../index';
 import { MediaElement } from '../../ui/media-element';
 import { createPlayer } from '../create-player';
 import { popupGroupContext } from '../popup-group-context';
@@ -26,7 +27,7 @@ describe('createPlayer', () => {
     expect(result.create).toBeInstanceOf(Function);
     expect(result.PlayerController).toBeDefined();
     expect(result.ProviderMixin).toBeInstanceOf(Function);
-    expect(result.ContainerMixin).toBeInstanceOf(Function);
+    expect(result).not.toHaveProperty('ContainerMixin');
   });
 
   it('create() returns a store instance', () => {
@@ -47,7 +48,6 @@ describe('createPlayer', () => {
   });
 
   it('ContainerMixin produces a valid custom element class', () => {
-    const { ContainerMixin } = createPlayer({ features: videoFeatures });
     const ContainerElement = ContainerMixin(MediaElement);
 
     expect(typeof ContainerElement).toBe('function');
@@ -55,7 +55,7 @@ describe('createPlayer', () => {
   });
 
   it('scopes popup coordination to container descendants', async () => {
-    const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+    const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
     class PopupGroupProbe extends MediaElement {
       popupGroup: PopupGroup | undefined;
@@ -101,7 +101,7 @@ describe('createPlayer', () => {
     expect(result.create).toBeInstanceOf(Function);
     expect(result.PlayerController).toBeDefined();
     expect(result.ProviderMixin).toBeInstanceOf(Function);
-    expect(result.ContainerMixin).toBeInstanceOf(Function);
+    expect(result).not.toHaveProperty('ContainerMixin');
   });
 
   it('creates background player with expected exports', () => {
@@ -111,7 +111,7 @@ describe('createPlayer', () => {
     expect(result.create).toBeInstanceOf(Function);
     expect(result.PlayerController).toBeDefined();
     expect(result.ProviderMixin).toBeInstanceOf(Function);
-    expect(result.ContainerMixin).toBeInstanceOf(Function);
+    expect(result).not.toHaveProperty('ContainerMixin');
   });
 
   it('maps selected feature inputs to kebab-cased reactive properties and attributes', async () => {

--- a/packages/html/src/store/container-mixin.ts
+++ b/packages/html/src/store/container-mixin.ts
@@ -1,7 +1,7 @@
-import { createPopupGroup, type MediaContainer, type PlayerStore } from '@videojs/core/dom';
+import { type AnyPlayerStore, createPopupGroup, type MediaContainer, type PlayerStore } from '@videojs/core/dom';
 import { ContextConsumer, ContextProvider } from '@videojs/element/context';
 import type { MediaElementConstructor } from '@/ui/media-element';
-import type { ContainerContext, PlayerContext } from '../player/context';
+import { type ContainerContext, containerContext, type PlayerContext, playerContext } from '../player/context';
 import { popupGroupContext } from '../player/popup-group-context';
 import type { PlayerConsumer, PlayerConsumerConstructor } from './types';
 
@@ -73,3 +73,13 @@ export function createContainerMixin<Store extends PlayerStore>(
     return PlayerContainerElement;
   };
 }
+
+/**
+ * Player container mixin configured for the default player contexts.
+ *
+ * Import this convenience mixin directly when composing a custom container.
+ */
+export const ContainerMixin = createContainerMixin<AnyPlayerStore>({
+  playerContext,
+  containerContext,
+});

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -23,7 +23,6 @@ import type { FC, ReactNode } from 'react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useDestroy } from '../utils/use-destroy';
-import { Container } from './container';
 import { PlayerContextProvider, useMedia, usePlayerContext } from './context';
 
 export interface CreatePlayerConfig<Features extends AnyPlayerFeature[]> {
@@ -39,7 +38,6 @@ export type PlayerProps<Config = object> = {
 
 export interface CreatePlayerResult<Store extends PlayerStore> {
   Player: FC<PlayerProps<InferPlayerConfig<Store>>>;
-  Container: typeof Container;
   usePlayer: UsePlayerHook<Store>;
   useMedia: () => Media | null;
 }
@@ -50,7 +48,7 @@ export type UsePlayerHook<Store extends PlayerStore> = {
 };
 
 /**
- * Create a player instance with a typed Player component, Container, and hooks.
+ * Create a player instance with a typed Player component and hooks.
  *
  * @label Video
  * @param config - Player configuration with features and optional display name.
@@ -145,7 +143,6 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
   return {
     Player,
-    Container,
     usePlayer,
     useMedia,
   };

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -19,6 +19,8 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: videoFeatures });
 
     assertType<CreatePlayerResult<VideoPlayerStore>>(result);
+    // @ts-expect-error Container is imported from the package root, not created per player.
+    result.Container;
   });
 
   it('resolves audio features to AudioPlayerStore', () => {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -5,6 +5,7 @@ import { Component, type ErrorInfo, type ReactNode, StrictMode, useState } from 
 import { renderToString } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider, useLocale } from '../../i18n';
+import { Container } from '../../index';
 import { useContainer, usePlayerContext } from '../context';
 import { createPlayer } from '../create-player';
 
@@ -351,7 +352,7 @@ describe('createPlayer', () => {
 
     it('does not derive a locale without an I18nProvider', async () => {
       document.documentElement.lang = 'de';
-      const { Player, Container } = createPlayer({ features: [mockSlice] });
+      const { Player } = createPlayer({ features: [mockSlice] });
 
       function Locale() {
         const container = useContainer();
@@ -373,7 +374,7 @@ describe('createPlayer', () => {
     });
 
     it('inherits an explicit I18nProvider', async () => {
-      const { Player, Container } = createPlayer({ features: [mockSlice] });
+      const { Player } = createPlayer({ features: [mockSlice] });
 
       function Locale() {
         const container = useContainer();
@@ -469,15 +470,14 @@ describe('createPlayer', () => {
   });
 
   describe('Container', () => {
-    it('is exported from createPlayer result', () => {
-      const { Container } = createPlayer({ features: [mockSlice] });
+    it('is imported independently of createPlayer', () => {
       expect(Container).toBeDefined();
     });
   });
 
   describe('full integration', () => {
     it('Player → Container → media attach flow', () => {
-      const { Player, Container, usePlayer } = createPlayer({ features: [mockSlice] });
+      const { Player, usePlayer } = createPlayer({ features: [mockSlice] });
 
       let store!: PlayerStore;
 

--- a/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/airplay-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { AirPlayButton, createPlayer } from '@videojs/react';
+import { AirPlayButton, Container, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx
@@ -1,9 +1,9 @@
-import { AudioTrackRadioGroup, createPlayer, Menu } from '@videojs/react';
+import { AudioTrackRadioGroup, Container, createPlayer, Menu } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
 
 function AudioMenu(): ReactNode {

--- a/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { BufferingIndicator, createPlayer } from '@videojs/react';
+import { BufferingIndicator, Container, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { CaptionsButton, createPlayer } from '@videojs/react';
+import { CaptionsButton, Container, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx
@@ -1,8 +1,8 @@
-import { CaptionsRadioGroup, createPlayer, Menu } from '@videojs/react';
+import { CaptionsRadioGroup, Container, createPlayer, Menu } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 function CaptionsMenu(): ReactNode {
   return (

--- a/site/src/components/docs/demos/cast-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/cast-button/react/css/BasicUsage.tsx
@@ -1,8 +1,8 @@
-import { CastButton, createPlayer } from '@videojs/react';
+import { CastButton, Container, createPlayer } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/controls/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/controls/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { Controls, createPlayer, PlayButton, Time } from '@videojs/react';
+import { Container, Controls, createPlayer, PlayButton, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/create-player/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/create-player/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer } = createPlayer({
+const { Player, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 

--- a/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, FullscreenButton } from '@videojs/react';
+import { Container, createPlayer, FullscreenButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.tsx
@@ -1,4 +1,5 @@
 import {
+  Container,
   createPlayer,
   Menu,
   useAudioTrackOptions,
@@ -10,7 +11,7 @@ import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
 
 function SettingsMenu(): ReactNode {

--- a/site/src/components/docs/demos/mute-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/mute-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, MuteButton } from '@videojs/react';
+import { Container, createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.tsx
+++ b/site/src/components/docs/demos/mute-button/react/css/VolumeLevels.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, MuteButton } from '@videojs/react';
+import { Container, createPlayer, MuteButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function VolumeLevels() {
   return (

--- a/site/src/components/docs/demos/pip-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/pip-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, PiPButton } from '@videojs/react';
+import { Container, createPlayer, PiPButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/play-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/play-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, PlayButton } from '@videojs/react';
+import { Container, createPlayer, PlayButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, PlaybackRateButton } from '@videojs/react';
+import { Container, createPlayer, PlaybackRateButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx
@@ -1,8 +1,8 @@
-import { createPlayer, Menu, PlaybackRateRadioGroup } from '@videojs/react';
+import { Container, createPlayer, Menu, PlaybackRateRadioGroup } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 function SpeedMenu(): ReactNode {
   return (

--- a/site/src/components/docs/demos/popover/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/popover/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Popover } from '@videojs/react';
+import { Container, createPlayer, Popover } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/poster/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, PlayButton, Poster } from '@videojs/react';
+import { Container, createPlayer, PlayButton, Poster } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx
@@ -1,9 +1,9 @@
-import { createPlayer, Menu, QualityRadioGroup } from '@videojs/react';
+import { Container, createPlayer, Menu, QualityRadioGroup } from '@videojs/react';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 import type { ReactNode } from 'react';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 const src = '{{VJS8_DEMO_VIDEO_HLS}}';
 
 function QualityMenu(): ReactNode {

--- a/site/src/components/docs/demos/seek-button/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/seek-button/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, SeekButton } from '@videojs/react';
+import { Container, createPlayer, SeekButton } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function BasicUsage() {
   return (

--- a/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/thumbnail/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Thumbnail } from '@videojs/react';
+import { Container, createPlayer, Thumbnail } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function TextTrackUsage() {
   return (

--- a/site/src/components/docs/demos/time-slider/react/css/WithChapters.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithChapters.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, TimeSlider } from '@videojs/react';
+import { Container, createPlayer, TimeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function WithChapters() {
   return (

--- a/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithParts.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, TimeSlider } from '@videojs/react';
+import { Container, createPlayer, TimeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function WithParts() {
   return (

--- a/site/src/components/docs/demos/time/react/css/CurrentDuration.tsx
+++ b/site/src/components/docs/demos/time/react/css/CurrentDuration.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Time } from '@videojs/react';
+import { Container, createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function CurrentDuration() {
   return (

--- a/site/src/components/docs/demos/time/react/css/CurrentTime.tsx
+++ b/site/src/components/docs/demos/time/react/css/CurrentTime.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Time } from '@videojs/react';
+import { Container, createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function CurrentTime() {
   return (

--- a/site/src/components/docs/demos/time/react/css/CustomNegativeSign.tsx
+++ b/site/src/components/docs/demos/time/react/css/CustomNegativeSign.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Time } from '@videojs/react';
+import { Container, createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function CustomNegativeSign() {
   return (

--- a/site/src/components/docs/demos/time/react/css/CustomSeparator.tsx
+++ b/site/src/components/docs/demos/time/react/css/CustomSeparator.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Time } from '@videojs/react';
+import { Container, createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function CustomSeparator() {
   return (

--- a/site/src/components/docs/demos/time/react/css/Remaining.tsx
+++ b/site/src/components/docs/demos/time/react/css/Remaining.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, Time } from '@videojs/react';
+import { Container, createPlayer, Time } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function Remaining() {
   return (

--- a/site/src/components/docs/demos/use-media/react/css/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-media/react/css/BasicUsage.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, isMediaSourceCapable, isMediaVideoDimensionsCapable } from '@videojs/react';
+import { Container, createPlayer, isMediaSourceCapable, isMediaVideoDimensionsCapable } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, useMedia } = createPlayer({
+const { Player, useMedia } = createPlayer({
   features: videoFeatures,
 });
 

--- a/site/src/components/docs/demos/use-player/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/Selector.tsx
@@ -1,7 +1,7 @@
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer } = createPlayer({
+const { Player, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 

--- a/site/src/components/docs/demos/use-player/react/css/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-player/react/css/StoreAccess.tsx
@@ -1,7 +1,7 @@
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer } = createPlayer({
+const { Player, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 

--- a/site/src/components/docs/demos/use-store/react/css/Selector.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/Selector.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, useStore } from '@videojs/react';
+import { Container, createPlayer, useStore } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer } = createPlayer({
+const { Player, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 

--- a/site/src/components/docs/demos/use-store/react/css/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-store/react/css/StoreAccess.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, useStore } from '@videojs/react';
+import { Container, createPlayer, useStore } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer } = createPlayer({
+const { Player, usePlayer } = createPlayer({
   features: videoFeatures,
 });
 

--- a/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
+++ b/site/src/components/docs/demos/volume-slider/react/css/WithParts.tsx
@@ -1,7 +1,7 @@
-import { createPlayer, MuteButton, VolumeSlider } from '@videojs/react';
+import { Container, createPlayer, MuteButton, VolumeSlider } from '@videojs/react';
 import { Video, videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function WithParts() {
   return (

--- a/site/src/content/blog/2026-03-10-videojs-v10-beta-hello-world-again.mdx
+++ b/site/src/content/blog/2026-03-10-videojs-v10-beta-hello-world-again.mdx
@@ -120,10 +120,10 @@ With v10 the file size story doesn't actually start with the baseline builds. Th
 For example here's a simple React "hello world" with just a video and play button, weighing in at **\<5 kB** **gzipped**.
 
 ```tsx
-import { createPlayer, features } from '@videojs/react';
+import { Container, createPlayer, features } from '@videojs/react';
 import { Video } from '@videojs/react/video';
 
-const { Player, Container, usePlayer } = createPlayer({
+const { Player, usePlayer } = createPlayer({
   features: [features.playback],
 });
 

--- a/site/src/content/docs/concepts/cast.mdx
+++ b/site/src/content/docs/concepts/cast.mdx
@@ -12,12 +12,12 @@ Add Google Cast to any Video.js streaming media element (HLS and DASH) by placin
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
-import { CastButton, createPlayer } from '@videojs/react';
+import { CastButton, Container, createPlayer } from '@videojs/react';
 import { GoogleCast } from '@videojs/react/media/google-cast';
 import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function App() {
   return (

--- a/site/src/content/docs/concepts/mux-data.mdx
+++ b/site/src/content/docs/concepts/mux-data.mdx
@@ -12,12 +12,12 @@ import Aside from '@/components/Aside.astro';
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { MuxData } from '@videojs/react/media/mux-data';
 import { MuxVideo } from '@videojs/react/media/mux-video';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 export default function App() {
   return (

--- a/site/src/content/docs/concepts/presets.mdx
+++ b/site/src/content/docs/concepts/presets.mdx
@@ -73,10 +73,10 @@ Add features to a preset's feature bundle to enable new functionality. For examp
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
-import { createPlayer, playbackFeature } from '@videojs/react';
+import { Container, createPlayer, playbackFeature } from '@videojs/react';
 import { backgroundFeatures, BackgroundVideo } from '@videojs/react/background';
 
-const { Player, Container } = createPlayer({ // [!code focus]
+const { Player } = createPlayer({ // [!code focus]
   features: [...backgroundFeatures, playbackFeature], // [!code focus]
 }); // [!code focus]
 

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -101,6 +101,8 @@ this.#store.value.setVolume(0.5);
 Your component needs to be inside <DocsLink slug="reference/player-provider">`<Player>`</DocsLink> to access state. Place it inside <DocsLink slug="reference/player-container">`<Container>`</DocsLink> if it should also participate in fullscreen and respond to user activity:
 
 ```tsx
+import { Container } from '@videojs/react';
+
 <Player> // [!code focus]
   <Container> // [!code focus]
     <VideoSkin>

--- a/site/src/content/docs/reference/container-mixin.mdx
+++ b/site/src/content/docs/reference/container-mixin.mdx
@@ -22,7 +22,9 @@ Use `ContainerMixin` when the <DocsLink slug="reference/provider-mixin">provider
 For a single element that both owns the store and attaches the container, compose both mixins on the same base class:
 
 ```ts
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+import { ContainerMixin, createPlayer } from '@videojs/html';
+
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 class VideoPlayer extends ProviderMixin(ContainerMixin(MediaElement)) {}
 ```
@@ -32,7 +34,9 @@ class VideoPlayer extends ProviderMixin(ContainerMixin(MediaElement)) {}
 Pair `ContainerMixin` with <DocsLink slug="reference/provider-mixin">`ProviderMixin`</DocsLink> when the store owner is a different element from the container:
 
 ```ts
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+import { ContainerMixin, createPlayer } from '@videojs/html';
+
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 // Provider owns the store, sits at the top
 class PlayerShell extends ProviderMixin(MediaElement) {}

--- a/site/src/content/docs/reference/create-player.mdx
+++ b/site/src/content/docs/reference/create-player.mdx
@@ -1,6 +1,6 @@
 ---
 title: createPlayer
-description: Factory function that creates a typed Player component, Container, and hooks
+description: Factory function that creates a typed Player component and hooks
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
@@ -16,12 +16,14 @@ import basicUsageReactCss from "@/components/docs/demos/create-player/react/css/
 The hook is typed according to the provided features, giving you full type safety for state selectors and actions.
 
 ```tsx
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer, useMedia } = createPlayer({
+const { Player, usePlayer, useMedia } = createPlayer({
   features: videoFeatures,
 });
+
+// Container is imported independently from createPlayer.
 ```
 
 ## Examples

--- a/site/src/content/docs/reference/html-create-player.mdx
+++ b/site/src/content/docs/reference/html-create-player.mdx
@@ -1,6 +1,6 @@
 ---
 title: createPlayer
-description: Factory function that creates a player instance with typed store, mixins, and controller for HTML custom elements
+description: Factory function that creates a player instance with a typed store, provider mixin, and controller for HTML custom elements
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
@@ -12,13 +12,13 @@ import basicUsageHtml from "@/components/docs/demos/html-create-player/html/css/
 import basicUsageHtmlCss from "@/components/docs/demos/html-create-player/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/html-create-player/html/css/BasicUsage.ts?raw";
 
-`createPlayer` is the entry point for setting up a Video.js player with HTML custom elements. It accepts a configuration object with a `features` array and returns a typed <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink>, `context`, `ProviderMixin`, `ContainerMixin`, and a `create` store factory.
+`createPlayer` is the entry point for setting up a Video.js player with HTML custom elements. It accepts a configuration object with a `features` array and returns a typed <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink>, `context`, `ProviderMixin`, and a `create` store factory. Import `ContainerMixin` separately from the main package when composing a container.
 
 ```ts title="player.ts"
-import { createPlayer, MediaElement, selectPlayback } from '@videojs/html';
+import { ContainerMixin, createPlayer, MediaElement, selectPlayback } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-const { ProviderMixin, ContainerMixin, PlayerController, context } = createPlayer({
+const { ProviderMixin, PlayerController, context } = createPlayer({
   features: videoFeatures,
 });
 
@@ -32,15 +32,15 @@ class PlayButton extends MediaElement {
 }
 ```
 
-`PlayerController`, `ProviderMixin`, and `ContainerMixin` are intended for controller hosts and custom-element composition. Keep wiring minimal in utility examples, and build concrete elements where needed.
+`PlayerController` and `ProviderMixin` are scoped to the created player's feature set. The root `ContainerMixin` consumes the shared player context, so the same import works with any created player.
 
 Use split elements (recommended for reusable skins/layouts):
 
 ```ts title="player.ts"
-import { createPlayer, MediaElement } from '@videojs/html';
+import { ContainerMixin, createPlayer, MediaElement } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 class PlayerRoot extends ProviderMixin(MediaElement) {}
 class PlayerRegion extends ContainerMixin(MediaElement) {}
@@ -49,10 +49,10 @@ class PlayerRegion extends ContainerMixin(MediaElement) {}
 Use a single composed element when the same element should both own the store and attach media:
 
 ```ts title="player.ts"
-import { createPlayer, MediaElement } from '@videojs/html';
+import { ContainerMixin, createPlayer, MediaElement } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 class ComposedPlayer extends ProviderMixin(ContainerMixin(MediaElement)) {}
 ```

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -42,13 +42,13 @@ The `<media-container>` is the player's physical surface. It defines the visual 
 ## How it's created
 
 <FrameworkCase frameworks={["react"]}>
-`Container` comes from the same `createPlayer()` call as `Player`.
+Import `Container` from the main React package. It connects to whichever `Player` contains it, so it does not need to be created for a specific feature set.
 
 ```tsx
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 ```
 
 <DocsLinkCard slug="reference/create-player">`createPlayer` reference</DocsLinkCard>
@@ -69,19 +69,15 @@ import '@videojs/html/video/player';
 </video-player>
 ```
 
-For custom behavior, use `ContainerMixin` from `createPlayer()`:
+For custom behavior, import the preconfigured `ContainerMixin` from the main HTML package:
 
 ```ts title="my-player.ts"
-import { createPlayer, MediaElement } from '@videojs/html';
-import { videoFeatures } from '@videojs/html/video';
-
-const { ContainerMixin } = createPlayer({ features: videoFeatures });
+import { ContainerMixin, MediaElement } from '@videojs/html';
 
 class MyContainer extends ContainerMixin(MediaElement) {}
 customElements.define('my-container', MyContainer);
 ```
 
-<DocsLinkCard slug="reference/html-create-player">createPlayer reference</DocsLinkCard>
 <DocsLinkCard slug="reference/container-mixin">ContainerMixin reference</DocsLinkCard>
 </FrameworkCase>
 

--- a/site/src/content/docs/reference/player-context.mdx
+++ b/site/src/content/docs/reference/player-context.mdx
@@ -37,10 +37,10 @@ const { context } = createPlayer({ features: videoFeatures });
 context === playerContext; // true
 ```
 
-Use the direct import when building reusable elements that don't depend on a specific `createPlayer` call. Destructure from `createPlayer` when you want all player utilities from a single result.
+Use the direct import when building reusable elements that don't depend on a specific `createPlayer` call.
 
 ### When you need this
 
-Most elements should use <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> (which accepts a context argument) rather than importing `playerContext` directly. Import it directly when you need to pass the context token to a lower-level API like <DocsLink slug="reference/container-mixin">`ContainerMixin`</DocsLink> or <DocsLink slug="reference/provider-mixin">`ProviderMixin`</DocsLink>.
+Most elements should use <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> (which accepts a context argument) rather than importing `playerContext` directly. Import it directly when you need to pass the context token to a lower-level factory such as `createContainerMixin` or `createProviderMixin`.
 
 <UtilReference util="playerContext" />

--- a/site/src/content/docs/reference/player-provider.mdx
+++ b/site/src/content/docs/reference/player-provider.mdx
@@ -20,9 +20,9 @@ The `<video-player>` element is the state boundary of your player. It creates a 
 <FrameworkCase frameworks={["react"]}>
 ```tsx title="App.tsx"
 import { videoFeatures } from '@videojs/react/video';
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 
-const { Player, Container } = createPlayer({ features: videoFeatures });
+const { Player } = createPlayer({ features: videoFeatures });
 
 function App() {
   return (
@@ -50,13 +50,13 @@ function App() {
 ## How it's created
 
 <FrameworkCase frameworks={["react"]}>
-Call `createPlayer()` with a `features` array. It returns `Player`, `Container`, `usePlayer`, and `useMedia` — everything you need for one player instance.
+Call `createPlayer()` with a `features` array. It returns `Player`, `usePlayer`, and `useMedia`. Import the shared `Container` separately when building a custom layout.
 
 ```tsx
-import { createPlayer } from '@videojs/react';
+import { Container, createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, Container, usePlayer, useMedia } = createPlayer({
+const { Player, usePlayer, useMedia } = createPlayer({
   features: videoFeatures,
 });
 ```
@@ -84,10 +84,10 @@ import '@videojs/html/video/player';
 If you need a custom feature set, a custom tag name, or want to combine provider+container into a single element, use `createPlayer()` to get `ProviderMixin` and compose your own class:
 
 ```ts title="my-player.ts"
-import { createPlayer, MediaElement } from '@videojs/html';
+import { ContainerMixin, createPlayer, MediaElement } from '@videojs/html';
 import { videoFeatures } from '@videojs/html/video';
 
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 class MyPlayer extends ProviderMixin(MediaElement) {}
 customElements.define('my-player', MyPlayer);

--- a/site/src/content/docs/reference/provider-mixin.mdx
+++ b/site/src/content/docs/reference/provider-mixin.mdx
@@ -27,7 +27,9 @@ On `disconnectedCallback`, the mixin detaches the current media target but keeps
 Use `ProviderMixin` separate from <DocsLink slug="reference/container-mixin">`ContainerMixin`</DocsLink> when the store owner is a different element from the container:
 
 ```ts
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+import { ContainerMixin, createPlayer } from '@videojs/html';
+
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 // Layout shell owns the store
 class AppShell extends ProviderMixin(MediaElement) {}
@@ -39,7 +41,9 @@ class VideoRegion extends ContainerMixin(MediaElement) {}
 When a single element handles both responsibilities, compose the mixins directly:
 
 ```ts
-const { ProviderMixin, ContainerMixin } = createPlayer({ features: videoFeatures });
+import { ContainerMixin, createPlayer } from '@videojs/html';
+
+const { ProviderMixin } = createPlayer({ features: videoFeatures });
 
 class VideoPlayer extends ProviderMixin(ContainerMixin(MediaElement)) {}
 ```


### PR DESCRIPTION
Refs #2156

## Summary

- remove React `Container` from every `createPlayer()` result
- remove HTML `ContainerMixin` from every `createPlayer()` result
- keep `Container` and a preconfigured `ContainerMixin` available from the React and HTML package roots
- migrate repository demos, guides, API references, internal rationale, and migration docs to explicit imports
- add runtime and type coverage for the new result shapes

## Stack

- depends on #2152
- #2152 depends on #2116

## Verification

- React focused `createPlayer` and preset tests: 27 passed
- HTML focused `createPlayer` tests: 9 passed
- `pnpm -F @videojs/react build`
- `pnpm -F @videojs/html build`
- `pnpm typecheck`
- `pnpm -F site api-docs`
- `pnpm -F site test` (532 tests)
- `pnpm -F site build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking public API change across `@videojs/react` and `@videojs/html`; every consumer that destructures `Container` or `ContainerMixin` from `createPlayer()` must update imports or builds will fail.
> 
> **Overview**
> **Breaking API change:** `createPlayer()` no longer returns layout primitives. React callers get only `Player`, `usePlayer`, and `useMedia`; HTML callers get `ProviderMixin`, `PlayerController`, `context`, and `create`—not `ContainerMixin`.
> 
> **Shared container exports:** React `Container` and HTML `ContainerMixin` (pre-wired to default `playerContext` / `containerContext`) are imported from `@videojs/react` and `@videojs/html`. `MediaContainerElement` uses that root mixin instead of a per-factory instance.
> 
> **Repo-wide migration:** Site demos, reference docs, migration guides, and the player–container separation decision doc now show explicit `Container` / `ContainerMixin` imports. Type and runtime tests assert the slimmer `createPlayer` result and that container APIs are not on it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08423a6332fe9f940ac7af702be1a4b8589a7dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->