### PR TITLE
feat(site): tailwind style preference + tailwind demo variants

### DIFF
--- a/.agents/skills/migrate-css-to-tailwind/SKILL.md
+++ b/.agents/skills/migrate-css-to-tailwind/SKILL.md
@@ -14,6 +14,10 @@ description: Migrate site styles to Tailwind v4. Use for CSS, modules, SCSS, sty
 
 Keep the change scoped to migration; report unrelated styling problems separately.
 
+Exception: docs demo `tailwind/` variants under `site/src/components/docs/demos` are copy-paste
+snippets for a stock Tailwind v4 setup — site theme tokens and site-only conventions do not apply
+there. Their rules live in the `write-api-reference` skill (`references/demo-patterns.md`).
+
 ## Example
 
 Input: “Migrate the site header module to Tailwind v4.”

--- a/.agents/skills/migrate-css-to-tailwind/SKILL.md
+++ b/.agents/skills/migrate-css-to-tailwind/SKILL.md
@@ -16,7 +16,8 @@ Keep the change scoped to migration; report unrelated styling problems separatel
 
 Exception: docs demo `tailwind/` variants under `site/src/components/docs/demos` are copy-paste
 snippets for a stock Tailwind v4 setup — site theme tokens and site-only conventions do not apply
-there. Their rules live in the `write-api-reference` skill (`references/demo-patterns.md`).
+there. Their rules live with the API reference demo patterns
+(`.agents/skills/write-api-reference/references/demo-patterns.md`).
 
 ## Example
 

--- a/.agents/skills/write-api-reference/references/demo-patterns.md
+++ b/.agents/skills/write-api-reference/references/demo-patterns.md
@@ -11,10 +11,29 @@ site/src/components/docs/demos/{component}/
 │   ├── BasicUsage.html      # Markup only (no <style> or <script>)
 │   ├── BasicUsage.css       # Styles
 │   └── BasicUsage.ts        # Side-effect imports for custom element registration
-└── react/css/
-    ├── BasicUsage.tsx        # React component
-    └── BasicUsage.css        # Styles
+├── html/tailwind/
+│   ├── BasicUsage.astro     # Same wrapper shape as the css variant
+│   ├── BasicUsage.html      # Markup with Tailwind utilities inline (no .css file)
+│   └── BasicUsage.ts        # Identical copy of the css variant's .ts
+├── react/css/
+│   ├── BasicUsage.tsx       # React component
+│   └── BasicUsage.css       # Styles
+└── react/tailwind/
+    └── BasicUsage.tsx       # css variant with Tailwind utility classes (no .css file)
 ```
+
+Every styled demo ships both a `css/` and a `tailwind/` variant with the same demo names; the MDX
+page gates them with `<StyleCase styles={["css"]}>` / `<StyleCase styles={["tailwind"]}>`. Demos
+with no stylesheet of their own (style-agnostic, e.g. JSON-config demos) live only in `css/` and
+render for both styles.
+
+Tailwind variants must stay copy-paste compatible with a stock Tailwind v4 setup — never use site
+theme tokens (`manila-*`, `text-h1`, `intent:`). The site theme resets the default color and text
+scales, so the stock tokens demos rely on (`gray-*`, `blue-500`, `neutral-*`, `text-xs`,
+`text-sm`) are re-declared verbatim in a dedicated `@theme` block in
+`site/src/styles/globals.css`; extend that block (stock values only) if a new demo needs another
+token. State styling uses data-attribute variants (`data-paused:`, `in-data-paused:`,
+`not-in-data-ended:`) in place of the css variant's attribute selectors.
 
 ## BEM Naming
 

--- a/.agents/skills/write-api-reference/references/mdx-structure.md
+++ b/.agents/skills/write-api-reference/references/mdx-structure.md
@@ -180,6 +180,13 @@ Renders a `<button>` with an automatic `aria-label`: "Unmute" when muted, "Mute"
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -192,14 +199,25 @@ Renders a `<button>` with an automatic `aria-label`: "Unmute" when muted, "Mute"
       <BasicUsageDemoHtml />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 ```
 
 Key details:
 - React demos use `client:idle` for hydration
 - HTML demos render server-side (no `client:*` directive)
-- React source tabs: `App.tsx`, `App.css`
-- HTML source tabs: `index.html`, `index.css`, `index.ts`
+- React source tabs: `App.tsx`, `App.css` (Tailwind variant: `App.tsx` only)
+- HTML source tabs: `index.html`, `index.css`, `index.ts` (Tailwind variant: `index.html`, `index.ts`)
+- Tailwind import names append `Tailwind` to the css names (`BasicUsageDemoReactTailwind`,
+  `basicUsageReactTailwindTsx`, `BasicUsageDemoHtmlTailwind`, `basicUsageTailwindHtml`,
+  `basicUsageTailwindHtmlTs`); place them directly after the corresponding css imports
 
 ### ComponentReference Component
 

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -48,6 +48,7 @@ pnpm -F site astro check
 ## Demos
 
 - Use `{{VJS*}}` placeholders from `scripts/replace-demo-placeholders.ts` for shared media URLs in HTML and React demos.
+- Every styled demo ships a `css/` and a `tailwind/` variant, gated in MDX with `<StyleCase>`. Tailwind variants use stock Tailwind v4 utilities only — never site theme tokens; the stock tokens demos rely on are re-declared in a dedicated `@theme` block in `src/styles/globals.css`. Structure and naming are owned by the `write-api-reference` skill (`references/demo-patterns.md`).
 - Keep demo-specific CSS scoped under a unique root class.
 - Prefix demo classes with framework, component, and variant.
 - Reflect meaningful HTML demo state to `data-*` attributes and style those attributes.

--- a/site/src/components/docs/demos/airplay-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/airplay-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/airplay-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/airplay-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,18 @@
+<video-player class="relative block">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-airplay-button
+            class="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px] data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:grayscale"
+        >
+            <span class="hidden in-data-[airplay-state=connected]:inline">Stop AirPlay</span>
+            <span class="hidden not-in-data-[airplay-state=connected]:inline">Start AirPlay</span>
+        </media-airplay-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/airplay-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/airplay-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/airplay-button';

