### PR TITLE
fix(skin): stabilize menu sizing and motion

### DIFF
--- a/packages/core/src/dom/ui/menu/tests/menu-size.test.ts
+++ b/packages/core/src/dom/ui/menu/tests/menu-size.test.ts
@@ -43,6 +43,39 @@ describe('syncMenuSize', () => {
     expect(content.style.getPropertyValue('--media-menu-height')).toBe('240px');
   });
 
+  it('does not count submenu start padding twice', () => {
+    const content = document.createElement('div');
+    const root = document.createElement('div');
+    const submenu = document.createElement('div');
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    submenu.setAttribute('data-submenu', '');
+    submenu.style.paddingLeft = '4px';
+    submenu.style.paddingTop = '4px';
+    submenu.style.paddingInlineStart = '4px';
+    submenu.style.paddingInlineEnd = '4px';
+    submenu.style.paddingBlockStart = '4px';
+    submenu.style.paddingBlockEnd = '4px';
+    submenu.append(first, second);
+    content.append(root, submenu);
+    setSize(root, 180, 120);
+    setSize(first, 220, 28);
+    setSize(second, 220, 28);
+    Object.defineProperties(first, {
+      offsetLeft: { configurable: true, value: 4 },
+      offsetTop: { configurable: true, value: 4 },
+    });
+    Object.defineProperties(second, {
+      offsetLeft: { configurable: true, value: 4 },
+      offsetTop: { configurable: true, value: 32 },
+    });
+
+    syncMenuSize(content);
+
+    expect(content.style.getPropertyValue('--media-menu-width')).toBe('228px');
+    expect(content.style.getPropertyValue('--media-menu-height')).toBe('64px');
+  });
+
   it('restores authored accessibility state after a submenu closes', () => {
     const content = document.createElement('div');
     const root = document.createElement('div');

--- a/packages/skins/src/default/css/components/button.css
+++ b/packages/skins/src/default/css/components/button.css
@@ -167,7 +167,7 @@
 @media (prefers-reduced-motion: reduce) {
   .media-default-skin .media-button {
     scale: 1;
-    transition-property: background-color, color, outline-offset;
+    transition-property: background-color, color;
     will-change: auto;
   }
 }

--- a/packages/skins/src/default/css/components/menus.css
+++ b/packages/skins/src/default/css/components/menus.css
@@ -31,7 +31,6 @@
     transition-timing-function: ease-out;
     transition-duration: var(--menu-transition-duration);
     transition-property: translate, filter;
-    will-change: translate, filter;
 
     &:where([data-starting-style], [data-ending-style]) {
       overflow: hidden;
@@ -215,7 +214,6 @@
       transition:
         translate var(--menu-transition-duration) ease-out,
         filter var(--menu-transition-duration) ease-out;
-      will-change: translate, filter;
     }
 
     &[data-submenu-expanded="true"] > :not([data-submenu]) {

--- a/packages/skins/src/default/css/video.css
+++ b/packages/skins/src/default/css/video.css
@@ -215,12 +215,10 @@
 
       @media (pointer: fine) {
         transition-property: filter, opacity, scale, translate;
-        will-change: filter, opacity, scale, translate;
       }
 
       @media (pointer: coarse) {
         transition-property: opacity, scale, translate;
-        will-change: opacity, scale, translate;
       }
     }
 
@@ -305,12 +303,10 @@
 
   @media (pointer: fine) {
     transition-property: filter, opacity, scale, translate;
-    will-change: filter, opacity, scale, translate;
   }
 
   @media (pointer: coarse) {
     transition-property: opacity, scale, translate;
-    will-change: opacity, scale, translate;
   }
 
   @container media-root (width > 42rem) {

--- a/packages/skins/src/default/tailwind/components/button.ts
+++ b/packages/skins/src/default/tailwind/components/button.ts
@@ -9,7 +9,7 @@ export const button = {
     'outline-2 outline-transparent -outline-offset-2',
     'transition-[background-color,color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'not-aria-disabled:active:scale-[0.97]',
-    'motion-reduce:scale-100 motion-reduce:transition-[background-color,color,outline-offset] motion-reduce:will-change-auto',
+    'motion-reduce:scale-100 motion-reduce:transition-[background-color,color] motion-reduce:will-change-auto',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2'
   ),

--- a/packages/skins/src/default/tailwind/components/menu.ts
+++ b/packages/skins/src/default/tailwind/components/menu.ts
@@ -6,7 +6,7 @@ import { surface } from './surface';
 const submenuPanel = cn(
   'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
   'z-10',
-  'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out will-change-[translate,filter]',
+  'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
   'data-starting-style:pointer-events-none data-ending-style:pointer-events-none',
   'data-starting-style:overflow-hidden data-ending-style:overflow-hidden',
   'data-starting-style:translate-x-full data-ending-style:translate-x-full',
@@ -76,7 +76,6 @@ export const menu = {
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     '[&>:not([data-submenu])]:translate-none [&>:not([data-submenu])]:transition-[translate,filter]',
     '[&>:not([data-submenu])]:duration-(--menu-transition-duration) [&>:not([data-submenu])]:ease-out',
-    '[&>:not([data-submenu])]:will-change-[translate,filter]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:-translate-x-full',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:blur',
     // Avoid restarting the covered-content transition in WebKit while the

--- a/packages/skins/src/default/tailwind/video.tailwind.ts
+++ b/packages/skins/src/default/tailwind/video.tailwind.ts
@@ -101,9 +101,7 @@ const controlsBase = cn(
   'peer-data-open/error:hidden!',
   'ease-(--controls-transition-timing-function)',
   'duration-[calc(var(--controls-transition-duration)/2)]',
-  'pointer-fine:will-change-[filter,opacity,scale,translate]',
   'pointer-fine:transition-[filter,opacity,scale,translate]',
-  'pointer-coarse:will-change-[opacity,scale,translate]',
   'pointer-coarse:transition-[opacity,scale,translate]',
   '@2xl/media-root:[--base-boundary-offset:3]'
 );

--- a/packages/skins/src/minimal/css/components/button.css
+++ b/packages/skins/src/minimal/css/components/button.css
@@ -174,7 +174,7 @@
 @media (prefers-reduced-motion: reduce) {
   .media-minimal-skin .media-button {
     scale: 1;
-    transition-property: background-color, outline-offset;
+    transition-property: background-color;
     will-change: auto;
   }
 }

--- a/packages/skins/src/minimal/css/components/menus.css
+++ b/packages/skins/src/minimal/css/components/menus.css
@@ -37,7 +37,6 @@
     transition-timing-function: ease-out;
     transition-duration: var(--menu-transition-duration);
     transition-property: translate, filter;
-    will-change: translate, filter;
 
     &:where([data-starting-style], [data-ending-style]) {
       overflow: hidden;
@@ -216,7 +215,6 @@
       transition:
         translate var(--menu-transition-duration) ease-out,
         filter var(--menu-transition-duration) ease-out;
-      will-change: translate, filter;
     }
 
     &[data-submenu-expanded="true"] > :not([data-submenu]) {

--- a/packages/skins/src/minimal/css/video.css
+++ b/packages/skins/src/minimal/css/video.css
@@ -190,12 +190,10 @@
 
   @media (pointer: fine) {
     transition-property: translate, filter, opacity;
-    will-change: translate, filter, opacity;
   }
 
   @media (pointer: coarse) {
     transition-property: translate, opacity;
-    will-change: translate, opacity;
   }
 
   &:not([data-visible]) {

--- a/packages/skins/src/minimal/tailwind/components/button.ts
+++ b/packages/skins/src/minimal/tailwind/components/button.ts
@@ -10,7 +10,7 @@ export const button = {
     'transition-[background-color,outline-offset,scale] will-change-[scale] duration-150 ease-out',
     'focus-visible:outline-(--focus-ring-color) focus-visible:outline-offset-2',
     'not-aria-disabled:active:scale-[0.97]',
-    'motion-reduce:scale-100 motion-reduce:transition-[background-color,outline-offset] motion-reduce:will-change-auto',
+    'motion-reduce:scale-100 motion-reduce:transition-[background-color] motion-reduce:will-change-auto',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     'supports-[corner-shape:squircle]:rounded-[--spacing(4)]',
     'supports-[corner-shape:squircle]:[corner-shape:squircle]'

--- a/packages/skins/src/minimal/tailwind/components/menu.ts
+++ b/packages/skins/src/minimal/tailwind/components/menu.ts
@@ -5,7 +5,7 @@ import { popup } from './popup';
 const submenuPanel = cn(
   'absolute inset-x-0 top-0 [max-height:inherit] overflow-auto overscroll-none p-(--menu-padding) outline-none',
   'z-10',
-  'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out will-change-[translate,filter]',
+  'translate-none transition-[translate,filter] duration-(--menu-transition-duration) ease-out',
   'data-starting-style:pointer-events-none data-ending-style:pointer-events-none',
   'data-starting-style:overflow-hidden data-ending-style:overflow-hidden',
   'data-starting-style:translate-x-full data-ending-style:translate-x-full',
@@ -76,7 +76,6 @@ export const menu = {
     'min-w-48! w-(--media-menu-width) h-(--media-menu-height)',
     '[&>:not([data-submenu])]:translate-none [&>:not([data-submenu])]:transition-[translate,filter]',
     '[&>:not([data-submenu])]:duration-(--menu-transition-duration) [&>:not([data-submenu])]:ease-out',
-    '[&>:not([data-submenu])]:will-change-[translate,filter]',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:-translate-x-full',
     '[&[data-submenu-expanded=true]>:not([data-submenu])]:blur',
     // Avoid restarting the covered-content transition in WebKit while the

--- a/packages/skins/src/minimal/tailwind/video.tailwind.ts
+++ b/packages/skins/src/minimal/tailwind/video.tailwind.ts
@@ -103,9 +103,7 @@ export const controls = cn(
   'ease-(--controls-transition-timing-function)',
   'duration-[calc(var(--controls-transition-duration)/2)]',
   'not-data-visible:duration-(--controls-transition-duration)',
-  'pointer-fine:will-change-[translate,filter,opacity]',
   'pointer-fine:transition-[translate,filter,opacity]',
-  'pointer-coarse:will-change-[translate,opacity]',
   'pointer-coarse:transition-[translate,opacity]',
   // Hidden state
   'not-data-visible:opacity-0 not-data-visible:pointer-events-none',

--- a/packages/utils/src/dom/layout.ts
+++ b/packages/utils/src/dom/layout.ts
@@ -70,6 +70,15 @@ export function getBlockExtent(edges: LogicalBoxEdges): number {
   return edges.blockStart + edges.blockEnd;
 }
 
+function getPaddingOrigin(element: Element): { x: number; y: number } {
+  const style = getComputedStyle(element);
+
+  return {
+    x: Number.parseFloat(style.paddingLeft) || 0,
+    y: Number.parseFloat(style.paddingTop) || 0,
+  };
+}
+
 export interface ChildMeasurement {
   element: HTMLElement;
   size: ElementSize;
@@ -123,6 +132,7 @@ export function measureElementChildren(
     : { inlineStart: 0, inlineEnd: 0, blockStart: 0, blockEnd: 0 };
   const inlinePadding = getInlineExtent(padding);
   const blockPadding = getBlockExtent(padding);
+  const paddingOrigin = includePadding ? getPaddingOrigin(container) : { x: 0, y: 0 };
 
   if (elements.length === 0) return { width: inlinePadding, height: blockPadding };
 
@@ -130,8 +140,8 @@ export function measureElementChildren(
     elements.map((element) => ({
       element,
       size: measure(element, width),
-      offsetLeft: element.offsetLeft,
-      offsetTop: element.offsetTop,
+      offsetLeft: element.offsetLeft - paddingOrigin.x,
+      offsetTop: element.offsetTop - paddingOrigin.y,
     }));
 
   let measurements = collect();

--- a/packages/utils/src/dom/tests/layout.test.ts
+++ b/packages/utils/src/dom/tests/layout.test.ts
@@ -84,9 +84,18 @@ describe('DOM layout utilities', () => {
     const first = document.createElement('div');
     const second = document.createElement('div');
     container.append(first, second);
-    Object.defineProperty(second, 'offsetTop', { configurable: true, value: 40 });
+    Object.defineProperties(first, {
+      offsetLeft: { configurable: true, value: 5 },
+      offsetTop: { configurable: true, value: 2 },
+    });
+    Object.defineProperties(second, {
+      offsetLeft: { configurable: true, value: 5 },
+      offsetTop: { configurable: true, value: 42 },
+    });
 
     vi.spyOn(globalThis, 'getComputedStyle').mockReturnValue({
+      paddingLeft: '5px',
+      paddingTop: '2px',
       paddingInlineStart: '5px',
       paddingInlineEnd: '5px',
       paddingBlockStart: '2px',

--- a/site/src/components/docs/demos/menu/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/menu/html/css/BasicUsage.css
@@ -84,7 +84,6 @@
   transition-timing-function: ease-in-out;
   transition-duration: var(--menu-transition-duration);
   transition-property: translate, filter;
-  will-change: translate;
 }
 
 .menu[data-submenu-expanded="true"] > :not([data-submenu]) {

--- a/site/src/components/docs/demos/menu/react/css/BasicUsage.css
+++ b/site/src/components/docs/demos/menu/react/css/BasicUsage.css
@@ -84,7 +84,6 @@
   transition-timing-function: ease-in-out;
   transition-duration: var(--menu-transition-duration);
   transition-property: translate, filter;
-  will-change: translate;
 }
 
 .menu[data-submenu-expanded="true"] > :not([data-submenu]) {


### PR DESCRIPTION
## Summary

Fix submenu sizing that counted leading padding twice and reduce persistent compositor hints that could contribute to Safari animation stutter.

## Changes

- Normalize child layout offsets against container padding so submenu height matches its rendered content
- Remove persistent `will-change` hints from menus, controls, and documentation demos while preserving transient indicator and Safari button hints
- Keep Default and Minimal CSS and Tailwind motion behavior in parity, including reduced-motion button transitions

## Testing

- `pnpm -F @videojs/skins test`
- `pnpm -F @videojs/skins check:skins`
- `pnpm --dir apps/sandbox build`
- `pnpm -F @videojs/utils test src/dom/tests/layout.test.ts`
- `pnpm -F @videojs/core test src/dom/ui/menu/tests/menu-size.test.ts`
- `pnpm exec biome check` on affected CSS and Tailwind sources
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted layout math fix with tests plus cosmetic/compositor CSS tweaks; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **settings submenu sizing** by normalizing child `offsetLeft`/`offsetTop` against the container’s padding origin in `measureElementChildren`, so leading padding is not counted twice when `--media-menu-width` / `--media-menu-height` are synced (new core and utils tests cover padded submenus).
> 
> Across **default/minimal** skins (CSS + Tailwind) and docs menu demos, removes persistent **`will-change`** on menu panels, covered root content, and video controls hide/show transitions; **prefers-reduced-motion** button rules no longer transition `outline-offset`. Safari-oriented **`will-change: scale`** on buttons is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0151ada4a040cef9e3c17afa9cafff54524743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->