### PR TITLE
feat(skin): add canonical video input bindings

### DIFF
--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -19,6 +19,8 @@ export * from './ui/error-dialog/error-dialog-data-attrs';
 export * from './ui/error-dialog/error-dialog-i18n';
 export * from './ui/fullscreen-button/fullscreen-button-core';
 export * from './ui/fullscreen-button/fullscreen-button-data-attrs';
+export * from './ui/gesture/gesture-core';
+export * from './ui/hotkey/hotkey-core';
 export * from './ui/indicator/indicator-labels';
 export * from './ui/indicator/indicator-lifecycle';
 export * from './ui/input-action/input-action';

--- a/packages/core/src/core/ui/components.generated.ts
+++ b/packages/core/src/core/ui/components.generated.ts
@@ -11,6 +11,8 @@ import ContainerDef from './container/container-component';
 import ControlsDef from './controls/controls-component';
 import ErrorDialogDef from './error-dialog/error-dialog-component';
 import FullscreenButtonDef from './fullscreen-button/fullscreen-button-component';
+import GestureDef from './gesture/gesture-component';
+import HotkeyDef from './hotkey/hotkey-component';
 import MenuDef from './menu/menu-component';
 import MuteButtonDef from './mute-button/mute-button-component';
 import PiPButtonDef from './pip-button/pip-button-component';
@@ -41,6 +43,8 @@ export const Container = createComponent(ContainerDef);
 export const Controls = createComponent(ControlsDef);
 export const ErrorDialog = createComponent(ErrorDialogDef);
 export const FullscreenButton = createComponent(FullscreenButtonDef);
+export const Gesture = createComponent(GestureDef);
+export const Hotkey = createComponent(HotkeyDef);
 export const Menu = createComponent(MenuDef);
 export const MuteButton = createComponent(MuteButtonDef);
 export const PiPButton = createComponent(PiPButtonDef);
