### PR TITLE
feat(packages): add twitch video media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -21,6 +21,7 @@ export const PRESETS = [
   'cloudflare-video',
   'spotify-audio',
   'tiktok-video',
+  'twitch-video',
 ] as const;
 
 /**
@@ -34,4 +35,5 @@ export const EMBED_PRESETS = [
   'cloudflare-video',
   'spotify-audio',
   'tiktok-video',
+  'twitch-video',
 ] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -358,6 +358,10 @@ export const SPOTIFY_AUDIO_SRC = 'https://open.spotify.com/episode/7makk4oTQel54
 
 export const TIKTOK_VIDEO_SRC = 'https://www.tiktok.com/@_luwes/video/7527476667770522893';
 
+// A VOD rather than a channel: a channel embed only plays while its streamer is
+// live, so it would show an offline banner most of the time.
+export const TWITCH_VIDEO_SRC = 'https://www.twitch.tv/videos/106400740';
+
 /** Returns true when the given source represents a live stream and should use the live-video skin. */
 export function isLiveSource(id: SourceId): boolean {
   return SOURCES[id].live === true;

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -102,6 +102,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'cloudflare-video': 'Cloudflare Stream Video',
   'spotify-audio': 'Spotify Audio',
   'tiktok-video': 'TikTok Video',
+  'twitch-video': 'Twitch Video',
 };
 
 export function Navbar({

--- a/apps/sandbox/templates/html-twitch-video/index.html
+++ b/apps/sandbox/templates/html-twitch-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Twitch Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-twitch-video/main.ts
+++ b/apps/sandbox/templates/html-twitch-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/twitch-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { TWITCH_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <twitch-video class="block w-full h-full" src="${TWITCH_VIDEO_SRC}" playsinline></twitch-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-twitch-video/index.html
+++ b/apps/sandbox/templates/react-twitch-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Twitch Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-twitch-video/main.tsx
+++ b/apps/sandbox/templates/react-twitch-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoPlayer } from '@app/shared/react/players';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { TWITCH_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { TwitchVideo } from '@videojs/react/media/twitch-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoPlayer>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <TwitchVideo className="block w-full h-full" src={TWITCH_VIDEO_SRC} playsInline />
+      </VideoSkinComponent>
+    </VideoPlayer>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/define/media/twitch-video.ts
+++ b/packages/html/src/define/media/twitch-video.ts
@@ -1,0 +1,14 @@
+import { TwitchVideo } from '../../media/twitch-video';
+import { safeDefine } from '../safe-define';
+
+export class TwitchVideoElement extends TwitchVideo {
+  static readonly tagName = 'twitch-video';
+}
+
+safeDefine(TwitchVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [TwitchVideoElement.tagName]: TwitchVideoElement;
+  }
+}

--- a/packages/html/src/media/twitch-video/index.ts
+++ b/packages/html/src/media/twitch-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/twitch-video/media.ts
+++ b/packages/html/src/media/twitch-video/media.ts
@@ -1,0 +1,55 @@
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { buildTwitchIframeSrc, TwitchMedia } from '@videojs/media/dom/twitch';
+import { escapeHtml } from '@videojs/utils/string';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class TwitchCustomMediaElement extends CustomMediaElement('iframe', TwitchMedia) {
+  static override getTemplateHTML = (attrs: Record<string, string>): string => {
+    const initialSrc = buildTwitchIframeSrc(attrs.src ?? '', templateAttrsToEmbedProps(attrs));
+    const srcAttr = initialSrc ? ` src="${escapeHtml(initialSrc)}"` : '';
+    return /*html*/ `
+      <style>
+        :host {
+          display: inline-block;
+          min-width: 300px;
+          min-height: 150px;
+          position: relative;
+        }
+        iframe {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          border: 0;
+        }
+        :host(:not([controls])) {
+          pointer-events: none;
+        }
+      </style>
+      <iframe
+        part="iframe"
+        ${srcAttr}
+        allow="accelerometer; fullscreen; autoplay; encrypted-media; picture-in-picture;"
+        sandbox="allow-modals allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        scrolling="no"
+        frameborder="0"
+        width="100%"
+        height="100%"
+        referrerpolicy="${escapeHtml(attrs.referrerpolicy ?? '')}"
+      ></iframe>
+    `;
+  };
+}
+
+function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+  return {
+    autoplay: attrs.autoplay !== undefined,
+    defaultMuted: attrs.muted !== undefined,
+    loop: attrs.loop !== undefined,
+    controls: attrs.controls !== undefined,
+    playsInline: attrs.playsinline !== undefined,
+    preload: (attrs.preload as 'none' | 'metadata' | 'auto' | undefined) ?? 'metadata',
+  };
+}
+
+export class TwitchVideo extends MediaAttachMixin(TwitchCustomMediaElement) {}

--- a/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
+++ b/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
@@ -28,6 +28,9 @@ function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailabil
       volume: 1,
       muted: false,
       volumeAvailability,
+      // Mute has an availability of its own, and this slider reads the level's;
+      // these tests vary that one and leave the mute available throughout.
+      mutedAvailability: 'available',
       setVolume: vi.fn(),
       toggleMuted: vi.fn(),
     }),

--- a/packages/media/src/dom/twitch/index.ts
+++ b/packages/media/src/dom/twitch/index.ts
@@ -1,0 +1,15 @@
+// The player API module is internal apart from the protocol typings, which
+// describe what the embed posts and what it accepts.
+
+export * from './media';
+export type {
+  TwitchCommandMessage,
+  TwitchEmbedMessage,
+  TwitchInboundMessage,
+  TwitchPlaybackState,
+  TwitchPlayerProxyMessage,
+  TwitchPlayerState,
+  TwitchVideoStats,
+} from './player-api';
+export * from './props';
+export * from './source';

