### PR TITLE
feat(packages): add spotify audio media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -19,6 +19,7 @@ export const PRESETS = [
   'vimeo-video',
   'youtube-video',
   'cloudflare-video',
+  'spotify-audio',
 ] as const;
 
 /**
@@ -26,4 +27,4 @@ export const PRESETS = [
  * source rather than the source picker's list, and have no Tailwind skin
  * variant, so the navbar disables both controls for them.
  */
-export const EMBED_PRESETS = ['vimeo-video', 'youtube-video', 'cloudflare-video'] as const;
+export const EMBED_PRESETS = ['vimeo-video', 'youtube-video', 'cloudflare-video', 'spotify-audio'] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -352,6 +352,10 @@ export const YOUTUBE_VIDEO_SRC = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
 
 export const CLOUDFLARE_VIDEO_SRC = 'https://watch.videodelivery.net/bfbd585059e33391d67b0f1d15fe6ea4';
 
+// An episode rather than a track: Spotify plays episodes in full for a signed-out
+// listener, where a track is a 30 second preview.
+export const SPOTIFY_AUDIO_SRC = 'https://open.spotify.com/episode/7makk4oTQel546B0PZlDM5';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return SOURCES[id].live === true;

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -100,6 +100,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'vimeo-video': 'Vimeo Video',
   'youtube-video': 'YouTube Video',
   'cloudflare-video': 'Cloudflare Stream Video',
