### PR TITLE
feat(media): bring the source rendition caps to the shaka media

### DIFF
--- a/packages/media/src/core/resolution.ts
+++ b/packages/media/src/core/resolution.ts
@@ -1,0 +1,35 @@
+import type { MediaResolution } from './types';
+
+/**
+ * Floor applied to the player-size cap unless a source names another.
+ *
+ * The low rungs of a ladder are there for bad network conditions, and at that
+ * end the relationship between resolution and perceived quality stops holding:
+ * a small player capped to 360p looks worse than its size alone suggests. No
+ * reliable signal exists to key that on, so a fixed floor stands in for one.
+ */
+export const DEFAULT_MIN_AUTO_RESOLUTION: MediaResolution = '720p';
+
+/**
+ * Pixel area of a resolution shorthand, assuming 16:9 — `'720p'` is
+ * `1280 × 720`, or `921_600`.
+ *
+ * Renditions are matched on area rather than literal height so anamorphic
+ * variants are judged by how many pixels they actually carry: a 2560×1080
+ * ultrawide rendition costs more than 16:9 1080p and is capped accordingly.
+ *
+ * Mirrors `maxResolutionToPixelArea` in `@videojs/spf`, and agrees with it on
+ * every rung whose 16:9 width is a whole number. It parts company at `'480p'`
+ * on purpose: 16:9 at 480 tall is 853.33 wide, ladders ship the rounded-up
+ * 854×480, and the exact area would put the standard 480p rendition over its
+ * own cap. Rounding the width up admits it while still excluding anything
+ * genuinely wider.
+ */
+export function resolutionToPixelArea(resolution: MediaResolution | undefined): number {
+  if (resolution === undefined) return Number.POSITIVE_INFINITY;
+
+  const height = Number.parseInt(resolution, 10);
+  if (!(Number.isFinite(height) && height > 0)) return Number.POSITIVE_INFINITY;
+
+  return Math.ceil((height * 16) / 9) * height;
+}

--- a/packages/media/src/dom/hls-js/cap-level.ts
+++ b/packages/media/src/dom/hls-js/cap-level.ts
@@ -1,5 +1,10 @@
 import Hls, { type Level } from 'hls.js';
+import { resolutionToPixelArea } from '../../core/resolution';
 import type { MediaResolution } from '../../core/types';
+
+// Shared with the Shaka media's rendition cap; both engines translate the same
+// source options through the same math.
+export { DEFAULT_MIN_AUTO_RESOLUTION, resolutionToPixelArea } from '../../core/resolution';
 
 /**
  * Live cap inputs the installed cap-level controller reads on every evaluation.
@@ -20,43 +25,9 @@ export interface RenditionCapPolicy {
   controller?: RenditionCapController | undefined;
 }
 
-/**
- * Floor applied to the player-size cap unless a source names another.
- *
- * The low rungs of a ladder are there for bad network conditions, and at that
- * end the relationship between resolution and perceived quality stops holding:
- * a small player capped to 360p looks worse than its size alone suggests. No
- * reliable signal exists to key that on, so a fixed floor stands in for one.
- */
-export const DEFAULT_MIN_AUTO_RESOLUTION: MediaResolution = '720p';
-
 export interface RenditionCapController {
   /** Re-evaluate the policy now rather than on hls.js's next tick. */
   apply(): void;
-}
-
-/**
- * Pixel area of a resolution shorthand, assuming 16:9 — `'720p'` is
- * `1280 × 720`, or `921_600`.
- *
- * Renditions are matched on area rather than literal height so anamorphic
- * variants are judged by how many pixels they actually carry: a 2560×1080
- * ultrawide rendition costs more than 16:9 1080p and is capped accordingly.
- *
- * Mirrors `maxResolutionToPixelArea` in `@videojs/spf`, and agrees with it on
- * every rung whose 16:9 width is a whole number. It parts company at `'480p'`
- * on purpose: 16:9 at 480 tall is 853.33 wide, ladders ship the rounded-up
- * 854×480, and the exact area would put the standard 480p rendition over its
- * own cap. Rounding the width up admits it while still excluding anything
- * genuinely wider.
- */
-export function resolutionToPixelArea(resolution: MediaResolution | undefined): number {
-  if (resolution === undefined) return Number.POSITIVE_INFINITY;
-
-  const height = Number.parseInt(resolution, 10);
-  if (!(Number.isFinite(height) && height > 0)) return Number.POSITIVE_INFINITY;
-
-  return Math.ceil((height * 16) / 9) * height;
 }
 
 /**

--- a/packages/media/src/dom/shaka/media.ts
+++ b/packages/media/src/dom/shaka/media.ts
@@ -12,10 +12,17 @@ import shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
 import type { DrmSystemsConfig } from '../../core/drm';
 import { MediaError } from '../../core/media-error';
 import { MediaTracksMixin } from '../../core/media-tracks';
-import { type MediaEngineHost, type MediaPreloadType, type MediaStreamType, MediaStreamTypes } from '../../core/types';
+import {
+  type MediaEngineHost,
+  type MediaPreloadType,
+  type MediaResolution,
+  type MediaStreamType,
+  MediaStreamTypes,
+} from '../../core/types';
 import { HTMLVideoElementHost } from '../video-host';
 import { ShakaMediaLiveMixin } from './live';
 import { ShakaMediaMediaTracksMixin } from './media-tracks';
+import { RenditionCapController } from './rendition-cap';
 import { didShimSelf } from './server-shim';
 import { ShakaMediaStreamTypeMixin } from './stream-type';
 
@@ -59,6 +66,54 @@ export interface ShakaSource {
    * is the browser's choice.
    */
   drm?: DrmSystemsConfig | undefined;
