### PR TITLE
feat(html): add server-safe conditional exports

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/videojs/v10",
     "directory": "packages/html"
   },
-  "main": "dist/default/index.js",
+  "main": "dist/server/index.js",
   "module": "dist/default/index.js",
   "types": "dist/dev/index.d.ts",
   "sideEffects": [
@@ -29,98 +29,227 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/dev/index.d.ts",
-      "development": "./dist/dev/index.js",
-      "default": "./dist/default/index.js"
+      "react-server": "./dist/server/index.js",
+      "edge-light": "./dist/server/index.js",
+      "workerd": "./dist/server/index.js",
+      "worker": "./dist/server/index.js",
+      "browser": {
+        "development": "./dist/dev/index.js",
+        "default": "./dist/default/index.js"
+      },
+      "default": "./dist/server/index.js"
     },
     "./icons": {
       "types": "./dist/dev/icons/index.d.ts",
       "development": "./dist/dev/icons/index.js",
       "default": "./dist/default/icons/index.js"
     },
+    "./icons/default": {
+      "types": "./dist/dev/icons/default/index.d.ts",
+      "development": "./dist/dev/icons/default/index.js",
+      "default": "./dist/default/icons/default/index.js"
+    },
+    "./icons/minimal": {
+      "types": "./dist/dev/icons/minimal/index.d.ts",
+      "development": "./dist/dev/icons/minimal/index.js",
+      "default": "./dist/default/icons/minimal/index.js"
+    },
     "./icons/*": {
       "types": "./dist/dev/icons/*/index.d.ts",
-      "development": "./dist/dev/icons/*/index.js",
-      "default": "./dist/default/icons/*/index.js"
+      "react-server": "./dist/server/icons/*/index.js",
+      "edge-light": "./dist/server/icons/*/index.js",
+      "workerd": "./dist/server/icons/*/index.js",
+      "worker": "./dist/server/icons/*/index.js",
+      "browser": {
+        "development": "./dist/dev/icons/*/index.js",
+        "default": "./dist/default/icons/*/index.js"
+      },
+      "default": "./dist/server/icons/*/index.js"
     },
     "./video": {
       "types": "./dist/dev/presets/video.d.ts",
-      "development": "./dist/dev/presets/video.js",
-      "default": "./dist/default/presets/video.js"
+      "react-server": "./dist/server/presets/video.js",
+      "edge-light": "./dist/server/presets/video.js",
+      "workerd": "./dist/server/presets/video.js",
+      "worker": "./dist/server/presets/video.js",
+      "browser": {
+        "development": "./dist/dev/presets/video.js",
+        "default": "./dist/default/presets/video.js"
+      },
+      "default": "./dist/server/presets/video.js"
     },
     "./video/*.css": "./dist/default/define/video/*.css",
     "./video/*": {
       "types": "./dist/dev/define/video/*.d.ts",
-      "development": "./dist/dev/define/video/*.js",
-      "default": "./dist/default/define/video/*.js"
+      "react-server": "./dist/server/define/video/*.js",
+      "edge-light": "./dist/server/define/video/*.js",
+      "workerd": "./dist/server/define/video/*.js",
+      "worker": "./dist/server/define/video/*.js",
+      "browser": {
+        "development": "./dist/dev/define/video/*.js",
+        "default": "./dist/default/define/video/*.js"
+      },
+      "default": "./dist/server/define/video/*.js"
     },
     "./audio": {
       "types": "./dist/dev/presets/audio.d.ts",
-      "development": "./dist/dev/presets/audio.js",
-      "default": "./dist/default/presets/audio.js"
+      "react-server": "./dist/server/presets/audio.js",
+      "edge-light": "./dist/server/presets/audio.js",
+      "workerd": "./dist/server/presets/audio.js",
+      "worker": "./dist/server/presets/audio.js",
+      "browser": {
+        "development": "./dist/dev/presets/audio.js",
+        "default": "./dist/default/presets/audio.js"
+      },
+      "default": "./dist/server/presets/audio.js"
     },
     "./audio/*.css": "./dist/default/define/audio/*.css",
     "./audio/*": {
       "types": "./dist/dev/define/audio/*.d.ts",
-      "development": "./dist/dev/define/audio/*.js",
-      "default": "./dist/default/define/audio/*.js"
+      "react-server": "./dist/server/define/audio/*.js",
+      "edge-light": "./dist/server/define/audio/*.js",
+      "workerd": "./dist/server/define/audio/*.js",
+      "worker": "./dist/server/define/audio/*.js",
+      "browser": {
+        "development": "./dist/dev/define/audio/*.js",
+        "default": "./dist/default/define/audio/*.js"
+      },
+      "default": "./dist/server/define/audio/*.js"
     },
     "./background": {
       "types": "./dist/dev/presets/background.d.ts",
-      "development": "./dist/dev/presets/background.js",
-      "default": "./dist/default/presets/background.js"
+      "react-server": "./dist/server/presets/background.js",
+      "edge-light": "./dist/server/presets/background.js",
+      "workerd": "./dist/server/presets/background.js",
+      "worker": "./dist/server/presets/background.js",
+      "browser": {
+        "development": "./dist/dev/presets/background.js",
+        "default": "./dist/default/presets/background.js"
+      },
+      "default": "./dist/server/presets/background.js"
     },
     "./background/*.css": "./dist/default/define/background/*.css",
     "./background/*": {
       "types": "./dist/dev/define/background/*.d.ts",
-      "development": "./dist/dev/define/background/*.js",
-      "default": "./dist/default/define/background/*.js"
+      "react-server": "./dist/server/define/background/*.js",
+      "edge-light": "./dist/server/define/background/*.js",
+      "workerd": "./dist/server/define/background/*.js",
+      "worker": "./dist/server/define/background/*.js",
+      "browser": {
+        "development": "./dist/dev/define/background/*.js",
+        "default": "./dist/default/define/background/*.js"
+      },
+      "default": "./dist/server/define/background/*.js"
     },
     "./live-video": {
       "types": "./dist/dev/presets/live-video.d.ts",
-      "development": "./dist/dev/presets/live-video.js",
-      "default": "./dist/default/presets/live-video.js"
+      "react-server": "./dist/server/presets/live-video.js",
+      "edge-light": "./dist/server/presets/live-video.js",
+      "workerd": "./dist/server/presets/live-video.js",
+      "worker": "./dist/server/presets/live-video.js",
+      "browser": {
+        "development": "./dist/dev/presets/live-video.js",
+        "default": "./dist/default/presets/live-video.js"
+      },
+      "default": "./dist/server/presets/live-video.js"
     },
     "./live-video/*.css": "./dist/default/define/live-video/*.css",
     "./live-video/*": {
       "types": "./dist/dev/define/live-video/*.d.ts",
-      "development": "./dist/dev/define/live-video/*.js",
-      "default": "./dist/default/define/live-video/*.js"
+      "react-server": "./dist/server/define/live-video/*.js",
+      "edge-light": "./dist/server/define/live-video/*.js",
+      "workerd": "./dist/server/define/live-video/*.js",
+      "worker": "./dist/server/define/live-video/*.js",
+      "browser": {
+        "development": "./dist/dev/define/live-video/*.js",
+        "default": "./dist/default/define/live-video/*.js"
+      },
+      "default": "./dist/server/define/live-video/*.js"
     },
     "./live-audio": {
       "types": "./dist/dev/presets/live-audio.d.ts",
-      "development": "./dist/dev/presets/live-audio.js",
-      "default": "./dist/default/presets/live-audio.js"
+      "react-server": "./dist/server/presets/live-audio.js",
+      "edge-light": "./dist/server/presets/live-audio.js",
+      "workerd": "./dist/server/presets/live-audio.js",
+      "worker": "./dist/server/presets/live-audio.js",
+      "browser": {
+        "development": "./dist/dev/presets/live-audio.js",
+        "default": "./dist/default/presets/live-audio.js"
+      },
+      "default": "./dist/server/presets/live-audio.js"
     },
     "./live-audio/*.css": "./dist/default/define/live-audio/*.css",
     "./live-audio/*": {
       "types": "./dist/dev/define/live-audio/*.d.ts",
-      "development": "./dist/dev/define/live-audio/*.js",
-      "default": "./dist/default/define/live-audio/*.js"
+      "react-server": "./dist/server/define/live-audio/*.js",
+      "edge-light": "./dist/server/define/live-audio/*.js",
+      "workerd": "./dist/server/define/live-audio/*.js",
+      "worker": "./dist/server/define/live-audio/*.js",
+      "browser": {
+        "development": "./dist/dev/define/live-audio/*.js",
+        "default": "./dist/default/define/live-audio/*.js"
+      },
+      "default": "./dist/server/define/live-audio/*.js"
     },
     "./ui/*": {
       "types": "./dist/dev/define/ui/*.d.ts",
-      "development": "./dist/dev/define/ui/*.js",
-      "default": "./dist/default/define/ui/*.js"
+      "react-server": "./dist/server/define/ui/*.js",
+      "edge-light": "./dist/server/define/ui/*.js",
+      "workerd": "./dist/server/define/ui/*.js",
+      "worker": "./dist/server/define/ui/*.js",
+      "browser": {
+        "development": "./dist/dev/define/ui/*.js",
+        "default": "./dist/default/define/ui/*.js"
+      },
+      "default": "./dist/server/define/ui/*.js"
     },
     "./feature/*": {
       "types": "./dist/dev/define/feature/*.d.ts",
-      "development": "./dist/dev/define/feature/*.js",
-      "default": "./dist/default/define/feature/*.js"
+      "react-server": "./dist/server/define/feature/*.js",
+      "edge-light": "./dist/server/define/feature/*.js",
+      "workerd": "./dist/server/define/feature/*.js",
+      "worker": "./dist/server/define/feature/*.js",
+      "browser": {
+        "development": "./dist/dev/define/feature/*.js",
+        "default": "./dist/default/define/feature/*.js"
+      },
+      "default": "./dist/server/define/feature/*.js"
     },
     "./media/mux-video": {
       "types": "./dist/dev/define/media/mux-video/index.d.ts",
-      "development": "./dist/dev/define/media/mux-video/index.js",
-      "default": "./dist/default/define/media/mux-video/index.js"
+      "react-server": "./dist/server/define/media/mux-video/index.js",
+      "edge-light": "./dist/server/define/media/mux-video/index.js",
+      "workerd": "./dist/server/define/media/mux-video/index.js",
+      "worker": "./dist/server/define/media/mux-video/index.js",
+      "browser": {
+        "development": "./dist/dev/define/media/mux-video/index.js",
+        "default": "./dist/default/define/media/mux-video/index.js"
+      },
+      "default": "./dist/server/define/media/mux-video/index.js"
     },
     "./media/mux-audio": {
       "types": "./dist/dev/define/media/mux-audio/index.d.ts",
-      "development": "./dist/dev/define/media/mux-audio/index.js",
-      "default": "./dist/default/define/media/mux-audio/index.js"
+      "react-server": "./dist/server/define/media/mux-audio/index.js",
+      "edge-light": "./dist/server/define/media/mux-audio/index.js",
+      "workerd": "./dist/server/define/media/mux-audio/index.js",
+      "worker": "./dist/server/define/media/mux-audio/index.js",
+      "browser": {
+        "development": "./dist/dev/define/media/mux-audio/index.js",
+        "default": "./dist/default/define/media/mux-audio/index.js"
+      },
+      "default": "./dist/server/define/media/mux-audio/index.js"
     },
     "./media/*": {
       "types": "./dist/dev/define/media/*.d.ts",
-      "development": "./dist/dev/define/media/*.js",
-      "default": "./dist/default/define/media/*.js"
+      "react-server": "./dist/server/define/media/*.js",
+      "edge-light": "./dist/server/define/media/*.js",
+      "workerd": "./dist/server/define/media/*.js",
+      "worker": "./dist/server/define/media/*.js",
+      "browser": {
+        "development": "./dist/dev/define/media/*.js",
+        "default": "./dist/default/define/media/*.js"
+      },
+      "default": "./dist/server/define/media/*.js"
     },
     "./cdn/media/*": {
       "types": "./cdn/media/*.dev.d.ts",
@@ -149,8 +278,27 @@
     },
     "./i18n": {
       "types": "./dist/dev/i18n/index.d.ts",
-      "development": "./dist/dev/i18n/index.js",
-      "default": "./dist/default/i18n/index.js"
+      "react-server": "./dist/server/i18n/index.js",
+      "edge-light": "./dist/server/i18n/index.js",
+      "workerd": "./dist/server/i18n/index.js",
+      "worker": "./dist/server/i18n/index.js",
+      "browser": {
+        "development": "./dist/dev/i18n/index.js",
+        "default": "./dist/default/i18n/index.js"
+      },
+      "default": "./dist/server/i18n/index.js"
+    },
+    "./i18n/locales/*/register": {
+      "types": "./dist/dev/i18n/locales/*/register.d.ts",
+      "react-server": "./dist/server/i18n/locales/*/register.js",
+      "edge-light": "./dist/server/i18n/locales/*/register.js",
+      "workerd": "./dist/server/i18n/locales/*/register.js",
+      "worker": "./dist/server/i18n/locales/*/register.js",
+      "browser": {
+        "development": "./dist/dev/i18n/locales/*/register.js",
+        "default": "./dist/default/i18n/locales/*/register.js"
+      },
+      "default": "./dist/server/i18n/locales/*/register.js"
     },
     "./i18n/locales/*": {
       "types": "./dist/dev/i18n/locales/*.d.ts",
@@ -160,17 +308,25 @@
     "./*.css": "./dist/default/define/*.css",
     "./*": {
       "types": "./dist/dev/define/*.d.ts",
-      "development": "./dist/dev/define/*.js",
-      "default": "./dist/default/define/*.js"
+      "react-server": "./dist/server/define/*.js",
+      "edge-light": "./dist/server/define/*.js",
+      "workerd": "./dist/server/define/*.js",
+      "worker": "./dist/server/define/*.js",
+      "browser": {
+        "development": "./dist/dev/define/*.js",
+        "default": "./dist/default/define/*.js"
+      },
+      "default": "./dist/server/define/*.js"
     }
   },
   "scripts": {
     "generate:vjsc": "vjsc generate",
     "check:vjsc": "vjsc generate --check",
     "prebuild": "pnpm run generate:vjsc",
-    "build": "tsdown",
+    "build": "tsdown && node --import tsx ./scripts/build-server.ts && pnpm run check:server",
     "build:cdn": "node --import tsx ./scripts/build-cdn-locales.ts && tsdown --config tsdown.cdn.config.ts",
     "check:cdn": "node --import tsx ./scripts/check-cdn-self-contained.ts",
+    "check:server": "node --import tsx ./scripts/check-server.ts",
     "build:archive": "node --import tsx ./scripts/build-dist-archive.ts",
     "build:watch": "tsdown --watch ./src --no-clean",
     "dev": "pnpm run build:watch",

--- a/packages/html/scripts/build-server.ts
+++ b/packages/html/scripts/build-server.ts
@@ -74,7 +74,7 @@ function createServerStubs(exportedNames: string[]): string[] {
 
   if (take('createPlayer')) {
     output.push(
-      'function createPlayer() { class PlayerElement {}; class PlayerController {}; return { PlayerElement, PlayerController, playerContext: undefined }; }'
+      'function createPlayer() { class PlayerController {}; const ProviderMixin = (Base) => Base; const create = () => undefined; return { ProviderMixin, PlayerController, context: undefined, create }; }'
     );
   }
   if (take('createPlayerController')) {

--- a/packages/html/scripts/build-server.ts
+++ b/packages/html/scripts/build-server.ts
@@ -1,0 +1,147 @@
+import { globSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import ts from 'typescript';
+
+const packageDir = resolve(import.meta.dirname, '..');
+const browserDir = resolve(packageDir, 'dist/default');
+const serverDir = resolve(packageDir, 'dist/server');
+
+const entryFiles = [
+  resolve(browserDir, 'index.js'),
+  resolve(browserDir, 'i18n/index.js'),
+  ...globSync('i18n/locales/**/register.js', { cwd: browserDir }).map((file) => resolve(browserDir, file)),
+  ...globSync('icons/**/index.js', { cwd: browserDir }).map((file) => resolve(browserDir, file)),
+  ...globSync('define/**/*.js', { cwd: browserDir }).map((file) => resolve(browserDir, file)),
+  ...globSync('presets/*.js', { cwd: browserDir }).map((file) => resolve(browserDir, file)),
+];
+
+interface Reexport {
+  exported: string;
+  imported: string;
+  source: string;
+}
+
+const isServerSafeDependency = (specifier: string) => /^@videojs\/(?:core|media|store|utils)(?:\/|$)/.test(specifier);
+
+function getExports(source: string, file: string): { names: string[]; reexports: Reexport[]; stars: string[] } {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const names = new Set<string>();
+  const imports = new Map<string, Omit<Reexport, 'exported'>>();
+  const reexports: Reexport[] = [];
+  const stars: string[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const source = statement.moduleSpecifier.text;
+    if (!isServerSafeDependency(source)) continue;
+
+    const clause = statement.importClause;
+    if (clause?.name) imports.set(clause.name.text, { imported: 'default', source });
+    if (!clause?.namedBindings || !ts.isNamedImports(clause.namedBindings)) continue;
+    for (const element of clause.namedBindings.elements) {
+      imports.set(element.name.text, { imported: element.propertyName?.text ?? element.name.text, source });
+    }
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isExportDeclaration(statement)) continue;
+
+    if (!statement.exportClause) {
+      if (statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)) {
+        stars.push(statement.moduleSpecifier.text);
+      }
+      continue;
+    }
+
+    if (!ts.isNamedExports(statement.exportClause)) continue;
+    for (const element of statement.exportClause.elements) {
+      const exported = element.name.text;
+      const imported = element.propertyName?.text ?? exported;
+      const dependency = imports.get(imported);
+      if (dependency) reexports.push({ exported, ...dependency });
+      else names.add(exported);
+    }
+  }
+
+  return { names: [...names].sort(), reexports, stars };
+}
+
+function createServerStubs(exportedNames: string[]): string[] {
+  const names = new Set(exportedNames);
+  const output: string[] = [];
+
+  const take = (name: string): boolean => names.delete(name);
+
+  if (take('createPlayer')) {
+    output.push(
+      'function createPlayer() { class PlayerElement {}; class PlayerController {}; return { PlayerElement, PlayerController, playerContext: undefined }; }'
+    );
+  }
+  if (take('createPlayerController')) {
+    output.push('function createPlayerController() { return class PlayerController {}; }');
+  }
+  if (take('createMediaAttachMixin')) {
+    output.push('function createMediaAttachMixin() { return (Base) => Base; }');
+  }
+  if (take('createI18n')) {
+    output.push(
+      'function createI18n() { const Mixin = (Base) => Base; return { context: undefined, I18nController: class I18nController {}, ProviderMixin: Mixin, TextMixin: Mixin }; }'
+    );
+  }
+
+  const functionNames = [...names].filter((name) => name === 'safeDefine' || /^define[A-Z]/.test(name));
+  if (functionNames.length > 0) {
+    output.push('const serverNoop = () => {};');
+    for (const name of functionNames) names.delete(name);
+  }
+
+  const classNames = [...names].filter(
+    (name) => name === 'ReactiveElement' || name.endsWith('Controller') || name.endsWith('Element')
+  );
+  for (const name of classNames) {
+    names.delete(name);
+    output.push(`class ${name} {}`);
+  }
+
+  const mixinNames = [...names].filter((name) => name.endsWith('Mixin'));
+  if (mixinNames.length > 0) {
+    output.push('const serverMixin = (Base) => Base;');
+    for (const name of mixinNames) names.delete(name);
+  }
+
+  if (names.size > 0) output.push('const serverStub = undefined;');
+
+  const bindings = [
+    ...['createPlayer', 'createPlayerController', 'createMediaAttachMixin', 'createI18n'].filter((name) =>
+      exportedNames.includes(name)
+    ),
+    ...classNames,
+    ...functionNames.map((name) => `serverNoop as ${name}`),
+    ...mixinNames.map((name) => `serverMixin as ${name}`),
+    ...[...names].map((name) => `serverStub as ${name}`),
+  ];
+  if (bindings.length > 0) output.push(`export { ${bindings.join(', ')} };`);
+
+  return output;
+}
+
+rmSync(serverDir, { recursive: true, force: true });
+
+for (const sourcePath of entryFiles) {
+  const outputPath = resolve(serverDir, relative(browserDir, sourcePath));
+  const { names, reexports, stars } = getExports(readFileSync(sourcePath, 'utf8'), sourcePath);
+  const output: string[] = [];
+
+  output.push(...createServerStubs(names));
+  for (const { exported, imported, source } of reexports) {
+    const binding = imported === exported ? imported : `${imported} as ${exported}`;
+    output.push(`export { ${binding} } from ${JSON.stringify(source)};`);
+  }
+  for (const specifier of stars) output.push(`export * from ${JSON.stringify(specifier)};`);
+  if (output.length === 0) output.push('export {};');
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${output.join('\n')}\n`);
+}
+
+console.log(`[server-build] ${entryFiles.length} import-safe entry modules`);

--- a/packages/html/scripts/build-server.ts
+++ b/packages/html/scripts/build-server.ts
@@ -5,6 +5,12 @@ import ts from 'typescript';
 const packageDir = resolve(import.meta.dirname, '..');
 const browserDir = resolve(packageDir, 'dist/default');
 const serverDir = resolve(packageDir, 'dist/server');
+const createPlayerSource = readFileSync(resolve(packageDir, 'src/player/create-player.ts'), 'utf8');
+const createPlayerResult = createPlayerSource.match(/export interface CreatePlayerResult[\s\S]*?\n}/)?.[0];
+
+if (!createPlayerResult) throw new Error('Could not find CreatePlayerResult');
+
+const createPlayerReturnsElement = /\bPlayerElement\s*:/.test(createPlayerResult);
 
 const entryFiles = [
   resolve(browserDir, 'index.js'),
@@ -74,7 +80,9 @@ function createServerStubs(exportedNames: string[]): string[] {
 
   if (take('createPlayer')) {
     output.push(
-      'function createPlayer() { class PlayerController {}; const ProviderMixin = (Base) => Base; const create = () => undefined; return { ProviderMixin, PlayerController, context: undefined, create }; }'
+      createPlayerReturnsElement
+        ? 'function createPlayer() { class PlayerElement {}; class PlayerController {}; return { PlayerElement, PlayerController, playerContext: undefined }; }'
+        : 'function createPlayer() { class PlayerController {}; const ProviderMixin = (Base) => Base; const create = () => undefined; return { ProviderMixin, PlayerController, context: undefined, create }; }'
     );
   }
   if (take('createPlayerController')) {

--- a/packages/html/scripts/check-server.ts
+++ b/packages/html/scripts/check-server.ts
@@ -1,0 +1,125 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, globSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const packageDir = resolve(import.meta.dirname, '..');
+const packageName = '@videojs/html';
+const serverDir = resolve(packageDir, 'dist/server');
+
+function toPublicSpecifiers(file: string): string[] {
+  const entry = file.replace(/\.js$/, '');
+  if (entry === 'index') return [packageName];
+  if (entry.startsWith('presets/')) return [`${packageName}/${entry.slice('presets/'.length)}`];
+  if (entry.startsWith('icons/element')) return [`${packageName}/${entry.replace(/\/index$/, '')}`];
+  if (entry === 'i18n/index') return [`${packageName}/i18n`];
+  if (entry.startsWith('i18n/locales/')) return [`${packageName}/${entry}`];
+  if (!entry.startsWith('define/')) return [];
+
+  const subpath = entry.slice('define/'.length);
+  if (subpath === 'i18n') return [];
+  if (subpath === 'media/mux-video/index' || subpath === 'media/mux-audio/index') {
+    return [`${packageName}/${subpath.replace(/\/index$/, '')}`, `${packageName}/${subpath}`];
+  }
+  return [`${packageName}/${subpath}`];
+}
+
+const imports = [...new Set(globSync('**/*.js', { cwd: serverDir }).flatMap(toPublicSpecifiers))].sort();
+
+function runNode(args: string[]): string {
+  const result = spawnSync(process.execPath, args, { cwd: packageDir, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+  return result.stdout.trim();
+}
+
+const importScript = `
+  await Promise.all(${JSON.stringify(imports)}.map((specifier) => import(specifier)));
+  const html = await import('${packageName}');
+  const custom = html.createPlayer({ features: [] });
+  if (typeof custom.PlayerElement !== 'function' || typeof custom.PlayerController !== 'function') {
+    throw new Error('createPlayer server facade is not composable');
+  }
+  const video = await import('${packageName}/video');
+  for (const name of ['PlayerController', 'VideoPlayerElement', 'VideoSkinElement']) {
+    if (typeof video[name] !== 'function') throw new Error(name + ' server export is not constructable');
+  }
+  if (!Array.isArray(video.videoFeatures)) throw new Error('videoFeatures server export is not usable');
+  const safeDefine = await import('${packageName}/safe-define');
+  if (typeof safeDefine.safeDefine !== 'function') throw new Error('safeDefine server export is not callable');
+  safeDefine.safeDefine(class ServerElement {});
+  const compounds = await import('${packageName}/ui/compounds');
+  for (const [name, define] of Object.entries(compounds)) {
+    if (name.startsWith('define')) {
+      if (typeof define !== 'function') throw new Error(name + ' server export is not callable');
+      define();
+    }
+  }
+`;
+for (const conditions of [
+  [],
+  ['react-server'],
+  ['edge-light'],
+  ['workerd'],
+  ['worker'],
+  ['react-server', 'browser'],
+  ['edge-light', 'browser'],
+  ['workerd', 'browser'],
+  ['worker', 'browser'],
+]) {
+  runNode([
+    ...conditions.map((condition) => `--conditions=${condition}`),
+    '--input-type=module',
+    '--eval',
+    importScript,
+  ]);
+}
+
+const resolutions = JSON.parse(
+  runNode([
+    '--input-type=module',
+    '--eval',
+    `console.log(JSON.stringify(${JSON.stringify(imports)}.map((specifier) => import.meta.resolve(specifier))))`,
+  ])
+) as string[];
+
+for (const resolution of resolutions) {
+  if (!resolution.includes('/dist/server/')) throw new Error(`Expected server resolution, received ${resolution}`);
+  const path = new URL(resolution);
+  if (!existsSync(path)) throw new Error(`Missing server entry: ${path.pathname}`);
+  if (/\b(?:document|HTMLElement|window)\b/.test(readFileSync(path, 'utf8'))) {
+    throw new Error(`Browser global found in server entry: ${path.pathname}`);
+  }
+}
+
+const packageJson = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8'));
+const videoExport = packageJson.exports['./video'];
+if (videoExport.browser?.default !== './dist/default/presets/video.js') {
+  throw new Error('Video preset is missing its production browser condition');
+}
+if (videoExport.browser?.development !== './dist/dev/presets/video.js') {
+  throw new Error('Video preset is missing its development browser condition');
+}
+
+const browserResolution = runNode([
+  '--conditions=browser',
+  '--input-type=module',
+  '--eval',
+  `console.log(import.meta.resolve('${packageName}/video'))`,
+]);
+if (!browserResolution.includes('/dist/default/presets/video.js')) {
+  throw new Error(`Expected production browser resolution, received ${browserResolution}`);
+}
+
+const devBrowserResolution = runNode([
+  '--conditions=browser',
+  '--conditions=development',
+  '--input-type=module',
+  '--eval',
+  `console.log(import.meta.resolve('${packageName}/video'))`,
+]);
+if (!devBrowserResolution.includes('/dist/dev/presets/video.js')) {
+  throw new Error(`Expected development browser resolution, received ${devBrowserResolution}`);
+}
+
+console.log(
+  `[server-check] ${imports.length} public imports across default, React server, Edge, workerd, worker, and browser conditions`
+);

--- a/packages/html/scripts/check-server.ts
+++ b/packages/html/scripts/check-server.ts
@@ -35,11 +35,14 @@ const importScript = `
   await Promise.all(${JSON.stringify(imports)}.map((specifier) => import(specifier)));
   const html = await import('${packageName}');
   const custom = html.createPlayer({ features: [] });
-  if (typeof custom.PlayerElement !== 'function' || typeof custom.PlayerController !== 'function') {
+  if (typeof custom.ProviderMixin !== 'function' || typeof custom.PlayerController !== 'function' || typeof custom.create !== 'function') {
     throw new Error('createPlayer server facade is not composable');
   }
+  class ServerHost {}
+  class ServerPlayer extends custom.ProviderMixin(ServerHost) {}
+  if (!(new ServerPlayer() instanceof ServerHost)) throw new Error('ProviderMixin server export is not composable');
   const video = await import('${packageName}/video');
-  for (const name of ['PlayerController', 'VideoPlayerElement', 'VideoSkinElement']) {
+  for (const name of ['MinimalVideoSkinElement', 'VideoSkinElement']) {
     if (typeof video[name] !== 'function') throw new Error(name + ' server export is not constructable');
   }
   if (!Array.isArray(video.videoFeatures)) throw new Error('videoFeatures server export is not usable');

--- a/packages/html/scripts/check-server.ts
+++ b/packages/html/scripts/check-server.ts
@@ -5,6 +5,15 @@ import { resolve } from 'node:path';
 const packageDir = resolve(import.meta.dirname, '..');
 const packageName = '@videojs/html';
 const serverDir = resolve(packageDir, 'dist/server');
+const createPlayerSource = readFileSync(resolve(packageDir, 'src/player/create-player.ts'), 'utf8');
+const createPlayerResult = createPlayerSource.match(/export interface CreatePlayerResult[\s\S]*?\n}/)?.[0];
+
+if (!createPlayerResult) throw new Error('Could not find CreatePlayerResult');
+
+const createPlayerReturnsElement = /\bPlayerElement\s*:/.test(createPlayerResult);
+const videoPresetExportsPlayer = /\bVideoPlayerElement\b/.test(
+  readFileSync(resolve(packageDir, 'src/presets/video.ts'), 'utf8')
+);
 
 function toPublicSpecifiers(file: string): string[] {
   const entry = file.replace(/\.js$/, '');
@@ -35,14 +44,26 @@ const importScript = `
   await Promise.all(${JSON.stringify(imports)}.map((specifier) => import(specifier)));
   const html = await import('${packageName}');
   const custom = html.createPlayer({ features: [] });
-  if (typeof custom.ProviderMixin !== 'function' || typeof custom.PlayerController !== 'function' || typeof custom.create !== 'function') {
-    throw new Error('createPlayer server facade is not composable');
+  if (${JSON.stringify(createPlayerReturnsElement)}) {
+    if (typeof custom.PlayerElement !== 'function' || typeof custom.PlayerController !== 'function' || !('playerContext' in custom)) {
+      throw new Error('createPlayer PlayerElement server facade is not composable');
+    }
+    class ServerPlayer extends custom.PlayerElement {}
+    new ServerPlayer();
+    new custom.PlayerController();
+  } else {
+    if (typeof custom.ProviderMixin !== 'function' || typeof custom.PlayerController !== 'function' || typeof custom.create !== 'function') {
+      throw new Error('createPlayer ProviderMixin server facade is not composable');
+    }
+    class ServerHost {}
+    class ServerPlayer extends custom.ProviderMixin(ServerHost) {}
+    if (!(new ServerPlayer() instanceof ServerHost)) throw new Error('ProviderMixin server export is not composable');
   }
-  class ServerHost {}
-  class ServerPlayer extends custom.ProviderMixin(ServerHost) {}
-  if (!(new ServerPlayer() instanceof ServerHost)) throw new Error('ProviderMixin server export is not composable');
   const video = await import('${packageName}/video');
-  for (const name of ['MinimalVideoSkinElement', 'VideoSkinElement']) {
+  const videoClasses = ${JSON.stringify(videoPresetExportsPlayer)}
+    ? ['PlayerController', 'VideoPlayerElement', 'VideoSkinElement']
+    : ['MinimalVideoSkinElement', 'VideoSkinElement'];
+  for (const name of videoClasses) {
     if (typeof video[name] !== 'function') throw new Error(name + ' server export is not constructable');
   }
   if (!Array.isArray(video.videoFeatures)) throw new Error('videoFeatures server export is not usable');

--- a/site/src/content/docs/concepts/browser-support.mdx
+++ b/site/src/content/docs/concepts/browser-support.mdx
@@ -38,4 +38,29 @@ TV platforms run embedded browsers with limited standards support. Video.js 10's
 
 ### Server-side rendering
 
-Video.js components render valid markup on the server. Interactivity — state management, media playback, and event handling — requires the browser and kicks in after hydration.
+Video.js components render valid markup on the server. Interactivity — custom-element registration, state management, media playback, and event handling — requires the browser and begins after hydration.
+
+`@videojs/html` publishes a DOM-free module facade for server-oriented conditions: `react-server`, `edge-light`, `workerd`, `worker`, and the server default. Browser builds select the real implementation through the `browser` condition. This means a framework can evaluate preset, UI, Media, and custom `createPlayer` imports while rendering or prerendering without requiring `window`, `document`, or `HTMLElement`.
+
+```tsx title="VideoPlayer.tsx"
+'use client';
+
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+
+export function VideoPlayer() {
+  return (
+    <video-player>
+      <video-skin>
+        <video src="movie.mp4" />
+      </video-skin>
+    </video-player>
+  );
+}
+```
+
+In the Next.js App Router, a normal Client Component boundary is enough; a delayed `dynamic(..., { ssr: false })` import is not required. The server facade preserves import and composition shapes, but it does not register elements or render DOM on the server. The browser bundle performs the upgrade.
+
+<Aside type="note">
+  A browser Web Worker is not a playback environment. Some bundlers, including Vite, select the `browser` condition for Web Worker bundles unless you configure worker-specific resolution. Keep `@videojs/html` in the document bundle; use runtime-neutral `@videojs/core`, `@videojs/media`, and `@videojs/store` APIs for worker logic.
+</Aside>


### PR DESCRIPTION
Refs #1343

## Summary

Allow every public `@videojs/html` entry to be evaluated during SSR, prerendering, and server/edge module analysis without requiring DOM globals. Browser conditions continue to resolve the real custom-element implementation.

## Changes

- publish DOM-free facades for the default, React server, Edge, workerd, and worker conditions
- derive the `createPlayer` facade from the source API, so it stays compatible before or after the PlayerElement change
- preserve constructable classes, callable definitions/mixins, feature arrays, and safe dependency re-exports
- validate every public import and mixed condition order during the package build
- document Next.js, SSR, and browser-worker behavior

## Testing

- `pnpm -F @videojs/html build`
- 178 public imports across default, React server, Edge, workerd, worker, and browser conditions
- future stack merge (`PlayerElement` + pure preset exports): all 10 dependency builds and server checks pass