### PR TITLE
fix(spf): report a verdict when the background ladder is undecodable

### DIFF
--- a/internal/design/spf/features/errors.md
+++ b/internal/design/spf/features/errors.md
@@ -226,7 +226,7 @@ DOM-free, so the codes are usable from any layer: `SvtaError`
 | `collectErrors` | `playback/behaviors/collect-errors.ts` | Owns the `errors` slot and its per-source lifecycle. No effects, no policy — a lifecycle owner, not an error handler. Same slot-owner-vs-writer split as `setupFailoverMonitor` / `failedCdns` |
 | `switchVideoTrack` / `switchAudioTrack` / `switchTextTrack` | `playback/behaviors/track-switching.ts` | Report the **verdict** (2011 / 2012) when a type has renditions but constraints pruned every one. Per-variant `noSupportedTrackCode`; text supplies none, since absent subtitles aren't a failure. Reports generically — it never reads a constraint's state, so it doesn't know *why* the set emptied |
 | `selectVideoTrack` | `playback/behaviors/select-tracks.ts` | The *pinned* variant. `entry` stays the only thing that ever **selects**; a sibling `effects` entry on the same `presentation-resolved` state only ever **de**selects, dropping a pick the constraints turned against. Keeping selection out of the reaction is what separates this from `switchVideoTrack` — a re-pick here would make it that behavior with extra steps — but it must *be* a reaction, since container and encryption are only known once a media playlist resolves, after `entry` ran. It reports nothing itself: whatever made the pick unplayable already reported its own cause (1004 / 4008), more specific than a verdict and already logged. A pick naming a track the manifest never offered is left alone, preserving the module's external-writes contract |
-| `reportAbsentTrackType` | `playback/behaviors/collect-errors.ts` | The one failure with no cause behind it: a source offering **no** renditions of a type the composition needs. Nothing resolves, so `reportUnsupportedTrackConditions` never runs and no cause exists to be more specific than a verdict. Shaped as a *constraint* rather than config so a composition opts in by adding it to `constraints` and one that doesn't pays nothing — it never actually constrains, returning its input untouched. Belongs at the head of the chain, where an empty input still means "the source offers none" rather than "the constraints ahead pruned them all." Idempotent, because the chain runs inside a `computed` that re-derives on every `presentation` write while the sequence keeps duplicates |
+| `reportAbsentTrackType` | `playback/behaviors/collect-errors.ts` | The failures with no cause behind them: a source offering **no** renditions of a type the composition needs, and a ladder the capability pre-pass prunes to nothing. Neither resolves anything, so `reportUnsupportedTrackConditions` never runs and no cause exists to be more specific than a verdict. Shaped as a *constraint* rather than config so a composition opts in by adding it to `constraints` and one that doesn't pays nothing — it never actually constrains, returning its input untouched. Belongs at the **tail** of the chain, where an empty input means "nothing playable here" — both shapes at once, which is what 2011 denotes. Idempotent, because the chain runs inside a `computed` that re-derives on every `presentation` write while the sequence keeps duplicates |
 | `resolveVideoTrack` / `resolveAudioTrack` / `resolveTextTrack` | `playback/behaviors/resolve-track.ts` | Call the `reportUnsupportedTrackConditions` seam post-parse, reporting **causes** per rendition as it resolves — before committing the parsed track |
 
 **Helpers and seams:**
@@ -305,6 +305,14 @@ console. Reporting a verdict from the deselect instead was the
 alternative; it stays rejected because selection there deliberately reports
 nothing (the cause is more specific and already logged), and because fatality is
 the adapter's to decide.
+
+Those measurements predate the tail placement of `reportAbsentTrackType`: both
+sources now report their cause and then 2011, once the pre-pass re-runs on the
+relabeled type and finds nothing left. First-fatal-wins still surfaces the cause, so
+`media.error` is unchanged and only the sequence grows — what stacked reporting
+(Principles 5–6) expects. The tail is also what covers a ladder pruned on `CODECS`:
+the one cause knowable from the multivariant playlist, and so the only one whose
+renditions are never picked, never resolved, and never report a cause at all.
 
 Both platform components forward it, since a consumer of either holds the element
 rather than the Media. `<hls-background-video>` re-fires `'error'` on itself and

