### PR TITLE
docs(site): document mute availability

### DIFF
--- a/site/src/content/docs/concepts/features.mdx
+++ b/site/src/content/docs/concepts/features.mdx
@@ -155,7 +155,7 @@ playback?.play();
 
 ### Checking for feature support
 
-Volume, fullscreen, and picture-in-picture expose an `*Availability` property because platform support varies. For example, iOS Safari doesn't allow programmatic volume control.
+Volume, fullscreen, and picture-in-picture expose availability properties because platform support varies. Volume has two independent properties: `volumeAvailability` for changing the volume level and `mutedAvailability` for toggling mute. For example, iOS Safari allows muting but doesn't allow programmatic volume control.
 
 | Value | Meaning |
 |---|---|
@@ -163,7 +163,7 @@ Volume, fullscreen, and picture-in-picture expose an `*Availability` property be
 | `'unavailable'` | Could work, not ready yet |
 | `'unsupported'` | Platform can never do this |
 
-Components that depend on availability (like <DocsLink slug="reference/pip-button">`PiPButton`</DocsLink> and <DocsLink slug="reference/fullscreen-button">`FullscreenButton`</DocsLink>) handle the three states for you:
+Components that depend on availability (like <DocsLink slug="reference/mute-button">`MuteButton`</DocsLink>, <DocsLink slug="reference/pip-button">`PiPButton`</DocsLink>, and <DocsLink slug="reference/fullscreen-button">`FullscreenButton`</DocsLink>) handle the three states for you:
 
 - **`unsupported`** — the HTML custom element receives the native `hidden` attribute (and `data-hidden`); React buttons return `null`. No CSS needed.
 - **`unavailable`** — the presentation controls stay hidden while capability detection is unresolved. Cast remains visible but disabled when its API is supported and no device is reachable.

--- a/site/src/content/docs/how-to/build-your-own-component.mdx
+++ b/site/src/content/docs/how-to/build-your-own-component.mdx
@@ -40,7 +40,7 @@ Need access to player state or actions? You'll want to familiarize yourself with
 
 Browse the full list in the **Features** section of the sidebar.
 
-Each feature also has an **availability** property (`'available'`, `'unavailable'`, or `'unsupported'`) for hiding controls the platform does not support. See <DocsLink slug="concepts/features">Features</DocsLink> for details.
+Features for platform-dependent capabilities also expose one or more **availability** properties (`'available'`, `'unavailable'`, or `'unsupported'`) for hiding controls the platform does not support. See <DocsLink slug="concepts/features">Features</DocsLink> for details.
 
 <FrameworkCase frameworks={["react"]}>
 

--- a/site/src/content/docs/reference/feature-volume.mdx
+++ b/site/src/content/docs/reference/feature-volume.mdx
@@ -7,7 +7,7 @@ import FeatureReference from "@/components/docs/api-reference/FeatureReference.a
 import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 
-Controls volume level and mute state.
+Controls volume level and mute state. These capabilities have independent availability values because media can support mute without supporting volume-level changes.
 
 <FeatureReference feature="volume" />
 
@@ -15,10 +15,14 @@ Controls volume level and mute state.
 
 <FrameworkCase frameworks={["react"]}>
 Pass `selectVolume` to <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> to subscribe to volume state. Returns `undefined` if the volume feature is not configured.
