### PR TITLE
fix(html): make emitted declarations consumable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Check public declarations
+        run: pnpm exec vp run @videojs/html#check:public-types
+
   test:
     needs: install
     name: Test (${{ matrix.package }})

--- a/packages/html/src/define/ui/thumbnail.ts
+++ b/packages/html/src/define/ui/thumbnail.ts
@@ -5,6 +5,6 @@ safeDefine(ThumbnailElement);
 
 declare global {
   interface HTMLElementTagNameMap {
-    [ThumbnailElement.tagName]: ThumbnailElement;
+    'media-thumbnail': ThumbnailElement;
   }
 }

--- a/packages/html/src/store/types.ts
+++ b/packages/html/src/store/types.ts
@@ -1,7 +1,7 @@
 import type { InferPlayerHtmlConfig, PlayerStore } from '@videojs/core/dom';
 import type { Constructor } from '@videojs/utils/types';
 
-import type { UIElement } from '@/ui/ui-element';
+import type { UIElement } from '../ui/ui-element';
 
 // ----------------------------------------
 // PlayerElement

--- a/packages/html/src/ui/input-indicator/input-indicator-element.ts
+++ b/packages/html/src/ui/input-indicator/input-indicator-element.ts
@@ -16,7 +16,7 @@ import type { PropertyValues } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
 import type { State as StoreState } from '@videojs/store';
 
-import { containerContext, playerContext } from '../../player/context';
+import { type ContainerContextConsumer, containerContext, playerContext } from '../../player/context';
 import { PlayerController } from '../../player/player-controller';
 import { UIElement } from '../ui-element';
 import type { LiveIndicator } from './live-indicator';
@@ -44,7 +44,7 @@ export abstract class InputIndicatorElement<IndicatorState extends IndicatorLife
   protected abstract syncCoreProps(): void;
 
   protected readonly player = new PlayerController(this, playerContext);
