### PR TITLE
fix(packages): make the TikTok embed answer the player's controls

### DIFF
--- a/apps/sandbox/templates/html-tiktok-video/main.ts
+++ b/apps/sandbox/templates/html-tiktok-video/main.ts
@@ -17,8 +17,9 @@ async function render() {
 
   document.getElementById('root')!.innerHTML = html`
     <video-player>
-      <${tag} class="aspect-[9/16] max-w-sm mx-auto">
-        <tiktok-video class="block w-full h-full" src="${TIKTOK_VIDEO_SRC}" playsinline></tiktok-video>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <!-- The host element floors itself at TikTok's portrait 325x578; clear that so it fits a landscape box. -->
+        <tiktok-video class="block w-full h-full min-w-0 min-h-0" src="${TIKTOK_VIDEO_SRC}" playsinline></tiktok-video>
       </${tag}>
     </video-player>
   `;

--- a/apps/sandbox/templates/react-tiktok-video/main.tsx
+++ b/apps/sandbox/templates/react-tiktok-video/main.tsx
@@ -18,7 +18,7 @@ function App() {
 
   return (
     <VideoPlayer>
-      <VideoSkinComponent skin={skin} styling={styling} className="aspect-[9/16] max-w-sm mx-auto">
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
         <TikTokVideo className="block w-full h-full" src={TIKTOK_VIDEO_SRC} playsInline />
       </VideoSkinComponent>
     </VideoPlayer>

--- a/packages/html/src/media/tests/tiktok-video.test.ts
+++ b/packages/html/src/media/tests/tiktok-video.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { TikTokVideo } from '../tiktok-video/media';
+
+const SRC = 'https://www.tiktok.com/@videojs/video/7273420104193772846';
+
+describe('TikTokVideo', () => {
+  // Asserted against the template because no DOM implementation the tests run in resolves `:host` for a computed
+  // style, which is also how the sibling embed hosts check theirs.
+  it('keeps the embed out of hit-testing so the skin above it sees hover', () => {
+    // A cross-origin frame swallows every pointer event it is given, and the skin never sees the hover that
+    // reveals the controls.
+    expect(TikTokVideo.getTemplateHTML({ src: SRC })).toMatch(
+      /:host\(:not\(\[controls\]\):not\(\[preload="none"\]\)\)\s*\{\s*pointer-events:\s*none/
+    );
+  });
+
+  it('leaves a dormant embed clickable', () => {
+    // `preload="none"` opts out of the bootstrap, so TikTok's own controls are the only thing left that can start
+    // the player. The rule stops applying rather than the frame stopping taking pointer events.
+    const template = TikTokVideo.getTemplateHTML({ src: SRC, preload: 'none' });
+    expect(template).toContain(':not([preload="none"])');
+  });
+
+  it('builds the embed with a bootstrap autoplay unless preload opts out', () => {
+    // `autoplay=1` is the embed parameter; the `allow` attribute names the feature policy and carries it either way.
+    expect(TikTokVideo.getTemplateHTML({ src: SRC })).toContain('autoplay=1');
+    expect(TikTokVideo.getTemplateHTML({ src: SRC, preload: 'none' })).not.toContain('autoplay=1');
+  });
+});

--- a/packages/html/src/media/tests/tiktok-video.test.ts
+++ b/packages/html/src/media/tests/tiktok-video.test.ts
@@ -21,9 +21,12 @@ describe('TikTokVideo', () => {
     expect(template).toContain(':not([preload="none"])');
   });
 
-  it('builds the embed with a bootstrap autoplay unless preload opts out', () => {
+  it('builds the embed with a bootstrap autoplay unless the player is left dormant', () => {
     // `autoplay=1` is the embed parameter; the `allow` attribute names the feature policy and carries it either way.
     expect(TikTokVideo.getTemplateHTML({ src: SRC })).toContain('autoplay=1');
     expect(TikTokVideo.getTemplateHTML({ src: SRC, preload: 'none' })).not.toContain('autoplay=1');
+    // The two cases the hit-testing rule above excludes are the two that skip the bootstrap, so the frame stays
+    // clickable exactly where its own controls are the only way to start it.
+    expect(TikTokVideo.getTemplateHTML({ src: SRC, controls: '' })).not.toContain('autoplay=1');
   });
 });

--- a/packages/html/src/media/tiktok-video/media.ts
+++ b/packages/html/src/media/tiktok-video/media.ts
@@ -1,4 +1,5 @@
 import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import type { TikTokMediaProps } from '@videojs/media/dom/tiktok';
 import { buildTikTokIframeSrc, TikTokMedia } from '@videojs/media/dom/tiktok';
 import { escapeHtml } from '@videojs/utils/string';
 import { MediaAttachMixin } from '../../store/media-attach-mixin';
@@ -25,12 +26,13 @@ class TikTokCustomMediaElement extends CustomMediaElement('iframe', TikTokMedia)
           height: 100%;
           border: 0;
         }
-        /* Deliberately no pointer-events opt-out, unlike the sibling embed hosts.
-           Hiding TikTok's chrome already leaves the frame with nothing to click,
-           and the embed will not start from a play command alone unless the frame
-           has its own user activation — so taking pointer events away removes the
-           only thing that can start it. Upstream's element leaves the frame
-           interactive for the same reason. */
+        /* A cross-origin frame swallows every pointer event, so the skin above it
+           never sees the hover that reveals the controls. Kept out of hit-testing
+           unless preload="none" left TikTok's player dormant, where the frame's own
+           controls are the only thing that can still start it. */
+        :host(:not([controls]):not([preload="none"])) {
+          pointer-events: none;
+        }
       </style>
       <iframe
         part="iframe"
@@ -47,13 +49,15 @@ class TikTokCustomMediaElement extends CustomMediaElement('iframe', TikTokMedia)
   };
 }
 
-// Only the props the embed URL is built from: TikTok reads nothing else out of it.
-function templateAttrsToEmbedProps(attrs: Record<string, string>) {
+// Only the props the embed URL is built from. `preload` is not a TikTok parameter, but it decides whether the URL
+// carries a bootstrap autoplay, and a URL differing from the host's would have it rebuild the frame on mount.
+function templateAttrsToEmbedProps(attrs: Record<string, string>): Partial<TikTokMediaProps> {
   return {
     autoplay: attrs.autoplay !== undefined,
     defaultMuted: attrs.muted !== undefined,
     loop: attrs.loop !== undefined,
     controls: attrs.controls !== undefined,
+    preload: attrs.preload as TikTokMediaProps['preload'],
   };
 }
 

--- a/packages/html/src/media/tiktok-video/media.ts
+++ b/packages/html/src/media/tiktok-video/media.ts
@@ -28,8 +28,9 @@ class TikTokCustomMediaElement extends CustomMediaElement('iframe', TikTokMedia)
         }
         /* A cross-origin frame swallows every pointer event, so the skin above it
            never sees the hover that reveals the controls. Kept out of hit-testing
-           unless preload="none" left TikTok's player dormant, where the frame's own
-           controls are the only thing that can still start it. */
+           except where the host leaves TikTok's player dormant, which is the same
+           pair of cases shouldBootstrapTikTokEmbed opts out of: then the frame's
+           own controls are the only thing that can still start it. */
         :host(:not([controls]):not([preload="none"])) {
           pointer-events: none;
         }

--- a/packages/media/src/dom/tiktok/media.ts
+++ b/packages/media/src/dom/tiktok/media.ts
@@ -219,7 +219,8 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   pause() {
     // A pause after a pending play is the later intent, so it cancels the replay rather than racing it.
     this.#playRequested = false;
-    this.#takeOver();
+    // Deliberately not a hand-over: only a play makes the embed's next report the caller's. Pausing a parked
+    // player asks for nothing it is not already doing, and taking it over would let the bootstrap's tail through.
     this.#post('pause');
   }
 
@@ -228,7 +229,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   }
   set currentTime(value) {
     if (this.#currentTime === value) return;
-    this.#takeOver();
+    // Scrubbing is not a hand-over either, for the same reason as `pause`.
     // A seek while the bootstrap is still running is where it has to leave the player; parking to the start would
     // rewind the caller, and the position they asked for would never be reported.
     if (this.#bootstrap !== 'off') this.#parkPosition = value;
@@ -237,7 +238,12 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     this.#currentTime = value;
     this.dispatchEvent(new Event('seeking'));
     this.dispatchEvent(new Event('timeupdate'));
-    this.#afterLoad(() => this.#post('seekTo', value));
+    this.#afterLoad(() => {
+      this.#post('seekTo', value);
+      // A player already parked is paused for good, so nothing is coming to confirm this one. A seek made while
+      // the bootstrap is still parking is settled by `#park` instead, once it lands on the position.
+      if (this.#bootstrap === 'parked') this.#settleSeek();
+    });
   }
 
   get duration() {
@@ -549,6 +555,8 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     this.#playFired = false;
     // TikTok mutes itself to get the unasked-for autoplay past the browser, so that mute is its own to undo.
     if (!this.#muted) this.#post('unMute');
+    // The park put the player on the position a seek was waiting for.
+    this.#settleSeek();
     // The play held back rather than raced against the park.
     if (this.#playRequested) {
       this.#playRequested = false;
@@ -557,9 +565,18 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     }
   }
 
-  // Hand a parked player to the caller: what the embed reports next is theirs.
+  // Hand a parked player to the caller: what the embed reports next is theirs. Only a play does this, since only a
+  // play makes the next report of playback something they asked for.
   #takeOver() {
     if (this.#bootstrap === 'parked') this.#bootstrap = 'off';
+  }
+
+  // Settle a seek the embed will not confirm. It reports a position only while it plays, so a seek on a player the
+  // bootstrap is holding paused would otherwise leave `seeking` stuck true and a slider stuck with it.
+  #settleSeek() {
+    if (!this.#seeking) return;
+    this.#seeking = false;
+    this.dispatchEvent(new Event('seeked'));
   }
 
   #onPlayerError({ errorCode, errorType }: TikTokPlayerError) {

--- a/packages/media/src/dom/tiktok/media.ts
+++ b/packages/media/src/dom/tiktok/media.ts
@@ -28,7 +28,7 @@ import {
   type TikTokPlayerError,
 } from './player-api';
 import { tiktokMediaDefaultProps } from './props';
-import { buildTikTokIframeSrc, type TikTokSource } from './source';
+import { buildTikTokIframeSrc, shouldBootstrapTikTokEmbed, type TikTokSource } from './source';
 
 const TikTokMediaBase = MediaPlayedRangesMixin(EventTarget);
 
@@ -61,6 +61,9 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   #srcUnsupported = false;
   // A play asked for before the embed could take one, replayed once it can.
   #playRequested = false;
+  // How far the bootstrap has got: `parking` until the autoplay nobody asked for is stopped, `parked` while the
+  // player waits for the caller's first command. Before `off`, what the embed reports is the bootstrap's own.
+  #bootstrap: 'off' | 'parking' | 'parked' = 'off';
   #playFired = false;
   #currentTime = 0;
   #duration = Number.NaN;
@@ -171,6 +174,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
       this.#post('pause');
       return;
     }
+    this.#bootstrap = shouldBootstrapTikTokEmbed(this.#snapshotProps()) ? 'parking' : 'off';
     // The new frame reports `onPlayerReady`, which is what settles this load.
     target.src = embedSrc;
   }
