### PR TITLE
fix(skin): style fixes

### DIFF
--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -94,7 +94,8 @@ export function createSlider(options: SliderOptions): SliderApi {
     cachedRect: DOMRect | null = null,
     capturedPointerId: number | null = null,
     lastDragPercent = 0,
-    committedOnRelease = false;
+    committedOnRelease = false,
+    pointingOnRelease = false;
 
   const throttledChange =
     changeThrottleMs > 0
@@ -124,8 +125,10 @@ export function createSlider(options: SliderOptions): SliderApi {
   }
 
   function endDrag(): void {
+    const pointing = committedOnRelease && pointingOnRelease;
+
     if (!isDragging) {
-      input.patch({ pointing: false });
+      input.patch({ pointing });
     } else {
       // Fire a final commit if pointerup didn't already handle it.
       if (!committedOnRelease) {
@@ -133,11 +136,12 @@ export function createSlider(options: SliderOptions): SliderApi {
       }
 
       isDragging = false;
-      input.patch({ dragging: false, pointing: false });
+      input.patch({ dragging: false, pointing });
       options.onDragEnd?.();
     }
 
     committedOnRelease = false;
+    pointingOnRelease = false;
     cleanup();
   }
 
@@ -167,6 +171,7 @@ export function createSlider(options: SliderOptions): SliderApi {
       cachedRect = el.getBoundingClientRect();
       cachedRTL = options.isRTL();
       committedOnRelease = false;
+      pointingOnRelease = false;
 
       releaseCapture();
       capturedPointerId = event.pointerId;
@@ -225,6 +230,13 @@ export function createSlider(options: SliderOptions): SliderApi {
       if (isNull(capturedPointerId)) return;
 
       const percent = getPercentFromPointerEvent(event, cachedRect!, options.getOrientation(), cachedRTL);
+      const releaseRect = options.getElement().getBoundingClientRect();
+      pointingOnRelease =
+        event.pointerType !== 'touch' &&
+        event.clientX >= releaseRect.left &&
+        event.clientX <= releaseRect.right &&
+        event.clientY >= releaseRect.top &&
+        event.clientY <= releaseRect.bottom;
 
       // Cancel any pending throttled change before the final unthrottled pair.
       throttledChange?.cancel();
@@ -297,7 +309,7 @@ export function createSlider(options: SliderOptions): SliderApi {
       if (newPercent !== null) {
         event.preventDefault();
         newPercent = clamp(newPercent, 0, 100);
-        input.patch({ pointerPercent: newPercent, dragPercent: newPercent });
+        input.patch({ pointerPercent: newPercent, dragPercent: newPercent, pointing: false });
         options.onValueChange?.(newPercent);
         options.onValueCommit?.(newPercent);
       }

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -281,13 +281,13 @@ describe('createSlider', () => {
       firePointerUp(slider, { clientX: 100 });
       expect(onValueCommit).toHaveBeenCalledWith(50);
 
-      // lostpointercapture cleans up drag state.
+      // lostpointercapture cleans up drag state while preserving mouse hover.
       fireLostPointerCapture(slider);
       flush();
 
       expect(onDragEnd).toHaveBeenCalled();
       expect(slider.input.current.dragging).toBe(false);
-      expect(slider.input.current.pointing).toBe(false);
+      expect(slider.input.current.pointing).toBe(true);
 
       slider.destroy();
     });
@@ -301,6 +301,34 @@ describe('createSlider', () => {
       firePointerUp(slider, { clientX: 100 });
 
       expect(onValueCommit).toHaveBeenCalledWith(50);
+
+      slider.destroy();
+    });
+
+    it('clears pointing when the mouse is released outside the slider', () => {
+      const el = createMockElement({ left: 0, width: 200 });
+      const slider = createSlider(createOptions({ getElement: () => el }));
+
+      slider.rootProps.onPointerDown(pointerEvent({ clientX: 100 }));
+      firePointerUp(slider, { clientX: 250 });
+      fireLostPointerCapture(slider);
+      flush();
+
+      expect(slider.input.current.pointing).toBe(false);
+
+      slider.destroy();
+    });
+
+    it('clears pointing after a touch release', () => {
+      const el = createMockElement({ left: 0, width: 200 });
+      const slider = createSlider(createOptions({ getElement: () => el }));
+
+      slider.rootProps.onPointerDown(pointerEvent({ clientX: 100, pointerType: 'touch' }));
+      firePointerUp(slider, { clientX: 100, pointerType: 'touch' });
+      fireLostPointerCapture(slider);
+      flush();
+
+      expect(slider.input.current.pointing).toBe(false);
 
       slider.destroy();
     });
@@ -606,6 +634,24 @@ describe('createSlider', () => {
 
       expect(event.preventDefault).not.toHaveBeenCalled();
       expect(onValueChange).not.toHaveBeenCalled();
+
+      slider.destroy();
+    });
+
+    it('clears pointing when the keyboard takes over after a mouse release', () => {
+      const el = createMockElement({ left: 0, width: 200 });
+      const slider = createSlider(createOptions({ getElement: () => el }));
+
+      slider.rootProps.onPointerDown(pointerEvent({ clientX: 100 }));
+      firePointerUp(slider, { clientX: 100 });
+      fireLostPointerCapture(slider);
+      flush();
+      expect(slider.input.current.pointing).toBe(true);
+
+      slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
+      flush();
+
+      expect(slider.input.current.pointing).toBe(false);
 
       slider.destroy();
     });

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -89,7 +89,7 @@ function getTemplateHTML() {
                   <media-slider-thumb class="${cn(slider.thumb.base, slider.thumb.persistent)}"></media-slider-thumb>
                 </media-volume-slider>
               </media-popover>
-              <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              <media-captions-button menu-for="captions-menu" commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, button.captions, iconState.captions.button)}">
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-button>

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -122,7 +122,7 @@ function getTemplateHTML() {
             </div>
 
             <div class="${cn(buttonGroupEnd, menu.settingsGroup)}">
-              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, iconState.captions.button)}">
+              <media-captions-button commandfor="captions-tooltip" class="${cn(button.base, button.subtle, button.icon, button.captions, iconState.captions.button)}">
                 ${renderIcon('captions-off', { class: cn(icon, iconState.captions.off) })}
                 ${renderIcon('captions-on', { class: cn(icon, iconState.captions.on) })}
               </media-captions-button>

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -159,7 +159,7 @@ function CaptionsTrigger(): ReactNode {
       <Tooltip.Root side="top">
         <Tooltip.Trigger
           render={
-            <CaptionsButton className={iconState.captions.button} render={<Button />}>
+            <CaptionsButton className={cn(button.captions, iconState.captions.button)} render={<Button />}>
               <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
               <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
             </CaptionsButton>
@@ -178,7 +178,7 @@ function CaptionsTrigger(): ReactNode {
       <Menu.Trigger
         disabled={disabled}
         render={
-          <CaptionsButton className={iconState.captions.button} render={<Button />}>
+          <CaptionsButton className={cn(button.captions, iconState.captions.button)} render={<Button />}>
             <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
             <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
           </CaptionsButton>

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -471,7 +471,7 @@ export function VideoSkinTailwind(props: VideoSkinProps): ReactNode {
               <Tooltip.Root side="top">
                 <Tooltip.Trigger
                   render={
-                    <CaptionsButton className={iconState.captions.button} render={<Button />}>
+                    <CaptionsButton className={cn(button.captions, iconState.captions.button)} render={<Button />}>
                       <CaptionsOffIcon className={cn(icon, iconState.captions.off)} />
                       <CaptionsOnIcon className={cn(icon, iconState.captions.on)} />
                     </CaptionsButton>

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -2,8 +2,7 @@
   --track-size: calc(var(--spacing) * 1);
   --track-highlighted-size: calc(var(--spacing) * 1.75);
   --track-border-radius: 99px;
-  --thumb-size: calc(var(--spacing) * 2.5);
-  --thumb-active-size: calc(var(--spacing) * 3);
+  --thumb-size: calc(var(--spacing) * 3);
   --chapter-gap: calc(var(--spacing) * 1);
   --chapter-inset-start: calc(var(--chapter-gap) / 2);
   --chapter-inset-end: calc(var(--chapter-gap) / 2);
@@ -56,13 +55,22 @@
       inset-block: 0;
       left: 0;
       width: 100%;
-      transition-property: clip-path;
     }
     &[data-orientation="vertical"] {
       inset-inline: 0;
       bottom: 0;
       height: 100%;
-      transition-property: clip-path;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      transition: clip-path 200ms ease-out;
+    }
+  }
+  &[data-dragging],
+  &[data-seeking] {
+    .media-slider__fill,
+    .media-slider__buffer {
+      transition-duration: 0ms;
     }
   }
 
@@ -87,6 +95,14 @@
     }
     &[data-orientation="vertical"] {
       clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--track-border-radius));
+    }
+  }
+  &[data-dragging] {
+    .media-slider__fill[data-orientation="horizontal"] {
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
+    }
+    .media-slider__fill[data-orientation="vertical"] {
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
     }
   }
 
@@ -170,45 +186,6 @@
     }
   }
 
-  /* Dragging — thumb and fill follow the pointer position */
-  &[data-dragging] {
-    .media-slider__thumb[data-orientation="horizontal"] {
-      left: var(--media-slider-pointer);
-    }
-    .media-slider__thumb[data-orientation="vertical"] {
-      top: calc(100% - var(--media-slider-pointer));
-    }
-    .media-slider__fill[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
-    }
-    .media-slider__fill[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
-    }
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .media-slider__thumb {
-      transition-property: opacity, height, width, outline-offset, left, top;
-    }
-    .media-slider__fill {
-      transition-timing-function: linear;
-      transition-duration: 200ms;
-    }
-    .media-slider__buffer {
-      transition-timing-function: ease-out;
-      transition-duration: 250ms;
-    }
-  }
-
-  &[data-dragging],
-  &[data-seeking] {
-    .media-slider__thumb,
-    .media-slider__fill,
-    .media-slider__buffer {
-      transition-duration: 0ms;
-    }
-  }
-
   /* Thumb */
   .media-slider__thumb {
     position: absolute;
@@ -225,10 +202,8 @@
       0 1px 3px 0 oklch(0 0 0 / 0.35),
       0 1px 2px -1px oklch(0 0 0 / 0.35);
     opacity: 0;
+    scale: 0.8;
     translate: -50% -50%;
-    transition-timing-function: ease-out;
-    transition-duration: 150ms;
-    transition-property: opacity, height, width, outline-offset;
 
     &[data-orientation="horizontal"] {
       top: 50%;
@@ -245,22 +220,12 @@
       opacity: 1;
     }
 
-    @media (hover: hover) and (pointer: fine) {
-      &:hover {
-        outline-color: oklch(from currentColor l c h / 0.15);
-        outline-offset: 0;
-      }
-    }
-
     &::after {
       position: absolute;
       inset: -4px;
       content: "";
       border-radius: inherit;
       box-shadow: 0 0 0 2px currentColor;
-      transition-timing-function: ease-out;
-      transition-duration: 150ms;
-      transition-property: opacity, scale;
     }
 
     &:not(:focus-visible)::after {
@@ -269,21 +234,50 @@
     }
 
     &.media-slider__thumb--persistent {
-      width: var(--thumb-active-size);
-      height: var(--thumb-active-size);
       opacity: 1;
+      scale: 1;
     }
-  }
 
-  &:active .media-slider__thumb,
-  &:focus-within .media-slider__thumb {
-    width: var(--thumb-active-size);
-    height: var(--thumb-active-size);
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        outline-color: oklch(from currentColor l c h / 0.15);
+        outline-offset: 0;
+      }
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      transition-timing-function: ease-out;
+      transition-duration: 150ms;
+      transition-property: opacity, outline-offset, left, top, scale;
+
+      &::after {
+        transition-timing-function: ease-out;
+        transition-duration: 150ms;
+        transition-property: opacity, scale;
+      }
+    }
   }
 
   @media (hover: hover) and (pointer: fine) {
     &:hover .media-slider__thumb {
       opacity: 1;
+      scale: 1;
+    }
+  }
+
+  &[data-dragging] .media-slider__thumb {
+    opacity: 1;
+    scale: 0.9;
+
+    @media (prefers-reduced-motion: no-preference) {
+      transition-property: opacity, outline-offset, scale;
+    }
+
+    &[data-orientation="horizontal"] {
+      left: var(--media-slider-pointer);
+    }
+    &[data-orientation="vertical"] {
+      top: calc(100% - var(--media-slider-pointer));
     }
   }
 

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -283,11 +283,17 @@
 
   /* Preview */
   .media-slider__preview {
-    --max-width: min(calc(var(--spacing) * 48), 100cqi);
-    --max-height: calc(var(--spacing) * 32);
+    --max-width-factor: 36;
+    --max-width: min(calc(var(--spacing) * var(--max-width-factor)), 100cqi);
+    /* Calculate the height based on the container aspect ratio */
+    --max-height: calc(var(--max-width) * (100cqb / 100cqi));
 
     min-width: var(--max-width);
     height: calc(var(--spacing) * 1);
+
+    @container media-root (width > 42rem) {
+      --max-width-factor: 48;
+    }
 
     .media-slider__thumbnail,
     .media-slider__value {

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -180,6 +180,12 @@
   .media-controls--primary,
   .media-controls--secondary {
     position: absolute;
+  }
+  /* Primary must be higher for the preview/thumbnail */
+  .media-controls--primary {
+    z-index: 20;
+  }
+  .media-controls--secondary {
     z-index: 10;
   }
 
@@ -194,6 +200,11 @@
     right: var(--inset);
     container-type: normal;
     transform-origin: top;
+  }
+
+  .media-time-controls {
+    flex: 1;
+    padding-inline: calc(var(--spacing) * 2);
   }
 
   @container media-root (width < 32rem) {
@@ -246,6 +257,10 @@
         }
       }
     }
