### PR TITLE
fix(skin): preserve slider preview behavior

### DIFF
--- a/apps/e2e/tests/sandbox-skin-styling.spec.ts
+++ b/apps/e2e/tests/sandbox-skin-styling.spec.ts
@@ -68,3 +68,70 @@ for (const { platform, skin, styling } of CASES) {
     });
   });
 }
+
+for (const { platform, styling } of CASES.filter(({ skin }) => skin === 'minimal')) {
+  test(`${platform} minimal ${styling} reveals the volume thumb on keyboard focus`, async ({ page }) => {
+    const query = new URLSearchParams({
+      styling,
+      skin: 'minimal',
+      source: 'mp4-1',
+      autoplay: '0',
+      muted: '1',
+      loop: '0',
+      preload: 'metadata',
+    });
+
+    await page.goto(`${SANDBOX_BASE}/${platform}-video/?${query}`, { waitUntil: 'domcontentloaded' });
+
+    const root = page.getByRole('group', { name: 'Media player' }).first();
+    await expect(root).toBeVisible({ timeout: 15_000 });
+
+    const muteButton = page.getByRole('button', { name: 'Unmute' }).first();
+    await muteButton.focus();
+    await page.keyboard.press('Tab');
+
+    const volumeThumb = page.getByRole('slider', { name: 'Volume' }).first();
+    await expect(volumeThumb).toBeFocused();
+    await expect(volumeThumb).toHaveCSS('opacity', '1');
+    await expect(volumeThumb).toHaveCSS('scale', '1');
+  });
+}
+
+for (const styling of ['css', 'tailwind'] as const) {
+  test(`html minimal ${styling} keeps the thumbnail inside the player`, async ({ page }) => {
+    const query = new URLSearchParams({
+      styling,
+      skin: 'minimal',
+      source: 'hls-1',
+      autoplay: '0',
+      muted: '1',
+      loop: '0',
+      preload: 'metadata',
+    });
+
+    await page.goto(`${SANDBOX_BASE}/html-video/?${query}`, { waitUntil: 'domcontentloaded' });
+
+    const root = page.getByRole('group', { name: 'Media player' }).first();
+    const slider = page.getByRole('slider', { name: 'Seek' }).first();
+    await expect(root).toBeVisible({ timeout: 15_000 });
+    await expect(slider).toBeVisible();
+
+    const sliderBox = await slider.boundingBox();
+    if (!sliderBox) throw new Error('Time slider is not visible');
+
+    const thumbnailImage = page.locator('media-slider-thumbnail').first();
+    const thumbnail = thumbnailImage.locator('xpath=..');
+    for (const x of [sliderBox.x + 1, sliderBox.x + sliderBox.width - 1]) {
+      await page.mouse.move(x, sliderBox.y + sliderBox.height / 2);
+      await expect(thumbnailImage).toBeAttached({ timeout: 15_000 });
+      await expect(thumbnailImage).not.toHaveAttribute('data-loading', { timeout: 15_000 });
+      await expect(thumbnail).toHaveCSS('scale', '1');
+
+      const [rootBox, thumbnailBox] = await Promise.all([root.boundingBox(), thumbnail.boundingBox()]);
+      if (!rootBox || !thumbnailBox) throw new Error('Player or thumbnail is not visible');
+
+      expect(thumbnailBox.x).toBeGreaterThanOrEqual(rootBox.x - 1);
+      expect(thumbnailBox.x + thumbnailBox.width).toBeLessThanOrEqual(rootBox.x + rootBox.width + 1);
+    }
+  });
+}

--- a/apps/e2e/tests/skin-container.spec.ts
+++ b/apps/e2e/tests/skin-container.spec.ts
@@ -25,7 +25,7 @@ for (const { framework, path } of SOURCE_SKINS) {
       await expect(container).toBeAttached();
       await expect(page.locator('video')).toBeAttached();
       await expect(container.locator('media-poster, img.media-poster')).toBeAttached();
-      await expect(container.locator('media-controls, .media-controls')).toBeAttached();
+      await expect(container.locator('media-controls, .media-controls-root')).toBeAttached();
       await expect(container.locator('.media-overlay')).toBeAttached();
       await expect(container.locator('media-seek-button, .media-seek-button')).toHaveCount(0);
 

--- a/apps/e2e/tests/video-controls.spec.ts
+++ b/apps/e2e/tests/video-controls.spec.ts
@@ -189,6 +189,23 @@ for (const { name, path } of UI_VIDEO_PAGES) {
       }
     });
 
