### PR TITLE
feat(packages): add gif media

### DIFF
--- a/apps/sandbox/app/constants.ts
+++ b/apps/sandbox/app/constants.ts
@@ -23,12 +23,14 @@ export const PRESETS = [
   'spotify-audio',
   'tiktok-video',
   'twitch-video',
+  'gif-video',
 ] as const;
 
 /**
  * Presets that hand playback to a third-party embed. They render one fixed
  * source rather than the source picker's list, and have no Tailwind skin
- * variant, so the navbar disables both controls for them.
+ * variant, so the navbar disables both controls for them. `gif-video` is not
+ * an embed but shares both constraints: it plays one fixed GIF source.
  */
 export const EMBED_PRESETS = [
   'vimeo-video',
@@ -37,4 +39,5 @@ export const EMBED_PRESETS = [
   'spotify-audio',
   'tiktok-video',
   'twitch-video',
+  'gif-video',
 ] as const;

--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -385,6 +385,10 @@ export function withMuxMaxResolution(url: string, maxResolution: string): string
 
 export const VIMEO_VIDEO_SRC = 'https://vimeo.com/648359100';
 
+// Served with permissive CORS headers, which GifMedia needs because it fetches
+// the file to decode frames rather than rendering it through an `<img>`.
+export const GIF_VIDEO_SRC = 'https://image.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA/animated.gif';
+
 export const YOUTUBE_VIDEO_SRC = 'https://www.youtube.com/watch?v=aqz-KE-bpKQ';
 
 export const CLOUDFLARE_VIDEO_SRC = 'https://watch.videodelivery.net/bfbd585059e33391d67b0f1d15fe6ea4';

--- a/apps/sandbox/templates/html-gif-video/index.html
+++ b/apps/sandbox/templates/html-gif-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — HTML GIF Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/html-gif-video/main.ts
+++ b/apps/sandbox/templates/html-gif-video/main.ts
@@ -1,0 +1,32 @@
+import '@app/styles.css';
+import '@videojs/html/video/player';
+import '@videojs/html/media/gif-video';
+import { createHtmlSandboxState, createLatestLoader } from '@app/shared/html/sandbox-state';
+import { loadVideoSkinTag } from '@app/shared/html/skins';
+import { onSkinChange } from '@app/shared/sandbox-listener';
+import { GIF_VIDEO_SRC } from '@app/shared/sources';
+
+const html = String.raw;
+
+const state = createHtmlSandboxState();
+const loadLatest = createLatestLoader();
+
+async function render() {
+  const tag = await loadLatest(() => loadVideoSkinTag(state.skin, state.styling));
+  if (!tag) return;
+
+  document.getElementById('root')!.innerHTML = html`
+    <video-player>
+      <${tag} class="aspect-video max-w-4xl mx-auto">
+        <gif-video class="block w-full h-full" src="${GIF_VIDEO_SRC}" loop></gif-video>
+      </${tag}>
+    </video-player>
+  `;
+}
+
+render();
+
+onSkinChange((skin) => {
+  state.skin = skin;
+  render();
+});

--- a/apps/sandbox/templates/react-gif-video/index.html
+++ b/apps/sandbox/templates/react-gif-video/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox — React GIF Video</title>
+    <link rel="preconnect" href="https://rsms.me/" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+  </head>
+  <body class="font-sans">
+    <div id="root" class="flex justify-center items-center min-h-screen p-2"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/sandbox/templates/react-gif-video/main.tsx
+++ b/apps/sandbox/templates/react-gif-video/main.tsx
@@ -1,0 +1,28 @@
+import '@app/styles.css';
+import { VideoPlayer } from '@app/shared/react/players';
+import { VideoSkinComponent } from '@app/shared/react/skins';
+import { useSkin } from '@app/shared/react/use-skin';
+import { GIF_VIDEO_SRC } from '@app/shared/sources';
+import type { Styling } from '@app/types';
+import { GifVideo } from '@videojs/react/media/gif-video';
+import { useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function readStyling(): Styling {
+  return new URLSearchParams(location.search).get('styling') === 'tailwind' ? 'tailwind' : 'css';
+}
+
+function App() {
+  const skin = useSkin();
+  const styling = useMemo(readStyling, []);
+
+  return (
+    <VideoPlayer>
+      <VideoSkinComponent skin={skin} styling={styling} className="aspect-video max-w-4xl mx-auto">
+        <GifVideo className="block w-full h-full" src={GIF_VIDEO_SRC} loop />
+      </VideoSkinComponent>
+    </VideoPlayer>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/html/src/define/media/gif-video.ts
+++ b/packages/html/src/define/media/gif-video.ts
@@ -1,0 +1,14 @@
+import { GifVideo } from '../../media/gif-video';
+import { safeDefine } from '../safe-define';
+
+export class GifVideoElement extends GifVideo {
+  static readonly tagName = 'gif-video';
+}
+
+safeDefine(GifVideoElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [GifVideoElement.tagName]: GifVideoElement;
+  }
+}

--- a/packages/html/src/media/gif-video/index.ts
+++ b/packages/html/src/media/gif-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/html/src/media/gif-video/media.ts
+++ b/packages/html/src/media/gif-video/media.ts
@@ -1,0 +1,30 @@
+import { CustomMediaElement, VideoCSSVars } from '@videojs/media/dom/custom-media-element';
+import { GifMedia } from '@videojs/media/dom/gif';
+import { MediaAttachMixin } from '../../store/media-attach-mixin';
+
+class GifCustomMediaElement extends CustomMediaElement('canvas', GifMedia) {
+  static override getTemplateHTML = (): string => {
+    return /*html*/ `
+      <style>
+        :host {
+          display: contents;
+        }
+
+        canvas {
+          display: block;
+          width: 100%;
+          height: 100%;
+          border-radius: var(${VideoCSSVars.borderRadius});
+          object-fit: var(${VideoCSSVars.objectFit}, contain);
+          object-position: var(${VideoCSSVars.objectPosition}, center);
+        }
+      </style>
+      <slot name="media">
+        <canvas part="canvas"></canvas>
+      </slot>
+      <slot></slot>
+    `;
+  };
+}
+
+export class GifVideo extends MediaAttachMixin(GifCustomMediaElement) {}

--- a/packages/html/src/media/tests/gif-video.test.ts
+++ b/packages/html/src/media/tests/gif-video.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GifVideo } from '../gif-video/media';
+
+let tagCounter = 0;
+
+function defineGifVideo(): string {
+  const tag = `test-gif-video-${tagCounter++}`;
+  customElements.define(tag, class extends GifVideo {});
+  return tag;
+}
+
+beforeEach(() => {
+  // Keep the fetch a `src` kicks off pending; these tests cover the element
+  // wiring, not the decode pipeline.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise<never>(() => {}))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GifVideo', () => {
+  it('renders a canvas into the shadow root', () => {
+    const tag = defineGifVideo();
+    const element = document.createElement(tag);
+
+    const canvas = element.shadowRoot?.querySelector('canvas');
+    expect(canvas).not.toBe(null);
+    expect(canvas?.getAttribute('part')).toBe('canvas');
+  });
+
+  it('forwards src to the media host and starts a fetch', () => {
+    const tag = defineGifVideo();
+    const element = document.createElement(tag) as HTMLElement & { src: string };
+
+    element.setAttribute('src', 'https://example.com/animated.gif');
+
+    expect(element.src).toBe('https://example.com/animated.gif');
+    expect(fetch).toHaveBeenCalledWith('https://example.com/animated.gif', expect.anything());
+  });
+
+  it('exposes the media surface through the element', () => {
+    const tag = defineGifVideo();
+    const element = document.createElement(tag) as HTMLElement & {
+      paused: boolean;
+      canPlayType: (type: string) => string;
+    };
+
+    expect(element.paused).toBe(true);
+    expect(element.canPlayType('image/gif')).toBe('probably');
+    expect(element.canPlayType('video/mp4')).toBe('');
+  });
+});

--- a/packages/html/vjsc/entries.generated.ts
+++ b/packages/html/vjsc/entries.generated.ts
@@ -143,6 +143,14 @@ export const Gesture = {
   },
 } as const;
 
+export const GifVideo = {
+  tagName: 'gif-video',
+  import: {
+    from: '@videojs/html/media/gif-video',
+    sideEffect: true,
+  },
+} as const;
+
 export const HlsAudio = {
   tagName: 'hls-audio',
   import: {
@@ -551,6 +559,14 @@ export const TimeSliderChapterTitle = {
   },
 } as const;
 
+export const Title = {
+  tagName: 'media-title',
+  import: {
+    from: '@videojs/html/ui/title',
+    sideEffect: true,
+  },
+} as const;
+
 export const Tooltip = {
   tagName: 'media-tooltip',
   import: {
@@ -658,6 +674,7 @@ export const entries = {
   ErrorDialog,
   FullscreenButton,
   Gesture,
+  GifVideo,
   HlsAudio,
   HlsBackgroundVideo,
   HlsJsVideo,
@@ -709,6 +726,7 @@ export const entries = {
   TimeSlider,
   TimeSliderChapters,
   TimeSliderChapterTitle,
+  Title,
   Tooltip,
   TooltipGroup,
   TooltipLabel,

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -56,6 +56,7 @@
     "@videojs/utils": "workspace:*",
     "@vimeo/player": "^2.30.3",
     "dashjs": "^5.2.0",
+    "gifuct-js": "^2.1.2",
     "hls.js": "^1.6.7",
     "mux-embed": "^5.17.10",
     "shaka-player": "^5.2.4"

--- a/packages/media/src/dom/gif/frame-source.ts
+++ b/packages/media/src/dom/gif/frame-source.ts
@@ -1,0 +1,30 @@
+// Browsers snap near-zero GIF frame delays (0 or 1 hundredths of a second) up
+// to 100ms rather than spinning; delays land here already converted to ms.
+const MIN_FRAME_DELAY_MS = 20;
+const SNAPPED_FRAME_DELAY_MS = 100;
+
+/** Normalize a raw GIF frame delay in ms the way browsers render it. */
+export function normalizeFrameDelay(delayMs: number): number {
+  return delayMs < MIN_FRAME_DELAY_MS ? SNAPPED_FRAME_DELAY_MS : delayMs;
+}
+
+/**
+ * A decoded GIF ready for playback: a fixed timing table plus a way to paint
+ * any fully composited frame. `GifMedia` owns the clock and playback state;
+ * a frame source owns decoding and frame compositing, so decoder backends
+ * (WebCodecs `ImageDecoder`, JS polyfill) stay swappable behind it.
+ */
+export interface GifFrameSource {
+  readonly width: number;
+  readonly height: number;
+  readonly frameCount: number;
+  /** Per-frame delay in ms, already normalized via `normalizeFrameDelay`. */
+  readonly delays: readonly number[];
+  /**
+   * Paint the fully composited frame `index` onto `ctx`. Backends that decode
+   * on demand resolve asynchronously and discard a draw once a newer one has
+   * been requested, so callers can fire and forget.
+   */
+  drawFrame(ctx: CanvasRenderingContext2D, index: number): void | Promise<void>;
+  destroy(): void;
+}

--- a/packages/media/src/dom/gif/gifuct-source.ts
+++ b/packages/media/src/dom/gif/gifuct-source.ts
@@ -1,0 +1,107 @@
+import type { ParsedFrame } from 'gifuct-js';
+import { decompressFrames, parseGIF } from 'gifuct-js';
+import type { GifFrameSource } from './frame-source';
+import { normalizeFrameDelay } from './frame-source';
+
+/**
+ * JS polyfill backend for `GifFrameSource`, used where WebCodecs
+ * `ImageDecoder` cannot decode GIFs. Decodes every frame to RGBA up front and
+ * composites the GIF's frame deltas onto an offscreen canvas.
+ */
+export function createGifuctSource(buffer: ArrayBuffer): GifFrameSource {
+  const gif = parseGIF(buffer);
+  const frames = decompressFrames(gif, true);
+  if (frames.length === 0) throw new Error('GIF contains no frames.');
+  return new GifuctSource(gif.lsd.width, gif.lsd.height, frames);
+}
+
+class GifuctSource implements GifFrameSource {
+  readonly width: number;
+  readonly height: number;
+  readonly delays: readonly number[];
+
+  #frames: ParsedFrame[];
+  #composite: HTMLCanvasElement | null = null;
+  #compositeCtx: CanvasRenderingContext2D | null = null;
+  #patchCanvas: HTMLCanvasElement | null = null;
+  /** Index of the frame currently composited offscreen, -1 when blank. */
+  #compositedIndex = -1;
+
+  constructor(width: number, height: number, frames: ParsedFrame[]) {
+    this.width = width;
+    this.height = height;
+    this.#frames = frames;
+    this.delays = frames.map((frame) => normalizeFrameDelay(frame.delay ?? 0));
+  }
+
+  get frameCount(): number {
+    return this.#frames.length;
+  }
+
+  drawFrame(ctx: CanvasRenderingContext2D, index: number): void {
+    const composite = this.#compositeUpTo(index);
+    if (!composite) return;
+    ctx.clearRect(0, 0, this.width, this.height);
+    ctx.drawImage(composite, 0, 0);
+  }
+
+  destroy(): void {
+    this.#frames = [];
+    this.#composite = null;
+    this.#compositeCtx = null;
+    this.#patchCanvas = null;
+    this.#compositedIndex = -1;
+  }
+
+  /**
+   * Composite the offscreen canvas forward to `index`. GIF frames are deltas
+   * over the previous state, so a backward jump clears and replays from frame
+   * 0; a forward jump applies only the frames in between.
+   */
+  #compositeUpTo(index: number): HTMLCanvasElement | null {
+    if (!this.#composite) {
+      // Canvas-less environments (jsdom) yield no context; drawing is skipped.
+      const canvas = globalThis.document?.createElement('canvas');
+      const ctx = canvas?.getContext('2d') ?? null;
+      if (!canvas || !ctx) return null;
+      canvas.width = this.width;
+      canvas.height = this.height;
+      this.#composite = canvas;
+      this.#compositeCtx = ctx;
+    }
+    const ctx = this.#compositeCtx!;
+
+    let from = this.#compositedIndex + 1;
+    if (index < this.#compositedIndex) {
+      ctx.clearRect(0, 0, this.width, this.height);
+      from = 0;
+    }
+    for (let i = from; i <= index; i++) {
+      this.#applyFrame(ctx, i);
+    }
+    this.#compositedIndex = index;
+    return this.#composite;
+  }
+
+  #applyFrame(ctx: CanvasRenderingContext2D, index: number): void {
+    const frame = this.#frames[index]!;
+    const previous = index > 0 ? this.#frames[index - 1]! : null;
+
+    // Disposal 2 restores the previous frame's region to background (treated
+    // as transparent, like browsers do); 3 (restore-previous) is rare and
+    // approximated the same way.
+    if (previous && previous.disposalType >= 2) {
+      const { left, top, width, height } = previous.dims;
+      ctx.clearRect(left, top, width, height);
+    }
+
+    const { left, top, width, height } = frame.dims;
+    const patchCanvas = (this.#patchCanvas ??= globalThis.document?.createElement('canvas'));
+    const patchCtx = patchCanvas?.getContext('2d');
+    if (!patchCanvas || !patchCtx) return;
+    patchCanvas.width = width;
+    patchCanvas.height = height;
+    patchCtx.putImageData(new ImageData(new Uint8ClampedArray(frame.patch), width, height), 0, 0);
+    ctx.drawImage(patchCanvas, left, top);
+  }
+}

--- a/packages/media/src/dom/gif/image-decoder-source.ts
+++ b/packages/media/src/dom/gif/image-decoder-source.ts
@@ -1,0 +1,132 @@
+import type { GifFrameSource } from './frame-source';
+import { normalizeFrameDelay } from './frame-source';
+
+// Minimal WebCodecs image-decode surface; TypeScript's dom lib does not ship
+// `ImageDecoder` yet, so these mirror just the members used here.
+interface ImageDecodeResult {
+  image: VideoFrame;
+}
+
+interface ImageTrack {
+  frameCount: number;
+}
+
+interface ImageTrackList {
+  ready: Promise<void>;
+  selectedTrack: ImageTrack | null;
+}
+
+interface NativeImageDecoder {
+  readonly tracks: ImageTrackList;
+  readonly completed: Promise<void>;
+  decode(options?: { frameIndex?: number }): Promise<ImageDecodeResult>;
+  close(): void;
+}
+
+interface ImageDecoderConstructor {
+  new (init: { data: BufferSource; type: string }): NativeImageDecoder;
+  isTypeSupported(type: string): Promise<boolean>;
+}
+
+const GIF_MIME_TYPE = 'image/gif';
+
+function nativeImageDecoder(): ImageDecoderConstructor | undefined {
+  return (globalThis as { ImageDecoder?: ImageDecoderConstructor }).ImageDecoder;
+}
+
+export async function isImageDecoderSupported(): Promise<boolean> {
+  const ImageDecoder = nativeImageDecoder();
+  if (!ImageDecoder) return false;
+  try {
+    return await ImageDecoder.isTypeSupported(GIF_MIME_TYPE);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * WebCodecs backend for `GifFrameSource`. The browser's decoder owns frame
+ * disposal and compositing, and frames re-decode on demand during playback
+ * instead of living in memory as RGBA for the life of the media. Only the
+ * timing table is walked up front, closing each frame as its duration is
+ * collected, since durations surface per decoded frame.
+ */
+export async function createImageDecoderSource(buffer: ArrayBuffer): Promise<GifFrameSource> {
+  const ImageDecoder = nativeImageDecoder();
+  if (!ImageDecoder) throw new Error('ImageDecoder is not available.');
+
+  const decoder = new ImageDecoder({ data: buffer, type: GIF_MIME_TYPE });
+  try {
+    await decoder.tracks.ready;
+    await decoder.completed;
+    const frameCount = decoder.tracks.selectedTrack?.frameCount ?? 0;
+    if (frameCount === 0) throw new Error('GIF contains no frames.');
+
+    const delays: number[] = [];
+    let width = 0;
+    let height = 0;
+    for (let i = 0; i < frameCount; i++) {
+      const { image } = await decoder.decode({ frameIndex: i });
+      if (i === 0) {
+        width = image.displayWidth;
+        height = image.displayHeight;
+      }
+      // VideoFrame durations are in microseconds.
+      delays.push(normalizeFrameDelay((image.duration ?? 0) / 1000));
+      image.close();
+    }
+    return new ImageDecoderSource(decoder, width, height, delays);
+  } catch (cause) {
+    decoder.close();
+    throw cause;
+  }
+}
+
+class ImageDecoderSource implements GifFrameSource {
+  readonly width: number;
+  readonly height: number;
+  readonly delays: readonly number[];
+
+  #decoder: NativeImageDecoder;
+  /** Monotonic draw ticket; a decode that is no longer the newest is discarded. */
+  #drawSeq = 0;
+
+  constructor(decoder: NativeImageDecoder, width: number, height: number, delays: readonly number[]) {
+    this.#decoder = decoder;
+    this.width = width;
+    this.height = height;
+    this.delays = delays;
+  }
+
+  get frameCount(): number {
+    return this.delays.length;
+  }
+
+  async drawFrame(ctx: CanvasRenderingContext2D, index: number): Promise<void> {
+    const seq = ++this.#drawSeq;
+    let image: VideoFrame;
+    try {
+      ({ image } = await this.#decoder.decode({ frameIndex: index }));
+    } catch {
+      // The decoder was closed mid-flight or the frame failed; skip the paint.
+      return;
+    }
+    if (seq !== this.#drawSeq) {
+      image.close();
+      return;
+    }
+    // Decoded frames carry the GIF's transparency, so clear before painting.
+    ctx.clearRect(0, 0, this.width, this.height);
+    ctx.drawImage(image, 0, 0);
+    image.close();
+  }
+
+  destroy(): void {
+    this.#drawSeq += 1;
+    try {
+      this.#decoder.close();
+    } catch {
+      // Already closed.
+    }
+  }
+}

--- a/packages/media/src/dom/gif/index.ts
+++ b/packages/media/src/dom/gif/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/media/src/dom/gif/media.ts
+++ b/packages/media/src/dom/gif/media.ts
@@ -1,11 +1,11 @@
 import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
-import type { ParsedFrame, ParsedGif } from 'gifuct-js';
-import { decompressFrames, parseGIF } from 'gifuct-js';
 import { EMPTY_TIME_RANGES } from '../../core/constants';
 import { MediaError } from '../../core/media-error';
 import type { CanPlayTypeResult, ErrorLike, MediaPreloadType, Video } from '../../core/types';
 import { MediaPlayedRangesMixin } from '../media-played-ranges';
 import { createTimeRange } from '../utils';
+import type { GifFrameSource } from './frame-source';
+import { createImageDecoderSource, isImageDecoderSupported } from './image-decoder-source';
 
 export interface GifMediaProps {
   src: string;
@@ -25,11 +25,6 @@ export const gifMediaDefaultProps: GifMediaProps = {
   playbackRate: 1,
 };
 
-// Browsers snap near-zero GIF frame delays (0 or 1 hundredths of a second) up
-// to 100ms rather than spinning; delays land here already converted to ms.
-const MIN_FRAME_DELAY_MS = 20;
-const SNAPPED_FRAME_DELAY_MS = 100;
-
 // Native media fires `timeupdate` every 250ms or so; GIF frames can be far
 // shorter, so advancing frames re-dispatches only after this much media time.
 const TIMEUPDATE_INTERVAL_MS = 250;
@@ -37,12 +32,27 @@ const TIMEUPDATE_INTERVAL_MS = 250;
 const READY_STATE_HAVE_NOTHING = 0;
 const READY_STATE_HAVE_ENOUGH_DATA = 4;
 
+/**
+ * Decode a fetched GIF into a frame source, preferring the browser's own
+ * WebCodecs `ImageDecoder`. The JS decoder is the polyfill, pulled in only
+ * where WebCodecs can't decode GIFs so the native path never ships it.
+ */
+async function createFrameSource(buffer: ArrayBuffer): Promise<GifFrameSource> {
+  if (await isImageDecoderSupported()) {
+    return createImageDecoderSource(buffer);
+  }
+  const { createGifuctSource } = await import('./gifuct-source');
+  return createGifuctSource(buffer);
+}
+
 const GifMediaBase = MediaPlayedRangesMixin(EventTarget);
 
 /**
- * Plays an animated GIF like a video: decodes its frames once and drives a
+ * Plays an animated GIF like a video: decodes its frames and drives a
  * `<canvas>` with its own clock, so playback can actually pause, seek, loop
  * on demand, and change rate — none of which an `<img>` rendering allows.
+ * Decoding uses WebCodecs `ImageDecoder` where available and falls back to a
+ * lazily-loaded JS decoder (gifuct-js) elsewhere.
  *
  * GIFs carry no audio, so the media exposes no volume or mute surface, and
  * fetching happens with `fetch()`, so the source must be same-origin or served
@@ -50,7 +60,6 @@ const GifMediaBase = MediaPlayedRangesMixin(EventTarget);
  */
 export class GifMedia extends GifMediaBase implements Partial<Video> {
   #canvas: HTMLCanvasElement | null = null;
-  #patchCanvas: HTMLCanvasElement | null = null;
 
   #src = gifMediaDefaultProps.src;
   #autoplay = gifMediaDefaultProps.autoplay;
@@ -60,10 +69,9 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   #playbackRate = gifMediaDefaultProps.playbackRate;
   #defaultPlaybackRate = gifMediaDefaultProps.playbackRate;
 
-  #gif: ParsedGif | null = null;
-  #frames: ParsedFrame[] = [];
+  #source: GifFrameSource | null = null;
   /** Per-frame delay in ms, normalized the way browsers render it. */
-  #delays: number[] = [];
+  #delays: readonly number[] = [];
   /** Cumulative start time of each frame in ms; one extra entry holds the total. */
   #starts: number[] = [0];
 
@@ -74,7 +82,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   #error: ErrorLike | null = null;
 
   #frameIndex = 0;
-  /** Index of the frame currently composited on the canvas, -1 when blank. */
+  /** Index of the last frame handed to the source to paint, -1 when none. */
   #renderedIndex = -1;
   /** Media time already spent inside the current frame, in ms. */
   #frameElapsed = 0;
@@ -101,17 +109,16 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     if (!target || this.#canvas === target) return;
     if (this.#canvas) this.detach();
     this.#canvas = target;
-    if (this.#gif) {
+    if (this.#source) {
       this.#sizeCanvas();
       this.#renderedIndex = -1;
-      this.#renderUpTo(this.#frameIndex);
+      this.#render(this.#frameIndex);
     }
   }
 
   detach(): void {
     if (!this.#canvas) return;
     this.#canvas = null;
-    this.#patchCanvas = null;
     this.#renderedIndex = -1;
   }
 
@@ -120,6 +127,8 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     this.#abort?.abort();
     this.#abort = null;
     this.#loadComplete?.resolve();
+    this.#source?.destroy();
+    this.#source = null;
     this.detach();
     super.destroy();
   }
@@ -135,7 +144,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   }
 
   get currentSrc(): string {
-    return this.#gif ? this.#src : '';
+    return this.#source ? this.#src : '';
   }
 
   get readyState(): number {
@@ -166,7 +175,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     this.#abort = null;
     this.#stopClock();
 
-    const hadData = this.#gif !== null;
+    const hadData = this.#source !== null;
     // A seek queued before any metadata is a start position for this load; one
     // left over from a previous source is not.
     const pendingSeek = hadData ? null : this.#pendingSeek;
@@ -202,23 +211,22 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     }
     if (abort !== this.#abort) return;
 
-    let gif: ParsedGif;
-    let frames: ParsedFrame[];
+    let source: GifFrameSource;
     try {
-      gif = parseGIF(buffer);
-      frames = decompressFrames(gif, true);
-      if (frames.length === 0) throw new Error('No frames');
+      source = await createFrameSource(buffer);
     } catch {
+      if (abort !== this.#abort) return;
       this.#fail(new MediaError('Failed to decode GIF.', MediaError.MEDIA_ERR_DECODE));
       return;
     }
+    if (abort !== this.#abort) {
+      // A newer load superseded this one while the decoder was working.
+      source.destroy();
+      return;
+    }
 
-    this.#gif = gif;
-    this.#frames = frames;
-    this.#delays = frames.map((frame) => {
-      const delay = frame.delay ?? 0;
-      return delay < MIN_FRAME_DELAY_MS ? SNAPPED_FRAME_DELAY_MS : delay;
-    });
+    this.#source = source;
+    this.#delays = source.delays;
     this.#starts = [0];
     for (const delay of this.#delays) {
       this.#starts.push(this.#starts[this.#starts.length - 1]! + delay);
@@ -236,7 +244,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     }
 
     this.#sizeCanvas();
-    this.#renderUpTo(this.#frameIndex);
+    this.#render(this.#frameIndex);
 
     this.dispatchEvent(new Event('loadeddata'));
     this.dispatchEvent(new Event('canplay'));
@@ -287,7 +295,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     this.#ended = false;
     if (wasPaused) this.dispatchEvent(new Event('play'));
 
-    if (!this.#gif) {
+    if (!this.#source) {
       if (!this.#abort) void this.#fetchAndDecode();
       await (this.#loadComplete ??= createPublicPromise<void>());
       if (this.#error) {
@@ -311,7 +319,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   }
 
   get currentTime(): number {
-    if (this.#frames.length === 0) return this.#pendingSeek ?? 0;
+    if (this.#frameCount === 0) return this.#pendingSeek ?? 0;
     let elapsed = this.#frameElapsed;
     if (!this.#paused && this.#timer !== null) {
       elapsed += (performance.now() - this.#frameClock) * this.#playbackRate;
@@ -320,7 +328,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     return Math.min(start + elapsed, this.#totalMs) / 1000;
   }
   set currentTime(value: number) {
-    if (this.#frames.length === 0) {
+    if (this.#frameCount === 0) {
       // No frame table to land on yet; applied once metadata arrives.
       this.#pendingSeek = value;
       return;
@@ -335,8 +343,8 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
 
   #seekTo(seconds: number): void {
     const ms = Math.min(Math.max(seconds * 1000, 0), this.#totalMs);
-    let index = this.#frames.length - 1;
-    for (let i = 0; i < this.#frames.length; i++) {
+    let index = this.#frameCount - 1;
+    for (let i = 0; i < this.#frameCount; i++) {
       if (ms < this.#starts[i + 1]!) {
         index = i;
         break;
@@ -345,16 +353,20 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     this.#frameIndex = index;
     this.#frameElapsed = ms - this.#starts[index]!;
     if (this.#ended && ms < this.#totalMs) this.#ended = false;
-    this.#renderUpTo(index);
+    this.#render(index);
     if (!this.#paused) this.#startClock();
   }
 
   get duration(): number {
-    return this.#frames.length > 0 ? this.#totalMs / 1000 : Number.NaN;
+    return this.#frameCount > 0 ? this.#totalMs / 1000 : Number.NaN;
+  }
+
+  get #frameCount(): number {
+    return this.#delays.length;
   }
 
   get #totalMs(): number {
-    return this.#starts[this.#frames.length] ?? 0;
+    return this.#starts[this.#frameCount] ?? 0;
   }
 
   get autoplay(): boolean {
@@ -362,7 +374,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   }
   set autoplay(value: boolean) {
     this.#autoplay = value;
-    if (value && this.#paused && this.#gif) void this.play();
+    if (value && this.#paused && this.#source) void this.play();
   }
 
   get loop(): boolean {
@@ -380,7 +392,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     // Bank time spent at the old rate before the new one changes the clock's scale.
     this.#syncElapsed();
     this.#playbackRate = value;
-    if (!this.#paused && this.#gif) this.#startClock();
+    if (!this.#paused && this.#source) this.#startClock();
     this.dispatchEvent(new Event('ratechange'));
   }
 
@@ -393,11 +405,11 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
 
   get buffered() {
     // The whole file decodes up front, so once loaded everything is buffered.
-    return this.#frames.length > 0 ? createTimeRange(0, this.duration) : EMPTY_TIME_RANGES;
+    return this.#frameCount > 0 ? createTimeRange(0, this.duration) : EMPTY_TIME_RANGES;
   }
 
   get seekable() {
-    return this.#frames.length > 0 ? createTimeRange(0, this.duration) : EMPTY_TIME_RANGES;
+    return this.#frameCount > 0 ? createTimeRange(0, this.duration) : EMPTY_TIME_RANGES;
   }
 
   get error(): ErrorLike | null {
@@ -405,16 +417,16 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   }
 
   get videoWidth(): number {
-    return this.#gif?.lsd.width ?? 0;
+    return this.#source?.width ?? 0;
   }
 
   get videoHeight(): number {
-    return this.#gif?.lsd.height ?? 0;
+    return this.#source?.height ?? 0;
   }
 
   #resetState(): void {
-    this.#gif = null;
-    this.#frames = [];
+    this.#source?.destroy();
+    this.#source = null;
     this.#delays = [];
     this.#starts = [0];
     this.#frameIndex = 0;
@@ -445,7 +457,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
 
   #startClock(): void {
     this.#stopClock();
-    if (this.#frames.length === 0) return;
+    if (this.#frameCount === 0) return;
     const remaining = this.#delays[this.#frameIndex]! - this.#frameElapsed;
     this.#frameClock = performance.now();
     this.#timer = setTimeout(this.#advance, Math.max(remaining / this.#playbackRate, 0));
@@ -461,10 +473,10 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     this.#timer = null;
     this.#frameElapsed = 0;
 
-    if (this.#frameIndex + 1 >= this.#frames.length) {
+    if (this.#frameIndex + 1 >= this.#frameCount) {
       if (this.#loop) {
         this.#frameIndex = 0;
-        this.#renderUpTo(0);
+        this.#render(0);
         this.#maybeTimeupdate();
         this.#startClock();
         return;
@@ -479,7 +491,7 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
     }
 
     this.#frameIndex += 1;
-    this.#renderUpTo(this.#frameIndex);
+    this.#render(this.#frameIndex);
     this.#maybeTimeupdate();
     this.#startClock();
   };
@@ -500,55 +512,24 @@ export class GifMedia extends GifMediaBase implements Partial<Video> {
   // ----------------------------------------
 
   #sizeCanvas(): void {
-    const gif = this.#gif;
+    const source = this.#source;
     const canvas = this.#canvas;
-    if (!gif || !canvas) return;
-    canvas.width = gif.lsd.width;
-    canvas.height = gif.lsd.height;
+    if (!source || !canvas) return;
+    canvas.width = source.width;
+    canvas.height = source.height;
   }
 
-  /**
-   * Composite the canvas forward to `index`. GIF frames are deltas over the
-   * previous state, so a backward jump clears and replays from frame 0; a
-   * forward jump draws only the frames in between.
-   */
-  #renderUpTo(index: number): void {
+  /** Ask the source to paint frame `index`; the clock never waits on a paint. */
+  #render(index: number): void {
     const canvas = this.#canvas;
-    if (!canvas || this.#frames.length === 0) return;
+    const source = this.#source;
+    if (!canvas || !source || index === this.#renderedIndex) return;
     // jsdom (and canvas-less environments) return null; playback state still advances.
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
-
-    let from = this.#renderedIndex + 1;
-    if (index < this.#renderedIndex) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      from = 0;
-    }
-    for (let i = from; i <= index; i++) {
-      this.#drawFrame(ctx, i);
-    }
     this.#renderedIndex = index;
-  }
-
-  #drawFrame(ctx: CanvasRenderingContext2D, index: number): void {
-    const frame = this.#frames[index]!;
-    const previous = index > 0 ? this.#frames[index - 1]! : null;
-
-    // Disposal 2 restores the previous frame's region to background (treated
-    // as transparent, like browsers do); 3 (restore-previous) is rare and
-    // approximated the same way.
-    if (previous && previous.disposalType >= 2) {
-      const { left, top, width, height } = previous.dims;
-      ctx.clearRect(left, top, width, height);
-    }
-
-    const { left, top, width, height } = frame.dims;
-    const patchCanvas = (this.#patchCanvas ??= globalThis.document?.createElement('canvas'));
-    const patchCtx = patchCanvas?.getContext('2d');
-    if (!patchCanvas || !patchCtx) return;
-    patchCanvas.width = width;
-    patchCanvas.height = height;
-    patchCtx.putImageData(new ImageData(new Uint8ClampedArray(frame.patch), width, height), 0, 0);
-    ctx.drawImage(patchCanvas, left, top);
+    // An on-demand backend paints asynchronously and discards stale draws
+    // itself, so a late frame never overwrites a newer one.
+    void source.drawFrame(ctx, index);
   }
 }

--- a/packages/media/src/dom/gif/media.ts
+++ b/packages/media/src/dom/gif/media.ts
@@ -1,0 +1,554 @@
+import { createPublicPromise, type PublicPromise } from '@videojs/utils/function';
+import type { ParsedFrame, ParsedGif } from 'gifuct-js';
+import { decompressFrames, parseGIF } from 'gifuct-js';
+import { EMPTY_TIME_RANGES } from '../../core/constants';
+import { MediaError } from '../../core/media-error';
+import type { CanPlayTypeResult, ErrorLike, MediaPreloadType, Video } from '../../core/types';
+import { MediaPlayedRangesMixin } from '../media-played-ranges';
+import { createTimeRange } from '../utils';
+
+export interface GifMediaProps {
+  src: string;
+  autoplay: boolean;
+  loop: boolean;
+  preload: MediaPreloadType;
+  crossOrigin: string | null;
+  playbackRate: number;
+}
+
+export const gifMediaDefaultProps: GifMediaProps = {
+  src: '',
+  autoplay: false,
+  loop: false,
+  preload: 'metadata',
+  crossOrigin: null,
+  playbackRate: 1,
+};
+
+// Browsers snap near-zero GIF frame delays (0 or 1 hundredths of a second) up
+// to 100ms rather than spinning; delays land here already converted to ms.
+const MIN_FRAME_DELAY_MS = 20;
+const SNAPPED_FRAME_DELAY_MS = 100;
+
+// Native media fires `timeupdate` every 250ms or so; GIF frames can be far
+// shorter, so advancing frames re-dispatches only after this much media time.
+const TIMEUPDATE_INTERVAL_MS = 250;
+
+const READY_STATE_HAVE_NOTHING = 0;
+const READY_STATE_HAVE_ENOUGH_DATA = 4;
+
+const GifMediaBase = MediaPlayedRangesMixin(EventTarget);
+
+/**
+ * Plays an animated GIF like a video: decodes its frames once and drives a
+ * `<canvas>` with its own clock, so playback can actually pause, seek, loop
+ * on demand, and change rate — none of which an `<img>` rendering allows.
+ *
+ * GIFs carry no audio, so the media exposes no volume or mute surface, and
+ * fetching happens with `fetch()`, so the source must be same-origin or served
+ * with CORS headers.
+ */
+export class GifMedia extends GifMediaBase implements Partial<Video> {
+  #canvas: HTMLCanvasElement | null = null;
+  #patchCanvas: HTMLCanvasElement | null = null;
+
+  #src = gifMediaDefaultProps.src;
+  #autoplay = gifMediaDefaultProps.autoplay;
+  #loop = gifMediaDefaultProps.loop;
+  #preload = gifMediaDefaultProps.preload;
+  #crossOrigin = gifMediaDefaultProps.crossOrigin;
+  #playbackRate = gifMediaDefaultProps.playbackRate;
+  #defaultPlaybackRate = gifMediaDefaultProps.playbackRate;
+
+  #gif: ParsedGif | null = null;
+  #frames: ParsedFrame[] = [];
+  /** Per-frame delay in ms, normalized the way browsers render it. */
+  #delays: number[] = [];
+  /** Cumulative start time of each frame in ms; one extra entry holds the total. */
+  #starts: number[] = [0];
+
+  #paused = true;
+  #ended = false;
+  #seeking = false;
+  #readyState: number = READY_STATE_HAVE_NOTHING;
+  #error: ErrorLike | null = null;
+
+  #frameIndex = 0;
+  /** Index of the frame currently composited on the canvas, -1 when blank. */
+  #renderedIndex = -1;
+  /** Media time already spent inside the current frame, in ms. */
+  #frameElapsed = 0;
+  /** Wall-clock timestamp of the last schedule, for measuring elapsed time. */
+  #frameClock = 0;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #lastTimeupdate = 0;
+  #pendingSeek: number | null = null;
+
+  #abort: AbortController | null = null;
+  #loadComplete: PublicPromise<void> | null = null;
+
+  /** GIF playback is self-driven, so there is no third-party engine underneath. */
+  get engine(): null {
+    return null;
+  }
+
+  get target(): HTMLCanvasElement | null {
+    return this.#canvas;
+  }
+
+  /** Bind the canvas the frames render into. Playback state survives detach; only drawing stops. */
+  attach(target: HTMLCanvasElement | null): void {
+    if (!target || this.#canvas === target) return;
+    if (this.#canvas) this.detach();
+    this.#canvas = target;
+    if (this.#gif) {
+      this.#sizeCanvas();
+      this.#renderedIndex = -1;
+      this.#renderUpTo(this.#frameIndex);
+    }
+  }
+
+  detach(): void {
+    if (!this.#canvas) return;
+    this.#canvas = null;
+    this.#patchCanvas = null;
+    this.#renderedIndex = -1;
+  }
+
+  override destroy(): void {
+    this.#stopClock();
+    this.#abort?.abort();
+    this.#abort = null;
+    this.#loadComplete?.resolve();
+    this.detach();
+    super.destroy();
+  }
+
+  get src(): string {
+    return this.#src;
+  }
+  /** Setting a source resets playback and fetches it, unless `preload` is `'none'` and `autoplay` is off. */
+  set src(value: string) {
+    if (this.#src === value) return;
+    this.#src = value;
+    void this.load();
+  }
+
+  get currentSrc(): string {
+    return this.#gif ? this.#src : '';
+  }
+
+  get readyState(): number {
+    return this.#readyState;
+  }
+
+  get preload(): MediaPreloadType {
+    return this.#preload;
+  }
+  set preload(value: MediaPreloadType) {
+    this.#preload = value;
+  }
+
+  get crossOrigin(): string | null {
+    return this.#crossOrigin;
+  }
+  set crossOrigin(value: string | null) {
+    this.#crossOrigin = value;
+  }
+
+  canPlayType(type: string): CanPlayTypeResult {
+    return /^image\/gif\s*(;|$)/i.test(type) ? 'probably' : '';
+  }
+
+  /** Reset playback and fetch the current source, honoring `preload: 'none'` until playback demands data. */
+  async load(): Promise<void> {
+    this.#abort?.abort();
+    this.#abort = null;
+    this.#stopClock();
+
+    const hadData = this.#gif !== null;
+    // A seek queued before any metadata is a start position for this load; one
+    // left over from a previous source is not.
+    const pendingSeek = hadData ? null : this.#pendingSeek;
+    this.#resetState();
+    this.#pendingSeek = pendingSeek;
+    if (hadData) this.dispatchEvent(new Event('emptied'));
+    if (!this.#src) return;
+
+    if (this.#preload === 'none' && !this.#autoplay) return;
+    await this.#fetchAndDecode();
+  }
+
+  async #fetchAndDecode(): Promise<void> {
+    const abort = new AbortController();
+    this.#abort = abort;
+    const loadComplete = (this.#loadComplete ??= createPublicPromise<void>());
+    this.dispatchEvent(new Event('loadstart'));
+
+    let buffer: ArrayBuffer;
+    try {
+      const response = await fetch(this.#src, {
+        signal: abort.signal,
+        credentials: this.#crossOrigin === 'use-credentials' ? 'include' : 'same-origin',
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      buffer = await response.arrayBuffer();
+    } catch (cause) {
+      if (abort.signal.aborted) return;
+      this.#fail(
+        new MediaError(`Failed to fetch GIF: ${(cause as Error)?.message ?? cause}`, MediaError.MEDIA_ERR_NETWORK)
+      );
+      return;
+    }
+    if (abort !== this.#abort) return;
+
+    let gif: ParsedGif;
+    let frames: ParsedFrame[];
+    try {
+      gif = parseGIF(buffer);
+      frames = decompressFrames(gif, true);
+      if (frames.length === 0) throw new Error('No frames');
+    } catch {
+      this.#fail(new MediaError('Failed to decode GIF.', MediaError.MEDIA_ERR_DECODE));
+      return;
+    }
+
+    this.#gif = gif;
+    this.#frames = frames;
+    this.#delays = frames.map((frame) => {
+      const delay = frame.delay ?? 0;
+      return delay < MIN_FRAME_DELAY_MS ? SNAPPED_FRAME_DELAY_MS : delay;
+    });
+    this.#starts = [0];
+    for (const delay of this.#delays) {
+      this.#starts.push(this.#starts[this.#starts.length - 1]! + delay);
+    }
+    this.#readyState = READY_STATE_HAVE_ENOUGH_DATA;
+
+    this.dispatchEvent(new Event('durationchange'));
+    this.dispatchEvent(new Event('loadedmetadata'));
+    this.dispatchEvent(new Event('resize'));
+
+    if (this.#pendingSeek !== null) {
+      const time = this.#pendingSeek;
+      this.#pendingSeek = null;
+      this.#seekTo(time);
+    }
+
+    this.#sizeCanvas();
+    this.#renderUpTo(this.#frameIndex);
+
+    this.dispatchEvent(new Event('loadeddata'));
+    this.dispatchEvent(new Event('canplay'));
+    this.dispatchEvent(new Event('canplaythrough'));
+
+    loadComplete.resolve();
+    this.#loadComplete = null;
+
+    if (!this.#paused) {
+      this.#startClock();
+      this.dispatchEvent(new Event('playing'));
+    } else if (this.#autoplay) {
+      void this.play();
+    }
+  }
+
+  #fail(error: MediaError): void {
+    // A later `play()` may retry the fetch; a stale controller would block it.
+    this.#abort = null;
+    this.#error = error;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.dispatchEvent(new Event('error'));
+    // Settle so `play()` callers reject on the stored error instead of hanging.
+    this.#loadComplete?.resolve();
+    this.#loadComplete = null;
+  }
+
+  get paused(): boolean {
+    return this.#paused;
+  }
+
+  get ended(): boolean {
+    return this.#ended;
+  }
+
+  get seeking(): boolean {
+    return this.#seeking;
+  }
+
+  async play(): Promise<void> {
+    if (!this.#src) {
+      throw new DOMException('No media source.', 'NotSupportedError');
+    }
+    if (this.#ended) this.#seekTo(0);
+
+    const wasPaused = this.#paused;
+    this.#paused = false;
+    this.#ended = false;
+    if (wasPaused) this.dispatchEvent(new Event('play'));
+
+    if (!this.#gif) {
+      if (!this.#abort) void this.#fetchAndDecode();
+      await (this.#loadComplete ??= createPublicPromise<void>());
+      if (this.#error) {
+        throw new DOMException(this.#error.message, 'NotSupportedError');
+      }
+      return;
+    }
+
+    if (wasPaused) {
+      this.#startClock();
+      this.dispatchEvent(new Event('playing'));
+    }
+  }
+
+  pause(): void {
+    if (this.#paused) return;
+    this.#syncElapsed();
+    this.#stopClock();
+    this.#paused = true;
+    this.dispatchEvent(new Event('pause'));
+  }
+
+  get currentTime(): number {
+    if (this.#frames.length === 0) return this.#pendingSeek ?? 0;
+    let elapsed = this.#frameElapsed;
+    if (!this.#paused && this.#timer !== null) {
+      elapsed += (performance.now() - this.#frameClock) * this.#playbackRate;
+    }
+    const start = this.#starts[this.#frameIndex]!;
+    return Math.min(start + elapsed, this.#totalMs) / 1000;
+  }
+  set currentTime(value: number) {
+    if (this.#frames.length === 0) {
+      // No frame table to land on yet; applied once metadata arrives.
+      this.#pendingSeek = value;
+      return;
+    }
+    this.#seeking = true;
+    this.dispatchEvent(new Event('seeking'));
+    this.#seekTo(value);
+    this.#seeking = false;
+    this.dispatchEvent(new Event('seeked'));
+    this.#dispatchTimeupdate();
+  }
+
+  #seekTo(seconds: number): void {
+    const ms = Math.min(Math.max(seconds * 1000, 0), this.#totalMs);
+    let index = this.#frames.length - 1;
+    for (let i = 0; i < this.#frames.length; i++) {
+      if (ms < this.#starts[i + 1]!) {
+        index = i;
+        break;
+      }
+    }
+    this.#frameIndex = index;
+    this.#frameElapsed = ms - this.#starts[index]!;
+    if (this.#ended && ms < this.#totalMs) this.#ended = false;
+    this.#renderUpTo(index);
+    if (!this.#paused) this.#startClock();
+  }
+
+  get duration(): number {
+    return this.#frames.length > 0 ? this.#totalMs / 1000 : Number.NaN;
+  }
+
+  get #totalMs(): number {
+    return this.#starts[this.#frames.length] ?? 0;
+  }
+
+  get autoplay(): boolean {
+    return this.#autoplay;
+  }
+  set autoplay(value: boolean) {
+    this.#autoplay = value;
+    if (value && this.#paused && this.#gif) void this.play();
+  }
+
+  get loop(): boolean {
+    return this.#loop;
+  }
+  set loop(value: boolean) {
+    this.#loop = value;
+  }
+
+  get playbackRate(): number {
+    return this.#playbackRate;
+  }
+  set playbackRate(value: number) {
+    if (this.#playbackRate === value) return;
+    // Bank time spent at the old rate before the new one changes the clock's scale.
+    this.#syncElapsed();
+    this.#playbackRate = value;
+    if (!this.#paused && this.#gif) this.#startClock();
+    this.dispatchEvent(new Event('ratechange'));
+  }
+
+  get defaultPlaybackRate(): number {
+    return this.#defaultPlaybackRate;
+  }
+  set defaultPlaybackRate(value: number) {
+    this.#defaultPlaybackRate = value;
+  }
+
+  get buffered() {
+    // The whole file decodes up front, so once loaded everything is buffered.
+    return this.#frames.length > 0 ? createTimeRange(0, this.duration) : EMPTY_TIME_RANGES;
+  }
+
+  get seekable() {
+    return this.#frames.length > 0 ? createTimeRange(0, this.duration) : EMPTY_TIME_RANGES;
+  }
+
+  get error(): ErrorLike | null {
+    return this.#error;
+  }
+
+  get videoWidth(): number {
+    return this.#gif?.lsd.width ?? 0;
+  }
+
+  get videoHeight(): number {
+    return this.#gif?.lsd.height ?? 0;
+  }
+
+  #resetState(): void {
+    this.#gif = null;
+    this.#frames = [];
+    this.#delays = [];
+    this.#starts = [0];
+    this.#frameIndex = 0;
+    this.#renderedIndex = -1;
+    this.#frameElapsed = 0;
+    this.#paused = true;
+    this.#ended = false;
+    this.#seeking = false;
+    this.#pendingSeek = null;
+    this.#error = null;
+    this.#readyState = READY_STATE_HAVE_NOTHING;
+    this.#lastTimeupdate = 0;
+    this.#loadComplete?.resolve();
+    this.#loadComplete = null;
+  }
+
+  // ----------------------------------------
+  // Playback clock
+  // ----------------------------------------
+
+  /** Fold wall-clock time since the last schedule into `#frameElapsed`. */
+  #syncElapsed(): void {
+    if (this.#timer === null) return;
+    const now = performance.now();
+    this.#frameElapsed += (now - this.#frameClock) * this.#playbackRate;
+    this.#frameClock = now;
+  }
+
+  #startClock(): void {
+    this.#stopClock();
+    if (this.#frames.length === 0) return;
+    const remaining = this.#delays[this.#frameIndex]! - this.#frameElapsed;
+    this.#frameClock = performance.now();
+    this.#timer = setTimeout(this.#advance, Math.max(remaining / this.#playbackRate, 0));
+  }
+
+  #stopClock(): void {
+    if (this.#timer === null) return;
+    clearTimeout(this.#timer);
+    this.#timer = null;
+  }
+
+  #advance = (): void => {
+    this.#timer = null;
+    this.#frameElapsed = 0;
+
+    if (this.#frameIndex + 1 >= this.#frames.length) {
+      if (this.#loop) {
+        this.#frameIndex = 0;
+        this.#renderUpTo(0);
+        this.#maybeTimeupdate();
+        this.#startClock();
+        return;
+      }
+      // Natural end: `paused` flips without a `pause` event, per native media.
+      this.#frameElapsed = this.#delays[this.#frameIndex]!;
+      this.#paused = true;
+      this.#ended = true;
+      this.#dispatchTimeupdate();
+      this.dispatchEvent(new Event('ended'));
+      return;
+    }
+
+    this.#frameIndex += 1;
+    this.#renderUpTo(this.#frameIndex);
+    this.#maybeTimeupdate();
+    this.#startClock();
+  };
+
+  #maybeTimeupdate(): void {
+    const now = this.#starts[this.#frameIndex]!;
+    if (Math.abs(now - this.#lastTimeupdate) < TIMEUPDATE_INTERVAL_MS) return;
+    this.#dispatchTimeupdate();
+  }
+
+  #dispatchTimeupdate(): void {
+    this.#lastTimeupdate = this.#starts[this.#frameIndex]! + this.#frameElapsed;
+    this.dispatchEvent(new Event('timeupdate'));
+  }
+
+  // ----------------------------------------
+  // Rendering
+  // ----------------------------------------
+
+  #sizeCanvas(): void {
+    const gif = this.#gif;
+    const canvas = this.#canvas;
+    if (!gif || !canvas) return;
+    canvas.width = gif.lsd.width;
+    canvas.height = gif.lsd.height;
+  }
+
+  /**
+   * Composite the canvas forward to `index`. GIF frames are deltas over the
+   * previous state, so a backward jump clears and replays from frame 0; a
+   * forward jump draws only the frames in between.
+   */
+  #renderUpTo(index: number): void {
+    const canvas = this.#canvas;
+    if (!canvas || this.#frames.length === 0) return;
+    // jsdom (and canvas-less environments) return null; playback state still advances.
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let from = this.#renderedIndex + 1;
+    if (index < this.#renderedIndex) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      from = 0;
+    }
+    for (let i = from; i <= index; i++) {
+      this.#drawFrame(ctx, i);
+    }
+    this.#renderedIndex = index;
+  }
+
+  #drawFrame(ctx: CanvasRenderingContext2D, index: number): void {
+    const frame = this.#frames[index]!;
+    const previous = index > 0 ? this.#frames[index - 1]! : null;
+
+    // Disposal 2 restores the previous frame's region to background (treated
+    // as transparent, like browsers do); 3 (restore-previous) is rare and
+    // approximated the same way.
+    if (previous && previous.disposalType >= 2) {
+      const { left, top, width, height } = previous.dims;
+      ctx.clearRect(left, top, width, height);
+    }
+
+    const { left, top, width, height } = frame.dims;
+    const patchCanvas = (this.#patchCanvas ??= globalThis.document?.createElement('canvas'));
+    const patchCtx = patchCanvas?.getContext('2d');
+    if (!patchCanvas || !patchCtx) return;
+    patchCanvas.width = width;
+    patchCanvas.height = height;
+    patchCtx.putImageData(new ImageData(new Uint8ClampedArray(frame.patch), width, height), 0, 0);
+    ctx.drawImage(patchCanvas, left, top);
+  }
+}

--- a/packages/media/src/dom/gif/tests/image-decoder-source.test.ts
+++ b/packages/media/src/dom/gif/tests/image-decoder-source.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createImageDecoderSource, isImageDecoderSupported } from '../image-decoder-source';
+
+interface FakeFrame {
+  displayWidth: number;
+  displayHeight: number;
+  duration: number;
+  close: ReturnType<typeof vi.fn>;
+}
+
+const state = {
+  frameCount: 3,
+  durations: [] as number[],
+  supported: true,
+};
+
+const createdFrames: FakeFrame[] = [];
+
+function frameFor(index: number): FakeFrame {
+  const frame = {
+    displayWidth: 4,
+    displayHeight: 3,
+    duration: state.durations[index] ?? 100_000,
+    close: vi.fn(),
+  };
+  createdFrames.push(frame);
+  return frame;
+}
+
+class FakeImageDecoder {
+  static last: FakeImageDecoder | null = null;
+  static isTypeSupported = vi.fn(async () => state.supported);
+
+  tracks = { ready: Promise.resolve(), selectedTrack: { frameCount: state.frameCount } };
+  completed = Promise.resolve();
+  decode = vi.fn(async (options?: { frameIndex?: number }) => ({ image: frameFor(options?.frameIndex ?? 0) }));
+  close = vi.fn();
+
+  constructor() {
+    FakeImageDecoder.last = this;
+  }
+}
+
+function fakeContext() {
+  return { clearRect: vi.fn(), drawImage: vi.fn() } as unknown as CanvasRenderingContext2D & {
+    clearRect: ReturnType<typeof vi.fn>;
+    drawImage: ReturnType<typeof vi.fn>;
+  };
+}
+
+beforeEach(() => {
+  state.frameCount = 3;
+  state.durations = [];
+  state.supported = true;
+  createdFrames.length = 0;
+  FakeImageDecoder.last = null;
+  vi.stubGlobal('ImageDecoder', FakeImageDecoder);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('isImageDecoderSupported', () => {
+  it('reports false without an ImageDecoder global', async () => {
+    vi.stubGlobal('ImageDecoder', undefined);
+    expect(await isImageDecoderSupported()).toBe(false);
+  });
+
+  it('reflects isTypeSupported for image/gif', async () => {
+    expect(await isImageDecoderSupported()).toBe(true);
+    state.supported = false;
+    expect(await isImageDecoderSupported()).toBe(false);
+  });
+
+  it('reports false when isTypeSupported throws', async () => {
+    FakeImageDecoder.isTypeSupported.mockRejectedValueOnce(new Error('nope'));
+    expect(await isImageDecoderSupported()).toBe(false);
+  });
+});
+
+describe('createImageDecoderSource', () => {
+  it('reads dimensions and a normalized ms delay table, closing timing frames', async () => {
+    // 50ms stays; 5ms and 0 snap to 100ms like browsers render them.
+    state.durations = [50_000, 5_000, 0];
+
+    const source = await createImageDecoderSource(new ArrayBuffer(8));
+
+    expect(source.width).toBe(4);
+    expect(source.height).toBe(3);
+    expect(source.frameCount).toBe(3);
+    expect(source.delays).toEqual([50, 100, 100]);
+    for (const frame of createdFrames) {
+      expect(frame.close).toHaveBeenCalled();
+    }
+  });
+
+  it('throws and closes the decoder when the track has no frames', async () => {
+    state.frameCount = 0;
+    await expect(createImageDecoderSource(new ArrayBuffer(8))).rejects.toThrow('no frames');
+    expect(FakeImageDecoder.last?.close).toHaveBeenCalled();
+  });
+
+  it('paints a decoded frame and closes it', async () => {
+    const source = await createImageDecoderSource(new ArrayBuffer(8));
+    const ctx = fakeContext();
+
+    await source.drawFrame(ctx, 1);
+
+    const painted = createdFrames[createdFrames.length - 1]!;
+    expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 4, 3);
+    expect(ctx.drawImage).toHaveBeenCalledWith(painted, 0, 0);
+    expect(painted.close).toHaveBeenCalled();
+  });
+
+  it('discards a stale draw once a newer one has been requested', async () => {
+    const source = await createImageDecoderSource(new ArrayBuffer(8));
+    const decoder = FakeImageDecoder.last!;
+    const ctx = fakeContext();
+
+    const pending = new Map<number, (result: { image: FakeFrame }) => void>();
+    decoder.decode.mockImplementation(
+      (options?: { frameIndex?: number }) =>
+        new Promise((resolve) => pending.set(options?.frameIndex ?? 0, resolve)) as never
+    );
+
+    const stale = source.drawFrame(ctx, 1);
+    const fresh = source.drawFrame(ctx, 2);
+
+    const freshFrame = frameFor(2);
+    pending.get(2)!({ image: freshFrame });
+    await fresh;
+    expect(ctx.drawImage).toHaveBeenCalledWith(freshFrame, 0, 0);
+
+    const staleFrame = frameFor(1);
+    pending.get(1)!({ image: staleFrame });
+    await stale;
+    expect(staleFrame.close).toHaveBeenCalled();
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the paint when a decode rejects', async () => {
+    const source = await createImageDecoderSource(new ArrayBuffer(8));
+    const decoder = FakeImageDecoder.last!;
+    const ctx = fakeContext();
+
+    decoder.decode.mockRejectedValueOnce(new Error('closed'));
+
+    await expect(source.drawFrame(ctx, 1)).resolves.toBeUndefined();
+    expect(ctx.drawImage).not.toHaveBeenCalled();
+  });
+
+  it('closes the decoder on destroy', async () => {
+    const source = await createImageDecoderSource(new ArrayBuffer(8));
+    source.destroy();
+    expect(FakeImageDecoder.last?.close).toHaveBeenCalled();
+  });
+});

--- a/packages/media/src/dom/gif/tests/media.test.ts
+++ b/packages/media/src/dom/gif/tests/media.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaError } from '../../../core/media-error';
+import { isMediaVolumeCapable } from '../../../core/predicate';
+import { GifMedia, gifMediaDefaultProps } from '..';
+
+// The decoder is gifuct-js's job; these tests drive the media's state machine
+// against a synthetic frame table instead of real GIF bytes.
+const { decodeState } = vi.hoisted(() => ({
+  decodeState: {
+    gif: null as unknown,
+    frames: [] as unknown[],
+    parseError: null as Error | null,
+  },
+}));
+
+vi.mock('gifuct-js', () => ({
+  parseGIF: vi.fn(() => {
+    if (decodeState.parseError) throw decodeState.parseError;
+    return decodeState.gif;
+  }),
+  decompressFrames: vi.fn(() => decodeState.frames),
+}));
+
+const FRAME_COUNT = 4;
+const FRAME_DELAY_MS = 100;
+
+function makeFrames(count = FRAME_COUNT, delay = FRAME_DELAY_MS) {
+  return Array.from({ length: count }, () => ({
+    dims: { top: 0, left: 0, width: 2, height: 2 },
+    delay,
+    disposalType: 1,
+    patch: new Uint8ClampedArray(2 * 2 * 4),
+  }));
+}
+
+function stubFetch(impl?: () => Promise<unknown>) {
+  const fetchMock = vi.fn(
+    impl ??
+      (async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(8),
+      }))
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+/** Flush the microtasks a load's fetch/decode chain awaits. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+async function createLoadedMedia(): Promise<GifMedia> {
+  const media = new GifMedia();
+  media.src = 'https://example.com/animated.gif';
+  await flush();
+  return media;
+}
+
+function recordEvents(media: GifMedia, types: string[]): string[] {
+  const seen: string[] = [];
+  for (const type of types) {
+    media.addEventListener(type as never, () => seen.push(type));
+  }
+  return seen;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  decodeState.gif = { lsd: { width: 2, height: 2 } };
+  decodeState.frames = makeFrames();
+  decodeState.parseError = null;
+  stubFetch();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('GifMedia', () => {
+  it('starts with default props and no metadata', () => {
+    const media = new GifMedia();
+    expect(media.src).toBe(gifMediaDefaultProps.src);
+    expect(media.paused).toBe(true);
+    expect(media.duration).toBeNaN();
+    expect(media.readyState).toBe(0);
+    expect(media.videoWidth).toBe(0);
+    expect(media.videoHeight).toBe(0);
+    expect(media.buffered.length).toBe(0);
+  });
+
+  it('has no volume surface, so volume UI reads it as unavailable', () => {
+    expect(isMediaVolumeCapable(new GifMedia())).toBe(false);
+  });
+
+  it('reports GIF sources as playable via canPlayType', () => {
+    const media = new GifMedia();
+    expect(media.canPlayType('image/gif')).toBe('probably');
+    expect(media.canPlayType('image/GIF; something')).toBe('probably');
+    expect(media.canPlayType('video/mp4')).toBe('');
+    expect(media.canPlayType('image/gifv')).toBe('');
+  });
+
+  it('loads metadata when a source is set', async () => {
+    const media = new GifMedia();
+    const seen = recordEvents(media, [
+      'loadstart',
+      'durationchange',
+      'loadedmetadata',
+      'loadeddata',
+      'canplay',
+      'canplaythrough',
+    ]);
+
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+
+    expect(seen).toEqual(['loadstart', 'durationchange', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough']);
+    expect(media.duration).toBeCloseTo((FRAME_COUNT * FRAME_DELAY_MS) / 1000);
+    expect(media.readyState).toBe(4);
+    expect(media.videoWidth).toBe(2);
+    expect(media.videoHeight).toBe(2);
+    expect(media.currentSrc).toBe('https://example.com/animated.gif');
+  });
+
+  it('reports the full range as buffered and seekable once loaded', async () => {
+    const media = await createLoadedMedia();
+    expect(media.buffered.length).toBe(1);
+    expect(media.buffered.start(0)).toBe(0);
+    expect(media.buffered.end(0)).toBeCloseTo(0.4);
+    expect(media.seekable.end(0)).toBeCloseTo(0.4);
+  });
+
+  it('does not fetch until playback with preload none', async () => {
+    const fetchMock = stubFetch();
+    const media = new GifMedia();
+    media.preload = 'none';
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const playing = media.play();
+    await flush();
+    await playing;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(media.paused).toBe(false);
+  });
+
+  it('plays through frames and ends without loop', async () => {
+    const media = await createLoadedMedia();
+    const seen = recordEvents(media, ['play', 'playing', 'ended']);
+
+    await media.play();
+    expect(seen).toEqual(['play', 'playing']);
+    expect(media.paused).toBe(false);
+
+    vi.advanceTimersByTime(FRAME_COUNT * FRAME_DELAY_MS + 10);
+
+    expect(seen).toEqual(['play', 'playing', 'ended']);
+    expect(media.ended).toBe(true);
+    // Natural end pauses without a `pause` event, like native media.
+    expect(media.paused).toBe(true);
+    expect(media.currentTime).toBeCloseTo(media.duration);
+  });
+
+  it('wraps around instead of ending when loop is on', async () => {
+    const media = await createLoadedMedia();
+    media.loop = true;
+    await media.play();
+
+    vi.advanceTimersByTime(FRAME_COUNT * FRAME_DELAY_MS + FRAME_DELAY_MS / 2);
+
+    expect(media.ended).toBe(false);
+    expect(media.paused).toBe(false);
+    expect(media.currentTime).toBeLessThan(media.duration);
+  });
+
+  it('restarts from the beginning when played after ending', async () => {
+    const media = await createLoadedMedia();
+    await media.play();
+    vi.advanceTimersByTime(FRAME_COUNT * FRAME_DELAY_MS + 10);
+    expect(media.ended).toBe(true);
+
+    await media.play();
+    expect(media.ended).toBe(false);
+    expect(media.currentTime).toBeLessThan(media.duration);
+  });
+
+  it('pauses and resumes at the same position', async () => {
+    const media = await createLoadedMedia();
+    const seen = recordEvents(media, ['pause']);
+    await media.play();
+
+    vi.advanceTimersByTime(FRAME_DELAY_MS * 2);
+    media.pause();
+
+    expect(seen).toEqual(['pause']);
+    expect(media.paused).toBe(true);
+    const pausedAt = media.currentTime;
+    expect(pausedAt).toBeCloseTo(0.2, 1);
+
+    vi.advanceTimersByTime(FRAME_DELAY_MS * 2);
+    expect(media.currentTime).toBe(pausedAt);
+  });
+
+  it('seeks to a time and dispatches seeking and seeked', async () => {
+    const media = await createLoadedMedia();
+    const seen = recordEvents(media, ['seeking', 'seeked', 'timeupdate']);
+
+    media.currentTime = 0.25;
+
+    expect(seen).toEqual(['seeking', 'seeked', 'timeupdate']);
+    expect(media.currentTime).toBeCloseTo(0.25);
+    expect(media.seeking).toBe(false);
+  });
+
+  it('clamps seeks to the seekable range', async () => {
+    const media = await createLoadedMedia();
+    media.currentTime = 99;
+    expect(media.currentTime).toBeCloseTo(media.duration);
+    media.currentTime = -5;
+    expect(media.currentTime).toBe(0);
+  });
+
+  it('applies a seek set before metadata once frames arrive', async () => {
+    const media = new GifMedia();
+    media.currentTime = 0.25;
+    expect(media.currentTime).toBe(0.25);
+
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+
+    expect(media.currentTime).toBeCloseTo(0.25);
+  });
+
+  it('scales frame timing by playbackRate', async () => {
+    const media = await createLoadedMedia();
+    const seen = recordEvents(media, ['ratechange']);
+    media.playbackRate = 2;
+    expect(seen).toEqual(['ratechange']);
+
+    await media.play();
+    // At 2x, the 400ms of frames elapse in 200ms of wall clock.
+    vi.advanceTimersByTime(FRAME_COUNT * (FRAME_DELAY_MS / 2) + 10);
+    expect(media.ended).toBe(true);
+  });
+
+  it('rejects play() without a source', async () => {
+    const media = new GifMedia();
+    await expect(media.play()).rejects.toMatchObject({ name: 'NotSupportedError' });
+  });
+
+  it('reports a network MediaError when the fetch fails', async () => {
+    stubFetch(async () => {
+      throw new Error('offline');
+    });
+    const media = new GifMedia();
+    const seen = recordEvents(media, ['error']);
+
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+
+    expect(seen).toEqual(['error']);
+    expect(media.error).toMatchObject({ code: MediaError.MEDIA_ERR_NETWORK });
+    expect(media.readyState).toBe(0);
+  });
+
+  it('reports a decode MediaError when parsing fails', async () => {
+    decodeState.parseError = new Error('not a gif');
+    const media = new GifMedia();
+    const seen = recordEvents(media, ['error']);
+
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+
+    expect(seen).toEqual(['error']);
+    expect(media.error).toMatchObject({ code: MediaError.MEDIA_ERR_DECODE });
+  });
+
+  it('rejects play() when loading fails', async () => {
+    stubFetch(async () => {
+      throw new Error('offline');
+    });
+    const media = new GifMedia();
+    media.preload = 'none';
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+
+    const playing = media.play();
+    playing.catch(() => {});
+    await flush();
+    await expect(playing).rejects.toMatchObject({ name: 'NotSupportedError' });
+  });
+
+  it('empties state when the source is replaced', async () => {
+    const media = await createLoadedMedia();
+    const seen = recordEvents(media, ['emptied']);
+    await media.play();
+    vi.advanceTimersByTime(FRAME_DELAY_MS);
+
+    media.src = '';
+    await flush();
+
+    expect(seen).toEqual(['emptied']);
+    expect(media.duration).toBeNaN();
+    expect(media.currentTime).toBe(0);
+    expect(media.paused).toBe(true);
+    expect(media.readyState).toBe(0);
+    expect(media.currentSrc).toBe('');
+  });
+
+  it('starts playback once loaded when autoplay is set', async () => {
+    const media = new GifMedia();
+    media.autoplay = true;
+    media.src = 'https://example.com/animated.gif';
+    await flush();
+
+    expect(media.paused).toBe(false);
+  });
+
+  it('sizes an attached canvas to the GIF dimensions', async () => {
+    const media = await createLoadedMedia();
+    const canvas = document.createElement('canvas');
+    // jsdom has no 2D context; rendering is skipped while sizing still applies.
+    canvas.getContext = () => null;
+    media.attach(canvas);
+    expect(canvas.width).toBe(2);
+    expect(canvas.height).toBe(2);
+    expect(media.target).toBe(canvas);
+
+    media.detach();
+    expect(media.target).toBeNull();
+  });
+
+  it('normalizes near-zero frame delays the way browsers do', async () => {
+    decodeState.frames = makeFrames(2, 0);
+    const media = await createLoadedMedia();
+    // Two zero-delay frames snap to 100ms each.
+    expect(media.duration).toBeCloseTo(0.2);
+  });
+
+  it('tracks played ranges while playing', async () => {
+    const media = await createLoadedMedia();
+    await media.play();
+    vi.advanceTimersByTime(FRAME_DELAY_MS * 3);
+    media.pause();
+
+    const played = media.played;
+    expect(played.length).toBe(1);
+    expect(played.start(0)).toBe(0);
+    expect(played.end(0)).toBeGreaterThan(0);
+  });
+});

--- a/packages/media/src/dom/gif/tests/media.test.ts
+++ b/packages/media/src/dom/gif/tests/media.test.ts
@@ -1,3 +1,4 @@
+import { parseGIF } from 'gifuct-js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MediaError } from '../../../core/media-error';
 import { isMediaVolumeCapable } from '../../../core/predicate';
@@ -45,9 +46,15 @@ function stubFetch(impl?: () => Promise<unknown>) {
   return fetchMock;
 }
 
-/** Flush the microtasks a load's fetch/decode chain awaits. */
+/**
+ * Flush the microtasks a load's fetch/decode chain awaits, including the
+ * dynamic import that pulls in the gifuct-js polyfill backend.
+ */
 async function flush(): Promise<void> {
-  for (let i = 0; i < 10; i++) await Promise.resolve();
+  for (let round = 0; round < 3; round++) {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    await vi.dynamicImportSettled();
+  }
 }
 
 async function createLoadedMedia(): Promise<GifMedia> {
@@ -351,5 +358,59 @@ describe('GifMedia', () => {
     expect(played.length).toBe(1);
     expect(played.start(0)).toBe(0);
     expect(played.end(0)).toBeGreaterThan(0);
+  });
+
+  describe('with WebCodecs ImageDecoder available', () => {
+    function makeVideoFrame(durationUs: number) {
+      return {
+        displayWidth: 2,
+        displayHeight: 2,
+        duration: durationUs,
+        close: vi.fn(),
+      };
+    }
+
+    beforeEach(() => {
+      class FakeImageDecoder {
+        static isTypeSupported = vi.fn(async (type: string) => type === 'image/gif');
+        tracks = { ready: Promise.resolve(), selectedTrack: { frameCount: FRAME_COUNT } };
+        completed = Promise.resolve();
+        decode = vi.fn(async () => ({ image: makeVideoFrame(FRAME_DELAY_MS * 1000) }));
+        close = vi.fn();
+      }
+      vi.stubGlobal('ImageDecoder', FakeImageDecoder);
+    });
+
+    it('prefers the native decoder over the gifuct-js polyfill', async () => {
+      const media = await createLoadedMedia();
+
+      expect(media.duration).toBeCloseTo((FRAME_COUNT * FRAME_DELAY_MS) / 1000);
+      expect(media.videoWidth).toBe(2);
+      expect(media.videoHeight).toBe(2);
+      expect(vi.mocked(parseGIF)).not.toHaveBeenCalled();
+    });
+
+    it('plays through frames and ends on the native path', async () => {
+      const media = await createLoadedMedia();
+      const seen = recordEvents(media, ['ended']);
+
+      await media.play();
+      vi.advanceTimersByTime(FRAME_COUNT * FRAME_DELAY_MS + 10);
+
+      expect(seen).toEqual(['ended']);
+      expect(media.ended).toBe(true);
+    });
+
+    it('paints decoded frames onto the attached canvas', async () => {
+      const media = await createLoadedMedia();
+      const ctx = { clearRect: vi.fn(), drawImage: vi.fn() };
+      const canvas = document.createElement('canvas');
+      canvas.getContext = (() => ctx) as unknown as typeof canvas.getContext;
+
+      media.attach(canvas);
+      await flush();
+
+      expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/media/tsdown.config.ts
+++ b/packages/media/tsdown.config.ts
@@ -18,6 +18,7 @@ const createConfig = (mode: PackageBuildMode): UserConfig => ({
     'dom/hls-js/index': './src/dom/hls-js/index.ts',
     'dom/native-hls/index': './src/dom/native-hls/index.ts',
     'dom/cloudflare/index': './src/dom/cloudflare/index.ts',
+    'dom/gif/index': './src/dom/gif/index.ts',
     'dom/shaka/index': './src/dom/shaka/index.ts',
     'dom/spotify/index': './src/dom/spotify/index.ts',
     'dom/tiktok/index': './src/dom/tiktok/index.ts',

--- a/packages/react/src/media/gif-video/index.ts
+++ b/packages/react/src/media/gif-video/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/packages/react/src/media/gif-video/media.tsx
+++ b/packages/react/src/media/gif-video/media.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { GifMediaProps } from '@videojs/media/dom/gif';
+import { GifMedia, gifMediaDefaultProps } from '@videojs/media/dom/gif';
+import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
+import { useAttachCanvas } from '../../utils/use-attach-canvas';
+import { useComposedRefs } from '../../utils/use-composed-refs';
+import { useMediaInstance } from '../../utils/use-media-instance';
+import { useSyncProps } from '../../utils/use-sync-props';
+
+export interface GifVideoProps extends Partial<GifMediaProps> {
+  children?: ReactNode;
+}
+
+export const GifVideo = forwardRef<HTMLCanvasElement, GifVideoProps>(function GifVideo({ children, ...rawProps }, ref) {
+  const media = useMediaInstance(GifMedia);
+  const props: Partial<GifMediaProps> & Record<string, unknown> = { ...rawProps };
+  const attachRef = useAttachCanvas(media);
+  const composedRef = useComposedRefs(attachRef, ref);
+  const canvasProps = useSyncProps<GifMediaProps, Record<string, unknown>>(media, props, gifMediaDefaultProps);
+
+  return (
+    <canvas role="img" aria-label="Animated GIF" {...canvasProps} ref={composedRef}>
+      {children}
+    </canvas>
+  );
+});
+
+export namespace GifVideo {
+  export type Props = GifVideoProps;
+}

--- a/packages/react/src/media/tests/gif-video.test.tsx
+++ b/packages/react/src/media/tests/gif-video.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GifVideo } from '../gif-video';
+
+beforeEach(() => {
+  // Keep the fetch a `src` kicks off pending; these tests cover the component
+  // wiring, not the decode pipeline.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise<never>(() => {}))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GifVideo', () => {
+  it('renders a canvas and starts fetching the source', () => {
+    const { container } = render(<GifVideo src="https://example.com/animated.gif" />);
+
+    expect(container.querySelector('canvas')).not.toBe(null);
+    expect(fetch).toHaveBeenCalledWith('https://example.com/animated.gif', expect.anything());
+  });
+
+  it('renders without a source and fetches when one arrives', () => {
+    const { rerender } = render(<GifVideo />);
+    expect(fetch).not.toHaveBeenCalled();
+
+    rerender(<GifVideo src="https://example.com/animated.gif" />);
+    expect(fetch).toHaveBeenCalledWith('https://example.com/animated.gif', expect.anything());
+  });
+
+  it('renders children as canvas fallback content', () => {
+    const { container } = render(
+      <GifVideo>
+        <span>Your browser does not support canvas.</span>
+      </GifVideo>
+    );
+    expect(container.querySelector('canvas span')).not.toBe(null);
+  });
+});

--- a/packages/react/src/utils/use-attach-canvas.ts
+++ b/packages/react/src/utils/use-attach-canvas.ts
@@ -1,0 +1,14 @@
+import type { MediaEngineHost } from '@videojs/media';
+import type { RefCallback } from 'react';
+import { useCallback } from 'react';
+
+export function useAttachCanvas<T extends HTMLCanvasElement>(media: MediaEngineHost): RefCallback<T> {
+  return useCallback(
+    (element: T | null) => {
+      if (element) media.attach?.(element);
+      else media.detach?.();
+      return () => media.detach?.();
+    },
+    [media]
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,9 @@ importers:
       dashjs:
         specifier: ^5.2.0
         version: 5.2.0(@svta/cml-cta@1.0.6(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0))(@svta/cml-structured-field-values@1.1.3(@svta/cml-utils@1.5.0))(@svta/cml-utils@1.5.0)
+      gifuct-js:
+        specifier: ^2.1.2
+        version: 2.1.2
       hls.js:
         specifier: ^1.6.7
         version: 1.6.15
@@ -6113,6 +6116,9 @@ packages:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
+
   git-cliff-darwin-arm64@2.12.0:
     resolution: {integrity: sha512-k3jzFDmkjc+6MjpnqvRenzMWRbZN5J+w3iQ8WNt9pSmPewNJIm92O/G6AbAxQaCbSfzQapeZ0e+5wSacVc62GA==}
     cpu: [arm64]
@@ -6692,6 +6698,9 @@ packages:
 
   jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-image-generator@1.0.4:
     resolution: {integrity: sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==}
@@ -15160,6 +15169,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
+
   git-cliff-darwin-arm64@2.12.0:
     optional: true
 
@@ -15817,6 +15830,8 @@ snapshots:
   jose@6.2.0: {}
 
   jpeg-js@0.4.4: {}
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-image-generator@1.0.4:
     dependencies:


### PR DESCRIPTION
## What

Adds a GIF media that plays animated GIFs like a video, following the standard media pattern end to end:

- **`@videojs/media/dom/gif`** — `GifMedia` implements `Partial<Video>`: it fetches the GIF, decodes it, and paints frames onto an attached `<canvas>` on its own `setTimeout` clock. That gives GIFs what an `<img>` rendering can't: `play()`/`pause()`, `currentTime` seeking, `duration` from the frame delay table, `loop` on demand, `playbackRate`, `buffered`/`seekable`/`played` ranges, `videoWidth`/`videoHeight`, and native-shaped events (`loadedmetadata` → `canplaythrough`, `timeupdate` throttled to ~250ms, `ended` without a `pause` event, etc.). Near-zero frame delays snap to 100ms the way browsers render them.
- **Decoder architecture** — decoding sits behind an internal `GifFrameSource` seam with two backends:
  - **WebCodecs [`ImageDecoder`](https://developer.mozilla.org/en-US/docs/Web/API/ImageDecoder) (primary)** — the browser's own decoder handles disposal/compositing and frames re-decode on demand during playback instead of persisting as RGBA. Only the timing table is walked once up front (durations surface per decoded frame), closing each frame as it goes. Backward seeks decode the target frame directly.
  - **[`gifuct-js`](https://www.npmjs.com/package/gifuct-js) (polyfill)** — the decode-everything-to-RGBA + patch-canvas compositor, pulled in via dynamic `import()` only where `ImageDecoder` can't decode GIFs (Safari today), so the native path never ships it.
- **`@videojs/html/media/gif-video`** — `<gif-video>` custom element (`CustomMediaElement('canvas', GifMedia)` + `MediaAttachMixin`), registered via `src/define/media/gif-video.ts`.
- **`@videojs/react/media/gif-video`** — `GifVideo` component, plus a `useAttachCanvas` util mirroring `useAttachIframe`.
- **Sandbox** — `gif-video` preset with `html-gif-video`/`react-gif-video` templates playing a CORS-enabled Mux GIF. It sits in `EMBED_PRESETS` because it shares those constraints (one fixed source, no Tailwind skin variant), not because it's an embed.
- **Tests** — 26 state-machine tests for `GifMedia` (both backends, decoder mocked/stubbed, fake timers), 9 unit tests for the `ImageDecoder` backend (delay normalization, stale-draw discard, lifecycle), plus element/component wiring tests in html and react.

## Relation to the earlier spike

`feat/gif-renderer` (sandbox-only, ~mid-2025) proved the decode-to-canvas approach but predates the current architecture: it lived in the old `packages/sandbox`, exposed only `play`/`pause`/`src`, and never implemented the media contract. This PR keeps its proven pieces (gifuct-js decoding, patch canvas compositing, disposal handling — now confined to the polyfill backend) and rebuilds the rest as a first-class media. The spike branch can be deleted once this lands.

## Known limitations (by design of the approach)

- **CORS is mandatory.** Frames are fetched with `fetch()`, so the GIF must be same-origin or served with CORS headers — an `<img>` can render cross-origin GIFs without them. `crossOrigin: 'use-credentials'` maps to credentialed fetch.
- **No audio, so no volume surface.** `volume`/`muted` are deliberately absent; `isMediaVolumeCapable` reports false and volume UI reads as unavailable.
- **Polyfill path holds the whole file as RGBA.** On the gifuct-js path all frames stay in memory (width × height × 4 bytes per frame — a 10s 800×600 GIF is ~400MB), backward seeks replay from frame 0, and disposal type 3 (restore-previous) is approximated as restore-to-background. The native `ImageDecoder` path avoids all three: frames re-decode on demand and the browser composites them.
- **Decode leniency differs by backend.** Browsers are famously forgiving of malformed GIFs; gifuct-js is stricter, so a broken GIF that renders in an `<img>` may throw `MEDIA_ERR_DECODE` on the polyfill path while the native path plays it.
- **The GIF's own loop count is ignored.** The Netscape loop extension isn't honored on either path; the `loop` prop decides, and without it the GIF plays once and ends (native `<img>` behavior would follow the embedded count).
- **No text tracks, PiP, fullscreen, or remote playback** — the canvas target supports none of these today (PiP would need `captureStream()` plumbing).

## Notes for reviewers

- `packages/html/vjsc/entries.generated.ts` also picks up a `Title`/`media-title` entry — the generated file on `main` was stale after #1997; `vjsc generate` restores it alongside the new `GifVideo` entry.
- gifuct-js is code-split out of the main `dom/gif` chunk (verified in the built output); browsers with `ImageDecoder` never fetch it.
- Verified the real pipeline in Node against `image.mux.com` (CORS `*`, 75 frames, 320×180, ~5s duration).
- `pnpm -F @videojs/media test` (1050 passed), html/react media suites, `pnpm typecheck`, `pnpm lint`, `pnpm check:workspace` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TiXcejBhztyoozgW9Xqfv

---
_Generated by [Claude Code](https://claude.ai/code/session_013TiXcejBhztyoozgW9Xqfv)_