### PR TITLE
refactor(react): reduce use client directives

### DIFF
--- a/packages/react/src/i18n/context.tsx
+++ b/packages/react/src/i18n/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   createTranslator,
   DEFAULT_LOCALE,

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   createTranslator,
   loadLocale as defaultLoader,

--- a/packages/react/src/media/audio.tsx
+++ b/packages/react/src/media/audio.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AudioHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/media/video.tsx
+++ b/packages/react/src/media/video.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { VideoHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/player/container.tsx
+++ b/packages/react/src/player/container.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   createPopupGroup,
   DEFAULT_CONTAINER_ROLE,

--- a/packages/react/src/player/context.tsx
+++ b/packages/react/src/player/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MediaContainer } from '@videojs/core/dom';
 import type { Media } from '@videojs/media';
 import type { UnknownState, UnknownStore } from '@videojs/store';

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   type AnyPlayerFeature,
   type AnyPlayerStore,

--- a/packages/react/src/player/popup-group-context.tsx
+++ b/packages/react/src/player/popup-group-context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { PopupGroup } from '@videojs/core/dom';
 import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';

--- a/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import {
   button,

--- a/packages/react/src/presets/audio/minimal-skin.tsx
+++ b/packages/react/src/presets/audio/minimal-skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';

--- a/packages/react/src/presets/audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/audio/skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import {
   button,

--- a/packages/react/src/presets/audio/skin.tsx
+++ b/packages/react/src/presets/audio/skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { playbackRateText } from '@videojs/core/i18n/text/menu';
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';

--- a/packages/react/src/presets/background/skin.tsx
+++ b/packages/react/src/presets/background/skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@videojs/utils/style';
 import type { BaseSkinProps } from '../types';
 

--- a/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   button,
   buttonGroup,

--- a/packages/react/src/presets/live-audio/minimal-skin.tsx
+++ b/packages/react/src/presets/live-audio/minimal-skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import {

--- a/packages/react/src/presets/live-audio/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-audio/skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   button,
   buttonGroup,

--- a/packages/react/src/presets/live-audio/skin.tsx
+++ b/packages/react/src/presets/live-audio/skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@videojs/utils/style';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 import { PauseIcon, PlayIcon, RestartIcon, SpinnerIcon, VolumeHighIcon, VolumeLowIcon, VolumeOffIcon } from '@/icons';

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { captionsText } from '@videojs/core/i18n/text/menu';
 import {
   bufferingIndicator,

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { captionsText } from '@videojs/core/i18n/text/menu';
 import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { captionsText } from '@videojs/core/i18n/text/menu';
 import {
   bufferingIndicator,

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { captionsText } from '@videojs/core/i18n/text/menu';
 import { isString } from '@videojs/utils/predicate';
 import { cn } from '@videojs/utils/style';

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   audioText,
   captionsText,

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   audioText,
   captionsText,

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   audioText,
   captionsText,

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   audioText,
   captionsText,

--- a/packages/react/src/ui/airplay-button/airplay-button.tsx
+++ b/packages/react/src/ui/airplay-button/airplay-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { AirPlayButtonCore, AirPlayButtonDataAttrs } from '@videojs/core';
 import { selectRemotePlayback } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/airplay-button/tests/airplay-button.test.tsx
+++ b/packages/react/src/ui/airplay-button/tests/airplay-button.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/react/src/ui/alert-dialog/alert-dialog-close.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-close.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 import { forwardRef, useCallback } from 'react';
 

--- a/packages/react/src/ui/alert-dialog/alert-dialog-description.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-description.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/alert-dialog/alert-dialog-popup.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-popup.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 import { forwardRef, useCallback } from 'react';
 

--- a/packages/react/src/ui/alert-dialog/alert-dialog-root.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { AlertDialogCore, AlertDialogDataAttrs, type AlertDialogProps } from '@videojs/core';
 import { createAlertDialog, createTransition } from '@videojs/core/dom';
 import { useSnapshot } from '@videojs/store/react';

--- a/packages/react/src/ui/alert-dialog/alert-dialog-title.tsx
+++ b/packages/react/src/ui/alert-dialog/alert-dialog-title.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/alert-dialog/context.tsx
+++ b/packages/react/src/ui/alert-dialog/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore, StateAttrMap } from '@videojs/core';
 import type { AlertDialogApi } from '@videojs/core/dom';
 import { createContext, useContext } from 'react';

--- a/packages/react/src/ui/audio-track-radio-group/audio-track-radio-group.tsx
+++ b/packages/react/src/ui/audio-track-radio-group/audio-track-radio-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type AudioTrackRadioGroupCore, AudioTrackRadioGroupDataAttrs } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
 import { isFunction } from '@videojs/utils/predicate';

--- a/packages/react/src/ui/audio-track-radio-group/tests/audio-track-radio-group.test.tsx
+++ b/packages/react/src/ui/audio-track-radio-group/tests/audio-track-radio-group.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import type { MediaAudioTrack } from '@videojs/media';

--- a/packages/react/src/ui/audio-track/tests/use-audio-track-options.test.tsx
+++ b/packages/react/src/ui/audio-track/tests/use-audio-track-options.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { MediaAudioTrack } from '@videojs/media';
 import type { ReactNode } from 'react';

--- a/packages/react/src/ui/audio-track/use-audio-track-options.ts
+++ b/packages/react/src/ui/audio-track/use-audio-track-options.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { AudioTrackRadioGroupCore, type AudioTrackRadioGroupOption } from '@videojs/core';
 import { selectAudioTrack } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
+++ b/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { BufferingIndicatorCore, BufferingIndicatorDataAttrs } from '@videojs/core';
 import { logMissingFeature, selectPlayback } from '@videojs/core/dom';
 import type { ForwardedRef } from 'react';

--- a/packages/react/src/ui/captions-button/captions-button.tsx
+++ b/packages/react/src/ui/captions-button/captions-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { CaptionsButtonCore, CaptionsButtonDataAttrs } from '@videojs/core';
 import { selectTextTrack } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/captions-button/tests/captions-button.test.tsx
+++ b/packages/react/src/ui/captions-button/tests/captions-button.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/react/src/ui/captions-radio-group/captions-radio-group.tsx
+++ b/packages/react/src/ui/captions-radio-group/captions-radio-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type CaptionsRadioGroupCore, CaptionsRadioGroupDataAttrs } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
 import { isFunction } from '@videojs/utils/predicate';

--- a/packages/react/src/ui/captions-radio-group/tests/captions-radio-group.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/captions-radio-group.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { createRef } from 'react';

--- a/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
+++ b/packages/react/src/ui/captions-radio-group/tests/use-captions-options.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { CAPTIONS_OFF_VALUE } from '@videojs/core';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';

--- a/packages/react/src/ui/captions-radio-group/use-captions-options.ts
+++ b/packages/react/src/ui/captions-radio-group/use-captions-options.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { CaptionsRadioGroupCore, type CaptionsRadioGroupOption } from '@videojs/core';
 import { selectTextTrack } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/cast-button/cast-button.tsx
+++ b/packages/react/src/ui/cast-button/cast-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { CastButtonCore, CastButtonDataAttrs } from '@videojs/core';
 import { selectRemotePlayback } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/controls/context.tsx
+++ b/packages/react/src/ui/controls/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ControlsState, StateAttrMap } from '@videojs/core';
 import { createContext, useContext } from 'react';
 

--- a/packages/react/src/ui/controls/controls-group.tsx
+++ b/packages/react/src/ui/controls/controls-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ControlsCore } from '@videojs/core';
 import type { ForwardedRef, ReactNode } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/controls/controls-root.tsx
