### PR TITLE
fix(packages): improve ui motion

### DIFF
--- a/packages/core/src/core/ui/menu/menu-item-data-attrs.ts
+++ b/packages/core/src/core/ui/menu/menu-item-data-attrs.ts
@@ -10,6 +10,9 @@ export const MenuItemDataAttrs = {
    * Use `[data-item]` as a shared selector to target all item types at once.
    */
   item: 'data-item',
-  /** Present when the item has keyboard or pointer focus (via roving tabindex). */
+  /**
+   * Present when the item is highlighted. Set to `pointer` when pointer
+   * movement caused the highlight; otherwise empty.
+   */
   highlighted: 'data-highlighted',
 } as const;

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -3,6 +3,7 @@ import type { MenuInput, MenuState } from '../../../core/ui/menu/menu-core';
 import { MenuCSSVars } from '../../../core/ui/menu/menu-css-vars';
 import { MenuItemDataAttrs } from '../../../core/ui/menu/menu-item-data-attrs';
 import { PopoverCSSVars } from '../../../core/ui/popover/popover-css-vars';
+import { forceLayout } from '../../utils/layout';
 import type { UIFocusEvent, UIKeyboardEvent } from '../event';
 import { createPopover, type PopoverChangeDetails, type PopoverOpenChangeReason } from '../popover/popover';
 import type { PositioningCSSVars, PositioningOptions } from '../popover/popover-positioning';
