### PR TITLE
fix(html): ship a cdn bundle for every media element

### DIFF
--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -1,4 +1,5 @@
 import '@app/styles.css';
+import { EMBED_PRESETS } from '@app/constants';
 import { renderChapters } from '@app/shared/html/chapters';
 import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
 import { CSS_SKIN_TAGS, LIVE_VIDEO_CSS_SKIN_TAGS } from '@app/shared/html/skin-tags';
@@ -18,12 +19,18 @@ import {
 } from '@app/shared/sandbox-listener';
 import {
   BACKGROUND_VIDEO_SRC,
+  CLOUDFLARE_VIDEO_SRC,
   getChapters,
   getPosterSrc,
   getStoryboardSrc,
   HLS_BACKGROUND_VIDEO_SRC,
   isLiveSource,
   SOURCES,
+  SPOTIFY_AUDIO_SRC,
+  TIKTOK_VIDEO_SRC,
+  TWITCH_VIDEO_SRC,
+  VIMEO_VIDEO_SRC,
+  YOUTUBE_VIDEO_SRC,
 } from '@app/shared/sources';
 import type { Preset, Skin } from '@app/types';
 import { getI18nTranslations } from '@videojs/html/cdn/i18n';
@@ -95,7 +102,9 @@ async function syncCdnI18nProvider(tag: SandboxLocaleTag, seq: number): Promise<
   await provider.updateComplete;
   if (seq !== localeApplySeq) return;
 
-  if (!import.meta.env.DEV || tag === 'en') return;
+  // An embed plays in a cross-origin frame with no <video> of its own, so the
+  // metadata gate the label check waits on never opens.
+  if (!import.meta.env.DEV || tag === 'en' || isEmbedPreset(preset)) return;
   if (!document.querySelector('media-play-button')) return;
 
   const expected = getI18nTranslations(tag)['buttons.play'];