+++ b/packages/react/src/ui/controls/controls-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { ControlsCore, ControlsDataAttrs } from '@videojs/core';
 import { logMissingFeature, selectControls } from '@videojs/core/dom';
 import type { ForwardedRef, ReactNode } from 'react';

--- a/packages/react/src/ui/create-context-part.tsx
+++ b/packages/react/src/ui/create-context-part.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { StateAttrMap } from '@videojs/core';
 import type { ForwardRefExoticComponent } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/create-media-button.tsx
+++ b/packages/react/src/ui/create-media-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { InferComponentState, InferMediaState, MediaButtonComponent, StateAttrMap } from '@videojs/core';
 import { logMissingFeature } from '@videojs/core/dom';
 import { isText, translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/error-dialog/context.tsx
+++ b/packages/react/src/ui/error-dialog/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ErrorLike } from '@videojs/media';
 import { createContext, useContext } from 'react';
 

--- a/packages/react/src/ui/error-dialog/error-dialog-close.tsx
+++ b/packages/react/src/ui/error-dialog/error-dialog-close.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 import { getErrorDialogDismissText } from '@videojs/core';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/error-dialog/error-dialog-description.tsx
+++ b/packages/react/src/ui/error-dialog/error-dialog-description.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 import { resolveErrorDialogDescription } from '@videojs/core';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/error-dialog/error-dialog-root.tsx
+++ b/packages/react/src/ui/error-dialog/error-dialog-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { AlertDialogDataAttrs, ErrorDialogCore } from '@videojs/core';
 import { createAlertDialog, createTransition, selectError } from '@videojs/core/dom';
 import { useSnapshot } from '@videojs/store/react';