+  /**
+   * Highest resolution adaptive bitrate selection may choose on its own.
+   *
+   * A ceiling on automatic selection, not a filter on what is available:
+   * renditions above it stay in `videoRenditions` and can still be selected by
+   * hand. Matching is by pixel area, so a `'720p'` cap admits any rendition at
+   * or below 1280×720 worth of pixels. When every rendition sits above the cap,
+   * the smallest one is used.
+   *
+   * Applied live — changing it never rebuilds the playback engine.
+   */
+  maxAutoResolution?: MediaResolution | undefined;
+  /**
+   * Whether the element's rendered size caps automatic selection. Defaults to
+   * `true`.
+   *
+   * A 400px-wide player has no use for a 4K rendition, so selection is held to
+   * the smallest rendition that still covers the element, measured in device
+   * pixels — a `2` device pixel ratio asks for twice what a CSS measurement
+   * would. The cap follows the element as it resizes, and `minAutoResolution`
+   * bounds how far down it can go. Set it to `false` for a player whose layout
+   * size understates what it needs, such as one that goes fullscreen without a
+   * resize.
+   *
+   * Applied live — changing it never rebuilds the playback engine. Shaka's own
+   * `abr.restrictToElementSize` (through `source.engine.shaka`) is a different
+   * thing: Shaka's built-in size cap, which knows nothing of
+   * `minAutoResolution` and composes with this one rather than replacing it.
+   */
+  capRenditionToPlayerSize?: boolean | undefined;
+  /**
+   * Lowest resolution `capRenditionToPlayerSize` may cap down to. Defaults to
+   * `'720p'`.
+   *
+   * Not a quality floor. It bounds the size-derived cap and nothing else: when
+   * bandwidth is poor, adaptive selection still drops below it, because the cap
+   * is a ceiling and selection stays free underneath. Nor does it raise an
+   * explicit `maxAutoResolution` — asking for at most `'360p'` alongside a
+   * `'720p'` floor yields `'360p'`.
+   *
+   * The default exists because the low rungs of a ladder are there for poor
+   * network conditions, and capping a small player to them looks worse than its
+   * size suggests. Name a lower rung to weaken the floor, or `'270p'` to lift
+   * it for any real ladder.
+   *
+   * Applied live — changing it never rebuilds the playback engine.
+   */
+  minAutoResolution?: MediaResolution | undefined;
   /** Playback options, keyed by the engine that reads them. */
   engine?: ShakaEngineConfig | undefined;
 }
@@ -88,16 +143,6 @@ export const shakaMediaDefaultProps: ShakaMediaProps = {
   streamType: MediaStreamTypes.UNKNOWN,
 };
 
-/**
- * Configuration this element applies on top of Shaka's own defaults — the
- * Shaka spelling of what the hls.js media ships (`capLevelToPlayerSize`):
- * adaptation stays within renditions no larger than the element rendering
- * them. Anything under `source.engine.shaka` overrides it.
- */
-const defaultShakaConfig: ShakaConfig = {
-  abr: { restrictToElementSize: true },
-};
-
 const ShakaMediaHost = MediaTracksMixin(HTMLVideoElementHost);
 
 class ShakaMediaBase
@@ -105,6 +150,7 @@ class ShakaMediaBase
   implements MediaEngineHost<shaka.Player, HTMLVideoElement>, Omit<ShakaMediaProps, 'streamType'>
 {
   #engine: shaka.Player | null = null;
+  #renditionCap: RenditionCapController | null = null;
   #src = shakaMediaDefaultProps.src;
   #source: ShakaSource | null = shakaMediaDefaultProps.source;
   #preload: MediaPreloadType = shakaMediaDefaultProps.preload;
@@ -134,7 +180,11 @@ class ShakaMediaBase
     }
 
     this.#engine = new shaka.Player();
