### PR TITLE
feat(packages): add right-to-left player support

### DIFF
--- a/apps/e2e/tests/sandbox-cdn-i18n.spec.ts
+++ b/apps/e2e/tests/sandbox-cdn-i18n.spec.ts
@@ -6,6 +6,26 @@ const SANDBOX_BASE = process.env.SANDBOX_URL ?? 'http://localhost:5299';
 
 test.use({ trace: 'off' });
 
+async function expectLTRControlOrder(scope: Page | Frame): Promise<void> {
+  const getX = async (selector: string): Promise<number> => {
+    const control = scope.locator(selector).first();
+    await expect(control).toBeVisible();
+    const box = await control.boundingBox();
+    if (!box) throw new Error(`Control has no bounding box: ${selector}`);
+    return box.x;
+  };
+  const [play, mute, settings, fullscreen] = await Promise.all([
+    getX(SELECTORS.playButton),
+    getX(SELECTORS.muteButton),
+    getX(SELECTORS.settingsButton),
+    getX(SELECTORS.fullscreenButton),
+  ]);
+
+  expect(play).toBeLessThan(mute);
+  expect(mute).toBeLessThan(settings);
+  expect(settings).toBeLessThan(fullscreen);
+}
+
 async function getPreviewFrame(page: Page, path: string): Promise<Frame> {
   await expect(page.locator('iframe[title="player demo"]')).toHaveAttribute('src', new RegExp(`^${path}`));
   await expect
@@ -54,5 +74,6 @@ test.describe('Sandbox CDN i18n', () => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     await expect(page.locator('media-i18n')).toHaveCSS('direction', 'rtl');
+    await expectLTRControlOrder(page);
   });
 });

--- a/apps/e2e/tests/sandbox-cdn-i18n.spec.ts
+++ b/apps/e2e/tests/sandbox-cdn-i18n.spec.ts
@@ -44,4 +44,15 @@ test.describe('Sandbox CDN i18n', () => {
       timeout: 15_000,
     });
   });
+
+  test('direct CDN page applies RTL direction to the document and player', async ({ page }) => {
+    await page.goto(
+      `${SANDBOX_BASE}/cdn/?preset=video&locale=ar&styling=css&skin=default&source=hls-1&autoplay=0&muted=0&loop=0&preload=metadata`,
+      { waitUntil: 'domcontentloaded' }
+    );
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.locator('media-i18n')).toHaveCSS('direction', 'rtl');
+  });
 });

--- a/apps/e2e/tests/sandbox-html-i18n.spec.ts
+++ b/apps/e2e/tests/sandbox-html-i18n.spec.ts
@@ -33,6 +33,32 @@ async function expectLTRControlOrder(scope: Page | Frame): Promise<void> {
   expect(settings).toBeLessThan(fullscreen);
 }
 
+async function expectLTRThumbnailCrop(page: Page): Promise<void> {
+  const slider = page.locator('[role="slider"]:visible').first();
+  await expect(slider).toBeVisible();
+  const box = await slider.boundingBox();
+  if (!box) throw new Error('Time slider is not visible');
+
+  await page.mouse.move(box.x + box.width * 0.75, box.y + box.height / 2);
+  const thumbnail = page.locator('media-slider-thumbnail, .media-thumbnail__image').first();
+  await expect(thumbnail).toBeAttached({ timeout: 15_000 });
+  await expect(thumbnail).not.toHaveAttribute('data-loading', { timeout: 15_000 });
+  await expect(thumbnail).toHaveAttribute('dir', 'ltr');
+
+  const crop = await thumbnail.evaluate((element) => {
+    const image = element.shadowRoot?.querySelector('img') ?? element.querySelector('img');
+    if (!image) return;
+
+    const hostBox = element.getBoundingClientRect();
+    const imageBox = image.getBoundingClientRect();
+    const transform = new DOMMatrix(getComputedStyle(image).transform);
+    return { actual: imageBox.left, expected: hostBox.left + transform.m41 };
+  });
+  if (!crop) throw new Error('Thumbnail image is not rendered');
+
+  expect(crop.actual).toBeCloseTo(crop.expected, 0);
+}
+
 function getPlayer(page: Page) {
   return page
     .locator('[role="group"]')
@@ -97,6 +123,7 @@ test.describe('Sandbox HTML i18n', () => {
     const provider = page.locator('media-i18n');
     await expect(provider.locator('video-skin')).toHaveCSS('direction', 'rtl');
     await expectLTRControlOrder(page);
+    await expectLTRThumbnailCrop(page);
   });
 });
 
@@ -121,6 +148,7 @@ test.describe('Sandbox React i18n', () => {
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     await expect(page.locator('.media-default-skin--video')).toHaveCSS('direction', 'rtl');
     await expectLTRControlOrder(page);
+    await expectLTRThumbnailCrop(page);
   });
 });
 

--- a/apps/e2e/tests/sandbox-html-i18n.spec.ts
+++ b/apps/e2e/tests/sandbox-html-i18n.spec.ts
@@ -13,6 +13,51 @@ async function expectSpanishPlayLabel(scope: Page | Frame): Promise<void> {
   await expect(playButton).toHaveAttribute('aria-label', 'Reproducir', { timeout: 15_000 });
 }
 
+async function expectLTRControlOrder(scope: Page | Frame): Promise<void> {
+  const getX = async (selector: string): Promise<number> => {
+    const control = scope.locator(selector).first();
+    await expect(control).toBeVisible();
+    const box = await control.boundingBox();
+    if (!box) throw new Error(`Control has no bounding box: ${selector}`);
+    return box.x;
+  };
+  const [play, mute, settings, fullscreen] = await Promise.all([
+    getX(SELECTORS.playButton),
+    getX(SELECTORS.muteButton),
+    getX(SELECTORS.settingsButton),
+    getX(SELECTORS.fullscreenButton),
+  ]);
+
+  expect(play).toBeLessThan(mute);
+  expect(mute).toBeLessThan(settings);
+  expect(settings).toBeLessThan(fullscreen);
+}
+
+function getPlayer(page: Page) {
+  return page
+    .locator('[role="group"]')
+    .filter({ has: page.locator('[role="slider"]') })
+    .first();
+}
+
+async function getControlOrder(page: Page): Promise<string[]> {
+  const player = getPlayer(page);
+  await expect(player).toBeVisible({ timeout: 15_000 });
+  const controls = player.locator('button, [role="button"], [role="slider"], time');
+  const visible = await Promise.all(
+    (await controls.all()).map(async (control, index) => {
+      if (!(await control.isVisible())) return;
+      const box = await control.boundingBox();
+      return box ? { index, x: box.x } : undefined;
+    })
+  );
+
+  return visible
+    .filter((control) => control !== undefined)
+    .sort((a, b) => a.x - b.x)
+    .map((control) => String(control.index));
+}
+
 async function getPreviewFrame(page: Page, path: string): Promise<Frame> {
   await expect(page.locator('iframe[title="player demo"]')).toHaveAttribute('src', new RegExp(`^${path}`));
   await expect
@@ -51,6 +96,7 @@ test.describe('Sandbox HTML i18n', () => {
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     const provider = page.locator('media-i18n');
     await expect(provider.locator('video-skin')).toHaveCSS('direction', 'rtl');
+    await expectLTRControlOrder(page);
   });
 });
 
@@ -74,5 +120,105 @@ test.describe('Sandbox React i18n', () => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
     await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
     await expect(page.locator('.media-default-skin--video')).toHaveCSS('direction', 'rtl');
+    await expectLTRControlOrder(page);
+  });
+});
+
+test.describe('Sandbox RTL playback control order', () => {
+  const cases = [
+    { name: 'HTML Default CSS video', path: 'html-video', skin: 'default', styling: 'css', source: 'hls-1' },
+    {
+      name: 'React Default Tailwind video',
+      path: 'react-video',
+      skin: 'default',
+      styling: 'tailwind',
+      source: 'hls-1',
+    },
+    {
+      name: 'HTML Minimal CSS video at small width',
+      path: 'html-video',
+      skin: 'minimal',
+      styling: 'css',
+      source: 'hls-1',
+      width: 480,
+    },
+    {
+      name: 'HTML Minimal CSS video at large width',
+      path: 'html-video',
+      skin: 'minimal',
+      styling: 'css',
+      source: 'hls-1',
+      width: 1280,
+    },
+    {
+      name: 'React Minimal Tailwind video at small width',
+      path: 'react-video',
+      skin: 'minimal',
+      styling: 'tailwind',
+      source: 'hls-1',
+      width: 480,
+    },
+    {
+      name: 'React Minimal Tailwind video at large width',
+      path: 'react-video',
+      skin: 'minimal',
+      styling: 'tailwind',
+      source: 'hls-1',
+      width: 1280,
+    },
+    {
+      name: 'HTML Default CSS audio',
+      path: 'html-audio',
+      skin: 'default',
+      styling: 'css',
+      source: 'hls-audio-only-cmaf',
+    },
+    {
+      name: 'React Minimal Tailwind audio',
+      path: 'react-audio',
+      skin: 'minimal',
+      styling: 'tailwind',
+      source: 'hls-audio-only-cmaf',
+    },
+  ] as const;
+
+  for (const controlCase of cases) {
+    test(`${controlCase.name} matches its LTR baseline`, async ({ page }) => {
+      if ('width' in controlCase) {
+        await page.setViewportSize({ width: controlCase.width, height: 720 });
+      }
+      const query = `styling=${controlCase.styling}&skin=${controlCase.skin}&source=${controlCase.source}&autoplay=0&muted=0&loop=0&preload=metadata`;
+
+      await page.goto(`${SANDBOX_BASE}/${controlCase.path}/?locale=en&${query}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      const ltrOrder = await getControlOrder(page);
+
+      await page.goto(`${SANDBOX_BASE}/${controlCase.path}/?locale=ar&${query}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+      await expect(getPlayer(page)).toHaveCSS('direction', 'rtl');
+      expect(await getControlOrder(page)).toEqual(ltrOrder);
+    });
+  }
+
+  test('Explicit LTR Tailwind player in an RTL document keeps LTR controls', async ({ page }) => {
+    const query = 'styling=tailwind&skin=default&source=hls-1&autoplay=0&muted=0&loop=0&preload=metadata';
+    await page.goto(`${SANDBOX_BASE}/react-video/?locale=en&${query}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    const ltrOrder = await getControlOrder(page);
+
+    await page.goto(`${SANDBOX_BASE}/react-video/?locale=ar&${query}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const player = getPlayer(page);
+    await expect(player).toBeVisible({ timeout: 15_000 });
+    await player.evaluate((element) => element.setAttribute('dir', 'ltr'));
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(player).toHaveCSS('direction', 'ltr');
+    expect(await getControlOrder(page)).toEqual(ltrOrder);
   });
 });

--- a/apps/e2e/tests/sandbox-html-i18n.spec.ts
+++ b/apps/e2e/tests/sandbox-html-i18n.spec.ts
@@ -4,6 +4,7 @@ import { SELECTORS } from '../fixtures/selectors';
 const SANDBOX_BASE = process.env.SANDBOX_URL ?? 'http://localhost:5299';
 
 const QUERY = 'locale=es&styling=css&skin=default&source=hls-1&autoplay=0&muted=0&loop=0&preload=metadata';
+const RTL_QUERY = 'locale=ar&styling=css&skin=default&source=hls-1&autoplay=0&muted=0&loop=0&preload=metadata';
 
 test.use({ trace: 'off' });
 
@@ -42,6 +43,15 @@ test.describe('Sandbox HTML i18n', () => {
     const frame = await getPreviewFrame(page, '/html-video/');
     await expectSpanishPlayLabel(frame);
   });
+
+  test('direct HTML page applies RTL locale to the player boundary', async ({ page }) => {
+    await page.goto(`${SANDBOX_BASE}/html-video/?${RTL_QUERY}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    const provider = page.locator('media-i18n');
+    await expect(provider.locator('video-skin')).toHaveCSS('direction', 'rtl');
+  });
 });
 
 test.describe('Sandbox React i18n', () => {
@@ -56,5 +66,13 @@ test.describe('Sandbox React i18n', () => {
     });
     const frame = await getPreviewFrame(page, '/react-video/');
     await expectSpanishPlayLabel(frame);
+  });
+
+  test('direct React page applies RTL direction to the document and player', async ({ page }) => {
+    await page.goto(`${SANDBOX_BASE}/react-video/?${RTL_QUERY}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('html')).toHaveAttribute('lang', 'ar');
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.locator('.media-default-skin--video')).toHaveCSS('direction', 'rtl');
   });
 });

--- a/apps/sandbox/app/shared/html/i18n.ts
+++ b/apps/sandbox/app/shared/html/i18n.ts
@@ -1,12 +1,13 @@
 import '@videojs/html/i18n';
 
+import { syncDocumentLocale } from '../i18n/document-locale';
 import { ensureSandboxLocale, type SandboxLocaleTag } from '../i18n/sandbox-locales';
 import { getInitialLocale, onLocaleChange } from '../sandbox-listener';
 
 let locale: SandboxLocaleTag = getInitialLocale();
 let localeApplySeq = 0;
 
-document.documentElement.lang = locale;
+syncDocumentLocale(locale);
 
 export function wrapSandboxHtmlI18n(content: string): string {
   return `<media-i18n>${content}</media-i18n>`;
@@ -21,7 +22,7 @@ export async function applySandboxHtmlLocale(next: SandboxLocaleTag): Promise<vo
   await ensureSandboxLocale(next);
   if (seq !== localeApplySeq) return;
   locale = next;
-  document.documentElement.lang = locale;
+  syncDocumentLocale(locale);
 }
 
 export function bindSandboxHtmlLocaleChange(rerender: () => void): void {
@@ -35,7 +36,7 @@ export function bindSandboxHtmlLocaleChange(rerender: () => void): void {
       await ensureSandboxLocale(next);
       if (seq !== localeApplySeq) return;
       locale = next;
-      document.documentElement.lang = locale;
+      syncDocumentLocale(locale);
       rerender();
     })();
   });

