### PR TITLE
fix(packages): restore menu trigger keyboard interaction

### DIFF
--- a/apps/e2e/fixtures/presentation.ts
+++ b/apps/e2e/fixtures/presentation.ts
@@ -1,0 +1,71 @@
+import type { Page } from '@playwright/test';
+
+export async function mockPresentation(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    let fullscreenElement: Element | null = null;
+    let pipElement: Element | null = null;
+
+    Object.defineProperties(document, {
+      fullscreenElement: { configurable: true, get: () => fullscreenElement },
+      fullscreenEnabled: { configurable: true, get: () => true },
+      pictureInPictureElement: { configurable: true, get: () => pipElement },
+      pictureInPictureEnabled: { configurable: true, get: () => true },
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'requestFullscreen', {
+      configurable: true,
+      value: async function requestFullscreen(this: HTMLElement) {
+        fullscreenElement = this;
+        document.dispatchEvent(new Event('fullscreenchange'));
+      },
+    });
+
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: async () => {
+        fullscreenElement = null;
+        document.dispatchEvent(new Event('fullscreenchange'));
+      },
+    });
+
+    Object.defineProperty(HTMLVideoElement.prototype, 'requestPictureInPicture', {
+      configurable: true,
+      value: async function requestPictureInPicture(this: HTMLVideoElement) {
+        pipElement = this;
+        this.dispatchEvent(new Event('enterpictureinpicture'));
+        return {};
+      },
+    });
+
+    Object.defineProperties(HTMLVideoElement.prototype, {
+      webkitPresentationMode: {
+        configurable: true,
+        get: function webkitPresentationMode(this: HTMLVideoElement) {
+          return pipElement === this ? 'picture-in-picture' : 'inline';
+        },
+      },
+      webkitSetPresentationMode: {
+        configurable: true,
+        value: function webkitSetPresentationMode(this: HTMLVideoElement, mode: string) {
+          const wasPip = pipElement === this;
+          pipElement = mode === 'picture-in-picture' ? this : null;
+
+          if (!wasPip && pipElement === this) {
+            this.dispatchEvent(new Event('enterpictureinpicture'));
+          } else if (wasPip && pipElement !== this) {
+            this.dispatchEvent(new Event('leavepictureinpicture'));
+          }
+        },
+      },
+    });
+
+    Object.defineProperty(document, 'exitPictureInPicture', {
+      configurable: true,
+      value: async () => {
+        const video = pipElement;
+        pipElement = null;
+        video?.dispatchEvent(new Event('leavepictureinpicture'));
+      },
+    });
+  });
+}