+
+Check `volumeAvailability` before showing a volume-level control, and check `mutedAvailability` before showing a mute control.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 Pass `selectVolume` to <DocsLink slug="reference/player-controller">`PlayerController`</DocsLink> to subscribe to volume state. Returns `undefined` if the volume feature is not configured.
+
+Check `volumeAvailability` before showing a volume-level control, and check `mutedAvailability` before showing a mute control.
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
@@ -27,7 +31,7 @@ import { selectVolume, usePlayer } from '@videojs/react';
 
 function VolumeSlider() {
   const vol = usePlayer(selectVolume);
-  if (!vol) return null;
+  if (!vol || vol.volumeAvailability !== 'available') return null;
 
   return (
     <input

--- a/site/src/content/docs/reference/mute-button.mdx
+++ b/site/src/content/docs/reference/mute-button.mdx
@@ -50,7 +50,16 @@ import volumeLevelsHtmlTs from "@/components/docs/demos/mute-button/html/css/Vol
 
 Toggles mute on and off, and exposes a derived `volumeLevel` based on the current volume and mute state.
 
+Mute availability is separate from volume-level availability because some media can accept a mute command without supporting volume changes. When mute is unavailable or unsupported, the HTML custom element receives the native `hidden` attribute and the React component returns `null`. Toggling is also ignored while mute is unavailable.
+
 ## Styling
+
+| Attribute | Values | Description |
+|-----------|--------|-------------|
+| `data-muted` | Present / absent | Present when the media is muted |
+| `data-volume-level` | `"off"` \| `"low"` \| `"medium"` \| `"high"` | Current volume level |
+| `data-availability` | `"available"` \| `"unavailable"` \| `"unsupported"` | Whether the media can be muted |
+| `data-hidden` | Present / absent | Present on the HTML element while mute is unavailable or unsupported |
 
 Style the button based on muted state:
 
@@ -89,6 +98,8 @@ media-mute-button[data-volume-level="high"] .icon-high { display: inline; }
 .mute-button[data-volume-level="high"] .icon-high { display: inline; }
 ```
 </FrameworkCase>
+
+Unavailable and unsupported buttons are hidden automatically. No availability selector or extra hiding CSS is required.
 
 ## Accessibility
 

--- a/site/src/content/docs/reference/volume-slider.mdx
+++ b/site/src/content/docs/reference/volume-slider.mdx
@@ -37,7 +37,7 @@ import withPartsHtmlTs from "@/components/docs/demos/volume-slider/html/css/With
 
 ## Behavior
 
-Controls the media volume level. The slider maps its 0–100 internal range to the media's 0–1 volume scale. When the media is muted, the fill level drops to 0 regardless of the stored volume value. When volume control is unavailable, the HTML custom element receives native `hidden`, `data-hidden`, and disabled ARIA semantics; the React component returns `null`.
+Controls the media volume level. The slider maps its 0–100 internal range to the media's 0–1 volume scale. When the media is muted, the fill level drops to 0 regardless of the stored volume value. When `volumeAvailability` is not `"available"`, the HTML custom element receives native `hidden`, `data-hidden`, and disabled ARIA semantics; the React component returns `null`. This is independent of `mutedAvailability`, which controls whether the mute button is shown.
 
 ## Styling
 


### PR DESCRIPTION
Closes #2201

## Summary

Document the independent mute and volume-level availability introduced by the Spotify media work. This clarifies when mute and volume controls render and how custom controls should choose the correct capability signal.

## Changes

- Explain the difference between `mutedAvailability` and `volumeAvailability`.
- Document `MuteButton` hiding behavior, inert toggling, and availability data attributes.
- Guard the React volume slider example with `volumeAvailability`.
- Clarify availability guidance for custom components and `VolumeSlider`.

## Testing

- `pnpm -F site astro check`
- `pnpm --dir site build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site documentation only; no runtime or API behavior changes.
> 
> **Overview**
> **Documentation-only** update for independent **`mutedAvailability`** and **`volumeAvailability`** (e.g. iOS can mute without programmatic volume).
> 
> The **Features** concept page now explains the split and lists **`MuteButton`** among availability-aware controls. **Custom component** guidance notes that some features expose multiple availability properties.
> 
> **Volume** reference adds selector guidance and guards the React slider example with **`volumeAvailability`**. **`MuteButton`** docs cover separate mute availability, auto-hide/inert toggling, and **`data-availability`** / **`data-hidden`**. **`VolumeSlider`** behavior text ties hiding to **`volumeAvailability`**, distinct from mute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713825c60ee5f0db18c9f14b395f0fcb1144556b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->