@@ -72,6 +76,8 @@ export const COMPONENTS = {
   Controls: ControlsDef,
   ErrorDialog: ErrorDialogDef,
   FullscreenButton: FullscreenButtonDef,
+  Gesture: GestureDef,
+  Hotkey: HotkeyDef,
   Menu: MenuDef,
   MuteButton: MuteButtonDef,
   PiPButton: PiPButtonDef,

--- a/packages/core/src/core/ui/gesture/gesture-component.ts
+++ b/packages/core/src/core/ui/gesture/gesture-component.ts
@@ -1,0 +1,4 @@
+import { defineComponent } from '@videojs/jsx';
+import type { GestureProps } from './gesture-core';
+
+export default defineComponent<GestureProps>({ name: 'Gesture' });

--- a/packages/core/src/core/ui/gesture/gesture-core.ts
+++ b/packages/core/src/core/ui/gesture/gesture-core.ts
@@ -1,0 +1,14 @@
+import type { InputAction } from '../input-action/input-action';
+
+export type GestureType = 'tap' | 'doubletap' | (string & {});
+export type GesturePointer = 'mouse' | 'touch' | 'pen';
+export type GestureRegion = 'left' | 'center' | 'right';
+
+export interface GestureProps {
+  type: GestureType;
+  action: InputAction;
+  value?: number | undefined;
+  pointer?: GesturePointer | undefined;
+  region?: GestureRegion | undefined;
+  disabled?: boolean | undefined;
+}

--- a/packages/core/src/core/ui/hotkey/hotkey-component.ts
+++ b/packages/core/src/core/ui/hotkey/hotkey-component.ts
@@ -1,0 +1,4 @@
+import { defineComponent } from '@videojs/jsx';
+import type { HotkeyProps } from './hotkey-core';
+
+export default defineComponent<HotkeyProps>({ name: 'Hotkey' });

--- a/packages/core/src/core/ui/hotkey/hotkey-core.ts
+++ b/packages/core/src/core/ui/hotkey/hotkey-core.ts
@@ -1,0 +1,9 @@
+import type { InputAction } from '../input-action/input-action';
+
+export interface HotkeyProps {
+  keys: string;
+  action: InputAction;
+  value?: number | undefined;
+  disabled?: boolean | undefined;
+  target?: 'player' | 'document' | undefined;
+}

--- a/packages/html/src/__generated__/skins/default-video/skin.ts
+++ b/packages/html/src/__generated__/skins/default-video/skin.ts
@@ -10,6 +10,8 @@ import '../../../define/ui/cast-button';
 import '../../../define/ui/controls';
 import '../../../define/ui/error-dialog';
 import '../../../define/ui/fullscreen-button';
+import '../../../define/ui/gesture';
+import '../../../define/ui/hotkey';
 import '../../../define/ui/menu';
 import '../../../define/ui/mute-button';
 import '../../../define/ui/pip-button';
@@ -263,6 +265,28 @@ export const skin = /* html */ `<media-container class="media-container media-sk
     </media-tooltip-group>
   </media-controls>
   <div class="media-overlay"></div>
+  <media-hotkey keys="Space" action="togglePaused"></media-hotkey>
+  <media-hotkey keys="k" action="togglePaused"></media-hotkey>
+  <media-hotkey keys="m" action="toggleMuted"></media-hotkey>
+  <media-hotkey keys="f" action="toggleFullscreen"></media-hotkey>
+  <media-hotkey keys="c" action="toggleSubtitles"></media-hotkey>
+  <media-hotkey keys="i" action="togglePictureInPicture"></media-hotkey>
+  <media-hotkey keys="ArrowRight" action="seekStep" value="5"></media-hotkey>
+  <media-hotkey keys="ArrowLeft" action="seekStep" value="-5"></media-hotkey>
+  <media-hotkey keys="l" action="seekStep" value="10"></media-hotkey>
+  <media-hotkey keys="j" action="seekStep" value="-10"></media-hotkey>
+  <media-hotkey keys="ArrowUp" action="volumeStep" value="0.05"></media-hotkey>
+  <media-hotkey keys="ArrowDown" action="volumeStep" value="-0.05"></media-hotkey>
+  <media-hotkey keys="0-9" action="seekToPercent"></media-hotkey>
+  <media-hotkey keys="Home" action="seekToPercent" value="0"></media-hotkey>
+  <media-hotkey keys="End" action="seekToPercent" value="100"></media-hotkey>
+  <media-hotkey keys="&gt;" action="speedUp"></media-hotkey>
+  <media-hotkey keys="&lt;" action="speedDown"></media-hotkey>
+  <media-gesture type="tap" action="togglePaused" pointer="mouse" region="center"></media-gesture>
+  <media-gesture type="tap" action="toggleControls" pointer="touch"></media-gesture>
+  <media-gesture type="doubletap" action="seekStep" value="-10" region="left"></media-gesture>
+  <media-gesture type="doubletap" action="toggleFullscreen" region="center"></media-gesture>
+  <media-gesture type="doubletap" action="seekStep" value="10" region="right"></media-gesture>
   <media-status-announcer class="media-status-announcer"></media-status-announcer>
   <div class="media-input-indicator-overlay">
     <media-volume-indicator class="media-volume-indicator">

--- a/packages/html/src/define/ui/gesture.ts
+++ b/packages/html/src/define/ui/gesture.ts
@@ -1,0 +1,10 @@
+import { GestureElement } from '../../ui/gesture/gesture-element';
+import { safeDefine } from '../safe-define';
+
+safeDefine(GestureElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [GestureElement.tagName]: GestureElement;
+  }
+}

--- a/packages/react/src/__generated__/skins/default-video/components/input/video-input-bindings.tsx
+++ b/packages/react/src/__generated__/skins/default-video/components/input/video-input-bindings.tsx
@@ -1,0 +1,32 @@
+import { Gesture } from '@/ui/gesture';
+import { Hotkey } from '@/ui/hotkey';
+
+export function VideoInputBindings() {
+  return (
+    <>
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
+      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
+      <Hotkey keys="l" action="seekStep" value={10} />
+      <Hotkey keys="j" action="seekStep" value={-10} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="0-9" action="seekToPercent" />
+      <Hotkey keys="Home" action="seekToPercent" value={0} />
+      <Hotkey keys="End" action="seekToPercent" value={100} />
+      <Hotkey keys=">" action="speedUp" />
+      <Hotkey keys="<" action="speedDown" />
+
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="seekStep" value={-10} region="left" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+      <Gesture type="doubletap" action="seekStep" value={10} region="right" />
+    </>
+  );
+}

--- a/packages/react/src/__generated__/skins/default-video/skin.tsx
+++ b/packages/react/src/__generated__/skins/default-video/skin.tsx
@@ -11,6 +11,7 @@ import { VolumePopover } from './components/controls/volume-popover';
 import { BufferingIndicator } from './components/feedback/buffering-indicator';
 import { ErrorDialog } from './components/feedback/error-dialog';
 import { VideoInputIndicators } from './components/feedback/video-input-indicators';
+import { VideoInputBindings } from './components/input/video-input-bindings';
 import { Container } from './components/layout/container';
 import { Overlay } from './components/layout/overlay';
 import { Poster } from './components/layout/poster';
@@ -64,6 +65,7 @@ export function DefaultVideoSkin({ children, className, poster, ...containerProp
       </Controls.Root>
 
       <Overlay />
+      <VideoInputBindings />
       <VideoInputIndicators />
     </Container>
   );

--- a/packages/skins/build/catalog/tests/resolve.test.ts
+++ b/packages/skins/build/catalog/tests/resolve.test.ts
@@ -49,6 +49,7 @@ describe('resolveSkinCatalog', () => {
           'status-announcer',
           'status-indicator',
           'time-slider',
+          'video-input-bindings',
           'video-settings-menu',
           'volume-indicator',
           'volume-popover',
@@ -66,6 +67,7 @@ describe('resolveSkinCatalog', () => {
       { name: 'status-announcer', dependencies: [] },
       { name: 'status-indicator', dependencies: [] },
       { name: 'time-slider', dependencies: [] },
+      { name: 'video-input-bindings', dependencies: [] },
       { name: 'video-settings-menu', dependencies: [] },
       { name: 'volume-indicator', dependencies: [] },
       { name: 'volume-popover', dependencies: ['mute-button', 'volume-slider'] },
@@ -90,6 +92,7 @@ describe('resolveSkinCatalog', () => {
       'status-announcer',
       'status-indicator',
       'time-slider',
+      'video-input-bindings',
       'video-settings-menu',
       'volume-indicator',
       'mute-button',
@@ -114,7 +117,7 @@ describe('resolveSkinCatalog', () => {
       './styles/components/volume-indicator.tailwind.ts',
       './styles/skins/default-video.tailwind.ts',
     ]);
-    expect(closure.sourceFiles).toHaveLength(29);
+    expect(closure.sourceFiles).toHaveLength(30);
     expect(closure.sourceFiles).toContain('./skins/default-video/skin.tsx');
   });
 

--- a/packages/skins/build/compiler/html.ts
+++ b/packages/skins/build/compiler/html.ts
@@ -52,6 +52,14 @@ const htmlComponents: Readonly<Record<string, HtmlComponentDescriptor>> = {
     modules: ['@videojs/html/ui/fullscreen-button'],
     elements: { FullscreenButtonPrimitive: 'media-fullscreen-button' },
   },
+  Gesture: {
+    modules: ['@videojs/html/ui/gesture'],
+    elements: { Gesture: 'media-gesture' },
+  },
+  Hotkey: {
+    modules: ['@videojs/html/ui/hotkey'],
+    elements: { Hotkey: 'media-hotkey' },
+  },
   MuteButton: {
     modules: ['@videojs/html/ui/mute-button'],
     elements: { MuteButtonPrimitive: 'media-mute-button' },

--- a/packages/skins/build/framework/tests/generate.test.ts
+++ b/packages/skins/build/framework/tests/generate.test.ts
@@ -20,6 +20,7 @@ describe('createFrameworkSkin', () => {
     const timeSlider = content(output, 'react', 'components/sliders/time-slider.tsx');
     const settingsMenu = content(output, 'react', 'components/menus/settings-menu.tsx');
     const qualityMenu = content(output, 'react', 'components/menus/quality-settings-menu.tsx');
+    const inputBindings = content(output, 'react', 'components/input/video-input-bindings.tsx');
 
     expect(files.map((file) => file.fileName)).toEqual([
       'components/buttons/airplay-button.tsx',
@@ -38,6 +39,7 @@ describe('createFrameworkSkin', () => {
       'components/feedback/status-indicator.tsx',
       'components/feedback/video-input-indicators.tsx',
       'components/feedback/volume-indicator.tsx',
+      'components/input/video-input-bindings.tsx',
       'components/layout/container.tsx',
       'components/layout/overlay.tsx',
       'components/layout/poster.tsx',
@@ -71,6 +73,8 @@ describe('createFrameworkSkin', () => {
     expect(qualityMenu).toContain('renderItem={(props, item) =>');
     expect(qualityMenu).toContain('{item.tier ? <sup');
     expect(qualityMenu).not.toContain('<Template');
+    expect(inputBindings.match(/<Hotkey /g)).toHaveLength(17);
+    expect(inputBindings.match(/<Gesture /g)).toHaveLength(5);
     expect(container).toContain('export function Container');
     expect(container).toContain('ContainerProps');
     expect(container).toContain('<ContainerPrimitive {...props}');
@@ -149,6 +153,8 @@ describe('createFrameworkSkin', () => {
     expect(html).toContain("import '@videojs/html/ui/status-indicator'");
     expect(html).toContain("import '@videojs/html/ui/time-slider-chapters'");
     expect(html).toContain("import '@videojs/html/ui/quality-radio-group'");
+    expect(html).toContain("import '@videojs/html/ui/hotkey'");
+    expect(html).toContain("import '@videojs/html/ui/gesture'");
     expect(html).toContain("import '@videojs/html/ui/volume-indicator'");
     expect(html).toContain('export const skin = /* html */ `<media-container');
     expect(html).toContain('class="media-container media-skin media-skin-video media-theme-default"');
@@ -173,6 +179,8 @@ describe('createFrameworkSkin', () => {
     expect(html).toContain('id="settings-quality-menu"');
     expect(html).toContain('<media-quality-radio-group class="media-group">');
     expect(html).toContain('<span data-part="label"></span>');
+    expect(html.match(/<media-hotkey /g)).toHaveLength(17);
+    expect(html.match(/<media-gesture /g)).toHaveLength(5);
     expect(html).toContain('<media-time-slider class="media-slider">');
     expect(html).toContain('<media-time-slider-chapters class="media-slider-chapters">');
     expect(html).toContain('<template>');

--- a/packages/skins/canonical/catalog.ts
+++ b/packages/skins/canonical/catalog.ts
@@ -230,5 +230,12 @@ export const skinCatalog = {
       title: 'Video Settings Menu',
       description: 'Nested video quality, audio track, playback rate, and captions settings menus.',
     }),
+    defineSkinComponent({
+      name: 'video-input-bindings',
+      type: 'component',
+      source: './components/input/video-input-bindings.tsx',
+      title: 'Video Input Bindings',
+      description: 'The standard keyboard and pointer bindings for on-demand video playback.',
+    }),
   ],
 } as const satisfies SkinCatalog;

