### PR TITLE
feat(packages): add tiktok video media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -20,6 +20,7 @@ export const PRESETS = [
   'youtube-video',
   'cloudflare-video',
   'spotify-audio',
+  'tiktok-video',
 ] as const;
 
 /**
@@ -27,4 +28,10 @@ export const PRESETS = [
  * source rather than the source picker's list, and have no Tailwind skin
  * variant, so the navbar disables both controls for them.
  */
-export const EMBED_PRESETS = ['vimeo-video', 'youtube-video', 'cloudflare-video', 'spotify-audio'] as const;
+export const EMBED_PRESETS = [
+  'vimeo-video',
+  'youtube-video',
+  'cloudflare-video',
+  'spotify-audio',
+  'tiktok-video',
+] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -356,6 +356,8 @@ export const CLOUDFLARE_VIDEO_SRC = 'https://watch.videodelivery.net/bfbd585059e
 // listener, where a track is a 30 second preview.
 export const SPOTIFY_AUDIO_SRC = 'https://open.spotify.com/episode/7makk4oTQel546B0PZlDM5';
 
+export const TIKTOK_VIDEO_SRC = 'https://www.tiktok.com/@_luwes/video/7527476667770522893';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return SOURCES[id].live === true;

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -101,6 +101,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'youtube-video': 'YouTube Video',
   'cloudflare-video': 'Cloudflare Stream Video',
   'spotify-audio': 'Spotify Audio',
