### PR TITLE
refactor(packages)!: normalize time slider chapters

### DIFF
--- a/packages/core/src/core/ui/time-slider/time-slider-chapters/core.ts
+++ b/packages/core/src/core/ui/time-slider/time-slider-chapters/core.ts
@@ -72,7 +72,6 @@ export class TimeSliderChaptersCore {
     chapters: TimeSliderChapterRange[];
     ranges: SliderSegmentRange[];
     max: number;
-    hasChapters: boolean;
   } {
     if (
       this.#result &&
@@ -83,17 +82,14 @@ export class TimeSliderChaptersCore {
       return this.#result;
     }
 
-    const chapters = normalizeChapterCues(cues, min, max);
-    const hasChapters = chapters.some((chapter) => chapter.cue !== null);
     const rangeMax = max > min ? max : min + 1;
-    const ranges = hasChapters
-      ? chapters.map(({ key, start, end, cue }) => ({ key, start, end, highlight: cue !== null }))
-      : [{ key: 'fallback', start: min, end: rangeMax, highlight: false }];
+    const chapters = normalizeChapterCues(cues, min, rangeMax);
+    const ranges = chapters.map(({ key, start, end, cue }) => ({ key, start, end, highlight: cue !== null }));
 
     this.#cues = cues;
     this.#min = min;
     this.#max = max;
-    this.#result = { chapters, ranges, max: rangeMax, hasChapters };
+    this.#result = { chapters, ranges, max: rangeMax };
     return this.#result;
   }
 

--- a/packages/core/src/core/ui/time-slider/time-slider-chapters/core.ts
+++ b/packages/core/src/core/ui/time-slider/time-slider-chapters/core.ts
@@ -82,8 +82,9 @@ export class TimeSliderChaptersCore {
       return this.#result;
     }
 
-    const rangeMax = max > min ? max : min + 1;
-    const chapters = normalizeChapterCues(cues, min, rangeMax);
+    const hasRange = max > min;
+    const rangeMax = hasRange ? max : min + 1;
+    const chapters = normalizeChapterCues(hasRange ? cues : [], min, rangeMax);
     const ranges = chapters.map(({ key, start, end, cue }) => ({ key, start, end, highlight: cue !== null }));
 
     this.#cues = cues;

--- a/packages/core/src/core/ui/time-slider/time-slider-chapters/tests/core.test.ts
+++ b/packages/core/src/core/ui/time-slider/time-slider-chapters/tests/core.test.ts
@@ -56,6 +56,14 @@ describe('TimeSliderChaptersCore', () => {
     });
   });
 