-    this.#engine.configure(defaultShakaConfig);
+    // The Shaka spelling of what the hls.js media ships (`capLevelToPlayerSize`):
+    // adaptation stays within renditions no larger than the element rendering
+    // them, floored so a small player is never capped onto the ladder's lowest
+    // rungs. The source's cap options steer it live.
+    this.#renditionCap = new RenditionCapController(this.#engine);
     this.#engine.addEventListener('error', this.#onEngineError);
   }
 
@@ -155,6 +205,7 @@ class ShakaMediaBase
     const engine = this.#engine;
     if (!engine || !isNewTarget) return;
 
+    this.#renditionCap?.observe(target);
     this.#run(engine.attach(target));
     // Shaka takes its lock in call order, so this runs after the attach above
     // without waiting on it here.
@@ -165,8 +216,10 @@ class ShakaMediaBase
     const engine = this.#engine;
     const wasAttached = this.target !== null;
 
-    // The play listener belongs to the target that is leaving.
+    // The play listener belongs to the target that is leaving, as does the
+    // size-derived rendition cap.
     this.#disarmPlayIntent();
+    this.#renditionCap?.observe(null);
 
     super.detach();
 
@@ -181,6 +234,9 @@ class ShakaMediaBase
     // Anything still in flight has nothing left to report to.
     this.#engine = null;
     this.#isDestroyed = true;
