### PR TITLE
feat(packages)!: name the resolved title `title`, and take it from config only

### DIFF
--- a/apps/sandbox/templates/metadata/main.tsx
+++ b/apps/sandbox/templates/metadata/main.tsx
@@ -12,9 +12,9 @@ type ContentDataVideo = HTMLVideoElement & {
   contentData: Record<string, string | null | undefined>;
 };
 
-function MetadataVideo({ contentTitle }: { contentTitle: string | null | undefined }) {
+function MetadataVideo({ mediaTitle }: { mediaTitle: string | null | undefined }) {
   const media = useRef<ContentDataVideo | null>(null);
-  const initialTitle = useRef(contentTitle);
+  const initialTitle = useRef(mediaTitle);
 
   const configureMedia = useCallback((element: HTMLVideoElement | null) => {
     if (!element) {
@@ -31,13 +31,13 @@ function MetadataVideo({ contentTitle }: { contentTitle: string | null | undefin
   }, []);
 
   useLayoutEffect(() => {
-    if (!media.current || Object.is(media.current.contentData.title, contentTitle)) return;
+    if (!media.current || Object.is(media.current.contentData.title, mediaTitle)) return;
     const contentData = { ...media.current.contentData };
-    if (contentTitle === undefined) delete contentData.title;
-    else contentData.title = contentTitle;
+    if (mediaTitle === undefined) delete contentData.title;
+    else contentData.title = mediaTitle;
     media.current.contentData = contentData;
     media.current.dispatchEvent(new Event('contentdatachange'));
-  }, [contentTitle]);
+  }, [mediaTitle]);
 
   return (
     <Video
@@ -52,14 +52,14 @@ function MetadataVideo({ contentTitle }: { contentTitle: string | null | undefin
 }
 
 function PlayerPreview({ mediaTitle }: { mediaTitle: string | null | undefined }) {
-  const contentTitle = usePlayer((state) => state.contentTitle);
+  const title = usePlayer((state) => state.title);
 
   return (
     <div className="relative mt-6 overflow-hidden rounded-lg bg-black shadow-lg">
-      <MetadataVideo contentTitle={mediaTitle} />
+      <MetadataVideo mediaTitle={mediaTitle} />
       <div className="pointer-events-none absolute inset-x-0 top-0 bg-gradient-to-b from-black/80 to-transparent px-5 pb-12 pt-4">
-        {contentTitle ? (
-          <h2 className="text-xl font-semibold text-white drop-shadow">{contentTitle}</h2>
+        {title ? (
+          <h2 className="text-xl font-semibold text-white drop-shadow">{title}</h2>
         ) : (
           <span className="text-sm text-white/70">No content title is defined</span>
         )}
@@ -71,7 +71,6 @@ function PlayerPreview({ mediaTitle }: { mediaTitle: string | null | undefined }
 const sources = [
   { key: 'user', label: 'User title' },
   { key: 'media', label: 'Media title' },
-  { key: 'default', label: 'User default' },
 ] as const;
 
 type SourceKey = (typeof sources)[number]['key'];
@@ -80,17 +79,14 @@ function App() {
   const [enabled, setEnabled] = useState<Record<SourceKey, boolean>>({
     user: true,
     media: true,
-    default: true,
   });
   const [values, setValues] = useState<Record<SourceKey, string>>({
     user: 'User title',
     media: 'Media title',
-    default: 'Default title',
   });
 
   const userTitle = enabled.user ? values.user : null;
   const mediaTitle = enabled.media ? values.media : undefined;
-  const defaultTitle = enabled.default ? values.default : null;
 
   return (
     <main className="mx-auto max-w-3xl p-8">
@@ -127,11 +123,11 @@ function App() {
         ))}
       </fieldset>
 
-      <Player contentTitle={userTitle} defaultContentTitle={defaultTitle}>
+      <Player title={userTitle}>
         <PlayerPreview mediaTitle={mediaTitle} />
       </Player>
 
-      <p className="mt-4 font-mono text-sm text-zinc-600">user ?? media ?? userDefault ?? featureDefault</p>
+      <p className="mt-4 font-mono text-sm text-zinc-600">user ?? media ?? featureDefault</p>
     </main>
   );
 }

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -59,13 +59,15 @@ export type PlayerFeatureConfig<State = never> = Record<
     action: ConfigActionKey<State>;
     /** Provider-owned source-state key whose value survives media detach. */
     state: ConfigStateKey<State>;
-    /**
-     * Attribute name the HTML provider element reads this input from, kebab-case,
-     * for a key whose own name is taken on an element. The matching property
-     * follows from it, so `content-title` is also `element.contentTitle`.
-     * Defaults to the kebab-cased key.
-     */
-    htmlAttribute?: string;
+    /** How an HTML provider element names this input, when the key's own name won't do. */
+    html?: {
+      /**
+       * Attribute name in markup, kebab-case, for a key whose own name is taken
+       * on an element. The matching property follows from it, so `content-title`
+       * is also `element.contentTitle`. Defaults to the kebab-cased key.
+       */
+      attribute: string;
+    };
   }
 >;
 
@@ -100,7 +102,7 @@ export type InferPlayerFeatureHtmlConfig<Feature extends AnyPlayerFeature> = Fea
     }
   : object;
 
-type HtmlPropertyKey<Key, Entry> = Entry extends { htmlAttribute: infer Attribute extends string }
+type HtmlPropertyKey<Key, Entry> = Entry extends { html: { attribute: infer Attribute extends string } }
   ? CamelCase<Attribute>
   : Key;
 

--- a/packages/core/src/dom/player.ts
+++ b/packages/core/src/dom/player.ts
@@ -17,7 +17,7 @@ import type {
   MediaVolumeState,
 } from '@videojs/media';
 import type { AnySlice, InferSliceSourceState, Slice, Store, UnionSliceState } from '@videojs/store';
-import type { Simplify, UnionToIntersection } from '@videojs/utils/types';
+import type { CamelCase, Simplify, UnionToIntersection } from '@videojs/utils/types';
 import type { metadataFeature } from './store/features/metadata';
 
 export interface MediaContainer extends HTMLElement {}
@@ -59,6 +59,13 @@ export type PlayerFeatureConfig<State = never> = Record<
     action: ConfigActionKey<State>;
     /** Provider-owned source-state key whose value survives media detach. */
     state: ConfigStateKey<State>;
+    /**
+     * Attribute name the HTML provider element reads this input from, kebab-case,
+     * for a key whose own name is taken on an element. The matching property
+     * follows from it, so `content-title` is also `element.contentTitle`.
+     * Defaults to the kebab-cased key.
+     */
+    htmlAttribute?: string;
   }
 >;
 
@@ -72,28 +79,55 @@ export type PlayerFeature<State, Derived = object, Config extends PlayerFeatureC
 
 export type AnyPlayerFeature = AnySlice<PlayerTarget> & { config?: PlayerFeatureConfig };
 
+type ConfigInputValue<Feature extends AnyPlayerFeature, Entry> = Entry extends { action: infer Action }
+  ? Action extends keyof InferSliceSourceState<Feature>
+    ? ActionInput<InferSliceSourceState<Feature>[Action]>
+    : never
+  : never;
+
 export type InferPlayerFeatureConfig<Feature extends AnyPlayerFeature> = Feature extends {
   config?: infer Config extends PlayerFeatureConfig;
 }
+  ? { [Key in keyof Config]: ConfigInputValue<Feature, Config[Key]> }
+  : object;
+
+/** The same inputs under the names they go by on an HTML element. */
+export type InferPlayerFeatureHtmlConfig<Feature extends AnyPlayerFeature> = Feature extends {
+  config?: infer Config extends PlayerFeatureConfig;
+}
   ? {
-      [Key in keyof Config]: Config[Key]['action'] extends keyof InferSliceSourceState<Feature>
-        ? ActionInput<InferSliceSourceState<Feature>[Config[Key]['action']]>
-        : never;
+      [Key in keyof Config as HtmlPropertyKey<Key, Config[Key]>]: ConfigInputValue<Feature, Config[Key]>;
     }
   : object;
+
+type HtmlPropertyKey<Key, Entry> = Entry extends { htmlAttribute: infer Attribute extends string }
+  ? CamelCase<Attribute>
+  : Key;
 
 export type UnionPlayerConfig<Features extends readonly AnyPlayerFeature[]> = Features extends readonly []
   ? object
   : Simplify<UnionToIntersection<InferPlayerFeatureConfig<Features[number]>>>;
 
+export type UnionPlayerHtmlConfig<Features extends readonly AnyPlayerFeature[]> = Features extends readonly []
+  ? object
+  : Simplify<UnionToIntersection<InferPlayerFeatureHtmlConfig<Features[number]>>>;
+
 declare const PLAYER_CONFIG: unique symbol;
+declare const PLAYER_HTML_CONFIG: unique symbol;
 
 export type PlayerStore<Features extends AnyPlayerFeature[] = []> = Store<PlayerTarget, UnionSliceState<Features>> & {
   readonly [PLAYER_CONFIG]?: UnionPlayerConfig<Features>;
+  readonly [PLAYER_HTML_CONFIG]?: UnionPlayerHtmlConfig<Features>;
 };
 
 export type InferPlayerConfig<Store> = Store extends {
   readonly [PLAYER_CONFIG]?: infer Config;
+}
+  ? Config
+  : object;
+
+export type InferPlayerHtmlConfig<Store> = Store extends {
+  readonly [PLAYER_HTML_CONFIG]?: infer Config;
 }
   ? Config
   : object;

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -4,59 +4,47 @@ import { listen } from '@videojs/utils/dom';
 import { definePlayerFeature } from '../../feature';
 import type { PlayerFeatureConfig } from '../../player';
 
-const MEDIA_CONTENT_TITLE = Symbol('@videojs/media-content-title');
-const USER_CONTENT_TITLE = Symbol('@videojs/user-content-title');
-const USER_DEFAULT_CONTENT_TITLE = Symbol('@videojs/user-default-content-title');
-const SET_USER_CONTENT_TITLE = Symbol('@videojs/set-user-content-title');
-const SET_USER_DEFAULT_CONTENT_TITLE = Symbol('@videojs/set-user-default-content-title');
-const DEFAULT_CONTENT_TITLE = '';
+const MEDIA_TITLE = Symbol('@videojs/media-title');
+const USER_TITLE = Symbol('@videojs/user-title');
+const SET_USER_TITLE = Symbol('@videojs/set-user-title');
+const DEFAULT_TITLE = '';
 
-interface MetadataSourceState extends Omit<MediaMetadataState, 'contentTitle'> {
-  [MEDIA_CONTENT_TITLE]: MediaContentValue;
-  [USER_CONTENT_TITLE]: MediaContentValue;
-  [USER_DEFAULT_CONTENT_TITLE]: MediaContentValue;
-  [SET_USER_CONTENT_TITLE](value: MediaContentValue): void;
-  [SET_USER_DEFAULT_CONTENT_TITLE](value: MediaContentValue): void;
+interface MetadataSourceState extends Omit<MediaMetadataState, 'title'> {
+  [MEDIA_TITLE]: MediaContentValue;
+  [USER_TITLE]: MediaContentValue;
+  [SET_USER_TITLE](value: MediaContentValue): void;
 }
 
 /**
- * Resolves user, media, and fallback content-title metadata into player state.
- * Included in the standard audio, video, and live presets.
+ * Resolves the content title into player state, preferring what the author set
+ * over what the media carries. Included in the standard audio, video, and live
+ * presets.
  */
 export const metadataFeature = definePlayerFeature({
   name: 'metadata',
   config: {
-    contentTitle: {
-      action: SET_USER_CONTENT_TITLE,
-      state: USER_CONTENT_TITLE,
-    },
-    defaultContentTitle: {
-      action: SET_USER_DEFAULT_CONTENT_TITLE,
-      state: USER_DEFAULT_CONTENT_TITLE,
+    title: {
+      action: SET_USER_TITLE,
+      state: USER_TITLE,
+      // `title` already means the tooltip on an element, so the input takes
+      // another name there.
+      htmlAttribute: 'content-title',
     },
   } satisfies PlayerFeatureConfig<MetadataSourceState>,
   state: ({ set }): MetadataSourceState => ({
-    [MEDIA_CONTENT_TITLE]: undefined,
-    [USER_CONTENT_TITLE]: undefined,
-    [USER_DEFAULT_CONTENT_TITLE]: undefined,
-    [SET_USER_CONTENT_TITLE]: (value) => set({ [USER_CONTENT_TITLE]: value }),
-    [SET_USER_DEFAULT_CONTENT_TITLE]: (value) => set({ [USER_DEFAULT_CONTENT_TITLE]: value }),
-    setContentTitle: (value) => set({ [USER_CONTENT_TITLE]: value }),
-    setDefaultContentTitle: (value) => set({ [USER_DEFAULT_CONTENT_TITLE]: value }),
+    [MEDIA_TITLE]: undefined,
+    [USER_TITLE]: undefined,
+    [SET_USER_TITLE]: (value) => set({ [USER_TITLE]: value }),
   }),
   derived: {
-    contentTitle: ({ get }) =>
-      get()[USER_CONTENT_TITLE] ??
-      get()[MEDIA_CONTENT_TITLE] ??
-      get()[USER_DEFAULT_CONTENT_TITLE] ??
-      DEFAULT_CONTENT_TITLE,
+    title: ({ get }) => get()[USER_TITLE] ?? get()[MEDIA_TITLE] ?? DEFAULT_TITLE,
   },
   attach({ target, signal, set }) {
     const { media } = target;
 
     if (!isMediaContentDataCapable(media)) return;
 
-    const sync = () => set({ [MEDIA_CONTENT_TITLE]: media.contentData?.title });
+    const sync = () => set({ [MEDIA_TITLE]: media.contentData?.title });
     sync();
     listen(media, 'contentdatachange', sync, { signal });
   },

--- a/packages/core/src/dom/store/features/metadata.ts
+++ b/packages/core/src/dom/store/features/metadata.ts
@@ -28,7 +28,7 @@ export const metadataFeature = definePlayerFeature({
       state: USER_TITLE,
       // `title` already means the tooltip on an element, so the input takes
       // another name there.
-      htmlAttribute: 'content-title',
+      html: { attribute: 'content-title' },
     },
   } satisfies PlayerFeatureConfig<MetadataSourceState>,
   state: ({ set }): MetadataSourceState => ({

--- a/packages/core/src/dom/store/features/tests/metadata.test.ts
+++ b/packages/core/src/dom/store/features/tests/metadata.test.ts
@@ -134,7 +134,7 @@ describe('metadataFeature', () => {
   });
 
   it('takes the title under another name in markup, where `title` is the tooltip', () => {
-    expect(titleConfig.htmlAttribute).toBe('content-title');
+    expect(titleConfig.html?.attribute).toBe('content-title');
   });
 
   it('selects the resolved title and nothing that writes it', () => {

--- a/packages/core/src/dom/store/features/tests/metadata.test.ts
+++ b/packages/core/src/dom/store/features/tests/metadata.test.ts
@@ -1,10 +1,18 @@
 import type { MediaContentData, MediaContentValue } from '@videojs/media';
 import { createStore } from '@videojs/store';
 import { describe, expect, it, vi } from 'vitest';
+import { setPlayerConfigValue } from '../../../feature';
 import type { PlayerTarget } from '../../../player';
 import { selectMetadata } from '../../selectors';
 import { metadataFeature } from '../metadata';
 import { audioFeatures, backgroundFeatures, liveAudioFeatures, liveVideoFeatures, videoFeatures } from '../presets';
+
+const titleConfig = metadataFeature.config!.title;
+
+/** Set the user title the way a provider does, through the feature's own config. */
+function setUserTitle(store: object, value: MediaContentValue): void {
+  setPlayerConfigValue(store, titleConfig, value);
+}
 
 class ContentDataMedia extends EventTarget {
   contentData: MediaContentData | undefined;
@@ -14,7 +22,7 @@ class ContentDataMedia extends EventTarget {
     this.contentData = contentData;
   }
 
-  setContentTitle(value: MediaContentValue): void {
+  setTitle(value: MediaContentValue): void {
     if (!this.contentData || Object.is(this.contentData.title, value)) return;
     const contentData = { ...this.contentData };
     if (value === undefined) delete contentData.title;
@@ -38,61 +46,57 @@ describe('metadataFeature', () => {
     expect(backgroundFeatures).not.toContain(metadataFeature);
   });
 
-  it('resolves user, media, user default, and feature default in order', () => {
+  it('resolves user, media, and feature default in order', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
 
-    expect(store.contentTitle).toBe('');
-
-    store.setDefaultContentTitle('fallback');
-    expect(store.contentTitle).toBe('fallback');
+    expect(store.title).toBe('');
 
     const media = new ContentDataMedia({ title: 'media' });
     store.attach(target(media));
-    expect(store.contentTitle).toBe('media');
+    expect(store.title).toBe('media');
 
-    store.setContentTitle('user');
-    expect(store.contentTitle).toBe('user');
+    setUserTitle(store, 'user');
+    expect(store.title).toBe('user');
 
-    media.setContentTitle('latest media');
-    expect(store.contentTitle).toBe('user');
+    media.setTitle('latest media');
+    expect(store.title).toBe('user');
 
-    store.setContentTitle(null);
-    expect(store.contentTitle).toBe('latest media');
+    setUserTitle(store, null);
+    expect(store.title).toBe('latest media');
   });
 
   it('treats empty and whitespace-only strings as literal values', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
-    store.setDefaultContentTitle('fallback');
-    store.setContentTitle('');
+    store.attach(target(new ContentDataMedia({ title: 'media' })));
 
-    expect(store.contentTitle).toBe('');
+    setUserTitle(store, '');
+    expect(store.title).toBe('');
 
-    store.setContentTitle('   ');
-    expect(store.contentTitle).toBe('   ');
+    setUserTitle(store, '   ');
+    expect(store.title).toBe('   ');
   });
 
   it('subscribes to content data before an asynchronous title arrives', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
-    store.setDefaultContentTitle('fallback');
     const media = new ContentDataMedia({});
     const addEventListener = vi.spyOn(media, 'addEventListener');
 
     store.attach(target(media));
 
-    expect(store.contentTitle).toBe('fallback');
+    expect(store.title).toBe('');
     expect(addEventListener).toHaveBeenCalledWith('contentdatachange', expect.any(Function), expect.anything());
 
-    media.setContentTitle('loaded title');
-    expect(store.contentTitle).toBe('loaded title');
+    media.setTitle('loaded title');
+    expect(store.title).toBe('loaded title');
 
-    media.setContentTitle(null);
-    expect(store.contentTitle).toBe('fallback');
+    media.setTitle(null);
+    expect(store.title).toBe('');
 
-    media.setContentTitle('replacement title');
-    expect(store.contentTitle).toBe('replacement title');
+    media.setTitle('replacement title');
+    expect(store.title).toBe('replacement title');
 
-    media.setContentTitle(undefined);
-    expect(store.contentTitle).toBe('fallback');
+    media.setTitle(undefined);
+    expect(store.title).toBe('');
   });
 
   it('subscribes when content data initially contains only another field', () => {
@@ -104,40 +108,40 @@ describe('metadataFeature', () => {
 
     expect(addEventListener).toHaveBeenCalledWith('contentdatachange', expect.any(Function), expect.anything());
 
-    media.setContentTitle('later title');
-    expect(store.contentTitle).toBe('later title');
+    media.setTitle('later title');
+    expect(store.title).toBe('later title');
   });
 
   it('does not listen to unsupported media', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
-    store.setDefaultContentTitle('fallback');
     const unsupported = new ContentDataMedia(undefined);
     const addEventListener = vi.spyOn(unsupported, 'addEventListener');
 
     store.attach(target(unsupported));
 
-    expect(store.contentTitle).toBe('fallback');
+    expect(store.title).toBe('');
     expect(addEventListener).not.toHaveBeenCalledWith('contentdatachange', expect.anything());
   });
 
   it('resets media metadata on detach while preserving user-owned state', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
-    store.setDefaultContentTitle('fallback');
+    setUserTitle(store, 'user');
     const detach = store.attach(target(new ContentDataMedia({ title: 'media' })));
 
     detach();
 
-    expect(store.contentTitle).toBe('fallback');
+    expect(store.title).toBe('user');
   });
 
-  it('selects only resolved metadata and public writers', () => {
+  it('takes the title under another name in markup, where `title` is the tooltip', () => {
+    expect(titleConfig.htmlAttribute).toBe('content-title');
+  });
+
+  it('selects the resolved title and nothing that writes it', () => {
     const store = createStore<PlayerTarget>()(metadataFeature);
 
-    expect(selectMetadata(store.state)).toEqual({
-      contentTitle: '',
-      setContentTitle: store.setContentTitle,
-      setDefaultContentTitle: store.setDefaultContentTitle,
-    });
-    expect(store.state).not.toHaveProperty('defaultContentTitle');
+    expect(selectMetadata(store.state)).toEqual({ title: '' });
+    expect(store.state).not.toHaveProperty('setTitle');
+    expect(store.state).not.toHaveProperty('defaultTitle');
   });
 });

--- a/packages/html/src/player/tests/create-player.test-d.ts
+++ b/packages/html/src/player/tests/create-player.test-d.ts
@@ -65,8 +65,8 @@ describe('createPlayer', () => {
     const metadataProvider = new MetadataProvider();
     const plainProvider = new PlainProvider();
 
+    // The store calls this `title`; on an element that name is the tooltip.
     assertType<string | null | undefined>(metadataProvider.contentTitle);
-    assertType<string | null | undefined>(metadataProvider.defaultContentTitle);
 
     // @ts-expect-error metadata properties are absent when the feature is absent.
     plainProvider.contentTitle;

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -114,7 +114,7 @@ describe('createPlayer', () => {
     expect(result).not.toHaveProperty('ContainerMixin');
   });
 
-  it('maps selected feature inputs to kebab-cased reactive properties and attributes', async () => {
+  it('maps selected feature inputs to reactive properties and attributes', async () => {
     const { ProviderMixin } = createPlayer({ features: [metadataFeature] });
     const ProviderElement = ProviderMixin(MediaElement);
     const tagName = 'test-metadata-provider';
@@ -122,12 +122,11 @@ describe('createPlayer', () => {
 
     const player = document.createElement(tagName) as InstanceType<typeof ProviderElement>;
     player.setAttribute('content-title', 'Attribute title');
-    player.setAttribute('default-content-title', 'Fallback');
     document.body.append(player);
 
     expect(player.contentTitle).toBe('Attribute title');
-    expect(player.store.contentTitle).toBe('Attribute title');
-    expect(ProviderElement.observedAttributes).toContain('default-content-title');
+    expect(player.store.title).toBe('Attribute title');
+    expect(ProviderElement.observedAttributes).toContain('content-title');
 
     player.contentTitle = 'Property title';
 
@@ -136,26 +135,35 @@ describe('createPlayer', () => {
 
     await player.updateComplete;
 
-    expect(player.store.contentTitle).toBe('Property title');
+    expect(player.store.title).toBe('Property title');
 
     player.setAttribute('content-title', '');
     await player.updateComplete;
-    expect(player.store.contentTitle).toBe('');
+    expect(player.store.title).toBe('');
 
     player.removeAttribute('content-title');
     await player.updateComplete;
-    expect(player.store.contentTitle).toBe('Fallback');
+    expect(player.store.title).toBe('');
+  });
 
-    player.store.setContentTitle('Imperative title');
+  it('leaves the element its own `title`, which means the tooltip', async () => {
+    const { ProviderMixin } = createPlayer({ features: [metadataFeature] });
+    const ProviderElement = ProviderMixin(MediaElement);
+    const tagName = 'test-title-provider';
+    customElements.define(tagName, ProviderElement);
 
-    expect(player.store.contentTitle).toBe('Imperative title');
-    expect(player.contentTitle).toBeNull();
-    expect(player.hasAttribute('content-title')).toBe(false);
-
-    player.remove();
+    const player = document.createElement(tagName) as InstanceType<typeof ProviderElement>;
     document.body.append(player);
 
-    expect(player.store.contentTitle).toBe('Imperative title');
+    // Nothing was installed over the native accessor, so this is still the tooltip.
+    expect(Object.getOwnPropertyDescriptor(ProviderElement.prototype, 'title')).toBeUndefined();
+    expect(ProviderElement.observedAttributes).not.toContain('title');
+
+    player.title = 'Tooltip';
+    await player.updateComplete;
+
+    expect(player.getAttribute('title')).toBe('Tooltip');
+    expect(player.store.title).toBe('');
   });
 
   it('leaves config attributes inert when their feature is absent', () => {

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -9,7 +9,7 @@ import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
 import type { Media } from '@videojs/media/dom';
 import { isNull } from '@videojs/utils/predicate';
-import { kebabCase } from '@videojs/utils/string';
+import { camelCase, kebabCase } from '@videojs/utils/string';
 import type { MediaElementConstructor } from '@/ui/media-element';
 import type { ContainerContext, MediaContext, PlayerContext } from '../player/context';
 import type { PlayerProviderConstructor } from './types';
@@ -25,6 +25,31 @@ export interface ProviderMixinConfig<Store extends PlayerStore> {
 export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaElementConstructor>(
   BaseClass: Class
 ) => Class & PlayerProviderConstructor<Store>;
+
+/** One configuration input, under the names it goes by on the element. */
+interface ConfigInput {
+  /** Reactive property mirroring the attribute. */
+  property: string;
+  attribute: string;
+  entry: PlayerFeatureConfig[string];
+}
+
+/**
+ * Name each input on the element. A key whose own name is taken there declares
+ * an `htmlAttribute` instead, and the property follows from that.
+ */
+function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
+  return Object.entries(config).map(([key, entry]) => {
+    const attribute = entry.htmlAttribute ?? kebabCase(key);
+
+    if (__DEV__ && entry.htmlAttribute && entry.htmlAttribute !== kebabCase(entry.htmlAttribute)) {
+      // Markup lowercases attribute names, so an uppercase letter here never matches.
+      console.warn(`[vjs-html] config htmlAttribute "${entry.htmlAttribute}" is not kebab-case and will never match`);
+    }
+
+    return { property: camelCase(attribute), attribute, entry };
+  });
+}
 
 /**
  * Create a mixin that provides player context to descendant elements and
@@ -42,13 +67,13 @@ export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaEleme
 export function createProviderMixin<Store extends PlayerStore>(
   options: ProviderMixinConfig<Store>
 ): ProviderMixin<Store> {
-  const configKeys = Object.keys(options.config);
+  const inputs = resolveInputs(options.config);
 
   return <Class extends MediaElementConstructor>(BaseClass: Class) => {
     class PlayerProviderElement extends BaseClass {
       static properties = {
         ...(BaseClass as unknown as { properties: PropertyDeclarationMap }).properties,
-        ...Object.fromEntries(configKeys.map((key) => [key, { type: String, attribute: kebabCase(key) }])),
+        ...Object.fromEntries(inputs.map(({ property, attribute }) => [property, { type: String, attribute }])),
       };
 
       #store: Store | null = options.factory();
@@ -131,9 +156,9 @@ export function createProviderMixin<Store extends PlayerStore>(
 
         // Configuration flows one way: only actual reactive property changes
         // write to the store. Store-side writers do not reflect back here.
-        for (const key of configKeys) {
-          if (!changed.has(key)) continue;
-          setPlayerConfigValue(this.store, options.config[key]!, (this as unknown as Record<string, unknown>)[key]);
+        for (const { property, entry } of inputs) {
+          if (!changed.has(property)) continue;
+          setPlayerConfigValue(this.store, entry, (this as unknown as Record<string, unknown>)[property]);
         }
       }
 
@@ -169,8 +194,8 @@ export function createProviderMixin<Store extends PlayerStore>(
         const store = this.store;
         if (this.#configuredStore === store) return;
 
-        for (const key of configKeys) {
-          setPlayerConfigValue(store, options.config[key]!, (this as unknown as Record<string, unknown>)[key]);
+        for (const { property, entry } of inputs) {
+          setPlayerConfigValue(store, entry, (this as unknown as Record<string, unknown>)[property]);
         }
         this.#configuredStore = store;
       }

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -36,15 +36,16 @@ interface ConfigInput {
 
 /**
  * Name each input on the element. A key whose own name is taken there declares
- * an `htmlAttribute` instead, and the property follows from that.
+ * an `html.attribute` instead, and the property follows from that.
  */
 function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
   return Object.entries(config).map(([key, entry]) => {
-    const attribute = entry.htmlAttribute ?? kebabCase(key);
+    const declared = entry.html?.attribute;
+    const attribute = declared ?? kebabCase(key);
 
-    if (__DEV__ && entry.htmlAttribute && entry.htmlAttribute !== kebabCase(entry.htmlAttribute)) {
+    if (__DEV__ && declared && declared !== kebabCase(declared)) {
       // Markup lowercases attribute names, so an uppercase letter here never matches.
-      console.warn(`[vjs-html] config htmlAttribute "${entry.htmlAttribute}" is not kebab-case and will never match`);
+      console.warn(`[vjs-html] config html.attribute "${declared}" is not kebab-case and will never match`);
     }
 
     return { property: camelCase(attribute), attribute, entry };

--- a/packages/html/src/store/types.ts
+++ b/packages/html/src/store/types.ts
@@ -1,4 +1,4 @@
-import type { InferPlayerConfig, PlayerStore } from '@videojs/core/dom';
+import type { InferPlayerHtmlConfig, PlayerStore } from '@videojs/core/dom';
 import type { Constructor } from '@videojs/utils/types';
 import type { MediaElement } from '@/ui/media-element';
 
@@ -7,7 +7,7 @@ import type { MediaElement } from '@/ui/media-element';
 // ----------------------------------------
 
 type ProviderProperties<Store extends PlayerStore> = {
-  -readonly [Key in keyof InferPlayerConfig<Store>]?: InferPlayerConfig<Store>[Key] | undefined;
+  -readonly [Key in keyof InferPlayerHtmlConfig<Store>]?: InferPlayerHtmlConfig<Store>[Key] | undefined;
 };
 
 export type PlayerProvider<Store extends PlayerStore> = MediaElement &

--- a/packages/media/src/core/state.ts
+++ b/packages/media/src/core/state.ts
@@ -148,12 +148,8 @@ export interface MediaStreamTypeState {
 
 /** Resolved content metadata exposed by the player store. */
 export interface MediaMetadataState {
-  /** The resolved content title. */
-  contentTitle: string;
-  /** Set or clear the user title override. */
-  setContentTitle(value: string | null): void;
-  /** Set or clear the fallback used when neither the user nor media supplies a title. */
-  setDefaultContentTitle(value: string | null): void;
+  /** The resolved content title. Set it through the player, not through the store. */
+  title: string;
 }
 
 export interface MediaLiveState {

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -53,12 +53,12 @@ describe('createPlayer', () => {
     const withMetadata = createPlayer({ features: [metadataFeature] });
     const withoutMetadata = createPlayer({ features: [features.playback] });
 
-    <withMetadata.Player contentTitle="Title" defaultContentTitle={null}>
+    <withMetadata.Player title="Title">
       <div />
     </withMetadata.Player>;
 
     // @ts-expect-error metadata props are absent when the feature is absent.
-    <withoutMetadata.Player contentTitle="Title">
+    <withoutMetadata.Player title="Title">
       <div />
     </withoutMetadata.Player>;
   });

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -126,7 +126,7 @@ describe('createPlayer', () => {
       }
 
       render(
-        <Player contentTitle="Replacement title">
+        <Player title="Replacement title">
           <Consumer />
         </Player>
       );
@@ -137,7 +137,7 @@ describe('createPlayer', () => {
       act(() => setMedia(document.createElement('video')));
 
       expect(store).not.toBe(destroyedStore);
-      expect(store.contentTitle).toBe('Replacement title');
+      expect(store.title).toBe('Replacement title');
     });
 
     it('survives React StrictMode without StoreError', () => {
@@ -227,49 +227,43 @@ describe('createPlayer', () => {
 
       function Consumer() {
         store = usePlayer();
-        return <span>{store.contentTitle}</span>;
+        return <span>{store.title}</span>;
       }
 
       const { rerender } = render(
-        <Player contentTitle="Initial title">
+        <Player title="Initial title">
           <Consumer />
         </Player>
       );
 
       expect(screen.getByText('Initial title')).toBeTruthy();
 
-      act(() => store.setDefaultContentTitle('Imperative fallback'));
       rerender(
-        <Player contentTitle="Initial title">
+        <Player title="Updated title">
           <Consumer />
         </Player>
       );
+      expect(store.title).toBe('Updated title');
 
-      rerender(
-        <Player contentTitle="Updated title">
-          <Consumer />
-        </Player>
-      );
-      expect(store.contentTitle).toBe('Updated title');
-
+      // Dropping the prop clears the override, leaving what the media carries.
       rerender(
         <Player>
           <Consumer />
         </Player>
       );
-      expect(store.contentTitle).toBe('Imperative fallback');
+      expect(store.title).toBe('');
     });
 
     it('seeds config inputs during SSR', () => {
       const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
-        return <span>{usePlayer((state) => state.contentTitle)}</span>;
+        return <span>{usePlayer((state) => state.title)}</span>;
       }
 
       expect(
         renderToString(
-          <Player contentTitle="SSR title">
+          <Player title="SSR title">
             <Consumer />
           </Player>
         )
@@ -280,18 +274,18 @@ describe('createPlayer', () => {
       const { Player, usePlayer } = createPlayer({ features: [metadataFeature] });
 
       function Consumer() {
-        return <span>{usePlayer((state) => state.contentTitle)}</span>;
+        return <span>{usePlayer((state) => state.title)}</span>;
       }
 
       const container = document.createElement('div');
       container.innerHTML = renderToString(
-        <Player contentTitle="Hydrated title">
+        <Player title="Hydrated title">
           <Consumer />
         </Player>
       );
 
       const view = render(
-        <Player contentTitle="Hydrated title">
+        <Player title="Hydrated title">
           <Consumer />
         </Player>,
         { container, hydrate: true }
@@ -331,7 +325,7 @@ describe('createPlayer', () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
       const { rerender } = render(
         <Boundary>
-          <Player contentTitle="Committed title">
+          <Player title="Committed title">
             <Consumer />
           </Player>
         </Boundary>
@@ -340,13 +334,13 @@ describe('createPlayer', () => {
 
       rerender(
         <Boundary>
-          <Player contentTitle="Abandoned title">
+          <Player title="Abandoned title">
             <Consumer fail />
           </Player>
         </Boundary>
       );
 
-      expect(committedStore.contentTitle).toBe('Committed title');
+      expect(committedStore.title).toBe('Committed title');
       consoleError.mockRestore();
     });
 

--- a/packages/react/src/presets/tests/player.test-d.tsx
+++ b/packages/react/src/presets/tests/player.test-d.tsx
@@ -14,14 +14,14 @@ import { usePlayer as useVideoPlayer, VideoPlayer } from '../video/player';
 
 describe('preset players', () => {
   it('exposes each preset player with its inferred configuration props', () => {
-    <VideoPlayer contentTitle="Video title">Video</VideoPlayer>;
-    <AudioPlayer contentTitle="Audio title">Audio</AudioPlayer>;
-    <LiveVideoPlayer contentTitle="Live video title">Live video</LiveVideoPlayer>;
-    <LiveAudioPlayer contentTitle="Live audio title">Live audio</LiveAudioPlayer>;
+    <VideoPlayer title="Video title">Video</VideoPlayer>;
+    <AudioPlayer title="Audio title">Audio</AudioPlayer>;
+    <LiveVideoPlayer title="Live video title">Live video</LiveVideoPlayer>;
+    <LiveAudioPlayer title="Live audio title">Live audio</LiveAudioPlayer>;
     <BackgroundVideoPlayer>Background video</BackgroundVideoPlayer>;
 
     // @ts-expect-error Background video does not include the metadata feature.
-    <BackgroundVideoPlayer contentTitle="Background title">Background video</BackgroundVideoPlayer>;
+    <BackgroundVideoPlayer title="Background title">Background video</BackgroundVideoPlayer>;
 
     // @ts-expect-error Preset players are components, not createPlayer result objects.
     VideoPlayer.Provider;

--- a/packages/react/src/presets/tests/player.test.tsx
+++ b/packages/react/src/presets/tests/player.test.tsx
@@ -25,12 +25,12 @@ describe('preset players', () => {
 
   it('forwards preset configuration props to the player store', () => {
     function Title() {
-      const title = useVideoPlayer((state) => state.contentTitle);
+      const title = useVideoPlayer((state) => state.title);
       return <span>{title}</span>;
     }
 
     render(
-      <VideoPlayer contentTitle="Preset title">
+      <VideoPlayer title="Preset title">
         <Title />
       </VideoPlayer>
     );

--- a/packages/utils/src/types/types.ts
+++ b/packages/utils/src/types/types.ts
@@ -3,6 +3,11 @@ export type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) ex
 /** Matches strings that include the literal substring `Needle` (for example a `{param}` token). */
 export type Contains<Needle extends string> = `${string}${Needle}${string}`;
 
+/** The type-level counterpart of `camelCase`, for kebab-case input. */
+export type CamelCase<Value extends string> = Value extends `${infer Head}-${infer Tail}`
+  ? `${Head}${Capitalize<CamelCase<Tail>>}`
+  : Value;
+
 export type EnsureRecord<Keys extends PropertyKey, Value, Target extends Record<Keys, Value>> = Target;
 
 export type Constructor<T, Arguments extends unknown[] = any[]> = new (...args: Arguments) => T;


### PR DESCRIPTION
Part of #1798. Stacked on #1998, and #2039 stacks on this.

Tag names are written without angle brackets throughout — this repo's PR body pipeline strips them.

## What changed

The metadata feature resolved a value called `contentTitle`, and offered `setContentTitle` and `setDefaultContentTitle` on the store for writing it. Both public writers are gone. An input reaches the store through the feature's own config now, which is the door the HTML provider element and the React player were already using.

`defaultContentTitle` goes with them. That tier existed so the config had somewhere to put a fallback, and nothing else ever read it. The chain is now user input, then whatever the media donates, then the empty string.

With the writers gone, the resolved value is free to be called `title`, matching the `contentData.title` the media hands over.

## The one wrinkle

`title` on an HTML element already means the tooltip, so a provider element can't take the input under that name. A config entry can now say what it goes by in markup instead:

```ts
title: {
  action: SET_USER_TITLE,
  state: USER_TITLE,
  html: { attribute: 'content-title' },
},
```

The matching property follows from the attribute, so `content-title` is also `element.contentTitle`. Nothing is installed over the native `title` accessor, and there's a test pinning that.

Declaring the attribute rather than the property is deliberate: markup is the surface an author actually types, and it's the one we're working around. A dev-only warning fires if the value isn't kebab-case, since markup lowercases attribute names and an uppercase letter there would silently never match.

`html` is nested rather than a flat `htmlAttribute` so the HTML-side naming has somewhere to grow.

## What this looks like from outside

| | before | after |
|---|---|---|
| store | `store.contentTitle` | `store.title` |
| React | `Player contentTitle=` | `Player title=` |
| markup | `content-title=""` | unchanged |
| element property | `player.contentTitle` | unchanged |
| store writers | `setContentTitle`, `setDefaultContentTitle` | none |
| fallback input | `defaultContentTitle` | none |

## Merging main

#1998 brought main in, and with it #2116 and #2154, which renamed `createPlayer`'s `Provider` to `Player` and moved `Container` out of the factory. Everything this branch touches follows that naming.

The rename also arrived with new preset-player tests on main that pass `contentTitle`. They merged without a conflict — nothing on this branch had touched those files — so they were silently wrong until `pnpm typecheck` caught them. They now pass `title`.

## Notes

- `CamelCase` is new in `@videojs/utils/types`, the type-level counterpart of the existing `camelCase`. It turns the declared attribute into the property name at the type level, so the element's typed properties match what actually exists on it at runtime.
- The core metadata tests set the user title through `setPlayerConfigValue` and the feature's own config entry, which is the only remaining door and the same one the players use.
- The metadata sandbox template drops its third "User default" tier.

## Testing

`pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace` all clean. Core 1421, html 344, react 440 — all passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Public API break across store, React props, and metadata precedence; HTML mapping must not collide with native `title`.
> 
> **Overview**
> **Breaking change:** metadata is exposed as **`store.title`** (was `contentTitle`). React uses **`Player title=`**; HTML keeps **`content-title`** / **`contentTitle`** on provider elements. **`defaultContentTitle`** and store writers **`setContentTitle`** / **`setDefaultContentTitle`** are removed—title is set only via player/feature config (`setPlayerConfigValue`).
> 
> Resolution is now **user config → media `contentData.title` → `''`** (no user-default tier). The metadata sandbox drops its third “User default” source.
> 
> Feature config gains optional **`html.attribute`** so a config key can map to a different markup name when the DOM name is reserved. Metadata uses `title` in config with `html: { attribute: 'content-title' }` so native **`title`** stays the tooltip. Core adds **`InferPlayerHtmlConfig`** / **`UnionPlayerHtmlConfig`** and **`CamelCase`** for typed element properties; the HTML provider mixin resolves attributes via **`resolveInputs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b045148b41f117ea288b253489d223d121ba487d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->