### PR TITLE
feat(skin): add canonical captions button

### DIFF
--- a/packages/core/src/core/ui/captions-button/captions-button-component.ts
+++ b/packages/core/src/core/ui/captions-button/captions-button-component.ts
@@ -1,0 +1,9 @@
+import { defineComponent } from '@videojs/jsx';
+
+import type { CaptionsButtonProps } from './captions-button-core';
+import { CaptionsButtonDataAttrs } from './captions-button-data-attrs';
+
+export default defineComponent<CaptionsButtonProps>({
+  name: 'CaptionsButton',
+  dataAttrs: CaptionsButtonDataAttrs,
+});

--- a/packages/core/src/core/ui/components.generated.ts
+++ b/packages/core/src/core/ui/components.generated.ts
@@ -2,6 +2,7 @@
 import { createComponent } from '@videojs/jsx';
 
 import BufferingIndicatorDef from './buffering-indicator/buffering-indicator-component';
+import CaptionsButtonDef from './captions-button/captions-button-component';
 import ContainerDef from './container/container-component';
 import ControlsDef from './controls/controls-component';
 import ErrorDialogDef from './error-dialog/error-dialog-component';
@@ -19,6 +20,7 @@ import TooltipDef from './tooltip/tooltip-component';
 import VolumeSliderDef from './volume-slider/volume-slider-component';
 
 export const BufferingIndicator = createComponent(BufferingIndicatorDef);
+export const CaptionsButton = createComponent(CaptionsButtonDef);
 export const Container = createComponent(ContainerDef);
 export const Controls = createComponent(ControlsDef);
 export const ErrorDialog = createComponent(ErrorDialogDef);