@@ -39,6 +40,7 @@ export interface MenuContentProps {
 export interface MenuHighlightOptions {
   focus?: boolean;
   preventScroll?: boolean;
+  pointer?: boolean;
 }
 
 export function isMenuNavigationKey(event: UIKeyboardEvent): boolean {
@@ -144,18 +146,29 @@ export function createMenu(options: MenuOptions): MenuApi {
       if (element === highlightedItem) highlight(getAdjacentNavigableItem(1), highlightOptions);
       return;
     }
-    if (highlightedItem === element) return;
+    if (highlightedItem === element) {
+      element?.setAttribute(MenuItemDataAttrs.highlighted, highlightOptions?.pointer === true ? 'pointer' : '');
+      return;
+    }
 
-    if (highlightedItem) {
-      highlightedItem.tabIndex = -1;
-      highlightedItem.removeAttribute(MenuItemDataAttrs.highlighted);
+    const previousItem = highlightedItem;
+    if (previousItem) {
+      previousItem.tabIndex = -1;
     }
 
     highlightedItem = element;
 
     if (element) {
       element.tabIndex = 0;
-      element.setAttribute(MenuItemDataAttrs.highlighted, '');
+      element.setAttribute(MenuItemDataAttrs.highlighted, highlightOptions?.pointer === true ? 'pointer' : '');
+
+      // Keep the later anchor resolved for one layout before moving upward.
+      // Without a stable start inset, Chromium skips the anchor transition.
+      if (previousItem && compareItems(element, previousItem) < 0 && highlightOptions?.pointer) {
+        forceLayout(element.parentElement);
+      }
+      previousItem?.removeAttribute(MenuItemDataAttrs.highlighted);
+
       if (highlightOptions?.focus !== false) {
         if (highlightOptions?.preventScroll) {
           element.focus({ preventScroll: true });
@@ -163,6 +176,8 @@ export function createMenu(options: MenuOptions): MenuApi {
           element.focus();
         }
       }
+    } else {
+      previousItem?.removeAttribute(MenuItemDataAttrs.highlighted);
     }
 
     options.onHighlightChange?.(element);

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -499,6 +499,18 @@ describe('createMenu', () => {
       expect(element.tabIndex).toBe(0);
     });
 
+    it('sets the highlight type for pointer highlights', () => {
+      const { menu } = createTestMenu();
+      const element = addItem('Alpha');
+      menu.registerItem(element);
+
+      menu.highlight(element, { focus: false, pointer: true });
+      expect(element.getAttribute(MenuItemDataAttrs.highlighted)).toBe('pointer');
+
+      menu.highlight(element);
+      expect(element.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
     it('removes data-highlighted and resets tabIndex on previously highlighted item', () => {
       const { menu } = createTestMenu();
       const a = addItem('Alpha');
@@ -512,6 +524,27 @@ describe('createMenu', () => {
       expect(a.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
       expect(a.tabIndex).toBe(-1);
       expect(b.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
+    it('lays out an earlier pointer highlight before removing the previous highlight', () => {
+      const { menu } = createTestMenu();
+      const a = addItem('Alpha');
+      const b = addItem('Beta');
+      menu.registerItem(a);
+      menu.registerItem(b);
+      menu.highlight(b, { focus: false, pointer: true });
+      const setHighlight = vi.spyOn(a, 'setAttribute');
+      const layout = vi.spyOn(document.body, 'getBoundingClientRect');
+      const removeHighlight = vi.spyOn(b, 'removeAttribute');
+
+      menu.highlight(a, { focus: false, pointer: true });
+
+      expect(setHighlight).toHaveBeenCalledWith(MenuItemDataAttrs.highlighted, 'pointer');
+      expect(layout).toHaveBeenCalledOnce();
+      expect(removeHighlight).toHaveBeenCalledWith(MenuItemDataAttrs.highlighted);
+      expect(setHighlight.mock.invocationCallOrder[0]).toBeLessThan(layout.mock.invocationCallOrder[0] ?? 0);
+      expect(layout.mock.invocationCallOrder[0]).toBeLessThan(removeHighlight.mock.invocationCallOrder[0] ?? 0);
+      layout.mockRestore();
     });
 
     it('calls onHighlightChange with the new element', () => {

--- a/packages/html/src/ui/menu/menu-checkbox-item-element.ts
+++ b/packages/html/src/ui/menu/menu-checkbox-item-element.ts
@@ -60,7 +60,7 @@ export class MenuCheckboxItemElement extends MediaElement {
           },
           onPointerenter: () => {
             const currentCtx = this.#ctx.value;
-            if (!this.disabled) currentCtx?.menu.highlight(this, { focus: false });
+            if (!this.disabled) currentCtx?.menu.highlight(this, { focus: false, pointer: true });
           },
         },
         { signal: this.#disconnect.signal }

--- a/packages/html/src/ui/menu/menu-item-element.ts
+++ b/packages/html/src/ui/menu/menu-item-element.ts
@@ -78,7 +78,7 @@ export class MenuItemElement extends MediaElement {
           },
           onPointerenter: () => {
             const currentCtx = this.#ctx.value;
-            if (!this.#isDisabled()) currentCtx?.menu.highlight(this, { focus: false });
+            if (!this.#isDisabled()) currentCtx?.menu.highlight(this, { focus: false, pointer: true });
           },
         },
         { signal: this.#disconnect.signal }

--- a/packages/html/src/ui/menu/menu-radio-item-element.ts
+++ b/packages/html/src/ui/menu/menu-radio-item-element.ts
@@ -63,7 +63,7 @@ export class MenuRadioItemElement extends MediaElement {
           },
           onPointerenter: () => {
             const currentMenuCtx = this.#menuCtx.value;
-            if (!this.disabled) currentMenuCtx?.menu.highlight(this, { focus: false });
+            if (!this.disabled) currentMenuCtx?.menu.highlight(this, { focus: false, pointer: true });
           },
         },
         { signal: this.#disconnect.signal }

--- a/packages/html/src/ui/status-indicator/status-indicator-element.ts
+++ b/packages/html/src/ui/status-indicator/status-indicator-element.ts
@@ -10,7 +10,7 @@ import type { PropertyDeclarationMap } from '@videojs/element';
 
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
-import { InputIndicatorElement } from '../input-indicator/input-indicator-element';
+import { InputIndicatorElement, type InputIndicatorOptions } from '../input-indicator/input-indicator-element';
 import { LiveIndicator } from '../input-indicator/live-indicator';
 
 export class StatusIndicatorElement extends InputIndicatorElement<StatusIndicatorCore.State> {
@@ -32,6 +32,7 @@ export class StatusIndicatorElement extends InputIndicatorElement<StatusIndicato
     dataAttrs: StatusIndicatorDataAttrs,
     render: renderStatusIndicator,
   });
+  readonly #options = { replayOnUpdate: false } satisfies InputIndicatorOptions;
 
   protected get core() {
     return this.#core;
@@ -43,6 +44,10 @@ export class StatusIndicatorElement extends InputIndicatorElement<StatusIndicato
 
   protected get liveIndicator() {
     return this.#liveIndicator;
+  }
+
+  protected override get options() {
+    return this.#options;
   }
 
   protected override syncCoreProps(): void {

--- a/packages/html/src/ui/status-indicator/tests/status-indicator-element.test.ts
+++ b/packages/html/src/ui/status-indicator/tests/status-indicator-element.test.ts
@@ -2,9 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { StatusIndicatorElement } from '../status-indicator-element';
 import { StatusIndicatorValueElement } from '../status-indicator-value-element';
 
+class TestStatusIndicatorElement extends StatusIndicatorElement {
+  get transitionOptions() {
+    return this.options;
+  }
+}
+
+customElements.define('test-status-indicator', TestStatusIndicatorElement);
+
 describe('StatusIndicatorElement', () => {
   it('exposes standalone tag names', () => {
     expect(StatusIndicatorElement.tagName).toBe('media-status-indicator');
     expect(StatusIndicatorValueElement.tagName).toBe('media-status-indicator-value');
+  });
+
+  it('keeps repeated updates in the current transition', () => {
+    const element = document.createElement('test-status-indicator') as TestStatusIndicatorElement;
+
+    expect(element.transitionOptions).toEqual({ replayOnUpdate: false });
   });
 });

--- a/packages/icons/src/assets/default/airplay-exit.svg
+++ b/packages/icons/src/assets/default/airplay-exit.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 18 18">
   <style>
-    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{fill-opacity:0}to{fill-opacity:.2}}
+    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{fill-opacity:0}to{fill-opacity:.2}}@media (prefers-reduced-motion:reduce){:root{--media-icon--airplay__fill-animation:none;--media-icon--airplay__triangle-animation:none}}
   </style>
   <path fill-opacity=".2" d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5a3.5 3.5 0 0 1-3.032 3.468L9.354 8.354a.5.5 0 0 0-.708 0l-5.615 5.614A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z" style="animation:var(--media-icon--airplay__fill-animation, media-icon--airplay__fill 1s ease-in-out infinite alternate)"/>
   <path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5l-.005.18a3.5 3.5 0 0 1-3.027 3.288L13 12h1.5a1.5 1.5 0 0 0 1.5-1.5v-5A1.5 1.5 0 0 0 14.5 4h-11A1.5 1.5 0 0 0 2 5.5v5A1.5 1.5 0 0 0 3.5 12H5l-1.968 1.967A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z"/>

--- a/packages/icons/src/assets/default/spinner.svg
+++ b/packages/icons/src/assets/default/spinner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" viewBox="0 0 18 18">
   <style>
-    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s linear infinite);animation-delay:var(--media-spinner-delay)}
+    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s linear infinite);animation-delay:var(--media-spinner-delay)}@media (prefers-reduced-motion:reduce){.media-spinner__segment{animation:none}}
   </style>
   <line x1="9" x2="9" y1="1.5" y2="4.5" class="media-spinner__segment" opacity=".5" style="--media-spinner-delay:0s"/>
   <line x1="14.5" x2="12.5" y1="3.5" y2="5.5" class="media-spinner__segment" opacity=".45" style="--media-spinner-delay:0.125s"/>

--- a/packages/icons/src/assets/minimal/airplay-exit.svg
+++ b/packages/icons/src/assets/minimal/airplay-exit.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 18 18">
   <style>
-    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{fill-opacity:0}to{fill-opacity:.2}}
+    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{fill-opacity:0}to{fill-opacity:.2}}@media (prefers-reduced-motion:reduce){:root{--media-icon--airplay__fill-animation:none;--media-icon--airplay__triangle-animation:none}}
   </style>
   <path fill-opacity=".2" d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5a3.5 3.5 0 0 1-3.032 3.468L9.354 8.354a.5.5 0 0 0-.708 0l-5.615 5.614A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z" style="animation:var(--media-icon--airplay__fill-animation, media-icon--airplay__fill 1s ease-in-out infinite alternate)"/>
   <path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5l-.005.18a3.5 3.5 0 0 1-3.027 3.288L13.5 12.5h1a2 2 0 0 0 2-2v-5a2 2 0 0 0-2-2h-11a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h1l-1.468 1.467A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z"/>

--- a/packages/icons/src/assets/minimal/spinner.svg
+++ b/packages/icons/src/assets/minimal/spinner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" viewBox="0 0 18 18">
   <style>
-    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s linear infinite);animation-delay:var(--media-spinner-delay)}
+    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s linear infinite);animation-delay:var(--media-spinner-delay)}@media (prefers-reduced-motion:reduce){.media-spinner__segment{animation:none}}
   </style>
   <line x1="9" x2="9" y1="1.5" y2="4.5" class="media-spinner__segment" opacity=".5" style="--media-spinner-delay:0s"/>
   <line x1="14.5" x2="12.5" y1="3.5" y2="5.5" class="media-spinner__segment" opacity=".45" style="--media-spinner-delay:0.125s"/>

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -129,27 +129,27 @@ export function useSlider<State extends SliderState = SliderState>(
   // Adjust CSS var percents for edge thumb alignment using live DOM measurements.
   const cssVars = options.getCSSVars(slider.adjustForAlignment(state));
 
-  useLayoutEffect(() => {
-    const sync = () => {
-      const element = rootElementRef.current;
-      if (!element) return;
-      const next = optionsRef.current.computeState(slider.input.current);
-      applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));
-    };
-
-    sync();
-    return slider.input.subscribe(sync);
-  }, [slider]);
-
-  // Ref callbacks for root and thumb elements.
-  const rootRef = useCallback(
-    (element: HTMLElement | null) => {
-      rootElementRef.current = element;
+  const syncStyles = useCallback(
+    (element = rootElementRef.current) => {
       if (!element) return;
       const next = optionsRef.current.computeState(slider.input.current);
       applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));
     },
     [slider]
+  );
+
+  useLayoutEffect(() => {
+    syncStyles();
+    return slider.input.subscribe(syncStyles);
+  }, [slider, syncStyles]);
+
+  // Ref callbacks for root and thumb elements.
+  const rootRef = useCallback(
+    (element: HTMLElement | null) => {
+      rootElementRef.current = element;
+      syncStyles(element);
+    },
+    [syncStyles]
   );
 
   const thumbRef = useCallback((element: HTMLElement | null) => {

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -11,7 +11,7 @@ import {
   selectControls,
 } from '@videojs/core/dom';
 import { useSnapshot } from '@videojs/store/react';
-import { isRTL } from '@videojs/utils/dom';
+import { applyStyles, isRTL } from '@videojs/utils/dom';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useOptionalPlayer } from '../../player/context';
 import { useDestroy } from '../../utils/use-destroy';
@@ -41,6 +41,7 @@ export interface UseSliderOptions<State extends SliderState = SliderState>
 
 export interface UseSliderReturnValue<State extends SliderState = SliderState> {
   state: State;
+  input: SliderApi['input'];
   cssVars: Record<string, string>;
   rootRef: React.RefCallback<HTMLElement>;
   thumbRef: React.RefCallback<HTMLElement>;
@@ -105,8 +106,14 @@ export function useSlider<State extends SliderState = SliderState>(
 
   useDestroy(slider);
 
-  // Subscribe to slider input state.
-  const input = useSnapshot(slider.input);
+  // Percentage changes are rendered directly below. React only needs to
+  // re-render when interaction state changes.
+  const interaction = useSnapshot(slider.input, ({ dragging, pointing, focused }) => ({
+    dragging,
+    pointing,
+    focused,
+  }));
+  const input = { ...slider.input.current, ...interaction };
 
   // Compute derived state from input + caller-provided projection.
   const state = options.computeState(input);
@@ -122,10 +129,28 @@ export function useSlider<State extends SliderState = SliderState>(
   // Adjust CSS var percents for edge thumb alignment using live DOM measurements.
   const cssVars = options.getCSSVars(slider.adjustForAlignment(state));
 
+  useLayoutEffect(() => {
+    const sync = () => {
+      const element = rootElementRef.current;
+      if (!element) return;
+      const next = optionsRef.current.computeState(slider.input.current);
+      applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));
+    };
+
+    sync();
+    return slider.input.subscribe(sync);
+  }, [slider]);
+
   // Ref callbacks for root and thumb elements.
-  const rootRef = useCallback((element: HTMLElement | null) => {
-    rootElementRef.current = element;
-  }, []);
+  const rootRef = useCallback(
+    (element: HTMLElement | null) => {
+      rootElementRef.current = element;
+      if (!element) return;
+      const next = optionsRef.current.computeState(slider.input.current);
+      applyStyles(element, optionsRef.current.getCSSVars(slider.adjustForAlignment(next)));
+    },
+    [slider]
+  );
 
   const thumbRef = useCallback((element: HTMLElement | null) => {
     thumbElementRef.current = element;
@@ -133,6 +158,7 @@ export function useSlider<State extends SliderState = SliderState>(
 
   return {
     state,
+    input: slider.input,
     cssVars,
     rootRef,
     thumbRef,

--- a/packages/react/src/ui/menu/menu-checkbox-item.tsx
+++ b/packages/react/src/ui/menu/menu-checkbox-item.tsx
@@ -42,7 +42,7 @@ export const MenuCheckboxItem = forwardRef<HTMLDivElement, MenuCheckboxItemProps
   const handlePointerEnter = useCallback(() => {
     const element = elementRef.current;
     if (!element || disabled) return;
-    menu.highlight(element, { focus: false });
+    menu.highlight(element, { focus: false, pointer: true });
   }, [menu, disabled]);
 
   return renderElement(

--- a/packages/react/src/ui/menu/menu-item.tsx
+++ b/packages/react/src/ui/menu/menu-item.tsx
@@ -43,7 +43,7 @@ export const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>(function MenuI
   const handlePointerEnter = useCallback(() => {
     const element = elementRef.current;
     if (!element || disabled) return;
-    menu.highlight(element, { focus: false });
+    menu.highlight(element, { focus: false, pointer: true });
   }, [menu, disabled]);
 
   return (

--- a/packages/react/src/ui/menu/menu-radio-item.tsx
+++ b/packages/react/src/ui/menu/menu-radio-item.tsx
@@ -45,7 +45,7 @@ export const MenuRadioItem = forwardRef<HTMLDivElement, MenuRadioItemProps>(func
   const handlePointerEnter = useCallback(() => {
     const element = elementRef.current;
     if (!element || disabled) return;
-    menu.highlight(element, { focus: false });
+    menu.highlight(element, { focus: false, pointer: true });
   }, [menu, disabled]);
 
   return renderElement(

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -78,7 +78,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
   const handlePointerEnter = useCallback(() => {
     const element = elementRef.current;
     if (!element || disabled || !parentMenuApi) return;
-    parentMenuApi.highlight(element, { focus: false });
+    parentMenuApi.highlight(element, { focus: false, pointer: true });
   }, [disabled, parentMenuApi]);
 
   // Root trigger mode — standard button that toggles the menu.

--- a/packages/react/src/ui/slider/context.tsx
+++ b/packages/react/src/ui/slider/context.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import type { SliderState, StateAttrMap } from '@videojs/core';
+import type { SliderInput, SliderState, StateAttrMap } from '@videojs/core';
 import type { SliderThumbProps } from '@videojs/core/dom';
+import type { State } from '@videojs/store';
 import type { ProviderProps, RefCallback } from 'react';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useSyncExternalStore } from 'react';
 
 export interface SliderContextValue {
   state: SliderState;
   /** Pointer position converted to the value domain (not 0–100 percent). */
   pointerValue: number;
+  input?: State<SliderInput> | undefined;
+  getPointerValue?: ((percent: number) => number) | undefined;
   thumbRef: RefCallback<HTMLElement>;
   thumbProps: SliderThumbProps;
   stateAttrMap: StateAttrMap<SliderState>;
@@ -28,4 +31,14 @@ export function useSliderContext(): SliderContextValue {
   const ctx = useContext(SliderContext);
   if (!ctx) throw new Error('Slider compound components must be used within a Slider.Root');
   return ctx;
+}
+
+export function useSliderPointerValue(enabled = true): number {
+  const context = useSliderContext();
+  const percent = useSyncExternalStore(
+    (onChange) => context.input?.subscribe(onChange) ?? (() => {}),
+    () => (enabled ? (context.input?.current.pointerPercent ?? null) : null),
+    () => (enabled ? (context.input?.current.pointerPercent ?? null) : null)
+  );
+  return percent === null ? context.pointerValue : (context.getPointerValue?.(percent) ?? context.pointerValue);
 }

--- a/packages/react/src/ui/slider/slider-root.tsx
+++ b/packages/react/src/ui/slider/slider-root.tsx
@@ -48,6 +48,7 @@ export const SliderRoot = forwardRef(function SliderRoot(
 
   const {
     state,
+    input,
     cssVars,
     rootRef,
     thumbRef: sliderThumbRef,
@@ -78,6 +79,8 @@ export const SliderRoot = forwardRef(function SliderRoot(
       value={{
         state,
         pointerValue: core.valueFromPercent(state.pointerPercent),
+        input,
+        getPointerValue: (percent) => core.valueFromPercent(percent),
         thumbRef: sliderThumbRef,
         thumbProps,
         stateAttrMap: SliderDataAttrs,

--- a/packages/react/src/ui/slider/slider-thumbnail.tsx
+++ b/packages/react/src/ui/slider/slider-thumbnail.tsx
@@ -4,13 +4,13 @@ import type { ThumbnailCore } from '@videojs/core';
 import { forwardRef } from 'react';
 
 import { Thumbnail, type ThumbnailProps } from '../thumbnail/thumbnail';
-import { useSliderContext } from './context';
+import { useSliderPointerValue } from './context';
 
 export interface SliderThumbnailProps extends Omit<ThumbnailProps, 'time'> {}
 
 export const SliderThumbnail = forwardRef<HTMLDivElement, SliderThumbnailProps>(
   function SliderThumbnail(componentProps, forwardedRef) {
-    const { pointerValue } = useSliderContext();
+    const pointerValue = useSliderPointerValue();
     return <Thumbnail ref={forwardedRef} {...componentProps} time={pointerValue} />;
   }
 );

--- a/packages/react/src/ui/slider/slider-value.tsx
+++ b/packages/react/src/ui/slider/slider-value.tsx
@@ -6,7 +6,7 @@ import { forwardRef } from 'react';
 
 import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
-import { useSliderContext } from './context';
+import { useSliderContext, useSliderPointerValue } from './context';
 
 export interface SliderValueProps extends UIComponentProps<'output', SliderState> {
   /** Which slider value to display: the current position or the pointer position. */
@@ -23,7 +23,8 @@ export const SliderValue = forwardRef(function SliderValue(
   const { render, className, style, type = 'current', format, ...elementProps } = componentProps;
 
   const context = useSliderContext();
-  const { state, pointerValue, formatValue } = context;
+  const { state, formatValue } = context;
+  const pointerValue = useSliderPointerValue(type === 'pointer');
 
   const rawValue = type === 'pointer' ? pointerValue : state.value;
 

--- a/packages/react/src/ui/status-indicator/status-indicator-root.tsx
+++ b/packages/react/src/ui/status-indicator/status-indicator-root.tsx
@@ -20,11 +20,15 @@ export const StatusIndicatorRoot = forwardRef(function StatusIndicatorRoot(
 ) {
   const { render, className, style, actions, closeDelay, ...elementProps } = componentProps;
   const translator = useTranslator();
-  const { elementRef, present, state } = useInputIndicatorRoot(() => new StatusIndicatorCore(), {
-    actions,
-    closeDelay,
-    labels: createInputIndicatorLabels(translator),
-  });
+  const { elementRef, present, state } = useInputIndicatorRoot(
+    () => new StatusIndicatorCore(),
+    {
+      actions,
+      closeDelay,
+      labels: createInputIndicatorLabels(translator),
+    },
+    { replayOnUpdate: false }
+  );
 
   if (!present) return null;
 

--- a/packages/react/src/ui/status-indicator/tests/status-indicator-root.test.tsx
+++ b/packages/react/src/ui/status-indicator/tests/status-indicator-root.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render } from '@testing-library/react';
+import type { StatusIndicatorCore } from '@videojs/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const inputIndicatorMock = vi.hoisted(() => ({
+  useInputIndicatorRoot: vi.fn(),
+}));
+
+vi.mock('../../input-indicator/use-input-indicator-root', () => inputIndicatorMock);
+
+import { StatusIndicatorRoot } from '../status-indicator-root';
+
+const state: StatusIndicatorCore.State = {
+  open: true,
+  generation: 1,
+  status: 'play',
+  label: 'Playing',
+  value: null,
+  transitionStarting: false,
+  transitionEnding: false,
+};
+
+beforeEach(() => {
+  inputIndicatorMock.useInputIndicatorRoot.mockReturnValue({
+    elementRef: { current: null },
+    present: true,
+    state,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('StatusIndicatorRoot', () => {
+  it('keeps repeated updates in the current transition', () => {
+    render(<StatusIndicatorRoot actions={['togglePaused']} />);
+
+    expect(inputIndicatorMock.useInputIndicatorRoot).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ actions: ['togglePaused'] }),
+      { replayOnUpdate: false }
+    );
+  });
+});

--- a/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
@@ -12,7 +12,7 @@ import { Fragment, forwardRef, useMemo, useState } from 'react';
 
 import type { HTMLProps, UIComponentProps } from '../../../utils/types';
 import { renderElement } from '../../../utils/use-render';
-import { useSliderContext } from '../../slider/context';
+import { useSliderContext, useSliderPointerValue } from '../../slider/context';
 
 type SegmentProps = Omit<HTMLProps<HTMLElement>, 'ref'>;
 
@@ -28,6 +28,7 @@ export const SliderSegments = forwardRef<HTMLDivElement, SliderSegmentsProps>(
   function SliderSegments(componentProps, ref) {
     const { ranges, min, max, renderSegment, render, className, style, ...elementProps } = componentProps;
     const slider = useSliderContext();
+    const pointerValue = useSliderPointerValue();
     const [core] = useState(() => new SliderSegmentsCore());
     const geometry = useMemo(
       () => core.getGeometry({ ranges, min, max, orientation: slider.state.orientation }),
@@ -36,7 +37,7 @@ export const SliderSegments = forwardRef<HTMLDivElement, SliderSegmentsProps>(
     const sliderAttrs = getStateDataAttrs(slider.state, slider.stateAttrMap);
 
     const segments = geometry.map((segment) => {
-      const state = core.getState(segment, slider.state, slider.pointerValue);
+      const state = core.getState(segment, slider.state, pointerValue);
       const segmentStyle = {
         [TimeSliderChapterCSSVars.start]: state.startPercent,
         [TimeSliderChapterCSSVars.end]: state.endPercent,
@@ -57,7 +58,7 @@ export const SliderSegments = forwardRef<HTMLDivElement, SliderSegmentsProps>(
       );
     });
 
-    const state = geometry.length > 0 ? core.getState(geometry[0]!, slider.state, slider.pointerValue) : null;
+    const state = geometry.length > 0 ? core.getState(geometry[0]!, slider.state, pointerValue) : null;
     if (!state) return null;
 
     return renderElement(

--- a/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapter-title.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapter-title.tsx
@@ -8,7 +8,7 @@ import { forwardRef, useMemo, useState } from 'react';
 import { usePlayer } from '../../../player/context';
 import type { UIComponentProps } from '../../../utils/types';
 import { renderElement } from '../../../utils/use-render';
-import { useSliderContext } from '../../slider/context';
+import { useSliderContext, useSliderPointerValue } from '../../slider/context';
 
 export interface TimeSliderChapterTitleState {
   /** Chapter at the current interaction value. */
@@ -24,6 +24,7 @@ export const TimeSliderChapterTitle = forwardRef<HTMLSpanElement, TimeSliderChap
   function TimeSliderChapterTitle(componentProps, ref) {
     const { render, className, style, ...elementProps } = componentProps;
     const slider = useSliderContext();
+    const pointerValue = useSliderPointerValue();
     const textTrack = usePlayer(selectTextTrack);
     const time = usePlayer(selectTime);
     const [core] = useState(() => new TimeSliderChaptersCore());
@@ -32,7 +33,7 @@ export const TimeSliderChapterTitle = forwardRef<HTMLSpanElement, TimeSliderChap
       [core, textTrack?.chaptersCues, time?.duration]
     );
     const keyboard = slider.state.interactive && !slider.state.pointing && !slider.state.dragging;
-    const value = slider.state.pointing || slider.state.dragging ? slider.pointerValue : slider.state.value;
+    const value = slider.state.pointing || slider.state.dragging ? pointerValue : slider.state.value;
     const chapter = core.findChapter(chapters, value);
     const cue = chapter?.cue ?? null;
     const state = { cue, text: cue?.text ?? '' };

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -71,46 +71,47 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
 
     const duration = time?.duration ?? 0;
 
-    const { state, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } = useSlider<TimeSliderCore.State>({
-      computeState: (input) => {
-        core.setInput(input);
-        if (!time || !buffer) {
-          core.setMedia({
-            currentTime: 0,
-            duration: 0,
-            seeking: false,
-            seek: noopSeek,
-            buffered: [],
-            seekable: [],
-          });
-        } else {
-          core.setMedia({ ...time, ...buffer });
-        }
+    const { state, input, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } =
+      useSlider<TimeSliderCore.State>({
+        computeState: (input) => {
+          core.setInput(input);
+          if (!time || !buffer) {
+            core.setMedia({
+              currentTime: 0,
+              duration: 0,
+              seeking: false,
+              seek: noopSeek,
+              buffered: [],
+              seekable: [],
+            });
+          } else {
+            core.setMedia({ ...time, ...buffer });
+          }
 
-        return core.getState();
-      },
-      getPercent: () => core.percentFromValue(time?.currentTime ?? 0),
-      getStepPercent: () => core.getStepPercent(),
-      getLargeStepPercent: () => core.getLargeStepPercent(),
-      orientation,
-      disabled,
-      changeThrottle,
-      adjustPercent: (rawPercent, thumbSize, trackSize) =>
-        core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
-      getCSSVars: getTimeSliderCSSVars,
-      onValueCommit: (percent) => {
-        const media = mediaRef.current;
-        if (media) media.seek(core.rawValueFromPercent(percent));
-      },
-      onDragStart: () => {
-        core.startDrag(playbackRef.current);
-        onDragStart?.();
-      },
-      onDragEnd: () => {
-        core.endDrag(playbackRef.current);
-        onDragEnd?.();
-      },
-    });
+          return core.getState();
+        },
+        getPercent: () => core.percentFromValue(time?.currentTime ?? 0),
+        getStepPercent: () => core.getStepPercent(),
+        getLargeStepPercent: () => core.getLargeStepPercent(),
+        orientation,
+        disabled,
+        changeThrottle,
+        adjustPercent: (rawPercent, thumbSize, trackSize) =>
+          core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
+        getCSSVars: getTimeSliderCSSVars,
+        onValueCommit: (percent) => {
+          const media = mediaRef.current;
+          if (media) media.seek(core.rawValueFromPercent(percent));
+        },
+        onDragStart: () => {
+          core.startDrag(playbackRef.current);
+          onDragStart?.();
+        },
+        onDragEnd: () => {
+          core.endDrag(playbackRef.current);
+          onDragEnd?.();
+        },
+      });
 
     if (!time) {
       if (__DEV__) logMissingFeature('TimeSlider', 'time');
@@ -122,6 +123,8 @@ export const TimeSliderRoot = forwardRef<HTMLDivElement, TimeSliderRootProps>(
         value={{
           state,
           pointerValue: core.rawValueFromPercent(state.pointerPercent),
+          input,
+          getPointerValue: (percent) => core.rawValueFromPercent(percent),
           thumbRef,
           thumbProps,
           stateAttrMap: TimeSliderDataAttrs,

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -64,25 +64,26 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
     const getStepPercent = () => core.getStepPercent();
     const setVolume = (percent: number) => volumeRef.current?.setVolume(percent / 100);
 
-    const { state, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } = useSlider<VolumeSliderCore.State>({
-      computeState: (input) => {
-        core.setInput(input);
-        core.setMedia(volume ?? noopVolume);
-        return core.getState();
-      },
-      getPercent,
-      getStepPercent,
-      getLargeStepPercent: () => core.getLargeStepPercent(),
-      orientation,
-      disabled: isDisabled,
-      adjustPercent: (rawPercent, thumbSize, trackSize) =>
-        core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
-      getCSSVars: getSliderCSSVars,
-      onValueChange: setVolume,
-      onValueCommit: setVolume,
-      onDragStart,
-      onDragEnd,
-    });
+    const { state, input, cssVars, rootRef, thumbRef, rootProps, rootStyle, thumbProps } =
+      useSlider<VolumeSliderCore.State>({
+        computeState: (input) => {
+          core.setInput(input);
+          core.setMedia(volume ?? noopVolume);
+          return core.getState();
+        },
+        getPercent,
+        getStepPercent,
+        getLargeStepPercent: () => core.getLargeStepPercent(),
+        orientation,
+        disabled: isDisabled,
+        adjustPercent: (rawPercent, thumbSize, trackSize) =>
+          core.adjustPercentForAlignment(rawPercent, thumbSize, trackSize),
+        getCSSVars: getSliderCSSVars,
+        onValueChange: setVolume,
+        onValueCommit: setVolume,
+        onDragStart,
+        onDragEnd,
+      });
 
     const [wheelHandler] = useState(() =>
       createWheelStep({
@@ -119,6 +120,8 @@ export const VolumeSliderRoot = forwardRef<HTMLDivElement, VolumeSliderRootProps
         value={{
           state,
           pointerValue: core.valueFromPercent(state.pointerPercent),
+          input,
+          getPointerValue: (percent) => core.valueFromPercent(percent),
           thumbRef,
           thumbProps,
           stateAttrMap: VolumeSliderDataAttrs,

--- a/packages/skins/src/default/css/components/buffering.css
+++ b/packages/skins/src/default/css/components/buffering.css
@@ -14,4 +14,8 @@
   &[data-visible] {
     display: grid;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    --media-spinner-animation: none;
+  }
 }

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -27,7 +27,7 @@
   }
 
   &:active:not([aria-disabled="true"]) {
-    scale: 0.98;
+    scale: 0.97;
   }
 
   &[aria-disabled="true"] {
@@ -68,7 +68,7 @@
   padding: 0;
 
   &:active:not([aria-disabled="true"]) {
-    scale: 0.9;
+    scale: 0.97;
   }
 
   .media-icon__container {
@@ -77,11 +77,10 @@
 
   .media-icon {
     grid-area: 1 / 1;
-    transition-behavior: allow-discrete;
-    transition-property: display, opacity;
-    transition-duration: 150ms;
-    transition-timing-function: ease-out;
     filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+    transition-timing-function: ease-out;
+    transition-duration: 150ms;
+    transition-property: opacity, scale;
   }
 }
 
@@ -162,5 +161,13 @@
 
   &[data-live-edge]::before {
     background-color: oklch(0.65 0.22 27);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .media-default-skin .media-button {
+    scale: 1;
+    transition-property: background-color, color, outline-offset;
+    will-change: auto;
   }
 }

--- a/packages/skins/src/default/css/components/input-indicator.css
+++ b/packages/skins/src/default/css/components/input-indicator.css
@@ -60,11 +60,11 @@
         filter: blur(8px);
         scale: 0.9;
       }
+    }
 
+    &[data-ending-style] {
       @media (prefers-reduced-motion: no-preference) {
-        &[data-ending-style] {
-          translate: 0 -25%;
-        }
+        translate: 0 -25%;
       }
     }
   }

--- a/packages/skins/src/default/css/components/menus.css
+++ b/packages/skins/src/default/css/components/menus.css
@@ -65,7 +65,11 @@
         content: "";
         background-color: var(--accent-background-color);
         border-radius: var(--menu-item-border-radius);
-        transition: inset ease-in-out 100ms;
+        transition: inset 100ms ease-in-out;
+      }
+
+      &:has([data-highlighted=""])::before {
+        transition-duration: 0ms;
       }
     }
   }
@@ -150,7 +154,6 @@
       display: none;
     }
 
-    &:hover,
     &[data-highlighted] {
       @supports (top: anchor(top)) {
         anchor-name: --menu-item-highlight-anchor;

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -1,4 +1,8 @@
 .media-default-skin .media-slider {
+  --thumb-size: calc(var(--spacing) * 2.5);
+  --thumb-active-size: calc(var(--spacing) * 3);
+  --track-border-radius: calc(Infinity * 1px);
+
   position: relative;
   display: flex;
   flex: 1;
@@ -6,7 +10,6 @@
   justify-content: center;
   cursor: pointer;
   outline: none;
-  border-radius: calc(infinity * 1px);
 
   &[data-orientation="horizontal"] {
     width: var(--slider-width, 100%);
@@ -24,7 +27,7 @@
     overflow: hidden;
     user-select: none;
     background-color: oklch(from currentColor l c h / 0.2);
-    border-radius: inherit;
+    border-radius: var(--track-border-radius);
     isolation: isolate;
 
     &[data-orientation="horizontal"] {
@@ -37,72 +40,6 @@
     }
   }
 
-  /* Thumb */
-  .media-slider__thumb {
-    position: absolute;
-    z-index: 10;
-    width: calc(var(--spacing) * 2.5);
-    height: calc(var(--spacing) * 2.5);
-    user-select: none;
-    outline: 4px solid transparent;
-    outline-offset: -4px;
-    background-color: currentColor;
-    border-radius: calc(Infinity * 1px);
-    box-shadow:
-      0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.1)),
-      0 1px 3px 0 oklch(0 0 0 / 0.35),
-      0 1px 2px -1px oklch(0 0 0 / 0.35);
-    opacity: 0;
-    translate: -50% -50%;
-    transition-timing-function: ease-out;
-    transition-duration: 150ms;
-    transition-property: opacity, height, width, outline-offset;
-
-    &[data-orientation="horizontal"] {
-      top: 50%;
-      left: var(--media-slider-fill);
-    }
-    &[data-orientation="vertical"] {
-      top: calc(100% - var(--media-slider-fill));
-      left: 50%;
-    }
-
-    &:hover,
-    &:focus {
-      outline-color: oklch(from currentColor l c h / 0.15);
-      outline-offset: 0;
-    }
-
-    &::after {
-      position: absolute;
-      inset: -4px;
-      content: "";
-      border-radius: inherit;
-      box-shadow: 0 0 0 2px currentColor;
-      transition-timing-function: ease-out;
-      transition-duration: 150ms;
-      transition-property: opacity, scale;
-    }
-
-    &:not(:focus-visible)::after {
-      opacity: 0;
-      scale: 0.5;
-    }
-  }
-
-  &:active .media-slider__thumb,
-  &:focus-within .media-slider__thumb,
-  .media-slider__thumb--persistent {
-    width: calc(var(--spacing) * 3);
-    height: calc(var(--spacing) * 3);
-  }
-
-  &:hover .media-slider__thumb,
-  .media-slider__thumb:focus-visible,
-  .media-slider__thumb--persistent {
-    opacity: 1;
-  }
-
   /* Shared track fills */
   .media-slider__buffer,
   .media-slider__fill {
@@ -113,12 +50,14 @@
     &[data-orientation="horizontal"] {
       inset-block: 0;
       left: 0;
-      transition-property: width;
+      width: 100%;
+      transition-property: clip-path;
     }
     &[data-orientation="vertical"] {
       inset-inline: 0;
       bottom: 0;
-      transition-property: height;
+      height: 100%;
+      transition-property: clip-path;
     }
   }
 
@@ -127,10 +66,10 @@
     background-color: oklch(from currentColor l c h / 0.2);
 
     &[data-orientation="horizontal"] {
-      width: var(--media-slider-buffer);
+      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round var(--track-border-radius));
     }
     &[data-orientation="vertical"] {
-      height: var(--media-slider-buffer);
+      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round var(--track-border-radius));
     }
   }
 
@@ -139,10 +78,10 @@
     background-color: var(--accent-color);
 
     &[data-orientation="horizontal"] {
-      width: var(--media-slider-fill);
+      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round var(--track-border-radius));
     }
     &[data-orientation="vertical"] {
-      height: var(--media-slider-fill);
+      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--track-border-radius));
     }
   }
 
@@ -171,6 +110,7 @@
     --chapter-gap: calc(var(--spacing) * 1);
     --chapter-inset-start: 0.5;
     --chapter-inset-end: 0.5;
+
     position: absolute;
     inset: 0;
     display: flex;
@@ -178,6 +118,7 @@
     justify-content: center;
     min-width: 0;
     min-height: 0;
+    border-radius: inherit;
 
     &:first-child {
       --chapter-inset-start: 0;
@@ -189,8 +130,8 @@
     .media-slider__chapter-track {
       --chapter-track-size: calc(var(--spacing) * 1);
       --chapter-track-highlighted-size: calc(var(--spacing) * 1.75);
-      --chapter-track-border-radius: calc(Infinity * 1px);
-      border-radius: var(--chapter-track-border-radius);
+
+      border-radius: inherit;
 
       @media (prefers-reduced-motion: no-preference) {
         transition: 200ms ease-out;
@@ -206,7 +147,7 @@
         clip-path: inset(
           0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
             calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) round
-            var(--chapter-track-border-radius)
+            var(--track-border-radius)
         );
       }
 
@@ -223,7 +164,7 @@
         clip-path: inset(
           calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
             calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) 0 round
-            var(--chapter-track-border-radius)
+            var(--track-border-radius)
         );
       }
 
@@ -242,10 +183,10 @@
       top: calc(100% - var(--media-slider-pointer));
     }
     .media-slider__fill[data-orientation="horizontal"] {
-      width: var(--media-slider-pointer);
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
     }
     .media-slider__fill[data-orientation="vertical"] {
-      height: var(--media-slider-pointer);
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
     }
   }
 
@@ -269,6 +210,84 @@
     .media-slider__fill,
     .media-slider__buffer {
       transition-duration: 0ms;
+    }
+  }
+
+  /* Thumb */
+  .media-slider__thumb {
+    position: absolute;
+    z-index: 10;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    user-select: none;
+    outline: 4px solid transparent;
+    outline-offset: -4px;
+    background-color: currentColor;
+    border-radius: calc(Infinity * 1px);
+    box-shadow:
+      0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.1)),
+      0 1px 3px 0 oklch(0 0 0 / 0.35),
+      0 1px 2px -1px oklch(0 0 0 / 0.35);
+    opacity: 0;
+    translate: -50% -50%;
+    transition-timing-function: ease-out;
+    transition-duration: 150ms;
+    transition-property: opacity, height, width, outline-offset;
+
+    &[data-orientation="horizontal"] {
+      top: 50%;
+      left: var(--media-slider-fill);
+    }
+    &[data-orientation="vertical"] {
+      top: calc(100% - var(--media-slider-fill));
+      left: 50%;
+    }
+
+    &:focus-visible {
+      outline-color: oklch(from currentColor l c h / 0.15);
+      outline-offset: 0;
+      opacity: 1;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        outline-color: oklch(from currentColor l c h / 0.15);
+        outline-offset: 0;
+      }
+    }
+
+    &::after {
+      position: absolute;
+      inset: -4px;
+      content: "";
+      border-radius: inherit;
+      box-shadow: 0 0 0 2px currentColor;
+      transition-timing-function: ease-out;
+      transition-duration: 150ms;
+      transition-property: opacity, scale;
+    }
+
+    &:not(:focus-visible)::after {
+      opacity: 0;
+      scale: 0.5;
+    }
+
+    &.media-slider__thumb--persistent {
+      width: var(--thumb-active-size);
+      height: var(--thumb-active-size);
+      opacity: 1;
+    }
+  }
+
+  &:active .media-slider__thumb,
+  &:focus-within .media-slider__thumb {
+    width: var(--thumb-active-size);
+    height: var(--thumb-active-size);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover .media-slider__thumb {
+      opacity: 1;
     }
   }
 

--- a/packages/skins/src/default/css/components/status-indicator.css
+++ b/packages/skins/src/default/css/components/status-indicator.css
@@ -18,9 +18,14 @@
   transition-property: opacity, scale;
 
   .media-icon {
-    display: none;
+    grid-area: 1 / 1;
     width: calc(var(--media-icon-size) * 1.5);
     height: calc(var(--media-icon-size) * 1.5);
+    opacity: 0;
+    scale: 0;
+    transition-timing-function: ease-out;
+    transition-duration: 150ms;
+    transition-property: opacity, scale;
 
     &.media-icon--play {
       translate: 1px 0;
@@ -29,7 +34,8 @@
 
   &[data-status="pause"] .media-icon--pause,
   &[data-status="play"] .media-icon--play {
-    display: block;
+    opacity: 1;
+    scale: 1;
   }
 
   &[data-starting-style],
@@ -46,5 +52,16 @@
   @media (prefers-reduced-motion: reduce) {
     transition-duration: 50ms;
     transition-property: opacity;
+
+    &[data-starting-style],
+    &[data-ending-style],
+    .media-icon {
+      scale: 1;
+    }
+
+    .media-icon {
+      transition-duration: 50ms;
+      transition-property: opacity;
+    }
   }
 }

--- a/packages/skins/src/default/css/components/thumbnail.css
+++ b/packages/skins/src/default/css/components/thumbnail.css
@@ -40,6 +40,10 @@
     }
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    --media-spinner-animation: none;
+  }
+
   &:has(.media-thumbnail__image[data-loading]) {
     width: var(--thumbnail-max-width);
     max-width: 100%;

--- a/packages/skins/src/default/css/components/volume-indicator.css
+++ b/packages/skins/src/default/css/components/volume-indicator.css
@@ -18,8 +18,8 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    &[data-min],
-    &[data-max] {
+    &[data-min]:not([data-starting-style], [data-ending-style]),
+    &[data-max]:not([data-starting-style], [data-ending-style]) {
       transform: translateX(0.25px);
       transition: transform 300ms linear(0, -24 20%, 16 40%, -8 60%, 4 80%, 1);
     }

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -55,6 +55,11 @@
     --error-dialog-transition-duration: 50ms;
     --error-dialog-transition-delay: 0ms;
     --popup-transition-duration: 0ms;
+
+    .media-error__dialog {
+      scale: 1;
+      transition-property: opacity;
+    }
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
@@ -136,7 +141,7 @@
 .media-default-skin--video .media-error[data-starting-style] .media-error__dialog,
 .media-default-skin--video .media-error[data-ending-style] .media-error__dialog {
   opacity: 0;
-  scale: 0.5;
+  scale: 0.95;
 }
 .media-default-skin--video .media-error[data-ending-style] .media-error__dialog {
   transition-delay: 0ms;

--- a/packages/skins/src/default/tailwind/components/buffering.ts
+++ b/packages/skins/src/default/tailwind/components/buffering.ts
@@ -1,3 +1,3 @@
 export const bufferingIndicator = {
-  root: 'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:grid',
+  root: 'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] motion-reduce:[--media-spinner-animation:none] data-visible:grid',
 };

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -8,7 +8,8 @@ export const button = {
     'py-2 px-4 rounded-full',
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
-    'not-aria-disabled:active:scale-[0.98]',
+    'not-aria-disabled:active:scale-[0.97]',
+    'motion-reduce:scale-100 motion-reduce:transition-[background-color,color,outline-offset] motion-reduce:will-change-auto',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2'
   ),
@@ -19,7 +20,7 @@ export const button = {
     'not-aria-disabled:focus-visible:bg-(--accent-background-color) not-aria-disabled:focus-visible:text-(--accent-text-color)',
     'not-aria-disabled:aria-expanded:bg-(--accent-background-color) not-aria-disabled:aria-expanded:text-(--accent-text-color)'
   ),
-  icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-90'),
+  icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-[0.97]'),
   seek: hideAtSmall,
   /**
    * Live variant: wide pill button with a status dot rendered via `::before`

--- a/packages/skins/src/default/tailwind/components/error.ts
+++ b/packages/skins/src/default/tailwind/components/error.ts
@@ -9,8 +9,9 @@ export const error = {
     'duration-(--error-dialog-transition-duration)',
     'delay-(--error-dialog-transition-delay)',
     'ease-(--error-dialog-transition-timing-function)',
-    'group-data-starting-style/error:opacity-0 group-data-starting-style/error:scale-50',
-    'group-data-ending-style/error:opacity-0 group-data-ending-style/error:scale-50',
+    'group-data-starting-style/error:opacity-0 group-data-starting-style/error:scale-95',
+    'group-data-ending-style/error:opacity-0 group-data-ending-style/error:scale-95',
+    'motion-reduce:scale-100 motion-reduce:transition-opacity',
     'group-data-ending-style/error:delay-0'
   ),
   content: 'flex flex-col gap-2 px-2 pt-2 pb-1.5',

--- a/packages/skins/src/default/tailwind/components/icon.ts
+++ b/packages/skins/src/default/tailwind/components/icon.ts
@@ -3,7 +3,7 @@ import { cn } from '@videojs/utils/style';
 export const icon = cn(
   'block [grid-area:1/1] size-(--media-icon-size) shrink-0',
   'drop-shadow-[0_1px_0_var(--shadow-current-color)]',
-  'transition-discrete transition-[display,opacity] duration-150 ease-out'
+  'transition-[opacity,scale] duration-150 ease-out'
 );
 
 export const iconHidden = 'hidden opacity-0';

--- a/packages/skins/src/default/tailwind/components/input-indicator.ts
+++ b/packages/skins/src/default/tailwind/components/input-indicator.ts
@@ -17,9 +17,9 @@ export const topIndicatorRoot = cn(
   'pointer-fine:motion-safe:will-change-[scale,translate,filter,opacity]',
   'pointer-fine:motion-safe:transition-[scale,translate,filter,opacity]',
   'pointer-fine:motion-safe:data-starting-style:blur-sm',
-  'pointer-fine:motion-safe:data-starting-style:scale-90',
+  'pointer-fine:motion-safe:data-starting-style:scale-95',
   'pointer-fine:motion-safe:data-ending-style:blur-sm',
-  'pointer-fine:motion-safe:data-ending-style:scale-90',
+  'pointer-fine:motion-safe:data-ending-style:scale-95',
   'motion-safe:data-ending-style:-translate-y-1/4',
   '[@media(prefers-reduced-transparency:reduce)]:[--surface-background-color:oklch(0_0_0)]',
   'contrast-more:[--surface-background-color:oklch(0_0_0)]'

--- a/packages/skins/src/default/tailwind/components/input-indicator.ts
+++ b/packages/skins/src/default/tailwind/components/input-indicator.ts
@@ -17,9 +17,9 @@ export const topIndicatorRoot = cn(
   'pointer-fine:motion-safe:will-change-[scale,translate,filter,opacity]',
   'pointer-fine:motion-safe:transition-[scale,translate,filter,opacity]',
   'pointer-fine:motion-safe:data-starting-style:blur-sm',
-  'pointer-fine:motion-safe:data-starting-style:scale-95',
+  'pointer-fine:motion-safe:data-starting-style:scale-90',
   'pointer-fine:motion-safe:data-ending-style:blur-sm',
-  'pointer-fine:motion-safe:data-ending-style:scale-95',
+  'pointer-fine:motion-safe:data-ending-style:scale-90',
   'motion-safe:data-ending-style:-translate-y-1/4',
   '[@media(prefers-reduced-transparency:reduce)]:[--surface-background-color:oklch(0_0_0)]',
   'contrast-more:[--surface-background-color:oklch(0_0_0)]'

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -50,7 +50,8 @@ const group = cn(
   'supports-[top:anchor(top)]:before:rounded-(--menu-item-border-radius)',
   'supports-[top:anchor(top)]:before:transition-[inset]',
   'supports-[top:anchor(top)]:before:duration-100',
-  'supports-[top:anchor(top)]:before:ease-in-out'
+  'supports-[top:anchor(top)]:before:ease-in-out',
+  'supports-[top:anchor(top)]:has-data-[highlighted=]:before:duration-0'
 );
 
 const menuHostShell = cn(
@@ -87,8 +88,6 @@ export const menu = {
   item: cn(
     itemBase,
     'justify-between tabular-nums text-inherit',
-    'supports-[top:anchor(top)]:hover:[anchor-name:--menu-item-highlight-anchor]',
-    'supports-[top:anchor(top)]:hover:bg-transparent',
     'supports-[top:anchor(top)]:data-highlighted:[anchor-name:--menu-item-highlight-anchor]',
     'supports-[top:anchor(top)]:data-highlighted:bg-transparent',
     'data-[availability=unavailable]:hidden data-[availability=unsupported]:hidden',

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -13,14 +13,15 @@ const previewContent = cn(
 
 export const slider = {
   root: cn(
-    'group/slider relative flex flex-1 items-center justify-center rounded-full outline-none cursor-pointer',
+    'group/slider relative flex flex-1 items-center justify-center rounded-(--track-border-radius) outline-none cursor-pointer',
+    '[--track-border-radius:calc(infinity*1px)]',
     // Horizontal
     'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--slider-width,100%) data-[orientation=horizontal]:h-(--slider-height,--spacing(8))',
     // Vertical
     'data-[orientation=vertical]:w-(--slider-width,--spacing(8)) data-[orientation=vertical]:h-(--slider-height,--spacing(20))'
   ),
   track: cn(
-    'relative isolate overflow-hidden bg-current/20 rounded-[inherit] select-none',
+    'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
     // Horizontal
     'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
     // Vertical
@@ -36,14 +37,14 @@ export const slider = {
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
     ),
     track: cn(
-      'relative isolate overflow-hidden bg-current/20 rounded-full select-none',
+      'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
       'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
       'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_round_calc(infinity*1px))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_round_var(--track-border-radius))]',
       'data-[orientation=vertical]:w-1 data-[orientation=vertical]:h-full',
       'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_0_round_calc(infinity*1px))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
     ),
   },
   fill: {
@@ -56,21 +57,21 @@ export const slider = {
       'bg-(--accent-color)',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_calc(infinity*1px))]',
-      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_calc(infinity*1px))]',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_calc(infinity*1px))]',
-      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_calc(infinity*1px))]'
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--track-border-radius))]'
     ),
     buffer: cn(
       'bg-current/20 motion-safe:duration-250 motion-safe:ease-out',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_calc(infinity*1px))]',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_calc(infinity*1px))]'
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
     ),
   },
   thumb: {

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -55,22 +55,22 @@ export const slider = {
     fill: cn(
       'bg-(--accent-color)',
       // Horizontal
-      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0',
-      'data-[orientation=horizontal]:transition-[width] data-[orientation=horizontal]:w-(--media-slider-fill)',
-      'group-data-dragging/slider:data-[orientation=horizontal]:w-(--media-slider-pointer)',
+      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_calc(infinity*1px))]',
+      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_calc(infinity*1px))]',
       // Vertical
-      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0',
-      'data-[orientation=vertical]:transition-[height] data-[orientation=vertical]:h-(--media-slider-fill)',
-      'group-data-dragging/slider:data-[orientation=vertical]:h-(--media-slider-pointer)'
+      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_calc(infinity*1px))]',
+      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_calc(infinity*1px))]'
     ),
     buffer: cn(
       'bg-current/20 motion-safe:duration-250 motion-safe:ease-out',
       // Horizontal
-      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0',
-      'data-[orientation=horizontal]:transition-[width] data-[orientation=horizontal]:w-(--media-slider-buffer)',
+      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_calc(infinity*1px))]',
       // Vertical
-      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0',
-      'data-[orientation=vertical]:transition-[height] data-[orientation=vertical]:h-(--media-slider-buffer)'
+      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_calc(infinity*1px))]'
     ),
   },
   thumb: {
@@ -99,7 +99,7 @@ export const slider = {
     persistent: 'size-3',
     interactive: cn(
       'size-2.5',
-      'opacity-0 focus-visible:opacity-100 group-hover/slider:opacity-100',
+      'opacity-0 focus-visible:opacity-100 pointer-fine:group-hover/slider:opacity-100',
       'group-active/slider:size-3 group-focus-within/slider:size-3'
     ),
   },

--- a/packages/skins/src/default/tailwind/components/status-indicator.ts
+++ b/packages/skins/src/default/tailwind/components/status-indicator.ts
@@ -27,13 +27,22 @@ export const statusIndicator = {
       'data-starting-style:scale-[0.85]',
       'data-ending-style:scale-[0.85]',
       'data-ending-style:duration-100',
-      'data-ending-style:ease-in'
+      'data-ending-style:ease-in',
+      'motion-reduce:data-starting-style:scale-100',
+      'motion-reduce:data-ending-style:scale-100'
     ),
     icon: {
-      base: 'hidden size-[calc(var(--media-icon-size)*1.5)]',
-      pause: 'group-data-[status=pause]/input-indicator:block',
+      base: cn(
+        'col-start-1 row-start-1 size-[calc(var(--media-icon-size)*1.5)]',
+        'opacity-0 scale-0',
+        '[transition-property:opacity,scale] duration-150 ease-out',
+        'motion-reduce:scale-100 motion-reduce:transition-opacity motion-reduce:duration-50'
+      ),
+      pause:
+        'group-data-[status=pause]/input-indicator:opacity-100 group-data-[status=pause]/input-indicator:scale-100',
       play: cn(
-        'group-data-[status=play]/input-indicator:block',
+        'group-data-[status=play]/input-indicator:opacity-100',
+        'group-data-[status=play]/input-indicator:scale-100',
         'group-data-[status=play]/input-indicator:translate-x-px'
       ),
     },

--- a/packages/skins/src/default/tailwind/components/thumbnail.ts
+++ b/packages/skins/src/default/tailwind/components/thumbnail.ts
@@ -3,8 +3,8 @@ import { cn } from '@videojs/utils/style';
 export const thumbnail = {
   root: cn(
     'group/thumbnail pointer-events-none bg-black/90 rounded-[--spacing(3)]',
-    'has-[[data-loading]]:w-(--thumbnail-max-width) has-[[data-loading]]:max-w-full',
-    'has-[[data-loading]]:aspect-video has-[[data-loading]]:overflow-hidden'
+    'has-data-loading:w-(--thumbnail-max-width) has-data-loading:max-w-full',
+    'has-data-loading:aspect-video has-data-loading:overflow-hidden'
   ),
   image: cn(
     'relative block max-w-(--thumbnail-max-width) max-h-(--max-height) overflow-clip rounded-[inherit]',
@@ -16,6 +16,6 @@ export const thumbnail = {
   spinner: cn(
     'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0',
     'transition-opacity duration-150 ease-out',
-    'group-not-has-[[role=img][data-loading]]/thumbnail:[--media-spinner-animation:none] group-has-[[role=img][data-loading]]/thumbnail:opacity-100'
+    'group-not-has-[[role=img][data-loading]]/thumbnail:[--media-spinner-animation:none] motion-reduce:[--media-spinner-animation:none] group-has-[[role=img][data-loading]]/thumbnail:opacity-100'
   ),
 };

--- a/packages/skins/src/default/tailwind/components/volume-indicator.ts
+++ b/packages/skins/src/default/tailwind/components/volume-indicator.ts
@@ -7,8 +7,8 @@ export const volumeIndicator = {
     'w-[min(80%,--spacing(48))]',
     'data-open:duration-100',
     '[transform:translateX(0)]',
-    'motion-safe:[&:is([data-min],[data-max])]:[transform:translateX(0.25px)]',
-    'motion-safe:[&:is([data-min],[data-max])]:[transition:transform_300ms_linear(0,-24_20%,16_40%,-8_60%,4_80%,1)]'
+    'motion-safe:[&:is([data-min],[data-max]):not([data-starting-style],[data-ending-style])]:[transform:translateX(0.25px)]',
+    'motion-safe:[&:is([data-min],[data-max]):not([data-starting-style],[data-ending-style])]:[transition:transform_300ms_linear(0,-24_20%,16_40%,-8_60%,4_80%,1)]'
   ),
   content: cn(
     topIndicatorContent,

--- a/packages/skins/src/minimal/css/components/buffering.css
+++ b/packages/skins/src/minimal/css/components/buffering.css
@@ -14,4 +14,8 @@
   &[data-visible] {
     display: grid;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    --media-spinner-animation: none;
+  }
 }

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -27,7 +27,7 @@
   }
 
   &:active:not([aria-disabled="true"]) {
-    scale: 0.98;
+    scale: 0.97;
   }
 
   &[aria-disabled="true"] {
@@ -75,7 +75,7 @@
   padding: 0;
 
   &:active:not([aria-disabled="true"]) {
-    scale: 0.9;
+    scale: 0.97;
   }
 
   .media-icon__container {
@@ -84,11 +84,10 @@
 
   .media-icon {
     grid-area: 1 / 1;
-    transition-behavior: allow-discrete;
-    transition-property: display, opacity;
-    transition-duration: 150ms;
-    transition-timing-function: ease-out;
     filter: drop-shadow(0 1px 0 var(--shadow-current-color));
+    transition-timing-function: ease-out;
+    transition-duration: 150ms;
+    transition-property: opacity, scale;
   }
 }
 
@@ -169,5 +168,13 @@
 
   &[data-live-edge]::before {
     background-color: oklch(0.65 0.22 27);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .media-minimal-skin .media-button {
+    scale: 1;
+    transition-property: background-color, outline-offset;
+    will-change: auto;
   }
 }

--- a/packages/skins/src/minimal/css/components/input-indicator.css
+++ b/packages/skins/src/minimal/css/components/input-indicator.css
@@ -72,11 +72,11 @@
       @media (pointer: fine) and (prefers-reduced-motion: no-preference) {
         filter: blur(8px);
       }
+    }
 
+    &[data-ending-style] {
       @media (prefers-reduced-motion: no-preference) {
-        &[data-ending-style] {
-          translate: 0 -100%;
-        }
+        translate: 0 -100%;
       }
     }
   }

--- a/packages/skins/src/minimal/css/components/menus.css
+++ b/packages/skins/src/minimal/css/components/menus.css
@@ -70,7 +70,11 @@
         content: "";
         background-color: var(--accent-background-color);
         border-radius: var(--menu-item-border-radius);
-        transition: inset ease-in-out 100ms;
+        transition: inset 100ms ease-in-out;
+      }
+
+      &:has([data-highlighted=""])::before {
+        transition-duration: 0ms;
       }
     }
   }
@@ -151,7 +155,6 @@
       display: none;
     }
 
-    &:hover,
     &[data-highlighted] {
       @supports (top: anchor(top)) {
         anchor-name: --menu-item-highlight-anchor;

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -1,4 +1,8 @@
 .media-minimal-skin .media-slider {
+  --thumb-size: calc(var(--spacing) * 3);
+  --thumb-active-size: calc(var(--spacing) * 3);
+  --track-border-radius: calc(Infinity * 1px);
+
   position: relative;
   display: flex;
   flex: 1;
@@ -6,7 +10,7 @@
   justify-content: center;
   cursor: pointer;
   outline: none;
-  border-radius: calc(Infinity * 1px);
+  border-radius: var(--track-border-radius);
 
   &[data-orientation="horizontal"] {
     width: var(--slider-width, 100%);
@@ -41,8 +45,8 @@
   .media-slider__thumb {
     position: absolute;
     z-index: 10;
-    width: calc(var(--spacing) * 3);
-    height: calc(var(--spacing) * 3);
+    width: var(--thumb-size);
+    height: var(--thumb-size);
     user-select: none;
     outline: 2px solid transparent;
     outline-offset: -2px;
@@ -76,12 +80,16 @@
 
   &:focus-within .media-slider__thumb,
   .media-slider__thumb--persistent {
+    width: var(--thumb-active-size);
+    height: var(--thumb-active-size);
     opacity: 1;
     scale: 1;
   }
 
   @media (hover: hover) and (pointer: fine) {
     &:hover .media-slider__thumb {
+      width: var(--thumb-active-size);
+      height: var(--thumb-active-size);
       opacity: 1;
       scale: 1;
     }
@@ -113,10 +121,10 @@
     background-color: oklch(from currentColor l c h / 0.2);
 
     &[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round calc(Infinity * 1px));
+      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round var(--track-border-radius));
     }
     &[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round calc(Infinity * 1px));
+      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round var(--track-border-radius));
     }
   }
 
@@ -125,10 +133,10 @@
     background-color: var(--accent-color);
 
     &[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round calc(Infinity * 1px));
+      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round var(--track-border-radius));
     }
     &[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round calc(Infinity * 1px));
+      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--track-border-radius));
     }
   }
 
@@ -175,8 +183,7 @@
     .media-slider__chapter-track {
       --chapter-track-size: calc(var(--spacing) * 0.75);
       --chapter-track-highlighted-size: calc(var(--spacing) * 1.25);
-      --chapter-track-border-radius: calc(Infinity * 1px);
-      border-radius: var(--chapter-track-border-radius);
+      border-radius: var(--track-border-radius);
 
       @media (prefers-reduced-motion: no-preference) {
         transition: 200ms ease-out;
@@ -192,7 +199,7 @@
         clip-path: inset(
           0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
             calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) round
-            var(--chapter-track-border-radius)
+            var(--track-border-radius)
         );
       }
 
@@ -209,7 +216,7 @@
         clip-path: inset(
           calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
             calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) 0 round
-            var(--chapter-track-border-radius)
+            var(--track-border-radius)
         );
       }
 
@@ -228,16 +235,16 @@
       top: calc(100% - var(--media-slider-pointer));
     }
     .media-slider__fill[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round calc(Infinity * 1px));
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
     }
     .media-slider__fill[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round calc(Infinity * 1px));
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
     }
   }
 
   @media (prefers-reduced-motion: no-preference) {
     .media-slider__thumb {
-      transition-property: opacity, scale, outline-offset, left, top;
+      transition-property: opacity, scale, height, width, outline-offset, left, top;
     }
     .media-slider__fill {
       transition-timing-function: linear;

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -74,11 +74,17 @@
     }
   }
 
-  &:hover .media-slider__thumb,
   &:focus-within .media-slider__thumb,
   .media-slider__thumb--persistent {
     opacity: 1;
     scale: 1;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover .media-slider__thumb {
+      opacity: 1;
+      scale: 1;
+    }
   }
 
   /* Shared track fills */
@@ -91,12 +97,14 @@
     &[data-orientation="horizontal"] {
       inset-block: 0;
       left: 0;
-      transition-property: width;
+      width: 100%;
+      transition-property: clip-path;
     }
     &[data-orientation="vertical"] {
       inset-inline: 0;
       bottom: 0;
-      transition-property: height;
+      height: 100%;
+      transition-property: clip-path;
     }
   }
 
@@ -105,10 +113,10 @@
     background-color: oklch(from currentColor l c h / 0.2);
 
     &[data-orientation="horizontal"] {
-      width: var(--media-slider-buffer);
+      clip-path: inset(0 calc(100% - var(--media-slider-buffer)) 0 0 round calc(Infinity * 1px));
     }
     &[data-orientation="vertical"] {
-      height: var(--media-slider-buffer);
+      clip-path: inset(calc(100% - var(--media-slider-buffer)) 0 0 0 round calc(Infinity * 1px));
     }
   }
 
@@ -117,10 +125,10 @@
     background-color: var(--accent-color);
 
     &[data-orientation="horizontal"] {
-      width: var(--media-slider-fill);
+      clip-path: inset(0 calc(100% - var(--media-slider-fill)) 0 0 round calc(Infinity * 1px));
     }
     &[data-orientation="vertical"] {
-      height: var(--media-slider-fill);
+      clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round calc(Infinity * 1px));
     }
   }
 
@@ -220,10 +228,10 @@
       top: calc(100% - var(--media-slider-pointer));
     }
     .media-slider__fill[data-orientation="horizontal"] {
-      width: var(--media-slider-pointer);
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round calc(Infinity * 1px));
     }
     .media-slider__fill[data-orientation="vertical"] {
-      height: var(--media-slider-pointer);
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round calc(Infinity * 1px));
     }
   }
 

--- a/packages/skins/src/minimal/css/components/status-indicator.css
+++ b/packages/skins/src/minimal/css/components/status-indicator.css
@@ -15,14 +15,20 @@
   transition-property: opacity, scale;
 
   .media-icon {
-    display: none;
+    grid-area: 1 / 1;
     width: calc(var(--media-icon-size) * 2);
     height: calc(var(--media-icon-size) * 2);
+    opacity: 0;
+    scale: 0;
+    transition-timing-function: ease-out;
+    transition-duration: 150ms;
+    transition-property: opacity, scale;
   }
 
   &[data-status="pause"] .media-icon--pause,
   &[data-status="play"] .media-icon--play {
-    display: block;
+    opacity: 1;
+    scale: 1;
   }
 
   &[data-starting-style],
@@ -39,5 +45,16 @@
   @media (prefers-reduced-motion: reduce) {
     transition-duration: 50ms;
     transition-property: opacity;
+
+    &[data-starting-style],
+    &[data-ending-style],
+    .media-icon {
+      scale: 1;
+    }
+
+    .media-icon {
+      transition-duration: 50ms;
+      transition-property: opacity;
+    }
   }
 }

--- a/packages/skins/src/minimal/css/components/thumbnail.css
+++ b/packages/skins/src/minimal/css/components/thumbnail.css
@@ -43,6 +43,10 @@
     }
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    --media-spinner-animation: none;
+  }
+
   &:has(.media-thumbnail__image[data-loading]) {
     width: var(--thumbnail-max-width);
     max-width: 100%;

--- a/packages/skins/src/minimal/css/components/volume-indicator.css
+++ b/packages/skins/src/minimal/css/components/volume-indicator.css
@@ -31,8 +31,8 @@
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    &[data-min] .media-volume-indicator__content,
-    &[data-max] .media-volume-indicator__content {
+    &[data-min]:not([data-starting-style], [data-ending-style]) .media-volume-indicator__content,
+    &[data-max]:not([data-starting-style], [data-ending-style]) .media-volume-indicator__content {
       transform: translateX(0.25px);
       transition: transform 300ms linear(0, -24 20%, 16 40%, -8 60%, 4 80%, 1);
     }

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -59,6 +59,11 @@
     --error-dialog-transition-duration: 50ms;
     --error-dialog-transition-delay: 0ms;
     --popup-transition-duration: 0ms;
+
+    .media-error__dialog {
+      scale: 1;
+      transition-property: opacity;
+    }
   }
 
   @media (prefers-reduced-transparency: reduce) or (prefers-contrast: more) {
@@ -152,7 +157,7 @@
 .media-minimal-skin--video .media-error[data-starting-style] .media-error__dialog,
 .media-minimal-skin--video .media-error[data-ending-style] .media-error__dialog {
   opacity: 0;
-  scale: 0.5;
+  scale: 0.95;
 }
 .media-minimal-skin--video .media-error[data-ending-style] .media-error__dialog {
   transition-delay: 0ms;

--- a/packages/skins/src/minimal/tailwind/components/buffering.ts
+++ b/packages/skins/src/minimal/tailwind/components/buffering.ts
@@ -1,2 +1,2 @@
 export const bufferingIndicator =
-  'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] data-visible:grid';
+  'peer/buffering absolute inset-0 z-10 hidden place-content-center pointer-events-none text-white not-data-visible:[--media-spinner-animation:none] motion-reduce:[--media-spinner-animation:none] data-visible:grid';

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -9,7 +9,8 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
-    'not-aria-disabled:active:scale-[0.98]',
+    'not-aria-disabled:active:scale-[0.97]',
+    'motion-reduce:scale-100 motion-reduce:transition-[background-color,outline-offset] motion-reduce:will-change-auto',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'
@@ -21,7 +22,7 @@ export const button = {
     'not-aria-disabled:focus-visible:bg-(--accent-background-color) not-aria-disabled:focus-visible:text-(--accent-text-color)',
     'not-aria-disabled:aria-expanded:bg-(--accent-background-color) not-aria-disabled:aria-expanded:text-(--accent-text-color)'
   ),
-  icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-90'),
+  icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-[0.97]'),
   seek: hideAtSmall,
   cast: hideAtSmall,
   airplay: hideAtSmall,

--- a/packages/skins/src/minimal/tailwind/components/error.ts
+++ b/packages/skins/src/minimal/tailwind/components/error.ts
@@ -10,8 +10,9 @@ export const error = {
     'duration-(--error-dialog-transition-duration)',
     'delay-(--error-dialog-transition-delay)',
     'ease-(--error-dialog-transition-timing-function)',
-    'group-data-starting-style/error:opacity-0 group-data-starting-style/error:scale-50',
-    'group-data-ending-style/error:opacity-0 group-data-ending-style/error:scale-50',
+    'group-data-starting-style/error:opacity-0 group-data-starting-style/error:scale-95',
+    'group-data-ending-style/error:opacity-0 group-data-ending-style/error:scale-95',
+    'motion-reduce:scale-100 motion-reduce:transition-opacity',
     'group-data-ending-style/error:delay-0'
   ),
   content: 'flex flex-col gap-2 py-1.5',

--- a/packages/skins/src/minimal/tailwind/components/icon.ts
+++ b/packages/skins/src/minimal/tailwind/components/icon.ts
@@ -3,7 +3,7 @@ import { cn } from '@videojs/utils/style';
 export const icon = cn(
   'block [grid-area:1/1] size-(--media-icon-size)',
   'drop-shadow-[0_1px_0_var(--shadow-current-color)]',
-  'transition-discrete transition-[display,opacity] duration-150 ease-out'
+  'transition-[opacity,scale] duration-150 ease-out'
 );
 
 export const iconHidden = 'hidden opacity-0';

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -49,7 +49,8 @@ const group = cn(
   'supports-[top:anchor(top)]:before:rounded-(--menu-item-border-radius)',
   'supports-[top:anchor(top)]:before:transition-[inset]',
   'supports-[top:anchor(top)]:before:duration-100',
-  'supports-[top:anchor(top)]:before:ease-in-out'
+  'supports-[top:anchor(top)]:before:ease-in-out',
+  'supports-[top:anchor(top)]:has-data-[highlighted=]:before:duration-0'
 );
 
 const menuHostShell = cn(
@@ -87,8 +88,6 @@ export const menu = {
   item: cn(
     itemBase,
     'justify-between tabular-nums text-inherit',
-    'supports-[top:anchor(top)]:hover:[anchor-name:--menu-item-highlight-anchor]',
-    'supports-[top:anchor(top)]:hover:bg-transparent',
     'supports-[top:anchor(top)]:data-highlighted:[anchor-name:--menu-item-highlight-anchor]',
     'supports-[top:anchor(top)]:data-highlighted:bg-transparent',
     'data-[availability=unavailable]:hidden data-[availability=unsupported]:hidden',

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -13,14 +13,15 @@ const previewContent = cn(
 
 export const slider = {
   root: cn(
-    'group/slider relative flex flex-1 items-center justify-center rounded-full outline-none cursor-pointer',
+    'group/slider relative flex flex-1 items-center justify-center rounded-(--track-border-radius) outline-none cursor-pointer',
+    '[--track-border-radius:calc(infinity*1px)]',
     // Horizontal
     'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--slider-width,100%) data-[orientation=horizontal]:h-(--slider-height,--spacing(8))',
     // Vertical
     'data-[orientation=vertical]:w-(--slider-width,--spacing(8)) data-[orientation=vertical]:h-(--slider-height,--spacing(20))'
   ),
   track: cn(
-    'relative isolate overflow-hidden bg-current/20 rounded-[inherit] select-none',
+    'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
     // Horizontal
     'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-0.75',
     // Vertical
@@ -36,14 +37,14 @@ export const slider = {
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
     ),
     track: cn(
-      'relative isolate overflow-hidden bg-current/20 rounded-full select-none',
+      'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
       'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-0.75',
       'group-data-highlighted/chapter:data-[orientation=horizontal]:h-[--spacing(1.25)]',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_round_calc(infinity*1px))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_round_var(--track-border-radius))]',
       'data-[orientation=vertical]:w-0.75 data-[orientation=vertical]:h-full',
       'group-data-highlighted/chapter:data-[orientation=vertical]:w-[--spacing(1.25)]',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_0_round_calc(infinity*1px))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
     ),
   },
   fill: {
@@ -56,21 +57,21 @@ export const slider = {
       'bg-(--accent-color)',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_calc(infinity*1px))]',
-      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_calc(infinity*1px))]',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_calc(infinity*1px))]',
-      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_calc(infinity*1px))]'
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
+      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--track-border-radius))]'
     ),
     buffer: cn(
       'bg-current/20 motion-safe:duration-250 motion-safe:ease-out',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_calc(infinity*1px))]',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_calc(infinity*1px))]'
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
     ),
   },
   thumb: {

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -55,22 +55,22 @@ export const slider = {
     fill: cn(
       'bg-(--accent-color)',
       // Horizontal
-      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0',
-      'data-[orientation=horizontal]:transition-[width] data-[orientation=horizontal]:w-(--media-slider-fill,0)',
-      'group-data-dragging/slider:data-[orientation=horizontal]:w-(--media-slider-pointer)',
+      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_calc(infinity*1px))]',
+      'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_calc(infinity*1px))]',
       // Vertical
-      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0',
-      'data-[orientation=vertical]:transition-[height] data-[orientation=vertical]:h-(--media-slider-fill,0)',
-      'group-data-dragging/slider:data-[orientation=vertical]:h-(--media-slider-pointer)'
+      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_calc(infinity*1px))]',
+      'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_calc(infinity*1px))]'
     ),
     buffer: cn(
       'bg-current/20 motion-safe:duration-250 motion-safe:ease-out',
       // Horizontal
-      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0',
-      'data-[orientation=horizontal]:transition-[width] data-[orientation=horizontal]:w-(--media-slider-buffer,0)',
+      'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
+      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_calc(infinity*1px))]',
       // Vertical
-      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0',
-      'data-[orientation=vertical]:transition-[height] data-[orientation=vertical]:h-(--media-slider-buffer)'
+      'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
+      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_calc(infinity*1px))]'
     ),
   },
   thumb: {
@@ -91,7 +91,7 @@ export const slider = {
     ),
     interactive: cn(
       'opacity-0 scale-70 origin-center',
-      'group-hover/slider:opacity-100 group-hover/slider:scale-100',
+      'pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100',
       'group-focus-within/slider:opacity-100 group-focus-within/slider:scale-100'
     ),
   },

