### PR TITLE
feat(skin): add canonical error dialog

### DIFF
--- a/packages/core/src/core/ui/components.generated.ts
+++ b/packages/core/src/core/ui/components.generated.ts
@@ -4,6 +4,7 @@ import { createComponent } from '@videojs/jsx';
 import BufferingIndicatorDef from './buffering-indicator/buffering-indicator-component';
 import ContainerDef from './container/container-component';
 import ControlsDef from './controls/controls-component';
+import ErrorDialogDef from './error-dialog/error-dialog-component';
 import FullscreenButtonDef from './fullscreen-button/fullscreen-button-component';
 import MuteButtonDef from './mute-button/mute-button-component';
 import PlayButtonDef from './play-button/play-button-component';
@@ -20,6 +21,7 @@ import VolumeSliderDef from './volume-slider/volume-slider-component';
 export const BufferingIndicator = createComponent(BufferingIndicatorDef);
 export const Container = createComponent(ContainerDef);
 export const Controls = createComponent(ControlsDef);
+export const ErrorDialog = createComponent(ErrorDialogDef);
 export const FullscreenButton = createComponent(FullscreenButtonDef);
 export const MuteButton = createComponent(MuteButtonDef);
 export const PlayButton = createComponent(PlayButtonDef);
@@ -37,6 +39,7 @@ export const COMPONENTS = {
   BufferingIndicator: BufferingIndicatorDef,
   Container: ContainerDef,
   Controls: ControlsDef,
+  ErrorDialog: ErrorDialogDef,
   FullscreenButton: FullscreenButtonDef,
   MuteButton: MuteButtonDef,
   PlayButton: PlayButtonDef,

--- a/packages/core/src/core/ui/error-dialog/error-dialog-component.ts
+++ b/packages/core/src/core/ui/error-dialog/error-dialog-component.ts
@@ -1,0 +1,15 @@
+import { defineComponent } from '@videojs/jsx';
+
+import { ErrorDialogDataAttrs } from './error-dialog-data-attrs';
+
+export default defineComponent({
+  name: 'ErrorDialog',
+  parts: {
+    Root: defineComponent(),
+    Popup: defineComponent(),
+    Title: defineComponent(),
+    Description: defineComponent(),
+    Close: defineComponent(),
+  },
+  dataAttrs: ErrorDialogDataAttrs,
+});

--- a/packages/html/src/__generated__/skins/default-video/skin.ts
+++ b/packages/html/src/__generated__/skins/default-video/skin.ts
@@ -2,6 +2,7 @@ import '../../../icons/element';
 import '../../../define/media/container';
 import '../../../define/ui/buffering-indicator';
 import '../../../define/ui/controls';
+import '../../../define/ui/error-dialog';
 import '../../../define/ui/fullscreen-button';
 import '../../../define/ui/mute-button';
 import '../../../define/ui/play-button';
@@ -19,6 +20,11 @@ export const skin = /* html */ `<media-container class="media-container media-sk
   <media-buffering-indicator class="media-buffering-indicator">
     <media-icon class="media-buffering-spinner-icon" name="spinner"></media-icon>
   </media-buffering-indicator>
+  <media-error-dialog class="media-surface media-error-dialog">
+    <media-alert-dialog-title class="media-error-dialog-title"></media-alert-dialog-title>
+    <media-alert-dialog-description class="media-error-dialog-description"></media-alert-dialog-description>
+    <media-alert-dialog-close class="media-button media-error-dialog-close"></media-alert-dialog-close>
+  </media-error-dialog>
   <media-controls class="media-controls">
     <media-tooltip-group>
       <media-controls-group class="media-controls-group-primary">

--- a/packages/html/src/__generated__/skins/default-video/styles/dialog.css
+++ b/packages/html/src/__generated__/skins/default-video/styles/dialog.css
@@ -1,0 +1,70 @@
+@layer videojs.components {
+  @scope (.media-skin-video) {
+    .media-error-dialog {
+      z-index: 20;
+      color: #fff;
+      border-radius: 1.75rem;
+      outline-style: none;
+      flex-direction: column;
+      gap: 0.75rem;
+      width: calc(100% - 1.5rem);
+      max-width: 18rem;
+      padding: 0.75rem;
+      transition:
+        opacity 0.35s cubic-bezier(0, 0, 0.2, 1) 0.1s,
+        scale 0.35s cubic-bezier(0, 0, 0.2, 1) 0.1s,
+        transform 0.35s cubic-bezier(0, 0, 0.2, 1) 0.1s;
+      display: flex;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      translate: -50% -50%;
+    }
+
+    .media-error-dialog:not([data-open]) {
+      display: none;
+    }
+
+    .media-error-dialog[data-ending-style] {
+      opacity: 0;
+      transition-delay: 0s;
+      scale: 0.5;
+    }
+
+    .media-error-dialog[data-starting-style] {
+      opacity: 0;
+      scale: 0.5;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .media-error-dialog {
+        transition-duration: 50ms;
+        transition-delay: 0s;
+      }
+    }
+
+    .media-error-dialog-close {
+      color: #000;
+      background-color: #fff;
+      width: 100%;
+      height: 2.25rem;
+      padding-inline: 1rem;
+      font-weight: 500;
+    }
+
+    .media-error-dialog-description {
+      overflow-wrap: anywhere;
+      opacity: 0.7;
+      padding-inline: 0.5rem;
+      padding-bottom: 0.375rem;
+    }
+
+    .media-error-dialog-title {
+      font-size: var(--media-font-size);
+      padding-inline: 0.5rem;
+      padding-top: 0.5rem;
+      font-weight: 600;
+      line-height: 1.25;
+    }
+  }
+}

--- a/packages/html/src/__generated__/skins/default-video/styles/styles.css
+++ b/packages/html/src/__generated__/skins/default-video/styles/styles.css
@@ -4,6 +4,7 @@
 @import './buttons.css';
 @import './container.css';
 @import './controls.css';
+@import './dialog.css';
 @import './overlays.css';
 @import './popups.css';
 @import './poster.css';

--- a/packages/react/src/__generated__/skins/default-video/components/feedback/error-dialog.tsx
+++ b/packages/react/src/__generated__/skins/default-video/components/feedback/error-dialog.tsx
@@ -1,0 +1,13 @@
+import { ErrorDialog as ErrorDialogPrimitive } from '@/ui/error-dialog';
+
+export function ErrorDialog() {
+  return (
+    <ErrorDialogPrimitive.Root>
+      <ErrorDialogPrimitive.Popup className="media-surface media-error-dialog">
+        <ErrorDialogPrimitive.Title className="media-error-dialog-title" />
+        <ErrorDialogPrimitive.Description className="media-error-dialog-description" />
+        <ErrorDialogPrimitive.Close className="media-button media-error-dialog-close" />
+      </ErrorDialogPrimitive.Popup>
+    </ErrorDialogPrimitive.Root>
+  );
+}

--- a/packages/react/src/__generated__/skins/default-video/skin.tsx
+++ b/packages/react/src/__generated__/skins/default-video/skin.tsx
@@ -5,6 +5,7 @@ import { FullscreenButton } from './components/buttons/fullscreen-button';
 import { PlayButton } from './components/buttons/play-button';
 import { VolumePopover } from './components/controls/volume-popover';
 import { BufferingIndicator } from './components/feedback/buffering-indicator';
+import { ErrorDialog } from './components/feedback/error-dialog';
 import { Container } from './components/layout/container';
 import { Overlay } from './components/layout/overlay';
 import { Poster } from './components/layout/poster';
@@ -30,6 +31,7 @@ export function DefaultVideoSkin({ children, className, poster, ...containerProp
         />
       )}
       <BufferingIndicator />
+      <ErrorDialog />
 
       <Controls.Root className="media-controls">
         <Tooltip.Provider>

--- a/packages/react/src/__generated__/skins/default-video/styles/dialog.css
+++ b/packages/react/src/__generated__/skins/default-video/styles/dialog.css
@@ -1,0 +1,70 @@
+@layer videojs.components {
+  @scope (.media-skin-video) {
+    .media-error-dialog {
+      z-index: 20;
+      color: #fff;
+      border-radius: 1.75rem;
+      outline-style: none;
+      flex-direction: column;
+      gap: 0.75rem;
+      width: calc(100% - 1.5rem);
+      max-width: 18rem;
+      padding: 0.75rem;
+      transition:
+        opacity 0.35s cubic-bezier(0, 0, 0.2, 1) 0.1s,
+        scale 0.35s cubic-bezier(0, 0, 0.2, 1) 0.1s,
+        transform 0.35s cubic-bezier(0, 0, 0.2, 1) 0.1s;
+      display: flex;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      translate: -50% -50%;
+    }
+
+    .media-error-dialog:not([data-open]) {
+      display: none;
+    }
+
+    .media-error-dialog[data-ending-style] {
+      opacity: 0;
+      transition-delay: 0s;
+      scale: 0.5;
+    }
+
+    .media-error-dialog[data-starting-style] {
+      opacity: 0;
+      scale: 0.5;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .media-error-dialog {
+        transition-duration: 50ms;
+        transition-delay: 0s;
+      }
+    }
+
+    .media-error-dialog-close {
+      color: #000;
+      background-color: #fff;
+      width: 100%;
+      height: 2.25rem;
+      padding-inline: 1rem;
+      font-weight: 500;
+    }
+
+    .media-error-dialog-description {
+      overflow-wrap: anywhere;
+      opacity: 0.7;
+      padding-inline: 0.5rem;
+      padding-bottom: 0.375rem;
+    }
+
+    .media-error-dialog-title {
+      font-size: var(--media-font-size);
+      padding-inline: 0.5rem;
+      padding-top: 0.5rem;
+      font-weight: 600;
+      line-height: 1.25;
+    }
+  }
+}

--- a/packages/react/src/__generated__/skins/default-video/styles/styles.css
+++ b/packages/react/src/__generated__/skins/default-video/styles/styles.css
@@ -4,6 +4,7 @@
 @import './buttons.css';
 @import './container.css';
 @import './controls.css';
+@import './dialog.css';
 @import './overlays.css';
 @import './popups.css';
 @import './poster.css';

--- a/packages/skins/build/catalog/tests/resolve.test.ts
+++ b/packages/skins/build/catalog/tests/resolve.test.ts
@@ -33,6 +33,7 @@ describe('resolveSkinCatalog', () => {
         dependencies: [
           'buffering-indicator',
           'container',
+          'error-dialog',
           'fullscreen-button',
           'overlay',
           'play-button',
@@ -41,6 +42,7 @@ describe('resolveSkinCatalog', () => {
           'volume-popover',
         ],
       },
+      { name: 'error-dialog', dependencies: [] },
       { name: 'fullscreen-button', dependencies: ['button-tooltip'] },
       { name: 'mute-button', dependencies: [] },
       { name: 'overlay', dependencies: [] },
@@ -56,6 +58,7 @@ describe('resolveSkinCatalog', () => {
     expect(closure.items.map((item) => item.name)).toEqual([
       'buffering-indicator',
       'container',
+      'error-dialog',
       'button-tooltip',
       'fullscreen-button',
       'overlay',
@@ -71,13 +74,14 @@ describe('resolveSkinCatalog', () => {
       './styles/components/buffering.tailwind.ts',
       './styles/components/button.tailwind.ts',
       './styles/components/container.tailwind.ts',
+      './styles/components/error-dialog.tailwind.ts',
       './styles/components/overlay.tailwind.ts',
       './styles/components/popup.tailwind.ts',
       './styles/components/poster.tailwind.ts',
       './styles/components/slider.tailwind.ts',
       './styles/skins/default-video.tailwind.ts',
     ]);
-    expect(closure.sourceFiles).toHaveLength(12);
+    expect(closure.sourceFiles).toHaveLength(13);
     expect(closure.sourceFiles).toContain('./skins/default-video/skin.tsx');
   });
 

--- a/packages/skins/build/compiler/html.ts
+++ b/packages/skins/build/compiler/html.ts
@@ -26,6 +26,15 @@ const htmlComponents: Readonly<Record<string, HtmlComponentDescriptor>> = {
     modules: ['@videojs/html/ui/controls'],
     elements: { 'Controls.Root': 'media-controls', 'Controls.Group': 'media-controls-group' },
   },
+  ErrorDialog: {
+    modules: ['@videojs/html/ui/error-dialog'],
+    elements: {
+      'ErrorDialogPrimitive.Popup': 'media-error-dialog',
+      'ErrorDialogPrimitive.Title': 'media-alert-dialog-title',
+      'ErrorDialogPrimitive.Description': 'media-alert-dialog-description',
+      'ErrorDialogPrimitive.Close': 'media-alert-dialog-close',
+    },
+  },
   FullscreenButton: {
     modules: ['@videojs/html/ui/fullscreen-button'],
     elements: { FullscreenButtonPrimitive: 'media-fullscreen-button' },
@@ -142,6 +151,7 @@ export function createCompilerHtmlConfig(styleTarget: CreateCompilerHtmlConfigOp
             containerPrimitiveClassName.replace(({ value }) => code.value.array([value, 'className'])),
             code.function('Container').setProps(['children', 'className']),
             code.jsx.element('Slot').replace('slot'),
+            code.jsx.element('ErrorDialogPrimitive.Root').unwrap(),
             code.jsx.element('OverlayPrimitive').replace('div'),
             code.jsx.element('Popover.Root').unwrap({ forwardPropsTo: 'Popover.Popup' }),
             code.jsx.element('Popover.Trigger').unwrap(),

--- a/packages/skins/build/framework/tests/generate.test.ts
+++ b/packages/skins/build/framework/tests/generate.test.ts
@@ -25,6 +25,7 @@ describe('createFrameworkSkin', () => {
       'components/buttons/play-button.tsx',
       'components/controls/volume-popover.tsx',
       'components/feedback/buffering-indicator.tsx',
+      'components/feedback/error-dialog.tsx',
       'components/layout/container.tsx',
       'components/layout/overlay.tsx',
       'components/layout/poster.tsx',
@@ -67,6 +68,7 @@ describe('createFrameworkSkin', () => {
       'styles/buttons.css',
       'styles/container.css',
       'styles/controls.css',
+      'styles/dialog.css',
       'styles/overlays.css',
       'styles/popups.css',
       'styles/poster.css',
@@ -80,6 +82,7 @@ describe('createFrameworkSkin', () => {
     expect(style(output, 'styles/buttons.css')).not.toContain('.media-play-button {');
     expect(style(output, 'styles/buttons.css')).not.toContain(':where(');
     expect(style(output, 'styles/controls.css')).toContain('.media-controls {');
+    expect(style(output, 'styles/dialog.css')).toContain('.media-error-dialog {');
     expect(style(output, 'styles/controls.css')).toContain('background-color: var(--media-surface-background)');
     expect(style(output, 'styles/popups.css')).toContain('.media-surface {');
     expect(style(output, 'styles/container.css')).toContain('.media-container {');
@@ -107,11 +110,14 @@ describe('createFrameworkSkin', () => {
     expect(html).toContain("import '@videojs/html/media/container'");
     expect(html).toContain("import '@videojs/html/ui/poster'");
     expect(html).toContain("import '@videojs/html/ui/buffering-indicator'");
+    expect(html).toContain("import '@videojs/html/ui/error-dialog'");
     expect(html).toContain('export const skin = /* html */ `<media-container');
     expect(html).toContain('class="media-container media-skin media-skin-video media-theme-default"');
     expect(html).toContain('<slot></slot>');
     expect(html).toContain('<media-poster class="media-poster"><slot name="poster"></slot></media-poster>');
     expect(html).toContain('<media-buffering-indicator class="media-buffering-indicator">');
+    expect(html).toContain('<media-error-dialog class="media-surface media-error-dialog">');
+    expect(html).toContain('<media-alert-dialog-title class="media-error-dialog-title">');
     expect(html).toContain('<div class="media-overlay"></div>');
     expect(html).toContain('<media-play-button class="media-button media-play-button">');
     expect(html).not.toContain('media-seek-button');

--- a/packages/skins/canonical/README.md
+++ b/packages/skins/canonical/README.md
@@ -21,6 +21,7 @@ The current authored paths are:
 - `components/buttons/seek-button.tsx`
 - `components/controls/volume-popover.tsx`
 - `components/feedback/buffering-indicator.tsx`
+- `components/feedback/error-dialog.tsx`
 - `components/layout/container.tsx`
 - `components/layout/overlay.tsx`
 - `components/layout/poster.tsx`

--- a/packages/skins/canonical/catalog.ts
+++ b/packages/skins/canonical/catalog.ts
@@ -101,6 +101,13 @@ export const skinCatalog = {
       description: 'A delayed spinner displayed while media is waiting for data.',
     }),
     defineSkinComponent({
+      name: 'error-dialog',
+      type: 'component',
+      source: './components/feedback/error-dialog.tsx',
+      title: 'Error Dialog',
+      description: 'An alert dialog that presents and dismisses playback errors.',
+    }),
+    defineSkinComponent({
       name: 'fullscreen-button',
       type: 'component',
       source: './components/buttons/fullscreen-button.tsx',

--- a/packages/skins/canonical/components/feedback/error-dialog.tsx
+++ b/packages/skins/canonical/components/feedback/error-dialog.tsx
@@ -1,0 +1,16 @@
+import { ErrorDialog as ErrorDialogPrimitive } from '@videojs/core/components';
+import buttonStyles from '../../styles/components/button.tailwind';
+import styles from '../../styles/components/error-dialog.tailwind';
+import popupStyles from '../../styles/components/popup.tailwind';
+
+export function ErrorDialog() {
+  return (
+    <ErrorDialogPrimitive.Root>
+      <ErrorDialogPrimitive.Popup className={[popupStyles.surface, styles.errorDialog]}>
+        <ErrorDialogPrimitive.Title className={styles.errorDialogTitle} />
+        <ErrorDialogPrimitive.Description className={styles.errorDialogDescription} />
+        <ErrorDialogPrimitive.Close className={[buttonStyles.button, styles.errorDialogClose]} />
+      </ErrorDialogPrimitive.Popup>
+    </ErrorDialogPrimitive.Root>
+  );
+}

--- a/packages/skins/canonical/registry/config.ts
+++ b/packages/skins/canonical/registry/config.ts
@@ -25,6 +25,7 @@ export const skinRegistry = {
   items: [
     'buffering-indicator',
     'default-video',
+    'error-dialog',
     'fullscreen-button',
     'overlay',
     'play-button',

--- a/packages/skins/canonical/registry/default/components/error-dialog/error-dialog.tsx
+++ b/packages/skins/canonical/registry/default/components/error-dialog/error-dialog.tsx
@@ -1,0 +1,13 @@
+import { ErrorDialog as ErrorDialogPrimitive } from '@videojs/react';
+
+export function ErrorDialog() {
+  return (
+    <ErrorDialogPrimitive.Root>
+      <ErrorDialogPrimitive.Popup className="bg-media-surface text-media-controls shadow-media-surface backdrop-blur-media-surface absolute top-1/2 left-1/2 z-20 flex w-[calc(100%-1.5rem)] max-w-72 -translate-x-1/2 -translate-y-1/2 flex-col gap-3 rounded-[1.75rem] p-3 text-white outline-none not-data-open:hidden transition-[opacity,scale,transform] duration-350 delay-100 ease-out data-starting-style:scale-50 data-starting-style:opacity-0 data-ending-style:scale-50 data-ending-style:opacity-0 data-ending-style:delay-0 motion-reduce:duration-50 motion-reduce:delay-0">
+        <ErrorDialogPrimitive.Title className="px-2 pt-2 text-media font-semibold leading-tight" />
+        <ErrorDialogPrimitive.Description className="px-2 pb-1.5 opacity-70 wrap-anywhere" />
+        <ErrorDialogPrimitive.Close className="grid size-media-control shrink-0 place-items-center rounded-media-pill border-0 bg-transparent p-0 text-inherit cursor-pointer outline-2 outline-transparent -outline-offset-2 hover:bg-media-control-hover focus-visible:bg-media-control-hover aria-expanded:bg-media-control-hover focus-visible:outline-current focus-visible:outline-offset-2 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 h-9 w-full bg-white px-4 font-medium text-black" />
+      </ErrorDialogPrimitive.Popup>
+    </ErrorDialogPrimitive.Root>
+  );
+}

--- a/packages/skins/canonical/registry/default/skin.tsx
+++ b/packages/skins/canonical/registry/default/skin.tsx
@@ -3,6 +3,7 @@ import { FullscreenButton } from '@/components/videojs/fullscreen-button/fullscr
 import { PlayButton } from '@/components/videojs/play-button/play-button';
 import { VolumePopover } from '@/components/videojs/volume-popover/volume-popover';
 import { BufferingIndicator } from '@/components/videojs/buffering-indicator/buffering-indicator';
+import { ErrorDialog } from '@/components/videojs/error-dialog/error-dialog';
 import { Container } from '@/components/videojs/container/container';
 import { Overlay } from '@/components/videojs/overlay/overlay';
 import { Poster } from '@/components/videojs/poster/poster';
@@ -27,6 +28,7 @@ export function DefaultVideoSkin({ children, className, poster, ...containerProp
         />
       )}
       <BufferingIndicator />
+      <ErrorDialog />
 
       <Controls.Root className="absolute inset-x-media-controls-gap bottom-media-controls-gap z-10 flex items-center gap-media-controls-gap rounded-media-pill p-media-controls-padding font-media text-media leading-none text-media-controls bg-media-surface shadow-media-surface backdrop-blur-media-surface">
         <Tooltip.Provider>

--- a/packages/skins/canonical/registry/registry.json
+++ b/packages/skins/canonical/registry/registry.json
@@ -64,6 +64,7 @@
       "registryDependencies": [
         "@videojs/buffering-indicator",
         "@videojs/container",
+        "@videojs/error-dialog",
         "@videojs/fullscreen-button",
         "@videojs/overlay",
         "@videojs/play-button",
@@ -71,6 +72,36 @@
         "@videojs/time-slider",
         "@videojs/volume-popover"
       ],
+      "meta": { "framework": "react", "style": "tailwind", "skin": "default-video" }
+    },
+    {
+      "name": "error-dialog",
+      "type": "registry:component",
+      "title": "Error Dialog",
+      "description": "An alert dialog that presents and dismisses playback errors.",
+      "files": [
+        {
+          "path": "canonical/registry/default/components/error-dialog/error-dialog.tsx",
+          "target": "components/videojs/error-dialog/error-dialog.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "canonical/registry/default/styles/base.css",
+          "target": "components/videojs/styles/base.css",
+          "type": "registry:file"
+        },
+        {
+          "path": "canonical/registry/default/styles/tailwind.css",
+          "target": "components/videojs/styles/tailwind.css",
+          "type": "registry:file"
+        },
+        {
+          "path": "canonical/registry/default/styles/themes/default.css",
+          "target": "components/videojs/styles/themes/default.css",
+          "type": "registry:file"
+        }
+      ],
+      "dependencies": ["@videojs/react"],
       "meta": { "framework": "react", "style": "tailwind", "skin": "default-video" }
     },
     {

--- a/packages/skins/canonical/skins/default-video/skin.tsx
+++ b/packages/skins/canonical/skins/default-video/skin.tsx
@@ -4,6 +4,7 @@ import { FullscreenButton } from '../../components/buttons/fullscreen-button';
 import { PlayButton } from '../../components/buttons/play-button';
 import { VolumePopover } from '../../components/controls/volume-popover';
 import { BufferingIndicator } from '../../components/feedback/buffering-indicator';
+import { ErrorDialog } from '../../components/feedback/error-dialog';
 import { Container } from '../../components/layout/container';
 import { Overlay } from '../../components/layout/overlay';
 import { Poster } from '../../components/layout/poster';
@@ -16,6 +17,7 @@ export function DefaultVideoSkin() {
       <Slot />
       <Poster />
       <BufferingIndicator />
+      <ErrorDialog />
 
       <Controls.Root className={styles.controls}>
         <Tooltip.Provider>

--- a/packages/skins/canonical/styles/components/error-dialog.tailwind.ts
+++ b/packages/skins/canonical/styles/components/error-dialog.tailwind.ts
@@ -1,0 +1,17 @@
+import { defineStyles } from '../define';
+
+export default defineStyles({
+  role: 'dialog',
+  styles: {
+    errorDialog: [
+      'absolute top-1/2 left-1/2 z-20 flex w-[calc(100%-1.5rem)] max-w-72 -translate-x-1/2 -translate-y-1/2 flex-col gap-3 rounded-[1.75rem] p-3 text-white outline-none',
+      'not-data-open:hidden transition-[opacity,scale,transform] duration-350 delay-100 ease-out',
+      'data-starting-style:scale-50 data-starting-style:opacity-0',
+      'data-ending-style:scale-50 data-ending-style:opacity-0 data-ending-style:delay-0',
+      'motion-reduce:duration-50 motion-reduce:delay-0',
+    ],
+    errorDialogTitle: 'px-2 pt-2 text-media font-semibold leading-tight',
+    errorDialogDescription: 'px-2 pb-1.5 opacity-70 wrap-anywhere',
+    errorDialogClose: 'h-9 w-full bg-white px-4 font-medium text-black',
+  },
+});

--- a/packages/skins/canonical/styles/define.ts
+++ b/packages/skins/canonical/styles/define.ts
@@ -1,6 +1,15 @@
 export const skinStyleDefinition = Symbol.for('@videojs/skins/style-definition');
 
-export const skinStyleRoles = ['buttons', 'container', 'controls', 'overlays', 'popups', 'poster', 'sliders'] as const;
+export const skinStyleRoles = [
+  'buttons',
+  'container',
+  'controls',
+  'dialog',
+  'overlays',
+  'popups',
+  'poster',
+  'sliders',
+] as const;
 
 export type SkinStyleRole = (typeof skinStyleRoles)[number];
 export type SkinStyleValue = string | readonly string[];


### PR DESCRIPTION
## Summary

- add the ErrorDialog semantic compound to the Core canonical manifest
- author a wrapper-free canonical error composition with component-owned dialog styles
- generate HTML, React, and registry projections and compose it before Controls

## Verification

- `pnpm -F @videojs/core build`
- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/skins check:skins`
- `pnpm -F @videojs/compiler test`

Stacked on #2189.

Closes #2188

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and generated skin artifacts; behavior relies on existing error-dialog core from a stacked PR, with no auth or data-path changes.
> 
> **Overview**
> Adds a **playback error alert dialog** to the default video skin, wired through the same canonical → generated pipeline as other feedback UI.
> 
> **Core** registers the `ErrorDialog` compound (`Root`, `Popup`, `Title`, `Description`, `Close`) in the generated components manifest. **Canonical** adds `components/feedback/error-dialog.tsx` with a new `dialog` style role and Tailwind module; **default-video** composes `<ErrorDialog />` after the buffering indicator and before controls.
> 
> Generated **HTML** (`media-error-dialog` / alert-dialog parts), **React**, and **registry** outputs are updated, including `dialog.css` and skin compiler mappings. Catalog, registry config, and skin build tests expect the new dependency and style file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d674b5658ab0e4b4282d836bb4217c07c4e7aeb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->