### PR TITLE
feat(packages): add cloudflare stream media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -18,4 +18,12 @@ export const PRESETS = [
   'mux-background-video',
   'vimeo-video',
   'youtube-video',
+  'cloudflare-video',
 ] as const;
+
+/**
+ * Presets that hand playback to a third-party embed. They render one fixed
+ * source rather than the source picker's list, and have no Tailwind skin
+ * variant, so the navbar disables both controls for them.
+ */
+export const EMBED_PRESETS = ['vimeo-video', 'youtube-video', 'cloudflare-video'] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -350,6 +350,8 @@ export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 
 export const YOUTUBE_VIDEO_SRC = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
 
+export const CLOUDFLARE_VIDEO_SRC = 'https://watch.videodelivery.net/bfbd585059e33391d67b0f1d15fe6ea4';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return SOURCES[id].live === true;

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -1,4 +1,4 @@
-import { PLATFORMS, PRESETS, STYLINGS } from '@app/constants';
+import { EMBED_PRESETS, PLATFORMS, PRESETS, STYLINGS } from '@app/constants';
 import { DEFAULT_SANDBOX_LOCALE, SANDBOX_LOCALE_TAGS, type SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
 import { DEFAULT_PRELOAD, PRELOAD_VALUES, type PreloadValue } from '@app/shared/sandbox-listener';
 import type { SourceId } from '@app/shared/sources';
@@ -24,9 +24,6 @@ import { Preview } from './preview';
 
 function getPagePath(platform: Platform, preset: Preset): string {
   if (platform === 'cdn') return '/cdn/';
-  if (preset === 'background-video') return `/${platform}-background-video/`;
-  if (preset === 'vimeo-video') return `/${platform}-vimeo-video/`;
-  if (preset === 'youtube-video') return `/${platform}-youtube-video/`;
   return `/${platform}-${preset}/`;
 }
 
@@ -82,6 +79,7 @@ export function App() {
   // Every background preset renders a fixed source and has no Tailwind skin.
   const backgroundPreset =
     preset === 'background-video' || preset === 'hls-background-video' || preset === 'mux-background-video';
+  const embedPreset = (EMBED_PRESETS as readonly Preset[]).includes(preset);
   const availableSources =
     preset === 'audio'
       ? MP4_SOURCE_IDS
@@ -176,15 +174,12 @@ export function App() {
     }
   }, [availableSources, source]);
 
-  // CDN, background video, and embed (Vimeo/YouTube) videos do not have a Tailwind skin variant.
+  // CDN, background video, and third-party embeds do not have a Tailwind skin variant.
   useEffect(() => {
-    if (
-      (platform === 'cdn' || backgroundPreset || preset === 'vimeo-video' || preset === 'youtube-video') &&
-      styling === 'tailwind'
-    ) {
+    if ((platform === 'cdn' || backgroundPreset || embedPreset) && styling === 'tailwind') {
       setStyling('css');
     }
-  }, [platform, preset, backgroundPreset, styling]);
+  }, [platform, backgroundPreset, embedPreset, styling]);
 
   const handleSourceChange = useCallback((value: string) => setSource(value as SourceId), []);
 