+    test('time slider preserves hover after a mouse drag release', async ({ page }) => {
+      await player.showControls();
+
+      const box = await player.timeSlider.boundingBox();
+      if (!box) throw new Error('Time slider not visible');
+
+      const x = box.x + box.width / 2;
+      const y = box.y + box.height / 2;
+      await page.mouse.move(x, y);
+      await page.mouse.down();
+      await page.mouse.move(x + 1, y);
+      await page.mouse.up();
+
+      await expect(player.timeSlider).not.toHaveAttribute(DATA_ATTRS.dragging);
+      await expect(player.timeSlider).toHaveAttribute(DATA_ATTRS.pointing, '');
+    });
+
     test('settings button shows its tooltip on focus and still opens the menu', async ({ page }) => {
       await player.showControls();
       await player.settingsButton.focus();

--- a/apps/e2e/tests/visual/video-skin.spec.ts
+++ b/apps/e2e/tests/visual/video-skin.spec.ts
@@ -145,8 +145,9 @@ test.describe('Visual — HTML Portrait Layout', () => {
       const thumbnail = document.querySelector('video-skin')!.shadowRoot!.querySelector('media-slider-thumbnail')!;
       const style = getComputedStyle(thumbnail);
       const probe = document.createElement('div');
-      probe.style.height = style.getPropertyValue('--max-height');
-      document.body.append(probe);
+      probe.style.position = 'absolute';
+      probe.style.height = style.getPropertyValue('--thumbnail-max-height');
+      thumbnail.parentElement!.append(probe);
 
       const configuredMaxHeight = parseFloat(getComputedStyle(probe).height);
       probe.remove();

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -125,20 +125,18 @@ export function createSlider(options: SliderOptions): SliderApi {
   }
 
   function endDrag(): void {
+    if (!isDragging) return;
+
     const pointing = committedOnRelease && pointingOnRelease;
 
-    if (!isDragging) {
-      input.patch({ pointing });
-    } else {
-      // Fire a final commit if pointerup didn't already handle it.
-      if (!committedOnRelease) {
-        options.onValueCommit?.(lastDragPercent);
-      }
-
-      isDragging = false;
-      input.patch({ dragging: false, pointing });
-      options.onDragEnd?.();
+    // Fire a final commit if pointerup didn't already handle it.
+    if (!committedOnRelease) {
+      options.onValueCommit?.(lastDragPercent);
     }
+
+    isDragging = false;
+    input.patch({ dragging: false, pointing });
+    options.onDragEnd?.();
 
     committedOnRelease = false;
     pointingOnRelease = false;

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -332,6 +332,23 @@ describe('createSlider', () => {
 
       slider.destroy();
     });
+
+    it('preserves mouse hover when a stale pointermove precedes lostpointercapture', () => {
+      const onDragEnd = vi.fn();
+      const el = createMockElement({ left: 0, width: 200 });
+      const slider = createSlider(createOptions({ getElement: () => el, onDragEnd }));
+
+      slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
+      firePointerUp(slider, { clientX: 100 });
+      firePointerMove(slider, { clientX: 100, buttons: 0 });
+      fireLostPointerCapture(slider);
+      flush();
+
+      expect(slider.input.current.pointing).toBe(true);
+      expect(onDragEnd).toHaveBeenCalledOnce();
+
+      slider.destroy();
+    });
   });
 
   describe('pointer: lostpointercapture', () => {

--- a/packages/skins/src/default/css/components/slider.css
+++ b/packages/skins/src/default/css/components/slider.css
@@ -283,23 +283,21 @@
 
   /* Preview */
   .media-slider__preview {
-    --max-width-factor: 36;
-    --max-width: min(calc(var(--spacing) * var(--max-width-factor)), 100cqi);
-    /* Calculate the height based on the container aspect ratio */
-    --max-height: calc(var(--max-width) * (100cqb / 100cqi));
+    --max-size-factor: 36;
+    --max-size: min(calc(var(--spacing) * var(--max-size-factor)), 100cqi);
 
-    min-width: var(--max-width);
+    min-width: var(--max-size);
     height: calc(var(--spacing) * 1);
 
     @container media-root (width > 42rem) {
-      --max-width-factor: 48;
+      --max-size-factor: 48;
     }
 
     .media-slider__thumbnail,
     .media-slider__value {
       position: absolute;
       left: 50%;
-      max-width: var(--max-width);
+      max-width: var(--max-size);
       opacity: 0;
       filter: blur(8px);
       transform-origin: bottom;
@@ -310,7 +308,8 @@
     }
 
     .media-slider__thumbnail {
-      --thumbnail-max-width: var(--max-width);
+      --thumbnail-max-width: var(--max-size);
+      --thumbnail-max-height: var(--max-size);
       bottom: calc(100% + (var(--spacing) * 9));
     }
 
@@ -324,7 +323,7 @@
 
     .media-slider__chapter-title {
       min-width: 0;
-      max-width: var(--max-width);
+      max-width: var(--max-size);
       padding-inline: calc(var(--spacing) * 6);
       overflow: hidden;
       text-overflow: ellipsis;

--- a/packages/skins/src/default/css/components/thumbnail.css
+++ b/packages/skins/src/default/css/components/thumbnail.css
@@ -8,7 +8,7 @@
     position: relative;
     display: block;
     max-width: var(--thumbnail-max-width);
-    max-height: var(--max-height);
+    max-height: var(--thumbnail-max-height);
     overflow: clip;
     border-radius: inherit;
 

--- a/packages/skins/src/default/tailwind/components/slider.ts
+++ b/packages/skins/src/default/tailwind/components/slider.ts
@@ -1,7 +1,7 @@
 import { cn } from '@videojs/utils/style';
 
 const previewContent = cn(
-  'absolute left-1/2 max-w-(--max-width)',
+  'absolute left-1/2 max-w-(--max-size)',
   '-translate-x-1/2 translate-y-2 scale-80 opacity-0 blur-lg origin-bottom',
   'transition-[filter,opacity,scale] duration-150 ease-out',
   'group-data-pointing/slider:scale-100 group-data-pointing/slider:opacity-100',
@@ -105,22 +105,25 @@ export const slider = {
     ),
   },
   preview: cn(
-    '[--max-width-factor:36]',
-    '[--max-width:min(calc(var(--spacing)*var(--max-width-factor)),100cqi)]',
-    '[--max-height:calc(var(--max-width)*(100cqb/100cqi))]',
-    '@2xl/media-root:[--max-width-factor:48]',
-    'min-w-(--max-width) h-1',
+    '[--max-size-factor:36]',
+    '[--max-size:min(calc(var(--spacing)*var(--max-size-factor)),100cqi)]',
+    '@2xl/media-root:[--max-size-factor:48]',
+    'min-w-(--max-size) h-1',
     'before:absolute before:z-1 before:top-1/2 before:left-1/2 before:size-1 before:bg-current before:rounded-full before:pointer-events-none',
     'before:shadow-[0_0_0_1px_var(--shadow-current-color,oklch(0_0_0/0.15)),0_1px_2px_0_oklch(0_0_0/0.35)]',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
     'before:transition-[opacity,scale] before:duration-200 before:ease-out',
     'data-pointing:not-data-dragging:before:opacity-100 data-pointing:not-data-dragging:before:scale-100'
   ),
-  thumbnail: cn(previewContent, '[--thumbnail-max-width:var(--max-width)] [bottom:calc(100%+--spacing(9))]'),
+  thumbnail: cn(
+    previewContent,
+    '[--thumbnail-max-width:var(--max-size)] [--thumbnail-max-height:var(--max-size)]',
+    '[bottom:calc(100%+--spacing(9))]'
+  ),
   value: cn(
     previewContent,
     '[bottom:calc(100%+--spacing(10.5))] flex flex-col items-center tabular-nums',
     'text-shadow-2xs text-shadow-(color:--shadow-current-color)'
   ),
-  chapterTitle: 'min-w-0 max-w-(--max-width) px-6 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
+  chapterTitle: 'min-w-0 max-w-(--max-size) px-6 overflow-hidden text-ellipsis whitespace-nowrap empty:hidden',
 };

--- a/packages/skins/src/default/tailwind/components/thumbnail.ts
+++ b/packages/skins/src/default/tailwind/components/thumbnail.ts
@@ -7,7 +7,7 @@ export const thumbnail = {
     'has-data-loading:aspect-video has-data-loading:overflow-hidden'
   ),
   image: cn(
-    'relative block max-w-(--thumbnail-max-width) max-h-(--max-height) overflow-clip rounded-[inherit]',
+    'relative block max-w-(--thumbnail-max-width) max-h-(--thumbnail-max-height) overflow-clip rounded-[inherit]',
     'transition-opacity duration-150 ease-out',
     'after:absolute after:inset-0 after:rounded-[inherit]',
     'after:bg-linear-to-t after:from-black/50 after:via-black/10 after:to-black/0',

--- a/packages/skins/src/minimal/css/components/slider.css
+++ b/packages/skins/src/minimal/css/components/slider.css
@@ -220,6 +220,7 @@
       outline-offset: 2px;
     }
 
+    &:focus-visible,
     &.media-slider__thumb--persistent {
       opacity: 1;
       scale: 1;
@@ -257,27 +258,25 @@
 
   /* Preview */
   .media-slider__preview {
-    --max-width-factor: 28;
-    --max-width: min(calc(var(--spacing) * var(--max-width-factor)), 100cqi);
-    /* Calculate the height based on the container aspect ratio */
-    --max-height: calc(var(--max-width) * (100cqb / 100cqi));
+    --max-size-factor: 28;
+    --max-size: min(calc(var(--spacing) * var(--max-size-factor)), 100cqi);
 
     min-width: 100%;
     height: calc(var(--spacing) * 1);
 
     @container media-root (width > 32rem) {
-      --max-width-factor: 36;
+      --max-size-factor: 36;
     }
 
     @container media-root (width > 42rem) {
-      --max-width-factor: 48;
+      --max-size-factor: 48;
     }
 
     .media-slider__thumbnail,
     .media-slider__value {
       position: absolute;
       left: var(--preview-left, var(--media-slider-pointer));
-      max-width: var(--max-width);
+      max-width: var(--max-size);
       opacity: 0;
       filter: blur(8px);
       transform-origin: bottom;
@@ -289,7 +288,8 @@
     }
 
     .media-slider__thumbnail {
-      --thumbnail-max-width: var(--max-width);
+      --thumbnail-max-width: var(--max-size);
+      --thumbnail-max-height: var(--max-size);
       bottom: calc(100% + (var(--spacing) * 11));
     }
 

--- a/packages/skins/src/minimal/css/components/thumbnail.css
+++ b/packages/skins/src/minimal/css/components/thumbnail.css
@@ -19,7 +19,7 @@
     position: relative;
     display: block;
     max-width: var(--thumbnail-max-width);
-    max-height: var(--max-height);
+    max-height: var(--thumbnail-max-height);
     overflow: clip;
     border-radius: inherit;
   }

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -302,9 +302,9 @@
 .media-minimal-skin--video .media-slider .media-slider__preview {
   --preview-end-inset: calc(100cqi - 100%);
   --preview-left: clamp(
-    calc(var(--max-width) / 2),
+    calc(var(--max-size) / 2),
     var(--media-slider-pointer),
-    calc(100% - var(--max-width) / 2 + var(--preview-end-inset))
+    calc(100% - var(--max-size) / 2 + var(--preview-end-inset))
   );
 
   @container media-root (width > 42rem) {

--- a/packages/skins/src/minimal/tailwind/components/slider.ts
+++ b/packages/skins/src/minimal/tailwind/components/slider.ts
@@ -1,7 +1,7 @@
 import { cn } from '@videojs/utils/style';
 
 const previewContent = cn(
-  'absolute [left:var(--preview-left,var(--media-slider-pointer))] max-w-(--max-width)',
+  'absolute [left:var(--preview-left,var(--media-slider-pointer))] max-w-(--max-size)',
   '-translate-x-1/2 translate-y-2 scale-80 opacity-0 blur-lg origin-bottom',
   'transition-[filter,opacity,scale] duration-150 ease-out',
   'group-data-pointing/slider:scale-100 group-data-pointing/slider:opacity-100',
@@ -84,6 +84,7 @@ export const slider = {
       'group-active/slider:size-3.5',
       'outline-2 outline-transparent -outline-offset-2',
       'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
+      'focus-visible:opacity-100 focus-visible:scale-100',
       // Horizontal
       'data-[orientation=horizontal]:top-1/2 data-[orientation=horizontal]:left-(--media-slider-fill,0)',
       'group-data-dragging/slider:data-[orientation=horizontal]:left-(--media-slider-pointer)',
@@ -95,10 +96,9 @@ export const slider = {
     interactive: cn('pointer-fine:group-hover/slider:opacity-100 pointer-fine:group-hover/slider:scale-100'),
   },
   preview: cn(
-    '[--max-width-factor:28]',
-    '[--max-width:min(calc(var(--spacing)*var(--max-width-factor)),100cqi)]',
-    '[--max-height:calc(var(--max-width)*(100cqb/100cqi))]',
-    '@lg/media-root:[--max-width-factor:36] @2xl/media-root:[--max-width-factor:48]',
+    '[--max-size-factor:28]',
+    '[--max-size:min(calc(var(--spacing)*var(--max-size-factor)),100cqi)]',
+    '@lg/media-root:[--max-size-factor:36] @2xl/media-root:[--max-size-factor:48]',
     'min-w-full h-1',
     'before:absolute before:z-1 before:bg-current/35 before:pointer-events-none',
     'before:-translate-1/2 before:opacity-0 before:scale-50',
@@ -109,7 +109,11 @@ export const slider = {
     'data-[orientation=vertical]:before:top-[calc(100%-var(--media-slider-pointer))] data-[orientation=vertical]:before:left-1/2',
     'data-[orientation=vertical]:before:w-5 data-[orientation=vertical]:before:h-px'
   ),
-  thumbnail: cn(previewContent, '[--thumbnail-max-width:var(--max-width)] [bottom:calc(100%+--spacing(11))]'),
+  thumbnail: cn(
+    previewContent,
+    '[--thumbnail-max-width:var(--max-size)] [--thumbnail-max-height:var(--max-size)]',
+    '[bottom:calc(100%+--spacing(11))]'
+  ),
   value: cn(
     previewContent,
     '[bottom:calc(100%+--spacing(5))] flex flex-row-reverse justify-center gap-2 px-3 tabular-nums',

--- a/packages/skins/src/minimal/tailwind/components/thumbnail.ts
+++ b/packages/skins/src/minimal/tailwind/components/thumbnail.ts
@@ -9,7 +9,7 @@ export const thumbnail = {
     'has-data-loading:aspect-video has-data-loading:overflow-hidden'
   ),
   image: cn(
-    'relative block max-w-(--thumbnail-max-width) max-h-(--max-height) overflow-clip rounded-[inherit]',
+    'relative block max-w-(--thumbnail-max-width) max-h-(--thumbnail-max-height) overflow-clip rounded-[inherit]',
     'transition-opacity duration-150 ease-out data-loading:opacity-0'
   ),
   spinner: cn(

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -186,7 +186,7 @@ export const slider = {
   preview: cn(
     baseSlider.preview,
     '[--preview-end-inset:calc(100cqi-100%)]',
-    '[--preview-left:clamp(calc(var(--max-width)/2),var(--media-slider-pointer),calc(100%-var(--max-width)/2+var(--preview-end-inset)))]',
+    '[--preview-left:clamp(calc(var(--max-size)/2),var(--media-slider-pointer),calc(100%-var(--max-size)/2+var(--preview-end-inset)))]',
     '@2xl/media-root:[--preview-left:var(--media-slider-pointer)]'
   ),
 };


### PR DESCRIPTION
Refs #2257

## Summary

Follow up on the merged skin styling work to address review feedback while preserving slider preview sizing and interaction behavior across CSS and Tailwind skins.

## Changes

- Keep Minimal slider thumbs visible during keyboard focus and persistent states
- Preserve hover after pointer drag cleanup
- Align preview maximum sizing between CSS and Tailwind implementations
- Clamp Minimal preview thumbnails within the player at both slider edges
- Add regression coverage for focus visibility, drag release, sizing, and overflow

## Testing

- Skins unit tests: 39 passed
- Skins build
- Core slider tests: 65 passed
- Vite Chromium and WebKit E2E: zero failures
- Sandbox Chromium E2E: zero failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pointer/drag cleanup in the shared slider and preview CSS variables used by both skins, but scope is narrow and covered by new unit and E2E tests.
> 
> **Overview**
> Follow-up on skin styling that fixes **slider preview sizing**, **hover after drag**, and **minimal keyboard focus** without changing unrelated player behavior.
> 
> **Core slider:** `endDrag` now always clears dragging and applies the post-release `pointing` state in one path, so a stale `pointermove` before `lostpointercapture` no longer drops hover on the time slider after a mouse drag.
> 
> **Skins (default + minimal, CSS + Tailwind):** Preview caps use a shared `--max-size` (replacing width/height split vars) and thumbnails bind `--thumbnail-max-height` to that size so previews stay consistent and bounded; minimal seek preview clamping uses `--max-size`. Minimal volume slider thumbs stay visible at **keyboard focus** (`:focus-visible` / matching Tailwind).
> 
> **Tests:** Unit coverage for the pointer edge case; E2E for drag-release hover, minimal volume thumb focus, and HTML minimal thumbnails staying inside the player at seek edges; container spec updated for `.media-controls-root`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a31be919d41bac7e3e50a52a71d3b12f2734f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->