--- a/packages/react/src/ui/error-dialog/error-dialog-title.tsx
+++ b/packages/react/src/ui/error-dialog/error-dialog-title.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AlertDialogCore } from '@videojs/core';
 import { getErrorDialogTitleText } from '@videojs/core';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/fullscreen-button/fullscreen-button.tsx
+++ b/packages/react/src/ui/fullscreen-button/fullscreen-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { FullscreenButtonCore, FullscreenButtonDataAttrs } from '@videojs/core';
 import { selectFullscreen } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/gesture/gesture.tsx
+++ b/packages/react/src/ui/gesture/gesture.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AnyPlayerStore } from '@videojs/core/dom';
 import {
   createDoubleTapGesture,

--- a/packages/react/src/ui/gesture/use-doubletap-gesture.ts
+++ b/packages/react/src/ui/gesture/use-doubletap-gesture.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { createDoubleTapGesture, type GesturePointerType, type GestureRegion } from '@videojs/core/dom';
 import type { RefObject } from 'react';
 import { useEffect } from 'react';

--- a/packages/react/src/ui/gesture/use-tap-gesture.ts
+++ b/packages/react/src/ui/gesture/use-tap-gesture.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { createTapGesture, type GesturePointerType, type GestureRegion } from '@videojs/core/dom';
 import type { RefObject } from 'react';
 import { useEffect } from 'react';

--- a/packages/react/src/ui/hooks/create-radio-options-hook.ts
+++ b/packages/react/src/ui/hooks/create-radio-options-hook.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { RadioOption, RadioOptionsState } from '@videojs/core';
 import { logMissingFeature } from '@videojs/core/dom';
 import { type Text, type TextParams, translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/hooks/use-button.ts
+++ b/packages/react/src/ui/hooks/use-button.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { createButton, type UIEvent } from '@videojs/core/dom';
 import type { ComponentPropsWithRef, Ref } from 'react';
 import { useCallback } from 'react';

--- a/packages/react/src/ui/hooks/use-positioned-state.ts
+++ b/packages/react/src/ui/hooks/use-positioned-state.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface PopupState {

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderInput, SliderState } from '@videojs/core';
 import {
   createSlider,

--- a/packages/react/src/ui/hotkey/hotkey.tsx
+++ b/packages/react/src/ui/hotkey/hotkey.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { AnyPlayerStore } from '@videojs/core/dom';
 import { createHotkey, type HotkeyActionName, isHotkeyToggleAction, resolveHotkeyAction } from '@videojs/core/dom';
 import type { ReactNode } from 'react';

--- a/packages/react/src/ui/hotkey/use-hotkey-shortcut.ts
+++ b/packages/react/src/ui/hotkey/use-hotkey-shortcut.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { getHotkeyCoordinator, type HotkeyShortcutDetails } from '@videojs/core/dom';
 import { useEffect, useState } from 'react';
 

--- a/packages/react/src/ui/hotkey/use-hotkey.ts
+++ b/packages/react/src/ui/hotkey/use-hotkey.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { createHotkey } from '@videojs/core/dom';
 import { useEffect } from 'react';
 

--- a/packages/react/src/ui/input-indicator/use-indicator-visibility.ts
+++ b/packages/react/src/ui/input-indicator/use-indicator-visibility.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { IndicatorVisibilityHandle } from '@videojs/core';
 import { getIndicatorVisibilityCoordinator } from '@videojs/core/dom';
 import { useCallback, useEffect, useRef, useState } from 'react';

--- a/packages/react/src/ui/input-indicator/use-input-action-subscription.ts
+++ b/packages/react/src/ui/input-indicator/use-input-action-subscription.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { InputActionEvent, MediaSnapshot } from '@videojs/core';
 import { getMediaSnapshot, subscribeToInputActions } from '@videojs/core/dom';
 import { useEffect } from 'react';

--- a/packages/react/src/ui/input-indicator/use-input-indicator-root.ts
+++ b/packages/react/src/ui/input-indicator/use-input-indicator-root.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { IndicatorLifecycleState, InputActionEvent, MediaSnapshot } from '@videojs/core';
 import type { State as StoreState } from '@videojs/store';
 import { useState, useSyncExternalStore } from 'react';

--- a/packages/react/src/ui/input-indicator/use-rendered-indicator-state.ts
+++ b/packages/react/src/ui/input-indicator/use-rendered-indicator-state.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { getRenderedIndicatorState, type IndicatorLifecycleState, isIndicatorPresent } from '@videojs/core';
 import { createTransition } from '@videojs/core/dom';
 import { useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';

--- a/packages/react/src/ui/live-button/live-button.tsx
+++ b/packages/react/src/ui/live-button/live-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { LiveButtonCore, LiveButtonDataAttrs, type LiveButtonMediaState } from '@videojs/core';
 import { logMissingFeature, selectBuffer, selectLive, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/menu/context.tsx
+++ b/packages/react/src/ui/menu/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuCore, MenuState, StateAttrMap } from '@videojs/core';
 import type { MediaContainer, MenuApi, PositioningBoundary } from '@videojs/core/dom';
 import { createContext, useContext } from 'react';

--- a/packages/react/src/ui/menu/menu-checkbox-item.tsx
+++ b/packages/react/src/ui/menu/menu-checkbox-item.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { forwardRef, useCallback, useEffect, useRef } from 'react';
 

--- a/packages/react/src/ui/menu/menu-content.tsx
+++ b/packages/react/src/ui/menu/menu-content.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import {
   getRootPositionOptions,

--- a/packages/react/src/ui/menu/menu-group-label.tsx
+++ b/packages/react/src/ui/menu/menu-group-label.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { forwardRef, useLayoutEffect } from 'react';
 

--- a/packages/react/src/ui/menu/menu-group.tsx
+++ b/packages/react/src/ui/menu/menu-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/menu/menu-item-indicator.tsx
+++ b/packages/react/src/ui/menu/menu-item-indicator.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/menu/menu-item.tsx
+++ b/packages/react/src/ui/menu/menu-item.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { completeMenuItemSelection } from '@videojs/core/dom';
 import { forwardRef, useCallback, useEffect, useRef } from 'react';

--- a/packages/react/src/ui/menu/menu-radio-group.tsx
+++ b/packages/react/src/ui/menu/menu-radio-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/menu/menu-radio-item.tsx
+++ b/packages/react/src/ui/menu/menu-radio-item.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { completeMenuItemSelection } from '@videojs/core/dom';
 import { forwardRef, useCallback, useEffect, useRef } from 'react';

--- a/packages/react/src/ui/menu/menu-root.tsx
+++ b/packages/react/src/ui/menu/menu-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { MenuCore, MenuDataAttrs } from '@videojs/core';
 import {
   createMenu,

--- a/packages/react/src/ui/menu/menu-separator.tsx
+++ b/packages/react/src/ui/menu/menu-separator.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuState } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MenuCore, MenuState } from '@videojs/core';
 import { isMenuNavigationKey } from '@videojs/core/dom';
 import { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';

--- a/packages/react/src/ui/menu/use-menu-group.tsx
+++ b/packages/react/src/ui/menu/use-menu-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type ReactElement, useCallback, useMemo, useState } from 'react';
 
 import { MenuGroupContextProvider } from './context';

--- a/packages/react/src/ui/mute-button/mute-button.tsx
+++ b/packages/react/src/ui/mute-button/mute-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { MuteButtonCore, MuteButtonDataAttrs } from '@videojs/core';
 import { selectVolume } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/pip-button/pip-button.tsx
+++ b/packages/react/src/ui/pip-button/pip-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { PiPButtonCore, PiPButtonDataAttrs } from '@videojs/core';
 import { selectPiP } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/play-button/play-button.tsx
+++ b/packages/react/src/ui/play-button/play-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { PlayButtonCore, PlayButtonDataAttrs } from '@videojs/core';
 import { selectPlayback } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/playback-rate-button/playback-rate-button.tsx
+++ b/packages/react/src/ui/playback-rate-button/playback-rate-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { PlaybackRateButtonCore, PlaybackRateButtonDataAttrs } from '@videojs/core';
 import { selectPlaybackRate } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/playback-rate-radio-group/playback-rate-radio-group.tsx
+++ b/packages/react/src/ui/playback-rate-radio-group/playback-rate-radio-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type PlaybackRateRadioGroupCore, PlaybackRateRadioGroupDataAttrs } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
 import { isFunction } from '@videojs/utils/predicate';

--- a/packages/react/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group.test.tsx
+++ b/packages/react/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { createRef } from 'react';

--- a/packages/react/src/ui/playback-rate/tests/use-playback-rate-options.test.tsx
+++ b/packages/react/src/ui/playback-rate/tests/use-playback-rate-options.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
+++ b/packages/react/src/ui/playback-rate/use-playback-rate-options.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   type PlaybackRateRadioGroupCore,
   PlaybackRateRadioGroupCore as PlaybackRateRadioGroupCoreClass,

--- a/packages/react/src/ui/popover/context.tsx
+++ b/packages/react/src/ui/popover/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { PopoverCore, StateAttrMap } from '@videojs/core';
 import type { MediaContainer, PopoverApi, PositioningBoundary } from '@videojs/core/dom';
 import { createContext, useContext } from 'react';

--- a/packages/react/src/ui/popover/popover-arrow.tsx
+++ b/packages/react/src/ui/popover/popover-arrow.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { PopoverState } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/popover/popover-popup.tsx
+++ b/packages/react/src/ui/popover/popover-popup.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { PopoverState } from '@videojs/core';
 import { forwardRef, useCallback, useMemo, useRef } from 'react';
 

--- a/packages/react/src/ui/popover/popover-root.tsx
+++ b/packages/react/src/ui/popover/popover-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type PopoverProps as CorePopoverProps, PopoverCore, PopoverDataAttrs } from '@videojs/core';
 import {
   createPopover,

--- a/packages/react/src/ui/popover/popover-trigger.tsx
+++ b/packages/react/src/ui/popover/popover-trigger.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { PopoverState } from '@videojs/core';
 import { forwardRef, useCallback } from 'react';
 

--- a/packages/react/src/ui/popover/use-popup-position.ts
+++ b/packages/react/src/ui/popover/use-popup-position.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   type MediaContainer,
   PopupPositioner,

--- a/packages/react/src/ui/poster/poster.tsx
+++ b/packages/react/src/ui/poster/poster.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { PosterCore, PosterDataAttrs } from '@videojs/core';
 import { logMissingFeature, selectPlayback } from '@videojs/core/dom';
 import type { ForwardedRef, SyntheticEvent } from 'react';

--- a/packages/react/src/ui/quality-radio-group/quality-radio-group.tsx
+++ b/packages/react/src/ui/quality-radio-group/quality-radio-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type QualityRadioGroupCore, QualityRadioGroupDataAttrs } from '@videojs/core';
 import { getStateDataAttrs } from '@videojs/core/dom';
 import { isFunction } from '@videojs/utils/predicate';

--- a/packages/react/src/ui/quality-radio-group/tests/quality-radio-group.test.tsx
+++ b/packages/react/src/ui/quality-radio-group/tests/quality-radio-group.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import type { MediaVideoRendition } from '@videojs/media';

--- a/packages/react/src/ui/quality/tests/use-quality-options.test.tsx
+++ b/packages/react/src/ui/quality/tests/use-quality-options.test.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import type { MediaVideoRendition } from '@videojs/media';

--- a/packages/react/src/ui/quality/use-quality-options.ts
+++ b/packages/react/src/ui/quality/use-quality-options.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { QualityRadioGroupCore, type QualityRadioGroupOption } from '@videojs/core';
 import { selectQuality } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/seek-button/seek-button.tsx
+++ b/packages/react/src/ui/seek-button/seek-button.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { SeekButtonCore, SeekButtonDataAttrs } from '@videojs/core';
 import { selectTime } from '@videojs/core/dom';
 

--- a/packages/react/src/ui/seek-indicator/context.tsx
+++ b/packages/react/src/ui/seek-indicator/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SeekIndicatorCore } from '@videojs/core';
 import { createContext, type ProviderProps, useContext } from 'react';
 

--- a/packages/react/src/ui/seek-indicator/seek-indicator-root.tsx
+++ b/packages/react/src/ui/seek-indicator/seek-indicator-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { SeekIndicatorCore, SeekIndicatorDataAttrs } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/seek-indicator/seek-indicator-value.tsx
+++ b/packages/react/src/ui/seek-indicator/seek-indicator-value.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { getSeekIndicatorDisplayValue, type SeekIndicatorCore } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/slider/context.tsx
+++ b/packages/react/src/ui/slider/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderInput, SliderState, StateAttrMap } from '@videojs/core';
 import type { SliderThumbProps } from '@videojs/core/dom';
 import type { State } from '@videojs/store';

