### PR TITLE
fix(packages): menu keyboard navigation

### DIFF
--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -4,6 +4,7 @@ import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 const UI_VIDEO_PAGES = VIDEO_PAGES.filter(({ media }) => media === 'video');
+const KEYBOARD_MENU_PAGES = UI_VIDEO_PAGES.filter(({ path }) => path.endsWith('video-mp4.html'));
 const EJECTED_HTML_VIDEO_PATH = '/pages/ejected-html-video-mp4.html';
 
 function getMediaVolume(page: Page): Promise<number> {
@@ -199,6 +200,36 @@ test.describe('Video Controls — Ejected HTML registration', () => {
     expect(errors).toEqual([]);
   });
 });
+
+for (const { name, path } of KEYBOARD_MENU_PAGES) {
+  test(`${name} restores submenu focus and continues keyboard navigation`, async ({ page }) => {
+    const player = new PlayerPage(page);
+    await page.goto(path);
+    await player.waitForMediaReady();
+    await player.showControls();
+
+    await player.settingsButton.focus();
+    await page.keyboard.press('Enter');
+    await expect(player.settingsSpeedItem).toBeVisible();
+    await expect(player.settingsSpeedItem).toBeFocused();
+
+    await page.keyboard.press('ArrowRight');
+    await expect(player.activeMenuPanel).toBeVisible();
+    await expect(player.activeMenuPanel.getByRole('menuitem').first()).toBeFocused();
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(player.activeMenuPanel).not.toBeVisible();
+    await expect(player.settingsSpeedItem).toBeFocused();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.locator('[role="menuitem"]:focus')).toHaveCount(1);
+
+    await page.keyboard.press('Tab');
+    await expect(player.settingsButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(player.settingsSpeedItem).not.toBeFocused();
+    await expect(page.locator('body')).not.toBeFocused();
+  });
+}
 
 for (const { name, path } of UI_VIDEO_PAGES) {
   test.describe(`Video Controls — ${name} UI`, () => {

--- a/packages/core/src/dom/ui/menu/create-menu.ts
+++ b/packages/core/src/dom/ui/menu/create-menu.ts
@@ -94,6 +94,8 @@ export interface MenuApi {
   highlight: (element: HTMLElement | null, options?: MenuHighlightOptions) => void;
   /** Programmatically highlight the first registered item. */
   highlightFirstItem: (options?: MenuHighlightOptions) => void;
+  /** Return focus to the trigger when the close reason requires it. */
+  restoreFocus: (options?: FocusOptions) => void;
   open: (reason?: MenuOpenChangeReason) => void;
   close: (reason?: MenuOpenChangeReason) => void;
   /** Commit the open state resolved by the platform adapter. */
@@ -119,7 +121,15 @@ export function createMenu(options: MenuOptions): MenuApi {
   let lastCloseReason: MenuOpenChangeReason | null = null;
 
   function isItemHidden(item: HTMLElement): boolean {
-    return Boolean(item.hidden || item.hasAttribute('data-hidden') || item.getAttribute('aria-hidden') === 'true');
+    const availability = item.getAttribute('data-availability');
+
+    return Boolean(
+      item.hidden ||
+        item.hasAttribute('data-hidden') ||
+        item.getAttribute('aria-hidden') === 'true' ||
+        availability === 'unavailable' ||
+        availability === 'unsupported'
+    );
   }
 
   function getNavigableItems(): HTMLElement[] {
@@ -194,6 +204,23 @@ export function createMenu(options: MenuOptions): MenuApi {
 
   function highlightFirstItem(options?: MenuHighlightOptions): void {
     highlight(getNavigableItems()[0] ?? null, options);
+  }
+
+  function restoreFocus(focusOptions?: FocusOptions): void {
+    if (
+      lastCloseReason === 'imperative-action' ||
+      lastCloseReason === 'group-open' ||
+      lastCloseReason === 'blur' ||
+      lastCloseReason === 'outside-click'
+    ) {
+      return;
+    }
+
+    if (focusOptions) {
+      triggerElement?.focus(focusOptions);
+    } else {
+      triggerElement?.focus();
+    }
   }
 
   function getInitialHighlightItem(): HTMLElement | null {
@@ -274,9 +301,7 @@ export function createMenu(options: MenuOptions): MenuApi {
       options.onOpenChangeComplete?.(open);
       // Return focus to the trigger after the close animation completes
       // so screen readers hear the correct context.
-      if (!open && lastCloseReason !== 'imperative-action' && lastCloseReason !== 'group-open') {
-        triggerElement?.focus();
-      }
+      if (!open) restoreFocus();
     },
     closeOnEscape: options.closeOnEscape,
     closeOnOutsideClick: options.closeOnOutsideClick,
@@ -429,6 +454,7 @@ export function createMenu(options: MenuOptions): MenuApi {
     registerSubmenu,
     highlight,
     highlightFirstItem,
+    restoreFocus,
     open: popover.open,
     close: popover.close,
     syncOpen,

--- a/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/create-menu.test.ts
@@ -406,6 +406,41 @@ describe('createMenu', () => {
       expect(focus).not.toHaveBeenCalled();
     });
 
+    it('does not restore focus when Tab moves focus outside', async () => {
+      const { menu } = createTestMenu();
+      const trigger = document.createElement('button');
+      const content = document.createElement('div');
+      const outside = document.createElement('button');
+      const focus = vi.spyOn(trigger, 'focus');
+
+      menu.setTriggerElement(trigger);
+      menu.setContentElement(content);
+      menu.open();
+      menu.contentProps.onFocusOut(makeFocusEvent(outside));
+
+      await vi.waitFor(() => {
+        expect(menu.input.current.active).toBe(false);
+      });
+
+      expect(focus).not.toHaveBeenCalled();
+    });
+
+    it('does not restore focus after an outside click', async () => {
+      const { menu } = createTestMenu();
+      const trigger = document.createElement('button');
+      const focus = vi.spyOn(trigger, 'focus');
+
+      menu.setTriggerElement(trigger);
+      menu.open();
+      menu.close('outside-click');
+
+      await vi.waitFor(() => {
+        expect(menu.input.current.active).toBe(false);
+      });
+
+      expect(focus).not.toHaveBeenCalled();
+    });
+
     it('does not restore focus when another grouped popup opens', async () => {
       const group = createPopupGroup();
       const first = createTestMenu({ group: () => group });
@@ -691,6 +726,20 @@ describe('createMenu', () => {
 
       expect(hidden.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
       expect(c.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
+    });
+
+    it.each(['unavailable', 'unsupported'])('ArrowDown skips %s items', (availability) => {
+      const { menu } = createTestMenu();
+      const hidden = addItem('Hidden');
+      const visible = addItem('Visible');
+      hidden.setAttribute('data-availability', availability);
+      menu.registerItem(hidden);
+      menu.registerItem(visible);
+
+      menu.contentProps.onKeyDown(makeKeyEvent('ArrowDown'));
+
+      expect(hidden.hasAttribute(MenuItemDataAttrs.highlighted)).toBe(false);
+      expect(visible.getAttribute(MenuItemDataAttrs.highlighted)).toBe('');
     });
 
     it('ArrowDown preserves position when the highlighted item becomes hidden', () => {

--- a/packages/html/src/ui/menu/menu-element.ts
+++ b/packages/html/src/ui/menu/menu-element.ts
@@ -282,19 +282,20 @@ export class MenuElement extends MediaElement {
       tabIndex: -1,
     });
 
-    if (isActive && !this.#submenuActive) {
-      this.#menu?.highlightFirstItem({ preventScroll: true });
-    } else if (!isActive && this.#submenuActive) {
-      triggerElement?.focus({ preventScroll: true });
-    }
-
-    this.#submenuActive = isActive;
     this.#cleanupSizeObserver?.();
     const parentContentElement = parentCtx.menu.contentElement;
     const syncSize = () => syncMenuSizeChain(parentContentElement);
     syncSize();
     this.#cleanupSizeObserver =
       isActive && parentContentElement ? observeMenuSize(parentContentElement, syncSize) : null;
+
+    if (isActive && !this.#submenuActive) {
+      this.#menu?.highlightFirstItem({ preventScroll: true });
+    } else if (!isActive && this.#submenuActive) {
+      this.#menu?.restoreFocus({ preventScroll: true });
+    }
+
+    this.#submenuActive = isActive;
   }
 
   #handleContentKeyDown = (event: UIKeyboardEvent): void => {

--- a/packages/html/src/ui/menu/tests/menu-element.test.ts
+++ b/packages/html/src/ui/menu/tests/menu-element.test.ts
@@ -502,9 +502,12 @@ describe('MenuElement', () => {
 
     root.open = true;
     trigger.id = 'child-trigger';
-    trigger.commandfor = 'child-menu';
+    trigger.setAttribute('commandfor', 'child-menu');
     child.id = 'child-menu';
     item.textContent = 'Auto';
+    const focus = vi.spyOn(trigger, 'focus').mockImplementation((options) => {
+      if (!rootItems.hasAttribute('inert')) HTMLElement.prototype.focus.call(trigger, options);
+    });
 
     item.addEventListener('select', onSelect);
     rootItems.append(trigger);
@@ -528,6 +531,7 @@ describe('MenuElement', () => {
     expect(rootItems.hasAttribute('inert')).toBe(true);
     expect(rootItems.getAttribute('aria-hidden')).toBe('true');
     expect(root.getAttribute('data-submenu-expanded')).toBe('true');
+    focus.mockClear();
 
     item.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 
@@ -544,6 +548,8 @@ describe('MenuElement', () => {
     });
     expect(rootItems.hasAttribute('inert')).toBe(false);
     expect(rootItems.hasAttribute('aria-hidden')).toBe(false);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(document.activeElement).toBe(trigger);
   });
 
   it('keeps the menu open when a checkbox item is toggled', async () => {

--- a/packages/react/src/ui/menu/menu-content.tsx
+++ b/packages/react/src/ui/menu/menu-content.tsx
@@ -16,41 +16,9 @@ import { useComposedRefs } from '../../utils/use-composed-refs';
 import { renderElement } from '../../utils/use-render';
 import { usePopupPosition } from '../popover/use-popup-position';
 import { useMenuContext } from './context';
+import { callKeyDownHandler, preventMenuKeyDefault } from './menu-keyboard';
 
 export interface MenuContentProps extends UIComponentProps<'div', MenuState> {}
-
-const menuPreventedNativeEvents = new WeakSet<Event>();
-
-function preventMenuKeyDefault(event: React.KeyboardEvent<HTMLDivElement>): void {
-  if (event.key !== 'Escape' && isMenuNavigationKey(event) && !event.defaultPrevented) {
-    event.preventDefault();
-    menuPreventedNativeEvents.add(event.nativeEvent);
-  }
-}
-
-function callKeyDownHandler(
-  handler: React.KeyboardEventHandler<HTMLDivElement> | undefined,
-  event: React.KeyboardEvent<HTMLDivElement>
-): boolean {
-  const defaultPreventedBeforeHandler = event.defaultPrevented && !menuPreventedNativeEvents.has(event.nativeEvent);
-
-  if (!handler) return defaultPreventedBeforeHandler;
-
-  let defaultPreventedByHandler = false;
-  const preventDefault = event.preventDefault;
-  event.preventDefault = () => {
-    defaultPreventedByHandler = true;
-    preventDefault.call(event);
-  };
-
-  try {
-    handler(event);
-  } finally {
-    event.preventDefault = preventDefault;
-  }
-
-  return defaultPreventedBeforeHandler || defaultPreventedByHandler;
-}
 
 /** Container for menu items. Positioned relative to the trigger at root level; renders in-place as a submenu panel when nested. */
 export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>(function MenuContent(
@@ -85,10 +53,6 @@ export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>(function
       return () => cancelAnimationFrame(frame);
     }
 
-    if (!isActive && wasActive) {
-      menu.triggerElement?.focus({ preventScroll: true });
-    }
-
     return undefined;
   }, [isActive, isSubmenu, menu]);
 
@@ -96,7 +60,10 @@ export const MenuContent = forwardRef<HTMLDivElement, MenuContentProps>(function
     (element: HTMLDivElement | null) => {
       menu.setContentElement(element);
       if (!element) {
-        requestAnimationFrame(() => syncMenuSizeChain(parent?.menu.contentElement ?? null));
+        requestAnimationFrame(() => {
+          syncMenuSizeChain(parent?.menu.contentElement ?? null);
+          if (!menu.input.current.active) menu.restoreFocus({ preventScroll: true });
+        });
       }
     },
     [menu, parent]

--- a/packages/react/src/ui/menu/menu-keyboard.ts
+++ b/packages/react/src/ui/menu/menu-keyboard.ts
@@ -1,0 +1,41 @@
+import { isMenuNavigationKey } from '@videojs/core/dom';
+
+const preventedEvents = new WeakSet<Event>();
+const canceledEvents = new WeakSet<Event>();
+
+// Menu keys are prevented during capture before native player hotkeys run.
+// Track that internal prevention so bubble handlers can still honor a consumer
+// that calls preventDefault() to opt out of the built-in menu behavior.
+export function preventMenuKeyDefault(event: React.KeyboardEvent<HTMLElement>): void {
+  if (event.key !== 'Escape' && isMenuNavigationKey(event) && !event.defaultPrevented) {
+    event.preventDefault();
+    preventedEvents.add(event.nativeEvent);
+  }
+}
+
+export function callKeyDownHandler<T extends HTMLElement>(
+  handler: React.KeyboardEventHandler<T> | undefined,
+  event: React.KeyboardEvent<T>
+): boolean {
+  const defaultPreventedBeforeHandler =
+    event.defaultPrevented && (!preventedEvents.has(event.nativeEvent) || canceledEvents.has(event.nativeEvent));
+
+  if (!handler) return defaultPreventedBeforeHandler;
+
+  let defaultPreventedByHandler = false;
+  const preventDefault = event.preventDefault;
+  event.preventDefault = () => {
+    defaultPreventedByHandler = true;
+    preventDefault.call(event);
+  };
+
+  try {
+    handler(event);
+  } finally {
+    event.preventDefault = preventDefault;
+  }
+
+  if (defaultPreventedByHandler) canceledEvents.add(event.nativeEvent);
+
+  return defaultPreventedBeforeHandler || defaultPreventedByHandler;
+}

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -8,16 +8,16 @@ import type { UIComponentProps } from '../../utils/types';
 import { renderElement } from '../../utils/use-render';
 import { useSafeId } from '../../utils/use-safe-id';
 import { MenuTriggerChildContextProvider, useMenuContext } from './context';
+import { callKeyDownHandler, preventMenuKeyDefault } from './menu-keyboard';
 
-export interface MenuTriggerProps extends Omit<UIComponentProps<'button', MenuState>, 'type'> {
+type MenuTriggerElement = HTMLButtonElement | HTMLDivElement;
+
+export interface MenuTriggerProps
+  extends Omit<UIComponentProps<'button', MenuState>, 'type' | 'onClick' | 'onKeyDown'> {
   /** Disables the trigger. */
   disabled?: boolean;
-}
-
-function preventMenuKeyDefault(event: React.KeyboardEvent<HTMLElement>): void {
-  if (event.key !== 'Escape' && isMenuNavigationKey(event) && !event.defaultPrevented) {
-    event.preventDefault();
-  }
+  onClick?: React.MouseEventHandler<MenuTriggerElement>;
+  onKeyDown?: React.KeyboardEventHandler<MenuTriggerElement>;
 }
 
 /**
@@ -57,7 +57,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
 
   const handleSubMenuClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      (onClick as React.MouseEventHandler<HTMLDivElement> | undefined)?.(event);
+      onClick?.(event);
       if (event.defaultPrevented) return;
       openSubMenu();
     },
@@ -66,8 +66,8 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
 
   const handleSubMenuKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      (onKeyDown as React.KeyboardEventHandler<HTMLDivElement> | undefined)?.(event);
-      if (disabled || event.defaultPrevented) return;
+      const defaultPreventedByUser = callKeyDownHandler(onKeyDown, event);
+      if (disabled || defaultPreventedByUser) return;
       if (event.key === 'ArrowRight') {
         event.preventDefault();
         openSubMenu();

--- a/packages/react/src/ui/menu/tests/menu.test.tsx
+++ b/packages/react/src/ui/menu/tests/menu.test.tsx
@@ -25,14 +25,20 @@ function makeDOMRect(x: number, y: number, width: number, height: number): DOMRe
   return new DOMRect(x, y, width, height);
 }
 
-function SubmenuFixture() {
+function SubmenuFixture({
+  onTriggerKeyDown,
+}: {
+  onTriggerKeyDown?: KeyboardEventHandler<HTMLButtonElement | HTMLDivElement>;
+}) {
   return (
     <MenuRoot defaultOpen>
       <MenuTrigger>Settings</MenuTrigger>
       <MenuContent data-testid="root-content">
         <div data-testid="root-items">
           <MenuRoot>
-            <MenuTrigger data-testid="submenu-trigger">Quality</MenuTrigger>
+            <MenuTrigger data-testid="submenu-trigger" {...(onTriggerKeyDown ? { onKeyDown: onTriggerKeyDown } : {})}>
+              Quality
+            </MenuTrigger>
             <MenuContent data-testid="submenu-content">
               <MenuItem data-testid="submenu-back">Back</MenuItem>
               <MenuItem data-testid="submenu-item">Auto</MenuItem>
@@ -98,6 +104,33 @@ function SubmenuPreventDefaultFixture({
             </MenuContent>
           </MenuRoot>
         </div>
+      </MenuContent>
+    </MenuRoot>
+  );
+}
+
+function NestedTriggerPreventDefaultFixture({
+  onTriggerKeyDown,
+}: {
+  onTriggerKeyDown: KeyboardEventHandler<HTMLButtonElement | HTMLDivElement>;
+}) {
+  return (
+    <MenuRoot defaultOpen>
+      <MenuTrigger>Settings</MenuTrigger>
+      <MenuContent>
+        <MenuRoot defaultOpen>
+          <MenuTrigger>Quality</MenuTrigger>
+          <MenuContent data-testid="submenu-content">
+            <MenuRoot>
+              <MenuTrigger data-testid="nested-trigger" onKeyDown={onTriggerKeyDown}>
+                Resolution
+              </MenuTrigger>
+              <MenuContent>
+                <MenuItem>1080p</MenuItem>
+              </MenuContent>
+            </MenuRoot>
+          </MenuContent>
+        </MenuRoot>
       </MenuContent>
     </MenuRoot>
   );
@@ -720,6 +753,38 @@ describe('MenuContent', () => {
     expect(screen.getByTestId('root-item').hasAttribute('data-highlighted')).toBe(false);
   });
 
+  it('opens a submenu with ArrowRight', async () => {
+    render(<SubmenuFixture />);
+
+    const trigger = screen.getByTestId('submenu-trigger');
+    fireEvent.keyDown(trigger, { key: 'ArrowRight' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('submenu-content')).not.toBeNull();
+      expect(screen.getByTestId('submenu-back').hasAttribute('data-highlighted')).toBe(true);
+    });
+  });
+
+  it('honors preventDefault from submenu trigger key handlers', () => {
+    const onKeyDown = vi.fn((event: ReactKeyboardEvent<HTMLElement>) => event.preventDefault());
+    render(<SubmenuFixture onTriggerKeyDown={onKeyDown} />);
+
+    fireEvent.keyDown(screen.getByTestId('submenu-trigger'), { key: 'ArrowRight' });
+
+    expect(onKeyDown).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId('submenu-content')).toBeNull();
+  });
+
+  it('preserves trigger preventDefault while the event bubbles through nested menus', () => {
+    const onKeyDown = vi.fn((event: ReactKeyboardEvent<HTMLElement>) => event.preventDefault());
+    render(<NestedTriggerPreventDefaultFixture onTriggerKeyDown={onKeyDown} />);
+
+    fireEvent.keyDown(screen.getByTestId('nested-trigger'), { key: 'ArrowLeft' });
+
+    expect(onKeyDown).toHaveBeenCalledOnce();
+    expect(screen.getByTestId('submenu-content').hasAttribute('data-ending-style')).toBe(false);
+  });
+
   it('highlights the first item when a submenu becomes active', async () => {
     render(<SubmenuFixture />);
 
@@ -785,6 +850,35 @@ describe('MenuContent', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('root-items').hasAttribute('inert')).toBe(false);
+    });
+  });
+
+  it('returns focus after the submenu exit transition completes', async () => {
+    render(<SubmenuFixture />);
+
+    const trigger = screen.getByTestId('submenu-trigger');
+    const focus = vi.spyOn(trigger, 'focus').mockImplementation((options) => {
+      if (!screen.getByTestId('root-items').hasAttribute('inert')) {
+        HTMLElement.prototype.focus.call(trigger, options);
+      }
+    });
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('submenu-back').hasAttribute('data-highlighted')).toBe(true);
+    });
+
+    fireEvent.click(screen.getByTestId('submenu-back'));
+
+    expect(screen.getByTestId('submenu-content').hasAttribute('data-ending-style')).toBe(true);
+    expect(screen.getByTestId('root-items').hasAttribute('inert')).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('submenu-content')).toBeNull();
+      expect(screen.getByTestId('root-items').hasAttribute('inert')).toBe(false);
+      expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+      expect(document.activeElement).toBe(trigger);
     });
   });
 


### PR DESCRIPTION
While doing some testing I noticed that the keyboard navigation in the menu was broken and you'd get stuck when going back from a sub menu. This fixes it. 

Closes #2215 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared menu keyboard/focus logic across core, HTML, and React player UI; behavior is well covered by new unit and e2e tests but regressions could affect accessibility and settings navigation.
> 
> **Overview**
> Fixes **keyboard navigation getting stuck** when leaving a submenu (e.g. ArrowLeft back to the parent list), especially in player settings menus.
> 
> **Core menu (`create-menu`)** adds **`restoreFocus`**, used after close animations to return focus to the trigger only when appropriate (skips blur, outside click, imperative close, and grouped popup switches). Arrow navigation now **skips items** marked `data-availability="unavailable"` or `"unsupported"`.
> 
> **HTML and React** wire submenu exit to **`restoreFocus`** (after transitions / unmount) instead of focusing the trigger immediately, and share **`menu-keyboard`** helpers so **`preventDefault()` on trigger/content `onKeyDown`** still opts out of built-in submenu open/back behavior when events bubble through nested menus.
> 
> **Tests**: new Playwright coverage for settings submenu focus + Arrow keys/Tab; expanded unit tests for focus restoration and availability skipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23200b76177dba889eee03fdd0d996356837a46c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->