+
+    this.#renditionCap?.destroy();
+    this.#renditionCap = null;
 
     if (engine) {
       engine.removeEventListener('error', this.#onEngineError);
@@ -224,10 +280,15 @@ class ShakaMediaBase
   set src(value) {
     // `src` says which source to play; every other field says how to play it,
     // so they carry over.
-    const { type, drm, engine } = this.#source ?? {};
+    const { type, drm, maxAutoResolution, capRenditionToPlayerSize, minAutoResolution, engine } = this.#source ?? {};
     const next: ShakaSource = {
       ...(type && { type }),
       ...(drm && { drm }),
+      ...(maxAutoResolution && { maxAutoResolution }),
+      // Definedness, not truthiness: `false` is the value worth naming, and the
+      // falsy one, so the neighbors' pattern would drop it.
+      ...(capRenditionToPlayerSize !== undefined && { capRenditionToPlayerSize }),
+      ...(minAutoResolution && { minAutoResolution }),
       ...(engine && { engine }),
       ...(value && { src: value }),
     };
@@ -296,12 +357,17 @@ class ShakaMediaBase
     // engine calls are guarded, so re-assigning an equivalent source — an inline
     // React prop, say — never disturbs what is already playing.
     const configChanged = !deepEqual(engineConfigKey(this.#source), engineConfigKey(source));
+    const capsChanged = !deepEqual(renditionCapKey(this.#source), renditionCapKey(source));
     const loadChanged = this.#src !== (source?.src ?? '') || this.#source?.type !== source?.type;
 
     this.#source = source;
     this.#src = source?.src ?? '';
 
     if (configChanged) this.#applyEngineConfig();
+    // The cap options are deliberately outside the engine config key, so
+    // changing one reaches the engine already running. A config change forces a
+    // re-apply either way: its reset lifted the restrictions the caps wrote.
+    if (configChanged || capsChanged) this.#applyRenditionCaps();
     if (loadChanged) this.#requestLoad();
 
     this.dispatchEvent(new Event('sourcechange'));
@@ -315,7 +381,6 @@ class ShakaMediaBase
     if (!engine) return;
 
     engine.resetConfiguration();
-    engine.configure(defaultShakaConfig);
 
     const config = withDrmConfig(this.#source?.engine?.shaka, this.#source?.drm);
     if (config) engine.configure(config);
@@ -323,6 +388,20 @@ class ShakaMediaBase
     // A wholesale re-apply raised the buffering goals a pending `'metadata'`
     // clamp held down; clamp again against the configuration now in force.
     if (this.#clampedGoals) this.#clampBuffering(engine);
+  }
+
+  /** Push the source's rendition caps down to the controller that applies them. */
+  #applyRenditionCaps() {
+    const { maxAutoResolution, capRenditionToPlayerSize, minAutoResolution, engine } = this.#source ?? {};
+
+    this.#renditionCap?.update({
+      maxAutoResolution,
+      capToPlayerSize: capRenditionToPlayerSize,
+      minAutoResolution,
+      // The computed ceilings intersect whatever `engine.shaka` restricted
+      // itself, so a stricter caller-configured ceiling stays in force.
+      baseRestrictions: engine?.shaka?.abr?.restrictions,
+    });
   }
 
   #requestLoad() {
@@ -487,6 +566,15 @@ function installPolyfills() {
  */
 function engineConfigKey(source: ShakaSource | null) {
   return { drm: source?.drm ?? null, shaka: source?.engine?.shaka ?? null };
+}
+
+/** The cap inputs on their own; they steer a running engine without a reload. */
+function renditionCapKey(source: ShakaSource | null) {
+  return {
+    maxAutoResolution: source?.maxAutoResolution ?? null,
+    capRenditionToPlayerSize: source?.capRenditionToPlayerSize ?? null,
+    minAutoResolution: source?.minAutoResolution ?? null,
+  };
 }
 
 /**

--- a/packages/media/src/dom/shaka/rendition-cap.ts
+++ b/packages/media/src/dom/shaka/rendition-cap.ts
@@ -1,0 +1,172 @@
+import type shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
+import { DEFAULT_MIN_AUTO_RESOLUTION, resolutionToPixelArea } from '../../core/resolution';
+import type { MediaResolution } from '../../core/types';
+
+/** Cap inputs, replaced together whenever the source changes. */
+export interface RenditionCapInputs {
+  /** Highest resolution ABR may auto-select, or `undefined` for no cap. */
+  maxAutoResolution?: MediaResolution | undefined;
+  /** Whether the element's rendered size caps automatic selection. Defaults to `true`. */
+  capToPlayerSize?: boolean | undefined;
+  /** Lowest resolution {@link capToPlayerSize} may cap down to. Defaults to `'720p'`. */
+  minAutoResolution?: MediaResolution | undefined;
+  /**
+   * The source's own `abr.restrictions`, which the computed ceilings must stay
+   * within. Shaka merges every `configure()` call, so whatever this controller
+   * writes last into the keys it owns is what stands — intersecting here is
+   * what keeps a stricter caller-configured ceiling in force.
+   */
+  baseRestrictions?: Partial<shaka.extern.Restrictions> | undefined;
+}
+
+/** The slice of `abr.restrictions` this controller owns. */
+interface CapRestrictions {
+  maxPixels: number;
+  maxWidth: number;
+  maxHeight: number;
+}
+
+/**
+ * Translates the source's rendition caps into Shaka's `abr.restrictions` — the
+ * Shaka spelling of what the hls.js media's cap-level controller does.
+ *
+ * `abr.restrictions` is the right seam for the same reason `autoLevelCapping`
+ * is on hls.js: it bounds automatic selection only. Renditions above a ceiling
+ * stay in `videoRenditions` and stay selectable by hand, and when nothing
+ * satisfies the restrictions Shaka falls back to the lowest-bandwidth variant
+ * rather than refusing to adapt.
+ *
+ * Shaka's own `abr.restrictToElementSize` is not used for the player-size cap
+ * because it offers no floor: the element measurement is inlined in
+ * `SimpleAbrManager.chooseVariant()` with nothing to override, so
+ * `minAutoResolution` could never reach it. This controller measures the
+ * element itself, floors the measurement, and rounds up to the smallest
+ * covering rendition — the same round-up Shaka's own cap performs.
+ */
+export class RenditionCapController {
+  #engine: shaka.Player;
+  #target: HTMLElement | null = null;
+  #resizeObserver: ResizeObserver | null = null;
+  #maxAutoResolution: MediaResolution | undefined;
+  #capToPlayerSize = true;
+  #minAutoResolution: MediaResolution = DEFAULT_MIN_AUTO_RESOLUTION;
+  #base: Partial<shaka.extern.Restrictions> = {};
+
+  constructor(engine: shaka.Player) {
+    this.#engine = engine;
+    // The ladder the size cap rounds up on arrives with the manifest and
+    // shifts whenever the playable set does.
+    engine.addEventListener('trackschanged', this.#onTracksChanged);
+  }
+
+  destroy() {
+    this.#engine.removeEventListener('trackschanged', this.#onTracksChanged);
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+    this.#target = null;
+  }
+
+  /** Follow `target`'s rendered size; `null` stops following. */
+  observe(target: HTMLElement | null) {
+    if (target === this.#target) return;
+
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+    this.#target = target;
+
+    if (target && typeof ResizeObserver === 'function') {
+      this.#resizeObserver = new ResizeObserver(() => this.#apply());
+      this.#resizeObserver.observe(target);
+    }
+
+    this.#apply();
+  }
+
+  /**
+   * Replace the cap inputs and re-evaluate now. Absent fields fall back to
+   * their defaults, so handing over a source with no caps named restores them.
+   */
+  update(inputs: RenditionCapInputs) {
+    this.#maxAutoResolution = inputs.maxAutoResolution;
+    this.#capToPlayerSize = inputs.capToPlayerSize ?? true;
+    this.#minAutoResolution = inputs.minAutoResolution ?? DEFAULT_MIN_AUTO_RESOLUTION;
+    this.#base = inputs.baseRestrictions ?? {};
+    this.#apply();
+  }
+
+  #apply() {
+    this.#engine.configure({ abr: { restrictions: this.#computeRestrictions() } });
+  }
+
+  /**
+   * The requested resolution ceiling lands on `maxPixels` — area, so
+   * anamorphic renditions are judged by the pixels they actually carry — and
+   * the size-derived one on `maxWidth`/`maxHeight`, the dimensions Shaka's own
+   * element cap weighs. Keeping them on separate keys is what lets each lift
+   * without disturbing the other. `Infinity` is Shaka's own "unrestricted", so
+   * lifting a cap writes the default back rather than leaving a stale ceiling
+   * behind.
+   */
+  #computeRestrictions(): CapRestrictions {
+    const size = this.#playerSizeCeiling();
+
+    return {
+      maxPixels: Math.min(this.#base.maxPixels ?? Infinity, resolutionToPixelArea(this.#maxAutoResolution)),
+      maxWidth: Math.min(this.#base.maxWidth ?? Infinity, size?.width ?? Infinity),
+      maxHeight: Math.min(this.#base.maxHeight ?? Infinity, size?.height ?? Infinity),
+    };
+  }
+
+  /**
+   * Dimensions of the smallest rendition that still covers the element,
+   * measured in device pixels, or `null` when there is no size to cap on.
+   *
+   * The floor lifts the measurement rather than the outcome: a 200px-tall
+   * player with a `'720p'` floor is capped as if it were 720 tall, and the
+   * round-up then admits whatever rendition covers *that*. A floor the ladder
+   * cannot reach caps nothing — every rendition already fits under it — which
+   * is what keeps the floor a bound on capping rather than a quality minimum.
+   */
+  #playerSizeCeiling(): { width: number; height: number } | null {
+    const target = this.#target;
+    if (!this.#capToPlayerSize || !target) return null;
+
+    const scale = globalThis.devicePixelRatio || 1;
+    const measuredWidth = target.clientWidth * scale;
+    const measuredHeight = target.clientHeight * scale;
+
+    // This cap *is* the element's size, so an element with no measurable size —
+    // hidden, detached, not laid out yet — derives none. A requested
+    // `maxAutoResolution` does not depend on layout and stands regardless.
+    if (!(measuredWidth > 0 && measuredHeight > 0)) return null;
+
+    const floorHeight = resolutionHeight(this.#minAutoResolution);
+    const width = Math.max(measuredWidth, Math.ceil((floorHeight * 16) / 9));
+    const height = Math.max(measuredHeight, floorHeight);
+
+    const ladder = this.#engine
+      .getVideoTracks()
+      .map((track) => ({ width: track.width ?? 0, height: track.height ?? 0 }))
+      .filter((track) => track.width > 0 && track.height > 0)
+      .sort((a, b) => a.width * a.height - b.width * b.height);
+
+    const covering = ladder.find((track) => track.width >= width && track.height >= height);
+    if (covering) return covering;
+
+    // Nothing covers the (floored) element: the whole ladder sits below it and
+    // needs no ceiling — a cap at the measurement could only cut out an
+    // oddly-shaped rendition that exceeds it on one axis alone.
+    if (ladder.length > 0) return null;
+
+    // No ladder to round up on yet. Cap at the measurement until the tracks
+    // arrive; `trackschanged` re-evaluates with the real rungs.
+    return { width: Math.ceil(width), height: Math.ceil(height) };
+  }
+
+  #onTracksChanged = () => this.#apply();
+}
+
+function resolutionHeight(resolution: MediaResolution): number {
+  const height = Number.parseInt(resolution, 10);
+  return Number.isFinite(height) && height > 0 ? height : 0;
+}

--- a/packages/media/src/dom/shaka/tests/rendition-cap.test.ts
+++ b/packages/media/src/dom/shaka/tests/rendition-cap.test.ts
@@ -1,0 +1,248 @@
+import type shaka from 'shaka-player/dist/shaka-player.compiled-es2021';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RenditionCapController } from '../rendition-cap';
+
+type FakeTrack = { width: number; height: number };
+
+const track = (width: number, height: number): FakeTrack => ({ width, height });
+
+/** 16:9 ladder, ascending, the shape `getVideoTracks()` reports. */
+const LADDER: FakeTrack[] = [track(640, 360), track(854, 480), track(1280, 720), track(1920, 1080), track(2560, 1440)];
+
+function createEngine(videoTracks: FakeTrack[] = LADDER) {
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  const engine = {
+    videoTracks,
+    configure: vi.fn(),
+    getVideoTracks: () => engine.videoTracks,
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      const typeListeners = listeners.get(type) ?? new Set();
+      typeListeners.add(listener);
+      listeners.set(type, typeListeners);
+    },
+    removeEventListener(type: string, listener: (event: unknown) => void) {
+      listeners.get(type)?.delete(listener);
+    },
+    emit(type: string) {
+      for (const listener of [...(listeners.get(type) ?? [])]) listener({ type });
+    },
+  };
+
+  return engine;
+}
+
+type FakeEngine = ReturnType<typeof createEngine>;
+
+const asPlayer = (engine: FakeEngine) => engine as unknown as shaka.Player;
+
+/** The `abr.restrictions` of the last `configure()` call. */
+function restrictions(engine: FakeEngine) {
+  return engine.configure.mock.lastCall?.[0].abr.restrictions;
+}
+
+/** jsdom lays nothing out, so the rendered size is stated instead. */
+function createTarget(width: number, height: number) {
+  const target = document.createElement('video');
+  Object.defineProperty(target, 'clientWidth', { value: width, configurable: true, writable: true });
+  Object.defineProperty(target, 'clientHeight', { value: height, configurable: true, writable: true });
+  return target;
+}
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  observed: Element[] = [];
+
+  constructor(private callback: () => void) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(element: Element) {
+    this.observed.push(element);
+  }
+
+  disconnect() {
+    this.observed = [];
+  }
+
+  resize() {
+    this.callback();
+  }
+}
+
+beforeEach(() => {
+  FakeResizeObserver.instances = [];
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RenditionCapController', () => {
+  it('translates maxAutoResolution into a pixel-area ceiling', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.update({ maxAutoResolution: '720p' });
+
+    expect(restrictions(engine)).toEqual({ maxPixels: 1280 * 720, maxWidth: Infinity, maxHeight: Infinity });
+  });
+
+  it('lifts every ceiling when no cap is asked for', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.update({ maxAutoResolution: '720p' });
+    controller.update({});
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: Infinity, maxHeight: Infinity });
+  });
+
+  it('caps to the smallest rendition that covers the element', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    // Wider and taller than the 720p floor, between the 1080p rung and the one
+    // below: the covering rung is what the cap admits.
+    controller.observe(createTarget(1500, 844));
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1920, maxHeight: 1080 });
+  });
+
+  it('never caps a small element below the default floor', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1280, maxHeight: 720 });
+  });
+
+  it('caps further down when the source names a lower floor', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    controller.update({ minAutoResolution: '360p' });
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 640, maxHeight: 360 });
+  });
+
+  it('keeps the floor subordinate to an explicit maxAutoResolution', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    controller.update({ maxAutoResolution: '360p' });
+
+    // The restrictions AND together, so the tighter `maxPixels` rules however
+    // high the floor holds the size-derived dimensions.
+    expect(restrictions(engine)).toEqual({ maxPixels: 640 * 360, maxWidth: 1280, maxHeight: 720 });
+  });
+
+  it('measures the element in device pixels', () => {
+    vi.stubGlobal('devicePixelRatio', 2);
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(960, 540));
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1920, maxHeight: 1080 });
+  });
+
+  it('derives no size cap from an element with no measurable size', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(0, 0));
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: Infinity, maxHeight: Infinity });
+  });
+
+  it('derives no size cap when capToPlayerSize is off', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    controller.update({ capToPlayerSize: false });
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: Infinity, maxHeight: Infinity });
+  });
+
+  it('leaves the whole ladder eligible when nothing covers the element', () => {
+    const engine = createEngine([track(640, 360)]);
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+
+    // The floor lifts the measurement past the ladder's top: nothing to cap.
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: Infinity, maxHeight: Infinity });
+  });
+
+  it('caps at the floored measurement until the ladder arrives', () => {
+    const engine = createEngine([]);
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1280, maxHeight: 720 });
+
+    engine.videoTracks = LADDER;
+    engine.emit('trackschanged');
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1280, maxHeight: 720 });
+  });
+
+  it('follows the element as it resizes', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+    const target = createTarget(320, 180);
+
+    controller.observe(target);
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1280, maxHeight: 720 });
+
+    Object.defineProperty(target, 'clientWidth', { value: 1920, configurable: true });
+    Object.defineProperty(target, 'clientHeight', { value: 1080, configurable: true });
+    FakeResizeObserver.instances[0]!.resize();
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: 1920, maxHeight: 1080 });
+  });
+
+  it('keeps a stricter caller-configured restriction in force', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    controller.update({
+      maxAutoResolution: '2160p',
+      baseRestrictions: { maxPixels: 1_000, maxWidth: 100 },
+    });
+
+    expect(restrictions(engine)).toEqual({ maxPixels: 1_000, maxWidth: 100, maxHeight: 720 });
+  });
+
+  it('lifts the size cap when it stops observing', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    controller.observe(null);
+
+    expect(restrictions(engine)).toEqual({ maxPixels: Infinity, maxWidth: Infinity, maxHeight: Infinity });
+    expect(FakeResizeObserver.instances[0]!.observed).toEqual([]);
+  });
+
+  it('stops evaluating once destroyed', () => {
+    const engine = createEngine();
+    const controller = new RenditionCapController(asPlayer(engine));
+
+    controller.observe(createTarget(320, 180));
+    controller.destroy();
+    engine.configure.mockClear();
+
+    engine.emit('trackschanged');
+
+    expect(engine.configure).not.toHaveBeenCalled();
+    expect(FakeResizeObserver.instances[0]!.observed).toEqual([]);
+  });
+});