+
+    .media-button--captions {
+      display: none;
+    }
   }
 
   @container media-root (width >= 32rem) {
@@ -282,11 +297,10 @@
         translate: 0 4px;
       }
     }
-  }
 
-  .media-time-controls {
-    flex: 1;
-    padding-inline: calc(var(--spacing) * 3);
+    .media-time-controls {
+      padding-inline: calc(var(--spacing) * 3);
+    }
   }
 
   @media (pointer: fine) {

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -22,6 +22,7 @@ export const button = {
   ),
   icon: cn('grid aspect-square p-0!', 'not-aria-disabled:active:scale-[0.97]'),
   seek: hideAtSmall,
+  captions: hideAtSmall,
   /**
    * Live variant: wide pill button with a status dot rendered via `::before`
    * (gray → red at the live edge) and "LIVE" as the button's own text.

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -105,7 +105,11 @@ export const slider = {
     ),
   },
   preview: cn(
-    '[--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-(--max-width) h-1',
+    '[--max-width-factor:36]',
+    '[--max-width:min(calc(var(--spacing)*var(--max-width-factor)),100cqi)]',
+    '[--max-height:calc(var(--max-width)*(100cqb/100cqi))]',
+    '@2xl/media-root:[--max-width-factor:48]',
+    'min-w-(--max-width) h-1',
     'before:absolute before:z-1 before:top-1/2 before:left-1/2 before:size-1 before:bg-current before:rounded-full before:pointer-events-none',
     'before:shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.15)),0_1px_2px_0_oklch(0_0_0/0.35)]',
     'before:-translate-1/2 before:opacity-0 before:scale-50',

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -49,37 +49,39 @@ export const slider = {
   fill: {
     base: cn(
       'absolute rounded-[inherit] pointer-events-none',
-      'motion-safe:duration-200 motion-safe:ease-linear',
+      'motion-safe:transition-[clip-path] motion-safe:duration-200 motion-safe:ease-out',
       'data-dragging:duration-0 data-seeking:duration-0'
     ),
     fill: cn(
       'bg-(--accent-color)',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
       'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
       'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--track-border-radius))]'
     ),
     buffer: cn(
-      'bg-current/20 motion-safe:duration-250 motion-safe:ease-out',
+      'bg-current/20',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
     ),
   },
   thumb: {
     base: cn(
-      'z-10 absolute -translate-x-1/2 -translate-y-1/2',
+      'z-10 absolute size-2.5 -translate-x-1/2 -translate-y-1/2',
       'bg-current rounded-full',
+      'opacity-0 scale-80',
       'shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.1)),0_1px_3px_0_oklch(0_0_0/0.35),0_1px_2px_-1px_oklch(0_0_0/0.35)]',
-      'transition-[opacity,height,width,outline-offset] motion-safe:transition-[opacity,height,width,outline-offset,left,top] duration-150 ease-out select-none',
+      'transition-none motion-safe:transition-[opacity,height,width,outline-offset,left,top,scale] duration-150 ease-out select-none',
       'data-dragging:duration-0 data-seeking:duration-0',
+      'group-active/slider:size-3',
       'outline-4 outline-transparent -outline-offset-4',
       'hover:outline-current/15 hover:outline-offset-0',
       'focus-visible:outline-current/15 focus-visible:outline-offset-0',
@@ -96,11 +98,10 @@ export const slider = {
       'data-[orientation=vertical]:left-1/2 data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill))]',
       'group-data-dragging/slider:data-[orientation=vertical]:top-[calc(100%-var(--media-slider-pointer))]'
     ),
-    persistent: 'size-3',
+    persistent: 'opacity-100 scale-100',
     interactive: cn(
-      'size-2.5',
-      'opacity-0 focus-visible:opacity-100 pointer-fine:group-hover/slider:opacity-100',
-      'group-active/slider:size-3 group-focus-within/slider:size-3'
+      'focus-visible:opacity-100',
+      'pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100'
     ),
   },
   preview: cn(

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -150,7 +150,7 @@ const splitControls = cn(
 
 export const primaryControls = cn(
   splitControls,
-  'bottom-2 inset-x-2 origin-bottom',
+  'z-20 bottom-2 inset-x-2 origin-bottom',
   '@max-lg/media-root:motion-safe:group-[:not([data-visible])]/controls:translate-y-1'
 );
 
@@ -171,7 +171,7 @@ export const spacer = 'grow';
 
 export const time = {
   ...baseTime,
-  group: cn(baseTime.group, 'px-3'),
+  group: cn(baseTime.group, 'px-2 @lg/media-root:px-3'),
 };
 
 /* Thumbnail (with video surface) */

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -257,11 +257,21 @@
 
   /* Preview */
   .media-slider__preview {
-    --max-width: min(calc(var(--spacing) * 48), 100cqi);
-    --max-height: calc(var(--spacing) * 32);
+    --max-width-factor: 28;
+    --max-width: min(calc(var(--spacing) * var(--max-width-factor)), 100cqi);
+    /* Calculate the height based on the container aspect ratio */
+    --max-height: calc(var(--max-width) * (100cqb / 100cqi));
 
     min-width: 100%;
     height: calc(var(--spacing) * 1);
+
+    @container media-root (width > 32rem) {
+      --max-width-factor: 36;
+    }
+
+    @container media-root (width > 42rem) {
+      --max-width-factor: 48;
+    }
 
     .media-slider__thumbnail,
     .media-slider__value {
@@ -280,7 +290,7 @@
 
     .media-slider__thumbnail {
       --thumbnail-max-width: var(--max-width);
-      bottom: calc(100% + (var(--spacing) * 12));
+      bottom: calc(100% + (var(--spacing) * 11));
     }
 
     .media-slider__value {

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -1,7 +1,11 @@
 .media-minimal-skin .media-slider {
+  --track-size: calc(var(--spacing) * 1);
+  --track-highlighted-size: calc(var(--spacing) * 1.75);
+  --track-border-radius: 99px;
   --thumb-size: calc(var(--spacing) * 3);
-  --thumb-active-size: calc(var(--spacing) * 3);
-  --track-border-radius: calc(Infinity * 1px);
+  --chapter-gap: calc(var(--spacing) * 1);
+  --chapter-inset-start: calc(var(--chapter-gap) / 2);
+  --chapter-inset-end: calc(var(--chapter-gap) / 2);
 
   position: relative;
   display: flex;
@@ -33,65 +37,11 @@
 
     &[data-orientation="horizontal"] {
       width: 100%;
-      height: calc(var(--spacing) * 0.75);
+      height: var(--track-size);
     }
     &[data-orientation="vertical"] {
-      width: calc(var(--spacing) * 0.75);
+      width: var(--track-size);
       height: 100%;
-    }
-  }
-
-  /* Thumb */
-  .media-slider__thumb {
-    position: absolute;
-    z-index: 10;
-    width: var(--thumb-size);
-    height: var(--thumb-size);
-    user-select: none;
-    outline: 2px solid transparent;
-    outline-offset: -2px;
-    background-color: currentColor;
-    border-radius: calc(Infinity * 1px);
-    box-shadow:
-      0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.15)),
-      0 1px 3px 0 oklch(0 0 0 / 0.15),
-      0 1px 2px -1px oklch(0 0 0 / 0.15);
-    opacity: 0;
-    transform-origin: center;
-    scale: 0.7;
-    translate: -50% -50%;
-    transition-timing-function: ease-out;
-    transition-duration: 150ms;
-
-    &[data-orientation="horizontal"] {
-      top: 50%;
-      left: var(--media-slider-fill);
-    }
-    &[data-orientation="vertical"] {
-      top: calc(100% - var(--media-slider-fill));
-      left: 50%;
-    }
-
-    &:focus-visible {
-      outline-color: var(--focus-ring-color);
-      outline-offset: 2px;
-    }
-  }
-
-  &:focus-within .media-slider__thumb,
-  .media-slider__thumb--persistent {
-    width: var(--thumb-active-size);
-    height: var(--thumb-active-size);
-    opacity: 1;
-    scale: 1;
-  }
-
-  @media (hover: hover) and (pointer: fine) {
-    &:hover .media-slider__thumb {
-      width: var(--thumb-active-size);
-      height: var(--thumb-active-size);
-      opacity: 1;
-      scale: 1;
     }
   }
 
@@ -106,13 +56,22 @@
       inset-block: 0;
       left: 0;
       width: 100%;
-      transition-property: clip-path;
     }
     &[data-orientation="vertical"] {
       inset-inline: 0;
       bottom: 0;
       height: 100%;
-      transition-property: clip-path;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      transition: clip-path 200ms ease-out;
+    }
+  }
+  &[data-dragging],
+  &[data-seeking] {
+    .media-slider__fill,
+    .media-slider__buffer {
+      transition-duration: 0ms;
     }
   }
 
