### PR TITLE
fix(media): avoid double detach when destroying DASH media

### DIFF
--- a/packages/media/src/dom/dash/media.ts
+++ b/packages/media/src/dom/dash/media.ts
@@ -58,9 +58,8 @@ class DashMediaBase
   }
 
   destroy() {
-    this.detach();
-    this.#engine.destroy();
     super.destroy();
+    this.#engine.destroy();
   }
 
   /**

--- a/packages/media/src/dom/dash/tests/dash-media.test.ts
+++ b/packages/media/src/dom/dash/tests/dash-media.test.ts
@@ -72,6 +72,7 @@ type MockEngine = {
   representations: MockRepresentation[];
   currentRepresentation: MockRepresentation | null;
   attachView: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
   attachSource: ReturnType<typeof vi.fn>;
   updateSettings: ReturnType<typeof vi.fn>;
   resetSettings: ReturnType<typeof vi.fn>;
@@ -150,6 +151,8 @@ describe('DashMedia', () => {
       media.destroy();
 
       expect(engine.attachView).toHaveBeenCalledWith(null);
+      expect(engine.attachView).toHaveBeenCalledOnce();
+      expect(engine.destroy).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
Refs #2368

## What changed

`DashMedia.destroy()` now lets the media host detach the target once before destroying dash.js. This avoids a second `attachView(null)` after dash.js has already cleared its internal video model.

```ts
// Before: detach -> engine.destroy -> base destroy -> detach again
// After:  base destroy -> one detach -> engine.destroy
super.destroy();
this.#engine.destroy();
```

The regression was exposed by connecting and removing `<dash-video>` in the cross-framework browser matrix and also exists on `main`.

## Testing

Rebased onto current `main`.

- `pnpm -F @videojs/media test src/dom/dash` (1 file, 23 passed; asserts `attachView(null)` and `engine.destroy()` are each called exactly once)
- `pnpm exec vp run @videojs/media#build`
- `pnpm typecheck` after `pnpm build:packages` (clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle ordering fix in DASH teardown with targeted unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **`DashMedia.destroy()`** no longer calls `detach()` before tearing down dash.js. Teardown is now **`super.destroy()`** (one host detach, including `attachView(null)`) followed by **`#engine.destroy()`**, instead of detaching twice around `engine.destroy()`.
> 
> That removes a second `attachView(null)` after dash.js has already cleared its video model—behavior that showed up when connecting and removing `<dash-video>` in the cross-framework browser matrix.
> 
> Tests now assert **`attachView(null)`** and **`engine.destroy()`** each run **exactly once** on destroy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e268692e471252d73e28f9ec5fc355faac488b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