@@ -204,12 +208,16 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     if (!this.#hasSource) return;
     // Not deferred: only the embed's own report settles the load, so whichever lands first wins, this or the replay.
     this.#playRequested = true;
+    // A play posted mid-park races the pause and can land first; `#park` replays it.
+    if (this.#bootstrap === 'parking') return;
+    this.#takeOver();
     this.#post('play');
   }
 
   pause() {
     // A pause after a pending play is the later intent, so it cancels the replay rather than racing it.
     this.#playRequested = false;
+    this.#takeOver();
     this.#post('pause');
   }
 
@@ -218,6 +226,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   }
   set currentTime(value) {
     if (this.#currentTime === value) return;
+    this.#takeOver();
     this.#seeking = true;
     // Report the requested position now; the embed only reports one periodically, so the seek would look lost.
     this.#currentTime = value;
@@ -364,20 +373,24 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     const target = this.#target;
     if (!target) return false;
 
+    const props = this.#snapshotProps();
     // The `src` property resolves an empty attribute to the document URL; only the attribute tells embed from empty.
     if (target.getAttribute('src')) {
+      // A server-rendered URL was built from these props by the same rule, so it carries the same bootstrap.
+      this.#bootstrap = shouldBootstrapTikTokEmbed(props) ? 'parking' : 'off';
       // The frame is already fetching the embed and will report `onPlayerReady` like any other.
       this.dispatchEvent(new Event('loadstart'));
       return true;
     }
 
-    const initialSrc = buildTikTokIframeSrc(this.#src, this.#snapshotProps());
+    const initialSrc = buildTikTokIframeSrc(this.#src, props);
     // No embed means no `onPlayerReady` is coming to settle this load.
     if (!initialSrc) {
       this.#loadComplete.resolve();
       return false;
     }
 
+    this.#bootstrap = shouldBootstrapTikTokEmbed(props) ? 'parking' : 'off';
     target.src = initialSrc;
     this.dispatchEvent(new Event('loadstart'));
     return true;
@@ -421,6 +434,8 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
         // Nothing for a level to drive without a volume to write, and the reported mute comes through `onMute`.
         break;
       case 'onMute':
+        // The mute a bootstrap autoplay forces on the embed is TikTok's own; `#park` undoes it.
+        if (this.#bootstrap !== 'off') break;
         // Muting leaves the volume alone, the way it does on a media element.
         this.#muted = !!message.value;
         this.dispatchEvent(new Event('volumechange'));
@@ -474,6 +489,8 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
       defaultMuted: this.#nextMuted,
       loop: this.#loop,
       controls: this.#controls,
+      // Read only to decide on a bootstrap autoplay; TikTok has no preload parameter.
+      preload: this.#preload,
       source: this.#source,
     };
   }
@@ -490,6 +507,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     this.#loaded = false;
     this.#srcUnsupported = false;
     this.#playFired = false;
+    this.#bootstrap = 'off';
     this.#error = null;
     this.#isFullscreen = false;
   }
@@ -500,7 +518,11 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     this.#readyState = READY_STATE_HAVE_METADATA;
     // The frame's URL does not always mute the embed, so assert it over the protocol at the first moment it can.
     if (this.#muted) this.#post('mute');
-    if (this.#playRequested) {
+    if (this.#bootstrap === 'parking') {
+      // It came up playing on the bootstrap autoplay; put it where one that never autoplayed would have been.
+      this.#post('pause');
+      this.#post('seekTo', 0);
+    } else if (this.#playRequested) {
       this.#playRequested = false;
       this.#post('play');
     }
@@ -509,6 +531,29 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
       this.dispatchEvent(new Event(type));
     }
     this.#loadComplete.resolve();
+  }
+
+  // Settle the bootstrap's playback. Stays `parked` rather than `off` because TikTok keeps reporting the tail of
+  // that autoplay, and a player nobody has asked to start should report none of it.
+  #park() {
+    if (this.#bootstrap === 'parked') return;
+    this.#bootstrap = 'parked';
+    this.#currentTime = 0;
+    this.#paused = true;
+    this.#playFired = false;
+    // TikTok mutes itself to get the unasked-for autoplay past the browser, so that mute is its own to undo.
+    if (!this.#muted) this.#post('unMute');
+    // The play held back rather than raced against the park.
+    if (this.#playRequested) {
+      this.#playRequested = false;
+      this.#takeOver();
+      this.#post('play');
+    }
+  }
+
+  // Hand a parked player to the caller: what the embed reports next is theirs.
+  #takeOver() {
+    if (this.#bootstrap === 'parked') this.#bootstrap = 'off';
   }
 
   #onPlayerError({ errorCode, errorType }: TikTokPlayerError) {
@@ -538,6 +583,14 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
 
   #onStateChange(state: number) {
     const emit = (type: string) => this.dispatchEvent(new Event(type));
+
+    if (this.#bootstrap !== 'off') {
+      // The bootstrap's own playback. Its tail arrives well after the park is posted, and `loop` restarts it, so
+      // every start is put back down rather than only the first.
+      if (state === STATE_PLAYING || state === STATE_BUFFERING) this.#post('pause');
+      else if (state === STATE_PAUSED || state === STATE_ENDED) this.#park();
+      return;
+    }
 
     if (state === STATE_PLAYING || state === STATE_BUFFERING) {
       if (!this.#playFired) {
@@ -574,15 +627,19 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   }
 
   #onCurrentTime(currentTime: number, duration: number) {
-    if (currentTime !== this.#currentTime) {
-      this.#currentTime = currentTime;
-      this.dispatchEvent(new Event('timeupdate'));
-    }
+    // The positions a bootstrap runs through are not the caller's, and the park returns to 0 anyway. Duration below
+    // is worth keeping whenever the embed knows it.
+    if (this.#bootstrap === 'off') {
+      if (currentTime !== this.#currentTime) {
+        this.#currentTime = currentTime;
+        this.dispatchEvent(new Event('timeupdate'));
+      }
 
-    if (this.#seeking) {
-      // The embed announces no seeks, so its next position report is the only sign one landed, change or not.
-      this.#seeking = false;
-      this.dispatchEvent(new Event('seeked'));
+      if (this.#seeking) {
+        // The embed announces no seeks, so its next position report is the only sign one landed, change or not.
+        this.#seeking = false;
+        this.dispatchEvent(new Event('seeked'));
+      }
     }
 
     if (isNumber(duration) && duration > 0 && duration !== this.#duration) {

--- a/packages/media/src/dom/tiktok/media.ts
+++ b/packages/media/src/dom/tiktok/media.ts
@@ -64,6 +64,8 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   // How far the bootstrap has got: `parking` until the autoplay nobody asked for is stopped, `parked` while the
   // player waits for the caller's first command. Before `off`, what the embed reports is the bootstrap's own.
   #bootstrap: 'off' | 'parking' | 'parked' = 'off';
+  // Where the park leaves the player: the start, or a position the caller seeked to before it got there.
+  #parkPosition = 0;
   #playFired = false;
   #currentTime = 0;
   #duration = Number.NaN;
@@ -227,6 +229,9 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   set currentTime(value) {
     if (this.#currentTime === value) return;
     this.#takeOver();
+    // A seek while the bootstrap is still running is where it has to leave the player; parking to the start would
+    // rewind the caller, and the position they asked for would never be reported.
+    if (this.#bootstrap !== 'off') this.#parkPosition = value;
     this.#seeking = true;
     // Report the requested position now; the embed only reports one periodically, so the seek would look lost.
     this.#currentTime = value;
@@ -508,6 +513,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     this.#srcUnsupported = false;
     this.#playFired = false;
     this.#bootstrap = 'off';
+    this.#parkPosition = 0;
     this.#error = null;
     this.#isFullscreen = false;
   }
@@ -521,7 +527,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
     if (this.#bootstrap === 'parking') {
       // It came up playing on the bootstrap autoplay; put it where one that never autoplayed would have been.
       this.#post('pause');
-      this.#post('seekTo', 0);
+      this.#post('seekTo', this.#parkPosition);
     } else if (this.#playRequested) {
       this.#playRequested = false;
       this.#post('play');
@@ -538,7 +544,7 @@ export class TikTokMedia extends TikTokMediaBase implements Partial<Video> {
   #park() {
     if (this.#bootstrap === 'parked') return;
     this.#bootstrap = 'parked';
-    this.#currentTime = 0;
+    this.#currentTime = this.#parkPosition;
     this.#paused = true;
     this.#playFired = false;
     // TikTok mutes itself to get the unasked-for autoplay past the browser, so that mute is its own to undo.

--- a/packages/media/src/dom/tiktok/props.ts
+++ b/packages/media/src/dom/tiktok/props.ts
@@ -3,9 +3,13 @@ import type { TikTokSource } from './source';
 
 /**
  * The `Video` members the TikTok host accepts, plus the source that names the
- * video. Three are stored and reported but never reach the embed: it always
- * plays inline, it decides for itself what to load ahead, and it draws the
- * video's own cover image, so `playsInline`, `preload`, and `poster` are inert.
+ * video. `playsInline` and `poster` are stored and reported but never reach the
+ * embed: it always plays inline and draws the video's own cover image.
+ *
+ * `preload` reaches no TikTok parameter either, but it is not inert: anything
+ * but `'none'` has the host bring TikTok's dormant player up with an `autoplay`
+ * it then parks (see `shouldBootstrapTikTokEmbed`). That buys commands the embed
+ * answers, not metadata — TikTok reports a duration of 0 until it plays.
  */
 export interface TikTokMediaProps
   extends Pick<

--- a/packages/media/src/dom/tiktok/props.ts
+++ b/packages/media/src/dom/tiktok/props.ts
@@ -8,8 +8,9 @@ import type { TikTokSource } from './source';
  *
  * `preload` reaches no TikTok parameter either, but it is not inert: anything
  * but `'none'` has the host bring TikTok's dormant player up with an `autoplay`
- * it then parks (see `shouldBootstrapTikTokEmbed`). That buys commands the embed
- * answers, not metadata — TikTok reports a duration of 0 until it plays.
+ * it then parks (see `shouldBootstrapTikTokEmbed`), which `controls` also opts
+ * out of by handing playback to TikTok's own chrome. That buys commands the
+ * embed answers, not metadata — TikTok reports a duration of 0 until it plays.
  */
 export interface TikTokMediaProps
   extends Pick<

--- a/packages/media/src/dom/tiktok/source.ts
+++ b/packages/media/src/dom/tiktok/source.ts
@@ -78,6 +78,17 @@ export function parseTikTokSource(src: string): ParsedTikTokSource | null {
   return id ? { id } : null;
 }
 
+/**
+ * Whether the embed has to carry an `autoplay` nobody asked for. TikTok builds its player lazily: without one it
+ * creates no media element, never reports `onPlayerReady`, and drops every command silently, until something is
+ * clicked inside the frame — which a frame under a player skin never gets. The host parks the player as soon as it
+ * is up, so this buys one that answers commands, not a video that plays.
+ */
+export function shouldBootstrapTikTokEmbed(props: Partial<TikTokMediaProps> = {}) {
+  // `preload="none"` trades those working controls back for an untouched network.
+  return !props.autoplay && props.preload !== 'none';
+}
+
 /** Build the iframe `src` URL for a TikTok embed from the given props. */
 export function buildTikTokIframeSrc(src: string, props: Partial<TikTokMediaProps> = {}) {
   const parsed = parseTikTokSource(src);
@@ -86,13 +97,12 @@ export function buildTikTokIframeSrc(src: string, props: Partial<TikTokMediaProp
   // something the player reads, so it never reaches the URL.
   const { referrerPolicy: _referrerPolicy, ...tiktok } = props.source?.engine?.tiktok ?? {};
   const params: Record<string, unknown> = {
-    // Hide TikTok chrome by default; pass nothing only when controls is explicitly true.
+    // Drops the progress bar and control buttons only: the centre play button, author header, and social rail all
+    // survive `controls=0`, and of those only the play button has a parameter of its own.
     controls: props.controls === true ? null : 0,
-    // Off is the player's default for all three, so an explicit `0` says nothing
-    // the embed does not already assume. Left out, the URL is the one upstream's
-    // element builds — worth matching exactly on an embed whose behavior can only
-    // be observed through a cross-origin frame.
-    autoplay: props.autoplay || null,
+    // Also carries a bootstrap autoplay, which the host parks once the player is up.
+    autoplay: props.autoplay || shouldBootstrapTikTokEmbed(props) || null,
+    // Off is the player's default for both, so an explicit `0` says nothing the embed does not already assume.
     muted: props.defaultMuted || null,
     loop: props.loop || null,
     // Keep what the player offers next inside the author's own videos rather

--- a/packages/media/src/dom/tiktok/source.ts
+++ b/packages/media/src/dom/tiktok/source.ts
@@ -85,8 +85,9 @@ export function parseTikTokSource(src: string): ParsedTikTokSource | null {
  * is up, so this buys one that answers commands, not a video that plays.
  */
 export function shouldBootstrapTikTokEmbed(props: Partial<TikTokMediaProps> = {}) {
-  // `preload="none"` trades those working controls back for an untouched network.
-  return !props.autoplay && props.preload !== 'none';
+  // `preload="none"` trades those working controls back for an untouched network, and `controls` hands the player
+  // to TikTok's own chrome, which the host must not park playback out from under.
+  return !props.autoplay && props.preload !== 'none' && props.controls !== true;
 }
 
 /** Build the iframe `src` URL for a TikTok embed from the given props. */

--- a/packages/media/src/dom/tiktok/tests/media.test.ts
+++ b/packages/media/src/dom/tiktok/tests/media.test.ts
@@ -62,6 +62,9 @@ async function attachAndLoad(
   // There is no embed to attach to without a source, so tests that don't care
   // which video is playing get one.
   if (!media.src) media.src = VIDEO_ID;
+  // Opt out of the bootstrap unless a test asks for it: it posts commands of its own and swallows what the embed
+  // reports, which is the subject of `TikTokMedia bootstrap` rather than of the protocol these tests check.
+  if (media.preload === tiktokMediaDefaultProps.preload) media.preload = 'none';
   const iframe = createIframe();
   media.attach(iframe);
   const commands = watchCommands(iframe);
@@ -129,14 +132,20 @@ describe('buildTikTokIframeSrc', () => {
     expect(src).toContain('loop=1');
   });
 
-  it('leaves autoplay, muted, and loop out rather than turning them off', () => {
-    // Off is the player's default for all three, so the URL this builds for a
-    // plain source is the one upstream's element builds, parameter for parameter.
-    const src = buildTikTokIframeSrc(VIDEO_ID, { autoplay: false, defaultMuted: false, loop: false });
+  it('leaves muted and loop out rather than turning them off', () => {
+    // Off is the player's default for both, so an explicit 0 says nothing.
+    const src = buildTikTokIframeSrc(VIDEO_ID, { defaultMuted: false, loop: false, preload: 'none' });
     expect(src).toBe(`https://www.tiktok.com/player/v1/${VIDEO_ID}?controls=0&rel=0`);
-    expect(buildTikTokIframeSrc(VIDEO_ID, tiktokMediaDefaultProps)).toBe(
-      `https://www.tiktok.com/player/v1/${VIDEO_ID}?controls=0&rel=0`
-    );
+  });
+
+  it('carries a bootstrap autoplay unless preload opts out', () => {
+    // An embed that never autoplays answers no command, so every preload but `none` takes the autoplay that
+    // brings TikTok's player up.
+    expect(buildTikTokIframeSrc(VIDEO_ID, tiktokMediaDefaultProps)).toContain('autoplay=1');
+    expect(buildTikTokIframeSrc(VIDEO_ID, { preload: 'auto' })).toContain('autoplay=1');
+    // An unset preload is the default one, so a bare source still brings it up.
+    expect(buildTikTokIframeSrc(VIDEO_ID)).toContain('autoplay=1');
+    expect(buildTikTokIframeSrc(VIDEO_ID, { preload: 'none' })).not.toContain('autoplay');
   });
 
   it('shows TikTok controls when controls=true', () => {
@@ -280,6 +289,8 @@ describe('TikTokMedia', () => {
 
   it('waits for a deferred embed to be ready before playing', async () => {
     const media = new TikTokMedia();
+    // This is about the play the caller asked for before the embed could take one, not the bootstrap's commands.
+    media.preload = 'none';
     const iframe = createIframe();
     media.attach(iframe);
 
@@ -883,6 +894,195 @@ describe('TikTokMedia', () => {
     await media.requestFullscreen();
 
     expect(media.isFullscreen).toBe(false);
+  });
+});
+
+// TikTok's player stays dormant without an autoplay, answering no command. The host brings it up with one nobody
+// asked for and parks it, so the caller gets a player that answers rather than a video that played.
+describe('TikTokMedia bootstrap', () => {
+  /** Attach with the bootstrap left on, the way every preload but `none` arrives. */
+  async function attachBootstrapped(media: TikTokMedia) {
+    if (!media.src) media.src = VIDEO_ID;
+    const iframe = createIframe();
+    media.attach(iframe);
+    const commands = watchCommands(iframe);
+    return { iframe, commands };
+  }
+
+  it('parks the player once the bootstrap embed reports ready', async () => {
+    const media = new TikTokMedia();
+    const { iframe, commands } = await attachBootstrapped(media);
+
+    report(iframe, 'onPlayerReady');
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'seekTo', value: 0 }, '*');
+    media.detach();
+  });
+
+  it('reports none of the playback the bootstrap runs through', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachBootstrapped(media);
+    const events: string[] = [];
+    for (const type of ['play', 'playing', 'pause', 'waiting', 'timeupdate', 'ended'] as const) {
+      media.addEventListener(type, () => events.push(type));
+    }
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.BUFFERING);
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    report(iframe, 'onCurrentTime', { currentTime: 1.5, duration: 12 });
+
+    expect(events).toEqual([]);
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('keeps a duration the embed reports while parking', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachBootstrapped(media);
+    const durationChange = vi.fn();
+    media.addEventListener('durationchange', durationChange);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onCurrentTime', { currentTime: 1.5, duration: 12 });
+
+    expect(media.duration).toBe(12);
+    expect(durationChange).toHaveBeenCalledTimes(1);
+    // The positions it ran through are the bootstrap's; the park returns to the start.
+    expect(media.currentTime).toBe(0);
+    media.detach();
+  });
+
+  it('leaves a parked player paused at the start', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachBootstrapped(media);
+    const pauseSpy = vi.fn();
+    media.addEventListener('pause', pauseSpy);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PLAYING);
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    // The park is not a pause the caller asked for, so it is not announced as one.
+    expect(pauseSpy).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    expect(media.currentTime).toBe(0);
+    media.detach();
+  });
+
+  it('puts the tail of the bootstrap autoplay back down', async () => {
+    const media = new TikTokMedia();
+    const { iframe, commands } = await attachBootstrapped(media);
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PAUSED);
+    commands.mockClear();
+
+    // The autoplay's tail arrives well after the park is posted, and `loop` restarts it; announcing either would
+    // report a playback nobody asked for.
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('hands the player over on the first command the caller gives', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachBootstrapped(media);
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PAUSED);
+    await media.play();
+
+    // From here what the embed reports is the caller's.
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(false);
+    media.detach();
+  });
+
+  it('undoes the mute TikTok forces on a bootstrap autoplay', async () => {
+    const media = new TikTokMedia();
+    const { iframe, commands } = await attachBootstrapped(media);
+    const volumeChange = vi.fn();
+    media.addEventListener('volumechange', volumeChange);
+
+    report(iframe, 'onPlayerReady');
+    // TikTok mutes itself to get the unasked-for autoplay past the browser.
+    report(iframe, 'onMute', true);
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'unMute' }, '*');
+    // The mute was never the caller's, so it was never reported as theirs either.
+    expect(media.muted).toBe(false);
+    expect(volumeChange).not.toHaveBeenCalled();
+    media.detach();
+  });
+
+  it('leaves a mute the caller did ask for alone', async () => {
+    const media = new TikTokMedia();
+    media.defaultMuted = true;
+    const { iframe, commands } = await attachBootstrapped(media);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    expect(commands).not.toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'unMute' }, '*');
+    expect(media.muted).toBe(true);
+    media.detach();
+  });
+
+  it('holds a play pressed during the bootstrap and replays it after the park', async () => {
+    const media = new TikTokMedia();
+    const { iframe, commands } = await attachBootstrapped(media);
+
+    report(iframe, 'onPlayerReady');
+    await media.play();
+
+    // Posting it now would race the park's pause, which could land last.
+    expect(commands).not.toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'play' }, '*');
+
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'play' }, '*');
+    media.detach();
+  });
+
+  it('takes an autoplay that was asked for as playback rather than a bootstrap', async () => {
+    const media = new TikTokMedia();
+    media.autoplay = true;
+    const { iframe, commands } = await attachBootstrapped(media);
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    expect(commands).not.toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(false);
+    media.detach();
+  });
+
+  it('leaves the player dormant under preload=none', async () => {
+    const media = new TikTokMedia();
+    media.preload = 'none';
+    const { iframe, commands } = await attachBootstrapped(media);
+
+    expect(iframe.getAttribute('src')).not.toContain('autoplay');
+
+    report(iframe, 'onPlayerReady');
+
+    expect(commands).not.toHaveBeenCalled();
+    media.detach();
   });
 });
 

--- a/packages/media/src/dom/tiktok/tests/media.test.ts
+++ b/packages/media/src/dom/tiktok/tests/media.test.ts
@@ -1072,6 +1072,45 @@ describe('TikTokMedia bootstrap', () => {
     media.detach();
   });
 
+  it('still puts the tail back down after the caller seeks a parked player', async () => {
+    const media = new TikTokMedia();
+    const { iframe, commands } = await attachBootstrapped(media);
+    const playSpy = vi.fn();
+    media.addEventListener('play', playSpy);
+
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PAUSED);
+    // Scrubbing a parked player is not asking it to play, so it must not hand the bootstrap's tail to the caller.
+    media.currentTime = 5;
+    await flushLoad();
+    commands.mockClear();
+
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(media.paused).toBe(true);
+    media.detach();
+  });
+
+  it('settles a seek the parked player will never report back', async () => {
+    const media = new TikTokMedia();
+    const { iframe } = await attachBootstrapped(media);
+    const seeked = vi.fn();
+    media.addEventListener('seeked', seeked);
+
+    report(iframe, 'onPlayerReady');
+    media.currentTime = 5;
+    await flushLoad();
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    // The embed reports positions only while it plays, so a paused player leaves the seek with nothing to
+    // confirm it. The park put it exactly where it was asked to go, which is confirmation enough.
+    expect(media.seeking).toBe(false);
+    expect(seeked).toHaveBeenCalledTimes(1);
+    media.detach();
+  });
+
   it('leaves the embed to drive itself when it is showing its own controls', async () => {
     const media = new TikTokMedia();
     media.controls = true;

--- a/packages/media/src/dom/tiktok/tests/media.test.ts
+++ b/packages/media/src/dom/tiktok/tests/media.test.ts
@@ -1072,6 +1072,36 @@ describe('TikTokMedia bootstrap', () => {
     media.detach();
   });
 
+  it('leaves the embed to drive itself when it is showing its own controls', async () => {
+    const media = new TikTokMedia();
+    media.controls = true;
+    const { iframe, commands } = await attachBootstrapped(media);
+
+    // TikTok's chrome is showing and the frame takes clicks, so a play started there is the caller's and putting
+    // it back down would fight the controls they are using.
+    report(iframe, 'onPlayerReady');
+    report(iframe, 'onStateChange', STATE.PLAYING);
+
+    expect(commands).not.toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'pause' }, '*');
+    expect(media.paused).toBe(false);
+    media.detach();
+  });
+
+  it('parks at a position the caller seeked to while it was still coming up', async () => {
+    const media = new TikTokMedia();
+    const { iframe, commands } = await attachBootstrapped(media);
+
+    report(iframe, 'onPlayerReady');
+    media.currentTime = 5;
+    await flushLoad();
+    report(iframe, 'onStateChange', STATE.PAUSED);
+
+    // The park returns the player to the start, but not over a position the caller has since asked for.
+    expect(commands).toHaveBeenCalledWith({ 'x-tiktok-player': true, type: 'seekTo', value: 5 }, '*');
+    expect(media.currentTime).toBe(5);
+    media.detach();
+  });
+
   it('leaves the player dormant under preload=none', async () => {
     const media = new TikTokMedia();
     media.preload = 'none';


### PR DESCRIPTION
## Summary

TikTok's embedded player never came up, so pressing play in our own controls did nothing at all — silently, with no error to go on — and hovering the player never revealed the controls. The embed now brings its player up on load, and the frame stops swallowing pointer events.

## Changes

- The embed URL now carries an `autoplay` nobody asked for. TikTok builds its player lazily: without one it creates no media element, never reports `onPlayerReady`, and drops every command posted to it until something is clicked inside the frame — which a cross-origin frame under a player skin never gets. The host parks the player back at a paused start as soon as it reports in, so what this buys is a player that answers commands, not a video that played.
- None of the bootstrap's playback is reported. TikTok keeps reporting the tail of it well after the park is posted, and `loop` restarts it by itself, so any unsolicited start is put back down rather than announced as the caller's.
- TikTok force-mutes itself to get that unasked-for autoplay past the browser. The mute is undone on the way out, so it is never reported as the caller's.
- `preload="none"` and `controls` both opt out and leave the player dormant, which is how every TikTok embed behaved before this. They are the two cases that leave something clickable able to start it, so they are also the two the hit-testing rule below keeps interactive.
- A seek made while the bootstrap is still running is where the park leaves the player, rather than being rewound to the start under the caller.
- The frame is kept out of hit-testing, the way the four sibling embed hosts already are. A cross-origin frame swallows every pointer event, so the skin above it never saw the hover that reveals the controls — measured on the real embed, 0 `pointermove` events reached the skin before, 13 after.
- Corrects two comments that did not match the embed's behavior: `controls=0` drops only the progress bar and control buttons, leaving the centre play button, the author header, and the like/comment/share rail; and the frame was never "nothing to click".

<details>
<summary>Implementation details</summary>

The bootstrap is a three-phase field rather than a boolean. `parking` runs from the embed being built until the unasked-for playback is stopped; `parked` is a player that is up and quiet, waiting for the caller's first command; `off` is a player the caller owns. The middle phase exists because TikTok goes on reporting the autoplay well after the park is posted, and a two-state version reported a playback nobody asked for — visible in Chromium as `paused === false` over a stopped video. It is also why a seek during the bootstrap moves the park's target position instead of taking the player over: taking over there would let that tail leak out as caller playback.

A `play()` during `parking` is held rather than posted, because it races the park's own pause and can lose; `#park` replays it once the player is settled.

The same rule decides the URL in all three places one is built (the media host, the custom element template, and the React host), so a server-rendered URL cannot drift from the one the host would build and trigger a frame rebuild on mount. It is also the rule the host CSS mirrors, so the frame stays clickable exactly where its own controls are the only way to start it.

`shouldBootstrapTikTokEmbed` becomes public API through the existing `export * from './source'` in the package barrel. Happy to make it module-private instead if that surface is unwanted.

Two things this does not do:

- `duration` still arrives with playback rather than on load: TikTok reports a duration of `0` until it plays, so the bootstrap buys controllability, not metadata. The `preload` docs say so.
- Every TikTok embed now fetches and briefly decodes video on load. That is the cost of a working play button, and `preload="none"` opts out.

No React embed host has the hit-testing opt-out, and no skin carries an `iframe` or `[data-cross-origin-frame]` rule, so by inspection the hover problem should affect every React embed host, not just TikTok. That is pre-existing and left alone here rather than fixed for one host in isolation.

</details>

## Testing

- `pnpm -F @videojs/media test` — 893 pass, including 13 new tests covering the bootstrap: the park, the swallowed playback, the tail being put back down, the forced mute being undone, a play held across the park, a seek kept across the park, a requested `autoplay` still being treated as playback, and the `preload="none"` and `controls` opt-outs.
- `pnpm -F @videojs/html test` — 348 pass, including 3 new tests for the hit-testing rule, the dormant exceptions, and the bootstrap autoplay in the template.
- `pnpm typecheck`, `pnpm check:workspace`.
- Manual, via Playwright against the real embed in both Chromium and WebKit: the player comes up silent and paused at 0, then play and pause driven only from our own controls both work, with sound, without any interaction inside the frame.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default TikTok load behavior (brief autoplay/decode) and playback state handling in a cross-origin embed path; mitigated by `preload="none"`/`controls` opt-outs and broad new test coverage.
> 
> **Overview**
> Fixes TikTok embeds where **custom skin play did nothing** and **hover never revealed controls** because TikTok’s player stayed dormant until in-frame clicks.
> 
> The embed URL now adds a **bootstrap `autoplay`** (unless `preload="none"`, `controls`, or caller `autoplay`) so TikTok initializes; `TikTokMedia` then **parks** playback (pause/seek, suppress bootstrap events, undo forced mute, replay deferred `play()`). `preload` is wired through URL building so SSR and runtime URLs stay aligned.
> 
> The `<tiktok-video>` host gets **`pointer-events: none`** when bootstrapped (matching other embed hosts), with exceptions when the frame must stay clickable. Sandbox TikTok demos switch to **landscape `aspect-video`**. New unit tests cover bootstrap, hit-testing, and URL rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210f9e3ddf71b5cd62d096ff1340e5b18eeff302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->