--- a/packages/react/src/ui/slider/slider-buffer.tsx
+++ b/packages/react/src/ui/slider/slider-buffer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderState } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/slider/slider-fill.tsx
+++ b/packages/react/src/ui/slider/slider-fill.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderState } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/slider/slider-preview.tsx
+++ b/packages/react/src/ui/slider/slider-preview.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderState } from '@videojs/core';
 import type { SliderPreviewOverflow } from '@videojs/core/dom';
 import { getSliderPreviewStyle } from '@videojs/core/dom';

--- a/packages/react/src/ui/slider/slider-root.tsx
+++ b/packages/react/src/ui/slider/slider-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { SliderCore, SliderDataAttrs } from '@videojs/core';
 import { getSliderCSSVars } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/slider/slider-thumb.tsx
+++ b/packages/react/src/ui/slider/slider-thumb.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderState } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/slider/slider-thumbnail.tsx
+++ b/packages/react/src/ui/slider/slider-thumbnail.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ThumbnailCore } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/slider/slider-track.tsx
+++ b/packages/react/src/ui/slider/slider-track.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderState } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/slider/slider-value.tsx
+++ b/packages/react/src/ui/slider/slider-value.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { SliderState } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/status-announcer/status-announcer.tsx
+++ b/packages/react/src/ui/status-announcer/status-announcer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { createStatusAnnouncerLabels, StatusAnnouncerCore } from '@videojs/core';
 import { shouldAnnounceStatusChange, subscribeToStatusAnnouncer } from '@videojs/core/dom';
 import type { ForwardedRef } from 'react';