--- a/packages/skins/canonical/components/input/video-input-bindings.tsx
+++ b/packages/skins/canonical/components/input/video-input-bindings.tsx
@@ -1,0 +1,31 @@
+import { Gesture, Hotkey } from '@videojs/core/components';
+
+export function VideoInputBindings() {
+  return (
+    <>
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
+      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
+      <Hotkey keys="l" action="seekStep" value={10} />
+      <Hotkey keys="j" action="seekStep" value={-10} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="0-9" action="seekToPercent" />
+      <Hotkey keys="Home" action="seekToPercent" value={0} />
+      <Hotkey keys="End" action="seekToPercent" value={100} />
+      <Hotkey keys=">" action="speedUp" />
+      <Hotkey keys="<" action="speedDown" />
+
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="seekStep" value={-10} region="left" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+      <Gesture type="doubletap" action="seekStep" value={10} region="right" />
+    </>
+  );
+}

--- a/packages/skins/canonical/registry/default/components/video-input-bindings/video-input-bindings.tsx
+++ b/packages/skins/canonical/registry/default/components/video-input-bindings/video-input-bindings.tsx
@@ -1,0 +1,31 @@
+import { Gesture, Hotkey } from '@videojs/react';
+
+export function VideoInputBindings() {
+  return (
+    <>
+      <Hotkey keys="Space" action="togglePaused" />
+      <Hotkey keys="k" action="togglePaused" />
+      <Hotkey keys="m" action="toggleMuted" />
+      <Hotkey keys="f" action="toggleFullscreen" />
+      <Hotkey keys="c" action="toggleSubtitles" />
+      <Hotkey keys="i" action="togglePictureInPicture" />
+      <Hotkey keys="ArrowRight" action="seekStep" value={5} />
+      <Hotkey keys="ArrowLeft" action="seekStep" value={-5} />
+      <Hotkey keys="l" action="seekStep" value={10} />
+      <Hotkey keys="j" action="seekStep" value={-10} />
+      <Hotkey keys="ArrowUp" action="volumeStep" value={0.05} />
+      <Hotkey keys="ArrowDown" action="volumeStep" value={-0.05} />
+      <Hotkey keys="0-9" action="seekToPercent" />
+      <Hotkey keys="Home" action="seekToPercent" value={0} />
+      <Hotkey keys="End" action="seekToPercent" value={100} />
+      <Hotkey keys=">" action="speedUp" />
+      <Hotkey keys="<" action="speedDown" />
+
+      <Gesture type="tap" action="togglePaused" pointer="mouse" region="center" />
+      <Gesture type="tap" action="toggleControls" pointer="touch" />
+      <Gesture type="doubletap" action="seekStep" value={-10} region="left" />
+      <Gesture type="doubletap" action="toggleFullscreen" region="center" />
+      <Gesture type="doubletap" action="seekStep" value={10} region="right" />
+    </>
+  );
+}

