### PR TITLE
feat(media): bring the shaka media to parity with the hls.js media

### DIFF
--- a/apps/e2e/fixtures/media.ts
+++ b/apps/e2e/fixtures/media.ts
@@ -38,6 +38,20 @@ export const VIDEO_PAGES = [
     resource: 'dash',
   },
   {
+    name: 'HTML Shaka Video HLS',
+    path: '/pages/html-shaka-video-hls.html',
+    framework: 'html',
+    media: 'shaka-video',
+    resource: 'hlsTs',
+  },
+  {
+    name: 'HTML Shaka Video DASH',
+    path: '/pages/html-shaka-video-dash.html',
+    framework: 'html',
+    media: 'shaka-video',
+    resource: 'dash',
+  },
+  {
     name: 'HTML Native HLS Video',
     path: '/pages/html-native-hls-video.html',
     framework: 'html',
@@ -64,6 +78,13 @@ export const VIDEO_PAGES = [
     path: '/pages/react-video-hls.html',
     framework: 'react',
     media: 'hlsjs-video',
+    resource: 'hlsTs',
+  },
+  {
+    name: 'React Shaka Video HLS',
+    path: '/pages/react-shaka-video-hls.html',
+    framework: 'react',
+    media: 'shaka-video',
     resource: 'hlsTs',
   },
 ] as const satisfies readonly PageEntry[];

--- a/apps/e2e/fixtures/selectors.ts
+++ b/apps/e2e/fixtures/selectors.ts
@@ -94,7 +94,7 @@ export const SELECTORS = {
   errorDialog: 'media-error-dialog, .media-error',
 
   // Media element — matches all renderer custom elements and native media
-  media: 'video, audio, hlsjs-video, hls-video, native-hls-video, dash-video, mux-video, mux-audio',
+  media: 'video, audio, hlsjs-video, hls-video, native-hls-video, dash-video, shaka-video, mux-video, mux-audio',
 } as const;
 
 /** Data attributes used for player state (same across both renderers). */

--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -84,6 +84,14 @@ const MEDIA_TYPES: Record<string, MediaTypeConfig> = {
     hasPoster: false,
     isAudio: false,
   },
