### PR TITLE
feat(cd): add manual dispatch to the deployment workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches:
       - main
+  # Recovery hatch: release-please recomputes each package's commit range from its
+  # latest release, so a missing tag makes that package replay old commits into the
+  # next release PR. Dispatching re-runs the calculation once the tag is restored,
+  # without needing an unrelated commit on main to trigger it. release-please
+  # detects the target branch from the repository default, so no ref input is
+  # needed here.
+  workflow_dispatch:
 
 # To use Turborepo Remote Caching, set the following environment variables.
 # env:


### PR DESCRIPTION
## Summary

`cd.yml` runs release-please, but only triggers on pushes to `main`. That leaves no way to re-run the release calculation after correcting release metadata, so recovery requires landing an unrelated commit just to nudge the pipeline. This adds a `workflow_dispatch` trigger.

The motivating incident: the `beta.27` run created tags and GitHub releases for 9 of 11 packages, silently skipping `@videojs/react` and `@videojs/spf` even though both published to npm. Release-please derives each package's commit range from its latest release, so with no `beta.27` release to anchor on, those two replayed old history into the pending `beta.28` release PR — about 180 stray changelog lines for `react` and 70 for `spf`, duplicating entries already written in the `beta.27` release commit. The missing tags and releases have since been restored on `390a449`, but the open release PR keeps the bad ranges until the workflow runs again.

## Changes

- Manual dispatch trigger on the deployment workflow, so the release PR can be regenerated on demand

<details>
<summary>Implementation details</summary>

No `target-branch` input is needed. In `release-please-action@v4` that input is only forwarded as `defaultBranch` to `GitHub.create()`, and when empty the branch is detected from the repository default via the API rather than from the trigger ref. Since the default branch is `main`, a dispatch run resolves identically to a push run.

Manual runs cannot publish unexpectedly. The `Publish` step and every build step before it are gated on `steps.release.outputs.releases_created == 'true'`, which is only true when release-please actually creates new releases. A recovery dispatch against normal `main` finds nothing to release, so it refreshes the release PR and skips the rest. The `environment: production` gate and `concurrency: production` group still apply, so a dispatch cannot race an in-flight deploy.

</details>

## Testing

Parsed the workflow with the workspace `yaml` package: triggers resolve to `{"push":{"branches":["main"]},"workflow_dispatch":null}`, with the `release` job and all 16 steps unchanged. Only the `on:` block is touched.

Dispatch cannot be exercised until this is on `main`, since GitHub reads dispatchable workflows from the default branch. Merging is itself a push to `main`, so it will trigger a run that regenerates the release PR with the corrected `react` and `spf` ranges — verify afterward that their changelog diffs drop to the same scale as the other packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only trigger change with no workflow logic edits; existing publish gates still prevent accidental releases on recovery runs.
> 
> **Overview**
> Adds **`workflow_dispatch`** to the production **Deployment** workflow (`.github/workflows/cd.yml`) so release-please can be re-run without pushing an unrelated commit to `main`.
> 
> This is meant as a **recovery hatch** when release metadata was fixed after a partial release (e.g. restored tags/releases): release-please recomputes each package’s range from its latest GitHub release, and a manual run refreshes the open release PR. Inline comments note that no branch input is required because release-please uses the repo default branch. **Jobs and steps are unchanged**; publish/build steps remain gated on `releases_created == 'true'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0591218b1580e2e95a3ade2d388edb6cea1ddee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->