### PR TITLE
fix(ci): skip the changelog forward-port on release commits

### DIFF
--- a/.github/workflows/forward-port-changelog.yml
+++ b/.github/workflows/forward-port-changelog.yml
@@ -22,6 +22,17 @@ concurrency:
 
 jobs:
   forward-port:
+    # Sit out the release commit. Merging the release PR trips this workflow and
+    # the release job at the same time, and the release job force-pushes main onto
+    # site/v10 as its last step, so the raw changelog reaches production that way
+    # regardless. Running here as well would only publish it early: this job takes
+    # about a minute, while the release job takes roughly four and can sit queued
+    # behind its `production` concurrency group for far longer. Skipping keeps a
+    # version's changelog off videojs.org until its packages are really on npm.
+    #
+    # This matches release-please's squashed release commit, `chore: release main
+    # (#1234)`. If that title ever changes, update this condition with it.
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore: release main') }}"
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Stacked on #2228 — targets `ci/forward-port-changelog` so the diff is just the guard. Merge this into that branch and #2228 stays the single PR to `main`, with its approval intact.

Addresses the open Bugbot thread on #2228 ([r3799720924](https://github.com/videojs/v10/pull/2228#discussion_r3799720924), "Stale production push during release"). The finding is correct.

## The race

Merging the release PR touches `site/src/content/changelog/**` — `release-pr.yml` writes `site/src/content/changelog/${VERSION}.mdx` onto the release branch, so the file arrives on `main` with that merge. Both the forward-port workflow and the release job start on that one push. The release job force-pushes `main` onto `site/v10` as its **last** step, so forward-port gets there first and publishes the raw changelog onto the previous release's docs tree.

Measured on the 10.0.0-beta.28 release ([run 32206115237](https://github.com/videojs/v10/actions/runs/32206115237)):

| Moment | Time |
| :--- | :--- |
| Release commit pushed to `main` | 01:46:06Z |
| Release published (prose bot fires) | 01:46:36Z |
| `Update site/v10 branch` force-push | 01:50:27Z |

So the gap is **4m21s** on a good day. The release job also carries `concurrency: production`, and runs in that group have queued far longer — [32227158411](https://github.com/videojs/v10/actions/runs/32227158411) spanned 71 minutes, [32228533378](https://github.com/videojs/v10/actions/runs/32228533378) spanned 2h23m. Forward-port has its own group and no such contention, so it is unaffected by the queue. That gap is how long videojs.org can advertise a version whose packages are not yet on npm — and if the release job fails before publishing, the stale state simply stays up. No CI runs on `site/v10` pushes (`ci.yml` and `website-tests.yml` are `main`-only), so nothing would flag it.

## The change

Skip the release commit and let the release job own that push. Nothing is lost: its force-push already carries the raw changelog. Every other path into the changelog folder — prose PRs, typo fixes — still forwards exactly as before, which is the case #2228 exists for.

The condition is keyed to release-please's squashed release commit title. Verified against every release commit the API returns (`#2221`, `#1916`, `#1815`, `#1599`, `#1477`, `#1375`, `#1353`, `#1341`, `#1339`, `#1336`, `#1313`, `#1308`, `#1232`) — all `chore: release main (#N)`, all single-parent squashes. `release-please-config.json` sets no `pull-request-title-pattern`, so the default title stands. A comment on the condition says to update it if that ever changes.

## Verification

- Parsed the workflow with a YAML loader. The expression **must** be quoted — unquoted, the `: ` inside `'chore: release main'` makes it an invalid plain scalar and GitHub rejects the whole workflow file. Caught before pushing.
- Simulated GitHub's case-insensitive `startsWith` against the real commit messages above: skips all 13 release commits, runs on both changelog-prose commits (`#2256`, `#2224`) and on `fix(ci): unblock the changelog prose bot (#2222)`.
- A null `head_commit` coerces to `''`, so the job runs rather than skips — it fails open toward syncing.

## Not addressed here

One narrower ordering bug remains, which this guard does not fix. The release job force-pushes the **release commit**, not `main`'s tip, so a prose PR merged inside that ~4-minute window gets forward-ported and then flattened by the force-push, with no further trigger to restore it. It needs a release and a merge-ready prose PR to collide in the same window, and re-running the workflow recovers it. Worth a follow-up rather than widening this change.

Also worth a touch-up on #2228's description: the "Why it can't affect a release" bullet claims the workflow "triggers on `push` to `main`, well after the release job is done." That is the one claim that does not hold — it triggers on the same push that starts the release job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkch8rpFpJGPf4gqsaWZ3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkch8rpFpJGPf4gqsaWZ3F)_