### PR TITLE
test(packages): add automated accessibility checks

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -15,6 +15,7 @@
     "test:ui": "playwright test --ui",
     "test:update": "playwright test --update-snapshots",
     "test:chromium": "playwright test --project=vite-chromium",
+    "test:a11y": "playwright test tests/accessibility.spec.ts --project=vite-chromium",
     "test:webkit": "playwright test --project=vite-webkit",
     "test:vite": "playwright test --project=vite-chromium",
     "test:sandbox": "playwright test --project=sandbox-chromium",
@@ -22,6 +23,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@playwright/test": "^1.52.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/apps/e2e/tests/accessibility.spec.ts
+++ b/apps/e2e/tests/accessibility.spec.ts
@@ -1,0 +1,81 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page, type TestInfo, test } from '@playwright/test';
+
+import { PlayerPage } from '../page-objects/player';
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'];
+
+const PLAYER_PAGES = [
+  { name: 'HTML video', path: '/pages/html-video-mp4.html' },
+  { name: 'React video', path: '/pages/react-video-mp4.html' },
+  { name: 'HTML audio', path: '/pages/html-audio-mp4.html' },
+  { name: 'React audio', path: '/pages/react-audio-mp4.html' },
+] as const;
+
+const VIDEO_PAGES = PLAYER_PAGES.filter(({ name }) => name.endsWith('video'));
+
+async function checkAccessibility(page: Page, testInfo: TestInfo, state: string): Promise<void> {
+  const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+
+  await testInfo.attach(`axe-${state}`, {
+    body: JSON.stringify(results, null, 2),
+    contentType: 'application/json',
+  });
+
+  const violations = results.violations.map(({ id, impact, help, nodes }) => ({
+    id,
+    impact,
+    help,
+    targets: nodes.map(({ target }) => target),
+  }));
+
+  expect(violations, `${state} has automatically detectable accessibility violations`).toEqual([]);
+
+  const brokenControls = await page.locator('[aria-controls]').evaluateAll((elements) =>
+    elements.flatMap((element) => {
+      const root = element.getRootNode() as Document | ShadowRoot;
+
+      return (element.getAttribute('aria-controls') ?? '')
+        .split(/\s+/)
+        .filter(Boolean)
+        .filter((id) => !root.getElementById(id))
+        .map((id) => ({ id, element: element.outerHTML }));
+    })
+  );
+
+  expect(brokenControls, `${state} has unresolved aria-controls references`).toEqual([]);
+}
+
+test.describe('Accessibility', () => {
+  for (const entry of PLAYER_PAGES) {
+    test(`${entry.name} initial state`, async ({ page }, testInfo) => {
+      const player = new PlayerPage(page);
+      await page.goto(entry.path);
+      await player.waitForMediaReady();
+
+      await checkAccessibility(page, testInfo, `${entry.name}-initial`);
+    });
+  }
+
+  for (const entry of VIDEO_PAGES) {
+    test(`${entry.name} settings menu`, async ({ page }, testInfo) => {
+      const player = new PlayerPage(page);
+      await page.goto(entry.path);
+      await player.waitForMediaReady();
+      await player.showControls();
+      await player.settingsButton.click();
+      await expect(player.settingsSpeedItem).toBeVisible();
+
+      await checkAccessibility(page, testInfo, `${entry.name}-settings`);
+    });
+
+    test(`${entry.name} playback rate menu`, async ({ page }, testInfo) => {
+      const player = new PlayerPage(page);
+      await page.goto(entry.path);
+      await player.waitForMediaReady();
+      await player.openPlaybackRateSettings();
+
+      await checkAccessibility(page, testInfo, `${entry.name}-playback-rate`);
+    });
+  }
+});

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -31,6 +31,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
 ) {
   const { core, menu, parent, state, contentId } = useMenuContext();
   const isSubMenuTrigger = parent !== null;
+  const controlledId = state.open || state.status === 'ending' ? contentId : undefined;
 
   const elementRef = useRef<HTMLElement>(null);
   const triggerId = useSafeId('sub-trigger');
@@ -116,7 +117,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
         forwardedRef={forwardedRef}
         elementRef={elementRef}
         triggerId={triggerId}
-        triggerAttrs={core.getTriggerAttrs(state, contentId)}
+        triggerAttrs={core.getTriggerAttrs(state, controlledId)}
         state={state}
         onSubMenuClick={handleSubMenuClick}
         onSubMenuKeyDown={handleSubMenuKeyDown}
@@ -134,7 +135,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
           state,
           ref: [forwardedRef as React.Ref<HTMLButtonElement>, triggerRef],
           props: [
-            { type: 'button' as const, ...core.getTriggerAttrs(state, contentId) },
+            { type: 'button' as const, ...core.getTriggerAttrs(state, controlledId) },
             disabled ? { disabled: true, 'aria-disabled': 'true' as const } : undefined,
             state.open ? { onKeyDownCapture: preventMenuKeyDefault } : undefined,
             rootTriggerProps,

--- a/packages/react/src/ui/menu/tests/menu.test.tsx
+++ b/packages/react/src/ui/menu/tests/menu.test.tsx
@@ -354,6 +354,43 @@ function DynamicMenuFixture({ showCaptions }: { showCaptions: boolean }) {
 }
 
 describe('MenuContent', () => {
+  it('only links triggers to rendered menu content', async () => {
+    render(<SubmenuFixture />);
+
+    const rootTrigger = screen.getByRole('button', { name: 'Settings' });
+    const rootContent = screen.getByTestId('root-content');
+    const submenuTrigger = screen.getByTestId('submenu-trigger');
+
+    expect(rootTrigger.getAttribute('aria-controls')).toBe(rootContent.id);
+    expect(submenuTrigger.hasAttribute('aria-controls')).toBe(false);
+
+    fireEvent.click(submenuTrigger);
+
+    await waitFor(() => {
+      const submenuContent = screen.getByTestId('submenu-content');
+      expect(submenuTrigger.getAttribute('aria-controls')).toBe(submenuContent.id);
+    });
+  });
+
+  it('omits aria-controls while root menu content is not rendered', async () => {
+    render(
+      <MenuRoot>
+        <MenuTrigger data-testid="trigger">Settings</MenuTrigger>
+        <MenuContent data-testid="content">Settings</MenuContent>
+      </MenuRoot>
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger.hasAttribute('aria-controls')).toBe(false);
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      const content = screen.getByTestId('content');
+      expect(trigger.getAttribute('aria-controls')).toBe(content.id);
+    });
+  });
+
   it('waits for a controlled owner to commit requested open changes', async () => {
     const onOpenChange = vi.fn();
     const renderMenu = (open: boolean) => (

--- a/packages/react/src/ui/popover/popover-trigger.tsx
+++ b/packages/react/src/ui/popover/popover-trigger.tsx
@@ -15,6 +15,7 @@ export const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>
   forwardedRef
 ) {
   const { core, popover, state, stateAttrMap, popupId } = usePopoverContext();
+  const controlledId = state.open ? popupId : undefined;
 
   const triggerRef = useCallback(
     (el: HTMLButtonElement | null) => {
@@ -38,7 +39,7 @@ export const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>
       props: [
         {
           type: 'button' as const,
-          ...core.getTriggerAttrs(state, popupId),
+          ...core.getTriggerAttrs(state, controlledId),
         },
         { ...restTriggerProps, onFocus: onFocusIn, onBlur: onFocusOut },
         elementProps,

--- a/packages/react/src/ui/popover/tests/popover.test.tsx
+++ b/packages/react/src/ui/popover/tests/popover.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as Popover from '../index.parts';
@@ -13,6 +13,32 @@ afterEach(() => {
 });
 
 describe('Popover', () => {
+  it('only links the trigger to a rendered popup', async () => {
+    render(
+      <Popover.Root>
+        <Popover.Trigger data-testid="trigger">Open</Popover.Trigger>
+        <Popover.Popup data-testid="popup">Content</Popover.Popup>
+      </Popover.Root>
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger.hasAttribute('aria-controls')).toBe(false);
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      const popup = screen.getByTestId('popup');
+      expect(trigger.getAttribute('aria-controls')).toBe(popup.id);
+    });
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('popup')).toBeNull();
+      expect(trigger.hasAttribute('aria-controls')).toBe(false);
+    });
+  });
+
   it('positions default-open and remounted popups before paint', async () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
       if (this.dataset.testid === 'trigger')

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -69,7 +69,7 @@ export const Poster = forwardRef(function Poster(
       state: core.getState(),
       stateAttrMap: PosterDataAttrs,
       ref: [forwardedRef, imgRef],
-      props: [elementProps, { 'data-loaded': loaded ? '' : undefined, onLoad: handleLoad }],
+      props: [{ alt: '' }, elementProps, { 'data-loaded': loaded ? '' : undefined, onLoad: handleLoad }],
     }
   );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
 
   apps/e2e:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.13.0
+        version: 4.13.0(playwright-core@1.59.1)
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.59.1
@@ -1041,6 +1044,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.4':
     resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4820,6 +4828,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -10051,6 +10063,11 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
+  '@axe-core/playwright@4.13.0(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -13751,6 +13768,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.13.0: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
## Summary

Add automated axe coverage to the Playwright E2E suite and fix the React accessibility issues exposed by those checks.

Closes #2212 

## Changes

- Scan initial HTML and React video and audio players with axe across WCAG A and AA rules
- Scan open settings and playback-rate menu states in Chromium and WebKit
- Verify every rendered `aria-controls` reference resolves within its DOM root
- Only render React menu and popover `aria-controls` while their controlled content exists
- Give the default React poster image decorative alternative text

## Testing

- `pnpm --dir apps/e2e exec playwright test tests/accessibility.spec.ts --project=vite-chromium --project=vite-webkit --workers=1 --trace=off` (16 passed)
- `pnpm -F @videojs/react test src/ui/menu/tests/menu.test.tsx src/ui/popover/tests/popover.test.tsx` (37 passed)
- `pnpm build:packages`
- Biome checks on changed files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are test additions and small ARIA/alt attribute fixes in UI primitives; no auth, data, or playback core logic.
> 
> **Overview**
> Adds **Playwright + axe** coverage for HTML/React video and audio players (initial load, settings menu, playback-rate menu) under WCAG 2.x A/AA tags, plus a custom check that every `aria-controls` ID resolves in its DOM root. New `test:a11y` script and `@axe-core/playwright` dependency wire this into the e2e app.
> 
> **React fixes** exposed by those scans: `MenuTrigger` and `PopoverTrigger` now pass a controlled content id into `getTriggerAttrs` only while the popup/menu is open (menus also keep the link during `ending` close animation); closed or unmounted content no longer gets a dangling `aria-controls`. Default `Poster` renders with `alt=""` so decorative poster images don’t fail image-alt rules. Unit tests lock in trigger/`aria-controls` behavior for menus (including submenus) and popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f3806fa2ee1aef8b47d6ec3edeef2f62260481d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->