+  it('ignores chapter cues until the slider domain is available', () => {
+    expect(new TimeSliderChaptersCore().getRanges([cue(0, 40, 'First')], 0, 0)).toMatchObject({
+      chapters: [{ key: 'gap-start-end', start: 0, end: 1, cue: null }],
+      ranges: [{ key: 'gap-start-end', start: 0, end: 1, highlight: false }],
+      max: 1,
+    });
+  });
+
   it('uses the real duration for ranges under one second', () => {
     const result = new TimeSliderChaptersCore().getRanges([cue(0, 0.5, 'Short')], 0, 0.5);
 

--- a/packages/core/src/core/ui/time-slider/time-slider-chapters/tests/core.test.ts
+++ b/packages/core/src/core/ui/time-slider/time-slider-chapters/tests/core.test.ts
@@ -41,19 +41,18 @@ describe('TimeSliderChaptersCore', () => {
     const chapter = cue(0, 40, 'First');
     const result = new TimeSliderChaptersCore().getRanges([chapter], 0, 100);
 
-    expect(result).toMatchObject({ max: 100, hasChapters: true });
+    expect(result).toMatchObject({ max: 100 });
     expect(result.ranges).toMatchObject([
       { start: 0, end: 40, highlight: true },
       { start: 40, end: 100, highlight: false },
     ]);
   });
 
-  it('creates a full fallback range when chapters are unavailable', () => {
+  it('normalizes unavailable chapters to one full-domain range', () => {
     expect(new TimeSliderChaptersCore().getRanges([], 0, 0)).toMatchObject({
-      chapters: [],
-      ranges: [{ key: 'fallback', start: 0, end: 1, highlight: false }],
+      chapters: [{ key: 'gap-start-end', start: 0, end: 1, cue: null }],
+      ranges: [{ key: 'gap-start-end', start: 0, end: 1, highlight: false }],
       max: 1,
-      hasChapters: false,
     });
   });
 

--- a/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
+++ b/packages/html/src/ui/time-slider/tests/time-slider-element.test.ts
@@ -200,25 +200,25 @@ describe('TimeSlider chapter elements', () => {
     expect(chapters.querySelector('svg')).toBeNull();
   });
 
-  it('keeps fallback content when the template is missing', async () => {
+  it('removes non-template content when the template is missing', async () => {
     const slider = createElement(TestSliderProviderElement);
     const chapters = createElement(TimeSliderChaptersElement);
-    const fallback = document.createElement('div');
-    fallback.className = 'fallback';
-    chapters.appendChild(fallback);
+    const content = document.createElement('div');
+    content.className = 'content';
+    chapters.appendChild(content);
     slider.appendChild(chapters);
     document.body.appendChild(slider);
     await chapters.updateComplete;
 
-    expect(chapters.querySelector('.fallback')).toBe(fallback);
+    expect(chapters.querySelector('.content')).toBeNull();
   });
 
   it('discovers a template on a later update', async () => {
     const slider = createElement(TestSliderProviderElement);
     const chapters = createElement(TimeSliderChaptersElement);
-    const fallback = document.createElement('div');
-    fallback.className = 'fallback';
-    chapters.appendChild(fallback);
+    const content = document.createElement('div');
+    content.className = 'content';
+    chapters.appendChild(content);
     slider.appendChild(chapters);
     document.body.appendChild(slider);
     await chapters.updateComplete;
@@ -230,7 +230,7 @@ describe('TimeSlider chapter elements', () => {
     await chapters.updateComplete;
 
     expect(chapters.querySelector('template')).toBe(template);
-    expect(chapters.querySelector('.fallback')).toBeNull();
+    expect(chapters.querySelector('.content')).toBeNull();
     expect(chapters.querySelectorAll('.chapter')).toHaveLength(1);
   });
 
@@ -239,20 +239,20 @@ describe('TimeSlider chapter elements', () => {
     ['multiple-root', '<div></div><div></div>'],
     ['non-HTML', '<svg></svg>'],
   ] as const) {
-    it(`keeps fallback content when the template is ${name}`, async () => {
+    it(`removes non-template content when the template is ${name}`, async () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const slider = createElement(TestSliderProviderElement);
       const chapters = createElement(TimeSliderChaptersElement);
-      const fallback = document.createElement('div');
-      fallback.className = 'fallback';
+      const unexpectedContent = document.createElement('div');
+      unexpectedContent.className = 'content';
       const template = document.createElement('template');
       template.innerHTML = content;
-      chapters.append(fallback, template);
+      chapters.append(unexpectedContent, template);
       slider.appendChild(chapters);
       document.body.appendChild(slider);
       await chapters.updateComplete;
 
-      expect(chapters.querySelector('.fallback')).toBe(fallback);
+      expect(chapters.querySelector('.content')).toBeNull();
       expect(warn).toHaveBeenCalledOnce();
       warn.mockRestore();
     });

--- a/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-chapters/time-slider-chapters-element.ts
@@ -17,8 +17,8 @@ import { sliderContext } from '../../slider/context';
 /**
  * Clones a light-DOM template once per normalized chapter range.
  *
- * The template must contain exactly one HTML root element. Non-template children remain visible when the template is
- * missing or invalid, allowing consumers to provide a regular slider track as a fallback.
+ * The required template must contain exactly one HTML root element. When no chapter cues are available, the template
+ * is cloned once for a full-duration range.
  */
 export class TimeSliderChaptersElement extends MediaElement {
   static readonly tagName = 'media-time-slider-chapters';
@@ -101,10 +101,16 @@ export class TimeSliderChaptersElement extends MediaElement {
     if (this.#templateChecked) return this.#templateRoot;
 
     const template = getTemplateElement(this);
-    if (!template) return null;
+    if (!template) {
+      for (const node of [...this.childNodes]) node.remove();
+      return null;
+    }
 
     this.#templateChecked = true;
     const root = getTemplateRoot(template);
+    for (const node of [...this.childNodes]) {
+      if (node !== template) node.remove();
+    }
     if (root?.namespaceURI !== 'http://www.w3.org/1999/xhtml') {
       if (__DEV__) {
         console.warn(`[${this.localName}] template must contain exactly one HTML root element.`);
@@ -113,10 +119,6 @@ export class TimeSliderChaptersElement extends MediaElement {
     }
 
     this.#templateRoot = root as HTMLElement;
-    for (const node of [...this.childNodes]) {
-      if (node !== template) node.remove();
-    }
-
     return this.#templateRoot;
   }
 

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -451,12 +451,7 @@ export function MinimalVideoSkinTailwind(props: MinimalVideoSkinProps): ReactNod
                     </TimeSlider.Track>
                   </div>
                 )}
-              >
-                <TimeSlider.Track render={<div className={slider.track} />}>
-                  <TimeSlider.Buffer render={<div className={cn(slider.fill.base, slider.fill.buffer)} />} />
-                  <TimeSlider.Fill render={<div className={cn(slider.fill.base, slider.fill.fill)} />} />
-                </TimeSlider.Track>
-              </TimeSlider.Chapters>
+              />
               <TimeSlider.Thumb render={<SliderThumb />} />
               <TimeSlider.Preview className={slider.preview}>
                 <div className={cn(thumbnail.root, slider.thumbnail)}>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -387,12 +387,7 @@ export function MinimalVideoSkin(props: MinimalVideoSkinProps): ReactNode {
                     </TimeSlider.Track>
                   </div>
                 )}
-              >
-                <TimeSlider.Track className="media-slider__track">
-                  <TimeSlider.Buffer className="media-slider__buffer" />
-                  <TimeSlider.Fill className="media-slider__fill" />
-                </TimeSlider.Track>
-              </TimeSlider.Chapters>
+              />
               <TimeSlider.Thumb className="media-slider__thumb" />
 
               <TimeSlider.Preview className="media-slider__preview">

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -449,12 +449,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
                       </TimeSlider.Track>
                     </div>
                   )}
-                >
-                  <TimeSlider.Track render={<div className={slider.track} />}>
-                    <TimeSlider.Buffer render={<div className={cn(slider.fill.base, slider.fill.buffer)} />} />
-                    <TimeSlider.Fill render={<div className={cn(slider.fill.base, slider.fill.fill)} />} />
-                  </TimeSlider.Track>
-                </TimeSlider.Chapters>
+                />
                 <TimeSlider.Thumb render={<SliderThumb />} />
                 <TimeSlider.Preview overflow="visible" className={slider.preview}>
                   <div className={cn(thumbnail.root, slider.thumbnail)}>

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -458,12 +458,7 @@ export function VideoSkin(props: VideoSkinProps): ReactNode {
                       </TimeSlider.Track>
                     </div>
                   )}
-                >
-                  <TimeSlider.Track className="media-slider__track">
-                    <TimeSlider.Buffer className="media-slider__buffer" />
-                    <TimeSlider.Fill className="media-slider__fill" />
-                  </TimeSlider.Track>
-                </TimeSlider.Chapters>
+                />
                 <TimeSlider.Thumb className="media-slider__thumb" />
 
                 <TimeSlider.Preview overflow="visible" className="media-slider__preview">

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -196,7 +196,7 @@ describe('TimeSliderRoot', () => {
 
 describe('TimeSlider compound', () => {
   it('provides collection state to chapter collection callbacks', () => {
-    const className = vi.fn((state: TimeSliderChaptersState) => (state.hasChapters ? 'chapters' : 'fallback'));
+    const className = vi.fn((_state: TimeSliderChaptersState) => 'chapters');
     const renderRoot = vi.fn((props: HTMLAttributes<HTMLElement>, state: TimeSliderChaptersState) => (
       <section {...props} data-count={state.chapters.length} />
     ));
@@ -213,12 +213,12 @@ describe('TimeSlider compound', () => {
       </Wrapper>
     );
 
-    expect(className).toHaveBeenCalledWith(expect.objectContaining({ hasChapters: true }));
+    expect(className).toHaveBeenCalledWith(expect.objectContaining({ chapters: expect.any(Array) }));
     expect(className.mock.calls[0]?.[0].chapters).toHaveLength(3);
     expect(className.mock.calls[0]?.[0]).not.toHaveProperty('active');
     expect(renderRoot).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ hasChapters: true, chapters: expect.any(Array) })
+      expect.objectContaining({ chapters: expect.any(Array) })
     );
     expect(container.querySelector('section.chapters')?.getAttribute('data-count')).toBe('3');
   });
@@ -238,9 +238,7 @@ describe('TimeSlider compound', () => {
                 </SliderTrack>
               </div>
             )}
-          >
-            <SliderTrack className="fallback" />
-          </TimeSliderChapters>
+          />
           <TimeSliderChapterTitle className="chapter-title" />
         </TimeSliderRoot>
       </Wrapper>
@@ -259,7 +257,6 @@ describe('TimeSlider compound', () => {
     expect(chapters[0]?.querySelector('.chapter-track')).toBeTruthy();
     expect(chapters[0]?.querySelector('.chapter-buffer')).toBeTruthy();
     expect(chapters[0]?.querySelector('.chapter-fill')).toBeTruthy();
-    expect(container.querySelector('.fallback')).toBeNull();
     expect((chapters[0] as HTMLElement).style.getPropertyValue('--media-slider-chapter-start')).toBe('0%');
     expect((chapters[0] as HTMLElement).style.getPropertyValue('--media-slider-chapter-end')).toBe(
       `${(40 / 120) * 100}%`
@@ -273,7 +270,7 @@ describe('TimeSlider compound', () => {
     expect(container.querySelector('.chapter-title')?.textContent).toBe('First');
   });
 
-  it('renders the regular track until chapters are available', () => {
+  it('renders one full-range chapter when chapter cues are unavailable', () => {
     const cues = mockTextTrackState.chaptersCues;
     mockTextTrackState.chaptersCues = [];
 
@@ -282,19 +279,21 @@ describe('TimeSlider compound', () => {
       const { container } = render(
         <Wrapper>
           <TimeSliderRoot>
-            <TimeSliderChapters className="chapters" renderChapter={(props) => <div {...props} className="chapter" />}>
-              <SliderTrack className="fallback">
-                <SliderBuffer />
-                <SliderFill />
-              </SliderTrack>
-            </TimeSliderChapters>
+            <TimeSliderChapters
+              className="chapters"
+              renderChapter={(props, state) => <div {...props} className="chapter" data-has-cue={state.cue !== null} />}
+            />
           </TimeSliderRoot>
         </Wrapper>
       );
 
       expect(container.querySelector('.chapters')).toBeTruthy();
-      expect(container.querySelector('.fallback')).toBeTruthy();
-      expect(container.querySelector('.chapter')).toBeNull();
+      const chapter = container.querySelector('.chapter') as HTMLElement;
+      expect(chapter).toBeTruthy();
+      expect(chapter.dataset.hasCue).toBe('false');
+      expect(chapter.style.getPropertyValue('--media-slider-chapter-start')).toBe('0%');
+      expect(chapter.style.getPropertyValue('--media-slider-chapter-end')).toBe('100%');
+      expect(chapter.style.getPropertyValue('--media-slider-chapter-width')).toBe('100%');
     } finally {
       mockTextTrackState.chaptersCues = cues;
     }

--- a/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
@@ -7,7 +7,7 @@ import {
   TimeSliderChapterCSSVars,
 } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import { Fragment, forwardRef, useMemo, useState } from 'react';
 
 import type { HTMLProps, UIComponentProps } from '../../../utils/types';
@@ -20,14 +20,13 @@ interface SliderSegmentsProps extends Omit<UIComponentProps<'div', SliderSegment
   ranges: readonly SliderSegmentRange[];
   min: number;
   max: number;
-  children?: ReactNode;
   renderSegment: (props: SegmentProps, state: SliderSegmentState) => ReactElement;
 }
 
 /** Private React adapter for rendering normalized numeric slider segments. */
 export const SliderSegments = forwardRef<HTMLDivElement, SliderSegmentsProps>(
   function SliderSegments(componentProps, ref) {
-    const { ranges, min, max, children, renderSegment, render, className, style, ...elementProps } = componentProps;
+    const { ranges, min, max, renderSegment, render, className, style, ...elementProps } = componentProps;
     const slider = useSliderContext();
     const [core] = useState(() => new SliderSegmentsCore());
     const geometry = useMemo(
@@ -67,7 +66,7 @@ export const SliderSegments = forwardRef<HTMLDivElement, SliderSegmentsProps>(
       {
         state,
         ref,
-        props: [{ 'aria-hidden': 'true' }, sliderAttrs, elementProps, { children: children ?? segments }],
+        props: [{ 'aria-hidden': 'true' }, sliderAttrs, elementProps, { children: segments }],
       }
     );
   }

--- a/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapters.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapters.tsx
@@ -9,7 +9,7 @@ import {
 } from '@videojs/core';
 import { getStateDataAttrs, selectBuffer, selectTextTrack, selectTime } from '@videojs/core/dom';
 import { isFunction } from '@videojs/utils/predicate';
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import { forwardRef, useMemo, useState } from 'react';
 
 import { usePlayer } from '../../../player/context';
@@ -19,35 +19,31 @@ import { SliderSegments } from './slider-segments';
 export type TimeSliderChapterState = TimeSliderChaptersCore.State;
 
 export interface TimeSliderChaptersState {
-  /** Normalized ranges spanning the slider domain. */
+  /** Normalized ranges spanning the full slider domain. */
   chapters: readonly TimeSliderChapterRange[];
-  /** Whether at least one authored chapter is available. */
-  hasChapters: boolean;
 }
 
 export interface TimeSliderChaptersProps extends Omit<UIComponentProps<'div', TimeSliderChaptersState>, 'children'> {
-  /** Slider track rendered until authored chapters are available. */
-  children?: ReactNode;
-  /** Render one consumer-owned subtree for every normalized chapter. */
+  /** Render one consumer-owned subtree for every normalized chapter range. */
   renderChapter: (props: Omit<HTMLProps<HTMLElement>, 'ref'>, state: TimeSliderChapterState) => ReactElement;
 }
 
-/** Renders normalized chapter ranges as consumer-owned light DOM. */
+/** Renders normalized chapter ranges across the full slider, including one full range when chapter cues are absent. */
 export const TimeSliderChapters = forwardRef<HTMLDivElement, TimeSliderChaptersProps>(
   function TimeSliderChapters(componentProps, ref) {
-    const { children, renderChapter, className, style, render, ...props } = componentProps;
+    const { renderChapter, className, style, render, ...props } = componentProps;
     const textTrack = usePlayer(selectTextTrack);
     const buffer = usePlayer(selectBuffer);
     const time = usePlayer(selectTime);
     const duration = time?.duration ?? 0;
     const [core] = useState(() => new TimeSliderChaptersCore());
-    const { chapters, ranges, max, hasChapters } = useMemo(
+    const { chapters, ranges, max } = useMemo(
       () => core.getRanges(textTrack?.chaptersCues ?? [], 0, duration),
       [core, textTrack?.chaptersCues, duration]
     );
     const bufferedEnd = buffer?.buffered.length ? buffer.buffered[buffer.buffered.length - 1]![1] : 0;
     const getChapterState = (segment: SliderSegmentState) => core.getState(segment, chapters, bufferedEnd);
-    const state = useMemo(() => ({ chapters, hasChapters }), [chapters, hasChapters]);
+    const state = useMemo(() => ({ chapters }), [chapters]);
 
     return (
       <SliderSegments
@@ -73,9 +69,7 @@ export const TimeSliderChapters = forwardRef<HTMLDivElement, TimeSliderChaptersP
 
           return renderChapter(chapterProps, state);
         }}
-      >
-        {hasChapters ? undefined : children}
-      </SliderSegments>
+      />
     );
   }
 );

--- a/site/src/components/docs/demos/time-slider/react/css/WithChapters.tsx
+++ b/site/src/components/docs/demos/time-slider/react/css/WithChapters.tsx
@@ -21,12 +21,7 @@ export default function WithChapters() {
                 </TimeSlider.Track>
               </div>
             )}
-          >
-            <TimeSlider.Track className="media-slider-track">
-              <TimeSlider.Buffer className="media-slider-buffer" />
-              <TimeSlider.Fill className="media-slider-fill" />
-            </TimeSlider.Track>
-          </TimeSlider.Chapters>
+          />
           <TimeSlider.Thumb className="media-slider-thumb" />
           <TimeSlider.Preview className="media-slider-preview">
             <TimeSlider.ChapterTitle className="media-slider-chapter-title" />

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -75,15 +75,10 @@ Add `Chapters` to progressively divide the track when a default `kind="chapters"
         </TimeSlider.Track>
       </div>
     )}
-  >
-    <TimeSlider.Track>
-      <TimeSlider.Buffer />
-      <TimeSlider.Fill />
-    </TimeSlider.Track>
-  </TimeSlider.Chapters>
+  />
   ```
 
-  `children` render as the regular slider track until authored chapters are available. `renderChapter` receives the attributes, styles, and state for each normalized chapter.
+  `renderChapter` receives the attributes, styles, and state for each normalized chapter range. When no chapter cues are available, it renders once as a full-width, cue-less range.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -100,7 +95,7 @@ Add `Chapters` to progressively divide the track when a default `kind="chapters"
   </media-time-slider-chapters>
   ```
 
-  The template must contain exactly one HTML root element. It remains in the light DOM and is cloned for each normalized chapter, including a full-duration range while chapter cues are unavailable. If the template is missing or invalid, non-template fallback content remains in place.
+  The required template must contain exactly one HTML root element. It remains in the light DOM and is cloned for each normalized chapter range. When no chapter cues are available, it is cloned once as a full-width, cue-less range.
 </FrameworkCase>
 
 ## Behavior
@@ -109,7 +104,7 @@ Displays and controls the current playback position. Dragging the slider seeks t
 
 Value changes during drag are throttled via the `changeThrottle` prop (default 100ms) using a leading+trailing throttle to keep the UI responsive without overwhelming the media element.
 
-Chapter cues are normalized into contiguous ranges. Any uncovered time becomes a gap range, so track geometry still spans the full duration. Gap ranges receive the same geometry styles but cannot be highlighted and have no chapter title.
+Chapter cues are normalized into contiguous ranges. Any uncovered time becomes a gap range, so track geometry always spans the full duration. With no usable chapter cues, one gap range spans the entire slider. Gap ranges receive the same geometry styles but cannot be highlighted and have no chapter title.
 
 ## Styling
 


### PR DESCRIPTION
## Summary

Remove the time-slider chapter fallback concept so every chapter range is rendered from one consumer-owned template or render function. Normalize missing chapter cues to one cue-less range spanning 100% of the slider, eliminating duplicated track, buffer, and fill markup.

## Changes

- Always return normalized chapter and slider segment ranges from core, including one full-domain gap when cues are unavailable
- Require an HTML template or React renderChapter implementation instead of supporting separate fallback children
- Remove duplicated fallback tracks from React video presets and the chapter demo
- Update JSDoc, API-facing types, reference docs, demos, and tests for the unified contract

## Testing

- pnpm -F @videojs/core test — 1,427 passed
- pnpm -F @videojs/html test — 344 passed
- pnpm -F @videojs/react test — 443 passed
- pnpm exec turbo run build --filter=@videojs/html --filter=@videojs/react
- pnpm typecheck
- pnpm -F site api-docs
- pnpm -F site exec vitest run scripts/api-docs-builder/src/tests/e2e.test.ts — 140 passed
- pnpm -F site astro check — 0 errors, 0 warnings
- Manually verified the HTML and React documentation demos render normalized segments without duplicate direct tracks, including the no-cues 100% range

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API and DOM behavior for custom chapter UIs that relied on fallback children; presets are updated in-repo but external consumers must migrate to the unified template/`renderChapter` contract.
> 
> **Overview**
> **Breaking change:** time slider chapters no longer support a separate fallback track (`children` in React, non-template light DOM in HTML). A single template or `renderChapter` path always drives the UI.
> 
> **Core:** `TimeSliderChaptersCore.getRanges` drops `hasChapters` and the special `fallback` segment. When duration is unavailable (`max <= min`), chapter cues are ignored and normalization yields one cue-less gap spanning the domain; otherwise ranges always come from `normalizeChapterCues` (including a full-domain gap when there are no cues).
> 
> **HTML:** `TimeSliderChaptersElement` strips non-template children when the template is missing or invalid instead of leaving fallback content visible.
> 
> **React:** `TimeSliderChapters` and `SliderSegments` remove `children` and `hasChapters` from the public API/state; presets, docs, and demos drop duplicated nested `TimeSlider.Track` fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0171e1e859537feb3fbbd273152617be9d1db057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->