--- a/packages/skins/src/minimal/tailwind/components/status-indicator.ts
+++ b/packages/skins/src/minimal/tailwind/components/status-indicator.ts
@@ -26,12 +26,20 @@ export const statusIndicator = {
       'data-starting-style:scale-[0.85]',
       'data-ending-style:scale-[0.85]',
       'data-ending-style:duration-100',
-      'data-ending-style:ease-in'
+      'data-ending-style:ease-in',
+      'motion-reduce:data-starting-style:scale-100',
+      'motion-reduce:data-ending-style:scale-100'
     ),
     icon: {
-      base: 'hidden size-[calc(var(--media-icon-size)*2)]',
-      pause: 'group-data-[status=pause]/input-indicator:block',
-      play: 'group-data-[status=play]/input-indicator:block',
+      base: cn(
+        'col-start-1 row-start-1 size-[calc(var(--media-icon-size)*2)]',
+        'opacity-0 scale-0',
+        '[transition-property:opacity,scale] duration-150 ease-out',
+        'motion-reduce:scale-100 motion-reduce:transition-opacity motion-reduce:duration-50'
+      ),
+      pause:
+        'group-data-[status=pause]/input-indicator:opacity-100 group-data-[status=pause]/input-indicator:scale-100',
+      play: 'group-data-[status=play]/input-indicator:opacity-100 group-data-[status=play]/input-indicator:scale-100',
     },
   },
 };