+  'shaka-video': {
+    element: 'shaka-video',
+    imports: ['@videojs/html/media/shaka-video'],
+    attrs: 'playsinline',
+    hasStoryboard: false,
+    hasPoster: false,
+    isAudio: false,
+  },
   audio: {
     element: 'audio',
     imports: [],
@@ -117,6 +125,7 @@ const MEDIA_TYPES: Record<string, MediaTypeConfig> = {
 const REACT_MEDIA: Record<string, { component: string; importPath: string }> = {
   video: { component: 'Video', importPath: '@videojs/react/video' },
   'hlsjs-video': { component: 'HlsJsVideo', importPath: '@videojs/react/media/hlsjs-video' },
+  'shaka-video': { component: 'ShakaVideo', importPath: '@videojs/react/media/shaka-video' },
   audio: { component: 'Audio', importPath: '@videojs/react/audio' },
   'hls-background-video': {
     component: 'HlsBackgroundVideo',
@@ -551,6 +560,20 @@ const PAGES: PageDef[] = [
   },
   { name: 'HTML DASH Video', path: 'html-dash-video', framework: 'html', media: 'dash-video', resource: 'dash' },
   {
+    name: 'HTML Shaka Video HLS',
+    path: 'html-shaka-video-hls',
+    framework: 'html',
+    media: 'shaka-video',
+    resource: 'hlsTs',
+  },
+  {
+    name: 'HTML Shaka Video DASH',
+    path: 'html-shaka-video-dash',
+    framework: 'html',
+    media: 'shaka-video',
+    resource: 'dash',
+  },
+  {
     name: 'HTML Native HLS Video',
     path: 'html-native-hls-video',
     framework: 'html',
@@ -566,6 +589,13 @@ const PAGES: PageDef[] = [
   // React Video
   { name: 'React Video MP4', path: 'react-video-mp4', framework: 'react', media: 'video', resource: 'mp4' },
   { name: 'React Video HLS', path: 'react-video-hls', framework: 'react', media: 'hlsjs-video', resource: 'hlsTs' },
+  {
+    name: 'React Shaka Video HLS',
+    path: 'react-shaka-video-hls',
+    framework: 'react',
+    media: 'shaka-video',
+    resource: 'hlsTs',
+  },
 
   // React Audio
   { name: 'React Audio MP4', path: 'react-audio-mp4', framework: 'react', media: 'audio', resource: 'mp4' },

--- a/packages/media/src/dom/shaka/live.ts
+++ b/packages/media/src/dom/shaka/live.ts
@@ -67,7 +67,9 @@ export function ShakaMediaLiveMixin<Base extends Constructor<ShakaEngineHost>>(B
 
     #onLoading = () => {
       this.#reset();
-      this.#armSeekToLive();
+      // A deferred load's own first `play` set the pending seek and then
+      // started this load; arming again would wipe that shot mid-flight.
+      if (!this.#seekToLivePending) this.#armSeekToLive();
     };
 
     #onUnloading = () => this.#reset();
@@ -75,8 +77,11 @@ export function ShakaMediaLiveMixin<Base extends Constructor<ShakaEngineHost>>(B
     #onLoaded = () => {
       this.#derive();
       // For deferred loading the manifest only arrives after the first play,
-      // so retry the seek once `liveEdgeStart` becomes finite.
-      if (this.#seekToLivePending) this.#trySeekToLive();
+      // so the pending seek resolves here. Either way the shot is spent: a
+      // load that came up on-demand has no edge to seek.
+      if (!this.#seekToLivePending) return;
+      this.#seekToLivePending = false;
+      this.#trySeekToLive();
     };
 
     #derive = () => {

--- a/packages/media/src/dom/shaka/live.ts
+++ b/packages/media/src/dom/shaka/live.ts
@@ -1,0 +1,159 @@
+import type { Constructor } from '@videojs/utils/types';
+import type { ShakaEngineHost } from './types';
+
+export function ShakaMediaLiveMixin<Base extends Constructor<ShakaEngineHost>>(BaseClass: Base) {
+  class ShakaMediaLive extends (BaseClass as Constructor<ShakaEngineHost>) {
+    #targetLiveWindow = Number.NaN;
+    #liveEdgeStartOffset: number | undefined;
+    #seekToLiveAbort: AbortController | null = null;
+    #seekToLivePending = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const { engine } = this;
+      if (!engine) return;
+
+      engine.addEventListener('loading', this.#onLoading);
+      engine.addEventListener('unloading', this.#onUnloading);
+      engine.addEventListener('manifestparsed', this.#derive);
+      engine.addEventListener('manifestupdated', this.#derive);
+      engine.addEventListener('loaded', this.#onLoaded);
+    }
+
+    attach(target: HTMLVideoElement) {
+      super.attach(target);
+      this.#armSeekToLive();
+    }
+
+    detach() {
+      this.#disarmSeekToLive();
+      super.detach();
+    }
+
+    destroy() {
+      const { engine } = this;
+
+      engine?.removeEventListener('loading', this.#onLoading);
+      engine?.removeEventListener('unloading', this.#onUnloading);
+      engine?.removeEventListener('manifestparsed', this.#derive);
+      engine?.removeEventListener('manifestupdated', this.#derive);
+      engine?.removeEventListener('loaded', this.#onLoaded);
+
+      this.#disarmSeekToLive();
+      this.#reset();
+
+      super.destroy();
+    }
+
+    get targetLiveWindow() {
+      return this.#targetLiveWindow;
+    }
+
+    // Derived from the engine's seek range at read time. No cached state, no
+    // event — re-read when `seekable`, `targetLiveWindow`, or `streamType`
+    // change.
+    get liveEdgeStart() {
+      if (this.#liveEdgeStartOffset === undefined) return Number.NaN;
+
+      const { engine } = this;
+      if (!engine) return Number.NaN;
+
+      const { end } = engine.seekRange();
+      if (!Number.isFinite(end)) return Number.NaN;
+
+      return end - this.#liveEdgeStartOffset;
+    }
+
+    #onLoading = () => {
+      this.#reset();
+      this.#armSeekToLive();
+    };
+
+    #onUnloading = () => this.#reset();
+
+    #onLoaded = () => {
+      this.#derive();
+      // For deferred loading the manifest only arrives after the first play,
+      // so retry the seek once `liveEdgeStart` becomes finite.
+      if (this.#seekToLivePending) this.#trySeekToLive();
+    };
+
+    #derive = () => {
+      const { engine } = this;
+
+      if (!engine || !(engine.isLive() || engine.isInProgress())) {
+        this.#reset();
+        return;
+      }
+
+      // The hls.js media reads the manifest's HOLD-BACK, falling back to the
+      // HLS spec's three target durations. Shaka resolves its own presentation
+      // delay but does not expose it publicly — `getManifest()` warns on every
+      // call that its shape is not covered by semver — so the same spec
+      // default is derived from the presentation's max segment duration.
+      const { maxSegmentDuration } = engine.getStats();
+      this.#liveEdgeStartOffset =
+        Number.isFinite(maxSegmentDuration) && maxSegmentDuration > 0 ? maxSegmentDuration * 3 : undefined;
+
+      // An in-progress recording keeps growing its window; regular live holds
+      // a sliding window of fixed size.
+      this.#setTargetLiveWindow(engine.isInProgress() ? Number.POSITIVE_INFINITY : 0);
+    };
+
+    #reset() {
+      this.#liveEdgeStartOffset = undefined;
+      this.#setTargetLiveWindow(Number.NaN);
+    }
+
+    #setTargetLiveWindow(value: number) {
+      if (Object.is(this.#targetLiveWindow, value)) return;
+      this.#targetLiveWindow = value;
+      this.dispatchEvent(new Event('targetlivewindowchange'));
+    }
+
+    /**
+     * Arm a one-shot seek-to-live on the first user-initiated `play`. Skipped
+     * when `autoplay` is set, since Shaka positions at the live edge during
+     * its own startup sequence and a programmatic seek would race that.
+     */
+    #armSeekToLive() {
+      this.#disarmSeekToLive();
+
+      const target = this.target as HTMLVideoElement | null;
+      if (!target || target.autoplay) return;
+
+      this.#seekToLiveAbort = new AbortController();
+      target.addEventListener(
+        'play',
+        () => {
+          this.#seekToLivePending = true;
+          this.#trySeekToLive();
+        },
+        { signal: this.#seekToLiveAbort.signal, once: true }
+      );
+    }
+
+    #disarmSeekToLive() {
+      this.#seekToLiveAbort?.abort();
+      this.#seekToLiveAbort = null;
+      this.#seekToLivePending = false;
+    }
+
+    #trySeekToLive() {
+      const target = this.target as HTMLVideoElement | null;
+      if (!target) return;
+
+      const { liveEdgeStart } = this;
+      if (!Number.isFinite(liveEdgeStart)) return;
+
+      if (target.currentTime < liveEdgeStart) {
+        target.currentTime = liveEdgeStart;
+      }
+      this.#seekToLivePending = false;
+    }
+  }
+
+  return ShakaMediaLive as unknown as Base &
+    Constructor<{ readonly liveEdgeStart: number; readonly targetLiveWindow: number }>;
+}

--- a/packages/media/src/dom/shaka/media-tracks.ts
+++ b/packages/media/src/dom/shaka/media-tracks.ts
@@ -6,11 +6,7 @@ import type {
   MediaVideoRenditionCapability,
   MediaVideoTrackCapability,
 } from '../../core/types';
-import type { HTMLVideoElementHost } from '../video-host';
-
-type ShakaEngineHost = HTMLVideoElementHost & {
-  readonly engine?: shaka.Player | null;
-};
+import type { ShakaEngineHost } from './types';
 
 type MediaTracksHost = ShakaEngineHost &
   MediaVideoTrackCapability &

--- a/packages/media/src/dom/shaka/media-tracks.ts
+++ b/packages/media/src/dom/shaka/media-tracks.ts
@@ -1,5 +1,5 @@
 import type { Constructor } from '@videojs/utils/types';
-import type shaka from 'shaka-player';
+import type shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
 
 import type {
   MediaAudioTrackCapability,

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -337,6 +337,10 @@ class ShakaMediaBase
     this.#error = null;
     this.#disarmPlayIntent();
     this.#isLoadDeferred = false;
+    // Each load decides its own clamping. Lifting the previous load's clamp
+    // first keeps a fresh clamp from capturing the clamped goals as the ones
+    // to restore, and lets a load with play intent run at full goals.
+    this.#restoreBuffering(engine);
 
     const { src } = this;
     if (!src) {

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -1,3 +1,7 @@
+// Keep this import first: it lends shaka's UMD evaluation the `self` global a
+// server runtime lacks. See `server-shim.ts`.
+import './server-shim';
+
 import { deepEqual } from '@videojs/utils/object';
 import { isObject } from '@videojs/utils/predicate';
 import shaka from 'shaka-player';
@@ -8,8 +12,13 @@ import { MediaTracksMixin } from '../../core/media-tracks';
 import type { MediaEngineHost } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { ShakaMediaMediaTracksMixin } from './media-tracks';
+import { didShimSelf } from './server-shim';
 
 export { shaka };
+
+if (didShimSelf) {
+  Reflect.deleteProperty(globalThis, 'self');
+}
 
 type Opaque = string | number | boolean | bigint | symbol | null | undefined | ArrayBufferView;
 
@@ -87,6 +96,10 @@ class ShakaMediaBase
 
   constructor() {
     super();
+
+    // A server render has no DOM to probe or play into; the client constructs
+    // an instance of its own. Even the support check needs browser globals.
+    if (typeof document === 'undefined') return;
 
     installPolyfills();
 

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -9,14 +9,15 @@ import { isObject } from '@videojs/utils/predicate';
 // no `exports` map, so the deep path is public surface — and `dist/*.ui*` is
 // where the UI library lives; never import those.
 import shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
-
 import type { DrmSystemsConfig } from '../../core/drm';
 import { MediaError } from '../../core/media-error';
 import { MediaTracksMixin } from '../../core/media-tracks';
-import type { MediaEngineHost } from '../../core/types';
+import { type MediaEngineHost, type MediaPreloadType, type MediaStreamType, MediaStreamTypes } from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
+import { ShakaMediaLiveMixin } from './live';
 import { ShakaMediaMediaTracksMixin } from './media-tracks';
 import { didShimSelf } from './server-shim';
+import { ShakaMediaStreamTypeMixin } from './stream-type';
 
 export { shaka };
 
@@ -76,22 +77,40 @@ export interface ShakaEngineConfig {
 export interface ShakaMediaProps {
   src: string;
   source: ShakaSource | null;
+  preload: MediaPreloadType;
+  streamType: MediaStreamType;
 }
 
 export const shakaMediaDefaultProps: ShakaMediaProps = {
   src: '',
   source: null,
+  preload: 'metadata',
+  streamType: MediaStreamTypes.UNKNOWN,
+};
+
+/**
+ * Configuration this element applies on top of Shaka's own defaults — the
+ * Shaka spelling of what the hls.js media ships (`capLevelToPlayerSize`):
+ * adaptation stays within renditions no larger than the element rendering
+ * them. Anything under `source.engine.shaka` overrides it.
+ */
+const defaultShakaConfig: ShakaConfig = {
+  abr: { restrictToElementSize: true },
 };
 
 const ShakaMediaHost = MediaTracksMixin(HTMLVideoElementHost);
 
 class ShakaMediaBase
   extends ShakaMediaHost
-  implements MediaEngineHost<shaka.Player, HTMLVideoElement>, ShakaMediaProps
+  implements MediaEngineHost<shaka.Player, HTMLVideoElement>, Omit<ShakaMediaProps, 'streamType'>
 {
   #engine: shaka.Player | null = null;
   #src = shakaMediaDefaultProps.src;
   #source: ShakaSource | null = shakaMediaDefaultProps.source;
+  #preload: MediaPreloadType = shakaMediaDefaultProps.preload;
+  #playIntentAbort: AbortController | null = null;
+  #isLoadDeferred = false;
+  #clampedGoals: { bufferingGoal: number; rebufferingGoal: number } | null = null;
   #error: MediaError | null = null;
   // The raw Shaka failures already announced. Held weakly: it answers nothing
   // but "seen before", and each failure is a fresh object.
@@ -115,6 +134,7 @@ class ShakaMediaBase
     }
 
     this.#engine = new shaka.Player();
+    this.#engine.configure(defaultShakaConfig);
     this.#engine.addEventListener('error', this.#onEngineError);
   }
 
@@ -129,6 +149,9 @@ class ShakaMediaBase
 
     super.attach(target);
 
+    // The stored preload may predate the target; the element reads its own.
+    if (target.preload !== this.#preload) target.preload = this.#preload;
+
     const engine = this.#engine;
     if (!engine || !isNewTarget) return;
 
@@ -142,6 +165,9 @@ class ShakaMediaBase
     const engine = this.#engine;
     const wasAttached = this.target !== null;
 
+    // The play listener belongs to the target that is leaving.
+    this.#disarmPlayIntent();
+
     super.detach();
 
     if (engine && wasAttached) this.#run(engine.detach());
@@ -149,6 +175,7 @@ class ShakaMediaBase
 
   destroy() {
     this.detach();
+    this.#disarmPlayIntent();
 
     const engine = this.#engine;
     // Anything still in flight has nothing left to report to.
@@ -211,6 +238,44 @@ class ShakaMediaBase
   }
 
   /**
+   * How much to fetch before playback is asked for, mirroring the media
+   * element's own `preload`. Shaka has no split between "know the source" and
+   * "buffer it", so this maps onto when and how `engine.load()` runs:
+   *
+   * - `'auto'` — load immediately with the configured buffering goals.
+   * - `'metadata'` — load immediately, holding buffering to about a segment;
+   *   the configured goals come back on the first play intent.
+   * - `'none'` / `''` — hold the load entirely until the first play intent.
+   *
+   * A play intent is a `play` event, a target that is already playing, or
+   * `autoplay` — which the spec lets override `preload` for good reason: with
+   * nothing fetched there is nothing whose readiness could ever fire it.
+   * Widening (`none` → `auto`) takes effect immediately; narrowing after a
+   * load began cannot un-fetch and leaves it alone.
+   */
+  get preload(): MediaPreloadType {
+    return this.#preload;
+  }
+
+  set preload(value: MediaPreloadType) {
+    if (this.#preload === value) return;
+    this.#preload = value;
+
+    const { target } = this;
+    if (target && target.preload !== value) target.preload = value;
+
+    const engine = this.#engine;
+    if (!engine) return;
+
+    if (this.#isLoadDeferred && (value === 'metadata' || value === 'auto')) {
+      this.#loadSource(engine);
+      return;
+    }
+
+    if (this.#clampedGoals && value === 'auto') this.#restoreBuffering(engine);
+  }
+
+  /**
    * Structured source: what to play (`src`, an optional `type`) plus how to
    * play it (`drm`, `engine.shaka`). Replacing it re-derives `src`.
    *
@@ -250,9 +315,14 @@ class ShakaMediaBase
     if (!engine) return;
 
     engine.resetConfiguration();
+    engine.configure(defaultShakaConfig);
 
     const config = withDrmConfig(this.#source?.engine?.shaka, this.#source?.drm);
     if (config) engine.configure(config);
+
+    // A wholesale re-apply raised the buffering goals a pending `'metadata'`
+    // clamp held down; clamp again against the configuration now in force.
+    if (this.#clampedGoals) this.#clampBuffering(engine);
   }
 
   #requestLoad() {
@@ -265,8 +335,78 @@ class ShakaMediaBase
 
   #loadSource(engine: shaka.Player) {
     this.#error = null;
+    this.#disarmPlayIntent();
+    this.#isLoadDeferred = false;
+
     const { src } = this;
-    this.#run(src ? engine.load(src, undefined, this.#source?.type) : engine.unload());
+    if (!src) {
+      this.#run(engine.unload());
+      return;
+    }
+
+    const { target } = this;
+    const hasPlayIntent = Boolean(target && (!target.paused || target.autoplay));
+    const preload = this.#preload;
+
+    if (!hasPlayIntent && (preload === 'none' || preload === '')) {
+      this.#isLoadDeferred = true;
+      // The `play` is itself the intent — no second look at the target.
+      this.#armPlayIntent(() => {
+        const deferredEngine = this.#engine;
+        if (deferredEngine) this.#startLoad(deferredEngine);
+      });
+      return;
+    }
+
+    if (!hasPlayIntent && preload === 'metadata') {
+      this.#clampBuffering(engine);
+      this.#armPlayIntent(() => {
+        const clampedEngine = this.#engine;
+        if (clampedEngine) this.#restoreBuffering(clampedEngine);
+      });
+    }
+
+    this.#startLoad(engine);
+  }
+
+  #startLoad(engine: shaka.Player) {
+    this.#isLoadDeferred = false;
+    this.#error = null;
+    this.#run(engine.load(this.src, undefined, this.#source?.type));
+  }
+
+  /**
+   * Holds Shaka's buffering to about one segment — the closest analog of
+   * fetching "metadata" an engine that always buffers through MSE has. The
+   * goals in force are captured first so the first play intent can put back
+   * exactly what configuration produced them.
+   */
+  #clampBuffering(engine: shaka.Player) {
+    const { bufferingGoal, rebufferingGoal } = engine.getConfiguration().streaming;
+    this.#clampedGoals = { bufferingGoal, rebufferingGoal };
+    engine.configure({ streaming: { bufferingGoal: 1, rebufferingGoal: 1 } });
+  }
+
+  #restoreBuffering(engine: shaka.Player) {
+    const goals = this.#clampedGoals;
+    if (!goals) return;
+    this.#clampedGoals = null;
+    engine.configure({ streaming: goals });
+  }
+
+  #armPlayIntent(onPlay: () => void) {
+    this.#disarmPlayIntent();
+
+    const { target } = this;
+    if (!target) return;
+
+    this.#playIntentAbort = new AbortController();
+    target.addEventListener('play', onPlay, { signal: this.#playIntentAbort.signal, once: true });
+  }
+
+  #disarmPlayIntent() {
+    this.#playIntentAbort?.abort();
+    this.#playIntentAbort = null;
   }
 
   /**
@@ -314,8 +454,12 @@ class ShakaMediaBase
 /**
  * @fires sourcechange - Fired when `source` changes, either directly or by resolving a new `src`. Read `source` for the new value.
  * @fires error - Fired when playback fails in a way Shaka could not recover from. Read `error` for the failure.
+ * @fires streamtypechange - Fired when the detected stream type changes. Read `streamType` for the new value.
+ * @fires targetlivewindowchange - Fired when the live window duration changes. Read `targetLiveWindow` for the new value.
  */
-export class ShakaMedia extends ShakaMediaMediaTracksMixin(ShakaMediaBase) {}
+export class ShakaMedia extends ShakaMediaLiveMixin(
+  ShakaMediaStreamTypeMixin(ShakaMediaMediaTracksMixin(ShakaMediaBase))
+) {}
 
 let arePolyfillsInstalled = false;
 

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -4,7 +4,11 @@ import './server-shim';
 
 import { deepEqual } from '@videojs/utils/object';
 import { isObject } from '@videojs/utils/predicate';
-import shaka from 'shaka-player';
+// The es2021 bundle is the same everything-but-UI API as the package default,
+// minus the ES5 down-compilation nothing this repo targets needs. Shaka ships
+// no `exports` map, so the deep path is public surface — and `dist/*.ui*` is
+// where the UI library lives; never import those.
+import shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
 
 import type { DrmSystemsConfig } from '../../core/drm';
 import { MediaError } from '../../core/media-error';

--- a/packages/media/src/dom/shaka/server-shim.ts
+++ b/packages/media/src/dom/shaka/server-shim.ts
@@ -1,0 +1,13 @@
+/**
+ * Shaka's UMD bundle reads the browser global `self` while it evaluates, so
+ * importing it on a server runtime throws before any feature detection can
+ * run. Evaluated ahead of `shaka-player` — keep it the first import of
+ * `media.ts` — this lends that evaluation a `self`, and `media.ts` takes it
+ * back as soon as shaka is through: a patched server global left behind would
+ * only confuse other libraries' environment detection.
+ */
+export const didShimSelf = typeof self === 'undefined';
+
+if (didShimSelf) {
+  (globalThis as { self?: typeof globalThis }).self = globalThis;
+}

--- a/packages/media/src/dom/shaka/stream-type.ts
+++ b/packages/media/src/dom/shaka/stream-type.ts
@@ -1,0 +1,80 @@
+import type { Constructor } from '@videojs/utils/types';
+import { type MediaStreamType, MediaStreamTypes } from '../../core/types';
+import type { ShakaEngineHost } from './types';
+
+export function ShakaMediaStreamTypeMixin<Base extends Constructor<ShakaEngineHost>>(BaseClass: Base) {
+  class ShakaMediaStreamType extends (BaseClass as Constructor<ShakaEngineHost>) {
+    #streamType: MediaStreamType = MediaStreamTypes.UNKNOWN;
+    #isUserStreamType = false;
+
+    constructor(...args: any[]) {
+      super(...args);
+
+      const { engine } = this;
+      if (!engine) return;
+
+      engine.addEventListener('loading', this.#forget);
+      engine.addEventListener('unloading', this.#forget);
+      engine.addEventListener('manifestparsed', this.#detect);
+      engine.addEventListener('manifestupdated', this.#detect);
+      // `src=` playback of a progressive file parses no manifest; `loaded` is
+      // the one signal every load path fires.
+      engine.addEventListener('loaded', this.#detect);
+    }
+
+    destroy() {
+      const { engine } = this;
+
+      engine?.removeEventListener('loading', this.#forget);
+      engine?.removeEventListener('unloading', this.#forget);
+      engine?.removeEventListener('manifestparsed', this.#detect);
+      engine?.removeEventListener('manifestupdated', this.#detect);
+      engine?.removeEventListener('loaded', this.#detect);
+
+      super.destroy();
+    }
+
+    get streamType(): MediaStreamType {
+      return this.#streamType;
+    }
+
+    set streamType(value: MediaStreamType) {
+      if (value === MediaStreamTypes.UNKNOWN) {
+        this.#isUserStreamType = false;
+        this.#update(MediaStreamTypes.UNKNOWN);
+        return;
+      }
+
+      this.#isUserStreamType = true;
+      this.#update(value);
+    }
+
+    #forget = () => this.#setDetected(MediaStreamTypes.UNKNOWN);
+
+    #detect = () => {
+      const { engine } = this;
+      if (!engine) return;
+
+      // An in-progress presentation — a live recording with a known end, like
+      // an in-progress DASH recording — reads as not live to `isLive()` but
+      // still grows its seekable window, so it is announced as live rather
+      // than on-demand.
+      const live = engine.isLive() || engine.isInProgress();
+
+      this.#setDetected(live ? MediaStreamTypes.LIVE : MediaStreamTypes.ON_DEMAND);
+    };
+
+    #setDetected(value: MediaStreamType): void {
+      if (this.#isUserStreamType) return;
+      this.#update(value);
+    }
+
+    #update(value: MediaStreamType): void {
+      if (this.#streamType === value) return;
+      this.#streamType = value;
+      this.dispatchEvent(new Event('streamtypechange'));
+    }
+  }
+
+  return ShakaMediaStreamType as unknown as Base & Constructor<{ streamType: MediaStreamType }>;
+}

--- a/packages/media/src/dom/shaka/tests/live.test.ts
+++ b/packages/media/src/dom/shaka/tests/live.test.ts
@@ -127,6 +127,18 @@ describe('ShakaMediaLiveMixin', () => {
     expect(video.currentTime).toBe(94);
   });
 
+  it('seeks to the live edge when the first play starts the load', () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const { video } = setupWithTarget(engine);
+
+    // A deferred load (`preload: 'none'`): the first play is what starts it.
+    video.dispatchEvent(new Event('play'));
+    engine.emit('loading');
+    engine.emit('loaded');
+
+    expect(video.currentTime).toBe(94);
+  });
+
   it('waits for the manifest when play comes first', () => {
     const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
     const { video } = setupWithTarget(engine);

--- a/packages/media/src/dom/shaka/tests/live.test.ts
+++ b/packages/media/src/dom/shaka/tests/live.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { HTMLVideoElementHost } from '../../video-host';
+import { ShakaMediaLiveMixin } from '../live';
+
+function createEngine({ live = false, inProgress = false, maxSegmentDuration = 2, seekEnd = 100 } = {}) {
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  const engine = {
+    live,
+    inProgress,
+    maxSegmentDuration,
+    seekEnd,
+    isLive: vi.fn(() => engine.live),
+    isInProgress: vi.fn(() => engine.inProgress),
+    getStats: vi.fn(() => ({ maxSegmentDuration: engine.maxSegmentDuration })),
+    seekRange: vi.fn(() => ({ start: 0, end: engine.seekEnd })),
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      const typeListeners = listeners.get(type) ?? new Set();
+      typeListeners.add(listener);
+      listeners.set(type, typeListeners);
+    },
+    removeEventListener(type: string, listener: (event: unknown) => void) {
+      listeners.get(type)?.delete(listener);
+    },
+    emit(type: string) {
+      for (const listener of [...(listeners.get(type) ?? [])]) listener({ type });
+    },
+  };
+
+  return engine;
+}
+
+class FakeHost extends HTMLVideoElementHost {
+  engine: ReturnType<typeof createEngine> | null;
+
+  constructor(engine: ReturnType<typeof createEngine> | null = null) {
+    super();
+    this.engine = engine;
+  }
+}
+
+const ShakaMediaLive = ShakaMediaLiveMixin(FakeHost as any) as unknown as new (
+  engine?: ReturnType<typeof createEngine> | null
+) => FakeHost & { readonly liveEdgeStart: number; readonly targetLiveWindow: number };
+
+function setupWithTarget(engine: ReturnType<typeof createEngine>) {
+  const video = document.createElement('video');
+  document.body.appendChild(video);
+  const media = new ShakaMediaLive(engine);
+  media.attach(video);
+  return { media, video };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('ShakaMediaLiveMixin', () => {
+  it('has no live window before anything loads', () => {
+    const media = new ShakaMediaLive(createEngine());
+    expect(media.targetLiveWindow).toBeNaN();
+    expect(media.liveEdgeStart).toBeNaN();
+  });
+
+  it('stays without a live window for on-demand loads', () => {
+    const engine = createEngine();
+    const media = new ShakaMediaLive(engine);
+
+    engine.emit('loaded');
+
+    expect(media.targetLiveWindow).toBeNaN();
+    expect(media.liveEdgeStart).toBeNaN();
+  });
+
+  it('derives a sliding window and the live edge for live loads', () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const media = new ShakaMediaLive(engine);
+    const onChange = vi.fn();
+    media.addEventListener('targetlivewindowchange', onChange);
+
+    engine.emit('manifestparsed');
+
+    expect(media.targetLiveWindow).toBe(0);
+    expect(media.liveEdgeStart).toBe(94);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an in-progress recording as a growing window', () => {
+    const engine = createEngine({ live: false, inProgress: true });
+    const media = new ShakaMediaLive(engine);
+
+    engine.emit('manifestparsed');
+
+    expect(media.targetLiveWindow).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('reads the live edge off the current seek range', () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const media = new ShakaMediaLive(engine);
+    engine.emit('manifestparsed');
+
+    engine.seekEnd = 160;
+
+    expect(media.liveEdgeStart).toBe(154);
+  });
+
+  it('resets when a new load starts', () => {
+    const engine = createEngine({ live: true });
+    const media = new ShakaMediaLive(engine);
+    engine.emit('manifestparsed');
+
+    engine.emit('loading');
+
+    expect(media.targetLiveWindow).toBeNaN();
+    expect(media.liveEdgeStart).toBeNaN();
+  });
+
+  it('seeks a paused target to the live edge on the first play', () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const { video } = setupWithTarget(engine);
+    engine.emit('loading');
+    engine.emit('loaded');
+
+    video.dispatchEvent(new Event('play'));
+
+    expect(video.currentTime).toBe(94);
+  });
+
+  it('waits for the manifest when play comes first', () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const { video } = setupWithTarget(engine);
+    engine.emit('loading');
+
+    video.dispatchEvent(new Event('play'));
+    expect(video.currentTime).toBe(0);
+
+    engine.emit('loaded');
+    expect(video.currentTime).toBe(94);
+  });
+
+  it('never rewinds a target already past the edge', () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const { video } = setupWithTarget(engine);
+    engine.emit('loading');
+    engine.emit('loaded');
+    video.currentTime = 200;
+
+    video.dispatchEvent(new Event('play'));
+
+    expect(video.currentTime).toBe(200);
+  });
+
+  it("leaves autoplay targets to shaka's own edge positioning", () => {
+    const engine = createEngine({ live: true, maxSegmentDuration: 2, seekEnd: 100 });
+    const video = document.createElement('video');
+    video.autoplay = true;
+    document.body.appendChild(video);
+    const media = new ShakaMediaLive(engine);
+    media.attach(video);
+    engine.emit('loaded');
+
+    video.dispatchEvent(new Event('play'));
+
+    expect(video.currentTime).toBe(0);
+  });
+});

--- a/packages/media/src/dom/shaka/tests/server.test.ts
+++ b/packages/media/src/dom/shaka/tests/server.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+// The real `shaka-player` module, not the mock the other suites install:
+// evaluating it is exactly what a server runtime trips over without the shim.
+describe('ShakaMedia', () => {
+  it('imports without browser globals and leaves none behind', async () => {
+    const { ShakaMedia } = await import('../index');
+
+    expect(typeof self).toBe('undefined');
+    expect(ShakaMedia).toBeTypeOf('function');
+  });
+
+  it('constructs inert on a server runtime', async () => {
+    const { ShakaMedia } = await import('../index');
+
+    const media = new ShakaMedia();
+
+    expect(media.engine).toBeNull();
+    expect(() => media.destroy()).not.toThrow();
+  });
+});

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -434,6 +434,32 @@ describe('ShakaMedia', () => {
       expect(engine.config.streaming).toEqual({ bufferingGoal: 1, rebufferingGoal: 1 });
     });
 
+    it('restores the real goals when a source replaces a clamped one', async () => {
+      const { video, media, engine } = setup({ preload: 'metadata' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+      media.source = { src: OTHER_MANIFEST };
+      await flush();
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(engine.config.streaming).toEqual({ bufferingGoal: 10, rebufferingGoal: 2 });
+    });
+
+    it('lifts the clamp when a replacing load starts with play intent', async () => {
+      const { video, media, engine } = setup({ preload: 'metadata' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      video.autoplay = true;
+      media.source = { src: OTHER_MANIFEST };
+      await flush();
+
+      expect(engine.config.streaming).toEqual({ bufferingGoal: 10, rebufferingGoal: 2 });
+    });
+
     it('holds the load for none until the first play', async () => {
       const { video, media, engine } = setup({ preload: 'none' });
 

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('shaka-player/dist/shaka-player.compiled-es2021', () => {
+  const CONFIG_DEFAULTS = { streaming: { bufferingGoal: 10, rebufferingGoal: 2 } };
+
   /** Shaka merges every `configure()` call into the current configuration. */
   function merge(target: Record<string, any>, source: Record<string, any>) {
     for (const [key, value] of Object.entries(source)) {
@@ -29,7 +31,9 @@ vi.mock('shaka-player/dist/shaka-player.compiled-es2021', () => {
       resetConfiguration: vi.fn(() => {
         player.config = {};
       }),
-      getConfiguration: vi.fn(() => player.config),
+      // The real `getConfiguration()` always returns a fully resolved
+      // configuration; `config` tracks only what was written.
+      getConfiguration: vi.fn(() => merge(structuredClone(CONFIG_DEFAULTS), player.config)),
       getVideoTracks: vi.fn(() => player.videoTracks),
       getAudioTracks: vi.fn(() => player.audioTracks),
       selectVideoTrack: vi.fn(),
@@ -113,11 +117,15 @@ type MockAudioTrack = {
   channelsCount?: number | null;
 };
 
-function setup() {
+function setup({ preload = 'auto' as const }: { preload?: ShakaMedia['preload'] } = {}) {
   const video = document.createElement('video');
   document.body.appendChild(video);
 
   const media = new ShakaMedia();
+  // Most suites exercise source, configuration, and error semantics, which
+  // read clearest when every assignment reaches the engine immediately; the
+  // preload suite opts back into the deferring defaults it is about.
+  media.preload = preload;
   media.attach(video);
 
   return { media, video, engine: media.engine as unknown as MockEngine };
@@ -127,6 +135,9 @@ function setup() {
 async function flush() {
   for (let index = 0; index < 5; index += 1) await Promise.resolve();
 }
+
+/** What the element itself configures on a fresh or reset engine. */
+const ELEMENT_DEFAULTS = { abr: { restrictToElementSize: true } };
 
 const MANIFEST = 'https://example.com/manifest.mpd';
 const OTHER_MANIFEST = 'https://example.com/other.m3u8';
@@ -221,7 +232,7 @@ describe('ShakaMedia', () => {
       media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
       await flush();
 
-      expect(engine.config).toEqual({ streaming: { bufferingGoal: 30 } });
+      expect(engine.config).toEqual({ ...ELEMENT_DEFAULTS, streaming: { bufferingGoal: 30 } });
     });
 
     it('derives src and loads the manifest', async () => {
@@ -277,7 +288,7 @@ describe('ShakaMedia', () => {
       await flush();
 
       expect(engine.load).not.toHaveBeenCalled();
-      expect(engine.config).toEqual({ streaming: { bufferingGoal: 60 } });
+      expect(engine.config).toEqual({ ...ELEMENT_DEFAULTS, streaming: { bufferingGoal: 60 } });
     });
 
     it('resets configuration instead of merging when a shaka option is dropped', async () => {
@@ -293,7 +304,7 @@ describe('ShakaMedia', () => {
       await flush();
 
       expect(engine.resetConfiguration).toHaveBeenCalled();
-      expect(engine.config).toEqual({ streaming: { bufferingGoal: 30 } });
+      expect(engine.config).toEqual({ ...ELEMENT_DEFAULTS, streaming: { bufferingGoal: 30 } });
     });
 
     it('hands a new source to shaka without waiting for the load in flight', async () => {
@@ -397,6 +408,102 @@ describe('ShakaMedia', () => {
     });
   });
 
+  describe('preload', () => {
+    it('clamps buffering for metadata until the first play', async () => {
+      const { video, media, engine } = setup({ preload: 'metadata' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      expect(engine.load).toHaveBeenCalledWith(MANIFEST, undefined, undefined);
+      expect(engine.config.streaming).toEqual({ bufferingGoal: 1, rebufferingGoal: 1 });
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(engine.config.streaming).toEqual({ bufferingGoal: 10, rebufferingGoal: 2 });
+    });
+
+    it('keeps a metadata clamp across a configuration re-apply', async () => {
+      const { media, engine } = setup({ preload: 'metadata' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+      media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 60 } } } };
+      await flush();
+
+      expect(engine.config.streaming).toEqual({ bufferingGoal: 1, rebufferingGoal: 1 });
+    });
+
+    it('holds the load for none until the first play', async () => {
+      const { video, media, engine } = setup({ preload: 'none' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      expect(engine.load).not.toHaveBeenCalled();
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(engine.load).toHaveBeenCalledWith(MANIFEST, undefined, undefined);
+    });
+
+    it('loads immediately for none when the target will autoplay', async () => {
+      const { video, media, engine } = setup({ preload: 'none' });
+      video.autoplay = true;
+
+      media.source = { src: MANIFEST };
+      await flush();
+
+      expect(engine.load).toHaveBeenCalledWith(MANIFEST, undefined, undefined);
+    });
+
+    it('releases a held load when preload widens', async () => {
+      const { media, engine } = setup({ preload: 'none' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+      media.preload = 'auto';
+
+      expect(engine.load).toHaveBeenCalledWith(MANIFEST, undefined, undefined);
+    });
+
+    it('holds only the newest source when one replaces a held one', async () => {
+      const { video, media, engine } = setup({ preload: 'none' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+      media.source = { src: OTHER_MANIFEST };
+      await flush();
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(engine.load).toHaveBeenCalledTimes(1);
+      expect(engine.load).toHaveBeenCalledWith(OTHER_MANIFEST, undefined, undefined);
+    });
+
+    it('drops a held load when the source clears', async () => {
+      const { video, media, engine } = setup({ preload: 'none' });
+
+      media.source = { src: MANIFEST };
+      await flush();
+      media.source = null;
+      await flush();
+
+      video.dispatchEvent(new Event('play'));
+
+      expect(engine.load).not.toHaveBeenCalled();
+      expect(engine.unload).toHaveBeenCalled();
+    });
+
+    it('mirrors onto the target element', () => {
+      const { video, media } = setup();
+
+      media.preload = 'none';
+
+      expect(video.preload).toBe('none');
+    });
+  });
+
   describe('videoRenditions', () => {
     it('mirrors the video tracks of the loaded asset', async () => {
       const { media, engine } = setup();
@@ -444,7 +551,7 @@ describe('ShakaMedia', () => {
       media.videoRenditions[1]!.selected = true;
       await flush();
 
-      expect(engine.config.abr).toEqual({ enabled: false });
+      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: false });
       expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
     });
 
@@ -459,7 +566,7 @@ describe('ShakaMedia', () => {
       media.videoRenditions[1]!.selected = false;
       await flush();
 
-      expect(engine.config.abr).toEqual({ enabled: true });
+      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: true });
     });
 
     it('leaves shaka configuration alone when nothing was ever pinned', async () => {
@@ -487,7 +594,7 @@ describe('ShakaMedia', () => {
       media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
       await flush();
 
-      expect(engine.config.abr).toEqual({ enabled: false });
+      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: false });
       expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
     });
 
@@ -504,7 +611,7 @@ describe('ShakaMedia', () => {
       await flush();
 
       expect([...media.videoRenditions]).toEqual([]);
-      expect(engine.config.abr).toEqual({ enabled: true });
+      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: true });
     });
 
     it('stops mirroring tracks once destroyed', async () => {

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('shaka-player', () => {
+vi.mock('shaka-player/dist/shaka-player.compiled-es2021', () => {
   /** Shaka merges every `configure()` call into the current configuration. */
   function merge(target: Record<string, any>, source: Record<string, any>) {
     for (const [key, value] of Object.entries(source)) {

--- a/packages/media/src/dom/shaka/tests/stream-type.test.ts
+++ b/packages/media/src/dom/shaka/tests/stream-type.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { MediaStreamTypes } from '../../../core/types';
+import { HTMLVideoElementHost } from '../../video-host';
+import { ShakaMediaStreamTypeMixin } from '../stream-type';
+
+function createEngine({ live = false, inProgress = false } = {}) {
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  const engine = {
+    live,
+    inProgress,
+    isLive: vi.fn(() => engine.live),
+    isInProgress: vi.fn(() => engine.inProgress),
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      const typeListeners = listeners.get(type) ?? new Set();
+      typeListeners.add(listener);
+      listeners.set(type, typeListeners);
+    },
+    removeEventListener(type: string, listener: (event: unknown) => void) {
+      listeners.get(type)?.delete(listener);
+    },
+    emit(type: string) {
+      for (const listener of [...(listeners.get(type) ?? [])]) listener({ type });
+    },
+  };
+
+  return engine;
+}
+
+class FakeHost extends HTMLVideoElementHost {
+  engine: ReturnType<typeof createEngine> | null;
+
+  constructor(engine: ReturnType<typeof createEngine> | null = null) {
+    super();
+    this.engine = engine;
+  }
+}
+
+const ShakaMediaStreamType = ShakaMediaStreamTypeMixin(FakeHost as any) as unknown as new (
+  engine?: ReturnType<typeof createEngine> | null
+) => FakeHost & { streamType: string };
+
+describe('ShakaMediaStreamTypeMixin', () => {
+  it('starts unknown', () => {
+    const media = new ShakaMediaStreamType(createEngine());
+    expect(media.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+
+  it('detects live once the source is loaded', () => {
+    const engine = createEngine({ live: true });
+    const media = new ShakaMediaStreamType(engine);
+    const onChange = vi.fn();
+    media.addEventListener('streamtypechange', onChange);
+
+    engine.emit('loaded');
+
+    expect(media.streamType).toBe(MediaStreamTypes.LIVE);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects on-demand from a parsed manifest', () => {
+    const engine = createEngine();
+    const media = new ShakaMediaStreamType(engine);
+
+    engine.emit('manifestparsed');
+
+    expect(media.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+  });
+
+  it('treats an in-progress recording as live', () => {
+    const engine = createEngine({ live: false, inProgress: true });
+    const media = new ShakaMediaStreamType(engine);
+
+    engine.emit('manifestparsed');
+
+    expect(media.streamType).toBe(MediaStreamTypes.LIVE);
+  });
+
+  it('forgets the detection when a new load starts', () => {
+    const engine = createEngine({ live: true });
+    const media = new ShakaMediaStreamType(engine);
+    engine.emit('loaded');
+
+    engine.emit('loading');
+
+    expect(media.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+
+  it('lets a user value win over detection until cleared', () => {
+    const engine = createEngine({ live: true });
+    const media = new ShakaMediaStreamType(engine);
+
+    media.streamType = MediaStreamTypes.ON_DEMAND;
+    engine.emit('loaded');
+    expect(media.streamType).toBe(MediaStreamTypes.ON_DEMAND);
+
+    media.streamType = MediaStreamTypes.UNKNOWN;
+    engine.emit('manifestupdated');
+    expect(media.streamType).toBe(MediaStreamTypes.LIVE);
+  });
+
+  it('stops detecting once destroyed', () => {
+    const engine = createEngine({ live: true });
+    const media = new ShakaMediaStreamType(engine);
+
+    media.destroy();
+    engine.emit('loaded');
+
+    expect(media.streamType).toBe(MediaStreamTypes.UNKNOWN);
+  });
+});

--- a/packages/media/src/dom/shaka/types.ts
+++ b/packages/media/src/dom/shaka/types.ts
@@ -1,0 +1,7 @@
+import type shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
+import type { HTMLVideoElementHost } from '../video-host';
+
+/** The host contract the Shaka media mixins compose over. */
+export type ShakaEngineHost = HTMLVideoElementHost & {
+  readonly engine?: shaka.Player | null;
+};


### PR DESCRIPTION
Refs #2276

## Summary

Extends the Shaka media landed in #2276 to feature parity with the hls.js media: server-render survival, stream type and live-edge behavior, and `preload` semantics — while shipping Shaka's es2021 bundle to cut what the entry costs.

## Changes

- **Survive server rendering.** Every `shaka-player` dist reads the bare `self` global while its UMD wrapper evaluates, so importing the media crashed any server runtime. A shim module lends the evaluation a `self` and takes it back immediately after, and the constructor bails before the `isBrowserSupported()` probe when there is no DOM (React reaches it via `useState(() => new ShakaMedia())` during server render). The server instance keeps `engine` null; the client constructs its own.
- **Ship the es2021 bundle.** The package default is the ES5 build carrying Closure's language polyfills for targets this repo doesn't support. The es2021 variant is the same everything-but-UI API with sibling type declarations, taking `@videojs/html/media/shaka-video` from 225.3 kB to 204.2 kB (−9.4%), with matching drops on the media and react entries. Shaka publishes no exports map, so the deep dist path is stable public surface.
- **`streamType`** with user override and `streamtypechange`, detected from `isLive()`/`isInProgress()` — an in-progress recording still grows its window, so it announces as live rather than on-demand.
- **`targetLiveWindow` and a read-time `liveEdgeStart`**, offset by three max segment durations per the HLS spec default, with the same armed one-shot seek-to-live on first user play the hls.js media performs. Everything reads public Shaka API — `getManifest()` warns that its shape sits outside semver, so the resolved presentation delay stays off limits.
- **`preload`** mapped onto when and how `load()` runs, since Shaka has no `autoStartLoad`: `none` holds the load until a play intent, and `metadata` (the default) loads with buffering clamped to about a segment until first play. `autoplay` counts as play intent, since with nothing fetched, readiness could never fire it.
- **`defaultShakaConfig`** applying `abr.restrictToElementSize` — the Shaka spelling of the hls.js media's `capLevelToPlayerSize` — re-applied under user configuration after every reset.
- **e2e coverage**: generated HTML pages for Shaka playing HLS and DASH plus a React HLS page, registered with the media fixtures and selectors.

## Testing

- `pnpm -F @videojs/media test src/dom/shaka` — 62 tests across 4 files, all passing
- Generated e2e pages exercise the element across HLS, DASH, and React

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Shaka load, live-edge, and preload behavior, so playback timing and buffering can change; SSR shimming of `self` is carefully scoped but still environment-sensitive.
> 
> **Overview**
> Brings `ShakaMedia` in line with the hls.js media: SSR-safe construction, `streamType` / live-edge APIs, `preload` semantics, and ABR capped to element size — while switching to Shaka’s es2021 bundle.
> 
> **Playback behavior.** `preload` now drives when `engine.load()` runs (`none` defers until play intent; `metadata` loads with buffering clamped to ~1s until play; `autoplay` counts as intent). Live streams expose `targetLiveWindow` and a read-time `liveEdgeStart` (3× max segment duration) and seek to the edge on first user play. `streamType` is detected from `isLive()` / `isInProgress()` with a user override. Default config sets `abr.restrictToElementSize`.
> 
> **Runtime.** A short `self` shim lets the UMD bundle evaluate on the server, then is removed; the constructor no-ops without `document`. Imports move to `shaka-player/dist/shaka-player.compiled-es2021`.
> 
> E2E fixtures add HTML HLS/DASH and React HLS Shaka pages; unit tests cover live, stream type, preload, and Node import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f292104bf31b2d5b6c5b0d0bf3ba7c07e4b8b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->