+  'tiktok-video': 'TikTok Video',
 };
 
 export function Navbar({

--- a/apps/sandbox/templates/html-tiktok-video/index.html
+++ b/apps/sandbox/templates/html-tiktok-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML TikTok Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-tiktok-video/main.ts
+++ b/apps/sandbox/templates/html-tiktok-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/tiktok-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { TIKTOK_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-[9/16] max-w-sm mx-auto">
+        <tiktok-video class="block w-full h-full" src="${TIKTOK_VIDEO_SRC}" playsinline></tiktok-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-tiktok-video/index.html
+++ b/apps/sandbox/templates/react-tiktok-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React TikTok Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-tiktok-video/main.tsx
+++ b/apps/sandbox/templates/react-tiktok-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoPlayer } from '@app/shared/react/players';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { TIKTOK_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { TikTokVideo } from '@videojs/react/media/tiktok-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoPlayer>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-[9/16] max-w-sm mx-auto">
+        <TikTokVideo className="block w-full h-full" src={TIKTOK_VIDEO_SRC} playsInline />
+      </VideoSkinComponent>
+    </VideoPlayer>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/define/media/tiktok-video.ts
+++ b/packages/html/src/define/media/tiktok-video.ts
@@ -1,0 +1,14 @@
+import { TikTokVideo } from '../../media/tiktok-video';
+import { safeDefine } from '../safe-define';
+
+export class TikTokVideoElement extends TikTokVideo {
+  static readonly tagName = 'tiktok-video';
+}
+
+safeDefine(TikTokVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [TikTokVideoElement.tagName]: TikTokVideoElement;
+  }
+}

--- a/packages/html/src/media/tiktok-video/index.ts
+++ b/packages/html/src/media/tiktok-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/tiktok-video/media.ts
+++ b/packages/html/src/media/tiktok-video/media.ts
@@ -1,0 +1,60 @@
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { buildTikTokIframeSrc, TikTokMedia } from '@videojs/media/dom/tiktok';
+import { escapeHtml } from '@videojs/utils/string';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class TikTokCustomMediaElement extends CustomMediaElement('iframe', TikTokMedia) {
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildTikTokIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: inline-block;
+          /* TikTok videos are portrait, and the player refuses to draw its chrome
+             below 325x578, so that is where this host starts rather than the
+             300x150 the landscape embeds use. */
+          min-width: 325px;
+          min-height: 578px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        /* Deliberately no pointer-events opt-out, unlike the sibling embed hosts.
+           Hiding TikTok's chrome already leaves the frame with nothing to click,
+           and the embed will not start from a play command alone unless the frame
+           has its own user activation — so taking pointer events away removes the
+           only thing that can start it. Upstream's element leaves the frame
+           interactive for the same reason. */
+      </style>
+      <iframe
+        part="iframe"
+        title="TikTok video player"
+        ${srcAttr}
+        allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        frameborder="0"
+        width="100%"
+        height="100%"
+        referrerpolicy="${escapeHtml(attrs.referrerpolicy ?? '')}"
+      ></iframe>
+    `;
+  };
+}
+
+// Only the props the embed URL is built from: TikTok reads nothing else out of it.
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+  };
+}
+
+export class TikTokVideo extends MediaAttachMixin(TikTokCustomMediaElement) {}

--- a/packages/media/src/dom/tiktok/index.ts
+++ b/packages/media/src/dom/tiktok/index.ts
@@ -1,0 +1,13 @@
+// The player API module is internal apart from the protocol typings, which
+// describe the messages the host exchanges with the embed.
+
+export * from './media';
+export type {
+  TikTokCurrentTime,
+  TikTokPlayerCommand,
+  TikTokPlayerCommandMessage,
+  TikTokPlayerEventMessage,
+  TikTokPlayerEventType,
+} from './player-api';
+export * from './props';
+export * from './source';

--- a/packages/media/src/dom/tiktok/media.ts
+++ b/packages/media/src/dom/tiktok/media.ts
@@ -1,0 +1,726 @@
+// Adapted from `tiktok-video-element` from `muxinc/media-elements`,
+// ported to TypeScript and reshaped as a media host to fit the v10
+// media-host architecture (mirrors `dom/youtube`).
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
+import { deepEqual } from '@videojs/utils/object';
+import { isNumber, isUndefined } from '@videojs/utils/predicate';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
+import { MediaError } from '../../core/media-error';
+import type { Video } from '../../core/types';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+import { createTimeRange } from '../utils';
+import {
+  createTikTokPlayerCommand,
+  ERROR_AUTOPLAY,
+  ERROR_CATEGORY_END,
+  ERROR_NETWORK_CATEGORY,
+  ERROR_PLAYER_CATEGORY,
+  isTikTokCurrentTime,
+  isTikTokPlayerError,
+  isTikTokPlayerMessage,
+  PLAYER_TARGET_ORIGIN,
+  STATE_BUFFERING,
+  STATE_ENDED,
+  STATE_INIT,
+  STATE_PAUSED,
+  STATE_PLAYING,
+  type TikTokPlayerCommand,
+  type TikTokPlayerError,
+} from './player-api';
+import { tiktokMediaDefaultProps } from './props';
+import { buildTikTokIframeSrc, type TikTokSource } from './source';
+
+const TikTokMediaBase = MediaPlayedRangesMixin(EventTarget);
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ */
+export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
+  #target: HTMLIFrameElement | null = null;
+  #loadComplete = createPublicPromise<void>();
+  /**
+   * Cancels the `message` listener. It lives on `window` rather than on the
+   * iframe, so nothing removes it when the frame goes; the signal is what keeps
+   * it from outliving the attach that added it.
+   */
+  #messages: AbortController | null = null;
+  /** Guards messages and deferred embeds across attach/detach cycles. */
+  #attachId = 0;
+
+  #src = tiktokMediaDefaultProps.src;
+  #autoplay = tiktokMediaDefaultProps.autoplay;
+  #defaultMuted = tiktokMediaDefaultProps.defaultMuted;
+  #loop = tiktokMediaDefaultProps.loop;
+  #controls = tiktokMediaDefaultProps.controls;
+  #playsInline = tiktokMediaDefaultProps.playsInline;
+  #preload = tiktokMediaDefaultProps.preload;
+  #poster = tiktokMediaDefaultProps.poster;
+  #source: TikTokSource | null = tiktokMediaDefaultProps.source;
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #loaded = false;
+  /** The current `src` names no TikTok video, so the embed still holds the last one. */
+  #srcUnsupported = false;
+  /** A play asked for before the embed could take one, replayed once it can. */
+  #playRequested = false;
+  #playFired = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #muted = false;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: MediaError | null = null;
+  #isFullscreen = false;
+
+  static PLAYER_SOFTWARE_NAME = 'tiktok-video';
+
+  /**
+   * The embed's window. TikTok publishes no player object — commands are posted
+   * to the frame — so the window the protocol is spoken to is the closest thing
+   * to one, and it is what a caller needs to speak it directly. Null until the
+   * iframe is in a document, since a frame that is not rendered has no window.
+   */
+  get engine() {
+    return this.#target?.contentWindow ?? null;
+  }
+
+  get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /**
+   * Bind the iframe hosting the embed. The embed follows as soon as an URL can
+   * be resolved, which is not always now: a framework that creates the element
+   * before setting `src` attaches an iframe with nothing to embed yet, and
+   * `load()` picks it up once a source arrives.
+   */
+  attach(target: HTMLIFrameElement | null): void {
+    if (!target || this.#target === target) return;
+    if (this.#target) this.detach();
+    this.#target = target;
+    this.#listen(target);
+    this.#beginLoad();
+    this.#createPlayer();
+  }
+
+  detach(): void {
+    if (!this.#target) return;
+    this.#attachId++;
+    this.#messages?.abort();
+    this.#messages = null;
+    this.#target = null;
+    // A play still waiting on an embed this host no longer has. Left set, the
+    // next frame to report ready would start playing on its own.
+    this.#playRequested = false;
+    // Unblock callers awaiting load; they re-check `#target` (now null) and no-op.
+    this.#loadComplete.resolve();
+    this.#resetState();
+  }
+
+  override destroy() {
+    this.detach();
+    super.destroy();
+  }
+
+  get src() {
+    return this.#src;
+  }
+  /** TikTok URL or id. Setting it re-derives `source`, carrying its player parameters over. */
+  set src(value) {
+    const { engine } = this.#source ?? {};
+    const next: TikTokSource = { ...(engine && { engine }), ...(value && { src: value }) };
+
+    // Everything happens in the `source` setter, so there is one path for storing
+    // it, deciding on a load, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  get currentSrc() {
+    // The `src` property resolves an empty attribute to the document URL, so only
+    // the attribute can report an embed that hasn't been built yet as empty.
+    return this.#target?.getAttribute('src') ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /**
+   * Rebuild the embed for the current source. The protocol has play, pause,
+   * seek, and mute and nothing that swaps the video, and the parameters shaping
+   * the player are read once when the frame loads — so writing the iframe URL
+   * again is the only way to load anything.
+   */
+  async load() {
+    // Nothing to reload without a target, and no load to wait on either.
+    if (!this.#target) return;
+    const load = this.#beginLoad();
+    // Wait a microtask: a framework sets `src` and the props that shape the embed
+    // in whatever order it likes, and the embed URL is only built once, so it has
+    // to see all of them.
+    await Promise.resolve();
+    // A later load took over while waiting; building the embed is its job now.
+    if (load !== this.#loadComplete) return;
+    const target = this.#target;
+    // Detached while waiting; `detach()` already settled this load.
+    if (!target) return;
+
+    const embedSrc = this.#src ? buildTikTokIframeSrc(this.#src, this.#snapshotProps()) : '';
+    // A frame already showing this embed has nothing to reload, and reloading it
+    // anyway would throw away the position it is playing from. Nothing is being
+    // discarded either, so the state stands and no lifecycle event is due.
+    if (embedSrc && target.getAttribute('src') === embedSrc) {
+      // The frame is either ready already or still fetching that URL, and only in
+      // the first case is there no `onPlayerReady` left to settle this load.
+      if (this.#loaded) load.resolve();
+      return;
+    }
+
+    // Reset before bailing on an empty src: a cleared source has nothing to load,
+    // but what we report about the old video still has to go.
+    this.#resetState();
+    if (!this.#src) {
+      // The embed has to go too. Left in place it keeps playing, and its progress
+      // reports write the state just cleared straight back. There is no unload
+      // command, so dropping the URL is what stops it.
+      load.resolve();
+      target.removeAttribute('src');
+      return;
+    }
+    this.dispatchEvent(new Event('emptied'));
+    this.dispatchEvent(new Event('loadstart'));
+    if (!embedSrc) {
+      this.#srcUnsupported = true;
+      this.#error = new MediaError(`Unrecognized TikTok source: ${this.#src}`, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen don't hang.
+      load.resolve();
+      // There is no video to swap the frame to, so the embed keeps playing the
+      // last one under an error the host is already reporting; pausing is all
+      // the protocol offers to stop it.
+      this.#post('pause');
+      return;
+    }
+    // The new frame reports `onPlayerReady`, which is what settles this load.
+    target.src = embedSrc;
+  }
+
+  /**
+   * Take over as the current load, returning its barrier. Settling the outgoing
+   * one is what keeps a superseded load from stranding callers that are already
+   * waiting; every exit from `load()` settles the barrier it was handed.
+   */
+  #beginLoad(): PublicPromise<void> {
+    this.#loadComplete.resolve();
+    this.#loadComplete = createPublicPromise<void>();
+    return this.#loadComplete;
+  }
+
+  /**
+   * Whether the embed is playing the source the host reports. It is not once the
+   * source is cleared or unrecognized: the embed holds the previous video either
+   * way, so what it reports and what `play()` would resume are no longer ours.
+   */
+  get #hasSource() {
+    return !!this.#src && !this.#srcUnsupported;
+  }
+
+  get paused() {
+    return this.#paused;
+  }
+
+  get ended() {
+    return this.#ended;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    // The embed went with the source it was built for, or still holds one that is
+    // no longer being reported, so there is nothing left here to resume.
+    if (!this.#hasSource) return;
+    // Posted without waiting on the load barrier. The embed reports nothing at
+    // all before it is ready, so a barrier only its own report can settle is
+    // exactly what leaves a press of play doing nothing — and the command is
+    // cheap enough to send at a frame that may not be listening yet. Whichever
+    // happens first wins: the embed takes this one, or takes the replay below.
+    this.#playRequested = true;
+    this.#post('play');
+  }
+
+  pause() {
+    // A pause between asking to play and the embed being ready is the later
+    // intent, so it cancels the replay rather than racing it.
+    this.#playRequested = false;
+    this.#post('pause');
+  }
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#seeking = true;
+    // Report the requested position right away: the embed only reports one every
+    // so often, and until then the seek would look like it never happened.
+    this.#currentTime = value;
+    this.dispatchEvent(new Event('seeking'));
+    this.dispatchEvent(new Event('timeupdate'));
+    this.#afterLoad(() => this.#post('seekTo', value));
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  // No volume surface: the embed reports a level but takes no command to set
+  // one, so there is nothing to write. Reporting it read-only would have the
+  // player render a slider that cannot move; mute is a separate capability and
+  // stays, because `mute` and `unMute` are commands the embed does take.
+
+  get muted() {
+    return this.#muted;
+  }
+  set muted(value) {
+    if (this.#muted === value) return;
+    this.#muted = value;
+    this.#afterLoad(() => this.#post(value ? 'mute' : 'unMute'));
+  }
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+  set autoplay(value) {
+    this.#autoplay = value;
+  }
+
+  get defaultMuted() {
+    return this.#defaultMuted;
+  }
+  set defaultMuted(value) {
+    this.#defaultMuted = value;
+    // Until the embed reports its own mute there is nothing to report but what it
+    // is being built with, the way a media element seeds `muted` from the `muted`
+    // attribute. It is also what has `onPlayerReady` assert the mute over the
+    // protocol, which the URL parameter alone does not always achieve.
+    if (!this.#loaded) this.#muted = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+  set loop(value) {
+    // The embed reads `loop` from the URL it was built with, so a change after
+    // that is honored by replaying on ENDED instead.
+    this.#loop = value;
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+  set controls(value) {
+    // Like `loop`, this is read from the URL the embed was built with, and the
+    // protocol has no command for it. Rebuilding the frame to show or hide TikTok
+    // chrome would restart the video, so it lands on the next load instead.
+    this.#controls = value;
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+  set playsInline(value) {
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+  set preload(value) {
+    this.#preload = value;
+  }
+
+  get poster() {
+    return this.#poster;
+  }
+  set poster(value) {
+    this.#poster = value;
+  }
+
+  /**
+   * Structured source: the TikTok URL or id in `src`, plus player parameters
+   * under `engine.tiktok`. Replacing it re-derives `src`; assigning an equivalent
+   * source is a no-op.
+   */
+  get source(): TikTokSource | null {
+    return this.#source;
+  }
+  set source(value: TikTokSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    const src = source?.src ?? '';
+    const srcChanged = this.#src !== src;
+    // Player parameters are read when the embed is built, so a change to them
+    // needs a reload of its own even though the video is the same.
+    const engineChanged = !deepEqual(this.#source?.engine?.tiktok ?? null, source?.engine?.tiktok ?? null);
+
+    this.#source = source;
+    this.#src = src;
+
+    if (srcChanged || engineChanged) void this.load();
+
+    // Assigning is always a source change, so it is always announced.
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+
+  get buffered() {
+    // The embed reports no buffer state, only a position, so the only stretch
+    // known to be available is the one already played through.
+    return this.#currentTime > 0 ? createTimeRange(0, this.#currentTime) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRange(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  /** Always empty: `closed_caption` is the embed's only say over captions. */
+  get textTracks() {
+    return EMPTY_TEXT_TRACKS;
+  }
+
+  get isFullscreen() {
+    return this.#isFullscreen;
+  }
+
+  // The protocol has no fullscreen command, so fullscreen targets the iframe itself.
+  async requestFullscreen() {
+    // Nothing entered fullscreen if there is no element to request it on, so the
+    // flag must not claim otherwise.
+    if (!this.#target?.requestFullscreen) return;
+    await this.#target.requestFullscreen();
+    this.#isFullscreen = true;
+  }
+
+  async exitFullscreen() {
+    const doc = globalThis.document;
+    if (doc?.fullscreenElement && doc.fullscreenElement === this.#target) {
+      await doc.exitFullscreen();
+    }
+    this.#isFullscreen = false;
+  }
+
+  /**
+   * Build the embed for the attached target. A target that arrived with a URL
+   * already holds one — a server-rendered iframe does — so it is left alone and
+   * its `onPlayerReady` settles the load. A target that cannot be resolved yet
+   * settles the load it was given; the next `load()` retries.
+   *
+   * @returns Whether the target holds an embed.
+   */
+  #createPlayer(): boolean {
+    const target = this.#target;
+    if (!target) return false;
+
+    // The `src` property resolves an empty attribute to the document URL, so it
+    // cannot tell an embed apart from a placeholder; the attribute can.
+    if (target.getAttribute('src')) {
+      // The frame is already fetching the embed and will report `onPlayerReady`
+      // for it like any other, so this load has begun just the same.
+      this.dispatchEvent(new Event('loadstart'));
+      return true;
+    }
+
+    const initialSrc = buildTikTokIframeSrc(this.#src, this.#snapshotProps());
+    // No embed means no `onPlayerReady` is coming to settle this load.
+    if (!initialSrc) {
+      this.#loadComplete.resolve();
+      return false;
+    }
+
+    target.src = initialSrc;
+    this.dispatchEvent(new Event('loadstart'));
+    return true;
+  }
+
+  /**
+   * Listen for what the embed reports. The messages arrive on `window` rather
+   * than on the frame that sent them, so every one has to be matched against the
+   * frame this host owns before it is allowed to touch state.
+   */
+  #listen(target: HTMLIFrameElement) {
+    const win = globalThis.window;
+    if (isUndefined(win)) return;
+    const attachId = this.#attachId;
+    this.#messages = new AbortController();
+    win.addEventListener('message', (event) => this.#onMessage(event, target, attachId), {
+      signal: this.#messages.signal,
+    });
+  }
+
+  #onMessage(event: MessageEvent, target: HTMLIFrameElement, attachId: number) {
+    if (this.#isStale(attachId)) return;
+    // A frame that is gone cannot have sent anything, so matching its absent
+    // window would let every foreign message through.
+    const frame = target.contentWindow;
+    if (!frame || event.source !== frame) return;
+    const message = event.data;
+    if (!isTikTokPlayerMessage(message)) return;
+    // An unrecognized source left the frame holding the video it was already
+    // playing, and it keeps reporting it — taking that would put the state just
+    // cleared right back, under an error the host is reporting.
+    if (this.#srcUnsupported) return;
+    // The embed stays silent until it is ready, so anything it says is proof
+    // enough that it is — `onPlayerReady` is not reliably the first thing it
+    // sends, and waiting only for that leaves the load open forever.
+    if (this.#hasSource) this.#onLoaded();
+
+    switch (message.type) {
+      case 'onPlayerReady':
+        break;
+      case 'onStateChange':
+        if (isNumber(message.value)) this.#onStateChange(message.value);
+        break;
+      case 'onCurrentTime':
+        if (isTikTokCurrentTime(message.value)) {
+          this.#onCurrentTime(message.value.currentTime, message.value.duration);
+        }
+        break;
+      case 'onVolumeChange':
+        // Reported but not carried: with no volume to write there is nothing for
+        // a level to drive, and the mute the embed reports comes through `onMute`.
+        break;
+      case 'onMute':
+        // Muting leaves the volume alone, the way it does on a media element.
+        this.#muted = !!message.value;
+        this.dispatchEvent(new Event('volumechange'));
+        break;
+      case 'onPlayerError':
+        if (isTikTokPlayerError(message.value)) this.#onPlayerError(message.value);
+        break;
+      case 'onError':
+        // Deprecated by TikTok in favor of `onPlayerError`, and the code it
+        // carries is a `MediaError` one rather than one of TikTok's, so it is
+        // taken as it stands when it is one.
+        this.#onError(
+          'TikTok player error; visit https://developers.tiktok.com/doc/embed-player for what the embed supports.',
+          isMediaErrorCode(message.value) ? message.value : MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+        );
+        break;
+      default:
+        if (__DEV__) console.warn(`Unhandled TikTok player message: ${message.type}`);
+        break;
+    }
+  }
+
+  /**
+   * Whether a message belongs to a superseded attach. A `message` event already
+   * being dispatched still reaches a listener removed during the dispatch, so
+   * what a frame reports has to be matched against the attach that bound it.
+   */
+  #isStale(attachId: number) {
+    return attachId !== this.#attachId;
+  }
+
+  /** Defer a command until `loadComplete` resolves, swallowing failures. */
+  #afterLoad(fn: () => void) {
+    this.#loadComplete.then(
+      () => {
+        if (!this.#target) return;
+        try {
+          fn();
+        } catch {
+          // Posting to a frame that is being torn down throws.
+        }
+      },
+      () => {}
+    );
+  }
+
+  /** Send a command to the embed, if there is a frame to send it to. */
+  #post(type: TikTokPlayerCommand, value?: number) {
+    const frame = this.#target?.contentWindow;
+    if (!frame) return;
+    frame.postMessage(createTikTokPlayerCommand(type, value), PLAYER_TARGET_ORIGIN);
+  }
+
+  /**
+   * The mute the next embed is built with. The frame reads it once from the URL,
+   * so a rebuild has to carry a mute set since the last one too; dropping it
+   * would bring the video back with sound.
+   */
+  get #nextMuted() {
+    return this.#defaultMuted || this.#muted;
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      defaultMuted: this.#nextMuted,
+      loop: this.#loop,
+      controls: this.#controls,
+      source: this.#source,
+    };
+  }
+
+  #resetState() {
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    // Whatever the next embed is built with is the state the video it holds comes
+    // back in.
+    this.#muted = this.#nextMuted;
+    this.#paused = !this.#autoplay;
+    this.#ended = false;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#loaded = false;
+    this.#srcUnsupported = false;
+    this.#playFired = false;
+    this.#error = null;
+    this.#isFullscreen = false;
+  }
+
+  #onLoaded() {
+    if (this.#loaded) return;
+    this.#loaded = true;
+    this.#readyState = READY_STATE_HAVE_METADATA;
+    // The URL the frame was built from does not always mute the embed, so the
+    // mute is asserted again over the protocol, which does, at the first moment
+    // the embed can take a command.
+    if (this.#muted) this.#post('mute');
+    // A play asked for before the embed could take one. This is that moment.
+    if (this.#playRequested) {
+      this.#playRequested = false;
+      this.#post('play');
+    }
+    // Duration arrives with the first progress report, which dispatches a
+    // `durationchange` of its own once it does.
+    for (const type of ['loadedmetadata', 'loadcomplete']) {
+      this.dispatchEvent(new Event(type));
+    }
+    this.#loadComplete.resolve();
+  }
+
+  #onPlayerError({ errorCode, errorType }: TikTokPlayerError) {
+    // A blocked play leaves a video that is loaded and still playable, which is
+    // not something a media element reports as an error — the browser rejects the
+    // play request instead. Setting `error` would put a permanent failure over a
+    // working video, so it is only ever reported, never recorded: silence here
+    // reads as "the embed ignored us", which is the hardest thing to diagnose
+    // about a player driven entirely through a cross-origin frame.
+    if (errorCode === ERROR_AUTOPLAY) {
+      if (__DEV__) {
+        console.warn(
+          'The TikTok embed refused to play: the browser blocked it. A cross-origin embed needs its own user activation, or a muted video, before it will start.'
+        );
+      }
+      return;
+    }
+    const named = errorType ? ` (${errorType})` : '';
+    this.#onError(
+      `TikTok player error ${errorCode}${named}; visit https://developers.tiktok.com/doc/embed-player for what the embed supports.`,
+      toMediaErrorCode(errorCode)
+    );
+  }
+
+  #onError(message: string, code: number) {
+    this.#error = new MediaError(message, code);
+    this.dispatchEvent(new Event('error'));
+    // Unblock callers awaiting load so play()/fullscreen don't hang.
+    this.#loadComplete.resolve();
+  }
+
+  #onStateChange(state: number) {
+    const emit = (type: string) => this.dispatchEvent(new Event(type));
+
+    if (state === STATE_PLAYING || state === STATE_BUFFERING) {
+      if (!this.#playFired) {
+        this.#playFired = true;
+        this.#paused = false;
+        this.#ended = false;
+        emit('play');
+      }
+    }
+
+    if (state === STATE_BUFFERING) {
+      emit('waiting');
+    } else if (state === STATE_PLAYING) {
+      this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+      this.#paused = false;
+      emit('playing');
+    } else if (state === STATE_PAUSED) {
+      this.#playFired = false;
+      this.#paused = true;
+      emit('pause');
+    } else if (state === STATE_ENDED) {
+      this.#playFired = false;
+      this.#paused = true;
+      emit('pause');
+      this.#ended = true;
+      emit('ended');
+      // An embed built with `loop` restarts on its own; this is for a `loop` set
+      // after that, and playing an embed that already restarted costs nothing.
+      if (this.#loop) void this.play();
+    } else if (state === STATE_INIT) {
+      // The embed reports this for a video it holds but has not started, which is
+      // a resource still loaded and so nothing a media element announces.
+      this.#playFired = false;
+      this.#paused = true;
+    }
+  }
+
+  #onCurrentTime(currentTime: number, duration: number) {
+    if (currentTime !== this.#currentTime) {
+      this.#currentTime = currentTime;
+      this.dispatchEvent(new Event('timeupdate'));
+    }
+
+    if (this.#seeking) {
+      // The embed announces no seeks, so the next position it reports is the only
+      // sign one landed — including when it lands on exactly the position asked
+      // for and there is no change to report.
+      this.#seeking = false;
+      this.dispatchEvent(new Event('seeked'));
+    }
+
+    if (isNumber(duration) && duration > 0 && duration !== this.#duration) {
+      this.#duration = duration;
+      this.dispatchEvent(new Event('durationchange'));
+    }
+  }
+}
+
+/**
+ * Read a TikTok player error code as a `MediaError` one. TikTok groups its codes
+ * by category rather than listing every one it may report, so the category is
+ * what is read; anything outside the ones it documents describes a video that
+ * cannot be played at all.
+ */
+function toMediaErrorCode(errorCode: number) {
+  if (errorCode >= ERROR_NETWORK_CATEGORY && errorCode < ERROR_PLAYER_CATEGORY) return MediaError.MEDIA_ERR_NETWORK;
+  if (errorCode >= ERROR_PLAYER_CATEGORY && errorCode < ERROR_CATEGORY_END) return MediaError.MEDIA_ERR_DECODE;
+  return MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED;
+}
+
+/** Whether a reported value is one of the codes a `MediaError` can carry. */
+function isMediaErrorCode(value: unknown): value is number {
+  return isNumber(value) && value >= MediaError.MEDIA_ERR_ABORTED && value <= MediaError.MEDIA_ERR_ENCRYPTED;
+}
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_FUTURE_DATA = 3;

--- a/packages/media/src/dom/tiktok/player-api.ts
+++ b/packages/media/src/dom/tiktok/player-api.ts
@@ -1,0 +1,102 @@
+// Minimal typings and constants for the TikTok embed player
+// (https://developers.tiktok.com/doc/embed-player).
+// TikTok ships no SDK: the embed is driven with `window.postMessage` in both
+// directions, so the message protocol is the whole API.
+
+import { isNumber, isObject, isString } from '@videojs/utils/predicate';
+
+/** Marker every player message carries, whichever way it travels. */
+export const PLAYER_MESSAGE_KEY = 'x-tiktok-player';
+
+/**
+ * Target origin for outbound commands. The embed answers from whichever TikTok
+ * origin served it and the commands carry nothing private, so they go to any.
+ */
+export const PLAYER_TARGET_ORIGIN = '*';
+
+/** Commands the embed accepts. Only `seekTo` carries a value: seconds. */
+export type TikTokPlayerCommand = 'play' | 'pause' | 'seekTo' | 'mute' | 'unMute';
+
+/** A command on its way to the embed. */
+export interface TikTokPlayerCommandMessage {
+  [PLAYER_MESSAGE_KEY]: true;
+  type: TikTokPlayerCommand;
+  value?: number;
+}
+
+/** The events the embed reports. */
+export type TikTokPlayerEventType =
+  | 'onPlayerReady'
+  | 'onStateChange'
+  | 'onCurrentTime'
+  | 'onVolumeChange'
+  | 'onMute'
+  | 'onPlayerError'
+  /** Deprecated by TikTok in favor of `onPlayerError`; older embeds still report it. */
+  | 'onError';
+
+/**
+ * A message from the embed. `value` stays unknown: it arrives from another
+ * origin, and what it holds depends on `type`.
+ */
+export interface TikTokPlayerEventMessage {
+  [PLAYER_MESSAGE_KEY]: true;
+  /** Widened past the known events, since the embed can report ones we don't handle. */
+  type: TikTokPlayerEventType | (string & {});
+  value?: unknown;
+}
+
+/** Payload of `onCurrentTime`, the embed's only progress report. */
+export interface TikTokCurrentTime {
+  currentTime: number;
+  duration: number;
+}
+
+/** Payload of `onPlayerError`. `errorType` names the code for a human. */
+export interface TikTokPlayerError {
+  errorCode: number;
+  errorType?: string;
+}
+
+// `onPlayerError` codes are grouped in thousand-wide categories: 1000s data and
+// validation (1001 invalid video), 2000s network and infrastructure (2001 server
+// error), 3000s player and runtime (3001 playback, 3002 autoplay). Only the
+// bounds and the one code that is not an error are named; the rest are read by
+// category, so codes TikTok adds later are read the same way.
+export const ERROR_AUTOPLAY = 3002;
+export const ERROR_NETWORK_CATEGORY = 2000;
+export const ERROR_PLAYER_CATEGORY = 3000;
+export const ERROR_CATEGORY_END = 4000;
+
+/**
+ * Whether a `message` event's data is one of the embed's messages. Every frame
+ * on the page posts to the same window, so the marker is what tells this
+ * protocol apart from everyone else's.
+ */
+export function isTikTokPlayerMessage(data: unknown): data is TikTokPlayerEventMessage {
+  if (!isObject(data)) return false;
+  const message = data as Partial<TikTokPlayerEventMessage>;
+  return !!message[PLAYER_MESSAGE_KEY] && isString(message.type);
+}
+
+/** Whether a value is the pair `onCurrentTime` reports. */
+export function isTikTokCurrentTime(value: unknown): value is TikTokCurrentTime {
+  return isObject(value) && isNumber((value as TikTokCurrentTime).currentTime);
+}
+
+/** Whether a value is the payload `onPlayerError` reports. */
+export function isTikTokPlayerError(value: unknown): value is TikTokPlayerError {
+  return isObject(value) && isNumber((value as TikTokPlayerError).errorCode);
+}
+
+/** Build a command message. A command without a value must not carry one at all. */
+export function createTikTokPlayerCommand(type: TikTokPlayerCommand, value?: number): TikTokPlayerCommandMessage {
+  return { [PLAYER_MESSAGE_KEY]: true, type, ...(isNumber(value) && { value }) };
+}
+
+// https://developers.tiktok.com/doc/embed-player
+export const STATE_INIT = -1;
+export const STATE_ENDED = 0;
+export const STATE_PLAYING = 1;
+export const STATE_PAUSED = 2;
+export const STATE_BUFFERING = 3;

--- a/packages/media/src/dom/tiktok/props.ts
+++ b/packages/media/src/dom/tiktok/props.ts
@@ -1,0 +1,29 @@
+import type { Video } from '../../core/types';
+import type { TikTokSource } from './source';
+
+/**
+ * The `Video` members the TikTok host accepts, plus the source that names the
+ * video. Three are stored and reported but never reach the embed: it always
+ * plays inline, it decides for itself what to load ahead, and it draws the
+ * video's own cover image, so `playsInline`, `preload`, and `poster` are inert.
+ */
+export interface TikTokMediaProps
+  extends Pick<
+    Video,
+    'src' | 'autoplay' | 'defaultMuted' | 'muted' | 'loop' | 'controls' | 'playsInline' | 'preload' | 'poster'
+  > {
+  source: TikTokSource | null;
+}
+
+export const tiktokMediaDefaultProps: TikTokMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  muted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  source: null,
+};

--- a/packages/media/src/dom/tiktok/source.ts
+++ b/packages/media/src/dom/tiktok/source.ts
@@ -1,0 +1,111 @@
+import { serializeEmbedParams } from '../utils';
+import type { TikTokMediaProps } from './props';
+
+/**
+ * TikTok engine options, spelled exactly as TikTok spells them
+ * (https://developers.tiktok.com/doc/embed-player). They are serialized onto the
+ * embed URL verbatim, so what you write here is what the player reads.
+ *
+ * Parameters the host owns are deliberately absent: `autoplay`, `controls`,
+ * `loop`, and `muted` come from the props of the same name, so configuring them
+ * here would give two ways to say one thing. The index signature still carries
+ * anything not listed here, so undocumented knobs and whatever TikTok adds next
+ * keep working.
+ */
+export interface TikTokEngineConfig extends Record<string, unknown> {
+  /** Show the closed-caption button. Defaults to `1`. */
+  closed_caption?: 0 | 1;
+  /** Show the video description. Defaults to `0`. */
+  description?: 0 | 1;
+  /** Show the fullscreen button. Defaults to `1`. */
+  fullscreen_button?: 0 | 1;
+  /** Show the track the video uses. Defaults to `0`. */
+  music_info?: 0 | 1;
+  /** Show the browser's native context menu. Defaults to `1`. */
+  native_context_menu?: 0 | 1;
+  /** Show the play button. Defaults to `1`. */
+  play_button?: 0 | 1;
+  /** Show the progress bar. Defaults to `1`. */
+  progress_bar?: 0 | 1;
+  /** Draw related videos from TikTok's recommendations (`1`) or the author's own videos (`0`). Defaults to `1`. */
+  rel?: 0 | 1;
+  /** Show the current playback time and duration. Defaults to `1`. */
+  timestamp?: 0 | 1;
+  /** Show the volume control. Defaults to `1`. */
+  volume_control?: 0 | 1;
+  /** `referrerpolicy` for the embed iframe. Not a TikTok player parameter. */
+  referrerPolicy?: ReferrerPolicy;
+}
+
+/** Structured TikTok source: which source to play, plus how to play it. */
+export interface TikTokSource {
+  /** TikTok URL or id. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: TikTokSourceEngineConfig | undefined;
+}
+
+/** The engines a TikTok source can configure. */
+export interface TikTokSourceEngineConfig {
+  /** TikTok's own player parameters, passed through untouched. */
+  tiktok?: TikTokEngineConfig | undefined;
+}
+
+/**
+ * Parsed pieces of a TikTok source URL. TikTok embeds one thing — a video named
+ * by a numeric id — so the id is all there is to take from a source.
+ */
+export interface ParsedTikTokSource {
+  /** Numeric video id. */
+  id: string;
+}
+
+/** Extract a TikTok video id from a raw numeric id or any recognized URL. */
+export function parseTikTokVideoId(src: string) {
+  return parseTikTokSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a TikTok source string. Recognizes raw numeric ids, `player/v1/` embed
+ * URLs, `share/video/` links, and the `@user/video/` URLs the app hands out.
+ */
+export function parseTikTokSource(src: string): ParsedTikTokSource | null {
+  if (!src) return null;
+  // A bare numeric id is how the embed URL itself names a video, so it is taken
+  // as one.
+  if (MATCH_ID.test(src)) return { id: src };
+  const id = MATCH_SRC.exec(src)?.[1];
+  return id ? { id } : null;
+}
+
+/** Build the iframe `src` URL for a TikTok embed from the given props. */
+export function buildTikTokIframeSrc(src: string, props: Partial<TikTokMediaProps> = {}) {
+  const parsed = parseTikTokSource(src);
+  if (!parsed) return '';
+  // `referrerPolicy` is an attribute of the iframe hosting the embed rather than
+  // something the player reads, so it never reaches the URL.
+  const { referrerPolicy: _referrerPolicy, ...tiktok } = props.source?.engine?.tiktok ?? {};
+  const params: Record<string, unknown> = {
+    // Hide TikTok chrome by default; pass nothing only when controls is explicitly true.
+    controls: props.controls === true ? null : 0,
+    // Off is the player's default for all three, so an explicit `0` says nothing
+    // the embed does not already assume. Left out, the URL is the one upstream's
+    // element builds — worth matching exactly on an embed whose behavior can only
+    // be observed through a cross-origin frame.
+    autoplay: props.autoplay || null,
+    muted: props.defaultMuted || null,
+    loop: props.loop || null,
+    // Keep what the player offers next inside the author's own videos rather
+    // than TikTok's recommendations, which is what `1` (the player's default)
+    // would pull in.
+    rel: 0,
+    // TikTok-specific knobs (`description`, `music_info`, `timestamp`, …) flow
+    // through here.
+    ...tiktok,
+  };
+  return `${EMBED_BASE}/${parsed.id}?${serializeEmbedParams(params)}`;
+}
+
+const EMBED_BASE = 'https://www.tiktok.com/player/v1';
+const MATCH_ID = /^\d+$/;
+const MATCH_SRC = /tiktok\.com\/(?:player\/v1\/|share\/video\/|@[^/]+\/video\/)(\d+)/;

--- a/packages/media/src/dom/tiktok/tests/media.test.ts
+++ b/packages/media/src/dom/tiktok/tests/media.test.ts
@@ -1,0 +1,962 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
+import { isMediaMutedCapable, isMediaVolumeCapable } from '../../../core/predicate';
+import type { Video } from '../../../core/types';
+import { buildTikTokIframeSrc, parseTikTokSource, parseTikTokVideoId, TikTokMedia, tiktokMediaDefaultProps } from '..';
+
+// https://developers.tiktok.com/doc/embed-player
+const STATE = { INIT: -1, ENDED: 0, PLAYING: 1, PAUSED: 2, BUFFERING: 3 } as const;
+
+const VIDEO_ID = '7273420104193772846';
+const OTHER_VIDEO_ID = '7268615078845893934';
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+/** jsdom only gives a connected iframe the window the embed posts from. */
+function createIframe(): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  return iframe;
+}
+
+/** An iframe as React renders it before a source resolves: `src` present but empty. */
+function createEmptySrcIframe(): HTMLIFrameElement {
+  const iframe = createIframe();
+  iframe.setAttribute('src', '');
+  return iframe;
+}
+
+function frameOf(iframe: HTMLIFrameElement): Window {
+  const frame = iframe.contentWindow;
+  if (!frame) throw new Error('iframe has no window');
+  return frame;
+}
+
+/** Spy on the commands posted to the embed. */
+function watchCommands(iframe: HTMLIFrameElement) {
+  return vi.spyOn(frameOf(iframe), 'postMessage');
+}
+
+/** Report a message the way the embed does: on `window`, from the embed's frame. */
+function report(iframe: HTMLIFrameElement, type: string, value?: unknown): void {
+  globalThis.dispatchEvent(
+    new MessageEvent('message', {
+      data: { 'x-tiktok-player': true, type, ...(value !== undefined && { value }) },
+      source: frameOf(iframe),
+    })
+  );
+}
+
+/** Flush the microtask a load waits on before the embed is built. */
+async function flushLoad(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function attachAndLoad(
+  media: TikTokMedia
+): Promise<{ iframe: HTMLIFrameElement; commands: ReturnType<typeof watchCommands> }> {
+  // There is no embed to attach to without a source, so tests that don't care
+  // which video is playing get one.
+  if (!media.src) media.src = VIDEO_ID;
+  const iframe = createIframe();
+  media.attach(iframe);
+  const commands = watchCommands(iframe);
+  report(iframe, 'onPlayerReady');
+  return { iframe, commands };
+}
+
+describe('parseTikTokVideoId', () => {
+  it('extracts id from a raw numeric id', () => {
+    expect(parseTikTokVideoId(VIDEO_ID)).toBe(VIDEO_ID);
+  });
+
+  it('extracts id from an embed player URL', () => {
+    expect(parseTikTokVideoId(`https://www.tiktok.com/player/v1/${VIDEO_ID}?controls=0`)).toBe(VIDEO_ID);
+  });
+
+  it('extracts id from a share link', () => {
+    expect(parseTikTokVideoId(`https://www.tiktok.com/share/video/${VIDEO_ID}`)).toBe(VIDEO_ID);
+  });
+
+  it('extracts id from an author URL', () => {
+    expect(parseTikTokVideoId(`https://www.tiktok.com/@videojs/video/${VIDEO_ID}`)).toBe(VIDEO_ID);
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseTikTokVideoId('')).toBe(null);
+  });
+
+  it('returns null for non-TikTok URLs', () => {
+    expect(parseTikTokVideoId('https://example.com/video/123')).toBe(null);
+  });
+
+  it('returns null for a TikTok URL that names no video', () => {
+    expect(parseTikTokVideoId('https://www.tiktok.com/@videojs')).toBe(null);
+  });
+});
+
+describe('parseTikTokSource', () => {
+  it('parses the video id out of every recognized form', () => {
+    expect(parseTikTokSource(VIDEO_ID)).toEqual({ id: VIDEO_ID });
+    expect(parseTikTokSource(`https://www.tiktok.com/player/v1/${VIDEO_ID}`)).toEqual({ id: VIDEO_ID });
+    expect(parseTikTokSource(`https://www.tiktok.com/share/video/${VIDEO_ID}/`)).toEqual({ id: VIDEO_ID });
+    expect(parseTikTokSource(`https://www.tiktok.com/@user.name/video/${VIDEO_ID}?is_from_webapp=1`)).toEqual({
+      id: VIDEO_ID,
+    });
+  });
+
+  it('returns null for an id that is not numeric', () => {
+    expect(parseTikTokSource('aqz-KE-bpKQ')).toBe(null);
+  });
+});
+
+describe('buildTikTokIframeSrc', () => {
+  it('builds the embed URL with hidden controls and related videos kept to the author', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID);
+    expect(src).toContain(`https://www.tiktok.com/player/v1/${VIDEO_ID}?`);
+    expect(src).toContain('controls=0');
+    expect(src).toContain('rel=0');
+  });
+
+  it('encodes autoplay, defaultMuted, and loop', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID, { autoplay: true, defaultMuted: true, loop: true });
+    expect(src).toContain('autoplay=1');
+    expect(src).toContain('muted=1');
+    expect(src).toContain('loop=1');
+  });
+
+  it('leaves autoplay, muted, and loop out rather than turning them off', () => {
+    // Off is the player's default for all three, so the URL this builds for a
+    // plain source is the one upstream's element builds, parameter for parameter.
+    const src = buildTikTokIframeSrc(VIDEO_ID, { autoplay: false, defaultMuted: false, loop: false });
+    expect(src).toBe(`https://www.tiktok.com/player/v1/${VIDEO_ID}?controls=0&rel=0`);
+    expect(buildTikTokIframeSrc(VIDEO_ID, tiktokMediaDefaultProps)).toBe(
+      `https://www.tiktok.com/player/v1/${VIDEO_ID}?controls=0&rel=0`
+    );
+  });
+
+  it('shows TikTok controls when controls=true', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID, { controls: true });
+    expect(src).not.toContain('controls=');
+  });
+
+  it('serializes TikTok player parameters verbatim', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID, {
+      source: {
+        engine: {
+          tiktok: {
+            closed_caption: 0,
+            description: 0,
+            fullscreen_button: 0,
+            music_info: 1,
+            native_context_menu: 1,
+            play_button: 0,
+            progress_bar: 0,
+            timestamp: 0,
+            volume_control: 0,
+          },
+        },
+      },
+    });
+    expect(src).toContain('closed_caption=0');
+    expect(src).toContain('description=0');
+    expect(src).toContain('fullscreen_button=0');
+    expect(src).toContain('music_info=1');
+    expect(src).toContain('native_context_menu=1');
+    expect(src).toContain('play_button=0');
+    expect(src).toContain('progress_bar=0');
+    expect(src).toContain('timestamp=0');
+    expect(src).toContain('volume_control=0');
+  });
+
+  it('carries undeclared TikTok player parameters through', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID, { source: { engine: { tiktok: { some_future_param: 'yes' } } } });
+    expect(src).toContain('some_future_param=yes');
+  });
+
+  it('lets TikTok player parameters override the defaults the host sets', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID, { source: { engine: { tiktok: { rel: 1 } } } });
+    expect(src).toContain('rel=1');
+  });
+
+  it('keeps referrerPolicy off the URL', () => {
+    const src = buildTikTokIframeSrc(VIDEO_ID, {
+      source: { engine: { tiktok: { referrerPolicy: 'no-referrer' } } },
+    });
+    expect(src).not.toContain('referrerPolicy');
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildTikTokIframeSrc('https://example.com/not-a-tiktok-url')).toBe('');
+    expect(buildTikTokIframeSrc('')).toBe('');
+  });
+});
+
+describe('TikTokMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new TikTokMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(tiktokMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sets the initial iframe src when attached', () => {
+    const media = new TikTokMedia();
+    media.src = `https://www.tiktok.com/@videojs/video/${VIDEO_ID}`;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.getAttribute('src')).toContain(`https://www.tiktok.com/player/v1/${VIDEO_ID}`);
+    expect(media.currentSrc).toBe(iframe.getAttribute('src'));
+    expect(media.target).toBe(iframe);
+    expect(media.engine).toBe(iframe.contentWindow);
+    media.detach();
+  });
+
+  it('defers the embed until a source arrives', async () => {
+    const media = new TikTokMedia();
+    const loadstart = vi.fn();
+    media.addEventListener('loadstart', loadstart);
+
+    // How every framework builds the element: created first, `src` set after.
+    const iframe = createIframe();
+    media.attach(iframe);
+    expect(iframe.getAttribute('src')).toBe(null);
+    expect(loadstart).not.toHaveBeenCalled();
+
+    media.src = VIDEO_ID;
+    await flushLoad();
+
+    expect(iframe.getAttribute('src')).toContain(`https://www.tiktok.com/player/v1/${VIDEO_ID}`);
+    expect(loadstart).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('defers the embed for an iframe rendered with an empty src', async () => {
+    const media = new TikTokMedia();
+    // React renders `src=""` before a source resolves. The `src` property reports
+    // the document URL for it, so only the attribute says there is no embed.
+    const iframe = createEmptySrcIframe();
+    media.attach(iframe);
+    expect(media.currentSrc).toBe('');
+
+    media.src = VIDEO_ID;
+    await flushLoad();
+
+    expect(iframe.getAttribute('src')).toContain(`https://www.tiktok.com/player/v1/${VIDEO_ID}`);
+    media.detach();
+  });
+
+  it('builds a deferred embed once for repeated source changes in the same task', async () => {
+    const media = new TikTokMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = VIDEO_ID;
+    media.src = OTHER_VIDEO_ID;
+    await flushLoad();
+
+    expect(iframe.getAttribute('src')).toContain(`https://www.tiktok.com/player/v1/${OTHER_VIDEO_ID}`);
+    media.detach();
+  });
+
+  it('does not leave play() waiting while the embed is deferred', async () => {
+    const media = new TikTokMedia();
+    media.attach(createIframe());
+
+    // No embed means no `onPlayerReady` is coming to report a load; waiting would hang.
+    await expect(media.play()).resolves.toBeUndefined();
+  });
+
+  it('waits for a deferred embed to be ready before playing', async () => {
+    const media = new TikTokMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = VIDEO_ID;
+    let played = false;
+    const pending = media.play().then(() => {
+      played = true;
+    });
+
+    await flushLoad();
+    await pending;
+    // Building the embed navigates the frame, so the commands it takes are the
+    // ones posted to the window it has now.
+    const commands = watchCommands(iframe);
+    // Play does not wait on the embed: it reports nothing until it is ready, so
+    // a barrier only its own report can settle would strand the request.
+    expect(played).toBe(true);
+
+    // The command is replayed at the first moment the embed can take one, so a
+    // play asked for before that still starts the video.
+    report(iframe, 'onPlayerReady');
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'play' }, '*');
+    media.detach();
+  });
+
+  it('does not replay a play the listener took back before the embed was ready', async () => {
+    const media = new TikTokMedia();
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = VIDEO_ID;
+    await media.play();
+    media.pause();
+    await flushLoad();
+
+    const commands = watchCommands(iframe);
+    report(iframe, 'onPlayerReady');
+
+    expect(commands).not.toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'play' }, '*');
+    media.detach();
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete once the embed is ready', async () => {
+    const media = new TikTokMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    await attachAndLoad(media);
+
+    expect(events).toEqual(['loadstart', 'loadedmetadata', 'loadcomplete']);
+    expect(media.readyState).toBe(1);
+    media.detach();
+  });
+
+  it('updates state from player state changes', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    const playSpy = vi.fn();
+    const waitingSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+    media.addEventListener('waiting', waitingSpy);
+
+    report(iframe, 'onStateChange', STATE.BUFFERING);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(waitingSpy).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(false);
+
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    expect(media.paused).toBe(false);
+    expect(media.readyState).toBe(3);
+    // play only fires once per playback start
+    expect(playSpy).toHaveBeenCalledTimes(1);
+
+    report(iframe, 'onStateChange', STATE.PAUSED);
+    expect(media.paused).toBe(true);
+
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    expect(playSpy).toHaveBeenCalledTimes(2);
+
+    report(iframe, 'onStateChange', STATE.ENDED);
+    expect(media.ended).toBe(true);
+    expect(media.paused).toBe(true);
+
+    report(iframe, 'onStateChange', STATE.INIT);
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('reports progress, duration, and seeks from the embed', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const events: string[] = [];
+    for (const type of ['timeupdate', 'durationchange', 'seeking', 'seeked'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    report(iframe, 'onCurrentTime', { currentTime: 2.5, duration: 15 });
+    expect(media.currentTime).toBe(2.5);
+    expect(media.duration).toBe(15);
+    expect(events).toEqual(['timeupdate', 'durationchange']);
+    // Only a position is reported, so what has played is all that is known to be
+    // buffered.
+    expect(media.buffered.length).toBe(1);
+    expect(media.buffered.end(0)).toBe(2.5);
+    expect(media.seekable.end(0)).toBe(15);
+
+    // A duration that has not changed is not announced again.
+    report(iframe, 'onCurrentTime', { currentTime: 3, duration: 15 });
+    expect(events).toEqual(['timeupdate', 'durationchange', 'timeupdate']);
+    media.detach();
+  });
+
+  it('reports mute changes from the embed', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const volumechange = vi.fn();
+    media.addEventListener('volumechange', volumechange);
+
+    report(iframe, 'onMute', true);
+    expect(media.muted).toBe(true);
+
+    report(iframe, 'onMute', false);
+    expect(media.muted).toBe(false);
+
+    // The level the embed reports goes nowhere: there is no volume to write, so
+    // nothing announces one changing.
+    report(iframe, 'onVolumeChange', 25);
+    expect(volumechange).toHaveBeenCalledTimes(2);
+    media.detach();
+  });
+
+  it('builds the embed with the mute the host is already reporting', () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    media.muted = true;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    // The frame reads mute once, out of the URL it is built with.
+    expect(iframe.getAttribute('src')).toContain('muted=1');
+    expect(media.muted).toBe(true);
+    media.detach();
+  });
+
+  it('reports the mute the embed is built with from defaultMuted', () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    media.defaultMuted = true;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.getAttribute('src')).toContain('muted=1');
+    // A media element comes up muted when it was created muted, rather than
+    // waiting for the embed to say so.
+    expect(media.muted).toBe(true);
+
+    const commands = watchCommands(iframe);
+    report(iframe, 'onPlayerReady');
+
+    // The URL parameter is not always honored, so the mute is asserted again
+    // over the protocol.
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'mute' }, '*');
+    media.detach();
+  });
+
+  it('leaves the mute the embed reports alone once it is loaded', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    report(iframe, 'onMute', false);
+
+    // `defaultMuted` seeds the embed that gets built; it does not talk over one
+    // that is already reporting for itself.
+    media.defaultMuted = true;
+
+    expect(media.muted).toBe(false);
+    media.detach();
+  });
+
+  it('carries a mute onto the embed it rebuilds', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe } = await attachAndLoad(media);
+    // Where `<tiktok-video muted>` lands: the attribute reaches `muted`, and the
+    // `src` sync behind it rebuilds the frame.
+    media.muted = true;
+
+    media.src = OTHER_VIDEO_ID;
+    await flushLoad();
+
+    expect(iframe.getAttribute('src')).toContain('muted=1');
+    expect(media.muted).toBe(true);
+
+    // Building the embed navigates the frame, so the commands it takes are the
+    // ones posted to the window it has now.
+    const commands = watchCommands(iframe);
+    report(iframe, 'onPlayerReady');
+
+    // The URL parameter is not always honored, so the mute is asserted again
+    // over the protocol.
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'mute' }, '*');
+    media.detach();
+  });
+
+  it('offers no volume surface but keeps mute', () => {
+    // The embed reports a level but takes no command to set one, so the member is
+    // absent rather than read-only — the player would render a slider that cannot
+    // move. `mute` and `unMute` are commands it does take, so mute stays.
+    const media = new TikTokMedia() as Partial<Video>;
+    expect(media.volume).toBeUndefined();
+    expect(media.muted).toBeDefined();
+    expect(isMediaVolumeCapable(media)).toBe(false);
+    expect(isMediaMutedCapable(media)).toBe(true);
+  });
+
+  it('posts play, pause, seekTo, and mute commands to the embed', async () => {
+    const media = new TikTokMedia();
+    const { commands } = await attachAndLoad(media);
+
+    await media.play();
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'play' }, '*');
+
+    media.pause();
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+
+    media.currentTime = 30;
+    media.muted = true;
+    // Commands defer via the loadComplete microtask — flush.
+    await flushLoad();
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'seekTo', value: 30 }, '*');
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'mute' }, '*');
+
+    media.muted = false;
+    await flushLoad();
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'unMute' }, '*');
+    media.detach();
+  });
+
+  it('completes a seek on the position the embed reports next', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const seeking = vi.fn();
+    const seeked = vi.fn();
+    media.addEventListener('seeking', seeking);
+    media.addEventListener('seeked', seeked);
+
+    media.currentTime = 30;
+    expect(media.seeking).toBe(true);
+    expect(seeking).toHaveBeenCalledTimes(1);
+    // The requested position is reported right away; the embed only reports one
+    // every so often.
+    expect(media.currentTime).toBe(30);
+
+    report(iframe, 'onCurrentTime', { currentTime: 30.2, duration: 60 });
+    expect(media.seeking).toBe(false);
+    expect(seeked).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('completes a seek that lands on exactly the position asked for', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const seeked = vi.fn();
+    media.addEventListener('seeked', seeked);
+
+    media.currentTime = 30;
+    // Landing on the requested position is the ordinary outcome, and while paused
+    // no other one may ever be reported.
+    report(iframe, 'onCurrentTime', { currentTime: 30, duration: 60 });
+
+    expect(media.seeking).toBe(false);
+    expect(seeked).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('does not report the embed emptied for a video it holds but has not started', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const emptied = vi.fn();
+    media.addEventListener('emptied', emptied);
+
+    report(iframe, 'onCurrentTime', { currentTime: 5, duration: 15 });
+    report(iframe, 'onStateChange', STATE.INIT);
+
+    // The resource is still loaded, so nothing was discarded to announce.
+    expect(emptied).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('replays on ended when loop is set', async () => {
+    const media = new TikTokMedia();
+    media.loop = true;
+    const { iframe, commands } = await attachAndLoad(media);
+
+    report(iframe, 'onStateChange', STATE.ENDED);
+    await flushLoad();
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'play' }, '*');
+    media.detach();
+  });
+
+  it('rewrites the iframe src when the source changes', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe } = await attachAndLoad(media);
+    report(iframe, 'onCurrentTime', { currentTime: 5, duration: 15 });
+
+    media.src = OTHER_VIDEO_ID;
+    await flushLoad();
+
+    // The protocol has nothing that swaps the video, so the frame is rebuilt.
+    expect(iframe.getAttribute('src')).toContain(`https://www.tiktok.com/player/v1/${OTHER_VIDEO_ID}`);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.readyState).toBe(0);
+
+    // The new frame reports itself ready, which completes the load.
+    const loadcomplete = vi.fn();
+    media.addEventListener('loadcomplete', loadcomplete);
+    report(iframe, 'onPlayerReady');
+    expect(loadcomplete).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('leaves a frame that already shows the embed alone', async () => {
+    const media = new TikTokMedia();
+    const iframe = createIframe();
+    // What a server-rendered element hands over: the URL these props build.
+    const embedSrc = buildTikTokIframeSrc(VIDEO_ID, tiktokMediaDefaultProps);
+    iframe.setAttribute('src', embedSrc);
+    media.attach(iframe);
+    report(iframe, 'onPlayerReady');
+
+    media.src = VIDEO_ID;
+    await flushLoad();
+
+    // Rewriting the same URL would reload the frame and lose its position.
+    expect(iframe.getAttribute('src')).toBe(embedSrc);
+    // No second `onPlayerReady` is coming, so the load has to settle itself.
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('waits for a frame that is still fetching the embed it already points at', async () => {
+    const media = new TikTokMedia();
+    const iframe = createIframe();
+    // What a server-rendered element hands over, before its embed reports ready.
+    iframe.setAttribute('src', buildTikTokIframeSrc(VIDEO_ID, tiktokMediaDefaultProps));
+    media.attach(iframe);
+    const events: string[] = [];
+    for (const type of ['emptied', 'loadstart'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    // The upgrade path: `src` syncs onto a frame already fetching that embed.
+    media.src = VIDEO_ID;
+    let played = false;
+    const pending = media.play().then(() => {
+      played = true;
+    });
+    await flushLoad();
+
+    // Nothing was discarded and nothing restarted, so the load the frame began is
+    // still the one running.
+    expect(events).toEqual([]);
+
+    await pending;
+    expect(played).toBe(true);
+
+    report(iframe, 'onPlayerReady');
+    media.detach();
+  });
+
+  it('completes the load on whatever the embed reports first', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const iframe = createIframe();
+    media.attach(iframe);
+    const loadComplete = vi.fn();
+    media.addEventListener('loadcomplete', loadComplete);
+    await flushLoad();
+
+    // `onPlayerReady` is not reliably the first thing the embed sends, and it
+    // says nothing at all before it is ready — so anything it reports settles the
+    // load rather than leaving it open forever.
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    expect(loadComplete).toHaveBeenCalledTimes(1);
+    expect(media.readyState).toBeGreaterThanOrEqual(1);
+    media.detach();
+  });
+
+  it('errors and unblocks pending play() when src is unrecognized', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe } = await attachAndLoad(media);
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    media.src = 'https://example.com/not-a-tiktok-url';
+    await flushLoad();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toBeInstanceOf(MediaError);
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+    expect(iframe.getAttribute('src')).toContain(VIDEO_ID);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('stops the embed and ignores what it reports when src is unrecognized', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe, commands } = await attachAndLoad(media);
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    media.src = 'https://example.com/not-a-tiktok-url';
+    await flushLoad();
+
+    // There is no video to swap the frame to, so the embed it still holds is
+    // paused rather than left playing under the error.
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+
+    commands.mockClear();
+    report(iframe, 'onCurrentTime', { currentTime: 5, duration: 15 });
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    // What the old embed reports is no longer ours to report or to resume.
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.paused).toBe(true);
+    expect(media.readyState).toBe(0);
+    await media.play();
+    expect(commands).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('surfaces player errors', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    report(iframe, 'onError');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toMatchObject({ code: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, fatal: true });
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('surfaces the player errors the embed reports today', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    report(iframe, 'onPlayerError', { errorCode: 1001, errorType: 'INVALID_VIDEO' });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(media.error).toMatchObject({ code: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED, fatal: true });
+    expect(media.error?.message).toContain('INVALID_VIDEO');
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('reads a player error by the category its code falls in', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    report(iframe, 'onPlayerError', { errorCode: 2001, errorType: 'SERVER_ERROR' });
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_NETWORK);
+
+    report(iframe, 'onPlayerError', { errorCode: 3001, errorType: 'PLAYBACK_ERROR' });
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_DECODE);
+    media.detach();
+  });
+
+  it('does not report a blocked autoplay as an error', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const errorSpy = vi.fn();
+    media.addEventListener('error', errorSpy);
+
+    report(iframe, 'onPlayerError', { errorCode: 3002, errorType: 'AUTOPLAY_ERROR' });
+
+    // The video is loaded and still playable, so nothing is wrong with it.
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(media.error).toBe(null);
+    media.detach();
+  });
+
+  it('takes the code the deprecated onError carries', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    // Its value is a `MediaError` code, unlike the TikTok codes `onPlayerError`
+    // reports.
+    report(iframe, 'onError', MediaError.MEDIA_ERR_NETWORK);
+
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_NETWORK);
+    media.detach();
+  });
+
+  it('ignores messages from another window and messages that are not the embed protocol', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const foreign = createIframe();
+
+    report(foreign, 'onStateChange', STATE.PLAYING);
+    globalThis.dispatchEvent(
+      new MessageEvent('message', { data: { type: 'onStateChange', value: STATE.PLAYING }, source: frameOf(iframe) })
+    );
+    globalThis.dispatchEvent(new MessageEvent('message', { data: 'hello', source: frameOf(iframe) }));
+
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('warns about messages it does not handle', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    report(iframe, 'onSomethingNew', 1);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('stops listening for the embed on detach', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+    const listeners = vi.spyOn(globalThis, 'addEventListener');
+
+    media.detach();
+    expect(media.target).toBe(null);
+    expect(media.engine).toBe(null);
+
+    // The listener lives on `window`, so nothing else would ever remove it.
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    report(iframe, 'onCurrentTime', { currentTime: 9, duration: 15 });
+
+    expect(media.paused).toBe(true);
+    expect(media.currentTime).toBe(0);
+    expect(listeners).not.toHaveBeenCalled();
+  });
+
+  it('ignores what a superseded frame reports', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe: stale } = await attachAndLoad(media);
+    media.detach();
+    const { iframe: current } = await attachAndLoad(media);
+    expect(current).not.toBe(stale);
+
+    report(stale, 'onStateChange', STATE.PLAYING);
+    report(stale, 'onMute', true);
+
+    expect(media.paused).toBe(true);
+    expect(media.muted).toBe(false);
+    media.detach();
+  });
+
+  it('unblocks pending play() when detached before the embed is ready', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    const pending = media.play();
+    media.detach();
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('tracks played ranges via the played-ranges mixin', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    report(iframe, 'onCurrentTime', { currentTime: 0.08, duration: 15 });
+    report(iframe, 'onCurrentTime', { currentTime: 0.16, duration: 15 });
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBe(0.16);
+    media.detach();
+  });
+
+  it('does not report fullscreen when there is no element to request it on', async () => {
+    const media = new TikTokMedia();
+
+    await media.requestFullscreen();
+
+    expect(media.isFullscreen).toBe(false);
+  });
+});
+
+describe('TikTokMedia source', () => {
+  it('derives src from a structured source and announces the change', () => {
+    const media = new TikTokMedia();
+    const sourceChange = vi.fn();
+    media.addEventListener('sourcechange', sourceChange);
+
+    media.source = { src: `https://www.tiktok.com/@videojs/video/${VIDEO_ID}` };
+
+    expect(media.src).toBe(`https://www.tiktok.com/@videojs/video/${VIDEO_ID}`);
+    expect(sourceChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-derives source from src, carrying TikTok player parameters over', () => {
+    const media = new TikTokMedia();
+    media.source = { src: VIDEO_ID, engine: { tiktok: { description: 0 } } };
+
+    media.src = OTHER_VIDEO_ID;
+
+    expect(media.source).toEqual({ engine: { tiktok: { description: 0 } }, src: OTHER_VIDEO_ID });
+  });
+
+  it('rebuilds the embed when only TikTok player parameters change', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe } = await attachAndLoad(media);
+
+    media.source = { src: VIDEO_ID, engine: { tiktok: { music_info: 0 } } };
+    await flushLoad();
+
+    // The player reads its parameters once, when the frame loads.
+    expect(iframe.getAttribute('src')).toContain('music_info=0');
+    media.detach();
+  });
+
+  it('serializes TikTok player parameters onto the initial iframe src', () => {
+    const media = new TikTokMedia();
+    media.source = { src: VIDEO_ID, engine: { tiktok: { timestamp: 0 } } };
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.getAttribute('src')).toContain('timestamp=0');
+    media.detach();
+  });
+
+  it('clears src when the source is set to null', () => {
+    const media = new TikTokMedia();
+    media.source = { src: VIDEO_ID };
+
+    media.source = null;
+
+    expect(media.src).toBe('');
+    expect(media.source).toBe(null);
+  });
+
+  it('drops the embed and resets state when the source is cleared', async () => {
+    const media = new TikTokMedia();
+    media.src = VIDEO_ID;
+    const { iframe, commands } = await attachAndLoad(media);
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    report(iframe, 'onCurrentTime', { currentTime: 5, duration: 15 });
+
+    media.source = null;
+    await flushLoad();
+
+    // Left in place the embed keeps playing and reports state straight back.
+    expect(iframe.getAttribute('src')).toBe(null);
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    expect(media.paused).toBe(true);
+    await expect(media.play()).resolves.toBeUndefined();
+    expect(commands).not.toHaveBeenCalled();
+    media.detach();
+  });
+});

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -19,6 +19,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
     'dom/cloudflare/index': './src/dom/cloudflare/index.ts',
     'dom/spotify/index': './src/dom/spotify/index.ts',
