### PR TITLE
refactor(icons): svg animation tweaks

### DIFF
--- a/packages/icons/src/assets/default/airplay-exit.svg
+++ b/packages/icons/src/assets/default/airplay-exit.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 18 18">
   <style>
-    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{fill-opacity:0}to{fill-opacity:.2}}@media (prefers-reduced-motion:reduce){:root{--media-icon--airplay__fill-animation:none;--media-icon--airplay__triangle-animation:none}}
+    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{opacity:0}to{opacity:.2}}@media (prefers-reduced-motion:reduce){:root{--media-icon--airplay__fill-animation:none;--media-icon--airplay__triangle-animation:none}}
   </style>
-  <path fill-opacity=".2" d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5a3.5 3.5 0 0 1-3.032 3.468L9.354 8.354a.5.5 0 0 0-.708 0l-5.615 5.614A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z" style="animation:var(--media-icon--airplay__fill-animation, media-icon--airplay__fill 1s ease-in-out infinite alternate)"/>
+  <path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5a3.5 3.5 0 0 1-3.032 3.468L9.354 8.354a.5.5 0 0 0-.708 0l-5.615 5.614A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z" style="animation:var(--media-icon--airplay__fill-animation, media-icon--airplay__fill 1s ease-in-out infinite alternate)"/>
   <path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5l-.005.18a3.5 3.5 0 0 1-3.027 3.288L13 12h1.5a1.5 1.5 0 0 0 1.5-1.5v-5A1.5 1.5 0 0 0 14.5 4h-11A1.5 1.5 0 0 0 2 5.5v5A1.5 1.5 0 0 0 3.5 12H5l-1.968 1.967A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z"/>
   <path d="M8.631 10.902a.5.5 0 0 1 .738 0l4.363 4.76a.5.5 0 0 1-.369.838H4.637a.5.5 0 0 1-.369-.838z" style="animation:var(--media-icon--airplay__triangle-animation, media-icon--airplay__triangle 1s ease-in-out infinite alternate)"/>
 </svg>

--- a/packages/icons/src/assets/default/spinner.svg
+++ b/packages/icons/src/assets/default/spinner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" viewBox="0 0 18 18">
   <style>
-    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s linear infinite);animation-delay:var(--media-spinner-delay)}@media (prefers-reduced-motion:reduce){.media-spinner__segment{animation:none}}
+    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s steps(8, end) infinite);animation-delay:var(--media-spinner-delay)}@media (prefers-reduced-motion:reduce){.media-spinner__segment{animation:none}}
   </style>
   <line x1="9" x2="9" y1="1.5" y2="4.5" class="media-spinner__segment" opacity=".5" style="--media-spinner-delay:0s"/>
   <line x1="14.5" x2="12.5" y1="3.5" y2="5.5" class="media-spinner__segment" opacity=".45" style="--media-spinner-delay:0.125s"/>

--- a/packages/icons/src/assets/minimal/airplay-exit.svg
+++ b/packages/icons/src/assets/minimal/airplay-exit.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 18 18">
   <style>
-    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{fill-opacity:0}to{fill-opacity:.2}}@media (prefers-reduced-motion:reduce){:root{--media-icon--airplay__fill-animation:none;--media-icon--airplay__triangle-animation:none}}
+    @keyframes media-icon--airplay__triangle{0%{translate:0 0}to{translate:0-2px}}@keyframes media-icon--airplay__fill{0%{opacity:0}to{opacity:.2}}@media (prefers-reduced-motion:reduce){:root{--media-icon--airplay__fill-animation:none;--media-icon--airplay__triangle-animation:none}}
   </style>
-  <path fill-opacity=".2" d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5a3.5 3.5 0 0 1-3.032 3.468L9.354 8.354a.5.5 0 0 0-.708 0l-5.615 5.614A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z" style="animation:var(--media-icon--airplay__fill-animation, media-icon--airplay__fill 1s ease-in-out infinite alternate)"/>
+  <path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5a3.5 3.5 0 0 1-3.032 3.468L9.354 8.354a.5.5 0 0 0-.708 0l-5.615 5.614A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z" style="animation:var(--media-icon--airplay__fill-animation, media-icon--airplay__fill 1s ease-in-out infinite alternate)"/>
   <path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v5l-.005.18a3.5 3.5 0 0 1-3.027 3.288L13.5 12.5h1a2 2 0 0 0 2-2v-5a2 2 0 0 0-2-2h-11a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h1l-1.468 1.467A3.5 3.5 0 0 1 0 10.5v-5A3.5 3.5 0 0 1 3.5 2z"/>
   <path d="M8.631 10.902a.5.5 0 0 1 .738 0l4.363 4.76a.5.5 0 0 1-.369.838H4.637a.5.5 0 0 1-.369-.838z" style="animation:var(--media-icon--airplay__triangle-animation, media-icon--airplay__triangle 1s ease-in-out infinite alternate)"/>
 </svg>

--- a/packages/icons/src/assets/minimal/spinner.svg
+++ b/packages/icons/src/assets/minimal/spinner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" viewBox="0 0 18 18">
   <style>
-    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s linear infinite);animation-delay:var(--media-spinner-delay)}@media (prefers-reduced-motion:reduce){.media-spinner__segment{animation:none}}
+    @keyframes media-spinner-fade{0%{opacity:1}to{opacity:0}}.media-spinner__segment{animation:var(--media-spinner-animation, media-spinner-fade 1s steps(8, end) infinite);animation-delay:var(--media-spinner-delay)}@media (prefers-reduced-motion:reduce){.media-spinner__segment{animation:none}}
   </style>
   <line x1="9" x2="9" y1="1.5" y2="4.5" class="media-spinner__segment" opacity=".5" style="--media-spinner-delay:0s"/>
   <line x1="14.5" x2="12.5" y1="3.5" y2="5.5" class="media-spinner__segment" opacity=".45" style="--media-spinner-delay:0.125s"/>


### PR DESCRIPTION
- Use `steps(8, end)` instead of `linear` timing function in `spinner.svg`:
  - `linear` → opacity value changes ~60/120 times/sec, potentially requiring continuous compositing/painting.
  - `steps(8, end)` → opacity only changes 8 times/sec.
  - The CSS animation machinery itself still runs continuously, but the browser has substantially fewer visual changes to deal with.
- Use `opacity` instead of `fill-opacity` in the `airplay-exit.svg` as `fill-opacity` can require repainting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only SVG/CSS animation changes in icon assets; no application logic or data paths affected.
> 
> **Overview**
> Tweaks animated SVG icons in **default** and **minimal** asset sets to reduce paint/compositing work without changing reduced-motion behavior.
> 
> **`spinner.svg`:** the segment fade animation timing changes from `linear` to **`steps(8, end)`**, so opacity updates in discrete steps instead of every frame.
> 
> **`airplay-exit.svg`:** the fill pulse keyframes and animated path switch from **`fill-opacity`** (and a static `fill-opacity` attribute) to animating **`opacity`**, avoiding fill repaints while keeping the same visual intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172c1e80372e11c0ef766ada3d2ae116369f5f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->