--- a/packages/media/src/dom/shaka/tests/shaka-media.test.ts
+++ b/packages/media/src/dom/shaka/tests/shaka-media.test.ts
@@ -136,8 +136,13 @@ async function flush() {
   for (let index = 0; index < 5; index += 1) await Promise.resolve();
 }
 
-/** What the element itself configures on a fresh or reset engine. */
-const ELEMENT_DEFAULTS = { abr: { restrictToElementSize: true } };
+/**
+ * What the element itself configures on a fresh or reset engine: the rendition
+ * cap's restrictions, all lifted — the test target has no measurable size and
+ * the sources under test name no caps.
+ */
+const DEFAULT_RESTRICTIONS = { maxPixels: Infinity, maxWidth: Infinity, maxHeight: Infinity };
+const ELEMENT_DEFAULTS = { abr: { restrictions: DEFAULT_RESTRICTIONS } };
 
 const MANIFEST = 'https://example.com/manifest.mpd';
 const OTHER_MANIFEST = 'https://example.com/other.m3u8';
@@ -374,9 +379,86 @@ describe('ShakaMedia', () => {
         servers: { [KeySystems.PLAYREADY]: 'https://example.com/playready' },
       });
     });
+
+    it('translates the rendition caps into abr restrictions', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, maxAutoResolution: '720p' };
+      await flush();
+
+      expect(engine.config.abr.restrictions.maxPixels).toBe(1280 * 720);
+    });
+
+    it('applies a cap change to the engine already running', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST };
+      await flush();
+      engine.load.mockClear();
+      engine.resetConfiguration.mockClear();
+
+      media.source = { src: MANIFEST, maxAutoResolution: '360p' };
+      await flush();
+
+      expect(engine.load).not.toHaveBeenCalled();
+      expect(engine.resetConfiguration).not.toHaveBeenCalled();
+      expect(engine.config.abr.restrictions.maxPixels).toBe(640 * 360);
+    });
+
+    it('keeps the rendition caps in force when shaka configuration is reset', async () => {
+      const { media, engine } = setup();
+
+      media.source = { src: MANIFEST, maxAutoResolution: '720p' };
+      await flush();
+
+      media.source = {
+        src: MANIFEST,
+        maxAutoResolution: '720p',
+        engine: { shaka: { streaming: { bufferingGoal: 30 } } },
+      };
+      await flush();
+
+      expect(engine.resetConfiguration).toHaveBeenCalled();
+      expect(engine.config.abr.restrictions.maxPixels).toBe(1280 * 720);
+    });
+
+    it('keeps a stricter shaka-configured restriction in force', async () => {
+      const { media, engine } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        maxAutoResolution: '2160p',
+        engine: { shaka: { abr: { restrictions: { maxPixels: 1_000 } } } },
+      };
+      await flush();
+
+      expect(engine.config.abr.restrictions.maxPixels).toBe(1_000);
+    });
   });
 
   describe('src', () => {
+    it('preserves the rendition caps across a src change', async () => {
+      const { media } = setup();
+
+      media.source = {
+        src: MANIFEST,
+        maxAutoResolution: '720p',
+        capRenditionToPlayerSize: false,
+        minAutoResolution: '360p',
+      };
+      await flush();
+
+      media.src = OTHER_MANIFEST;
+      await flush();
+
+      expect(media.source).toEqual({
+        src: OTHER_MANIFEST,
+        maxAutoResolution: '720p',
+        capRenditionToPlayerSize: false,
+        minAutoResolution: '360p',
+      });
+    });
+
     it('preserves source configuration across a src change', async () => {
       const { media, engine } = setup();
 
@@ -577,7 +659,7 @@ describe('ShakaMedia', () => {
       media.videoRenditions[1]!.selected = true;
       await flush();
 
-      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: false });
+      expect(engine.config.abr).toEqual({ restrictions: DEFAULT_RESTRICTIONS, enabled: false });
       expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
     });
 
@@ -592,7 +674,7 @@ describe('ShakaMedia', () => {
       media.videoRenditions[1]!.selected = false;
       await flush();
 
-      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: true });
+      expect(engine.config.abr).toEqual({ restrictions: DEFAULT_RESTRICTIONS, enabled: true });
     });
 
     it('leaves shaka configuration alone when nothing was ever pinned', async () => {
@@ -620,7 +702,7 @@ describe('ShakaMedia', () => {
       media.source = { src: MANIFEST, engine: { shaka: { streaming: { bufferingGoal: 30 } } } };
       await flush();
 
-      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: false });
+      expect(engine.config.abr).toEqual({ restrictions: DEFAULT_RESTRICTIONS, enabled: false });
       expect(engine.selectVideoTrack).toHaveBeenCalledWith(engine.videoTracks[1]);
     });
 