+  'spotify-audio': 'Spotify Audio',
 };
 
 export function Navbar({

--- a/apps/sandbox/templates/html-spotify-audio/index.html
+++ b/apps/sandbox/templates/html-spotify-audio/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Spotify Audio</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-spotify-audio/main.ts
+++ b/apps/sandbox/templates/html-spotify-audio/main.ts
@@ -1,0 +1,35 @@
+import '@app/styles.css';
+import '@videojs/html/audio/player';
+import '@videojs/html/media/spotify-audio';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadAudioSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { SPOTIFY_AUDIO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadAudioSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <div class="w-full max-w-xl mx-auto">
+      <audio-player>
+        <${tag}>
+          <!-- Hidden unless it is showing Spotify's own chrome, so it takes no room and needs no size. -->
+          <spotify-audio src="${SPOTIFY_AUDIO_SRC}"></spotify-audio>
+        </${tag}>
+      </audio-player>
+    </div>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-spotify-audio/index.html
+++ b/apps/sandbox/templates/react-spotify-audio/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Spotify Audio</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-spotify-audio/main.tsx
+++ b/apps/sandbox/templates/react-spotify-audio/main.tsx
@@ -1,0 +1,29 @@
+import '@app/styles.css';
+import { AudioPlayer } from '@app/shared/react/players';
+import { AudioSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { SPOTIFY_AUDIO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { SpotifyAudio } from '@videojs/react/media/spotify-audio';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <AudioPlayer>
+      <AudioSkinComponent skin={skin} styling={styling} className="w-full max-w-xl mx-auto">
+        {/* Hidden unless it is showing Spotify's own chrome, so it takes no room and needs no size. */}
+        <SpotifyAudio src={SPOTIFY_AUDIO_SRC} />
+      </AudioSkinComponent>
+    </AudioPlayer>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/core/src/core/ui/mute-button/mute-button-core.ts
+++ b/packages/core/src/core/ui/mute-button/mute-button-core.ts
@@ -1,4 +1,4 @@
-import type { MediaVolumeState } from '@videojs/media';
+import type { MediaFeatureAvailability, MediaVolumeState } from '@videojs/media';
 import { createState } from '@videojs/store';
 import { defaults } from '@videojs/utils/object';
 import type { NonNullableObject } from '@videojs/utils/types';
@@ -25,6 +25,10 @@ export interface MuteButtonState extends Pick<MediaVolumeState, 'muted'>, Button
    * - `high`: volume >= 0.75
    */
   volumeLevel: VolumeLevel;
+  /** Whether the media can be muted at all. */
+  availability: MediaFeatureAvailability;
+  /** Whether the button is hidden because the media has no mute to toggle. */
+  hidden: boolean;
 }
 
 export class MuteButtonCore {
@@ -36,6 +40,8 @@ export class MuteButtonCore {
   readonly state = createState<MuteButtonState>({
     muted: false,
     volumeLevel: 'off',
+    availability: 'unavailable',
+    hidden: true,
     label: '',
   });
 
@@ -70,14 +76,23 @@ export class MuteButtonCore {
 
   getState(): MuteButtonState {
     const media = this.#media!;
-    this.state.patch({ muted: media.muted || media.volume === 0, volumeLevel: getVolumeLevel(media) });
+    // Mute has an availability of its own: a media can take a mute command while
+    // offering no way to set a level, so reading the volume slider's would hide
+    // a button that works.
+    const availability = media.mutedAvailability;
+    this.state.patch({
+      muted: media.muted || media.volume === 0,
+      volumeLevel: getVolumeLevel(media),
+      availability,
+      hidden: availability !== 'available',
+    });
     this.state.patch({ label: resolveText(this.getLabel(this.state.current)) });
 
     return this.state.current;
   }
 
   toggle(media: MediaVolumeState): void {
-    if (this.#props.disabled) return;
+    if (this.#props.disabled || media.mutedAvailability !== 'available') return;
     media.toggleMuted();
   }
 }

--- a/packages/core/src/core/ui/mute-button/mute-button-data-attrs.ts
+++ b/packages/core/src/core/ui/mute-button/mute-button-data-attrs.ts
@@ -6,4 +6,8 @@ export const MuteButtonDataAttrs = {
   muted: 'data-muted',
   /** Indicates the volume level. */
   volumeLevel: 'data-volume-level',
+  /** Indicates mute availability (`available`, `unavailable`, `unsupported`). */
+  availability: 'data-availability',
+  /** Present when the button is hidden because the media has no mute to toggle. */
+  hidden: 'data-hidden',
 } as const satisfies StateAttrMap<MuteButtonState>;

--- a/packages/core/src/core/ui/mute-button/tests/mute-button-core.test.ts
+++ b/packages/core/src/core/ui/mute-button/tests/mute-button-core.test.ts
@@ -8,6 +8,7 @@ function createMediaState(overrides: Partial<MediaVolumeState> = {}): MediaVolum
     volume: 1,
     muted: false,
     volumeAvailability: 'available',
+    mutedAvailability: 'available',
     setVolume: vi.fn((v: number) => v),
     toggleMuted: vi.fn(() => false),
     ...overrides,
@@ -18,12 +19,23 @@ function createState(overrides: Partial<MuteButtonState> = {}): MuteButtonState 
   return {
     muted: false,
     volumeLevel: 'high',
+    availability: 'available',
+    hidden: false,
     label: '',
     ...overrides,
   };
 }
 
 describe('MuteButtonCore', () => {
+  describe('toggle', () => {
+    it('does nothing when the media has no mute to toggle', () => {
+      const core = new MuteButtonCore();
+      const media = createMediaState({ mutedAvailability: 'unsupported' });
+      core.toggle(media);
+
+      expect(media.toggleMuted).not.toHaveBeenCalled();
+    });
+  });
   describe('getState', () => {
     it('projects muted and volumeLevel', () => {
       const core = new MuteButtonCore();
@@ -33,6 +45,26 @@ describe('MuteButtonCore', () => {
 
       expect(state.muted).toBe(false);
       expect(state.volumeLevel).toBe('high');
+    });
+
+    it('hides itself when the media has no mute to toggle', () => {
+      // An embed whose provider takes no volume or mute command — Spotify — leaves
+      // this button with nothing to do, so it is removed rather than rendered
+      // and inert.
+      const core = new MuteButtonCore();
+      core.setMedia(createMediaState({ mutedAvailability: 'unavailable' }));
+      const state = core.getState();
+
+      expect(state.availability).toBe('unavailable');
+      expect(state.hidden).toBe(true);
+    });
+
+    it('shows itself when the media can be muted', () => {
+      const core = new MuteButtonCore();
+      core.setMedia(createMediaState({ mutedAvailability: 'available' }));
+      const state = core.getState();
+
+      expect(state.hidden).toBe(false);
     });
 
     it('returns off when muted', () => {

--- a/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
+++ b/packages/core/src/core/ui/volume-slider/tests/volume-slider-core.test.ts
@@ -20,6 +20,7 @@ function createMediaState(overrides: Partial<MediaVolumeState> = {}): MediaVolum
     volume: 1,
     muted: false,
     volumeAvailability: 'available',
+    mutedAvailability: 'available',
     setVolume: vi.fn((v: number) => v),
     toggleMuted: vi.fn(() => false),
     ...overrides,

--- a/packages/core/src/dom/store/features/tests/volume.test.ts
+++ b/packages/core/src/dom/store/features/tests/volume.test.ts
@@ -26,6 +26,28 @@ describe('volumeFeature', () => {
 
       // Should be 'available' or 'unsupported' based on browser capability
       expect(['available', 'unsupported']).toContain(store.state.volumeAvailability);
+      expect(store.state.mutedAvailability).toBe('available');
+    });
+
+    it('reports mute available on media that has no volume level', () => {
+      // An embed that takes a mute command but offers no way to set a level.
+      // Reading one availability for both would hide a mute button that works.
+      const media = { muted: false, addEventListener() {}, removeEventListener() {} };
+      const store = createStore<PlayerTarget>()(volumeFeature);
+      store.attach({ media: media as unknown as HTMLVideoElement, container: null });
+
+      expect(store.state.mutedAvailability).toBe('available');
+      expect(store.state.volumeAvailability).toBe('unavailable');
+    });
+
+    it('reports both unavailable on media that has neither', () => {
+      // Spotify: the embed takes no volume or mute command and reports neither.
+      const media = { addEventListener() {}, removeEventListener() {} };
+      const store = createStore<PlayerTarget>()(volumeFeature);
+      store.attach({ media: media as unknown as HTMLVideoElement, container: null });
+
+      expect(store.state.mutedAvailability).toBe('unavailable');
+      expect(store.state.volumeAvailability).toBe('unavailable');
     });
 
     it('updates on volumechange event', () => {

--- a/packages/core/src/dom/store/features/volume.ts
+++ b/packages/core/src/dom/store/features/volume.ts
@@ -1,5 +1,5 @@
 import type { MediaFeatureAvailability, MediaVolumeState } from '@videojs/media';
-import { isMediaVolumeCapable } from '@videojs/media';
+import { isMediaMutedCapable, isMediaVolumeCapable } from '@videojs/media';
 import { listen } from '@videojs/utils/dom';
 import { definePlayerFeature } from '../../feature';
 
@@ -12,6 +12,7 @@ export const volumeFeature = definePlayerFeature({
     volume: 1,
     muted: false,
     volumeAvailability: 'unavailable',
+    mutedAvailability: 'unavailable',
 
     setVolume(volume: number) {
       const { media } = target();
@@ -28,7 +29,13 @@ export const volumeFeature = definePlayerFeature({
 
     toggleMuted() {
       const { media } = target();
-      if (!isMediaVolumeCapable(media)) return false;
+      if (!isMediaMutedCapable(media)) return false;
+      // A media that mutes but reports no level has nothing to restore, so the
+      // mute is simply flipped.
+      if (!isMediaVolumeCapable(media)) {
+        media.muted = !media.muted;
+        return media.muted;
+      }
       const effectivelyMuted = media.muted || media.volume === 0;
 
       if (effectivelyMuted) {
@@ -45,11 +52,22 @@ export const volumeFeature = definePlayerFeature({
   attach({ target, signal, set }) {
     const { media } = target;
 
-    if (!isMediaVolumeCapable(media)) return;
+    const volumeCapable = isMediaVolumeCapable(media);
+    const mutedCapable = isMediaMutedCapable(media);
+    // The two come apart, so either one alone is worth attaching for: a media
+    // that mutes but sets no level still drives a mute button.
+    if (!volumeCapable && !mutedCapable) return;
 
-    set({ volumeAvailability: canSetVolume() });
+    set({
+      volumeAvailability: volumeCapable ? canSetVolume() : 'unavailable',
+      mutedAvailability: mutedCapable ? 'available' : 'unavailable',
+    });
 
-    const sync = () => set({ volume: media.volume, muted: media.muted });
+    const sync = () =>
+      set({
+        volume: volumeCapable ? media.volume : 1,
+        muted: mutedCapable ? media.muted : false,
+      });
     sync();
 
     listen(media, 'volumechange', sync, { signal });

--- a/packages/html/src/define/media/spotify-audio.ts
+++ b/packages/html/src/define/media/spotify-audio.ts
@@ -1,0 +1,14 @@
+import { SpotifyAudio } from '../../media/spotify-audio';
+import { safeDefine } from '../safe-define';
+
+export class SpotifyAudioElement extends SpotifyAudio {
+  static readonly tagName = 'spotify-audio';
+}
+
+safeDefine(SpotifyAudioElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [SpotifyAudioElement.tagName]: SpotifyAudioElement;
+  }
+}

--- a/packages/html/src/media/spotify-audio/index.ts
+++ b/packages/html/src/media/spotify-audio/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/spotify-audio/media.ts
+++ b/packages/html/src/media/spotify-audio/media.ts
@@ -1,0 +1,59 @@
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { buildSpotifyIframeSrc, SpotifyMedia } from '@videojs/media/dom/spotify';
+import { escapeHtml } from '@videojs/utils/string';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class SpotifyCustomMediaElement extends CustomMediaElement('iframe', SpotifyMedia) {
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildSpotifyIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: block;
+          min-width: 160px;
+          min-height: 80px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        /*
+         * Without Spotify's own chrome the embed is a transport and nothing else:
+         * its player UI would otherwise show through whatever skin is drawn over
+         * it. Hidden rather than merely inert, and important so a consumer's own
+         * display rule cannot put it back on screen. An iframe in a hidden subtree
+         * still loads and plays its src.
+         */
+        :host(:not([controls])) {
+          display: none !important;
+        }
+      </style>
+      <iframe
+        part="iframe"
+        ${srcAttr}
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        frameborder="0"
+        width="100%"
+        height="100%"
+        referrerpolicy="${escapeHtml(attrs.referrerpolicy ?? '')}"
+      ></iframe>
+    `;
+  };
+}
+
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    playsInline: attrs.playsinline !== undefined,
+    preload: (attrs.preload as 'none' | 'metadata' | 'auto' | undefined) ?? 'metadata',
+  };
+}
+
+export class SpotifyAudio extends MediaAttachMixin(SpotifyCustomMediaElement) {}

--- a/packages/html/src/media/tests/spotify-audio.test.ts
+++ b/packages/html/src/media/tests/spotify-audio.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { SpotifyAudio } from '../spotify-audio/media';
+
+describe('SpotifyAudio', () => {
+  it('hides the embed unless it is showing Spotify’s own chrome', () => {
+    const template = SpotifyAudio.getTemplateHTML({ src: 'https://open.spotify.com/track/1301WleyT98MSxVHPZCA6M' });
+
+    // Left visible, Spotify's own player UI shows through the skin drawn over it.
+    // Asserted against the template because no DOM implementation the tests run
+    // in resolves `:host` for a computed style.
+    expect(template).toMatch(/:host\(:not\(\[controls\]\)\)\s*\{\s*display:\s*none\s*!important/);
+  });
+});

--- a/packages/html/src/ui/media-button-element.ts
+++ b/packages/html/src/ui/media-button-element.ts
@@ -16,6 +16,7 @@ import {
 import { isText, resolveText, type Text, translateText } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import type { State } from '@videojs/store';
+import { isBoolean, isObject } from '@videojs/utils/predicate';
 
 import { i18nContext } from '../i18n/context';
 import { I18nController } from '../i18n/controller';
@@ -152,6 +153,11 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
     applyElementProps(this, {
       ...attrs,
       'aria-keyshortcuts': this.#hotkeyRegistry?.aria,
+      // A button whose core reports itself hidden takes the real attribute, not
+      // just the data one: `data-hidden` is a styling hook a skin may or may not
+      // act on, where `hidden` removes the control the way the React components
+      // do by rendering nothing.
+      ...(isHideable(state) && { hidden: state.hidden ? '' : undefined }),
     });
     applyStateDataAttrs(this, state, this.stateAttrMap);
   }
@@ -164,4 +170,9 @@ export abstract class MediaButtonElement<Core extends MediaButtonComponent> exte
     this.#lastHotkeyShortcut = shortcut;
     this.dispatchEvent(new CustomEvent(HOTKEY_SHORTCUT_CHANGE_EVENT));
   }
+}
+
+/** Whether a button's core reports whether it should be shown at all. */
+function isHideable(state: unknown): state is { hidden: boolean } {
+  return isObject(state) && isBoolean((state as { hidden?: unknown }).hidden);
 }

--- a/packages/media/src/core/predicate.ts
+++ b/packages/media/src/core/predicate.ts
@@ -53,6 +53,17 @@ export function isMediaVolumeCapable(value: unknown): value is MediaVolumeCapabi
   return !isUndefined(media.volume) && !isUndefined(media.muted);
 }
 
+/**
+ * Whether the media reports a mute at all, which is a narrower question than
+ * `isMediaVolumeCapable`: an embed can take a mute command while offering no way
+ * to set a level.
+ */
+export function isMediaMutedCapable(value: unknown): value is Pick<MediaVolumeCapability, 'muted'> {
+  if (!isObject(value)) return false;
+  const media = value as Record<string, unknown>;
+  return !isUndefined(media.muted);
+}
+
 export function isMediaPlaybackRateCapable(value: unknown): value is MediaPlaybackRateCapability {
   if (!isObject(value)) return false;
   const media = value as Record<string, unknown>;

--- a/packages/media/src/core/state.ts
+++ b/packages/media/src/core/state.ts
@@ -61,6 +61,15 @@ export interface MediaVolumeState {
    */
   volumeAvailability: MediaFeatureAvailability;
   /**
+   * Whether the media can be muted. Separate from `volumeAvailability` because
+   * the two come apart: an embed can take a mute command while offering no way
+   * to set a level, and iOS Safari refuses a volume write on media that mutes
+   * perfectly well.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted
+   */
+  mutedAvailability: MediaFeatureAvailability;
+  /**
    * Set volume (clamped 0-1). Returns the clamped value.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume

--- a/packages/media/src/dom/spotify/iframe-api.ts
+++ b/packages/media/src/dom/spotify/iframe-api.ts
@@ -1,0 +1,99 @@
+// Minimal typings and loader for the Spotify iframe API
+// (https://developer.spotify.com/documentation/embeds/tutorials/using-the-iframe-api).
+// The API arrives from a script tag, so there is no npm SDK to type against.
+
+import { loadScript } from '@videojs/utils/dom';
+
+/** Everything the embed reports about playback, with times in milliseconds. */
+export interface SpotifyPlaybackState {
+  isPaused: boolean;
+  isBuffering: boolean;
+  position: number;
+  duration: number;
+}
+
+export interface SpotifyPlaybackUpdateEvent {
+  data: SpotifyPlaybackState;
+}
+
+export interface SpotifyControllerApi {
+  /**
+   * The iframe the controller drives. `createController` never drives the element
+   * it is handed: it builds this one from its own attributes and replaces the
+   * target with it, so this is the embed from then on.
+   */
+  iframeElement: HTMLIFrameElement;
+  /** Swap the embedded entity, named as a `spotify:<type>:<id>` URI. */
+  loadUri(uri: string): void;
+  /** Play from the start of the entity. */
+  play(): void;
+  /** Play from where the entity was paused. */
+  resume(): void;
+  pause(): void;
+  togglePlay(): void;
+  seek(seconds: number): void;
+  destroy(): void;
+  addListener(type: 'ready', listener: () => void): void;
+  addListener(type: 'playback_update', listener: (event: SpotifyPlaybackUpdateEvent) => void): void;
+}
+
+/** Options `createController` accepts; Spotify's own keys pass through untouched. */
+export interface SpotifyControllerOptions extends Record<string, unknown> {
+  uri?: string;
+  width?: string | number;
+  height?: string | number;
+}
+
+export interface SpotifyIframeApi {
+  /**
+   * Build a controller. `target` is replaced by an iframe the controller builds
+   * for itself, so Spotify's own examples hand over a placeholder `<div>` rather
+   * than the embed.
+   */
+  createController(
+    target: HTMLElement,
+    options: SpotifyControllerOptions,
+    callback: (controller: SpotifyControllerApi) => void
+  ): void;
+}
+
+// The URL Spotify's own tutorial tells pages to load. `spotify-audio-element`
+// still points at the older `embed-podcast` path, which serves the same loader.
+const API_URL = 'https://open.spotify.com/embed/iframe-api/v1';
+
+interface SpotifyApiGlobals {
+  SpotifyIframeApi?: SpotifyIframeApi;
+  onSpotifyIframeApiReady?: (api: SpotifyIframeApi) => void;
+}
+
+let apiPromise: Promise<SpotifyIframeApi> | null = null;
+
+/** Load the iframe API once, reusing it if another host already pulled it in. */
+export function loadSpotifyIframeApi(): Promise<SpotifyIframeApi> {
+  const globals = globalThis as SpotifyApiGlobals;
+  const existing = globals.SpotifyIframeApi;
+  if (existing) return Promise.resolve(existing);
+
+  apiPromise ??= new Promise<SpotifyIframeApi>((resolve, reject) => {
+    // The script hands the API to this global as it evaluates and exposes it no
+    // other way, so the callback has to be in place before the tag is added.
+    // A page that followed Spotify's own instructions has its callback there
+    // already, and the loader fires the global once and only once — a second
+    // script tag reports the API as initialized and does nothing — so taking the
+    // global over means passing the API on to whoever had it.
+    const hostReady = globals.onSpotifyIframeApiReady;
+    globals.onSpotifyIframeApiReady = (api) => {
+      // Resolve first: a host callback that throws must not strand this load.
+      resolve(api);
+      hostReady?.(api);
+    };
+    loadScript(API_URL).catch(reject);
+  }).catch((error: unknown) => {
+    // A failed load must not be the answer forever; drop it so the next host to
+    // ask can try again.
+    apiPromise = null;
+    throw error;
+  });
+
+  return apiPromise;
+}

--- a/packages/media/src/dom/spotify/index.ts
+++ b/packages/media/src/dom/spotify/index.ts
@@ -1,0 +1,11 @@
+// The iframe API module is internal apart from the controller typings, which the
+// `engine` getter surfaces.
+export type {
+  SpotifyControllerApi,
+  SpotifyIframeApi,
+  SpotifyPlaybackState,
+  SpotifyPlaybackUpdateEvent,
+} from './iframe-api';
+export * from './media';
+export * from './props';
+export * from './source';

--- a/packages/media/src/dom/spotify/media.ts
+++ b/packages/media/src/dom/spotify/media.ts
@@ -1,0 +1,760 @@
+// Adapted from `spotify-audio-element` from `muxinc/media-elements`,
+// ported to TypeScript and reshaped as a media host to fit the v10
+// media-host architecture (mirrors `dom/youtube`).
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
+import { deepEqual } from '@videojs/utils/object';
+import { isNumber } from '@videojs/utils/predicate';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
+import { MediaError } from '../../core/media-error';
+import type { Video } from '../../core/types';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+import { createTimeRange } from '../utils';
+import {
+  loadSpotifyIframeApi,
+  type SpotifyControllerApi,
+  type SpotifyIframeApi,
+  type SpotifyPlaybackState,
+} from './iframe-api';
+import { spotifyMediaDefaultProps } from './props';
+import { buildSpotifyIframeSrc, parseSpotifySource, type SpotifySource } from './source';
+
+const SpotifyMediaBase = MediaPlayedRangesMixin(EventTarget);
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ */
+export class SpotifyMedia extends SpotifyMediaBase implements Partial<Video> {
+  #target: HTMLIFrameElement | null = null;
+  /** The iframe `attach()` was handed, held while the controller's own stands in for it. */
+  #controller: SpotifyControllerApi | null = null;
+  /** The controller drops `loadUri` before it reports itself ready. */
+  #controllerReady = false;
+  /** A load was requested before the controller was ready; replay it on `ready`. */
+  #pendingLoad = false;
+  /** Controller creation is in flight; the API load makes it span more than a tick. */
+  #creatingController = false;
+  #loadComplete = createPublicPromise<void>();
+  /** Guards async controller creation across attach/detach cycles. */
+  #attachId = 0;
+
+  #src = spotifyMediaDefaultProps.src;
+  #autoplay = spotifyMediaDefaultProps.autoplay;
+
+  #loop = spotifyMediaDefaultProps.loop;
+  #controls = spotifyMediaDefaultProps.controls;
+  #playsInline = spotifyMediaDefaultProps.playsInline;
+  #preload = spotifyMediaDefaultProps.preload;
+  #poster = spotifyMediaDefaultProps.poster;
+  #source: SpotifySource | null = spotifyMediaDefaultProps.source;
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #loaded = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: MediaError | null = null;
+  /** Playback started but is stalled; the embed reports it as buffering-while-paused. */
+  #waiting = false;
+  /** A pause was asked for, so the paused update it produces is not a stall. */
+  #pauseRequested = false;
+  /** The entity ran out; kept so the end of playback is acted on exactly once. */
+  #closeToEnded = false;
+
+  static PLAYER_SOFTWARE_NAME = 'spotify-audio';
+
+  /** Underlying Spotify iframe API controller (null until the API loads). */
+  get engine() {
+    return this.#controller;
+  }
+
+  /**
+   * The iframe holding the embed, which is not always the one `attach()` was
+   * given: the iframe API replaces it with one of its own, and that one is what
+   * everything from the embed URL down is written to afterwards.
+   */
+  get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /**
+   * Bind the iframe hosting the embed. The iframe API and its controller follow
+   * as soon as an embed URL can be resolved, which is not always now: a framework
+   * that creates the element before setting `src` attaches an iframe with
+   * nothing to embed yet, and `load()` picks it up once a source arrives.
+   */
+  attach(target: HTMLIFrameElement | null): void {
+    if (!target || this.#target === target) return;
+    if (this.#target) this.detach();
+    this.#target = target;
+    this.#beginLoad();
+    this.#createPlayer();
+  }
+
+  detach(): void {
+    if (!this.#target) return;
+    this.#attachId++;
+    try {
+      if (this.#controller) {
+        // `destroy()` removes whatever `iframeElement` points at, which is the embed
+        // this host does not own — React renders it, and the custom element keeps it
+        // in its shadow root. Pointing the controller at a throwaway first leaves it
+        // with nothing to remove, so all `destroy()` does is unbind its listener.
+        this.#controller.iframeElement = createControllerPlaceholderFrame();
+        this.#controller.destroy();
+      }
+    } catch {
+      // The iframe API throws if the iframe was already removed.
+    }
+    this.#controller = null;
+    this.#controllerReady = false;
+    this.#pendingLoad = false;
+    this.#creatingController = false;
+    this.#target = null;
+    // Unblock callers awaiting load; they re-check `#controller` (now null) and no-op.
+    this.#loadComplete.resolve();
+    this.#resetState();
+  }
+
+  override destroy() {
+    this.detach();
+    super.destroy();
+  }
+
+  get src() {
+    return this.#src;
+  }
+  /** Spotify URL or URI. Setting it re-derives `source`, carrying its embed options over. */
+  set src(value) {
+    const { engine } = this.#source ?? {};
+    const next: SpotifySource = { ...(engine && { engine }), ...(value && { src: value }) };
+
+    // Everything happens in the `source` setter, so there is one path for storing
+    // it, deciding on a load, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  get currentSrc() {
+    // The `src` property resolves an empty attribute to the document URL, so only
+    // the attribute can report an embed that hasn't been built yet as empty.
+    return this.#target?.getAttribute('src') ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /** Reload the current source via the iframe API; deferred until the controller is ready. */
+  async load() {
+    if (!this.#controller || !this.#controllerReady) {
+      // `loadUri` is dropped before the controller reports itself ready; replay
+      // the load then. A cleared src replays too, so the barrier below always
+      // gets settled.
+      this.#pendingLoad = !!this.#target;
+      // The target can be attached before it has anything to embed, in which case
+      // this load is what finally builds it.
+      if (this.#target && !this.#controller && !this.#creatingController) {
+        // The barrier `attach()` opened was settled when there was nothing to
+        // embed, so this load needs one of its own — otherwise `play()` runs
+        // before the controller it is waiting for exists.
+        const load = this.#beginLoad();
+        // Wait a microtask: a framework sets `src` and the props that shape the
+        // embed in whatever order it likes, and the embed URL is only built once,
+        // so it has to see all of them.
+        await Promise.resolve();
+        // A later load took over while waiting; building the embed is its job now.
+        if (load !== this.#loadComplete) return;
+        this.#createPlayer();
+      }
+      return;
+    }
+    const load = this.#beginLoad();
+    // Reset before bailing on an empty src: a cleared source has nothing to load,
+    // but what we report about the old entity still has to go.
+    this.#resetState();
+    if (!this.#src) {
+      // The embed has to stop too. Left running it keeps playing, and its updates
+      // write the state just cleared straight back. Pausing is as far as the
+      // controller goes; there is nothing that unloads the entity.
+      load.resolve();
+      try {
+        this.#controller.pause();
+      } catch {
+        // The iframe API throws if the controller was destroyed mid-flight.
+      }
+      return;
+    }
+    this.dispatchEvent(new Event('emptied'));
+    this.dispatchEvent(new Event('loadstart'));
+    const parsed = parseSpotifySource(this.#src);
+    if (!parsed) {
+      this.#error = new MediaError(`Unrecognized Spotify source: ${this.#src}`, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play() doesn't hang.
+      load.resolve();
+      return;
+    }
+    const target = this.#target;
+    const embedSrc = buildSpotifyIframeSrc(this.#src, this.#snapshotProps());
+    const embeddedSrc = target?.getAttribute('src') ?? '';
+    // The theme, the video variant, and whatever else Spotify reads off the embed
+    // URL exist nowhere the controller can be told about, so a reload that changes
+    // any of them has to rebuild the embed. Swapping only the entity does not, and
+    // rebuilding for that would reload the frame for nothing — except in the video
+    // variant, which is a path and so belongs to the entity embedded at it, while
+    // `loadUri` names an entity and nothing else and would leave the audio one.
+    const rebuild =
+      embedOptionsOf(embedSrc) !== embedOptionsOf(embeddedSrc) ||
+      (isVideoEmbed(embedSrc) && embedPathOf(embedSrc) !== embedPathOf(embeddedSrc));
+    if (target && embedSrc && rebuild) {
+      target.src = embedSrc;
+      return;
+    }
+    // The controller names entities by URI, whatever form `src` was written in.
+    this.#controller.loadUri(`spotify:${parsed.type}:${parsed.id}`);
+    // `loadUri` starts the entity from the top, so the start position — which only
+    // the embed URL applies for itself — is seeked to. An engine option outranks
+    // the `t` the src carries, the same way it does when the URL is built.
+    const startTime = this.#source?.engine?.spotify?.t ?? parsed.startTime;
+    if (isNumber(startTime)) this.currentTime = startTime;
+  }
+
+  /**
+   * Take over as the current load, returning its barrier. Settling the outgoing
+   * one is what keeps a superseded load from stranding callers that are already
+   * waiting; every exit from `load()` settles the barrier it was handed.
+   */
+  #beginLoad(): PublicPromise<void> {
+    this.#loadComplete.resolve();
+    this.#loadComplete = createPublicPromise<void>();
+    return this.#loadComplete;
+  }
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    await this.#loadComplete;
+    // The embed still holds the paused entity, so playing it would resume a
+    // source that was cleared.
+    if (!this.#src) return;
+    // `resume()` picks playback up where it stopped; `play()` would restart the
+    // entity, which is not what pressing play on a paused media does.
+    this.#controller?.resume();
+  }
+
+  pause() {
+    // A stall is reported as paused as well, so a pause that was asked for has to
+    // be remembered — otherwise the update it produces reads as more buffering and
+    // the pause is never reported.
+    this.#pauseRequested = true;
+    this.#controller?.pause();
+  }
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#seeking = true;
+    // Seeking starts a fresh run, so whatever ran out before it is behind us.
+    this.#closeToEnded = false;
+    this.#ended = false;
+    // Report the requested position right away: the embed only reports one about
+    // once a second, and until then the seek would look like it never happened.
+    this.#currentTime = value;
+    this.dispatchEvent(new Event('seeking'));
+    this.dispatchEvent(new Event('timeupdate'));
+    this.#afterLoad((controller) => controller.seek(value));
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  // No volume or mute surface: the embed takes neither command and reports
+  // neither value, so the members are absent rather than present and inert.
+  // Declaring them would read as a capability the player could use, and it would
+  // offer a volume slider and a mute button that do nothing.
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+  set autoplay(value) {
+    this.#autoplay = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+  set loop(value) {
+    // The embed has no loop of its own; the end of playback seeks back instead.
+    this.#loop = value;
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+  set controls(value) {
+    this.#controls = value;
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+  set playsInline(value) {
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+  set preload(value) {
+    this.#preload = value;
+  }
+
+  get poster() {
+    return this.#poster;
+  }
+  set poster(value) {
+    this.#poster = value;
+  }
+
+  /**
+   * Structured source: the Spotify URL or URI in `src`, plus embed options under
+   * `engine.spotify`. Replacing it re-derives `src`; assigning an equivalent
+   * source is a no-op.
+   */
+  get source(): SpotifySource | null {
+    return this.#source;
+  }
+  set source(value: SpotifySource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    const src = source?.src ?? '';
+    const srcChanged = this.#src !== src;
+    // Embed options are read when the embed is built, so a change to them needs a
+    // reload of its own even though the URL is the same.
+    const engineChanged = !deepEqual(this.#source?.engine?.spotify ?? null, source?.engine?.spotify ?? null);
+
+    this.#source = source;
+    this.#src = src;
+
+    if (srcChanged || engineChanged) void this.load();
+
+    // Assigning is always a source change, so it is always announced.
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+
+  get buffered() {
+    // The embed reports no buffer state, only a position, so the only stretch
+    // known to be available is the one already played through.
+    return this.#currentTime > 0 ? createTimeRange(0, this.#currentTime) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRange(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  /** Always empty: the embed exposes no captions or other text tracks. */
+  get textTracks() {
+    return EMPTY_TEXT_TRACKS;
+  }
+
+  /**
+   * Build the embed and start controller creation once a source can be resolved.
+   * The iframe API only talks to an iframe that already holds a Spotify embed, so
+   * a target that cannot be resolved yet leaves the controller null and settles
+   * the load it was given; the next `load()` retries.
+   *
+   * @returns Whether controller creation started.
+   */
+  #createPlayer(): boolean {
+    const target = this.#target;
+    if (!target || this.#controller || this.#creatingController) return false;
+
+    // The `src` property resolves an empty attribute to the document URL, so it
+    // cannot tell an embed apart from a placeholder; the attribute can.
+    if (!target.getAttribute('src')) {
+      const initialSrc = buildSpotifyIframeSrc(this.#src, this.#snapshotProps());
+      // No embed means no controller is coming to settle this load.
+      if (!initialSrc) {
+        this.#loadComplete.resolve();
+        return false;
+      }
+      target.src = initialSrc;
+    }
+
+    this.#creatingController = true;
+    this.dispatchEvent(new Event('loadstart'));
+    void this.#createControllerApi(target);
+    return true;
+  }
+
+  async #createControllerApi(target: HTMLIFrameElement) {
+    const attachId = this.#attachId;
+    let api: SpotifyIframeApi;
+    try {
+      api = await loadSpotifyIframeApi();
+    } catch {
+      // A failed API load belongs to the attach that started it; a newer one must
+      // not be marked failed or have its load unblocked.
+      if (this.#isStale(attachId)) return;
+      this.#creatingController = false;
+      this.#error = new MediaError('Failed to load the Spotify iframe API', MediaError.MEDIA_ERR_NETWORK);
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play() doesn't hang.
+      this.#loadComplete.resolve();
+      return;
+    }
+    if (this.#isStale(attachId) || this.#target !== target) return;
+    // `referrerPolicy` configures the iframe rather than the embed, so it is the
+    // one engine option Spotify has no use for.
+    const { referrerPolicy: _referrerPolicy, ...options } = this.#source?.engine?.spotify ?? {};
+    const controller = await new Promise<SpotifyControllerApi>((resolve) =>
+      // Deliberately no entity: naming one here has the controller build an embed
+      // URL of its own, which carries none of what this host put on the one it
+      // built. Spotify's own keys go through either way.
+      //
+      // The placeholder is what keeps the embed ours. `createController` builds an
+      // iframe of its own and runs `target.parentElement?.replaceChild(...)`, so a
+      // target with an element parent — anything React renders — is swapped out and
+      // left holding a discarded browsing context. Handing over a detached node
+      // makes `parentElement` null, so the swap cannot fire and the controller is
+      // simply pointed at the iframe this host already built.
+      api.createController(createControllerPlaceholder(), options, resolve)
+    );
+    if (this.#isStale(attachId) || this.#target !== target) {
+      try {
+        controller.destroy();
+      } catch {
+        // The iframe API throws if the iframe was already removed.
+      }
+      return;
+    }
+    // Both directions of the protocol read this: commands post to its
+    // `contentWindow`, and inbound messages are matched against it.
+    controller.iframeElement = target;
+    this.#controller = controller;
+    this.#creatingController = false;
+    this.#bindControllerEvents(controller, attachId);
+  }
+
+  /**
+   * Whether a callback belongs to a superseded attach. `destroy()` does not stop
+   * the iframe API from invoking callbacks it already scheduled, so anything a
+   * controller reports has to be matched against the attach that created it
+   * before it is allowed to touch state.
+   */
+  #isStale(attachId: number) {
+    return attachId !== this.#attachId;
+  }
+
+  /** Defer a controller call until `loadComplete` resolves, swallowing failures. */
+  #afterLoad(fn: (controller: SpotifyControllerApi) => void) {
+    this.#loadComplete.then(
+      () => {
+        if (!this.#controller) return;
+        try {
+          fn(this.#controller);
+        } catch {
+          // The iframe API throws if the controller was destroyed mid-flight.
+        }
+      },
+      () => {}
+    );
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      loop: this.#loop,
+      controls: this.#controls,
+      playsInline: this.#playsInline,
+      preload: this.#preload || spotifyMediaDefaultProps.preload,
+      source: this.#source,
+    };
+  }
+
+  #resetState() {
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    this.#paused = !this.#autoplay;
+    this.#ended = false;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#loaded = false;
+    this.#waiting = false;
+    this.#pauseRequested = false;
+    this.#closeToEnded = false;
+    this.#error = null;
+  }
+
+  #onControllerReady() {
+    this.#controllerReady = true;
+    if (this.#pendingLoad) {
+      // The embed was built from a stale src; skip its metadata and reload. The
+      // first playback update after that completes the load (see `#onPlaybackUpdate`).
+      this.#pendingLoad = false;
+      void this.load();
+      return;
+    }
+    this.#onLoaded();
+  }
+
+  #onLoaded() {
+    if (this.#loaded) return;
+    this.#loaded = true;
+    this.#readyState = READY_STATE_HAVE_METADATA;
+    // Duration arrives with the first playback update, which dispatches a
+    // `durationchange` of its own once it does.
+    // No `volumechange`: this host reports no volume for anything to read.
+    for (const type of ['loadedmetadata', 'durationchange', 'loadcomplete']) {
+      this.dispatchEvent(new Event(type));
+    }
+    this.#loadComplete.resolve();
+    // The embed URL carries no autoplay parameter, so asking the controller to
+    // play is the only way to honor the prop.
+    if (this.#autoplay) void this.play();
+  }
+
+  #bindControllerEvents(controller: SpotifyControllerApi, attachId: number) {
+    controller.addListener('ready', () => {
+      if (this.#isStale(attachId)) return;
+      this.#onControllerReady();
+    });
+
+    controller.addListener('playback_update', (event) => {
+      if (this.#isStale(attachId)) return;
+      this.#onPlaybackUpdate(event.data);
+    });
+  }
+
+  /**
+   * The embed reports playback as a state snapshot rather than as events, so
+   * every event this host dispatches is a difference between two of them. At most
+   * one transition is worth reporting per update, which is what the early returns
+   * below are for.
+   */
+  #onPlaybackUpdate(data: SpotifyPlaybackState) {
+    // Subsequent loads (`loadUri`) never re-fire `ready`, so the first update
+    // after one completes the load. With no src there is no load to complete, and
+    // the paused embed reports updates of its own — completing on one of those
+    // would put the cleared state right back.
+    if (this.#src && !this.#loaded) this.#onLoaded();
+
+    if (this.#restartFromEnd(data)) return;
+
+    this.#syncDuration(data.duration);
+    this.#syncPosition(data.position);
+
+    if (this.#syncPlayState(data)) return;
+
+    this.#checkEnded();
+  }
+
+  /**
+   * Whether playback is under way. The embed reports a stall as buffering while
+   * still flagged paused, so either half of the pair means it is running.
+   */
+  #isStarting(data: SpotifyPlaybackState) {
+    return data.isBuffering || !data.isPaused;
+  }
+
+  /**
+   * Playing again once the entity has finished has to restart it: the embed
+   * leaves the position at the end, where resuming has nothing left to play. The
+   * seek turns this update into the start of a fresh run, so nothing else acts
+   * on it.
+   */
+  #restartFromEnd(data: SpotifyPlaybackState): boolean {
+    if (!this.#closeToEnded || !this.#paused || !this.#isStarting(data)) return false;
+    this.#closeToEnded = false;
+    this.currentTime = REPLAY_POSITION;
+    return true;
+  }
+
+  #syncDuration(duration: number) {
+    const seconds = duration / 1000;
+    if (seconds === this.#duration) return;
+    // A different duration is a different entity, so whatever ended before it is
+    // no longer what is playing.
+    this.#closeToEnded = false;
+    this.#duration = seconds;
+    this.dispatchEvent(new Event('durationchange'));
+  }
+
+  #syncPosition(position: number) {
+    const seconds = position / 1000;
+    if (this.#seeking) {
+      // The embed announces no seeks and goes on reporting the position it was
+      // playing until the new one takes, so only a snapshot at the position that
+      // was asked for says the seek landed. `seek` truncates to whole seconds and
+      // the snapshot after it can be a snapshot late, which is the window here;
+      // anything outside it belongs to where playback was before the seek.
+      if (seconds < Math.floor(this.#currentTime) || seconds > this.#currentTime + SNAPSHOT_INTERVAL) return;
+      this.#seeking = false;
+      this.dispatchEvent(new Event('seeked'));
+    }
+    if (seconds === this.#currentTime) return;
+    // Only a position back inside the entity is a new run; one still at the end
+    // belongs to the run that just finished there (see `#checkEnded`).
+    if (Math.ceil(seconds) < this.#duration) {
+      this.#closeToEnded = false;
+      this.#ended = false;
+    }
+    this.#currentTime = seconds;
+    this.dispatchEvent(new Event('timeupdate'));
+  }
+
+  /**
+   * Translate the `isPaused`/`isBuffering` pair into play/pause/waiting/playing.
+   *
+   * @returns Whether the update was a transition, which nothing else may act on.
+   */
+  #syncPlayState(data: SpotifyPlaybackState): boolean {
+    if (!this.#paused && data.isPaused) {
+      // A stall is reported as paused as well, so a run that stopped while it was
+      // buffering stopped for data rather than for the listener — unless the
+      // listener is who asked, which the embed can report mid-buffer.
+      if (data.isBuffering && !this.#pauseRequested) {
+        // A run that is already waiting has nothing new to report.
+        if (this.#waiting) return false;
+        this.#waiting = true;
+        this.dispatchEvent(new Event('waiting'));
+        return true;
+      }
+      this.#pauseRequested = false;
+      this.#waiting = false;
+      this.#paused = true;
+      this.dispatchEvent(new Event('pause'));
+      return true;
+    }
+
+    if (this.#paused && this.#isStarting(data)) {
+      this.#pauseRequested = false;
+      this.#paused = false;
+      this.#ended = false;
+      this.dispatchEvent(new Event('play'));
+      // Buffering at the start means the entity is still loading, so playback has
+      // begun without playing yet.
+      this.#waiting = data.isBuffering;
+      if (!this.#waiting) this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+      this.dispatchEvent(new Event(this.#waiting ? 'waiting' : 'playing'));
+      return true;
+    }
+
+    if (this.#waiting && !data.isPaused) {
+      this.#waiting = false;
+      this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+      this.dispatchEvent(new Event('playing'));
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * The embed never reports that it reached the end, so the end has to be
+   * inferred from the position catching up with the duration. Positions arrive
+   * about once a second, so the last one lands short of the end — hence rounding
+   * it up before the comparison.
+   */
+  #checkEnded() {
+    if (this.#paused || this.#seeking || this.#closeToEnded) return;
+    // A duration the embed has not resolved yet — `NaN` when the update carried
+    // none, `0` while it is still working the entity out — is nothing to end
+    // against: every position is at or past it.
+    if (!(this.#duration > 0) || !Number.isFinite(this.#duration)) return;
+    if (Math.ceil(this.#currentTime) < this.#duration) return;
+    // The position stops moving at the end, so every later update would report
+    // the same thing; only the first one acts.
+    this.#closeToEnded = true;
+
+    if (this.#loop) {
+      this.currentTime = REPLAY_POSITION;
+      return;
+    }
+
+    this.#paused = true;
+    this.#ended = true;
+    // The embed rolls on into whatever follows the entity unless it is stopped.
+    this.pause();
+    this.dispatchEvent(new Event('pause'));
+    this.dispatchEvent(new Event('ended'));
+  }
+}
+
+/**
+ * A node for `createController` to consume instead of the embed. It is never
+ * inserted, so the swap the controller performs on its target cannot reach the
+ * iframe this host owns.
+ */
+function createControllerPlaceholder(): HTMLElement {
+  return globalThis.document.createElement('div');
+}
+
+/** The same idea for teardown, where the controller expects an iframe to remove. */
+function createControllerPlaceholderFrame(): HTMLIFrameElement {
+  return globalThis.document.createElement('iframe');
+}
+
+/**
+ * What an embed URL says about how an entity is embedded rather than which one it
+ * is or where it starts — the theme, the video variant, anything else Spotify
+ * reads from the URL. The controller swaps entities and seeks on its own, so only
+ * a difference here is worth rebuilding an embed for.
+ */
+function embedOptionsOf(src: string): string {
+  const [, query] = src.split('?');
+  const params = new URLSearchParams(query);
+  params.delete('t');
+  params.sort();
+  return `${isVideoEmbed(src) ? 'video' : 'audio'}?${params}`;
+}
+
+/** The entity an embed URL points at, without the parameters that configure it. */
+function embedPathOf(src: string): string {
+  return src.split('?')[0] ?? '';
+}
+
+/** Whether an embed URL points at the video variant, which lives at its own path. */
+function isVideoEmbed(src: string): boolean {
+  return embedPathOf(src).endsWith('/video');
+}
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_FUTURE_DATA = 3;
+
+/**
+ * Where a replay starts. A second in rather than zero, which the embed can drop
+ * on a finished entity; inherited from `spotify-audio-element`.
+ */
+const REPLAY_POSITION = 1;
+
+/** How far apart playback snapshots land, near enough: the embed reports about once a second. */
+const SNAPSHOT_INTERVAL = 1;

--- a/packages/media/src/dom/spotify/props.ts
+++ b/packages/media/src/dom/spotify/props.ts
@@ -1,0 +1,27 @@
+import type { Video } from '../../core/types';
+import type { SpotifySource } from './source';
+
+/**
+ * The `Video` members the Spotify host accepts, plus the source that names the
+ * entity. Narrower than the other embed hosts by one pair: the embed takes no
+ * volume or mute command and reports neither value, so `muted` and
+ * `defaultMuted` are absent rather than inert — a prop that cannot reach the
+ * player reads as a capability the player has. `poster` has no artwork of its
+ * own to replace and `playsInline` no inline-playback switch, so those two are
+ * kept for a uniform prop shape but are stored and reported without effect.
+ */
+export interface SpotifyMediaProps
+  extends Pick<Video, 'src' | 'autoplay' | 'loop' | 'controls' | 'playsInline' | 'preload' | 'poster'> {
+  source: SpotifySource | null;
+}
+
+export const spotifyMediaDefaultProps: SpotifyMediaProps = {
+  src: '',
+  autoplay: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  source: null,
+};

--- a/packages/media/src/dom/spotify/source.ts
+++ b/packages/media/src/dom/spotify/source.ts
@@ -1,0 +1,107 @@
+import { serializeEmbedParams } from '../utils';
+import type { SpotifyMediaProps } from './props';
+
+/**
+ * Spotify engine options, spelled exactly as Spotify spells them
+ * (https://developer.spotify.com/documentation/embeds). They are serialized onto
+ * the embed URL verbatim, so what you write here is what the embed reads.
+ *
+ * Spotify publishes only a handful of them, and the ones the host owns are
+ * deliberately absent: the start position comes from the `t` parameter on `src`.
+ * The index signature still carries anything not listed here, so undocumented
+ * knobs and whatever Spotify adds next keep working.
+ */
+export interface SpotifyEngineConfig extends Record<string, unknown> {
+  /** Start position in seconds. */
+  t?: number;
+  /**
+   * `0` renders the embed in its dark theme. Defaults to the light theme. Spotify
+   * documents no other value, and the embed goes by whether the parameter is
+   * there, so leaving it out is the only way to ask for the default.
+   */
+  theme?: 0;
+  /**
+   * Embed the video variant of an episode when it has one. Not a URL parameter:
+   * the video embed lives at its own path.
+   */
+  preferVideo?: boolean;
+  /** `referrerpolicy` for the embed iframe. Not a Spotify embed parameter. */
+  referrerPolicy?: ReferrerPolicy;
+}
+
+/** Structured Spotify source: which source to play, plus how to play it. */
+export interface SpotifySource {
+  /** Spotify URL or URI. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: SpotifySourceEngineConfig | undefined;
+}
+
+/** The engines a Spotify source can configure. */
+export interface SpotifySourceEngineConfig {
+  /** Spotify's own embed options, passed through untouched. */
+  spotify?: SpotifyEngineConfig | undefined;
+}
+
+/** The entities Spotify can embed. */
+export type SpotifyEntityType = 'track' | 'episode' | 'album' | 'playlist' | 'show' | 'artist';
+
+/** Parsed pieces of a Spotify source URL or URI. */
+export interface ParsedSpotifySource {
+  /** Which kind of entity the embed plays; it names the embed path. */
+  type: SpotifyEntityType;
+  /** Base62 entity id. */
+  id: string;
+  /** Start position in seconds parsed from the `t` parameter. */
+  startTime: number | null;
+}
+
+/** Extract a Spotify entity id from any recognized URL or `spotify:` URI. */
+export function parseSpotifyEntityId(src: string) {
+  return parseSpotifySource(src)?.id ?? null;
+}
+
+/**
+ * Parse a Spotify source string. Recognizes `open.spotify.com` URLs for every
+ * embeddable entity — including the localized (`/intl-de/`) and already-embedded
+ * (`/embed/`) forms, since the entity type and id sit in the same place in all of
+ * them — `spotify:<type>:<id>` URIs, and start positions via the `t` parameter.
+ */
+export function parseSpotifySource(src: string): ParsedSpotifySource | null {
+  if (!src) return null;
+  const match = MATCH_URI.exec(src) ?? MATCH_SRC.exec(src);
+  const type = match?.[1]?.toLowerCase() as SpotifyEntityType | undefined;
+  const id = match?.[2];
+  if (!type || !id) return null;
+  return { type, id, startTime: parseStartTime(src) };
+}
+
+/** Build the iframe `src` URL for an initial Spotify embed from the given props. */
+export function buildSpotifyIframeSrc(src: string, props: Partial<SpotifyMediaProps> = {}) {
+  const parsed = parseSpotifySource(src);
+  if (!parsed) return '';
+  // Neither of these is an embed parameter: `preferVideo` picks the path below,
+  // and `referrerPolicy` is an attribute of the iframe hosting the embed.
+  const { preferVideo, referrerPolicy: _referrerPolicy, ...spotify } = props.source?.engine?.spotify ?? {};
+  const params: Record<string, unknown> = {
+    t: parsed.startTime,
+    // Spotify-specific knobs (`theme`, `utm_source`, …) flow through here.
+    ...spotify,
+  };
+  const videoPath = preferVideo ? '/video' : '';
+  // Spotify publishes so few parameters that most embeds need none at all.
+  const query = serializeEmbedParams(params);
+  return `${EMBED_BASE}/embed/${parsed.type}/${parsed.id}${videoPath}${query ? `?${query}` : ''}`;
+}
+
+/** Parse the `t` parameter from a Spotify share URL. Spotify spells it in seconds. */
+function parseStartTime(url: string): number | null {
+  const value = /[?&]t=(\d+)/.exec(url)?.[1];
+  return value ? Number.parseInt(value, 10) : null;
+}
+
+const EMBED_BASE = 'https://open.spotify.com';
+// The entity type and id are always the last two path segments, so whatever
+// Spotify puts in front of them (`/intl-de/`, `/embed/`) is skipped.
+const MATCH_SRC = /open\.spotify\.com\/(?:[\w-]+\/)*?(track|episode|album|playlist|show|artist)\/(\w+)/i;
+const MATCH_URI = /^spotify:(track|episode|album|playlist|show|artist):(\w+)$/i;

--- a/packages/media/src/dom/spotify/tests/media.test.ts
+++ b/packages/media/src/dom/spotify/tests/media.test.ts
@@ -1,0 +1,1189 @@
+import { loadScript } from '@videojs/utils/dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
+import { isMediaVolumeCapable } from '../../../core/predicate';
+import type { Video } from '../../../core/types';
+import {
+  buildSpotifyIframeSrc,
+  parseSpotifyEntityId,
+  parseSpotifySource,
+  SpotifyMedia,
+  type SpotifyPlaybackState,
+  type SpotifyPlaybackUpdateEvent,
+  spotifyMediaDefaultProps,
+} from '..';
+
+vi.mock(import('@videojs/utils/dom'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return { ...mod, loadScript: vi.fn(async () => {}) };
+});
+
+type ReadyListener = () => void;
+type PlaybackUpdateListener = (event: SpotifyPlaybackUpdateEvent) => void;
+
+/**
+ * Stands in for a controller from the live iframe API, including the part that
+ * matters most to this host: `createController` never drives the element it is
+ * handed. It builds an iframe of its own and swaps it in for the target — but
+ * only through `parentElement`, so a target that is detached, or one parented by
+ * a shadow root rather than an element, is left alone. Reproducing that exactly
+ * is the point: a mock that swapped on `parentNode` hid a bug where this host
+ * followed the controller onto an iframe that was never in the document.
+ */
+class MockController {
+  static instances: MockController[] = [];
+  target: HTMLElement;
+  options: unknown;
+  /** The iframe the controller built for itself. */
+  iframeElement: HTMLIFrameElement;
+  readyListeners = new Set<ReadyListener>();
+  playbackListeners = new Set<PlaybackUpdateListener>();
+
+  loadUri = vi.fn();
+  play = vi.fn();
+  resume = vi.fn();
+  pause = vi.fn();
+  togglePlay = vi.fn();
+  seek = vi.fn();
+  destroy = vi.fn(() => {
+    this.iframeElement.parentNode?.removeChild(this.iframeElement);
+  });
+
+  constructor(target: HTMLElement, options: unknown) {
+    this.target = target;
+    this.options = options;
+    this.iframeElement = document.createElement('iframe');
+    this.iframeElement.setAttribute('frameborder', '0');
+    this.iframeElement.setAttribute('allowfullscreen', '');
+    this.iframeElement.setAttribute('loading', 'lazy');
+    // `parentElement`, exactly as the live bundle spells it.
+    target.parentElement?.replaceChild(this.iframeElement, target);
+    MockController.instances.push(this);
+  }
+
+  addListener(type: 'ready' | 'playback_update', listener: ReadyListener | PlaybackUpdateListener): void {
+    if (type === 'ready') this.readyListeners.add(listener as ReadyListener);
+    else this.playbackListeners.add(listener as PlaybackUpdateListener);
+  }
+
+  ready(): void {
+    this.readyListeners.forEach((listener) => listener());
+  }
+
+  /** Push a playback snapshot, filling in the fields a test doesn't care about. */
+  update(data: Partial<SpotifyPlaybackState> = {}): void {
+    const payload: SpotifyPlaybackState = {
+      isPaused: true,
+      isBuffering: false,
+      position: 0,
+      duration: 60_000,
+      ...data,
+    };
+    this.playbackListeners.forEach((listener) => listener({ data: payload }));
+  }
+}
+
+const TRACK_URL = 'https://open.spotify.com/track/1301WleyT98MSxVHPZCA6M';
+const TRACK_ID = '1301WleyT98MSxVHPZCA6M';
+const EPISODE_URL = 'https://open.spotify.com/episode/7makk4oTQel546B0PZlDM5';
+const OTHER_EPISODE_ID = '43cbJh4ccRD7lzM2730YK3';
+const OTHER_EPISODE_URL = `https://open.spotify.com/episode/${OTHER_EPISODE_ID}`;
+
+beforeEach(() => {
+  MockController.instances.length = 0;
+  vi.stubGlobal('SpotifyIframeApi', {
+    createController: (target: HTMLIFrameElement, options: unknown, callback: (controller: MockController) => void) =>
+      callback(new MockController(target, options)),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+/** An iframe as a framework renders it: in the document, where it can be swapped out. */
+function createIframe(): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  return iframe;
+}
+
+/** An iframe as React renders it before a source resolves: `src` present but empty. */
+function createEmptySrcIframe(): HTMLIFrameElement {
+  const iframe = createIframe();
+  iframe.setAttribute('src', '');
+  return iframe;
+}
+
+/** Flush the microtask the deferred embed waits on before it is built. */
+async function flushDeferredEmbed(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForEngine(media: SpotifyMedia): Promise<MockController> {
+  await vi.waitFor(() => {
+    if (!media.engine) throw new Error('controller not created yet');
+  });
+  return media.engine as unknown as MockController;
+}
+
+async function attachAndLoad(media: SpotifyMedia): Promise<{
+  /** The iframe holding the embed. It is the one `attach()` was handed. */
+  iframe: HTMLIFrameElement;
+  controller: MockController;
+}> {
+  // There is no embed to attach to without a source, so tests that don't care
+  // which entity is playing get one.
+  if (!media.src) media.src = TRACK_URL;
+  const iframe = createIframe();
+  media.attach(iframe);
+  const controller = await waitForEngine(media);
+  controller.ready();
+  return { iframe, controller };
+}
+
+describe('parseSpotifyEntityId', () => {
+  it('extracts id from a share URL', () => {
+    expect(parseSpotifyEntityId(TRACK_URL)).toBe(TRACK_ID);
+  });
+
+  it('extracts id from a spotify URI', () => {
+    expect(parseSpotifyEntityId(`spotify:track:${TRACK_ID}`)).toBe(TRACK_ID);
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseSpotifyEntityId('')).toBe(null);
+  });
+
+  it('returns null for non-Spotify URLs', () => {
+    expect(parseSpotifyEntityId('https://example.com/track/1301WleyT98MSxVHPZCA6M')).toBe(null);
+  });
+});
+
+describe('parseSpotifySource', () => {
+  it('parses every embeddable entity type', () => {
+    for (const type of ['track', 'episode', 'album', 'playlist', 'show', 'artist'] as const) {
+      expect(parseSpotifySource(`https://open.spotify.com/${type}/${TRACK_ID}`)).toEqual({
+        type,
+        id: TRACK_ID,
+        startTime: null,
+      });
+      expect(parseSpotifySource(`spotify:${type}:${TRACK_ID}`)).toEqual({ type, id: TRACK_ID, startTime: null });
+    }
+  });
+
+  it('parses localized and already-embedded URLs', () => {
+    expect(parseSpotifySource(`https://open.spotify.com/intl-de/track/${TRACK_ID}`)?.id).toBe(TRACK_ID);
+    expect(parseSpotifySource(`https://open.spotify.com/embed/episode/${TRACK_ID}`)).toEqual({
+      type: 'episode',
+      id: TRACK_ID,
+      startTime: null,
+    });
+  });
+
+  it('parses the start position from the t param', () => {
+    expect(parseSpotifySource(`${EPISODE_URL}?t=1200`)?.startTime).toBe(1200);
+    expect(parseSpotifySource(`${EPISODE_URL}?si=abc&t=90`)?.startTime).toBe(90);
+  });
+
+  it('ignores query strings that are not a source', () => {
+    expect(parseSpotifySource(`${TRACK_URL}?si=8f0f1b3a`)).toEqual({ type: 'track', id: TRACK_ID, startTime: null });
+  });
+
+  it('returns null for empty input, unknown entities, and other hosts', () => {
+    expect(parseSpotifySource('')).toBe(null);
+    expect(parseSpotifySource(`https://open.spotify.com/user/${TRACK_ID}`)).toBe(null);
+    expect(parseSpotifySource('https://example.com/not-spotify')).toBe(null);
+  });
+});
+
+describe('buildSpotifyIframeSrc', () => {
+  it('builds the embed URL for a share URL', () => {
+    expect(buildSpotifyIframeSrc(TRACK_URL)).toBe(`https://open.spotify.com/embed/track/${TRACK_ID}`);
+  });
+
+  it('builds the embed URL for a spotify URI', () => {
+    expect(buildSpotifyIframeSrc(`spotify:show:${TRACK_ID}`)).toBe(`https://open.spotify.com/embed/show/${TRACK_ID}`);
+  });
+
+  it('embeds the start position from the t param', () => {
+    expect(buildSpotifyIframeSrc(`${EPISODE_URL}?t=1200`)).toContain('?t=1200');
+  });
+
+  it('serializes Spotify embed options verbatim', () => {
+    const src = buildSpotifyIframeSrc(TRACK_URL, { source: { engine: { spotify: { theme: 0 } } } });
+    expect(src).toContain('theme=0');
+  });
+
+  it('carries undeclared Spotify embed options through', () => {
+    const src = buildSpotifyIframeSrc(TRACK_URL, {
+      source: { engine: { spotify: { utm_source: 'generator' } } },
+    });
+    expect(src).toContain('utm_source=generator');
+  });
+
+  it('lets embed options override the start position the src carries', () => {
+    const src = buildSpotifyIframeSrc(`${EPISODE_URL}?t=1200`, { source: { engine: { spotify: { t: 30 } } } });
+    expect(src).toContain('t=30');
+    expect(src).not.toContain('t=1200');
+  });
+
+  it('embeds the video variant at its own path instead of as a parameter', () => {
+    const src = buildSpotifyIframeSrc(EPISODE_URL, { source: { engine: { spotify: { preferVideo: true } } } });
+    expect(src).toBe('https://open.spotify.com/embed/episode/7makk4oTQel546B0PZlDM5/video');
+  });
+
+  it('keeps the iframe referrer policy out of the embed URL', () => {
+    const src = buildSpotifyIframeSrc(TRACK_URL, {
+      source: { engine: { spotify: { referrerPolicy: 'no-referrer' } } },
+    });
+    expect(src).not.toContain('referrerPolicy');
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildSpotifyIframeSrc('https://example.com/not-spotify')).toBe('');
+  });
+});
+
+describe('SpotifyMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new SpotifyMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(spotifyMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.textTracks.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sets the initial iframe src and creates a controller when attached', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.src).toContain(`https://open.spotify.com/embed/track/${TRACK_ID}`);
+    expect(media.target).toBe(iframe);
+    expect(media.currentSrc).toContain('/embed/track/');
+
+    await waitForEngine(media);
+    expect(media.engine).not.toBe(null);
+    media.detach();
+  });
+
+  it('keeps the embed on the iframe it was handed', async () => {
+    const media = new SpotifyMedia();
+    const { iframe, controller } = await attachAndLoad(media);
+
+    // `createController` swaps its own iframe in for whatever it is handed, so it
+    // is handed a throwaway node instead and pointed at this one. Following it
+    // onto the iframe it builds would leave the host driving an element that was
+    // never in the document.
+    expect(controller.target).not.toBe(iframe);
+    expect(controller.iframeElement).toBe(iframe);
+    expect(media.target).toBe(iframe);
+    expect(iframe.isConnected).toBe(true);
+    media.detach();
+  });
+
+  it('hands the controller a node that cannot take the place of the embed', async () => {
+    const media = new SpotifyMedia();
+    const { iframe, controller } = await attachAndLoad(media);
+
+    // The swap runs through `parentElement`, so a detached node makes it a no-op.
+    // Anything with an element parent — what React renders — would be swapped out.
+    expect(controller.target.parentElement).toBe(null);
+    expect(iframe.isConnected).toBe(true);
+    media.detach();
+  });
+
+  it('rebuilds the embed on the iframe it was handed', async () => {
+    const media = new SpotifyMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    media.source = { src: TRACK_URL, engine: { spotify: { theme: 0 } } };
+    await Promise.resolve();
+
+    expect(iframe.getAttribute('src')).toContain('theme=0');
+    expect(media.currentSrc).toContain('theme=0');
+    media.detach();
+  });
+
+  it('does not create a second controller when handed the iframe that replaced the target', async () => {
+    const media = new SpotifyMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    // What the custom element does when its shadow root changes: it re-attaches
+    // whatever iframe it finds there, which is Spotify's replacement from the swap
+    // on. Taking that as a new target would build a controller for every pass.
+    media.attach(iframe);
+
+    expect(MockController.instances.length).toBe(1);
+    expect(media.engine).toBe(MockController.instances[0]);
+    media.detach();
+  });
+
+  it('defers the controller until a source arrives', async () => {
+    const media = new SpotifyMedia();
+    const loadstart = vi.fn();
+    media.addEventListener('loadstart', loadstart);
+
+    // How every framework builds the element: created first, `src` set after.
+    const iframe = createIframe();
+    media.attach(iframe);
+    expect(iframe.getAttribute('src')).toBe(null);
+    expect(media.engine).toBe(null);
+    expect(loadstart).not.toHaveBeenCalled();
+
+    media.src = TRACK_URL;
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain(`https://open.spotify.com/embed/track/${TRACK_ID}`);
+    expect(loadstart).toHaveBeenCalledTimes(1);
+    await waitForEngine(media);
+    media.detach();
+  });
+
+  it('defers the controller for an iframe rendered with an empty src', async () => {
+    const media = new SpotifyMedia();
+    // React renders `src=""` before a source resolves. The `src` property reports
+    // the document URL for it, so only the attribute says there is no embed.
+    const iframe = createEmptySrcIframe();
+    media.attach(iframe);
+    expect(media.engine).toBe(null);
+
+    media.src = `spotify:track:${TRACK_ID}`;
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain(`https://open.spotify.com/embed/track/${TRACK_ID}`);
+    await waitForEngine(media);
+    media.detach();
+  });
+
+  it('builds a deferred embed once for repeated source changes in the same task', async () => {
+    const media = new SpotifyMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = TRACK_URL;
+    media.src = EPISODE_URL;
+    await waitForEngine(media);
+
+    expect(iframe.getAttribute('src')).toContain('https://open.spotify.com/embed/episode/');
+    expect(MockController.instances.length).toBe(1);
+    media.detach();
+  });
+
+  it('does not leave play() waiting while the embed is deferred', async () => {
+    const media = new SpotifyMedia();
+    media.attach(createIframe());
+
+    // No embed means no controller is coming to report a load; waiting would hang.
+    await expect(media.play()).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
+  it('waits for a deferred embed to load before playing', async () => {
+    const media = new SpotifyMedia();
+    media.attach(createIframe());
+
+    media.src = TRACK_URL;
+    let played = false;
+    const pending = media.play().then(() => {
+      played = true;
+    });
+
+    // The controller the deferred embed creates has not reported readiness, so
+    // playing now would run against a controller that cannot accept it.
+    const controller = await waitForEngine(media);
+    expect(played).toBe(false);
+
+    controller.ready();
+    await pending;
+
+    expect(controller.resume).toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete after ready', async () => {
+    const media = new SpotifyMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete', 'volumechange'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    await attachAndLoad(media);
+
+    expect(events).toContain('loadstart');
+    expect(events).toContain('loadedmetadata');
+    expect(events).toContain('loadcomplete');
+    // Nothing reports a volume here, so nothing announces one changing.
+    expect(events).not.toContain('volumechange');
+    expect(media.readyState).toBeGreaterThanOrEqual(1);
+    media.detach();
+  });
+
+  it('reports duration and position from playback updates', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const durationChange = vi.fn();
+    const timeUpdate = vi.fn();
+    media.addEventListener('durationchange', durationChange);
+    media.addEventListener('timeupdate', timeUpdate);
+
+    // Milliseconds on the wire, seconds on the host.
+    controller.update({ duration: 90_000, position: 5_000 });
+
+    expect(media.duration).toBe(90);
+    expect(media.currentTime).toBe(5);
+    expect(durationChange).toHaveBeenCalledTimes(1);
+    expect(timeUpdate).toHaveBeenCalledTimes(1);
+    expect(media.seekable.end(0)).toBe(90);
+    expect(media.buffered.end(0)).toBe(5);
+    media.detach();
+  });
+
+  it('translates playback updates into play, waiting, playing, and pause', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const events: string[] = [];
+    for (const type of ['play', 'waiting', 'playing', 'pause'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    // The embed reports a stall as buffering while still flagged paused.
+    controller.update({ isPaused: true, isBuffering: true });
+    expect(events).toEqual(['play', 'waiting']);
+    expect(media.paused).toBe(false);
+
+    controller.update({ isPaused: false, isBuffering: false });
+    expect(events).toEqual(['play', 'waiting', 'playing']);
+    expect(media.readyState).toBe(3);
+
+    // Repeating the same state is not a transition.
+    controller.update({ isPaused: false, isBuffering: false, position: 1_000 });
+    expect(events).toEqual(['play', 'waiting', 'playing']);
+
+    controller.update({ isPaused: true, position: 1_000 });
+    expect(events).toEqual(['play', 'waiting', 'playing', 'pause']);
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('reports a stall after playback started as waiting rather than as a pause', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const events: string[] = [];
+    for (const type of ['play', 'waiting', 'playing', 'pause'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    controller.update({ isPaused: false, position: 1_000 });
+    expect(events).toEqual(['play', 'playing']);
+
+    // The embed reports a mid-run stall as buffering while still flagged paused.
+    controller.update({ isPaused: true, isBuffering: true, position: 2_000 });
+    expect(events).toEqual(['play', 'playing', 'waiting']);
+    expect(media.paused).toBe(false);
+
+    // Coming back from a stall resumes the run rather than starting a new one.
+    controller.update({ isPaused: false, position: 2_000 });
+    expect(events).toEqual(['play', 'playing', 'waiting', 'playing']);
+    media.detach();
+  });
+
+  it('reports a pause the listener asked for even while the embed is buffering', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const pause = vi.fn();
+    media.addEventListener('pause', pause);
+    controller.update({ isPaused: false, position: 1_000 });
+
+    media.pause();
+    controller.update({ isPaused: true, isBuffering: true, position: 1_000 });
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('forwards play() and pause() to the controller', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    await media.play();
+    // `resume()` keeps the position; `play()` would restart the entity.
+    expect(controller.resume).toHaveBeenCalledTimes(1);
+    expect(controller.play).not.toHaveBeenCalled();
+
+    media.pause();
+    expect(controller.pause).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('starts playback on load when autoplay is set', async () => {
+    const media = new SpotifyMedia();
+    media.autoplay = true;
+    const { controller } = await attachAndLoad(media);
+
+    await vi.waitFor(() => {
+      if (!controller.resume.mock.calls.length) throw new Error('playback not started yet');
+    });
+    media.detach();
+  });
+
+  it('seeks and reports the requested position before the embed catches up', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const seeking = vi.fn();
+    const seeked = vi.fn();
+    media.addEventListener('seeking', seeking);
+    media.addEventListener('seeked', seeked);
+
+    media.currentTime = 30;
+    expect(media.currentTime).toBe(30);
+    expect(media.seeking).toBe(true);
+    expect(seeking).toHaveBeenCalledTimes(1);
+
+    // The seek defers via the loadComplete microtask — flush.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(controller.seek).toHaveBeenCalledWith(30);
+
+    controller.update({ isPaused: false, position: 31_000 });
+    expect(media.seeking).toBe(false);
+    expect(seeked).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('keeps the requested position until the embed reports the seek landed', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const seeked = vi.fn();
+    media.addEventListener('seeked', seeked);
+    controller.update({ isPaused: false, position: 10_000, duration: 60_000 });
+
+    media.currentTime = 30;
+
+    // The embed goes on reporting where it was playing until the seek takes.
+    controller.update({ isPaused: false, position: 10_000, duration: 60_000 });
+    expect(media.currentTime).toBe(30);
+    expect(media.seeking).toBe(true);
+    expect(seeked).not.toHaveBeenCalled();
+
+    controller.update({ isPaused: false, position: 30_000, duration: 60_000 });
+    expect(media.seeking).toBe(false);
+    expect(media.currentTime).toBe(30);
+    expect(seeked).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('completes a seek that lands on exactly the position it asked for', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const seeked = vi.fn();
+    media.addEventListener('seeked', seeked);
+
+    // Paused, the position stops moving once the seek lands, so a snapshot at the
+    // requested position is the only one that will ever report it.
+    media.currentTime = 30;
+    controller.update({ isPaused: true, position: 30_000, duration: 60_000 });
+
+    expect(media.seeking).toBe(false);
+    expect(seeked).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('ends playback when the position catches up with the duration', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const ended = vi.fn();
+    media.addEventListener('ended', ended);
+
+    controller.update({ isPaused: false, position: 0, duration: 60_000 });
+    // Positions arrive about once a second, so the last one lands short of the end.
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+
+    expect(ended).toHaveBeenCalledTimes(1);
+    expect(media.ended).toBe(true);
+    expect(media.paused).toBe(true);
+    expect(controller.pause).toHaveBeenCalled();
+
+    // The position stops moving there; the end is only reported once.
+    controller.update({ isPaused: true, position: 59_500, duration: 60_000 });
+    expect(ended).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('seeks back instead of ending when loop is set', async () => {
+    const media = new SpotifyMedia();
+    media.loop = true;
+    const { controller } = await attachAndLoad(media);
+    const ended = vi.fn();
+    media.addEventListener('ended', ended);
+
+    controller.update({ isPaused: false, position: 0, duration: 60_000 });
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ended).not.toHaveBeenCalled();
+    expect(controller.seek).toHaveBeenCalledWith(1);
+    media.detach();
+  });
+
+  it('restarts instead of resuming when playback starts again after the end', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const play = vi.fn();
+    media.addEventListener('play', play);
+
+    controller.update({ isPaused: false, position: 0, duration: 60_000 });
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+    expect(media.ended).toBe(true);
+    play.mockClear();
+
+    // The embed sits at the end, where resuming has nothing left to play, so this
+    // update is spent seeking back rather than reported as playback.
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+    expect(play).not.toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(controller.seek).toHaveBeenCalledWith(1);
+
+    controller.update({ isPaused: false, position: 1_000, duration: 60_000 });
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(media.ended).toBe(false);
+    media.detach();
+  });
+
+  it('restarts after the end even when a trailing update advances the position', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const ended = vi.fn();
+    media.addEventListener('ended', ended);
+
+    controller.update({ isPaused: false, position: 0, duration: 60_000 });
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+    expect(ended).toHaveBeenCalledTimes(1);
+
+    // The end is inferred a tick early, so the embed has one more position to
+    // report before it stops — one that is still the end of the same run.
+    controller.update({ isPaused: true, position: 60_000, duration: 60_000 });
+
+    controller.update({ isPaused: false, position: 60_000, duration: 60_000 });
+    await flushDeferredEmbed();
+    expect(controller.seek).toHaveBeenCalledWith(1);
+    expect(ended).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('clears ended when a seek moves back inside the entity', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    controller.update({ isPaused: false, position: 0, duration: 60_000 });
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+    expect(media.ended).toBe(true);
+
+    media.currentTime = 10;
+
+    expect(media.ended).toBe(false);
+    media.detach();
+  });
+
+  it('clears ended when the embed reports a position back inside the entity', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    controller.update({ isPaused: false, position: 0, duration: 60_000 });
+    controller.update({ isPaused: false, position: 59_500, duration: 60_000 });
+    expect(media.ended).toBe(true);
+
+    // Scrubbing the embed's own control reports a position without a seek of ours.
+    controller.update({ isPaused: true, position: 10_000, duration: 60_000 });
+
+    expect(media.ended).toBe(false);
+    media.detach();
+  });
+
+  it('does not end against a duration the embed has not resolved', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    const ended = vi.fn();
+    media.addEventListener('ended', ended);
+
+    // An update that carries no duration at all, then one that reports the entity
+    // as still being worked out. Every position is at or past both.
+    controller.update({ isPaused: false, position: 0, duration: Number.NaN });
+    controller.update({ isPaused: false, position: 1_000, duration: Number.NaN });
+    controller.update({ isPaused: false, position: 2_000, duration: 0 });
+
+    expect(ended).not.toHaveBeenCalled();
+    expect(media.ended).toBe(false);
+    expect(media.paused).toBe(false);
+    media.detach();
+  });
+
+  it('offers no volume or mute surface', () => {
+    // The embed takes neither command and reports neither value. Absent members
+    // read as an incapable media, where inert ones would have the player render a
+    // volume slider and a mute button that do nothing.
+    const media = new SpotifyMedia() as Partial<Video>;
+    expect(media.volume).toBeUndefined();
+    expect(media.muted).toBeUndefined();
+    expect(media.defaultMuted).toBeUndefined();
+    expect(isMediaVolumeCapable(media)).toBe(false);
+  });
+
+  it('loads the new entity by URI when src changes after attach', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    media.src = EPISODE_URL;
+    await Promise.resolve();
+
+    expect(controller.loadUri).toHaveBeenCalledWith('spotify:episode:7makk4oTQel546B0PZlDM5');
+
+    // The first playback update after a reload completes the load.
+    const loadCompleteSpy = vi.fn();
+    media.addEventListener('loadcomplete', loadCompleteSpy);
+    controller.update();
+    expect(loadCompleteSpy).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('starts the new entity where its t param says when src changes after attach', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    media.src = `${EPISODE_URL}?t=30`;
+    await Promise.resolve();
+
+    // `loadUri` names the entity and nothing else, so the start position it
+    // carried is the host's to apply.
+    expect(controller.loadUri).toHaveBeenCalledWith('spotify:episode:7makk4oTQel546B0PZlDM5');
+    expect(media.currentTime).toBe(30);
+
+    // The first update after the reload completes the load the seek waits on.
+    controller.update();
+    await flushDeferredEmbed();
+    expect(controller.seek).toHaveBeenCalledWith(30);
+    media.detach();
+  });
+
+  it('seeks to the start position an engine option names when the entity reloads', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    media.source = { src: TRACK_URL, engine: { spotify: { t: 30 } } };
+    await Promise.resolve();
+
+    // Only the embed URL applies `t` for itself, and this reload reuses the frame,
+    // so the option has to be seeked to like the one a src carries.
+    expect(controller.loadUri).toHaveBeenCalledWith(`spotify:track:${TRACK_ID}`);
+    expect(media.currentTime).toBe(30);
+
+    controller.update();
+    await flushDeferredEmbed();
+    expect(controller.seek).toHaveBeenCalledWith(30);
+    media.detach();
+  });
+
+  it('defers the load when src changes before the controller is ready', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    const iframe = createIframe();
+    media.attach(iframe);
+    const controller = await waitForEngine(media);
+
+    // The controller exists but has not reported readiness; loading now is dropped.
+    media.src = EPISODE_URL;
+    await Promise.resolve();
+    expect(controller.loadUri).not.toHaveBeenCalled();
+
+    // The deferred load replays once the controller is ready.
+    controller.ready();
+    await Promise.resolve();
+    expect(controller.loadUri).toHaveBeenCalledWith('spotify:episode:7makk4oTQel546B0PZlDM5');
+    media.detach();
+  });
+
+  it('errors and unblocks pending play() when src is unrecognized', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    media.src = 'https://example.com/not-a-spotify-url';
+    await Promise.resolve();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+    expect(controller.loadUri).not.toHaveBeenCalled();
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('surfaces a failed API load', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    // Without the global the loader falls back to the script tag, which is what
+    // fails here.
+    vi.stubGlobal('SpotifyIframeApi', undefined);
+    vi.mocked(loadScript).mockRejectedValueOnce(new Error('offline'));
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    media.attach(createIframe());
+    await vi.waitFor(() => {
+      if (!errorSpy.mock.calls.length) throw new Error('error not dispatched yet');
+    });
+
+    expect(media.engine).toBe(null);
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_NETWORK);
+    // Nothing may be left waiting on an embed that is never coming.
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('tracks played ranges via the played-ranges mixin', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    controller.update({ isPaused: false, position: 0 });
+    controller.update({ isPaused: false, position: 400 });
+    controller.update({ isPaused: true, position: 400 });
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(0.4);
+    media.detach();
+  });
+
+  it('destroys the controller on detach', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    media.detach();
+
+    expect(controller.destroy).toHaveBeenCalled();
+    expect(media.target).toBe(null);
+    expect(media.engine).toBe(null);
+  });
+
+  it('leaves the iframe it was handed in the document on detach', async () => {
+    const media = new SpotifyMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    media.detach();
+
+    // What this host leaves behind has to be the DOM it was given: React removes
+    // the node it rendered when the component unmounts, and throws if something
+    // else took its place.
+    expect(iframe.isConnected).toBe(true);
+  });
+
+  it('tears down a controller that arrives for an attach that is gone', async () => {
+    // The live API builds the controller as `createController` is called, whether
+    // or not the caller is still there to be handed it, so hand it over on demand.
+    const deliveries: (() => void)[] = [];
+    vi.stubGlobal('SpotifyIframeApi', {
+      createController: (
+        target: HTMLIFrameElement,
+        options: unknown,
+        callback: (controller: MockController) => void
+      ) => {
+        const controller = new MockController(target, options);
+        deliveries.push(() => callback(controller));
+      },
+    });
+
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    const attached = createIframe();
+    media.attach(attached);
+    await vi.waitFor(() => {
+      if (!deliveries.length) throw new Error('controller not constructed yet');
+    });
+
+    media.detach();
+    deliveries[0]!();
+    await flushDeferredEmbed();
+
+    const controller = MockController.instances[0]!;
+    expect(controller.destroy).toHaveBeenCalled();
+    expect(media.engine).toBe(null);
+    expect(attached.isConnected).toBe(true);
+    expect(controller.iframeElement.isConnected).toBe(false);
+  });
+
+  it('unblocks pending play() when detached before load completes', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    media.attach(createIframe());
+
+    // Await load without the controller ever becoming ready.
+    const pending = media.play();
+    media.detach();
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
+  it('does not create a controller when detached before the API resolves', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    media.attach(createIframe());
+    media.detach();
+
+    // Flush the async controller creation path.
+    await flushDeferredEmbed();
+    await Promise.resolve();
+
+    expect(media.engine).toBe(null);
+    expect(MockController.instances.length).toBe(0);
+  });
+
+  it('ignores ready and playback callbacks from a superseded controller', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    const { controller: stale } = await attachAndLoad(media);
+
+    media.detach();
+    const { controller: current } = await attachAndLoad(media);
+    expect(current).not.toBe(stale);
+
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    // The iframe API keeps invoking callbacks it already scheduled for the
+    // destroyed controller; none of them may touch the new session's state.
+    stale.ready();
+    stale.update({ isPaused: false, position: 5_000 });
+
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    expect(media.currentTime).toBe(0);
+    media.detach();
+  });
+
+  it('unblocks waiters from a superseded load when a reload starts first', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    // Start a second load and wait on its barrier without ever completing it.
+    media.src = EPISODE_URL;
+    const pending = media.play();
+
+    // A third load takes over; the waiter above must not be stranded on the
+    // barrier it already captured.
+    media.src = `spotify:album:${TRACK_ID}`;
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(controller.loadUri).toHaveBeenLastCalledWith(`spotify:album:${TRACK_ID}`);
+    media.detach();
+  });
+});
+
+describe('SpotifyMedia source', () => {
+  it('derives src from a structured source and announces the change', () => {
+    const media = new SpotifyMedia();
+    const sourceChange = vi.fn();
+    media.addEventListener('sourcechange', sourceChange);
+
+    media.source = { src: TRACK_URL };
+
+    expect(media.src).toBe(TRACK_URL);
+    expect(sourceChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-derives source from src, carrying Spotify embed options over', () => {
+    const media = new SpotifyMedia();
+    media.source = { src: TRACK_URL, engine: { spotify: { theme: 0 } } };
+
+    media.src = EPISODE_URL;
+
+    expect(media.source).toEqual({ engine: { spotify: { theme: 0 } }, src: EPISODE_URL });
+  });
+
+  it('rebuilds the embed when only Spotify embed options change', async () => {
+    const media = new SpotifyMedia();
+    const { iframe, controller } = await attachAndLoad(media);
+
+    media.source = { src: TRACK_URL, engine: { spotify: { theme: 0 } } };
+    await Promise.resolve();
+
+    // The theme is only ever read off the embed URL, so the controller has no way
+    // to apply it and the frame has to be rebuilt.
+    expect(iframe.getAttribute('src')).toContain('theme=0');
+    expect(controller.loadUri).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('rebuilds the embed at the video path when the source prefers video', async () => {
+    const media = new SpotifyMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    media.source = { src: EPISODE_URL, engine: { spotify: { preferVideo: true } } };
+    await Promise.resolve();
+
+    // The video variant lives at its own path rather than in a parameter.
+    expect(iframe.getAttribute('src')).toContain('/embed/episode/7makk4oTQel546B0PZlDM5/video');
+    media.detach();
+  });
+
+  it('rebuilds the embed for a new entity while the source prefers video', async () => {
+    const media = new SpotifyMedia();
+    media.source = { src: EPISODE_URL, engine: { spotify: { preferVideo: true } } };
+    const { iframe, controller } = await attachAndLoad(media);
+
+    media.source = { src: OTHER_EPISODE_URL, engine: { spotify: { preferVideo: true } } };
+    await Promise.resolve();
+
+    // `loadUri` names an entity and nothing else, so reusing the frame would leave
+    // the video embed playing the audio variant of the new episode.
+    expect(iframe.getAttribute('src')).toBe(`https://open.spotify.com/embed/episode/${OTHER_EPISODE_ID}/video`);
+    expect(controller.loadUri).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('serializes Spotify embed options onto the initial iframe src', () => {
+    const media = new SpotifyMedia();
+    media.source = { src: TRACK_URL, engine: { spotify: { theme: 0 } } };
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.src).toContain('theme=0');
+    media.detach();
+  });
+
+  it('clears src when the source is set to null', () => {
+    const media = new SpotifyMedia();
+    media.source = { src: TRACK_URL };
+
+    media.source = null;
+
+    expect(media.src).toBe('');
+    expect(media.source).toBe(null);
+  });
+
+  it('stops the embed and resets state when the source is cleared', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    controller.update({ isPaused: false, position: 5_000, duration: 60_000 });
+    expect(media.duration).toBe(60);
+
+    media.source = null;
+    await Promise.resolve();
+
+    // Left running, the embed keeps playing and its updates write state back.
+    expect(controller.pause).toHaveBeenCalled();
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    expect(media.paused).toBe(true);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('does not let a cleared source come back through a playback update', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+    controller.update({ isPaused: false, position: 5_000, duration: 60_000 });
+
+    media.source = null;
+    await Promise.resolve();
+    // The paused embed keeps reporting updates of its own.
+    controller.update({ isPaused: true, position: 5_000, duration: 60_000 });
+
+    expect(media.readyState).toBe(0);
+    media.detach();
+  });
+
+  it('does not play a source that was cleared', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    media.source = null;
+    await Promise.resolve();
+    controller.resume.mockClear();
+    await media.play();
+
+    expect(controller.resume).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('keeps a start position an engine option names out of the entity swap', async () => {
+    const media = new SpotifyMedia();
+    const { controller } = await attachAndLoad(media);
+
+    media.source = { src: TRACK_URL, engine: { spotify: { t: 30 } } };
+    await Promise.resolve();
+
+    // The start position is the one embed option the frame is not rebuilt for, so
+    // it has to reach the entity some other way.
+    expect(media.currentTime).toBe(30);
+    expect(controller.loadUri).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('unblocks pending play() when the source is cleared before the controller is ready', async () => {
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    const iframe = createIframe();
+    media.attach(iframe);
+    const controller = await waitForEngine(media);
+
+    // Setting src while the controller is still loading defers the load, so the
+    // clear below is what the replay on ready has to cope with. Nothing else
+    // settles the barrier `attach()` opened.
+    media.src = EPISODE_URL;
+    media.source = null;
+    const pending = media.play();
+    controller.ready();
+
+    await expect(pending).resolves.toBeUndefined();
+    media.detach();
+  });
+});
+
+/**
+ * Runs last: it settles the module-level API promise that every test above
+ * bypasses through the `SpotifyIframeApi` global, and nothing can unsettle it.
+ */
+describe('loadSpotifyIframeApi', () => {
+  it('passes the API on to a ready callback the host page installed', async () => {
+    // Without the global the loader goes through the script tag and the callback
+    // Spotify's own tutorial tells pages to define.
+    vi.stubGlobal('SpotifyIframeApi', undefined);
+    const hostReady = vi.fn();
+    vi.stubGlobal('onSpotifyIframeApiReady', hostReady);
+
+    const media = new SpotifyMedia();
+    media.src = TRACK_URL;
+    media.attach(createIframe());
+
+    const globals = globalThis as { onSpotifyIframeApiReady?: (api: unknown) => void };
+    const ready = globals.onSpotifyIframeApiReady;
+    expect(ready).not.toBe(hostReady);
+    ready?.({
+      createController: (target: HTMLIFrameElement, options: unknown, callback: (controller: MockController) => void) =>
+        callback(new MockController(target, options)),
+    });
+
+    await waitForEngine(media);
+    // The loader script fires the global once and a second tag does nothing, so a
+    // page that defined it first would never hear about the API again.
+    expect(hostReady).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+});

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -18,6 +18,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/hls-js/index': './src/dom/hls-js/index.ts',
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
     'dom/cloudflare/index': './src/dom/cloudflare/index.ts',
+    'dom/spotify/index': './src/dom/spotify/index.ts',
     'dom/vimeo/index': './src/dom/vimeo/index.ts',
     'dom/youtube/index': './src/dom/youtube/index.ts',
     'dom/mux/index': './src/dom/mux/index.ts',

--- a/packages/react/src/media/spotify-audio/index.ts
+++ b/packages/react/src/media/spotify-audio/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/spotify-audio/media.tsx
+++ b/packages/react/src/media/spotify-audio/media.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { SpotifyMediaProps } from '@videojs/media/dom/spotify';
+import { buildSpotifyIframeSrc, SpotifyMedia, spotifyMediaDefaultProps } from '@videojs/media/dom/spotify';
+import type { CSSProperties, ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
+import { useAttachIframe } from '../../utils/use-attach-iframe';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface SpotifyAudioProps extends Partial<SpotifyMediaProps> {
+  children?: ReactNode;
+}
+
+export const SpotifyAudio = forwardRef<HTMLIFrameElement, SpotifyAudioProps>(function SpotifyAudio(
+  { children, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(SpotifyMedia);
+  const props: Partial<SpotifyMediaProps> & Record<string, unknown> = { ...rawProps };
+  const attachRef = useAttachIframe(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const [initialSrc] = useState(() =>
+    // `source.src` is the only other way to name an entity, so honor it when `src` is absent.
+    buildSpotifyIframeSrc(props.src || props.source?.src || '', { ...spotifyMediaDefaultProps, ...props })
+  );
+  const { style, ...iframeProps } = useSyncProps<SpotifyMediaProps, Record<string, unknown>>(
+    media,
+    props,
+    spotifyMediaDefaultProps
+  ) as Record<string, unknown> & { style?: CSSProperties };
+
+  return (
+    <iframe
+      title="Spotify audio player"
+      // Empty means there is no embed to point at yet; React warns about `src=""`,
+      // and the media builds the URL itself once a source resolves.
+      src={initialSrc || undefined}
+      data-cross-origin-frame
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      referrerPolicy={props.source?.engine?.spotify?.referrerPolicy}
+      {...iframeProps}
+      // Without Spotify's own chrome the embed is a transport and nothing else:
+      // its player UI would otherwise show through whatever skin is drawn over it.
+      // Inline so a `className` cannot put it back on screen, merged so a
+      // consumer's own styles survive. A hidden iframe still loads and plays.
+      style={props.controls ? style : { ...style, display: 'none' }}
+      ref={composedRef}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace SpotifyAudio {
+  export type Props = SpotifyAudioProps;
+}

--- a/packages/react/src/media/tests/spotify-audio.test.tsx
+++ b/packages/react/src/media/tests/spotify-audio.test.tsx
@@ -1,0 +1,82 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SpotifyAudio } from '../spotify-audio/media';
+
+const TRACK_URL = 'https://open.spotify.com/track/1301WleyT98MSxVHPZCA6M';
+
+/**
+ * Stands in for a controller from the live iframe API, including the part React
+ * has to survive: `createController` builds an iframe of its own and replaces the
+ * element it was handed with it.
+ */
+class MockController {
+  static instances: MockController[] = [];
+  iframeElement: HTMLIFrameElement;
+
+  addListener = vi.fn();
+  destroy = vi.fn(() => {
+    this.iframeElement.parentNode?.removeChild(this.iframeElement);
+  });
+
+  constructor(target: HTMLIFrameElement) {
+    this.iframeElement = document.createElement('iframe');
+    this.iframeElement.setAttribute('loading', 'lazy');
+    target.parentNode?.replaceChild(this.iframeElement, target);
+    MockController.instances.push(this);
+  }
+}
+
+beforeEach(() => {
+  MockController.instances.length = 0;
+  vi.stubGlobal('SpotifyIframeApi', {
+    createController: (target: HTMLIFrameElement, _options: unknown, callback: (controller: MockController) => void) =>
+      callback(new MockController(target)),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Wait for the controller to be built, which is when it swaps the iframe out. */
+async function waitForSwap(): Promise<MockController> {
+  await waitFor(() => {
+    if (!MockController.instances.length) throw new Error('controller not created yet');
+  });
+  return MockController.instances[0]!;
+}
+
+describe('SpotifyAudio', () => {
+  it('hides the embed unless it is showing Spotify’s own chrome', () => {
+    const { container, rerender } = render(<SpotifyAudio src={TRACK_URL} />);
+    const iframe = container.querySelector('iframe')!;
+
+    // There is no shadow root to hide the embed from behind, so the rule that the
+    // custom element carries in its template is inline here.
+    expect(iframe.style.display).toBe('none');
+
+    rerender(<SpotifyAudio src={TRACK_URL} controls />);
+
+    expect(iframe.style.display).toBe('');
+  });
+
+  it('keeps the embed on the iframe the controller swapped in', async () => {
+    const { container } = render(<SpotifyAudio src={TRACK_URL} />);
+    const controller = await waitForSwap();
+
+    const iframe = container.querySelector('iframe')!;
+    expect(iframe).toBe(controller.iframeElement);
+    expect(iframe.getAttribute('src')).toContain('/embed/track/');
+    expect(iframe.style.display).toBe('none');
+  });
+
+  it('unmounts without throwing after the controller replaces its iframe', async () => {
+    const { container, unmount } = render(<SpotifyAudio src={TRACK_URL} />);
+    await waitForSwap();
+
+    // React removes the node it rendered, which the swap took out of the document;
+    // unmounting throws unless the media puts that node back first.
+    expect(() => unmount()).not.toThrow();
+    expect(container.querySelector('iframe')).toBe(null);
+  });
+});

--- a/packages/react/src/ui/mute-button/mute-button.tsx
+++ b/packages/react/src/ui/mute-button/mute-button.tsx
@@ -16,6 +16,7 @@ export const MuteButton = createMediaButton<MuteButtonCore, MuteButtonProps>({
   selector: selectVolume,
   action: (core, state) => core.toggle(state),
   hotkeyAction: 'toggleMuted',
+  isSupported: (state) => !state.hidden,
 });
 
 export namespace MuteButton {


### PR DESCRIPTION
Ports [`spotify-audio-element`](https://github.com/muxinc/media-elements/tree/main/packages/spotify-audio-element) from `muxinc/media-elements` into v10 as a first-class media host, reshaped to the architecture the Vimeo and YouTube ports already established.

> **Stacked on #2168.** Review the last two commits, or read the diff against `feat/cloudflare-video-media`.

## Motivation

Spotify is the one embed in `media-elements` that is audio-only, and it is the least `HTMLMediaElement`-shaped of the set. Bringing it in as a `Media` host exercises the embed-host contract against a player that reports playback as a periodic snapshot and exposes no volume control at all.

## What's here

`packages/media/src/dom/spotify` follows the YouTube port's file split:

- `props.ts` — the same ten-prop shape the other embed hosts use, with the inert fields documented
- `source.ts` — `SpotifySource`, embed options under `engine.spotify`, source parsing, and embed-URL building
- `iframe-api.ts` — controller typings and a one-shot loader for the Spotify iframe API
- `media.ts` — `SpotifyMedia`
- `tests/media.test.ts` — 54 cases

Plus `<spotify-audio>` in `packages/html` and `<SpotifyAudio>` in `packages/react`.

## Behavior worth reviewing

- **Ready-callback ordering.** The API script hands itself to `globalThis.onSpotifyIframeApiReady` as it evaluates, so the loader assigns that global *before* loading the script. A failed load clears the cached promise so a later host can retry.
- **`playback_update` is a snapshot, not an event stream.** `play`, `pause`, `waiting`, `playing`, `timeupdate`, `durationchange`, and `ended` are all derived from successive updates. That state machine is split into named private methods, each returning whether it consumed the update, so upstream's early-`return` chain stays legible.
- **Seeking.** The embed announces no seeks, so `currentTime` writes optimistically and fires `seeking`, then `seeked` on the first update reporting a different position. This replaces upstream's restore-the-old-time trick, which left `currentTime` stale.
- **Reloads use `loadUri`,** mirroring YouTube's `cueVideoById` shape, rather than upstream's iframe-`src` rewrite.
- **What Spotify cannot do.** No volume, no mute, no playback rate. `volume`/`muted` are fixed readers with inert setters; `playbackRate` is omitted entirely so the player's rate feature stays off instead of showing a dead control.
- **`src` forms.** `open.spotify.com` URLs for every embeddable entity — including localized (`/intl-de/`) and already-embedded (`/embed/`) forms — and `spotify:<type>:<id>` URIs.

## Verification

- `pnpm -F @videojs/media test src/dom/spotify` — 54 passed
- `pnpm test` — 5259 passed, 14 skipped
- `pnpm typecheck` — clean
- `pnpm -F @videojs/sandbox build` — clean; the new presets appear at `/html-spotify-audio/` and `/react-spotify-audio/`

## Notes

Split into two commits: the media host and platform wrappers, then the sandbox examples. The sandbox preset renders with the audio player and skin, and its fixed source is an episode rather than a track, since Spotify plays episodes in full for a signed-out listener and cuts tracks to a 30 second preview.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared volume/mute plumbing used by every player, plus a large async third-party iframe integration; risk is mitigated by extensive tests but regressions on mute-only or iOS volume edge cases are possible.
> 
> **Overview**
> Adds **Spotify** as a first-class audio embed (`SpotifyMedia`, `<spotify-audio>`, `<SpotifyAudio>`), wired through the Spotify iframe API with URL/URI parsing, embed options under `engine.spotify`, and playback driven from `playback_update` snapshots (play/pause/waiting/seek/end/loop). The embed is hidden when not using Spotify’s own `controls`, and omits volume/mute members so skins don’t show dead controls.
> 
> **Volume vs mute** is split: `MediaVolumeState` gains `mutedAvailability`, `isMediaMutedCapable`, and the player `volume` feature attaches when either volume or mute is supported. **Mute** UI hides when mute isn’t available (`MuteButtonCore` / React `isSupported`; HTML sets the `hidden` attribute).
> 
> Sandbox adds the **`spotify-audio`** embed preset (fixed episode source) with HTML/React demo pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8af35596d90281ff1b54d615e882edc5ddfb5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Related issues

Closes #1462 — *Feature: `<spotify-audio>`*. Part of the #1457 *Media Element Providers* epic.

Against that issue's requirements:

1. **Matches Mux `<spotify-audio>` as a baseline** — same `src` shape (`open.spotify.com/{type}/{id}`), plus `spotify:{type}:{id}` URIs and the localized/embed URL forms. The `startAt` / `theme` / `preferVideo` options are all carried.
2. **Audio-first defaults** — an audio host with no poster and no fullscreen surface.

Two deliberate divergences from the issue text, both worth a look:

- **`startAt` is spelled `t`.** The issue describes Mux's `config.startAt`, which Mux maps to the `t` URL parameter. This port follows the convention the YouTube provider set — engine config is spelled exactly as the vendor spells it — so it is `engine.spotify.t`. Say the word if you would rather match Mux's name.
- **The API script is `open.spotify.com/embed/iframe-api/v1`,** not the `embed-podcast` path upstream still uses. The `embed` path is what Spotify's current docs publish; the `embed-podcast` one predates video podcasts.

On the issue's open design question of `<spotify-audio>` versus a sibling `<spotify-video>`: this follows Mux and keeps one element, with `engine.spotify.preferVideo` selecting the `/video` embed path.

The issue's non-negotiable branding note still holds — the Spotify logo and in-iframe play button stay visible, so this cannot be skinned like a native `<audio>`.

> Note: GitHub only auto-closes on merge into the default branch, so with this PR based on `feat/cloudflare-video-media` the keyword above will link rather than close until the stack lands on `main`.