--- a/packages/react/src/ui/status-indicator/context.tsx
+++ b/packages/react/src/ui/status-indicator/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { StatusIndicatorCore } from '@videojs/core';
 import { createContext, type ProviderProps, useContext } from 'react';
 

--- a/packages/react/src/ui/status-indicator/status-indicator-root.tsx
+++ b/packages/react/src/ui/status-indicator/status-indicator-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { createInputIndicatorLabels, StatusIndicatorCore, StatusIndicatorDataAttrs } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/status-indicator/status-indicator-value.tsx
+++ b/packages/react/src/ui/status-indicator/status-indicator-value.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { getStatusIndicatorDisplayValue, type StatusIndicatorCore } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/thumbnail/thumbnail.tsx
+++ b/packages/react/src/ui/thumbnail/thumbnail.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   mapCuesToThumbnails,
   ThumbnailCore,

--- a/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/slider-segments.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   type SliderSegmentRange,
   type SliderSegmentState,

--- a/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapter-title.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapter-title.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { TimeSliderChaptersCore } from '@videojs/core';
 import { selectTextTrack, selectTime } from '@videojs/core/dom';
 import type { MediaTextCue } from '@videojs/media';

--- a/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapters.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-chapters/time-slider-chapters.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   type SliderSegmentState,
   TimeSliderChapterCSSVars,