--- a/apps/sandbox/app/shared/i18n/document-locale.ts
+++ b/apps/sandbox/app/shared/i18n/document-locale.ts
@@ -1,0 +1,7 @@
+import { getTextDirection } from '@videojs/utils/i18n';
+
+export function syncDocumentLocale(locale: string): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.lang = locale;
+  document.documentElement.dir = getTextDirection(locale);
+}

--- a/apps/sandbox/app/shared/react/sandbox-i18n.tsx
+++ b/apps/sandbox/app/shared/react/sandbox-i18n.tsx
@@ -1,22 +1,18 @@
+import { syncDocumentLocale } from '@app/shared/i18n/document-locale';
 import { ensureSandboxLocale } from '@app/shared/i18n/sandbox-locales';
 import { I18nProvider } from '@videojs/react/i18n';
 import { type ReactNode, useEffect } from 'react';
 
 import { useLocale } from './use-locale';
 
-function syncHtmlLang(locale: string): void {
-  if (typeof document === 'undefined' || document.documentElement.lang === locale) return;
-  document.documentElement.lang = locale;
-}
-
-/** Composes React i18n and syncs `<html lang>` for sandbox locale demos. */
+/** Composes React i18n and syncs the document locale for sandbox demos. */
 export function SandboxI18nProvider({ children }: { children: ReactNode }) {
   const locale = useLocale();
 
-  syncHtmlLang(locale);
+  syncDocumentLocale(locale);
 
   useEffect(() => {
-    syncHtmlLang(locale);
+    syncDocumentLocale(locale);
     void ensureSandboxLocale(locale).catch(() => {
       // I18nProvider still lazy-loads registry packs when prefetch fails.
     });

--- a/apps/sandbox/templates/cdn/main.ts
+++ b/apps/sandbox/templates/cdn/main.ts
@@ -6,6 +6,7 @@ import { CSS_SKIN_TAGS, LIVE_VIDEO_CSS_SKIN_TAGS } from '@app/shared/html/skin-t
 import { renderStoryboard } from '@app/shared/html/storyboard';
 import { loadAudioStylesheets, loadVideoStylesheets } from '@app/shared/html/stylesheets';
 import { ensureCdnSandboxLocale } from '@app/shared/i18n/cdn-sandbox-locales';
+import { syncDocumentLocale } from '@app/shared/i18n/document-locale';
 import type { SandboxLocaleTag } from '@app/shared/i18n/locale-meta';
 import {
   getInitialLocale,
@@ -123,7 +124,7 @@ async function applyLocale(next: SandboxLocaleTag): Promise<void> {
   await ensureCdnSandboxLocale(next);
   if (seq !== localeApplySeq) return;
   locale = next;
-  document.documentElement.lang = locale;
+  syncDocumentLocale(locale);
   await syncCdnI18nProvider(locale, seq);
 }
 
@@ -456,7 +457,7 @@ async function render() {
 }
 
 async function init(): Promise<void> {
-  document.documentElement.lang = locale;
+  syncDocumentLocale(locale);
   await render();
 }
 
@@ -504,7 +505,7 @@ onLocaleChange((next) => {
     await ensureCdnSandboxLocale(next);
     if (seq !== localeApplySeq) return;
     locale = next;
-    document.documentElement.lang = locale;
+    syncDocumentLocale(locale);
     await render();
   })();
 });

--- a/packages/core/src/core/ui/thumbnail/tests/thumbnail-core.test.ts
+++ b/packages/core/src/core/ui/thumbnail/tests/thumbnail-core.test.ts
@@ -414,11 +414,12 @@ describe('ThumbnailCore', () => {
   });
 
   describe('getAttrs', () => {
-    it('returns role img and aria-hidden', () => {
+    it('returns image attributes with physical LTR cropping', () => {
       const core = new ThumbnailCore();
       const state = core.getState(false, false, createImage());
       const attrs = core.getAttrs(state);
 
+      expect(attrs.dir).toBe('ltr');
       expect(attrs.role).toBe('img');
       expect(attrs['aria-hidden']).toBe('true');
     });

--- a/packages/core/src/core/ui/thumbnail/thumbnail-core.ts
+++ b/packages/core/src/core/ui/thumbnail/thumbnail-core.ts
@@ -142,6 +142,8 @@ export class ThumbnailCore {
 
   getAttrs(_state: ThumbnailState) {
     return {
+      // Sprite coordinates are physical offsets from the image's left edge.
+      dir: 'ltr' as const,
       role: 'img' as const,
       'aria-hidden': 'true' as const,
     };

--- a/packages/core/src/dom/ui/popover/popover-positioning.ts
+++ b/packages/core/src/dom/ui/popover/popover-positioning.ts
@@ -1,4 +1,5 @@
 import { getElementSize, resolveCSSLength, supportsAnchorPositioning } from '@videojs/utils/dom';
+import type { TextDirection } from '@videojs/utils/i18n';
 import { clamp } from '@videojs/utils/number';
 import type { PopoverAlign, PopoverSide } from '../../../core/ui/popover/popover-core';
 import { PopoverCSSVars } from '../../../core/ui/popover/popover-css-vars';
@@ -9,6 +10,7 @@ export { getPositionedSide } from '@videojs/utils/dom';
 export interface PositioningOptions {
   side: PopoverSide;
   align: PopoverAlign;
+  direction?: TextDirection;
 }
 
 export interface PositioningOffsets {
@@ -61,6 +63,11 @@ function formatPixels(value: number): string {
 function shiftCrossAxis(value: number, boundaryStart: number, boundaryEnd: number, size: number): number {
   const max = boundaryEnd - size;
   return max < boundaryStart ? boundaryStart : clamp(value, boundaryStart, max);
+}
+
+function getHorizontalAlign({ align, direction = 'ltr' }: PositioningOptions): PopoverAlign {
+  if (direction !== 'rtl') return align;
+  return align === 'start' ? 'end' : align === 'end' ? 'start' : align;
 }
 
 function getAnchorCrossAxisShift(
@@ -166,6 +173,7 @@ function getAnchorPositionCSS(
   // Side positioning — always use calc() with the CSS var so the offset
   // is resolved at paint time without any JS round-trip.
   if (side === 'top' || side === 'bottom') {
+    const horizontalAlign = getHorizontalAlign(opts);
     style[insetProp] = `calc(anchor(${side}) + ${SIDE_OFFSET_VAR})`;
 
     if (triggerRect && boundaryRect) {
@@ -175,7 +183,7 @@ function getAnchorPositionCSS(
         triggerRect.width,
         boundaryRect.left,
         boundaryRect.right,
-        align,
+        horizontalAlign,
         offsets.alignOffset,
         boundaryOffset
       );
@@ -187,9 +195,9 @@ function getAnchorPositionCSS(
     }
 
     // Alignment along the cross axis
-    if (align === 'start') {
+    if (horizontalAlign === 'start') {
       style.left = `calc(anchor(left) + ${ALIGN_OFFSET_VAR})`;
-    } else if (align === 'end') {
+    } else if (horizontalAlign === 'end') {
       style.right = `calc(anchor(right) + ${ALIGN_OFFSET_VAR})`;
     } else {
       style.justifySelf = 'anchor-center';
@@ -306,9 +314,10 @@ export function getManualPositionStyle(
 
   // Alignment along cross axis
   if (side === 'top' || side === 'bottom') {
-    if (align === 'start') {
+    const horizontalAlign = getHorizontalAlign(opts);
+    if (horizontalAlign === 'start') {
       left = triggerRect.left + alignOffset;
-    } else if (align === 'end') {
+    } else if (horizontalAlign === 'end') {
       left = triggerRect.right - popupRect.width + alignOffset;
     } else {
       left = triggerRect.left + (triggerRect.width - popupRect.width) / 2 + alignOffset;

--- a/packages/core/src/dom/ui/popover/popup-positioner.ts
+++ b/packages/core/src/dom/ui/popover/popup-positioner.ts
@@ -3,6 +3,7 @@ import {
   getAnchorNames,
   getPositionedSide,
   type InlineStyleSnapshot,
+  isRTL,
   observeResize,
   rafThrottle,
   restoreInlineStyles,
@@ -146,7 +147,8 @@ export class PopupPositioner {
     const options = this.#options;
     if (!options?.position || !options.trigger || !options.popup) return;
 
-    const triggerRect = options.trigger.getBoundingClientRect();
+    const trigger = options.trigger;
+    const triggerRect = trigger.getBoundingClientRect();
     const boundaryRect = getPositioningBoundaryRect(this.#boundaryElement);
     const offsets = resolveOffsets(options.popup, options.cssVars);
     const preferredPosition = options.position;
@@ -155,7 +157,7 @@ export class PopupPositioner {
       const side = getPositionedSide(triggerRect, popupRect, boundaryRect, preferredPosition, offsets);
       const { positionAnchor: _, ...style } = getAnchorPositionStyle(
         options.anchorName,
-        { ...preferredPosition, side },
+        { ...preferredPosition, side, direction: isRTL(trigger) ? 'rtl' : 'ltr' },
         triggerRect,
         anchorSupported ? undefined : popupRect,
         boundaryRect,

--- a/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popover-positioning.test.ts
@@ -107,6 +107,14 @@ describe('getManualPositionStyle', () => {
     expect(style.left).toBe('20px');
   });
 
+  it('resolves horizontal start and end from RTL direction', () => {
+    const start = getManualPositionStyle(trigger, popup, { side: 'top', align: 'start', direction: 'rtl' });
+    const end = getManualPositionStyle(trigger, popup, { side: 'top', align: 'end', direction: 'rtl' });
+
+    expect(start.left).toBe('20px');
+    expect(end.left).toBe('100px');
+  });
+
   it('applies alignOffset from resolved CSS vars', () => {
     const offsets: PositioningOffsets = { sideOffset: 0, alignOffset: 10 };
     const style = getManualPositionStyle(trigger, popup, { side: 'top', align: 'start' }, offsets);
@@ -422,6 +430,14 @@ describe('getAnchorPositionStyle (CSS Anchor Positioning)', () => {
     expect(style.bottom).toBe('calc(anchor(top) + var(--media-popover-side-offset, 0px))');
     expect(style.left).toBe('35px');
     expect(style.translate).toBe('clamp(-27px, -50%, calc(257px - 100%)) 0');
+  });
+
+  it('resolves horizontal start from RTL direction', async () => {
+    const getStyle = await importWithAnchorSupport();
+    const style = getStyle('a', { side: 'top', align: 'start', direction: 'rtl' });
+
+    expect(style.right).toBe(`calc(anchor(right) + ${ALIGN_VAR})`);
+    expect(style.left).toBeUndefined();
   });
 
   it('places popover above trigger for side=top using CSS var offset', async () => {

--- a/packages/core/src/dom/ui/popover/tests/popup-positioner.test.ts
+++ b/packages/core/src/dom/ui/popover/tests/popup-positioner.test.ts
@@ -46,6 +46,30 @@ describe('PopupPositioner', () => {
     expect(popup.style.left).toBe('');
   });
 
+  it('resolves horizontal start from the trigger direction', () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    const trigger = document.createElement('button');
+    const popup = document.createElement('div');
+    trigger.dir = 'rtl';
+
+    mockRect(document.documentElement, 0, 0, 800, 600);
+    mockRect(trigger, 100, 200, 120, 40);
+    mockRect(popup, 0, 0, 200, 80);
+    Object.defineProperty(popup, 'offsetWidth', { configurable: true, value: 200 });
+    Object.defineProperty(popup, 'offsetHeight', { configurable: true, value: 80 });
+
+    const positioner = new PopupPositioner();
+    positioner.sync({
+      anchorName: 'settings',
+      position: { side: 'top', align: 'start' },
+      trigger,
+      popup,
+    });
+
+    expect(popup.style.left).toBe('20px');
+    positioner.cleanup();
+  });
+
   it('shares resize tracking and batches follow-up measurements', () => {
     let resize: (() => void) | undefined;
     const disconnect = vi.fn();

--- a/packages/core/src/dom/ui/slider.ts
+++ b/packages/core/src/dom/ui/slider.ts
@@ -15,7 +15,6 @@ export interface SliderOptions {
   getThumbElement?: (() => HTMLElement | null) | undefined;
 
   getOrientation: () => 'horizontal' | 'vertical';
-  isRTL: () => boolean;
   isDisabled: () => boolean;
 
   /** Current value as 0–100 percent. Used by keyboard stepping. */
@@ -90,7 +89,6 @@ export function createSlider(options: SliderOptions): SliderApi {
   const changeThrottleMs = options.changeThrottle ?? 0;
 
   let isDragging = false,
-    cachedRTL = false,
     cachedRect: DOMRect | null = null,
     capturedPointerId: number | null = null,
     lastDragPercent = 0,
@@ -167,7 +165,6 @@ export function createSlider(options: SliderOptions): SliderApi {
       const el = options.getElement();
 
       cachedRect = el.getBoundingClientRect();
-      cachedRTL = options.isRTL();
       committedOnRelease = false;
       pointingOnRelease = false;
 
@@ -175,7 +172,7 @@ export function createSlider(options: SliderOptions): SliderApi {
       capturedPointerId = event.pointerId;
       el.setPointerCapture(event.pointerId);
 
-      const percent = getPercentFromPointerEvent(event, cachedRect, options.getOrientation(), cachedRTL);
+      const percent = getPercentFromPointerEvent(event, cachedRect, options.getOrientation());
 
       isDragging = true;
       lastDragPercent = percent;
@@ -201,7 +198,7 @@ export function createSlider(options: SliderOptions): SliderApi {
           return;
         }
 
-        const percent = getPercentFromPointerEvent(event, cachedRect!, options.getOrientation(), cachedRTL);
+        const percent = getPercentFromPointerEvent(event, cachedRect!, options.getOrientation());
 
         lastDragPercent = percent;
         input.patch({ dragPercent: percent, pointerPercent: percent });
@@ -213,7 +210,7 @@ export function createSlider(options: SliderOptions): SliderApi {
       // No capture — hover preview.
       const el = options.getElement();
       const rect = el.getBoundingClientRect();
-      const percent = getPercentFromPointerEvent(event, rect, options.getOrientation(), options.isRTL());
+      const percent = getPercentFromPointerEvent(event, rect, options.getOrientation());
 
       input.patch({ pointing: true, pointerPercent: percent });
     },
@@ -227,7 +224,7 @@ export function createSlider(options: SliderOptions): SliderApi {
 
       if (isNull(capturedPointerId)) return;
 
-      const percent = getPercentFromPointerEvent(event, cachedRect!, options.getOrientation(), cachedRTL);
+      const percent = getPercentFromPointerEvent(event, cachedRect!, options.getOrientation());
       const releaseRect = options.getElement().getBoundingClientRect();
       pointingOnRelease =
         event.pointerType !== 'touch' &&
@@ -268,21 +265,16 @@ export function createSlider(options: SliderOptions): SliderApi {
       // Round to nearest step before stepping to prevent drift from pointer drags.
       const rounded = roundToStep(currentPercent, stepPercent, 0);
 
-      const rtl = options.isRTL();
-
-      // Horizontal arrows flip for RTL. Vertical arrows are unaffected.
-      const horizontalSign = rtl ? -1 : 1;
-
       const step = event.shiftKey ? largeStepPercent : stepPercent;
 
       let newPercent: number | null = null;
 
       switch (event.key) {
         case 'ArrowRight':
-          newPercent = rounded + step * horizontalSign;
+          newPercent = rounded + step;
           break;
         case 'ArrowLeft':
-          newPercent = rounded - step * horizontalSign;
+          newPercent = rounded - step;
           break;
         case 'ArrowUp':
           newPercent = rounded + step;

--- a/packages/core/src/dom/ui/tests/slider.test.ts
+++ b/packages/core/src/dom/ui/tests/slider.test.ts
@@ -1,8 +1,12 @@
 import { flush } from '@videojs/store';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { UIKeyboardEvent, UIPointerEvent } from '../event';
 import { createSlider, type SliderApi, type SliderOptions } from '../slider';
+
+afterEach(() => {
+  document.documentElement.removeAttribute('dir');
+});
 
 // --- Helpers ---
 
@@ -32,7 +36,6 @@ function createOptions(overrides: Partial<SliderOptions> = {}): SliderOptions {
   return {
     getElement: () => createMockElement(),
     getOrientation: () => 'horizontal',
-    isRTL: () => false,
     isDisabled: () => false,
     getPercent: () => 50,
     getStepPercent: () => 1,
@@ -687,48 +690,36 @@ describe('createSlider', () => {
     });
   });
 
-  describe('keyboard: RTL', () => {
-    it('flips ArrowRight to decrement in RTL', () => {
+  describe('keyboard in an RTL document', () => {
+    it('keeps ArrowRight increasing', () => {
       const onValueChange = vi.fn();
-      const slider = createSlider(
-        createOptions({
-          isRTL: () => true,
-          getPercent: () => 50,
-          getStepPercent: () => 1,
-          onValueChange,
-        })
-      );
+      document.documentElement.dir = 'rtl';
+      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
 
       slider.thumbProps.onKeyDown(keyboardEvent('ArrowRight'));
-
-      expect(onValueChange).toHaveBeenCalledWith(49);
-
-      slider.destroy();
-    });
-
-    it('flips ArrowLeft to increment in RTL', () => {
-      const onValueChange = vi.fn();
-      const slider = createSlider(
-        createOptions({
-          isRTL: () => true,
-          getPercent: () => 50,
-          getStepPercent: () => 1,
-          onValueChange,
-        })
-      );
-
-      slider.thumbProps.onKeyDown(keyboardEvent('ArrowLeft'));
 
       expect(onValueChange).toHaveBeenCalledWith(51);
 
       slider.destroy();
     });
 
-    it('does not flip ArrowUp/ArrowDown in RTL', () => {
+    it('keeps ArrowLeft decreasing', () => {
       const onValueChange = vi.fn();
+      document.documentElement.dir = 'rtl';
+      const slider = createSlider(createOptions({ getPercent: () => 50, getStepPercent: () => 1, onValueChange }));
+
+      slider.thumbProps.onKeyDown(keyboardEvent('ArrowLeft'));
+
+      expect(onValueChange).toHaveBeenCalledWith(49);
+
+      slider.destroy();
+    });
+
+    it('keeps ArrowUp and ArrowDown unchanged', () => {
+      const onValueChange = vi.fn();
+      document.documentElement.dir = 'rtl';
       const slider = createSlider(
         createOptions({
-          isRTL: () => true,
           getPercent: () => 50,
           getStepPercent: () => 1,
           onValueChange,
@@ -824,34 +815,16 @@ describe('createSlider', () => {
     });
   });
 
-  describe('orientation: vertical + RTL', () => {
-    it('ignores RTL for vertical orientation', () => {
-      const el = createMockElement({ top: 0, height: 100 });
-      const slider = createSlider(
-        createOptions({ getElement: () => el, getOrientation: () => 'vertical', isRTL: () => true })
-      );
-
-      slider.rootProps.onPointerDown(pointerEvent({ clientY: 25 }));
-      flush();
-
-      // Same result as vertical + LTR — RTL has no effect.
-      expect(slider.input.current.pointerPercent).toBe(75);
-
-      slider.destroy();
-    });
-  });
-
-  describe('RTL pointer', () => {
-    it('flips horizontal percent for RTL', () => {
+  describe('pointer in an RTL document', () => {
+    it('keeps horizontal percent chronological', () => {
       const el = createMockElement({ left: 0, width: 200 });
-      const slider = createSlider(createOptions({ getElement: () => el, isRTL: () => true }));
+      el.dir = 'rtl';
+      const slider = createSlider(createOptions({ getElement: () => el }));
 
-      // RTL: right = 0%, left = 100%
-      // clientX=50, rect.right=200 → (200-50)/200 = 75%
       slider.rootProps.onPointerDown(pointerEvent({ clientX: 50 }));
       flush();
 
-      expect(slider.input.current.pointerPercent).toBe(75);
+      expect(slider.input.current.pointerPercent).toBe(25);
 
       slider.destroy();
     });

--- a/packages/core/src/dom/utils/pointer.ts
+++ b/packages/core/src/dom/utils/pointer.ts
@@ -4,15 +4,12 @@ import { clamp } from '@videojs/utils/number';
 export function getPercentFromPointerEvent(
   event: { clientX: number; clientY: number },
   rect: DOMRect,
-  orientation: 'horizontal' | 'vertical',
-  isRTL: boolean
+  orientation: 'horizontal' | 'vertical'
 ): number {
   let ratio: number;
 
   if (orientation === 'vertical') {
     ratio = 1 - (event.clientY - rect.top) / rect.height;
-  } else if (isRTL) {
-    ratio = (rect.right - event.clientX) / rect.width;
   } else {
     ratio = (event.clientX - rect.left) / rect.width;
   }

--- a/packages/core/src/dom/utils/tests/pointer.test.ts
+++ b/packages/core/src/dom/utils/tests/pointer.test.ts
@@ -22,67 +22,49 @@ function pointer(clientX = 0, clientY = 0) {
 }
 
 describe('getPercentFromPointerEvent', () => {
-  describe('horizontal LTR', () => {
+  describe('horizontal', () => {
     it('returns 0 at the left edge', () => {
-      expect(getPercentFromPointerEvent(pointer(0), rect(), 'horizontal', false)).toBe(0);
+      expect(getPercentFromPointerEvent(pointer(0), rect(), 'horizontal')).toBe(0);
     });
 
     it('returns 100 at the right edge', () => {
-      expect(getPercentFromPointerEvent(pointer(200), rect(), 'horizontal', false)).toBe(100);
+      expect(getPercentFromPointerEvent(pointer(200), rect(), 'horizontal')).toBe(100);
     });
 
     it('returns 50 at the midpoint', () => {
-      expect(getPercentFromPointerEvent(pointer(100), rect(), 'horizontal', false)).toBe(50);
+      expect(getPercentFromPointerEvent(pointer(100), rect(), 'horizontal')).toBe(50);
     });
 
     it('clamps below 0', () => {
-      expect(getPercentFromPointerEvent(pointer(-10), rect(), 'horizontal', false)).toBe(0);
+      expect(getPercentFromPointerEvent(pointer(-10), rect(), 'horizontal')).toBe(0);
     });
 
     it('clamps above 100', () => {
-      expect(getPercentFromPointerEvent(pointer(250), rect(), 'horizontal', false)).toBe(100);
-    });
-  });
-
-  describe('horizontal RTL', () => {
-    it('returns 0 at the right edge', () => {
-      expect(getPercentFromPointerEvent(pointer(200), rect(), 'horizontal', true)).toBe(0);
-    });
-
-    it('returns 100 at the left edge', () => {
-      expect(getPercentFromPointerEvent(pointer(0), rect(), 'horizontal', true)).toBe(100);
-    });
-
-    it('returns 50 at the midpoint', () => {
-      expect(getPercentFromPointerEvent(pointer(100), rect(), 'horizontal', true)).toBe(50);
+      expect(getPercentFromPointerEvent(pointer(250), rect(), 'horizontal')).toBe(100);
     });
   });
 
   describe('vertical', () => {
     it('returns 100 at the top edge', () => {
-      expect(getPercentFromPointerEvent(pointer(0, 0), rect(), 'vertical', false)).toBe(100);
+      expect(getPercentFromPointerEvent(pointer(0, 0), rect(), 'vertical')).toBe(100);
     });
 
     it('returns 0 at the bottom edge', () => {
-      expect(getPercentFromPointerEvent(pointer(0, 100), rect(), 'vertical', false)).toBe(0);
+      expect(getPercentFromPointerEvent(pointer(0, 100), rect(), 'vertical')).toBe(0);
     });
 
     it('returns 50 at the midpoint', () => {
-      expect(getPercentFromPointerEvent(pointer(0, 50), rect(), 'vertical', false)).toBe(50);
+      expect(getPercentFromPointerEvent(pointer(0, 50), rect(), 'vertical')).toBe(50);
     });
   });
 
   describe('zero-sized rect', () => {
     it('returns 0 for zero-width horizontal rect', () => {
-      expect(getPercentFromPointerEvent(pointer(50), rect({ width: 0 }), 'horizontal', false)).toBe(0);
+      expect(getPercentFromPointerEvent(pointer(50), rect({ width: 0 }), 'horizontal')).toBe(0);
     });
 
     it('returns 0 for zero-height vertical rect', () => {
-      expect(getPercentFromPointerEvent(pointer(0, 50), rect({ height: 0 }), 'vertical', false)).toBe(0);
-    });
-
-    it('returns 0 for zero-width RTL rect', () => {
-      expect(getPercentFromPointerEvent(pointer(50), rect({ width: 0 }), 'horizontal', true)).toBe(0);
+      expect(getPercentFromPointerEvent(pointer(0, 50), rect({ height: 0 }), 'vertical')).toBe(0);
     });
   });
 });

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -98,7 +98,7 @@ function getTemplateHTML() {
                 <media-captions-radio-group class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="${menu.indicator}">
                         ${renderIcon('check', { class: cn(icon, menu.icon) })}
                       </media-menu-item-indicator>

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -78,7 +78,7 @@ function getTemplateHTML() {
               <media-captions-radio-group class="media-menu__group">
                 <template>
                   <media-menu-radio-item class="media-menu__item">
-                    <span data-part="label"></span>
+                    <bdi data-part="label" dir="auto"></bdi>
                     <media-menu-item-indicator force-mount class="media-menu__indicator">
                       ${renderIcon('check', { class: 'media-icon' })}
                     </media-menu-item-indicator>

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -99,7 +99,7 @@ function getTemplateHTML() {
                 <media-captions-radio-group class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="${menu.indicator}">
                         ${renderIcon('check', { class: cn(icon, menu.icon) })}
                       </media-menu-item-indicator>

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -79,7 +79,7 @@ function getTemplateHTML() {
                 <media-captions-radio-group class="media-menu__group">
                   <template>
                     <media-menu-radio-item class="media-menu__item">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="media-menu__indicator">
                         ${renderIcon('check', { class: 'media-icon' })}
                       </media-menu-item-indicator>

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -143,7 +143,7 @@ function getTemplateHTML() {
                     ${renderIcon('switches', { class: cn(icon, menu.icon) })}
                     ${renderText(qualityText)}
                     <span class="${menu.hint}">
-                      <span data-part="hint" class="${menu.hintLabel}"></span>
+                      <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                       ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron) })}
                     </span>
                   </media-menu-item>
@@ -151,7 +151,7 @@ function getTemplateHTML() {
                     ${renderIcon('speech', { class: icon })}
                     ${renderText(audioText)}
                     <span class="${menu.hint}">
-                      <span data-part="hint" class="${menu.hintLabel}"></span>
+                      <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                       ${renderIcon('chevron', { class: cn(icon, menu.chevron) })}
                     </span>
                   </media-menu-item>
@@ -159,7 +159,7 @@ function getTemplateHTML() {
                     ${renderIcon('speed', { class: cn(icon, menu.icon) })}
                     ${renderText(speedText)}
                     <span class="${menu.hint}">
-                      <span data-part="hint" class="${menu.hintLabel}"></span>
+                      <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                       ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron) })}
                     </span>
                   </media-menu-item>
@@ -167,7 +167,7 @@ function getTemplateHTML() {
                     ${renderIcon('captions-off', { class: cn(icon, menu.icon) })}
                     ${renderText(captionsText)}
                     <span class="${menu.hint}">
-                      <span data-part="hint" class="${menu.hintLabel}"></span>
+                      <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                       ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron) })}
                     </span>
                   </media-menu-item>
@@ -175,7 +175,7 @@ function getTemplateHTML() {
 
               <media-menu id="settings-quality-menu" class="${menu.submenuPanel}">
                 <media-menu-item class="${menu.back}">
-                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                   ${renderText(qualityText)}
                 </media-menu-item>
                 <div class="${menu.separator}"></div>
@@ -183,7 +183,7 @@ function getTemplateHTML() {
                   <template>
                     <media-menu-radio-item class="${menu.item}">
                       <span>
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <sup data-part="tier" class="${menu.tier}"></sup>
                       </span>
                       <span data-part="badge" class="${badge}"></span>
@@ -197,14 +197,14 @@ function getTemplateHTML() {
 
               <media-menu id="settings-audio-menu" class="${menu.submenuPanel}">
                 <media-menu-item class="${menu.back}">
-                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                   ${renderText(audioText)}
                 </media-menu-item>
                 <div class="${menu.separator}"></div>
                 <media-audio-track-radio-group class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="${menu.indicator}">
                         ${renderIcon('check', { class: icon })}
                       </media-menu-item-indicator>
@@ -215,14 +215,14 @@ function getTemplateHTML() {
 
               <media-menu id="settings-speed-menu" class="${menu.submenuPanel}">
                 <media-menu-item class="${menu.back}">
-                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                   ${renderText(speedText)}
                 </media-menu-item>
                 <div class="${menu.separator}"></div>
                 <media-playback-rate-radio-group class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="${menu.indicator}">
                         ${renderIcon('check', { class: cn(icon, menu.icon) })}
                       </media-menu-item-indicator>
@@ -233,14 +233,14 @@ function getTemplateHTML() {
 
               <media-menu id="settings-captions-menu" class="${menu.submenuPanel}">
                 <media-menu-item class="${menu.back}">
-                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                  ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                   ${renderText(captionsText)}
                 </media-menu-item>
                 <div class="${menu.separator}"></div>
                 <media-captions-radio-group class="${menu.group}">
                   <template>
                     <media-menu-radio-item class="${menu.item}">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="${menu.indicator}">
                         ${renderIcon('check', { class: cn(icon, menu.icon) })}
                       </media-menu-item-indicator>

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -120,7 +120,7 @@ function getTemplateHTML() {
                     ${renderIcon('switches', { class: 'media-icon' })}
                     ${renderText(qualityText)}
                     <span class="media-menu__hint">
-                      <span data-part="hint" class="media-menu__hint-label"></span>
+                      <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                       ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                     </span>
                   </media-menu-item>
@@ -128,7 +128,7 @@ function getTemplateHTML() {
                     ${renderIcon('speech', { class: 'media-icon' })}
                     ${renderText(audioText)}
                     <span class="media-menu__hint">
-                      <span data-part="hint" class="media-menu__hint-label"></span>
+                      <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                       ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                     </span>
                   </media-menu-item>
@@ -136,7 +136,7 @@ function getTemplateHTML() {
                     ${renderIcon('speed', { class: 'media-icon' })}
                     ${renderText(speedText)}
                     <span class="media-menu__hint">
-                      <span data-part="hint" class="media-menu__hint-label"></span>
+                      <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                       ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                     </span>
                   </media-menu-item>
@@ -144,7 +144,7 @@ function getTemplateHTML() {
                     ${renderIcon('captions-off', { class: 'media-icon' })}
                     ${renderText(captionsText)}
                     <span class="media-menu__hint">
-                      <span data-part="hint" class="media-menu__hint-label"></span>
+                      <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                       ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                     </span>
                   </media-menu-item>
@@ -160,7 +160,7 @@ function getTemplateHTML() {
                   <template>
                     <media-menu-radio-item class="media-menu__item">
                       <span>
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <sup data-part="tier" class="media-menu__tier"></sup>
                       </span>
                       <span data-part="badge" class="media-badge"></span>
@@ -181,7 +181,7 @@ function getTemplateHTML() {
                 <media-audio-track-radio-group class="media-menu__group">
                   <template>
                     <media-menu-radio-item class="media-menu__item">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="media-menu__indicator">
                         ${renderIcon('check', { class: 'media-icon' })}
                       </media-menu-item-indicator>
@@ -199,7 +199,7 @@ function getTemplateHTML() {
                 <media-playback-rate-radio-group class="media-menu__group">
                   <template>
                     <media-menu-radio-item class="media-menu__item">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="media-menu__indicator">
                         ${renderIcon('check', { class: 'media-icon' })}
                       </media-menu-item-indicator>
@@ -217,7 +217,7 @@ function getTemplateHTML() {
                 <media-captions-radio-group class="media-menu__group">
                   <template>
                     <media-menu-radio-item class="media-menu__item">
-                      <span data-part="label"></span>
+                      <bdi data-part="label" dir="auto"></bdi>
                       <media-menu-item-indicator force-mount class="media-menu__indicator">
                         ${renderIcon('check', { class: 'media-icon' })}
                       </media-menu-item-indicator>

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -143,7 +143,7 @@ function getTemplateHTML() {
                       ${renderIcon('switches', { class: cn(icon, menu.icon) })}
                       ${renderText(qualityText)}
                       <span class="${menu.hint}">
-                        <span data-part="hint" class="${menu.hintLabel}"></span>
+                        <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                         ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron) })}
                       </span>
                     </media-menu-item>
@@ -151,7 +151,7 @@ function getTemplateHTML() {
                       ${renderIcon('speech', { class: icon })}
                       ${renderText(audioText)}
                       <span class="${menu.hint}">
-                        <span data-part="hint" class="${menu.hintLabel}"></span>
+                        <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                         ${renderIcon('chevron', { class: cn(icon, menu.chevron) })}
                       </span>
                     </media-menu-item>
@@ -159,7 +159,7 @@ function getTemplateHTML() {
                       ${renderIcon('speed', { class: cn(icon, menu.icon) })}
                       ${renderText(speedText)}
                       <span class="${menu.hint}">
-                        <span data-part="hint" class="${menu.hintLabel}"></span>
+                        <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                         ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron) })}
                       </span>
                     </media-menu-item>
@@ -167,7 +167,7 @@ function getTemplateHTML() {
                       ${renderIcon('captions-off', { class: cn(icon, menu.icon) })}
                       ${renderText(captionsText)}
                       <span class="${menu.hint}">
-                        <span data-part="hint" class="${menu.hintLabel}"></span>
+                        <bdi data-part="hint" dir="auto" class="${menu.hintLabel}"></bdi>
                         ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron) })}
                       </span>
                     </media-menu-item>
@@ -175,7 +175,7 @@ function getTemplateHTML() {
 
                 <media-menu id="settings-quality-menu" class="${menu.submenuPanel}">
                   <media-menu-item class="${menu.back}">
-                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                     ${renderText(qualityText)}
                   </media-menu-item>
                   <div class="${menu.separator}"></div>
@@ -183,7 +183,7 @@ function getTemplateHTML() {
                     <template>
                       <media-menu-radio-item class="${menu.item}">
                         <span>
-                          <span data-part="label"></span>
+                          <bdi data-part="label" dir="auto"></bdi>
                           <sup data-part="tier" class="${menu.tier}"></sup>
                         </span>
                         <span data-part="badge" class="${badge}"></span>
@@ -197,14 +197,14 @@ function getTemplateHTML() {
 
                 <media-menu id="settings-audio-menu" class="${menu.submenuPanel}">
                   <media-menu-item class="${menu.back}">
-                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                     ${renderText(audioText)}
                   </media-menu-item>
                   <div class="${menu.separator}"></div>
                   <media-audio-track-radio-group class="${menu.group}">
                     <template>
                       <media-menu-radio-item class="${menu.item}">
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <media-menu-item-indicator force-mount class="${menu.indicator}">
                           ${renderIcon('check', { class: icon })}
                         </media-menu-item-indicator>
@@ -215,14 +215,14 @@ function getTemplateHTML() {
 
                 <media-menu id="settings-speed-menu" class="${menu.submenuPanel}">
                   <media-menu-item class="${menu.back}">
-                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                     ${renderText(speedText)}
                   </media-menu-item>
                   <div class="${menu.separator}"></div>
                   <media-playback-rate-radio-group class="${menu.group}">
                     <template>
                       <media-menu-radio-item class="${menu.item}">
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <media-menu-item-indicator force-mount class="${menu.indicator}">
                           ${renderIcon('check', { class: cn(icon, menu.icon) })}
                         </media-menu-item-indicator>
@@ -233,14 +233,14 @@ function getTemplateHTML() {
 
                 <media-menu id="settings-captions-menu" class="${menu.submenuPanel}">
                   <media-menu-item class="${menu.back}">
-                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped) })}
+                    ${renderIcon('chevron', { class: cn(icon, menu.icon, menu.chevron, iconFlipped, menu.backChevron) })}
                     ${renderText(captionsText)}
                   </media-menu-item>
                   <div class="${menu.separator}"></div>
                   <media-captions-radio-group class="${menu.group}">
                     <template>
                       <media-menu-radio-item class="${menu.item}">
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <media-menu-item-indicator force-mount class="${menu.indicator}">
                           ${renderIcon('check', { class: cn(icon, menu.icon) })}
                         </media-menu-item-indicator>

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -117,7 +117,7 @@ function getTemplateHTML() {
                       ${renderIcon('switches', { class: 'media-icon' })}
                       ${renderText(qualityText)}
                       <span class="media-menu__hint">
-                        <span data-part="hint" class="media-menu__hint-label"></span>
+                        <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                         ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                       </span>
                     </media-menu-item>
@@ -125,7 +125,7 @@ function getTemplateHTML() {
                       ${renderIcon('speech', { class: 'media-icon' })}
                       ${renderText(audioText)}
                       <span class="media-menu__hint">
-                        <span data-part="hint" class="media-menu__hint-label"></span>
+                        <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                         ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                       </span>
                     </media-menu-item>
@@ -133,7 +133,7 @@ function getTemplateHTML() {
                       ${renderIcon('speed', { class: 'media-icon' })}
                       ${renderText(speedText)}
                       <span class="media-menu__hint">
-                        <span data-part="hint" class="media-menu__hint-label"></span>
+                        <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                         ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                       </span>
                     </media-menu-item>
@@ -141,7 +141,7 @@ function getTemplateHTML() {
                       ${renderIcon('captions-off', { class: 'media-icon' })}
                       ${renderText(captionsText)}
                       <span class="media-menu__hint">
-                        <span data-part="hint" class="media-menu__hint-label"></span>
+                        <bdi data-part="hint" dir="auto" class="media-menu__hint-label"></bdi>
                         ${renderIcon('chevron', { class: 'media-icon media-menu__chevron' })}
                       </span>
                     </media-menu-item>
@@ -157,7 +157,7 @@ function getTemplateHTML() {
                     <template>
                       <media-menu-radio-item class="media-menu__item">
                         <span>
-                          <span data-part="label"></span>
+                          <bdi data-part="label" dir="auto"></bdi>
                           <sup data-part="tier" class="media-menu__tier"></sup>
                         </span>
                         <span data-part="badge" class="media-badge"></span>
@@ -178,7 +178,7 @@ function getTemplateHTML() {
                   <media-audio-track-radio-group class="media-menu__group">
                     <template>
                       <media-menu-radio-item class="media-menu__item">
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <media-menu-item-indicator force-mount class="media-menu__indicator">
                           ${renderIcon('check', { class: 'media-icon' })}
                         </media-menu-item-indicator>
@@ -196,7 +196,7 @@ function getTemplateHTML() {
                   <media-playback-rate-radio-group class="media-menu__group">
                     <template>
                       <media-menu-radio-item class="media-menu__item">
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <media-menu-item-indicator force-mount class="media-menu__indicator">
                           ${renderIcon('check', { class: 'media-icon' })}
                         </media-menu-item-indicator>
@@ -214,7 +214,7 @@ function getTemplateHTML() {
                   <media-captions-radio-group class="media-menu__group">
                     <template>
                       <media-menu-radio-item class="media-menu__item">
-                        <span data-part="label"></span>
+                        <bdi data-part="label" dir="auto"></bdi>
                         <media-menu-item-indicator force-mount class="media-menu__indicator">
                           ${renderIcon('check', { class: 'media-icon' })}
                         </media-menu-item-indicator>

--- a/packages/html/src/i18n/provider-mixin.ts
+++ b/packages/html/src/i18n/provider-mixin.ts
@@ -14,6 +14,7 @@ import {
 import type { PropertyValues, ReactiveElement } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
 import { mergeLocaleOverlays, subscribeAmbientLang } from '@videojs/utils/dom';
+import { getTextDirection, type TextDirection } from '@videojs/utils/i18n';
 import type { Constructor } from '@videojs/utils/types';
 
 import type { I18nContext, I18nContextValue } from './context';
@@ -37,9 +38,11 @@ export function createI18nProviderMixin({ context, loader = defaultLoader }: I18
       static properties = {
         ...Base.properties,
         lang: { type: String, reflect: true },
+        dir: { type: String, reflect: true },
       };
 
       lang = '';
+      dir = '';
 
       readonly #i18nProvider = new ContextProvider(this, {
         context,
@@ -65,6 +68,7 @@ export function createI18nProviderMixin({ context, loader = defaultLoader }: I18
       #publishedLocale: Locale | undefined;
       #publishedRegistryEpoch = -1;
       #publishedLazyLayer: Partial<FlatTranslations> | undefined;
+      #derivedDirection: TextDirection | undefined;
 
       protected get i18nValue(): I18nContextValue {
         return this.#i18nValue;
@@ -106,6 +110,7 @@ export function createI18nProviderMixin({ context, loader = defaultLoader }: I18
             this.#resetLazyAndLoad();
           }
         }
+        this.#syncDirection(locale);
         this.#publish();
       }
 
@@ -131,6 +136,26 @@ export function createI18nProviderMixin({ context, loader = defaultLoader }: I18
 
       #resolvedLocale(): Locale {
         return resolveProviderLocale(this);
+      }
+
+      #syncDirection(locale: Locale): void {
+        const current = this.dir.trim().toLowerCase();
+        const isDerived = this.#derivedDirection !== undefined && current === this.#derivedDirection;
+
+        if (!this.lang.trim()) {
+          if (isDerived) this.dir = '';
+          this.#derivedDirection = undefined;
+          return;
+        }
+
+        if (current && !isDerived) {
+          this.#derivedDirection = undefined;
+          return;
+        }
+
+        const direction = getTextDirection(locale);
+        this.#derivedDirection = direction;
+        if (this.dir !== direction) this.dir = direction;
       }
 
       #publish(): void {

--- a/packages/html/src/i18n/tests/create-i18n.test.ts
+++ b/packages/html/src/i18n/tests/create-i18n.test.ts
@@ -12,6 +12,7 @@ describe('createI18n (HTML)', () => {
     resetBrowserTranslationCacheForTesting();
     document.body.innerHTML = '';
     document.documentElement.removeAttribute('lang');
+    document.documentElement.removeAttribute('dir');
     await Promise.resolve();
     await Promise.resolve();
     vi.restoreAllMocks();
@@ -24,6 +25,51 @@ describe('createI18n (HTML)', () => {
     document.body.appendChild(provider);
     await Promise.resolve();
     expect(provider.getAttribute('lang')).toBe('fr');
+  });
+
+  it('derives direction from the resolved locale', async () => {
+    const provider = new MediaI18nProviderElement();
+    provider.lang = 'ar';
+    document.body.appendChild(provider);
+    await provider.updateComplete;
+
+    expect(provider.dir).toBe('rtl');
+
+    provider.lang = 'en';
+    await provider.updateComplete;
+    expect(provider.dir).toBe('ltr');
+  });
+
+  it('preserves an explicit direction', async () => {
+    const provider = new MediaI18nProviderElement();
+    provider.lang = 'ar';
+    provider.dir = 'ltr';
+    document.body.appendChild(provider);
+    await provider.updateComplete;
+
+    expect(provider.dir).toBe('ltr');
+  });
+
+  it('inherits ambient language and direction without adding a direction', async () => {
+    document.documentElement.lang = 'ar';
+    document.documentElement.dir = 'ltr';
+    const provider = new MediaI18nProviderElement();
+    document.body.appendChild(provider);
+    await provider.updateComplete;
+
+    expect(provider.hasAttribute('lang')).toBe(false);
+    expect(provider.hasAttribute('dir')).toBe(false);
+  });
+
+  it('clears a derived direction when its explicit language is removed', async () => {
+    const provider = new MediaI18nProviderElement();
+    provider.lang = 'ar';
+    document.body.appendChild(provider);
+    await provider.updateComplete;
+
+    provider.lang = '';
+    await provider.updateComplete;
+    expect(provider.dir).toBe('');
   });
 
   it('media-text translates text content inside provider', async () => {

--- a/packages/html/src/ui/slider/slider-element.ts
+++ b/packages/html/src/ui/slider/slider-element.ts
@@ -10,7 +10,7 @@ import {
 import { type Text, translateText } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
-import { applyStyles, isRTL } from '@videojs/utils/dom';
+import { applyStyles } from '@videojs/utils/dom';
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
 import { playerContext } from '../../player/context';
@@ -63,7 +63,6 @@ export class SliderElement extends MediaElement {
       getElement: () => this,
       getThumbElement: () => this.querySelector<HTMLElement>('media-slider-thumb'),
       getOrientation: () => this.orientation,
-      isRTL: () => isRTL(this),
       isDisabled: () => this.disabled,
       getPercent: () => this.#core.percentFromValue(this.value),
       getStepPercent: () => this.#core.getStepPercent(),

--- a/packages/html/src/ui/time-slider/time-slider-element.ts
+++ b/packages/html/src/ui/time-slider/time-slider-element.ts
@@ -14,7 +14,7 @@ import {
 import { type Text, translateText } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
-import { applyStyles, isRTL } from '@videojs/utils/dom';
+import { applyStyles } from '@videojs/utils/dom';
 import { formatTime } from '@videojs/utils/time';
 
 import { i18nContext } from '../../i18n/context';
@@ -70,7 +70,6 @@ export class TimeSliderElement extends MediaElement {
       getElement: () => this,
       getThumbElement: () => this.querySelector<HTMLElement>('media-slider-thumb'),
       getOrientation: () => this.orientation,
-      isRTL: () => isRTL(this),
       isDisabled: () => this.disabled || !this.#timeState.value,
       getPercent: () => {
         const media = this.#timeState.value;

--- a/packages/html/src/ui/volume-slider/volume-slider-element.ts
+++ b/packages/html/src/ui/volume-slider/volume-slider-element.ts
@@ -13,7 +13,7 @@ import {
 import { type Text, translateText } from '@videojs/core/i18n';
 import type { PropertyDeclarationMap, PropertyValues } from '@videojs/element';
 import { ContextProvider } from '@videojs/element/context';
-import { applyStyles, isRTL } from '@videojs/utils/dom';
+import { applyStyles } from '@videojs/utils/dom';
 
 import { i18nContext } from '../../i18n/context';
 import { I18nController } from '../../i18n/controller';
@@ -72,7 +72,6 @@ export class VolumeSliderElement extends MediaElement {
       getElement: () => this,
       getThumbElement: () => this.querySelector<HTMLElement>('media-slider-thumb'),
       getOrientation: () => this.orientation,
-      isRTL: () => isRTL(this),
       isDisabled,
       getPercent,
       getStepPercent,

--- a/packages/react/src/i18n/context.tsx
+++ b/packages/react/src/i18n/context.tsx
@@ -14,8 +14,10 @@ export type AddLocaleRoot = () => () => void;
 export interface I18nContextValue {
   translator: Translator;
   locale: Locale;
-  /** True when a provider received an explicit locale prop. */
+  /** True when the locale resolves from an explicit provider prop. */
   localeFromProp: boolean;
+  /** @internal True when the nearest provider received an explicit locale prop. */
+  localeFromOwnProp?: boolean;
   /** Overrides passed to this provider. */
   translations?: Partial<Translations>;
   /** Callback inherited by nested locale roots. */

--- a/packages/react/src/i18n/create-i18n.tsx
+++ b/packages/react/src/i18n/create-i18n.tsx
@@ -75,6 +75,7 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
     langRootRef,
     parentLocale,
     localeFromProp = localeProp !== undefined,
+    localeFromOwnProp = localeProp !== undefined,
     translations: translationsProp,
     children,
     onActiveLocaleChange,
@@ -98,10 +99,11 @@ export function createI18n(options?: CreateI18nOptions): CreateI18nResult {
         translator,
         locale: resolvedLocale,
         localeFromProp,
+        localeFromOwnProp,
         ...(translationsProp !== undefined ? { translations: translationsProp } : {}),
         ...(onActiveLocaleChange !== undefined ? { onActiveLocaleChange } : {}),
       }),
-      [translator, resolvedLocale, localeFromProp, translationsProp, onActiveLocaleChange]
+      [translator, resolvedLocale, localeFromProp, localeFromOwnProp, translationsProp, onActiveLocaleChange]
     );
 
     return (

--- a/packages/react/src/i18n/get-provider-root-props.ts
+++ b/packages/react/src/i18n/get-provider-root-props.ts
@@ -32,6 +32,7 @@ function mergeTranslations(
 export interface I18nProviderRootProps extends I18nProviderProps {
   parentLocale?: I18nContextValue['locale'];
   localeFromProp?: boolean;
+  localeFromOwnProp?: boolean;
   parentAddLocaleRoot?: AddLocaleRoot;
 }
 
@@ -46,7 +47,7 @@ export function getProviderRootProps(
 
   // Nested providers without their own locale root or overrides can use the
   // existing parent context instead of mounting another root.
-  if (parent && !hasOverrides && (!langRootOnly || parent.localeFromProp)) {
+  if (parent && !hasOverrides && (!langRootOnly || (parent.localeFromOwnProp ?? parent.localeFromProp))) {
     return undefined;
   }
 
@@ -57,11 +58,14 @@ export function getProviderRootProps(
       ? mergeTranslations(parent.translations, props.translations)
       : (props.translations ?? (langRootOnly ? parent?.translations : undefined));
   const onActiveLocaleChange = props.onActiveLocaleChange ?? parent?.onActiveLocaleChange;
+  const localeFromProp =
+    props.locale !== undefined || (props.langRootRef === undefined && parent?.localeFromProp === true);
 
   return {
     ...props,
     ...(inheritedLocale !== undefined ? { locale: inheritedLocale } : {}),
-    localeFromProp: props.locale !== undefined,
+    localeFromProp,
+    localeFromOwnProp: props.locale !== undefined,
     ...(parentLocale !== undefined ? { parentLocale } : {}),
     ...(inheritedTranslations !== undefined ? { translations: inheritedTranslations } : {}),
     ...(onActiveLocaleChange !== undefined ? { onActiveLocaleChange } : {}),

--- a/packages/react/src/player/container.tsx
+++ b/packages/react/src/player/container.tsx
@@ -5,16 +5,18 @@ import {
   focusContainer,
 } from '@videojs/core/dom';
 import { labelText } from '@videojs/core/i18n/text/container';
+import { getTextDirection } from '@videojs/utils/i18n';
 import {
   forwardRef,
   type HTMLAttributes,
   type PointerEventHandler,
   type ReactNode,
+  useContext,
   useEffect,
   useRef,
   useState,
 } from 'react';
-import { useTranslator } from '../i18n/context';
+import { I18nContext, useTranslator } from '../i18n/context';
 import { useComposedRefs } from '../utils/use-composed-refs';
 import { useContainerAttach } from './context';
 import { PopupGroupProvider } from './popup-group-context';
@@ -30,12 +32,15 @@ export const Container = forwardRef<HTMLDivElement, ContainerProps>(function Con
     role = DEFAULT_CONTAINER_ROLE,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
+    lang: langProp,
+    dir: dirProp,
     ...props
   },
   ref
 ) {
   const setContainer = useContainerAttach();
   const translator = useTranslator();
+  const i18n = useContext(I18nContext);
   const [popupGroup] = useState(() => createPopupGroup());
   const internalRef = useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs(ref, internalRef);
@@ -56,6 +61,11 @@ export const Container = forwardRef<HTMLDivElement, ContainerProps>(function Con
     ariaLabel !== undefined || ariaLabelledBy !== undefined
       ? { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy }
       : { 'aria-label': translator(labelText) };
+  const lang = langProp ?? (i18n?.localeFromProp ? i18n.locale : undefined);
+  const localeProps = {
+    lang,
+    dir: dirProp ?? (lang ? getTextDirection(lang) : undefined),
+  };
 
   return (
     <div
@@ -63,6 +73,7 @@ export const Container = forwardRef<HTMLDivElement, ContainerProps>(function Con
       role={role}
       tabIndex={tabIndex}
       {...accessibleNameProps}
+      {...localeProps}
       {...props}
       onPointerUp={handlePointerUp}
     >

--- a/packages/react/src/player/tests/context.test.tsx
+++ b/packages/react/src/player/tests/context.test.tsx
@@ -22,6 +22,7 @@ import { useOptionalPopupGroup } from '../popup-group-context';
 afterEach(() => {
   cleanup();
   document.documentElement.removeAttribute('lang');
+  document.documentElement.removeAttribute('dir');
 });
 
 function createWrapper(value: PlayerContextValue) {
@@ -289,6 +290,97 @@ describe('Container', () => {
     );
 
     expect(container.firstElementChild?.getAttribute('aria-label')).toBe('Lecteur multimédia');
+  });
+
+  it('applies the provider locale and direction to the container', () => {
+    const value = createContextValue();
+    const { I18nProvider } = createI18n();
+    const { container } = render(
+      <I18nProvider locale="ar">
+        <PlayerContextProvider value={value}>
+          <Container />
+        </PlayerContextProvider>
+      </I18nProvider>
+    );
+
+    expect(container.firstElementChild?.getAttribute('lang')).toBe('ar');
+    expect(container.firstElementChild?.getAttribute('dir')).toBe('rtl');
+  });
+
+  it('applies an explicit locale through a translations-only provider', () => {
+    const value = createContextValue();
+    const { I18nProvider } = createI18n();
+    const { container } = render(
+      <I18nProvider locale="ar">
+        <I18nProvider translations={{}}>
+          <PlayerContextProvider value={value}>
+            <Container />
+          </PlayerContextProvider>
+        </I18nProvider>
+      </I18nProvider>
+    );
+
+    expect(container.firstElementChild?.getAttribute('lang')).toBe('ar');
+    expect(container.firstElementChild?.getAttribute('dir')).toBe('rtl');
+  });
+
+  it('inherits ambient language and direction without adding attributes', () => {
+    document.documentElement.lang = 'ar';
+    document.documentElement.dir = 'ltr';
+    const value = createContextValue();
+    const { I18nProvider } = createI18n();
+    const { container } = render(
+      <I18nProvider>
+        <PlayerContextProvider value={value}>
+          <Container />
+        </PlayerContextProvider>
+      </I18nProvider>
+    );
+
+    expect(container.firstElementChild?.hasAttribute('lang')).toBe(false);
+    expect(container.firstElementChild?.hasAttribute('dir')).toBe(false);
+  });
+
+  it('derives direction from an explicit container language', () => {
+    const value = createContextValue();
+    const { I18nProvider } = createI18n();
+    const { container } = render(
+      <I18nProvider locale="ar">
+        <PlayerContextProvider value={value}>
+          <Container lang="en" />
+        </PlayerContextProvider>
+      </I18nProvider>
+    );
+
+    expect(container.firstElementChild?.getAttribute('lang')).toBe('en');
+    expect(container.firstElementChild?.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('preserves explicit container language and direction', () => {
+    const value = createContextValue();
+    const { I18nProvider } = createI18n();
+    const { container } = render(
+      <I18nProvider locale="ar">
+        <PlayerContextProvider value={value}>
+          <Container lang="en" dir="ltr" />
+        </PlayerContextProvider>
+      </I18nProvider>
+    );
+
+    expect(container.firstElementChild?.getAttribute('lang')).toBe('en');
+    expect(container.firstElementChild?.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('does not add language attributes without a provider', () => {
+    const value = createContextValue();
+    const { container } = render(
+      <PlayerContextProvider value={value}>
+        <Container />
+      </PlayerContextProvider>
+    );
+
+    expect(container.firstElementChild?.hasAttribute('lang')).toBe(false);
+    expect(container.firstElementChild?.hasAttribute('dir')).toBe(false);
   });
 
   it('preserves explicit accessible naming', () => {

--- a/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tailwind.tsx
@@ -190,7 +190,7 @@ function CaptionsTrigger(): ReactNode {
         >
           {captions.options.map((option) => (
             <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
-              <span>{option.label}</span>
+              <bdi dir="auto">{option.label}</bdi>
               <Menu.ItemIndicator checked={option.value === captions.value} forceMount className={menu.indicator}>
                 <CheckIcon className={cn(icon, menu.icon)} />
               </Menu.ItemIndicator>

--- a/packages/react/src/presets/live-video/minimal-skin.tsx
+++ b/packages/react/src/presets/live-video/minimal-skin.tsx
@@ -152,7 +152,7 @@ function CaptionsTrigger(): ReactNode {
               value={option.value}
               disabled={option.disabled}
             >
-              <span>{option.label}</span>
+              <bdi dir="auto">{option.label}</bdi>
               <Menu.ItemIndicator
                 checked={option.value === captions.value}
                 forceMount

--- a/packages/react/src/presets/live-video/skin.tailwind.tsx
+++ b/packages/react/src/presets/live-video/skin.tailwind.tsx
@@ -191,7 +191,7 @@ function CaptionsTrigger(): ReactNode {
         >
           {captions.options.map((option) => (
             <Menu.RadioItem key={option.value} className={menu.item} value={option.value} disabled={option.disabled}>
-              <span>{option.label}</span>
+              <bdi dir="auto">{option.label}</bdi>
               <Menu.ItemIndicator checked={option.value === captions.value} forceMount className={menu.indicator}>
                 <CheckIcon className={cn(icon, menu.icon)} />
               </Menu.ItemIndicator>

--- a/packages/react/src/presets/live-video/skin.tsx
+++ b/packages/react/src/presets/live-video/skin.tsx
@@ -153,7 +153,7 @@ function CaptionsTrigger(): ReactNode {
               value={option.value}
               disabled={option.disabled}
             >
-              <span>{option.label}</span>
+              <bdi dir="auto">{option.label}</bdi>
               <Menu.ItemIndicator checked={option.value === value} forceMount className="media-menu__indicator">
                 <CheckIcon className="media-icon" />
               </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/minimal-skin.tailwind.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tailwind.tsx
@@ -173,7 +173,11 @@ function VolumePopover(): ReactNode {
 }
 
 function MenuChevron({ flipped = false }: { flipped?: boolean }): ReactNode {
-  return <ChevronIcon className={cn(icon, menu.icon, menu.chevron, flipped ? iconFlipped : undefined)} />;
+  return (
+    <ChevronIcon
+      className={cn(icon, menu.icon, menu.chevron, flipped ? cn(iconFlipped, menu.backChevron) : undefined)}
+    />
+  );
 }
 
 function SettingsMenu(): ReactNode {
@@ -217,7 +221,9 @@ function SettingsMenu(): ReactNode {
                     <QualityIcon className={cn(icon, menu.icon)} />
                     <span>{t(qualityText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{quality.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {quality.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -234,10 +240,10 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(qualityText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>
+                      <bdi dir="auto">
                         {item.label}
                         {item.tier ? <sup className={menu.tier}>{item.tier}</sup> : null}
-                      </span>
+                      </bdi>
                       {item.badge ? <span className={badge}>{item.badge}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
@@ -258,7 +264,9 @@ function SettingsMenu(): ReactNode {
                     <SpeechIcon className={icon} />
                     <span>{t(audioText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{audioTrack.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {audioTrack.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -275,7 +283,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(audioText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={icon} />
                       </Menu.ItemIndicator>
@@ -295,7 +303,9 @@ function SettingsMenu(): ReactNode {
                     <SpeedIcon className={cn(icon, menu.icon)} />
                     <span>{t(speedText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{playbackRate.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {playbackRate.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -312,7 +322,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(playbackRateText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
                       </Menu.ItemIndicator>
@@ -332,7 +342,9 @@ function SettingsMenu(): ReactNode {
                     <CaptionsOffIcon className={cn(icon, menu.icon)} />
                     <span>{t(captionsText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{captions.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {captions.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -349,7 +361,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(captionsText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
                       </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/minimal-skin.tsx
+++ b/packages/react/src/presets/video/minimal-skin.tsx
@@ -158,7 +158,9 @@ function SettingsMenu(): ReactNode {
                     <QualityIcon className="media-icon" />
                     <span>{t(qualityText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{quality.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {quality.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -175,10 +177,10 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(qualityText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>
+                      <bdi dir="auto">
                         {item.label}
                         {item.tier ? <sup className="media-menu__tier">{item.tier}</sup> : null}
-                      </span>
+                      </bdi>
                       {item.badge ? <span className="media-badge">{item.badge}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
@@ -199,7 +201,9 @@ function SettingsMenu(): ReactNode {
                     <SpeechIcon className="media-icon" />
                     <span>{t(audioText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{audioTrack.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {audioTrack.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -216,7 +220,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(audioText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>
@@ -236,7 +240,9 @@ function SettingsMenu(): ReactNode {
                     <SpeedIcon className="media-icon" />
                     <span>{t(speedText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{playbackRate.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {playbackRate.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -253,7 +259,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(playbackRateText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>
@@ -273,7 +279,9 @@ function SettingsMenu(): ReactNode {
                     <CaptionsOffIcon className="media-icon" />
                     <span>{t(captionsText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{captions.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {captions.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -290,7 +298,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(captionsText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/skin.tailwind.tsx
+++ b/packages/react/src/presets/video/skin.tailwind.tsx
@@ -175,7 +175,11 @@ function VolumePopover(): ReactNode {
 }
 
 function MenuChevron({ flipped = false }: { flipped?: boolean }): ReactNode {
-  return <ChevronIcon className={cn(icon, menu.icon, menu.chevron, flipped ? iconFlipped : undefined)} />;
+  return (
+    <ChevronIcon
+      className={cn(icon, menu.icon, menu.chevron, flipped ? cn(iconFlipped, menu.backChevron) : undefined)}
+    />
+  );
 }
 
 function SettingsMenu(): ReactNode {
@@ -219,7 +223,9 @@ function SettingsMenu(): ReactNode {
                     <QualityIcon className={cn(icon, menu.icon)} />
                     <span>{t(qualityText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{quality.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {quality.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -236,10 +242,10 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(qualityText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>
+                      <bdi dir="auto">
                         {item.label}
                         {item.tier ? <sup className={menu.tier}>{item.tier}</sup> : null}
-                      </span>
+                      </bdi>
                       {item.badge ? <span className={badge}>{item.badge}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
@@ -260,7 +266,9 @@ function SettingsMenu(): ReactNode {
                     <SpeechIcon className={icon} />
                     <span>{t(audioText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{audioTrack.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {audioTrack.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -277,7 +285,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(audioText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={icon} />
                       </Menu.ItemIndicator>
@@ -297,7 +305,9 @@ function SettingsMenu(): ReactNode {
                     <SpeedIcon className={cn(icon, menu.icon)} />
                     <span>{t(speedText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{playbackRate.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {playbackRate.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -314,7 +324,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(playbackRateText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
                       </Menu.ItemIndicator>
@@ -334,7 +344,9 @@ function SettingsMenu(): ReactNode {
                     <CaptionsOffIcon className={cn(icon, menu.icon)} />
                     <span>{t(captionsText)}</span>
                     <span className={menu.hint}>
-                      <span className={menu.hintLabel}>{captions.selectedLabel}</span>
+                      <bdi dir="auto" className={menu.hintLabel}>
+                        {captions.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -351,7 +363,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(captionsText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className={menu.item}>
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className={menu.indicator}>
                         <CheckIcon className={cn(icon, menu.icon)} />
                       </Menu.ItemIndicator>

--- a/packages/react/src/presets/video/skin.tsx
+++ b/packages/react/src/presets/video/skin.tsx
@@ -158,7 +158,9 @@ function SettingsMenu(): ReactNode {
                     <QualityIcon className="media-icon" />
                     <span>{t(qualityText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{quality.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {quality.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -175,10 +177,10 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(qualityText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>
+                      <bdi dir="auto">
                         {item.label}
                         {item.tier ? <sup className="media-menu__tier">{item.tier}</sup> : null}
-                      </span>
+                      </bdi>
                       {item.badge ? <span className="media-badge">{item.badge}</span> : null}
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
@@ -199,7 +201,9 @@ function SettingsMenu(): ReactNode {
                     <SpeechIcon className="media-icon" />
                     <span>{t(audioText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{audioTrack.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {audioTrack.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -216,7 +220,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(audioText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>
@@ -236,7 +240,9 @@ function SettingsMenu(): ReactNode {
                     <SpeedIcon className="media-icon" />
                     <span>{t(speedText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{playbackRate.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {playbackRate.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -253,7 +259,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(playbackRateText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>
@@ -273,7 +279,9 @@ function SettingsMenu(): ReactNode {
                     <CaptionsOffIcon className="media-icon" />
                     <span>{t(captionsText)}</span>
                     <span className="media-menu__hint">
-                      <span className="media-menu__hint-label">{captions.selectedLabel}</span>
+                      <bdi dir="auto" className="media-menu__hint-label">
+                        {captions.selectedLabel}
+                      </bdi>
                       <MenuChevron />
                     </span>
                   </div>
@@ -290,7 +298,7 @@ function SettingsMenu(): ReactNode {
                   aria-label={t(captionsText)}
                   renderItem={(props, item) => (
                     <Menu.RadioItem {...props} className="media-menu__item">
-                      <span>{item.label}</span>
+                      <bdi dir="auto">{item.label}</bdi>
                       <Menu.ItemIndicator checked={item.checked} forceMount className="media-menu__indicator">
                         <CheckIcon className="media-icon" />
                       </Menu.ItemIndicator>

--- a/packages/react/src/ui/hooks/use-slider.ts
+++ b/packages/react/src/ui/hooks/use-slider.ts
@@ -9,7 +9,7 @@ import {
   selectControls,
 } from '@videojs/core/dom';
 import { useSnapshot } from '@videojs/store/react';
-import { applyStyles, isRTL } from '@videojs/utils/dom';
+import { applyStyles } from '@videojs/utils/dom';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useOptionalPlayer } from '../../player/context';
 import { useDestroy } from '../../utils/use-destroy';
@@ -80,7 +80,6 @@ export function useSlider<State extends SliderState = SliderState>(
       getElement: () => rootElementRef.current!,
       getThumbElement: () => thumbElementRef.current,
       getOrientation: () => optionsRef.current.orientation ?? 'horizontal',
-      isRTL: () => (rootElementRef.current ? isRTL(rootElementRef.current) : false),
       isDisabled: () => optionsRef.current.disabled ?? false,
       getPercent: () => optionsRef.current.getPercent(),
       getStepPercent: () => optionsRef.current.getStepPercent(),

--- a/packages/skins/src/default/css/components/button-group.css
+++ b/packages/skins/src/default/css/components/button-group.css
@@ -2,4 +2,8 @@
   display: flex;
   gap: 1px;
   align-items: center;
+
+  &:dir(rtl) {
+    flex-direction: row-reverse;
+  }
 }

--- a/packages/skins/src/default/css/components/controls.css
+++ b/packages/skins/src/default/css/components/controls.css
@@ -10,4 +10,8 @@
   container: media-controls / inline-size;
   text-shadow: 0 1px 0 var(--shadow-current-color);
   border-radius: calc(Infinity * 1px);
+
+  &:dir(rtl) {
+    flex-direction: row-reverse;
+  }
 }

--- a/packages/skins/src/default/css/components/icons.css
+++ b/packages/skins/src/default/css/components/icons.css
@@ -7,6 +7,11 @@
   width: var(--media-icon-size);
   height: var(--media-icon-size);
 }
-.media-default-skin .media-icon--flipped {
+.media-default-skin .media-icon--flipped,
+.media-default-skin:dir(rtl) .media-menu__chevron {
   scale: -1 1;
+}
+
+.media-default-skin:dir(rtl) .media-menu__chevron.media-icon--flipped {
+  scale: 1 1;
 }

--- a/packages/skins/src/default/css/components/menus.css
+++ b/packages/skins/src/default/css/components/menus.css
@@ -38,6 +38,10 @@
       filter: blur(8px);
       translate: 100% 0;
     }
+
+    &:dir(rtl):where([data-starting-style], [data-ending-style]) {
+      translate: -100% 0;
+    }
   }
 
   .media-menu__separator {
@@ -80,7 +84,7 @@
     gap: calc(var(--spacing) * 1.5);
     align-items: center;
     padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 2);
-    text-align: left;
+    text-align: start;
     text-shadow: 0 1px 0 var(--shadow-current-color);
     cursor: pointer;
     user-select: none;
@@ -124,8 +128,7 @@
 
   .media-menu__indicator {
     flex-shrink: 0;
-    margin-right: calc(var(--spacing) * -1);
-    margin-left: auto;
+    margin-inline: auto calc(var(--spacing) * -1);
     opacity: 0;
 
     .media-icon {
@@ -162,8 +165,8 @@
   }
 
   .media-menu__tier {
+    padding-inline-start: calc(var(--spacing) * 0.5);
     padding-top: 1px;
-    padding-left: calc(var(--spacing) * 0.5);
     font-size: var(--font-size-tiny);
     font-weight: 600;
     line-height: 1;
@@ -180,8 +183,8 @@
     gap: calc(var(--spacing) * 1);
     align-items: center;
     min-width: 0;
-    padding-left: calc(var(--spacing) * 2);
-    margin-left: auto;
+    padding-inline-start: calc(var(--spacing) * 2);
+    margin-inline-start: auto;
     color: oklch(from currentColor l c h / 0.65);
   }
 
@@ -219,6 +222,10 @@
     &[data-submenu-expanded="true"] > :not([data-submenu]) {
       filter: blur(8px);
       translate: -100% 0;
+    }
+
+    &:dir(rtl)[data-submenu-expanded="true"] > :not([data-submenu]) {
+      translate: 100% 0;
     }
 
     /* WebKit can restart the covered-content transition while the

--- a/packages/skins/src/default/css/components/time.css
+++ b/packages/skins/src/default/css/components/time.css
@@ -5,6 +5,10 @@
   align-items: center;
   container: media-time-controls / inline-size;
 
+  &:dir(rtl) {
+    flex-direction: row-reverse;
+  }
+
   > .media-time:last-child {
     @container media-time-controls (width < 16rem) {
       display: none;

--- a/packages/skins/src/default/tailwind/components/button-group.ts
+++ b/packages/skins/src/default/tailwind/components/button-group.ts
@@ -1,1 +1,1 @@
-export const buttonGroup = 'flex items-center gap-px';
+export const buttonGroup = 'flex items-center gap-px [&:dir(rtl)]:flex-row-reverse';

--- a/packages/skins/src/default/tailwind/components/controls.ts
+++ b/packages/skins/src/default/tailwind/components/controls.ts
@@ -9,7 +9,7 @@ export const controls = cn(
   '[--media-tooltip-side-offset:var(--media-popover-side-offset)]',
   '[--media-popover-boundary-offset:calc(var(--spacing)*var(--base-boundary-offset,2))]',
   '[--media-tooltip-boundary-offset:var(--media-popover-boundary-offset)]',
-  '[padding:calc(var(--spacing)*var(--controls-padding,1))] flex items-center',
+  '[padding:calc(var(--spacing)*var(--controls-padding,1))] flex items-center [&:dir(rtl)]:flex-row-reverse',
   'rounded-full',
   // Text shadow
   'text-shadow-2xs text-shadow-(color:--shadow-current-color)'

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -4,18 +4,19 @@ import { popup } from './popup';
 import { surface } from './surface';
 
 const submenuPanel = cn(
+  '[--submenu-translate:100%] rtl:[--submenu-translate:-100%]',
   'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
   'z-10',
   'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
   'data-starting-style:pointer-events-none data-ending-style:pointer-events-none',
   'data-starting-style:overflow-hidden data-ending-style:overflow-hidden',
-  'data-starting-style:translate-x-full data-ending-style:translate-x-full',
+  'data-starting-style:[translate:var(--submenu-translate)_0] data-ending-style:[translate:var(--submenu-translate)_0]',
   'data-starting-style:blur data-ending-style:blur'
 );
 
 const itemBase = cn(
   'group/menu-item relative flex cursor-pointer select-none items-center gap-1.5 rounded-(--menu-item-border-radius) py-1.5 px-2',
-  'text-left',
+  'text-start',
   'text-shadow-2xs text-shadow-(color:--shadow-current-color)',
   'outline-2 -outline-offset-2 outline-transparent',
   'transition-colors duration-100 ease-in-out',
@@ -76,7 +77,8 @@ export const menu = {
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     '[&>:not([data-submenu])]:translate-none [&>:not([data-submenu])]:transition-[translate,filter]',
     '[&>:not([data-submenu])]:duration-(--menu-transition-duration) [&>:not([data-submenu])]:ease-out',
-    '[&[data-submenu-expanded=true]>:not([data-submenu])]:-translate-x-full',
+    '[--submenu-parent-translate:-100%] rtl:[--submenu-parent-translate:100%]',
+    '[&[data-submenu-expanded=true]>:not([data-submenu])]:[translate:var(--submenu-parent-translate)_0]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:blur',
     // Avoid restarting the covered-content transition in WebKit while the
     // anchor-positioned highlight is active.
@@ -93,15 +95,16 @@ export const menu = {
     'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
   ),
   separator: 'my-1 border-b border-[oklch(0_0_0/0.1)] shadow-[0_1px_0_0_oklch(1_0_0/0.075)]',
-  tier: 'pl-0.5 pt-px text-(length:--font-size-tiny) font-semibold leading-none text-current/70',
-  indicator: 'ml-auto -mr-1 shrink-0 opacity-0 group-aria-checked/menu-item:opacity-100',
+  tier: 'ps-0.5 pt-px text-(length:--font-size-tiny) font-semibold leading-none text-current/70',
+  indicator: 'ms-auto -me-1 shrink-0 opacity-0 group-aria-checked/menu-item:opacity-100',
   icon: 'shrink-0 text-current/65 drop-shadow-[0_1px_0_var(--shadow-current-color)] group-hover/menu-item:text-inherit group-data-highlighted/menu-item:text-inherit',
   /** Nested submenu panel. */
   submenuPanel,
   back: cn(itemBase, 'mb-0.5 w-full'),
-  hint: 'ml-auto inline-flex min-w-0 items-center gap-1 pl-2 text-current/65',
+  hint: 'ms-auto inline-flex min-w-0 items-center gap-1 ps-2 text-current/65',
   hintLabel: 'max-w-24 overflow-hidden text-ellipsis whitespace-nowrap',
-  chevron: 'size-3.5',
+  chevron: 'size-3.5 rtl:[scale:-1_1]',
+  backChevron: 'rtl:[scale:1_1]',
   settingsGroup: 'group/settings',
   settingsTrigger: 'group',
   settingsIcon: 'transition-transform duration-150 ease-in-out group-aria-expanded:rotate-90 motion-reduce:duration-0',

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -4,7 +4,7 @@ import { popup } from './popup';
 import { surface } from './surface';
 
 const submenuPanel = cn(
-  '[--submenu-translate:100%] rtl:[--submenu-translate:-100%]',
+  '[--submenu-translate:100%] [&:dir(rtl)]:[--submenu-translate:-100%]',
   'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
   'z-10',
   'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
@@ -77,7 +77,7 @@ export const menu = {
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     '[&>:not([data-submenu])]:translate-none [&>:not([data-submenu])]:transition-[translate,filter]',
     '[&>:not([data-submenu])]:duration-(--menu-transition-duration) [&>:not([data-submenu])]:ease-out',
-    '[--submenu-parent-translate:-100%] rtl:[--submenu-parent-translate:100%]',
+    '[--submenu-parent-translate:-100%] [&:dir(rtl)]:[--submenu-parent-translate:100%]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:[translate:var(--submenu-parent-translate)_0]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:blur',
     // Avoid restarting the covered-content transition in WebKit while the
@@ -103,8 +103,8 @@ export const menu = {
   back: cn(itemBase, 'mb-0.5 w-full'),
   hint: 'ms-auto inline-flex min-w-0 items-center gap-1 ps-2 text-current/65',
   hintLabel: 'max-w-24 overflow-hidden text-ellipsis whitespace-nowrap',
-  chevron: 'size-3.5 rtl:[scale:-1_1]',
-  backChevron: 'rtl:[scale:1_1]',
+  chevron: 'size-3.5 [&:dir(rtl)]:[scale:-1_1]',
+  backChevron: '[&:dir(rtl)]:[scale:1_1]',
   settingsGroup: 'group/settings',
   settingsTrigger: 'group',
   settingsIcon: 'transition-transform duration-150 ease-in-out group-aria-expanded:rotate-90 motion-reduce:duration-0',

--- a/packages/skins/src/default/tailwind/components/time.ts
+++ b/packages/skins/src/default/tailwind/components/time.ts
@@ -1,5 +1,6 @@
 export const time = {
-  group: '@container/media-time flex items-center flex-1 gap-2.5 @max-[16rem]/media-time:[&>*:last-child]:hidden',
+  group:
+    '@container/media-time flex items-center flex-1 gap-2.5 [&:dir(rtl)]:flex-row-reverse @max-[16rem]/media-time:[&>*:last-child]:hidden',
   current: 'tabular-nums',
   duration:
     'tabular-nums cursor-pointer rounded-[--spacing(1)] outline-2 outline-transparent -outline-offset-2 transition-[outline-color,outline-offset] duration-100 ease-out focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',

--- a/packages/skins/src/minimal/css/components/button-group.css
+++ b/packages/skins/src/minimal/css/components/button-group.css
@@ -2,4 +2,8 @@
   display: flex;
   gap: 1px;
   align-items: center;
+
+  &:dir(rtl) {
+    flex-direction: row-reverse;
+  }
 }

--- a/packages/skins/src/minimal/css/components/controls.css
+++ b/packages/skins/src/minimal/css/components/controls.css
@@ -11,4 +11,8 @@
   text-shadow: 0 1px 0 var(--shadow-current-color);
   background-color: var(--controls-background-color);
   backdrop-filter: var(--controls-backdrop-filter);
+
+  &:dir(rtl) {
+    flex-direction: row-reverse;
+  }
 }

--- a/packages/skins/src/minimal/css/components/icons.css
+++ b/packages/skins/src/minimal/css/components/icons.css
@@ -7,6 +7,11 @@
   width: var(--media-icon-size);
   height: var(--media-icon-size);
 }
-.media-minimal-skin .media-icon--flipped {
+.media-minimal-skin .media-icon--flipped,
+.media-minimal-skin:dir(rtl) .media-menu__chevron {
   scale: -1 1;
+}
+
+.media-minimal-skin:dir(rtl) .media-menu__chevron.media-icon--flipped {
+  scale: 1 1;
 }

--- a/packages/skins/src/minimal/css/components/menus.css
+++ b/packages/skins/src/minimal/css/components/menus.css
@@ -44,6 +44,10 @@
       filter: blur(8px);
       translate: 100% 0;
     }
+
+    &:dir(rtl):where([data-starting-style], [data-ending-style]) {
+      translate: -100% 0;
+    }
   }
 
   .media-menu__separator {
@@ -85,7 +89,7 @@
     gap: calc(var(--spacing) * 1.5);
     align-items: center;
     padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 2);
-    text-align: left;
+    text-align: start;
     text-shadow: 0 1px 0 var(--shadow-current-color);
     cursor: pointer;
     user-select: none;
@@ -129,8 +133,7 @@
 
   .media-menu__indicator {
     flex-shrink: 0;
-    margin-right: calc(var(--spacing) * -1);
-    margin-left: auto;
+    margin-inline: auto calc(var(--spacing) * -1);
     opacity: 0;
   }
 
@@ -163,8 +166,8 @@
   }
 
   .media-menu__tier {
+    padding-inline-start: calc(var(--spacing) * 0.5);
     padding-top: 1px;
-    padding-left: calc(var(--spacing) * 0.5);
     font-size: var(--font-size-tiny);
     font-weight: 600;
     line-height: 1;
@@ -181,8 +184,8 @@
     gap: calc(var(--spacing) * 1);
     align-items: center;
     min-width: 0;
-    padding-left: calc(var(--spacing) * 2);
-    margin-left: auto;
+    padding-inline-start: calc(var(--spacing) * 2);
+    margin-inline-start: auto;
     color: oklch(from currentColor l c h / 0.65);
   }
 
@@ -220,6 +223,10 @@
     &[data-submenu-expanded="true"] > :not([data-submenu]) {
       filter: blur(8px);
       translate: -100% 0;
+    }
+
+    &:dir(rtl)[data-submenu-expanded="true"] > :not([data-submenu]) {
+      translate: 100% 0;
     }
 
     /* WebKit can restart the covered-content transition while the

--- a/packages/skins/src/minimal/css/components/time.css
+++ b/packages/skins/src/minimal/css/components/time.css
@@ -5,12 +5,20 @@
   gap: calc(var(--spacing) * 3);
   align-items: center;
   container: media-time-controls / inline-size;
+
+  &:dir(rtl) {
+    flex-direction: row;
+  }
 }
 
 .media-minimal-skin .media-time-group {
   display: flex;
   gap: calc(var(--spacing) * 1);
   align-items: center;
+
+  &:dir(rtl) {
+    flex-direction: row-reverse;
+  }
 }
 
 .media-minimal-skin .media-time {
@@ -45,6 +53,10 @@
 @container media-root (width > 42rem) {
   .media-minimal-skin .media-time-controls {
     flex-direction: row;
+
+    &:dir(rtl) {
+      flex-direction: row-reverse;
+    }
   }
 
   .media-minimal-skin .media-time--duration,

--- a/packages/skins/src/minimal/tailwind/components/button-group.ts
+++ b/packages/skins/src/minimal/tailwind/components/button-group.ts
@@ -1,1 +1,1 @@
-export const buttonGroup = 'flex items-center gap-px';
+export const buttonGroup = 'flex items-center gap-px [&:dir(rtl)]:flex-row-reverse';

--- a/packages/skins/src/minimal/tailwind/components/controls.ts
+++ b/packages/skins/src/minimal/tailwind/components/controls.ts
@@ -9,7 +9,7 @@ export const controls = cn(
   '[--media-tooltip-side-offset:var(--media-popover-side-offset)]',
   '[--media-popover-boundary-offset:calc(var(--spacing)*(var(--base-boundary-offset,0)+var(--controls-padding,1)))]',
   '[--media-tooltip-boundary-offset:var(--media-popover-boundary-offset)]',
-  '[padding:calc(var(--spacing)*var(--controls-padding,1))] flex items-center',
+  '[padding:calc(var(--spacing)*var(--controls-padding,1))] flex items-center [&:dir(rtl)]:flex-row-reverse',
   // Appearance (driven by CSS variables set on the root)
   'bg-(--controls-background-color)',
   '[backdrop-filter:var(--controls-backdrop-filter)]',

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -3,7 +3,7 @@ import { cn } from '@videojs/utils/style';
 import { popup } from './popup';
 
 const submenuPanel = cn(
-  '[--submenu-translate:100%] rtl:[--submenu-translate:-100%]',
+  '[--submenu-translate:100%] [&:dir(rtl)]:[--submenu-translate:-100%]',
   'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
   'z-10',
   'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
@@ -77,7 +77,7 @@ export const menu = {
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     '[&>:not([data-submenu])]:translate-none [&>:not([data-submenu])]:transition-[translate,filter]',
     '[&>:not([data-submenu])]:duration-(--menu-transition-duration) [&>:not([data-submenu])]:ease-out',
-    '[--submenu-parent-translate:-100%] rtl:[--submenu-parent-translate:100%]',
+    '[--submenu-parent-translate:-100%] [&:dir(rtl)]:[--submenu-parent-translate:100%]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:[translate:var(--submenu-parent-translate)_0]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:blur',
     // Avoid restarting the covered-content transition in WebKit while the
@@ -103,8 +103,8 @@ export const menu = {
   back: cn(itemBase, 'mb-0.5 w-full'),
   hint: 'ms-auto inline-flex min-w-0 items-center gap-1 ps-2 text-current/65',
   hintLabel: 'max-w-24 overflow-hidden text-ellipsis whitespace-nowrap',
-  chevron: 'size-3.5 rtl:[scale:-1_1]',
-  backChevron: 'rtl:[scale:1_1]',
+  chevron: 'size-3.5 [&:dir(rtl)]:[scale:-1_1]',
+  backChevron: '[&:dir(rtl)]:[scale:1_1]',
   settingsGroup: 'group/settings',
   settingsTrigger: 'group',
   settingsIcon: 'transition-transform duration-150 ease-in-out group-aria-expanded:rotate-90 motion-reduce:duration-0',

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -3,18 +3,19 @@ import { cn } from '@videojs/utils/style';
 import { popup } from './popup';
 
 const submenuPanel = cn(
+  '[--submenu-translate:100%] rtl:[--submenu-translate:-100%]',
   'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
   'z-10',
   'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
   'data-starting-style:pointer-events-none data-ending-style:pointer-events-none',
   'data-starting-style:overflow-hidden data-ending-style:overflow-hidden',
-  'data-starting-style:translate-x-full data-ending-style:translate-x-full',
+  'data-starting-style:[translate:var(--submenu-translate)_0] data-ending-style:[translate:var(--submenu-translate)_0]',
   'data-starting-style:blur data-ending-style:blur'
 );
 
 const itemBase = cn(
   'group/menu-item relative flex cursor-pointer select-none items-center gap-1.5 rounded-(--menu-item-border-radius) py-1.5 px-2',
-  'text-left',
+  'text-start',
   'text-shadow-2xs text-shadow-(color:--shadow-current-color)',
   'outline-2 -outline-offset-2 outline-transparent',
   'transition-colors duration-100 ease-in-out',
@@ -76,7 +77,8 @@ export const menu = {
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     '[&>:not([data-submenu])]:translate-none [&>:not([data-submenu])]:transition-[translate,filter]',
     '[&>:not([data-submenu])]:duration-(--menu-transition-duration) [&>:not([data-submenu])]:ease-out',
-    '[&[data-submenu-expanded=true]>:not([data-submenu])]:-translate-x-full',
+    '[--submenu-parent-translate:-100%] rtl:[--submenu-parent-translate:100%]',
+    '[&[data-submenu-expanded=true]>:not([data-submenu])]:[translate:var(--submenu-parent-translate)_0]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:blur',
     // Avoid restarting the covered-content transition in WebKit while the
     // anchor-positioned highlight is active.
@@ -93,15 +95,16 @@ export const menu = {
     'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
   ),
   separator: 'my-1 border-b border-[oklch(1_0_0/0.1)]',
-  tier: 'pl-0.5 pt-px text-(length:--font-size-tiny) font-semibold leading-none text-current/70',
-  indicator: 'ml-auto -mr-1 shrink-0 opacity-0 group-aria-checked/menu-item:opacity-100',
+  tier: 'ps-0.5 pt-px text-(length:--font-size-tiny) font-semibold leading-none text-current/70',
+  indicator: 'ms-auto -me-1 shrink-0 opacity-0 group-aria-checked/menu-item:opacity-100',
   icon: 'shrink-0 text-current/50 drop-shadow-[0_1px_0_var(--shadow-current-color)] group-hover/menu-item:text-inherit group-data-highlighted/menu-item:text-inherit',
   /** Nested submenu panel. */
   submenuPanel,
   back: cn(itemBase, 'mb-0.5 w-full'),
-  hint: 'ml-auto inline-flex min-w-0 items-center gap-1 pl-2 text-current/65',
+  hint: 'ms-auto inline-flex min-w-0 items-center gap-1 ps-2 text-current/65',
   hintLabel: 'max-w-24 overflow-hidden text-ellipsis whitespace-nowrap',
-  chevron: 'size-3.5',
+  chevron: 'size-3.5 rtl:[scale:-1_1]',
+  backChevron: 'rtl:[scale:1_1]',
   settingsGroup: 'group/settings',
   settingsTrigger: 'group',
   settingsIcon: 'transition-transform duration-150 ease-in-out group-aria-expanded:rotate-90 motion-reduce:duration-0',

--- a/packages/skins/src/minimal/tailwind/components/time.ts
+++ b/packages/skins/src/minimal/tailwind/components/time.ts
@@ -1,7 +1,7 @@
 import { cn } from '@videojs/utils/style';
 
 export const time = {
-  group: 'flex items-center gap-1',
+  group: 'flex items-center gap-1 [&:dir(rtl)]:flex-row-reverse',
   current: cn(
     'hidden tabular-nums cursor-pointer rounded-[--spacing(1)] outline-2 outline-transparent -outline-offset-2',
     'transition-[outline-color,outline-offset] duration-100 ease-out',
@@ -13,7 +13,7 @@ export const time = {
   separator: cn('hidden', '@2xl/media-root:inline @2xl/media-root:text-current/60'),
   duration: cn('tabular-nums', '@2xl/media-root:text-current/60'),
   controls: cn(
-    '@container/media-time-controls flex flex-row-reverse items-center flex-1 gap-3',
-    '@2xl/media-root:flex-row'
+    '@container/media-time-controls flex flex-row-reverse items-center flex-1 gap-3 [&:dir(rtl)]:flex-row',
+    '@2xl/media-root:flex-row @2xl/media-root:[&:dir(rtl)]:flex-row-reverse'
   ),
 };

--- a/packages/utils/src/dom/direction.ts
+++ b/packages/utils/src/dom/direction.ts
@@ -1,6 +1,6 @@
 /** Check whether an element's text direction is right-to-left. */
 export function isRTL(element: Element): boolean {
-  const dir = element.closest('[dir]')?.getAttribute('dir');
-  if (dir) return dir.toLowerCase() === 'rtl';
+  const dir = element.closest('[dir]')?.getAttribute('dir')?.toLowerCase();
+  if (dir === 'rtl' || dir === 'ltr') return dir === 'rtl';
   return getComputedStyle(element).direction === 'rtl';
 }

--- a/packages/utils/src/dom/tests/direction.test.ts
+++ b/packages/utils/src/dom/tests/direction.test.ts
@@ -32,4 +32,13 @@ describe('isRTL', () => {
 
     expect(isRTL(el)).toBe(true);
   });
+
+  it.each(['auto', 'invalid'])('uses computed direction for dir="%s"', (dir) => {
+    const el = document.createElement('div');
+    el.setAttribute('dir', dir);
+    el.style.direction = 'rtl';
+    document.body.appendChild(el);
+
+    expect(isRTL(el)).toBe(true);
+  });
 });

--- a/packages/utils/src/i18n/direction.ts
+++ b/packages/utils/src/i18n/direction.ts
@@ -1,0 +1,13 @@
+export type TextDirection = 'ltr' | 'rtl';
+
+const RTL_SCRIPTS = new Set(['Adlm', 'Arab', 'Hebr', 'Mand', 'Mend', 'Nkoo', 'Rohg', 'Samr', 'Syrc', 'Thaa', 'Yezi']);
+
+/** Resolve the writing direction of a BCP 47 locale. */
+export function getTextDirection(locale: string): TextDirection {
+  try {
+    const script = new Intl.Locale(locale).maximize().script;
+    return script && RTL_SCRIPTS.has(script) ? 'rtl' : 'ltr';
+  } catch {
+    return 'ltr';
+  }
+}

--- a/packages/utils/src/i18n/index.ts
+++ b/packages/utils/src/i18n/index.ts
@@ -1,2 +1,4 @@
 /** Default locale used when no player or ambient locale is available. */
 export const DEFAULT_LOCALE = 'en';
+
+export { getTextDirection, type TextDirection } from './direction';

--- a/packages/utils/src/i18n/tests/direction.test.ts
+++ b/packages/utils/src/i18n/tests/direction.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTextDirection } from '../direction';
+
+describe('getTextDirection', () => {
+  it.each(['ar', 'fa-IR', 'he', 'ur', 'ar-Arab'])('returns RTL for %s', (locale) => {
+    expect(getTextDirection(locale)).toBe('rtl');
+  });
+
+  it.each(['en', 'es-MX', 'ja', 'ar-Latn'])('returns LTR for %s', (locale) => {
+    expect(getTextDirection(locale)).toBe('ltr');
+  });
+
+  it('defaults invalid locales to LTR', () => {
+    expect(getTextDirection('not_a_locale')).toBe('ltr');
+  });
+});

--- a/site/src/content/docs/how-to/i18n-switch-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-switch-locale.mdx
@@ -47,6 +47,29 @@ An <DocsLink slug="reference/i18n-provider">`I18nProvider`</DocsLink> without `l
 
 </FrameworkCase>
 
+## Set text direction
+
+`lang` identifies the content language. `dir` controls text and layout direction. Browsers do not infer one from the other, so set both when the locale applies to the whole document:
+
+```ts
+document.documentElement.lang = 'ar';
+document.documentElement.dir = 'rtl';
+```
+
+Set `dir` back to `ltr` when you switch to a left-to-right language. This prevents the previous direction from remaining active.
+
+When React's `locale` is explicit, the player applies its resolved `lang` and `dir` to the container. A `lang` or `dir` passed to that container overrides the rendered DOM boundary only; translations still come from `I18nProvider locale`.
+
+In HTML, `<media-i18n lang>` sets the provider locale and derives its direction. An explicit `dir` on `<media-i18n>` overrides that derived direction.
+
+Providers without an explicit locale inherit ambient document language and direction. In that case, set `lang` and `dir` on `<html>` or another ancestor:
+
+```html
+<html lang="ar" dir="rtl">
+```
+
+RTL mirrors control ordering, menu motion, and navigation chevrons. Time-semantic media icons remain unchanged. Horizontal time and volume sliders retain a physical left-to-right value scale: Left Arrow decreases the value, Right Arrow increases it, and the minimum remains on the left.
+
 ## Explicit provider language
 
 <FrameworkCase frameworks={["react"]}>

--- a/site/src/content/docs/how-to/i18n-switch-locale.mdx
+++ b/site/src/content/docs/how-to/i18n-switch-locale.mdx
@@ -68,7 +68,7 @@ Providers without an explicit locale inherit ambient document language and direc
 <html lang="ar" dir="rtl">
 ```
 
-RTL mirrors control ordering, menu motion, and navigation chevrons. Time-semantic media icons remain unchanged. Horizontal time and volume sliders retain a physical left-to-right value scale: Left Arrow decreases the value, Right Arrow increases it, and the minimum remains on the left.
+RTL preserves playback control ordering and time-semantic media icons while mirroring menu motion and navigation chevrons. Horizontal time and volume sliders retain a physical left-to-right value scale: Left Arrow decreases the value, Right Arrow increases it, and the minimum remains on the left.
 
 ## Explicit provider language
 


### PR DESCRIPTION
## Summary

Add first-class RTL support to HTML and React players so explicit RTL locales set direction consistently while ambient author language and direction remain respected.

Closes #670

## Changes

- Resolve text direction from BCP 47 locales and apply it at player and document boundaries
- Preserve the established physical left-to-right playback control order and horizontal time and volume scales in RTL
- Mirror logical menu layout, submenu motion, and navigation chevrons across Default and Minimal CSS and Tailwind skins
- Resolve logical popover alignment from the trigger direction and isolate user-authored track labels
- Scope Tailwind direction variants to each element's computed direction so explicit nested overrides remain respected
- Keep storyboard sprite cropping physically left-to-right so RTL thumbnail previews show the correct frame
- Add RTL sandbox coverage and document the `lang` and `dir` contract

## Testing

- `pnpm -F @videojs/utils test src/dom/tests/direction.test.ts src/i18n/tests/direction.test.ts`
- `pnpm -F @videojs/core test src/dom/ui/tests/slider.test.ts src/dom/utils/tests/pointer.test.ts src/dom/ui/popover/tests/popover-positioning.test.ts src/dom/ui/popover/tests/popup-positioner.test.ts`
- `pnpm -F @videojs/core test src/core/ui/thumbnail/tests/thumbnail-core.test.ts` (33 passed)
- `pnpm -F @videojs/html test src/i18n/tests/create-i18n.test.ts`
- `pnpm -F @videojs/html test src/ui/slider/tests/slider-thumbnail-element.test.ts` (7 passed)
- `pnpm -F @videojs/react test src/player/tests/context.test.tsx`
- `pnpm -F @videojs/react test src/ui/slider/tests/slider-thumbnail.test.tsx` (8 passed)
- `pnpm -F @videojs/skins check:skins`
- `pnpm --dir apps/sandbox build`
- `pnpm --dir apps/e2e exec playwright test tests/sandbox-html-i18n.spec.ts tests/sandbox-cdn-i18n.spec.ts --project=sandbox-chromium --workers=1` (18 passed)
- `pnpm --dir site astro check` (0 errors)
- Biome and `git diff --check`

The rendered RTL matrix covers HTML and React, CSS and Tailwind, Default and Minimal, audio and video, both Minimal responsive layouts, an explicit LTR player nested inside an RTL document, and physical storyboard sprite cropping in Arabic.

Repository-wide `pnpm typecheck` still reports four pre-existing SPF metadata errors in `capabilities.ts`, `report-track-conditions.ts`, and the HLS adapter; no changed RTL file is implicated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large layout and interaction change across HTML/React players, skins, sliders, and popovers. Not security-critical, but RTL/LTR mismatches can break seeking, menus, and nested direction overrides.
> 
> **Overview**
> Adds first-class RTL support: locales now resolve writing direction, and explicit `lang`/`dir` is applied at HTML (`media-i18n`) and React (`Container`) player boundaries while ambient document direction is still inherited.
> 
> **Playback stays physically LTR.** Control order, time/volume sliders, keyboard arrows, and storyboard thumbnail crops no longer flip in RTL. Popovers resolve `start`/`end` from the trigger direction.
> 
> Skins (Default/Minimal, CSS and Tailwind) mirror menus, submenu motion, and chevrons with logical spacing. Track labels use `<bdi dir="auto">`. Sandbox demos sync `html lang` and `dir`, with e2e coverage and docs for the `lang`/`dir` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1724fd08ada77a2b0abcce6ff81781ff14d5acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->