### PR TITLE
fix(skin): misc style fixes

### DIFF
--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -329,7 +329,7 @@
     .media-slider__chapter-title {
       min-width: 0;
       max-width: var(--max-width);
-      padding-inline: calc(var(--spacing) * 3);
+      padding-inline: calc(var(--spacing) * 6);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -360,13 +360,14 @@
       transition-duration: 200ms;
       transition-property: opacity, scale;
     }
+  }
 
-    &[data-pointing]:not([data-dragging])::before,
-    &[data-pointing] :is(.media-slider__thumbnail, .media-slider__value),
-    &[data-interactive]:not([data-pointing]):not([data-dragging]) :is(.media-slider__value, .media-slider__thumbnail) {
-      opacity: 1;
-      filter: blur(0);
-      scale: 1;
-    }
+  &:is([data-pointing], :has(:focus-visible))
+    .media-slider__preview
+    :is(.media-slider__value, .media-slider__thumbnail),
+  .media-slider__preview[data-pointing]:not([data-dragging])::before {
+    opacity: 1;
+    filter: blur(0);
+    scale: 1;
   }
 }

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -109,6 +109,10 @@
       --scale: 1.75;
     }
   }
+
+  * {
+    --focus-ring-color: oklch(1 0 0);
+  }
 }
 
 /* Error Dialog  */

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -4,11 +4,10 @@ const previewContent = cn(
   'absolute left-1/2 max-w-(--max-width)',
   '-translate-x-1/2 translate-y-2 scale-80 opacity-0 blur-lg origin-bottom',
   'transition-[filter,opacity,scale] duration-150 ease-out',
-  'group-data-pointing/preview:scale-100 group-data-pointing/preview:opacity-100',
-  'group-data-pointing/preview:blur-none',
-  'group-data-interactive/preview:group-not-data-pointing/preview:group-not-data-dragging/preview:scale-100',
-  'group-data-interactive/preview:group-not-data-pointing/preview:group-not-data-dragging/preview:opacity-100',
-  'group-data-interactive/preview:group-not-data-pointing/preview:group-not-data-dragging/preview:blur-none'
+  'group-data-pointing/slider:scale-100 group-data-pointing/slider:opacity-100',
+  'group-data-pointing/slider:blur-none',
+  'group-has-focus-visible/slider:scale-100 group-has-focus-visible/slider:opacity-100',
+  'group-has-focus-visible/slider:blur-none'
 );
 
 export const slider = {
@@ -105,7 +104,7 @@ export const slider = {
     ),
   },
   preview: cn(
-    'group/preview [--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-(--max-width) h-1',
+    '[--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-(--max-width) h-1',
     'before:absolute before:z-1 before:top-1/2 before:left-1/2 before:size-1 before:bg-current before:rounded-full before:pointer-events-none',
     'before:shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.15)),0_1px_2px_0_oklch(0_0_0/0.35)]',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
@@ -118,5 +117,5 @@ export const slider = {
     '[bottom:calc(100%+--spacing(10.5))] flex flex-col items-center tabular-nums',
     'text-shadow-2xs text-shadow-(color:--shadow-current-color)'
   ),
-  chapterTitle: 'min-w-0 max-w-(--max-width) px-3 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
+  chapterTitle: 'min-w-0 max-w-(--max-width) px-6 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
 };

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -34,6 +34,7 @@ export const container = (isShadowDOM: boolean) =>
     '[--default-accent-color:oklch(1_0_0)]',
     '[--border-color:light-dark(oklch(0_0_0/0.1),oklch(1_0_0/0.15))]',
     '[--focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+    '**:[--focus-ring-color:oklch(1_0_0)]',
     '[--container-border-radius:var(--media-border-radius,1.75rem)]',
     '[--media-video-border-radius:var(--container-border-radius)]',
     '[--controls-transition-duration:100ms]',

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -328,15 +328,6 @@
       transition-property: opacity, scale;
     }
 
