### PR TITLE
fix(skin): use finite radius value

### DIFF
--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -1,7 +1,12 @@
 .media-default-skin .media-slider {
+  --track-size: calc(var(--spacing) * 1);
+  --track-highlighted-size: calc(var(--spacing) * 1.75);
+  --track-border-radius: 99px;
   --thumb-size: calc(var(--spacing) * 2.5);
   --thumb-active-size: calc(var(--spacing) * 3);
-  --track-border-radius: calc(Infinity * 1px);
+  --chapter-gap: calc(var(--spacing) * 1);
+  --chapter-inset-start: calc(var(--chapter-gap) / 2);
+  --chapter-inset-end: calc(var(--chapter-gap) / 2);
 
   position: relative;
   display: flex;
@@ -32,10 +37,10 @@
 
     &[data-orientation="horizontal"] {
       width: 100%;
-      height: calc(var(--spacing) * 1);
+      height: var(--track-size);
     }
     &[data-orientation="vertical"] {
-      width: calc(var(--spacing) * 1);
+      width: var(--track-size);
       height: 100%;
     }
   }
@@ -107,10 +112,6 @@
   }
 
   .media-slider__chapter {
-    --chapter-gap: calc(var(--spacing) * 1);
-    --chapter-inset-start: 0.5;
-    --chapter-inset-end: 0.5;
-
     position: absolute;
     inset: 0;
     display: flex;
@@ -121,16 +122,13 @@
     border-radius: inherit;
 
     &:first-child {
-      --chapter-inset-start: 0;
+      --chapter-inset-start: 0px;
     }
     &:last-child {
-      --chapter-inset-end: 0;
+      --chapter-inset-end: 0px;
     }
 
     .media-slider__chapter-track {
-      --chapter-track-size: calc(var(--spacing) * 1);
-      --chapter-track-highlighted-size: calc(var(--spacing) * 1.75);
-
       border-radius: inherit;
 
       @media (prefers-reduced-motion: no-preference) {
@@ -143,16 +141,15 @@
       clip-path: inset(0 calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start));
 
       .media-slider__chapter-track {
-        height: var(--chapter-track-size);
+        height: var(--track-size);
         clip-path: inset(
-          0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) round
-            var(--track-border-radius)
+          0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) round var(--track-border-radius)
         );
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        height: var(--chapter-track-highlighted-size);
+        height: var(--track-highlighted-size);
       }
     }
 