@@ -139,6 +98,14 @@
       clip-path: inset(calc(100% - var(--media-slider-fill)) 0 0 0 round var(--track-border-radius));
     }
   }
+  &[data-dragging] {
+    .media-slider__fill[data-orientation="horizontal"] {
+      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
+    }
+    .media-slider__fill[data-orientation="vertical"] {
+      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
+    }
+  }
 
   /* Chapters */
   .media-slider__chapters {
@@ -162,9 +129,6 @@
   }
 
   .media-slider__chapter {
-    --chapter-gap: calc(var(--spacing) * 1);
-    --chapter-inset-start: calc(var(--chapter-gap) / 2);
-    --chapter-inset-end: calc(var(--chapter-gap) / 2);
     position: absolute;
     inset: 0;
     display: flex;
@@ -181,8 +145,6 @@
     }
 
     .media-slider__chapter-track {
-      --chapter-track-size: calc(var(--spacing) * 0.75);
-      --chapter-track-highlighted-size: calc(var(--spacing) * 1.25);
       border-radius: var(--track-border-radius);
 
       @media (prefers-reduced-motion: no-preference) {
@@ -195,7 +157,7 @@
       clip-path: inset(0 calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start));
 
       .media-slider__chapter-track {
-        height: var(--chapter-track-size);
+        height: var(--track-size);
         clip-path: inset(
           0 calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
             calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) round var(--track-border-radius)
@@ -203,7 +165,7 @@
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        height: var(--chapter-track-highlighted-size);
+        height: var(--track-highlighted-size);
       }
     }
 
