### PR TITLE
feat(packages): add shaka player media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -12,6 +12,7 @@ export const PRESETS = [
   'hls-video',
   'hls-audio',
   'dash-video',
+  'shaka-video',
   'audio',
   'background-video',
   'hls-background-video',

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -349,6 +349,11 @@ export const MUX_SPF_SOURCE_IDS = SOURCE_IDS.filter(
 export const SPF_HLS_SOURCE_IDS = MUX_SPF_SOURCE_IDS.filter((id) => !isMuxSource(id));
 export const MP4_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'mp4');
 export const DASH_SOURCE_IDS = SOURCE_IDS.filter((id) => SOURCES[id].type === 'dash');
+/**
+ * Shaka plays DASH and HLS from one element, so it is the only preset offered
+ * both. The DRM assets are left out until the sandbox hands it license servers.
+ */
+export const SHAKA_SOURCE_IDS = SOURCE_IDS.filter((id) => !isDrmSource(id) && !isMuxSource(id));
 export const DEFAULT_SOURCE: SourceId = 'hls-1';
 export const DEFAULT_AUDIO_SOURCE: SourceId = 'mp4-1';
 export const DEFAULT_DASH_SOURCE: SourceId = 'dash-1';

--- a/apps/sandbox/app/shell/app.tsx
+++ b/apps/sandbox/app/shell/app.tsx
@@ -15,6 +15,7 @@ import {
   MUX_SOURCE_IDS,
   MUX_SPF_SOURCE_IDS,
   NON_DASH_SOURCE_IDS,
+  SHAKA_SOURCE_IDS,
   SOURCES,
   SPF_HLS_SOURCE_IDS,
 } from '@app/shared/sources';
@@ -101,15 +102,17 @@ export function App() {
       ? MP4_SOURCE_IDS
       : preset === 'dash-video'
         ? DASH_SOURCE_IDS
-        : structuredSource && muxPreset
-          ? MUX_SOURCE_IDS
-          : structuredSource && hlsPreset
-            ? HLS_SOURCE_IDS
-            : structuredSource && muxSpfPreset
-              ? MUX_SPF_SOURCE_IDS
-              : spfHlsPreset || muxSpfPreset || spfBackgroundPreset
-                ? SPF_HLS_SOURCE_IDS
-                : NON_DASH_SOURCE_IDS;
+        : preset === 'shaka-video'
+          ? SHAKA_SOURCE_IDS
+          : structuredSource && muxPreset
+            ? MUX_SOURCE_IDS
+            : structuredSource && hlsPreset
+              ? HLS_SOURCE_IDS
+              : structuredSource && muxSpfPreset
+                ? MUX_SPF_SOURCE_IDS
+                : spfHlsPreset || muxSpfPreset || spfBackgroundPreset
+                  ? SPF_HLS_SOURCE_IDS
+                  : NON_DASH_SOURCE_IDS;
 
   // Keep the URL in sync with all state.
   useEffect(() => {
@@ -175,9 +178,10 @@ export function App() {
     }
   }, [preset, source]);
 
-  // Constrain source away from DASH for non-DASH presets
+  // Constrain source away from DASH for presets that cannot play it. Shaka is
+  // not one of them — it plays DASH and HLS from the same element.
   useEffect(() => {
-    if (preset !== 'dash-video' && SOURCES[source].type === 'dash') {
+    if (preset !== 'dash-video' && preset !== 'shaka-video' && SOURCES[source].type === 'dash') {
       setSource(DEFAULT_SOURCE);
     }
   }, [preset, source]);

--- a/apps/sandbox/app/shell/navbar.tsx
+++ b/apps/sandbox/app/shell/navbar.tsx
@@ -108,6 +108,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   'hls-video': 'HLS Video',
   'hls-audio': 'HLS Audio',
   'dash-video': 'DASH Video',
+  'shaka-video': 'Shaka Video',
   audio: 'Audio',
   'background-video': 'Background Video',
   'hls-background-video': 'HLS Background Video (SPF)',

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -140,6 +140,7 @@ async function loadCdnPreset(preset: Preset, skin: Skin, live: boolean) {
     case 'native-hls-video':
     case 'hls-video':
     case 'dash-video':
+    case 'shaka-video':
     case 'vimeo-video':
     case 'youtube-video':
     case 'cloudflare-video':
@@ -212,6 +213,9 @@ async function loadCdnMedia(preset: Preset) {
       break;
     case 'dash-video':
       await import('@videojs/html/cdn/media/dash-video');
+      break;
+    case 'shaka-video':
+      await import('@videojs/html/cdn/media/shaka-video');
       break;
     // Each embed is one bundle beside the rest, so a page reaches a third-party
     // player the same way it reaches an HLS one — no npm-only step.
@@ -302,6 +306,7 @@ function getMediaTag(preset: Preset): string {
     'hls-video': 'hls-video',
     'hls-audio': 'hls-audio',
     'dash-video': 'dash-video',
+    'shaka-video': 'shaka-video',
     'vimeo-video': 'vimeo-video',
     'youtube-video': 'youtube-video',
     'cloudflare-video': 'cloudflare-video',
@@ -331,7 +336,8 @@ function isVideoPreset(preset: Preset): boolean {
     preset === 'mux-video-spf' ||
     preset === 'native-hls-video' ||
     preset === 'hls-video' ||
-    preset === 'dash-video'
+    preset === 'dash-video' ||
+    preset === 'shaka-video'
   );
 }
 

--- a/apps/sandbox/templates/html-shaka-video/index.html
+++ b/apps/sandbox/templates/html-shaka-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML Shaka Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-shaka-video/main.ts
+++ b/apps/sandbox/templates/html-shaka-video/main.ts
@@ -1,0 +1,79 @@
+import '@app/styles.css';
+import { bindSandboxHtmlLocaleChange, prepareSandboxHtmlLocale, wrapSandboxHtmlI18n } from '@app/shared/html/i18n';
+import '@videojs/html/video/player';
+import '@videojs/html/media/shaka-video';
+import { createHtmlSandboxState, createLatestLoader, renderMediaAttrs } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { renderStoryboard } from '@app/shared/html/storyboard';
+import {
+  onAutoplayChange,
+  onLoopChange,
+  onMutedChange,
+  onPreloadChange,
+  onSkinChange,
+  onSourceChange,
+} from '@app/shared/sandbox-listener';
+import { getPosterSrc, getStoryboardSrc, SOURCES } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  await prepareSandboxHtmlLocale();
+
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  const storyboard = getStoryboardSrc(state.source);
+  const poster = getPosterSrc(state.source);
+  const mediaAttrs = renderMediaAttrs(state);
+
+  document.getElementById('root')!.innerHTML = wrapSandboxHtmlI18n(html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <!-- Shaka plays DASH and HLS from the same element, so the source list here is not
+             narrowed to one manifest format the way the dash.js sandbox is. -->
+        <shaka-video src="${SOURCES[state.source].url}" ${mediaAttrs} playsinline>
+          ${renderStoryboard(storyboard)}
+        </shaka-video>
+        ${poster ? html`<img slot="poster" src="${poster}" alt="Video poster" />` : ''}
+      </${tag}>
+    </video-player>
+  `);
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});
+
+onSourceChange((source) => {
+  state.source = source;
+  render();
+});
+
+onAutoplayChange((autoplay) => {
+  state.autoplay = autoplay;
+  render();
+});
+
+onMutedChange((muted) => {
+  state.muted = muted;
+  render();
+});
+
+onLoopChange((loop) => {
+  state.loop = loop;
+  render();
+});
+
+onPreloadChange((preload) => {
+  state.preload = preload;
+  render();
+});
+
+bindSandboxHtmlLocaleChange(render);

--- a/apps/sandbox/templates/react-shaka-video/index.html
+++ b/apps/sandbox/templates/react-shaka-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React Shaka Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-shaka-video/main.tsx
+++ b/apps/sandbox/templates/react-shaka-video/main.tsx
@@ -1,0 +1,50 @@
+import '@app/styles.css';
+import { VideoPlayer } from '@app/shared/react/players';
+import { SandboxI18nProvider } from '@app/shared/react/sandbox-i18n';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useAutoplay } from '@app/shared/react/use-autoplay';
+import { useLoop } from '@app/shared/react/use-loop';
+import { useMuted } from '@app/shared/react/use-muted';
+import { usePreload } from '@app/shared/react/use-preload';
+import { useSkin } from '@app/shared/react/use-skin';
+import { useSource } from '@app/shared/react/use-source';
+import { SOURCES } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { ShakaVideo } from '@videojs/react/media/shaka-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const source = useSource();
+  const styling = useMemo(readStyling, []);
+  const autoplay = useAutoplay();
+  const muted = useMuted();
+  const loop = useLoop();
+  const preload = usePreload();
+
+  return (
+    <SandboxI18nProvider>
+      <VideoPlayer>
+        <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+          {/* Shaka plays DASH and HLS from the same element, so the source list here is not
+              narrowed to one manifest format the way the dash.js sandbox is. */}
+          <ShakaVideo
+            src={SOURCES[source].url ?? ''}
+            autoPlay={autoplay}
+            muted={muted}
+            loop={loop}
+            preload={preload}
+            playsInline
+          />
+        </VideoSkinComponent>
+      </VideoPlayer>
+    </SandboxI18nProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/define/media/shaka-video.ts
+++ b/packages/html/src/define/media/shaka-video.ts
@@ -1,0 +1,14 @@
+import { ShakaVideo } from '../../media/shaka-video';
+import { safeDefine } from '../safe-define';
+
+export class ShakaVideoElement extends ShakaVideo {
+  static readonly tagName = 'shaka-video';
+}
+
+safeDefine(ShakaVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [ShakaVideoElement.tagName]: ShakaVideoElement;
+  }
+}

--- a/packages/html/src/media/shaka-video/index.ts
+++ b/packages/html/src/media/shaka-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/shaka-video/media.ts
+++ b/packages/html/src/media/shaka-video/media.ts
@@ -1,0 +1,5 @@
+import { CustomMediaElement } from '@videojs/media/dom/custom-media-element';
+import { ShakaMedia } from '@videojs/media/dom/shaka';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+export class ShakaVideo extends MediaAttachMixin(CustomMediaElement('video', ShakaMedia)) {}

--- a/packages/html/vjsc/entries.generated.ts
+++ b/packages/html/vjsc/entries.generated.ts
@@ -375,6 +375,14 @@ export const SeekIndicatorValue = {
   },
 } as const;
 
+export const ShakaVideo = {
+  tagName: 'shaka-video',
+  import: {
+    from: '@videojs/html/media/shaka-video',
+    sideEffect: true,
+  },
+} as const;
+
 export const Slider = {
   tagName: 'media-slider',
   import: {
@@ -679,6 +687,7 @@ export const entries = {
   SeekButton,
   SeekIndicator,
   SeekIndicatorValue,
+  ShakaVideo,
   Slider,
   SliderBuffer,
   SliderFill,

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -57,7 +57,8 @@
     "@vimeo/player": "^2.30.3",
     "dashjs": "^5.2.0",
     "hls.js": "^1.6.7",
-    "mux-embed": "^5.17.10"
+    "mux-embed": "^5.17.10",
+    "shaka-player": "^5.2.4"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.40",

--- a/packages/media/src/dom/shaka/index.ts
+++ b/packages/media/src/dom/shaka/index.ts
@@ -1,0 +1,3 @@
+export type { DrmSystemConfig, DrmSystemsConfig, KeySystem } from '../../core/drm';
+export { KeySystems } from '../../core/drm';
+export * from './media';

--- a/packages/media/src/dom/shaka/media-tracks.ts
+++ b/packages/media/src/dom/shaka/media-tracks.ts
@@ -1,0 +1,276 @@
+import type { Constructor } from '@videojs/utils/types';
+import type shaka from 'shaka-player';
+
+import type {
+  MediaAudioTrackCapability,
+  MediaVideoRenditionCapability,
+  MediaVideoTrackCapability,
+} from '../../core/types';
+import type { HTMLVideoElementHost } from '../video-host';
+
+type ShakaEngineHost = HTMLVideoElementHost & {
+  readonly engine?: shaka.Player | null;
+};
+
+type MediaTracksHost = ShakaEngineHost &
+  MediaVideoTrackCapability &
+  MediaAudioTrackCapability &
+  MediaVideoRenditionCapability;
+
+/**
+ * Mirrors the Shaka video and audio tracks of the loaded asset into the media
+ * element's `videoRenditions` / `audioTracks` lists, and wires user selection
+ * back to `engine.selectVideoTrack()` and `engine.selectAudioTrack()`.
+ *
+ * Shaka video tracks are a flattened view over the manifest's variants rather
+ * than a list of their own, so they are hung off a single `'main'` video track —
+ * the one the renditions of the asset that is playing are read from.
+ *
+ * Requires the media-tracks mixin (track-list infrastructure) to be applied
+ * earlier in the chain so the host exposes `addVideoTrack`, `videoRenditions`,
+ * and friends.
+ */
+export function ShakaMediaMediaTracksMixin<Base extends Constructor<MediaTracksHost>>(BaseClass: Base) {
+  class ShakaMediaMediaTracks extends (BaseClass as Constructor<MediaTracksHost>) {
+    // The source is announced as a whole, so the URL it resolved to last is what
+    // tells a new asset apart from a configuration-only change.
+    #src = '';
+    // Shaka identifies neither kind of track by an id, so what it last announced
+    // is what a re-announcement of the same set is recognized by.
+    #videoTracksKey = '';
+    #audioTracksKey = '';
+    #isAbrOff = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const { engine } = this;
+      if (!engine) return;
+
+      engine.addEventListener('trackschanged', this.#onTracksChanged);
+      engine.addEventListener('audiotrackschanged', this.#onAudioTracksChanged);
+      engine.addEventListener('variantchanged', this.#onVariantChanged);
+      engine.addEventListener('adaptation', this.#onVariantChanged);
+      engine.addEventListener('audiotrackchanged', this.#onAudioTrackChanged);
+
+      this.addEventListener('sourcechange', this.#onSourceChange);
+      this.videoRenditions.addEventListener('change', this.#switchRendition);
+      this.audioTracks.addEventListener('change', this.#switchAudioTrack);
+    }
+
+    destroy() {
+      const { engine } = this;
+
+      engine?.removeEventListener('trackschanged', this.#onTracksChanged);
+      engine?.removeEventListener('audiotrackschanged', this.#onAudioTracksChanged);
+      engine?.removeEventListener('variantchanged', this.#onVariantChanged);
+      engine?.removeEventListener('adaptation', this.#onVariantChanged);
+      engine?.removeEventListener('audiotrackchanged', this.#onAudioTrackChanged);
+
+      this.removeEventListener('sourcechange', this.#onSourceChange);
+      this.videoRenditions.removeEventListener('change', this.#switchRendition);
+      this.audioTracks.removeEventListener('change', this.#switchAudioTrack);
+
+      this.#reset();
+
+      super.destroy();
+    }
+
+    // Shaka re-announces its tracks whenever the playable set changes — a new
+    // asset, a new period, a restriction lifted. Rebuilding throws away the
+    // rendition a user pinned, so it only happens when the set is actually
+    // different.
+    #onTracksChanged = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      const videoTracks = engine.getVideoTracks();
+      const key = videoTracksKey(videoTracks);
+      if (key === this.#videoTracksKey) return;
+      this.#videoTracksKey = key;
+
+      this.#removeVideoTracks();
+      this.#restoreAbr();
+
+      const videoTrack = this.addVideoTrack('main');
+      // Selecting the track is what puts its renditions in `videoRenditions`, so
+      // it happens before any is added and their `addrendition` events land.
+      videoTrack.selected = true;
+
+      for (const [index, track] of videoTracks.entries()) {
+        const rendition = videoTrack.addRendition(
+          // A Shaka video track is a set of manifest variants rather than one
+          // playable URL, so there is nothing to point at.
+          '',
+          track.width ?? undefined,
+          track.height ?? undefined,
+          track.codecs ?? undefined,
+          track.bandwidth,
+          track.frameRate ?? undefined
+        );
+
+        // Shaka has no id of its own for a track, so its position in the list is
+        // what a selection is looked back up by.
+        rendition.id = `${index}`;
+      }
+
+      this.#setActiveRendition(videoTracks);
+      // Audio tracks arrive with the asset, and Shaka announces them separately
+      // only when they change after that.
+      this.#onAudioTracksChanged();
+    };
+
+    #onAudioTracksChanged = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      const audioTracks = engine.getAudioTracks();
+      const key = audioTracksKey(audioTracks);
+      if (key === this.#audioTracksKey) return;
+      this.#audioTracksKey = key;
+
+      this.#removeAudioTracks();
+
+      for (const [index, track] of audioTracks.entries()) {
+        const audioTrack = this.addAudioTrack(
+          track.primary ? 'main' : 'alternative',
+          track.label ?? track.language,
+          track.language
+        );
+
+        audioTrack.id = `${index}`;
+        audioTrack.enabled = track.active;
+      }
+    };
+
+    #onVariantChanged = () => {
+      const { engine } = this;
+      if (engine) this.#setActiveRendition(engine.getVideoTracks());
+    };
+
+    #onAudioTrackChanged = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      const activeIndex = engine.getAudioTracks().findIndex((track) => track.active);
+
+      for (const audioTrack of this.audioTracks) {
+        audioTrack.enabled = audioTrack.id === `${activeIndex}`;
+      }
+    };
+
+    #switchRendition = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      // Multiple renditions can be selected, but Shaka plays exactly one video
+      // track at a time, so the first one wins.
+      const selected = [...this.videoRenditions].find((rendition) => rendition.selected);
+
+      if (!selected?.id) {
+        this.#restoreAbr();
+        return;
+      }
+
+      const videoTrack = engine.getVideoTracks()[Number(selected.id)];
+      if (!videoTrack) return;
+
+      this.#isAbrOff = true;
+      engine.configure({ abr: { enabled: false } });
+      engine.selectVideoTrack(videoTrack);
+    };
+
+    #switchAudioTrack = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      // `enabled` is not exclusive the way video `selected` is, so prefer a
+      // newly enabled track over the one that is already playing.
+      const enabledTracks = [...this.audioTracks].filter((track) => track.enabled);
+      const audioTracks = engine.getAudioTracks();
+
+      const selectedTrack = enabledTracks.find((track) => !audioTracks[Number(track.id)]?.active) ?? enabledTracks[0];
+      if (!selectedTrack?.id) return;
+
+      const audioTrack = audioTracks[Number(selectedTrack.id)];
+      if (audioTrack && !audioTrack.active) engine.selectAudioTrack(audioTrack);
+
+      // Disable the rest so future change events resolve unambiguously.
+      for (const track of enabledTracks) {
+        if (track !== selectedTrack) track.enabled = false;
+      }
+    };
+
+    #onSourceChange = () => {
+      const srcChanged = this.src !== this.#src;
+      this.#src = this.src;
+
+      // A new asset announces tracks of its own, and the one that is going away
+      // leaves nothing to select from.
+      if (srcChanged) {
+        this.#reset();
+        return;
+      }
+
+      // Applying `engine.shaka` resets Shaka's configuration wholesale, which
+      // drops the adaptation this mixin turned off; re-apply the selection it
+      // was for.
+      if (this.#isAbrOff && this.#isEngineAbrOn()) this.#switchRendition();
+    };
+
+    // Shaka's own reading rather than what this mixin last asked for:
+    // configuration is reset out from under it, and only the engine knows
+    // whether that happened. Announcing a source that changed nothing must leave
+    // the pinned track alone, or an inline React `source` prop would interrupt
+    // playback on every render.
+    #isEngineAbrOn() {
+      return this.engine?.getConfiguration().abr?.enabled !== false;
+    }
+
+    #setActiveRendition(videoTracks: shaka.extern.VideoTrack[]) {
+      const activeIndex = videoTracks.findIndex((track) => track.active);
+
+      for (const rendition of this.videoRenditions) {
+        rendition.active = activeIndex >= 0 && rendition.id === `${activeIndex}`;
+      }
+    }
+
+    #reset() {
+      this.#removeVideoTracks();
+      this.#removeAudioTracks();
+      this.#restoreAbr();
+      this.#videoTracksKey = '';
+      this.#audioTracksKey = '';
+    }
+
+    // Only ever undoes what a selection turned off, so a Shaka configuration
+    // that disables adaptation on purpose is left as configured.
+    #restoreAbr() {
+      if (!this.#isAbrOff) return;
+      this.#isAbrOff = false;
+      this.engine?.configure({ abr: { enabled: true } });
+    }
+
+    #removeVideoTracks() {
+      for (const videoTrack of this.videoTracks) {
+        this.removeVideoTrack(videoTrack);
+      }
+    }
+
+    #removeAudioTracks() {
+      for (const audioTrack of this.audioTracks) {
+        this.removeAudioTrack(audioTrack);
+      }
+    }
+  }
+
+  return ShakaMediaMediaTracks as unknown as Base;
+}
+
+function videoTracksKey(tracks: shaka.extern.VideoTrack[]) {
+  return tracks.map((track) => `${track.width}x${track.height}|${track.codecs}|${track.bandwidth}|${track.hdr}`).join();
+}
+
+function audioTracksKey(tracks: shaka.extern.AudioTrack[]) {
+  return tracks.map((track) => `${track.language}|${track.label}|${track.roles}|${track.channelsCount}`).join();
+}

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -1,4 +1,5 @@
 import { deepEqual } from '@videojs/utils/object';
+import { isObject } from '@videojs/utils/predicate';
 import shaka from 'shaka-player';
 
 import type { DrmSystemsConfig } from '../../core/drm';
@@ -79,8 +80,9 @@ class ShakaMediaBase
   #src = shakaMediaDefaultProps.src;
   #source: ShakaSource | null = shakaMediaDefaultProps.source;
   #error: MediaError | null = null;
-  // The raw Shaka failure last seen, whichever path delivered it first.
-  #reported: unknown = null;
+  // The raw Shaka failures already announced. Held weakly: it answers nothing
+  // but "seen before", and each failure is a fresh object.
+  #reported = new WeakSet<object>();
   #isDestroyed = false;
 
   constructor() {
@@ -246,7 +248,6 @@ class ShakaMediaBase
 
   #loadSource(engine: shaka.Player) {
     this.#error = null;
-    this.#reported = null;
     const { src } = this;
     this.#run(src ? engine.load(src, undefined, this.#source?.type) : engine.unload());
   }
@@ -275,9 +276,13 @@ class ShakaMediaBase
 
     // One failure can arrive twice — rejecting the engine call it broke and
     // announcing itself on the `error` event — so whichever lands first is the
-    // one that counts.
-    if (error === this.#reported) return;
-    this.#reported = error;
+    // one that counts. This outlives the load it came from: an `error` handler
+    // that assigns a fallback `src` would otherwise see the rejection still in
+    // flight land as a fresh failure against the source it just started.
+    if (isObject(error)) {
+      if (this.#reported.has(error)) return;
+      this.#reported.add(error);
+    }
 
     const mediaError = toMediaError(error);
     // An aborted load or a failure Shaka intends to retry is not worth

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -1,0 +1,377 @@
+import { deepEqual } from '@videojs/utils/object';
+import shaka from 'shaka-player';
+
+import type { DrmSystemsConfig } from '../../core/drm';
+import { MediaError } from '../../core/media-error';
+import { MediaTracksMixin } from '../../core/media-tracks';
+import type { MediaEngineHost } from '../../core/types';
+import { HTMLVideoElementHost } from '../video-host';
+import { ShakaMediaMediaTracksMixin } from './media-tracks';
+
+export { shaka };
+
+type Opaque = string | number | boolean | bigint | symbol | null | undefined | ArrayBufferView;
+
+/**
+ * Every level optional. Shaka's own configuration type describes a fully
+ * resolved configuration, while `configure()` merges whatever subset it is
+ * handed into the current one.
+ */
+type DeepPartial<T> = T extends Opaque | readonly any[] | ((...args: any[]) => any)
+  ? T
+  : { [Key in keyof T]?: DeepPartial<T[Key]> };
+
+/** Shaka Player's configuration, as `configure()` accepts it. */
+export type ShakaConfig = DeepPartial<shaka.extern.PlayerConfiguration>;
+
+/** Structured Shaka source: which source to play, plus how to play it. */
+export interface ShakaSource {
+  /**
+   * Manifest URL. Shaka plays DASH, HLS, and progressive files from the same
+   * property. Mirrors the host's `src` property.
+   */
+  src?: string | undefined;
+  /**
+   * MIME type of the source. Handed to Shaka as the type to parse `src` as,
+   * which is what makes an extensionless manifest URL playable.
+   */
+  type?: string | undefined;
+  /**
+   * License servers for protected content, keyed by EME key system id.
+   *
+   * Translated into the `drm.servers` and `drm.advanced` Shaka configures EME
+   * from. Name every system you hold a license server for — which one is used
+   * is the browser's choice.
+   */
+  drm?: DrmSystemsConfig | undefined;
+  /** Playback options, keyed by the engine that reads them. */
+  engine?: ShakaEngineConfig | undefined;
+}
+
+/** The engines a Shaka source can configure. */
+export interface ShakaEngineConfig {
+  /**
+   * Shaka Player's own configuration, passed through untouched. Replacing it
+   * resets any previously applied configuration. A `drm.servers` of its own
+   * replaces `source.drm` — an escape hatch for licensing against the parts of
+   * Shaka's DRM configuration `source.drm` does not cover.
+   */
+  shaka?: ShakaConfig | undefined;
+}
+
+export interface ShakaMediaProps {
+  src: string;
+  source: ShakaSource | null;
+}
+
+export const shakaMediaDefaultProps: ShakaMediaProps = {
+  src: '',
+  source: null,
+};
+
+const ShakaMediaHost = MediaTracksMixin(HTMLVideoElementHost);
+
+class ShakaMediaBase
+  extends ShakaMediaHost
+  implements MediaEngineHost<shaka.Player, HTMLVideoElement>, ShakaMediaProps
+{
+  #engine: shaka.Player | null = null;
+  #src = shakaMediaDefaultProps.src;
+  #source: ShakaSource | null = shakaMediaDefaultProps.source;
+  #error: MediaError | null = null;
+  #isDestroyed = false;
+
+  constructor() {
+    super();
+
+    installPolyfills();
+
+    if (!shaka.Player.isBrowserSupported()) {
+      if (__DEV__) {
+        console.warn('[vjs-shaka] This browser lacks the APIs Shaka Player needs. Nothing will play.');
+      }
+      return;
+    }
+
+    this.#engine = new shaka.Player();
+    this.#engine.addEventListener('error', this.#onEngineError);
+  }
+
+  attach(target: HTMLVideoElement) {
+    // Shaka's `attach()` tears playback down and builds it back up, so the
+    // target it is already playing in is left alone.
+    const isNewTarget = this.target !== target;
+    // Read before attaching: a source assigned while there was nothing to play
+    // it in never reached the engine, and this attach is what loads it. Anything
+    // assigned from here on has a target of its own to load into.
+    const hasUnloadedSource = Boolean(this.#src);
+
+    super.attach(target);
+
+    const engine = this.#engine;
+    if (!engine || !isNewTarget) return;
+
+    this.#run(engine.attach(target));
+    // Shaka takes its lock in call order, so this runs after the attach above
+    // without waiting on it here.
+    if (hasUnloadedSource) this.#loadSource(engine);
+  }
+
+  detach() {
+    const engine = this.#engine;
+    const wasAttached = this.target !== null;
+
+    super.detach();
+
+    if (engine && wasAttached) this.#run(engine.detach());
+  }
+
+  destroy() {
+    this.detach();
+
+    const engine = this.#engine;
+    // Anything still in flight has nothing left to report to.
+    this.#engine = null;
+    this.#isDestroyed = true;
+
+    if (engine) {
+      engine.removeEventListener('error', this.#onEngineError);
+      // Shaka aborts whatever is in flight itself, so a teardown that races a
+      // load has nothing left to report.
+      engine.destroy().catch(() => {});
+    }
+
+    super.destroy();
+  }
+
+  /**
+   * Underlying playback engine — the Shaka `Player` instance, or `null` when
+   * the browser cannot run it. An advanced escape hatch for direct engine
+   * access; normal playback is driven through this element's own properties
+   * and methods.
+   */
+  get engine() {
+    return this.#engine;
+  }
+
+  /**
+   * The last playback failure, or `null`. Shaka loads asynchronously, so a
+   * manifest that cannot be played fails after `src` was assigned rather than at
+   * the assignment; the `error` event is when to read this.
+   *
+   * A Shaka failure says more about what went wrong than the media element's
+   * own `error` does, so it wins while there is one; anything the element failed
+   * on by itself still reads through.
+   */
+  get error() {
+    return this.#error ?? super.error;
+  }
+
+  get src() {
+    return this.#src;
+  }
+
+  /** Manifest URL. Setting it re-derives `source`, carrying its settings over. */
+  set src(value) {
+    // `src` says which source to play; every other field says how to play it,
+    // so they carry over.
+    const { type, drm, engine } = this.#source ?? {};
+    const next: ShakaSource = {
+      ...(type && { type }),
+      ...(drm && { drm }),
+      ...(engine && { engine }),
+      ...(value && { src: value }),
+    };
+
+    // Everything happens in the `source` setter, so there is one path for
+    // storing it, telling the engine, and dispatching `sourcechange`.
+    this.source = Object.keys(next).length > 0 ? next : null;
+  }
+
+  /**
+   * Structured source: what to play (`src`, an optional `type`) plus how to
+   * play it (`drm`, `engine.shaka`). Replacing it re-derives `src`.
+   *
+   * Shaka takes configuration on a live player, so changing `engine.shaka`
+   * re-applies it in place instead of recreating the engine.
+   */
+  get source(): ShakaSource | null {
+    return this.#source;
+  }
+
+  set source(value: ShakaSource | null) {
+    const source = value ?? null;
+    // Changing anything takes a new object, so handing the same one back costs
+    // nothing.
+    if (source === this.#source) return;
+
+    // Assigning is always a source change, so it is always announced. Only the
+    // engine calls are guarded, so re-assigning an equivalent source — an inline
+    // React prop, say — never disturbs what is already playing.
+    const configChanged = !deepEqual(engineConfigKey(this.#source), engineConfigKey(source));
+    const loadChanged = this.#src !== (source?.src ?? '') || this.#source?.type !== source?.type;
+
+    this.#source = source;
+    this.#src = source?.src ?? '';
+
+    if (configChanged) this.#applyEngineConfig();
+    if (loadChanged) this.#requestLoad();
+
+    this.dispatchEvent(new Event('sourcechange'));
+  }
+
+  // `engine.shaka` is replaced, not merged, but Shaka merges every
+  // `configure()` call into the current configuration — reset first so dropping
+  // a key clears it instead of leaving the previous value behind.
+  #applyEngineConfig() {
+    const engine = this.#engine;
+    if (!engine) return;
+
+    engine.resetConfiguration();
+
+    const config = withDrmConfig(this.#source?.engine?.shaka, this.#source?.drm);
+    if (config) engine.configure(config);
+  }
+
+  #requestLoad() {
+    const engine = this.#engine;
+    // Nothing to load into yet — `attach()` loads what is waiting.
+    if (!engine || !this.target) return;
+
+    this.#loadSource(engine);
+  }
+
+  #loadSource(engine: shaka.Player) {
+    this.#error = null;
+    const { src } = this;
+    this.#run(src ? engine.load(src, undefined, this.#source?.type) : engine.unload());
+  }
+
+  /**
+   * Shaka's `attach()`, `load()`, `unload()`, and `detach()` are asynchronous,
+   * and the player orders them itself: each takes an internal lock in call
+   * order, and a newer one interrupts whatever it supersedes. So a call is
+   * issued as it comes — holding it until the one before it settles would keep
+   * a new source waiting on a manifest that hangs, when cutting that load short
+   * is the point of assigning one.
+   *
+   * Nothing awaits these, so a rejection is reported rather than left unhandled.
+   */
+  #run(operation: Promise<unknown>) {
+    operation.catch((error) => this.#reportError(error));
+  }
+
+  #onEngineError = (event: Event) => {
+    this.#reportError((event as Event & { detail?: unknown }).detail);
+  };
+
+  #reportError(error: unknown) {
+    // A teardown rejects whatever it was racing; there is no one left to tell.
+    if (this.#isDestroyed) return;
+
+    const mediaError = toMediaError(error);
+    // Superseding a load aborts the one in flight. That is this element doing
+    // its job, not a failure worth announcing.
+    if (!mediaError) return;
+
+    this.#error = mediaError;
+    this.dispatchEvent(new ErrorEvent('error', { error: mediaError, message: mediaError.message }));
+  }
+}
+
+/**
+ * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
+ * @fires error - Fired when playback fails. Read `error` for the failure.
+ */
+export class ShakaMedia extends ShakaMediaMediaTracksMixin(ShakaMediaBase) {}
+
+let arePolyfillsInstalled = false;
+
+/**
+ * Patches the browser APIs Shaka expects before anything reads them. Shaka
+ * ships these as polyfills it does not install itself, and both
+ * `isBrowserSupported()` and the DRM path depend on them — FairPlay EME on
+ * Safari is patched in from here. Installing is global, so it happens once.
+ */
+function installPolyfills() {
+  if (arePolyfillsInstalled) return;
+  arePolyfillsInstalled = true;
+
+  shaka.polyfill.installAll();
+}
+
+/**
+ * Everything Shaka is configured from. Compared structurally, so equivalent
+ * options never re-apply — including nested ones like `drm`, which a flat
+ * comparison would see as changed whenever the object identity did.
+ */
+function engineConfigKey(source: ShakaSource | null) {
+  return { drm: source?.drm ?? null, shaka: source?.engine?.shaka ?? null };
+}
+
+/**
+ * Shaka configuration with the source's DRM licensing folded in. Shaka names
+ * license servers under `drm.servers` and server certificates under
+ * `drm.advanced`, so `source.drm` is translated into both — unless
+ * `engine.shaka.drm.servers` names servers of its own, which replaces it.
+ */
+function withDrmConfig(config: ShakaConfig | undefined, drm: DrmSystemsConfig | undefined) {
+  const systems = Object.entries(drm ?? {});
+  if (systems.length === 0 || config?.drm?.servers) return config;
+
+  const servers: Record<string, string> = {};
+  const advanced: Record<string, { serverCertificateUri: string }> = {};
+
+  for (const [keySystem, system] of systems) {
+    servers[keySystem] = system.licenseUrl;
+    if (system.serverCertificateUrl) advanced[keySystem] = { serverCertificateUri: system.serverCertificateUrl };
+  }
+
+  return {
+    ...config,
+    drm: {
+      ...config?.drm,
+      servers,
+      // Advanced options a caller set for a key system are more specific than a
+      // certificate URL derived from `source.drm`, so they win.
+      ...(Object.keys(advanced).length > 0 && { advanced: { ...advanced, ...config?.drm?.advanced } }),
+    },
+  } satisfies ShakaConfig;
+}
+
+const categoryToCode: Record<number, number> = {
+  [shaka.util.Error.Category.NETWORK]: MediaError.MEDIA_ERR_NETWORK,
+  [shaka.util.Error.Category.MEDIA]: MediaError.MEDIA_ERR_DECODE,
+  [shaka.util.Error.Category.MANIFEST]: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,
+  [shaka.util.Error.Category.STREAMING]: MediaError.MEDIA_ERR_DECODE,
+  [shaka.util.Error.Category.DRM]: MediaError.MEDIA_ERR_ENCRYPTED,
+};
+
+/** Shaka codes for a load that a newer one replaced. */
+const abortedCodes = new Set<number>([shaka.util.Error.Code.LOAD_INTERRUPTED, shaka.util.Error.Code.OPERATION_ABORTED]);
+
+/**
+ * A Shaka failure as a `MediaError`, or `null` when there is nothing to report.
+ *
+ * Shaka classifies a failure by category rather than by a media error code, and
+ * marks a recoverable one as such — it retries those itself, so only a critical
+ * failure ends up fatal here.
+ */
+function toMediaError(error: unknown): MediaError | null {
+  if (!isShakaError(error)) {
+    return error instanceof Error ? new MediaError(error.message, MediaError.MEDIA_ERR_CUSTOM, true) : null;
+  }
+
+  if (abortedCodes.has(error.code)) return null;
+
+  const code = categoryToCode[error.category] ?? MediaError.MEDIA_ERR_CUSTOM;
+  const fatal = error.severity === shaka.util.Error.Severity.CRITICAL;
+  const mediaError = new MediaError(error.message, code, fatal, `shaka-${error.code}`);
+  mediaError.data = error;
+
+  return mediaError;
+}
+
+function isShakaError(value: unknown): value is shaka.util.Error & { message?: string } {
+  return typeof value === 'object' && value !== null && 'code' in value && 'category' in value;
+}

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -79,6 +79,8 @@ class ShakaMediaBase
   #src = shakaMediaDefaultProps.src;
   #source: ShakaSource | null = shakaMediaDefaultProps.source;
   #error: MediaError | null = null;
+  // The raw Shaka failure last seen, whichever path delivered it first.
+  #reported: unknown = null;
   #isDestroyed = false;
 
   constructor() {
@@ -155,9 +157,10 @@ class ShakaMediaBase
   }
 
   /**
-   * The last playback failure, or `null`. Shaka loads asynchronously, so a
-   * manifest that cannot be played fails after `src` was assigned rather than at
-   * the assignment; the `error` event is when to read this.
+   * The last playback failure Shaka could not recover from, or `null`. Shaka
+   * loads asynchronously, so a manifest that cannot be played fails after `src`
+   * was assigned rather than at the assignment; the `error` event is when to
+   * read this.
    *
    * A Shaka failure says more about what went wrong than the media element's
    * own `error` does, so it wins while there is one; anything the element failed
@@ -243,6 +246,7 @@ class ShakaMediaBase
 
   #loadSource(engine: shaka.Player) {
     this.#error = null;
+    this.#reported = null;
     const { src } = this;
     this.#run(src ? engine.load(src, undefined, this.#source?.type) : engine.unload());
   }
@@ -269,9 +273,15 @@ class ShakaMediaBase
     // A teardown rejects whatever it was racing; there is no one left to tell.
     if (this.#isDestroyed) return;
 
+    // One failure can arrive twice — rejecting the engine call it broke and
+    // announcing itself on the `error` event — so whichever lands first is the
+    // one that counts.
+    if (error === this.#reported) return;
+    this.#reported = error;
+
     const mediaError = toMediaError(error);
-    // Superseding a load aborts the one in flight. That is this element doing
-    // its job, not a failure worth announcing.
+    // An aborted load or a failure Shaka intends to retry is not worth
+    // announcing.
     if (!mediaError) return;
 
     this.#error = mediaError;
@@ -281,7 +291,7 @@ class ShakaMediaBase
 
 /**
  * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
- * @fires error - Fired when playback fails. Read `error` for the failure.
+ * @fires error - Fired when playback fails in a way Shaka could not recover from. Read `error` for the failure.
  */
 export class ShakaMedia extends ShakaMediaMediaTracksMixin(ShakaMediaBase) {}
 
@@ -353,9 +363,14 @@ const abortedCodes = new Set<number>([shaka.util.Error.Code.LOAD_INTERRUPTED, sh
 /**
  * A Shaka failure as a `MediaError`, or `null` when there is nothing to report.
  *
- * Shaka classifies a failure by category rather than by a media error code, and
- * marks a recoverable one as such — it retries those itself, so only a critical
- * failure ends up fatal here.
+ * Only a failure Shaka gave up on is reported. Shaka marks one it means to
+ * retry as recoverable and fires it on the way through, and an announced error
+ * stands until the next load — so announcing those would leave the error UI
+ * over playback that is still running. Whatever a retry cannot save comes back
+ * as critical.
+ *
+ * Shaka classifies a failure by category rather than by a media error code, so
+ * the code is derived from that.
  */
 function toMediaError(error: unknown): MediaError | null {
   if (!isShakaError(error)) {
@@ -364,9 +379,16 @@ function toMediaError(error: unknown): MediaError | null {
 
   if (abortedCodes.has(error.code)) return null;
 
+  if (error.severity !== shaka.util.Error.Severity.CRITICAL) {
+    if (__DEV__) {
+      console.warn('[vjs-shaka] Shaka reported a recoverable failure and will retry it.', error);
+    }
+
+    return null;
+  }
+
   const code = categoryToCode[error.category] ?? MediaError.MEDIA_ERR_CUSTOM;
-  const fatal = error.severity === shaka.util.Error.Severity.CRITICAL;
-  const mediaError = new MediaError(error.message, code, fatal, `shaka-${error.code}`);
+  const mediaError = new MediaError(error.message, code, true, `shaka-${error.code}`);
   mediaError.data = error;
 
   return mediaError;

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -586,12 +586,37 @@ describe('ShakaMedia', () => {
       expect(media.error).toMatchObject({ code: 5, fatal: true });
     });
 
-    it('marks a recoverable failure as non-fatal', async () => {
+    it('leaves a recoverable failure to shaka to retry', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
 
       engine.emit('error', { detail: shakaError({ severity: 1 }) });
 
-      expect(media.error).toMatchObject({ fatal: false });
+      // Announcing it would put the error UI over playback that is still going.
+      expect(onError).not.toHaveBeenCalled();
+      expect(media.error).toBeNull();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('recoverable'), expect.anything());
+    });
+
+    it('reports a failure once when shaka both rejects and announces it', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      // Shaka hands the same failure to the `error` event and to the call it broke.
+      const failure = shakaError({ category: 6, code: 6001 });
+      engine.load.mockImplementationOnce(async () => {
+        engine.emit('error', { detail: failure });
+        throw failure;
+      });
+
+      media.src = MANIFEST;
+      await flush();
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(media.error).toMatchObject({ code: 5, fatal: true });
     });
 
     it('ignores a load that a newer one replaced', async () => {

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -1,0 +1,610 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('shaka-player', () => {
+  /** Shaka merges every `configure()` call into the current configuration. */
+  function merge(target: Record<string, any>, source: Record<string, any>) {
+    for (const [key, value] of Object.entries(source)) {
+      const isPlainObject = typeof value === 'object' && value !== null && !Array.isArray(value);
+      target[key] = isPlainObject ? merge({ ...target[key] }, value) : value;
+    }
+    return target;
+  }
+
+  function create() {
+    const listeners = new Map<string, Set<(event: any) => void>>();
+
+    const player = {
+      config: {} as Record<string, any>,
+      videoTracks: [] as any[],
+      audioTracks: [] as any[],
+      attach: vi.fn(async () => {}),
+      detach: vi.fn(async () => {}),
+      load: vi.fn(async (_src?: string, _startTime?: unknown, _mimeType?: string) => {}),
+      unload: vi.fn(async () => {}),
+      destroy: vi.fn(async () => {}),
+      configure: vi.fn((config: Record<string, any>) => {
+        player.config = merge(player.config, config);
+        return true;
+      }),
+      resetConfiguration: vi.fn(() => {
+        player.config = {};
+      }),
+      getConfiguration: vi.fn(() => player.config),
+      getVideoTracks: vi.fn(() => player.videoTracks),
+      getAudioTracks: vi.fn(() => player.audioTracks),
+      selectVideoTrack: vi.fn(),
+      selectAudioTrack: vi.fn(),
+      addEventListener: vi.fn((type: string, listener: (event: any) => void) => {
+        const typeListeners = listeners.get(type) ?? new Set();
+        typeListeners.add(listener);
+        listeners.set(type, typeListeners);
+      }),
+      removeEventListener: vi.fn((type: string, listener: (event: any) => void) => {
+        listeners.get(type)?.delete(listener);
+      }),
+      /** Test-only: dispatch a Shaka player event to its listeners. */
+      emit(type: string, event: Record<string, unknown> = {}) {
+        for (const listener of [...(listeners.get(type) ?? [])]) listener({ type, ...event });
+      },
+    };
+
+    return player;
+  }
+
+  function Player(this: unknown) {
+    return create();
+  }
+
+  Player.isBrowserSupported = () => true;
+
+  const polyfill = { installAll: vi.fn() };
+
+  const util = {
+    Error: {
+      Category: { NETWORK: 1, TEXT: 2, MEDIA: 3, MANIFEST: 4, STREAMING: 5, DRM: 6, PLAYER: 7 },
+      Code: { LOAD_INTERRUPTED: 7000, OPERATION_ABORTED: 7001, BAD_HTTP_STATUS: 1001 },
+      Severity: { RECOVERABLE: 1, CRITICAL: 2 },
+    },
+  };
+
+  return { default: { Player, polyfill, util } };
+});
+
+import { KeySystems } from '../../../core/drm';
+import type { ShakaSource } from '../index';
+import { ShakaMedia, shaka } from '../index';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+type MockEngine = {
+  config: Record<string, any>;
+  videoTracks: MockVideoTrack[];
+  audioTracks: MockAudioTrack[];
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+  load: ReturnType<typeof vi.fn>;
+  unload: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  configure: ReturnType<typeof vi.fn>;
+  resetConfiguration: ReturnType<typeof vi.fn>;
+  selectVideoTrack: ReturnType<typeof vi.fn>;
+  selectAudioTrack: ReturnType<typeof vi.fn>;
+  emit(type: string, event?: Record<string, unknown>): void;
+};
+
+type MockVideoTrack = {
+  active: boolean;
+  bandwidth: number;
+  width?: number;
+  height?: number;
+  codecs?: string;
+  frameRate?: number;
+  hdr?: string | null;
+};
+
+type MockAudioTrack = {
+  active: boolean;
+  primary: boolean;
+  language: string;
+  label?: string | null;
+  roles?: string[];
+  channelsCount?: number | null;
+};
+
+function setup() {
+  const video = document.createElement('video');
+  document.body.appendChild(video);
+
+  const media = new ShakaMedia();
+  media.attach(video);
+
+  return { media, video, engine: media.engine as unknown as MockEngine };
+}
+
+/** Engine calls are queued, and track list events are dispatched a microtask later. */
+async function flush() {
+  for (let index = 0; index < 5; index += 1) await Promise.resolve();
+}
+
+const MANIFEST = 'https://example.com/manifest.mpd';
+const OTHER_MANIFEST = 'https://example.com/other.m3u8';
+
+const VIDEO_TRACKS: MockVideoTrack[] = [
+  { active: true, bandwidth: 6_000_000, width: 1920, height: 1080, codecs: 'avc1.640028', frameRate: 30 },
+  { active: false, bandwidth: 3_000_000, width: 1280, height: 720, codecs: 'avc1.64001f', frameRate: 30 },
+];
+
+const AUDIO_TRACKS: MockAudioTrack[] = [
+  { active: true, primary: true, language: 'en', label: 'English', roles: ['main'], channelsCount: 2 },
+  { active: false, primary: false, language: 'fr', label: 'French', roles: ['alternate'], channelsCount: 2 },
+];
+
+/** Shaka announces the tracks of an asset once it is loaded. */
+function loadTracks(engine: MockEngine, videoTracks = VIDEO_TRACKS, audioTracks = AUDIO_TRACKS) {
+  engine.videoTracks = videoTracks.map((track) => ({ ...track }));
+  engine.audioTracks = audioTracks.map((track) => ({ ...track }));
+  engine.emit('trackschanged');
+}
+
+function shakaError(overrides: Record<string, unknown> = {}) {
+  return { severity: 2, category: 1, code: 1001, data: [], message: 'Bad HTTP status', ...overrides };
+}
+
+describe('ShakaMedia', () => {
+  describe('constructor', () => {
+    it('installs the browser polyfills shaka does not install itself', () => {
+      new ShakaMedia();
+      expect(shaka.polyfill.installAll).toHaveBeenCalled();
+
+      const installs = vi.mocked(shaka.polyfill.installAll).mock.calls.length;
+      new ShakaMedia();
+
+      // Installing patches globals, so it happens once however many elements there are.
+      expect(shaka.polyfill.installAll).toHaveBeenCalledTimes(installs);
+    });
+  });
+
+  describe('attach', () => {
+    it('attaches the engine to the target', async () => {
+      const { engine, video } = setup();
+      await flush();
+
+      expect(engine.attach).toHaveBeenCalledWith(video);
+    });
+
+    it('loads a source that was assigned before there was a target', async () => {
+      const video = document.createElement('video');
+      const media = new ShakaMedia();
+      const engine = media.engine as unknown as MockEngine;
+
+      media.src = MANIFEST;
+      await flush();
+      expect(engine.load).not.toHaveBeenCalled();
+
+      media.attach(video);
+      await flush();
+
+      expect(engine.attach).toHaveBeenCalledWith(video);
+      expect(engine.load).toHaveBeenCalledExactlyOnceWith(MANIFEST, undefined, undefined);
+    });
+
+    it('leaves the target it is already attached to alone', async () => {
+      const { media, engine, video } = setup();
+      await flush();
+
+      media.attach(video);
+      await flush();
+
+      expect(engine.attach).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('destroy', () => {
+    it('detaches and destroys the engine', async () => {
+      const { media, engine } = setup();
+      await flush();
+
+      media.destroy();
+      await flush();
+
+      expect(engine.destroy).toHaveBeenCalled();
+      expect(media.engine).toBeNull();
+    });
+  });
+
+  describe('source', () => {
+    it('forwards shaka configuration to the player', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.config).toEqual({ streaming: { bufferingGoal: 30 } });
+    });
+
+    it('derives src and loads the manifest', async () => {
+      const { media, engine } = setup();
+      const sourcechange = vi.fn();
+      media.addEventListener('sourcechange', sourcechange);
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      expect(media.src).toBe(MANIFEST);
+      expect(engine.load).toHaveBeenCalledExactlyOnceWith(MANIFEST, undefined, undefined);
+      expect(sourcechange).toHaveBeenCalledTimes(1);
+    });
+
+    it('hands the source type to shaka as the type to parse the manifest as', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, type: 'application/dash+xml' };
+      await flush();
+
+      expect(engine.load).toHaveBeenCalledWith(MANIFEST, undefined, 'application/dash+xml');
+    });
+
+    it('leaves the engine alone for a structurally equal source', async () => {
+      const { media, engine } = setup();
+      const source: ShakaSource = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+
+      media.source = source;
+      await flush();
+
+      const sourcechange = vi.fn();
+      media.addEventListener('sourcechange', sourcechange);
+      engine.load.mockClear();
+      engine.configure.mockClear();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.load).not.toHaveBeenCalled();
+      expect(engine.configure).not.toHaveBeenCalled();
+      expect(sourcechange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload the manifest when only shaka configuration changes', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+      engine.load.mockClear();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 60 } } } };
+      await flush();
+
+      expect(engine.load).not.toHaveBeenCalled();
+      expect(engine.config).toEqual({ streaming: { bufferingGoal: 60 } });
+    });
+
+    it('resets configuration instead of merging when a shaka option is dropped', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        engine: { shaka: { streaming: { bufferingGoal: 30, rebufferingGoal: 5 } } },
+      };
+      await flush();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.resetConfiguration).toHaveBeenCalled();
+      expect(engine.config).toEqual({ streaming: { bufferingGoal: 30 } });
+    });
+
+    it('hands a new source to shaka without waiting for the load in flight', async () => {
+      const { media, engine } = setup();
+      // A manifest that never resolves is what a new source has to cut short.
+      engine.load.mockImplementation(() => new Promise(() => {}));
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      media.source = { src: OTHER_MANIFEST };
+      await flush();
+
+      expect(engine.load).toHaveBeenNthCalledWith(2, OTHER_MANIFEST, undefined, undefined);
+    });
+
+    it('unloads when src is cleared', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      media.source = null;
+      await flush();
+
+      expect(media.src).toBe('');
+      expect(engine.unload).toHaveBeenCalled();
+    });
+
+    it('translates source drm into shaka license servers and certificates', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        drm: {
+          [KeySystems.WIDEVINE]: { licenseUrl: 'https://example.com/widevine' },
+          [KeySystems.FAIRPLAY]: {
+            licenseUrl: 'https://example.com/fairplay',
+            serverCertificateUrl: 'https://example.com/cert',
+          },
+        },
+      };
+      await flush();
+
+      expect(engine.config.drm).toEqual({
+        servers: {
+          [KeySystems.WIDEVINE]: 'https://example.com/widevine',
+          [KeySystems.FAIRPLAY]: 'https://example.com/fairplay',
+        },
+        advanced: {
+          [KeySystems.FAIRPLAY]: { serverCertificateUri: 'https://example.com/cert' },
+        },
+      });
+    });
+
+    it('lets shaka license servers replace the source drm configuration', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        drm: { [KeySystems.WIDEVINE]: { licenseUrl: 'https://example.com/widevine' } },
+        engine: { shaka: { drm: { servers: { [KeySystems.PLAYREADY]: 'https://example.com/playready' } } } },
+      };
+      await flush();
+
+      expect(engine.config.drm).toEqual({
+        servers: { [KeySystems.PLAYREADY]: 'https://example.com/playready' },
+      });
+    });
+  });
+
+  describe('src', () => {
+    it('preserves source configuration across a src change', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+      engine.configure.mockClear();
+
+      media.src = OTHER_MANIFEST;
+      await flush();
+
+      expect(media.source).toEqual({
+        src: OTHER_MANIFEST,
+        engine: { shaka: { streaming: { bufferingGoal: 30 } } },
+      });
+      expect(engine.load).toHaveBeenLastCalledWith(OTHER_MANIFEST, undefined, undefined);
+      expect(engine.configure).not.toHaveBeenCalled();
+    });
+
+    it('fires sourcechange through the source setter', async () => {
+      const { media } = setup();
+      const sourcechange = vi.fn();
+      media.addEventListener('sourcechange', sourcechange);
+
+      media.src = MANIFEST;
+      await flush();
+
+      expect(sourcechange).toHaveBeenCalledTimes(1);
+      expect(media.source).toEqual({ src: MANIFEST });
+    });
+  });
+
+  describe('videoRenditions', () => {
+    it('mirrors the video tracks of the loaded asset', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      expect([...media.videoRenditions].map((rendition) => rendition.height)).toEqual([1080, 720]);
+      expect([...media.videoRenditions].map((rendition) => rendition.id)).toEqual(['0', '1']);
+      expect([...media.videoRenditions].map((rendition) => rendition.bitrate)).toEqual([6_000_000, 3_000_000]);
+    });
+
+    it('marks the video track shaka is playing active', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([true, false]);
+
+      engine.videoTracks = [
+        { ...VIDEO_TRACKS[0]!, active: false },
+        { ...VIDEO_TRACKS[1]!, active: true },
+      ];
+      engine.emit('adaptation');
+
+      expect([...media.videoRenditions].map((rendition) => rendition.active)).toEqual([false, true]);
+    });
+
+    it('leaves the list alone when the same tracks are announced again', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      const [rendition] = [...media.videoRenditions];
+      engine.emit('trackschanged');
+      await flush();
+
+      expect([...media.videoRenditions][0]).toBe(rendition);
+    });
+
+    it('pins the selected track and turns shaka adaptation off', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+
+      expect(engine.config.abr).toEqual({ enabled: false });
+      expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
+    });
+
+    it('hands adaptation back to shaka when the selection is cleared', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+
+      media.videoRenditions[1]!.selected = false;
+      await flush();
+
+      expect(engine.config.abr).toEqual({ enabled: true });
+    });
+
+    it('leaves shaka configuration alone when nothing was ever pinned', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+      engine.configure.mockClear();
+
+      media.videoRenditions[0]!.selected = false;
+      await flush();
+
+      expect(engine.configure).not.toHaveBeenCalled();
+    });
+
+    it('re-pins the selected track when shaka configuration is re-applied', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+      engine.selectVideoTrack.mockClear();
+
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
+      await flush();
+
+      expect(engine.config.abr).toEqual({ enabled: false });
+      expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
+    });
+
+    it('drops renditions and restores adaptation when the source changes', async () => {
+      const { media, engine } = setup();
+      media.src = MANIFEST;
+      loadTracks(engine);
+      await flush();
+
+      media.videoRenditions[1]!.selected = true;
+      await flush();
+
+      media.src = OTHER_MANIFEST;
+      await flush();
+
+      expect([...media.videoRenditions]).toEqual([]);
+      expect(engine.config.abr).toEqual({ enabled: true });
+    });
+
+    it('stops mirroring tracks once destroyed', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.destroy();
+      await flush();
+
+      loadTracks(engine, [{ active: true, bandwidth: 1_000_000, width: 640, height: 360 }]);
+      await flush();
+
+      expect([...media.videoRenditions]).toEqual([]);
+    });
+  });
+
+  describe('audioTracks', () => {
+    it('mirrors the audio tracks of the loaded asset', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      expect([...media.audioTracks].map((track) => track.language)).toEqual(['en', 'fr']);
+      expect([...media.audioTracks].map((track) => track.kind)).toEqual(['main', 'alternative']);
+      expect([...media.audioTracks].map((track) => track.enabled)).toEqual([true, false]);
+    });
+
+    it('selects the enabled audio track', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      media.audioTracks[1]!.enabled = true;
+      await flush();
+
+      expect(engine.selectAudioTrack).toHaveBeenCalledWith(engine.audioTracks[1]);
+      expect([...media.audioTracks].map((track) => track.enabled)).toEqual([false, true]);
+    });
+
+    it('mirrors the audio track shaka switched to', async () => {
+      const { media, engine } = setup();
+      loadTracks(engine);
+      await flush();
+
+      engine.audioTracks = [
+        { ...AUDIO_TRACKS[0]!, active: false },
+        { ...AUDIO_TRACKS[1]!, active: true },
+      ];
+      engine.emit('audiotrackchanged');
+      await flush();
+
+      expect([...media.audioTracks].map((track) => track.enabled)).toEqual([false, true]);
+    });
+  });
+
+  describe('error', () => {
+    it('reports a failed load', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      engine.load.mockRejectedValueOnce(shakaError());
+      media.src = MANIFEST;
+      await flush();
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(media.error).toMatchObject({ code: 2, fatal: true, context: 'shaka-1001' });
+    });
+
+    it('reports an engine error event', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      engine.emit('error', { detail: shakaError({ category: 6, code: 6001 }) });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(media.error).toMatchObject({ code: 5, fatal: true });
+    });
+
+    it('marks a recoverable failure as non-fatal', async () => {
+      const { media, engine } = setup();
+
+      engine.emit('error', { detail: shakaError({ severity: 1 }) });
+
+      expect(media.error).toMatchObject({ fatal: false });
+    });
+
+    it('ignores a load that a newer one replaced', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+      media.addEventListener('error', onError);
+
+      engine.load.mockRejectedValueOnce(shakaError({ category: 7, code: 7000 }));
+      media.src = MANIFEST;
+      await flush();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(media.error).toBeNull();
+    });
+  });
+});

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -619,6 +619,32 @@ describe('ShakaMedia', () => {
       expect(media.error).toMatchObject({ code: 5, fatal: true });
     });
 
+    it('does not re-announce a failure against the source an error handler fell back to', async () => {
+      const { media, engine } = setup();
+      const onError = vi.fn();
+
+      // The `error` event lands first; the rejection of the load it broke is
+      // still in flight when the handler starts a new one.
+      const failure = shakaError();
+      engine.load.mockImplementationOnce(async () => {
+        engine.emit('error', { detail: failure });
+        await Promise.resolve();
+        throw failure;
+      });
+
+      media.addEventListener('error', () => {
+        onError();
+        media.src = OTHER_MANIFEST;
+      });
+
+      media.src = MANIFEST;
+      await flush();
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(engine.load).toHaveBeenLastCalledWith(OTHER_MANIFEST, undefined, undefined);
+      expect(media.error).toBeNull();
+    });
+
     it('ignores a load that a newer one replaced', async () => {
       const { media, engine } = setup();
       const onError = vi.fn();

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -18,6 +18,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/hls-js/index': './src/dom/hls-js/index.ts',
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
     'dom/cloudflare/index': './src/dom/cloudflare/index.ts',
+    'dom/shaka/index': './src/dom/shaka/index.ts',
     'dom/spotify/index': './src/dom/spotify/index.ts',
     'dom/tiktok/index': './src/dom/tiktok/index.ts',
     'dom/twitch/index': './src/dom/twitch/index.ts',

--- a/packages/react/src/media/shaka-video/index.ts
+++ b/packages/react/src/media/shaka-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/shaka-video/media.tsx
+++ b/packages/react/src/media/shaka-video/media.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { ShakaMediaProps } from '@videojs/media/dom/shaka';
+import { ShakaMedia, shakaMediaDefaultProps } from '@videojs/media/dom/shaka';
+import type { ReactNode, VideoHTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+import { useAttachMedia } from '../../utils/use-attach-media';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface ShakaVideoProps
+  extends Omit<VideoHTMLAttributes<HTMLVideoElement>, keyof ShakaMediaProps>,
+    Partial<ShakaMediaProps> {
+  children?: ReactNode;
+}
+
+export const ShakaVideo = forwardRef<HTMLVideoElement, ShakaVideoProps>(function ShakaVideo(
+  { children, ...props },
+  ref
+) {
+  const media = useMediaInstance(ShakaMedia);
+  const attachRef = useAttachMedia(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const htmlProps = useSyncProps(media, props, shakaMediaDefaultProps);
+
+  return (
+    <video ref={composedRef} {...htmlProps}>
+      {children}
+    </video>
+  );
+});
+
+export namespace ShakaVideo {
+  export type Props = ShakaVideoProps;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,9 @@ importers:
       mux-embed:
         specifier: ^5.17.10
         version: 5.17.10
+      shaka-player:
+        specifier: ^5.2.4
+        version: 5.2.6
     devDependencies:
       '@types/chrome':
         specifier: ^0.1.40
@@ -8395,6 +8398,10 @@ packages:
     resolution: {integrity: sha512-M1AvZKFWcCzWRDoyApIqJMSLIpY8Ev4uBGuiPLSFmiTbixXhPmzotSTvLzFmBrfoIxG9aIg2dZOETblEaXGUnQ==}
     engines: {node: '>=20.18.1'}
     hasBin: true
+
+  shaka-player@5.2.6:
+    resolution: {integrity: sha512-/AIgm9CzhTJu5Ba5l6kKczQn7k6MeMqpQmbtvRrUfgYnWxnQfZ20bhQd7TtD5sCypE9x+nr9vxA6bVBlz+nP8A==}
+    engines: {node: '>=18'}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -17932,6 +17939,8 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - typescript
+
+  shaka-player@5.2.6: {}
 
   sharp@0.34.5:
     dependencies:


### PR DESCRIPTION
Closes #1458 Refs #1774, #1411

Replaces #2164 — same change, rebased onto `main` with the two Bugbot findings from that PR addressed.

## Summary

Adds a Shaka Player media — `<shaka-video>` for HTML and `<ShakaVideo>` for React — so DASH and HLS play from one engine with Shaka's DRM stack behind the standardized `source.drm` API.

## Changes

- `ShakaMedia` in `@videojs/media/dom/shaka`, exposing `src`, structured `source`, `engine` (the `shaka.Player` escape hatch), and `error`.
- **DASH + HLS from one element.** `source.type` is passed to Shaka as the type to parse the manifest as, which is what makes an extensionless URL playable.
- **DRM.** `source.drm` (the same engine-neutral shape hls.js and native HLS read) becomes Shaka's `drm.servers` plus `drm.advanced[…].serverCertificateUri`. `engine.shaka.drm.servers` replaces it as an escape hatch, matching the hls.js precedent.
- **Video renditions and audio tracks** mirror into `videoRenditions` / `audioTracks`. Selecting a rendition pins the Shaka video track with ABR off and hands adaptation back when the selection clears.
- **Errors are reported.** Shaka loads asynchronously, so a manifest that cannot be played fails after `src` was assigned. Categories map to `MediaError` codes. Only a failure Shaka gave up on is announced — a recoverable one it means to retry warns in dev instead — and a load superseded by a newer one is not announced at all.
- Sandbox pages for HTML, React, and CDN.

## Implementation details

**Shape.** This follows `DashMedia` for source handling — one long-lived engine, `src` re-derives `source` carrying config over, `configure()` is reset before re-applying so dropping a key clears it, and sources compare structurally so an inline React `source` prop never interrupts playback. It follows `HlsJsMedia` for DRM and error reporting.

**Async lifecycle.** Shaka's `attach`, `load`, `unload`, and `detach` are all asynchronous, but the player orders them itself: each takes an internal lock in call order, and a newer one interrupts what it supersedes. So each call is issued as it comes rather than chained behind the one before it — a rejection is reported rather than propagated, since nothing awaits them. A source assigned before there is a target loads when `attach()` arrives; re-attaching the same target is a no-op, since Shaka's `attach()` tears playback down and rebuilds it.

**Polyfills.** Shaka ships browser patches it does not install itself, and both `isBrowserSupported()` and FairPlay EME depend on them, so `shaka.polyfill.installAll()` runs once before the first player is constructed.

**Track identity.** Shaka 5's `getVideoTracks()` / `getAudioTracks()` return plain objects with no ids, so a rendition's position in the list is what a selection is looked back up by, and the property set is what a re-announcement of the same tracks is recognized by. That last part is why `trackschanged` firing mid-playback does not throw away a user's pinned rendition. This uses the Shaka 5 track APIs rather than the variant de-duplication in Mux's `shaka-video-element`, which targets Shaka 4.

**Scope of #1774.** The standardized `source.drm` path is wired end to end, but the richer parts of Shaka's DRM config (headers, robustness, key-system mapping) are reachable only through `engine.shaka.drm` for now — hence `Refs` rather than `Closes`.

## Addressed from #2164

- **Source changes did not abort in-flight loads.** A new `src` was queued behind the current `engine.load()`, so a hanging first URL blocked the source the caller just assigned. The external serialization chain is gone; calls go straight to the engine and Shaka's own supersession does the interrupting.
- **Shaka polyfills were never installed.** `installPolyfills()` now runs in the constructor before `isBrowserSupported()`.

And from the review of this PR:

- **Recoverable errors blocked the playback UI.** `errorFeature` sets `error` on any `error` event with no `fatal` check, so a failure Shaka was about to retry put the error dialog over playback that was still running — and left it there, since nothing clears an error until the next load. `toMediaError()` now drops anything below `Severity.CRITICAL`, matching the hls.js media; a recoverable one warns under `__DEV__`.
- **Load failures dispatched twice.** Shaka hands the same `shaka.util.Error` to the `error` event and to the promise of the call it broke. `#reportError` dedupes on raw-error identity, so one problem is one `error` event.
- **A stale failure could be re-announced after a source change.** That dedupe reset with each load, so an `error` handler assigning a fallback `src` reopened the window and the still-in-flight rejection landed as a fresh failure against the new source. Reported failures now live in a `WeakSet` that outlives the load they came from.

## Not included

No e2e page, no `site` reference page, and no Mux Data support (mux-embed has no Shaka monitor, so the sandbox templates omit it). Happy to add any of these here or as follow-ups.

## Testing

- `pnpm -F @videojs/media test` — 1006 passing, 35 of them over a mocked `shaka-player` covering attach ordering, source and config semantics, load supersession, polyfill installation, DRM translation, renditions, audio tracks, and error reporting.
- `pnpm typecheck`, `pnpm check:workspace`, builds of `media`, `html` (including `build:cdn`), `react`, and `sandbox`.
- Manual: `pnpm dev`, pick the **Shaka Video** preset, and switch between HLS and DASH sources — both play, and the quality menu switches renditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New third-party playback engine with async load/error and DRM wiring affects core media behavior, but it follows existing Dash/Hls patterns and has broad unit test coverage.
> 
> **Overview**
> Adds **Shaka Player** as a new media engine so **DASH and HLS** can play from one element via `<shaka-video>` / `<ShakaVideo>`, with sandbox **Shaka Video** preset and HTML/React/CDN templates.
> 
> **`@videojs/media/dom/shaka`** introduces `ShakaMedia` with structured `source` (optional manifest `type`, `source.drm` mapped to Shaka license servers, passthrough `engine.shaka`), polyfill install, and async attach/load without serializing calls so new URLs can supersede hung loads. **Critical-only** Shaka errors surface as `MediaError` (recoverable retries and aborted loads are ignored; duplicate reject/event failures are deduped). A **media-tracks mixin** mirrors Shaka video/audio into `videoRenditions` / `audioTracks`, pins quality with ABR off, and restores adaptation when selection clears.
> 
> The sandbox wires **`SHAKA_SOURCE_IDS`** (non-DRM, non-Mux) and treats `shaka-video` like dash for DASH sources while still allowing HLS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bd3878337495663f901bef47abfd7ebca8e2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