@@ -637,7 +719,7 @@ describe('ShakaMedia', () => {
       await flush();
 
       expect([...media.videoRenditions]).toEqual([]);
-      expect(engine.config.abr).toEqual({ restrictToElementSize: true, enabled: true });
+      expect(engine.config.abr).toEqual({ restrictions: DEFAULT_RESTRICTIONS, enabled: true });
     });
 
     it('stops mirroring tracks once destroyed', async () => {

--- a/site/src/content/docs/concepts/media-sources.mdx
+++ b/site/src/content/docs/concepts/media-sources.mdx
@@ -231,7 +231,7 @@ The cap limits automatic selection without hiding anything. Renditions above it 
 
 Renditions are matched on pixel area rather than height, which keeps unusual aspect ratios honest: an ultrawide 2560×1080 rendition carries more pixels than 16:9 1080p, so a `'1080p'` cap leaves it out. When every rendition sits above the cap, the smallest one plays.
 
-Changing the cap applies to the running engine, so playback continues uninterrupted. It needs the hls.js engine — native HLS playback ignores it, and audio-only streams have no video renditions to cap.
+Changing the cap applies to the running engine, so playback continues uninterrupted. It needs an engine with the lever — hls.js and Shaka both have one, native HLS playback ignores it — and audio-only streams have no video renditions to cap.
 
 ### Capping to the player's size
 


### PR DESCRIPTION
Refs #2285

## Summary

Fast follow to #2285, as requested in review: bring `source.maxAutoResolution`, `source.capRenditionToPlayerSize`, and `source.minAutoResolution` (added to the hls.js media in #2061 / #2243) to the shaka media, with the same semantics.

## Changes

- `ShakaSource` accepts the three cap options. They apply live — changing one steers the running engine without a configuration reset or a reload — and carry over across `src` changes like the rest of the "how to play it" fields.
- `maxAutoResolution` lands on `abr.restrictions.maxPixels`: a pixel-area ceiling on automatic selection only, so renditions above it stay in `videoRenditions` and stay selectable by hand. When nothing satisfies the restrictions, Shaka's own fallback picks the lowest-bandwidth variant — the same "play something over-spec rather than refuse to adapt" behavior the hls.js cap has.
- The player-size cap (default on, as before) now honors the `minAutoResolution` floor (default `'720p'`): a small player is capped to the smallest covering rendition, but never below the floor. The floor bounds the size-derived cap only — bandwidth-driven adaptation still drops below it, and an explicit lower `maxAutoResolution` still wins.
- A caller's own `engine.shaka.abr.restrictions` ceilings intersect with the computed ones, so a stricter configured restriction stays in force.
- The shared resolution math moves from `hls-js/cap-level.ts` into `core/resolution.ts` so both engines translate the same options through the same numbers (including the deliberate 480p rounding). The hls.js module re-exports it; no behavior change on that side.

<details>
<summary>Implementation details</summary>

Shaka's built-in `abr.restrictToElementSize` couldn't carry the floor: the element measurement is inlined in `SimpleAbrManager.chooseVariant()` with no seam to override (unlike hls.js's `getMaxLevel()`), and `abr.restrictions.minPixels` would be a hard eligibility floor that blocks bandwidth-driven drops — exactly what `minAutoResolution` must not do.

So the default config's `restrictToElementSize: true` is replaced by a `RenditionCapController` that owns the size cap: it measures the attached target in device pixels via `ResizeObserver`, floors the measurement at `minAutoResolution`'s 16:9 dimensions, and rounds up to the smallest covering rendition from `getVideoTracks()` (re-evaluated on `trackschanged`) — the same round-up Shaka's own cap performs. The size ceiling is written to `abr.restrictions.maxWidth`/`maxHeight` and the resolution ceiling to `maxPixels`, so each lifts without disturbing the other; `Infinity` is Shaka's own "unrestricted", so lifting a cap restores the default rather than leaving a stale ceiling behind. Setting `abr.restrictToElementSize: true` through `engine.shaka` remains an escape hatch and composes with this cap rather than fighting it.

The cap options live outside the engine-config key: changing one never triggers the `resetConfiguration()` path, and a config change forces a cap re-apply since the reset lifted the written restrictions.

Follow-up worth pursuing upstream: a floor option for Shaka's native `restrictToElementSize` would let us delete the custom size-cap machinery and go fully native.

</details>

## Testing

- `pnpm -F @videojs/media test` — full suite passes, including 15 new `RenditionCapController` tests (floor, covering round-up, device pixels, unmeasured element, resize follow, base-restriction intersection, teardown) and 5 new `ShakaMedia` wiring tests (live change without reload, survival across a config reset, `src` carry-over).
- `pnpm -F @videojs/html test` and `pnpm typecheck` pass.
- Verified in a real browser against the sandbox `html-shaka-video` template: shrinking the window engaged the floored size cap at the 1280×720 rung, `maxAutoResolution: '360p'` applied live and adaptation dropped to 640×360, and clearing it restored `maxPixels: Infinity` with the size cap still in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)