### PR TITLE
fix(core): include menu triggers in tab order

### DIFF
--- a/apps/e2e/tests/keyboard.spec.ts
+++ b/apps/e2e/tests/keyboard.spec.ts
@@ -77,8 +77,7 @@ for (const entry of PAGES as readonly PageEntry[]) {
         await expect(player.volumeSlider).toBeVisible();
         await expectTabFocus(page, player.volumeSliderThumb);
       } else {
-        // WebKit follows Safari's default keyboard-access policy for native buttons.
-        if (browserName !== 'webkit') await expectTabFocus(page, player.settingsButton);
+        await expectTabFocus(page, player.settingsButton);
         for (const control of [player.castButton, player.airPlayButton, player.pipButton, player.fullscreenButton]) {
           if (await control.isVisible()) await expectTabFocus(page, control);
         }

--- a/packages/core/src/core/ui/menu/menu-core.ts
+++ b/packages/core/src/core/ui/menu/menu-core.ts
@@ -83,6 +83,7 @@ export class MenuCore {
 
   getTriggerAttrs(state: MenuState, contentId?: string) {
     return {
+      ...(!state.isSubmenu && { tabIndex: 0 }),
       'aria-haspopup': 'menu' as const,
       'aria-expanded': state.open && state.status !== 'ending' ? 'true' : 'false',
       'aria-controls': contentId,

--- a/packages/core/src/core/ui/menu/tests/menu-core.test.ts
+++ b/packages/core/src/core/ui/menu/tests/menu-core.test.ts
@@ -100,6 +100,7 @@ describe('MenuCore', () => {
       const state = core.getState();
       const attrs = core.getTriggerAttrs(state);
 
+      expect(attrs.tabIndex).toBe(0);
       expect(attrs['aria-haspopup']).toBe('menu');
       expect(attrs['aria-expanded']).toBe('false');
       expect(attrs['aria-controls']).toBeUndefined();
@@ -131,6 +132,16 @@ describe('MenuCore', () => {
       const attrs = core.getTriggerAttrs(state, 'my-menu');
 
       expect(attrs['aria-controls']).toBe('my-menu');
+    });
+
+    it('leaves submenu tabindex to roving focus management', () => {
+      const core = new MenuCore();
+      core.setProps({ isSubmenu: true });
+      core.setInput(createInput());
+      const state = core.getState();
+      const attrs = core.getTriggerAttrs(state);
+
+      expect('tabIndex' in attrs).toBe(false);
     });
   });
 

--- a/packages/html/src/ui/menu/tests/menu-element.test.ts
+++ b/packages/html/src/ui/menu/tests/menu-element.test.ts
@@ -185,6 +185,7 @@ describe('MenuElement', () => {
     document.body.append(trigger, root);
     await root.updateComplete;
 
+    expect(trigger.getAttribute('tabindex')).toBe('0');
     expect(root.getAttribute('data-side')).toBe('bottom');
   });
 

--- a/packages/react/src/ui/menu/tests/menu.test.tsx
+++ b/packages/react/src/ui/menu/tests/menu.test.tsx
@@ -387,6 +387,17 @@ function DynamicMenuFixture({ showCaptions }: { showCaptions: boolean }) {
 }
 
 describe('MenuContent', () => {
+  it('includes the root trigger in sequential focus', () => {
+    render(
+      <MenuRoot>
+        <MenuTrigger>Settings</MenuTrigger>
+        <MenuContent>Playback speed</MenuContent>
+      </MenuRoot>
+    );
+
+    expect(screen.getByRole('button', { name: 'Settings' }).getAttribute('tabindex')).toBe('0');
+  });
+
   it('only links triggers to rendered menu content', async () => {
     render(<SubmenuFixture />);
 


### PR DESCRIPTION
## Summary

Ensure root menu triggers explicitly participate in sequential keyboard focus across WebKit platforms. This keeps the Settings control in a consistent tab order instead of compensating for platform differences in the E2E test.

## Changes

- Add `tabIndex: 0` to root menu trigger attributes while leaving submenu tabindex to roving focus management
- Verify the explicit attribute through Core, HTML, and React tests
- Require Settings in the E2E tab order while continuing to check AirPlay, Cast, PiP, and fullscreen according to visibility

## Testing

- `pnpm -F @videojs/core test src/core/ui/menu/tests/menu-core.test.ts`
- `pnpm -F @videojs/html test src/ui/menu/tests/menu-element.test.ts`
- `pnpm -F @videojs/react test src/ui/menu/tests/menu.test.tsx`
- `pnpm -F @videojs/core build`
- `pnpm typecheck`
- Biome check for all changed files
- `git diff --check`

Focused Playwright runs could not complete locally because the Vite pages timed out during navigation before reaching test assertions in both Chromium and WebKit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small accessibility attribute change with explicit submenu exclusion and broad test updates; no auth, data, or API surface changes.
> 
> **Overview**
> Root **menu triggers** now get **`tabIndex: 0`** from `MenuCore.getTriggerAttrs`, so Settings and other top-level menu buttons stay in the normal Tab sequence—including on WebKit, where native button focus behavior was inconsistent.
> 
> **Submenu** triggers still omit `tabIndex` so roving focus inside menus is unchanged. Coverage was added in core, HTML, and React tests, and the keyboard E2E no longer skips the Settings control on WebKit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1733b1e6451420df80efac9321f633e2935ffc5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->