@@ -160,16 +157,15 @@
       clip-path: inset(calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start) 0);
 
       .media-slider__chapter-track {
-        width: var(--chapter-track-size);
+        width: var(--track-size);
         clip-path: inset(
-          calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) 0 round
-            var(--track-border-radius)
+          calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) 0 round var(--track-border-radius)
         );
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        width: var(--chapter-track-highlighted-size);
+        width: var(--track-highlighted-size);
       }
     }
   }

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -13,7 +13,8 @@ const previewContent = cn(
 export const slider = {
   root: cn(
     'group/slider relative flex flex-1 items-center justify-center rounded-(--track-border-radius) outline-none cursor-pointer',
-    '[--track-border-radius:calc(infinity*1px)]',
+    '[--track-border-radius:99px]',
+    '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:calc(var(--chapter-gap)/2)] [--chapter-inset-end:calc(var(--chapter-gap)/2)]',
     // Horizontal
     'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--slider-width,100%) data-[orientation=horizontal]:h-(--slider-height,--spacing(8))',
     // Vertical
@@ -30,8 +31,7 @@ export const slider = {
   chapter: {
     base: cn(
       'group/chapter absolute inset-0 flex items-center justify-center min-w-0 min-h-0',
-      '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:0.5] [--chapter-inset-end:0.5]',
-      'first:[--chapter-inset-start:0] last:[--chapter-inset-end:0]',
+      'first:[--chapter-inset-start:0px] last:[--chapter-inset-end:0px]',
       'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]',
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
     ),
@@ -40,10 +40,10 @@ export const slider = {
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
       'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
       'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_round_var(--track-border-radius))]',
       'data-[orientation=vertical]:w-1 data-[orientation=vertical]:h-full',
       'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
     ),
   },
   fill: {

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -163,8 +163,8 @@
 
   .media-slider__chapter {
     --chapter-gap: calc(var(--spacing) * 1);
-    --chapter-inset-start: 0.5;
-    --chapter-inset-end: 0.5;
+    --chapter-inset-start: calc(var(--chapter-gap) / 2);
+    --chapter-inset-end: calc(var(--chapter-gap) / 2);
     position: absolute;
     inset: 0;
     display: flex;
@@ -174,10 +174,10 @@
     min-height: 0;
 
     &:first-child {
-      --chapter-inset-start: 0;
+      --chapter-inset-start: 0px;
     }
     &:last-child {
-      --chapter-inset-end: 0;
+      --chapter-inset-end: 0px;
     }
 
     .media-slider__chapter-track {
@@ -197,9 +197,8 @@
       .media-slider__chapter-track {
         height: var(--chapter-track-size);
         clip-path: inset(
-          0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) round
-            var(--track-border-radius)
+          0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) round var(--track-border-radius)
         );
       }
 
@@ -214,9 +213,8 @@
       .media-slider__chapter-track {
         width: var(--chapter-track-size);
         clip-path: inset(
-          calc(100% - var(--media-slider-chapter-end) + var(--chapter-gap) * var(--chapter-inset-end)) 0
-            calc(var(--media-slider-chapter-start) + var(--chapter-gap) * var(--chapter-inset-start)) 0 round
-            var(--track-border-radius)
+          calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
+            calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) 0 round var(--track-border-radius)
         );
       }
 

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -30,8 +30,8 @@ export const slider = {
   chapter: {
     base: cn(
       'group/chapter absolute inset-0 flex items-center justify-center min-w-0 min-h-0',
-      '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:0.5] [--chapter-inset-end:0.5]',
-      'first:[--chapter-inset-start:0] last:[--chapter-inset-end:0]',
+      '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:calc(var(--chapter-gap)/2)] [--chapter-inset-end:calc(var(--chapter-gap)/2)]',
+      'first:[--chapter-inset-start:0px] last:[--chapter-inset-end:0px]',
       'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]',
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
     ),
@@ -40,10 +40,10 @@ export const slider = {
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
       'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-0.75',
       'group-data-highlighted/chapter:data-[orientation=horizontal]:h-[--spacing(1.25)]',
-      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_round_var(--track-border-radius))]',
       'data-[orientation=vertical]:w-0.75 data-[orientation=vertical]:h-full',
       'group-data-highlighted/chapter:data-[orientation=vertical]:w-[--spacing(1.25)]',
-      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-gap)*var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-gap)*var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
     ),
   },
   fill: {


### PR DESCRIPTION
Safari doesn't seem to like `calc(Infinity * 1px)` as the `round` value in a `clip-path` `inset()` function. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only slider/chapter styling in skin packages; no runtime or security impact, with a small chance of subtle rounding differences vs. fully pill-shaped tracks.
> 
> **Overview**
> Fixes **Safari** rendering of chaptered sliders by replacing **`calc(Infinity * 1px)`** with **`99px`** for `--track-border-radius` on the **default** skin (CSS + Tailwind), so `clip-path: inset(... round var(--track-border-radius))` gets a finite `round` radius.
> 
> Chapter segment **clip-path** math is updated in **default** and **minimal** skins: insets are **`calc(var(--chapter-gap) / 2)`** (or **`0px`** on first/last chapter) and added directly in the inset expression, instead of unitless **`0.5`** factors multiplied by **`--chapter-gap`**. Default also hoists **`--track-size`** / **`--track-highlighted-size`** and reuses them for the main track and chapter tracks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47829054ac968257d32016542673072ea5d8295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->