@@ -211,7 +173,7 @@
       clip-path: inset(calc(100% - var(--media-slider-chapter-end)) 0 var(--media-slider-chapter-start) 0);
 
       .media-slider__chapter-track {
-        width: var(--chapter-track-size);
+        width: var(--track-size);
         clip-path: inset(
           calc(100% - var(--media-slider-chapter-end) + var(--chapter-inset-end)) 0
             calc(var(--media-slider-chapter-start) + var(--chapter-inset-start)) 0 round var(--track-border-radius)
@@ -219,47 +181,77 @@
       }
 
       &[data-highlighted] .media-slider__chapter-track {
-        width: var(--chapter-track-highlighted-size);
+        width: var(--track-highlighted-size);
       }
     }
   }
 
-  /* Dragging — thumb and fill follow the pointer position */
-  &[data-dragging] {
-    .media-slider__thumb[data-orientation="horizontal"] {
+  /* Thumb */
+  .media-slider__thumb {
+    position: absolute;
+    z-index: 10;
+    width: var(--thumb-size);
+    height: var(--thumb-size);
+    user-select: none;
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+    background-color: currentColor;
+    border-radius: calc(Infinity * 1px);
+    box-shadow:
+      0 0 0 1px var(--shadow-current-color, oklch(0 0 0 / 0.15)),
+      0 1px 3px 0 oklch(0 0 0 / 0.15),
+      0 1px 2px -1px oklch(0 0 0 / 0.15);
+    opacity: 0;
+    transform-origin: center;
+    scale: 0.7;
+    translate: -50% -50%;
+
+    &[data-orientation="horizontal"] {
+      top: 50%;
+      left: var(--media-slider-fill);
+    }
+    &[data-orientation="vertical"] {
+      top: calc(100% - var(--media-slider-fill));
+      left: 50%;
+    }
+
+    &:focus-visible {
+      outline-color: var(--focus-ring-color);
+      outline-offset: 2px;
+    }
+
+    &.media-slider__thumb--persistent {
+      opacity: 1;
+      scale: 1;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      transition-timing-function: ease-out;
+      transition-duration: 150ms;
+      transition-property: opacity, outline-offset, left, top, scale;
+    }
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover .media-slider__thumb {
+      opacity: 1;
+      scale: 1;
+    }
+  }
+
+  &[data-dragging] .media-slider__thumb {
+    opacity: 1;
+    scale: 0.9;
+
+    @media (prefers-reduced-motion: no-preference) {
+      transition-property: opacity, outline-offset, scale;
+    }
+
+    &[data-orientation="horizontal"] {
       left: var(--media-slider-pointer);
     }
-    .media-slider__thumb[data-orientation="vertical"] {
+    &[data-orientation="vertical"] {
       top: calc(100% - var(--media-slider-pointer));
-    }
-    .media-slider__fill[data-orientation="horizontal"] {
-      clip-path: inset(0 calc(100% - var(--media-slider-pointer)) 0 0 round var(--track-border-radius));
-    }
-    .media-slider__fill[data-orientation="vertical"] {
-      clip-path: inset(calc(100% - var(--media-slider-pointer)) 0 0 0 round var(--track-border-radius));
-    }
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .media-slider__thumb {
-      transition-property: opacity, scale, height, width, outline-offset, left, top;
-    }
-    .media-slider__fill {
-      transition-timing-function: linear;
-      transition-duration: 200ms;
-    }
-    .media-slider__buffer {
-      transition-timing-function: ease-out;
-      transition-duration: 250ms;
-    }
-  }
-
-  &[data-dragging],
-  &[data-seeking] {
-    .media-slider__thumb,
-    .media-slider__fill,
-    .media-slider__buffer {
-      transition-duration: 0ms;
     }
   }
 

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -174,6 +174,7 @@
   --base-boundary-offset: 1;
   --inset-factor: 1;
   --inset: calc(var(--spacing) * var(--inset-factor));
+  --volume-mask: linear-gradient(to right, transparent 10%, #000 25%, #000 100%);
 
   position: absolute;
   inset-inline: var(--inset);
@@ -229,6 +230,37 @@
     justify-content: end;
   }
 
+  :is(.media-time-controls, .media-button-group:last-child) {
+    mask-image: var(--volume-mask-image, none);
+    mask-repeat: no-repeat;
+    mask-position: var(--volume-mask-position, 100% 0);
+    mask-size: var(--volume-mask-size, 200% 100%);
+    transition: mask-position 50ms ease-out;
+  }
+
+  @container media-root (width <= 42rem) {
+    .media-popover--volume {
+      --media-popover-side-offset: calc(var(--spacing) * 3);
+    }
+  }
+
+  &:has(.media-button--mute[aria-expanded="true"]) {
+    @container media-root (width <= 42rem) {
+      .media-button-group:last-child {
+        --volume-mask-image: var(--volume-mask);
+        --volume-mask-position: 0 0;
+        --volume-mask-size: 400% 100%;
+      }
+    }
+
+    @container media-root (width > 42rem) {
+      .media-time-controls {
+        --volume-mask-image: var(--volume-mask);
+        --volume-mask-position: 0 0;
+      }
+    }
+  }
+
   @container media-root (width > 42rem) {
     --inset-factor: 2;
     --base-side-offset: 2;
@@ -245,20 +277,6 @@
     .media-button-group:first-child,
     .media-button-group:last-child {
       flex: 0 0 auto;
-    }
-
-    .media-time-controls {
-      mask-position: 100% 0;
-      mask-size: 200% 100%;
-      transition: mask-position 50ms ease-out;
-    }
-
-    &:has(.media-button--mute[aria-expanded="true"]) .media-time-controls {
-      mask-image: linear-gradient(to right, transparent 10%, #000 25%, #000 100%);
-    }
-
-    &:has(.media-button--mute[aria-expanded="true"]) .media-time-controls {
-      mask-position: 0 0;
     }
   }
 }

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -13,7 +13,8 @@ const previewContent = cn(
 export const slider = {
   root: cn(
     'group/slider relative flex flex-1 items-center justify-center rounded-(--track-border-radius) outline-none cursor-pointer',
-    '[--track-border-radius:calc(infinity*1px)]',
+    '[--track-border-radius:99px]',
+    '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:calc(var(--chapter-gap)/2)] [--chapter-inset-end:calc(var(--chapter-gap)/2)]',
     // Horizontal
     'data-[orientation=horizontal]:min-w-20 data-[orientation=horizontal]:w-(--slider-width,100%) data-[orientation=horizontal]:h-(--slider-height,--spacing(8))',
     // Vertical
@@ -22,15 +23,14 @@ export const slider = {
   track: cn(
     'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
     // Horizontal
-    'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-0.75',
+    'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
     // Vertical
-    'data-[orientation=vertical]:w-0.75 data-[orientation=vertical]:h-full'
+    'data-[orientation=vertical]:w-1 data-[orientation=vertical]:h-full'
   ),
   chapters: cn('relative flex flex-1 items-center min-w-0 min-h-0 size-full rounded-[inherit]'),
   chapter: {
     base: cn(
       'group/chapter absolute inset-0 flex items-center justify-center min-w-0 min-h-0',
-      '[--chapter-gap:calc(var(--spacing)*1)] [--chapter-inset-start:calc(var(--chapter-gap)/2)] [--chapter-inset-end:calc(var(--chapter-gap)/2)]',
       'first:[--chapter-inset-start:0px] last:[--chapter-inset-end:0px]',
       'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start))]',
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end))_0_var(--media-slider-chapter-start)_0)]'
@@ -38,48 +38,50 @@ export const slider = {
     track: cn(
       'relative isolate overflow-hidden bg-current/20 rounded-(--track-border-radius) select-none',
       'motion-safe:transition-[height,width] motion-safe:duration-200 motion-safe:ease-out',
-      'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-0.75',
-      'group-data-highlighted/chapter:data-[orientation=horizontal]:h-[--spacing(1.25)]',
+      'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:h-1',
+      'group-data-highlighted/chapter:data-[orientation=horizontal]:h-1.75',
       'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_round_var(--track-border-radius))]',
-      'data-[orientation=vertical]:w-0.75 data-[orientation=vertical]:h-full',
-      'group-data-highlighted/chapter:data-[orientation=vertical]:w-[--spacing(1.25)]',
+      'data-[orientation=vertical]:w-1 data-[orientation=vertical]:h-full',
+      'group-data-highlighted/chapter:data-[orientation=vertical]:w-1.75',
       'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-chapter-end)+var(--chapter-inset-end))_0_calc(var(--media-slider-chapter-start)+var(--chapter-inset-start))_0_round_var(--track-border-radius))]'
     ),
   },
   fill: {
     base: cn(
       'absolute rounded-[inherit] pointer-events-none',
-      'motion-safe:duration-200 motion-safe:ease-linear',
+      'motion-safe:transition-[clip-path] motion-safe:duration-200 motion-safe:ease-out',
       'data-dragging:duration-0 data-seeking:duration-0'
     ),
     fill: cn(
       'bg-(--accent-color)',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-fill))_0_0_round_var(--track-border-radius))]',
       'group-data-dragging/slider:data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-pointer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-fill))_0_0_0_round_var(--track-border-radius))]',
       'group-data-dragging/slider:data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-pointer))_0_0_0_round_var(--track-border-radius))]'
     ),
     buffer: cn(
-      'bg-current/20 motion-safe:duration-250 motion-safe:ease-out',
+      'bg-current/20',
       // Horizontal
       'data-[orientation=horizontal]:inset-y-0 data-[orientation=horizontal]:left-0 data-[orientation=horizontal]:w-full',
-      'data-[orientation=horizontal]:transition-[clip-path] data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
+      'data-[orientation=horizontal]:[clip-path:inset(0_calc(100%-var(--media-slider-buffer))_0_0_round_var(--track-border-radius))]',
       // Vertical
       'data-[orientation=vertical]:inset-x-0 data-[orientation=vertical]:bottom-0 data-[orientation=vertical]:h-full',
-      'data-[orientation=vertical]:transition-[clip-path] data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
+      'data-[orientation=vertical]:[clip-path:inset(calc(100%-var(--media-slider-buffer))_0_0_0_round_var(--track-border-radius))]'
     ),
   },
   thumb: {
     base: cn(
       'z-10 absolute size-3 -translate-x-1/2 -translate-y-1/2',
       'bg-current rounded-full',
+      'opacity-0 scale-70 origin-center',
       'shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.15)),0_1px_3px_0_oklch(0_0_0/0.15),0_1px_2px_-1px_oklch(0_0_0/0.15)]',
-      'transition-[opacity,scale,outline-offset] motion-safe:transition-[opacity,scale,outline-offset,left,top] duration-150 ease-out select-none',
+      'transition-none motion-safe:transition-[opacity,height,width,outline-offset,left,top,scale] duration-150 ease-out select-none',
       'data-dragging:duration-0 data-seeking:duration-0',
+      'group-active/slider:size-3.5',
       'outline-2 outline-transparent -outline-offset-2',
       'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
       // Horizontal
@@ -89,11 +91,8 @@ export const slider = {
       'data-[orientation=vertical]:left-1/2 data-[orientation=vertical]:top-[calc(100%-var(--media-slider-fill,0))]',
       'group-data-dragging/slider:data-[orientation=vertical]:top-[calc(100%-var(--media-slider-pointer))]'
     ),
-    interactive: cn(
-      'opacity-0 scale-70 origin-center',
-      'pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100',
-      'group-focus-within/slider:opacity-100 group-focus-within/slider:scale-100'
-    ),
+    persistent: 'opacity-100 scale-100',
+    interactive: cn('pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100'),
   },
   preview: cn(
     '[--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-full h-1',

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -95,7 +95,11 @@ export const slider = {
     interactive: cn('pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100'),
   },
   preview: cn(
-    '[--max-width:min(--spacing(48),100cqi)] [--max-height:--spacing(32)] min-w-full h-1',
+    '[--max-width-factor:28]',
+    '[--max-width:min(calc(var(--spacing)*var(--max-width-factor)),100cqi)]',
+    '[--max-height:calc(var(--max-width)*(100cqb/100cqi))]',
+    '@lg/media-root:[--max-width-factor:36] @2xl/media-root:[--max-width-factor:48]',
+    'min-w-full h-1',
     'before:absolute before:z-1 before:bg-current/35 before:pointer-events-none',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
     'before:transition-[opacity,scale] before:duration-200 before:ease-out',
@@ -105,7 +109,7 @@ export const slider = {
     'data-[orientation=vertical]:before:top-[calc(100%-var(--media-slider-pointer))] data-[orientation=vertical]:before:left-1/2',
     'data-[orientation=vertical]:before:w-5 data-[orientation=vertical]:before:h-px'
   ),
-  thumbnail: cn(previewContent, '[--thumbnail-max-width:var(--max-width)] [bottom:calc(100%+--spacing(12))]'),
+  thumbnail: cn(previewContent, '[--thumbnail-max-width:var(--max-width)] [bottom:calc(100%+--spacing(11))]'),
   value: cn(
     previewContent,
     '[bottom:calc(100%+--spacing(5))] flex flex-row-reverse justify-center gap-2 px-3 tabular-nums',

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -109,6 +109,7 @@ export const controls = cn(
   // Position & wrapping layout (small)
   'absolute bottom-1 inset-x-1',
   '[--base-side-offset:5] [--base-boundary-offset:1]',
+  '[--volume-mask:linear-gradient(to_right,transparent_10%,black_25%,black_100%)]',
   'gap-x-2 flex-wrap rounded-[--spacing(3)] group/controls',
   'text-white z-20',
   'peer-data-open/error:hidden',
@@ -129,8 +130,23 @@ export const controls = cn(
 
 /* Button groups */
 
+const volumeMaskTarget = cn(
+  '[mask-image:var(--volume-mask-image,none)]',
+  '[mask-repeat:no-repeat]',
+  '[mask-position:var(--volume-mask-position,100%_0)]',
+  '[mask-size:var(--volume-mask-size,200%_100%)]',
+  '[transition:mask-position_50ms_ease-out]'
+);
+
 export const buttonGroupStart = cn(baseButtonGroup, 'flex-1 @2xl/media-root:flex-none');
-export const buttonGroupEnd = cn(baseButtonGroup, 'flex-1 justify-end @2xl/media-root:flex-none');
+export const buttonGroupEnd = cn(
+  baseButtonGroup,
+  volumeMaskTarget,
+  'flex-1 justify-end @2xl/media-root:flex-none',
+  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--volume-mask-image:var(--volume-mask)]',
+  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--volume-mask-position:0_0]',
+  'group-has-[[data-volume-level][aria-expanded=true]]/controls:@max-2xl/media-root:[--volume-mask-size:400%_100%]'
+);
 
 export const spacer = 'grow';
 
@@ -140,12 +156,11 @@ export const time = {
   ...baseTime,
   controls: cn(
     baseTime.controls,
+    volumeMaskTarget,
     '[--slider-height:--spacing(5)] grow-0 shrink-0 basis-full order-[-1] px-1.5',
     '@2xl/media-root:[--slider-height:--spacing(8)] @2xl/media-root:grow @2xl/media-root:shrink @2xl/media-root:basis-0 @2xl/media-root:order-[unset]',
-    '@2xl/media-root:[mask-position:100%_0] @2xl/media-root:[mask-size:200%_100%]',
-    '@2xl/media-root:[transition:mask-position_50ms_ease-out]',
-    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[mask-image:linear-gradient(to_right,transparent_10%,black_25%,black_100%)]',
-    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[mask-position:0_0]'
+    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[--volume-mask-image:var(--volume-mask)]',
+    'group-has-[[data-volume-level][aria-expanded=true]]/controls:@2xl/media-root:[--volume-mask-position:0_0]'
   ),
 };
 
@@ -180,7 +195,7 @@ export const slider = {
 
 export const popup = {
   ...basePopup,
-  volume: cn(basePopup.popover, 'p-0 bg-transparent'),
+  volume: cn(basePopup.popover, 'p-0 bg-transparent', '@max-2xl/media-root:[--media-popover-side-offset:--spacing(3)]'),
 };
 
 /* Menu */


### PR DESCRIPTION
- Ensure the previous pointing state is restored on captions after mouse down. 
- Hide captions toggle button on small displays in default skin.
- Ensure preview thumbnails don't overflow container on smaller displays. 
- Ensure secondary controls don't render on top of preview thumbnails. 
- Thumb sizing style fixes. 
- General slider CSS cleanup. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI/CSS and slider input state with new tests; no auth, data, or API surface changes. Risk is limited to regressions in slider hover/preview and responsive control visibility.
> 
> **Overview**
> **Slider interaction** now keeps `data-pointing` after a mouse release inside the control (so hover previews and related UI stay active), while releases outside the bounds, touch, and keyboard adjustment clear pointing. Core logic lives in `createSlider` via `pointingOnRelease` and updated `endDrag` / `onPointerUp` handling, with matching unit tests.
> 
> **Default & minimal skins** refactor slider thumbs to use **opacity/scale** instead of resizing, align fill/buffer transitions, drive drag fill from `--media-slider-pointer`, and size seek **preview thumbnails** from container aspect ratio with responsive max-width factors so previews don’t overflow small players.
> 
> **Video layout**: primary controls get a higher **z-index** so time-slider previews sit above secondary controls; the **captions** control is hidden on narrow viewports (`button.captions` / `.media-button--captions`); time-control padding is tweaked. **Minimal** skin refactors the volume-open **mask** so small vs large breakpoints mask the correct control group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74cf259599798d195eb92998294f34555cbaba15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->