-    &[data-pointing] .media-slider__value,
-    &[data-pointing] .media-slider__thumbnail,
-    &[data-interactive]:not([data-pointing]):not([data-dragging]) .media-slider__value,
-    &[data-interactive]:not([data-pointing]):not([data-dragging]) .media-slider__thumbnail {
-      opacity: 1;
-      filter: blur(0);
-      scale: 1;
-    }
-
     &[data-orientation="horizontal"]::before {
       top: 50%;
       left: var(--media-slider-pointer);
@@ -354,5 +345,13 @@
       opacity: 1;
       scale: 1;
     }
+  }
+
+  &:is([data-pointing], :has(:focus-visible))
+    .media-slider__preview
+    :is(.media-slider__value, .media-slider__thumbnail) {
+    opacity: 1;
+    filter: blur(0);
+    scale: 1;
   }
 }

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -112,6 +112,10 @@
       --scale: 1.75;
     }
   }
+
+  * {
+    --focus-ring-color: oklch(1 0 0);
+  }
 }
 
 /* Error Dialog */

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -4,11 +4,10 @@ const previewContent = cn(
   'absolute [left:var(--preview-left,var(--media-slider-pointer))] max-w-(--max-width)',
   '-translate-x-1/2 translate-y-2 scale-80 opacity-0 blur-lg origin-bottom',
   'transition-[filter,opacity,scale] duration-150 ease-out',
-  'group-data-pointing/preview:scale-100 group-data-pointing/preview:opacity-100',
-  'group-data-pointing/preview:blur-none',
-  'group-data-interactive/preview:group-not-data-pointing/preview:group-not-data-dragging/preview:scale-100',
-  'group-data-interactive/preview:group-not-data-pointing/preview:group-not-data-dragging/preview:opacity-100',
-  'group-data-interactive/preview:group-not-data-pointing/preview:group-not-data-dragging/preview:blur-none'
+  'group-data-pointing/slider:scale-100 group-data-pointing/slider:opacity-100',
+  'group-data-pointing/slider:blur-none',
+  'group-has-focus-visible/slider:scale-100 group-has-focus-visible/slider:opacity-100',
+  'group-has-focus-visible/slider:blur-none'
 );
 
 export const slider = {
@@ -97,7 +96,7 @@ export const slider = {
     ),
   },
   preview: cn(
-    'group/preview [--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-full h-1',
+    '[--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-full h-1',
     'before:absolute before:z-1 before:bg-current/35 before:pointer-events-none',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
     'before:transition-[opacity,scale] before:duration-200 before:ease-out',

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -30,6 +30,7 @@ export const container = (isShadowDOM: boolean) =>
     '[--default-accent-color:oklch(1_0_0)]',
     '[--border-color:light-dark(oklch(0_0_0/0.15),oklch(1_0_0/0.15))]',
     '[--focus-ring-color:light-dark(oklch(0_0_0),oklch(1_0_0))]',
+    '**:[--focus-ring-color:oklch(1_0_0)]',
     '[--container-border-radius:var(--media-border-radius,0.75rem)]',
     '[--media-video-border-radius:var(--container-border-radius)]',
     '[--controls-background-color:transparent]',


### PR DESCRIPTION
- Add a little more horizontal padding to the chapter title in the slider preview. 
- Ensure the slider preview disappears even when the slider still has focus but not `:focus-visible`.
- Fix focus ring color being too dark. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/Tailwind-only presentation and focus-indicator tweaks with no logic or API changes.
> 
> **Overview**
> Polishes **default** and **minimal** video skin styling for sliders and focus rings.
> 
> **Slider preview** no longer stays open from generic “interactive” focus: thumbnail/value/chapter UI only shows while **pointing** or when the slider has **`:focus-visible`**, so a mouse-driven focus that isn’t visibly focused can hide the preview again. Tailwind mirrors this with `group-data-pointing/slider` and `group-has-focus-visible/slider` on the slider root instead of preview-scoped `data-interactive` rules.
> 
> **Default** seek preview chapter titles get **wider horizontal padding** (`spacing * 3` → `* 6` in CSS; `px-3` → `px-6` in Tailwind).
> 
> **Focus rings** on the video container force **`--focus-ring-color` to white** for all descendants (CSS `*` override and Tailwind `**:[--focus-ring-color:…]`), fixing rings that read too dark on the dark player chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fde0f1120509915e23509473bb2cb06718eeb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->