--- a/packages/media/src/dom/twitch/media.ts
+++ b/packages/media/src/dom/twitch/media.ts
@@ -296,6 +296,11 @@ export class TwitchMedia extends TwitchMediaBase implements Partial<Video> {
   set volume(value) {
     if (this.#volume === value) return;
     this.#volume = value;
+    // Nothing else will announce this. A snapshot is read as a patch against
+    // what is already reported, so the embed echoing the level it was just told
+    // to take reads as unchanged and says nothing; the write is the change, and
+    // it is announced here the way a media element announces its own.
+    this.dispatchEvent(new Event('volumechange'));
     // The embed takes the same 0–1 range `HTMLMediaElement` does.
     this.#afterLoad(() => this.#sendCommand(COMMAND_SET_VOLUME, value));
   }
@@ -306,6 +311,9 @@ export class TwitchMedia extends TwitchMediaBase implements Partial<Video> {
   set muted(value) {
     if (this.#muted === value) return;
     this.#muted = value;
+    // Announced here for the same reason the level is: the embed's echo of a
+    // mute it was told to take is not a change.
+    this.dispatchEvent(new Event('volumechange'));
     this.#afterLoad(() => this.#sendCommand(COMMAND_SET_MUTED, value));
   }
 
@@ -669,6 +677,9 @@ export class TwitchMedia extends TwitchMediaBase implements Partial<Video> {
       this.dispatchEvent(new Event('timeupdate'));
     }
 
+    // Only a level or mute that differs from what is already reported is a
+    // change: the rest is the embed echoing a command back, which the setter
+    // that sent it has announced already.
     const volumeChanged = isNumber(state.volume) && state.volume !== this.#volume;
     const mutedChanged = !isUndefined(state.muted) && state.muted !== this.#muted;
     if (volumeChanged || mutedChanged) {

--- a/packages/media/src/dom/twitch/media.ts
+++ b/packages/media/src/dom/twitch/media.ts
@@ -1,0 +1,764 @@
+// Adapted from `twitch-video-element` from `muxinc/media-elements`,
+// ported to TypeScript and reshaped as a media host to fit the v10
+// media-host architecture (mirrors `dom/youtube`).
+//
+// Source: https://github.com/muxinc/media-elements
+// License: MIT
+
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
+import { deepEqual } from '@videojs/utils/object';
+import { isNumber, isUndefined } from '@videojs/utils/predicate';
+import { EMPTY_TEXT_TRACKS, EMPTY_TIME_RANGES } from '../../core/constants';
+import { MediaError } from '../../core/media-error';
+import type { Video } from '../../core/types';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+import { createTimeRange } from '../utils';
+import {
+  COMMAND_PAUSE,
+  COMMAND_PLAY,
+  COMMAND_SEEK,
+  COMMAND_SET_CHANNEL,
+  COMMAND_SET_MUTED,
+  COMMAND_SET_VIDEO,
+  COMMAND_SET_VOLUME,
+  EMBED_NAMESPACE,
+  isTwitchMessage,
+  PLAYBACK_BUFFERING,
+  PLAYBACK_ENDED,
+  PLAYBACK_PLAYING,
+  PLAYER_PROXY_NAMESPACE,
+  TWITCH_PLAYER_ORIGIN,
+  type TwitchCommandMessage,
+  type TwitchPlaybackState,
+  type TwitchPlayerState,
+} from './player-api';
+import { twitchMediaDefaultProps } from './props';
+import { buildTwitchIframeSrc, parseTwitchSource, type TwitchSource } from './source';
+
+const TwitchMediaBase = MediaPlayedRangesMixin(EventTarget);
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ */
+export class TwitchMedia extends TwitchMediaBase implements Partial<Video> {
+  #target: HTMLIFrameElement | null = null;
+  /**
+   * Listening for the embed's messages is what "having a player" amounts to
+   * here, so this doubles as the marker that one exists; aborting it is the
+   * whole teardown.
+   */
+  #messages: AbortController | null = null;
+  /** The embed drops every command until it has posted `ready`. */
+  #playerReady = false;
+  /** A load was requested before the embed was ready; replay it on `ready`. */
+  #pendingLoad = false;
+  /** A rebuilt embed is on its way; the one being replaced can still be talking. */
+  #rebuilding = false;
+  #loadComplete = createPublicPromise<void>();
+  /** Guards deferred work across attach/detach cycles. */
+  #attachId = 0;
+  /** The embed URL currently in the iframe, or `''` when the iframe brought its own. */
+  #embedSrc = '';
+
+  #src = twitchMediaDefaultProps.src;
+  #autoplay = twitchMediaDefaultProps.autoplay;
+  #defaultMuted = twitchMediaDefaultProps.defaultMuted;
+  #loop = twitchMediaDefaultProps.loop;
+  #controls = twitchMediaDefaultProps.controls;
+  #playsInline = twitchMediaDefaultProps.playsInline;
+  #preload = twitchMediaDefaultProps.preload;
+  #poster = twitchMediaDefaultProps.poster;
+  #source: TwitchSource | null = twitchMediaDefaultProps.source;
+
+  /** Which kind of thing is loaded; a live channel behaves unlike a VOD. */
+  #kind: 'video' | 'channel' | null = null;
+  /** Last playback state the embed reported; null until it reports one. */
+  #playback: TwitchPlaybackState | null = null;
+  #paused = true;
+  #seeking = false;
+  #loaded = false;
+  #currentTime = 0;
+  #duration = Number.NaN;
+  #volume = 1;
+  #muted = false;
+  #playbackRate = 1;
+  #progress = 0;
+  #readyState = READY_STATE_HAVE_NOTHING;
+  #error: MediaError | null = null;
+  #isFullscreen = false;
+
+  static PLAYER_SOFTWARE_NAME = 'twitch-video';
+
+  /**
+   * The embed's own window. Twitch ships no SDK — every command is a message
+   * posted to this window — so it is the closest thing to a player object there
+   * is, and the only handle worth exposing. Null until an embed is bound and the
+   * iframe is in a document.
+   */
+  get engine(): Window | null {
+    return this.#messages ? (this.#target?.contentWindow ?? null) : null;
+  }
+
+  get target(): HTMLIFrameElement | null {
+    return this.#target;
+  }
+
+  /**
+   * Bind the iframe hosting the embed. The embed follows as soon an embed URL
+   * can be resolved, which is not always now: a framework that creates the
+   * element before setting `src` attaches an iframe with nothing to embed yet,
+   * and `load()` picks it up once a source arrives.
+   */
+  attach(target: HTMLIFrameElement | null): void {
+    if (!target || this.#target === target) return;
+    if (this.#target) this.detach();
+    this.#target = target;
+    this.#beginLoad();
+    this.#createPlayer();
+  }
+
+  detach(): void {
+    if (!this.#target) return;
+    this.#attachId++;
+    // The `message` listener is on the host window, which outlives the iframe,
+    // so dropping it here is what keeps a detached embed from driving state.
+    this.#messages?.abort();
+    this.#messages = null;
+    this.#playerReady = false;
+    this.#pendingLoad = false;
+    this.#rebuilding = false;
+    this.#embedSrc = '';
+    this.#target = null;
+    // Unblock callers awaiting load; they re-check the embed (now gone) and no-op.
+    this.#loadComplete.resolve();
+    this.#resetState();
+  }
+
+  override destroy() {
+    this.detach();
+    super.destroy();
+  }
+
+  get src() {
+    return this.#src;
+  }
+  /** Twitch VOD or channel URL. Setting it re-derives `source`, carrying its embed parameters over. */
+  set src(value) {
+    const { engine } = this.#source ?? {};
+    const next: TwitchSource = { ...(engine && { engine }), ...(value && { src: value }) };
+
+    // Everything happens in the `source` setter, so there is one path for storing
+    // it, deciding on a load, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  get currentSrc() {
+    // The `src` property resolves an empty attribute to the document URL, so only
+    // the attribute can report an embed that hasn't been built yet as empty.
+    return this.#target?.getAttribute('src') ?? '';
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  /** Reload the current source, swapping it into the running embed where possible. */
+  async load() {
+    if (!this.#messages || !this.#playerReady) {
+      // Commands are dropped before the embed posts `ready`; replay the load
+      // then. A cleared src replays too, so the barrier below always gets settled.
+      this.#pendingLoad = !!this.#target;
+      // The target can be attached before it has anything to embed, in which case
+      // this load is what finally builds it.
+      if (this.#target && !this.#messages) {
+        // The barrier `attach()` opened was settled when there was nothing to
+        // embed, so this load needs one of its own — otherwise `play()` runs
+        // before the embed it is waiting for exists.
+        const load = this.#beginLoad();
+        // Wait a microtask: a framework sets `src` and the props that shape the
+        // embed in whatever order it likes, and the embed URL is only built once,
+        // so it has to see all of them.
+        await Promise.resolve();
+        // A later load took over while waiting; building the embed is its job now.
+        if (load !== this.#loadComplete) return;
+        // The embed is built from the current source, so `ready` has nothing to replay.
+        this.#pendingLoad = false;
+        this.#createPlayer();
+      }
+      return;
+    }
+    const load = this.#beginLoad();
+    // Reset before bailing on an empty src: a cleared source has nothing to load,
+    // but what we report about the old video still has to go.
+    this.#resetState();
+    if (!this.#src) {
+      // The embed has to stop too. Left running it keeps playing, and its state
+      // messages write what was just cleared straight back.
+      load.resolve();
+      this.#sendCommand(COMMAND_PAUSE);
+      return;
+    }
+    this.dispatchEvent(new Event('emptied'));
+    this.dispatchEvent(new Event('loadstart'));
+    const parsed = parseTwitchSource(this.#src);
+    if (!parsed) {
+      this.#error = new MediaError(`Unrecognized Twitch source: ${this.#src}`, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+      this.dispatchEvent(new Event('error'));
+      // Unblock callers awaiting load so play()/fullscreen don't hang.
+      load.resolve();
+      return;
+    }
+    this.#kind = parsed.kind;
+    const nextEmbedSrc = buildTwitchIframeSrc(this.#src, this.#snapshotProps());
+
+    // `SET_VIDEO`/`SET_CHANNEL` swap the content without tearing the embed (and
+    // its session) down, so they are preferred. Everything except *which* video
+    // or channel is playing rides on the embed URL, though, so only a change
+    // that is nothing but the content can be commanded; anything else — a
+    // changed embed parameter, or an iframe whose URL we never built and so
+    // cannot compare — has to rebuild the iframe.
+    if (isContentOnlyChange(this.#embedSrc, nextEmbedSrc)) {
+      this.#embedSrc = nextEmbedSrc;
+      if (parsed.kind === 'video') this.#sendCommand(COMMAND_SET_VIDEO, `v${parsed.id}`);
+      else this.#sendCommand(COMMAND_SET_CHANNEL, parsed.channel);
+      return;
+    }
+
+    this.#embedSrc = nextEmbedSrc;
+    // A rebuilt embed posts `ready` again, which is what completes this load.
+    this.#playerReady = false;
+    this.#rebuilding = true;
+    if (this.#target) this.#target.src = nextEmbedSrc;
+  }
+
+  /**
+   * Take over as the current load, returning its barrier. Settling the outgoing
+   * one is what keeps a superseded load from stranding callers that are already
+   * waiting; every exit from `load()` settles the barrier it was handed.
+   */
+  #beginLoad(): PublicPromise<void> {
+    this.#loadComplete.resolve();
+    this.#loadComplete = createPublicPromise<void>();
+    return this.#loadComplete;
+  }
+
+  get paused() {
+    // Until the embed describes itself, our own play()/pause() calls are the
+    // only answer there is.
+    if (!this.#playback) return this.#paused;
+    // Buffering is playing that is waiting; everything else the embed can be —
+    // loaded but not started, stopped, finished — is paused.
+    return this.#playback !== PLAYBACK_PLAYING && this.#playback !== PLAYBACK_BUFFERING;
+  }
+
+  get ended() {
+    // A live channel never ends. Twitch reports the stream going away as
+    // `offline`, which is re-dispatched under its own name rather than dressed
+    // up as the end of a video that has no end.
+    if (this.#kind === 'channel') return false;
+    return this.#playback === PLAYBACK_ENDED;
+  }
+
+  get seeking() {
+    return this.#seeking;
+  }
+
+  async play() {
+    await this.#loadComplete;
+    // The embed still holds the paused video, so playing it would resume a
+    // source that was cleared.
+    if (!this.#src) return;
+    this.#paused = false;
+    this.#sendCommand(COMMAND_PLAY);
+  }
+
+  pause() {
+    this.#paused = true;
+    this.#sendCommand(COMMAND_PAUSE);
+  }
+
+  get currentTime() {
+    return this.#currentTime;
+  }
+  set currentTime(value) {
+    if (this.#currentTime === value) return;
+    this.#currentTime = value;
+    this.#afterLoad(() => this.#sendCommand(COMMAND_SEEK, value));
+  }
+
+  get duration() {
+    return this.#duration;
+  }
+
+  get volume() {
+    return this.#volume;
+  }
+  set volume(value) {
+    if (this.#volume === value) return;
+    this.#volume = value;
+    // The embed takes the same 0–1 range `HTMLMediaElement` does.
+    this.#afterLoad(() => this.#sendCommand(COMMAND_SET_VOLUME, value));
+  }
+
+  get muted() {
+    return this.#muted;
+  }
+  set muted(value) {
+    if (this.#muted === value) return;
+    this.#muted = value;
+    this.#afterLoad(() => this.#sendCommand(COMMAND_SET_MUTED, value));
+  }
+
+  get playbackRate() {
+    return this.#playbackRate;
+  }
+  set playbackRate(value) {
+    // The embed has no rate command, so this is reported back but never applied.
+    this.#playbackRate = value;
+  }
+
+  get autoplay() {
+    return this.#autoplay;
+  }
+  set autoplay(value) {
+    this.#autoplay = value;
+  }
+
+  get defaultMuted() {
+    return this.#defaultMuted;
+  }
+  set defaultMuted(value) {
+    this.#defaultMuted = value;
+  }
+
+  get loop() {
+    return this.#loop;
+  }
+  set loop(value) {
+    // The embed has no loop parameter; the end of a VOD restarts it instead.
+    this.#loop = value;
+  }
+
+  get controls() {
+    return this.#controls;
+  }
+  set controls(value) {
+    // Which chrome the embed draws is fixed in its URL, so upstream rebuilds the
+    // iframe to change it. Not here: the player draws its own controls over the
+    // embed, and losing the session — playback restarts from zero — to hide a set
+    // of controls that were already covered is the worse trade. The next load
+    // picks the new value up.
+    this.#controls = value;
+  }
+
+  get playsInline() {
+    return this.#playsInline;
+  }
+  set playsInline(value) {
+    this.#playsInline = value;
+  }
+
+  get preload() {
+    return this.#preload;
+  }
+  set preload(value) {
+    this.#preload = value;
+  }
+
+  get poster() {
+    return this.#poster;
+  }
+  set poster(value) {
+    this.#poster = value;
+  }
+
+  /**
+   * Structured source: the Twitch VOD or channel URL in `src`, plus embed
+   * parameters under `engine.twitch`. Replacing it re-derives `src`; assigning
+   * an equivalent source is a no-op.
+   */
+  get source(): TwitchSource | null {
+    return this.#source;
+  }
+  set source(value: TwitchSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    const src = source?.src ?? '';
+    const srcChanged = this.#src !== src;
+    // Embed parameters are read when the embed URL is built, so a change to them
+    // needs a reload of its own even though the source is the same.
+    const engineChanged = !deepEqual(this.#source?.engine?.twitch ?? null, source?.engine?.twitch ?? null);
+
+    this.#source = source;
+    this.#src = src;
+
+    if (srcChanged || engineChanged) void this.load();
+
+    // Assigning is always a source change, so it is always announced.
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+
+  get buffered() {
+    // `bufferSize` counts the seconds buffered *ahead* of the playhead rather
+    // than naming a position, so the range is anchored to `currentTime`.
+    return this.#progress > 0
+      ? createTimeRange(this.#currentTime, this.#currentTime + this.#progress)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    // A live channel reports an infinite duration, which leaves no range to
+    // report: the embed exposes no DVR window to seek within.
+    return this.#duration > 0 && Number.isFinite(this.#duration)
+      ? createTimeRange(0, this.#duration)
+      : EMPTY_TIME_RANGES;
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  get textTracks() {
+    // The embed can only be told to turn captions on or off; it never says which
+    // tracks exist, so there is nothing to enumerate.
+    return EMPTY_TEXT_TRACKS;
+  }
+
+  get isFullscreen() {
+    return this.#isFullscreen;
+  }
+
+  // The embed exposes no fullscreen command, so fullscreen targets the iframe itself.
+  async requestFullscreen() {
+    // Nothing entered fullscreen if there is no element to request it on, so the
+    // flag must not claim otherwise.
+    if (!this.#target?.requestFullscreen) return;
+    await this.#target.requestFullscreen();
+    this.#isFullscreen = true;
+  }
+
+  async exitFullscreen() {
+    const doc = globalThis.document;
+    if (doc?.fullscreenElement && doc.fullscreenElement === this.#target) {
+      await doc.exitFullscreen();
+    }
+    this.#isFullscreen = false;
+  }
+
+  /**
+   * Build the embed and start listening to it once a source can be resolved. A
+   * target that cannot be resolved yet stays unbound and settles the load it was
+   * given; the next `load()` retries.
+   *
+   * @returns Whether the embed was bound.
+   */
+  #createPlayer(): boolean {
+    const target = this.#target;
+    if (!target || this.#messages) return false;
+
+    // The `src` property resolves an empty attribute to the document URL, so it
+    // cannot tell an embed apart from a placeholder; the attribute can.
+    const existingSrc = target.getAttribute('src');
+    if (!existingSrc) {
+      const initialSrc = buildTwitchIframeSrc(this.#src, this.#snapshotProps());
+      // No embed means no `ready` is coming to settle this load.
+      if (!initialSrc) {
+        this.#loadComplete.resolve();
+        return false;
+      }
+      target.src = initialSrc;
+    } else {
+      // A URL built where there was no `location` — server rendering — names only
+      // the hostnames that were configured, and Twitch refuses to play in a page
+      // its URL never named. Nothing else about a URL we did not build is ours to
+      // second-guess.
+      const withParent = withPageParent(existingSrc);
+      if (withParent !== existingSrc) target.src = withParent;
+    }
+    this.#kind = parseTwitchSource(this.#src)?.kind ?? null;
+    // An iframe that arrived with its own URL is still worth remembering: a
+    // later source change compares against it to decide whether it can be
+    // swapped in place.
+    this.#embedSrc = target.getAttribute('src') ?? '';
+
+    const attachId = this.#attachId;
+    this.#messages = new AbortController();
+    globalThis.addEventListener('message', (event) => void this.#onMessage(event, attachId), {
+      signal: this.#messages.signal,
+    });
+
+    this.dispatchEvent(new Event('loadstart'));
+    return true;
+  }
+
+  /**
+   * Whether deferred work belongs to a superseded attach. The settle delay below
+   * outlives a `detach()`, so anything the embed reports has to be matched
+   * against the attach that bound it before it is allowed to touch state.
+   */
+  #isStale(attachId: number) {
+    return attachId !== this.#attachId;
+  }
+
+  /** Defer a command until `loadComplete` resolves, dropping it if the embed is gone. */
+  #afterLoad(fn: () => void) {
+    this.#loadComplete.then(
+      () => {
+        if (!this.#messages) return;
+        fn();
+      },
+      () => {}
+    );
+  }
+
+  #sendCommand(command: number, params?: unknown) {
+    const embedWindow = this.#target?.contentWindow;
+    if (!embedWindow) return;
+    const message: TwitchCommandMessage = { namespace: PLAYER_PROXY_NAMESPACE, eventName: command, params };
+    embedWindow.postMessage(message, TWITCH_PLAYER_ORIGIN);
+  }
+
+  #snapshotProps() {
+    return {
+      autoplay: this.#autoplay,
+      defaultMuted: this.#defaultMuted,
+      loop: this.#loop,
+      controls: this.#controls,
+      playsInline: this.#playsInline,
+      preload: this.#preload || twitchMediaDefaultProps.preload,
+      source: this.#source,
+    };
+  }
+
+  #resetState() {
+    this.#kind = null;
+    this.#playback = null;
+    this.#currentTime = 0;
+    this.#duration = Number.NaN;
+    this.#muted = false;
+    this.#paused = !this.#autoplay;
+    this.#playbackRate = 1;
+    this.#progress = 0;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#seeking = false;
+    this.#loaded = false;
+    this.#volume = 1;
+    this.#error = null;
+    this.#isFullscreen = false;
+  }
+
+  async #onMessage(event: MessageEvent, attachId: number) {
+    if (this.#isStale(attachId)) return;
+    const embedWindow = this.#target?.contentWindow;
+    // Any frame on the page can post to this window, so only the embed we bound
+    // is allowed to drive state.
+    if (!embedWindow || event.source !== embedWindow) return;
+    const { data } = event;
+    if (!isTwitchMessage(data)) return;
+
+    if (data.namespace === EMBED_NAMESPACE) {
+      // The lifecycle event lands before the state snapshot that explains it, so
+      // give the snapshot a moment to arrive before acting on the event.
+      await new Promise((resolve) => setTimeout(resolve, STATE_SETTLE_MS));
+      // The wait outlives a detach, and the embed it belonged to may be gone.
+      if (this.#isStale(attachId)) return;
+      this.#onEmbedEvent(data.eventName);
+      return;
+    }
+    if (data.eventName === 'UPDATE_STATE') this.#onUpdateState(data.params ?? {});
+  }
+
+  #onEmbedEvent(eventName: string) {
+    // Nothing is loaded, so nothing the embed reports is about this media.
+    // Upstream stops listening outright when the source is cleared; the iframe is
+    // not ours to remove, so the stopped embed is ignored here instead. `ready`
+    // is the exception: a load that arrived before the embed could hear it is
+    // replayed on `ready`, and clearing the source is such a load.
+    if (eventName !== 'ready' && !this.#src) return;
+
+    switch (eventName) {
+      case 'ready': {
+        this.#playerReady = true;
+        this.#rebuilding = false;
+        if (this.#pendingLoad) {
+          // The embed was built from a stale src; skip its metadata and reload.
+          this.#pendingLoad = false;
+          void this.load();
+          return;
+        }
+        this.#onLoaded();
+        return;
+      }
+      case 'seek': {
+        this.#seeking = true;
+        this.dispatchEvent(new Event('seeking'));
+        return;
+      }
+      case 'playing': {
+        if (this.#seeking) {
+          this.#seeking = false;
+          this.dispatchEvent(new Event('seeked'));
+        }
+        this.#readyState = READY_STATE_HAVE_FUTURE_DATA;
+        this.dispatchEvent(new Event('playing'));
+        return;
+      }
+      case 'ended': {
+        // Dispatched for a live channel too, the way a native element ends when a
+        // live resource runs out; only `ended` the *state* refuses to latch, so
+        // that a channel between streams does not read as a finished video.
+        this.dispatchEvent(new Event('ended'));
+        // No loop parameter and no repeat command, so a repeat is a seek back to
+        // the start followed by a play.
+        if (this.#loop) {
+          this.currentTime = 0;
+          void this.play();
+        }
+        return;
+      }
+      default: {
+        // `play`, `pause`, `offline`, `online`, … all read as media events under
+        // the names the embed already gives them.
+        this.dispatchEvent(new Event(eventName));
+      }
+    }
+  }
+
+  /**
+   * Apply a player state snapshot. The embed sends only what changed, so an
+   * absent field means "unchanged", not "unset".
+   */
+  #onUpdateState(state: TwitchPlayerState) {
+    // An iframe keeps its window across a `src` change, so the document on its way
+    // out still passes for the embed. What it reports describes the content being
+    // replaced, and completing this load on it would hand callers a player that
+    // is not there yet; the rebuilt embed's `ready` is what completes it.
+    if (this.#rebuilding) return;
+    // With no source loaded there is nothing for a snapshot to describe, and
+    // applying one would write the cleared video's time and duration straight
+    // back — the stopped embed keeps reporting them.
+    if (!this.#src) return;
+
+    // A rebuilt embed reports `ready`, but a swapped one reports nothing at all —
+    // it simply starts describing the new content — so the first snapshot after
+    // a load is what completes it. Only once the embed has reported `ready`,
+    // though: snapshots start arriving before it does, and completing the load on
+    // one of those would release the commands waiting on it into an embed that
+    // drops them.
+    if (this.#playerReady && !this.#loaded) this.#onLoaded();
+
+    if (state.playback && state.playback !== this.#playback) {
+      // A stall reaches us only as a playback state — no lifecycle event says the
+      // embed ran dry — so entering that state is the whole of `waiting`.
+      if (state.playback === PLAYBACK_BUFFERING) this.dispatchEvent(new Event('waiting'));
+      this.#playback = state.playback;
+    }
+
+    // A live channel has no length to report, and the seconds-since-live Twitch
+    // sends in its place is not one, so `#onLoaded` fixed it at Infinity.
+    if (this.#kind !== 'channel' && isNumber(state.duration) && state.duration !== this.#duration) {
+      this.#duration = state.duration;
+      this.dispatchEvent(new Event('durationchange'));
+    }
+
+    if (isNumber(state.currentTime) && state.currentTime !== this.#currentTime) {
+      this.#currentTime = state.currentTime;
+      this.dispatchEvent(new Event('timeupdate'));
+    }
+
+    const volumeChanged = isNumber(state.volume) && state.volume !== this.#volume;
+    const mutedChanged = !isUndefined(state.muted) && state.muted !== this.#muted;
+    if (volumeChanged || mutedChanged) {
+      if (isNumber(state.volume)) this.#volume = state.volume;
+      if (!isUndefined(state.muted)) this.#muted = state.muted;
+      this.dispatchEvent(new Event('volumechange'));
+    }
+
+    const bufferSize = state.stats?.videoStats?.bufferSize;
+    if (isNumber(bufferSize) && bufferSize !== this.#progress) {
+      this.#progress = bufferSize;
+      // Buffered media ahead of a playing head is as far as the embed lets us
+      // see; it never says the whole thing has arrived.
+      if (this.#readyState >= READY_STATE_HAVE_FUTURE_DATA && bufferSize > 0) {
+        this.#readyState = READY_STATE_HAVE_ENOUGH_DATA;
+      }
+      this.dispatchEvent(new Event('progress'));
+    }
+  }
+
+  #onLoaded() {
+    if (this.#loaded) return;
+    this.#loaded = true;
+    this.#readyState = READY_STATE_HAVE_METADATA;
+    this.dispatchEvent(new Event('loadedmetadata'));
+    if (this.#kind === 'channel') {
+      // Live: there is no end to seek to, so report it the way a live
+      // `HTMLMediaElement` does instead of waiting for a duration that is never
+      // coming.
+      this.#duration = Number.POSITIVE_INFINITY;
+      this.dispatchEvent(new Event('durationchange'));
+    }
+    this.dispatchEvent(new Event('loadcomplete'));
+    this.#loadComplete.resolve();
+  }
+}
+
+/**
+ * Whether two embed URLs differ only in which video or channel they name, which
+ * is the one difference the embed can be commanded through. An unbuilt or
+ * unparsable URL is no comparison at all, so it answers no.
+ */
+function isContentOnlyChange(current: string, next: string): boolean {
+  const currentBase = withoutContent(current);
+  const nextBase = withoutContent(next);
+  return currentBase !== null && currentBase === nextBase;
+}
+
+/**
+ * Name the page as one of the embed's parents when the URL does not already. The
+ * embed checks its frame's ancestors against `parent` and refuses to play when
+ * the page is missing from it, which is what a URL built without a `location` —
+ * server rendering — leaves behind.
+ */
+function withPageParent(embedSrc: string): string {
+  const hostname = globalThis.location?.hostname;
+  if (!hostname) return embedSrc;
+  let url: URL;
+  try {
+    url = new URL(embedSrc);
+  } catch {
+    return embedSrc;
+  }
+  // Only the embed reads `parent`; an iframe pointed anywhere else is not ours.
+  if (url.origin !== TWITCH_PLAYER_ORIGIN) return embedSrc;
+  if (url.searchParams.getAll('parent').includes(hostname)) return embedSrc;
+  url.searchParams.append('parent', hostname);
+  return url.toString();
+}
+
+function withoutContent(embedSrc: string): string | null {
+  if (!embedSrc) return null;
+  try {
+    const url = new URL(embedSrc);
+    url.searchParams.delete('video');
+    url.searchParams.delete('channel');
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The embed posts its lifecycle events and the player state behind them
+ * separately, in that order, so acting on an event means waiting out this gap
+ * first. Ten milliseconds is what `twitch-video-element` settled on.
+ */
+const STATE_SETTLE_MS = 10;
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_METADATA = 1;
+const READY_STATE_HAVE_FUTURE_DATA = 3;
+const READY_STATE_HAVE_ENOUGH_DATA = 4;

--- a/packages/media/src/dom/twitch/player-api.ts
+++ b/packages/media/src/dom/twitch/player-api.ts
@@ -1,0 +1,102 @@
+// Minimal typings for the Twitch embed's postMessage protocol
+// (https://dev.twitch.tv/docs/embed/video-and-clips/).
+// Twitch publishes no SDK for `player.twitch.tv`, so there is nothing to load
+// and nothing to type against: the embed is driven entirely by messages, and
+// their shapes are transcribed here.
+
+import { isObject, isString } from '@videojs/utils/predicate';
+
+/** Embed origin. It is both where the embed is served from and where commands are posted. */
+export const TWITCH_PLAYER_ORIGIN = 'https://player.twitch.tv';
+
+/** Namespace on the commands the host posts, and on the state snapshots that come back. */
+export const PLAYER_PROXY_NAMESPACE = 'twitch-embed-player-proxy';
+
+/** Namespace on the lifecycle events the embed emits. */
+export const EMBED_NAMESPACE = 'twitch-embed';
+
+// Commands the embed accepts, posted as the numeric `eventName` of a
+// `twitch-embed-player-proxy` message.
+export const COMMAND_DISABLE_CAPTIONS = 0;
+export const COMMAND_ENABLE_CAPTIONS = 1;
+export const COMMAND_PAUSE = 2;
+export const COMMAND_PLAY = 3;
+export const COMMAND_SEEK = 4;
+export const COMMAND_SET_CHANNEL = 5;
+export const COMMAND_SET_CHANNEL_ID = 6;
+export const COMMAND_SET_COLLECTION = 7;
+export const COMMAND_SET_QUALITY = 8;
+export const COMMAND_SET_VIDEO = 9;
+export const COMMAND_SET_MUTED = 10;
+export const COMMAND_SET_VOLUME = 11;
+
+// Values the `playback` field of a player state snapshot takes.
+export const PLAYBACK_IDLE = 'Idle';
+export const PLAYBACK_READY = 'Ready';
+export const PLAYBACK_BUFFERING = 'Buffering';
+export const PLAYBACK_PLAYING = 'Playing';
+export const PLAYBACK_ENDED = 'Ended';
+
+/** Where the embed is in its playback lifecycle. */
+export type TwitchPlaybackState =
+  | typeof PLAYBACK_IDLE
+  | typeof PLAYBACK_READY
+  | typeof PLAYBACK_BUFFERING
+  | typeof PLAYBACK_PLAYING
+  | typeof PLAYBACK_ENDED;
+
+/** Delivery statistics the embed reports alongside its player state. */
+export interface TwitchVideoStats extends Record<string, unknown> {
+  /** Seconds of media buffered ahead of the playhead. */
+  bufferSize?: number;
+}
+
+/**
+ * Player state snapshot. The embed sends only what changed, so every field is
+ * optional and a snapshot has to be read as a patch rather than a whole state.
+ */
+export interface TwitchPlayerState {
+  /** Length of the VOD in seconds. Live channels report no meaningful duration. */
+  duration?: number;
+  currentTime?: number;
+  /** Volume in the `0`–`1` range, matching `HTMLMediaElement`. */
+  volume?: number;
+  muted?: boolean;
+  playback?: TwitchPlaybackState;
+  stats?: { videoStats?: TwitchVideoStats };
+}
+
+/** Lifecycle event the embed emits (`ready`, `play`, `pause`, `seek`, `ended`, `offline`, …). */
+export interface TwitchEmbedMessage {
+  namespace: typeof EMBED_NAMESPACE;
+  eventName: string;
+  params?: unknown;
+}
+
+/** Player state snapshot, pushed on the same namespace the host sends commands on. */
+export interface TwitchPlayerProxyMessage {
+  namespace: typeof PLAYER_PROXY_NAMESPACE;
+  eventName: string;
+  params?: TwitchPlayerState;
+}
+
+/** Anything the embed posts back to the host. */
+export type TwitchInboundMessage = TwitchEmbedMessage | TwitchPlayerProxyMessage;
+
+/** Command the host posts to the embed. Its `eventName` is one of the numeric codes above. */
+export interface TwitchCommandMessage {
+  namespace: typeof PLAYER_PROXY_NAMESPACE;
+  eventName: number;
+  params?: unknown;
+}
+
+/**
+ * Narrow the payload of a `message` event to something the embed sent. Any page
+ * can post to the host window, so the namespace is what separates the embed's
+ * messages from everyone else's.
+ */
+export function isTwitchMessage(data: unknown): data is TwitchInboundMessage {
+  if (!isObject(data)) return false;
+  const { namespace, eventName } = data as { namespace?: unknown; eventName?: unknown };
+  return isString(eventName) && (namespace === EMBED_NAMESPACE || namespace === PLAYER_PROXY_NAMESPACE);
+}

--- a/packages/media/src/dom/twitch/props.ts
+++ b/packages/media/src/dom/twitch/props.ts
@@ -1,0 +1,31 @@
+import type { Video } from '../../core/types';
+import type { TwitchSource } from './source';
+
+/**
+ * The `Video` members the Twitch host accepts, plus the source that names the
+ * video or channel. Three of them never reach the embed: `loop`, which it has no
+ * parameter for and the host emulates by seeking a finished VOD back to the
+ * start (a live channel never ends, so it never repeats); `playsInline`, which
+ * Twitch decides for itself on a phone; and `poster`, which the embed draws
+ * itself and offers no way to replace.
+ */
+export interface TwitchMediaProps
+  extends Pick<
+    Video,
+    'src' | 'autoplay' | 'defaultMuted' | 'muted' | 'loop' | 'controls' | 'playsInline' | 'preload' | 'poster'
+  > {
+  source: TwitchSource | null;
+}
+
+export const twitchMediaDefaultProps: TwitchMediaProps = {
+  src: '',
+  autoplay: false,
+  defaultMuted: false,
+  muted: false,
+  loop: false,
+  controls: false,
+  playsInline: true,
+  preload: 'metadata',
+  poster: '',
+  source: null,
+};

--- a/packages/media/src/dom/twitch/source.ts
+++ b/packages/media/src/dom/twitch/source.ts
@@ -1,0 +1,138 @@
+import { isNil, isString } from '@videojs/utils/predicate';
+import { TWITCH_PLAYER_ORIGIN } from './player-api';
+import { type TwitchMediaProps, twitchMediaDefaultProps } from './props';
+
+/**
+ * Twitch engine options, spelled exactly as Twitch spells them
+ * (https://dev.twitch.tv/docs/embed/video-and-clips/). They are serialized onto
+ * the embed URL verbatim, so what you write here is what the player reads.
+ *
+ * Parameters the host owns are deliberately absent: `video` and `channel` come
+ * from `src`, and `controls`, `autoplay` and `muted` come from the props of the
+ * same name, so configuring them here would give two ways to say one thing. So
+ * are the ones Twitch documents for something other than the player URL —
+ * `allowfullscreen` is an iframe attribute set by inclusion, and `quality`
+ * belongs to the scripted embed's `setQuality` — since naming them here would
+ * promise an effect the URL cannot have. The index signature still carries
+ * anything not listed, so undocumented knobs and whatever Twitch adds next keep
+ * working.
+ */
+export interface TwitchEngineConfig extends Record<string, unknown> {
+  /**
+   * Every hostname the embed may be framed by. Twitch checks the frame's
+   * ancestors against it and refuses to play when the current page is missing,
+   * which is why the page's own hostname is always included on top of this.
+   */
+  parent?: string | readonly string[];
+  /** Collection to play through, starting from the video named by `src`. */
+  collection?: string;
+  /** Start position, spelled the way Twitch spells timestamps: `1h30m10s`. */
+  time?: string;
+  /**
+   * `referrerpolicy` for the embed iframe. Not a Twitch embed parameter, so it
+   * never reaches the URL: the React player applies it to the iframe it renders,
+   * and the HTML player reads its own `referrerpolicy` attribute instead.
+   */
+  referrerPolicy?: ReferrerPolicy;
+}
+
+/** Structured Twitch source: which source to play, plus how to play it. */
+export interface TwitchSource {
+  /** Twitch VOD or channel URL. Mirrors the host's `src` property. */
+  src?: string | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: TwitchSourceEngineConfig | undefined;
+}
+
+/** The engines a Twitch source can configure. */
+export interface TwitchSourceEngineConfig {
+  /** Twitch's own embed parameters, passed through untouched. */
+  twitch?: TwitchEngineConfig | undefined;
+}
+
+/** Parsed pieces of a Twitch source URL. */
+export interface ParsedTwitchSource {
+  /** `'video'` for VODs, `'channel'` for live channels. */
+  kind: 'video' | 'channel';
+  /** Numeric VOD id, without the `v` prefix the embed parameter carries. Null for channels. */
+  id: string | null;
+  /** Channel name. Null for VODs. */
+  channel: string | null;
+}
+
+/** Extract a Twitch VOD id from any recognized video URL. */
+export function parseTwitchVideoId(src: string) {
+  return parseTwitchSource(src)?.id ?? null;
+}
+
+/**
+ * Parse a Twitch source string. Recognizes VOD URLs (`twitch.tv/videos/<id>`
+ * and `twitch.tv/?video=<id>`) and channel URLs (`twitch.tv/<channel>`), with
+ * or without the `www.` and `go.` hosts, and with or without a trailing slash.
+ */
+export function parseTwitchSource(src: string): ParsedTwitchSource | null {
+  if (!src) return null;
+  // A VOD URL also satisfies the channel pattern's host, so it is tried first.
+  const videoId = MATCH_VIDEO.exec(src)?.[1];
+  if (videoId) return { kind: 'video', id: videoId, channel: null };
+  const channel = MATCH_CHANNEL.exec(src)?.[1];
+  if (channel) return { kind: 'channel', id: null, channel };
+  return null;
+}
+
+/** Build the iframe `src` URL for an initial Twitch embed from the given props. */
+export function buildTwitchIframeSrc(src: string, props: Partial<TwitchMediaProps> = {}) {
+  const parsed = parseTwitchSource(src);
+  if (!parsed) return '';
+  // Neither of these travels with the rest: `parent` repeats (see below), and
+  // `referrerPolicy` is an attribute of the iframe hosting the embed.
+  const { parent, referrerPolicy: _referrerPolicy, ...twitch } = props.source?.engine?.twitch ?? {};
+  const params: Record<string, unknown> = {
+    // The embed names its content by parameter rather than by path.
+    ...(parsed.kind === 'video' ? { video: `v${parsed.id}` } : { channel: parsed.channel }),
+    // Both default to on in the embed, so only turning them off says anything.
+    controls: props.controls === true ? null : false,
+    autoplay: props.autoplay === true ? null : false,
+    muted: props.defaultMuted ?? twitchMediaDefaultProps.defaultMuted,
+    preload: props.preload ?? twitchMediaDefaultProps.preload,
+    // Twitch-specific knobs (`time`, `collection`, …) flow through here.
+    ...twitch,
+  };
+
+  const query = new URLSearchParams();
+  for (const key in params) {
+    const value = params[key];
+    // Twitch reads every parameter by value, so an empty one says nothing and is
+    // left off. The shared `serializeEmbedParams` cannot be used for this reason:
+    // it writes the `1` an HTML attribute's presence means, which `time` and
+    // `collection` would read as content, and `1`/`0` for booleans, which Twitch
+    // spells out as the words `true` and `false`.
+    if (isNil(value) || value === '') continue;
+    query.set(key, String(value));
+  }
+  // `parent` is the one parameter that repeats — one entry per hostname the
+  // embed may be framed by — so it is appended rather than set with the rest.
+  for (const host of resolveParentHosts(parent)) query.append('parent', host);
+
+  if (__DEV__ && !query.has('parent')) {
+    console.warn(
+      '[vjs-twitch] The Twitch embed refuses to play without a `parent` hostname. Set `engine.twitch.parent` to the host page.'
+    );
+  }
+
+  return `${TWITCH_PLAYER_ORIGIN}/?${query.toString()}`;
+}
+
+/** The configured parent hostnames plus the page's own, deduplicated. */
+function resolveParentHosts(parent: TwitchEngineConfig['parent']): string[] {
+  const configured = isString(parent) ? [parent] : (parent ?? []);
+  const hosts = [...configured, globalThis.location?.hostname];
+  return [...new Set(hosts.filter((host): host is string => isString(host) && host !== ''))];
+}
+
+// The host is pinned to the start of the string or to the `//` a scheme ends
+// with, so that another Twitch subdomain cannot pass for one of these: a
+// `clips.twitch.tv` URL names a clip this embed cannot play, not a channel of
+// the same name.
+const MATCH_VIDEO = /(?:^|\/\/)(?:www\.|go\.)?twitch\.tv\/(?:videos?\/|\?video=)(\d+)\/?(?:$|\?)/;
+const MATCH_CHANNEL = /(?:^|\/\/)(?:www\.|go\.)?twitch\.tv\/([a-zA-Z0-9_]+)\/?(?:$|\?)/;

--- a/packages/media/src/dom/twitch/tests/media.test.ts
+++ b/packages/media/src/dom/twitch/tests/media.test.ts
@@ -434,6 +434,37 @@ describe('TwitchMedia', () => {
     media.detach();
   });
 
+  it('announces a volume or mute it is given, without repeating the embed echo', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const volumechange = vi.fn();
+    media.addEventListener('volumechange', volumechange);
+
+    // A snapshot is a patch against what is already reported, so nothing else
+    // is going to announce a level the host set itself.
+    media.volume = 0.5;
+    expect(media.volume).toBe(0.5);
+    expect(volumechange).toHaveBeenCalledTimes(1);
+
+    media.muted = true;
+    expect(media.muted).toBe(true);
+    expect(volumechange).toHaveBeenCalledTimes(2);
+
+    // The embed echoing what it was told is not a second change.
+    postPlayerState(iframe, { volume: 0.5, muted: true });
+    expect(volumechange).toHaveBeenCalledTimes(2);
+
+    // A level set from the embed's own controls still is.
+    postPlayerState(iframe, { volume: 0.8 });
+    expect(media.volume).toBe(0.8);
+    expect(volumechange).toHaveBeenCalledTimes(3);
+
+    // Setting what is already reported changes nothing.
+    media.volume = 0.8;
+    expect(volumechange).toHaveBeenCalledTimes(3);
+    media.detach();
+  });
+
   it('updates state from player state snapshots', async () => {
     const media = new TwitchMedia();
     const { iframe } = await attachAndLoad(media);

--- a/packages/media/src/dom/twitch/tests/media.test.ts
+++ b/packages/media/src/dom/twitch/tests/media.test.ts
@@ -1,0 +1,846 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
+import { buildTwitchIframeSrc, parseTwitchSource, parseTwitchVideoId, TwitchMedia, twitchMediaDefaultProps } from '..';
+
+const VOD_SRC = 'https://www.twitch.tv/videos/123456789';
+const CHANNEL_SRC = 'https://www.twitch.tv/twitchpresents';
+const ORIGIN = 'https://player.twitch.tv';
+const PROXY_NAMESPACE = 'twitch-embed-player-proxy';
+const EMBED_NAMESPACE = 'twitch-embed';
+
+// https://dev.twitch.tv/docs/embed/video-and-clips/
+const COMMAND = { PAUSE: 2, PLAY: 3, SEEK: 4, SET_CHANNEL: 5, SET_VIDEO: 9, SET_MUTED: 10, SET_VOLUME: 11 } as const;
+
+/** How long the host waits for the state snapshot behind a lifecycle event. */
+const SETTLE_MS = 10;
+
+interface EmbedWindow {
+  postMessage: ReturnType<typeof vi.fn>;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/**
+ * An iframe with a stand-in for the embed's window. It is the whole protocol
+ * surface: commands are posted to it, and only messages claiming to come from it
+ * are allowed to drive state.
+ */
+function createIframe(): HTMLIFrameElement {
+  const iframe = document.createElement('iframe');
+  Object.defineProperty(iframe, 'contentWindow', {
+    value: { postMessage: vi.fn() } satisfies EmbedWindow,
+    configurable: true,
+  });
+  return iframe;
+}
+
+/** An iframe as React renders it before a source resolves: `src` present but empty. */
+function createEmptySrcIframe(): HTMLIFrameElement {
+  const iframe = createIframe();
+  iframe.setAttribute('src', '');
+  return iframe;
+}
+
+function embedOf(iframe: HTMLIFrameElement): EmbedWindow {
+  return iframe.contentWindow as unknown as EmbedWindow;
+}
+
+/**
+ * Post a message as the embed would. A real `MessageEvent` cannot name an
+ * arbitrary object as its `source`, so the event is assembled by hand.
+ */
+function postFromWindow(source: unknown, data: unknown): void {
+  const event = new Event('message');
+  Object.defineProperties(event, { data: { value: data }, source: { value: source } });
+  globalThis.dispatchEvent(event);
+}
+
+function postEmbedEvent(iframe: HTMLIFrameElement, eventName: string): void {
+  postFromWindow(iframe.contentWindow, { namespace: EMBED_NAMESPACE, eventName });
+}
+
+function postPlayerState(iframe: HTMLIFrameElement, params: Record<string, unknown>): void {
+  postFromWindow(iframe.contentWindow, { namespace: PROXY_NAMESPACE, eventName: 'UPDATE_STATE', params });
+}
+
+/** Wait out the delay the host gives a lifecycle event's state snapshot to arrive. */
+async function settle(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(SETTLE_MS);
+}
+
+/** Flush the microtask the deferred embed waits on before it is built. */
+async function flushDeferredEmbed(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function command(eventName: number, params?: unknown) {
+  return { namespace: PROXY_NAMESPACE, eventName, params };
+}
+
+async function attachAndLoad(media: TwitchMedia): Promise<{ iframe: HTMLIFrameElement; embed: EmbedWindow }> {
+  // There is no embed to attach to without a source, so tests that don't care
+  // which video is playing get one.
+  if (!media.src) media.src = VOD_SRC;
+  const iframe = createIframe();
+  media.attach(iframe);
+  postEmbedEvent(iframe, 'ready');
+  await settle();
+  return { iframe, embed: embedOf(iframe) };
+}
+
+describe('parseTwitchVideoId', () => {
+  it('extracts id from a videos URL', () => {
+    expect(parseTwitchVideoId(VOD_SRC)).toBe('123456789');
+  });
+
+  it('extracts id from a video query URL', () => {
+    expect(parseTwitchVideoId('https://www.twitch.tv/?video=123456789')).toBe('123456789');
+  });
+
+  it('returns null for a channel URL', () => {
+    expect(parseTwitchVideoId(CHANNEL_SRC)).toBe(null);
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseTwitchVideoId('')).toBe(null);
+  });
+
+  it('returns null for non-Twitch URLs', () => {
+    expect(parseTwitchVideoId('https://example.com/videos/123456789')).toBe(null);
+  });
+});
+
+describe('parseTwitchSource', () => {
+  it('parses a VOD URL', () => {
+    expect(parseTwitchSource(VOD_SRC)).toEqual({ kind: 'video', id: '123456789', channel: null });
+  });
+
+  it('parses the singular video path and the go. host', () => {
+    expect(parseTwitchSource('https://go.twitch.tv/video/987')).toEqual({ kind: 'video', id: '987', channel: null });
+  });
+
+  it('parses a channel URL', () => {
+    expect(parseTwitchSource(CHANNEL_SRC)).toEqual({ kind: 'channel', id: null, channel: 'twitchpresents' });
+  });
+
+  it('prefers the VOD reading of a URL that satisfies both patterns', () => {
+    expect(parseTwitchSource('https://www.twitch.tv/videos/123456789?t=1h')?.kind).toBe('video');
+  });
+
+  it('parses a URL that was pasted with a trailing slash', () => {
+    expect(parseTwitchSource(`${VOD_SRC}/`)).toEqual({ kind: 'video', id: '123456789', channel: null });
+    expect(parseTwitchSource(`${CHANNEL_SRC}/`)).toEqual({ kind: 'channel', id: null, channel: 'twitchpresents' });
+  });
+
+  it('returns null for a clip URL rather than reading the slug as a channel', () => {
+    expect(parseTwitchSource('https://clips.twitch.tv/AwkwardHelplessSalamanderSwiftRage')).toBe(null);
+  });
+
+  it('returns null for a non-Twitch URL', () => {
+    expect(parseTwitchSource('https://example.com/twitchpresents')).toBe(null);
+  });
+});
+
+describe('buildTwitchIframeSrc', () => {
+  it('builds a VOD embed URL with the page hostname as parent', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC);
+    expect(src).toContain(`${ORIGIN}/?video=v123456789`);
+    expect(src).toContain('controls=false');
+    expect(src).toContain('autoplay=false');
+    expect(src).toContain('muted=false');
+    expect(src).toContain('preload=metadata');
+    expect(src).toContain(`parent=${globalThis.location.hostname}`);
+  });
+
+  it('builds a channel embed URL', () => {
+    expect(buildTwitchIframeSrc(CHANNEL_SRC)).toContain(`${ORIGIN}/?channel=twitchpresents`);
+  });
+
+  it('leaves the embed on its own defaults when controls and autoplay are set', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC, { controls: true, autoplay: true, defaultMuted: true });
+    expect(src).not.toContain('controls=');
+    expect(src).not.toContain('autoplay=');
+    expect(src).toContain('muted=true');
+  });
+
+  it('repeats parent for every hostname, including the page it is embedded in', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC, {
+      source: { engine: { twitch: { parent: ['embed.example.com', 'www.example.com'] } } },
+    });
+    const parents = new URL(src).searchParams.getAll('parent');
+    expect(parents).toEqual(['embed.example.com', 'www.example.com', globalThis.location.hostname]);
+  });
+
+  it('does not repeat a parent that is already the page hostname', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC, {
+      source: { engine: { twitch: { parent: globalThis.location.hostname } } },
+    });
+    expect(new URL(src).searchParams.getAll('parent')).toEqual([globalThis.location.hostname]);
+  });
+
+  it('forwards Twitch-specific knobs, spelling booleans the way Twitch reads them', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC, {
+      source: { engine: { twitch: { time: '1h30m10s', collection: 'abc123', allowfullscreen: false } } },
+    });
+    expect(src).toContain('time=1h30m10s');
+    expect(src).toContain('collection=abc123');
+    expect(src).toContain('allowfullscreen=false');
+  });
+
+  it('leaves out a parameter that was given no value', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC, {
+      source: { engine: { twitch: { time: '', collection: 'abc123' } } },
+    });
+    // An empty value is not presence: written through, `time=1` is a timestamp
+    // the embed cannot read.
+    expect(src).not.toContain('time=');
+    expect(src).toContain('collection=abc123');
+  });
+
+  it('keeps referrerPolicy off the embed URL', () => {
+    const src = buildTwitchIframeSrc(VOD_SRC, {
+      source: { engine: { twitch: { referrerPolicy: 'no-referrer' } } },
+    });
+    expect(src).not.toContain('referrerPolicy');
+  });
+
+  it('returns empty string for invalid src', () => {
+    expect(buildTwitchIframeSrc('https://example.com/videos/1')).toBe('');
+    expect(buildTwitchIframeSrc('')).toBe('');
+  });
+});
+
+describe('TwitchMedia', () => {
+  it('has expected default state before attach', () => {
+    const media = new TwitchMedia();
+    expect(media.engine).toBe(null);
+    expect(media.target).toBe(null);
+    expect(media.paused).toBe(true);
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBe(0);
+    expect(media.duration).toBeNaN();
+    expect(media.src).toBe(twitchMediaDefaultProps.src);
+    expect(media.buffered.length).toBe(0);
+    expect(media.textTracks.length).toBe(0);
+    expect(media.played.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sets the initial iframe src and binds the embed when attached', () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    expect(iframe.getAttribute('src')).toContain(`${ORIGIN}/?video=v123456789`);
+    expect(media.currentSrc).toBe(iframe.getAttribute('src'));
+    expect(media.target).toBe(iframe);
+    expect(media.engine).toBe(iframe.contentWindow);
+    media.detach();
+  });
+
+  it('names the page as a parent on an embed URL that arrived without one', () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    const iframe = createIframe();
+    // Server rendering has no `location`, so the URL it froze names only the
+    // hostnames the app configured, and the embed would refuse to play.
+    iframe.setAttribute('src', `${ORIGIN}/?video=v123456789&parent=embed.example.com`);
+    media.attach(iframe);
+
+    expect(new URL(iframe.getAttribute('src') ?? '').searchParams.getAll('parent')).toEqual([
+      'embed.example.com',
+      globalThis.location.hostname,
+    ]);
+    media.detach();
+  });
+
+  it('leaves an embed URL that already names the page alone', () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    const iframe = createIframe();
+    const src = `${ORIGIN}/?video=v123456789&parent=${globalThis.location.hostname}`;
+    iframe.setAttribute('src', src);
+    media.attach(iframe);
+
+    expect(iframe.getAttribute('src')).toBe(src);
+    media.detach();
+  });
+
+  it('defers the embed until a source arrives', async () => {
+    const media = new TwitchMedia();
+    const loadstart = vi.fn();
+    media.addEventListener('loadstart', loadstart);
+
+    // How every framework builds the element: created first, `src` set after.
+    const iframe = createIframe();
+    media.attach(iframe);
+    expect(iframe.getAttribute('src')).toBe(null);
+    expect(media.engine).toBe(null);
+    expect(loadstart).not.toHaveBeenCalled();
+
+    media.src = VOD_SRC;
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain('video=v123456789');
+    expect(loadstart).toHaveBeenCalledTimes(1);
+    expect(media.engine).toBe(iframe.contentWindow);
+    media.detach();
+  });
+
+  it('defers the embed for an iframe rendered with an empty src', async () => {
+    const media = new TwitchMedia();
+    // React renders `src=""` before a source resolves. The `src` property reports
+    // the document URL for it, so only the attribute says there is no embed.
+    const iframe = createEmptySrcIframe();
+    media.attach(iframe);
+    expect(media.engine).toBe(null);
+
+    media.src = VOD_SRC;
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain('video=v123456789');
+    media.detach();
+  });
+
+  it('builds a deferred embed once for repeated source changes in the same task', async () => {
+    const media = new TwitchMedia();
+    const loadstart = vi.fn();
+    media.addEventListener('loadstart', loadstart);
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = VOD_SRC;
+    media.src = 'https://www.twitch.tv/videos/222';
+    await flushDeferredEmbed();
+
+    expect(iframe.getAttribute('src')).toContain('video=v222');
+    expect(loadstart).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('does not leave play() waiting while the embed is deferred', async () => {
+    const media = new TwitchMedia();
+    media.attach(createIframe());
+
+    // No embed means no `ready` is coming to report a load; waiting would hang.
+    await expect(media.play()).resolves.toBeUndefined();
+    expect(media.engine).toBe(null);
+  });
+
+  it('emits loadstart on attach and loadedmetadata/loadcomplete after ready', async () => {
+    const media = new TwitchMedia();
+    const events: string[] = [];
+    for (const type of ['loadstart', 'loadedmetadata', 'loadcomplete'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    await attachAndLoad(media);
+
+    expect(events).toEqual(['loadstart', 'loadedmetadata', 'loadcomplete']);
+    expect(media.readyState).toBe(1);
+    media.detach();
+  });
+
+  it('waits for the embed to report ready before playing', async () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    let played = false;
+    const pending = media.play().then(() => {
+      played = true;
+    });
+    await flushDeferredEmbed();
+    expect(played).toBe(false);
+
+    postEmbedEvent(iframe, 'ready');
+    await settle();
+    await pending;
+
+    expect(embedOf(iframe).postMessage).toHaveBeenCalledWith(command(COMMAND.PLAY), ORIGIN);
+    media.detach();
+  });
+
+  it('does not complete the load on a snapshot that arrives before ready', async () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    const iframe = createIframe();
+    media.attach(iframe);
+    const loadcomplete = vi.fn();
+    media.addEventListener('loadcomplete', loadcomplete);
+
+    let played = false;
+    void media.play().then(() => {
+      played = true;
+    });
+    // The player proxy starts describing the embed before the embed says it can
+    // hear anything; every command until then is dropped.
+    postPlayerState(iframe, { duration: 120, playback: 'Ready' });
+    await flushDeferredEmbed();
+
+    expect(loadcomplete).not.toHaveBeenCalled();
+    expect(played).toBe(false);
+    expect(embedOf(iframe).postMessage).not.toHaveBeenCalled();
+
+    postEmbedEvent(iframe, 'ready');
+    await settle();
+    await flushDeferredEmbed();
+
+    expect(loadcomplete).toHaveBeenCalledTimes(1);
+    expect(embedOf(iframe).postMessage).toHaveBeenCalledWith(command(COMMAND.PLAY), ORIGIN);
+    media.detach();
+  });
+
+  it('forwards play() and pause() to the embed', async () => {
+    const media = new TwitchMedia();
+    const { iframe, embed } = await attachAndLoad(media);
+
+    await media.play();
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.PLAY), ORIGIN);
+    expect(media.paused).toBe(false);
+
+    media.pause();
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.PAUSE), ORIGIN);
+    expect(media.paused).toBe(true);
+
+    // The embed's own report takes over as soon as there is one.
+    postPlayerState(iframe, { playback: 'Playing' });
+    expect(media.paused).toBe(false);
+    media.detach();
+  });
+
+  it('forwards setters to the embed after load', async () => {
+    const media = new TwitchMedia();
+    const { embed } = await attachAndLoad(media);
+
+    media.currentTime = 30;
+    media.volume = 0.5;
+    media.muted = true;
+
+    // Setters defer via the loadComplete microtask — flush.
+    await flushDeferredEmbed();
+
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.SEEK, 30), ORIGIN);
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.SET_VOLUME, 0.5), ORIGIN);
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.SET_MUTED, true), ORIGIN);
+    media.detach();
+  });
+
+  it('updates state from player state snapshots', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const events: string[] = [];
+    for (const type of ['durationchange', 'timeupdate', 'volumechange', 'progress'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    postPlayerState(iframe, {
+      duration: 120,
+      currentTime: 5,
+      volume: 0.5,
+      muted: true,
+      playback: 'Playing',
+      stats: { videoStats: { bufferSize: 10 } },
+    });
+
+    expect(events).toEqual(['durationchange', 'timeupdate', 'volumechange', 'progress']);
+    expect(media.duration).toBe(120);
+    expect(media.currentTime).toBe(5);
+    expect(media.volume).toBe(0.5);
+    expect(media.muted).toBe(true);
+    expect(media.paused).toBe(false);
+    expect(media.seekable.start(0)).toBe(0);
+    expect(media.seekable.end(0)).toBe(120);
+    // `bufferSize` is buffer ahead of the playhead, not a position.
+    expect(media.buffered.start(0)).toBe(5);
+    expect(media.buffered.end(0)).toBe(15);
+
+    // Only what changed is reported, and an unchanged field says nothing.
+    events.length = 0;
+    postPlayerState(iframe, { currentTime: 6 });
+    expect(events).toEqual(['timeupdate']);
+    expect(media.duration).toBe(120);
+    media.detach();
+  });
+
+  it('emits waiting when the embed reports buffering', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const waiting = vi.fn();
+    media.addEventListener('waiting', waiting);
+
+    postPlayerState(iframe, { playback: 'Buffering' });
+
+    expect(waiting).toHaveBeenCalledTimes(1);
+    // A stall is not a pause; the embed is still trying to play.
+    expect(media.paused).toBe(false);
+
+    // Still buffering is still the same stall.
+    postPlayerState(iframe, { playback: 'Buffering' });
+    expect(waiting).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('reports the end of a VOD from the playback state', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const ended = vi.fn();
+    media.addEventListener('ended', ended);
+
+    postPlayerState(iframe, { playback: 'Ended' });
+    postEmbedEvent(iframe, 'ended');
+    await settle();
+
+    expect(media.ended).toBe(true);
+    expect(media.paused).toBe(true);
+    expect(ended).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('maps seek and playing onto seeking/seeked', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const events: string[] = [];
+    for (const type of ['seeking', 'seeked', 'playing'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    postEmbedEvent(iframe, 'seek');
+    await settle();
+    expect(media.seeking).toBe(true);
+
+    postEmbedEvent(iframe, 'playing');
+    await settle();
+    expect(media.seeking).toBe(false);
+    expect(events).toEqual(['seeking', 'seeked', 'playing']);
+    expect(media.readyState).toBe(3);
+    media.detach();
+  });
+
+  it('re-dispatches the embed events that already read as media events', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const events: string[] = [];
+    for (const type of ['play', 'pause', 'offline'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    for (const type of ['play', 'pause', 'offline']) {
+      postEmbedEvent(iframe, type);
+      await settle();
+    }
+
+    expect(events).toEqual(['play', 'pause', 'offline']);
+    media.detach();
+  });
+
+  it('ignores messages from a window that is not the embed', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const timeupdate = vi.fn();
+    media.addEventListener('timeupdate', timeupdate);
+
+    postFromWindow({ postMessage: vi.fn() }, { namespace: PROXY_NAMESPACE, eventName: 'UPDATE_STATE', params: {} });
+    postFromWindow(iframe.contentWindow, { namespace: 'some-other-embed', eventName: 'UPDATE_STATE' });
+
+    expect(timeupdate).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('removes its message listener on detach', async () => {
+    const addEventListener = vi.spyOn(globalThis, 'addEventListener');
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    const options = addEventListener.mock.calls.find(([type]) => type === 'message')?.[2] as AddEventListenerOptions;
+    expect(options.signal?.aborted).toBe(false);
+
+    media.detach();
+    expect(options.signal?.aborted).toBe(true);
+
+    // Nothing the embed says afterwards can reach the host.
+    const timeupdate = vi.fn();
+    media.addEventListener('timeupdate', timeupdate);
+    postPlayerState(iframe, { currentTime: 9 });
+    expect(timeupdate).not.toHaveBeenCalled();
+    addEventListener.mockRestore();
+  });
+
+  it('ignores a settling embed event from a superseded attach', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    const playing = vi.fn();
+    media.addEventListener('playing', playing);
+
+    // The event is in flight when the attach it belongs to goes away.
+    postEmbedEvent(iframe, 'playing');
+    media.detach();
+    await settle();
+
+    expect(playing).not.toHaveBeenCalled();
+  });
+
+  it('unblocks pending play() when detached before the embed reports ready', async () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    media.attach(createIframe());
+
+    const pending = media.play();
+    media.detach();
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('errors and unblocks pending play() when src is unrecognized', async () => {
+    const media = new TwitchMedia();
+    await attachAndLoad(media);
+    const error = vi.fn();
+    media.addEventListener('error', error);
+
+    media.src = 'https://example.com/not-twitch';
+    await flushDeferredEmbed();
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(media.error?.code).toBe(MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+    await expect(media.play()).resolves.toBeUndefined();
+    media.detach();
+  });
+
+  it('tracks played ranges via the played-ranges mixin', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    postPlayerState(iframe, { currentTime: 0, playback: 'Playing' });
+    postEmbedEvent(iframe, 'play');
+    await settle();
+    postPlayerState(iframe, { currentTime: 10 });
+    postEmbedEvent(iframe, 'pause');
+    await settle();
+
+    const played = media.played;
+    expect(played.length).toBeGreaterThanOrEqual(1);
+    expect(played.end(0)).toBeGreaterThan(0);
+    media.detach();
+  });
+
+  it('does not report fullscreen when there is no element to request it on', async () => {
+    const media = new TwitchMedia();
+    await media.requestFullscreen();
+    expect(media.isFullscreen).toBe(false);
+  });
+});
+
+describe('TwitchMedia live channels', () => {
+  it('reports an infinite duration and no seekable range', async () => {
+    const media = new TwitchMedia();
+    media.src = CHANNEL_SRC;
+    const { iframe } = await attachAndLoad(media);
+
+    expect(iframe.getAttribute('src')).toContain('channel=twitchpresents');
+    expect(media.duration).toBe(Number.POSITIVE_INFINITY);
+    expect(media.seekable.length).toBe(0);
+    media.detach();
+  });
+
+  it('keeps the infinite duration and never ends', async () => {
+    const media = new TwitchMedia();
+    media.src = CHANNEL_SRC;
+    const { iframe } = await attachAndLoad(media);
+    const durationchange = vi.fn();
+    media.addEventListener('durationchange', durationchange);
+
+    // Twitch sends the seconds it has been streaming, which is not a duration.
+    postPlayerState(iframe, { duration: 42, playback: 'Ended' });
+
+    expect(durationchange).not.toHaveBeenCalled();
+    expect(media.duration).toBe(Number.POSITIVE_INFINITY);
+    expect(media.ended).toBe(false);
+    media.detach();
+  });
+});
+
+describe('TwitchMedia source', () => {
+  it('derives src from a structured source and announces the change', () => {
+    const media = new TwitchMedia();
+    const sourceChange = vi.fn();
+    media.addEventListener('sourcechange', sourceChange);
+
+    media.source = { src: VOD_SRC };
+
+    expect(media.src).toBe(VOD_SRC);
+    expect(sourceChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-derives source from src, carrying Twitch embed parameters over', () => {
+    const media = new TwitchMedia();
+    media.source = { src: VOD_SRC, engine: { twitch: { time: '0h1m0s' } } };
+
+    media.src = CHANNEL_SRC;
+
+    expect(media.source).toEqual({ engine: { twitch: { time: '0h1m0s' } }, src: CHANNEL_SRC });
+  });
+
+  it('serializes Twitch embed parameters onto the initial iframe src', () => {
+    const media = new TwitchMedia();
+    media.source = { src: VOD_SRC, engine: { twitch: { time: '0h1m0s', parent: 'embed.example.com' } } };
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    const src = iframe.getAttribute('src') ?? '';
+    expect(src).toContain('time=0h1m0s');
+    expect(new URL(src).searchParams.getAll('parent')).toContain('embed.example.com');
+    media.detach();
+  });
+
+  it('swaps a new VOD into the running embed instead of rebuilding it', async () => {
+    const media = new TwitchMedia();
+    const { iframe, embed } = await attachAndLoad(media);
+    const embedSrc = iframe.getAttribute('src');
+
+    media.src = 'https://www.twitch.tv/videos/222';
+    await flushDeferredEmbed();
+
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.SET_VIDEO, 'v222'), ORIGIN);
+    // The embed (and its session) is still the one that was there.
+    expect(iframe.getAttribute('src')).toBe(embedSrc);
+
+    // A swap reports no readiness of its own, so the first snapshot completes it.
+    const loadcomplete = vi.fn();
+    media.addEventListener('loadcomplete', loadcomplete);
+    postPlayerState(iframe, { duration: 30 });
+    expect(loadcomplete).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('swaps a channel into an embed that was playing a VOD', async () => {
+    const media = new TwitchMedia();
+    const { embed } = await attachAndLoad(media);
+
+    media.src = CHANNEL_SRC;
+    await flushDeferredEmbed();
+
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.SET_CHANNEL, 'twitchpresents'), ORIGIN);
+    media.detach();
+  });
+
+  it('rebuilds the embed when an embed parameter changes', async () => {
+    const media = new TwitchMedia();
+    const { iframe, embed } = await attachAndLoad(media);
+
+    media.source = { src: VOD_SRC, engine: { twitch: { time: '0h1m0s' } } };
+    await flushDeferredEmbed();
+
+    // Embed parameters only exist on the URL, so there is nothing to command.
+    expect(embed.postMessage).not.toHaveBeenCalledWith(command(COMMAND.SET_VIDEO, 'v123456789'), ORIGIN);
+    expect(iframe.getAttribute('src')).toContain('time=0h1m0s');
+
+    // The rebuilt embed reports `ready` again, which completes the load.
+    const loadcomplete = vi.fn();
+    media.addEventListener('loadcomplete', loadcomplete);
+    postEmbedEvent(iframe, 'ready');
+    await settle();
+    expect(loadcomplete).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('ignores what the outgoing embed reports while a rebuilt one is in flight', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+
+    media.source = { src: VOD_SRC, engine: { twitch: { time: '0h1m0s' } } };
+    await flushDeferredEmbed();
+
+    const loadcomplete = vi.fn();
+    media.addEventListener('loadcomplete', loadcomplete);
+    // The iframe keeps its window across the `src` change, so the document on its
+    // way out still reaches the host, describing the video being replaced.
+    postPlayerState(iframe, { duration: 120, currentTime: 42 });
+
+    expect(loadcomplete).not.toHaveBeenCalled();
+    expect(media.currentTime).toBe(0);
+
+    postEmbedEvent(iframe, 'ready');
+    await settle();
+    expect(loadcomplete).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
+  it('replays a source change that arrived before the embed was ready', async () => {
+    const media = new TwitchMedia();
+    media.src = VOD_SRC;
+    const iframe = createIframe();
+    media.attach(iframe);
+
+    media.src = 'https://www.twitch.tv/videos/222';
+    await flushDeferredEmbed();
+    // Commands are dropped before `ready`, so nothing has been sent yet.
+    expect(embedOf(iframe).postMessage).not.toHaveBeenCalled();
+
+    postEmbedEvent(iframe, 'ready');
+    await settle();
+
+    expect(embedOf(iframe).postMessage).toHaveBeenCalledWith(command(COMMAND.SET_VIDEO, 'v222'), ORIGIN);
+    media.detach();
+  });
+
+  it('stops the embed and resets state when the source is cleared', async () => {
+    const media = new TwitchMedia();
+    const { iframe, embed } = await attachAndLoad(media);
+    postPlayerState(iframe, { duration: 120, currentTime: 5, playback: 'Playing' });
+
+    media.source = null;
+    await flushDeferredEmbed();
+
+    expect(media.src).toBe('');
+    expect(embed.postMessage).toHaveBeenCalledWith(command(COMMAND.PAUSE), ORIGIN);
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    media.detach();
+  });
+
+  it('ignores what the stopped embed reports after the source is cleared', async () => {
+    const media = new TwitchMedia();
+    const { iframe } = await attachAndLoad(media);
+    postPlayerState(iframe, { duration: 120, currentTime: 5, playback: 'Playing' });
+
+    media.source = null;
+    await flushDeferredEmbed();
+
+    const events: string[] = [];
+    for (const type of ['durationchange', 'timeupdate', 'progress', 'playing'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+    // A paused embed keeps describing the video it still holds.
+    postPlayerState(iframe, { duration: 120, currentTime: 5, stats: { videoStats: { bufferSize: 10 } } });
+    postEmbedEvent(iframe, 'playing');
+    await settle();
+
+    expect(events).toEqual([]);
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    expect(media.buffered.length).toBe(0);
+    expect(media.readyState).toBe(0);
+    media.detach();
+  });
+
+  it('does not play a source that was cleared', async () => {
+    const media = new TwitchMedia();
+    const { embed } = await attachAndLoad(media);
+
+    media.source = null;
+    await flushDeferredEmbed();
+    embed.postMessage.mockClear();
+
+    await media.play();
+    expect(embed.postMessage).not.toHaveBeenCalled();
+    media.detach();
+  });
+});

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -20,6 +20,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/cloudflare/index': './src/dom/cloudflare/index.ts',
     'dom/spotify/index': './src/dom/spotify/index.ts',
     'dom/tiktok/index': './src/dom/tiktok/index.ts',
+    'dom/twitch/index': './src/dom/twitch/index.ts',
     'dom/vimeo/index': './src/dom/vimeo/index.ts',
     'dom/youtube/index': './src/dom/youtube/index.ts',
     'dom/mux/index': './src/dom/mux/index.ts',

--- a/packages/react/src/media/twitch-video/index.ts
+++ b/packages/react/src/media/twitch-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/twitch-video/media.tsx
+++ b/packages/react/src/media/twitch-video/media.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { TwitchMediaProps } from '@videojs/media/dom/twitch';
+import { buildTwitchIframeSrc, TwitchMedia, twitchMediaDefaultProps } from '@videojs/media/dom/twitch';
+import type { ReactNode } from 'react';
+import { forwardRef, useState } from 'react';
+import { useAttachIframe } from '../../utils/use-attach-iframe';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface TwitchVideoProps extends Partial<TwitchMediaProps> {
+  children?: ReactNode;
+}
+
+export const TwitchVideo = forwardRef<HTMLIFrameElement, TwitchVideoProps>(function TwitchVideo(
+  { children, ...rawProps },
+  ref
+) {
+  const media = useMediaInstance(TwitchMedia);
+  const props: Partial<TwitchMediaProps> & Record<string, unknown> = { ...rawProps };
+  const attachRef = useAttachIframe(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const [initialSrc] = useState(() =>
+    // Server rendering has no `location` to name as the embed's parent, and Twitch
+    // refuses to play in a page its URL never named. Rendering no `src` leaves the
+    // URL to `attach()`, which builds it where there is a hostname to name.
+    globalThis.location
+      ? // `source.src` is the only other way to name a video, so honor it when `src` is absent.
+        buildTwitchIframeSrc(props.src || props.source?.src || '', { ...twitchMediaDefaultProps, ...props })
+      : ''
+  );
+  const iframeProps = useSyncProps<TwitchMediaProps, Record<string, unknown>>(media, props, twitchMediaDefaultProps);
+
+  return (
+    <iframe
+      title="Twitch video player"
+      // Empty means there is no embed to point at yet; React warns about `src=""`,
+      // and the media builds the URL itself once a source resolves.
+      src={initialSrc || undefined}
+      data-cross-origin-frame
+      allow="accelerometer; fullscreen; autoplay; encrypted-media; picture-in-picture;"
+      sandbox="allow-modals allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      scrolling="no"
+      frameBorder={0}
+      width="100%"
+      height="100%"
+      referrerPolicy={props.source?.engine?.twitch?.referrerPolicy}
+      {...iframeProps}
+      ref={composedRef}
+    >
+      {children}
+    </iframe>
+  );
+});
+
+export namespace TwitchVideo {
+  export type Props = TwitchVideoProps;
+}

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -18,6 +18,7 @@ const noopVolume = {
   volume: 0,
   muted: false,
   volumeAvailability: 'unsupported' as const,
+  mutedAvailability: 'unsupported' as const,
   setVolume: () => 0,
   toggleMuted: () => false,
 };


### PR DESCRIPTION
Ports [`twitch-video-element`](https://github.com/muxinc/media-elements/tree/main/packages/twitch-video-element) from `muxinc/media-elements` into v10 as a first-class media host, reshaped to the architecture the Vimeo and YouTube ports already established.

> **Stacked on #2170.** Review the last two commits, or read the diff against `feat/tiktok-video-media`.

## Motivation

Twitch is the last of the four `media-elements` iframe embeds, and the only one that plays live content. It is also the only one whose embed refuses to load without being told which hostnames may frame it, which the host has to get right on the reviewer's behalf.

## What's here

`packages/media/src/dom/twitch` follows the YouTube port's file split, with `player-api.ts` standing in for the SDK loader:

- `props.ts` — the same ten-prop shape the other embed hosts use, with the inert fields documented
- `source.ts` — `TwitchSource`, embed parameters under `engine.twitch`, source parsing, and embed-URL building
- `player-api.ts` — the wire protocol: origin and namespace constants, the command codes, playback-state constants, message typings, and the inbound type guard
- `media.ts` — `TwitchMedia`
- `tests/media.test.ts` — 50 cases

Plus `<twitch-video>` in `packages/html` and `<TwitchVideo>` in `packages/react`.

## Behavior worth reviewing

- **Swap versus rebuild.** Everything except *which* video or channel is playing rides on the embed URL. `load()` builds the next URL and compares it against the current one with `video`/`channel` stripped: a content-only change is commanded with `SET_VIDEO` / `SET_CHANNEL` and keeps the session alive (including VOD↔channel switches), while a changed embed parameter rewrites `target.src`.
- **Load completion.** A rebuilt embed re-posts `ready`; a swapped one posts nothing, so the first `UPDATE_STATE` after a load completes it — the Twitch analogue of YouTube's "any post-load state change completes the load".
- **`parent` is handled outside `serializeEmbedParams`.** It repeats once per framing hostname, which `URLSearchParams.set` cannot express, so the rest is serialized normally and `parent` is appended per host, always unioned with the page's own hostname. A `__DEV__` warning fires when it resolves to nothing, since Twitch refuses to embed then.
- **Booleans are spelled `true` / `false`,** not `1` / `0`. Twitch reads the words where the YouTube and Vimeo embeds read the digits.
- **Live channels.** A channel source gets `duration = Infinity` at load and ignores duration snapshots (Twitch sends seconds-since-live there), which leaves `seekable` empty through the existing finite-duration check, and `ended` is hard-false — Twitch reports a stream going away as `offline`, which is re-dispatched under its own name.
- **`buffered` is anchored to `currentTime`,** because `stats.videoStats.bufferSize` is seconds buffered *ahead* of the playhead, not a position. Upstream reports `(0, bufferSize)`, which I read as a bug.
- **Listener lifetime.** The `message` listener lives on the host window, which outlives the iframe, so its `AbortController` doubles as the "a player exists" marker. Every handler checks for a superseded attach, because the protocol's ~10 ms settle delay outlives a detach.

## Verification

- `pnpm -F @videojs/media test src/dom/twitch` — 50 passed
- `pnpm test` — 5259 passed, 14 skipped
- `pnpm typecheck` — clean
- `pnpm -F @videojs/sandbox build` — clean; the new presets appear at `/html-twitch-video/` and `/react-twitch-video/`

## Notes

Split into two commits: the media host and platform wrappers, then the sandbox examples. The sandbox's fixed source is a VOD rather than a channel, since a channel embed only plays while its streamer is live.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New embed integration with complex attach/detach, message timing, and parent-hostname requirements; mostly isolated to new Twitch code paths with good test coverage, but touches shared media/volume store shapes slightly.
> 
> **Overview**
> Adds **first-class Twitch playback** as a v10 iframe media host (ported from `twitch-video-element`), alongside the other third-party embed providers.
> 
> **`TwitchMedia`** drives `player.twitch.tv` via `postMessage` (no SDK): URL parsing for VODs and live channels, embed URL building with required repeating `parent` hostnames, and load lifecycle that **swaps** content with `SET_VIDEO` / `SET_CHANNEL` when only the video/channel changes versus **rebuilding** the iframe when embed params change. Live channels get infinite duration and never report `ended`; VOD loop is emulated after `ended`.
> 
> Platform surface: **`<twitch-video>`** (HTML custom element), **`<TwitchVideo>`** (React, deferring SSR `src` until `attach` can add the page parent), new **`dom/twitch`** package export, and sandbox **`twitch-video`** preset with fixed VOD demo plus HTML/React templates. Includes a large **`media.test.ts`** suite and tiny **`mutedAvailability`** stubs in volume-slider tests/noop for store shape parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f598bb2b83ff0878736af4291512d9864f9b6079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Related issues

Part of the #1457 *Media Element Providers* epic, which tracks bringing v10 to parity with the breadth of sources in `muxinc/media-elements`.

**There is no Twitch issue to close.** The epic's sub-issues cover YouTube (#1434, closed), Vimeo (#1435, closed), Wistia (#1459), JW Player (#1460), Cloudflare Stream (#1461), Spotify (#1462), SoundCloud (#1454), Mixcloud (#1456), Shaka (#1458), and Player.js (#1455) — Twitch was never filed, even though `twitch-video-element` ships in `media-elements`.

Twitch is also the only provider in this batch that plays live content, so it is the first embed host to exercise the unending-duration path. Worth filing an issue under #1457 for traceability; I can do that if you want it.


**Update:** filed as #2174 and attached as a sub-issue of #1457. Closes #2174.