--- a/packages/react/src/ui/time-slider/time-slider-root.tsx
+++ b/packages/react/src/ui/time-slider/time-slider-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { TimeSliderCore, TimeSliderDataAttrs } from '@videojs/core';
 import { getTimeSliderCSSVars, logMissingFeature, selectBuffer, selectPlayback, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/time/time-group.tsx
+++ b/packages/react/src/ui/time/time-group.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ForwardedRef, ReactNode } from 'react';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/time/time-separator.tsx
+++ b/packages/react/src/ui/time/time-separator.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ForwardedRef, ReactNode } from 'react';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/time/time-value.tsx
+++ b/packages/react/src/ui/time/time-value.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { TimeCore, TimeDataAttrs } from '@videojs/core';
 import { logMissingFeature, selectTime } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/ui/tooltip/context.tsx
+++ b/packages/react/src/ui/tooltip/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { StateAttrMap, TooltipCore } from '@videojs/core';
 import type { MediaContainer, PositioningBoundary, TooltipApi } from '@videojs/core/dom';
 import { createContext, useContext } from 'react';

--- a/packages/react/src/ui/tooltip/group-context.tsx
+++ b/packages/react/src/ui/tooltip/group-context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { TooltipGroupCore } from '@videojs/core';
 import { createContext, useContext } from 'react';
 

