### PR TITLE
feat(core): prefer locale-matched captions on toggle

### DIFF
--- a/packages/core/src/dom/store/features/tests/text-track.test.ts
+++ b/packages/core/src/dom/store/features/tests/text-track.test.ts
@@ -1,5 +1,5 @@
 import { createStore } from '@videojs/store';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { PlayerTarget } from '../../../player';
 import { textTrackFeature } from '../text-track';
 
@@ -202,6 +202,63 @@ describe('textTrackFeature', () => {
       expect(disabled).toBe(false);
       expect(subtitlesTrack.mode).toBe('disabled');
       expect(captionsTrack.mode).toBe('disabled');
+    });
+
+    it('toggleSubtitles() prefers an exact browser locale match', () => {
+      const language = vi.spyOn(navigator, 'language', 'get').mockReturnValue('fr-CA');
+      const video = createVideo();
+      const frenchTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-fr', language: 'fr-FR' });
+      const canadianTrack = createMockTrack('subtitles', 'disabled', {
+        id: 'subtitles-fr-ca',
+        language: 'fr-CA',
+      });
+      mockTextTracks(video, [frenchTrack, canadianTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.toggleSubtitles()).toBe(true);
+      expect(frenchTrack.mode).toBe('disabled');
+      expect(canadianTrack.mode).toBe('showing');
+
+      language.mockRestore();
+    });
+
+    it('toggleSubtitles() falls back from a regional browser locale to its language', () => {
+      const language = vi.spyOn(navigator, 'language', 'get').mockReturnValue('fr-BE');
+      const video = createVideo();
+      const canadianTrack = createMockTrack('subtitles', 'disabled', {
+        id: 'subtitles-fr-ca',
+        language: 'fr-CA',
+      });
+      const frenchTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-fr', language: 'fr' });
+      mockTextTracks(video, [canadianTrack, frenchTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.toggleSubtitles()).toBe(true);
+      expect(canadianTrack.mode).toBe('disabled');
+      expect(frenchTrack.mode).toBe('showing');
+
+      language.mockRestore();
+    });
+
+    it('toggleSubtitles() uses the first track when the browser locale does not match', () => {
+      const language = vi.spyOn(navigator, 'language', 'get').mockReturnValue('fr-BE');
+      const video = createVideo();
+      const spanishTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-es', language: 'es' });
+      const englishTrack = createMockTrack('subtitles', 'disabled', { id: 'subtitles-en', language: 'en' });
+      mockTextTracks(video, [spanishTrack, englishTrack]);
+
+      const store = createStore<PlayerTarget>()(textTrackFeature);
+      store.attach({ media: video, container: null });
+
+      expect(store.state.toggleSubtitles()).toBe(true);
+      expect(spanishTrack.mode).toBe('showing');
+      expect(englishTrack.mode).toBe('disabled');
+
+      language.mockRestore();
     });
 
     it('toggleSubtitles() restores the track that was showing', () => {

--- a/packages/core/src/dom/store/features/text-track.ts
+++ b/packages/core/src/dom/store/features/text-track.ts
@@ -7,6 +7,7 @@ import type {
 } from '@videojs/media';
 import { isMediaTextTrackCapable, isQuerySelectorAllCapable } from '@videojs/media';
 import { findTrackElement, isCaptionOrSubtitleTrack, listen } from '@videojs/utils/dom';
+import { DEFAULT_LOCALE, findLocaleKeys, getCanonicalLocaleKey } from '../../../core/i18n';
 import { definePlayerFeature } from '../../feature';
 
 interface IdentifiedTrack {
@@ -35,6 +36,24 @@ function showOnly(tracks: IdentifiedTrack[], active: TextTrackLike | null): void
     const mode = track === active ? 'showing' : 'disabled';
     if (track.mode !== mode) track.mode = mode;
   }
+}
+
+function findLocaleTrack(tracks: IdentifiedTrack[], locale: string): IdentifiedTrack | undefined {
+  const localeKey = getCanonicalLocaleKey(locale);
+  const keys = findLocaleKeys(locale);
+
+  // Translation lookup falls back to English; caption selection should not.
+  if (localeKey !== DEFAULT_LOCALE && !localeKey.startsWith(`${DEFAULT_LOCALE}-`)) keys.pop();
+
+  for (const key of keys) {
+    const exact = tracks.find(({ track }) => getCanonicalLocaleKey(track.language) === key);
+    if (exact) return exact;
+
+    const regional = tracks.find(({ track }) => getCanonicalLocaleKey(track.language).startsWith(`${key}-`));
+    if (regional) return regional;
+  }
+
+  return undefined;
 }
 
 export const textTrackFeature = definePlayerFeature({
@@ -67,9 +86,13 @@ export const textTrackFeature = definePlayerFeature({
           return false;
         }
 
-        // Restore the remembered track, falling back to the first one the
-        // captions menu offers when there is nothing to restore.
-        const next = showing ?? subtitlesTracks.find(({ id }) => id === lastShownId) ?? subtitlesTracks[0]!;
+        // Restore the remembered track, then prefer the browser locale before
+        // falling back to the first track the captions menu offers.
+        const next =
+          showing ??
+          subtitlesTracks.find(({ id }) => id === lastShownId) ??
+          findLocaleTrack(subtitlesTracks, globalThis.navigator?.language ?? '') ??
+          subtitlesTracks[0]!;
         lastShownId = next.id;
         showOnly(subtitlesTracks, next.track);
 


### PR DESCRIPTION
Closes #1423

## Summary

Prefer captions matching the browser locale when a viewer enables captions for the first time. Previously selected tracks still take precedence, and unmatched locales retain the existing first-track fallback.

## Changes

- Match caption and subtitle languages against `navigator.language`
- Prefer exact BCP 47 matches before progressively broader language matches
- Preserve remembered user selections and avoid the translation-specific English fallback

## Testing

- `pnpm -F @videojs/core test` — 1,437 tests passed
- `pnpm -F @videojs/core build`
- `pnpm exec biome check packages/core/src/dom/store/features/text-track.ts packages/core/src/dom/store/features/tests/text-track.test.ts`

Repository-wide `pnpm typecheck` remains blocked by existing SPF metadata errors in unchanged files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized default track selection only affects subtitle toggle when no prior choice exists; remembered selections and explicit picks are unchanged.
> 
> **Overview**
> **`toggleSubtitles()`** now picks a caption/subtitle track from **`navigator.language`** when nothing is already showing and there is no remembered selection—instead of always using the first menu track.
> 
> Selection walks the same BCP 47 chain as i18n (**exact tag**, then broader language, then regional variants on tracks). The **English translation fallback is stripped** for non-English browser locales so captions are not auto-selected to English just because UI strings would fall back there. **Previously shown or explicitly selected tracks still win.**
> 
> New unit tests mock **`navigator.language`** for exact match, language fallback, and no-match → first track.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e27e467af0bbf851330c422697994fa93a65244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->