@@ -218,8 +213,7 @@ export function App() {
         isSpfHls={spfHlsPreset}
         isMuxVideo={preset === 'mux-video'}
         isMuxAudio={preset === 'mux-audio'}
-        isVimeoVideo={preset === 'vimeo-video'}
-        isYouTubeVideo={preset === 'youtube-video'}
+        isEmbedMedia={embedPreset}
         platforms={PLATFORMS}
         stylings={STYLINGS}
         presets={PRESETS}

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -33,8 +33,7 @@ type NavbarProps = {
   isSpfHls: boolean;
   isMuxVideo: boolean;
   isMuxAudio: boolean;
-  isVimeoVideo: boolean;
-  isYouTubeVideo: boolean;
+  isEmbedMedia: boolean;
   platforms: readonly Platform[];
   stylings: readonly Styling[];
   presets: readonly Preset[];
@@ -100,6 +99,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'mux-background-video': 'Mux Background Video (SPF)',
   'vimeo-video': 'Vimeo Video',
   'youtube-video': 'YouTube Video',
+  'cloudflare-video': 'Cloudflare Stream Video',
 };
 
 export function Navbar({
@@ -130,8 +130,7 @@ export function Navbar({
   isSpfHls,
   isMuxVideo,
   isMuxAudio,
-  isVimeoVideo,
-  isYouTubeVideo,
+  isEmbedMedia,
   platforms,
   stylings,
   presets,
@@ -160,7 +159,7 @@ export function Navbar({
           options={stylings.map((s) => ({
             value: s,
             label: s === 'css' ? 'CSS' : 'Tailwind',
-            disabled: s === 'tailwind' && (isBackgroundVideo || isVimeoVideo || isYouTubeVideo || platform === 'cdn'),
+            disabled: s === 'tailwind' && (isBackgroundVideo || isEmbedMedia || platform === 'cdn'),
           }))}
         />
 
@@ -198,7 +197,7 @@ export function Navbar({
               const note = expectedOutcomeNote(sources[id], preset);
               return { value: id, label: note ? `${sources[id].label} — ${note}` : sources[id].label };
             })}
-          disabled={isBackgroundVideo || isVimeoVideo || isYouTubeVideo}
+          disabled={isBackgroundVideo || isEmbedMedia}
         />
       </div>
 

--- a/apps/sandbox/templates/html-cloudflare-video/index.html
+++ b/apps/sandbox/templates/html-cloudflare-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Cloudflare Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-cloudflare-video/main.ts
+++ b/apps/sandbox/templates/html-cloudflare-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/cloudflare-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { CLOUDFLARE_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <cloudflare-video class="block w-full h-full" src="${CLOUDFLARE_VIDEO_SRC}" playsinline></cloudflare-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-cloudflare-video/index.html
+++ b/apps/sandbox/templates/react-cloudflare-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Cloudflare Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-cloudflare-video/main.tsx
+++ b/apps/sandbox/templates/react-cloudflare-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoPlayer } from '@app/shared/react/players';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { CLOUDFLARE_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { CloudflareVideo } from '@videojs/react/media/cloudflare-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoPlayer>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <CloudflareVideo className="block w-full h-full" src={CLOUDFLARE_VIDEO_SRC} playsInline />
+      </VideoSkinComponent>
+    </VideoPlayer>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/core/src/dom/presentation/pip.ts
+++ b/packages/core/src/dom/presentation/pip.ts
@@ -1,4 +1,5 @@
 import type { MediaPictureInPictureCapability } from '@videojs/media';
+import { isMediaPictureInPictureCapable } from '@videojs/media';
 import type { WebKitVideoElement } from '@videojs/utils/dom';
 import { isFunction } from '@videojs/utils/predicate';
 
@@ -11,6 +12,19 @@ export function isPictureInPictureEnabled() {
 
   const video = document.createElement('video') as WebKitVideoElement;
   return isFunction(video.webkitSetPresentationMode);
+}
+
+/**
+ * Whether this media can enter picture-in-picture at all, which is a separate
+ * question from whether the browser supports it. Mirrors the branches
+ * `requestPictureInPicture` takes below, so anything it would refuse to act on
+ * reports as incapable here — an iframe embed whose provider has no
+ * picture-in-picture can never enter it, however capable the browser is.
+ */
+export function isPictureInPictureCapable(media: EventTarget) {
+  const webkitVideo = media as WebKitVideoElement;
+  if (isFunction(webkitVideo.webkitSetPresentationMode)) return true;
+  return isMediaPictureInPictureCapable(media);
 }
 
 export function isPictureInPicture(media: EventTarget) {

--- a/packages/core/src/dom/store/features/pip.ts
+++ b/packages/core/src/dom/store/features/pip.ts
@@ -5,6 +5,7 @@ import { exitFullscreen, isFullscreen } from '../../presentation/fullscreen';
 import {
   exitPictureInPicture,
   isPictureInPicture,
+  isPictureInPictureCapable,
   isPictureInPictureEnabled,
   requestPictureInPicture,
 } from '../../presentation/pip';
@@ -49,8 +50,12 @@ export const pipFeature = definePlayerFeature({
   attach({ target, signal, set }) {
     const { media } = target;
 
+    // Both halves have to hold: the browser has to offer picture-in-picture, and
+    // this media has to be able to enter it. Asking only the browser leaves an
+    // embed that has no picture-in-picture — YouTube, Cloudflare Stream — showing
+    // a control that silently does nothing.
     set({
-      pipAvailability: isPictureInPictureEnabled() ? 'available' : 'unsupported',
+      pipAvailability: isPictureInPictureEnabled() && isPictureInPictureCapable(media) ? 'available' : 'unsupported',
     });
 
     const sync = () =>

--- a/packages/core/src/dom/store/features/tests/pip.test.ts
+++ b/packages/core/src/dom/store/features/tests/pip.test.ts
@@ -6,6 +6,25 @@ import type { PlayerTarget } from '../../../player';
 import { createMockVideo } from '../../../tests/test-helpers';
 import { pipFeature } from '../pip';
 
+function enablePictureInPicture() {
+  Object.defineProperty(document, 'pictureInPictureEnabled', {
+    value: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * A video element as a browser that supports picture-in-picture presents one.
+ * happy-dom implements neither the method nor the property, so a bare element
+ * reads as media that cannot enter picture-in-picture at all.
+ */
+function createPipCapableVideo(): HTMLVideoElement {
+  const video = createMockVideo();
+  video.requestPictureInPicture = async () => ({}) as PictureInPictureWindow;
+  return video;
+}
+
 describe('pipFeature', () => {
   let originalPictureInPictureEnabled: boolean | undefined;
 
@@ -37,13 +56,34 @@ describe('pipFeature', () => {
     });
 
     it('detects PiP availability when supported', () => {
-      Object.defineProperty(document, 'pictureInPictureEnabled', {
-        value: true,
-        writable: true,
-        configurable: true,
-      });
+      enablePictureInPicture();
 
-      const video = createMockVideo();
+      const video = createPipCapableVideo();
+      const store = createStore<PlayerTarget>()(pipFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.pipAvailability).toBe('available');
+    });
+
+    it('reports media that cannot enter PiP as unsupported', () => {
+      enablePictureInPicture();
+
+      // What an iframe embed looks like when its provider has no
+      // picture-in-picture: the browser offers it, this media cannot use it.
+      const media = createMockVideo();
+      const store = createStore<PlayerTarget>()(pipFeature);
+      store.attach({ media, container: null });
+
+      expect(store.state.pipAvailability).toBe('unsupported');
+    });
+
+    it('reports WebKit presentation mode as available', () => {
+      enablePictureInPicture();
+
+      // iPhone Safari reaches picture-in-picture through presentation mode rather
+      // than through `requestPictureInPicture`, so the media is capable without it.
+      const video = createMockVideo() as WebKitVideoElement;
+      video.webkitSetPresentationMode = () => {};
       const store = createStore<PlayerTarget>()(pipFeature);
       store.attach({ media: video, container: null });
 

--- a/packages/html/src/define/media/cloudflare-video.ts
+++ b/packages/html/src/define/media/cloudflare-video.ts
@@ -1,0 +1,14 @@
+import { CloudflareVideo } from '../../media/cloudflare-video';
+import { safeDefine } from '../safe-define';
+
+export class CloudflareVideoElement extends CloudflareVideo {
+  static readonly tagName = 'cloudflare-video';
+}
+
+safeDefine(CloudflareVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [CloudflareVideoElement.tagName]: CloudflareVideoElement;
+  }
+}

--- a/packages/html/src/media/cloudflare-video/index.ts
+++ b/packages/html/src/media/cloudflare-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/cloudflare-video/media.ts
+++ b/packages/html/src/media/cloudflare-video/media.ts
@@ -1,0 +1,55 @@
+import { buildCloudflareIframeSrc, CloudflareMedia } from '@videojs/media/dom/cloudflare';
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { escapeHtml } from '@videojs/utils/string';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class CloudflareCustomMediaElement extends CustomMediaElement('iframe', CloudflareMedia) {
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildCloudflareIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: inline-block;
+          min-width: 300px;
+          min-height: 150px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        :host(:not([controls])) {
+          pointer-events: none;
+        }
+      </style>
+      <iframe
+        part="iframe"
+        ${srcAttr}
+        allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        frameborder="0"
+        width="100%"
+        height="100%"
+        referrerpolicy="${escapeHtml(attrs.referrerpolicy ?? '')}"
+      ></iframe>
+    `;
+  };
+}
+
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    preload: (attrs.preload as 'none' | 'metadata' | 'auto' | undefined) ?? 'metadata',
+    // The Stream embed paints the poster itself, so it is part of the URL.
+    poster: attrs.poster ?? '',
+  };
+}
+
+export class CloudflareVideo extends MediaAttachMixin(CloudflareCustomMediaElement) {}

--- a/packages/media/src/core/predicate.ts
+++ b/packages/media/src/core/predicate.ts
@@ -8,6 +8,7 @@ import type {
   MediaErrorCapability,
   MediaLiveCapability,
   MediaPauseCapability,
+  MediaPictureInPictureCapability,
   MediaPlaybackRateCapability,
   MediaRemotePlaybackCapability,
   MediaSeekCapability,
@@ -56,6 +57,17 @@ export function isMediaPlaybackRateCapable(value: unknown): value is MediaPlayba
   if (!isObject(value)) return false;
   const media = value as Record<string, unknown>;
   return !isUndefined(media.playbackRate);
+}
+
+/**
+ * Only `requestPictureInPicture` is required. A native video element carries it
+ * but leaves exiting to `document`, so demanding the pair would rule out the one
+ * media that most certainly can.
+ */
+export function isMediaPictureInPictureCapable(value: unknown): value is MediaPictureInPictureCapability {
+  if (!isObject(value)) return false;
+  const media = value as Record<string, unknown>;
+  return isFunction(media.requestPictureInPicture);
 }
 
 export function isMediaBufferCapable(value: unknown): value is MediaBufferCapability {

--- a/packages/media/src/dom/cloudflare/index.ts
+++ b/packages/media/src/dom/cloudflare/index.ts
@@ -1,0 +1,7 @@
+// The Stream SDK module is internal apart from the player typings, which the
+// `engine` getter surfaces.
+
+export * from './media';
+export * from './props';
+export * from './source';
+export type { CloudflareStreamApi, CloudflareStreamPlayerApi } from './stream-api';

--- a/packages/media/src/dom/cloudflare/media.ts
+++ b/packages/media/src/dom/cloudflare/media.ts
@@ -1,0 +1,797 @@
+// Adapted from `cloudflare-video-element` from `muxinc/media-elements`,
+// ported to TypeScript and reshaped as a media host to fit the v10
+// media-host architecture (mirrors `dom/youtube`).
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
+import { deepEqual } from '@videojs/utils/object';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
+import { MediaError } from '../../core/media-error';
+import type { TextTrackListLike, Video } from '../../core/types';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+import { createTimeRange } from '../utils';
+import { cloudflareMediaDefaultProps } from './props';
+import { buildCloudflareIframeSrc, type CloudflareSource, parseCloudflareSource } from './source';
+import { type CloudflareStreamApi, type CloudflareStreamPlayerApi, loadCloudflareStreamApi } from './stream-api';
+
+const CloudflareMediaBase = MediaPlayedRangesMixin(EventTarget);
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ */
+export class CloudflareMedia extends CloudflareMediaBase implements Partial<Video> {
+  #target: HTMLIFrameElement | null = null;
+  #player: CloudflareStreamPlayerApi | null = null;
+  /** Player creation is in flight; the SDK load makes it span more than a tick. */
+  #creatingPlayer = false;
+  /** A load was requested while the SDK was loading; replay it once the player exists. */
+  #pendingLoad = false;
+  /**
+   * Barrier for the load in progress. Player calls wait on it, and its identity
+   * doubles as the load's identity — a late response compares the barrier it
+   * started with against this one to learn whether it still owns the load.
+   */
+  #loadComplete = createPublicPromise<void>();
+  /** Guards async player creation across attach/detach cycles. */
+  #attachId = 0;
+  /** The SDK has no teardown, so its listeners are unbound one by one. */
+  #playerListeners: [type: string, listener: () => void][] = [];
+
+  #src = cloudflareMediaDefaultProps.src;
+  #autoplay = cloudflareMediaDefaultProps.autoplay;
+  #defaultMuted = cloudflareMediaDefaultProps.defaultMuted;
+  #loop = cloudflareMediaDefaultProps.loop;
+  #controls = cloudflareMediaDefaultProps.controls;
+  #playsInline = cloudflareMediaDefaultProps.playsInline;
+  #preload = cloudflareMediaDefaultProps.preload;
+  #poster = cloudflareMediaDefaultProps.poster;
+  #source: CloudflareSource | null = cloudflareMediaDefaultProps.source;
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #loaded = false;
+  /** The current `src` names no Cloudflare video, so the embed still holds the last one. */
+  #srcUnsupported = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #volume = 1;
+  #muted = false;
+  #playbackRate = 1;
+  #progress = 0;
+  #videoWidth = Number.NaN;
+  #videoHeight = Number.NaN;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: MediaError | null = null;
+  #isFullscreen = false;
+
+  #textTracksHost: HTMLVideoElement | null = null;
+
+  static PLAYER_SOFTWARE_NAME = 'cloudflare-video';
+
+  /** Underlying Stream SDK player instance (null until the SDK loads). */
+  get engine() {
+    return this.#player;
+  }
+
+  get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /**
+   * Bind the iframe hosting the embed. The SDK and its player follow as soon as
+   * an embed URL can be resolved, which is not always now: a framework that
+   * creates the element before setting `src` attaches an iframe with nothing to
+   * embed yet, and `load()` picks it up once a source arrives.
+   */
+  attach(target: HTMLIFrameElement | null): void {
+    if (!target || this.#target === target) return;
+    if (this.#target) this.detach();
+    this.#target = target;
+    this.#beginLoad();
+    this.#createPlayer();
+  }
+
+  detach(): void {
+    if (!this.#target) return;
+    this.#attachId++;
+    this.#unbindPlayerEvents();
+    // The SDK offers no teardown, so pausing is all that keeps a detached embed
+    // from playing on out of sight.
+    this.#pauseEmbed();
+    this.#player = null;
+    this.#creatingPlayer = false;
+    this.#pendingLoad = false;
+    this.#textTracksHost = null;
+    this.#target = null;
+    // Unblock callers awaiting load; they re-check `#player` (now null) and no-op.
+    this.#loadComplete.resolve();
+    this.#resetState();
+  }
+
+  override destroy() {
+    this.detach();
+    super.destroy();
+  }
+
+  get src() {
+    return this.#src;
+  }
+  /** Cloudflare URL, video UID, or signed token. Setting it re-derives `source`, carrying its embed parameters over. */
+  set src(value) {
+    const { engine } = this.#source ?? {};
+    const next: CloudflareSource = { ...(engine && { engine }), ...(value && { src: value }) };
+
+    // Everything happens in the `source` setter, so there is one path for storing
+    // it, deciding on a load, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  get currentSrc() {
+    // The `src` property resolves an empty attribute to the document URL, so only
+    // the attribute can report an embed that hasn't been built yet as empty.
+    return this.#target?.getAttribute('src') ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /** Reload the current source through the Stream player; no-op until `attach()`. */
+  async load() {
+    if (!this.#player) {
+      // Nothing to reload without a target, and no load to wait on either.
+      if (!this.#target) return;
+      if (this.#creatingPlayer) {
+        // The iframe is being built from a stale src. Replaying once the player
+        // exists is the only way to reach the new one, and the barrier that
+        // creation opened is still the one callers are waiting on.
+        this.#pendingLoad = true;
+        return;
+      }
+      // The target was attached before it had anything to embed, so this load is
+      // what finally builds it. Wait a microtask first: a framework sets `src`
+      // and the props that shape the embed in whatever order it likes, and the
+      // embed URL is only built once, so it has to see all of them.
+      const load = this.#beginLoad();
+      this.#resetState();
+      await Promise.resolve();
+      // A later load took over while waiting; building the embed is its job now.
+      if (load !== this.#loadComplete) return;
+      this.#createPlayer();
+      return;
+    }
+    const load = this.#beginLoad();
+    // Reset before bailing on an empty src: a cleared source has nothing to load,
+    // but what we report about the old video still has to go.
+    this.#resetState();
+    // `emptied` is what announces that reset, so it comes before the empty-src
+    // bail rather than after it: clearing the source is the one case where the
+    // embed reports nothing further, leaving anything listening on the last
+    // video's duration and buffer forever.
+    this.dispatchEvent(new Event('emptied'));
+    if (!this.#src) {
+      // The embed has to stop too. Left running it keeps playing, and its events
+      // write the state just cleared straight back.
+      load.resolve();
+      this.#pauseEmbed();
+      return;
+    }
+    this.dispatchEvent(new Event('loadstart'));
+    const parsed = parseCloudflareSource(this.#src);
+    if (!parsed) {
+      this.#srcUnsupported = true;
+      this.#error = new MediaError(
+        `Unrecognized Cloudflare Stream source: ${this.#src}`,
+        MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+      );
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen don't hang.
+      load.resolve();
+      // There is no video to swap to, so the embed keeps playing the last one
+      // under an error the host is already reporting.
+      this.#pauseEmbed();
+      return;
+    }
+    // Embed parameters live on the iframe URL and the embed reads them once, so
+    // a change to them only lands by rebuilding it. The player swap below moves
+    // the video and nothing else, and assigning the id it already holds may not
+    // report metadata at all, which would leave this load unsettled.
+    const target = this.#target;
+    const nextSrc = buildCloudflareIframeSrc(this.#src, this.#snapshotProps());
+    if (target && nextSrc && embedParamsOf(nextSrc) !== embedParamsOf(target.getAttribute('src') ?? '')) {
+      // The rebuilt embed reports its own metadata, which settles this load.
+      target.src = nextSrc;
+      return;
+    }
+    // The Stream player mimics `HTMLVideoElement` down to a writable `src`, so a
+    // new video is one assignment away; rebuilding the iframe would throw away a
+    // working embed and the SDK connection with it.
+    this.#player.src = parsed.id;
+  }
+
+  /**
+   * Take over as the current load, returning its barrier. Settling the outgoing
+   * one is what keeps a superseded load from stranding callers that are already
+   * waiting; every exit from `load()` settles the barrier it was handed.
+   */
+  #beginLoad(): PublicPromise<void> {
+    this.#loadComplete.resolve();
+    this.#loadComplete = createPublicPromise<void>();
+    return this.#loadComplete;
+  }
+
+  /**
+   * Whether the embed is playing the source the host reports. It is not once the
+   * source is cleared or unrecognized: the embed holds the previous video either
+   * way, so what it reports and what `play()` would resume are no longer ours.
+   */
+  get #hasSource() {
+    return !!this.#src && !this.#srcUnsupported;
+  }
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    await this.#loadComplete;
+    // The embed still holds the paused video, so playing it would resume a
+    // source that is no longer the one being reported.
+    if (!this.#hasSource) return;
+    await this.#player?.play();
+  }
+
+  pause() {
+    this.#player?.pause();
+  }
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#currentTime = value;
+    this.#afterLoad((p) => {
+      p.currentTime = value;
+    });
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  get volume() {
+    return this.#volume;
+  }
+  set volume(value) {
+    if (this.#volume === value) return;
+    this.#volume = value;
+    this.#afterLoad((p) => {
+      p.volume = value;
+    });
+  }
+
+  get muted() {
+    return this.#muted;
+  }
+  set muted(value) {
+    if (this.#muted === value) return;
+    this.#muted = value;
+    this.#afterLoad((p) => {
+      p.muted = value;
+    });
+  }
+
+  get playbackRate() {
+    return this.#playbackRate;
+  }
+  set playbackRate(value) {
+    if (this.#playbackRate === value) return;
+    this.#playbackRate = value;
+    this.#afterLoad((p) => {
+      p.playbackRate = value;
+    });
+  }
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+  set autoplay(value) {
+    this.#autoplay = value;
+    this.#afterLoad((p) => {
+      p.autoplay = value;
+    });
+  }
+
+  get defaultMuted() {
+    return this.#defaultMuted;
+  }
+  set defaultMuted(value) {
+    // The embed reads its initial muted state from the URL; afterwards `muted`
+    // is the only way to reach the player.
+    this.#defaultMuted = value;
+    // Until the embed reports its own volume state there is nothing to report but
+    // what it is being built with, the way a media element seeds `muted` from
+    // `defaultMuted`. Waiting for the embed to say so would have a muted autoplay
+    // read as unmuted for as long as the SDK takes to arrive.
+    if (!this.#loaded) this.#muted = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+  set loop(value) {
+    this.#loop = value;
+    this.#afterLoad((p) => {
+      p.loop = value;
+    });
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+  set controls(value) {
+    this.#controls = value;
+    this.#afterLoad((p) => {
+      p.controls = value;
+    });
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+  set playsInline(value) {
+    // The Stream embed plays inline on its own and has no knob for it.
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+  set preload(value) {
+    this.#preload = value;
+    this.#afterLoad((p) => {
+      p.preload = value;
+    });
+  }
+
+  get poster() {
+    return this.#poster;
+  }
+  set poster(value) {
+    this.#poster = value;
+    this.#afterLoad((p) => {
+      p.poster = value;
+    });
+  }
+
+  /**
+   * Structured source: the Cloudflare URL, video UID, or signed token in `src`,
+   * plus embed parameters under `engine.cloudflare`. Replacing it re-derives
+   * `src`; assigning an equivalent source is a no-op.
+   */
+  get source(): CloudflareSource | null {
+    return this.#source;
+  }
+  set source(value: CloudflareSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    const src = source?.src ?? '';
+    const srcChanged = this.#src !== src;
+    // Embed parameters are read when the embed is built, so a change to them
+    // needs a reload of its own even though the URL is the same.
+    const engineChanged = !deepEqual(this.#source?.engine?.cloudflare ?? null, source?.engine?.cloudflare ?? null);
+
+    this.#source = source;
+    this.#src = src;
+
+    if (srcChanged || engineChanged) void this.load();
+
+    // Assigning is always a source change, so it is always announced.
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+
+  get buffered() {
+    return this.#progress > 0 ? createTimeRange(0, this.#progress) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRange(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  /**
+   * The SDK exposes no track API, so this list stays empty; the embed picks a
+   * track from the `defaultTextTrack` parameter and owns it from there.
+   */
+  get textTracks() {
+    this.#textTracksHost ??= globalThis.document?.createElement('video') ?? null;
+    return (this.#textTracksHost?.textTracks as TextTrackListLike) ?? EMPTY_TEXT_TRACKS;
+  }
+
+  get videoWidth() {
+    return this.#videoWidth;
+  }
+
+  get videoHeight() {
+    return this.#videoHeight;
+  }
+
+  get isFullscreen() {
+    return this.#isFullscreen;
+  }
+
+  // The SDK exposes no fullscreen controls, so fullscreen targets the iframe itself.
+  async requestFullscreen() {
+    // Nothing entered fullscreen if there is no element to request it on, so the
+    // flag must not claim otherwise.
+    if (!this.#target?.requestFullscreen) return;
+    await this.#target.requestFullscreen();
+    this.#isFullscreen = true;
+  }
+
+  async exitFullscreen() {
+    const doc = globalThis.document;
+    if (doc?.fullscreenElement && doc.fullscreenElement === this.#target) {
+      await doc.exitFullscreen();
+    }
+    this.#isFullscreen = false;
+  }
+
+  // No picture-in-picture surface: the Stream SDK exposes no request or exit
+  // method and reports no enter or leave event, so there is nothing to drive or
+  // to follow. Declaring the members anyway would have the player offer a control
+  // that silently does nothing.
+
+  /**
+   * Build the embed and start player creation once a source can be resolved. The
+   * SDK only talks to an iframe that already holds a Stream embed, so a target
+   * that cannot be resolved yet leaves the player null and settles the load it
+   * was given; the next `load()` retries.
+   *
+   * @returns Whether player creation started.
+   */
+  #createPlayer(): boolean {
+    const target = this.#target;
+    if (!target || this.#player || this.#creatingPlayer) return false;
+
+    // Whether the embed came from the document rather than from here — server-
+    // rendered markup, or a hydrated tree. The reload it needs happens once the
+    // SDK is in hand, but the question has to be answered now: an iframe built
+    // here navigates on its own while the SDK loads, and would look
+    // server-rendered by the time it resolves.
+    let serverRendered = false;
+    // The `src` property resolves an empty attribute to the document URL, so it
+    // cannot tell an embed apart from a placeholder; the attribute can.
+    if (!target.getAttribute('src')) {
+      const initialSrc = buildCloudflareIframeSrc(this.#src, this.#snapshotProps());
+      // No embed means no player is coming to settle this load.
+      if (!initialSrc) {
+        this.#loadComplete.resolve();
+        return false;
+      }
+      target.src = initialSrc;
+    } else {
+      serverRendered = hasEmbedNavigated(target);
+    }
+
+    this.#creatingPlayer = true;
+    this.dispatchEvent(new Event('loadstart'));
+    void this.#createPlayerApi(target, serverRendered);
+    return true;
+  }
+
+  async #createPlayerApi(target: HTMLIFrameElement, serverRendered: boolean) {
+    const attachId = this.#attachId;
+    let api: CloudflareStreamApi;
+    try {
+      api = await loadCloudflareStreamApi();
+    } catch {
+      // A failed SDK load belongs to the attach that started it; a newer one must
+      // not be marked failed or have its load unblocked.
+      if (this.#isStale(attachId)) return;
+      this.#creatingPlayer = false;
+      this.#error = new MediaError('Failed to load the Cloudflare Stream SDK', MediaError.MEDIA_ERR_NETWORK);
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen don't hang.
+      this.#loadComplete.resolve();
+      return;
+    }
+    if (this.#isStale(attachId) || this.#target !== target) return;
+    if (serverRendered) {
+      // A server-rendered embed finished loading long before the SDK was there to
+      // hear it, and the `iframeReady` message it posts once on load went
+      // nowhere. Reassigning the URL reloads the frame so that message is sent
+      // again — which only helps if the SDK is already loaded, so this waits for
+      // the script rather than happening when the frame is bound.
+      const embedSrc = target.src;
+      target.src = embedSrc;
+    }
+    const player = api(target);
+    this.#player = player;
+    this.#creatingPlayer = false;
+    this.#bindPlayerEvents(player, attachId);
+    if (this.#pendingLoad) {
+      // A source arrived while the SDK was loading, so the embed points at the
+      // previous one; only the player can be moved off it now.
+      this.#pendingLoad = false;
+      void this.load();
+    }
+  }
+
+  /**
+   * Whether a callback belongs to a superseded attach. An embed can keep
+   * reporting after the reference to its player is gone, so anything a player
+   * reports has to be matched against the attach that created it before it is
+   * allowed to touch state.
+   */
+  #isStale(attachId: number) {
+    return attachId !== this.#attachId;
+  }
+
+  /** Pause the embed, tolerating an iframe the SDK can no longer reach. */
+  #pauseEmbed() {
+    try {
+      this.#player?.pause();
+    } catch {
+      // The SDK throws if the iframe was already removed.
+    }
+  }
+
+  /** Defer a player call until `loadComplete` resolves, swallowing failures. */
+  #afterLoad(fn: (player: CloudflareStreamPlayerApi) => void) {
+    this.#loadComplete.then(
+      () => {
+        if (!this.#player) return;
+        try {
+          fn(this.#player);
+        } catch {
+          // The SDK throws if the iframe was already removed.
+        }
+      },
+      () => {}
+    );
+  }
+
+  /**
+   * What the next embed has to be built muted with. Rebuilding throws the
+   * player's own volume state away with the frame, so a video the user muted at
+   * runtime would come back with sound unless the URL carries the mute forward.
+   */
+  get #nextMuted() {
+    return this.#defaultMuted || this.#muted;
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      defaultMuted: this.#nextMuted,
+      loop: this.#loop,
+      controls: this.#controls,
+      preload: this.#preload || cloudflareMediaDefaultProps.preload,
+      poster: this.#poster,
+      source: this.#source,
+    };
+  }
+
+  #resetState() {
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    // Whatever the next embed is built with is the state the video it holds comes
+    // back in.
+    this.#muted = this.#nextMuted;
+    this.#paused = !this.#autoplay;
+    this.#ended = false;
+    this.#playbackRate = 1;
+    this.#progress = 0;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#loaded = false;
+    this.#srcUnsupported = false;
+    this.#volume = 1;
+    this.#error = null;
+    this.#videoWidth = Number.NaN;
+    this.#videoHeight = Number.NaN;
+    this.#isFullscreen = false;
+  }
+
+  #onLoaded() {
+    if (this.#loaded) return;
+    this.#loaded = true;
+    this.#readyState = READY_STATE_HAVE_METADATA;
+    const player = this.#player;
+    if (player) {
+      this.#duration = toDuration(player.duration);
+      this.#muted = player.muted;
+      this.#volume = player.volume;
+      this.#playbackRate = player.playbackRate;
+      this.#videoWidth = player.videoWidth;
+      this.#videoHeight = player.videoHeight;
+    }
+    for (const type of ['loadedmetadata', 'durationchange', 'volumechange', 'loadcomplete']) {
+      this.dispatchEvent(new Event(type));
+    }
+    this.#loadComplete.resolve();
+  }
+
+  #onError() {
+    // The embed reports the failure without a code or a message, so all that can
+    // be said about it is that playback stopped.
+    this.#error = new MediaError('Cloudflare Stream playback error', MediaError.MEDIA_ERR_CUSTOM, true);
+    this.dispatchEvent(new Event('error'));
+    // Unblock callers awaiting load so play()/fullscreen don't hang.
+    this.#loadComplete.resolve();
+  }
+
+  #bindPlayerEvents(player: CloudflareStreamPlayerApi, attachId: number) {
+    const listen = (type: string, handle: () => void) => {
+      const listener = () => {
+        // A source that is gone or unrecognized has nothing left to report, and
+        // the embed keeps reporting the video it still holds — completing on that
+        // would put the state just cleared right back.
+        if (this.#isStale(attachId) || !this.#hasSource) return;
+        handle();
+      };
+      player.addEventListener(type, listener);
+      this.#playerListeners.push([type, listener]);
+    };
+    // The embed speaks the HTML media vocabulary, so most events are the state
+    // they carry plus a re-dispatch under the same name.
+    const on = (type: string, update?: () => void) =>
+      listen(type, () => {
+        update?.();
+        this.dispatchEvent(new Event(type));
+      });
+
+    // `loadedmetadata` is what completes a load, and `#onLoaded` dispatches it.
+    listen('loadedmetadata', () => this.#onLoaded());
+    on('loadeddata', () => {
+      this.#readyState = READY_STATE_HAVE_CURRENT_DATA;
+    });
+    on('play', () => {
+      this.#paused = false;
+      this.#ended = false;
+    });
+    on('playing', () => {
+      this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+      this.#paused = false;
+    });
+    on('pause', () => {
+      this.#paused = true;
+    });
+    on('ended', () => {
+      this.#paused = true;
+      this.#ended = true;
+    });
+    on('timeupdate', () => {
+      this.#currentTime = player.currentTime;
+    });
+    on('durationchange', () => {
+      this.#duration = toDuration(player.duration);
+    });
+    on('volumechange', () => {
+      this.#volume = player.volume;
+      this.#muted = player.muted;
+    });
+    on('ratechange', () => {
+      this.#playbackRate = player.playbackRate;
+    });
+    on('progress', () => {
+      this.#progress = toBufferedEnd(player);
+    });
+    on('seeking', () => {
+      this.#seeking = true;
+    });
+    on('seeked', () => {
+      this.#seeking = false;
+      this.#currentTime = player.currentTime;
+    });
+    on('resize', () => {
+      this.#videoWidth = player.videoWidth;
+      this.#videoHeight = player.videoHeight;
+    });
+    for (const type of PASSTHROUGH_EVENTS) on(type);
+    listen('error', () => this.#onError());
+  }
+
+  #unbindPlayerEvents() {
+    for (const [type, listener] of this.#playerListeners) {
+      try {
+        this.#player?.removeEventListener(type, listener);
+      } catch {
+        // The SDK throws if the iframe was already removed.
+      }
+    }
+    this.#playerListeners.length = 0;
+  }
+}
+
+/**
+ * Events that carry no state of their own, including the encrypted-media pair
+ * and Cloudflare's ad lifecycle.
+ *
+ * `emptied` and `loadstart` are deliberately not among them even though the
+ * embed reports both: the host announces its own load lifecycle, and passing the
+ * embed's copies through would double up on every source change.
+ */
+const PASSTHROUGH_EVENTS = [
+  'waiting',
+  'stalled',
+  'suspend',
+  'abort',
+  'canplay',
+  'canplaythrough',
+  'encrypted',
+  'waitingforkey',
+  'stream-adstart',
+  'stream-adend',
+  'stream-adtimeout',
+];
+
+/** The embed reports `0` until it knows the duration; `HTMLMediaElement` reports `NaN`. */
+function toDuration(duration: number) {
+  return duration > 0 ? duration : Number.NaN;
+}
+
+function toBufferedEnd(player: CloudflareStreamPlayerApi) {
+  const { buffered } = player;
+  return buffered?.length ? buffered.end(buffered.length - 1) : 0;
+}
+
+/**
+ * The part of an embed URL that does not name the video: its origin and query.
+ * Two URLs differing only in the id can be swapped on the player, where a
+ * difference here has to be rebuilt, because the embed reads its parameters when
+ * it loads and never again.
+ */
+function embedParamsOf(src: string): string {
+  try {
+    const url = new URL(src);
+    return `${url.origin}${url.search}`;
+  } catch {
+    // Not a URL yet, so nothing it holds can match what is being built.
+    return '';
+  }
+}
+
+/**
+ * Whether the embed has already navigated to its URL. An iframe this host just
+ * built has not: navigation starts after the current task, so it is still on
+ * `about:blank`, which is same-origin and readable. One that came from the
+ * document's own markup has long since navigated cross-origin, and reading its
+ * location throws.
+ */
+function hasEmbedNavigated(target: HTMLIFrameElement): boolean {
+  const frame = target.contentWindow;
+  if (!frame) return false;
+  try {
+    return frame.location.href !== 'about:blank';
+  } catch {
+    // Cross-origin, so the embed is already there.
+    return true;
+  }
+}
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_CURRENT_DATA = 2;
+const READY_STATE_HAVE_FUTURE_DATA = 3;

--- a/packages/media/src/dom/cloudflare/props.ts
+++ b/packages/media/src/dom/cloudflare/props.ts
@@ -1,0 +1,28 @@
+import type { Video } from '../../core/types';
+import type { CloudflareSource } from './source';
+
+/**
+ * The `Video` members the Cloudflare host accepts, plus the source that names
+ * the video. `playsInline` is stored and reported but never reaches the player:
+ * the Stream embed has no inline-playback knob and plays inline on its own.
+ */
+export interface CloudflareMediaProps
+  extends Pick<
+    Video,
+    'src' | 'autoplay' | 'defaultMuted' | 'muted' | 'loop' | 'controls' | 'playsInline' | 'preload' | 'poster'
+  > {
+  source: CloudflareSource | null;
+}
+
+export const cloudflareMediaDefaultProps: CloudflareMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  muted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  source: null,
+};

--- a/packages/media/src/dom/cloudflare/source.ts
+++ b/packages/media/src/dom/cloudflare/source.ts
@@ -1,0 +1,118 @@
+import { serializeEmbedParams } from '../utils';
+import { type CloudflareMediaProps, cloudflareMediaDefaultProps } from './props';
+
+/**
+ * Cloudflare Stream engine options, spelled exactly as Cloudflare spells them
+ * (https://developers.cloudflare.com/stream/viewing-videos/using-the-stream-player/).
+ * They are serialized onto the embed URL verbatim, so what you write here is
+ * what the player reads. The embed reads them once, when its URL is built, so
+ * changing them after the iframe exists only takes effect on the next embed.
+ *
+ * Parameters the host owns are deliberately absent: `controls`, `autoplay`,
+ * `loop`, `muted`, `preload`, and `poster` come from the props of the same name,
+ * so configuring them here would give two ways to say one thing. The index
+ * signature still carries anything not listed here, so undocumented knobs and
+ * whatever Cloudflare adds next keep working.
+ */
+export interface CloudflareEngineConfig extends Record<string, unknown> {
+  /** BCP 47 language of the text track to show by default (`'en'`, `'de'`). */
+  defaultTextTrack?: string;
+  /** Any CSS color for the progress bar and other player accents. */
+  primaryColor?: string;
+  /** Any CSS color for the letterbox bars around a video that does not fill the player. */
+  letterboxColor?: string;
+  /** Where playback starts, in seconds or as a time string (`'5m30s'`). */
+  startTime?: number | string;
+  /** VAST tag to play as a pre-roll ad. Reported through the `stream-ad*` events. */
+  'ad-url'?: string;
+  /** `referrerpolicy` for the embed iframe. Not a Cloudflare player parameter. */
+  referrerPolicy?: ReferrerPolicy;
+}
+
+/** Structured Cloudflare source: which source to play, plus how to play it. */
+export interface CloudflareSource {
+  /** Cloudflare Stream URL, video UID, or signed token. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: CloudflareSourceEngineConfig | undefined;
+}
+
+/** The engines a Cloudflare source can configure. */
+export interface CloudflareSourceEngineConfig {
+  /** Cloudflare's own embed parameters, passed through untouched. */
+  cloudflare?: CloudflareEngineConfig | undefined;
+}
+
+/** Parsed pieces of a Cloudflare Stream source. */
+export interface ParsedCloudflareSource {
+  /** Video UID, or the signed token standing in for one. */
+  id: string;
+  /** Whether `id` is a signed token rather than a plain video UID. */
+  signed: boolean;
+  /**
+   * Per-customer embed origin (`https://customer-<code>.cloudflarestream.com`)
+   * when the source names one, otherwise null for the shared host. Signed and
+   * access-controlled videos are only served from the customer origin, so it has
+   * to survive parsing rather than being collapsed into the shared one.
+   */
+  origin: string | null;
+}
+
+/** Extract a Cloudflare video UID from a raw UID, a signed token, or any recognized URL. */
+export function parseCloudflareVideoId(src: string) {
+  return parseCloudflareSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a Cloudflare Stream source string. Recognizes `videodelivery.net` and
+ * `cloudflarestream.com` URLs (embed, iframe, manifest, and thumbnail paths all
+ * carry the id in the same position), raw 32-character video UIDs, and signed
+ * tokens, which stand in for the UID wherever it appears.
+ */
+export function parseCloudflareSource(src: string): ParsedCloudflareSource | null {
+  if (!src) return null;
+  const id = MATCH_SRC.exec(src)?.[1] ?? (MATCH_VIDEO_ID.test(src) || MATCH_SIGNED_TOKEN.test(src) ? src : null);
+  if (!id) return null;
+  return { id, signed: MATCH_SIGNED_TOKEN.test(id), origin: MATCH_CUSTOMER_ORIGIN.exec(src)?.[1] ?? null };
+}
+
+/** Build the iframe `src` URL for an initial Cloudflare Stream embed from the given props. */
+export function buildCloudflareIframeSrc(src: string, props: Partial<CloudflareMediaProps> = {}) {
+  const parsed = parseCloudflareSource(src);
+  if (!parsed) return '';
+  // `referrerPolicy` is an attribute of the iframe hosting the embed rather than
+  // something the player reads, so it never reaches the URL.
+  const { referrerPolicy: _referrerPolicy, ...cloudflare } = props.source?.engine?.cloudflare ?? {};
+  const params: Record<string, unknown> = {
+    // Hide Cloudflare chrome by default; pass nothing only when controls is explicitly true.
+    controls: props.controls === true ? null : 0,
+    autoplay: props.autoplay,
+    loop: props.loop,
+    muted: props.defaultMuted,
+    // `||` rather than `??`: `preload` is empty for a bare `preload` attribute,
+    // and empty serializes to `1`, which is not one of the values Cloudflare
+    // accepts.
+    preload: props.preload || cloudflareMediaDefaultProps.preload,
+    // Cloudflare reads `poster` as an image URL, so an unset one has to be absent
+    // rather than empty: empty serializes to `1`, and the embed rejects that with
+    // "poster value should be a valid encoded URL" instead of painting its own
+    // thumbnail. A real URL needs no encoding here — `URLSearchParams` does it.
+    poster: props.poster || null,
+    // Cloudflare-specific knobs (`primaryColor`, `startTime`, `ad-url`, …) flow through here.
+    ...cloudflare,
+  };
+  // A customer origin embeds at `/<id>/iframe`, where the shared host embeds at
+  // `/<id>`; rebuilding onto the shared host would drop the very origin a signed
+  // or access-controlled video is authorized for.
+  const base = parsed.origin ? `${parsed.origin}/${parsed.id}/iframe` : `${EMBED_BASE}/${parsed.id}`;
+  return `${base}?${serializeEmbedParams(params)}`;
+}
+
+const EMBED_BASE = 'https://iframe.videodelivery.net';
+const MATCH_SRC = /(?:cloudflarestream\.com|videodelivery\.net)\/([\w-.]+)/i;
+// Only the per-customer subdomain is preserved. The `watch.` and bare hosts are
+// pages rather than embeds, so they still resolve to the shared embed host.
+const MATCH_CUSTOMER_ORIGIN = /^(https?:\/\/customer-[\w-]+\.cloudflarestream\.com)/i;
+const MATCH_VIDEO_ID = /^[a-z\d]{32}$/i;
+// Signed tokens are JWTs, so a bare one is three dot-separated base64url segments.
+const MATCH_SIGNED_TOKEN = /^[\w-]+\.[\w-]+\.[\w-]+$/;

--- a/packages/media/src/dom/cloudflare/source.ts
+++ b/packages/media/src/dom/cloudflare/source.ts
@@ -84,11 +84,17 @@ export function buildCloudflareIframeSrc(src: string, props: Partial<CloudflareM
   // something the player reads, so it never reaches the URL.
   const { referrerPolicy: _referrerPolicy, ...cloudflare } = props.source?.engine?.cloudflare ?? {};
   const params: Record<string, unknown> = {
-    // Hide Cloudflare chrome by default; pass nothing only when controls is explicitly true.
+    // `controls` defaults to on and is read by value, so hiding Cloudflare's own
+    // chrome takes an explicit `0`; passing nothing leaves it shown.
     controls: props.controls === true ? null : 0,
-    autoplay: props.autoplay,
-    loop: props.loop,
-    muted: props.defaultMuted,
+    // These three are read by presence rather than by value, unlike `controls`
+    // and unlike every other embed this package talks to. Cloudflare documents it
+    // for `autoplay` — "if you don't want the video to autoplay, don't include the
+    // autoplay flag at all (instead of setting it to autoplay=false)" — and
+    // `loop` and `muted` read the same way. Sending `0` turns all three *on*.
+    autoplay: props.autoplay || null,
+    loop: props.loop || null,
+    muted: props.defaultMuted || null,
     // `||` rather than `??`: `preload` is empty for a bare `preload` attribute,
     // and empty serializes to `1`, which is not one of the values Cloudflare
     // accepts.

--- a/packages/media/src/dom/cloudflare/stream-api.ts
+++ b/packages/media/src/dom/cloudflare/stream-api.ts
@@ -1,0 +1,51 @@
+// Minimal typings and loader for the Cloudflare Stream player SDK
+// (https://developers.cloudflare.com/stream/viewing-videos/using-the-stream-player/using-the-player-api/).
+// The SDK arrives from a script tag, so there is no npm SDK to type against.
+
+import { loadScript } from '@videojs/utils/dom';
+
+/**
+ * The Stream player mimics `HTMLVideoElement`, so its properties, methods, and
+ * events are spelled the way the native element spells them. Only the parts of
+ * that surface the SDK actually implements are typed here.
+ */
+export interface CloudflareStreamPlayerApi {
+  play(): Promise<void> | void;
+  pause(): void;
+  addEventListener(type: string, listener: (event: Event) => void): void;
+  removeEventListener(type: string, listener: (event: Event) => void): void;
+  /** Video UID or signed token. Assigning one swaps the video without a new embed. */
+  src: string;
+  currentTime: number;
+  volume: number;
+  muted: boolean;
+  playbackRate: number;
+  loop: boolean;
+  autoplay: boolean;
+  controls: boolean;
+  preload: string;
+  poster: string;
+  readonly paused: boolean;
+  readonly ended: boolean;
+  readonly seeking: boolean;
+  readonly duration: number;
+  readonly buffered: TimeRanges;
+  readonly played: TimeRanges;
+  readonly videoWidth: number;
+  readonly videoHeight: number;
+}
+
+/** The SDK is a single factory: hand it the embed iframe, get its player back. */
+export type CloudflareStreamApi = (target: HTMLIFrameElement) => CloudflareStreamPlayerApi;
+
+const API_URL = 'https://embed.videodelivery.net/embed/sdk.latest.js';
+
+/** Load the Stream SDK once, reusing it if another host already pulled it in. */
+export async function loadCloudflareStreamApi(): Promise<CloudflareStreamApi> {
+  const existing = (globalThis as { Stream?: CloudflareStreamApi }).Stream;
+  if (existing) return existing;
+  await loadScript(API_URL);
+  const api = (globalThis as { Stream?: CloudflareStreamApi }).Stream;
+  if (!api) throw new Error('Cloudflare Stream SDK failed to load');
+  return api;
+}

--- a/packages/media/src/dom/cloudflare/tests/media.test.ts
+++ b/packages/media/src/dom/cloudflare/tests/media.test.ts
@@ -1,0 +1,1083 @@
+import { loadScript } from '@videojs/utils/dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
+import type { Video } from '../../../core/types';
+import {
+  buildCloudflareIframeSrc,
+  CloudflareMedia,
+  cloudflareMediaDefaultProps,
+  parseCloudflareSource,
+  parseCloudflareVideoId,
+} from '..';
+
+vi.mock(import('@videojs/utils/dom'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return { ...mod, loadScript: vi.fn(async () => {}) };
+});
+
+const VIDEO_ID = 'ea95132c15732412d22c1476fa83f27a';
+const OTHER_VIDEO_ID = '8d3c1e05d1a4e9f9e0f0b2c1a7d64f3b';
+const SIGNED_TOKEN = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlYTk1MTMyYyJ9.hOZ8Q9-signature';
+
+/** The Stream player mimics `HTMLVideoElement`, so the mock reads and writes like one. */
+class MockPlayer {
+  static instances: MockPlayer[] = [];
+  target: HTMLIFrameElement;
+  listeners = new Map<string, Set<(event: Event) => void>>();
+
+  src = '';
+  currentTime = 0;
+  volume = 1;
+  muted = false;
+  playbackRate = 1;
+  loop = false;
+  autoplay = false;
+  controls = false;
+  preload = 'metadata';
+  poster = '';
+  paused = true;
+  ended = false;
+  seeking = false;
+  duration = 60;
+  buffered = timeRanges(0);
+  played = timeRanges(0);
+  videoWidth = 1920;
+  videoHeight = 1080;
+
+  play = vi.fn(async () => {});
+  pause = vi.fn();
+
+  constructor(target: HTMLIFrameElement) {
+    this.target = target;
+    MockPlayer.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string): void {
+    this.listeners.get(type)?.forEach((listener) => listener(new Event(type)));
+  }
+}
+
+function timeRanges(end: number): TimeRanges {
+  return { length: end > 0 ? 1 : 0, start: () => 0, end: () => end } as unknown as TimeRanges;
+}
+
+beforeEach(() => {
+  MockPlayer.instances.length = 0;
+  vi.stubGlobal('Stream', (target: HTMLIFrameElement) => new MockPlayer(target));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createIframe(): HTMLIFrameElement {
+  return document.createElement('iframe');
+}
+
+/** An iframe as React renders it before a source resolves: `src` present but empty. */
+function createEmptySrcIframe(): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('src', '');
+  return iframe;
+}
+
+/**
+ * An iframe as a server-rendered page delivers it: the embed URL is already in
+ * the markup and the frame has navigated to it, so a same-origin read of its
+ * location throws the way a real cross-origin embed does.
+ */
+function createServerRenderedIframe(src: string): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('src', src);
+  Object.defineProperty(iframe, 'contentWindow', {
+    configurable: true,
+    get: () => ({
+      get location(): Location {
+        throw new DOMException('cross-origin', 'SecurityError');
+      },
+    }),
+  });
+  return iframe;
+}
+
+/** Record every `src` assignment, so a same-URL reload is visible. */
+function spyOnSrcAssignment(iframe: HTMLIFrameElement, current: string): string[] {
+  const assigned: string[] = [];
+  Object.defineProperty(iframe, 'src', {
+    configurable: true,
+    get: () => current,
+    set: (value: string) => assigned.push(value),
+  });
+  return assigned;
+}
+
+/** Flush the microtask the deferred embed waits on before it is built. */
+async function flushDeferredEmbed(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForEngine(media: CloudflareMedia): Promise<MockPlayer> {
+  await vi.waitFor(() => {
+    if (!media.engine) throw new Error('player not created yet');
+  });
+  return media.engine as unknown as MockPlayer;
+}
+
+async function attachAndLoad(media: CloudflareMedia): Promise<{ iframe: HTMLIFrameElement; player: MockPlayer }> {
+  // There is no embed to attach to without a source, so tests that don't care
+  // which video is playing get one.
+  if (!media.src) media.src = VIDEO_ID;
+  const iframe = createIframe();
+  media.attach(iframe);
+  const player = await waitForEngine(media);
+  player.emit('loadedmetadata');
+  return { iframe, player };
+}
+
+describe('parseCloudflareVideoId', () => {
+  it('extracts id from a raw video UID', () => {
+    expect(parseCloudflareVideoId(VIDEO_ID)).toBe(VIDEO_ID);
+  });
+
+  it('extracts id from a videodelivery.net URL', () => {
+    expect(parseCloudflareVideoId(`https://videodelivery.net/${VIDEO_ID}`)).toBe(VIDEO_ID);
+  });
+
+  it('extracts id from a customer subdomain URL', () => {
+    expect(parseCloudflareVideoId(`https://customer-abc123.cloudflarestream.com/${VIDEO_ID}/iframe`)).toBe(VIDEO_ID);
+  });
+
+  it('extracts id from a manifest URL', () => {
+    expect(parseCloudflareVideoId(`https://videodelivery.net/${VIDEO_ID}/manifest/video.m3u8`)).toBe(VIDEO_ID);
+  });
+
+  it('extracts a signed token standing in for the id', () => {
+    expect(parseCloudflareVideoId(`https://videodelivery.net/${SIGNED_TOKEN}`)).toBe(SIGNED_TOKEN);
+  });
+
+  it('accepts a bare signed token', () => {
+    expect(parseCloudflareVideoId(SIGNED_TOKEN)).toBe(SIGNED_TOKEN);
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseCloudflareVideoId('')).toBe(null);
+  });
+
+  it('returns null for non-Cloudflare sources', () => {
+    expect(parseCloudflareVideoId('https://example.com/video.mp4')).toBe(null);
+    expect(parseCloudflareVideoId('not-a-cloudflare-id')).toBe(null);
+  });
+});
+
+describe('parseCloudflareSource', () => {
+  it('reports a plain video UID as unsigned', () => {
+    expect(parseCloudflareSource(VIDEO_ID)).toEqual({ id: VIDEO_ID, signed: false, origin: null });
+  });
+
+  it('reports a signed token as signed', () => {
+    expect(parseCloudflareSource(`https://videodelivery.net/${SIGNED_TOKEN}`)).toEqual({
+      id: SIGNED_TOKEN,
+      signed: true,
+      origin: null,
+    });
+  });
+
+  it('keeps the per-customer origin', () => {
+    expect(parseCloudflareSource(`https://customer-abc123.cloudflarestream.com/${VIDEO_ID}/iframe`)).toEqual({
+      id: VIDEO_ID,
+      signed: false,
+      origin: 'https://customer-abc123.cloudflarestream.com',
+    });
+  });
+
+  it('reports the shared hosts as having no customer origin', () => {
+    expect(parseCloudflareSource(`https://watch.videodelivery.net/${VIDEO_ID}`)?.origin).toBe(null);
+    expect(parseCloudflareSource(`https://watch.cloudflarestream.com/${VIDEO_ID}`)?.origin).toBe(null);
+  });
+
+  it('returns null for an unrecognized source', () => {
+    expect(parseCloudflareSource('https://example.com/not-cloudflare')).toBe(null);
+  });
+});
+
+describe('buildCloudflareIframeSrc', () => {
+  it('builds embed URL with hidden controls and the default preload', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID);
+    expect(src).toContain(`https://iframe.videodelivery.net/${VIDEO_ID}?`);
+    expect(src).toContain('controls=0');
+    expect(src).toContain('preload=metadata');
+  });
+
+  it('encodes autoplay, defaultMuted, loop', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { autoplay: true, defaultMuted: true, loop: true });
+    expect(src).toContain('autoplay=1');
+    expect(src).toContain('muted=1');
+    expect(src).toContain('loop=1');
+  });
+
+  it('shows Cloudflare controls when controls=true', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { controls: true });
+    expect(src).not.toContain('controls=');
+  });
+
+  it('falls back to the default preload when the attribute carries no value', () => {
+    // A bare `preload` attribute reads as empty, which serializes to `1` — not
+    // one of the values Cloudflare accepts.
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { preload: '' });
+    expect(src).toContain(`preload=${cloudflareMediaDefaultProps.preload}`);
+    expect(src).not.toContain('preload=1');
+  });
+
+  it('forwards preload and poster', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { preload: 'auto', poster: 'https://example.com/poster.jpg' });
+    expect(src).toContain('preload=auto');
+    expect(src).toContain('poster=https%3A%2F%2Fexample.com%2Fposter.jpg');
+  });
+
+  it('omits poster when none is set', () => {
+    // Cloudflare reads `poster` as an image URL, and an empty one serializes to
+    // `1`, which the embed refuses with "poster value should be a valid encoded
+    // URL" rather than falling back to its own thumbnail.
+    expect(buildCloudflareIframeSrc(VIDEO_ID)).not.toContain('poster=');
+    expect(buildCloudflareIframeSrc(VIDEO_ID, { poster: '' })).not.toContain('poster=');
+    expect(buildCloudflareIframeSrc(VIDEO_ID, { poster: '' })).not.toContain('poster=1');
+    // The React host passes the defaults through, so the very first embed URL
+    // carries whatever an unset poster serializes to.
+    expect(buildCloudflareIframeSrc(VIDEO_ID, cloudflareMediaDefaultProps)).not.toContain('poster=');
+  });
+
+  it('serializes Cloudflare embed parameters verbatim', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID, {
+      source: {
+        engine: {
+          cloudflare: {
+            defaultTextTrack: 'de',
+            primaryColor: '#ff0000',
+            letterboxColor: 'transparent',
+            startTime: '5m30s',
+            'ad-url': 'https://ads.example.com/vast.xml',
+          },
+        },
+      },
+    });
+    expect(src).toContain('defaultTextTrack=de');
+    expect(src).toContain('primaryColor=%23ff0000');
+    expect(src).toContain('letterboxColor=transparent');
+    expect(src).toContain('startTime=5m30s');
+    expect(src).toContain('ad-url=https%3A%2F%2Fads.example.com%2Fvast.xml');
+  });
+
+  it('keeps referrerPolicy off the embed URL', () => {
+    // It configures the iframe hosting the embed; the player has no such
+    // parameter and would be handed a stray one.
+    const src = buildCloudflareIframeSrc(VIDEO_ID, {
+      source: { engine: { cloudflare: { referrerPolicy: 'no-referrer' } } },
+    });
+    expect(src).not.toContain('referrerPolicy');
+    expect(src).not.toContain('no-referrer');
+  });
+
+  it('carries undeclared Cloudflare embed parameters through', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { source: { engine: { cloudflare: { someFutureParam: 'on' } } } });
+    expect(src).toContain('someFutureParam=on');
+  });
+
+  it('lets Cloudflare embed parameters override the defaults the host sets', () => {
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { source: { engine: { cloudflare: { controls: 1 } } } });
+    expect(src).toContain('controls=1');
+  });
+
+  it('builds the embed URL for a signed token', () => {
+    expect(buildCloudflareIframeSrc(SIGNED_TOKEN)).toContain(`https://iframe.videodelivery.net/${SIGNED_TOKEN}?`);
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildCloudflareIframeSrc('https://example.com/video.mp4')).toBe('');
+  });
+
+  it('embeds on the per-customer origin when the source names one', () => {
+    const src = buildCloudflareIframeSrc(`https://customer-abc123.cloudflarestream.com/${VIDEO_ID}/iframe`);
+    expect(src).toContain(`https://customer-abc123.cloudflarestream.com/${VIDEO_ID}/iframe?`);
+    expect(src).not.toContain('videodelivery.net');
+  });
+
+  it('keeps a signed token on its per-customer origin', () => {
+    // Signed playback is only authorized for the customer origin, so collapsing
+    // it onto the shared host would answer 401.
+    const src = buildCloudflareIframeSrc(`https://customer-abc123.cloudflarestream.com/${SIGNED_TOKEN}/iframe`);
+    expect(src).toContain(`https://customer-abc123.cloudflarestream.com/${SIGNED_TOKEN}/iframe?`);
+  });
+
+  it('embeds on the shared host for a watch URL', () => {
+    expect(buildCloudflareIframeSrc(`https://watch.cloudflarestream.com/${VIDEO_ID}`)).toContain(
+      `https://iframe.videodelivery.net/${VIDEO_ID}?`
+    );
+  });
+});
+
+describe('CloudflareMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new CloudflareMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(cloudflareMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('offers no picture-in-picture surface', () => {
+    // The Stream SDK documents no request or exit method and no enter or leave
+    // event, so the members are absent rather than present and inert — a control
+    // the player cannot drive is worse than one it does not offer.
+    const media = new CloudflareMedia() as Partial<Video>;
+    expect(media.requestPictureInPicture).toBeUndefined();
+    expect(media.exitPictureInPicture).toBeUndefined();
+    expect(media.isPictureInPicture).toBeUndefined();
+    expect(media.disablePictureInPicture).toBeUndefined();
+  });
+
+  it('reloads a server-rendered embed so the SDK does not miss its ready message', async () => {
+    // The frame already navigated, so it has posted `iframeReady` with nothing
+    // listening; only a reload puts that message back after the SDK attaches.
+    const embedSrc = `https://iframe.videodelivery.net/${VIDEO_ID}?controls=0`;
+    const iframe = createServerRenderedIframe(embedSrc);
+    const assigned = spyOnSrcAssignment(iframe, embedSrc);
+
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.attach(iframe);
+    await waitForEngine(media);
+
+    // Same URL, reassigned: that is what reloads the frame.
+    expect(assigned).toEqual([embedSrc]);
+    media.detach();
+  });
+
+  it('reloads a server-rendered embed only once the SDK is there to hear it', async () => {
+    // Reloading before the script lands loses the `iframeReady` message all over
+    // again, which is the only thing the reload exists to recover.
+    const embedSrc = `https://iframe.videodelivery.net/${VIDEO_ID}?controls=0`;
+    const iframe = createServerRenderedIframe(embedSrc);
+    const assigned = spyOnSrcAssignment(iframe, embedSrc);
+    // How many reloads had happened by the time the SDK was handed the frame.
+    const assignedAtPlayerCreation: number[] = [];
+
+    let resolveSdk!: () => void;
+    vi.stubGlobal('Stream', undefined);
+    vi.mocked(loadScript).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSdk = () => {
+            vi.stubGlobal('Stream', (target: HTMLIFrameElement) => {
+              assignedAtPlayerCreation.push(assigned.length);
+              return new MockPlayer(target);
+            });
+            resolve();
+          };
+        })
+    );
+
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.attach(iframe);
+    await flushDeferredEmbed();
+
+    expect(assigned).toEqual([]);
+
+    resolveSdk();
+    await waitForEngine(media);
+
+    expect(assigned).toEqual([embedSrc]);
+    expect(assignedAtPlayerCreation).toEqual([1]);
+    media.detach();
+  });
+
+  it('leaves a client-rendered embed alone', async () => {
+    // The embed URL is in the markup, as React renders it, but the frame has not
+    // navigated yet: the ready message is still coming, and a reload would only
+    // throw away the load already in flight. Asserted on assignments rather than
+    // on the attribute, since reassigning the same URL reloads the frame without
+    // changing what the attribute reads.
+    const embedSrc = `https://iframe.videodelivery.net/${VIDEO_ID}?controls=0`;
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('src', embedSrc);
+    const assigned = spyOnSrcAssignment(iframe, embedSrc);
+
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.attach(iframe);
+    await waitForEngine(media);
+
+    expect(assigned).toEqual([]);
+    media.detach();
+  });
+
+  it('sets the initial iframe src and creates a player when attached', async () => {
+    const media = new CloudflareMedia();
+    media.src = `https://customer-abc123.cloudflarestream.com/${VIDEO_ID}/iframe`;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.src).toContain(`https://customer-abc123.cloudflarestream.com/${VIDEO_ID}/iframe`);
+    expect(media.target).toBe(iframe);
+
+    await waitForEngine(media);
+    expect(media.engine).not.toBe(null);
+    media.detach();
+  });
+
+  it('defers the player until a source arrives', async () => {
+    const media = new CloudflareMedia();
+    const loadstart = vi.fn();
+    media.addEventListener('loadstart', loadstart);
+
+    // How every framework builds the element: created first, `src` set after.
+    const iframe = createIframe();
+    media.attach(iframe);
+    expect(iframe.getAttribute('src')).toBe(null);
+    expect(media.engine).toBe(null);
+    expect(loadstart).not.toHaveBeenCalled();
+
+    media.src = VIDEO_ID;
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain(`https://iframe.videodelivery.net/${VIDEO_ID}`);
+    expect(loadstart).toHaveBeenCalledTimes(1);
+    await waitForEngine(media);
+    media.detach();
+  });
+
+  it('defers the player for an iframe rendered with an empty src', async () => {
+    const media = new CloudflareMedia();
+    // React renders `src=""` before a source resolves. The `src` property reports
+    // the document URL for it, so only the attribute says there is no embed.
+    const iframe = createEmptySrcIframe();
+    media.attach(iframe);
+    expect(media.engine).toBe(null);
+
+    media.src = VIDEO_ID;
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain(`https://iframe.videodelivery.net/${VIDEO_ID}`);
+    await waitForEngine(media);
+    media.detach();
+  });
+
+  it('builds a deferred embed once for repeated source changes in the same task', async () => {
+    const media = new CloudflareMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = VIDEO_ID;
+    media.src = OTHER_VIDEO_ID;
+    await waitForEngine(media);
+
+    expect(iframe.getAttribute('src')).toContain(`https://iframe.videodelivery.net/${OTHER_VIDEO_ID}`);
+    expect(MockPlayer.instances.length).toBe(1);
+    media.detach();
+  });
+
+  it('does not leave play() waiting while the embed is deferred', async () => {
+    const media = new CloudflareMedia();
+    media.attach(createIframe());
+
+    // No embed means no player is coming to report a load; waiting would hang.
+    await expect(media.play()).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
+  it('waits for a deferred embed to load before playing', async () => {
+    const media = new CloudflareMedia();
+    media.attach(createIframe());
+
+    media.src = VIDEO_ID;
+    let played = false;
+    const pending = media.play().then(() => {
+      played = true;
+    });
+
+    // The player the deferred embed creates has not reported metadata, so
+    // playing now would run against a video that is not there yet.
+    const player = await waitForEngine(media);
+    expect(played).toBe(false);
+
+    player.emit('loadedmetadata');
+    await pending;
+
+    expect(player.play).toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete after metadata', async () => {
+    const media = new CloudflareMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete', 'durationchange'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    await attachAndLoad(media);
+    expect(events).toContain('loadstart');
+    expect(events).toContain('loadedmetadata');
+    expect(events).toContain('loadcomplete');
+    expect(events).toContain('durationchange');
+    expect(media.duration).toBe(60);
+    expect(media.readyState).toBe(1);
+    media.detach();
+  });
+
+  it('updates state from player events', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+
+    const playSpy = vi.fn();
+    const waitingSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+    media.addEventListener('waiting', waitingSpy);
+
+    player.emit('loadeddata');
+    expect(media.readyState).toBe(2);
+
+    player.emit('waiting');
+    expect(waitingSpy).toHaveBeenCalledTimes(1);
+
+    player.emit('play');
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(false);
+
+    player.emit('playing');
+    expect(media.readyState).toBe(3);
+
+    player.currentTime = 5;
+    player.emit('timeupdate');
+    expect(media.currentTime).toBe(5);
+
+    player.volume = 0.25;
+    player.muted = true;
+    player.emit('volumechange');
+    expect(media.volume).toBe(0.25);
+    expect(media.muted).toBe(true);
+
+    player.playbackRate = 1.5;
+    player.emit('ratechange');
+    expect(media.playbackRate).toBe(1.5);
+
+    player.buffered = timeRanges(30);
+    player.emit('progress');
+    expect(media.buffered.end(0)).toBe(30);
+    expect(media.seekable.end(0)).toBe(60);
+
+    player.emit('seeking');
+    expect(media.seeking).toBe(true);
+    player.emit('seeked');
+    expect(media.seeking).toBe(false);
+
+    player.videoWidth = 1280;
+    player.videoHeight = 720;
+    player.emit('resize');
+    expect(media.videoWidth).toBe(1280);
+    expect(media.videoHeight).toBe(720);
+
+    player.emit('pause');
+    expect(media.paused).toBe(true);
+
+    player.emit('ended');
+    expect(media.ended).toBe(true);
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('forwards the ad lifecycle events the embed adds', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+    const adStart = vi.fn();
+    media.addEventListener('stream-adstart', adStart);
+
+    player.emit('stream-adstart');
+
+    expect(adStart).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('forwards the encrypted-media events the embed reports', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+    const encrypted = vi.fn();
+    const waitingForKey = vi.fn();
+    media.addEventListener('encrypted', encrypted);
+    media.addEventListener('waitingforkey', waitingForKey);
+
+    player.emit('encrypted');
+    player.emit('waitingforkey');
+
+    expect(encrypted).toHaveBeenCalledTimes(1);
+    expect(waitingForKey).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('reports the mute the embed is being built with before it reports one', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.defaultMuted = true;
+    media.attach(createIframe());
+
+    // The embed URL carries the mute, so anything reading `muted` in the meantime
+    // would draw an unmuted volume control over silent video.
+    expect(media.muted).toBe(true);
+    await waitForEngine(media);
+    expect(media.muted).toBe(true);
+    media.detach();
+  });
+
+  it('carries a runtime mute onto a rebuilt embed', async () => {
+    const media = new CloudflareMedia();
+    media.source = { src: VIDEO_ID, engine: { cloudflare: { primaryColor: '#ff0000' } } };
+    const { iframe, player } = await attachAndLoad(media);
+
+    player.muted = true;
+    player.emit('volumechange');
+    expect(media.muted).toBe(true);
+
+    // A changed embed parameter rebuilds the frame, and the new one knows only
+    // what its URL tells it.
+    media.source = { src: VIDEO_ID, engine: { cloudflare: { primaryColor: '#0000ff' } } };
+    await Promise.resolve();
+
+    expect(iframe.getAttribute('src')).toContain('muted=1');
+    expect(media.muted).toBe(true);
+    media.detach();
+  });
+
+  it('forwards play() and pause() to the player', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+
+    await media.play();
+    expect(player.play).toHaveBeenCalledTimes(1);
+
+    media.pause();
+    expect(player.pause).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('forwards setters to the player after load', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+
+    media.currentTime = 30;
+    media.volume = 0.5;
+    media.muted = true;
+    media.playbackRate = 1.5;
+    media.loop = true;
+    media.controls = true;
+    media.preload = 'auto';
+    media.poster = 'https://example.com/poster.jpg';
+
+    // Setters defer via the loadComplete microtask — flush.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(player.currentTime).toBe(30);
+    expect(player.volume).toBe(0.5);
+    expect(player.muted).toBe(true);
+    expect(player.playbackRate).toBe(1.5);
+    expect(player.loop).toBe(true);
+    expect(player.controls).toBe(true);
+    expect(player.preload).toBe('auto');
+    expect(player.poster).toBe('https://example.com/poster.jpg');
+    media.detach();
+  });
+
+  it('swaps the video on the existing player when src changes after attach', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { iframe, player } = await attachAndLoad(media);
+    const embedSrc = iframe.getAttribute('src');
+
+    media.src = `https://videodelivery.net/${OTHER_VIDEO_ID}`;
+    await Promise.resolve();
+
+    // The embed and the SDK connection survive the swap; only the video changes.
+    expect(player.src).toBe(OTHER_VIDEO_ID);
+    expect(iframe.getAttribute('src')).toBe(embedSrc);
+    expect(MockPlayer.instances.length).toBe(1);
+
+    // The new video's metadata completes the reload.
+    const loadCompleteSpy = vi.fn();
+    media.addEventListener('loadcomplete', loadCompleteSpy);
+    player.emit('loadedmetadata');
+    expect(loadCompleteSpy).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('defers the swap when src changes while the SDK is still loading', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    // The embed is already built from the first src; only the player can be
+    // moved off it, and there is no player until the SDK resolves.
+    media.src = OTHER_VIDEO_ID;
+    const player = await waitForEngine(media);
+
+    expect(iframe.getAttribute('src')).toContain(VIDEO_ID);
+    expect(player.src).toBe(OTHER_VIDEO_ID);
+    media.detach();
+  });
+
+  it('completes the deferred swap rather than the embed it replaced', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.attach(createIframe());
+    media.src = OTHER_VIDEO_ID;
+
+    // Binding the embed's events and replaying the deferred load happen in one
+    // task, so the swap owns the barrier before any metadata can arrive.
+    const player = await waitForEngine(media);
+    const loadCompleteSpy = vi.fn();
+    media.addEventListener('loadcomplete', loadCompleteSpy);
+    expect(media.readyState).toBe(0);
+
+    player.emit('loadedmetadata');
+
+    expect(loadCompleteSpy).toHaveBeenCalledTimes(1);
+    await media.play();
+    expect(player.play).toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('errors and unblocks pending play() when src is unrecognized', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    await attachAndLoad(media);
+
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    media.src = 'https://example.com/not-a-cloudflare-video';
+    await Promise.resolve();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('stops the embed when src is unrecognized', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { player } = await attachAndLoad(media);
+    player.emit('playing');
+    player.pause.mockClear();
+    player.play.mockClear();
+
+    media.src = 'https://example.com/not-a-cloudflare-video';
+    await Promise.resolve();
+
+    // There is no video to swap to, so the embed keeps the previous one; left
+    // running it plays on under the error and writes the reset state back.
+    expect(player.pause).toHaveBeenCalled();
+    player.currentTime = 20;
+    player.emit('timeupdate');
+    player.emit('ended');
+    expect(media.currentTime).toBe(0);
+    expect(media.ended).toBe(false);
+    expect(media.duration).toBeNaN();
+
+    await media.play();
+    expect(player.play).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('surfaces player errors', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+    player.emit('error');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error).toMatchObject({ code: MediaError.MEDIA_ERR_CUSTOM, fatal: true });
+    media.detach();
+  });
+
+  it('errors and unblocks pending play() when the SDK is unavailable', async () => {
+    vi.stubGlobal('Stream', undefined);
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    media.attach(createIframe());
+
+    await vi.waitFor(() => {
+      if (!errorSpy.mock.calls.length) throw new Error('SDK has not failed yet');
+    });
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_NETWORK);
+    await expect(media.play()).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+    media.detach();
+  });
+
+  it('tracks played ranges via the played-ranges mixin', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+
+    player.emit('play');
+    player.currentTime = 0.08;
+    player.emit('timeupdate');
+    player.currentTime = 0.16;
+    player.emit('timeupdate');
+    player.emit('pause');
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(0.16);
+    media.detach();
+  });
+
+  it('pauses the embed and stops listening to it on detach', async () => {
+    const media = new CloudflareMedia();
+    const { player } = await attachAndLoad(media);
+
+    media.detach();
+
+    expect(player.pause).toHaveBeenCalled();
+    expect(media.target).toBe(null);
+    expect(media.engine).toBe(null);
+
+    // The embed lives on in the iframe; nothing it reports may reach the media.
+    player.currentTime = 42;
+    player.emit('timeupdate');
+    expect(media.currentTime).toBe(0);
+  });
+
+  it('unblocks pending play() when detached before load completes', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.attach(createIframe());
+
+    // Await load without the player ever reporting metadata.
+    const pending = media.play();
+    media.detach();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
+  it('does not create a player when detached before the SDK resolves', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    media.attach(createIframe());
+    media.detach();
+
+    // Flush the async player creation path.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(media.engine).toBe(null);
+  });
+
+  it('ignores events from a superseded player', async () => {
+    const media = new CloudflareMedia();
+    const { player: stale } = await attachAndLoad(media);
+
+    media.detach();
+    const { player: current } = await attachAndLoad(media);
+    expect(current).not.toBe(stale);
+
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    // The old embed keeps reporting; none of it may touch the new session.
+    stale.emit('play');
+    stale.volume = 0.1;
+    stale.emit('volumechange');
+
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    expect(media.volume).toBe(1);
+    media.detach();
+  });
+
+  it('unblocks waiters from a superseded load when a reload starts first', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { player } = await attachAndLoad(media);
+
+    // Start a second load and wait on its barrier without ever completing it.
+    media.src = OTHER_VIDEO_ID;
+    const pending = media.play();
+
+    // A third load takes over; the waiter above must not be stranded on the
+    // barrier it already captured.
+    media.src = SIGNED_TOKEN;
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(player.src).toBe(SIGNED_TOKEN);
+    media.detach();
+  });
+
+  it('does not report fullscreen when there is no element to request it on', async () => {
+    const media = new CloudflareMedia();
+
+    await media.requestFullscreen();
+
+    expect(media.isFullscreen).toBe(false);
+  });
+});
+
+describe('CloudflareMedia source', () => {
+  it('derives src from a structured source and announces the change', () => {
+    const media = new CloudflareMedia();
+    const sourceChange = vi.fn();
+    media.addEventListener('sourcechange', sourceChange);
+
+    media.source = { src: `https://videodelivery.net/${VIDEO_ID}` };
+
+    expect(media.src).toBe(`https://videodelivery.net/${VIDEO_ID}`);
+    expect(sourceChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-derives source from src, carrying Cloudflare embed parameters over', () => {
+    const media = new CloudflareMedia();
+    media.source = { src: VIDEO_ID, engine: { cloudflare: { primaryColor: '#ff0000' } } };
+
+    media.src = OTHER_VIDEO_ID;
+
+    expect(media.source).toEqual({ engine: { cloudflare: { primaryColor: '#ff0000' } }, src: OTHER_VIDEO_ID });
+  });
+
+  it('rebuilds the embed when only Cloudflare embed parameters change', async () => {
+    const media = new CloudflareMedia();
+    media.source = { src: VIDEO_ID, engine: { cloudflare: { primaryColor: '#ff0000' } } };
+    const { iframe, player } = await attachAndLoad(media);
+    expect(iframe.getAttribute('src')).toContain('primaryColor=%23ff0000');
+    player.src = '';
+
+    media.source = { src: VIDEO_ID, engine: { cloudflare: { primaryColor: '#0000ff' } } };
+    await Promise.resolve();
+
+    // Embed parameters live on the URL and are read once, so only a rebuilt embed
+    // applies them. Swapping the video on the player would leave the old color in
+    // place, and re-assigning the id it already holds reports no metadata to
+    // settle the load with.
+    expect(iframe.getAttribute('src')).toContain('primaryColor=%230000ff');
+    expect(player.src).toBe('');
+    media.detach();
+  });
+
+  it('serializes Cloudflare embed parameters onto the initial iframe src', () => {
+    const media = new CloudflareMedia();
+    media.source = { src: VIDEO_ID, engine: { cloudflare: { defaultTextTrack: 'de' } } };
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.src).toContain('defaultTextTrack=de');
+    media.detach();
+  });
+
+  it('clears src when the source is set to null', () => {
+    const media = new CloudflareMedia();
+    media.source = { src: VIDEO_ID };
+
+    media.source = null;
+
+    expect(media.src).toBe('');
+    expect(media.source).toBe(null);
+  });
+
+  it('pauses the embed and resets state when the source is cleared', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { player } = await attachAndLoad(media);
+    player.emit('playing');
+    expect(media.duration).toBe(60);
+    player.pause.mockClear();
+
+    media.source = null;
+    await Promise.resolve();
+
+    // Left running, the embed keeps playing and its events write state back.
+    expect(player.pause).toHaveBeenCalled();
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    expect(media.paused).toBe(true);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('announces the reset when the source is cleared', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { player } = await attachAndLoad(media);
+    player.emit('playing');
+
+    const emptied = vi.fn();
+    media.addEventListener('emptied', emptied);
+    media.source = null;
+    await Promise.resolve();
+
+    // The embed is paused and its events are ignored from here, so nothing else
+    // is coming to say the last video's duration and buffer are gone.
+    expect(emptied).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('does not let a cleared source come back through a player event', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { player } = await attachAndLoad(media);
+    player.emit('playing');
+
+    media.source = null;
+    await Promise.resolve();
+    // The embed reports its own wind-down after the source is gone.
+    player.currentTime = 20;
+    player.emit('timeupdate');
+    player.emit('ended');
+
+    expect(media.duration).toBeNaN();
+    expect(media.readyState).toBe(0);
+    expect(media.currentTime).toBe(0);
+    expect(media.ended).toBe(false);
+    media.detach();
+  });
+
+  it('does not play a source that was cleared', async () => {
+    const media = new CloudflareMedia();
+    media.src = VIDEO_ID;
+    const { player } = await attachAndLoad(media);
+
+    media.source = null;
+    await Promise.resolve();
+    player.play.mockClear();
+    await media.play();
+
+    expect(player.play).not.toHaveBeenCalled();
+    media.detach();
+  });
+});

--- a/packages/media/src/dom/cloudflare/tests/media.test.ts
+++ b/packages/media/src/dom/cloudflare/tests/media.test.ts
@@ -229,6 +229,22 @@ describe('buildCloudflareIframeSrc', () => {
     expect(src).toContain('loop=1');
   });
 
+  it('omits autoplay, muted, and loop rather than turning them off', () => {
+    // Cloudflare reads these three by presence, not by value, so `autoplay=0`
+    // autoplays and `muted=0` starts the video silenced — which also makes the
+    // volume control look broken, since the embed is muted underneath it.
+    const src = buildCloudflareIframeSrc(VIDEO_ID, { autoplay: false, defaultMuted: false, loop: false });
+    expect(src).not.toContain('autoplay');
+    expect(src).not.toContain('muted');
+    expect(src).not.toContain('loop');
+
+    // The props the HTML and React wrappers pass by default must be just as quiet.
+    const fromDefaults = buildCloudflareIframeSrc(VIDEO_ID, cloudflareMediaDefaultProps);
+    expect(fromDefaults).not.toContain('autoplay');
+    expect(fromDefaults).not.toContain('muted');
+    expect(fromDefaults).not.toContain('loop');
+  });
+
   it('shows Cloudflare controls when controls=true', () => {
     const src = buildCloudflareIframeSrc(VIDEO_ID, { controls: true });
     expect(src).not.toContain('controls=');

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -17,6 +17,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/dash/index': './src/dom/dash/index.ts',
     'dom/hls-js/index': './src/dom/hls-js/index.ts',
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
+    'dom/cloudflare/index': './src/dom/cloudflare/index.ts',
     'dom/vimeo/index': './src/dom/vimeo/index.ts',
     'dom/youtube/index': './src/dom/youtube/index.ts',
     'dom/mux/index': './src/dom/mux/index.ts',

--- a/packages/react/src/media/cloudflare-video/index.ts
+++ b/packages/react/src/media/cloudflare-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/cloudflare-video/media.tsx
+++ b/packages/react/src/media/cloudflare-video/media.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { CloudflareMediaProps } from '@videojs/media/dom/cloudflare';
+import { buildCloudflareIframeSrc, CloudflareMedia, cloudflareMediaDefaultProps } from '@videojs/media/dom/cloudflare';
+import type { ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
+import { useAttachIframe } from '../../utils/use-attach-iframe';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface CloudflareVideoProps extends Partial<CloudflareMediaProps> {
+  children?: ReactNode;
+}
+
+export const CloudflareVideo = forwardRef<HTMLIFrameElement, CloudflareVideoProps>(function CloudflareVideo(
+  { children, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(CloudflareMedia);
+  const props: Partial<CloudflareMediaProps> & Record<string, unknown> = { ...rawProps };
+  const attachRef = useAttachIframe(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const [initialSrc] = useState(() =>
+    // `source.src` is the only other way to name a video, so honor it when `src` is absent.
+    buildCloudflareIframeSrc(props.src || props.source?.src || '', {
+      ...cloudflareMediaDefaultProps,
+      ...props,
+      // The embed reads mute once, out of the URL it is rendered with, and either
+      // prop says to start muted. Leaving `muted` out of the URL would leave a
+      // muted autoplay blocked by the browser, since the embed comes up audible.
+      defaultMuted: !!(props.defaultMuted || props.muted),
+    })
+  );
+  const iframeProps = useSyncProps<CloudflareMediaProps, Record<string, unknown>>(
+    media,
+    props,
+    cloudflareMediaDefaultProps
+  );
+
+  return (
+    <iframe
+      title="Cloudflare Stream video player"
+      // Empty means there is no embed to point at yet; React warns about `src=""`,
+      // and the media builds the URL itself once a source resolves.
+      src={initialSrc || undefined}
+      data-cross-origin-frame
+      allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      referrerPolicy={props.source?.engine?.cloudflare?.referrerPolicy}
+      {...iframeProps}
+      ref={composedRef}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace CloudflareVideo {
+  export type Props = CloudflareVideoProps;
+}


### PR DESCRIPTION
Ports [`cloudflare-video-element`](https://github.com/muxinc/media-elements/tree/main/packages/cloudflare-video-element) from `muxinc/media-elements` into v10 as a first-class media host, reshaped to the architecture the Vimeo and YouTube ports already established.

## Motivation

Cloudflare Stream is one of the iframe embeds `media-elements` supports and v10 does not. The upstream element is an `HTMLMediaElement` shim; this port keeps the behavior but re-expresses it as a `Media` host so it composes with the v10 player, store, and skins the same way `<vimeo-video>` and `<youtube-video>` do.

## What's here

`packages/media/src/dom/cloudflare` follows the YouTube port's file split:

- `props.ts` — the same ten-prop shape the other embed hosts use, so the platform wrappers stay uniform
- `source.ts` — `CloudflareSource`, embed-parameter typings under `engine.cloudflare`, source parsing, and embed-URL building
- `stream-api.ts` — minimal typings and a one-shot loader for the Stream player SDK
- `media.ts` — `CloudflareMedia`
- `tests/media.test.ts` — 52 cases

Plus `<cloudflare-video>` in `packages/html` and `<CloudflareVideo>` in `packages/react`.

## Behavior worth reviewing

- **Source swaps reuse the player.** The Stream player mimics `HTMLVideoElement` down to a writable `src`, so a source change assigns the new UID instead of rebuilding the iframe. The embed keeps its session, and the following `loadedmetadata` completes the reload.
- **No polling.** The embed pushes real `timeupdate`, `progress`, `seeking`, `seeked`, and `durationchange`, so there is no counterpart to the YouTube port's 50 ms poll.
- **Teardown.** The SDK exposes no `destroy()`, so `detach()` unbinds each listener it registered and pauses the embed — the only way to stop an orphaned iframe from playing.
- **`src` forms.** Full `cloudflarestream.com` / `videodelivery.net` URLs, bare 32-character video UIDs, and signed tokens, which stand in for the UID wherever it appears.
- **Props Cloudflare can't honor** (`playsInline`, and `defaultMuted` after build time) are stored and documented as inert rather than silently dropped. Conversely `loop`, `autoplay`, `controls`, `preload`, and `poster` *are* writable on the player, so unlike YouTube their setters take effect live.

## Verification

- `pnpm -F @videojs/media test src/dom/cloudflare` — 52 passed
- `pnpm test` — 5259 passed, 14 skipped
- `pnpm typecheck` — clean
- `pnpm -F @videojs/sandbox build` — clean; the new presets appear at `/html-cloudflare-video/` and `/react-cloudflare-video/`

## Notes

Split into two commits: the media host and platform wrappers, then the sandbox examples. The sandbox commit also collapses the navbar's per-provider `isVimeoVideo` / `isYouTubeVideo` booleans into an `EMBED_PRESETS` list, so adding an embed preset is a one-line change.

This is the first of four stacked PRs adding iframe media from `media-elements`; Spotify, TikTok, and Twitch follow on top of it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new async embed integration (SDK load, SSR reload, signed/customer origins) plus a user-visible PiP behavior change for YouTube and other embeds.
> 
> **Overview**
> Adds **Cloudflare Stream** as a v10 media host (aligned with Vimeo/YouTube): `CloudflareMedia` drives the Stream iframe via the SDK, parses UIDs/tokens/customer origins, builds embed URLs (including `source.engine.cloudflare` passthrough), swaps videos through the player’s `src` when possible, and rebuilds the iframe when embed params change. **`<cloudflare-video>`** and **`<CloudflareVideo>`** wrap that host; the sandbox gains a **`cloudflare-video`** preset with fixed demo source and HTML/React pages.
> 
> Sandbox navbar logic is refactored so Vimeo/YouTube/Cloudflare share **`EMBED_PRESETS`** and a single **`isEmbedMedia`** flag (Tailwind + source picker disabled for embeds).
> 
> **Picture-in-picture availability** now requires both browser support and media that can enter PiP (`isMediaPictureInPictureCapable` / `isPictureInPictureCapable`), so iframe providers without PiP (including Cloudflare and **YouTube**) no longer show a dead PiP control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618a399c8b2573dd6c28a06fa4f05cd9bd52e53b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Related issues

Closes #1461 — *Feature: Cloudflare Stream Provider*. Part of the #1457 *Media Element Providers* epic, alongside the closed Vimeo (#1435) and YouTube (#1434) providers.

Both numbered requirements are covered:

1. **Iframe params passthrough** — `autoplay`, `controls`, `loop`, `muted`, `preload`, and `poster` come from the host props of the same name; `primaryColor`, `letterboxColor`, `defaultTextTrack`, `startTime`, and `ad-url` go through `source.engine.cloudflare`, which has an index signature so undocumented knobs pass through too.
2. **Iframe SDK integration** — the adapter loads the SDK for full `HTMLMediaElement`-like control rather than wrapping the iframe params alone.

All three design notes are addressed:

- **Two equivalent embed hosts.** `parseCloudflareSource` reports the per-customer origin when the source names one, and the embed is rebuilt onto it at `/<id>/iframe` instead of being collapsed onto the shared `iframe.videodelivery.net` host. That is what makes signed and access-controlled videos playable — the shared host is not authorized for them. `watch.` and bare hosts are pages rather than embeds, so they still resolve to the shared host.
- **Custom ad events.** `stream-adstart`, `stream-adend`, and `stream-adtimeout` are re-dispatched under their own names rather than filtered or remapped.
- **SSR caveat.** An embed that came from the document rather than from this host — server-rendered markup, or a hydrated tree — has already navigated and posted its one `iframeReady` message with nothing listening. `#createPlayer` now reloads the frame in that case, so the message arrives after the SDK is attached. The condition is narrow on purpose: an embed this host just built has not navigated yet, so reloading it would only throw away the load already in flight. That is detected by reading the frame's location — `about:blank` for a frame that has not navigated, and a cross-origin throw once the embed is there.

Verified by mutation: making the reload unconditional, removing it, and collapsing the customer origin onto the shared host each fail the suite.

> Note: GitHub only auto-closes on merge into the default branch. This PR targets `main`, so the keyword above will close #1461 on merge.


---

**Added:** `fix(packages): gate picture-in-picture availability on the media` — a third commit, kept separate because it is a core fix rather than part of the Cloudflare port.

Removing Cloudflare's picture-in-picture surface (it has none: the Stream SDK documents no request or exit method and no enter or leave event, and upstream's element exposes neither) turned out not to be enough. `pipAvailability` asked only `isPictureInPictureEnabled()` — a pure browser check — so the control rendered for every media regardless of whether it could ever enter picture-in-picture. YouTube has always shown a button that does nothing; Cloudflare Stream would have joined it.

Availability now requires both halves: a browser that offers picture-in-picture, and a media that can enter it. The media half is a new `isMediaPictureInPictureCapable` predicate, checked through a DOM-aware wrapper that mirrors the branches `requestPictureInPicture` already takes — so WebKit presentation mode still counts and iPhone Safari keeps its button.

Verified against every media in the repo: native `<video>`, the `VideoHost`-backed elements (`mux-video`, `hls-video`, `dash-video`, …) and Vimeo stay capable; YouTube, Cloudflare, Spotify, TikTok, and Twitch report `unsupported`. The predicate requires only `requestPictureInPicture`, since a native video element leaves exiting to `document` and demanding the pair would rule out the one media that most certainly can.

Note the behavior change beyond this port: **YouTube's picture-in-picture button now hides** rather than rendering and doing nothing.
