### PR TITLE
feat(packages): add shaka player media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -12,6 +12,7 @@ export const PRESETS = [
   'hls-video',
   'hls-audio',
   'dash-video',
+  'shaka-video',
   'audio',
   'background-video',
   'hls-background-video',

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -326,6 +326,11 @@ export const MUX_SPF_SOURCE_IDS = SOURCE_IDS.filter(
 export const SPF_HLS_SOURCE_IDS = MUX_SPF_SOURCE_IDS.filter((id) => !isMuxSource(id));
 export const MP4_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'mp4');
 export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'dash');
+/**
+ * Shaka plays DASH and HLS from one element, so it is the only preset offered
+ * both. The DRM assets are left out until the sandbox hands it license servers.
+ */
+export const SHAKA_SOURCE_IDS = SOURCE_IDS.filter((id) => !isDrmSource(id) && !isMuxSource(id));
 export const DEFAULT_SOURCE: SourceId = 'hls-1';
 export const DEFAULT_AUDIO_SOURCE: SourceId = 'mp4-1';
 export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -14,6 +14,7 @@ import {
   MUX_SOURCE_IDS,
   MUX_SPF_SOURCE_IDS,
   NON_DASH_SOURCE_IDS,
+  SHAKA_SOURCE_IDS,
   SOURCES,
   SPF_HLS_SOURCE_IDS,
 } from '@app/shared/sources';