--- a/packages/react/src/ui/tooltip/tooltip-arrow.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-arrow.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { TooltipState } from '@videojs/core';
 
 import type { UIComponentProps } from '../../utils/types';

--- a/packages/react/src/ui/tooltip/tooltip-label.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-label.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { TooltipState } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/tooltip/tooltip-popup.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-popup.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { TooltipCSSVars, type TooltipState } from '@videojs/core';
 import { forwardRef, useCallback, useMemo, useRef } from 'react';
 

--- a/packages/react/src/ui/tooltip/tooltip-provider.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-provider.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { TooltipGroupCore, type TooltipGroupProps } from '@videojs/core';
 import type { ReactNode } from 'react';
 import { useState } from 'react';

--- a/packages/react/src/ui/tooltip/tooltip-root.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type TooltipProps as CoreTooltipProps, TooltipCore, TooltipDataAttrs } from '@videojs/core';
 import {
   createTooltip,

--- a/packages/react/src/ui/tooltip/tooltip-shortcut.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-shortcut.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { TooltipState } from '@videojs/core';
 import { forwardRef } from 'react';
 

--- a/packages/react/src/ui/tooltip/tooltip-trigger.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-trigger.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { TooltipState } from '@videojs/core';
 import { forwardRef, useCallback } from 'react';
 

--- a/packages/react/src/ui/volume-indicator/context.tsx
+++ b/packages/react/src/ui/volume-indicator/context.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { VolumeIndicatorCore } from '@videojs/core';
 import { createContext, type ProviderProps, useContext } from 'react';
 

--- a/packages/react/src/ui/volume-indicator/volume-indicator-fill.tsx
+++ b/packages/react/src/ui/volume-indicator/volume-indicator-fill.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { type VolumeIndicatorCore, VolumeIndicatorCSSVars } from '@videojs/core';
 import { isFunction } from '@videojs/utils/predicate';
 import type { CSSProperties, ForwardedRef } from 'react';

--- a/packages/react/src/ui/volume-indicator/volume-indicator-root.tsx
+++ b/packages/react/src/ui/volume-indicator/volume-indicator-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { createInputIndicatorLabels, VolumeIndicatorCore, VolumeIndicatorDataAttrs } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/volume-indicator/volume-indicator-value.tsx
+++ b/packages/react/src/ui/volume-indicator/volume-indicator-value.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { getVolumeIndicatorDisplayValue, type VolumeIndicatorCore } from '@videojs/core';
 import type { ForwardedRef } from 'react';
 import { forwardRef } from 'react';

--- a/packages/react/src/ui/volume-slider/volume-slider-root.tsx
+++ b/packages/react/src/ui/volume-slider/volume-slider-root.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { VolumeSliderCore, VolumeSliderDataAttrs } from '@videojs/core';
 import { createWheelStep, getSliderCSSVars, logMissingFeature, selectVolume } from '@videojs/core/dom';
 import { translateText } from '@videojs/core/i18n';

--- a/packages/react/src/utils/merge-props.ts
+++ b/packages/react/src/utils/merge-props.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ComponentPropsWithRef, CSSProperties, ElementType, SyntheticEvent } from 'react';
 
 type Props<T extends ElementType = ElementType> = ComponentPropsWithRef<T>;