+    'dom/tiktok/index': './src/dom/tiktok/index.ts',
     'dom/vimeo/index': './src/dom/vimeo/index.ts',
     'dom/youtube/index': './src/dom/youtube/index.ts',
     'dom/mux/index': './src/dom/mux/index.ts',

--- a/packages/react/src/media/tiktok-video/index.ts
+++ b/packages/react/src/media/tiktok-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/tiktok-video/media.tsx
+++ b/packages/react/src/media/tiktok-video/media.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import type { TikTokMediaProps } from '@videojs/media/dom/tiktok';
+import { buildTikTokIframeSrc, TikTokMedia, tiktokMediaDefaultProps } from '@videojs/media/dom/tiktok';
+import type { ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
+import { useAttachIframe } from '../../utils/use-attach-iframe';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface TikTokVideoProps extends Partial<TikTokMediaProps> {
+  children?: ReactNode;
+}
+
+export const TikTokVideo = forwardRef<HTMLIFrameElement, TikTokVideoProps>(function TikTokVideo(
+  { children, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(TikTokMedia);
+  const props: Partial<TikTokMediaProps> & Record<string, unknown> = { ...rawProps };
+  const attachRef = useAttachIframe(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const [initialSrc] = useState(() =>
+    // `source.src` is the only other way to name a video, so honor it when `src` is absent.
+    buildTikTokIframeSrc(props.src || props.source?.src || '', {
+      ...tiktokMediaDefaultProps,
+      ...props,
+      // The frame reads mute once, out of the URL it is rendered with, and either
+      // prop says to start muted. Rendering it any other way than the media
+      // builds it would have the media rebuild the frame on mount.
+      defaultMuted: !!(props.defaultMuted || props.muted),
+    })
+  );
+  const iframeProps = useSyncProps<TikTokMediaProps, Record<string, unknown>>(media, props, tiktokMediaDefaultProps);
+
+  return (
+    <iframe
+      title="TikTok video player"
+      // Empty means there is no embed to point at yet; React warns about `src=""`,
+      // and the media builds the URL itself once a source resolves.
+      src={initialSrc || undefined}
+      data-cross-origin-frame
+      allow="accelerometer; fullscreen; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      referrerPolicy={props.source?.engine?.tiktok?.referrerPolicy}
+      {...iframeProps}
+      ref={composedRef}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace TikTokVideo {
+  export type Props = TikTokVideoProps;
+}


### PR DESCRIPTION
Ports [`tiktok-video-element`](https://github.com/muxinc/media-elements/tree/main/packages/tiktok-video-element) from `muxinc/media-elements` into v10 as a first-class media host, reshaped to the architecture the Vimeo and YouTube ports already established.

> **Stacked on #2169.** Review the last two commits, or read the diff against `feat/spotify-audio-media`.

## Motivation

TikTok is the first embed in this set with no SDK at all: the `postMessage` protocol *is* the API. Bringing it in as a `Media` host means the embed-host contract has to hold with no player object to hang state on and no library smoothing over the message plumbing.

## What's here

`packages/media/src/dom/tiktok` follows the YouTube port's file split, with `player-api.ts` standing in for the SDK loader:

- `props.ts` — the same ten-prop shape the other embed hosts use, with the inert fields documented
- `source.ts` — `TikTokSource`, embed parameters under `engine.tiktok`, source parsing, and embed-URL building
- `player-api.ts` — the wire protocol: message typings, player-state constants, inbound type guards, and the outbound command builder
- `media.ts` — `TikTokMedia`
- `tests/media.test.ts` — 49 cases

Plus `<tiktok-video>` in `packages/html` and `<TikTokVideo>` in `packages/react`.

## Behavior worth reviewing

- **A source change rewrites the iframe URL.** The protocol has `play`, `pause`, `seekTo`, `mute`, and `unMute` and nothing that swaps a video, and the URL parameters are read once when the frame loads. `load()` therefore builds the URL and writes it, and the new frame's `onPlayerReady` settles the barrier. It skips the rewrite when the URL is already identical, so a hydrating React tree does not reload the frame and lose its position.
- **Listener lifetime.** One `message` listener on `window`, bound through an `AbortController` signal that `detach()` aborts. Handlers are additionally guarded by a captured attach id and by `event.source === target.contentWindow`, so a superseded attach and every other frame on the page are both filtered out.
- **No `#pendingLoad` / `#creatingPlayer`.** Those exist in the YouTube and Spotify ports because their APIs drop swap commands before `ready`. Rewriting a URL works at any time, so the pending-load replay is unnecessary.
- **`engine` returns the embed's `contentWindow`,** because that is literally what the protocol is spoken to; there is no player object to expose.
- **Volume writes are refused** (with a `__DEV__` warning) since the embed ignores them; reads still track `onVolumeChange`. `onMute` sets `muted` only, rather than also zeroing `volume` as upstream does, because HTML media keeps the two separate.
- **`src` forms.** `@user/video/<id>`, `share/video/<id>`, `player/v1/<id>`, and bare numeric ids.

## Verification

- `pnpm -F @videojs/media test src/dom/tiktok` — 49 passed
- `pnpm test` — 5259 passed, 14 skipped
- `pnpm typecheck` — clean
- `pnpm -F @videojs/sandbox build` — clean; the new presets appear at `/html-tiktok-video/` and `/react-tiktok-video/`

## Notes

Split into two commits: the media host and platform wrappers, then the sandbox examples. The HTML host and the sandbox presets are sized to TikTok's portrait aspect rather than the shared 16:9 frame.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new cross-origin iframe integration with global message listeners and nuanced load/play edge cases; behavior is heavily tested but still third-party-embed dependent.
> 
> **Overview**
> Adds **first-class TikTok embed playback** to v10 by porting `tiktok-video-element` into a `TikTokMedia` host aligned with the YouTube/Vimeo embed architecture, plus HTML `<tiktok-video>`, React `<TikTokVideo>`, and sandbox presets.
> 
> The new `packages/media/src/dom/tiktok` stack drives the iframe purely via TikTok’s `postMessage` protocol (no SDK): URL parsing and embed building in `source.ts`, wire types in `player-api.ts`, and `TikTokMedia` that rewrites the iframe `src` on source or engine-parameter changes, skips reload when the URL is unchanged, and filters `window` messages by attach id and `event.source`. Playback exposes mute/seek/play/pause but **no volume API**; the HTML host uses portrait minimum dimensions and keeps the iframe interactive for user activation.
> 
> Sandbox registers `tiktok-video` as an embed preset (fixed `TIKTOK_VIDEO_SRC`, navbar label, source picker disabled) with HTML and React demo templates at 9:16 aspect ratio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f85254a1459f6ffa143c675528e22c825fe81aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Related issues

Part of the #1457 *Media Element Providers* epic, which tracks bringing v10 to parity with the breadth of sources in `muxinc/media-elements`.

**There is no TikTok issue to close.** The epic's sub-issues cover YouTube (#1434, closed), Vimeo (#1435, closed), Wistia (#1459), JW Player (#1460), Cloudflare Stream (#1461), Spotify (#1462), SoundCloud (#1454), Mixcloud (#1456), Shaka (#1458), and Player.js (#1455) — TikTok was never filed, even though `tiktok-video-element` ships in `media-elements`.

Worth filing one under #1457 for traceability, so the epic reflects what actually landed. I can do that if you want it.


**Update:** filed as #2173 and attached as a sub-issue of #1457. Closes #2173.
