### PR TITLE
feat(ci): add pkg.pr.new preview releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,104 @@
+name: Preview Releases
+
+# Publishes an installable preview of every public package to pkg.pr.new so
+# changes can be tried out without waiting for a release. Nothing is published
+# to npm. See https://github.com/stackblitz-labs/pkg.pr.new
+#
+# Requires the pkg.pr.new GitHub App to be installed on the repository:
+# https://github.com/apps/pkg-pr-new
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches-ignore:
+      - 'rfc/**'
+  # Lets a maintainer opt a fork's pull request into previews by approving it.
+  pull_request_review:
+    types: [submitted]
+
+# A preview URL is an installable artifact carrying the Video.js name, and this
+# job builds whatever code it checks out. Never grant scopes or expose secrets
+# here: `pull_request_review` runs in the base-repo context, so a fork's code
+# would inherit them.
+permissions: {}
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    # Only publish code that someone with repository access either pushed
+    # themselves or explicitly approved:
+    #   - push: only maintainers can land on main.
+    #   - pull_request: branch lives in this repo, so its author has write access.
+    #   - pull_request_review: a fork's pull request, approved by an owner, org
+    #     member, or collaborator. Re-approve after new commits to refresh it.
+    if: >-
+      ${{
+        github.event_name == 'push'
+        || (github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository)
+        || (github.event_name == 'pull_request_review'
+            && github.event.review.state == 'approved'
+            && github.event.pull_request.head.repo.full_name != github.repository
+            && !startsWith(github.event.pull_request.base.ref, 'rfc/')
+            && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      # pkg.pr.new keys previews by the head commit, so check out that commit
+      # rather than the pull request's merge ref.
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Build packages
+        run: pnpm build:packages
+
+      # Keep this list in sync with the public packages built by `build:packages`.
+      # @videojs/cli is excluded because it is built separately and depends on a
+      # full site build, which is too slow for a per-commit preview.
+      #
+      # VIDEOJS_SKIP_PACKAGE_DOCS lets the @videojs/html and @videojs/react
+      # prepack scripts pack without site-generated markdown; previews don't need
+      # bundled docs. --previewVersion rewrites versions to 0.0.0-preview-<sha>
+      # so a preview can never satisfy a semver range for a real npm release.
+      - name: Publish preview packages
+        env:
+          VIDEOJS_SKIP_PACKAGE_DOCS: '1'
+        run: >
+          pnpm exec pkg-pr-new publish --pnpm --previewVersion --packageManager=pnpm
+          './packages/core'
+          './packages/element'
+          './packages/html'
+          './packages/media'
+          './packages/react'
+          './packages/spf'
+          './packages/store'
+          './packages/utils'

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -36,6 +36,10 @@ jobs:
     #   - pull_request: branch lives in this repo, so its author has write access.
     #   - pull_request_review: a fork's pull request, approved by an owner, org
     #     member, or collaborator. Re-approve after new commits to refresh it.
+    #
+    # An approval only counts for the exact commit it was written against, so a
+    # fork cannot land new commits between the review being started and
+    # submitted and have them published on the back of the earlier approval.
     if: >-
       ${{
         github.event_name == 'push'
@@ -43,6 +47,7 @@ jobs:
             && github.event.pull_request.head.repo.full_name == github.repository)
         || (github.event_name == 'pull_request_review'
             && github.event.review.state == 'approved'
+            && github.event.review.commit_id == github.event.pull_request.head.sha
             && github.event.pull_request.head.repo.full_name != github.repository
             && !startsWith(github.event.pull_request.base.ref, 'rfc/')
             && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
@@ -51,12 +56,13 @@ jobs:
 
     steps:
       # pkg.pr.new keys previews by the head commit, so check out that commit
-      # rather than the pull request's merge ref.
+      # rather than the pull request's merge ref. On an approval, build the exact
+      # commit that was reviewed.
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.review.commit_id || github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -95,11 +95,16 @@ jobs:
       # prepack scripts pack without site-generated markdown; previews don't need
       # bundled docs. --previewVersion rewrites versions to 0.0.0-preview-<sha>
       # so a preview can never satisfy a semver range for a real npm release.
+      #
+      # --peerDeps matters because @videojs/store peer-depends on @videojs/element:
+      # `pnpm pack` resolves that `workspace:*` to the current release, so without
+      # it an install pulls a published @videojs/element alongside the preview one
+      # and ends up with two copies of the custom-element base.
       - name: Publish preview packages
         env:
           VIDEOJS_SKIP_PACKAGE_DOCS: '1'
         run: >
-          pnpm exec pkg-pr-new publish --pnpm --previewVersion --packageManager=pnpm
+          pnpm exec pkg-pr-new publish --pnpm --previewVersion --peerDeps --packageManager=pnpm
           './packages/core'
           './packages/element'
           './packages/html'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ pnpm add https://pkg.pr.new/@videojs/html@<pr-number-or-sha>
 
 Use this to try a change in a real project before it is released. Previews are versioned `0.0.0-preview-<sha>` so they can never satisfy a semver range for a real release, and they ship without the bundled markdown docs that real releases include.
 
-Because a preview is an installable artifact carrying the Video.js name, it is only published for code someone with repository access pushed or vouched for. Pull requests from a branch in this repo publish automatically; **pull requests from a fork publish only once a maintainer approves them**, and need a fresh approval after new commits.
+Because a preview is an installable artifact carrying the Video.js name, it is only published for code someone with repository access pushed or vouched for. Pull requests from a branch in this repo publish automatically; **pull requests from a fork publish only once a maintainer approves them**. The approval has to be written against the pull request's latest commit, so any new commit needs a fresh approval before it is published.
 
 ### ✅ Workspace Consistency
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,18 @@ On `pnpm dev:sandbox`, `setup.ts` copies any file from `templates/` that doesn't
 
 See [`apps/sandbox/README.md`](./apps/sandbox/README.md) for the full model, including the `app/` shell, the `@app/*` alias for shared code, and how to add a new sandbox entry point.
 
+### 🚚 Preview Releases
+
+Pull requests and commits on `main` publish an installable preview of the public packages to [pkg.pr.new][pkg-pr-new] — nothing is published to npm. A bot comment on the PR lists the install commands, and the same URLs work by commit SHA:
+
+```sh
+pnpm add https://pkg.pr.new/@videojs/html@<pr-number-or-sha>
+```
+
+Use this to try a change in a real project before it is released. Previews are versioned `0.0.0-preview-<sha>` so they can never satisfy a semver range for a real release, and they ship without the bundled markdown docs that real releases include.
+
+Because a preview is an installable artifact carrying the Video.js name, it is only published for code someone with repository access pushed or vouched for. Pull requests from a branch in this repo publish automatically; **pull requests from a fork publish only once a maintainer approves them**, and need a fresh approval after new commits.
+
 ### ✅ Workspace Consistency
 
 Before opening a PR, run the workspace consistency check to catch common mistakes (CI coverage, scope mismatches, broken define imports, etc.):
@@ -227,6 +239,7 @@ pnpm up <package>@<version> -r
 > We try to be very intentional with any dependencies we add to this project. This is true of both developer/tooling dependencies and especially package-level (source) dependencies. If you find yourself needing to add a dependency, we strongly encourage you to check in with the core maintainers before proceeding to avoid wasted time and effort for everyone involved (yourself included!).
 
 [pnpm-filtering]: https://pnpm.io/filtering
+[pkg-pr-new]: https://github.com/stackblitz-labs/pkg.pr.new
 
 ## Using AI
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![package-badge]][package]
 [![discord-badge]][discord]
 [![pnpm](https://img.shields.io/badge/maintained%20with-pnpm-cc00ff.svg)](https://pnpm.io/)
+[![preview-badge]][preview]
 
 Modern, modular, and composable media player framework for Web and React.
 
@@ -64,3 +65,5 @@ participating in this project you agree to abide by its terms.
 [discord]: https://discord.gg/JBqHh485uF
 [discord-badge]: https://img.shields.io/discord/507627062434070529?color=%235865F2&label=%20&logo=discord&logoColor=white
 [gh-discussions]: https://github.com/videojs/v10/discussions
+[preview]: https://pkg.pr.new/~/videojs/v10
+[preview-badge]: https://pkg.pr.new/badge/videojs/v10

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lightningcss": "^1.32.0",
     "lint-staged": "^16.2.3",
     "magic-string": "^0.30.21",
+    "pkg-pr-new": "^0.0.88",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
+      pkg-pr-new:
+        specifier: ^0.0.88
+        version: 0.0.88
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -228,7 +231,7 @@ importers:
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/compiler:
     dependencies:
@@ -250,7 +253,7 @@ importers:
         version: 8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -294,7 +297,7 @@ importers:
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/html:
     dependencies:
@@ -337,7 +340,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/icons:
     dependencies:
@@ -371,7 +374,7 @@ importers:
         version: 4.23.1
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/jsx:
     devDependencies:
@@ -383,7 +386,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/media:
     dependencies:
@@ -586,7 +589,7 @@ importers:
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260421.2)(@volar/typescript@2.4.28)(tsx@4.23.1)(typescript@6.0.2)(unrun@0.2.39)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   site:
     dependencies:
@@ -782,7 +785,7 @@ importers:
         version: 4.5.0(@typescript/typescript6@6.0.0)(rollup@4.59.0)(supports-color@7.2.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -7789,6 +7792,10 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
+    hasBin: true
+
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
@@ -13177,7 +13184,7 @@ snapshots:
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13211,7 +13218,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -13231,9 +13238,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -13287,7 +13294,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -17134,6 +17141,8 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  pkg-pr-new@0.0.88: {}
+
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
@@ -18806,7 +18815,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))

--- a/site/scripts/copy-package-docs.ts
+++ b/site/scripts/copy-package-docs.ts
@@ -191,6 +191,13 @@ function main(): void {
     process.exit(1);
   }
 
+  // Preview releases (pkg.pr.new) pack straight from source, and building the
+  // site just to bundle docs into a throwaway tarball is not worth the CI time.
+  if (process.env.VIDEOJS_SKIP_PACKAGE_DOCS) {
+    console.log(`• Skipped packages/${target}/docs/ (VIDEOJS_SKIP_PACKAGE_DOCS is set)`);
+    return;
+  }
+
   try {
     const copiedFiles = packageDocumentation({ target, version: process.env.npm_package_version });
     console.log(`✓ Copied ${copiedFiles} doc files to packages/${target}/docs/`);


### PR DESCRIPTION
## Summary

Adds [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) continuous releases, so any pull request or commit on `main` produces an installable preview of the public packages without publishing to npm. Previews are gated on repository access, so an outside contributor cannot get a package published under the Video.js name just by opening a pull request.

## Changes

- Pull requests and `main` commits publish previews of `core`, `element`, `html`, `media`, `react`, `spf`, `store`, and `utils`. A bot comment on the pull request lists the install commands.
- Previews are only published for code someone with repository access pushed or vouched for:
  - `push` to `main` — only maintainers can land there.
  - a pull request from a branch **in this repo** — pushing it required write access.
  - a pull request from a **fork** — only after an owner, org member, or collaborator approves it. New commits need a fresh approval.
- Previews are versioned `0.0.0-preview-<sha>`, so one can never satisfy a semver range for a real npm release and quietly win a lockfile resolution.
- `VIDEOJS_SKIP_PACKAGE_DOCS` lets the `@videojs/html` and `@videojs/react` `prepack` scripts pack without site-generated markdown. Real releases are unchanged and still fail loudly when the site was not built.
- `CONTRIBUTING.md` documents how to install a preview and states the fork-approval rule up front.

<details>
<summary>Implementation details</summary>

**Why the docs opt-out exists.** `pkg-pr-new` packs each directory, and packing runs `prepack`. For `@videojs/html` and `@videojs/react` that copies `site/dist/docs/framework/*` into the tarball and hard-errors when it is missing. Building the Astro site per commit is far too slow for a preview, and preview installs do not need bundled docs, so the workflow opts out via an env var rather than the script silently degrading.

**Why checkout is pinned to the head commit.** `pkg-pr-new` derives the published SHA from the server for `pull_request` events, but from `git rev-parse HEAD` for every other event. Without an explicit `ref`, an approval-triggered run would pack the *base* branch and publish it under the pull request's SHA.

**Security posture.** `pull_request_review` runs in the base-repo context, where a workflow token would normally carry write scopes. The workflow declares `permissions: {}` and references no secrets, so approved fork code runs with nothing to steal or push with. There is a comment on the block saying so.

**Contributor check.** The fork opt-in uses the review's `author_association` (`OWNER`/`MEMBER`/`COLLABORATOR`), which needs no third-party action and no token scopes. An exact `write`/`admin` check would require a `repos.getCollaboratorPermissionLevel` call from a separate job; happy to swap that in if the looser set is a concern.

**`@videojs/cli` is excluded** because it is built separately and depends transitively on a full site build.

**Lockfile churn.** Installing the new devDependency also rewrites unrelated peer-resolution keys (`jsdom` and `@types/node` peer suffixes). `pnpm@11.17.0` regenerates those on any install against `main` today, so the churn is not specific to this change.

</details>

## Testing

- `pnpm lint`, `pnpm check:workspace` (10/10), and `pnpm -F site test scripts/tests/copy-package-docs.test.ts` (19 passed).
- Smoke-packed `@videojs/html` with `VIDEOJS_SKIP_PACKAGE_DOCS=1` and confirmed the tarball builds with resolved workspace dependencies.
- Verified `--pnpm`, `--previewVersion`, and `--packageManager` exist in `pkg-pr-new@0.0.88`.

The publish step and the access gate can only be exercised on GitHub. Worth watching the first run on this pull request, and the first fork pull request to confirm the job skips until approved.

> [!IMPORTANT]
> The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) must be installed on `videojs/v10` before the first run, or the publish step fails. That needs org-owner access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publishes installable artifacts under the Video.js package names, so workflow gating and checkout pinning matter; changes are CI/docs tooling rather than player runtime logic.
> 
> **Overview**
> Adds **continuous preview releases** via [pkg.pr.new](https://pkg.pr.new): a new **Preview Releases** workflow builds public workspace packages and publishes installable tarballs (not npm) on `main` pushes and eligible pull requests.
> 
> The workflow uses **empty `permissions`**, strict **when** conditions (in-repo PRs automatically; **fork PRs only after maintainer approval** on the current head SHA), and checkout pinned to the **reviewed/head commit** so previews cannot be tied to the wrong code. Publishing runs `pnpm build:packages`, sets `VIDEOJS_SKIP_PACKAGE_DOCS` for faster packs, and uses `pkg-pr-new` with `--previewVersion` (`0.0.0-preview-<sha>`) and `--peerDeps` so workspace peers resolve consistently.
> 
> **`copy-package-docs.ts`** now no-ops when `VIDEOJS_SKIP_PACKAGE_DOCS` is set. **CONTRIBUTING.md** and **README** document install URLs and add a preview badge. Root **`pkg-pr-new`** devDependency and lockfile updates support the CLI in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f3db250185f05535b59000dc95f76bb1ff4ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->