--- a/site/src/components/docs/demos/airplay-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/airplay-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,20 @@
+import { AirPlayButton, Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <AirPlayButton
+          className="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px] data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:grayscale"
+          render={(props, state) => (
+            <button {...props}>{state.state === 'connected' ? 'Stop AirPlay' : 'Start AirPlay'}</button>
+          )}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.html
@@ -1,0 +1,39 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <hlsjs-video
+            class="w-full"
+            src="{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}"
+            autoplay
+            crossorigin="anonymous"
+            muted
+            playsinline
+            loop
+        ></hlsjs-video>
+        <div class="absolute right-2.5 bottom-2.5">
+            <button
+                type="button"
+                commandfor="audio-menu"
+                class="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+            >
+                Audio
+            </button>
+            <media-menu
+                id="audio-menu"
+                side="top"
+                align="end"
+                class="[--media-menu-side-offset:8px] box-border grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]"
+            >
+                <media-audio-track-radio-group class="grid gap-0.5" label="Audio tracks">
+                    <template>
+                        <media-menu-radio-item
+                            class="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+                        >
+                            <span data-part="label"></span>
+                            <media-menu-item-indicator force-mount class="opacity-0 in-aria-checked:opacity-100">✓</media-menu-item-indicator>
+                        </media-menu-radio-item>
+                    </template>
+                </media-audio-track-radio-group>
+            </media-menu>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.ts
@@ -1,0 +1,4 @@
+import '@videojs/html/video/player';
+import '@videojs/html/media/hlsjs-video';
+import '@videojs/html/ui/menu';
+import '@videojs/html/ui/audio-track-radio-group';

--- a/site/src/components/docs/demos/audio-track-radio-group/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/audio-track-radio-group/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,49 @@
+import { AudioTrackRadioGroup, Container, createPlayer, Menu } from '@videojs/react';
+import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+import { videoFeatures } from '@videojs/react/video';
+import type { ReactNode } from 'react';
+
+const { Player } = createPlayer({ features: videoFeatures });
+const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
+
+function AudioMenu(): ReactNode {
+  return (
+    <Menu.Root side="top" align="end">
+      <Menu.Trigger
+        className="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+        render={<button type="button" />}
+      >
+        Audio
+      </Menu.Trigger>
+      <Menu.Content className="[--media-menu-side-offset:8px] box-border m-0 grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg border-0 bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]">
+        <AudioTrackRadioGroup
+          className="grid gap-0.5"
+          renderItem={(props, item) => (
+            <Menu.RadioItem
+              {...props}
+              className="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+            >
+              {item.label}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="opacity-0 in-aria-checked:opacity-100">
+                ✓
+              </Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <HlsJsVideo className="w-full" src={src} autoPlay crossOrigin="anonymous" muted playsInline loop />
+        <div className="absolute right-2.5 bottom-2.5">
+          <AudioMenu />
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/background-video/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/background-video/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/background-video/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/background-video/html/tailwind/BasicUsage.html
@@ -1,0 +1,5 @@
+<div class="grid aspect-video w-full">
+    <background-video
+        src="{{VJS10_DEMO_BACKGROUND_VIDEO_MP4}}"
+    ></background-video>
+</div>

--- a/site/src/components/docs/demos/background-video/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/background-video/html/tailwind/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/media/background-video';

--- a/site/src/components/docs/demos/background-video/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/background-video/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,9 @@
+import { BackgroundVideo } from '@videojs/react/media/background-video';
+
+export default function BasicUsage() {
+  return (
+    <div className="relative aspect-video w-full">
+      <BackgroundVideo src="{{VJS10_DEMO_BACKGROUND_VIDEO_MP4}}" />
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.html
@@ -1,0 +1,14 @@
+<video-player class="relative flex h-full w-full">
+    <media-container>
+        <video
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-buffering-indicator class="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
+            <div class="hidden size-12 animate-spin rounded-full border-4 border-white/30 border-t-white [animation-duration:0.8s] in-data-visible:block"></div>
+        </media-buffering-indicator>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/buffering-indicator';

--- a/site/src/components/docs/demos/buffering-indicator/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/buffering-indicator/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,24 @@
+import { BufferingIndicator, Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative flex h-full w-full">
+        <Video src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <BufferingIndicator
+          className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center"
+          render={(props, state) => (
+            <div {...props}>
+              {state.visible && (
+                <div className="hidden size-12 animate-spin rounded-full border-4 border-white/30 border-t-white [animation-duration:0.8s] in-data-visible:block" />
+              )}
+            </div>
+          )}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/captions-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/captions-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/captions-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,20 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        >
+            <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
+        </video>
+        <media-captions-button
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-active:inline">Captions Off</span>
+            <span class="hidden not-in-data-active:inline">Captions On</span>
+        </media-captions-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/captions-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/captions-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/captions-button';

--- a/site/src/components/docs/demos/captions-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,22 @@
+import { CaptionsButton, Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop>
+          <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
+        </Video>
+        <CaptionsButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => (
+            <button {...props}>{state.subtitlesShowing ? 'Captions Off' : 'Captions On'}</button>
+          )}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.html
@@ -1,0 +1,41 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        >
+            <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
+            <track kind="subtitles" src="/docs/demos/captions-button/captions.vtt" srclang="es" label="Spanish" />
+        </video>
+        <div class="absolute right-2.5 bottom-2.5">
+            <button
+                type="button"
+                commandfor="captions-menu"
+                class="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+            >
+                Captions
+            </button>
+            <media-menu
+                id="captions-menu"
+                side="top"
+                align="end"
+                class="[--media-menu-side-offset:8px] box-border grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]"
+            >
+                <media-captions-radio-group class="grid gap-0.5" label="Captions">
+                    <template>
+                        <media-menu-radio-item
+                            class="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+                        >
+                            <span data-part="label"></span>
+                            <media-menu-item-indicator force-mount class="opacity-0 in-aria-checked:opacity-100">✓</media-menu-item-indicator>
+                        </media-menu-radio-item>
+                    </template>
+                </media-captions-radio-group>
+            </media-menu>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/menu';
+import '@videojs/html/ui/captions-radio-group';

--- a/site/src/components/docs/demos/captions-radio-group/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/captions-radio-group/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,50 @@
+import { CaptionsRadioGroup, Container, createPlayer, Menu } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+import type { ReactNode } from 'react';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+function CaptionsMenu(): ReactNode {
+  return (
+    <Menu.Root side="top" align="end">
+      <Menu.Trigger
+        className="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+        render={<button type="button" />}
+      >
+        Captions
+      </Menu.Trigger>
+      <Menu.Content className="[--media-menu-side-offset:8px] box-border m-0 grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg border-0 bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]">
+        <CaptionsRadioGroup
+          className="grid gap-0.5"
+          renderItem={(props, item) => (
+            <Menu.RadioItem
+              {...props}
+              className="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+            >
+              {item.label}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="opacity-0 in-aria-checked:opacity-100">
+                ✓
+              </Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop>
+          <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
+          <track kind="subtitles" src="/docs/demos/captions-button/captions.vtt" srcLang="es" label="Spanish" />
+        </Video>
+        <div className="absolute right-2.5 bottom-2.5">
+          <CaptionsMenu />
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/cast-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/cast-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/cast-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/cast-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,18 @@
+<video-player class="relative block">
+    <media-container>
+        <hlsjs-video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_HLS}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></hlsjs-video>
+        <media-cast-button
+            class="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px] data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:grayscale"
+        >
+            <span class="hidden in-data-[cast-state=connected]:inline">Stop casting</span>
+            <span class="hidden not-in-data-[cast-state=connected]:inline">Start casting</span>
+        </media-cast-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/cast-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/cast-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/media/hlsjs-video';
+import '@videojs/html/ui/cast-button';

--- a/site/src/components/docs/demos/cast-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/cast-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,21 @@
+import { CastButton, Container, createPlayer } from '@videojs/react';
+import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+import { videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <HlsJsVideo className="w-full" src="{{VJS10_DEMO_VIDEO_HLS}}" autoPlay muted playsInline loop />
+        <CastButton
+          className="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px] data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:grayscale"
+          render={(props, state) => (
+            <button {...props}>{state.connection === 'connected' ? 'Stop casting' : 'Start casting'}</button>
+          )}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/controls/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/controls/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/controls/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/controls/html/tailwind/BasicUsage.html
@@ -1,0 +1,32 @@
+<video-player class="relative block">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+
+        <media-controls
+            class="pointer-events-none absolute inset-0 flex items-end bg-linear-to-t from-black/45 to-transparent to-45% p-3 transition-opacity duration-250 not-data-visible:opacity-0"
+        >
+            <media-controls-group
+                class="pointer-events-auto flex w-full items-center justify-between"
+                aria-label="Playback controls"
+            >
+                <media-play-button
+                    class="cursor-pointer rounded-full border border-white/25 bg-white/75 px-4 py-2 text-sm text-black backdrop-blur-[10px]"
+                >
+                    <span class="hidden in-data-paused:inline">Play</span>
+                    <span class="hidden not-in-data-paused:inline">Pause</span>
+                </media-play-button>
+                <media-time
+                    class="inline-flex items-center gap-1 rounded-full border border-white/25 bg-white/75 px-4 py-2 text-sm text-black backdrop-blur-[10px]"
+                    type="current"
+                ></media-time>
+            </media-controls-group>
+        </media-controls>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/controls/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/controls/html/tailwind/BasicUsage.ts
@@ -1,0 +1,4 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/controls';
+import '@videojs/html/ui/play-button';
+import '@videojs/html/ui/time';

--- a/site/src/components/docs/demos/controls/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/controls/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,31 @@
+import { Container, Controls, createPlayer, PlayButton, Time } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+
+        <Controls.Root className="pointer-events-none absolute inset-0 flex items-end bg-linear-to-t from-black/45 to-transparent to-45% p-3 transition-opacity duration-250 not-data-visible:opacity-0">
+          <Controls.Group
+            className="pointer-events-auto flex w-full items-center justify-between"
+            aria-label="Playback controls"
+          >
+            <PlayButton
+              className="cursor-pointer rounded-full border border-white/25 bg-white/75 px-4 py-2 text-sm text-black backdrop-blur-[10px]"
+              render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}
+            />
+
+            <Time.Value
+              type="current"
+              className="inline-flex items-center gap-1 rounded-full border border-white/25 bg-white/75 px-4 py-2 text-sm text-black backdrop-blur-[10px]"
+            />
+          </Controls.Group>
+        </Controls.Root>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/create-player/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/create-player/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,34 @@
+import { Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player, usePlayer } = createPlayer({
+  features: videoFeatures,
+});
+
+function Controls() {
+  const store = usePlayer();
+  const paused = usePlayer((s) => s.paused);
+
+  return (
+    <div className="absolute bottom-2.5 left-2.5">
+      <button
+        type="button"
+        className="cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        onClick={() => (paused ? store.play() : store.pause())}
+      >
+        {paused ? 'Play' : 'Pause'}
+      </button>
+    </div>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline />
+        <Controls />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/dash-video/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/dash-video/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/dash-video/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/dash-video/html/tailwind/BasicUsage.html
@@ -1,0 +1,9 @@
+<media-container class="relative block aspect-video w-full">
+    <dash-video
+        src="{{VJS10_DEMO_DASH}}"
+        autoplay
+        muted
+        playsinline
+        loop
+    ></dash-video>
+</media-container>

--- a/site/src/components/docs/demos/dash-video/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/dash-video/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/media/container';
+import '@videojs/html/media/dash-video';

--- a/site/src/components/docs/demos/dash-video/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/dash-video/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,5 @@
+import { DashVideo } from '@videojs/react/media/dash-video';
+
+export default function BasicUsage() {
+  return <DashVideo className="aspect-video w-full" src="{{VJS10_DEMO_DASH}}" autoPlay muted playsInline loop />;
+}

--- a/site/src/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,18 @@
+<video-player class="relative block">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-fullscreen-button
+            class="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-fullscreen:inline">Exit Fullscreen</span>
+            <span class="hidden not-in-data-fullscreen:inline">Fullscreen</span>
+        </media-fullscreen-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/fullscreen-button';

--- a/site/src/components/docs/demos/fullscreen-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/fullscreen-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer, FullscreenButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <FullscreenButton
+          className="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => <button {...props}>{state.fullscreen ? 'Exit Fullscreen' : 'Fullscreen'}</button>}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/hls-audio/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/hls-audio/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/hls-audio/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/hls-audio/html/tailwind/BasicUsage.html
@@ -1,0 +1,5 @@
+<hls-audio
+    class="h-13.5 w-full"
+    src="{{VJS10_DEMO_VIDEO_HLS}}"
+    controls
+></hls-audio>

--- a/site/src/components/docs/demos/hls-audio/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/hls-audio/html/tailwind/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/media/hls-audio';

--- a/site/src/components/docs/demos/hls-audio/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/hls-audio/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,5 @@
+import { HlsAudio } from '@videojs/react/media/hls-audio';
+
+export default function BasicUsage() {
+  return <HlsAudio className="h-13.5 w-full" src="{{VJS10_DEMO_VIDEO_HLS}}" controls />;
+}

--- a/site/src/components/docs/demos/hls-video/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/hls-video/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/hls-video/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/hls-video/html/tailwind/BasicUsage.html
@@ -1,0 +1,9 @@
+<media-container class="relative block aspect-video w-full">
+    <hls-video
+        src="{{VJS10_DEMO_VIDEO_HLS}}"
+        autoplay
+        muted
+        playsinline
+        loop
+    ></hls-video>
+</media-container>

--- a/site/src/components/docs/demos/hls-video/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/hls-video/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/media/container';
+import '@videojs/html/media/hls-video';

--- a/site/src/components/docs/demos/hls-video/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/hls-video/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,5 @@
+import { HlsVideo } from '@videojs/react/media/hls-video';
+
+export default function BasicUsage() {
+  return <HlsVideo className="aspect-video w-full" src="{{VJS10_DEMO_VIDEO_HLS}}" autoPlay muted playsInline loop />;
+}

--- a/site/src/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.html
@@ -1,0 +1,9 @@
+<media-container class="relative block aspect-video w-full">
+    <hlsjs-video
+        src="{{VJS10_DEMO_VIDEO_HLS}}"
+        autoplay
+        muted
+        playsinline
+        loop
+    ></hlsjs-video>
+</media-container>

--- a/site/src/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/media/container';
+import '@videojs/html/media/hlsjs-video';

--- a/site/src/components/docs/demos/hlsjs-video/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/hlsjs-video/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,5 @@
+import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+
+export default function BasicUsage() {
+  return <HlsJsVideo className="aspect-video w-full" src="{{VJS10_DEMO_VIDEO_HLS}}" autoPlay muted playsInline loop />;
+}

--- a/site/src/components/docs/demos/html-create-player/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/html-create-player/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/html-create-player/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/html-create-player/html/tailwind/BasicUsage.html
@@ -1,0 +1,17 @@
+<demo-video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+        ></video>
+        <demo-play-toggle
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-paused:inline">Play</span>
+            <span class="hidden not-in-data-paused:inline">Pause</span>
+        </demo-play-toggle>
+    </media-container>
+</demo-video-player>

--- a/site/src/components/docs/demos/html-create-player/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/html-create-player/html/tailwind/BasicUsage.ts
@@ -1,0 +1,59 @@
+import {
+  applyElementProps,
+  applyStateDataAttrs,
+  createButton,
+  createPlayer,
+  MediaElement,
+  PlayerController,
+  selectPlayback,
+} from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+import '@videojs/html/media/container';
+
+const { ProviderMixin, context } = createPlayer({
+  features: videoFeatures,
+});
+
+class VideoPlayer extends ProviderMixin(MediaElement) {
+  static readonly tagName = 'demo-video-player';
+}
+
+class PlayToggle extends MediaElement {
+  static readonly tagName = 'demo-play-toggle';
+
+  readonly #player = new PlayerController(this, context, selectPlayback);
+
+  #disconnect: AbortController | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.#disconnect = new AbortController();
+
+    const buttonProps = createButton({
+      onActivate: () => {
+        const state = this.#player.value;
+        if (!state) return;
+        state.paused ? state.play() : state.pause();
+      },
+      isDisabled: () => !this.#player.value,
+    });
+
+    applyElementProps(this, buttonProps, { signal: this.#disconnect.signal });
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+
+  protected override update(changed: Map<string, unknown>): void {
+    super.update(changed);
+    const state = this.#player.value;
+    if (!state) return;
+    applyStateDataAttrs(this, state, { paused: 'data-paused', ended: 'data-ended' });
+  }
+}
+
+customElements.define(VideoPlayer.tagName, VideoPlayer);
+customElements.define(PlayToggle.tagName, PlayToggle);

--- a/site/src/components/docs/demos/i18n/html/tailwind/BuiltIn.astro
+++ b/site/src/components/docs/demos/i18n/html/tailwind/BuiltIn.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BuiltIn.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BuiltIn.ts";
+</script>

--- a/site/src/components/docs/demos/i18n/html/tailwind/BuiltIn.html
+++ b/site/src/components/docs/demos/i18n/html/tailwind/BuiltIn.html
@@ -1,0 +1,9 @@
+<div class="p-4">
+  <media-i18n lang="es">
+    <video-player class="block w-full">
+      <video-skin class="block aspect-video w-full">
+        <video class="block w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline preload="none"></video>
+      </video-skin>
+    </video-player>
+  </media-i18n>
+</div>

--- a/site/src/components/docs/demos/i18n/html/tailwind/BuiltIn.ts
+++ b/site/src/components/docs/demos/i18n/html/tailwind/BuiltIn.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';

--- a/site/src/components/docs/demos/i18n/html/tailwind/Fallback.astro
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Fallback.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './Fallback.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./Fallback.ts";
+</script>

--- a/site/src/components/docs/demos/i18n/html/tailwind/Fallback.html
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Fallback.html
@@ -1,0 +1,9 @@
+<div class="p-4">
+  <media-i18n lang="en">
+    <video-player class="block w-full">
+      <video-skin class="block aspect-video w-full">
+        <video class="block w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline preload="none"></video>
+      </video-skin>
+    </video-player>
+  </media-i18n>
+</div>

--- a/site/src/components/docs/demos/i18n/html/tailwind/Fallback.ts
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Fallback.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';

--- a/site/src/components/docs/demos/i18n/html/tailwind/Language.astro
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Language.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './Language.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./Language.ts";
+</script>

--- a/site/src/components/docs/demos/i18n/html/tailwind/Language.html
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Language.html
@@ -1,0 +1,13 @@
+<div class="html-i18n-language grid gap-4 p-4">
+  <label class="flex items-center gap-2">
+    Language
+    <select class="px-2 py-1"></select>
+  </label>
+  <media-i18n lang="en">
+    <video-player class="block w-full">
+      <video-skin class="block aspect-video w-full">
+        <video class="block w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline></video>
+      </video-skin>
+    </video-player>
+  </media-i18n>
+</div>

--- a/site/src/components/docs/demos/i18n/html/tailwind/Language.ts
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Language.ts
@@ -1,0 +1,19 @@
+import { LOCALES } from '@videojs/html/i18n';
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+
+const root = document.querySelector<HTMLElement>('.html-i18n-language');
+const select = root?.querySelector('select');
+const provider = root?.querySelector('media-i18n');
+const languageNames = new Intl.DisplayNames(['en'], { type: 'language' });
+
+for (const locale of ['en', ...LOCALES]) {
+  const option = document.createElement('option');
+  option.value = locale;
+  option.textContent = languageNames.of(locale) ?? locale;
+  select?.append(option);
+}
+
+select?.addEventListener('change', () => {
+  provider?.setAttribute('lang', select.value);
+});

--- a/site/src/components/docs/demos/i18n/html/tailwind/Registered.astro
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Registered.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './Registered.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./Registered.ts";
+</script>

--- a/site/src/components/docs/demos/i18n/html/tailwind/Registered.html
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Registered.html
@@ -1,0 +1,9 @@
+<div class="p-4">
+  <media-i18n lang="en-x-demo">
+    <video-player class="block w-full">
+      <video-skin class="block aspect-video w-full">
+        <video class="block w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsinline preload="none"></video>
+      </video-skin>
+    </video-player>
+  </media-i18n>
+</div>

--- a/site/src/components/docs/demos/i18n/html/tailwind/Registered.ts
+++ b/site/src/components/docs/demos/i18n/html/tailwind/Registered.ts
@@ -1,0 +1,9 @@
+import { registerI18n } from '@videojs/html/i18n';
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+
+registerI18n('en-x-demo', {
+  buttons: {
+    play: 'Registered custom translation',
+  },
+});

--- a/site/src/components/docs/demos/i18n/react/tailwind/BuiltIn.tsx
+++ b/site/src/components/docs/demos/i18n/react/tailwind/BuiltIn.tsx
@@ -1,0 +1,21 @@
+import { createPlayer } from '@videojs/react';
+import { I18nProvider } from '@videojs/react/i18n';
+import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
+
+import '@videojs/react/video/skin.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BuiltIn() {
+  return (
+    <Player>
+      <I18nProvider locale="es">
+        <div className="p-4">
+          <VideoSkin className="aspect-video w-full">
+            <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline preload="none" />
+          </VideoSkin>
+        </div>
+      </I18nProvider>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/i18n/react/tailwind/Fallback.tsx
+++ b/site/src/components/docs/demos/i18n/react/tailwind/Fallback.tsx
@@ -1,0 +1,21 @@
+import { createPlayer } from '@videojs/react';
+import { I18nProvider } from '@videojs/react/i18n';
+import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
+
+import '@videojs/react/video/skin.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function Fallback() {
+  return (
+    <Player>
+      <I18nProvider locale="en">
+        <div className="p-4">
+          <VideoSkin className="aspect-video w-full">
+            <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline preload="none" />
+          </VideoSkin>
+        </div>
+      </I18nProvider>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/i18n/react/tailwind/Language.tsx
+++ b/site/src/components/docs/demos/i18n/react/tailwind/Language.tsx
@@ -1,0 +1,41 @@
+import { createPlayer } from '@videojs/react';
+import { I18nProvider, LOCALES } from '@videojs/react/i18n';
+import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
+import { useState } from 'react';
+
+import '@videojs/react/video/skin.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+const locales = ['en', ...LOCALES] as const;
+type Locale = (typeof locales)[number];
+const languageNames = new Intl.DisplayNames(['en'], { type: 'language' });
+
+export default function Language() {
+  const [locale, setLocale] = useState<Locale>('en');
+
+  return (
+    <div className="grid gap-4 p-4">
+      <label className="flex items-center gap-2">
+        Language
+        <select
+          className="px-2 py-1"
+          value={locale}
+          onChange={(event) => setLocale(event.currentTarget.value as Locale)}
+        >
+          {locales.map((value) => (
+            <option key={value} value={value}>
+              {languageNames.of(value) ?? value}
+            </option>
+          ))}
+        </select>
+      </label>
+      <Player>
+        <I18nProvider locale={locale}>
+          <VideoSkin className="aspect-video w-full">
+            <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline />
+          </VideoSkin>
+        </I18nProvider>
+      </Player>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/i18n/react/tailwind/Override.tsx
+++ b/site/src/components/docs/demos/i18n/react/tailwind/Override.tsx
@@ -1,0 +1,21 @@
+import { createPlayer } from '@videojs/react';
+import { I18nProvider } from '@videojs/react/i18n';
+import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
+
+import '@videojs/react/video/skin.css';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function Override() {
+  return (
+    <Player>
+      <I18nProvider locale="en" translations={{ buttons: { play: 'Player override' } }}>
+        <div className="p-4">
+          <VideoSkin className="aspect-video w-full">
+            <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline preload="none" />
+          </VideoSkin>
+        </div>
+      </I18nProvider>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/i18n/react/tailwind/Registered.tsx
+++ b/site/src/components/docs/demos/i18n/react/tailwind/Registered.tsx
@@ -1,0 +1,27 @@
+import { createPlayer } from '@videojs/react';
+import { I18nProvider, registerI18n } from '@videojs/react/i18n';
+import { Video, VideoSkin, videoFeatures } from '@videojs/react/video';
+
+import '@videojs/react/video/skin.css';
+
+registerI18n('en-x-demo', {
+  buttons: {
+    play: 'Registered custom translation',
+  },
+});
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function Registered() {
+  return (
+    <Player>
+      <I18nProvider locale="en-x-demo">
+        <div className="p-4">
+          <VideoSkin className="aspect-video w-full">
+            <Video src="{{VJS10_DEMO_VIDEO_MP4}}" muted playsInline preload="none" />
+          </VideoSkin>
+        </div>
+      </I18nProvider>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/menu/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/menu/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/menu/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/menu/html/tailwind/BasicUsage.html
@@ -1,0 +1,181 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <hlsjs-video
+            class="w-full"
+            src="{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}"
+            autoplay
+            crossorigin="anonymous"
+            muted
+            playsinline
+            loop
+        >
+            <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srclang="en" label="English" />
+            <track kind="subtitles" src="/docs/demos/captions-button/captions.vtt" srclang="es" label="Spanish" />
+        </hlsjs-video>
+        <div class="absolute right-2.5 bottom-2.5">
+            <button
+                type="button"
+                commandfor="settings-menu"
+                class="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+            >Settings</button>
+            <media-menu
+                id="settings-menu"
+                side="top"
+                align="end"
+                class="relative box-border h-(--media-menu-height) max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] w-(--media-menu-width) max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] min-w-45 overflow-hidden overscroll-none rounded-lg bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px] transition-[width,height,opacity,filter] duration-[220ms] ease-in-out [--media-menu-side-offset:8px]"
+            >
+                <div
+                    class="absolute inset-0 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] in-data-[submenu-expanded=true]:-translate-x-full in-data-[submenu-expanded=true]:blur-sm"
+                >
+                    <media-menu-item
+                        commandfor="quality-menu"
+                        class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                    >
+                        <span>Quality</span>
+                        <span class="inline-flex items-center gap-2 text-white/72">
+                            <span data-part="hint"></span>
+                            <span aria-hidden="true" class="text-lg leading-none">›</span>
+                        </span>
+                    </media-menu-item>
+                    <media-menu-item
+                        commandfor="audio-menu"
+                        class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                    >
+                        <span>Audio</span>
+                        <span class="inline-flex items-center gap-2 text-white/72">
+                            <span data-part="hint"></span>
+                            <span aria-hidden="true" class="text-lg leading-none">›</span>
+                        </span>
+                    </media-menu-item>
+                    <media-menu-item
+                        commandfor="speed-menu"
+                        class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                    >
+                        <span>Speed</span>
+                        <span class="inline-flex items-center gap-2 text-white/72">
+                            <span data-part="hint"></span>
+                            <span aria-hidden="true" class="text-lg leading-none">›</span>
+                        </span>
+                    </media-menu-item>
+                    <media-menu-item
+                        commandfor="captions-menu"
+                        class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                    >
+                        <span>Captions</span>
+                        <span class="inline-flex items-center gap-2 text-white/72">
+                            <span data-part="hint"></span>
+                            <span aria-hidden="true" class="text-lg leading-none">›</span>
+                        </span>
+                    </media-menu-item>
+                    <media-menu-item
+                        class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                    >Copy link</media-menu-item>
+                </div>
+
+                <media-menu
+                    id="quality-menu"
+                    class="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full"
+                >
+                    <media-menu-item
+                        class="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16"
+                    >
+                        <span aria-hidden="true" class="text-lg leading-none text-white/72">‹</span>
+                        Quality
+                    </media-menu-item>
+                    <media-quality-radio-group class="grid gap-0.5">
+                        <template>
+                            <media-menu-radio-item
+                                class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                            >
+                                <span>
+                                    <span data-part="label"></span>
+                                    <sup data-part="tier" class="ml-0.5 text-[10px]"></sup>
+                                </span>
+                                <span data-part="badge" class="ml-auto text-white/72"></span>
+                                <media-menu-item-indicator
+                                    force-mount
+                                    class="opacity-0 in-aria-checked:opacity-100"
+                                >✓</media-menu-item-indicator>
+                            </media-menu-radio-item>
+                        </template>
+                    </media-quality-radio-group>
+                </media-menu>
+
+                <media-menu
+                    id="audio-menu"
+                    class="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full"
+                >
+                    <media-menu-item
+                        class="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16"
+                    >
+                        <span aria-hidden="true" class="text-lg leading-none text-white/72">‹</span>
+                        Audio
+                    </media-menu-item>
+                    <media-audio-track-radio-group class="grid gap-0.5">
+                        <template>
+                            <media-menu-radio-item
+                                class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                            >
+                                <span data-part="label"></span>
+                                <media-menu-item-indicator
+                                    force-mount
+                                    class="opacity-0 in-aria-checked:opacity-100"
+                                >✓</media-menu-item-indicator>
+                            </media-menu-radio-item>
+                        </template>
+                    </media-audio-track-radio-group>
+                </media-menu>
+
+                <media-menu
+                    id="speed-menu"
+                    class="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full"
+                >
+                    <media-menu-item
+                        class="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16"
+                    >
+                        <span aria-hidden="true" class="text-lg leading-none text-white/72">‹</span>
+                        Speed
+                    </media-menu-item>
+                    <media-playback-rate-radio-group class="grid gap-0.5">
+                        <template>
+                            <media-menu-radio-item
+                                class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                            >
+                                <span data-part="label"></span>
+                                <media-menu-item-indicator
+                                    force-mount
+                                    class="opacity-0 in-aria-checked:opacity-100"
+                                >✓</media-menu-item-indicator>
+                            </media-menu-radio-item>
+                        </template>
+                    </media-playback-rate-radio-group>
+                </media-menu>
+
+                <media-menu
+                    id="captions-menu"
+                    class="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full"
+                >
+                    <media-menu-item
+                        class="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16"
+                    >
+                        <span aria-hidden="true" class="text-lg leading-none text-white/72">‹</span>
+                        Captions
+                    </media-menu-item>
+                    <media-captions-radio-group class="grid gap-0.5">
+                        <template>
+                            <media-menu-radio-item
+                                class="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16 data-[availability=unavailable]:hidden"
+                            >
+                                <span data-part="label"></span>
+                                <media-menu-item-indicator
+                                    force-mount
+                                    class="opacity-0 in-aria-checked:opacity-100"
+                                >✓</media-menu-item-indicator>
+                            </media-menu-radio-item>
+                        </template>
+                    </media-captions-radio-group>
+                </media-menu>
+            </media-menu>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/menu/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/menu/html/tailwind/BasicUsage.ts
@@ -1,0 +1,7 @@
+import '@videojs/html/video/player';
+import '@videojs/html/media/hlsjs-video';
+import '@videojs/html/ui/menu';
+import '@videojs/html/ui/quality-radio-group';
+import '@videojs/html/ui/audio-track-radio-group';
+import '@videojs/html/ui/playback-rate-radio-group';
+import '@videojs/html/ui/captions-radio-group';

--- a/site/src/components/docs/demos/menu/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/menu/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,274 @@
+import {
+  Container,
+  createPlayer,
+  Menu,
+  useAudioTrackOptions,
+  useCaptionsOptions,
+  usePlaybackRateOptions,
+  useQualityOptions,
+} from '@videojs/react';
+import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+import { videoFeatures } from '@videojs/react/video';
+import type { ReactNode } from 'react';
+
+const { Player } = createPlayer({ features: videoFeatures });
+const src = '{{VJS10_MULTI_AUDIO_DEMO_VIDEO_HLS}}';
+
+function SettingsMenu(): ReactNode {
+  const playbackRate = usePlaybackRateOptions();
+  const quality = useQualityOptions();
+  const audioTrack = useAudioTrackOptions();
+  const captions = useCaptionsOptions();
+  const hasPlaybackRate = playbackRate?.state.availability === 'available';
+  const hasQuality = quality?.state.availability === 'available';
+  const hasAudioTrack = audioTrack?.state.availability === 'available';
+  const hasCaptions = captions?.state.availability === 'available';
+
+  if (!hasPlaybackRate && !hasQuality && !hasAudioTrack && !hasCaptions) return null;
+
+  return (
+    <Menu.Root side="top" align="end">
+      <Menu.Trigger
+        className="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+        aria-label="Settings"
+        render={<button type="button" />}
+      >
+        Settings
+      </Menu.Trigger>
+      <Menu.Content className="relative m-0 box-border h-(--media-menu-height) max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] w-(--media-menu-width) max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] min-w-45 overflow-hidden overscroll-none rounded-lg border-0 bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px] transition-[width,height,opacity,filter] duration-[220ms] ease-in-out [--media-menu-side-offset:8px]">
+        <div className="absolute inset-0 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] in-data-[submenu-expanded=true]:-translate-x-full in-data-[submenu-expanded=true]:blur-sm">
+          {hasQuality ? (
+            <Menu.Root>
+              <Menu.Trigger
+                className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                render={(props) => (
+                  <div {...props}>
+                    <span>Quality</span>
+                    <span className="inline-flex items-center gap-2 text-white/72">
+                      {quality.selectedLabel}
+                      <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                        ›
+                      </span>
+                    </span>
+                  </div>
+                )}
+              />
+              <Menu.Content className="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full">
+                <Menu.Item className="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16">
+                  <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                    ‹
+                  </span>
+                  Quality
+                </Menu.Item>
+                <Menu.RadioGroup
+                  className="grid gap-0.5"
+                  value={quality.value}
+                  onValueChange={quality.setValue}
+                  aria-label="Quality"
+                >
+                  {quality.options.map((option) => (
+                    <Menu.RadioItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                    >
+                      <span>
+                        {option.label}
+                        {option.tier ? <sup className="ml-0.5 text-[10px]">{option.tier}</sup> : null}
+                      </span>
+                      {option.badge ? <span className="ml-auto text-white/72">{option.badge}</span> : null}
+                      <Menu.ItemIndicator
+                        checked={option.value === quality.value}
+                        forceMount
+                        className="text-lg leading-none text-white/72 opacity-0 in-aria-checked:opacity-100"
+                      >
+                        ✓
+                      </Menu.ItemIndicator>
+                    </Menu.RadioItem>
+                  ))}
+                </Menu.RadioGroup>
+              </Menu.Content>
+            </Menu.Root>
+          ) : null}
+
+          {hasAudioTrack ? (
+            <Menu.Root>
+              <Menu.Trigger
+                className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                render={(props) => (
+                  <div {...props}>
+                    <span>Audio</span>
+                    <span className="inline-flex items-center gap-2 text-white/72">
+                      {audioTrack.selectedLabel}
+                      <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                        ›
+                      </span>
+                    </span>
+                  </div>
+                )}
+              />
+              <Menu.Content className="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full">
+                <Menu.Item className="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16">
+                  <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                    ‹
+                  </span>
+                  Audio
+                </Menu.Item>
+                <Menu.RadioGroup
+                  className="grid gap-0.5"
+                  value={audioTrack.value}
+                  onValueChange={audioTrack.setValue}
+                  aria-label="Audio tracks"
+                >
+                  {audioTrack.options.map((option) => (
+                    <Menu.RadioItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                    >
+                      <span>{option.label}</span>
+                      <Menu.ItemIndicator
+                        checked={option.value === audioTrack.value}
+                        forceMount
+                        className="text-lg leading-none text-white/72 opacity-0 in-aria-checked:opacity-100"
+                      >
+                        ✓
+                      </Menu.ItemIndicator>
+                    </Menu.RadioItem>
+                  ))}
+                </Menu.RadioGroup>
+              </Menu.Content>
+            </Menu.Root>
+          ) : null}
+
+          {hasPlaybackRate ? (
+            <Menu.Root>
+              <Menu.Trigger
+                className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                render={(props) => (
+                  <div {...props}>
+                    <span>Speed</span>
+                    <span className="inline-flex items-center gap-2 text-white/72">
+                      {playbackRate.selectedLabel}
+                      <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                        ›
+                      </span>
+                    </span>
+                  </div>
+                )}
+              />
+              <Menu.Content className="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full">
+                <Menu.Item className="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16">
+                  <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                    ‹
+                  </span>
+                  Speed
+                </Menu.Item>
+                <Menu.RadioGroup
+                  className="grid gap-0.5"
+                  value={playbackRate.value}
+                  onValueChange={playbackRate.setValue}
+                  aria-label="Playback rate"
+                >
+                  {playbackRate.options.map((option) => (
+                    <Menu.RadioItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                    >
+                      <span>{option.label}</span>
+                      <Menu.ItemIndicator
+                        checked={option.value === playbackRate.value}
+                        forceMount
+                        className="text-lg leading-none text-white/72 opacity-0 in-aria-checked:opacity-100"
+                      >
+                        ✓
+                      </Menu.ItemIndicator>
+                    </Menu.RadioItem>
+                  ))}
+                </Menu.RadioGroup>
+              </Menu.Content>
+            </Menu.Root>
+          ) : null}
+
+          {hasCaptions ? (
+            <Menu.Root>
+              <Menu.Trigger
+                className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                render={(props) => (
+                  <div {...props}>
+                    <span>Captions</span>
+                    <span className="inline-flex items-center gap-2 text-white/72">
+                      {captions.selectedLabel}
+                      <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                        ›
+                      </span>
+                    </span>
+                  </div>
+                )}
+              />
+              <Menu.Content className="absolute inset-0 z-1 grid translate-x-0 gap-0.5 overflow-auto overscroll-none p-1.5 outline-none transition-[translate,filter] duration-[220ms] ease-in-out will-change-[translate] data-starting-style:overflow-hidden data-starting-style:pointer-events-none data-starting-style:blur-sm data-starting-style:translate-x-full data-ending-style:overflow-hidden data-ending-style:pointer-events-none data-ending-style:blur-sm data-ending-style:translate-x-full">
+                <Menu.Item className="flex min-h-8 cursor-pointer items-center justify-start gap-2 rounded-md px-2.5 hover:bg-white/16">
+                  <span aria-hidden="true" className="text-lg leading-none text-white/72">
+                    ‹
+                  </span>
+                  Captions
+                </Menu.Item>
+                <Menu.RadioGroup
+                  className="grid gap-0.5"
+                  value={captions.value}
+                  onValueChange={captions.setValue}
+                  aria-label="Captions"
+                >
+                  {captions.options.map((option) => (
+                    <Menu.RadioItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+                    >
+                      <span>{option.label}</span>
+                      <Menu.ItemIndicator
+                        checked={option.value === captions.value}
+                        forceMount
+                        className="text-lg leading-none text-white/72 opacity-0 in-aria-checked:opacity-100"
+                      >
+                        ✓
+                      </Menu.ItemIndicator>
+                    </Menu.RadioItem>
+                  ))}
+                </Menu.RadioGroup>
+              </Menu.Content>
+            </Menu.Root>
+          ) : null}
+
+          <Menu.Item
+            className="flex min-h-8 cursor-pointer items-center justify-between rounded-md px-2.5 data-highlighted:bg-white/16"
+            onSelect={() => navigator.clipboard?.writeText(window.location.href)}
+          >
+            Copy link
+          </Menu.Item>
+        </div>
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <HlsJsVideo className="w-full" src={src} autoPlay crossOrigin="anonymous" muted playsInline loop>
+          <track kind="captions" src="/docs/demos/captions-button/captions.vtt" srcLang="en" label="English" />
+          <track kind="subtitles" src="/docs/demos/captions-button/captions.vtt" srcLang="es" label="Spanish" />
+        </HlsJsVideo>
+        <div className="absolute right-2.5 bottom-2.5">
+          <SettingsMenu />
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/mute-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/mute-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/mute-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/mute-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,18 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-mute-button
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-muted:inline">Unmute</span>
+            <span class="hidden not-in-data-muted:inline">Mute</span>
+        </media-mute-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/mute-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/mute-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/mute-button';

--- a/site/src/components/docs/demos/mute-button/html/tailwind/VolumeLevels.astro
+++ b/site/src/components/docs/demos/mute-button/html/tailwind/VolumeLevels.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './VolumeLevels.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./VolumeLevels.ts";
+</script>

--- a/site/src/components/docs/demos/mute-button/html/tailwind/VolumeLevels.html
+++ b/site/src/components/docs/demos/mute-button/html/tailwind/VolumeLevels.html
@@ -1,0 +1,20 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-mute-button
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-[volume-level=off]:inline">Off</span>
+            <span class="hidden in-data-[volume-level=low]:inline">Low</span>
+            <span class="hidden in-data-[volume-level=medium]:inline">Medium</span>
+            <span class="hidden in-data-[volume-level=high]:inline">High</span>
+        </media-mute-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/mute-button/html/tailwind/VolumeLevels.ts
+++ b/site/src/components/docs/demos/mute-button/html/tailwind/VolumeLevels.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/mute-button';

--- a/site/src/components/docs/demos/mute-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/mute-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer, MuteButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <MuteButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/mute-button/react/tailwind/VolumeLevels.tsx
+++ b/site/src/components/docs/demos/mute-button/react/tailwind/VolumeLevels.tsx
@@ -1,0 +1,28 @@
+import { Container, createPlayer, MuteButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function VolumeLevels() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <MuteButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => (
+            <button {...props}>
+              {state.volumeLevel === 'off'
+                ? 'Off'
+                : state.volumeLevel === 'low'
+                  ? 'Low'
+                  : state.volumeLevel === 'medium'
+                    ? 'Medium'
+                    : 'High'}
+            </button>
+          )}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/mux-audio/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/mux-audio/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/mux-audio/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/mux-audio/html/tailwind/BasicUsage.html
@@ -1,0 +1,6 @@
+<mux-audio
+    class="h-13.5 w-full"
+    src="{{VJS10_DEMO_VIDEO_HLS}}"
+    crossorigin="anonymous"
+    controls
+></mux-audio>

--- a/site/src/components/docs/demos/mux-audio/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/mux-audio/html/tailwind/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/media/mux-audio';

--- a/site/src/components/docs/demos/mux-audio/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/mux-audio/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,5 @@
+import { MuxAudio } from '@videojs/react/media/mux-audio';
+
+export default function BasicUsage() {
+  return <MuxAudio className="h-13.5 w-full" src="{{VJS10_DEMO_VIDEO_HLS}}" crossOrigin="anonymous" controls />;
+}

--- a/site/src/components/docs/demos/mux-video/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/mux-video/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/mux-video/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/mux-video/html/tailwind/BasicUsage.html
@@ -1,0 +1,10 @@
+<media-container class="relative block aspect-video w-full">
+    <mux-video
+        src="{{VJS10_DEMO_VIDEO_HLS}}"
+        autoplay
+        muted
+        playsinline
+        loop
+        crossorigin="anonymous"
+    ></mux-video>
+</media-container>

--- a/site/src/components/docs/demos/mux-video/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/mux-video/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/media/container';
+import '@videojs/html/media/mux-video';

--- a/site/src/components/docs/demos/mux-video/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/mux-video/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,15 @@
+import { MuxVideo } from '@videojs/react/media/mux-video';
+
+export default function BasicUsage() {
+  return (
+    <MuxVideo
+      className="aspect-video w-full"
+      src="{{VJS10_DEMO_VIDEO_HLS}}"
+      autoPlay
+      muted
+      playsInline
+      loop
+      crossOrigin="anonymous"
+    />
+  );
+}

--- a/site/src/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.html
@@ -1,0 +1,9 @@
+<media-container class="relative block aspect-video w-full">
+    <native-hls-video
+        src="{{VJS10_DEMO_VIDEO_HLS}}"
+        autoplay
+        muted
+        playsinline
+        loop
+    ></native-hls-video>
+</media-container>

--- a/site/src/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/media/container';
+import '@videojs/html/media/native-hls-video';

--- a/site/src/components/docs/demos/native-hls-video/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/native-hls-video/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,7 @@
+import { NativeHlsVideo } from '@videojs/react/media/native-hls-video';
+
+export default function BasicUsage() {
+  return (
+    <NativeHlsVideo className="aspect-video w-full" src="{{VJS10_DEMO_VIDEO_HLS}}" autoPlay muted playsInline loop />
+  );
+}

--- a/site/src/components/docs/demos/pip-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/pip-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/pip-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/pip-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,18 @@
+<video-player class="relative block">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-pip-button
+            class="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-pip:inline">Exit PiP</span>
+            <span class="hidden not-in-data-pip:inline">Enter PiP</span>
+        </media-pip-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/pip-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/pip-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/pip-button';

--- a/site/src/components/docs/demos/pip-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/pip-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer, PiPButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <PiPButton
+          className="absolute right-2.5 bottom-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => <button {...props}>{state.pip ? 'Exit PiP' : 'Enter PiP'}</button>}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/play-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/play-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/play-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/play-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,18 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+        ></video>
+        <media-play-button
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-paused:not-in-data-ended:inline">Play</span>
+            <span class="hidden not-in-data-paused:inline">Pause</span>
+            <span class="hidden in-data-ended:inline">Replay</span>
+        </media-play-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/play-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/play-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/play-button';

--- a/site/src/components/docs/demos/play-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/play-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,20 @@
+import { Container, createPlayer, PlayButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline />
+        <PlayButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => (
+            <button {...props}>{state.ended ? 'Replay' : state.paused ? 'Play' : 'Pause'}</button>
+          )}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,14 @@
+<video-player class="relative">
+    <video
+        class="w-full"
+        src="{{VJS10_DEMO_VIDEO_MP4}}"
+        autoplay
+        muted
+        playsinline
+        loop
+    ></video>
+    <media-playback-rate-button
+        class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px] after:content-[attr(data-rate)_'×']"
+    >
+    </media-playback-rate-button>
+</video-player>

--- a/site/src/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/playback-rate-button';

--- a/site/src/components/docs/demos/playback-rate-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer, PlaybackRateButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <PlaybackRateButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => <button {...props}>{Math.round(state.rate * 10) / 10}&times;</button>}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.html
@@ -1,0 +1,38 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <div class="absolute right-2.5 bottom-2.5">
+            <button
+                type="button"
+                commandfor="speed-menu"
+                class="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+            >
+                Speed
+            </button>
+            <media-menu
+                id="speed-menu"
+                side="top"
+                align="end"
+                class="[--media-menu-side-offset:8px] box-border grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]"
+            >
+                <media-playback-rate-radio-group class="grid gap-0.5" aria-label="Speed">
+                    <template>
+                        <media-menu-radio-item
+                            class="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+                        >
+                            <span data-part="label"></span>
+                            <media-menu-item-indicator force-mount class="opacity-0 in-aria-checked:opacity-100">✓</media-menu-item-indicator>
+                        </media-menu-radio-item>
+                    </template>
+                </media-playback-rate-radio-group>
+            </media-menu>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/menu';
+import '@videojs/html/ui/playback-rate-radio-group';

--- a/site/src/components/docs/demos/playback-rate-radio-group/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/playback-rate-radio-group/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,47 @@
+import { Container, createPlayer, Menu, PlaybackRateRadioGroup } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+import type { ReactNode } from 'react';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+function SpeedMenu(): ReactNode {
+  return (
+    <Menu.Root side="top" align="end">
+      <Menu.Trigger
+        className="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+        render={<button type="button" />}
+      >
+        Speed
+      </Menu.Trigger>
+      <Menu.Content className="[--media-menu-side-offset:8px] box-border m-0 grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg border-0 bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]">
+        <PlaybackRateRadioGroup
+          className="grid gap-0.5"
+          renderItem={(props, item) => (
+            <Menu.RadioItem
+              {...props}
+              className="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+            >
+              {item.label}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="opacity-0 in-aria-checked:opacity-100">
+                ✓
+              </Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <div className="absolute right-2.5 bottom-2.5">
+          <SpeedMenu />
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/player-controller/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/player-controller/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/player-controller/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/player-controller/html/tailwind/BasicUsage.html
@@ -1,0 +1,36 @@
+<demo-ctrl-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+        ></video>
+        <div class="flex items-center gap-4 border-t border-black/10 bg-black/5 p-3">
+            <demo-ctrl-actions class="flex gap-1.5">
+                <button
+                    type="button"
+                    class="play cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+                >
+                    Play
+                </button>
+                <button
+                    type="button"
+                    class="pause cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+                >
+                    Pause
+                </button>
+                <button
+                    type="button"
+                    class="volume cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+                >
+                    50% Volume
+                </button>
+            </demo-ctrl-actions>
+            <demo-ctrl-state class="text-[13px] text-gray-700 tabular-nums">
+                <span class="text">Paused: Yes | Time: 0.0s | Volume: 100%</span>
+            </demo-ctrl-state>
+        </div>
+    </media-container>
+</demo-ctrl-player>

--- a/site/src/components/docs/demos/player-controller/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/player-controller/html/tailwind/BasicUsage.ts
@@ -1,0 +1,78 @@
+import {
+  applyElementProps,
+  createButton,
+  createPlayer,
+  MediaElement,
+  PlayerController,
+  selectPlayback,
+  selectTime,
+  selectVolume,
+} from '@videojs/html';
+import { videoFeatures } from '@videojs/html/video';
+import '@videojs/html/media/container';
+
+const { ProviderMixin, context } = createPlayer({
+  features: videoFeatures,
+});
+
+class DemoPlayer extends ProviderMixin(MediaElement) {
+  static readonly tagName = 'demo-ctrl-player';
+}
+
+class PlayerActions extends MediaElement {
+  static readonly tagName = 'demo-ctrl-actions';
+
+  readonly #player = new PlayerController(this, context);
+
+  #disconnect: AbortController | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.#disconnect = new AbortController();
+    const signal = this.#disconnect.signal;
+
+    const playBtn = this.querySelector<HTMLButtonElement>('.play')!;
+    const pauseBtn = this.querySelector<HTMLButtonElement>('.pause')!;
+    const volumeBtn = this.querySelector<HTMLButtonElement>('.volume')!;
+
+    const bind = (el: HTMLElement, action: () => void) => {
+      const props = createButton({ onActivate: action, isDisabled: () => !this.#player.value });
+      applyElementProps(el, props, { signal });
+    };
+
+    bind(playBtn, () => this.#player.value?.play());
+    bind(pauseBtn, () => this.#player.value?.pause());
+    bind(volumeBtn, () => this.#player.value?.setVolume(0.5));
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+  }
+}
+
+class PlayerState extends MediaElement {
+  static readonly tagName = 'demo-ctrl-state';
+
+  readonly #playback = new PlayerController(this, context, selectPlayback);
+  readonly #time = new PlayerController(this, context, selectTime);
+  readonly #volume = new PlayerController(this, context, selectVolume);
+
+  protected override update(changed: Map<string, unknown>): void {
+    super.update(changed);
+    const playback = this.#playback.value;
+    const time = this.#time.value;
+    const volume = this.#volume.value;
+    if (!playback) return;
+
+    const el = this.querySelector('.text');
+    if (el) {
+      el.textContent = `Paused: ${playback.paused ? 'Yes' : 'No'} | Time: ${(time?.currentTime ?? 0).toFixed(1)}s | Volume: ${Math.round((volume?.volume ?? 0) * 100)}%`;
+    }
+  }
+}
+
+customElements.define(DemoPlayer.tagName, DemoPlayer);
+customElements.define(PlayerActions.tagName, PlayerActions);
+customElements.define(PlayerState.tagName, PlayerState);

--- a/site/src/components/docs/demos/popover/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/popover/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/popover/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/popover/html/tailwind/BasicUsage.html
@@ -1,0 +1,27 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <div class="absolute bottom-2.5 left-2.5">
+            <button
+                type="button"
+                commandfor="popover-demo"
+                class="cursor-pointer rounded-full border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]"
+            >Settings</button>
+            <media-popover
+                id="popover-demo"
+                class="rounded-lg bg-black/85 px-4 py-3 text-sm whitespace-nowrap text-white backdrop-blur-[10px]"
+            >
+                <div>
+                    Popover content
+                </div>
+            </media-popover>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/popover/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/popover/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/popover';

--- a/site/src/components/docs/demos/popover/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/popover/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,25 @@
+import { Container, createPlayer, Popover } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <div className="absolute bottom-2.5 left-2.5">
+          <Popover.Root>
+            <Popover.Trigger className="cursor-pointer rounded-full border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]">
+              Settings
+            </Popover.Trigger>
+            <Popover.Popup className="m-0 rounded-lg border-0 bg-black/85 px-4 py-3 text-sm text-white backdrop-blur-[10px] [--media-popover-side-offset:8px]">
+              <Popover.Arrow className="fill-black/85" />
+              <div className="whitespace-nowrap">Popover content</div>
+            </Popover.Popup>
+          </Popover.Root>
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/poster/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/poster/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/poster/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/poster/html/tailwind/BasicUsage.html
@@ -1,0 +1,25 @@
+<!-- biome-ignore-all lint/a11y/useMediaCaption: TODO -->
+<video-player class="relative block">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            playsinline
+        ></video>
+
+        <media-poster class="pointer-events-none absolute inset-0 transition-opacity duration-250 not-data-visible:opacity-0">
+            <img
+                class="h-full w-full object-cover"
+                src="{{VJS10_DEMO_POSTER}}"
+                alt="Video thumbnail"
+            />
+        </media-poster>
+
+        <media-play-button
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/25 bg-white/75 px-4 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-paused:inline">Play</span>
+            <span class="hidden not-in-data-paused:inline">Pause</span>
+        </media-play-button>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/poster/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/poster/html/tailwind/BasicUsage.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/play-button';
+import '@videojs/html/ui/poster';

--- a/site/src/components/docs/demos/poster/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/poster/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,24 @@
+import { Container, createPlayer, PlayButton, Poster } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" playsInline />
+
+        <Poster
+          className="pointer-events-none absolute inset-0 h-full w-full object-cover transition-opacity duration-250 not-data-visible:opacity-0"
+          src="{{VJS10_DEMO_POSTER}}"
+        />
+
+        <PlayButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/25 bg-white/75 px-4 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => <button {...props}>{state.paused ? 'Play' : 'Pause'}</button>}
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.html
@@ -1,0 +1,43 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <hlsjs-video
+            class="w-full"
+            src="{{VJS8_DEMO_VIDEO_HLS}}"
+            autoplay
+            crossorigin="anonymous"
+            muted
+            playsinline
+            loop
+        ></hlsjs-video>
+        <div class="absolute right-2.5 bottom-2.5">
+            <button
+                type="button"
+                commandfor="quality-menu"
+                class="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+            >
+                Quality
+            </button>
+            <media-menu
+                id="quality-menu"
+                side="top"
+                align="end"
+                class="[--media-menu-side-offset:8px] box-border grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]"
+            >
+                <media-quality-radio-group class="grid gap-0.5" label="Quality">
+                    <template>
+                        <media-menu-radio-item
+                            class="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+                        >
+                            <span>
+                                <span data-part="label"></span>
+                                <sup data-part="tier" class="ml-0.5 text-[10px]"></sup>
+                            </span>
+                            <span data-part="badge" class="ml-auto text-white/72"></span>
+                            <media-menu-item-indicator force-mount class="opacity-0 in-aria-checked:opacity-100">✓</media-menu-item-indicator>
+                        </media-menu-radio-item>
+                    </template>
+                </media-quality-radio-group>
+            </media-menu>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.ts
@@ -1,0 +1,4 @@
+import '@videojs/html/video/player';
+import '@videojs/html/media/hlsjs-video';
+import '@videojs/html/ui/menu';
+import '@videojs/html/ui/quality-radio-group';

--- a/site/src/components/docs/demos/quality-radio-group/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/quality-radio-group/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,53 @@
+import { Container, createPlayer, Menu, QualityRadioGroup } from '@videojs/react';
+import { HlsJsVideo } from '@videojs/react/media/hlsjs-video';
+import { videoFeatures } from '@videojs/react/video';
+import type { ReactNode } from 'react';
+
+const { Player } = createPlayer({ features: videoFeatures });
+const src = '{{VJS8_DEMO_VIDEO_HLS}}';
+
+function QualityMenu(): ReactNode {
+  return (
+    <Menu.Root side="top" align="end">
+      <Menu.Trigger
+        className="cursor-pointer rounded-full border border-white/35 bg-white/75 px-4 py-1.5 text-black backdrop-blur-[10px]"
+        render={<button type="button" />}
+      >
+        Quality
+      </Menu.Trigger>
+      <Menu.Content className="[--media-menu-side-offset:8px] box-border m-0 grid min-w-45 max-w-[var(--media-menu-available-width,var(--media-popover-available-width,none))] max-h-[var(--media-menu-available-height,var(--media-popover-available-height,none))] gap-0.5 overflow-auto overscroll-none rounded-lg border-0 bg-black/88 p-1.5 text-sm text-white backdrop-blur-[10px]">
+        <QualityRadioGroup
+          className="grid gap-0.5"
+          renderItem={(props, item) => (
+            <Menu.RadioItem
+              {...props}
+              className="flex min-h-8 cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 data-highlighted:bg-white/16"
+            >
+              <span>
+                {item.label}
+                {item.tier ? <sup className="ml-0.5 text-[10px]">{item.tier}</sup> : null}
+              </span>
+              {item.badge ? <span className="ml-auto text-white/72">{item.badge}</span> : null}
+              <Menu.ItemIndicator checked={item.checked} forceMount className="opacity-0 in-aria-checked:opacity-100">
+                ✓
+              </Menu.ItemIndicator>
+            </Menu.RadioItem>
+          )}
+        />
+      </Menu.Content>
+    </Menu.Root>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <HlsJsVideo className="w-full" src={src} autoPlay crossOrigin="anonymous" muted playsInline loop />
+        <div className="absolute right-2.5 bottom-2.5">
+          <QualityMenu />
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/render-element/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/render-element/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,68 @@
+import { renderElement } from '@videojs/react';
+import { type ReactNode, useState } from 'react';
+
+interface TagState {
+  active: boolean;
+}
+
+function Tag({
+  className,
+  style,
+  render,
+  active,
+  children,
+}: renderElement.ComponentProps<TagState> & { active: boolean; children?: ReactNode }) {
+  const state: TagState = { active };
+
+  return renderElement(
+    'span',
+    { className, style, render },
+    {
+      state,
+      props: { children },
+      stateAttrMap: { active: 'data-active' },
+    }
+  );
+}
+
+export default function BasicUsage() {
+  const [active, setActive] = useState(false);
+
+  const className = (state: TagState) =>
+    state.active
+      ? 'inline-flex items-center rounded-full bg-blue-500 px-3 py-1.5 text-white transition-all duration-200'
+      : 'inline-flex items-center rounded-full bg-gray-200 px-3 py-1.5 text-gray-700 transition-all duration-200';
+
+  const style = (state: TagState) => ({
+    fontSize: state.active ? '1.125rem' : '0.875rem',
+  });
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <button
+        type="button"
+        className="cursor-pointer self-start rounded-md border border-gray-300 bg-neutral-100 px-4 py-1.5"
+        onClick={() => setActive((prev) => !prev)}
+      >
+        {active ? 'Deactivate' : 'Activate'}
+      </button>
+
+      <div className="flex flex-wrap gap-3">
+        <Tag active={active} className={className} style={style}>
+          Default &lt;span&gt;
+        </Tag>
+
+        <Tag active={active} className={className} style={style} render={<strong />}>
+          Element &lt;strong&gt;
+        </Tag>
+
+        <Tag
+          active={active}
+          className={className}
+          style={style}
+          render={(props, state) => <em {...props}>{state.active ? 'Active!' : 'Inactive'}</em>}
+        />
+      </div>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/seek-button/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/seek-button/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/seek-button/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/seek-button/html/tailwind/BasicUsage.html
@@ -1,0 +1,26 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <div class="absolute bottom-2.5 left-2.5 flex gap-2">
+            <media-seek-button
+                seconds="-5"
+                class="cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 whitespace-nowrap text-black backdrop-blur-[10px]"
+            >
+                <span class="hidden in-data-[direction=backward]:inline">&#9194; 5s</span>
+            </media-seek-button>
+            <media-seek-button
+                seconds="10"
+                class="cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 whitespace-nowrap text-black backdrop-blur-[10px]"
+            >
+                <span class="hidden in-data-[direction=forward]:inline">10s &#9193;</span>
+            </media-seek-button>
+        </div>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/seek-button/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/seek-button/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/seek-button';

--- a/site/src/components/docs/demos/seek-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/seek-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,34 @@
+import { Container, createPlayer, SeekButton } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <div className="absolute bottom-2.5 left-2.5 flex gap-2">
+          <SeekButton
+            seconds={-5}
+            className="cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 whitespace-nowrap text-black backdrop-blur-[10px]"
+            render={(props, state) => (
+              <button {...props}>
+                {state.direction === 'backward' ? '\u23EA' : '\u23E9'} {5}s
+              </button>
+            )}
+          />
+          <SeekButton
+            seconds={10}
+            className="cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 whitespace-nowrap text-black backdrop-blur-[10px]"
+            render={(props, state) => (
+              <button {...props}>
+                {10}s {state.direction === 'forward' ? '\u23E9' : '\u23EA'}
+              </button>
+            )}
+          />
+        </div>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/slider/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/slider/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/slider/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/slider/html/tailwind/BasicUsage.html
@@ -1,0 +1,14 @@
+<div class="flex items-center bg-neutral-900 p-6">
+    <media-slider class="relative flex h-5 w-full cursor-pointer items-center" value="50">
+        <media-slider-track
+            class="absolute inset-x-0 h-1 rounded-full bg-white/30 transition-[height] duration-150 in-data-interactive:h-1.5"
+        >
+            <media-slider-fill
+                class="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white"
+            ></media-slider-fill>
+        </media-slider-track>
+        <media-slider-thumb
+            class="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110"
+        ></media-slider-thumb>
+    </media-slider>
+</div>

--- a/site/src/components/docs/demos/slider/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/slider/html/tailwind/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/ui/slider';

--- a/site/src/components/docs/demos/slider/html/tailwind/WithPreview.astro
+++ b/site/src/components/docs/demos/slider/html/tailwind/WithPreview.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './WithPreview.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./WithPreview.ts";
+</script>

--- a/site/src/components/docs/demos/slider/html/tailwind/WithPreview.html
+++ b/site/src/components/docs/demos/slider/html/tailwind/WithPreview.html
@@ -1,0 +1,22 @@
+<div class="flex items-center bg-neutral-900 px-6 py-10">
+    <media-slider class="relative flex h-5 w-full cursor-pointer items-center" value="50">
+        <media-slider-track
+            class="absolute inset-x-0 h-1 rounded-full bg-white/30 transition-[height] duration-150 in-data-interactive:h-1.5"
+        >
+            <media-slider-fill
+                class="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white"
+            ></media-slider-fill>
+        </media-slider-track>
+        <media-slider-thumb
+            class="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110"
+        ></media-slider-thumb>
+        <media-slider-preview
+            class="pointer-events-none absolute bottom-full mb-1.5 opacity-0 transition-opacity duration-150 in-data-pointing:opacity-100"
+        >
+            <media-slider-value
+                type="pointer"
+                class="rounded-sm bg-black/80 px-1.5 py-0.5 text-xs whitespace-nowrap text-white"
+            ></media-slider-value>
+        </media-slider-preview>
+    </media-slider>
+</div>

--- a/site/src/components/docs/demos/slider/html/tailwind/WithPreview.ts
+++ b/site/src/components/docs/demos/slider/html/tailwind/WithPreview.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/ui/slider';

--- a/site/src/components/docs/demos/slider/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/slider/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,21 @@
+import { Slider } from '@videojs/react';
+import { useState } from 'react';
+
+export default function BasicUsage() {
+  const [value, setValue] = useState(50);
+
+  return (
+    <div className="flex items-center bg-neutral-900 p-6">
+      <Slider.Root
+        className="relative flex h-5 w-full cursor-pointer items-center"
+        value={value}
+        onValueChange={setValue}
+      >
+        <Slider.Track className="absolute inset-x-0 h-1 rounded-full bg-white/30 transition-[height] duration-150 in-data-interactive:h-1.5">
+          <Slider.Fill className="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white" />
+        </Slider.Track>
+        <Slider.Thumb className="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110" />
+      </Slider.Root>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/slider/react/tailwind/WithPreview.tsx
+++ b/site/src/components/docs/demos/slider/react/tailwind/WithPreview.tsx
@@ -1,0 +1,27 @@
+import { Slider } from '@videojs/react';
+import { useState } from 'react';
+
+export default function WithPreview() {
+  const [value, setValue] = useState(50);
+
+  return (
+    <div className="flex items-center bg-neutral-900 px-6 py-10">
+      <Slider.Root
+        className="relative flex h-5 w-full cursor-pointer items-center"
+        value={value}
+        onValueChange={setValue}
+      >
+        <Slider.Track className="absolute inset-x-0 h-1 rounded-full bg-white/30 transition-[height] duration-150 in-data-interactive:h-1.5">
+          <Slider.Fill className="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white" />
+        </Slider.Track>
+        <Slider.Thumb className="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110" />
+        <Slider.Preview className="pointer-events-none absolute bottom-full mb-1.5 opacity-0 transition-opacity duration-150 in-data-pointing:opacity-100">
+          <Slider.Value
+            type="pointer"
+            className="rounded-sm bg-black/80 px-1.5 py-0.5 text-xs whitespace-nowrap text-white"
+          />
+        </Slider.Preview>
+      </Slider.Root>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/thumbnail/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/thumbnail/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/thumbnail/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/thumbnail/html/tailwind/BasicUsage.html
@@ -1,0 +1,25 @@
+<section class="relative block max-w-70">
+    <video-player>
+        <media-container>
+            <video
+                class="pointer-events-none absolute h-px w-px opacity-0"
+                src="{{VJS10_DEMO_VIDEO_MP4}}"
+                preload="auto"
+                muted
+                playsinline
+                crossorigin="anonymous"
+            >
+                <track
+                    kind="metadata"
+                    label="thumbnails"
+                    src="/docs/demos/thumbnail/basic.vtt"
+                    default
+                />
+            </video>
+            <media-thumbnail
+                class="block w-auto min-w-0 max-w-60 data-hidden:hidden"
+                time="12"
+            ></media-thumbnail>
+        </media-container>
+    </video-player>
+</section>

--- a/site/src/components/docs/demos/thumbnail/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/thumbnail/html/tailwind/BasicUsage.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/thumbnail';

--- a/site/src/components/docs/demos/thumbnail/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/thumbnail/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,24 @@
+import { Container, createPlayer, Thumbnail } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function TextTrackUsage() {
+  return (
+    <Player>
+      <Container className="relative max-w-70">
+        <Video
+          className="pointer-events-none absolute h-px w-px opacity-0"
+          src="{{VJS10_DEMO_VIDEO_MP4}}"
+          preload="auto"
+          muted
+          playsInline
+          crossOrigin="anonymous"
+        >
+          <track kind="metadata" label="thumbnails" src="/docs/demos/thumbnail/basic.vtt" default />
+        </Video>
+        <Thumbnail className="block w-auto min-w-0 max-w-60 data-hidden:hidden" time={12} />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time-slider/html/tailwind/WithChapters.astro
+++ b/site/src/components/docs/demos/time-slider/html/tailwind/WithChapters.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './WithChapters.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./WithChapters.ts";
+</script>

--- a/site/src/components/docs/demos/time-slider/html/tailwind/WithChapters.html
+++ b/site/src/components/docs/demos/time-slider/html/tailwind/WithChapters.html
@@ -1,0 +1,37 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+            crossorigin="anonymous"
+        >
+            <track
+                kind="chapters"
+                src="/docs/demos/time-slider/chapters.vtt"
+                srclang="en"
+                default
+            />
+        </video>
+        <media-time-slider class="absolute inset-x-3 bottom-2 flex h-5 cursor-pointer items-center text-white">
+            <media-time-slider-chapters class="relative block h-full w-full">
+                <template>
+                    <div class="absolute inset-0 flex items-center [clip-path:inset(0_calc(100%_-_var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]">
+                        <media-slider-track class="absolute inset-x-0 block h-1 overflow-hidden rounded-full bg-white/30 transition-[height] duration-150 in-data-highlighted:h-1.75 [clip-path:inset(0_calc(100%_-_var(--media-slider-chapter-end)_+_2px)_0_calc(var(--media-slider-chapter-start)_+_2px)_round_9999px)]">
+                            <media-slider-buffer class="absolute inset-y-0 left-0 block w-(--media-slider-buffer) rounded-[inherit] bg-white/30 transition-[width] duration-200 ease-linear"></media-slider-buffer>
+                            <media-slider-fill class="absolute inset-y-0 left-0 block w-(--media-slider-fill) rounded-[inherit] bg-white transition-[width] duration-200 ease-linear in-data-dragging:w-(--media-slider-pointer) in-data-dragging:duration-0"></media-slider-fill>
+                        </media-slider-track>
+                    </div>
+                </template>
+            </media-time-slider-chapters>
+            <media-slider-thumb class="absolute top-1/2 left-(--media-slider-fill) block size-3 -translate-1/2 rounded-full bg-white in-data-dragging:left-(--media-slider-pointer)"></media-slider-thumb>
+            <media-slider-preview class="pointer-events-none absolute bottom-full left-(--media-slider-pointer) flex -translate-x-1/2 -translate-y-1 gap-1.5 rounded-sm bg-black/80 px-1.75 py-0.75 whitespace-nowrap text-white opacity-0 in-data-pointing:opacity-100 in-data-interactive:not-in-data-pointing:opacity-100">
+                <media-time-slider-chapter-title class="empty:hidden"></media-time-slider-chapter-title>
+                <media-slider-value type="pointer"></media-slider-value>
+            </media-slider-preview>
+        </media-time-slider>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time-slider/html/tailwind/WithChapters.ts
+++ b/site/src/components/docs/demos/time-slider/html/tailwind/WithChapters.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time-slider';
+import '@videojs/html/ui/time-slider-chapters';

--- a/site/src/components/docs/demos/time-slider/html/tailwind/WithParts.astro
+++ b/site/src/components/docs/demos/time-slider/html/tailwind/WithParts.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './WithParts.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./WithParts.ts";
+</script>

--- a/site/src/components/docs/demos/time-slider/html/tailwind/WithParts.html
+++ b/site/src/components/docs/demos/time-slider/html/tailwind/WithParts.html
@@ -1,0 +1,20 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-time-slider class="absolute inset-x-0 bottom-0 flex h-5 cursor-pointer items-center">
+            <media-slider-track class="absolute inset-x-0 h-1 rounded-full bg-white/30 transition-[height] duration-150 in-data-interactive:h-1.5">
+                <media-slider-buffer class="absolute top-0 left-0 h-full w-(--media-slider-buffer) rounded-full bg-white/40"></media-slider-buffer>
+                <media-slider-fill class="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white in-data-dragging:w-(--media-slider-pointer)"></media-slider-fill>
+            </media-slider-track>
+            <media-slider-thumb class="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:left-(--media-slider-pointer) in-data-dragging:scale-110"></media-slider-thumb>
+            <media-slider-value type="pointer" class="pointer-events-none absolute bottom-full left-(--media-slider-pointer) mb-1.5 -translate-x-1/2 rounded-sm bg-black/80 px-1.5 py-0.5 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-150 in-data-pointing:opacity-100"></media-slider-value>
+        </media-time-slider>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time-slider/html/tailwind/WithParts.ts
+++ b/site/src/components/docs/demos/time-slider/html/tailwind/WithParts.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time-slider';

--- a/site/src/components/docs/demos/time-slider/react/tailwind/WithChapters.tsx
+++ b/site/src/components/docs/demos/time-slider/react/tailwind/WithChapters.tsx
@@ -1,0 +1,45 @@
+import { Container, createPlayer, TimeSlider } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function WithChapters() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video
+          className="w-full"
+          src="{{VJS10_DEMO_VIDEO_MP4}}"
+          autoPlay
+          muted
+          playsInline
+          loop
+          crossOrigin="anonymous"
+        >
+          <track kind="chapters" src="/docs/demos/time-slider/chapters.vtt" srcLang="en" default />
+        </Video>
+        <TimeSlider.Root className="absolute inset-x-3 bottom-2 flex h-5 cursor-pointer items-center text-white">
+          <TimeSlider.Chapters
+            className="relative h-full w-full"
+            renderChapter={(props) => (
+              <div
+                {...props}
+                className="absolute inset-0 flex items-center [clip-path:inset(0_calc(100%_-_var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]"
+              >
+                <TimeSlider.Track className="absolute inset-x-0 h-1 overflow-hidden rounded-full bg-white/30 transition-[height] duration-150 in-data-highlighted:h-1.75 [clip-path:inset(0_calc(100%_-_var(--media-slider-chapter-end)_+_2px)_0_calc(var(--media-slider-chapter-start)_+_2px)_round_9999px)]">
+                  <TimeSlider.Buffer className="absolute inset-y-0 left-0 w-(--media-slider-buffer) rounded-[inherit] bg-white/30 transition-[width] duration-200 ease-linear" />
+                  <TimeSlider.Fill className="absolute inset-y-0 left-0 w-(--media-slider-fill) rounded-[inherit] bg-white transition-[width] duration-200 ease-linear in-data-dragging:w-(--media-slider-pointer) in-data-dragging:duration-0" />
+                </TimeSlider.Track>
+              </div>
+            )}
+          />
+          <TimeSlider.Thumb className="absolute top-1/2 left-(--media-slider-fill) size-3 -translate-1/2 rounded-full bg-white in-data-dragging:left-(--media-slider-pointer)" />
+          <TimeSlider.Preview className="pointer-events-none absolute bottom-full left-(--media-slider-pointer) flex -translate-x-1/2 -translate-y-1 gap-1.5 rounded-sm bg-black/80 px-1.75 py-0.75 whitespace-nowrap text-white opacity-0 in-data-pointing:opacity-100 in-data-interactive:not-in-data-pointing:opacity-100">
+            <TimeSlider.ChapterTitle className="empty:hidden" />
+            <TimeSlider.Value type="pointer" />
+          </TimeSlider.Preview>
+        </TimeSlider.Root>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time-slider/react/tailwind/WithParts.tsx
+++ b/site/src/components/docs/demos/time-slider/react/tailwind/WithParts.tsx
@@ -1,0 +1,25 @@
+import { Container, createPlayer, TimeSlider } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function WithParts() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <TimeSlider.Root className="absolute inset-x-0 bottom-0 flex h-5 cursor-pointer items-center">
+          <TimeSlider.Track className="absolute inset-x-0 h-1 rounded-full bg-white/30 transition-[height] duration-150 in-data-interactive:h-1.5">
+            <TimeSlider.Buffer className="absolute top-0 left-0 h-full w-(--media-slider-buffer) rounded-full bg-white/40" />
+            <TimeSlider.Fill className="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white in-data-dragging:w-(--media-slider-pointer)" />
+          </TimeSlider.Track>
+          <TimeSlider.Thumb className="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:left-(--media-slider-pointer) in-data-dragging:scale-110" />
+          <TimeSlider.Value
+            type="pointer"
+            className="pointer-events-none absolute bottom-full left-(--media-slider-pointer) mb-1.5 -translate-x-1/2 rounded-sm bg-black/80 px-1.5 py-0.5 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-150 in-data-pointing:opacity-100"
+          />
+        </TimeSlider.Root>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time/html/tailwind/CurrentDuration.astro
+++ b/site/src/components/docs/demos/time/html/tailwind/CurrentDuration.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './CurrentDuration.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./CurrentDuration.ts";
+</script>

--- a/site/src/components/docs/demos/time/html/tailwind/CurrentDuration.html
+++ b/site/src/components/docs/demos/time/html/tailwind/CurrentDuration.html
@@ -1,0 +1,19 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-time-group
+            class="absolute bottom-2.5 left-2.5 flex items-center gap-1 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+        >
+            <media-time type="current"></media-time>
+            <media-time-separator></media-time-separator>
+            <media-time type="duration"></media-time>
+        </media-time-group>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time/html/tailwind/CurrentDuration.ts
+++ b/site/src/components/docs/demos/time/html/tailwind/CurrentDuration.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time';

--- a/site/src/components/docs/demos/time/html/tailwind/CurrentTime.astro
+++ b/site/src/components/docs/demos/time/html/tailwind/CurrentTime.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './CurrentTime.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./CurrentTime.ts";
+</script>

--- a/site/src/components/docs/demos/time/html/tailwind/CurrentTime.html
+++ b/site/src/components/docs/demos/time/html/tailwind/CurrentTime.html
@@ -1,0 +1,16 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-time
+            class="absolute bottom-2.5 left-2.5 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+            type="current"
+        ></media-time>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time/html/tailwind/CurrentTime.ts
+++ b/site/src/components/docs/demos/time/html/tailwind/CurrentTime.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time';

--- a/site/src/components/docs/demos/time/html/tailwind/CustomNegativeSign.astro
+++ b/site/src/components/docs/demos/time/html/tailwind/CustomNegativeSign.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './CustomNegativeSign.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./CustomNegativeSign.ts";
+</script>

--- a/site/src/components/docs/demos/time/html/tailwind/CustomNegativeSign.html
+++ b/site/src/components/docs/demos/time/html/tailwind/CustomNegativeSign.html
@@ -1,0 +1,17 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-time
+            class="absolute bottom-2.5 left-2.5 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+            type="remaining"
+            negative-sign="~"
+        ></media-time>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time/html/tailwind/CustomNegativeSign.ts
+++ b/site/src/components/docs/demos/time/html/tailwind/CustomNegativeSign.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time';

--- a/site/src/components/docs/demos/time/html/tailwind/CustomSeparator.astro
+++ b/site/src/components/docs/demos/time/html/tailwind/CustomSeparator.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './CustomSeparator.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./CustomSeparator.ts";
+</script>

--- a/site/src/components/docs/demos/time/html/tailwind/CustomSeparator.html
+++ b/site/src/components/docs/demos/time/html/tailwind/CustomSeparator.html
@@ -1,0 +1,19 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-time-group
+            class="absolute bottom-2.5 left-2.5 flex items-center gap-1 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+        >
+            <media-time type="current"></media-time>
+            <media-time-separator> of </media-time-separator>
+            <media-time type="duration"></media-time>
+        </media-time-group>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time/html/tailwind/CustomSeparator.ts
+++ b/site/src/components/docs/demos/time/html/tailwind/CustomSeparator.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time';

--- a/site/src/components/docs/demos/time/html/tailwind/Remaining.astro
+++ b/site/src/components/docs/demos/time/html/tailwind/Remaining.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './Remaining.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./Remaining.ts";
+</script>

--- a/site/src/components/docs/demos/time/html/tailwind/Remaining.html
+++ b/site/src/components/docs/demos/time/html/tailwind/Remaining.html
@@ -1,0 +1,16 @@
+<video-player class="relative">
+    <media-container>
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-time
+            class="absolute bottom-2.5 left-2.5 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+            type="remaining"
+        ></media-time>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/time/html/tailwind/Remaining.ts
+++ b/site/src/components/docs/demos/time/html/tailwind/Remaining.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/time';

--- a/site/src/components/docs/demos/time/react/tailwind/CurrentDuration.tsx
+++ b/site/src/components/docs/demos/time/react/tailwind/CurrentDuration.tsx
@@ -1,0 +1,19 @@
+import { Container, createPlayer, Time } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function CurrentDuration() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <Time.Group className="absolute bottom-2.5 left-2.5 flex items-center gap-1 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]">
+          <Time.Value type="current" />
+          <Time.Separator />
+          <Time.Value type="duration" />
+        </Time.Group>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time/react/tailwind/CurrentTime.tsx
+++ b/site/src/components/docs/demos/time/react/tailwind/CurrentTime.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer, Time } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function CurrentTime() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <Time.Value
+          type="current"
+          className="absolute bottom-2.5 left-2.5 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time/react/tailwind/CustomNegativeSign.tsx
+++ b/site/src/components/docs/demos/time/react/tailwind/CustomNegativeSign.tsx
@@ -1,0 +1,19 @@
+import { Container, createPlayer, Time } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function CustomNegativeSign() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <Time.Value
+          type="remaining"
+          negativeSign="~"
+          className="absolute bottom-2.5 left-2.5 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time/react/tailwind/CustomSeparator.tsx
+++ b/site/src/components/docs/demos/time/react/tailwind/CustomSeparator.tsx
@@ -1,0 +1,19 @@
+import { Container, createPlayer, Time } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function CustomSeparator() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <Time.Group className="absolute bottom-2.5 left-2.5 flex items-center gap-1 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]">
+          <Time.Value type="current" />
+          <Time.Separator> of </Time.Separator>
+          <Time.Value type="duration" />
+        </Time.Group>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/time/react/tailwind/Remaining.tsx
+++ b/site/src/components/docs/demos/time/react/tailwind/Remaining.tsx
@@ -1,0 +1,18 @@
+import { Container, createPlayer, Time } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function Remaining() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <Time.Value
+          type="remaining"
+          className="absolute bottom-2.5 left-2.5 rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black tabular-nums backdrop-blur-[10px]"
+        />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/tooltip/html/tailwind/BasicUsage.astro
+++ b/site/src/components/docs/demos/tooltip/html/tailwind/BasicUsage.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './BasicUsage.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./BasicUsage.ts";
+</script>

--- a/site/src/components/docs/demos/tooltip/html/tailwind/BasicUsage.html
+++ b/site/src/components/docs/demos/tooltip/html/tailwind/BasicUsage.html
@@ -1,0 +1,15 @@
+<div class="flex items-center justify-center px-6 py-10">
+    <button
+        type="button"
+        commandfor="tooltip-demo"
+        class="cursor-pointer rounded-full border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]"
+    >
+        Hover me
+    </button>
+    <media-tooltip
+        id="tooltip-demo"
+        class="pointer-events-none rounded-md bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]"
+    >
+        Tooltip content
+    </media-tooltip>
+</div>

--- a/site/src/components/docs/demos/tooltip/html/tailwind/BasicUsage.ts
+++ b/site/src/components/docs/demos/tooltip/html/tailwind/BasicUsage.ts
@@ -1,0 +1,1 @@
+import '@videojs/html/ui/tooltip';

--- a/site/src/components/docs/demos/tooltip/html/tailwind/Grouping.astro
+++ b/site/src/components/docs/demos/tooltip/html/tailwind/Grouping.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './Grouping.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./Grouping.ts";
+</script>

--- a/site/src/components/docs/demos/tooltip/html/tailwind/Grouping.html
+++ b/site/src/components/docs/demos/tooltip/html/tailwind/Grouping.html
@@ -1,0 +1,43 @@
+<media-tooltip-group class="flex items-center justify-center px-6 py-10">
+    <button
+        type="button"
+        commandfor="tooltip-play"
+        class="cursor-pointer border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]"
+    >
+        Play
+    </button>
+    <media-tooltip
+        id="tooltip-play"
+        class="pointer-events-none rounded-md bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]"
+    >
+        Play video
+    </media-tooltip>
+
+    <button
+        type="button"
+        commandfor="tooltip-mute"
+        class="cursor-pointer border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]"
+    >
+        Mute
+    </button>
+    <media-tooltip
+        id="tooltip-mute"
+        class="pointer-events-none rounded-md bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]"
+    >
+        Mute audio
+    </media-tooltip>
+
+    <button
+        type="button"
+        commandfor="tooltip-fullscreen"
+        class="cursor-pointer border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]"
+    >
+        Fullscreen
+    </button>
+    <media-tooltip
+        id="tooltip-fullscreen"
+        class="pointer-events-none rounded-md bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]"
+    >
+        Enter fullscreen
+    </media-tooltip>
+</media-tooltip-group>

--- a/site/src/components/docs/demos/tooltip/html/tailwind/Grouping.ts
+++ b/site/src/components/docs/demos/tooltip/html/tailwind/Grouping.ts
@@ -1,0 +1,2 @@
+import '@videojs/html/ui/tooltip';
+import '@videojs/html/ui/tooltip-group';

--- a/site/src/components/docs/demos/tooltip/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/tooltip/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,17 @@
+import { Tooltip } from '@videojs/react';
+
+export default function BasicUsage() {
+  return (
+    <div className="flex items-center justify-center px-6 py-10">
+      <Tooltip.Root>
+        <Tooltip.Trigger className="cursor-pointer rounded-full border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]">
+          Hover me
+        </Tooltip.Trigger>
+        <Tooltip.Popup className="pointer-events-none m-0 rounded-md border-0 bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]">
+          <Tooltip.Arrow className="fill-black/85" />
+          <Tooltip.Label>Tooltip content</Tooltip.Label>
+        </Tooltip.Popup>
+      </Tooltip.Root>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/tooltip/react/tailwind/Grouping.tsx
+++ b/site/src/components/docs/demos/tooltip/react/tailwind/Grouping.tsx
@@ -1,0 +1,37 @@
+import { Tooltip } from '@videojs/react';
+
+export default function Grouping() {
+  return (
+    <div className="flex items-center justify-center px-6 py-10">
+      <Tooltip.Provider>
+        <Tooltip.Root>
+          <Tooltip.Trigger className="cursor-pointer border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]">
+            Play
+          </Tooltip.Trigger>
+          <Tooltip.Popup className="pointer-events-none m-0 rounded-md border-0 bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]">
+            <Tooltip.Arrow className="fill-black/85" />
+            <Tooltip.Label>Play video</Tooltip.Label>
+          </Tooltip.Popup>
+        </Tooltip.Root>
+        <Tooltip.Root>
+          <Tooltip.Trigger className="cursor-pointer border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]">
+            Mute
+          </Tooltip.Trigger>
+          <Tooltip.Popup className="pointer-events-none m-0 rounded-md border-0 bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]">
+            <Tooltip.Arrow className="fill-black/85" />
+            <Tooltip.Label>Mute audio</Tooltip.Label>
+          </Tooltip.Popup>
+        </Tooltip.Root>
+        <Tooltip.Root>
+          <Tooltip.Trigger className="cursor-pointer border border-white/30 bg-white/70 px-4 py-1.5 text-black backdrop-blur-[10px]">
+            Fullscreen
+          </Tooltip.Trigger>
+          <Tooltip.Popup className="pointer-events-none m-0 rounded-md border-0 bg-black/85 px-2.5 py-1 text-[13px] whitespace-nowrap text-white backdrop-blur-[10px] [--media-tooltip-side-offset:8px]">
+            <Tooltip.Arrow className="fill-black/85" />
+            <Tooltip.Label>Enter fullscreen</Tooltip.Label>
+          </Tooltip.Popup>
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/use-button/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-button/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,31 @@
+import { useButton } from '@videojs/react';
+import type { Ref } from 'react';
+import { useState } from 'react';
+
+export default function BasicUsage() {
+  const [count, setCount] = useState(0);
+  const [disabled, setDisabled] = useState(false);
+
+  const { getButtonProps, buttonRef } = useButton({
+    displayName: 'ActivateButton',
+    onActivate: () => setCount((c) => c + 1),
+    isDisabled: () => disabled,
+  });
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <button
+        ref={buttonRef as Ref<HTMLButtonElement>}
+        {...getButtonProps()}
+        className="cursor-pointer self-start rounded-md border border-gray-300 bg-neutral-100 px-5 py-2 tabular-nums transition-opacity duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled}
+      >
+        Activated {count} times
+      </button>
+      <label className="flex items-center gap-1.5 text-sm text-gray-500">
+        <input type="checkbox" checked={disabled} onChange={(e) => setDisabled(e.target.checked)} />
+        Disabled
+      </label>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/use-locale/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-locale/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,52 @@
+import { I18nProvider, useLocale } from '@videojs/react/i18n';
+import { useState } from 'react';
+
+const locales = ['en-US', 'fr-FR', 'ja-JP'] as const;
+type Locale = (typeof locales)[number];
+
+function LocaleDetails() {
+  const locale = useLocale();
+  const date = new Intl.DateTimeFormat(locale, {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  }).format(new Date('2026-01-15T12:00:00Z'));
+
+  return (
+    <dl className="m-0 grid gap-2">
+      <div className="flex items-center gap-2">
+        <dt className="text-gray-500">Active locale</dt>
+        <dd className="m-0">{locale}</dd>
+      </div>
+      <div className="flex items-center gap-2">
+        <dt className="text-gray-500">Formatted date</dt>
+        <dd className="m-0" lang={locale}>
+          {date}
+        </dd>
+      </div>
+    </dl>
+  );
+}
+
+export default function BasicUsage() {
+  const [locale, setLocale] = useState<Locale>('en-US');
+
+  return (
+    <div className="grid gap-4 p-4">
+      <label className="flex items-center gap-2">
+        Locale
+        <select
+          className="px-2 py-1"
+          value={locale}
+          onChange={(event) => setLocale(event.currentTarget.value as Locale)}
+        >
+          {locales.map((value) => (
+            <option key={value}>{value}</option>
+          ))}
+        </select>
+      </label>
+      <I18nProvider locale={locale}>
+        <LocaleDetails />
+      </I18nProvider>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/use-media/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-media/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,46 @@
+import { Container, createPlayer, isMediaSourceCapable, isMediaVideoDimensionsCapable } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player, useMedia } = createPlayer({
+  features: videoFeatures,
+});
+
+function MediaInfo() {
+  const media = useMedia();
+
+  if (!media) return null;
+
+  return (
+    <dl className="m-0 flex flex-col gap-1 border-t border-black/10 bg-black/5 p-3 text-[13px]">
+      {isMediaSourceCapable(media) && (
+        <div className="flex gap-2">
+          <dt className="min-w-20 text-gray-500">src</dt>
+          <dd className="m-0 truncate tabular-nums">{media.currentSrc || '—'}</dd>
+        </div>
+      )}
+      {isMediaVideoDimensionsCapable(media) && (
+        <>
+          <div className="flex gap-2">
+            <dt className="min-w-20 text-gray-500">videoWidth</dt>
+            <dd className="m-0 truncate tabular-nums">{media.videoWidth}px</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="min-w-20 text-gray-500">videoHeight</dt>
+            <dd className="m-0 truncate tabular-nums">{media.videoHeight}px</dd>
+          </div>
+        </>
+      )}
+    </dl>
+  );
+}
+
+export default function BasicUsage() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <MediaInfo />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/use-player/react/tailwind/Selector.tsx
+++ b/site/src/components/docs/demos/use-player/react/tailwind/Selector.tsx
@@ -1,0 +1,40 @@
+import { Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player, usePlayer } = createPlayer({
+  features: videoFeatures,
+});
+
+function StateDisplay() {
+  const state = usePlayer((s) => ({
+    paused: s.paused,
+    currentTime: s.currentTime,
+    duration: s.duration,
+  }));
+
+  return (
+    <dl className="m-0 flex gap-4 border-t border-black/10 bg-black/5 p-3 text-[13px]">
+      <div className="flex gap-2">
+        <dt className="text-gray-500">Paused</dt>
+        <dd className="m-0 tabular-nums">{String(state.paused)}</dd>
+      </div>
+      <div className="flex gap-2">
+        <dt className="text-gray-500">Time</dt>
+        <dd className="m-0 tabular-nums">
+          {state.currentTime.toFixed(1)}s / {state.duration.toFixed(1)}s
+        </dd>
+      </div>
+    </dl>
+  );
+}
+
+export default function Selector() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <StateDisplay />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/use-player/react/tailwind/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-player/react/tailwind/StoreAccess.tsx
@@ -1,0 +1,40 @@
+import { Container, createPlayer } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player, usePlayer } = createPlayer({
+  features: videoFeatures,
+});
+
+function Controls() {
+  const store = usePlayer();
+
+  return (
+    <div className="flex gap-1.5 border-t border-black/10 bg-black/5 p-3">
+      <button
+        type="button"
+        className="cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+        onClick={() => store.play()}
+      >
+        Play
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+        onClick={() => store.pause()}
+      >
+        Pause
+      </button>
+    </div>
+  );
+}
+
+export default function StoreAccess() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <Controls />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/use-store/react/tailwind/Selector.tsx
+++ b/site/src/components/docs/demos/use-store/react/tailwind/Selector.tsx
@@ -1,0 +1,38 @@
+import { Container, createPlayer, useStore } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player, usePlayer } = createPlayer({
+  features: videoFeatures,
+});
+
+function DerivedState() {
+  const store = usePlayer();
+  const derived = useStore(store, (s) => ({
+    remaining: s.duration - s.currentTime,
+    progress: s.duration > 0 ? (s.currentTime / s.duration) * 100 : 0,
+  }));
+
+  return (
+    <dl className="m-0 flex gap-4 border-t border-black/10 bg-black/5 p-3 text-[13px]">
+      <div className="flex gap-2">
+        <dt className="text-gray-500">Remaining</dt>
+        <dd className="m-0 tabular-nums">{derived.remaining.toFixed(1)}s</dd>
+      </div>
+      <div className="flex gap-2">
+        <dt className="text-gray-500">Progress</dt>
+        <dd className="m-0 tabular-nums">{derived.progress.toFixed(1)}%</dd>
+      </div>
+    </dl>
+  );
+}
+
+export default function Selector() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <DerivedState />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/use-store/react/tailwind/StoreAccess.tsx
+++ b/site/src/components/docs/demos/use-store/react/tailwind/StoreAccess.tsx
@@ -1,0 +1,41 @@
+import { Container, createPlayer, useStore } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player, usePlayer } = createPlayer({
+  features: videoFeatures,
+});
+
+function SeekControls() {
+  const store = usePlayer();
+  const s = useStore(store);
+
+  return (
+    <div className="flex gap-1.5 border-t border-black/10 bg-black/5 p-3">
+      <button
+        type="button"
+        className="cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+        onClick={() => s.seek(0)}
+      >
+        Go to start
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer rounded-md border border-gray-300 bg-white px-3 py-1 text-[13px]"
+        onClick={() => s.seek(s.state.duration / 2)}
+      >
+        Go to middle
+      </button>
+    </div>
+  );
+}
+
+export default function StoreAccess() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <SeekControls />
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/components/docs/demos/use-translator/react/tailwind/BasicUsage.tsx
+++ b/site/src/components/docs/demos/use-translator/react/tailwind/BasicUsage.tsx
@@ -1,0 +1,55 @@
+import { I18nProvider, useTranslator } from '@videojs/react/i18n';
+import { useState } from 'react';
+
+const translations = {
+  es: {
+    buttons: { play: 'Reproducir' },
+    seek: { forward: 'Adelantar {seconds} segundos' },
+  },
+  fr: {
+    buttons: { play: 'Lire' },
+    seek: { forward: 'Avancer de {seconds} secondes' },
+  },
+} as const;
+
+type Locale = keyof typeof translations;
+
+function Labels() {
+  const t = useTranslator();
+
+  return (
+    <dl className="m-0 grid gap-2">
+      <div className="flex items-center gap-2">
+        <dt className="text-gray-500">Button</dt>
+        <dd className="m-0">{t('buttons.play', { default: 'Play' })}</dd>
+      </div>
+      <div className="flex items-center gap-2">
+        <dt className="text-gray-500">Parameterized</dt>
+        <dd className="m-0">{t('seek.forward', { seconds: 10, default: 'Seek forward {seconds} seconds' })}</dd>
+      </div>
+    </dl>
+  );
+}
+
+export default function BasicUsage() {
+  const [locale, setLocale] = useState<Locale>('es');
+
+  return (
+    <div className="grid gap-4 p-4">
+      <label className="flex items-center gap-2">
+        Language
+        <select
+          className="px-2 py-1"
+          value={locale}
+          onChange={(event) => setLocale(event.currentTarget.value as Locale)}
+        >
+          <option value="es">Spanish</option>
+          <option value="fr">French</option>
+        </select>
+      </label>
+      <I18nProvider locale={locale} translations={translations[locale]}>
+        <Labels />
+      </I18nProvider>
+    </div>
+  );
+}

--- a/site/src/components/docs/demos/volume-slider/html/tailwind/WithParts.astro
+++ b/site/src/components/docs/demos/volume-slider/html/tailwind/WithParts.astro
@@ -1,0 +1,9 @@
+---
+import HtmlDemo from '@/components/docs/demos/HtmlDemo.astro';
+import html from './WithParts.html?raw';
+---
+
+<HtmlDemo html={html} />
+<script>
+  import "./WithParts.ts";
+</script>

--- a/site/src/components/docs/demos/volume-slider/html/tailwind/WithParts.html
+++ b/site/src/components/docs/demos/volume-slider/html/tailwind/WithParts.html
@@ -1,0 +1,25 @@
+<video-player class="relative block">
+    <media-container class="relative block">
+        <video
+            class="w-full"
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-mute-button
+            class="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+        >
+            <span class="hidden in-data-muted:inline">Unmute</span>
+            <span class="hidden not-in-data-muted:inline">Mute</span>
+        </media-mute-button>
+        <media-volume-slider class="absolute right-2.5 bottom-2.5 flex h-5 w-25 cursor-pointer items-center">
+            <media-slider-track class="absolute inset-x-0 h-1 rounded-full bg-white/30 backdrop-blur-[10px] transition-[height] duration-150 in-data-interactive:h-1.5">
+                <media-slider-fill class="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white"></media-slider-fill>
+            </media-slider-track>
+            <media-slider-thumb class="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110"></media-slider-thumb>
+            <media-slider-value type="pointer" class="pointer-events-none absolute bottom-full left-(--media-slider-pointer) mb-1.5 -translate-x-1/2 rounded-sm bg-black/80 px-1.5 py-0.5 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-150 in-data-pointing:opacity-100"></media-slider-value>
+        </media-volume-slider>
+    </media-container>
+</video-player>

--- a/site/src/components/docs/demos/volume-slider/html/tailwind/WithParts.ts
+++ b/site/src/components/docs/demos/volume-slider/html/tailwind/WithParts.ts
@@ -1,0 +1,3 @@
+import '@videojs/html/video/player';
+import '@videojs/html/ui/mute-button';
+import '@videojs/html/ui/volume-slider';

--- a/site/src/components/docs/demos/volume-slider/react/tailwind/WithParts.tsx
+++ b/site/src/components/docs/demos/volume-slider/react/tailwind/WithParts.tsx
@@ -1,0 +1,28 @@
+import { Container, createPlayer, MuteButton, VolumeSlider } from '@videojs/react';
+import { Video, videoFeatures } from '@videojs/react/video';
+
+const { Player } = createPlayer({ features: videoFeatures });
+
+export default function WithParts() {
+  return (
+    <Player>
+      <Container className="relative">
+        <Video className="w-full" src="{{VJS10_DEMO_VIDEO_MP4}}" autoPlay muted playsInline loop />
+        <MuteButton
+          className="absolute bottom-2.5 left-2.5 cursor-pointer rounded-full border border-white/30 bg-white/70 px-5 py-2 text-black backdrop-blur-[10px]"
+          render={(props, state) => <button {...props}>{state.muted ? 'Unmute' : 'Mute'}</button>}
+        />
+        <VolumeSlider.Root className="absolute right-2.5 bottom-2.5 flex h-5 w-25 cursor-pointer items-center">
+          <VolumeSlider.Track className="absolute inset-x-0 h-1 rounded-full bg-white/30 backdrop-blur-[10px] transition-[height] duration-150 in-data-interactive:h-1.5">
+            <VolumeSlider.Fill className="absolute top-0 left-0 h-full w-(--media-slider-fill) rounded-full bg-white" />
+          </VolumeSlider.Track>
+          <VolumeSlider.Thumb className="absolute left-(--media-slider-fill) size-3.5 -translate-x-1/2 scale-0 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] transition-transform duration-150 in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110" />
+          <VolumeSlider.Value
+            type="pointer"
+            className="pointer-events-none absolute bottom-full left-(--media-slider-pointer) mb-1.5 -translate-x-1/2 rounded-sm bg-black/80 px-1.5 py-0.5 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-150 in-data-pointing:opacity-100"
+          />
+        </VolumeSlider.Root>
+      </Container>
+    </Player>
+  );
+}

--- a/site/src/content/docs/concepts/i18n.mdx
+++ b/site/src/content/docs/concepts/i18n.mdx
@@ -14,24 +14,43 @@ import LanguageDemoHtml from '@/components/docs/demos/i18n/html/css/Language.ast
 import languageHtml from '@/components/docs/demos/i18n/html/css/Language.html?raw';
 import languageHtmlCss from '@/components/docs/demos/i18n/html/css/Language.css?raw';
 import languageHtmlTs from '@/components/docs/demos/i18n/html/css/Language.ts?raw';
+import LanguageDemoHtmlTailwind from '@/components/docs/demos/i18n/html/tailwind/Language.astro';
+import languageTailwindHtml from '@/components/docs/demos/i18n/html/tailwind/Language.html?raw';
+import languageTailwindHtmlTs from '@/components/docs/demos/i18n/html/tailwind/Language.ts?raw';
 import LanguageDemoReact from '@/components/docs/demos/i18n/react/css/Language';
 import languageReactTsx from '@/components/docs/demos/i18n/react/css/Language.tsx?raw';
 import languageReactCss from '@/components/docs/demos/i18n/react/css/Language.css?raw';
+import LanguageDemoReactTailwind from '@/components/docs/demos/i18n/react/tailwind/Language';
+import languageReactTailwindTsx from '@/components/docs/demos/i18n/react/tailwind/Language.tsx?raw';
 import SourceDemo from '@/components/docs/demos/i18n/SourceDemo.astro';
 import RegisteredDemoHtml from '@/components/docs/demos/i18n/html/css/Registered.astro';
 import registeredHtmlTs from '@/components/docs/demos/i18n/html/css/Registered.ts?raw';
+import RegisteredDemoHtmlTailwind from '@/components/docs/demos/i18n/html/tailwind/Registered.astro';
+import registeredTailwindHtmlTs from '@/components/docs/demos/i18n/html/tailwind/Registered.ts?raw';
 import BuiltInDemoHtml from '@/components/docs/demos/i18n/html/css/BuiltIn.astro';
 import builtInHtml from '@/components/docs/demos/i18n/html/css/BuiltIn.html?raw';
+import BuiltInDemoHtmlTailwind from '@/components/docs/demos/i18n/html/tailwind/BuiltIn.astro';
+import builtInTailwindHtml from '@/components/docs/demos/i18n/html/tailwind/BuiltIn.html?raw';
 import FallbackDemoHtml from '@/components/docs/demos/i18n/html/css/Fallback.astro';
 import fallbackHtml from '@/components/docs/demos/i18n/html/css/Fallback.html?raw';
+import FallbackDemoHtmlTailwind from '@/components/docs/demos/i18n/html/tailwind/Fallback.astro';
+import fallbackTailwindHtml from '@/components/docs/demos/i18n/html/tailwind/Fallback.html?raw';
 import OverrideDemoReact from '@/components/docs/demos/i18n/react/css/Override';
 import overrideReactTsx from '@/components/docs/demos/i18n/react/css/Override.tsx?raw';
+import OverrideDemoReactTailwind from '@/components/docs/demos/i18n/react/tailwind/Override';
+import overrideReactTailwindTsx from '@/components/docs/demos/i18n/react/tailwind/Override.tsx?raw';
 import RegisteredDemoReact from '@/components/docs/demos/i18n/react/css/Registered';
 import registeredReactTsx from '@/components/docs/demos/i18n/react/css/Registered.tsx?raw';
+import RegisteredDemoReactTailwind from '@/components/docs/demos/i18n/react/tailwind/Registered';
+import registeredReactTailwindTsx from '@/components/docs/demos/i18n/react/tailwind/Registered.tsx?raw';
 import BuiltInDemoReact from '@/components/docs/demos/i18n/react/css/BuiltIn';
 import builtInReactTsx from '@/components/docs/demos/i18n/react/css/BuiltIn.tsx?raw';
+import BuiltInDemoReactTailwind from '@/components/docs/demos/i18n/react/tailwind/BuiltIn';
+import builtInReactTailwindTsx from '@/components/docs/demos/i18n/react/tailwind/BuiltIn.tsx?raw';
 import FallbackDemoReact from '@/components/docs/demos/i18n/react/css/Fallback';
 import fallbackReactTsx from '@/components/docs/demos/i18n/react/css/Fallback.tsx?raw';
+import FallbackDemoReactTailwind from '@/components/docs/demos/i18n/react/tailwind/Fallback';
+import fallbackReactTailwindTsx from '@/components/docs/demos/i18n/react/tailwind/Fallback.tsx?raw';
 
 Video.js displays its controls in English by default. Use internationalization when the player should match another language used by your site or application.
 
@@ -57,6 +76,17 @@ Wrap the player with `<media-i18n>`. Choose any shipped language to lazy-load it
   </Demo>
 </StyleCase>
 
+<StyleCase styles={["tailwind"]}>
+  <Demo
+    files={[
+      { title: "index.html", code: languageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: languageTailwindHtmlTs, lang: "ts" },
+    ]}
+  >
+    <LanguageDemoHtmlTailwind />
+  </Demo>
+</StyleCase>
+
 Set `lang` on `<media-i18n>` when one player needs a different language from the rest of the page.
 
 </FrameworkCase>
@@ -73,6 +103,16 @@ Mount `I18nProvider` inside the player `Provider`. Choose any shipped language t
     ]}
   >
     <LanguageDemoReact client:idle />
+  </Demo>
+</StyleCase>
+
+<StyleCase styles={["tailwind"]}>
+  <Demo
+    files={[
+      { title: "App.tsx", code: languageReactTailwindTsx, lang: "tsx" },
+    ]}
+  >
+    <LanguageDemoReactTailwind client:idle />
   </Demo>
 </StyleCase>
 
@@ -151,6 +191,37 @@ Choose a source, then hover the play button to see its resolved label.
   </TabsRoot>
 </StyleCase>
 
+<StyleCase styles={["tailwind"]}>
+  <TabsRoot client:idle>
+    <TabsList client:idle label="Translation source examples">
+      <Tab client:idle value="override" initial>Player override</Tab>
+      <Tab client:idle value="registered">Registered</Tab>
+      <Tab client:idle value="built-in">Built-in</Tab>
+      <Tab client:idle value="fallback">Fallback</Tab>
+    </TabsList>
+    <TabsPanel client:idle value="override" initial className="max-h-none overflow-visible p-0">
+      <SourceDemo code={overrideReactTailwindTsx} lang="tsx">
+        <OverrideDemoReactTailwind client:idle />
+      </SourceDemo>
+    </TabsPanel>
+    <TabsPanel client:idle value="registered" className="max-h-none overflow-visible p-0">
+      <SourceDemo code={registeredReactTailwindTsx} lang="tsx">
+        <RegisteredDemoReactTailwind client:idle />
+      </SourceDemo>
+    </TabsPanel>
+    <TabsPanel client:idle value="built-in" className="max-h-none overflow-visible p-0">
+      <SourceDemo code={builtInReactTailwindTsx} lang="tsx">
+        <BuiltInDemoReactTailwind client:idle />
+      </SourceDemo>
+    </TabsPanel>
+    <TabsPanel client:idle value="fallback" className="max-h-none overflow-visible p-0">
+      <SourceDemo code={fallbackReactTailwindTsx} lang="tsx">
+        <FallbackDemoReactTailwind client:idle />
+      </SourceDemo>
+    </TabsPanel>
+  </TabsRoot>
+</StyleCase>
+
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -181,6 +252,31 @@ Choose a source, then hover the play button to see its resolved label.
     <TabsPanel client:idle value="fallback" className="max-h-none overflow-visible p-0">
       <SourceDemo code={fallbackHtml} lang="html">
         <FallbackDemoHtml />
+      </SourceDemo>
+    </TabsPanel>
+  </TabsRoot>
+</StyleCase>
+
+<StyleCase styles={["tailwind"]}>
+  <TabsRoot client:idle>
+    <TabsList client:idle label="Translation source examples">
+      <Tab client:idle value="registered" initial>Registered</Tab>
+      <Tab client:idle value="built-in">Built-in</Tab>
+      <Tab client:idle value="fallback">Fallback</Tab>
+    </TabsList>
+    <TabsPanel client:idle value="registered" initial className="max-h-none overflow-visible p-0">
+      <SourceDemo code={registeredTailwindHtmlTs} lang="ts">
+        <RegisteredDemoHtmlTailwind />
+      </SourceDemo>
+    </TabsPanel>
+    <TabsPanel client:idle value="built-in" className="max-h-none overflow-visible p-0">
+      <SourceDemo code={builtInTailwindHtml} lang="html">
+        <BuiltInDemoHtmlTailwind />
+      </SourceDemo>
+    </TabsPanel>
+    <TabsPanel client:idle value="fallback" className="max-h-none overflow-visible p-0">
+      <SourceDemo code={fallbackTailwindHtml} lang="html">
+        <FallbackDemoHtmlTailwind />
       </SourceDemo>
     </TabsPanel>
   </TabsRoot>

--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -54,44 +54,82 @@ If you'd like to customize them you can fully customize them by "ejecting" the c
 
 While eventually we’ll have a CLI that will eject skins in your preferred framework and style, for now we invite you to try it out with these copy-paste-ready implementations.
 
-{/*TODO: Add StyleCase for tailwind variants once tailwind is a supported style (see #840)*/}
-
 ### Default Video Skin
 
 <FrameworkCase frameworks={["react"]}>
-  <EjectedSkin id="default-video-react" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="default-video-react" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="default-video-react-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-  <EjectedSkin id="default-video" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="default-video" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="default-video-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 ### Default Audio Skin
 
 <FrameworkCase frameworks={["react"]}>
-  <EjectedSkin id="default-audio-react" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="default-audio-react" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="default-audio-react-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-  <EjectedSkin id="default-audio" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="default-audio" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="default-audio-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 ### Minimal Video Skin
 
 <FrameworkCase frameworks={["react"]}>
-  <EjectedSkin id="minimal-video-react" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="minimal-video-react" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="minimal-video-react-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-  <EjectedSkin id="minimal-video" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="minimal-video" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="minimal-video-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 ### Minimal Audio Skin
 
 <FrameworkCase frameworks={["react"]}>
-  <EjectedSkin id="minimal-audio-react" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="minimal-audio-react" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="minimal-audio-react-tailwind" />
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-  <EjectedSkin id="minimal-audio" />
+  <StyleCase styles={["css"]}>
+    <EjectedSkin id="minimal-audio" />
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <EjectedSkin id="minimal-audio-tailwind" />
+  </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/how-to/write-guides.mdx
+++ b/site/src/content/docs/how-to/write-guides.mdx
@@ -14,10 +14,15 @@ import Demo from '@/components/docs/demos/Demo.astro';
 import BasicUsageDemoReact from '@/components/docs/demos/play-button/react/css/BasicUsage';
 import basicUsageReactTsx from '@/components/docs/demos/play-button/react/css/BasicUsage.tsx?raw';
 import basicUsageReactCss from '@/components/docs/demos/play-button/react/css/BasicUsage.css?raw';
+import BasicUsageDemoReactTailwind from '@/components/docs/demos/play-button/react/tailwind/BasicUsage';
+import basicUsageReactTailwindTsx from '@/components/docs/demos/play-button/react/tailwind/BasicUsage.tsx?raw';
 import BasicUsageDemoHtml from '@/components/docs/demos/play-button/html/css/BasicUsage.astro';
 import basicUsageHtml from '@/components/docs/demos/play-button/html/css/BasicUsage.html?raw';
 import basicUsageHtmlCss from '@/components/docs/demos/play-button/html/css/BasicUsage.css?raw';
 import basicUsageHtmlTs from '@/components/docs/demos/play-button/html/css/BasicUsage.ts?raw';
+import BasicUsageDemoHtmlTailwind from '@/components/docs/demos/play-button/html/tailwind/BasicUsage.astro';
+import basicUsageTailwindHtml from '@/components/docs/demos/play-button/html/tailwind/BasicUsage.html?raw';
+import basicUsageTailwindHtmlTs from '@/components/docs/demos/play-button/html/tailwind/BasicUsage.ts?raw';
 
 What is a guide? In this context, it's a document in the docs that's not an API reference. For API references, see <DocsLink slug="reference/write-references">Write reference pages</DocsLink>.
 
@@ -119,7 +124,7 @@ Keep documentation clear, human, and useful. Here are the key rules:
 ## 5. Understand MDX and our components
 
 ### `<FrameworkCase>` and `<StyleCase>`
-First, understand that the guide you write will be rendered for every framework / style combination (e.g., HTML + CSS, React + CSS) unless you restrict it to specific frameworks in the sidebar config as shown above.
+First, understand that the guide you write will be rendered for every framework / style combination (e.g., HTML + CSS, HTML + Tailwind, React + CSS, React + Tailwind) unless you restrict it to specific frameworks in the sidebar config as shown above.
 
 Use the `<FrameworkCase>` and `<StyleCase>` components to conditionally show content to just one framework or style:
 
@@ -563,6 +568,13 @@ Which renders as:
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -573,6 +585,14 @@ Which renders as:
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/airplay-button.mdx
+++ b/site/src/content/docs/reference/airplay-button.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/airplay-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/airplay-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/airplay-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/airplay-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/airplay-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/airplay-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/airplay-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/airplay-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/airplay-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/airplay-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/airplay-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/airplay-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -116,6 +121,13 @@ Renders a `<button>` with an automatic `aria-label`: "Start AirPlay" when discon
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -126,6 +138,14 @@ Renders a `<button>` with an automatic `aria-label`: "Start AirPlay" when discon
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/audio-track-radio-group.mdx
+++ b/site/src/content/docs/reference/audio-track-radio-group.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/audio-track-radio-group/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/audio-track-radio-group/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/audio-track-radio-group/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/audio-track-radio-group/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/audio-track-radio-group/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/audio-track-radio-group/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/audio-track-radio-group/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/audio-track-radio-group/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/audio-track-radio-group/html/tailwind/BasicUsage.ts?raw";
 
 Creates radio items from the player audio track state and selects the enabled track.
 
@@ -100,6 +105,13 @@ The element receives an accessible label from the `label` property or defaults t
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -110,6 +122,14 @@ The element receives an accessible label from the `label` property or defaults t
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/background-video.mdx
+++ b/site/src/content/docs/reference/background-video.mdx
@@ -20,12 +20,17 @@ import Tr from "@/components/typography/Tr.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/background-video/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/background-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/background-video/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/background-video/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/background-video/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/background-video/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/background-video/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/background-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/background-video/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/background-video/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/background-video/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/background-video/html/tailwind/BasicUsage.ts?raw";
 
 Decorative background video. By default it's muted, looped, and autoplaying — use the opt-out attributes below to change that. Renders a `<video>` inside a shadow DOM, positioned to fill its container.
 
@@ -42,6 +47,13 @@ Decorative background video. By default it's muted, looped, and autoplaying — 
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -52,6 +64,14 @@ Decorative background video. By default it's muted, looped, and autoplaying — 
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/buffering-indicator.mdx
+++ b/site/src/content/docs/reference/buffering-indicator.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/buffering-indicator/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/buffering-indicator/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/buffering-indicator/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/buffering-indicator/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/buffering-indicator/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/buffering-indicator/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/buffering-indicator/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -56,6 +61,13 @@ Hide and show the indicator based on the `data-visible` attribute.
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -66,6 +78,14 @@ Hide and show the indicator based on the `data-visible` attribute.
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/captions-button.mdx
+++ b/site/src/content/docs/reference/captions-button.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/captions-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/captions-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/captions-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/captions-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/captions-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/captions-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/captions-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/captions-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/captions-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/captions-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/captions-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/captions-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -82,6 +87,13 @@ In menu-trigger mode, the button behaves as a menu trigger and reflects menu sta
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -92,6 +104,14 @@ In menu-trigger mode, the button behaves as a menu trigger and reflects menu sta
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/captions-radio-group.mdx
+++ b/site/src/content/docs/reference/captions-radio-group.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/captions-radio-group/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/captions-radio-group/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/captions-radio-group/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/captions-radio-group/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/captions-radio-group/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/captions-radio-group/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/captions-radio-group/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/captions-radio-group/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/captions-radio-group/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/captions-radio-group/html/tailwind/BasicUsage.ts?raw";
 
 Creates radio items from the player text track state and selects the showing caption or subtitle track.
 
@@ -100,6 +105,13 @@ The element receives an accessible label from the `label` property or defaults t
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -110,6 +122,14 @@ The element receives an accessible label from the `label` property or defaults t
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/cast-button.mdx
+++ b/site/src/content/docs/reference/cast-button.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/cast-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/cast-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/cast-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/cast-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/cast-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/cast-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/cast-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/cast-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/cast-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/cast-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/cast-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/cast-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -111,6 +116,13 @@ Override with the `label` prop. Keyboard activation: <kbd>Enter</kbd> / <kbd>Spa
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -121,6 +133,14 @@ Override with the `label` prop. Keyboard activation: <kbd>Enter</kbd> / <kbd>Spa
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/controls.mdx
+++ b/site/src/content/docs/reference/controls.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/controls/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/controls/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/controls/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/controls/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/controls/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/controls/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/controls/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/controls/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/controls/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/controls/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/controls/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/controls/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -121,6 +126,15 @@ No ARIA role is applied to `Controls.Root` — it is a layout wrapper, not a lan
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -133,6 +147,16 @@ No ARIA role is applied to `Controls.Root` — it is a layout wrapper, not a lan
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/create-player.mdx
+++ b/site/src/content/docs/reference/create-player.mdx
@@ -10,6 +10,8 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/create-player/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/create-player/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/create-player/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/create-player/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/create-player/react/tailwind/BasicUsage.tsx?raw";
 
 `createPlayer` is the entry point for setting up a Video.js player in React. It accepts a configuration object with a `features` array and returns hooks and components for building a player.
 
@@ -39,6 +41,15 @@ const { Player, usePlayer, useMedia } = createPlayer({
       ]}
     >
       <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/dash-video.mdx
+++ b/site/src/content/docs/reference/dash-video.mdx
@@ -15,12 +15,16 @@ import { TabsRoot, TabsList, Tab, TabsPanel } from "@/components/Tabs";
 import ServerCode from "@/components/Code/ServerCode.astro";
 import basicUsageReactTsx from "@/components/docs/demos/dash-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/dash-video/react/css/BasicUsage.css?raw";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/dash-video/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/dash-video/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/dash-video/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/dash-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/dash-video/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/dash-video/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/dash-video/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/dash-video/html/tailwind/BasicUsage.ts?raw";
 
 DASH video element powered by [dash.js](https://github.com/Dash-Industry-Forum/dash.js/) for MPEG-DASH adaptive bitrate streaming.
 
@@ -44,6 +48,16 @@ DASH video element powered by [dash.js](https://github.com/Dash-Industry-Forum/d
       </TabsPanel>
     </TabsRoot>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <TabsRoot client:idle>
+      <TabsList client:idle label="Basic usage source code">
+        <Tab client:idle value="App.tsx" initial>App.tsx</Tab>
+      </TabsList>
+      <TabsPanel client:idle value="App.tsx" initial>
+        <ServerCode code={basicUsageReactTailwindTsx} lang="tsx" />
+      </TabsPanel>
+    </TabsRoot>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -54,6 +68,14 @@ DASH video element powered by [dash.js](https://github.com/Dash-Industry-Forum/d
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/fullscreen-button.mdx
+++ b/site/src/content/docs/reference/fullscreen-button.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/fullscreen-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/fullscreen-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/fullscreen-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/fullscreen-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/fullscreen-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/fullscreen-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/fullscreen-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -99,6 +104,15 @@ Renders a `<button>` with an automatic `aria-label`: "Enter fullscreen" or "Exit
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -111,6 +125,16 @@ Renders a `<button>` with an automatic `aria-label`: "Enter fullscreen" or "Exit
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/hls-audio.mdx
+++ b/site/src/content/docs/reference/hls-audio.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/hls-audio/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/hls-audio/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/hls-audio/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/hls-audio/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/hls-audio/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/hls-audio/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/hls-audio/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/hls-audio/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/hls-audio/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/hls-audio/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/hls-audio/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/hls-audio/html/tailwind/BasicUsage.ts?raw";
 
 Audio-only HLS element that plays just the audio rendition of an HLS stream — even when the source is a mixed audio/video manifest. Useful for audio podcast players, background audio, and bandwidth-constrained contexts where downloading video data would be wasted. For full audio/video HLS playback, see [HlsVideo](/docs/framework/html/reference/hls-video/).
 
@@ -36,6 +41,13 @@ Audio-only HLS element that plays just the audio rendition of an HLS stream — 
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -46,6 +58,14 @@ Audio-only HLS element that plays just the audio rendition of an HLS stream — 
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/hls-video.mdx
+++ b/site/src/content/docs/reference/hls-video.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/hls-video/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/hls-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/hls-video/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/hls-video/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/hls-video/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/hls-video/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/hls-video/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/hls-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/hls-video/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/hls-video/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/hls-video/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/hls-video/html/tailwind/BasicUsage.ts?raw";
 
 Lightweight HLS video element optimized for minimal bundle size. For full hls.js feature support, use [HlsJsVideo](/docs/framework/html/reference/hlsjs-video/) instead.
 
@@ -36,6 +41,13 @@ Lightweight HLS video element optimized for minimal bundle size. For full hls.js
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -46,6 +58,14 @@ Lightweight HLS video element optimized for minimal bundle size. For full hls.js
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/hlsjs-video.mdx
+++ b/site/src/content/docs/reference/hlsjs-video.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/hlsjs-video/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/hlsjs-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/hlsjs-video/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/hlsjs-video/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/hlsjs-video/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/hlsjs-video/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/hlsjs-video/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/hlsjs-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/hlsjs-video/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/hlsjs-video/html/tailwind/BasicUsage.ts?raw";
 
 HLS video element powered by [hls.js](https://github.com/video-dev/hls.js/) for adaptive bitrate streaming. It's the recommended choice for HLS playback: full feature support across every browser. For alternatives, see [NativeHlsVideo](/docs/framework/html/reference/native-hls-video/) (browser-native HLS) or [HlsVideo](/docs/framework/html/reference/hls-video/) (lightweight HLS).
 
@@ -36,6 +41,13 @@ HLS video element powered by [hls.js](https://github.com/video-dev/hls.js/) for 
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -46,6 +58,14 @@ HLS video element powered by [hls.js](https://github.com/video-dev/hls.js/) for 
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/html-create-player.mdx
+++ b/site/src/content/docs/reference/html-create-player.mdx
@@ -11,6 +11,9 @@ import BasicUsageDemoHtml from "@/components/docs/demos/html-create-player/html/
 import basicUsageHtml from "@/components/docs/demos/html-create-player/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/html-create-player/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/html-create-player/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/html-create-player/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/html-create-player/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/html-create-player/html/tailwind/BasicUsage.ts?raw";
 
 `createPlayer` is the entry point for setting up a Video.js player with HTML custom elements. It accepts a configuration object with a `features` array and returns a typed <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink>, `context`, `ProviderMixin`, and a `create` store factory. Import `ContainerMixin` separately from the main package when composing a container.
 
@@ -68,6 +71,14 @@ class ComposedPlayer extends ProviderMixin(ContainerMixin(MediaElement)) {}
     { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
   ]}>
     <BasicUsageDemoHtml />
+  </Demo>
+</StyleCase>
+<StyleCase styles={["tailwind"]}>
+  <Demo files={[
+    { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+    { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+  ]}>
+    <BasicUsageDemoHtmlTailwind />
   </Demo>
 </StyleCase>
 

--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/menu/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/menu/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/menu/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/menu/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/menu/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/menu/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/menu/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/menu/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/menu/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/menu/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/menu/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/menu/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -177,6 +182,13 @@ Use `Menu.GroupLabel` or `<media-menu-group-label>` inside grouped choices so th
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -187,6 +199,14 @@ Use `Menu.GroupLabel` or `<media-menu-group-label>` inside grouped choices so th
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/mute-button.mdx
+++ b/site/src/content/docs/reference/mute-button.mdx
@@ -14,23 +14,33 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/mute-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/mute-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/mute-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/mute-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/mute-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/mute-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/mute-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/mute-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/mute-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/mute-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/mute-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/mute-button/html/tailwind/BasicUsage.ts?raw";
 
 {/* React demos — Volume Levels */}
 import VolumeLevelsDemoReact from "@/components/docs/demos/mute-button/react/css/VolumeLevels";
 import volumeLevelsReactTsx from "@/components/docs/demos/mute-button/react/css/VolumeLevels.tsx?raw";
 import volumeLevelsReactCss from "@/components/docs/demos/mute-button/react/css/VolumeLevels.css?raw";
+import VolumeLevelsDemoReactTailwind from "@/components/docs/demos/mute-button/react/tailwind/VolumeLevels";
+import volumeLevelsReactTailwindTsx from "@/components/docs/demos/mute-button/react/tailwind/VolumeLevels.tsx?raw";
 
 {/* HTML demos — Volume Levels */}
 import VolumeLevelsDemoHtml from "@/components/docs/demos/mute-button/html/css/VolumeLevels.astro";
 import volumeLevelsHtml from "@/components/docs/demos/mute-button/html/css/VolumeLevels.html?raw";
 import volumeLevelsHtmlCss from "@/components/docs/demos/mute-button/html/css/VolumeLevels.css?raw";
 import volumeLevelsHtmlTs from "@/components/docs/demos/mute-button/html/css/VolumeLevels.ts?raw";
+import VolumeLevelsDemoHtmlTailwind from "@/components/docs/demos/mute-button/html/tailwind/VolumeLevels.astro";
+import volumeLevelsTailwindHtml from "@/components/docs/demos/mute-button/html/tailwind/VolumeLevels.html?raw";
+import volumeLevelsTailwindHtmlTs from "@/components/docs/demos/mute-button/html/tailwind/VolumeLevels.ts?raw";
 
 ## Anatomy
 
@@ -107,6 +117,13 @@ Renders a `<button>` with an automatic `aria-label`: "Unmute" when muted, "Mute"
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -117,6 +134,14 @@ Renders a `<button>` with an automatic `aria-label`: "Unmute" when muted, "Mute"
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -132,6 +157,13 @@ Renders a `<button>` with an automatic `aria-label`: "Unmute" when muted, "Mute"
       <VolumeLevelsDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: volumeLevelsReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <VolumeLevelsDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -142,6 +174,14 @@ Renders a `<button>` with an automatic `aria-label`: "Unmute" when muted, "Mute"
       { title: "index.ts", code: volumeLevelsHtmlTs, lang: "ts" },
     ]}>
       <VolumeLevelsDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: volumeLevelsTailwindHtml, lang: "html" },
+      { title: "index.ts", code: volumeLevelsTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <VolumeLevelsDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/mux-audio.mdx
+++ b/site/src/content/docs/reference/mux-audio.mdx
@@ -16,12 +16,17 @@ import DocsLinkCard from "@/components/docs/DocsLinkCard.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/mux-audio/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/mux-audio/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/mux-audio/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/mux-audio/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/mux-audio/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/mux-audio/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/mux-audio/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/mux-audio/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/mux-audio/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/mux-audio/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/mux-audio/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/mux-audio/html/tailwind/BasicUsage.ts?raw";
 
 Audio element for playing Mux-hosted HLS streams. Built on hls.js with Mux-specific optimizations.
 
@@ -67,6 +72,13 @@ Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -77,6 +89,14 @@ Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/mux-video.mdx
+++ b/site/src/content/docs/reference/mux-video.mdx
@@ -16,12 +16,17 @@ import DocsLinkCard from "@/components/docs/DocsLinkCard.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/mux-video/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/mux-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/mux-video/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/mux-video/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/mux-video/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/mux-video/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/mux-video/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/mux-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/mux-video/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/mux-video/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/mux-video/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/mux-video/html/tailwind/BasicUsage.ts?raw";
 
 Video element for playing Mux-hosted HLS streams. Built on hls.js with Mux-specific optimizations.
 
@@ -150,6 +155,13 @@ Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -160,6 +172,14 @@ Register the elements by importing `@videojs/html/media/mux-data` and `@videojs/
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/native-hls-video.mdx
+++ b/site/src/content/docs/reference/native-hls-video.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/native-hls-video/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/native-hls-video/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/native-hls-video/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/native-hls-video/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/native-hls-video/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/native-hls-video/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/native-hls-video/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/native-hls-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/native-hls-video/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/native-hls-video/html/tailwind/BasicUsage.ts?raw";
 
 HLS video element that relies on the browser's native HLS support. Works on Safari and other browsers with built-in HLS playback. For cross-browser HLS support, use [HlsJsVideo](/docs/framework/html/reference/hlsjs-video/) instead.
 
@@ -36,6 +41,13 @@ HLS video element that relies on the browser's native HLS support. Works on Safa
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -46,6 +58,14 @@ HLS video element that relies on the browser's native HLS support. Works on Safa
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/pip-button.mdx
+++ b/site/src/content/docs/reference/pip-button.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/pip-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/pip-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/pip-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/pip-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/pip-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/pip-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/pip-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/pip-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/pip-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/pip-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/pip-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/pip-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -97,6 +102,13 @@ Renders a `<button>` with an automatic `aria-label`: "Enter PiP" or "Exit PiP". 
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -107,6 +119,14 @@ Renders a `<button>` with an automatic `aria-label`: "Enter PiP" or "Exit PiP". 
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/play-button.mdx
+++ b/site/src/content/docs/reference/play-button.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/play-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/play-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/play-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/play-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/play-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/play-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/play-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/play-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/play-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/play-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/play-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/play-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -104,6 +109,13 @@ Renders a `<button>` element with an automatic `aria-label` that updates based o
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -114,6 +126,14 @@ Renders a `<button>` element with an automatic `aria-label` that updates based o
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/playback-rate-button.mdx
+++ b/site/src/content/docs/reference/playback-rate-button.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/playback-rate-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/playback-rate-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/playback-rate-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/playback-rate-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/playback-rate-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/playback-rate-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/playback-rate-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -82,6 +87,13 @@ In menu-trigger mode, the button behaves as a menu trigger and reflects menu sta
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -92,6 +104,14 @@ In menu-trigger mode, the button behaves as a menu trigger and reflects menu sta
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/playback-rate-radio-group.mdx
+++ b/site/src/content/docs/reference/playback-rate-radio-group.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/playback-rate-radio-group/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/playback-rate-radio-group/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/playback-rate-radio-group/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/playback-rate-radio-group/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/playback-rate-radio-group/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/playback-rate-radio-group/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/playback-rate-radio-group/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/playback-rate-radio-group/html/tailwind/BasicUsage.ts?raw";
 
 Creates radio items from the player playback rate state and selects the playback speed.
 
@@ -100,6 +105,13 @@ The element receives an accessible label from the `label` property or defaults t
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -110,6 +122,14 @@ The element receives an accessible label from the `label` property or defaults t
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/player-controller.mdx
+++ b/site/src/content/docs/reference/player-controller.mdx
@@ -12,6 +12,9 @@ import BasicUsageDemoHtml from "@/components/docs/demos/player-controller/html/c
 import basicUsageHtml from "@/components/docs/demos/player-controller/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/player-controller/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/player-controller/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/player-controller/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/player-controller/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/player-controller/html/tailwind/BasicUsage.ts?raw";
 
 `PlayerController` is a reactive controller that consumes the player store from <DocsLink slug="reference/player-context">`playerContext`</DocsLink>. Without a selector it returns the store instance directly (no subscription — use this for actions). With a selector it returns the selected value and subscribes to changes, triggering a host update on shallow-equal change. Access the current value via `.value`, which returns `undefined` until connected to a provider.
 
@@ -29,6 +32,16 @@ import basicUsageHtmlTs from "@/components/docs/demos/player-controller/html/css
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/popover.mdx
+++ b/site/src/content/docs/reference/popover.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/popover/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/popover/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/popover/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/popover/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/popover/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/popover/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/popover/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/popover/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/popover/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/popover/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/popover/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/popover/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -151,6 +156,15 @@ The trigger receives `aria-expanded` reflecting the open state. When `modal` is 
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -163,6 +177,16 @@ The trigger receives `aria-expanded` reflecting the open state. When `modal` is 
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/poster.mdx
+++ b/site/src/content/docs/reference/poster.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/poster/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/poster/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/poster/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/poster/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/poster/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/poster/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/poster/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/poster/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/poster/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/poster/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/poster/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/poster/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -86,6 +91,15 @@ Unlike the native `<video poster>` attribute, this component allows you to provi
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -98,6 +112,16 @@ Unlike the native `<video poster>` attribute, this component allows you to provi
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/quality-radio-group.mdx
+++ b/site/src/content/docs/reference/quality-radio-group.mdx
@@ -15,12 +15,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/quality-radio-group/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/quality-radio-group/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/quality-radio-group/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/quality-radio-group/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/quality-radio-group/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/quality-radio-group/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/quality-radio-group/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/quality-radio-group/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/quality-radio-group/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/quality-radio-group/html/tailwind/BasicUsage.ts?raw";
 
 Creates radio items from the player video rendition state and selects automatic or manual quality.
 
@@ -102,6 +107,13 @@ The element receives an accessible label from the `label` property or defaults t
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -112,6 +124,14 @@ The element receives an accessible label from the `label` property or defaults t
       { title: "index.ts", code: basicUsageHtmlTs, lang: "ts" },
     ]}>
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+      { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/render-element.mdx
+++ b/site/src/content/docs/reference/render-element.mdx
@@ -11,6 +11,8 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/render-element/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/render-element/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/render-element/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/render-element/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/render-element/react/tailwind/BasicUsage.tsx?raw";
 
 `renderElement` renders a UI component element, handling default tag rendering, render props (element or function), props merging, ref composition, and state-driven `className`/`style`.
 
@@ -64,6 +66,15 @@ The `render` prop lets consumers fully customize the rendered element while pres
       ]}
     >
       <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/seek-button.mdx
+++ b/site/src/content/docs/reference/seek-button.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/seek-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/seek-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/seek-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/seek-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/seek-button/react/tailwind/BasicUsage.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/seek-button/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/seek-button/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/seek-button/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/seek-button/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/seek-button/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/seek-button/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/seek-button/html/tailwind/BasicUsage.ts?raw";
 
 ## Anatomy
 
@@ -58,6 +63,15 @@ Renders a `<button>` with an automatic `aria-label` describing the action, e.g. 
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -70,6 +84,16 @@ Renders a `<button>` with an automatic `aria-label` describing the action, e.g. 
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/slider.mdx
+++ b/site/src/content/docs/reference/slider.mdx
@@ -15,21 +15,31 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/slider/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/slider/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/slider/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/slider/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/slider/react/tailwind/BasicUsage.tsx?raw";
 
 import WithPreviewDemoReact from "@/components/docs/demos/slider/react/css/WithPreview";
 import withPreviewReactTsx from "@/components/docs/demos/slider/react/css/WithPreview.tsx?raw";
 import withPreviewReactCss from "@/components/docs/demos/slider/react/css/WithPreview.css?raw";
+import WithPreviewDemoReactTailwind from "@/components/docs/demos/slider/react/tailwind/WithPreview";
+import withPreviewReactTailwindTsx from "@/components/docs/demos/slider/react/tailwind/WithPreview.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/slider/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/slider/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/slider/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/slider/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/slider/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/slider/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/slider/html/tailwind/BasicUsage.ts?raw";
 
 import WithPreviewDemoHtml from "@/components/docs/demos/slider/html/css/WithPreview.astro";
 import withPreviewHtml from "@/components/docs/demos/slider/html/css/WithPreview.html?raw";
 import withPreviewHtmlCss from "@/components/docs/demos/slider/html/css/WithPreview.css?raw";
 import withPreviewHtmlTs from "@/components/docs/demos/slider/html/css/WithPreview.ts?raw";
+import WithPreviewDemoHtmlTailwind from "@/components/docs/demos/slider/html/tailwind/WithPreview.astro";
+import withPreviewTailwindHtml from "@/components/docs/demos/slider/html/tailwind/WithPreview.html?raw";
+import withPreviewTailwindHtmlTs from "@/components/docs/demos/slider/html/tailwind/WithPreview.ts?raw";
 
 ## Anatomy
 
@@ -148,6 +158,15 @@ A slider with track, fill, and thumb.
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -160,6 +179,16 @@ A slider with track, fill, and thumb.
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -179,6 +208,15 @@ A slider with a pointer-tracking preview that displays the value at the current 
       <WithPreviewDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: withPreviewReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <WithPreviewDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -191,6 +229,16 @@ A slider with a pointer-tracking preview that displays the value at the current 
       ]}
     >
       <WithPreviewDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: withPreviewTailwindHtml, lang: "html" },
+        { title: "index.ts", code: withPreviewTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <WithPreviewDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -14,6 +14,8 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import TextTrackDemoReact from "@/components/docs/demos/thumbnail/react/css/BasicUsage";
 import textTrackReactTsx from "@/components/docs/demos/thumbnail/react/css/BasicUsage.tsx?raw";
 import textTrackReactCss from "@/components/docs/demos/thumbnail/react/css/BasicUsage.css?raw";
+import TextTrackDemoReactTailwind from "@/components/docs/demos/thumbnail/react/tailwind/BasicUsage";
+import textTrackReactTailwindTsx from "@/components/docs/demos/thumbnail/react/tailwind/BasicUsage.tsx?raw";
 import JsonDemoReact from "@/components/docs/demos/thumbnail/react/css/JsonUsage";
 import jsonReactTsx from "@/components/docs/demos/thumbnail/react/css/JsonUsage.tsx?raw";
 import JsonSpriteDemoReact from "@/components/docs/demos/thumbnail/react/css/JsonSpriteUsage";
@@ -24,6 +26,9 @@ import TextTrackDemoHtml from "@/components/docs/demos/thumbnail/html/css/BasicU
 import textTrackHtml from "@/components/docs/demos/thumbnail/html/css/BasicUsage.html?raw";
 import textTrackHtmlCss from "@/components/docs/demos/thumbnail/html/css/BasicUsage.css?raw";
 import textTrackHtmlTs from "@/components/docs/demos/thumbnail/html/css/BasicUsage.ts?raw";
+import TextTrackDemoHtmlTailwind from "@/components/docs/demos/thumbnail/html/tailwind/BasicUsage.astro";
+import textTrackTailwindHtml from "@/components/docs/demos/thumbnail/html/tailwind/BasicUsage.html?raw";
+import textTrackTailwindHtmlTs from "@/components/docs/demos/thumbnail/html/tailwind/BasicUsage.ts?raw";
 import JsonDemoHtml from "@/components/docs/demos/thumbnail/html/css/JsonUsage.astro";
 import jsonHtml from "@/components/docs/demos/thumbnail/html/css/JsonUsage.html?raw";
 import jsonHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonUsage.ts?raw";
@@ -152,6 +157,15 @@ React renders a `<div>` element. Add a `className` to style it:
       <TextTrackDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: textTrackReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <TextTrackDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -166,60 +180,62 @@ React renders a `<div>` element. Add a `className` to style it:
       <TextTrackDemoHtml />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: textTrackTailwindHtml, lang: "html" },
+        { title: "index.ts", code: textTrackTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <TextTrackDemoHtmlTailwind />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 ### JSON Array
 
 <FrameworkCase frameworks={["react"]}>
-  <StyleCase styles={["css"]}>
-    <Demo
-      files={[
-        { title: "App.tsx", code: jsonReactTsx, lang: "tsx" },
-      ]}
-    >
-      <JsonDemoReact client:idle />
-    </Demo>
-  </StyleCase>
+  <Demo
+    files={[
+      { title: "App.tsx", code: jsonReactTsx, lang: "tsx" },
+    ]}
+  >
+    <JsonDemoReact client:idle />
+  </Demo>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-  <StyleCase styles={["css"]}>
-    <Demo
-      files={[
-        { title: "index.html", code: jsonHtml, lang: "html" },
-        { title: "index.ts", code: jsonHtmlTs, lang: "ts" },
-      ]}
-    >
-      <JsonDemoHtml />
-    </Demo>
-  </StyleCase>
+  <Demo
+    files={[
+      { title: "index.html", code: jsonHtml, lang: "html" },
+      { title: "index.ts", code: jsonHtmlTs, lang: "ts" },
+    ]}
+  >
+    <JsonDemoHtml />
+  </Demo>
 </FrameworkCase>
 
 ### JSON Sprite Array
 
 <FrameworkCase frameworks={["react"]}>
-  <StyleCase styles={["css"]}>
-    <Demo
-      files={[
-        { title: "App.tsx", code: jsonSpriteReactTsx, lang: "tsx" },
-      ]}
-    >
-      <JsonSpriteDemoReact client:idle />
-    </Demo>
-  </StyleCase>
+  <Demo
+    files={[
+      { title: "App.tsx", code: jsonSpriteReactTsx, lang: "tsx" },
+    ]}
+  >
+    <JsonSpriteDemoReact client:idle />
+  </Demo>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
-  <StyleCase styles={["css"]}>
-    <Demo
-      files={[
-        { title: "index.html", code: jsonSpriteHtml, lang: "html" },
-        { title: "index.ts", code: jsonSpriteHtmlTs, lang: "ts" },
-      ]}
-    >
-      <JsonSpriteDemoHtml />
-    </Demo>
-  </StyleCase>
+  <Demo
+    files={[
+      { title: "index.html", code: jsonSpriteHtml, lang: "html" },
+      { title: "index.ts", code: jsonSpriteHtmlTs, lang: "ts" },
+    ]}
+  >
+    <JsonSpriteDemoHtml />
+  </Demo>
 </FrameworkCase>
 
 <ComponentReference component="Thumbnail" />

--- a/site/src/content/docs/reference/time-slider.mdx
+++ b/site/src/content/docs/reference/time-slider.mdx
@@ -14,19 +14,29 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import WithPartsDemoReact from "@/components/docs/demos/time-slider/react/css/WithParts";
 import withPartsReactTsx from "@/components/docs/demos/time-slider/react/css/WithParts.tsx?raw";
 import withPartsReactCss from "@/components/docs/demos/time-slider/react/css/WithParts.css?raw";
+import WithPartsDemoReactTailwind from "@/components/docs/demos/time-slider/react/tailwind/WithParts";
+import withPartsReactTailwindTsx from "@/components/docs/demos/time-slider/react/tailwind/WithParts.tsx?raw";
 import WithChaptersDemoReact from "@/components/docs/demos/time-slider/react/css/WithChapters";
 import withChaptersReactTsx from "@/components/docs/demos/time-slider/react/css/WithChapters.tsx?raw";
 import withChaptersReactCss from "@/components/docs/demos/time-slider/react/css/WithChapters.css?raw";
+import WithChaptersDemoReactTailwind from "@/components/docs/demos/time-slider/react/tailwind/WithChapters";
+import withChaptersReactTailwindTsx from "@/components/docs/demos/time-slider/react/tailwind/WithChapters.tsx?raw";
 
 {/* HTML demos */}
 import WithPartsDemoHtml from "@/components/docs/demos/time-slider/html/css/WithParts.astro";
 import withPartsHtml from "@/components/docs/demos/time-slider/html/css/WithParts.html?raw";
 import withPartsHtmlCss from "@/components/docs/demos/time-slider/html/css/WithParts.css?raw";
 import withPartsHtmlTs from "@/components/docs/demos/time-slider/html/css/WithParts.ts?raw";
+import WithPartsDemoHtmlTailwind from "@/components/docs/demos/time-slider/html/tailwind/WithParts.astro";
+import withPartsTailwindHtml from "@/components/docs/demos/time-slider/html/tailwind/WithParts.html?raw";
+import withPartsTailwindHtmlTs from "@/components/docs/demos/time-slider/html/tailwind/WithParts.ts?raw";
 import WithChaptersDemoHtml from "@/components/docs/demos/time-slider/html/css/WithChapters.astro";
 import withChaptersHtml from "@/components/docs/demos/time-slider/html/css/WithChapters.html?raw";
 import withChaptersHtmlCss from "@/components/docs/demos/time-slider/html/css/WithChapters.css?raw";
 import withChaptersHtmlTs from "@/components/docs/demos/time-slider/html/css/WithChapters.ts?raw";
+import WithChaptersDemoHtmlTailwind from "@/components/docs/demos/time-slider/html/tailwind/WithChapters.astro";
+import withChaptersTailwindHtml from "@/components/docs/demos/time-slider/html/tailwind/WithChapters.html?raw";
+import withChaptersTailwindHtmlTs from "@/components/docs/demos/time-slider/html/tailwind/WithChapters.ts?raw";
 
 ## Anatomy
 
@@ -182,6 +192,15 @@ Nest sub-components for full control over the slider's DOM structure. This examp
       <WithPartsDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: withPartsReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <WithPartsDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -194,6 +213,16 @@ Nest sub-components for full control over the slider's DOM structure. This examp
       ]}
     >
       <WithPartsDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: withPartsTailwindHtml, lang: "html" },
+        { title: "index.ts", code: withPartsTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <WithPartsDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -213,6 +242,15 @@ Add a default chapters track, then provide the markup used for each chapter. The
       <WithChaptersDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: withChaptersReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <WithChaptersDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -225,6 +263,16 @@ Add a default chapters track, then provide the markup used for each chapter. The
       ]}
     >
       <WithChaptersDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: withChaptersTailwindHtml, lang: "html" },
+        { title: "index.ts", code: withChaptersTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <WithChaptersDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/time.mdx
+++ b/site/src/content/docs/reference/time.mdx
@@ -14,44 +14,69 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import CurrentTimeDemoReact from "@/components/docs/demos/time/react/css/CurrentTime";
 import currentTimeReactTsx from "@/components/docs/demos/time/react/css/CurrentTime.tsx?raw";
 import currentTimeReactCss from "@/components/docs/demos/time/react/css/CurrentTime.css?raw";
+import CurrentTimeDemoReactTailwind from "@/components/docs/demos/time/react/tailwind/CurrentTime";
+import currentTimeReactTailwindTsx from "@/components/docs/demos/time/react/tailwind/CurrentTime.tsx?raw";
 
 import CurrentDurationDemoReact from "@/components/docs/demos/time/react/css/CurrentDuration";
 import currentDurationReactTsx from "@/components/docs/demos/time/react/css/CurrentDuration.tsx?raw";
 import currentDurationReactCss from "@/components/docs/demos/time/react/css/CurrentDuration.css?raw";
+import CurrentDurationDemoReactTailwind from "@/components/docs/demos/time/react/tailwind/CurrentDuration";
+import currentDurationReactTailwindTsx from "@/components/docs/demos/time/react/tailwind/CurrentDuration.tsx?raw";
 
 import RemainingDemoReact from "@/components/docs/demos/time/react/css/Remaining";
 import remainingReactTsx from "@/components/docs/demos/time/react/css/Remaining.tsx?raw";
 import remainingReactCss from "@/components/docs/demos/time/react/css/Remaining.css?raw";
+import RemainingDemoReactTailwind from "@/components/docs/demos/time/react/tailwind/Remaining";
+import remainingReactTailwindTsx from "@/components/docs/demos/time/react/tailwind/Remaining.tsx?raw";
 
 import CustomSeparatorDemoReact from "@/components/docs/demos/time/react/css/CustomSeparator";
 import customSeparatorReactTsx from "@/components/docs/demos/time/react/css/CustomSeparator.tsx?raw";
 import customSeparatorReactCss from "@/components/docs/demos/time/react/css/CustomSeparator.css?raw";
+import CustomSeparatorDemoReactTailwind from "@/components/docs/demos/time/react/tailwind/CustomSeparator";
+import customSeparatorReactTailwindTsx from "@/components/docs/demos/time/react/tailwind/CustomSeparator.tsx?raw";
 
 import CustomNegativeSignDemoReact from "@/components/docs/demos/time/react/css/CustomNegativeSign";
 import customNegativeSignReactTsx from "@/components/docs/demos/time/react/css/CustomNegativeSign.tsx?raw";
 import customNegativeSignReactCss from "@/components/docs/demos/time/react/css/CustomNegativeSign.css?raw";
+import CustomNegativeSignDemoReactTailwind from "@/components/docs/demos/time/react/tailwind/CustomNegativeSign";
+import customNegativeSignReactTailwindTsx from "@/components/docs/demos/time/react/tailwind/CustomNegativeSign.tsx?raw";
 
 {/* HTML demos */}
 import CurrentTimeDemoHtml from "@/components/docs/demos/time/html/css/CurrentTime.astro";
 import currentTimeHtml from "@/components/docs/demos/time/html/css/CurrentTime.html?raw";
 import currentTimeHtmlCss from "@/components/docs/demos/time/html/css/CurrentTime.css?raw";
 import currentTimeHtmlTs from "@/components/docs/demos/time/html/css/CurrentTime.ts?raw";
+import CurrentTimeDemoHtmlTailwind from "@/components/docs/demos/time/html/tailwind/CurrentTime.astro";
+import currentTimeTailwindHtml from "@/components/docs/demos/time/html/tailwind/CurrentTime.html?raw";
+import currentTimeTailwindHtmlTs from "@/components/docs/demos/time/html/tailwind/CurrentTime.ts?raw";
 import CurrentDurationDemoHtml from "@/components/docs/demos/time/html/css/CurrentDuration.astro";
 import currentDurationHtml from "@/components/docs/demos/time/html/css/CurrentDuration.html?raw";
 import currentDurationHtmlCss from "@/components/docs/demos/time/html/css/CurrentDuration.css?raw";
 import currentDurationHtmlTs from "@/components/docs/demos/time/html/css/CurrentDuration.ts?raw";
+import CurrentDurationDemoHtmlTailwind from "@/components/docs/demos/time/html/tailwind/CurrentDuration.astro";
+import currentDurationTailwindHtml from "@/components/docs/demos/time/html/tailwind/CurrentDuration.html?raw";
+import currentDurationTailwindHtmlTs from "@/components/docs/demos/time/html/tailwind/CurrentDuration.ts?raw";
 import RemainingDemoHtml from "@/components/docs/demos/time/html/css/Remaining.astro";
 import remainingHtml from "@/components/docs/demos/time/html/css/Remaining.html?raw";
 import remainingHtmlCss from "@/components/docs/demos/time/html/css/Remaining.css?raw";
 import remainingHtmlTs from "@/components/docs/demos/time/html/css/Remaining.ts?raw";
+import RemainingDemoHtmlTailwind from "@/components/docs/demos/time/html/tailwind/Remaining.astro";
+import remainingTailwindHtml from "@/components/docs/demos/time/html/tailwind/Remaining.html?raw";
+import remainingTailwindHtmlTs from "@/components/docs/demos/time/html/tailwind/Remaining.ts?raw";
 import CustomSeparatorDemoHtml from "@/components/docs/demos/time/html/css/CustomSeparator.astro";
 import customSeparatorHtml from "@/components/docs/demos/time/html/css/CustomSeparator.html?raw";
 import customSeparatorHtmlCss from "@/components/docs/demos/time/html/css/CustomSeparator.css?raw";
 import customSeparatorHtmlTs from "@/components/docs/demos/time/html/css/CustomSeparator.ts?raw";
+import CustomSeparatorDemoHtmlTailwind from "@/components/docs/demos/time/html/tailwind/CustomSeparator.astro";
+import customSeparatorTailwindHtml from "@/components/docs/demos/time/html/tailwind/CustomSeparator.html?raw";
+import customSeparatorTailwindHtmlTs from "@/components/docs/demos/time/html/tailwind/CustomSeparator.ts?raw";
 import CustomNegativeSignDemoHtml from "@/components/docs/demos/time/html/css/CustomNegativeSign.astro";
 import customNegativeSignHtml from "@/components/docs/demos/time/html/css/CustomNegativeSign.html?raw";
 import customNegativeSignHtmlCss from "@/components/docs/demos/time/html/css/CustomNegativeSign.css?raw";
 import customNegativeSignHtmlTs from "@/components/docs/demos/time/html/css/CustomNegativeSign.ts?raw";
+import CustomNegativeSignDemoHtmlTailwind from "@/components/docs/demos/time/html/tailwind/CustomNegativeSign.astro";
+import customNegativeSignTailwindHtml from "@/components/docs/demos/time/html/tailwind/CustomNegativeSign.html?raw";
+import customNegativeSignTailwindHtmlTs from "@/components/docs/demos/time/html/tailwind/CustomNegativeSign.ts?raw";
 
 ## Anatomy
 
@@ -146,6 +171,13 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       <CurrentTimeDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: currentTimeReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <CurrentTimeDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -156,6 +188,14 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       { title: "index.ts", code: currentTimeHtmlTs, lang: "ts" },
     ]}>
       <CurrentTimeDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: currentTimeTailwindHtml, lang: "html" },
+      { title: "index.ts", code: currentTimeTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <CurrentTimeDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -171,6 +211,13 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       <CurrentDurationDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: currentDurationReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <CurrentDurationDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -181,6 +228,14 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       { title: "index.ts", code: currentDurationHtmlTs, lang: "ts" },
     ]}>
       <CurrentDurationDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: currentDurationTailwindHtml, lang: "html" },
+      { title: "index.ts", code: currentDurationTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <CurrentDurationDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -196,6 +251,13 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       <RemainingDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: remainingReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <RemainingDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -206,6 +268,14 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       { title: "index.ts", code: remainingHtmlTs, lang: "ts" },
     ]}>
       <RemainingDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: remainingTailwindHtml, lang: "html" },
+      { title: "index.ts", code: remainingTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <RemainingDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -221,6 +291,13 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       <CustomSeparatorDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: customSeparatorReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <CustomSeparatorDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -231,6 +308,14 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       { title: "index.ts", code: customSeparatorHtmlTs, lang: "ts" },
     ]}>
       <CustomSeparatorDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: customSeparatorTailwindHtml, lang: "html" },
+      { title: "index.ts", code: customSeparatorTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <CustomSeparatorDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -246,6 +331,13 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       <CustomNegativeSignDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "App.tsx", code: customNegativeSignReactTailwindTsx, lang: "tsx" },
+    ]}>
+      <CustomNegativeSignDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -256,6 +348,14 @@ Toggleable time displays receive `role="button"`, `tabindex="0"`, and keyboard s
       { title: "index.ts", code: customNegativeSignHtmlTs, lang: "ts" },
     ]}>
       <CustomNegativeSignDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo files={[
+      { title: "index.html", code: customNegativeSignTailwindHtml, lang: "html" },
+      { title: "index.ts", code: customNegativeSignTailwindHtmlTs, lang: "ts" },
+    ]}>
+      <CustomNegativeSignDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/tooltip.mdx
+++ b/site/src/content/docs/reference/tooltip.mdx
@@ -14,21 +14,31 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/tooltip/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/tooltip/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/tooltip/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/tooltip/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/tooltip/react/tailwind/BasicUsage.tsx?raw";
 
 import GroupingDemoReact from "@/components/docs/demos/tooltip/react/css/Grouping";
 import groupingReactTsx from "@/components/docs/demos/tooltip/react/css/Grouping.tsx?raw";
 import groupingReactCss from "@/components/docs/demos/tooltip/react/css/Grouping.css?raw";
+import GroupingDemoReactTailwind from "@/components/docs/demos/tooltip/react/tailwind/Grouping";
+import groupingReactTailwindTsx from "@/components/docs/demos/tooltip/react/tailwind/Grouping.tsx?raw";
 
 {/* HTML demos */}
 import BasicUsageDemoHtml from "@/components/docs/demos/tooltip/html/css/BasicUsage.astro";
 import basicUsageHtml from "@/components/docs/demos/tooltip/html/css/BasicUsage.html?raw";
 import basicUsageHtmlCss from "@/components/docs/demos/tooltip/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/tooltip/html/css/BasicUsage.ts?raw";
+import BasicUsageDemoHtmlTailwind from "@/components/docs/demos/tooltip/html/tailwind/BasicUsage.astro";
+import basicUsageTailwindHtml from "@/components/docs/demos/tooltip/html/tailwind/BasicUsage.html?raw";
+import basicUsageTailwindHtmlTs from "@/components/docs/demos/tooltip/html/tailwind/BasicUsage.ts?raw";
 
 import GroupingDemoHtml from "@/components/docs/demos/tooltip/html/css/Grouping.astro";
 import groupingHtml from "@/components/docs/demos/tooltip/html/css/Grouping.html?raw";
 import groupingHtmlCss from "@/components/docs/demos/tooltip/html/css/Grouping.css?raw";
 import groupingHtmlTs from "@/components/docs/demos/tooltip/html/css/Grouping.ts?raw";
+import GroupingDemoHtmlTailwind from "@/components/docs/demos/tooltip/html/tailwind/Grouping.astro";
+import groupingTailwindHtml from "@/components/docs/demos/tooltip/html/tailwind/Grouping.html?raw";
+import groupingTailwindHtmlTs from "@/components/docs/demos/tooltip/html/tailwind/Grouping.ts?raw";
 
 ## Anatomy
 
@@ -170,6 +180,15 @@ The trigger receives `aria-describedby` pointing to the popup when open. The pop
       <BasicUsageDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -182,6 +201,16 @@ The trigger receives `aria-describedby` pointing to the popup when open. The pop
       ]}
     >
       <BasicUsageDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: basicUsageTailwindHtml, lang: "html" },
+        { title: "index.ts", code: basicUsageTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <BasicUsageDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>
@@ -203,6 +232,15 @@ The trigger receives `aria-describedby` pointing to the popup when open. The pop
       <GroupingDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: groupingReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <GroupingDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -219,6 +257,16 @@ The trigger receives `aria-describedby` pointing to the popup when open. The pop
       ]}
     >
       <GroupingDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: groupingTailwindHtml, lang: "html" },
+        { title: "index.ts", code: groupingTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <GroupingDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/use-button.mdx
+++ b/site/src/content/docs/reference/use-button.mdx
@@ -11,6 +11,8 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/use-button/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/use-button/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/use-button/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/use-button/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/use-button/react/tailwind/BasicUsage.tsx?raw";
 
 `useButton` provides button behavior including keyboard activation and accessibility checks. It returns a `getButtonProps` function for spreading onto a `<button>` element and a `buttonRef` for validation.
 
@@ -29,6 +31,15 @@ import basicUsageReactCss from "@/components/docs/demos/use-button/react/css/Bas
       ]}
     >
       <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/use-locale.mdx
+++ b/site/src/content/docs/reference/use-locale.mdx
@@ -11,6 +11,8 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/use-locale/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/use-locale/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/use-locale/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/use-locale/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/use-locale/react/tailwind/BasicUsage.tsx?raw";
 
 <FrameworkCase frameworks={["react"]}>
 
@@ -30,6 +32,15 @@ Switch the provider locale to see `useLocale` supply the BCP 47 tag used to form
     ]}
   >
     <BasicUsageDemoReact client:idle />
+  </Demo>
+</StyleCase>
+<StyleCase styles={["tailwind"]}>
+  <Demo
+    files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}
+  >
+    <BasicUsageDemoReactTailwind client:idle />
   </Demo>
 </StyleCase>
 

--- a/site/src/content/docs/reference/use-media.mdx
+++ b/site/src/content/docs/reference/use-media.mdx
@@ -11,6 +11,8 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/use-media/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/use-media/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/use-media/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/use-media/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/use-media/react/tailwind/BasicUsage.tsx?raw";
 
 The `useMedia` hook returned by <DocsLink slug="reference/create-player">`createPlayer`</DocsLink> returns the current `Media` object (or `null` if no media has been registered yet). `Media` is a runtime-agnostic playback interface — any instance that conforms to it, including an `HTMLVideoElement`, can be the media. It exposes capabilities like `play()` and event subscription rather than assuming a native element. It must be called within the matching `Player`. The media object becomes available after a `<Video>` or `<Audio>` component mounts inside the player tree. To attach a custom media element instead of the built-in components, see <DocsLink slug="reference/use-media-attach">`useMediaAttach`</DocsLink>.
 
@@ -31,6 +33,15 @@ const { Player, useMedia } = createPlayer({ features: videoFeatures });
       ]}
     >
       <BasicUsageDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <BasicUsageDemoReactTailwind client:idle />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/use-player.mdx
+++ b/site/src/content/docs/reference/use-player.mdx
@@ -11,9 +11,13 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import StoreAccessDemoReact from "@/components/docs/demos/use-player/react/css/StoreAccess";
 import storeAccessReactTsx from "@/components/docs/demos/use-player/react/css/StoreAccess.tsx?raw";
 import storeAccessReactCss from "@/components/docs/demos/use-player/react/css/StoreAccess.css?raw";
+import StoreAccessDemoReactTailwind from "@/components/docs/demos/use-player/react/tailwind/StoreAccess";
+import storeAccessReactTailwindTsx from "@/components/docs/demos/use-player/react/tailwind/StoreAccess.tsx?raw";
 import SelectorDemoReact from "@/components/docs/demos/use-player/react/css/Selector";
 import selectorReactTsx from "@/components/docs/demos/use-player/react/css/Selector.tsx?raw";
 import selectorReactCss from "@/components/docs/demos/use-player/react/css/Selector.css?raw";
+import SelectorDemoReactTailwind from "@/components/docs/demos/use-player/react/tailwind/Selector";
+import selectorReactTailwindTsx from "@/components/docs/demos/use-player/react/tailwind/Selector.tsx?raw";
 
 The `usePlayer` hook returned by <DocsLink slug="reference/create-player">`createPlayer`</DocsLink> gives you access to the player store from any component within its `Player`. It's typed to the features you passed to `createPlayer`, and has two overloads — without arguments for direct store access, or with a selector for reactive state subscriptions.
 
@@ -47,6 +51,15 @@ Call `usePlayer()` without arguments to get the store instance. Use this for imp
       <StoreAccessDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: storeAccessReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <StoreAccessDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 ### Selector Subscription
@@ -62,6 +75,15 @@ Pass a selector function to subscribe to specific state. The component re-render
       ]}
     >
       <SelectorDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: selectorReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <SelectorDemoReactTailwind client:idle />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/use-store.mdx
+++ b/site/src/content/docs/reference/use-store.mdx
@@ -11,9 +11,13 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import StoreAccessDemoReact from "@/components/docs/demos/use-store/react/css/StoreAccess";
 import storeAccessReactTsx from "@/components/docs/demos/use-store/react/css/StoreAccess.tsx?raw";
 import storeAccessReactCss from "@/components/docs/demos/use-store/react/css/StoreAccess.css?raw";
+import StoreAccessDemoReactTailwind from "@/components/docs/demos/use-store/react/tailwind/StoreAccess";
+import storeAccessReactTailwindTsx from "@/components/docs/demos/use-store/react/tailwind/StoreAccess.tsx?raw";
 import SelectorDemoReact from "@/components/docs/demos/use-store/react/css/Selector";
 import selectorReactTsx from "@/components/docs/demos/use-store/react/css/Selector.tsx?raw";
 import selectorReactCss from "@/components/docs/demos/use-store/react/css/Selector.css?raw";
+import SelectorDemoReactTailwind from "@/components/docs/demos/use-store/react/tailwind/Selector";
+import selectorReactTailwindTsx from "@/components/docs/demos/use-store/react/tailwind/Selector.tsx?raw";
 
 `useStore` subscribes to a store instance directly. It has the same two overloads as <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> — without a selector for store access, or with a selector for reactive state. Within `Player`, `usePlayer` is usually simpler since it reads the store from context. Reach for `useStore` when you have a store instance directly or need to derive computed values from the store.
 
@@ -34,6 +38,15 @@ Call `useStore(store)` without a selector to get the store instance back for imp
       <StoreAccessDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: storeAccessReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <StoreAccessDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 ### Selector Subscription
@@ -49,6 +62,15 @@ Pass a selector to derive and subscribe to computed values from the store. The c
       ]}
     >
       <SelectorDemoReact client:idle />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: selectorReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <SelectorDemoReactTailwind client:idle />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/use-translator.mdx
+++ b/site/src/content/docs/reference/use-translator.mdx
@@ -11,6 +11,8 @@ import StyleCase from "@/components/docs/StyleCase.astro";
 import BasicUsageDemoReact from "@/components/docs/demos/use-translator/react/css/BasicUsage";
 import basicUsageReactTsx from "@/components/docs/demos/use-translator/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/use-translator/react/css/BasicUsage.css?raw";
+import BasicUsageDemoReactTailwind from "@/components/docs/demos/use-translator/react/tailwind/BasicUsage";
+import basicUsageReactTailwindTsx from "@/components/docs/demos/use-translator/react/tailwind/BasicUsage.tsx?raw";
 
 <FrameworkCase frameworks={["react"]}>
 
@@ -30,6 +32,15 @@ Switch the provider locale to see `useTranslator` resolve a simple key and a par
     ]}
   >
     <BasicUsageDemoReact client:idle />
+  </Demo>
+</StyleCase>
+<StyleCase styles={["tailwind"]}>
+  <Demo
+    files={[
+      { title: "App.tsx", code: basicUsageReactTailwindTsx, lang: "tsx" },
+    ]}
+  >
+    <BasicUsageDemoReactTailwind client:idle />
   </Demo>
 </StyleCase>
 

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -14,12 +14,17 @@ import Demo from "@/components/docs/demos/Demo.astro";
 import WithPartsDemoReact from "@/components/docs/demos/volume-slider/react/css/WithParts";
 import withPartsReactTsx from "@/components/docs/demos/volume-slider/react/css/WithParts.tsx?raw";
 import withPartsReactCss from "@/components/docs/demos/volume-slider/react/css/WithParts.css?raw";
+import WithPartsDemoReactTailwind from "@/components/docs/demos/volume-slider/react/tailwind/WithParts";
+import withPartsReactTailwindTsx from "@/components/docs/demos/volume-slider/react/tailwind/WithParts.tsx?raw";
 
 {/* HTML demos */}
 import WithPartsDemoHtml from "@/components/docs/demos/volume-slider/html/css/WithParts.astro";
 import withPartsHtml from "@/components/docs/demos/volume-slider/html/css/WithParts.html?raw";
 import withPartsHtmlCss from "@/components/docs/demos/volume-slider/html/css/WithParts.css?raw";
 import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/WithParts.ts?raw";
+import WithPartsDemoHtmlTailwind from "@/components/docs/demos/volume-slider/html/tailwind/WithParts.astro";
+import withPartsTailwindHtml from "@/components/docs/demos/volume-slider/html/tailwind/WithParts.html?raw";
+import withPartsTailwindHtmlTs from "@/components/docs/demos/volume-slider/html/tailwind/WithParts.ts?raw";
 
 ## Anatomy
 
@@ -89,6 +94,15 @@ Nest sub-components for full control over the slider's DOM structure. This examp
       <WithPartsDemoReact client:idle />
     </Demo>
   </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "App.tsx", code: withPartsReactTailwindTsx, lang: "tsx" },
+      ]}
+    >
+      <WithPartsDemoReactTailwind client:idle />
+    </Demo>
+  </StyleCase>
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
@@ -101,6 +115,16 @@ Nest sub-components for full control over the slider's DOM structure. This examp
       ]}
     >
       <WithPartsDemoHtml />
+    </Demo>
+  </StyleCase>
+  <StyleCase styles={["tailwind"]}>
+    <Demo
+      files={[
+        { title: "index.html", code: withPartsTailwindHtml, lang: "html" },
+        { title: "index.ts", code: withPartsTailwindHtmlTs, lang: "ts" },
+      ]}
+    >
+      <WithPartsDemoHtmlTailwind />
     </Demo>
   </StyleCase>
 </FrameworkCase>

--- a/site/src/content/docs/reference/write-references.mdx
+++ b/site/src/content/docs/reference/write-references.mdx
@@ -82,6 +82,24 @@ src/components/docs/demos/{name}/react/css/
 └── BasicUsage.css      # Styles
 ```
 
+### Tailwind variants
+
+Every styled demo also ships a `tailwind/` twin with the same demo names, gated in the MDX page with `<StyleCase styles={["css"]}>` / `<StyleCase styles={["tailwind"]}>`:
+
+```
+src/components/docs/demos/{name}/html/tailwind/
+├── BasicUsage.astro    # Same wrapper shape as the css variant
+├── BasicUsage.html     # Markup with Tailwind utilities inline (no .css file)
+└── BasicUsage.ts       # Identical copy of the css variant's .ts
+
+src/components/docs/demos/{name}/react/tailwind/
+└── BasicUsage.tsx      # css variant with Tailwind utility classes (no .css file)
+```
+
+Tailwind variants mirror the css variant 1:1 and must stay copy-paste compatible with a stock Tailwind v4 setup — never use site theme tokens. The stock tokens demos rely on are re-declared in a dedicated `@theme` block in `src/styles/globals.css`; extend that block (stock values only) if a new demo needs another token. State-dependent styling uses data-attribute variants (`data-paused:`, `in-data-paused:`, `not-in-data-ended:`) in place of the css variant's attribute selectors. Demos with no stylesheet of their own (for example JSON-config demos) stay `css/`-only and render for both styles.
+
+Tailwind import names in the MDX page append `Tailwind` to the css names (`BasicUsageDemoReactTailwind`, `basicUsageReactTailwindTsx`, `basicUsageTailwindHtml`, `basicUsageTailwindHtmlTs`), placed directly after the corresponding css imports. React Tailwind demos show a single `App.tsx` tab; HTML Tailwind demos show `index.html` + `index.ts` (no css tab).
+
 ### BEM naming
 
 Use BEM class names for CSS scoping. The block name follows the pattern `{framework}-{component}-{variant}`:

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -206,6 +206,8 @@
   --text-xs--line-height: calc(1 / 0.75);
   --text-sm: 0.875rem;
   --text-sm--line-height: calc(1.25 / 0.875);
+  --text-lg: 1.125rem;
+  --text-lg--line-height: calc(1.75 / 1.125);
 }
 
 @custom-variant intent (&:hover, &:focus-within);

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -185,6 +185,29 @@
   }
 }
 
+/*
+  Stock Tailwind tokens consumed by the docs demos (src/components/docs/demos).
+  The site theme above resets the default color and text scales, but demo
+  snippets must remain copy-paste compatible with a stock Tailwind setup, so
+  these values are verbatim from tailwindcss/theme.css. Do not use them for
+  site UI; extend the site theme above instead.
+*/
+/* biome-ignore assist/source/useSortedProperties: grouped to mirror tailwindcss/theme.css. */
+@theme {
+  --color-gray-200: oklch(92.8% 0.006 264.531);
+  --color-gray-300: oklch(87.2% 0.01 258.338);
+  --color-gray-500: oklch(55.1% 0.027 264.364);
+  --color-gray-700: oklch(37.3% 0.034 259.733);
+  --color-neutral-100: oklch(97% 0 0);
+  --color-neutral-900: oklch(20.5% 0 0);
+  --color-blue-500: oklch(62.3% 0.214 259.815);
+
+  --text-xs: 0.75rem;
+  --text-xs--line-height: calc(1 / 0.75);
+  --text-sm: 0.875rem;
+  --text-sm--line-height: calc(1.25 / 0.875);
+}
+
 @custom-variant intent (&:hover, &:focus-within);
 @custom-variant supports-container {
   @supports (container: size) {

--- a/site/src/types/docs.ts
+++ b/site/src/types/docs.ts
@@ -1,6 +1,6 @@
 export const FRAMEWORK_STYLES = {
-  react: ['css'],
-  html: ['css'],
+  react: ['css', 'tailwind'],
+  html: ['css', 'tailwind'],
 } as const;
 
 export type SupportedFramework = keyof typeof FRAMEWORK_STYLES;
@@ -14,6 +14,7 @@ export const FRAMEWORK_LABELS: Record<SupportedFramework, string> = {
 
 export const STYLE_LABELS: Record<AnySupportedStyle, string> = {
   css: 'CSS',
+  tailwind: 'Tailwind',
 };
 
 export const SUPPORTED_FRAMEWORKS = Object.keys(FRAMEWORK_STYLES) as (keyof typeof FRAMEWORK_STYLES)[];


### PR DESCRIPTION
## Summary

Rebuilds #1684 from the current state of `main`: enables `tailwind` as a docs style preference (refs #840) and gives every styled demo a Tailwind variant, so the docs offer an equivalent CSS/Tailwind experience the same way they offer equivalent HTML/React experiences.

- **Style support**: `tailwind` added to `FRAMEWORK_STYLES` / `STYLE_LABELS` — the style selector, `<StyleCase>` gating, before-paint init, and `?style=tailwind` deep links all derive from this (`site/src/types/docs.ts` is the single source of truth; `content.config.ts` and the routing/sidebar tests already modeled multi-style support).
- **Theme support for demos**: the site's Tailwind theme resets the default color/text scales, so the stock tokens demos rely on (`gray-200/300/500/700`, `neutral-100/900`, `blue-500`, `text-xs/sm/lg`) are re-declared verbatim in a dedicated `@theme` block in `globals.css`. Demo snippets stay copy-paste compatible with a stock Tailwind v4 setup. Follow-up #1685 tracks replacing this with a scoped, demo-only stock stylesheet.
- **Customize-skins guide**: surfaces the Tailwind ejected-skin variants the generator already produces (`*-tailwind` ids) behind `<StyleCase>`, closing out the remaining #840 task.
- **Demo variants**: `html/tailwind/` and `react/tailwind/` variants for all reference demos, mirroring the current `css/` variants 1:1 — same markup, utilities inline, state reflection via `data-*` variants (`data-paused:`, `in-data-paused:`, `not-in-data-ended:`) instead of attribute selectors. Style-agnostic demos (no stylesheet, e.g. JSON-config demos) stay `css/`-only and render for both styles.
- **Agent docs**: tailwind demo conventions documented in the `write-api-reference` skill (`demo-patterns.md`, `mdx-structure.md`), `site/AGENTS.md`, the write-references how-to, and a demo-exception note in the tailwind migration skill.

Compared to #1684, everything is rewritten against main's current demo idioms: `{{VJS*}}` media placeholders, the `const { Player } = createPlayer(...)` / `Container` API, the `SimpleHls*` → `Hls*` rename, and Tailwind twins for the demos added since (radio groups, menu, i18n, `hls-video`/`hls-audio`, `use-locale`, `use-translator`, direct player components). It also fixes a variant-ordering hazard from the original slider twins: `data-dragging` always co-occurs with `data-interactive`, so the thumb scale pair is expressed as mutually exclusive variants (`in-data-interactive:not-in-data-dragging:scale-100 in-data-dragging:scale-110`) instead of relying on source order.

## Verification

- [x] All Tailwind classes used by demos compile against stock Tailwind v4 (`@tailwindcss/node` compile check over all 101 tailwind demo files: 223/228 unique classes generate; the 5 that don't are intentional JS-hook classes in `player-controller` and the i18n language demo)
- [x] Site unit tests pass (`pnpm -F site test`)
- [x] Production site build passes (`pnpm build:site`)
- [x] `pnpm typecheck` and `pnpm check:workspace` pass
- [ ] Visual spot-check of demo parity on the deploy preview

## Notes for review

- Both style variants of a demo are present in the DOM and gated via `html[data-style]`, so reference pages mount two copies of each demo (hidden videos still load). Same mechanism the framework gating already uses, but worth knowing for page-weight expectations.
- Known approximations carried over from the CSS variants (guide-sanctioned): `ease` timing → Tailwind default timing function, `text-*` utilities also set line-height, `#ccc` → `gray-300`, `#1a1a1a` → `neutral-900`. New in this pass: the menu's submenu enter/exit keyframes are approximated with the panel's existing transition (same endpoints), and the buffering spinner uses `animate-spin` with an `[animation-duration:0.8s]` arbitrary property.
- Styling prose sections on reference pages show css snippets un-gated by `<StyleCase>` (same as before this PR); adding tailwind prose twins there is left as a possible follow-up.

Supersedes #1684. Refs #840, follow-up: #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uMqc7FmfVw7mMaTbwKVF9