### PR TITLE
fix(test): update active submenu selectors

### DIFF
--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -25,7 +25,7 @@ function unchecked(selector: string): string {
 const menu = '[role="menu"]';
 const item = '[role="menuitem"]';
 const option = '[role="menuitemradio"]';
-const activeMenu = `${menu}[data-menu-view-state="active"]`;
+const activeSubmenu = `${menu}[data-submenu][data-open]:not([data-ending-style])`;
 const playbackRateOptions = [
   `#playback-rate-menu ${option}`,
   withinControls(`.media-menu--playback-rate ${option}`),
@@ -56,9 +56,9 @@ export const SELECTORS = {
     withinControls('button[aria-haspopup="menu"][aria-label^="Playback rate"]:not(.media-menu__item)'),
   ].join(', '),
   playbackRateUncheckedOptions: unchecked(playbackRateOptions),
-  activeMenuOptions: `${activeMenu} ${option}`,
-  activeMenuPanel: '.media-menu__panel[data-menu-view-state="active"]',
-  activeMenuUncheckedOptions: unchecked(`${activeMenu} ${option}`),
+  activeMenuOptions: `${activeSubmenu} ${option}`,
+  activeMenuPanel: `${activeSubmenu}.media-menu__panel`,
+  activeMenuUncheckedOptions: unchecked(`${activeSubmenu} ${option}`),
   settingsButton: [
     withinControls('.media-button--settings'),
     withinControls('button[commandfor="settings-menu"]'),


### PR DESCRIPTION
## Summary

Update the E2E menu selectors to follow the current submenu lifecycle attributes. The menu composition no longer exposes `data-menu-view-state`, which left playback-rate, captions, and menu-scroll tests waiting for elements that were already rendered.

## Changes

- Select the open nested menu through `data-submenu` and `data-open`
- Exclude exit-retained submenu panels marked with `data-ending-style`
- Reuse the updated selector for active options, unchecked options, and scroll panels

## Testing

- `pnpm lint:fix:file apps/e2e/fixtures/selectors.ts`
- `pnpm --dir apps/e2e test:all --reporter=line` (371 passed, 17 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector updates with no production or security impact; aligns fixtures with current menu markup.
> 
> **Overview**
> E2E **active menu** locators in `selectors.ts` no longer use `data-menu-view-state="active"`, which the player menu stack no longer sets.
> 
> They now target the open nested menu via **`[role="menu"][data-submenu][data-open]:not([data-ending-style])`**, and wire that through **`activeMenuOptions`**, **`activeMenuPanel`**, and **`activeMenuUncheckedOptions`** so playback-rate, captions, and scroll tests wait on the right DOM again instead of timing out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a048c8c728fe216f0db5d581af4189cbb128f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->