### PR TITLE
fix(ci): cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches-ignore:
       - 'rfc/**'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, labeled, synchronize]
 
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     name: E2E (${{ matrix.browser }})

--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: website-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Cancel obsolete CI work when a newer commit lands on the same ref, so checks triggered by successive merges to `main` spend capacity only on the latest revision.

## Changes

- Give CI, E2E, and Website Tests independent concurrency groups scoped by Git ref
- Cancel an older in-progress run when a newer run enters the same group
- Preserve parallel execution across workflows and unrelated branches or pull requests

## Testing

- `pnpm check:workspace`
- `pnpm exec prettier --check .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/website-tests.yml`
- YAML parse and concurrency assertions for all three workflows
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application or deployment impact; the tradeoff is superseded commits may not finish CI before cancellation.
> 
> **Overview**
> Adds GitHub Actions **concurrency** to the **CI**, **E2E Tests**, and **Website Tests** workflows so only the latest run for a given ref keeps going.
> 
> Each workflow gets its own group (`ci-`, `e2e-`, `website-tests-` plus `github.ref`) with **`cancel-in-progress: true`**, so rapid pushes or PR updates stop older in-flight runs instead of piling up. Unrelated refs and the three workflows still run in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48dc84cf9a52314857428d4bd58d059f9dd11606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->