-  protected readonly container = new ContextConsumer(this, {
+  protected readonly container: ContainerContextConsumer = new ContextConsumer(this, {
     context: containerContext,
     callback: () => this.#reconnect(),
     subscribe: true,

--- a/packages/html/src/ui/slider/slider-thumbnail-element.ts
+++ b/packages/html/src/ui/slider/slider-thumbnail-element.ts
@@ -4,7 +4,6 @@ import { ContextConsumer } from '@videojs/element/context';
 import { ThumbnailElement } from '../thumbnail/thumbnail-element';
 import { sliderContext } from './context';
 
-// @ts-expect-error TS2417 — tagName narrows to a different literal for custom element registration.
 export class SliderThumbnailElement extends ThumbnailElement {
   static override readonly tagName = 'media-slider-thumbnail';
 

--- a/packages/html/src/ui/thumbnail/thumbnail-element.ts
+++ b/packages/html/src/ui/thumbnail/thumbnail-element.ts
@@ -25,7 +25,7 @@ img {
 }`;
 
 export class ThumbnailElement extends UIElement {
-  static readonly tagName = 'media-thumbnail';
+  static readonly tagName: string = 'media-thumbnail';
 
   static override properties = {
     time: { type: Number },

--- a/packages/html/tests/public-types/index.ts
+++ b/packages/html/tests/public-types/index.ts
@@ -1,0 +1,90 @@
+/**
+ * Strict consumer of the emitted `@videojs/html` declarations.
+ *
+ * Resolves the package through its own `exports` map, so every import below lands on `dist/dev/**.d.ts` rather than
+ * source. `skipLibCheck: false` makes the compiler check those declaration files themselves, which is what a strict
+ * downstream project sees and what the source typecheck cannot observe.
+ */
+import type { PlayerStore, VideoPlayerStore } from '@videojs/html';
+import {
+  createPlayer,
+  PlayerController,
+  playerContext,
+  selectPlayback,
+  SliderThumbnailElement,
+  ThumbnailElement,
+  UIElement,
+  videoFeatures,
+} from '@videojs/html';
+import { createI18n, type Locale } from '@videojs/html/i18n';
+import '@videojs/html/media/hls-video';
+import '@videojs/html/ui/play-button';
+import '@videojs/html/ui/slider-thumbnail';
+import '@videojs/html/ui/thumbnail';
+import { PlayerController as VideoPlayerController, VideoPlayerElement, VideoSkinElement } from '@videojs/html/video';
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+
+type Extends<A, B extends A> = B;
+
+// createPlayer returns the element class, bound controller, and shared context.
+const {
+  PlayerElement,
+  PlayerController: BoundController,
+  playerContext: boundContext,
+} = createPlayer({
+  features: videoFeatures,
+});
+
+class CustomPlayerElement extends PlayerElement {}
+
+class PlayButtonLike extends UIElement {
+  readonly #playback = new BoundController(this, selectPlayback);
+  readonly #generic = new PlayerController(this, playerContext, selectPlayback);
+
+  get paused(): boolean {
+    return Boolean(this.#playback.value?.paused && this.#generic.value?.paused);
+  }
+}
+
+class SkinLike extends UIElement {
+  readonly #player = new VideoPlayerController(this);
+
+  get store(): VideoPlayerStore | undefined {
+    return this.#player.value;
+  }
+}
+
+// Preset exports keep their concrete element types.
+const skin: VideoSkinElement = document.createElement('video-skin');
+const player: VideoPlayerElement = document.createElement('video-player');
+const hls: HTMLElementTagNameMap['hls-video'] = document.createElement('hls-video');
+
+// Define modules must register tag names for both the base and the derived thumbnail element.
+const thumbnail: ThumbnailElement = document.createElement('media-thumbnail');
+const sliderThumbnail: SliderThumbnailElement = document.createElement('media-slider-thumbnail');
+const playButton = document.createElement('media-play-button');
+
+// Relationships the declarations must preserve; a broken constraint is a compile error.
+export type PublicTypeAssertions = [
+  Extends<ThumbnailElement, SliderThumbnailElement>,
+  Extends<typeof playerContext, typeof boundContext>,
+  Extends<PlayerStore, VideoPlayerStore>,
+];
+
+const locale: Locale = 'en';
+const i18n = createI18n();
+
+void [
+  CustomPlayerElement,
+  PlayButtonLike,
+  SkinLike,
+  skin,
+  player,
+  hls,
+  thumbnail,
+  sliderThumbnail,
+  playButton,
+  locale,
+  i18n,
+];

--- a/packages/html/tests/public-types/tsconfig.json
+++ b/packages/html/tests/public-types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ES2022",
+    "types": [],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["index.ts"]
+}

--- a/packages/html/tsconfig.dts.json
+++ b/packages/html/tsconfig.dts.json
@@ -4,9 +4,6 @@
     "composite": false,
     "incremental": false,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "useDefineForClassFields": false
   },
   "include": ["src/**/*.ts"]

--- a/packages/html/tsconfig.json
+++ b/packages/html/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@/*": ["./src/*"]
-    },
     "declarationDir": "types",
     "useDefineForClassFields": false
   },

--- a/packages/html/vite.config.ts
+++ b/packages/html/vite.config.ts
@@ -27,8 +27,6 @@ const skinsDir = resolve(packageDir, '../skins/src');
 /** The light-DOM sheet every non-background skin pulls in. Kept out of the shadow sheets. */
 const globalCss = resolve(packageDir, 'src/define/global.css');
 
-const srcDir = new URL('./src', import.meta.url).pathname;
-const srcAlias = { '@': srcDir };
 const localeTags = [...LOCALES, ...localeAliases(LOCALES)];
 
 const defineEntries = Object.fromEntries(
@@ -90,7 +88,6 @@ const createPackConfig = (mode: PackageBuildMode): PackUserConfig => ({
   deps: {
     alwaysBundle: [/^@videojs\/icons/, /^@videojs\/skins/],
   },
-  alias: srcAlias,
   plugins: [
     copyCssPlugin({ skinsDir, outDir: `dist/${mode}` }),
     inlineCssPlugin({ skinsDir, minify: !isDevBuildMode(mode) }),
@@ -257,7 +254,6 @@ for (const mode of cdnBuildModes) {
       ],
     },
     outDir: cdnOutDir,
-    alias: srcAlias,
     define: {
       __DEV__: isProd ? 'false' : 'true',
     },
@@ -317,6 +313,13 @@ export default defineConfig({
         // inspect files emitted by the other config. They remain outputs only.
         input: [...cachedTaskInputs, '!src/cdn/locales/', '!src/cdn/locales/**', '!cdn/', '!cdn/**'],
         output: ['src/cdn/locales/**', 'cdn/**'],
+      },
+      'check:public-types': {
+        // Compiles a strict consumer (`skipLibCheck: false`) against the emitted declarations through the package
+        // `exports` map. The source typecheck cannot see what the dts pipeline emits, so this is the only place a
+        // consumer-facing declaration error surfaces before publish.
+        command: 'tsgo --project tests/public-types/tsconfig.json',
+        dependsOn: ['build'],
       },
       'test:ci': packageTestTask(),
     },


### PR DESCRIPTION
Refs #2369

## Summary

Make the built `@videojs/html` declaration surface typecheck for a strict external consumer (`skipLibCheck: false`), and guard it with a Vite+ task so regressions are caught in CI.

Reworked from scratch against the current Vite+ pipeline (`vp pack` with `unbundle: true`, tsgo-emitted dts). The old tsdown-era branch and its `ProviderMixin` fixture no longer applied.

## What the strict fixture found

A consumer compiled against `dist/dev/**.d.ts` through the package `exports` map hit 26 errors before this change:

- **TS2694 `Namespace 'index_d_exports' has no exported member 'AnyPlayerStore' | 'VideoPlayerStore' | 'TransitionApi'`** across ~19 leaf declaration files (buttons, indicators, preset players). Root cause: the `@/*` `paths` alias in `tsconfig.dts.json` made the declaration emitter write `import("@/index").X` for any type reachable through the barrel. The dts plugin then resolved that back into a synthesized `index_d_exports` namespace whose member list omits `export *` re-exports, so every type that reaches the root entry via `export * from '@videojs/core/dom'` was unresolvable. This is the same type loss the original PR described; it still reproduces under the tsgo unbundled pipeline, but the fix is to stop the emitter choosing the barrel rather than to hand-list re-exports.
- **TS2417** in `ui/slider/slider-thumbnail-element.d.ts`: the `// @ts-expect-error` on the `tagName` override is dropped from the emitted declaration, so consumers see the static-side incompatibility directly.
- **TS2307 `Cannot find module '@lit/context'`** in `ui/input-indicator/input-indicator-element.d.ts`: the inferred `ContextConsumer<Context<...>, this>` type leaked a specifier for a package `@videojs/html` does not depend on.

## Changes

- Retire the `@/` source alias in `packages/html`: rewrite its single use (`src/store/types.ts`) to a relative import, drop `paths` from both html tsconfigs, and drop the now-unused `alias` from the package and CDN pack configs. Leaf declarations now import `@videojs/core/dom` directly and no `index_d_exports` namespace is synthesized.
- Widen `ThumbnailElement.tagName` to `string` and key the `media-thumbnail` tag map entry literally (same pattern as `dialog-close`/`popover`/`menu`), so `SliderThumbnailElement` overrides the tag without a suppression.
- Annotate `InputIndicatorElement.container` with the existing `ContainerContextConsumer` alias so the declaration references `@videojs/element/context` types rather than `@lit/context`.
- Add `packages/html/tests/public-types/` — a strict consumer (`strict`, `skipLibCheck: false`, `moduleResolution: bundler`) that resolves `@videojs/html` via self-referencing package `exports` and imports the root entry, `./video` preset, `./video/player`, `./video/skin`, `./ui/thumbnail`, `./ui/slider-thumbnail`, `./ui/play-button`, `./media/hls-video`, and `./i18n` using the current API shapes (`createPlayer` → `{ PlayerElement, PlayerController, playerContext }`, `UIElement`).
- Add a cached `check:public-types` task to `packages/html/vite.config.ts` (`tsgo --project tests/public-types/tsconfig.json`, `dependsOn: ['build']`) and run it in the CI `typecheck` job after `pnpm build:packages`. It is not folded into `build` so the default dev loop is unchanged.

`packages/react` carries the same `@/*` `paths` alias; it is out of scope here but likely has the same emitter behaviour and is worth a follow-up.

## Testing

- `pnpm exec vp run @videojs/html#build`
- `pnpm exec tsgo --project packages/html/tests/public-types/tsconfig.json` — 26 errors before the source fixes, 0 after
- `pnpm exec vp run @videojs/html#check:public-types` (twice; second run is a cache hit)
- `pnpm exec vp run @videojs/html#build:cdn`
- `pnpm -F @videojs/html test` — 63 files, 450 tests passed
- `pnpm typecheck`
- `pnpm lint:fix:file <touched files>`
- `pnpm check:workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect TypeScript declarations and build/CI checks, not runtime behavior, but they define the public typing contract consumers rely on at compile time.
> 
> **Overview**
> **Fixes `@videojs/html` so published `.d.ts` files typecheck for strict downstream consumers** (`skipLibCheck: false`), and **blocks regressions in CI** via a new `check:public-types` step after package build.
> 
> The declaration pipeline no longer uses the `@/*` path alias (removed from tsconfigs and Vite pack/CDN configs; the lone `@/` import is now relative). That stops emitted leaf declarations from pulling types through a broken `index_d_exports` barrel and restores exports like `VideoPlayerStore` and `TransitionApi`. **Thumbnail** typing is adjusted so `SliderThumbnailElement` can override `tagName` without a source-only suppression (`tagName: string`, literal `media-thumbnail` in `HTMLElementTagNameMap`). **Input indicators** annotate `container` as `ContainerContextConsumer` so public types reference `@videojs/element/context` instead of leaking `@lit/context`.
> 
> A new **`tests/public-types`** fixture imports the package through its `exports` map (root, video preset, UI define modules, i18n, etc.) and asserts key type relationships. **`vp run @videojs/html#check:public-types`** runs `tsgo` on that project after `build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6060a6b8cd31c11ea3642d97b5a4e0b335549712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->