### PR TITLE
feat(react): expose createPlayerStore

### DIFF
--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -38,6 +38,8 @@ export type PlayerProps<Config = object> = {
 
 export interface CreatePlayerResult<Store extends PlayerStore> {
   Player: FC<PlayerProps<InferPlayerConfig<Store>>>;
+  /** Creates a standalone store with the configured features. */
+  createPlayerStore: () => Store;
   usePlayer: UsePlayerHook<Store>;
   useMedia: () => Media | null;
 }
@@ -48,7 +50,7 @@ export type UsePlayerHook<Store extends PlayerStore> = {
 };
 
 /**
- * Create a player instance with a typed Player component and hooks.
+ * Create a player instance with a typed Player component, standalone store factory, and hooks.
  *
  * @label Video
  * @param config - Player configuration with features and optional display name.
@@ -78,8 +80,12 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
   const featureConfig = combinePlayerFeatureConfigs(config.features);
   const configKeys = Object.keys(featureConfig);
 
+  function createPlayerStore() {
+    return createStore<PlayerTarget>()(slice);
+  }
+
   function createConfiguredStore(values: Record<string, unknown>) {
-    const store = createStore<PlayerTarget>()(slice);
+    const store = createPlayerStore();
     applyConfigValues(store, featureConfig, values);
     return store;
   }
@@ -143,6 +149,7 @@ export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): Cr
 
   return {
     Player,
+    createPlayerStore,
     usePlayer,
     useMedia,
   };

--- a/packages/react/src/player/tests/create-player.test-d.tsx
+++ b/packages/react/src/player/tests/create-player.test-d.tsx
@@ -19,6 +19,7 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: videoFeatures });
 
     assertType<CreatePlayerResult<VideoPlayerStore>>(result);
+    assertType<VideoPlayerStore>(result.createPlayerStore());
     // @ts-expect-error Container is imported from the package root, not created per player.
     result.Container;
   });
@@ -27,6 +28,7 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: audioFeatures });
 
     assertType<CreatePlayerResult<AudioPlayerStore>>(result);
+    assertType<AudioPlayerStore>(result.createPlayerStore());
   });
 
   it('resolves spread video features to VideoPlayerStore', () => {
@@ -47,6 +49,7 @@ describe('createPlayer', () => {
     const result = createPlayer({ features: [customFeature] });
 
     assertType<CreatePlayerResult<PlayerStore<[Slice<PlayerTarget, CustomState>]>>>(result);
+    assertType<PlayerStore<[Slice<PlayerTarget, CustomState>]>>(result.createPlayerStore());
   });
 
   it('infers config props from selected features', () => {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -23,6 +23,18 @@ describe('createPlayer', () => {
     }),
   });
 
+  it('creates a standalone store with the configured features', () => {
+    const { createPlayerStore } = createPlayer({ features: [mockSlice] });
+    const store = createPlayerStore();
+
+    expect(store.volume).toBe(1);
+    expect(store.muted).toBe(false);
+    expect(store.paused).toBe(true);
+    expect(typeof store.subscribe).toBe('function');
+
+    store.destroy();
+  });
+
   describe('Player', () => {
     it('creates store on mount', () => {
       const { Player, usePlayer } = createPlayer({ features: [mockSlice] });

--- a/site/src/content/docs/reference/create-player.mdx
+++ b/site/src/content/docs/reference/create-player.mdx
@@ -1,6 +1,6 @@
 ---
 title: createPlayer
-description: Factory function that creates a typed Player component and hooks
+description: Factory function that creates a typed Player component, store factory, and hooks
 ---
 
 import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
@@ -11,7 +11,7 @@ import BasicUsageDemoReact from "@/components/docs/demos/create-player/react/css
 import basicUsageReactTsx from "@/components/docs/demos/create-player/react/css/BasicUsage.tsx?raw";
 import basicUsageReactCss from "@/components/docs/demos/create-player/react/css/BasicUsage.css?raw";
 
-`createPlayer` is the entry point for setting up a Video.js player in React. It accepts a configuration object with a `features` array and returns hooks and components for building a player.
+`createPlayer` is the entry point for setting up a Video.js player in React. It accepts a configuration object with a `features` array and returns a `Player` component, a standalone store factory, and hooks for building a player.
 
 The hook is typed according to the provided features, giving you full type safety for state selectors and actions.
 
@@ -19,12 +19,14 @@ The hook is typed according to the provided features, giving you full type safet
 import { Container, createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, usePlayer, useMedia } = createPlayer({
+const { Player, createPlayerStore, usePlayer, useMedia } = createPlayer({
   features: videoFeatures,
 });
 
 // Container is imported independently from createPlayer.
 ```
+
+`createPlayerStore()` creates the same feature-typed store without mounting `Player`. Use it when an imperative integration needs to own the store directly; React components should normally read the player-owned store with `usePlayer`.
 
 ## Examples
 

--- a/site/src/content/docs/reference/player-provider.mdx
+++ b/site/src/content/docs/reference/player-provider.mdx
@@ -50,16 +50,18 @@ function App() {
 ## How it's created
 
 <FrameworkCase frameworks={["react"]}>
-Call `createPlayer()` with a `features` array. It returns `Player`, `usePlayer`, and `useMedia`. Import the shared `Container` separately when building a custom layout.
+Call `createPlayer()` with a `features` array. It returns `Player`, `createPlayerStore`, `usePlayer`, and `useMedia`. Import the shared `Container` separately when building a custom layout.
 
 ```tsx
 import { Container, createPlayer } from '@videojs/react';
 import { videoFeatures } from '@videojs/react/video';
 
-const { Player, usePlayer, useMedia } = createPlayer({
+const { Player, createPlayerStore, usePlayer, useMedia } = createPlayer({
   features: videoFeatures,
 });
 ```
+
+`Player` owns its store for normal React usage. `createPlayerStore()` is the typed escape hatch for integrations that need to own a standalone store.
 
 The <DocsLink slug="concepts/features">features</DocsLink> you pass determine what state is available in the store. `videoFeatures` is a <DocsLink slug="concepts/presets">preset</DocsLink> that includes playback, volume, fullscreen, and other standard video controls.
 


### PR DESCRIPTION
## Summary

Expose a typed standalone store factory from React `createPlayer()`. `Player` continues to own its store for normal React usage; imperative integrations can opt into owning the same feature-configured store shape directly.

## Before

```ts
const { Player, usePlayer, useMedia } = createPlayer({
  features: videoFeatures,
});
```

## After

```ts
const { Player, createPlayerStore, usePlayer, useMedia } = createPlayer({
  features: videoFeatures,
});

const store = createPlayerStore(); // VideoPlayerStore
```

The returned store type follows video, audio, and custom feature inference. Internally, `Player` uses the same factory before applying its React prop configuration.

## Testing

- React: 452 tests and package build
- Site: 534 tests, generated API docs, and production build
- Workspace: typecheck