@@ -87,15 +88,17 @@ export function App() {
       ? MP4_SOURCE_IDS
       : preset === 'dash-video'
         ? DASH_SOURCE_IDS
-        : structuredSource && muxPreset
-          ? MUX_SOURCE_IDS
-          : structuredSource && hlsPreset
-            ? HLS_SOURCE_IDS
-            : structuredSource && muxSpfPreset
-              ? MUX_SPF_SOURCE_IDS
-              : spfHlsPreset || muxSpfPreset
-                ? SPF_HLS_SOURCE_IDS
-                : NON_DASH_SOURCE_IDS;
+        : preset === 'shaka-video'
+          ? SHAKA_SOURCE_IDS
+          : structuredSource && muxPreset
+            ? MUX_SOURCE_IDS
+            : structuredSource && hlsPreset
+              ? HLS_SOURCE_IDS
+              : structuredSource && muxSpfPreset
+                ? MUX_SPF_SOURCE_IDS
+                : spfHlsPreset || muxSpfPreset
+                  ? SPF_HLS_SOURCE_IDS
+                  : NON_DASH_SOURCE_IDS;
 
   // Keep the URL in sync with all state.
   useEffect(() => {
@@ -161,9 +164,10 @@ export function App() {
     }
   }, [preset, source]);
 
-  // Constrain source away from DASH for non-DASH presets
+  // Constrain source away from DASH for presets that cannot play it. Shaka is
+  // not one of them — it plays DASH and HLS from the same element.
   useEffect(() => {
-    if (preset !== 'dash-video' && SOURCES[source].type === 'dash') {
+    if (preset !== 'dash-video' && preset !== 'shaka-video' && SOURCES[source].type === 'dash') {
       setSource(DEFAULT_SOURCE);
     }
   }, [preset, source]);

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -94,6 +94,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'hls-video': 'HLS Video',
   'hls-audio': 'HLS Audio',
   'dash-video': 'DASH Video',
+  'shaka-video': 'Shaka Video',
   audio: 'Audio',
   'background-video': 'Background Video',
   'hls-background-video': 'HLS Background Video (SPF)',

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -131,6 +131,7 @@ async function loadCdnPreset(preset: Preset, skin: Skin, live: boolean) {
     case 'native-hls-video':
     case 'hls-video':
     case 'dash-video':
+    case 'shaka-video':
       if (live) {
         if (skin === 'minimal') await import('@videojs/html/cdn/live-video-minimal');
         else await import('@videojs/html/cdn/live-video');
@@ -198,6 +199,9 @@ async function loadCdnMedia(preset: Preset) {
     case 'dash-video':
       await import('@videojs/html/cdn/media/dash-video');
       break;
+    case 'shaka-video':
+      await import('@videojs/html/cdn/media/shaka-video');
+      break;
   }
 }
 
@@ -237,6 +241,7 @@ function getMediaTag(preset: Preset): string {
     'hls-video': 'hls-video',
     'hls-audio': 'hls-audio',
     'dash-video': 'dash-video',
+    'shaka-video': 'shaka-video',
     audio: 'audio',
     'background-video': 'background-video',
     'hls-background-video': 'hls-background-video',
@@ -260,7 +265,8 @@ function isVideoPreset(preset: Preset): boolean {
     preset === 'mux-video-spf' ||
     preset === 'native-hls-video' ||
     preset === 'hls-video' ||
-    preset === 'dash-video'
+    preset === 'dash-video' ||
+    preset === 'shaka-video'
   );
 }
 

--- a/apps/sandbox/templates/html-shaka-video/index.html
+++ b/apps/sandbox/templates/html-shaka-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Shaka Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-shaka-video/main.ts
+++ b/apps/sandbox/templates/html-shaka-video/main.ts
@@ -1,0 +1,79 @@
+import '@app/styles.css';
+import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI18n } from '@app/shared/html/i18n';
+import '@videojs/html/video/player';
+import '@videojs/html/media/shaka-video';
+import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { renderStoryboard } from '@app/shared/html/storyboard';
+import {
+  onAutoplayChange,
+  onLoopChange,
+  onMutedChange,
+  onPreloadChange,
+  onSkinChange,
+  onSourceChange,
+} from '@app/shared/sandbox-listener';
+import { getPosterSrc, getStoryboardSrc, SOURCES } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  await prepareSandboxHtmlLocale();
+
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  const storyboard = getStoryboardSrc(state.source);
+  const poster = getPosterSrc(state.source);
+  const mediaAttrs = renderMediaAttrs(state);
+
+  document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <!-- Shaka plays DASH and HLS from the same element, so the source list here is not
+             narrowed to one manifest format the way the dash.js sandbox is. -->
+        <shaka-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline>
+          ${renderStoryboard(storyboard)}
+        </shaka-video>
+        ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
+      </${tag}>
+    </video-player>
+  `);
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});
+
+onSourceChange((source) => {
+  state.source = source;
+  render();
+});
+
+onAutoplayChange((autoplay) => {
+  state.autoplay = autoplay;
+  render();
+});
+
+onMutedChange((muted) => {
+  state.muted = muted;
+  render();
+});
+
+onLoopChange((loop) => {
+  state.loop = loop;
+  render();
+});
+
+onPreloadChange((preload) => {
+  state.preload = preload;
+  render();
+});
+
+bindSandboxHtmlLocaleChange(render);

--- a/apps/sandbox/templates/react-shaka-video/index.html
+++ b/apps/sandbox/templates/react-shaka-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Shaka Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-shaka-video/main.tsx
+++ b/apps/sandbox/templates/react-shaka-video/main.tsx
@@ -1,0 +1,50 @@
+import '@app/styles.css';
+import { VideoProvider } from '@app/shared/react/providers';
+import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useAutoplay } from '@app/shared/react/use-autoplay';
+import { useLoop } from '@app/shared/react/use-loop';
+import { useMuted } from '@app/shared/react/use-muted';
+import { usePreload } from '@app/shared/react/use-preload';
+import { useSkin } from '@app/shared/react/use-skin';
+import { useSource } from '@app/shared/react/use-source';
+import { SOURCES } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { ShakaVideo } from '@videojs/react/media/shaka-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const source = useSource();
+  const styling = useMemo(readStyling, []);
+  const autoplay = useAutoplay();
+  const muted = useMuted();
+  const loop = useLoop();
+  const preload = usePreload();
+
+  return (
+    <SandboxI18nProvider>
+      <VideoProvider>
+        <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+          {/* Shaka plays DASH and HLS from the same element, so the source list here is not
+              narrowed to one manifest format the way the dash.js sandbox is. */}
+          <ShakaVideo
+            src={SOURCES[source].url ?? ''}
+            autoPlay={autoplay}
+            muted={muted}
+            loop={loop}
+            preload={preload}
+            playsInline
+          />
+        </VideoSkinComponent>
+      </VideoProvider>
+    </SandboxI18nProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/cdn/media/shaka-video.ts
+++ b/packages/html/src/cdn/media/shaka-video.ts
@@ -1,0 +1,1 @@
+import '../../define/media/shaka-video';

--- a/packages/html/src/define/media/shaka-video.ts
+++ b/packages/html/src/define/media/shaka-video.ts
@@ -1,0 +1,14 @@
+import { ShakaVideo } from '../../media/shaka-video';
+import { safeDefine } from '../safe-define';
+
+export class ShakaVideoElement extends ShakaVideo {
+  static readonly tagName = 'shaka-video';
+}
+
+safeDefine(ShakaVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [ShakaVideoElement.tagName]: ShakaVideoElement;
+  }
+}

--- a/packages/html/src/media/shaka-video/index.ts
+++ b/packages/html/src/media/shaka-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/shaka-video/media.ts
+++ b/packages/html/src/media/shaka-video/media.ts
@@ -1,0 +1,5 @@
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { ShakaMedia } from '@videojs/media/dom/shaka';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+export class ShakaVideo extends MediaAttachMixin(CustomMediaElement('video', ShakaMedia)) {}

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -41,6 +41,7 @@ const media = [
   'mux-video',
   'native-hls-video',
   'dash-video',
+  'shaka-video',
 ];
 
 /**

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -57,7 +57,8 @@
     "@vimeo/player": "^2.30.3",
     "dashjs": "^5.2.0",
     "hls.js": "^1.6.7",
-    "mux-embed": "^5.17.10"
+    "mux-embed": "^5.17.10",
+    "shaka-player": "^5.2.4"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.40",

--- a/packages/media/src/dom/shaka/index.ts
+++ b/packages/media/src/dom/shaka/index.ts
@@ -1,0 +1,3 @@
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
+export { KeySystems } from '../../core/drm';
+export * from './media';

--- a/packages/media/src/dom/shaka/media-tracks.ts
+++ b/packages/media/src/dom/shaka/media-tracks.ts
@@ -1,0 +1,276 @@
+import type { Constructor } from '@videojs/utils/types';
+import type shaka from 'shaka-player';
+
+import type {
+  MediaAudioTrackCapability,
+  MediaVideoRenditionCapability,
+  MediaVideoTrackCapability,
+} from '../../core/types';
+import type { HTMLVideoElementHost } from '../video-host';
+
+type ShakaEngineHost = HTMLVideoElementHost & {
+  readonly engine?: shaka.Player | null;
+};
+
+type MediaTracksHost = ShakaEngineHost &
+  MediaVideoTrackCapability &
+  MediaAudioTrackCapability &
+  MediaVideoRenditionCapability;
+
+/**
+ * Mirrors the Shaka video and audio tracks of the loaded asset into the media
+ * element's `videoRenditions` / `audioTracks` lists, and wires user selection
+ * back to `engine.selectVideoTrack()` and `engine.selectAudioTrack()`.
+ *
+ * Shaka video tracks are a flattened view over the manifest's variants rather
+ * than a list of their own, so they are hung off a single `'main'` video track —
+ * the one the renditions of the asset that is playing are read from.
+ *
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied
+ * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
+ * and friends.
+ */
+export function ShakaMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
+  class ShakaMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
+    // The source is announced as a whole, so the URL it resolved to last is what
+    // tells a new asset apart from a configuration-only change.
+    #src = '';
+    // Shaka identifies neither kind of track by an id, so what it last announced
+    // is what a re-announcement of the same set is recognized by.
+    #videoTracksKey = '';
+    #audioTracksKey = '';
+    #isAbrOff = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const { engine } = this;
+      if (!engine) return;
+
+      engine.addEventListener('trackschanged', this.#onTracksChanged);
+      engine.addEventListener('audiotrackschanged', this.#onAudioTracksChanged);
+      engine.addEventListener('variantchanged', this.#onVariantChanged);
+      engine.addEventListener('adaptation', this.#onVariantChanged);
+      engine.addEventListener('audiotrackchanged', this.#onAudioTrackChanged);
+
+      this.addEventListener('sourcechange', this.#onSourceChange);
+      this.videoRenditions.addEventListener('change', this.#switchRendition);
+      this.audioTracks.addEventListener('change', this.#switchAudioTrack);
+    }
+
+    destroy() {
+      const { engine } = this;
+
+      engine?.removeEventListener('trackschanged', this.#onTracksChanged);
+      engine?.removeEventListener('audiotrackschanged', this.#onAudioTracksChanged);
+      engine?.removeEventListener('variantchanged', this.#onVariantChanged);
+      engine?.removeEventListener('adaptation', this.#onVariantChanged);
+      engine?.removeEventListener('audiotrackchanged', this.#onAudioTrackChanged);
+
+      this.removeEventListener('sourcechange', this.#onSourceChange);
+      this.videoRenditions.removeEventListener('change', this.#switchRendition);
+      this.audioTracks.removeEventListener('change', this.#switchAudioTrack);
+
+      this.#reset();
+
+      super.destroy();
+    }
+
+    // Shaka re-announces its tracks whenever the playable set changes — a new
+    // asset, a new period, a restriction lifted. Rebuilding throws away the
+    // rendition a user pinned, so it only happens when the set is actually
+    // different.
+    #onTracksChanged = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      const videoTracks = engine.getVideoTracks();
+      const key = videoTracksKey(videoTracks);
+      if (key === this.#videoTracksKey) return;
+      this.#videoTracksKey = key;
+
+      this.#removeVideoTracks();
+      this.#restoreAbr();
+
+      const videoTrack = this.addVideoTrack('main');
+      // Selecting the track is what puts its renditions in `videoRenditions`, so
+      // it happens before any is added and their `addrendition` events land.
+      videoTrack.selected = true;
+
+      for (const [index, track] of videoTracks.entries()) {
+        const rendition = videoTrack.addRendition(
+          // A Shaka video track is a set of manifest variants rather than one
+          // playable URL, so there is nothing to point at.
+          '',
+          track.width ?? undefined,
+          track.height ?? undefined,
+          track.codecs ?? undefined,
+          track.bandwidth,
+          track.frameRate ?? undefined
+        );
+
+        // Shaka has no id of its own for a track, so its position in the list is
+        // what a selection is looked back up by.
+        rendition.id = `${index}`;
+      }
+
+      this.#setActiveRendition(videoTracks);
+      // Audio tracks arrive with the asset, and Shaka announces them separately
+      // only when they change after that.
+      this.#onAudioTracksChanged();
+    };
+
+    #onAudioTracksChanged = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      const audioTracks = engine.getAudioTracks();
+      const key = audioTracksKey(audioTracks);
+      if (key === this.#audioTracksKey) return;
+      this.#audioTracksKey = key;
+
+      this.#removeAudioTracks();
+
+      for (const [index, track] of audioTracks.entries()) {
+        const audioTrack = this.addAudioTrack(
+          track.primary ? 'main' : 'alternative',
+          track.label ?? track.language,
+          track.language
+        );
+
+        audioTrack.id = `${index}`;
+        audioTrack.enabled = track.active;
+      }
+    };
+
+    #onVariantChanged = () => {
+      const { engine } = this;
+      if (engine) this.#setActiveRendition(engine.getVideoTracks());
+    };
+
+    #onAudioTrackChanged = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      const activeIndex = engine.getAudioTracks().findIndex((track) => track.active);
+
+      for (const audioTrack of this.audioTracks) {
+        audioTrack.enabled = audioTrack.id === `${activeIndex}`;
+      }
+    };
+
+    #switchRendition = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      // Multiple renditions can be selected, but Shaka plays exactly one video
+      // track at a time, so the first one wins.
+      const selected = [...this.videoRenditions].find((rendition) => rendition.selected);
+
+      if (!selected?.id) {
+        this.#restoreAbr();
+        return;
+      }
+
+      const videoTrack = engine.getVideoTracks()[Number(selected.id)];
+      if (!videoTrack) return;
+
+      this.#isAbrOff = true;
+      engine.configure({ abr: { enabled: false } });
+      engine.selectVideoTrack(videoTrack);
+    };
+
+    #switchAudioTrack = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      // `enabled` is not exclusive the way video `selected` is, so prefer a
+      // newly enabled track over the one that is already playing.
+      const enabledTracks = [...this.audioTracks].filter((track) => track.enabled);
+      const audioTracks = engine.getAudioTracks();
+
+      const selectedTrack = enabledTracks.find((track) => !audioTracks[Number(track.id)]?.active) ?? enabledTracks[0];
+      if (!selectedTrack?.id) return;
+
+      const audioTrack = audioTracks[Number(selectedTrack.id)];
+      if (audioTrack && !audioTrack.active) engine.selectAudioTrack(audioTrack);
+
+      // Disable the rest so future change events resolve unambiguously.
+      for (const track of enabledTracks) {
+        if (track !== selectedTrack) track.enabled = false;
+      }
+    };
+
+    #onSourceChange = () => {
+      const srcChanged = this.src !== this.#src;
+      this.#src = this.src;
+
+      // A new asset announces tracks of its own, and the one that is going away
+      // leaves nothing to select from.
+      if (srcChanged) {
+        this.#reset();
+        return;
+      }
+
+      // Applying `engine.shaka` resets Shaka's configuration wholesale, which
+      // drops the adaptation this mixin turned off; re-apply the selection it
+      // was for.
+      if (this.#isAbrOff && this.#isEngineAbrOn()) this.#switchRendition();
+    };
+
+    // Shaka's own reading rather than what this mixin last asked for:
+    // configuration is reset out from under it, and only the engine knows
+    // whether that happened. Announcing a source that changed nothing must leave
+    // the pinned track alone, or an inline React `source` prop would interrupt
+    // playback on every render.
+    #isEngineAbrOn() {
+      return this.engine?.getConfiguration().abr?.enabled !== false;
+    }
+
+    #setActiveRendition(videoTracks: shaka.extern.VideoTrack[]) {
+      const activeIndex = videoTracks.findIndex((track) => track.active);
+
+      for (const rendition of this.videoRenditions) {
+        rendition.active = activeIndex >= 0 && rendition.id === `${activeIndex}`;
+      }
+    }
+
+    #reset() {
+      this.#removeVideoTracks();
+      this.#removeAudioTracks();
+      this.#restoreAbr();
+      this.#videoTracksKey = '';
+      this.#audioTracksKey = '';
+    }
+
+    // Only ever undoes what a selection turned off, so a Shaka configuration
+    // that disables adaptation on purpose is left as configured.
+    #restoreAbr() {
+      if (!this.#isAbrOff) return;
+      this.#isAbrOff = false;
+      this.engine?.configure({ abr: { enabled: true } });
+    }
+
+    #removeVideoTracks() {
+      for (const videoTrack of this.videoTracks) {
+        this.removeVideoTrack(videoTrack);
+      }
+    }
+
+    #removeAudioTracks() {
+      for (const audioTrack of this.audioTracks) {
+        this.removeAudioTrack(audioTrack);
+      }
+    }
+  }
+
+  return ShakaMediaMediaTracks as unknown as Base;
+}
+
+function videoTracksKey(tracks: shaka.extern.VideoTrack[]) {
+  return tracks.map((track) => `${track.width}x${track.height}|${track.codecs}|${track.bandwidth}|${track.hdr}`).join();
+}
+
+function audioTracksKey(tracks: shaka.extern.AudioTrack[]) {
+  return tracks.map((track) => `${track.language}|${track.label}|${track.roles}|${track.channelsCount}`).join();
+}

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -1,0 +1,363 @@
+import { deepEqual } from '@videojs/utils/object';
+import shaka from 'shaka-player';
+
+import type { DrmSystemsConfig } from '../../core/drm';
+import { MediaError } from '../../core/media-error';
+import { MediaTracksMixin } from '../../core/media-tracks';
+import type { MediaEngineHost } from '../../core/types';
+import { HTMLVideoElementHost } from '../video-host';
+import { ShakaMediaMediaTracksMixin } from './media-tracks';
+
+export { shaka };
+
+type Opaque = string | number | boolean | bigint | symbol | null | undefined | ArrayBufferView;
+
+/**
+ * Every level optional. Shaka's own configuration type describes a fully
+ * resolved configuration, while `configure()` merges whatever subset it is
+ * handed into the current one.
+ */
+type DeepPartial<T> = T extends Opaque | readonly any[] | ((...args: any[]) => any)
+  ? T
+  : { [Key in keyof T]?: DeepPartial<T[Key]> };
+
+/** Shaka Player's configuration, as `configure()` accepts it. */
+export type ShakaConfig = DeepPartial<shaka.extern.PlayerConfiguration>;
+
+/** Structured Shaka source: which source to play, plus how to play it. */
+export interface ShakaSource {
+  /**
+   * Manifest URL. Shaka plays DASH, HLS, and progressive files from the same
+   * property. Mirrors the host's `src` property.
+   */
+  src?: string | undefined;
+  /**
+   * MIME type of the source. Handed to Shaka as the type to parse `src` as,
+   * which is what makes an extensionless manifest URL playable.
+   */
+  type?: string | undefined;
+  /**
+   * License servers for protected content, keyed by EME key system id.
+   *
+   * Translated into the `drm.servers` and `drm.advanced` Shaka configures EME
+   * from. Name every system you hold a license server for — which one is used
+   * is the browser's choice.
+   */
+  drm?: DrmSystemsConfig | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: ShakaEngineConfig | undefined;
+}
+
+/** The engines a Shaka source can configure. */
+export interface ShakaEngineConfig {
+  /**
+   * Shaka Player's own configuration, passed through untouched. Replacing it
+   * resets any previously applied configuration. A `drm.servers` of its own
+   * replaces `source.drm` — an escape hatch for licensing against the parts of
+   * Shaka's DRM configuration `source.drm` does not cover.
+   */
+  shaka?: ShakaConfig | undefined;
+}
+
+export interface ShakaMediaProps {
+  src: string;
+  source: ShakaSource | null;
+}
+
+export const shakaMediaDefaultProps: ShakaMediaProps = {
+  src: '',
+  source: null,
+};
+
+const ShakaMediaHost = MediaTracksMixin(HTMLVideoElementHost);
+
+class ShakaMediaBase
+  extends ShakaMediaHost
+  implements MediaEngineHost<shaka.Player, HTMLVideoElement>, ShakaMediaProps
+{
+  #engine: shaka.Player | null = null;
+  #src = shakaMediaDefaultProps.src;
+  #source: ShakaSource | null = shakaMediaDefaultProps.source;
+  #error: MediaError | null = null;
+  // Every engine call is queued behind the one before it, starting from here.
+  #pending: Promise<void> = Promise.resolve();
+  #isDestroyed = false;
+
+  constructor() {
+    super();
+
+    if (!shaka.Player.isBrowserSupported()) {
+      if (__DEV__) {
+        console.warn('[vjs-shaka] This browser lacks the APIs Shaka Player needs. Nothing will play.');
+      }
+      return;
+    }
+
+    this.#engine = new shaka.Player();
+    this.#engine.addEventListener('error', this.#onEngineError);
+  }
+
+  attach(target: HTMLVideoElement) {
+    // Shaka's `attach()` tears playback down and builds it back up, so the
+    // target it is already playing in is left alone.
+    const isNewTarget = this.target !== target;
+    // Read before attaching: a source assigned while there was nothing to play
+    // it in never reached the engine, and this attach is what loads it. Anything
+    // assigned from here on has a target of its own to load into.
+    const hasUnloadedSource = Boolean(this.#src);
+
+    super.attach(target);
+
+    const engine = this.#engine;
+    if (!engine || !isNewTarget) return;
+
+    this.#enqueue(async () => {
+      await engine.attach(target);
+      if (hasUnloadedSource) await this.#loadSource(engine);
+    });
+  }
+
+  detach() {
+    const engine = this.#engine;
+    const wasAttached = this.target !== null;
+
+    super.detach();
+
+    if (engine && wasAttached) this.#enqueue(() => engine.detach());
+  }
+
+  destroy() {
+    this.detach();
+
+    const engine = this.#engine;
+    // Anything still queued has nothing left to run against.
+    this.#engine = null;
+    this.#isDestroyed = true;
+
+    if (engine) {
+      engine.removeEventListener('error', this.#onEngineError);
+      // Shaka aborts whatever is in flight itself, so a teardown that races a
+      // load has nothing left to report.
+      engine.destroy().catch(() => {});
+    }
+
+    super.destroy();
+  }
+
+  /**
+   * Underlying playback engine — the Shaka `Player` instance, or `null` when
+   * the browser cannot run it. An advanced escape hatch for direct engine
+   * access; normal playback is driven through this element's own properties
+   * and methods.
+   */
+  get engine() {
+    return this.#engine;
+  }
+
+  /**
+   * The last playback failure, or `null`. Shaka loads asynchronously, so a
+   * manifest that cannot be played fails after `src` was assigned rather than at
+   * the assignment; the `error` event is when to read this.
+   *
+   * A Shaka failure says more about what went wrong than the media element's
+   * own `error` does, so it wins while there is one; anything the element failed
+   * on by itself still reads through.
+   */
+  get error() {
+    return this.#error ?? super.error;
+  }
+
+  get src() {
+    return this.#src;
+  }
+
+  /** Manifest URL. Setting it re-derives `source`, carrying its settings over. */
+  set src(value) {
+    // `src` says which source to play; every other field says how to play it,
+    // so they carry over.
+    const { type, drm, engine } = this.#source ?? {};
+    const next: ShakaSource = {
+      ...(type && { type }),
+      ...(drm && { drm }),
+      ...(engine && { engine }),
+      ...(value && { src: value }),
+    };
+
+    // Everything happens in the `source` setter, so there is one path for
+    // storing it, telling the engine, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  /**
+   * Structured source: what to play (`src`, an optional `type`) plus how to
+   * play it (`drm`, `engine.shaka`). Replacing it re-derives `src`.
+   *
+   * Shaka takes configuration on a live player, so changing `engine.shaka`
+   * re-applies it in place instead of recreating the engine.
+   */
+  get source(): ShakaSource | null {
+    return this.#source;
+  }
+
+  set source(value: ShakaSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    // Assigning is always a source change, so it is always announced. Only the
+    // engine calls are guarded, so re-assigning an equivalent source — an inline
+    // React prop, say — never disturbs what is already playing.
+    const configChanged = !deepEqual(engineConfigKey(this.#source), engineConfigKey(source));
+    const loadChanged = this.#src !== (source?.src ?? '') || this.#source?.type !== source?.type;
+
+    this.#source = source;
+    this.#src = source?.src ?? '';
+
+    if (configChanged) this.#applyEngineConfig();
+    if (loadChanged) this.#requestLoad();
+
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+
+  // `engine.shaka` is replaced, not merged, but Shaka merges every
+  // `configure()` call into the current configuration — reset first so dropping
+  // a key clears it instead of leaving the previous value behind.
+  #applyEngineConfig() {
+    const engine = this.#engine;
+    if (!engine) return;
+
+    engine.resetConfiguration();
+
+    const config = withDrmConfig(this.#source?.engine?.shaka, this.#source?.drm);
+    if (config) engine.configure(config);
+  }
+
+  #requestLoad() {
+    const engine = this.#engine;
+    // Nothing to load into yet — `attach()` loads what is waiting.
+    if (!engine || !this.target) return;
+
+    this.#enqueue(() => this.#loadSource(engine));
+  }
+
+  #loadSource(engine: shaka.Player) {
+    this.#error = null;
+    const { src } = this;
+    return src ? engine.load(src, undefined, this.#source?.type) : engine.unload();
+  }
+
+  /**
+   * Shaka's `attach()`, `load()`, `unload()`, and `destroy()` are asynchronous
+   * and must not overlap, so every engine call goes on one chain. A failure is
+   * reported here rather than rejected, or it would take everything queued
+   * behind it down with it.
+   */
+  #enqueue(task: () => Promise<unknown>) {
+    this.#pending = this.#pending.then(async () => {
+      if (this.#isDestroyed) return;
+
+      try {
+        await task();
+      } catch (error) {
+        this.#reportError(error);
+      }
+    });
+  }
+
+  #onEngineError = (event: Event) => {
+    this.#reportError((event as Event & { detail?: unknown }).detail);
+  };
+
+  #reportError(error: unknown) {
+    const mediaError = toMediaError(error);
+    // Superseding a load aborts the one in flight. That is this element doing
+    // its job, not a failure worth announcing.
+    if (!mediaError) return;
+
+    this.#error = mediaError;
+    this.dispatchEvent(new ErrorEvent('error', { error: mediaError, message: mediaError.message }));
+  }
+}
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires error - Fired when playback fails. Read `error` for the failure.
+ */
+export class ShakaMedia extends ShakaMediaMediaTracksMixin(ShakaMediaBase) {}
+
+/**
+ * Everything Shaka is configured from. Compared structurally, so equivalent
+ * options never re-apply — including nested ones like `drm`, which a flat
+ * comparison would see as changed whenever the object identity did.
+ */
+function engineConfigKey(source: ShakaSource | null) {
+  return { drm: source?.drm ?? null, shaka: source?.engine?.shaka ?? null };
+}
+
+/**
+ * Shaka configuration with the source's DRM licensing folded in. Shaka names
+ * license servers under `drm.servers` and server certificates under
+ * `drm.advanced`, so `source.drm` is translated into both — unless
+ * `engine.shaka.drm.servers` names servers of its own, which replaces it.
+ */
+function withDrmConfig(config: ShakaConfig | undefined, drm: DrmSystemsConfig | undefined) {
+  const systems = Object.entries(drm ?? {});
+  if (systems.length === 0 || config?.drm?.servers) return config;
+
+  const servers: Record<string, string> = {};
+  const advanced: Record<string, { serverCertificateUri: string }> = {};
+
+  for (const [keySystem, system] of systems) {
+    servers[keySystem] = system.licenseUrl;
+    if (system.serverCertificateUrl) advanced[keySystem] = { serverCertificateUri: system.serverCertificateUrl };
+  }
+
+  return {
+    ...config,
+    drm: {
+      ...config?.drm,
+      servers,
+      // Advanced options a caller set for a key system are more specific than a
+      // certificate URL derived from `source.drm`, so they win.
+      ...(Object.keys(advanced).length > 0 && { advanced: { ...advanced, ...config?.drm?.advanced } }),
+    },
+  } satisfies ShakaConfig;
+}
+
+const categoryToCode: Record<number, number> = {
+  [shaka.util.Error.Category.NETWORK]: MediaError.MEDIA_ERR_NETWORK,
+  [shaka.util.Error.Category.MEDIA]: MediaError.MEDIA_ERR_DECODE,
+  [shaka.util.Error.Category.MANIFEST]: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,
+  [shaka.util.Error.Category.STREAMING]: MediaError.MEDIA_ERR_DECODE,
+  [shaka.util.Error.Category.DRM]: MediaError.MEDIA_ERR_ENCRYPTED,
+};
+
+/** Shaka codes for a load that a newer one replaced. */
+const abortedCodes = new Set<number>([shaka.util.Error.Code.LOAD_INTERRUPTED, shaka.util.Error.Code.OPERATION_ABORTED]);
+
+/**
+ * A Shaka failure as a `MediaError`, or `null` when there is nothing to report.
+ *
+ * Shaka classifies a failure by category rather than by a media error code, and
+ * marks a recoverable one as such — it retries those itself, so only a critical
+ * failure ends up fatal here.
+ */
+function toMediaError(error: unknown): MediaError | null {
+  if (!isShakaError(error)) {
+    return error instanceof Error ? new MediaError(error.message, MediaError.MEDIA_ERR_CUSTOM, true) : null;
+  }
+
+  if (abortedCodes.has(error.code)) return null;
+
+  const code = categoryToCode[error.category] ?? MediaError.MEDIA_ERR_CUSTOM;
+  const fatal = error.severity === shaka.util.Error.Severity.CRITICAL;
+  const mediaError = new MediaError(error.message, code, fatal, `shaka-${error.code}`);
+  mediaError.data = error;
+
+  return mediaError;
+}
+
+function isShakaError(value: unknown): value is shaka.util.Error & { message?: string } {
+  return typeof value === 'object' && value !== null && 'code' in value && 'category' in value;
+}

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -1,0 +1,581 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('shaka-player', () => {
+  /** Shaka merges every `configure()` call into the current configuration. */
+  function merge(target: Record<string, any>, source: Record<string, any>) {
+    for (const [key, value] of Object.entries(source)) {
+      const isPlainObject = typeof value === 'object' && value !== null && !Array.isArray(value);
+      target[key] = isPlainObject ? merge({ ...target[key] }, value) : value;
+    }
+    return target;
+  }
+
+  function create() {
+    const listeners = new Map<string, Set<(event: any) => void>>();
+
+    const player = {
+      config: {} as Record<string, any>,
+      videoTracks: [] as any[],
+      audioTracks: [] as any[],
+      attach: vi.fn(async () => {}),
+      detach: vi.fn(async () => {}),
+      load: vi.fn(async (_src?: string, _startTime?: unknown, _mimeType?: string) => {}),
+      unload: vi.fn(async () => {}),
+      destroy: vi.fn(async () => {}),
+      configure: vi.fn((config: Record<string, any>) => {
+        player.config = merge(player.config, config);
+        return true;
+      }),
+      resetConfiguration: vi.fn(() => {
+        player.config = {};
+      }),
+      getConfiguration: vi.fn(() => player.config),
+      getVideoTracks: vi.fn(() => player.videoTracks),
+      getAudioTracks: vi.fn(() => player.audioTracks),
+      selectVideoTrack: vi.fn(),
+      selectAudioTrack: vi.fn(),
+      addEventListener: vi.fn((type: string, listener: (event: any) => void) => {
+        const typeListeners = listeners.get(type) ?? new Set();
+        typeListeners.add(listener);
+        listeners.set(type, typeListeners);
+      }),
+      removeEventListener: vi.fn((type: string, listener: (event: any) => void) => {
+        listeners.get(type)?.delete(listener);
+      }),
+      /** Test-only: dispatch a Shaka player event to its listeners. */
+      emit(type: string, event: Record<string, unknown> = {}) {
+        for (const listener of [...(listeners.get(type) ?? [])]) listener({ type, ...event });
+      },
+    };
+
+    return player;
+  }
+
+  function Player(this: unknown) {
+    return create();
+  }
+
+  Player.isBrowserSupported = () => true;
+
+  const util = {
+    Error: {
+      Category: { NETWORK: 1, TEXT: 2, MEDIA: 3, MANIFEST: 4, STREAMING: 5, DRM: 6, PLAYER: 7 },
+      Code: { LOAD_INTERRUPTED: 7000, OPERATION_ABORTED: 7001, BAD_HTTP_STATUS: 1001 },
+      Severity: { RECOVERABLE: 1, CRITICAL: 2 },
+    },
+  };
+
+  return { default: { Player, util } };
+});
+
+import { KeySystems } from '../../../core/drm';
+import type { ShakaSource } from '../index';
+import { ShakaMedia } from '../index';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+type MockEngine = {
+  config: Record<string, any>;
+  videoTracks: MockVideoTrack[];
+  audioTracks: MockAudioTrack[];
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+  load: ReturnType<typeof vi.fn>;
+  unload: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  configure: ReturnType<typeof vi.fn>;
+  resetConfiguration: ReturnType<typeof vi.fn>;
+  selectVideoTrack: ReturnType<typeof vi.fn>;
+  selectAudioTrack: ReturnType<typeof vi.fn>;
+  emit(type: string, event?: Record<string, unknown>): void;
+};
+
+type MockVideoTrack = {
+  active: boolean;
+  bandwidth: number;
+  width?: number;
+  height?: number;
+  codecs?: string;
+  frameRate?: number;
+  hdr?: string | null;
+};
+
+type MockAudioTrack = {
+  active: boolean;
+  primary: boolean;
+  language: string;
+  label?: string | null;
+  roles?: string[];
+  channelsCount?: number | null;
+};
+
+function setup() {
+  const video = document.createElement('video');
+  document.body.appendChild(video);
+
+  const media = new ShakaMedia();
+  media.attach(video);
+
+  return { media, video, engine: media.engine as unknown as MockEngine };
+}
+
+/** Engine calls are queued, and track list events are dispatched a microtask later. */
+async function flush() {
+  for (let index = 0; index < 5; index += 1) await Promise.resolve();
+}
+
+const MANIFEST = 'https://example.com/manifest.mpd';
+const OTHER_MANIFEST = 'https://example.com/other.m3u8';
+
+const VIDEO_TRACKS: MockVideoTrack[] = [
+  { active: true, bandwidth: 6_000_000, width: 1920, height: 1080, codecs: 'avc1.640028', frameRate: 30 },
+  { active: false, bandwidth: 3_000_000, width: 1280, height: 720, codecs: 'avc1.64001f', frameRate: 30 },
+];
+
+const AUDIO_TRACKS: MockAudioTrack[] = [
+  { active: true, primary: true, language: 'en', label: 'English', roles: ['main'], channelsCount: 2 },
+  { active: false, primary: false, language: 'fr', label: 'French', roles: ['alternate'], channelsCount: 2 },
+];
+
+/** Shaka announces the tracks of an asset once it is loaded. */
+function loadTracks(engine: MockEngine, videoTracks = VIDEO_TRACKS, audioTracks = AUDIO_TRACKS) {
+  engine.videoTracks = videoTracks.map((track) => ({ ...track }));
+  engine.audioTracks = audioTracks.map((track) => ({ ...track }));
+  engine.emit('trackschanged');
+}
+
+function shakaError(overrides: Record<string, unknown> = {}) {
+  return { severity: 2, category: 1, code: 1001, data: [], message: 'Bad HTTP status', ...overrides };
+}
+
+describe('ShakaMedia', () => {
+  describe('attach', () => {
+    it('attaches the engine to the target', async () => {
+      const { engine, video } = setup();
+      await flush();
+
+      expect(engine.attach).toHaveBeenCalledWith(video);
+    });
+
+    it('loads a source that was assigned before there was a target', async () => {
+      const video = document.createElement('video');
+      const media = new ShakaMedia();
+      const engine = media.engine as unknown as MockEngine;
+
+      media.src = MANIFEST;
+      await flush();
+      expect(engine.load).not.toHaveBeenCalled();
+
+      media.attach(video);
+      await flush();
+
+      expect(engine.attach).toHaveBeenCalledWith(video);
+      expect(engine.load).toHaveBeenCalledExactlyOnceWith(MANIFEST, undefined, undefined);
+    });
+
+    it('leaves the target it is already attached to alone', async () => {
+      const { media, engine, video } = setup();
+      await flush();
+
+      media.attach(video);
+      await flush();
+
+      expect(engine.attach).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('destroy', () => {
+    it('detaches and destroys the engine', async () => {
+      const { media, engine } = setup();
+      await flush();
+
+      media.destroy();
+      await flush();
+
+      expect(engine.destroy).toHaveBeenCalled();
+      expect(media.engine).toBeNull();
+    });
+  });
+
+  describe('source', () => {
+    it('forwards shaka configuration to the player', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.config).toEqual({ streaming: { bufferingGoal: 30 } });
+    });
+
+    it('derives src and loads the manifest', async () => {
+      const { media, engine } = setup();
+      const sourcechange = vi.fn();
+      media.addEventListener('sourcechange', sourcechange);
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      expect(media.src).toBe(MANIFEST);
+      expect(engine.load).toHaveBeenCalledExactlyOnceWith(MANIFEST, undefined, undefined);
+      expect(sourcechange).toHaveBeenCalledTimes(1);
+    });
+
+    it('hands the source type to shaka as the type to parse the manifest as', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, type: 'application/dash+xml' };
+      await flush();
+
+      expect(engine.load).toHaveBeenCalledWith(MANIFEST, undefined, 'application/dash+xml');
+    });
+
+    it('leaves the engine alone for a structurally equal source', async () => {
+      const { media, engine } = setup();
+      const source: ShakaSource = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+
+      media.source = source;
+      await flush();
+
+      const sourcechange = vi.fn();
+      media.addEventListener('sourcechange', sourcechange);
+      engine.load.mockClear();
+      engine.configure.mockClear();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.load).not.toHaveBeenCalled();
+      expect(engine.configure).not.toHaveBeenCalled();
+      expect(sourcechange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload the manifest when only shaka configuration changes', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+      engine.load.mockClear();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 60 } } } };
+      await flush();
+
+      expect(engine.load).not.toHaveBeenCalled();
+      expect(engine.config).toEqual({ streaming: { bufferingGoal: 60 } });
+    });
+
+    it('resets configuration instead of merging when a shaka option is dropped', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        engine: { shaka: { streaming: { bufferingGoal: 30, rebufferingGoal: 5 } } },
+      };
+      await flush();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.resetConfiguration).toHaveBeenCalled();
+      expect(engine.config).toEqual({ streaming: { bufferingGoal: 30 } });
+    });
+
+    it('unloads when src is cleared', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      media.source = null;
+      await flush();
+
+      expect(media.src).toBe('');
+      expect(engine.unload).toHaveBeenCalled();
+    });
+
+    it('translates source drm into shaka license servers and certificates', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        drm: {
+          [KeySystems.WIDEVINE]: { licenseUrl: 'https://example.com/widevine' },
+          [KeySystems.FAIRPLAY]: {
+            licenseUrl: 'https://example.com/fairplay',
+            serverCertificateUrl: 'https://example.com/cert',
+          },
+        },
+      };
+      await flush();
+
+      expect(engine.config.drm).toEqual({
+        servers: {
+          [KeySystems.WIDEVINE]: 'https://example.com/widevine',
+          [KeySystems.FAIRPLAY]: 'https://example.com/fairplay',
+        },
+        advanced: {
+          [KeySystems.FAIRPLAY]: { serverCertificateUri: 'https://example.com/cert' },
+        },
+      });
+    });
+
+    it('lets shaka license servers replace the source drm configuration', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        drm: { [KeySystems.WIDEVINE]: { licenseUrl: 'https://example.com/widevine' } },
+        engine: { shaka: { drm: { servers: { [KeySystems.PLAYREADY]: 'https://example.com/playready' } } } },
+      };
+      await flush();
+
+      expect(engine.config.drm).toEqual({
+        servers: { [KeySystems.PLAYREADY]: 'https://example.com/playready' },
+      });
+    });
+  });
+
+  describe('src', () => {
+    it('preserves source configuration across a src change', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+      engine.configure.mockClear();
+
+      media.src = OTHER_MANIFEST;
+      await flush();
+
+      expect(media.source).toEqual({
+        src: OTHER_MANIFEST,
+        engine: { shaka: { streaming: { bufferingGoal: 30 } } },
+      });
+      expect(engine.load).toHaveBeenLastCalledWith(OTHER_MANIFEST, undefined, undefined);
+      expect(engine.configure).not.toHaveBeenCalled();
+    });
+
+    it('fires sourcechange through the source setter', async () => {
+      const { media } = setup();
+      const sourcechange = vi.fn();
+      media.addEventListener('sourcechange', sourcechange);
+
+      media.src = MANIFEST;
+      await flush();
+
+      expect(sourcechange).toHaveBeenCalledTimes(1);
+      expect(media.source).toEqual({ src: MANIFEST });
+    });
+  });
+
+  describe('videoRenditions', () => {
+    it('mirrors the video tracks of the loaded asset', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      expect([...media.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 720]);
+      expect([...media.videoRenditions].map((rendition) => rendition.id)).toEqual(['0', '1']);
+      expect([...media.videoRenditions].map((rendition) => rendition.bitrate)).toEqual([6_000_000, 3_000_000]);
+    });
+
+    it('marks the video track shaka is playing active', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([true, false]);
+
+      engine.videoTracks = [
+        { ...VIDEO_TRACKS[0]!, active: false },
+        { ...VIDEO_TRACKS[1]!, active: true },
+      ];
+      engine.emit('adaptation');
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+    });
+
+    it('leaves the list alone when the same tracks are announced again', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      const [rendition] = [...media.videoRenditions];
+      engine.emit('trackschanged');
+      await flush();
+
+      expect([...media.videoRenditions][0]).toBe(rendition);
+    });
+
+    it('pins the selected track and turns shaka adaptation off', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+
+      expect(engine.config.abr).toEqual({ enabled: false });
+      expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
+    });
+
+    it('hands adaptation back to shaka when the selection is cleared', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+
+      media.videoRenditions[1]!.selected = false;
+      await flush();
+
+      expect(engine.config.abr).toEqual({ enabled: true });
+    });
+
+    it('leaves shaka configuration alone when nothing was ever pinned', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+      engine.configure.mockClear();
+
+      media.videoRenditions[0]!.selected = false;
+      await flush();
+
+      expect(engine.configure).not.toHaveBeenCalled();
+    });
+
+    it('re-pins the selected track when shaka configuration is re-applied', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+      engine.selectVideoTrack.mockClear();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.config.abr).toEqual({ enabled: false });
+      expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
+    });
+
+    it('drops renditions and restores adaptation when the source changes', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+
+      media.src = OTHER_MANIFEST;
+      await flush();
+
+      expect([...media.videoRenditions]).toEqual([]);
+      expect(engine.config.abr).toEqual({ enabled: true });
+    });
+
+    it('stops mirroring tracks once destroyed', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.destroy();
+      await flush();
+
+      loadTracks(engine, [{ active: true, bandwidth: 1_000_000, width: 640, height: 360 }]);
+      await flush();
+
+      expect([...media.videoRenditions]).toEqual([]);
+    });
+  });
+
+  describe('audioTracks', () => {
+    it('mirrors the audio tracks of the loaded asset', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      expect([...media.audioTracks].map((track) => track.language)).toEqual(['en', 'fr']);
+      expect([...media.audioTracks].map((track) => track.kind)).toEqual(['main', 'alternative']);
+      expect([...media.audioTracks].map((track) => track.enabled)).toEqual([true, false]);
+    });
+
+    it('selects the enabled audio track', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.audioTracks[1]!.enabled = true;
+      await flush();
+
+      expect(engine.selectAudioTrack).toHaveBeenCalledWith(engine.audioTracks[1]);
+      expect([...media.audioTracks].map((track) => track.enabled)).toEqual([false, true]);
+    });
+
+    it('mirrors the audio track shaka switched to', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      engine.audioTracks = [
+        { ...AUDIO_TRACKS[0]!, active: false },
+        { ...AUDIO_TRACKS[1]!, active: true },
+      ];
+      engine.emit('audiotrackchanged');
+      await flush();
+
+      expect([...media.audioTracks].map((track) => track.enabled)).toEqual([false, true]);
+    });
+  });
+
+  describe('error', () => {
+    it('reports a failed load', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      engine.load.mockRejectedValueOnce(shakaError());
+      media.src = MANIFEST;
+      await flush();
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(media.error).toMatchObject({ code: 2, fatal: true, context: 'shaka-1001' });
+    });
+
+    it('reports an engine error event', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      engine.emit('error', { detail: shakaError({ category: 6, code: 6001 }) });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(media.error).toMatchObject({ code: 5, fatal: true });
+    });
+
+    it('marks a recoverable failure as non-fatal', async () => {
+      const { media, engine } = setup();
+
+      engine.emit('error', { detail: shakaError({ severity: 1 }) });
+
+      expect(media.error).toMatchObject({ fatal: false });
+    });
+
+    it('ignores a load that a newer one replaced', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      engine.load.mockRejectedValueOnce(shakaError({ category: 7, code: 7000 }));
+      media.src = MANIFEST;
+      await flush();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(media.error).toBeNull();
+    });
+  });
+});

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -17,6 +17,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/dash/index': './src/dom/dash/index.ts',
     'dom/hls-js/index': './src/dom/hls-js/index.ts',
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
+    'dom/shaka/index': './src/dom/shaka/index.ts',
     'dom/vimeo/index': './src/dom/vimeo/index.ts',
     'dom/youtube/index': './src/dom/youtube/index.ts',
     'dom/mux/index': './src/dom/mux/index.ts',

--- a/packages/react/src/media/shaka-video/index.ts
+++ b/packages/react/src/media/shaka-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/shaka-video/media.tsx
+++ b/packages/react/src/media/shaka-video/media.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { ShakaMediaProps } from '@videojs/media/dom/shaka';
+import { ShakaMedia, shakaMediaDefaultProps } from '@videojs/media/dom/shaka';
+import type { ReactNode, VideoHTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+import { useAttachMedia } from '../../utils/use-attach-media';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface ShakaVideoProps
+  extends Omit<VideoHTMLAttributes<HTMLVideoElement>, keyof ShakaMediaProps>,
+    Partial<ShakaMediaProps> {
+  children?: ReactNode;
+}
+
+export const ShakaVideo = forwardRef<HTMLVideoElement, ShakaVideoProps>(function ShakaVideo(
+  { children, ...props },
+  ref
+) {
+  const media = useMediaInstance(ShakaMedia);
+  const attachRef = useAttachMedia(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const htmlProps = useSyncProps(media, props, shakaMediaDefaultProps);
+
+  return (
+    <video ref={composedRef} {...htmlProps}>
+      {children}
+    </video>
+  );
+});
+
+export namespace ShakaVideo {
+  export type Props = ShakaVideoProps;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,7 +225,7 @@ importers:
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/compiler:
     dependencies:
@@ -247,7 +247,7 @@ importers:
         version: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -291,7 +291,7 @@ importers:
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/html:
     dependencies:
@@ -334,7 +334,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/icons:
     dependencies:
@@ -368,7 +368,7 @@ importers:
         version: 4.23.1
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/jsx:
     devDependencies:
@@ -380,7 +380,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/media:
     dependencies:
@@ -399,6 +399,9 @@ importers:
       mux-embed:
         specifier: ^5.17.10
         version: 5.17.10
+      shaka-player:
+        specifier: ^5.2.4
+        version: 5.2.4
     devDependencies:
       '@types/chrome':
         specifier: ^0.1.40
@@ -583,7 +586,7 @@ importers:
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   site:
     dependencies:
@@ -779,7 +782,7 @@ importers:
         version: 4.5.0(@typescript/typescript6@6.0.0)(rollup@4.59.0)(supports-color@7.2.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -8350,6 +8353,10 @@ packages:
     engines: {node: '>=20.18.1'}
     hasBin: true
 
+  shaka-player@5.2.4:
+    resolution: {integrity: sha512-vf81av2EIcb03jRpeeZBhrPT3PMyggXnZA9k4sxGBxpr/H6v0iEL6b51T2Kwz5YNrQG/yDYoadgBW+oW40LeoA==}
+    engines: {node: '>=18'}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -13160,7 +13167,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13194,7 +13201,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -13214,9 +13221,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13270,7 +13277,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@26.1.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -17871,6 +17878,8 @@ snapshots:
       - supports-color
       - typescript
 
+  shaka-player@5.2.4: {}
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -18787,7 +18796,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
Closes #1458
Refs #1774, #1411

## Summary

Adds a Shaka Player media — `<shaka-video>` for HTML and `<ShakaVideo>` for React — so DASH and HLS play from one engine with Shaka's DRM stack behind the standardized `source.drm` API.

## Changes

- `ShakaMedia` in `@videojs/media/dom/shaka`, exposing `src`, structured `source`, `engine` (the `shaka.Player` escape hatch), and `error`.
- **DASH + HLS from one element.** `source.type` is passed to Shaka as the type to parse the manifest as, which is what makes an extensionless URL playable.
- **DRM.** `source.drm` (the same engine-neutral shape hls.js and native HLS read) becomes Shaka's `drm.servers` plus `drm.advanced[…].serverCertificateUri`. `engine.shaka.drm.servers` replaces it as an escape hatch, matching the hls.js precedent.
- **Video renditions and audio tracks** mirror into `videoRenditions` / `audioTracks`. Selecting a rendition pins the Shaka video track with ABR off and hands adaptation back when the selection clears.
- **Errors are reported.** Shaka loads asynchronously, so a manifest that cannot be played fails after `src` was assigned. Categories map to `MediaError` codes, severity drives `fatal`, and a load superseded by a newer one is not announced.
- Sandbox pages for HTML, React, and CDN.

<details>
<summary>Implementation details</summary>

**Shape.** This follows `DashMedia` for source handling — one long-lived engine, `src` re-derives `source` carrying config over, `configure()` is reset before re-applying so dropping a key clears it, and sources compare structurally so an inline React `source` prop never interrupts playback. It follows `HlsJsMedia` for DRM and error reporting.

**Async lifecycle.** Shaka's `attach`, `load`, `unload`, and `detach` all return promises and must not overlap, so engine calls run on one serialized chain and a rejection is reported rather than propagated (it would otherwise reject everything queued behind it). A source assigned before there is a target loads when `attach()` arrives; re-attaching the same target is a no-op, since Shaka's `attach()` tears playback down and rebuilds it.

**Track identity.** Shaka 5's `getVideoTracks()` / `getAudioTracks()` return plain objects with no ids, so a rendition's position in the list is what a selection is looked back up by, and the property set is what a re-announcement of the same tracks is recognized by. That last part is why `trackschanged` firing mid-playback does not throw away a user's pinned rendition. This uses the Shaka 5 track APIs rather than the variant de-duplication in Mux's `shaka-video-element`, which targets Shaka 4.

**Scope of #1774.** The standardized `source.drm` path is wired end to end, but the richer parts of Shaka's DRM config (headers, robustness, key-system mapping) are reachable only through `engine.shaka.drm` for now — hence `Refs` rather than `Closes`.

**Note on `pnpm-lock.yaml`.** Beyond adding `shaka-player`, the install re-resolved a `jsdom` peer entry (`jsdom@27.4.0` → `jsdom@27.4.0(supports-color@7.2.0)`). That is deterministic churn from the current pnpm, not an intended change.

</details>

## Not included

No e2e page, no `site` reference page, and no Mux Data support (mux-embed has no Shaka monitor, so the sandbox templates omit it). Happy to add any of these here or as follow-ups.

## Testing

1. `pnpm -F @videojs/media test` — 31 new tests over a mocked `shaka-player` covering attach ordering, source and config semantics, DRM translation, renditions, audio tracks, and error reporting.
2. `pnpm typecheck`, `pnpm check:workspace`, and builds of `media`, `html`, and `react`.
3. Manual: `pnpm dev`, pick the **Shaka Video** preset, and switch between HLS and DASH sources — both play, and the quality menu switches renditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New playback engine with async lifecycle, DRM translation, and track/ABR bridging—well tested but touches core media behavior and adds a sizeable dependency.
> 
> **Overview**
> Adds **Shaka Player** as a first-class playback path: `<shaka-video>` / `<ShakaVideo>` with a new **`shaka-video`** sandbox preset and CDN bundle.
> 
> **`ShakaMedia`** (`@videojs/media/dom/shaka`) drives a long-lived `shaka.Player` with `src` / structured `source` (optional manifest `type`, `source.drm` → Shaka license servers, `engine.shaka` escape hatch), serialized async attach/load/unload, and Shaka errors mapped to **`MediaError`**. Video renditions and audio tracks mirror into the standard track APIs, including manual quality selection with ABR off/on.
> 
> The sandbox wires **`SHAKA_SOURCE_IDS`** so one preset can switch **HLS and DASH** (DRM/Mux playback-ID sources excluded for now). **`shaka-player`** is added as a dependency; HTML/React templates and **`tsdown`** CDN entries ship the new element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3f0d8f3623c78fedaadf4d3c6e6010fa8ceef2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->