### PR TITLE
docs(site): update menu and slider references

### DIFF
--- a/.agents/skills/write-docs/references/component-libraries.md
+++ b/.agents/skills/write-docs/references/component-libraries.md
@@ -135,16 +135,18 @@ import { Slider } from "@videojs/react";
 ```tsx
 import { useSlider } from "@videojs/react";
 
-function CustomSlider() {
-  const { rootProps, trackProps, thumbProps, state } = useSlider({
-    defaultValue: 50,
-  });
+function CustomSlider({ options }: { options: useSlider.Options }) {
+  const { rootRef, thumbRef, rootProps, rootStyle, thumbProps, cssVars, state } =
+    useSlider(options);
 
   return (
-    <div {...rootProps}>
-      <div {...trackProps}>
-        <div {...thumbProps} />
-      </div>
+    <div
+      ref={rootRef}
+      {...rootProps}
+      style={{ ...cssVars, ...rootStyle }}
+      data-dragging={state.dragging || undefined}
+    >
+      <div ref={thumbRef} {...thumbProps} />
     </div>
   );
 }

--- a/site/src/content/docs/reference/menu.mdx
+++ b/site/src/content/docs/reference/menu.mdx
@@ -114,7 +114,7 @@ Set `type="playback-rate"`, `type="quality"`, `type="audio-track"`, or `type="ca
 
 Use data attributes to style open state, highlighted items, selected radio items, and submenu views:
 
-`data-highlighted` is added to the current menu item. The highlighted item is the item that keyboard selection will act on. It changes when the menu opens, when the pointer moves over another item, when the user presses arrow keys, or when type-ahead search finds a match.
+`data-highlighted` identifies the current menu item. Its value is `"pointer"` when pointer movement caused the highlight and an empty string for other highlights, including keyboard navigation and type-ahead search. Use `[data-highlighted]` to match any highlighted item or `[data-highlighted=""]` to match highlights that were not caused by pointer movement.
 
 On root menu content, `data-side` reflects the rendered side and can differ from the preferred `side` prop after collision handling. Submenus do not have `data-side`.
 
@@ -126,6 +126,11 @@ On root menu content, `data-side` reflects the rendered side and can differ from
 
   .menu-item[data-highlighted] {
     background: rgba(255, 255, 255, 0.16);
+    transition: background-color 100ms ease-in-out;
+  }
+
+  .menu-item[data-highlighted=""] {
+    transition-duration: 0ms;
   }
 
   [role="menuitemradio"][aria-checked="true"] {
@@ -142,6 +147,11 @@ On root menu content, `data-side` reflects the rendered side and can differ from
 
   media-menu-item[data-highlighted] {
     background: rgba(255, 255, 255, 0.16);
+    transition: background-color 100ms ease-in-out;
+  }
+
+  media-menu-item[data-highlighted=""] {
+    transition-duration: 0ms;
   }
 
   media-menu-radio-item[aria-checked="true"] {

--- a/site/src/content/docs/reference/use-slider.mdx
+++ b/site/src/content/docs/reference/use-slider.mdx
@@ -1,0 +1,53 @@
+---
+title: useSlider
+description: Hook for connecting slider input behavior to custom React elements
+---
+
+import UtilReference from "@/components/docs/api-reference/UtilReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
+
+`useSlider` is the low-level hook behind the <DocsLink slug="reference/slider">Slider</DocsLink>, <DocsLink slug="reference/time-slider">TimeSlider</DocsLink>, and <DocsLink slug="reference/volume-slider">VolumeSlider</DocsLink> components. Use it when you need to build a new slider primitive with custom state calculations. For standard player controls, use the built-in components.
+
+## Import
+
+```tsx
+import { useSlider } from "@videojs/react";
+```
+
+## Usage
+
+Pass callbacks that convert raw slider input into your component state, values, and CSS variables. Attach the returned root props, ref, and styles to the pointer target. Attach the thumb props and ref to the focusable thumb.
+
+```tsx
+function CustomSlider({ options }: { options: useSlider.Options }) {
+  const {
+    state,
+    input,
+    cssVars,
+    rootRef,
+    thumbRef,
+    rootProps,
+    rootStyle,
+    thumbProps,
+  } = useSlider(options);
+
+  return (
+    <div
+      ref={rootRef}
+      {...rootProps}
+      style={{ ...cssVars, ...rootStyle }}
+      data-dragging={state.dragging || undefined}
+    >
+      <div
+        ref={thumbRef}
+        {...thumbProps}
+        data-focused={input.current.focused || undefined}
+      />
+    </div>
+  );
+}
+```
+
+`state` is the derived state for the current render. `input` is the underlying reactive state container. Read `input.current` for the latest raw input or call `input.subscribe(listener)` when another system needs to observe changes outside React rendering.
+
+<UtilReference util="useSlider" />

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -199,6 +199,7 @@ export const sidebar: Sidebar = [
           { slug: 'reference/use-player-context', frameworks: ['react'] },
           { slug: 'reference/use-quality-options', frameworks: ['react'] },
           { slug: 'reference/use-selector', frameworks: ['react'] },
+          { slug: 'reference/use-slider', frameworks: ['react'] },
           { slug: 'reference/use-snapshot', frameworks: ['react'] },
           { slug: 'reference/container-mixin', frameworks: ['html'] },
           { slug: 'reference/media-attach-mixin', frameworks: ['html'] },


### PR DESCRIPTION
Closes #2210

## Summary

Update the site documentation for the menu highlight semantics and the public React `useSlider` return value introduced by #2208.

## Changes

- Explain how `data-highlighted` distinguishes pointer-driven highlights from keyboard and type-ahead highlights.
- Add a React `useSlider` reference page backed by the generated API model, including the `input` state container.
- Correct the stale low-level `useSlider` example in the documentation skill reference.

## Testing

- `pnpm -F site api-docs`
- `cd site && node_modules/.bin/astro check` (0 errors)
- `cd site && node_modules/.bin/vitest run src/utils/tests/utilReferenceModel.test.ts` (10 passed)
- `node build/scripts/check-workspace.mjs` (10 passed)
- Prettier check and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Site and agent documentation only; no changes to player behavior, APIs, or security-sensitive code.
> 
> **Overview**
> **Docs-only** follow-up to the menu highlight and `useSlider` API work (#2208): no runtime or library code changes.
> 
> The **Menu** reference now documents **`data-highlighted`** as `"pointer"` vs an empty string for keyboard/type-ahead highlights, with CSS that animates pointer-driven highlights and skips transition on non-pointer highlights (React and HTML examples).
> 
> A new **`useSlider`** reference page describes the hook behind Slider/TimeSlider/VolumeSlider, including **`rootRef`/`thumbRef`**, **`cssVars`/`rootStyle`**, **`state`**, and the **`input`** reactive container, plus generated API via `UtilReference`. The page is registered in the docs sidebar, and the write-docs skill’s low-level **`useSlider`** example is updated to match the current return shape (no separate track wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b9d0951773a16477160c9bb69bb7522ec704e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->