@@ -131,6 +140,11 @@ async function loadCdnPreset(preset: Preset, skin: Skin, live: boolean) {
     case 'native-hls-video':
     case 'hls-video':
     case 'dash-video':
+    case 'vimeo-video':
+    case 'youtube-video':
+    case 'cloudflare-video':
+    case 'tiktok-video':
+    case 'twitch-video':
       if (live) {
         if (skin === 'minimal') await import('@videojs/html/cdn/live-video-minimal');
         else await import('@videojs/html/cdn/live-video');
@@ -143,6 +157,7 @@ async function loadCdnPreset(preset: Preset, skin: Skin, live: boolean) {
     case 'mux-audio':
     case 'mux-audio-spf':
     case 'hls-audio':
+    case 'spotify-audio':
       if (skin === 'minimal') await import('@videojs/html/cdn/audio-minimal');
       else await import('@videojs/html/cdn/audio');
       break;
@@ -198,6 +213,26 @@ async function loadCdnMedia(preset: Preset) {
     case 'dash-video':
       await import('@videojs/html/cdn/media/dash-video');
       break;
+    // Each embed is one bundle beside the rest, so a page reaches a third-party
+    // player the same way it reaches an HLS one — no npm-only step.
+    case 'vimeo-video':
+      await import('@videojs/html/cdn/media/vimeo-video');
+      break;
+    case 'youtube-video':
+      await import('@videojs/html/cdn/media/youtube-video');
+      break;
+    case 'cloudflare-video':
+      await import('@videojs/html/cdn/media/cloudflare-video');
+      break;
+    case 'spotify-audio':
+      await import('@videojs/html/cdn/media/spotify-audio');
+      break;
+    case 'tiktok-video':
+      await import('@videojs/html/cdn/media/tiktok-video');
+      break;
+    case 'twitch-video':
+      await import('@videojs/html/cdn/media/twitch-video');
+      break;
   }
 }
 
@@ -206,8 +241,38 @@ async function loadCdnMedia(preset: Preset) {
 // ---------------------------------------------------------------------------
 
 function isAudioPreset(preset: Preset): boolean {
-  return preset === 'audio' || preset === 'mux-audio' || preset === 'mux-audio-spf' || preset === 'hls-audio';
+  return (
+    preset === 'audio' ||
+    preset === 'mux-audio' ||
+    preset === 'mux-audio-spf' ||
+    preset === 'hls-audio' ||
+    preset === 'spotify-audio'
+  );
 }
+
+function isEmbedPreset(preset: Preset): boolean {
+  return (EMBED_PRESETS as readonly Preset[]).includes(preset);
+}
+
+/**
+ * An embed fills the skin box the way `<video>` does on its own.
+ *
+ * TikTok's host floors itself at the portrait 325x578 its player refuses to draw
+ * below, so a landscape box needs that floor cleared.
+ */
+function getEmbedMediaClass(preset: Preset): string {
+  return preset === 'tiktok-video' ? 'block w-full h-full min-w-0 min-h-0' : 'block w-full h-full';
+}
+
+/** The one source each embed plays: a provider page URL, not one of the picker's files. */
+const EMBED_SOURCES: Partial<Record<Preset, string>> = {
+  'vimeo-video': VIMEO_VIDEO_SRC,
+  'youtube-video': YOUTUBE_VIDEO_SRC,
+  'cloudflare-video': CLOUDFLARE_VIDEO_SRC,
+  'spotify-audio': SPOTIFY_AUDIO_SRC,
+  'tiktok-video': TIKTOK_VIDEO_SRC,
+  'twitch-video': TWITCH_VIDEO_SRC,
+};
 
 function isBackgroundPreset(preset: Preset): boolean {
   return preset === 'background-video' || preset === 'hls-background-video' || preset === 'mux-background-video';
@@ -237,6 +302,12 @@ function getMediaTag(preset: Preset): string {
     'hls-video': 'hls-video',
     'hls-audio': 'hls-audio',
     'dash-video': 'dash-video',
+    'vimeo-video': 'vimeo-video',
+    'youtube-video': 'youtube-video',
+    'cloudflare-video': 'cloudflare-video',
+    'spotify-audio': 'spotify-audio',
+    'tiktok-video': 'tiktok-video',
+    'twitch-video': 'twitch-video',
     audio: 'audio',
     'background-video': 'background-video',
     'hls-background-video': 'hls-background-video',
@@ -310,8 +381,15 @@ async function render() {
       : preset === 'hls-background-video'
         ? HLS_BACKGROUND_VIDEO_SRC
         : BACKGROUND_VIDEO_SRC;
-  const sourceAttr = isBackgroundPreset(preset) ? `src="${backgroundSrc}"` : `src="${source.url}"`;
-  const mediaAttrs = renderMediaAttrs(state);
+  const sourceAttr = isBackgroundPreset(preset)
+    ? `src="${backgroundSrc}"`
+    : `src="${EMBED_SOURCES[preset] ?? source.url}"`;
+  // An embed hands playback to a provider that owns autoplay, looping, and how much
+  // it preloads, so the settings menu has nothing to attach to — same as the
+  // per-embed pages on the html and react platforms.
+  const mediaAttrs = isEmbedPreset(preset) ? '' : renderMediaAttrs(state);
+  const crossoriginAttr = isEmbedPreset(preset) ? '' : 'crossorigin="anonymous"';
+  const mediaClassAttr = isEmbedPreset(preset) ? `class="${getEmbedMediaClass(preset)}"` : '';
 
   // Background video needs viewport dimensions instead of flex centering.
   if (isBackgroundPreset(preset)) {
@@ -351,7 +429,7 @@ async function render() {
 
   const skin = html`
     <${skinTag} class="aspect-video max-w-4xl mx-auto">
-      <${mediaTag} ${sourceAttr} ${mediaAttrs} playsinline crossorigin="anonymous">
+      <${mediaTag} ${mediaClassAttr} ${sourceAttr} ${mediaAttrs} playsinline ${crossoriginAttr}>
         ${isVideoPreset(preset) ? renderChapters(getChapters(state.source)) : ''}
         ${renderStoryboard(storyboard)}
       </${mediaTag}>

--- a/packages/html/scripts/cdn-graph.ts
+++ b/packages/html/scripts/cdn-graph.ts
@@ -12,6 +12,15 @@ import { dirname, relative, resolve } from 'node:path';
 const SPECIFIER = /(?:\bfrom|\bimport)\s*\(?\s*["']([^"']+)["']/g;
 
 /**
+ * JSDoc blocks, dropped before the scan.
+ *
+ * Their `{import('…')}` type annotations are indistinguishable from dynamic imports, and the
+ * modules they name are types that no bundle ever loads — third-party dev bundles are full of
+ * them. Minified production bundles carry no JSDoc, so nothing real is hidden by this.
+ */
+const JSDOC_BLOCK = /\/\*\*[\s\S]*?\*\//g;
+
+/**
  * Drop matches that cannot be module specifiers.
  *
  * The scan is a regex rather than a parser, so it also sees the words `from` and `import` inside
@@ -24,7 +33,9 @@ function isLikelySpecifier(value: string): boolean {
 }
 
 export function collectSpecifiers(code: string): string[] {
-  return [...code.matchAll(SPECIFIER)].map((match) => match[1] as string).filter(isLikelySpecifier);
+  return [...code.replace(JSDOC_BLOCK, '').matchAll(SPECIFIER)]
+    .map((match) => match[1] as string)
+    .filter(isLikelySpecifier);
 }
 
 function isAbsoluteSpecifier(specifier: string): boolean {

--- a/packages/html/scripts/tests/cdn-graph.test.ts
+++ b/packages/html/scripts/tests/cdn-graph.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { collectSpecifiers } from '../cdn-graph.ts';
+
+describe('collectSpecifiers', () => {
+  it('collects static and dynamic specifiers', () => {
+    const code = [
+      'import { a } from "./chunk-a.js";',
+      'export { b } from "./chunk-b.js";',
+      'const c = await import("./chunk-c.js");',
+    ].join('\n');
+
+    expect(collectSpecifiers(code)).toEqual(['./chunk-a.js', './chunk-b.js', './chunk-c.js']);
+  });
+
+  it('ignores type imports in JSDoc without hiding the code around them', () => {
+    const code = [
+      'import { a } from "./chunk-a.js";',
+      "/** @typedef {import('./player.types').PlayerControls} PlayerControls */",
+      "/** @typedef {import('timing-object').ITimingObject} TimingObject */",
+      'const b = await import("./chunk-b.js");',
+    ].join('\n');
+
+    expect(collectSpecifiers(code)).toEqual(['./chunk-a.js', './chunk-b.js']);
+  });
+
+  it('ignores prose that reads like a specifier', () => {
+    expect(collectSpecifiers('// Re-exported from "the store package"')).toEqual([]);
+    expect(collectSpecifiers('throw new Error(`imported from "${name}"`)')).toEqual([]);
+  });
+});

--- a/packages/html/src/cdn/media/dash-video.ts
+++ b/packages/html/src/cdn/media/dash-video.ts
@@ -1,1 +1,0 @@
-import '../../define/media/dash-video';

--- a/packages/html/src/cdn/media/google-cast.ts
+++ b/packages/html/src/cdn/media/google-cast.ts
@@ -1,1 +1,0 @@
-import '../../define/media/google-cast';

--- a/packages/html/src/cdn/media/hls-audio.ts
+++ b/packages/html/src/cdn/media/hls-audio.ts
@@ -1,1 +1,0 @@
-import '../../define/media/hls-audio';

--- a/packages/html/src/cdn/media/hls-background-video.ts
+++ b/packages/html/src/cdn/media/hls-background-video.ts
@@ -1,1 +1,0 @@
-import '../../define/media/hls-background-video';

--- a/packages/html/src/cdn/media/hls-video.ts
+++ b/packages/html/src/cdn/media/hls-video.ts
@@ -1,1 +1,0 @@
-import '../../define/media/hls-video';

--- a/packages/html/src/cdn/media/hlsjs-video.ts
+++ b/packages/html/src/cdn/media/hlsjs-video.ts
@@ -1,1 +1,0 @@
-import '../../define/media/hlsjs-video';

--- a/packages/html/src/cdn/media/mux-audio/hls-js.ts
+++ b/packages/html/src/cdn/media/mux-audio/hls-js.ts
@@ -1,1 +1,0 @@
-import '../../../define/media/mux-audio/hls-js';

--- a/packages/html/src/cdn/media/mux-audio/index.ts
+++ b/packages/html/src/cdn/media/mux-audio/index.ts
@@ -1,1 +1,0 @@
-import '../../../define/media/mux-audio';

--- a/packages/html/src/cdn/media/mux-audio/spf.ts
+++ b/packages/html/src/cdn/media/mux-audio/spf.ts
@@ -1,1 +1,0 @@
-import '../../../define/media/mux-audio/spf';

--- a/packages/html/src/cdn/media/mux-background-video.ts
+++ b/packages/html/src/cdn/media/mux-background-video.ts
@@ -1,1 +1,0 @@
-import '../../define/media/mux-background-video';

--- a/packages/html/src/cdn/media/mux-data.ts
+++ b/packages/html/src/cdn/media/mux-data.ts
@@ -1,1 +1,0 @@
-import '../../define/media/mux-data';

--- a/packages/html/src/cdn/media/mux-video/hls-js.ts
+++ b/packages/html/src/cdn/media/mux-video/hls-js.ts
@@ -1,1 +1,0 @@
-import '../../../define/media/mux-video/hls-js';

--- a/packages/html/src/cdn/media/mux-video/index.ts
+++ b/packages/html/src/cdn/media/mux-video/index.ts
@@ -1,1 +1,0 @@
-import '../../../define/media/mux-video';

--- a/packages/html/src/cdn/media/mux-video/spf.ts
+++ b/packages/html/src/cdn/media/mux-video/spf.ts
@@ -1,1 +1,0 @@
-import '../../../define/media/mux-video/spf';

--- a/packages/html/src/cdn/media/native-hls-video.ts
+++ b/packages/html/src/cdn/media/native-hls-video.ts
@@ -1,1 +1,0 @@
-import '../../define/media/native-hls-video';

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -1,4 +1,4 @@
-import { globSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { globSync, readdirSync, writeFileSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { UserConfig } from 'tsdown';
@@ -29,23 +29,17 @@ const presets = [
   'audio-minimal-ui',
   'background',
 ];
-const media = [
-  'google-cast',
-  'hls-audio',
-  'hls-background-video',
-  'hls-video',
-  'hlsjs-video',
-  'mux-audio',
-  'mux-background-video',
-  'mux-data',
-  'mux-video',
-  'native-hls-video',
-  'dash-video',
-];
+
+const mediaDir = 'src/define/media';
 
 /**
- * Media entries, one bundle per name — or per flavor, for a name that is a
- * directory.
+ * Media entries, one bundle per module under `src/define/media` — or per flavor,
+ * for a module that is a directory.
+ *
+ * Read from the definitions themselves rather than a hand-kept list, so anything
+ * published as `@videojs/html/media/<name>` also ships as `cdn/media/<name>.js`.
+ * A hand-kept list let several media elements ship on npm with no CDN bundle,
+ * and therefore nothing in the release archive cut from this output.
  *
  * A directory ships its index as the flavor-neutral bundle and each flavor
  * beside it, so `media/mux-video/spf` reads the same as the npm subpath it
@@ -57,18 +51,20 @@ const media = [
  * where two flavors of one element can end up in a single realm — see the
  * tag-collision note in `define/media/mux-video/spf`.
  */
-const mediaEntries = media.flatMap((name) => {
-  const dir = `src/cdn/media/${name}`;
+const mediaEntries = readdirSync(mediaDir, { withFileTypes: true })
+  .flatMap((entry) => {
+    if (entry.isDirectory()) {
+      return globSync(`${mediaDir}/${entry.name}/*.ts`).map((src) => {
+        const flavor = basename(src, '.ts');
+        return { src, name: flavor === 'index' ? `media/${entry.name}` : `media/${entry.name}/${flavor}` };
+      });
+    }
 
-  if (!statSync(dir, { throwIfNoEntry: false })?.isDirectory()) {
-    return [{ src: `${dir}.ts`, name: `media/${name}` }];
-  }
-
-  return globSync(`${dir}/*.ts`).map((src) => {
-    const flavor = basename(src, '.ts');
-    return { src, name: flavor === 'index' ? `media/${name}` : `media/${name}/${flavor}` };
-  });
-});
+    return entry.name.endsWith('.ts')
+      ? [{ src: `${mediaDir}/${entry.name}`, name: `media/${basename(entry.name, '.ts')}` }]
+      : [];
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
 
 const localeEntries = globSync('src/cdn/locales/*.ts').map((file) => ({
   src: file,

--- a/packages/html/tsdown.cdn.config.ts
+++ b/packages/html/tsdown.cdn.config.ts
@@ -36,10 +36,9 @@ const mediaDir = 'src/define/media';
  * Media entries, one bundle per module under `src/define/media` — or per flavor,
  * for a module that is a directory.
  *
- * Read from the definitions themselves rather than a hand-kept list, so anything
- * published as `@videojs/html/media/<name>` also ships as `cdn/media/<name>.js`.
- * A hand-kept list let several media elements ship on npm with no CDN bundle,
- * and therefore nothing in the release archive cut from this output.
+ * Discovered from the definitions so the two delivery surfaces cannot drift:
+ * whatever ships on npm as `@videojs/html/media/<name>` also ships as
+ * `cdn/media/<name>.js`, and as a file in the archive cut from this output.
  *
  * A directory ships its index as the flavor-neutral bundle and each flavor
  * beside it, so `media/mux-video/spf` reads the same as the npm subpath it

--- a/site/scripts/build-cdn-manifest.ts
+++ b/site/scripts/build-cdn-manifest.ts
@@ -3,7 +3,7 @@
  *
  * Scans the built `@videojs/html` CDN media bundles and records which media
  * subpaths actually ship a CDN build. The installation page uses this to hide
- * the CDN install option for renderers that have no CDN bundle (e.g. Vimeo).
+ * the CDN install option for a renderer that has no CDN bundle.
  *
  * Produces `site/src/content/cdn-media.json` as an array of `{ id }` entries
  * (one per media subpath), consumed via the `cdnMedia` content collection.

--- a/site/src/components/installation/HTMLInstallTabsClient.tsx
+++ b/site/src/components/installation/HTMLInstallTabsClient.tsx
@@ -42,8 +42,8 @@ export default function HTMLInstallTabs({ cdnMedia }: HTMLInstallTabsProps) {
   // tab (cdn when available, else npm). That reset swaps in new DOM nodes rather
   // than toggling `data-tab-active` on existing ones, so the observer above
   // doesn't catch it — sync the store explicitly. Without this, a stale `cdn`
-  // can survive onto a renderer with no CDN build (e.g. Vimeo), where the usage
-  // block would then wrongly drop its required JS import lines.
+  // can survive onto a renderer with no CDN build, where the usage block would
+  // then wrongly drop its required JS import lines.
   useEffect(() => {
     installMethod.set(supportsCdn ? 'cdn' : 'npm');
   }, [supportsCdn]);

--- a/site/src/utils/installation/__tests__/cdn-code.test.ts
+++ b/site/src/utils/installation/__tests__/cdn-code.test.ts
@@ -75,7 +75,7 @@ describe('rendererSupportsCdn', () => {
     expect(rendererSupportsCdn('mux-audio', manifest)).toBe(true);
   });
 
-  it('returns false for vimeo, which has no CDN build', () => {
+  it('returns false for a media renderer absent from the manifest', () => {
     expect(rendererSupportsCdn('vimeo', manifest)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #2241

## Summary

`@videojs/html` publishes `media/youtube-video` on npm but never built a CDN bundle for it, so the bundle was missing from `cdn/` and from the distribution archive attached to each release. The CDN build now takes its media entries from the element definitions themselves, so anything published as `@videojs/html/media/<name>` also ships as `cdn/media/<name>.js`.

## Changes

- CDN media entries are read from `src/define/media` instead of a hand-kept list. Eight elements had drifted off that list — YouTube, Vimeo, Cloudflare, Spotify, TikTok, Twitch, `background-video`, and `container` — and now build, ship on the CDN, and land in the release archive.
- The one-line mirror modules under `src/cdn/media` are gone; they only re-imported the definitions and were the place the drift happened.
- The self-contained guard no longer trips on JSDoc. Building the Vimeo bundle exposed `@vimeo/player`'s `{import('timing-object')}` type annotations being read as real dynamic imports, so JSDoc blocks are stripped before the specifier scan.
- The installation page picks the new bundles up through the existing manifest, so YouTube and the other embeds now offer a CDN install path.
- The sandbox's CDN platform plays the third-party embeds. Its page picks bundles by switching on the preset, and the six embed presets matched no case — no player bundle, no media bundle, and a plain `<video>` pointed at a provider page URL. Each one now loads its bundle pair and renders with the fixed source and sizing its per-embed html page uses.

<details>
<summary>Implementation details</summary>

The archive is cut from the production CDN entries (`build:archive` → `tsdown.cdn.config.ts`'s exported `entries`), so a missing entry meant a missing archive file — nothing about the archive script needed changing. Flavor directories keep their layout (`media/mux-video/spf`), which is what keeps CDN paths equal to the npm media subpaths the installation page resolves against.

The JSDoc strip is safe for the archive's closure resolution, which shares the same scan: production bundles are minified and carry no JSDoc, so no real specifier can hide inside a stripped block.

Embeds on the CDN page skip the autoplay/loop/preload attributes and the DEV-only i18n label probe. The provider owns those settings, and the probe waits on a `<video>` that a cross-origin iframe embed never has — both matching how the html and react embed pages already behave.

</details>

## Testing

1. `pnpm -F @videojs/html build:cdn && pnpm -F @videojs/html check:cdn` — 420 bundles, every specifier resolves inside `cdn/`.
2. `pnpm -F @videojs/html build:archive` — 208 bundles from 90 entries; `tar -tzf archive/videojs-html-*.tar.gz` now lists `media/youtube-video.js` alongside vimeo, cloudflare, spotify, tiktok, and twitch.
3. `pnpm -F @videojs/html test`, `pnpm -F site test`, `pnpm typecheck`, `pnpm check:workspace`.
4. Sandbox: `pnpm -F @videojs/sandbox build`, then `/cdn/?preset=<embed>` in headless Chromium for all six embeds — each registers its element, mounts, creates its provider iframe, and upgrades the player. (TikTok's `AbortError: The play() request was interrupted by a call to pause()` reproduces on the existing `/html-tiktok-video/` page and is unrelated.)

New unit coverage for the specifier scan lives in `packages/html/scripts/tests/cdn-graph.test.ts`.