@@ -37,6 +39,7 @@ export const VolumeSlider = createComponent(VolumeSliderDef);
 
 export const COMPONENTS = {
   BufferingIndicator: BufferingIndicatorDef,
+  CaptionsButton: CaptionsButtonDef,
   Container: ContainerDef,
   Controls: ControlsDef,
   ErrorDialog: ErrorDialogDef,

--- a/packages/html/src/__generated__/skins/default-video/skin.ts
+++ b/packages/html/src/__generated__/skins/default-video/skin.ts
@@ -1,6 +1,7 @@
 import '../../../icons/element';
 import '../../../define/media/container';
 import '../../../define/ui/buffering-indicator';
+import '../../../define/ui/captions-button';
 import '../../../define/ui/controls';
 import '../../../define/ui/error-dialog';
 import '../../../define/ui/fullscreen-button';
@@ -58,6 +59,14 @@ export const skin = /* html */ `<media-container class="media-container media-sk
         <media-time class="media-time" type="remaining" toggle></media-time>
       </media-controls-group>
       <media-controls-group class="media-controls-group-primary">
+        <media-captions-button class="media-button media-captions-button">
+          <media-icon class="media-button-icon media-captions-off-icon" name="captions-off"></media-icon>
+          <media-icon class="media-button-icon media-captions-on-icon" name="captions-on"></media-icon>
+        </media-captions-button>
+        <media-tooltip side="top" class="media-surface media-tooltip">
+          <media-tooltip-label></media-tooltip-label>
+          <media-tooltip-shortcut class="media-tooltip-shortcut"></media-tooltip-shortcut>
+        </media-tooltip>
         <media-mute-button class="media-button media-mute-button">
           <media-icon class="media-button-icon media-volume-off-icon" name="volume-off"></media-icon>
           <media-icon class="media-button-icon media-volume-low-icon" name="volume-low"></media-icon>

--- a/packages/html/src/__generated__/skins/default-video/styles/buttons.css
+++ b/packages/html/src/__generated__/skins/default-video/styles/buttons.css
@@ -44,6 +44,30 @@
       filter: drop-shadow(0 1px 0 var(--media-shadow-color));
     }
 
+    .media-captions-off-icon {
+      opacity: 0;
+      display: none;
+    }
+
+    @scope (.media-captions-button) {
+      &:not([data-active]) .media-captions-off-icon {
+        opacity: 1;
+        display: block;
+      }
+    }
+
+    .media-captions-on-icon {
+      opacity: 0;
+      display: none;
+    }
+
+    @scope (.media-captions-button) {
+      &[data-active] .media-captions-on-icon {
+        opacity: 1;
+        display: block;
+      }
+    }
+
     .media-fullscreen-enter-icon {
       opacity: 0;
       display: none;

--- a/packages/react/src/__generated__/skins/default-video/components/buttons/captions-button.tsx
+++ b/packages/react/src/__generated__/skins/default-video/components/buttons/captions-button.tsx
@@ -1,0 +1,14 @@
+import { CaptionsButton as CaptionsButtonPrimitive } from '@/ui/captions-button';
+import { CaptionsOffIcon, CaptionsOnIcon } from '@/icons';
+import { ButtonTooltip } from './button-tooltip';
+
+export function CaptionsButton() {
+  return (
+    <ButtonTooltip side="top">
+      <CaptionsButtonPrimitive className="media-button media-captions-button">
+        <CaptionsOffIcon className="media-button-icon media-captions-off-icon" />
+        <CaptionsOnIcon className="media-button-icon media-captions-on-icon" />
+      </CaptionsButtonPrimitive>
+    </ButtonTooltip>
+  );
+}

--- a/packages/react/src/__generated__/skins/default-video/skin.tsx
+++ b/packages/react/src/__generated__/skins/default-video/skin.tsx
@@ -1,6 +1,7 @@
 import { Controls } from '@/ui/controls';
 import { Time as TimePrimitive } from '@/ui/time';
 import { Tooltip } from '@/ui/tooltip';
+import { CaptionsButton } from './components/buttons/captions-button';
 import { FullscreenButton } from './components/buttons/fullscreen-button';
 import { PlayButton } from './components/buttons/play-button';
 import { VolumePopover } from './components/controls/volume-popover';
@@ -46,6 +47,7 @@ export function DefaultVideoSkin({ children, className, poster, ...containerProp
           </Controls.Group>
 
           <Controls.Group className="media-controls-group-primary">
+            <CaptionsButton />
             <VolumePopover />
             <FullscreenButton />
           </Controls.Group>

--- a/packages/react/src/__generated__/skins/default-video/styles/buttons.css
+++ b/packages/react/src/__generated__/skins/default-video/styles/buttons.css
@@ -44,6 +44,30 @@
       filter: drop-shadow(0 1px 0 var(--media-shadow-color));
     }
 
+    .media-captions-off-icon {
+      opacity: 0;
+      display: none;
+    }
+
+    @scope (.media-captions-button) {
+      &:not([data-active]) .media-captions-off-icon {
+        opacity: 1;
+        display: block;
+      }
+    }
+
+    .media-captions-on-icon {
+      opacity: 0;
+      display: none;
+    }
+
+    @scope (.media-captions-button) {
+      &[data-active] .media-captions-on-icon {
+        opacity: 1;
+        display: block;
+      }
+    }
+
     .media-fullscreen-enter-icon {
       opacity: 0;
       display: none;

--- a/packages/skins/build/catalog/tests/resolve.test.ts
+++ b/packages/skins/build/catalog/tests/resolve.test.ts
@@ -25,6 +25,7 @@ describe('resolveSkinCatalog', () => {
         name: 'button-tooltip',
         dependencies: [],
       },
+      { name: 'captions-button', dependencies: ['button-tooltip'] },
       { name: 'container', dependencies: [] },
       {
         name: 'default-video',
@@ -32,6 +33,7 @@ describe('resolveSkinCatalog', () => {
         theme: 'default',
         dependencies: [
           'buffering-indicator',
+          'captions-button',
           'container',
           'error-dialog',
           'fullscreen-button',
@@ -57,9 +59,10 @@ describe('resolveSkinCatalog', () => {
     const closure = resolveSkinClosure(resolved, 'default-video');
     expect(closure.items.map((item) => item.name)).toEqual([
       'buffering-indicator',
+      'button-tooltip',
+      'captions-button',
       'container',
       'error-dialog',
-      'button-tooltip',
       'fullscreen-button',
       'overlay',
       'play-button',
@@ -81,7 +84,7 @@ describe('resolveSkinCatalog', () => {
       './styles/components/slider.tailwind.ts',
       './styles/skins/default-video.tailwind.ts',
     ]);
-    expect(closure.sourceFiles).toHaveLength(13);
+    expect(closure.sourceFiles).toHaveLength(14);
     expect(closure.sourceFiles).toContain('./skins/default-video/skin.tsx');
   });
 

--- a/packages/skins/build/compiler/html.ts
+++ b/packages/skins/build/compiler/html.ts
@@ -18,6 +18,10 @@ const htmlComponents: Readonly<Record<string, HtmlComponentDescriptor>> = {
     modules: ['@videojs/html/ui/buffering-indicator'],
     elements: { BufferingIndicatorPrimitive: 'media-buffering-indicator' },
   },
+  CaptionsButton: {
+    modules: ['@videojs/html/ui/captions-button'],
+    elements: { CaptionsButtonPrimitive: 'media-captions-button' },
+  },
   Container: {
     modules: ['@videojs/html/media/container'],
     elements: { ContainerPrimitive: 'media-container' },
@@ -108,6 +112,8 @@ const componentTags = Object.fromEntries(
 );
 
 const iconNames = {
+  CaptionsOffIcon: 'captions-off',
+  CaptionsOnIcon: 'captions-on',
   FullscreenEnterIcon: 'fullscreen-enter',
   FullscreenExitIcon: 'fullscreen-exit',
   PauseIcon: 'pause',

--- a/packages/skins/build/framework/tests/generate.test.ts
+++ b/packages/skins/build/framework/tests/generate.test.ts
@@ -20,6 +20,7 @@ describe('createFrameworkSkin', () => {
 
     expect(files.map((file) => file.fileName)).toEqual([
       'components/buttons/button-tooltip.tsx',
+      'components/buttons/captions-button.tsx',
       'components/buttons/fullscreen-button.tsx',
       'components/buttons/mute-button.tsx',
       'components/buttons/play-button.tsx',
@@ -110,12 +111,14 @@ describe('createFrameworkSkin', () => {
     expect(html).toContain("import '@videojs/html/media/container'");
     expect(html).toContain("import '@videojs/html/ui/poster'");
     expect(html).toContain("import '@videojs/html/ui/buffering-indicator'");
+    expect(html).toContain("import '@videojs/html/ui/captions-button'");
     expect(html).toContain("import '@videojs/html/ui/error-dialog'");
     expect(html).toContain('export const skin = /* html */ `<media-container');
     expect(html).toContain('class="media-container media-skin media-skin-video media-theme-default"');
     expect(html).toContain('<slot></slot>');
     expect(html).toContain('<media-poster class="media-poster"><slot name="poster"></slot></media-poster>');
     expect(html).toContain('<media-buffering-indicator class="media-buffering-indicator">');
+    expect(html).toContain('<media-captions-button class="media-button media-captions-button">');
     expect(html).toContain('<media-error-dialog class="media-surface media-error-dialog">');
     expect(html).toContain('<media-alert-dialog-title class="media-error-dialog-title">');
     expect(html).toContain('<div class="media-overlay"></div>');

--- a/packages/skins/canonical/README.md
+++ b/packages/skins/canonical/README.md
@@ -15,6 +15,7 @@ The current authored paths are:
 
 - `skins/default-video/skin.tsx`
 - `components/buttons/button-tooltip.tsx`
+- `components/buttons/captions-button.tsx`
 - `components/buttons/fullscreen-button.tsx`
 - `components/buttons/mute-button.tsx`
 - `components/buttons/play-button.tsx`

--- a/packages/skins/canonical/catalog.ts
+++ b/packages/skins/canonical/catalog.ts
@@ -115,6 +115,13 @@ export const skinCatalog = {
       description: 'A button that enters and exits fullscreen with state-aware icons and an accessible tooltip.',
     }),
     defineSkinComponent({
+      name: 'captions-button',
+      type: 'component',
+      source: './components/buttons/captions-button.tsx',
+      title: 'Captions Button',
+      description: 'A state-aware button that toggles captions and subtitles.',
+    }),
+    defineSkinComponent({
       name: 'mute-button',
       type: 'component',
       source: './components/buttons/mute-button.tsx',

--- a/packages/skins/canonical/components/buttons/captions-button.tsx
+++ b/packages/skins/canonical/components/buttons/captions-button.tsx
@@ -1,0 +1,15 @@
+import { CaptionsButton as CaptionsButtonPrimitive } from '@videojs/core/components';
+import { CaptionsOffIcon, CaptionsOnIcon } from '@videojs/icons/components';
+import styles from '../../styles/components/button.tailwind';
+import { ButtonTooltip } from './button-tooltip';
+
+export function CaptionsButton() {
+  return (
+    <ButtonTooltip side="top">
+      <CaptionsButtonPrimitive className={[styles.button, styles.captionsButton]}>
+        <CaptionsOffIcon className={[styles.buttonIcon, styles.captionsOffIcon]} />
+        <CaptionsOnIcon className={[styles.buttonIcon, styles.captionsOnIcon]} />
+      </CaptionsButtonPrimitive>
+    </ButtonTooltip>
+  );
+}

--- a/packages/skins/canonical/registry/config.ts
+++ b/packages/skins/canonical/registry/config.ts
@@ -24,6 +24,7 @@ export const skinRegistry = {
   style: 'tailwind',
   items: [
     'buffering-indicator',
+    'captions-button',
     'default-video',
     'error-dialog',
     'fullscreen-button',

--- a/packages/skins/canonical/registry/default/components/captions-button/captions-button.tsx
+++ b/packages/skins/canonical/registry/default/components/captions-button/captions-button.tsx
@@ -1,0 +1,14 @@
+import { CaptionsButton as CaptionsButtonPrimitive } from '@videojs/react';
+import { CaptionsOffIcon, CaptionsOnIcon } from '@videojs/react/icons';
+import { ButtonTooltip } from '@/components/videojs/button-tooltip/button-tooltip';
+
+export function CaptionsButton() {
+  return (
+    <ButtonTooltip side="top">
+      <CaptionsButtonPrimitive className="grid size-media-control shrink-0 place-items-center rounded-media-pill border-0 bg-transparent p-0 text-inherit cursor-pointer outline-2 outline-transparent -outline-offset-2 hover:bg-media-control-hover focus-visible:bg-media-control-hover aria-expanded:bg-media-control-hover focus-visible:outline-current focus-visible:outline-offset-2 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 group/captions">
+        <CaptionsOffIcon className="size-media-icon drop-shadow-media-icon hidden opacity-0 group-not-data-active/captions:block group-not-data-active/captions:opacity-100" />
+        <CaptionsOnIcon className="size-media-icon drop-shadow-media-icon hidden opacity-0 group-data-active/captions:block group-data-active/captions:opacity-100" />
+      </CaptionsButtonPrimitive>
+    </ButtonTooltip>
+  );
+}

--- a/packages/skins/canonical/registry/default/skin.tsx
+++ b/packages/skins/canonical/registry/default/skin.tsx
@@ -1,4 +1,5 @@
 import { Controls, Time as TimePrimitive, Tooltip } from '@videojs/react';
+import { CaptionsButton } from '@/components/videojs/captions-button/captions-button';
 import { FullscreenButton } from '@/components/videojs/fullscreen-button/fullscreen-button';
 import { PlayButton } from '@/components/videojs/play-button/play-button';
 import { VolumePopover } from '@/components/videojs/volume-popover/volume-popover';
@@ -43,6 +44,7 @@ export function DefaultVideoSkin({ children, className, poster, ...containerProp
           </Controls.Group>
 
           <Controls.Group className="flex items-center gap-media-controls-gap">
+            <CaptionsButton />
             <VolumePopover />
             <FullscreenButton />
           </Controls.Group>

--- a/packages/skins/canonical/registry/registry.json
+++ b/packages/skins/canonical/registry/registry.json
@@ -34,6 +34,41 @@
       "meta": { "framework": "react", "style": "tailwind", "skin": "default-video" }
     },
     {
+      "name": "captions-button",
+      "type": "registry:component",
+      "title": "Captions Button",
+      "description": "A state-aware button that toggles captions and subtitles.",
+      "files": [
+        {
+          "path": "canonical/registry/default/components/button-tooltip/button-tooltip.tsx",
+          "target": "components/videojs/button-tooltip/button-tooltip.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "canonical/registry/default/components/captions-button/captions-button.tsx",
+          "target": "components/videojs/captions-button/captions-button.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "canonical/registry/default/styles/base.css",
+          "target": "components/videojs/styles/base.css",
+          "type": "registry:file"
+        },
+        {
+          "path": "canonical/registry/default/styles/tailwind.css",
+          "target": "components/videojs/styles/tailwind.css",
+          "type": "registry:file"
+        },
+        {
+          "path": "canonical/registry/default/styles/themes/default.css",
+          "target": "components/videojs/styles/themes/default.css",
+          "type": "registry:file"
+        }
+      ],
+      "dependencies": ["@videojs/react", "react"],
+      "meta": { "framework": "react", "style": "tailwind", "skin": "default-video" }
+    },
+    {
       "name": "default-video",
       "type": "registry:block",
       "title": "Default Video Skin",
@@ -63,6 +98,7 @@
       "dependencies": ["@videojs/react", "@videojs/utils", "react"],
       "registryDependencies": [
         "@videojs/buffering-indicator",
+        "@videojs/captions-button",
         "@videojs/container",
         "@videojs/error-dialog",
         "@videojs/fullscreen-button",

--- a/packages/skins/canonical/skins/default-video/skin.tsx
+++ b/packages/skins/canonical/skins/default-video/skin.tsx
@@ -1,5 +1,6 @@
 import { Controls, Time as TimePrimitive, Tooltip } from '@videojs/core/components';
 import { Slot } from '@videojs/jsx';
+import { CaptionsButton } from '../../components/buttons/captions-button';
 import { FullscreenButton } from '../../components/buttons/fullscreen-button';
 import { PlayButton } from '../../components/buttons/play-button';
 import { VolumePopover } from '../../components/controls/volume-popover';
@@ -32,6 +33,7 @@ export function DefaultVideoSkin() {
           </Controls.Group>
 
           <Controls.Group className={styles.controlsGroup.primary}>
+            <CaptionsButton />
             <VolumePopover />
             <FullscreenButton />
           </Controls.Group>

--- a/packages/skins/canonical/styles/components/button.tailwind.ts
+++ b/packages/skins/canonical/styles/components/button.tailwind.ts
@@ -13,10 +13,13 @@ export default defineStyles({
   styles: {
     button: buttonStyles,
     buttonIcon: 'size-media-icon drop-shadow-media-icon',
+    captionsButton: 'group/captions',
     fullscreenButton: 'group/fullscreen',
     muteButton: 'group/mute',
     playButton: 'group/play',
     seekButton: '',
+    captionsOffIcon: 'hidden opacity-0 group-not-data-active/captions:block group-not-data-active/captions:opacity-100',
+    captionsOnIcon: 'hidden opacity-0 group-data-active/captions:block group-data-active/captions:opacity-100',
     fullscreenEnterIcon: [
       'hidden opacity-0 group-not-data-fullscreen/fullscreen:block group-not-data-fullscreen/fullscreen:opacity-100',
     ],


### PR DESCRIPTION
## Summary

- add CaptionsButton to the Core canonical component manifest
- author the canonical toggle with off/on icons and shared tooltip composition
- generate HTML, React, and registry projections and add it to the end controls group

## Verification

- `pnpm -F @videojs/core build`
- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/skins check:skins`
- `pnpm -F @videojs/compiler test`

Stacked on #2190.

Closes #2106

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and skin/catalog wiring only; toggle behavior lives in existing core captions logic with no auth or data-path changes.
> 
> **Overview**
> Adds a **Captions** control to the default video skin so users can toggle subtitles from the primary controls group (before volume and fullscreen).
> 
> The change wires the existing core `CaptionsButton` primitive into the component manifest, then authors a canonical skin piece that pairs off/on icons with the shared `ButtonTooltip` and `data-active`-driven styling (same pattern as fullscreen/mute). HTML, React, and shadcn-style registry outputs are regenerated; the skin catalog, HTML compiler mappings, and tests are updated so `captions-button` resolves as a first-class installable component with `button-tooltip` as a dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61b7bd52b3119f3fda555fc0b6bc0cc14663366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->