--- a/packages/skins/canonical/registry/default/skin.tsx
+++ b/packages/skins/canonical/registry/default/skin.tsx
@@ -9,6 +9,7 @@ import { VolumePopover } from '@/components/videojs/volume-popover/volume-popove
 import { BufferingIndicator } from '@/components/videojs/buffering-indicator/buffering-indicator';
 import { ErrorDialog } from '@/components/videojs/error-dialog/error-dialog';
 import { VideoInputIndicators } from './internal/components/feedback/video-input-indicators';
+import { VideoInputBindings } from '@/components/videojs/video-input-bindings/video-input-bindings';
 import { Container } from '@/components/videojs/container/container';
 import { Overlay } from '@/components/videojs/overlay/overlay';
 import { Poster } from '@/components/videojs/poster/poster';
@@ -61,6 +62,7 @@ export function DefaultVideoSkin({ children, className, poster, ...containerProp
       </Controls.Root>
 
       <Overlay />
+      <VideoInputBindings />
       <VideoInputIndicators />
     </Container>
   );

--- a/packages/skins/canonical/registry/registry.json
+++ b/packages/skins/canonical/registry/registry.json
@@ -145,6 +145,11 @@
       "description": "A video skin with play, current and remaining time, volume, fullscreen, tooltips, and thumbnail previews.",
       "files": [
         {
+          "path": "canonical/registry/default/components/video-input-bindings/video-input-bindings.tsx",
+          "target": "components/videojs/video-input-bindings/video-input-bindings.tsx",
+          "type": "registry:component"
+        },
+        {
           "path": "canonical/registry/default/components/video-settings-menu/audio-track-settings-menu.tsx",
           "target": "components/videojs/video-settings-menu/audio-track-settings-menu.tsx",
           "type": "registry:component"

--- a/packages/skins/canonical/skins/default-video/skin.tsx
+++ b/packages/skins/canonical/skins/default-video/skin.tsx
@@ -10,6 +10,7 @@ import { VolumePopover } from '../../components/controls/volume-popover';
 import { BufferingIndicator } from '../../components/feedback/buffering-indicator';
 import { ErrorDialog } from '../../components/feedback/error-dialog';
 import { VideoInputIndicators } from '../../components/feedback/video-input-indicators';
+import { VideoInputBindings } from '../../components/input/video-input-bindings';
 import { Container } from '../../components/layout/container';
 import { Overlay } from '../../components/layout/overlay';
 import { Poster } from '../../components/layout/poster';
@@ -50,6 +51,7 @@ export function DefaultVideoSkin() {
       </Controls.Root>
 
       <Overlay />
+      <VideoInputBindings />
       <VideoInputIndicators />
     </Container>
   );


### PR DESCRIPTION
## Summary
- add a reusable canonical composition for the standard video hotkeys and gestures
- define framework-neutral binding props in Core and project the exact mapping to React and HTML
- add the missing standalone HTML gesture registration without generating visual styles

## Verification
- pnpm -F @videojs/core build
- pnpm -F @videojs/html build
- pnpm -F @videojs/skins test
- pnpm -F @videojs/skins check:skins
- pnpm typecheck

Closes #2110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a large set of default keyboard and gesture handlers on every default-video skin consumer; behavior relies on existing input-action plumbing but is user-facing across generated and registry skins.
> 
> **Overview**
> Introduces **`Hotkey`** and **`Gesture`** as framework-neutral core components (typed props wired to `InputAction`) and exports them through the component registry for JSX/HTML/React projection.
> 
> Adds a reusable **`VideoInputBindings`** skin component that declares the standard default-video keyboard shortcuts (play/pause, seek, volume, fullscreen, captions, PiP, speed) and pointer gestures (center click to pause, touch tap for controls, double-tap seek/fullscreen by region). That composition is mounted on the **default-video** skin in canonical, registry, and generated React/HTML outputs, with the HTML skin compiler mapping to `<media-hotkey>` / `<media-gesture>` and standalone **`gesture`** custom-element registration.
> 
> Skin catalog, registry block files, and generator tests are updated so **`video-input-bindings`** is part of the default-video closure and emitted consistently across targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49c275a381e9b8727784b08acdcbeec22d75bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->