--- a/packages/react/src/utils/use-attach-iframe.ts
+++ b/packages/react/src/utils/use-attach-iframe.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MediaEngineHost } from '@videojs/media';
 import type { RefCallback } from 'react';
 import { useCallback } from 'react';

--- a/packages/react/src/utils/use-attach-media.ts
+++ b/packages/react/src/utils/use-attach-media.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MediaEngineHost } from '@videojs/media';
 import type { RefCallback } from 'react';
 import { useCallback } from 'react';

--- a/packages/react/src/utils/use-composed-refs.ts
+++ b/packages/react/src/utils/use-composed-refs.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { isFunction } from '@videojs/utils/predicate';
 import type { Ref, RefCallback } from 'react';
 

--- a/packages/react/src/utils/use-destroy.ts
+++ b/packages/react/src/utils/use-destroy.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useEffect, useRef } from 'react';
 
 import { useLatestRef } from './use-latest-ref';

--- a/packages/react/src/utils/use-force-render.ts
+++ b/packages/react/src/utils/use-force-render.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useReducer } from 'react';
 
 export function useForceRender() {

--- a/packages/react/src/utils/use-latest-ref.ts
+++ b/packages/react/src/utils/use-latest-ref.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useRef } from 'react';
 
 /**

--- a/packages/react/src/utils/use-media-component.ts
+++ b/packages/react/src/utils/use-media-component.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { HTMLMediaTargetLike, MediaComponent } from '@videojs/media/dom/media-host';
 import { addMediaComponent, HTMLMediaElementHost } from '@videojs/media/dom/media-host';
 import { useEffect, useState } from 'react';

--- a/packages/react/src/utils/use-media-instance.ts
+++ b/packages/react/src/utils/use-media-instance.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import type { Media } from '@videojs/media';
 import { useState } from 'react';
 

--- a/packages/react/src/utils/use-render.tsx
+++ b/packages/react/src/utils/use-render.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { getStateDataAttrs, type StateAttrMap } from '@videojs/core/dom';
 import { isFunction } from '@videojs/utils/predicate';
 import type { CSSProperties, ReactElement, Ref } from 'react';

--- a/packages/react/src/utils/use-safe-id.ts
+++ b/packages/react/src/utils/use-safe-id.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useId } from 'react';
 
 const UNSAFE_CHARS = /[^a-zA-Z0-9_-]/g;


### PR DESCRIPTION
## Summary

- Remove redundant `use client` directives from React implementation files covered by package entrypoint boundaries.
- Keep client boundaries on directly importable skin modules.
- Preserve existing package exports and React utility behavior.

## Validation

- `pnpm check:workspace`
- `pnpm lint`
- `pnpm test`
- `pnpm test:cli`
- `pnpm test:size`
- `pnpm build:packages`
- `pnpm --dir site build`
- Next.js 16.3.1 production build and TypeScript check against the local package
- Chromium and WebKit E2E matrix with tracing disabled: 399 passed, 17 skipped

## Existing repository blockers

- `pnpm typecheck` reports four unrelated SPF metadata errors involving `id`, `encrypted`, and `lowLatency`.
- The full Turbo build reaches 16 successful tasks before the sandbox build fails because `@videojs/spf/background-video` is not exported and `app/shared/react/providers` is missing.
- Local Playwright trace finalization hangs and produces malformed archives, so the E2E matrix was run with `--trace=off`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misplaced client boundaries can break Next.js builds or mark server modules as client; risk is mitigated by keeping directives on package entrypoints and directly importable skins, with broad test coverage noted in the PR.
> 
> **Overview**
> This PR trims **Next.js / RSC client boundaries** in `@videojs/react` by removing `'use client'` from most internal modules (player, i18n, UI primitives, hooks, utils, and tests) that are only reached through paths already marked client.
> 
> **`'use client'` is added** on preset **skin** modules under `presets/*` (default, minimal, and Tailwind variants for audio, video, live, and background). Those files are exposed as separate package subpath exports (e.g. `@videojs/react/video/skin`), so they need their own directive when imported directly—not only via the root `@videojs/react` entry.
> 
> No runtime API or export surface changes are intended; behavior should match prior builds, with clearer boundary placement and less directive noise in the implementation tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce651a32e4fc7b0e6791623db2942c4ad8fa2c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->