--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -49,6 +49,8 @@ export const SELECTORS = {
   muteButton: 'media-mute-button, .media-button--mute',
   fullscreenButton: 'media-fullscreen-button, .media-button--fullscreen',
   pipButton: 'media-pip-button, .media-button--pip',
+  castButton: 'media-cast-button, .media-button--cast',
+  airPlayButton: 'media-airplay-button, .media-button--airplay',
   captionsButton: 'media-captions-button, .media-button--captions',
   playbackRateButton: [
     withinControls('media-playback-rate-button'),
@@ -82,6 +84,7 @@ export const SELECTORS = {
     '[data-type="duration"].media-time',
     '[data-type="remaining"].media-time',
   ].join(', '),
+  timeToggle: 'media-time[toggle], time.media-time[role="button"]',
   poster: 'media-poster, img[data-loaded]',
   bufferingIndicator: 'media-buffering-indicator, .media-buffering-indicator',
   thumbnail: 'media-slider-thumbnail, .media-thumbnail__image',

--- a/apps/e2e/page-objects/player.ts
+++ b/apps/e2e/page-objects/player.ts
@@ -38,6 +38,10 @@ export class PlayerPage {
     return this.page.locator(SELECTORS.timeSlider).first();
   }
 
+  get timeSliderThumb(): Locator {
+    return this.timeSlider.getByRole('slider');
+  }
+
   get muteButton(): Locator {
     return this.page.locator(SELECTORS.muteButton).first();
   }
@@ -46,12 +50,24 @@ export class PlayerPage {
     return this.page.locator(SELECTORS.volumeSlider).first();
   }
 
+  get volumeSliderThumb(): Locator {
+    return this.volumeSlider.getByRole('slider');
+  }
+
   get fullscreenButton(): Locator {
     return this.page.locator(SELECTORS.fullscreenButton).first();
   }
 
   get pipButton(): Locator {
     return this.page.locator(SELECTORS.pipButton).first();
+  }
+
+  get castButton(): Locator {
+    return this.page.locator(SELECTORS.castButton).first();
+  }
+
+  get airPlayButton(): Locator {
+    return this.page.locator(SELECTORS.airPlayButton).first();
   }
 
   get captionsButton(): Locator {
@@ -97,6 +113,10 @@ export class PlayerPage {
 
   get duration(): Locator {
     return this.page.locator(SELECTORS.duration).first();
+  }
+
+  get timeToggle(): Locator {
+    return this.page.locator(SELECTORS.timeToggle).first();
   }
 
   get thumbnail(): Locator {

--- a/apps/e2e/tests/keyboard.spec.ts
+++ b/apps/e2e/tests/keyboard.spec.ts
@@ -1,87 +1,228 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
+import { AUDIO_PAGES, type PageEntry, VIDEO_PAGES } from '../fixtures/media';
+import { mockPresentation } from '../fixtures/presentation';
 import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
-test.describe('Keyboard Navigation', () => {
-  let player: PlayerPage;
+const PAGES = [...AUDIO_PAGES, ...VIDEO_PAGES].filter(
+  ({ path }) => path.endsWith('-audio-mp4.html') || path.endsWith('-video-mp4.html')
+);
 
-  test.beforeEach(async ({ page }) => {
-    player = new PlayerPage(page);
-    await page.goto('/pages/html-video-mp4.html');
-    await player.waitForMediaReady();
+function getMediaValue(page: Page, key: 'currentTime' | 'volume'): Promise<number> {
+  return page.evaluate(
+    ({ selector, key }) => {
+      const host = document.querySelector(selector) as HTMLMediaElement | null;
+      const media = (host?.querySelector?.('video, audio') as HTMLMediaElement) ?? host;
+      return media?.[key] ?? 0;
+    },
+    { selector: SELECTORS.media, key }
+  );
+}
+
+async function expectTabFocus(page: Page, element: Locator): Promise<void> {
+  await page.keyboard.press('Tab');
+  await expect(element).toBeFocused();
+}
+
+for (const entry of PAGES as readonly PageEntry[]) {
+  const isAudio = entry.media === 'audio';
+
+  test.describe(`Keyboard Navigation — ${entry.name}`, () => {
+    let player: PlayerPage;
+
+    test.beforeEach(async ({ page }) => {
+      if (!isAudio) await mockPresentation(page);
+      player = new PlayerPage(page);
+      await page.goto(entry.path);
+      await player.waitForMediaReady();
+      await player.showControls();
+    });
+
+    test('tabs through every available control', async ({ browserName, page }) => {
+      await player.playerRoot.evaluate((root) => {
+        const before = document.createElement('button');
+        const after = document.createElement('button');
+        before.tabIndex = 0;
+        after.tabIndex = 0;
+        before.dataset.focusSentinel = 'before';
+        after.dataset.focusSentinel = 'after';
+        root.before(before);
+        root.after(after);
+      });
+      const before = page.locator('[data-focus-sentinel="before"]');
+      const after = page.locator('[data-focus-sentinel="after"]');
+      await before.focus();
+
+      await expectTabFocus(page, player.playerRoot);
+      if (!isAudio && browserName === 'firefox') {
+        await expectTabFocus(page, page.locator('video').first());
+      }
+      await expectTabFocus(page, player.playButton);
+
+      if (isAudio) {
+        await expectTabFocus(page, player.seekBackward);
+        await expectTabFocus(page, player.seekForward);
+      } else {
+        await expectTabFocus(page, player.muteButton);
+        await expect(player.volumeSlider).toBeVisible();
+        await expectTabFocus(page, player.volumeSliderThumb);
+      }
+
+      await expectTabFocus(page, player.timeSliderThumb);
+      await expectTabFocus(page, player.timeToggle);
+
+      if (isAudio) {
+        await expectTabFocus(page, player.playbackRateButton);
+        await expectTabFocus(page, player.muteButton);
+        await expect(player.volumeSlider).toBeVisible();
+        await expectTabFocus(page, player.volumeSliderThumb);
+      } else {
+        // WebKit follows Safari's default keyboard-access policy for native buttons.
+        if (browserName !== 'webkit') await expectTabFocus(page, player.settingsButton);
+        for (const control of [player.castButton, player.airPlayButton, player.pipButton, player.fullscreenButton]) {
+          if (await control.isVisible()) await expectTabFocus(page, control);
+        }
+      }
+
+      await page.keyboard.press('Tab');
+      await expect(after).toBeFocused();
+      if (isAudio) await expect(player.volumeSlider).toBeHidden();
+      await page.keyboard.press('Shift+Tab');
+      await expect(isAudio ? player.muteButton : player.fullscreenButton).toBeFocused();
+    });
+
+    test('operates buttons, sliders, and time display from the keyboard', async ({ page }) => {
+      await player.playButton.focus();
+      await page.keyboard.press('Space');
+      await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused);
+      await page.keyboard.press('Enter');
+      await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
+
+      await player.timeSliderThumb.focus();
+      const timeBefore = await getMediaValue(page, 'currentTime');
+      await page.keyboard.press('ArrowRight');
+      await expect.poll(() => getMediaValue(page, 'currentTime')).toBeGreaterThan(timeBefore);
+      await page.keyboard.press('Home');
+      await expect.poll(() => getMediaValue(page, 'currentTime')).toBe(0);
+
+      const timeType = await player.timeToggle.getAttribute('data-type');
+      await player.timeToggle.focus();
+      await page.keyboard.press('Enter');
+      await expect(player.timeToggle).not.toHaveAttribute('data-type', timeType!);
+      await page.keyboard.press('Space');
+      await expect(player.timeToggle).toHaveAttribute('data-type', timeType!);
+
+      await player.muteButton.focus();
+      await page.keyboard.press('Space');
+      await expect(player.muteButton).not.toHaveAttribute(DATA_ATTRS.muted);
+      await page.keyboard.press('Enter');
+      await expect(player.muteButton).toHaveAttribute(DATA_ATTRS.muted, '');
+
+      await expect(player.volumeSlider).toBeVisible();
+      await player.volumeSliderThumb.focus();
+      await page.keyboard.press('End');
+      await expect.poll(() => getMediaValue(page, 'volume')).toBe(1);
+      await page.keyboard.press('ArrowDown');
+      await expect.poll(() => getMediaValue(page, 'volume')).toBeLessThan(1);
+
+      if (isAudio) {
+        await player.seekTo(50);
+        const middle = await getMediaValue(page, 'currentTime');
+        await player.seekBackward.focus();
+        await page.keyboard.press('Enter');
+        await expect.poll(() => getMediaValue(page, 'currentTime')).toBeLessThan(middle);
+        const back = await getMediaValue(page, 'currentTime');
+        await player.seekForward.focus();
+        await page.keyboard.press('Space');
+        await expect.poll(() => getMediaValue(page, 'currentTime')).toBeGreaterThan(back);
+      } else {
+        await player.pipButton.focus();
+        await page.keyboard.press('Enter');
+        await expect(player.pipButton).toHaveAttribute(DATA_ATTRS.pip, '');
+        await page.keyboard.press('Space');
+        await expect(player.pipButton).not.toHaveAttribute(DATA_ATTRS.pip);
+
+        await player.fullscreenButton.focus();
+        await page.keyboard.press('Enter');
+        await expect(player.fullscreenButton).toHaveAttribute(DATA_ATTRS.fullscreen, '');
+        await page.keyboard.press('Space');
+        await expect(player.fullscreenButton).not.toHaveAttribute(DATA_ATTRS.fullscreen);
+      }
+    });
+
+    if (isAudio) {
+      test('navigates the playback rate menu and restores focus', async ({ page }) => {
+        const trigger = player.playbackRateButton;
+        const menu = page.getByRole('menu');
+        const checkedOption = menu.getByRole('menuitemradio', { checked: true });
+        const focusedOption = menu.locator('[role="menuitemradio"]:focus');
+
+        await trigger.focus();
+        await page.keyboard.press('Enter');
+        await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        await expect(checkedOption).toBeFocused();
+
+        await page.keyboard.press('Escape');
+        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        await expect(trigger).toBeFocused();
+
+        await page.keyboard.press('Space');
+        await expect(checkedOption).toBeFocused();
+        await page.keyboard.press('ArrowDown');
+        await expect(focusedOption).toBeFocused();
+        const nextRate = await focusedOption.getAttribute(DATA_ATTRS.rate);
+        expect(nextRate).not.toBeNull();
+
+        await page.keyboard.press('Enter');
+        await expect(trigger).toHaveAttribute(DATA_ATTRS.rate, nextRate!);
+        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        await expect(trigger).toBeFocused();
+
+        await page.keyboard.press('Enter');
+        await expect(menu.getByRole('menuitemradio', { checked: true })).toBeFocused();
+        await page.keyboard.press('Tab');
+        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        await expect(player.muteButton).toBeFocused();
+      });
+    } else {
+      test('operates captions with Enter and Space when a track is available', async ({ page }) => {
+        await page.evaluate(() => {
+          const video = document.querySelector('video');
+          if (!video) return;
+
+          const track = document.createElement('track');
+          track.kind = 'subtitles';
+          track.label = 'English';
+          track.srclang = 'en';
+          track.src = `data:text/vtt,${encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:30.000\nTest caption')}`;
+          video.append(track);
+        });
+
+        await expect(player.captionsButton).toBeVisible();
+        await player.captionsButton.focus();
+        await page.keyboard.press('Space');
+        await expect(player.captionsButton).toHaveAttribute(DATA_ATTRS.active, '');
+        await page.keyboard.press('Enter');
+        await expect(player.captionsButton).not.toHaveAttribute(DATA_ATTRS.active);
+      });
+
+      test('navigates settings submenus and restores focus', async ({ page }) => {
+        await player.settingsButton.focus();
+        await page.keyboard.press('Enter');
+        await expect(player.settingsSpeedItem).toBeFocused();
+
+        await page.keyboard.press('ArrowRight');
+        await expect(player.activeMenuPanel).toBeVisible();
+        await expect(player.activeMenuPanel.getByRole('menuitem').first()).toBeFocused();
+
+        await page.keyboard.press('ArrowLeft');
+        await expect(player.activeMenuPanel).not.toBeVisible();
+        await expect(player.settingsSpeedItem).toBeFocused();
+
+        await page.keyboard.press('Escape');
+        await expect(player.settingsButton).toHaveAttribute('aria-expanded', 'false');
+        await expect(player.settingsButton).toBeFocused();
+      });
+    }
   });
-
-  test('Space key toggles play/pause on play button', async ({ page }) => {
-    await player.playButton.focus();
-    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
-
-    await page.keyboard.press('Space');
-    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused);
-
-    await page.keyboard.press('Space');
-    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
-  });
-
-  test('Enter key toggles play/pause on play button', async ({ page }) => {
-    await player.playButton.focus();
-    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
-
-    await page.keyboard.press('Enter');
-    await expect(player.playButton).not.toHaveAttribute(DATA_ATTRS.paused);
-
-    await page.keyboard.press('Enter');
-    await expect(player.playButton).toHaveAttribute(DATA_ATTRS.paused, '');
-  });
-
-  test('Tab navigates between controls', async ({ page }) => {
-    await player.playButton.focus();
-    await expect(player.playButton).toBeFocused();
-
-    await page.keyboard.press('Tab');
-    await expect(player.playButton).not.toBeFocused();
-  });
-
-  test('Enter and Space toggle the time control', async ({ page }) => {
-    const time = page.locator('media-time[toggle]').first();
-
-    await expect(time).toHaveAttribute('data-type', 'remaining');
-    await expect(time).toHaveAttribute('role', 'button');
-    await time.focus();
-
-    await page.keyboard.press('Enter');
-    await expect(time).toHaveAttribute('data-type', 'duration');
-
-    await page.keyboard.press('Space');
-    await expect(time).toHaveAttribute('data-type', 'remaining');
-  });
-
-  test('Arrow keys adjust time slider', async ({ page }) => {
-    // Seek somewhere first so arrow keys have room to adjust
-    await player.seekTo(50);
-
-    // The slider thumb (role="slider") receives keyboard focus, not the slider root
-    const sliderThumb = page.locator(SELECTORS.sliderThumb).first();
-    await sliderThumb.focus();
-
-    // Press ArrowRight — should trigger a seek (data-started is already set from seekTo)
-    const timeBefore = await player.currentTime.textContent();
-    await page.keyboard.press('ArrowRight');
-    await page.waitForTimeout(500);
-
-    // Time should have changed after arrow key
-    const timeAfter = await player.currentTime.textContent();
-    expect(timeAfter).not.toBe(timeBefore);
-  });
-
-  test('Space key toggles mute on mute button', async ({ page }) => {
-    await player.muteButton.focus();
-    // Media starts muted (see PlayerPage.waitForMediaReady)
-    await expect(player.muteButton).toHaveAttribute(DATA_ATTRS.muted, '');
-
-    await page.keyboard.press('Space');
-    await expect(player.muteButton).not.toHaveAttribute(DATA_ATTRS.muted);
-
-    await page.keyboard.press('Space');
-    await expect(player.muteButton).toHaveAttribute(DATA_ATTRS.muted, '');
-  });
-});
+}

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -1,10 +1,10 @@
 import { expect, type Page, test } from '@playwright/test';
 import { ALL_VIDEO_PAGES, type PageEntry, VIDEO_PAGES } from '../fixtures/media';
+import { mockPresentation } from '../fixtures/presentation';
 import { DATA_ATTRS, SELECTORS } from '../fixtures/selectors';
 import { PlayerPage } from '../page-objects/player';
 
 const UI_VIDEO_PAGES = VIDEO_PAGES.filter(({ media }) => media === 'video');
-const KEYBOARD_MENU_PAGES = UI_VIDEO_PAGES.filter(({ path }) => path.endsWith('video-mp4.html'));
 const EJECTED_HTML_VIDEO_PATH = '/pages/ejected-html-video-mp4.html';
 
 function getMediaVolume(page: Page): Promise<number> {
@@ -13,76 +13,6 @@ function getMediaVolume(page: Page): Promise<number> {
     const actual = (media?.querySelector?.('video') as HTMLMediaElement) ?? media;
     return actual?.volume ?? 1;
   }, SELECTORS.media);
-}
-
-async function mockPresentation(page: Page): Promise<void> {
-  await page.addInitScript(() => {
-    let fullscreenElement: Element | null = null;
-    let pipElement: Element | null = null;
-
-    Object.defineProperties(document, {
-      fullscreenElement: { configurable: true, get: () => fullscreenElement },
-      fullscreenEnabled: { configurable: true, get: () => true },
-      pictureInPictureElement: { configurable: true, get: () => pipElement },
-      pictureInPictureEnabled: { configurable: true, get: () => true },
-    });
-
-    Object.defineProperty(HTMLElement.prototype, 'requestFullscreen', {
-      configurable: true,
-      value: async function requestFullscreen(this: HTMLElement) {
-        fullscreenElement = this;
-        document.dispatchEvent(new Event('fullscreenchange'));
-      },
-    });
-
-    Object.defineProperty(document, 'exitFullscreen', {
-      configurable: true,
-      value: async () => {
-        fullscreenElement = null;
-        document.dispatchEvent(new Event('fullscreenchange'));
-      },
-    });
-
-    Object.defineProperty(HTMLVideoElement.prototype, 'requestPictureInPicture', {
-      configurable: true,
-      value: async function requestPictureInPicture(this: HTMLVideoElement) {
-        pipElement = this;
-        this.dispatchEvent(new Event('enterpictureinpicture'));
-        return {};
-      },
-    });
-
-    Object.defineProperties(HTMLVideoElement.prototype, {
-      webkitPresentationMode: {
-        configurable: true,
-        get: function webkitPresentationMode(this: HTMLVideoElement) {
-          return pipElement === this ? 'picture-in-picture' : 'inline';
-        },
-      },
-      webkitSetPresentationMode: {
-        configurable: true,
-        value: function webkitSetPresentationMode(this: HTMLVideoElement, mode: string) {
-          const wasPip = pipElement === this;
-          pipElement = mode === 'picture-in-picture' ? this : null;
-
-          if (!wasPip && pipElement === this) {
-            this.dispatchEvent(new Event('enterpictureinpicture'));
-          } else if (wasPip && pipElement !== this) {
-            this.dispatchEvent(new Event('leavepictureinpicture'));
-          }
-        },
-      },
-    });
-
-    Object.defineProperty(document, 'exitPictureInPicture', {
-      configurable: true,
-      value: async () => {
-        const video = pipElement;
-        pipElement = null;
-        video?.dispatchEvent(new Event('leavepictureinpicture'));
-      },
-    });
-  });
 }
 
 for (const { name, path, skipBrowsers } of ALL_VIDEO_PAGES as readonly PageEntry[]) {
@@ -200,36 +130,6 @@ test.describe('Video Controls — Ejected HTML registration', () => {
     expect(errors).toEqual([]);
   });
 });
-
-for (const { name, path } of KEYBOARD_MENU_PAGES) {
-  test(`${name} restores submenu focus and continues keyboard navigation`, async ({ page }) => {
-    const player = new PlayerPage(page);
-    await page.goto(path);
-    await player.waitForMediaReady();
-    await player.showControls();
-
-    await player.settingsButton.focus();
-    await page.keyboard.press('Enter');
-    await expect(player.settingsSpeedItem).toBeVisible();
-    await expect(player.settingsSpeedItem).toBeFocused();
-
-    await page.keyboard.press('ArrowRight');
-    await expect(player.activeMenuPanel).toBeVisible();
-    await expect(player.activeMenuPanel.getByRole('menuitem').first()).toBeFocused();
-
-    await page.keyboard.press('ArrowLeft');
-    await expect(player.activeMenuPanel).not.toBeVisible();
-    await expect(player.settingsSpeedItem).toBeFocused();
-
-    await page.keyboard.press('ArrowDown');
-    await expect(page.locator('[role="menuitem"]:focus')).toHaveCount(1);
-
-    await page.keyboard.press('Tab');
-    await expect(player.settingsButton).toHaveAttribute('aria-expanded', 'false');
-    await expect(player.settingsSpeedItem).not.toBeFocused();
-    await expect(page.locator('body')).not.toBeFocused();
-  });
-}
 
 for (const { name, path } of UI_VIDEO_PAGES) {
   test.describe(`Video Controls — ${name} UI`, () => {

--- a/packages/html/src/ui/playback-rate-button/playback-rate-button-element.ts
+++ b/packages/html/src/ui/playback-rate-button/playback-rate-button-element.ts
@@ -5,7 +5,6 @@ import type { MediaPlaybackRateState } from '@videojs/media';
 
 import { playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
-import { toggleCommandTarget } from '../command-for';
 import { MediaButtonElement } from '../media-button-element';
 
 export class PlaybackRateButtonElement extends MediaButtonElement<PlaybackRateButtonCore> {
@@ -27,7 +26,9 @@ export class PlaybackRateButtonElement extends MediaButtonElement<PlaybackRateBu
   protected activate(state: MediaPlaybackRateState, event?: UIEvent): void {
     if (this.commandfor) {
       if (event instanceof KeyboardEvent) {
-        toggleCommandTarget(this, this.commandfor);
+        // Custom elements do not synthesize a click from keyboard activation.
+        // Dispatch one so the linked menu follows its normal open lifecycle.
+        this.click();
       }
       return;
     }

--- a/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
+++ b/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
@@ -233,6 +233,7 @@ describe('PlaybackRateButtonElement', () => {
 
     await waitForAssertion(() => {
       expect(menu.open).toBe(true);
+      expect(menu.querySelector('[role="menuitemradio"][aria-checked="true"]')).toBe(document.activeElement);
     });
   });
 
@@ -246,6 +247,7 @@ describe('PlaybackRateButtonElement', () => {
 
     await waitForAssertion(() => {
       expect(menu.open).toBe(true);
+      expect(menu.querySelector('[role="menuitemradio"][aria-checked="true"]')).toBe(document.activeElement);
     });
   });
 

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -2,6 +2,7 @@
 
 import type { MenuCore, MenuState } from '@videojs/core';
 import { isMenuNavigationKey } from '@videojs/core/dom';
+import { isInteractiveActivation } from '@videojs/utils/dom';
 import { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import type { UIComponentProps } from '../../utils/types';
@@ -99,7 +100,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
         return;
       }
 
-      if (event.key === 'Enter' || event.key === ' ') {
+      if (isInteractiveActivation(event.nativeEvent)) {
         event.preventDefault();
         menu.triggerProps.onClick(event.nativeEvent);
         return;

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -90,20 +90,33 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
     [menu]
   );
 
-  const rootTriggerProps = useMemo(() => {
-    if (!disabled) return menu.triggerProps;
+  const handleRootKeyDown = useCallback(
+    (event: React.KeyboardEvent<MenuTriggerElement>) => {
+      const defaultPreventedByUser = callKeyDownHandler(onKeyDown, event);
 
-    return {
-      onClick: (event: React.MouseEvent<HTMLElement>) => {
+      if (disabled || defaultPreventedByUser) {
+        if (disabled && isMenuNavigationKey(event)) event.preventDefault();
+        return;
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
-      },
-      onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
-        if (event.key === 'Enter' || event.key === ' ' || isMenuNavigationKey(event)) {
-          event.preventDefault();
-        }
-      },
-    };
-  }, [disabled, menu.triggerProps]);
+        menu.triggerProps.onClick(event);
+        return;
+      }
+
+      menu.triggerProps.onKeyDown(event);
+    },
+    [disabled, menu.triggerProps, onKeyDown]
+  );
+
+  const rootTriggerProps = useMemo(
+    () => ({
+      onClick: disabled ? (event: React.MouseEvent<HTMLElement>) => event.preventDefault() : menu.triggerProps.onClick,
+      onKeyDown: handleRootKeyDown,
+    }),
+    [disabled, handleRootKeyDown, menu.triggerProps]
+  );
 
   // Submenu trigger mode — renders as a div with role="menuitem"
   if (isSubMenuTrigger) {

--- a/packages/react/src/ui/menu/menu-trigger.tsx
+++ b/packages/react/src/ui/menu/menu-trigger.tsx
@@ -101,7 +101,7 @@ export const MenuTrigger = forwardRef<HTMLButtonElement | HTMLDivElement, MenuTr
 
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
-        menu.triggerProps.onClick(event);
+        menu.triggerProps.onClick(event.nativeEvent);
         return;
       }
 

--- a/packages/react/src/ui/menu/tests/menu.test.tsx
+++ b/packages/react/src/ui/menu/tests/menu.test.tsx
@@ -424,6 +424,39 @@ describe('MenuContent', () => {
     });
   });
 
+  it.each(['Enter', ' '])('opens a root menu with %j', async (key) => {
+    render(
+      <MenuRoot>
+        <MenuTrigger data-testid="trigger">Settings</MenuTrigger>
+        <MenuContent data-testid="content">Settings</MenuContent>
+      </MenuRoot>
+    );
+
+    const trigger = screen.getByTestId('trigger');
+    fireEvent.keyDown(trigger, { key });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('content')).not.toBeNull();
+    });
+  });
+
+  it('honors preventDefault from root trigger key handlers', () => {
+    const onKeyDown = vi.fn((event: ReactKeyboardEvent<HTMLElement>) => event.preventDefault());
+    render(
+      <MenuRoot>
+        <MenuTrigger data-testid="trigger" onKeyDown={onKeyDown}>
+          Settings
+        </MenuTrigger>
+        <MenuContent data-testid="content">Settings</MenuContent>
+      </MenuRoot>
+    );
+
+    fireEvent.keyDown(screen.getByTestId('trigger'), { key: 'Enter' });
+
+    expect(onKeyDown).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId('content')).toBeNull();
+  });
+
   it('waits for a controlled owner to commit requested open changes', async () => {
     const onOpenChange = vi.fn();
     const renderMenu = (open: boolean) => (


### PR DESCRIPTION
Closes #2233

## Summary

Restore keyboard activation for standalone playback-rate menus and preserve the normal menu focus lifecycle in both React and HTML players.

## Changes

- Open React root menu triggers with Enter and Space while respecting disabled and consumer-prevented events
- Route HTML playback-rate keyboard activation through the menu trigger click lifecycle so the selected option receives focus
- Cover keyboard traversal and operation across representative HTML and React audio/video players

## Testing

- `pnpm -F @videojs/react test src/ui/menu/tests/menu.test.tsx`
- `pnpm -F @videojs/html test src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts`
- `pnpm --dir apps/e2e exec playwright test tests/keyboard.spec.ts --project=vite-chromium --project=vite-webkit --project=vite-firefox` (42 passed)
- Biome and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared menu trigger behavior in React and HTML player UI; regressions could affect keyboard/mouse menu opening, but changes are covered by unit and broad e2e keyboard tests.
> 
> **Overview**
> **Menu keyboard activation** is fixed on both stacks. React `MenuTrigger` now runs the same open path as a click on **Enter** and **Space**, while still honoring **disabled** state and **`preventDefault`** from consumer `onKeyDown` handlers. The HTML playback-rate button with `commandfor` no longer toggles the linked menu directly on keyboard; it **`click()`**s so the menu follows its normal open lifecycle and focus lands on the checked rate option.
> 
> **E2E** gains a shared **`mockPresentation`** fixture (fullscreen/PIP shims), extra selectors/page-object locators (cast, airplay, time toggle, slider thumbs), and **`keyboard.spec.ts`** is rewritten to run tab order and keyboard operation across representative MP4 audio/video demo pages—including playback-rate and settings menus—while the overlapping settings-submenu test is removed from **`video-controls.spec.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4461afa1a32f56603a93e0147a4c9c25b0efde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->