### PR TITLE
fix(compiler): add version to vjsc package

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vjsc",
+  "version": "0.0.0",
   "type": "module",
   "description": "Private compiler infrastructure for Video.js source transforms and builds",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Preview releases have been failing on `main` since #2234. `pnpm pack` cannot resolve `workspace:*` specifiers pointing at the `vjsc` package because `packages/compiler` declares no `version`, so pnpm reports the dependency as "not installed".

## Changes

- Add `"version": "0.0.0"` to `packages/compiler/package.json`

<details>
<summary>Why this broke</summary>

`pnpm pack` and `pnpm publish` rewrite every `workspace:*` specifier into a concrete version before writing the tarball, and they do this for `devDependencies` too. A workspace package with no `version` field cannot be resolved, and pnpm surfaces it as a misleading error:

```
[ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL] Cannot resolve workspace protocol of
dependency "vjsc" because this dependency is not installed. Try running "pnpm install".
```

The dependency is in fact installed (`packages/core/node_modules/vjsc -> ../../compiler`); only the version lookup fails.

#2234 added `"vjsc": "workspace:*"` as a devDependency of `core`, `html`, `react`, `icons`, and `skins`, so all five became unpackable at once. `pkg-pr-new` hits `core` first and exits, which is what the preview job reports. This would also have broken the next real npm release, not just previews.

`vjsc` stays `"private": true` and is absent from `.github/release-please/release-please-config.json`, so release-please will never bump or publish it. Dependents use `workspace:*`, so the literal value is never surfaced to consumers. `apps/sandbox` already uses the same `0.0.0` placeholder.

</details>

## Testing

- Reproduced the failure locally after a fresh `pnpm install --frozen-lockfile`
- `pnpm pack` now succeeds for all 8 packages in the preview publish list (`core`, `element`, `html`, `media`, `react`, `spf`, `store`, `utils`) plus `icons`, `skins`, `cli`, and `compiler`
- `pnpm check:workspace` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest field with no runtime or security impact; fixes CI/pack resolution only.
> 
> **Overview**
> Adds **`"version": "0.0.0"`** to `packages/compiler/package.json` for the private **`vjsc`** workspace package.
> 
> That unblocks **`pnpm pack`** / preview publish flows: after **`vjsc`** was added as a **`workspace:*`** devDependency on packages like **`core`**, **`html`**, **`react`**, **`icons`**, and **`skins`**, pnpm could not rewrite those specifiers without a version on **`vjsc`**, which broke preview releases (and would have affected real publishes). The placeholder matches other internal packages (e.g. sandbox); **`vjsc`** stays **`private`** and is not release-please managed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7426e36d4b6d036e4c7073fcb7fe4a746126c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->