--- a/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
+++ b/packages/spf/src/playback/adapters/hls-background-video/adapter.ts
@@ -56,9 +56,9 @@ export interface HlsBackgroundVideoMediaAPI extends HlsBackgroundVideoMediaProps
  * 1004 and an encrypted one 4008, each with no verdict behind it, and the element
  * then sits at `readyState 0` with `error` null forever.
  *
- * The verdict is still listed, for the one shape that reports nothing else: a
- * source offering no video renditions at all, which `reportAbsentTrackType`
- * reports from the head of the constraint chain.
+ * The verdict is still listed, for the shapes that report nothing else: no video
+ * renditions at all, or a ladder pruned before anything resolves — both of which
+ * `reportAbsentTrackType` covers from the tail of the constraint chain.
  *
  * First-fatal-wins then surfaces the cause rather than the verdict when both are
  * present, which is the more specific of the two.

--- a/packages/spf/src/playback/behaviors/collect-errors.ts
+++ b/packages/spf/src/playback/behaviors/collect-errors.ts
@@ -78,14 +78,14 @@ export function emitError(state: ErrorEmitterState, error: SvtaError): void {
  * composition opts in by adding it to `constraints` — nothing to thread through
  * config, and no cost at all to a composition that leaves it out.
  *
- * **Belongs first in the chain.** A constraint sees the list as it stands at its
- * own position, so only at the head does an empty input mean "the source offers
- * none of this type" rather than "the constraints ahead of me pruned them all."
+ * **Belongs last in the chain.** A constraint sees the list as it stands at its
+ * own position, so only at the tail does an empty input mean "nothing playable
+ * here" — none of this type offered, or the constraints ahead pruned them all.
  *
- * This is the one failure no per-rendition cause can report: causes come from
- * `reportUnsupportedTrackConditions` as each media playlist resolves, and here
- * nothing resolves, because there is nothing to resolve. Everything else already
- * reports something more specific than a verdict.
+ * These are the failures no per-rendition cause can report: causes come from
+ * `reportUnsupportedTrackConditions` as each media playlist resolves, and a
+ * rendition pruned before selection never resolves. Container and encryption
+ * aren't knowable until one does; CODECS is, so an undecodable ladder isn't.
  *
  * Idempotent because the constraint chain runs inside a `computed` that re-derives
  * on every `presentation` write — segment appends and live reloads included — and
@@ -94,7 +94,7 @@ export function emitError(state: ErrorEmitterState, error: SvtaError): void {
  *
  * @example
  * // engine-background-video.ts — video-only, so a source with none can't play
- * constraints: [reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK), excludeUnplayableTracks]
+ * constraints: [excludeUnplayableTracks, reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK)]
  */
 export function reportAbsentTrackType<T>(code: number): SelectionRule<T, ErrorEmitterState> {
   return (tracks, { state }) => {

--- a/packages/spf/src/playback/engines/hls/engine-background-video.ts
+++ b/packages/spf/src/playback/engines/hls/engine-background-video.ts
@@ -111,9 +111,9 @@ export interface BackgroundVideoEngineConfig
   extends ShareSignalsConfig<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   /**
    * Hard-constraint pre-pass handed to `selectVideoTrack`. Defaults to
-   * `[reportAbsentTrackType(2011), excludeUnplayableTracks]` — report a source
-   * offering no video at all (this engine composes only video, so it can never
-   * play one), then prune the renditions this environment can't decode.
+   * `[excludeUnplayableTracks, reportAbsentTrackType(2011)]` — prune the renditions
+   * this environment can't decode, then report 2011 if nothing is left (this engine
+   * composes only video, so a source with none playable can never play).
    */
   constraints?: SelectVideoTrackConfig['constraints'];
   /**
@@ -199,7 +199,7 @@ export function createBackgroundVideoEngine(
 ): Composition<BackgroundVideoEngineState, BackgroundVideoEngineContext> {
   const finalConfig = {
     ...config,
-    constraints: config.constraints ?? [reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK), excludeUnplayableTracks],
+    constraints: config.constraints ?? [excludeUnplayableTracks, reportAbsentTrackType(SVTA_NO_SUPPORTED_VIDEO_TRACK)],
     rules: config.rules ?? [screenResolutionCap, preferHighestResolution],
     parsePresentation: config.parsePresentation ?? parseMultivariantPlaylist,
     resolveDuration: getResolvedSelectedTrackDuration,

--- a/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
+++ b/packages/spf/src/playback/engines/hls/tests/engine-background-video.test.ts
@@ -103,17 +103,71 @@ describe('createBackgroundVideoEngine', () => {
       engine.destroy();
     });
 
-    // MPEG-TS: the capability constraint prunes it, so nothing is selected. No
-    // verdict — the cause (1004) is reported by `resolveVideoTrack` as the playlist
-    // resolves, which is more specific and needs no manifest fetch here.
+    // MPEG-TS: the capability constraint prunes it, so nothing is selected and the
+    // emptied set reports 2011. The cause (1004) precedes it in the real flow, where
+    // the track is picked and resolves first; this presentation starts pre-relabeled.
     it('makes no pick for an unplayable container', async () => {
       const engine = createBackgroundVideoEngine();
       engine.state.presentation.set(unplayablePresentation());
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(engine.state.selectedVideoTrackId.get()).toBeUndefined();
-      expect(engine.state.errors.get()).toBeUndefined();
+      expect(engine.state.errors.get()).toEqual([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
       engine.destroy();
+    });
+
+    // CODECS is in the multivariant playlist, so an undecodable ladder is pruned
+    // before anything is picked and nothing resolves to report a cause. The emptied
+    // survivor set is the only thing left to report, which is why 2011 covers it.
+    it('reports for a ladder the environment cannot decode', async () => {
+      const engine = createBackgroundVideoEngine({ canPlayTrack: () => false });
+      engine.state.presentation.set(undecodablePresentation());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(engine.state.selectedVideoTrackId.get()).toBeUndefined();
+      expect(engine.state.errors.get()).toEqual([{ code: SVTA_NO_SUPPORTED_VIDEO_TRACK }]);
+      engine.destroy();
+    });
+
+    // fMP4 throughout, so only the injected codec probe rejects it.
+    const undecodablePresentation = (): MaybeResolvedPresentation => ({
+      id: 'p',
+      url: 'https://example.com/v.m3u8',
+      startTime: 0,
+      selectionSets: [
+        {
+          id: 'video-set',
+          type: 'video',
+          switchingSets: [
+            {
+              id: 'video-switching',
+              type: 'video',
+              tracks: [
+                {
+                  type: 'video',
+                  id: '720p-hevc',
+                  url: 'https://example.com/720p.m3u8',
+                  bandwidth: 2_000_000,
+                  mimeType: 'video/mp4',
+                  codecs: ['hvc1.1.6.L93.B0'],
+                  width: 1280,
+                  height: 720,
+                },
+                {
+                  type: 'video',
+                  id: '1080p-hevc',
+                  url: 'https://example.com/1080p.m3u8',
+                  bandwidth: 5_000_000,
+                  mimeType: 'video/mp4',
+                  codecs: ['hvc1.1.6.L120.B0'],
+                  width: 1920,
+                  height: 1080,
+                },
+              ],
+            },
+          ],
+        },
+      ],
     });
 
     // The one failure with no per-rendition cause behind it: nothing resolves, so

--- a/packages/spf/src/playback/primitives/selection-rules.ts
+++ b/packages/spf/src/playback/primitives/selection-rules.ts
@@ -77,9 +77,10 @@ export function applyRules<T, State, Context, Config>(
  * `applyRules`, this never skips an empty result and never early-bails — every
  * constraint always applies, and an empty survivor set is a real outcome
  * ("nothing playable here"), not a fall-through. Because each constraint only
- * removes, the order they run in can't change the result.
+ * removes, the order they run in can't change which tracks survive — though one
+ * that also *reports* reads the list at its own position, so placement matters.
  *
- * @param constraints - Constraints to apply (pooled, order-independent)
+ * @param constraints - Constraints to apply, in order
  * @param tracks - Candidate tracks
  * @param deps - The behavior's `{ state, context, config }`, passed to each constraint
  * @returns The playable survivors (possibly empty)
@@ -139,7 +140,7 @@ export interface CapabilityConstraintConfig {
  * Passes everything through when there's no probe (a composition that didn't
  * wire one, or DOM-free tests). When it prunes *every* track, the empty result is
  * preserved (per `applyConstraints`) — "nothing playable" — which each consuming
- * behavior answers by clearing its selection and reporting the type's verdict.
+ * behavior answers by clearing its selection; reporting the verdict is separate.
  */
 export function excludeUnplayableTracks<T, State, Context, Config>(
   tracks: readonly T[],


### PR DESCRIPTION
Fast-follow to #2135, which merged without this fix.

## Summary

A background video whose whole ladder is undecodable in this environment — an HEVC or
AV1 source — stalls silently: no error is reported anywhere, and the element sits at
`readyState 0` with `error` null. This is the exact failure mode the unplayable-source
surface added in #2135 exists to close, left open for the one cause that is knowable
before playback starts.

Scoped to the background-video engine. `reportAbsentTrackType` is composed by no other
engine, so nothing else changes behavior; the remaining files are comment corrections.

## Changes

- `createBackgroundVideoEngine` now defaults its constraints to
  `[excludeUnplayableTracks, reportAbsentTrackType(2011)]` rather than the reverse. At the
  tail of the chain an empty input means "nothing playable here", which is what 2011
  already denotes — renditions all excluded as unplayable, *or* none offered to begin
  with. Only the second half was reaching a consumer.
- A container or encryption failure can now report `[1004, 2011]` rather than `[1004]`.
  `media.error` is unchanged: first-fatal-wins still surfaces the cause, and the 99001
  substitution is untouched. Only the logged sequence grows.
- Comments in `collect-errors`, `selection-rules`, and the background adapter argued for
  the old position, or claimed a verdict the pinned selection never emitted. They now
  describe what the code does.

<details>
<summary>Why codec is the only cause with nothing behind it</summary>

`reportAbsentTrackType` fires on an empty input at whatever position it holds, so at the
head of the chain it only ever saw the raw track list.

`CODECS` is in the **multivariant** playlist, so `excludeUnplayableTracks` can prune an
undecodable ladder *before* anything is picked. Nothing resolves, so
`reportUnsupportedTrackConditions` never runs and no cause exists — and the type was
still non-empty when the head-position reporter looked at it, so no verdict was emitted
either.

Container and encryption escape this only because neither is knowable until a media
playlist resolves: `parse-multivariant` labels every video track `video/mp4`, so those
renditions are always picked and resolved first and report 1004 or 4008 on the way down.

The order of `applyConstraints` cannot change *which* tracks survive, but this rule's
report is a side effect, and side effects are order-dependent. That distinction is now
written down where the old claim was.

</details>

## Testing

`pnpm -F @videojs/spf test` — 1519 passing / 11 skipped, including a new
`'reports for a ladder the environment cannot decode'` case (two-rendition HEVC ladder,
`canPlayTrack: () => false`), confirmed failing against the previous ordering.

`'makes no pick for an unplayable container'` is updated: it had codified the gap by
asserting `errors` stays `undefined`. The adapter needed no new test — its existing
`'explains a source with no video renditions too'` already drives the `[{code: 2011}]`
sequence through `media.error` and the console log, which is what this now produces.

Also green: `@videojs/html` and `@videojs/react` background-media suites, `pnpm typecheck`,
`pnpm check:workspace`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the background engine emits fatal 2011 (including stacking it after 1004/4008). Adapter mapping and first-fatal-wins are unchanged, but error sequences and consumer-visible failures for codec-pruned sources now fire.
> 
> **Overview**
> Closes a silent stall on background video when the whole ladder is pruned by capability (e.g. HEVC/AV1) before anything resolves.
> 
> `createBackgroundVideoEngine` now defaults constraints to `[excludeUnplayableTracks, reportAbsentTrackType(2011)]`. At the **tail**, an empty set means “nothing playable” — no video offered *or* everything pruned — so 2011 covers codec-only failures that never hit `reportUnsupportedTrackConditions`. Container/DRM paths can now stack `[cause, 2011]`; first-fatal-wins still surfaces the cause, so `media.error` is unchanged.
> 
> Scoped to this engine (`reportAbsentTrackType` is not composed elsewhere). Tests cover an injected-undecodable HEVC ladder and expect 2011 after an unplayable-container prune.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da2fd798e0d5296e11d4a93565de879b538defc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->