### PR TITLE
Discovery: merge Concepts into Getting started

### DIFF
--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -27,7 +27,7 @@ Treat implementation, types, tests, and content schemas as factual sources. Read
    - Code or error examples: the matching file in `patterns/`
    - New artifact scaffold: the matching file in `templates/`
 4. Lead with the user outcome or concept. Use complete, verified examples and explain only non-obvious parts.
-5. Add the sidebar entry and framework/style restrictions for new site pages.
+5. Add the sidebar entry and framework/style restrictions for new site pages. Choose the section by when the reader needs the page, not by the page's directory; `Getting started` holds both concept pages and early how-to guides in one reading order.
 6. Run examples or relevant tests where practical and render affected MDX for every supported variant.
 
 Do not duplicate signatures TypeScript already expresses. API-builder exports are the exception when its tests require structured JSDoc fields.

--- a/site/README.md
+++ b/site/README.md
@@ -118,7 +118,7 @@ You'll learn most of what you need to know about writing guides by reading [`src
 High-level primer?
 
 - Guides are written in MDX and stored in `src/content/docs/`
-- Guides are separated into how-to guides (focused on an outcome) and concept guides (focused on understanding) according to the [Diataxis](https://diataxis.fr) framework.
+- Guides are separated into how-to guides (focused on an outcome) and concept guides (focused on understanding) according to the [Diataxis](https://diataxis.fr) framework. That split is an authoring convention, expressed as directories — it is not what the reader sees. The sidebar sections in [docs.config.ts](src/docs.config.ts) are a separate, reader-facing call, and "Getting started" mixes both kinds of page into one reading order.
 - Astro's [Content Collections API](https://docs.astro.build/en/guides/content-collections/) transforms the MDX into data
 - That data is rendered in `src/pages/docs/framework/[framework]/[...slug].astro`
 - Standard MDX typography is defined in `src/components/typography/`

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -27,22 +27,38 @@ Oh hey by the way. A lot of this knowledge is encoded in the `docs` Claude skill
 
 ## 1. Understand our documentation structure
 
-First, read and understand [Diátaxis](https://diataxis.fr/). We organize documentation into three modes:
+There are two structures here, and they don't line up one-to-one. Learn both.
+
+### How readers navigate: three sidebar sections
+
+1. **Getting started**: One reading order, from "should I use this?" through to a player you understand. Most of the docs live here.
+2. **How to**: Recipes for a specific outcome, reached when you already have a player and want it to do one more thing.
+3. **API Reference**: Lookup for every public export.
+
+### How we author: three Diátaxis modes
+
+Read and understand [Diátaxis](https://diataxis.fr/). Each mode has its own directory:
 
 1. **Concept pages** (`src/content/docs/concepts/`): Explain how and why things work — design decisions, trade-offs, and context. General understanding, spanning multiple APIs, can be applied to multiple outcomes. As we write guides, what are things we need people to understand in multiple places and don’t want to duplicate the content? Diátaxis calls this mode "explanation."
 2. **How-to guides** (`src/content/docs/how-to/`): Spans multiple concepts in order to achieve a specific outcome with step-by-step instructions. Address a real user goal, assume competence, and link to concept pages instead of explaining inline.
 3. **Reference pages** (`src/content/docs/reference/`): Component API documentation. These are scaffolded using `write-api-reference` and the api-docs-builder. Again, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink> for details.
 
 <Aside type="note">
-Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials section yet — something we've intentionally chosen to omit, for now. Learning-oriented content lives in the Getting started how-to guides instead.
+Diátaxis has a fourth mode — learning-oriented **tutorials**. We don't have a tutorials directory, something we've intentionally chosen to omit for now. Learning-oriented content is carried by the order of the Getting started section instead.
 </Aside>
+
+### Where the two structures meet
+
+The Getting started section is deliberately mixed: it holds nearly every concept page plus the few how-to guides a first-time reader needs, in the order we want them read. Diátaxis is a tool for deciding **how to write a page**, not a label we hang over the sidebar — readers don't arrive wanting "explanation," they arrive wanting a player.
+
+So expect a concept page and a how-to guide to sit next to each other in Getting started, and don't let a page's directory decide its section. Sidebar placement is a separate call, made in `src/docs.config.ts`.
 
 To pick a mode, use the Diátaxis [compass](https://diataxis.fr/compass/). Ask two questions: does the content inform **action** (practical steps) or **cognition** (understanding)? And does it serve the reader's **study** (acquiring skills) or their **work** (applying them)?
 
 | | Informs action | Informs cognition |
 |---|---|---|
 | **Serves work** | How-to guide | Reference page |
-| **Serves study** | How-to guide (Getting started) | Concept page |
+| **Serves study** | How-to guide | Concept page |
 
 **When in doubt, write a concept page.** Most new documentation should be concept pages. Use this table to decide between the two:
 
@@ -80,7 +96,12 @@ Optional frontmatter fields:
 
 ## 3. Add that guide to the sidebar
 
-Next, open `src/docs.config.ts` and add your guide to the appropriate section of the sidebar. For example, to add a how-to guide on "Writing guides", you would add:
+Next, open `src/docs.config.ts` and add your guide to the sidebar. Pick the section by asking when a reader needs the page, not by which directory it lives in:
+
+- Would a reader want this on the way to their first working player, or shortly after? **Getting started** — and put it at the point in that list where they'd want it.
+- Is it a one-off task someone comes back for later? **How to**.
+
+For example, to add a how-to guide on "Writing guides", you would add:
 
 ```ts
 {

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -18,40 +18,40 @@ export const sidebar: Sidebar = [
     ],
   },
   {
+    // One reading order, top to bottom. The `concepts/` and `how-to/` directories are an
+    // authoring distinction (Diátaxis mode); they are deliberately not a reader-facing one.
     sidebarLabel: 'Getting started',
-    // May change when we revisit this section's boundary with Concepts (#1105)
-    llmsDescription: 'Installation, project setup, and introductory guides.',
+    llmsDescription:
+      'Read these in order to go from nothing to a player you understand: install it, learn how a player is put together, then learn each piece you are likely to reach for.',
     contents: [
-      { slug: 'how-to/installation' },
+      // Land and install.
       { slug: 'concepts/why-videojs' },
+      { slug: 'how-to/installation' },
       { slug: 'concepts/overview' },
+      // How a player is put together.
+      { slug: 'concepts/presets' },
+      { slug: 'concepts/skins' },
+      { slug: 'concepts/ui-components' },
+      { slug: 'concepts/features' },
+      { slug: 'concepts/media-sources' },
+      // Things every production player has to answer for.
+      { slug: 'concepts/accessibility' },
+      { slug: 'concepts/i18n', sidebarLabel: 'Internationalization' },
+      { slug: 'concepts/security' },
+      { slug: 'concepts/browser-support' },
+      // Optional integrations.
+      { slug: 'concepts/cast', sidebarLabel: 'Google Cast' },
+      { slug: 'concepts/mux-data' },
+      // Working with us.
       { slug: 'how-to/build-with-ai' },
       { slug: 'concepts/v10-roadmap', sidebarLabel: 'Roadmap' },
       { href: '/changelog', sidebarLabel: 'Changelog' },
-      { slug: 'concepts/browser-support' },
-    ],
-  },
-  {
-    sidebarLabel: 'Concepts',
-    llmsDescription:
-      'Understanding-oriented pages that explain how and why things work. Read these to build a mental model of the library.',
-    contents: [
-      { slug: 'concepts/features' },
-      { slug: 'concepts/skins' },
-      { slug: 'concepts/presets' },
-      { slug: 'concepts/ui-components' },
-      { slug: 'concepts/accessibility' },
-      { slug: 'concepts/media-sources' },
-      { slug: 'concepts/cast', sidebarLabel: 'Google Cast' },
-      { slug: 'concepts/mux-data' },
-      { slug: 'concepts/security' },
-      { slug: 'concepts/i18n', sidebarLabel: 'Internationalization' },
     ],
   },
   {
     sidebarLabel: 'How to',
     llmsDescription:
-      'Task-oriented guides with step-by-step instructions to achieve a specific outcome by applying one or more concepts. Each guide may assume you already understand the relevant concepts.',
+      'Task-oriented guides with step-by-step instructions to achieve a specific outcome. Each guide may assume you have already read the relevant Getting started pages.',
     contents: [
       { slug: 'how-to/customize-skins' },
       { slug: 'how-to/build-your-own-component' },


### PR DESCRIPTION
Refs #1105

> **This is a spike.** It exists to see how the merged section *feels*, not to be merged as-is. The open question is at the bottom — please look at the sidebar in a browser before reacting to the diff.

## Summary

The Getting started / Concepts boundary was never crisp, and #1105 has been open about it for a while. The reason: the two sections were labeled from **different taxonomies**. "Concepts," "How to," and "API Reference" name Diátaxis modes; "Getting started" names a point in the reader's journey. Any page that was both an early read *and* an explanation — Overview, Why Video.js?, Browser support — could justifiably sit in either, and there was no principle to settle it.

This collapses the two into a single `Getting started` section ordered as one reading arc, and separates the two structures in the authoring docs: `concepts/` and `how-to/` stay an authoring convention, while sidebar placement becomes an independent, reader-facing call.

The sidebar now reads **journey → recipes → lookup**.

## Changes

- **One `Getting started` section**, 17 items, flat, ordered to be read top to bottom. "Why Video.js?" moves above "Installation" — it's the pitch, and it's the SEO landing page.
- **`write-guides.mdx`** now teaches both structures explicitly (three sidebar sections, three Diátaxis modes) and where they meet. Removed `How-to guide (Getting started)` from the Diátaxis compass table — that parenthetical *was* the mixed taxonomy in miniature. Picking a sidebar section is now framed as "when does the reader need this?", not "which directory is it in?"
- **`site/README.md`** and **`write-docs` skill** carry the same rule, so the next author doesn't reintroduce the conflation.
- **No slugs change.** No URLs move, and `videojs docs concepts/overview` still works.

<details>
<summary>Ordering, and what was deliberately left alone</summary>

The 17 items are ordered in four runs, marked with comments in `docs.config.ts` but **not** surfaced as sub-headings in the UI:

1. Land and install — Why Video.js?, Installation, Overview
2. How a player is put together — Presets, Skins, UI components, Features, Media sources
3. What production demands — Accessibility, i18n, Security, Browser support
4. Optional integrations — Google Cast, Mux Data
5. Working with us — Build with AI, Roadmap, Changelog

Left alone on purpose:

- **Directory structure.** Moving files out of `concepts/` would churn every URL, every `<DocsLink>`, and the CLI's `videojs docs` args, to test an idea that doesn't require it. The directories are still a useful authoring distinction.
- **"Concept page" as an authoring term.** It survives the merge intact in the skills and templates. What changed is the claim that it's a *navigation* label.

</details>

## Testing

- `pnpm -F site test` — 532 passing
- `pnpm check:workspace` — 10 passing
- `pnpm build:site` — clean; generated `llms.txt` reads well as a single ordered list
- Not yet reviewed in a browser — see below

## The open question

**Is a flat 17-item section better or worse than the boundary problem it solves?**

I kept it flat deliberately. Sub-grouping would smuggle the old boundary back in under a different name, so flat is the honest version of the experiment. But it's a tall section and it defaults to open (`SidebarItem.astro` opens unless `defaultOpen: false`), so it will dominate the nav.

Pull the branch, run `pnpm dev:site`, and judge whether it reads as *a clear path* or *a wall*. If it's a wall, the fallback is sub-grouping by the runs above — which is a real answer, just a less pure one.