--- a/packages/skins/src/minimal/tailwind/components/thumbnail.ts
+++ b/packages/skins/src/minimal/tailwind/components/thumbnail.ts
@@ -5,8 +5,8 @@ export const thumbnail = {
     'group/thumbnail pointer-events-none bg-black/90 rounded-[--spacing(2)]',
     'after:absolute after:inset-0 after:rounded-[inherit]',
     'after:ring-1 after:ring-black/5 after:shadow-sm after:shadow-black/20',
-    'has-[[data-loading]]:w-(--thumbnail-max-width) has-[[data-loading]]:max-w-full',
-    'has-[[data-loading]]:aspect-video has-[[data-loading]]:overflow-hidden'
+    'has-data-loading:w-(--thumbnail-max-width) has-data-loading:max-w-full',
+    'has-data-loading:aspect-video has-data-loading:overflow-hidden'
   ),
   image: cn(
     'relative block max-w-(--thumbnail-max-width) max-h-(--max-height) overflow-clip rounded-[inherit]',
@@ -15,6 +15,6 @@ export const thumbnail = {
   spinner: cn(
     'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0',
     'transition-opacity duration-150 ease-out',
-    'group-not-has-[[role=img][data-loading]]/thumbnail:[--media-spinner-animation:none] group-has-[[role=img][data-loading]]/thumbnail:opacity-100'
+    'group-not-has-[[role=img][data-loading]]/thumbnail:[--media-spinner-animation:none] motion-reduce:[--media-spinner-animation:none] group-has-[[role=img][data-loading]]/thumbnail:opacity-100'
   ),
 };

--- a/packages/skins/src/minimal/tailwind/components/volume-indicator.ts
+++ b/packages/skins/src/minimal/tailwind/components/volume-indicator.ts
@@ -7,8 +7,8 @@ export const volumeIndicator = {
     topIndicatorContent,
     'w-[min(80%,--spacing(56))]',
     '[transform:translateX(0)]',
-    'motion-safe:group-[:is([data-min],[data-max])]/input-indicator:[transform:translateX(0.25px)]',
-    'motion-safe:group-[:is([data-min],[data-max])]/input-indicator:[transition:transform_300ms_linear(0,-24_20%,16_40%,-8_60%,4_80%,1)]'
+    'motion-safe:group-[:is([data-min],[data-max]):not([data-starting-style],[data-ending-style])]/input-indicator:[transform:translateX(0.25px)]',
+    'motion-safe:group-[:is([data-min],[data-max]):not([data-starting-style],[data-ending-style])]/input-indicator:[transition:transform_300ms_linear(0,-24_20%,16_40%,-8_60%,4_80%,1)]'
   ),
   progress: cn(
     'relative w-full h-0.75 rounded-full bg-current/20',

--- a/packages/skins/src/shared/css/video/icon-state.css
+++ b/packages/skins/src/shared/css/video/icon-state.css
@@ -7,24 +7,17 @@
 
 /* --- All icons hidden by default --- */
 
-.media-button--play .media-icon--restart,
-.media-button--play .media-icon--play,
-.media-button--play .media-icon--pause,
-.media-button--mute .media-icon--volume-off,
-.media-button--mute .media-icon--volume-low,
-.media-button--mute .media-icon--volume-high,
-.media-button--fullscreen .media-icon--fullscreen-enter,
-.media-button--fullscreen .media-icon--fullscreen-exit,
-.media-button--pip .media-icon--pip-enter,
-.media-button--pip .media-icon--pip-exit,
-.media-button--cast .media-icon--cast-enter,
-.media-button--cast .media-icon--cast-exit,
-.media-button--airplay .media-icon--airplay-enter,
-.media-button--airplay .media-icon--airplay-exit,
-.media-button--captions .media-icon--captions-off,
-.media-button--captions .media-icon--captions-on {
-  display: none;
+.media-button--play .media-icon,
+.media-button--mute .media-icon,
+.media-button--fullscreen .media-icon,
+.media-button--pip .media-icon,
+.media-button--cast .media-icon,
+.media-button--airplay .media-icon,
+.media-button--captions .media-icon {
   opacity: 0;
+}
+.media-button--play .media-icon {
+  scale: 0;
 }
 
 /* --- Active icon per state --- */
@@ -62,8 +55,8 @@
 .media-button--captions:not([data-active]) .media-icon--captions-off,
 /* Captions: active → captions on */
 .media-button--captions[data-active] .media-icon--captions-on {
-  display: block;
   opacity: 1;
+  scale: 1;
 }
 
 /* --- Pause keyframe animations on inactive icons --- */
@@ -75,4 +68,11 @@
 .media-button--airplay:not([data-airplay-state="connected"]) {
   --media-icon--airplay__fill-animation: none;
   --media-icon--airplay__triangle-animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .media-button--airplay {
+    --media-icon--airplay__fill-animation: none;
+    --media-icon--airplay__triangle-animation: none;
+  }
 }

--- a/packages/skins/src/shared/tailwind/icon-state.ts
+++ b/packages/skins/src/shared/tailwind/icon-state.ts
@@ -8,45 +8,45 @@
 export const iconState = {
   play: {
     button: 'group',
-    restart: 'hidden opacity-0 group-data-ended:block group-data-ended:opacity-100',
+    restart: 'opacity-0 scale-0 group-data-ended:opacity-100 group-data-ended:scale-100',
     play: [
-      'hidden opacity-0',
-      'group-not-data-ended:group-data-paused:block',
+      'opacity-0 scale-0',
       'group-not-data-ended:group-data-paused:opacity-100',
-      'group-not-data-ended:group-not-data-started:block',
+      'group-not-data-ended:group-data-paused:scale-100',
       'group-not-data-ended:group-not-data-started:opacity-100',
+      'group-not-data-ended:group-not-data-started:scale-100',
     ].join(' '),
     pause:
-      'hidden opacity-0 group-data-started:group-not-data-paused:group-not-data-ended:block group-data-started:group-not-data-paused:group-not-data-ended:opacity-100',
+      'opacity-0 scale-0 group-data-started:group-not-data-paused:group-not-data-ended:opacity-100 group-data-started:group-not-data-paused:group-not-data-ended:scale-100',
   },
   mute: {
     button: 'group',
-    volumeOff: 'hidden opacity-0 group-data-muted:block group-data-muted:opacity-100',
+    volumeOff: 'opacity-0 group-data-muted:opacity-100 group-data-muted:scale-100',
     volumeLow:
-      'hidden opacity-0 group-not-data-muted:group-data-[volume-level=low]:block group-not-data-muted:group-data-[volume-level=low]:opacity-100',
+      'opacity-0 group-not-data-muted:group-data-[volume-level=low]:opacity-100 group-not-data-muted:group-data-[volume-level=low]:scale-100',
     volumeHigh:
-      'hidden opacity-0 group-not-data-muted:group-not-data-[volume-level=low]:block group-not-data-muted:group-not-data-[volume-level=low]:opacity-100',
+      'opacity-0 group-not-data-muted:group-not-data-[volume-level=low]:opacity-100 group-not-data-muted:group-not-data-[volume-level=low]:scale-100',
   },
   fullscreen: {
     button: 'group',
-    enter: 'hidden opacity-0 group-not-data-fullscreen:block group-not-data-fullscreen:opacity-100',
-    exit: 'hidden opacity-0 group-data-fullscreen:block group-data-fullscreen:opacity-100',
+    enter: 'opacity-0 group-not-data-fullscreen:opacity-100 group-not-data-fullscreen:scale-100',
+    exit: 'opacity-0 group-data-fullscreen:opacity-100 group-data-fullscreen:scale-100',
   },
   captions: {
     button: 'group',
-    off: 'hidden opacity-0 group-not-data-active:block group-not-data-active:opacity-100',
-    on: 'hidden opacity-0 group-data-active:block group-data-active:opacity-100',
+    off: 'opacity-0 group-not-data-active:opacity-100 group-not-data-active:scale-100',
+    on: 'opacity-0 group-data-active:opacity-100 group-data-active:scale-100',
   },
   pip: {
     button: 'group',
-    off: 'hidden opacity-0 group-not-data-pip:block group-not-data-pip:opacity-100',
-    on: 'hidden opacity-0 group-data-pip:block group-data-pip:opacity-100',
+    off: 'opacity-0 group-not-data-pip:opacity-100 group-not-data-pip:scale-100',
+    on: 'opacity-0 group-data-pip:opacity-100 group-data-pip:scale-100',
   },
   cast: {
     button: 'group',
     enter:
-      'hidden opacity-0 group-not-data-[cast-state=connected]:block group-not-data-[cast-state=connected]:opacity-100',
-    exit: 'hidden opacity-0 group-data-[cast-state=connected]:block group-data-[cast-state=connected]:opacity-100',
+      'opacity-0 group-not-data-[cast-state=connected]:opacity-100 group-not-data-[cast-state=connected]:scale-100',
+    exit: 'opacity-0 group-data-[cast-state=connected]:opacity-100 group-data-[cast-state=connected]:scale-100',
   },
   airplay: {
     // `group` enables the icon-state variants below. The two CSS-variable
@@ -57,9 +57,11 @@ export const iconState = {
       'group',
       'not-data-[airplay-state=connected]:[--media-icon--airplay__fill-animation:none]',
       'not-data-[airplay-state=connected]:[--media-icon--airplay__triangle-animation:none]',
+      'motion-reduce:[--media-icon--airplay__fill-animation:none]',
+      'motion-reduce:[--media-icon--airplay__triangle-animation:none]',
     ].join(' '),
     enter:
-      'hidden opacity-0 group-not-data-[airplay-state=connected]:block group-not-data-[airplay-state=connected]:opacity-100',
-    exit: 'hidden opacity-0 group-data-[airplay-state=connected]:block group-data-[airplay-state=connected]:opacity-100',
+      'opacity-0 group-not-data-[airplay-state=connected]:opacity-100 group-not-data-[airplay-state=connected]:scale-100',
+    exit: 'opacity-0 group-data-[airplay-state=connected]:opacity-100 group-data-[airplay-state=connected]:scale-100',
   },
 };


### PR DESCRIPTION
## Summary

Improve player motion across controls, menus, sliders, and status indicators while keeping Default and Minimal vanilla/Tailwind skins aligned. The changes also preserve repeated feedback transitions and make motion safer for reduced-motion users.

Closes #2211 

## Changes

- Smooth state-icon and repeated play/pause status transitions without remounting or discrete display changes
- Keep slider pointer-driven UI synchronized and preserve rounded fill/buffer edges using clip-path
- Distinguish pointer menu highlights, stabilize upward anchor transitions in Chromium, and keep keyboard movement immediate
- Limit hover motion to fine pointers and disable or simplify non-essential motion under reduced-motion preferences
- Maintain matching behavior across HTML, React, Default, Minimal, vanilla CSS, and Tailwind styles

## Testing

- pnpm -F @videojs/core test
- pnpm -F @videojs/html test
- pnpm -F @videojs/react test
- pnpm -F @videojs/skins test
- pnpm -F @videojs/icons test
- pnpm -F @videojs/core build
- pnpm -F @videojs/html build
- pnpm -F @videojs/react build
- pnpm -F @videojs/skins build
- pnpm -F @videojs/icons build
- pnpm exec biome check packages/core packages/html packages/icons packages/react packages/skins
- git diff --check

pnpm typecheck remains blocked by pre-existing SPF type errors in media capability and adapter code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches menu highlight semantics, React slider update timing, and wide default/minimal CSS—mostly visual/UX with tests, but regressions could show up in menu highlighting, scrubber smoothness, or motion on specific browsers.
> 
> **Overview**
> Refines player motion and keeps HTML, React, Default, and Minimal skins aligned.
> 
> **Menus** tag pointer-driven highlights on `data-highlighted` (`pointer` vs empty) so CSS can animate the anchor highlight on hover but keep keyboard moves instant; upward pointer moves force a layout before clearing the previous highlight so Chromium still runs the anchor transition. HTML and React menu items pass `pointer: true` on `pointerenter`.
> 
> **Sliders (React)** stop re-rendering on every percent tick: interaction flags still use `useSnapshot`, while fill/buffer CSS vars sync via `slider.input.subscribe` and `applyStyles`. Pointer-driven pieces (`SliderValue`, thumbnails, chapter UI) subscribe through `useSliderPointerValue`.
> 
> **Status / input indicators** set `replayOnUpdate: false` so rapid play/pause (and similar) updates swap content inside the open transition instead of restarting it.
> 
> **Skins & icons** shift multi-state controls from `display` toggles to **opacity/scale** transitions, drive slider progress with **clip-path** (rounded ends), gate hover motion to **fine pointers**, and add **`prefers-reduced-motion`** (and related) overrides for spinners, buttons, errors, volume wiggle, and AirPlay SVG animations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc9d5035a2fe1049a9471dcc95ad821c95c5673c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->