### PR TITLE
fix(core): tolerate void remote playback cancellation

### DIFF
--- a/packages/core/src/dom/store/features/remote-playback.ts
+++ b/packages/core/src/dom/store/features/remote-playback.ts
@@ -71,7 +71,7 @@ export const remotePlaybackFeature = definePlayerFeature({
       });
 
     signal.addEventListener('abort', () => {
-      media.remote?.cancelWatchAvailability?.().catch(() => {});
+      media.remote?.cancelWatchAvailability?.()?.catch(() => {});
     });
   },
 });

--- a/packages/core/src/dom/store/features/tests/remote-playback.test.ts
+++ b/packages/core/src/dom/store/features/tests/remote-playback.test.ts
@@ -21,7 +21,7 @@ function createRemote(overrides: Partial<RemotePlaybackLike> = {}) {
 interface RemotePlaybackLike {
   state: string;
   watchAvailability: (callback: (available: boolean) => void) => Promise<number>;
-  cancelWatchAvailability?: (id?: number) => Promise<void>;
+  cancelWatchAvailability?: (id?: number) => Promise<void> | void;
 }
 
 function attach(media: Media) {
@@ -64,5 +64,15 @@ describe('remotePlaybackFeature', () => {
     (remote as { cancelWatchAvailability?: unknown }).cancelWatchAvailability = undefined;
 
     expect(() => controller.abort()).not.toThrow();
+  });
+
+  it('does not throw when cancelWatchAvailability returns void', () => {
+    const remote = createRemote({ cancelWatchAvailability: vi.fn(() => undefined) });
+    const media = { remote } as unknown as Media;
+
+    const { controller } = attach(media);
+
+    expect(() => controller.abort()).not.toThrow();
+    expect(remote.cancelWatchAvailability).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
Refs #2367

## Summary

Avoid throwing during remote-playback cleanup when a browser implements `cancelWatchAvailability()` without returning a promise.

## Changes

- conditionally attach the rejection handler when cancellation returns a promise
- cover both promise-returning and void-returning browser implementations

## Testing

Rebased onto current `main`.

- `pnpm -F @videojs/core test src/dom/store/features/tests/remote-playback.test.ts` (1 file, 3 passed)
- `pnpm exec vp run @videojs/core#build`
- `pnpm typecheck` after `pnpm build:packages` (clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in feature teardown with new unit coverage; no auth, data, or API surface impact.
> 
> **Overview**
> Fixes abort-time cleanup on the W3C Remote Playback path when `cancelWatchAvailability()` does not return a promise. The abort handler now uses optional call chaining (`?.()`) before `.catch()`, so a void return no longer causes a runtime error from calling `.catch` on `undefined`.
> 
> Tests widen the mock type to `Promise<void> | void` and add a case that abort still succeeds when cancellation returns void.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444317ac8c64c0c748f64b9bd85cc7929777deb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
