### PR TITLE
feat(skin): complete canonical volume popover

### DIFF
--- a/packages/compiler/src/rewrite.ts
+++ b/packages/compiler/src/rewrite.ts
@@ -81,6 +81,7 @@ export interface CreateHelpers {
     number(value: number): ts.NumericLiteral;
     object(properties?: readonly ts.ObjectLiteralElementLike[]): ts.ObjectLiteralExpression;
     onlyIf(options: ValueOnlyIfOptions): ts.ConditionalExpression;
+    property(object: ValueReference, name: string): ts.PropertyAccessExpression;
     string(value: string): ts.StringLiteral;
     typeOf(value: ValueReference): ts.TypeOfExpression;
     undefined(): ts.Identifier;
@@ -142,6 +143,7 @@ export interface ValueHelpers {
   isArray(): MatchPredicate;
   number(value: number): ts.NumericLiteral;
   object(properties?: readonly ts.ObjectLiteralElementLike[]): ts.ObjectLiteralExpression;
+  property(object: ValueReference, name: string): ts.PropertyAccessExpression;
   string(value: string): ts.StringLiteral;
   typeOf(value: ValueReference): ts.TypeOfExpression;
   when(
@@ -224,9 +226,9 @@ export interface FunctionSelection {
   addProps(props: readonly FunctionPropSpec[], parameterIndex?: number): CompilerTransform;
   insertBefore(statements: FunctionSiblingStatementSpec): CompilerTransform;
   setProps(props: readonly FunctionPropSpec[], options?: FunctionPropsOptions): CompilerTransform;
-  append(statements: StatementSpec): CompilerTransform;
-  beforeReturn(statements: StatementSpec): CompilerTransform;
-  prepend(statements: StatementSpec): CompilerTransform;
+  append(statements: FunctionStatementSpec): CompilerTransform;
+  beforeReturn(statements: FunctionStatementSpec): CompilerTransform;
+  prepend(statements: FunctionStatementSpec): CompilerTransform;
 }
 
 export interface ModuleSelection {
@@ -250,6 +252,7 @@ export interface ConstStatementOptions {
 }
 
 export type StatementSpec = ts.Statement | readonly ts.Statement[];
+export type FunctionStatementSpec = StatementSpec | ((context: FunctionDeclarationContext) => StatementSpec);
 export type FunctionSiblingStatementSpec = StatementSpec | ((context: FunctionDeclarationContext) => StatementSpec);
 
 export interface TransformHelpers {
@@ -437,6 +440,7 @@ function createValueHelpers(match: MatchHelpers, create: CreateHelpers): ValueHe
     isArray: match.value.array,
     number: create.value.number,
     object: create.value.object,
+    property: create.value.property,
     string: create.value.string,
     typeOf: create.value.typeOf,
     when(value, condition, fallback) {
@@ -733,6 +737,9 @@ function createCreateHelpers(): CreateHelpers {
       },
       object(properties = []) {
         return ts.factory.createObjectLiteralExpression([...properties]);
+      },
+      property(object, name) {
+        return ts.factory.createPropertyAccessExpression(valueFromReference(object), name);
       },
       onlyIf(options) {
         const value = valueFromReference(options.value);
@@ -1157,12 +1164,14 @@ function removeVariableDeclarations(name: string | RegExp): CompilerTransform {
 function editFunctionBody(
   declaration: ts.FunctionDeclaration,
   position: 'prepend' | 'append' | 'beforeReturn',
-  statements: StatementSpec,
+  statements: FunctionStatementSpec,
   factory: ts.NodeFactory
 ): ts.FunctionDeclaration | undefined {
   if (!declaration.body) return undefined;
 
-  const nextStatements = normalizeStatements(statements);
+  const functionContext: FunctionDeclarationContext = { function: declaration, factory };
+  const resolved = typeof statements === 'function' ? statements(functionContext) : statements;
+  const nextStatements = normalizeStatements(resolved);
   if (nextStatements.length === 0) return undefined;
 
   let bodyStatements: ts.Statement[];

--- a/packages/compiler/src/tests/transform.test.ts
+++ b/packages/compiler/src/tests/transform.test.ts
@@ -342,7 +342,12 @@ export function Template({ backdrop }) {
               ),
               code
                 .function('Template')
-                .prepend(code.statement.const('backdropState', code.value.call(useBackdrop, ['backdrop']))),
+                .prepend(() =>
+                  code.statement.const(
+                    'backdropState',
+                    code.value.call(useBackdrop, [code.value.property('backdrop', 'state')])
+                  )
+                ),
               code
                 .function('Template')
                 .beforeReturn(code.statement.const('ready', code.value.call('Boolean', ['backdropState']))),
@@ -357,7 +362,7 @@ export function Template({ backdrop }) {
     expect(result.code.indexOf('import { Frame }')).toBeLessThan(result.code.indexOf('export const TOP_ACTIONS'));
     expect(result.code).toContain('import { useBackdrop } from "@fixture/react"');
     expect(compactCode).toContain(compact('export const TOP_ACTIONS = ["togglePaused"] as const;'));
-    expect(compactCode).toContain(compact('const backdropState = useBackdrop(backdrop);'));
+    expect(compactCode).toContain(compact('const backdropState = useBackdrop(backdrop.state);'));
     expect(compactCode).toContain(compact('const ready = Boolean(backdropState);return <Frame />;'));
   });
 });

--- a/packages/html/src/__generated__/skins/default-video/styles/popups.css
+++ b/packages/html/src/__generated__/skins/default-video/styles/popups.css
@@ -41,5 +41,9 @@
       margin: 0;
       padding-block: 0.75rem;
     }
+
+    .media-volume-popover:has(:is(media-volume-slider[data-hidden])) {
+      display: none;
+    }
   }
 }

--- a/packages/react/src/__generated__/skins/default-video/components/controls/volume-popover.tsx
+++ b/packages/react/src/__generated__/skins/default-video/components/controls/volume-popover.tsx
@@ -1,14 +1,24 @@
+import type { PopoverProps, VolumeSliderProps } from '@videojs/core';
 import { Popover } from '@/ui/popover';
 import { MuteButton } from '../buttons/mute-button';
 import { VolumeSlider } from '../sliders/volume-slider';
+import { usePlayer } from '@/player/context';
 
-export function VolumePopover() {
-  return (
-    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+export interface VolumePopoverProps {
+  side?: PopoverProps['side'];
+  orientation?: VolumeSliderProps['orientation'];
+}
+
+export function VolumePopover({ side = 'top', orientation = 'vertical' }: VolumePopoverProps = {}) {
+  const volumeAvailability = usePlayer((state) => state.volumeAvailability);
+  return volumeAvailability === 'available' ? (
+    <Popover.Root openOnHover delay={200} closeDelay={100} side={side}>
       <Popover.Trigger render={<MuteButton />} />
       <Popover.Popup className="media-surface media-volume-popover">
-        <VolumeSlider orientation="vertical" />
+        <VolumeSlider orientation={orientation} />
       </Popover.Popup>
     </Popover.Root>
+  ) : (
+    <MuteButton />
   );
 }

--- a/packages/react/src/__generated__/skins/default-video/styles/popups.css
+++ b/packages/react/src/__generated__/skins/default-video/styles/popups.css
@@ -41,5 +41,9 @@
       margin: 0;
       padding-block: 0.75rem;
     }
+
+    .media-volume-popover:has(:is(media-volume-slider[data-hidden])) {
+      display: none;
+    }
   }
 }

--- a/packages/skins/build/compiler/react.ts
+++ b/packages/skins/build/compiler/react.ts
@@ -20,6 +20,7 @@ export function createCompilerReactConfig(options: CreateCompilerReactConfigOpti
     options.resolveImport ? options.resolveImport(reference) : reference;
   const containerProps = requiredReactImport(resolveImport, 'ContainerProps');
   const posterProps = requiredReactImport(resolveImport, 'PosterProps');
+  const usePlayerRef = requiredReactImport(resolveImport, 'usePlayer');
   return defineConfig({
     target: jsx({
       imports: {
@@ -53,9 +54,11 @@ export function createCompilerReactConfig(options: CreateCompilerReactConfigOpti
           const ReactNode = code.import('react', 'ReactNode', { type: true });
           const ContainerProps = code.import(containerProps.source, containerProps.name, { type: true });
           const PosterProps = code.import(posterProps.source, posterProps.name, { type: true });
+          const usePlayer = code.import(usePlayerRef.source, usePlayerRef.name);
           const defaultVideoSkin = code.function('DefaultVideoSkin');
           const container = code.function('Container');
           const poster = code.function('Poster');
+          const volumePopover = code.function('VolumePopover');
           const posterIsString = () => code.value.equal(code.value.typeOf('poster'), code.value.string('string'));
 
           return [
@@ -138,6 +141,23 @@ export function createCompilerReactConfig(options: CreateCompilerReactConfigOpti
                 )
               ),
             poster.jsx.element('PosterPrimitive').selfClosing(),
+            volumePopover.prepend(() =>
+              code.statement.const(
+                'volumeAvailability',
+                code.value.call(usePlayer, [
+                  code.value.arrow(['state'], code.value.property('state', 'volumeAvailability')),
+                ])
+              )
+            ),
+            volumePopover.jsx
+              .element('Popover.Root')
+              .replace(({ element }) =>
+                code.value.conditional(
+                  code.value.equal('volumeAvailability', code.value.string('available')),
+                  element,
+                  code.jsx.create('MuteButton')
+                )
+              ),
             code.variable('OverlayPrimitive').remove(),
             code.jsx.element('OverlayPrimitive').replace('div'),
             code.variable('InputIndicatorOverlayPrimitive').remove(),

--- a/packages/skins/canonical/components/controls/volume-popover.tsx
+++ b/packages/skins/canonical/components/controls/volume-popover.tsx
@@ -1,16 +1,22 @@
+import type { PopoverProps, VolumeSliderProps } from '@videojs/core';
 import { Popover } from '@videojs/core/components';
 import styles from '../../styles/components/popup.tailwind';
 import { MuteButton } from '../buttons/mute-button';
 import { VolumeSlider } from '../sliders/volume-slider';
 
-export function VolumePopover() {
+export interface VolumePopoverProps {
+  side?: PopoverProps['side'];
+  orientation?: VolumeSliderProps['orientation'];
+}
+
+export function VolumePopover({ side = 'top', orientation = 'vertical' }: VolumePopoverProps = {}) {
   return (
-    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+    <Popover.Root openOnHover delay={200} closeDelay={100} side={side}>
       <Popover.Trigger>
         <MuteButton />
       </Popover.Trigger>
       <Popover.Popup className={[styles.surface, styles.volumePopover]}>
-        <VolumeSlider orientation="vertical" />
+        <VolumeSlider orientation={orientation} />
       </Popover.Popup>
     </Popover.Root>
   );

--- a/packages/skins/canonical/registry/default/components/volume-popover/volume-popover.tsx
+++ b/packages/skins/canonical/registry/default/components/volume-popover/volume-popover.tsx
@@ -1,14 +1,23 @@
-import { Popover } from '@videojs/react';
+import type { PopoverProps, VolumeSliderProps } from '@videojs/core';
+import { Popover, usePlayer } from '@videojs/react';
 import { MuteButton } from '@/components/videojs/mute-button/mute-button';
 import { VolumeSlider } from '@/components/videojs/volume-slider/volume-slider';
 
-export function VolumePopover() {
-  return (
-    <Popover.Root openOnHover delay={200} closeDelay={100} side="top">
+export interface VolumePopoverProps {
+  side?: PopoverProps['side'];
+  orientation?: VolumeSliderProps['orientation'];
+}
+
+export function VolumePopover({ side = 'top', orientation = 'vertical' }: VolumePopoverProps = {}) {
+  const volumeAvailability = usePlayer((state) => state.volumeAvailability);
+  return volumeAvailability === 'available' ? (
+    <Popover.Root openOnHover delay={200} closeDelay={100} side={side}>
       <Popover.Trigger render={<MuteButton />} />
-      <Popover.Popup className="bg-media-surface text-media-controls shadow-media-surface backdrop-blur-media-surface m-0 rounded-media-pill border-0 py-3">
-        <VolumeSlider orientation="vertical" />
+      <Popover.Popup className="bg-media-surface text-media-controls shadow-media-surface backdrop-blur-media-surface m-0 rounded-media-pill border-0 py-3 has-[media-volume-slider[data-hidden]]:hidden">
+        <VolumeSlider orientation={orientation} />
       </Popover.Popup>
     </Popover.Root>
+  ) : (
+    <MuteButton />
   );
 }

--- a/packages/skins/canonical/registry/registry.json
+++ b/packages/skins/canonical/registry/registry.json
@@ -603,7 +603,7 @@
           "type": "registry:file"
         }
       ],
-      "dependencies": ["@videojs/react"],
+      "dependencies": ["@videojs/core", "@videojs/react"],
       "registryDependencies": ["@videojs/volume-slider"],
       "meta": { "framework": "react", "style": "tailwind", "skin": "default-video" }
     },

--- a/packages/skins/canonical/styles/components/popup.tailwind.ts
+++ b/packages/skins/canonical/styles/components/popup.tailwind.ts
@@ -9,6 +9,6 @@ export default defineStyles({
       'data-open:flex data-open:items-center data-open:gap-1',
     ],
     tooltipShortcut: 'text-[0.75em] font-semibold',
-    volumePopover: 'm-0 rounded-media-pill border-0 py-3',
+    volumePopover: ['m-0 rounded-media-pill border-0 py-3', 'has-[media-volume-slider[data-hidden]]:hidden'],
   },
 });

--- a/packages/skins/scripts/generate-skins.ts
+++ b/packages/skins/scripts/generate-skins.ts
@@ -176,6 +176,7 @@ function reactPackageImportResolver(reference: ImportRef): ImportRef | false {
     if (reference.name === 'Poster' || reference.name === 'PosterProps') {
       return { ...reference, source: '@/ui/poster' };
     }
+    if (reference.name === 'usePlayer') return { ...reference, source: '@/player/context' };
     if (reference.name === 'RenderProp') return { ...reference, source: '@/utils/types' };
     return { ...reference, source: `@/ui/${reactComponentModule(reference.name)}` };
   }


### PR DESCRIPTION
## Summary

- parameterize canonical VolumePopover for side and slider orientation variants
- lower React availability to the packaged MuteButton fallback without leaking target imports
- hide the static HTML popup when VolumeSlider reports unavailable

## Verification

- `pnpm -F @videojs/compiler test`
- `pnpm -F @videojs/compiler build`
- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/skins check:skins`

Stacked on #2193.

Closes #1968

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generated player UI and compiler-driven React lowering for volume controls; behavior changes when volume is unavailable but scope is limited and covered by compiler/skin checks.
> 
> **Overview**
> **VolumePopover** gains optional `side` and `orientation` props across canonical, registry, and generated React skins. Registry and packaged React implementations read **`volumeAvailability`** from `usePlayer` and render the hover popover only when volume is **`available`**; otherwise they show **`MuteButton`** alone so target-specific imports stay inside the skin compiler pipeline.
> 
> Static/HTML styling now **hides the volume popover** when the embedded volume slider is marked unavailable (`media-volume-slider[data-hidden]`), via generated CSS and Tailwind `has-[...]:hidden` on registry popups.
> 
> The **`@videojs/compiler` rewrite API** adds **`code.value.property`** for property-access expressions and lets **`prepend` / `append` / `beforeReturn`** accept callbacks that receive the function declaration context (used by tests and the React skin plugin to inject `usePlayer` and conditional JSX for `VolumePopover`). Skin generation maps **`usePlayer`** imports to `@/player/context`, and the volume-popover registry item lists **`@videojs/core`** for shared prop types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4780abe21ef4668d7db5513b248d3b2b52cb0e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->