### PR TITLE
feat(spf): keep track selection within the initial codec family

### DIFF
--- a/apps/sandbox/app/shared/sources.ts
+++ b/apps/sandbox/app/shared/sources.ts
@@ -156,6 +156,21 @@ const SOURCE_MAP = {
     type: 'hls',
     subType: 'mp4',
   },
+  /**
+   * Apple's official HLS example stream (bipbop advanced, fMP4): HEVC and AVC
+   * renditions of the same content in one multivariant playlist, which makes
+   * it the shared mixed-codec source — the initial pick decides a codec
+   * family and SPF's ABR must hold it for the source's lifetime (no
+   * `SourceBuffer.changeType()`). Deliberately messy beyond the codecs: not
+   * CMAF-compliant, ~44ms A/V origin skew, a 10s timestamp origin, and VTT
+   * subtitles relying on `X-TIMESTAMP-MAP`.
+   */
+  'hls-mixed-codec': {
+    label: 'HLS - Apple bipbop (HEVC + AVC)',
+    url: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8',
+    type: 'hls',
+    subType: 'mp4',
+  },
   // The `hls-3` and `hls-1` assets again, named by playback ID instead of URL.
   // Nothing about the content differs — they exist so the Mux presets exercise
   // the structured `source` on an ordinary public asset, where every other

--- a/apps/sandbox/templates/spf-segment-loading/index.html
+++ b/apps/sandbox/templates/spf-segment-loading/index.html
@@ -326,11 +326,6 @@
           <option value="auto">auto</option>
         </select>
       </label>
-      <label
-        title="Filter out HEVC renditions so ABR stays within one codec family, avoiding SourceBuffer.changeType() (not yet implemented). Needed for mixed-codec sources like the Apple bipbop example."
-      >
-        <input type="checkbox" id="avc-only-toggle" /> AVC-only (avoid changeType)
-      </label>
     </div>
 
     <div id="share-url-section">

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -8,7 +8,6 @@ import '@app/styles.css';
 //   autoplay=true        Start with autoplay enabled
 //   loop=true            Loop playback
 //   preload=auto|metadata|none  Initial preload mode
-//   avcOnly=true         Filter out HEVC renditions (avoids changeType; see the toggle)
 
 import { SOURCE_IDS, SOURCES } from '@app/shared/sources';
 import { effect, snapshot } from '@videojs/spf';
@@ -30,7 +29,6 @@ const playerSizeDiv = document.getElementById('player-size-display') as HTMLDivE
 const srcPreset = document.getElementById('src-preset') as HTMLSelectElement;
 const srcInput = document.getElementById('src-input') as HTMLInputElement;
 const setSrcBtn = document.getElementById('set-src') as HTMLButtonElement;
-const avcOnlyToggle = document.getElementById('avc-only-toggle') as HTMLInputElement;
 const mutedToggle = document.getElementById('muted-toggle') as HTMLInputElement;
 const autoplayToggle = document.getElementById('autoplay-toggle') as HTMLInputElement;
 const loopToggle = document.getElementById('loop-toggle') as HTMLInputElement;
@@ -41,25 +39,16 @@ const shareLink = document.getElementById('share-link') as HTMLAnchorElement;
 const DEFAULT_STREAM = 'https://stream.mux.com/JX01bG8eB4uaoV3OpDuK602rBfvdSgrMObjwuUOBn4JrQ.m3u8';
 
 // Preset sources. The non-zero-PTS examples exercise `timestampOffset` relocation
-// (A/V encodes at native PTS ≠ 0, but currentTime/seekable stay 0-based). Apple's
-// example muxes HEVC + AVC renditions, so it needs AVC-only (see `avcOnly`).
+// (A/V encodes at native PTS ≠ 0, but currentTime/seekable stay 0-based).
 // `unsupported`, when set, is the reason SPF can't play the source; such presets
 // are shown disabled (see the picker population) rather than hidden.
-type Preset = { label: string; url: string; avcOnly?: boolean; unsupported?: string };
-
-// Harness-specific sources not in the shared registry. The Apple bipbop example
-// muxes HEVC + AVC, so it needs AVC-only — engine-limitation metadata that
-// doesn't belong in shared SOURCES (no other template needs it).
-const HARNESS_PRESETS: Preset[] = [
-  {
-    label: 'Apple bipbop HEVC (44ms A/V skew + VTT X-TIMESTAMP-MAP · needs AVC-only)',
-    url: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8',
-    avcOnly: true,
-  },
-];
+type Preset = { label: string; url: string; unsupported?: string };
 
 // Dropdown = every HLS source from the shared registry (DASH/raw-mp4 filtered out
-// since the raw SPF HLS engine can't play them) plus the harness-specific extras.
+// since the raw SPF HLS engine can't play them). Mixed-codec sources (the Apple
+// bipbop example, `hls-mixed-codec`) need no special handling here anymore: the
+// engine's default `preferredCodecs` lands the initial pick on AVC/AAC and its
+// sticky codec-family rule keeps ABR there.
 // SPF only demuxes fmp4/CMAF segments, not MPEG-TS, so TS sources are kept visible
 // but flagged unsupported (disabled in the picker) rather than silently dropped.
 // Unsupported presets sort to the end (stable sort preserves registry order otherwise).
@@ -72,14 +61,7 @@ const PRESETS: Preset[] = [
     if (source.subType === 'ts') preset.unsupported = 'TS — unsupported';
     return preset;
   }),
-  ...HARNESS_PRESETS,
 ].sort((a, b) => Number(!!a.unsupported) - Number(!!b.unsupported));
-
-// Apple's bipbop example muxes HEVC (`hvc1`/`hev1`) + AVC renditions of the same content;
-// cross-codec ABR would need `SourceBuffer.changeType()` (not yet implemented), so filtering
-// to AVC keeps ABR within one codec family. Harmless for single-codec Mux sources.
-const avcOnly = (track: { codecs?: string[] }) =>
-  !track.codecs?.some((codec) => codec.startsWith('hvc1') || codec.startsWith('hev1'));
 
 const params = new URLSearchParams(window.location.search);
 const INITIAL_SRC = params.get('src') ?? DEFAULT_STREAM;
@@ -87,10 +69,9 @@ const INITIAL_MUTED = params.get('muted') === 'true';
 const INITIAL_AUTOPLAY = params.get('autoplay') === 'true';
 const INITIAL_LOOP = params.get('loop') === 'true';
 const INITIAL_PRELOAD = (params.get('preload') as 'auto' | 'metadata' | 'none') ?? 'none';
-const INITIAL_AVC_ONLY = params.get('avcOnly') === 'true';
 
-// Populate the preset picker; selecting one loads it (and enables AVC-only if the
-// preset needs it). Reflects the current src when it matches a preset.
+// Populate the preset picker; selecting one loads it. Reflects the current src
+// when it matches a preset.
 for (const preset of PRESETS) {
   const label = preset.unsupported ? `${preset.label} (${preset.unsupported})` : preset.label;
   const option = new Option(label, preset.url);
@@ -105,7 +86,6 @@ mutedToggle.checked = INITIAL_MUTED;
 autoplayToggle.checked = INITIAL_AUTOPLAY;
 loopToggle.checked = INITIAL_LOOP;
 preloadSelect.value = INITIAL_PRELOAD;
-avcOnlyToggle.checked = INITIAL_AVC_ONLY;
 updateShareUrl();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -164,7 +144,6 @@ function updateShareUrl() {
   if (autoplayToggle.checked) p.set('autoplay', 'true');
   if (loopToggle.checked) p.set('loop', 'true');
   if (preloadSelect.value !== 'none') p.set('preload', preloadSelect.value);
-  if (avcOnlyToggle.checked) p.set('avcOnly', 'true');
   const url = `${window.location.origin}${window.location.pathname}${p.size > 0 ? `?${p}` : ''}`;
   shareLink.href = url;
   shareLink.textContent = url;
@@ -775,9 +754,6 @@ function startEngine(src: string) {
 
   engine = createHlsVideoEngine({
     initialBandwidth: 1_000_000,
-    // AVC-only filters HEVC so ABR never crosses codec families (no changeType).
-    // Omitted (not set to undefined) when off, per exactOptionalPropertyTypes.
-    ...(avcOnlyToggle.checked ? { canPlayTrack: avcOnly } : {}),
     onSignalsReady: (refs) => {
       signals = refs;
     },
@@ -980,15 +956,8 @@ srcPreset.addEventListener('change', () => {
   const preset = PRESETS.find((p) => p.url === srcPreset.value);
   if (!preset) return;
   srcInput.value = preset.url;
-  if (preset.avcOnly) avcOnlyToggle.checked = true;
-  log(`Preset: ${preset.label}${preset.avcOnly ? ' (AVC-only enabled)' : ''}`, 'info');
+  log(`Preset: ${preset.label}`, 'info');
   startEngine(preset.url);
-  updateShareUrl();
-});
-
-avcOnlyToggle.addEventListener('change', () => {
-  log(`AVC-only: ${avcOnlyToggle.checked} — re-creating engine`, 'warning');
-  startEngine(srcInput.value.trim() || DEFAULT_STREAM);
   updateShareUrl();
 });
 

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -46,9 +46,9 @@ type Preset = { label: string; url: string; unsupported?: string };
 
 // Dropdown = every HLS source from the shared registry (DASH/raw-mp4 filtered out
 // since the raw SPF HLS engine can't play them). Mixed-codec sources (the Apple
-// bipbop example, `hls-mixed-codec`) need no special handling here anymore: the
-// engine's default `preferredCodecs` lands the initial pick on AVC/AAC and its
-// sticky codec-family constraint keeps ABR there.
+// bipbop example, `hls-mixed-codec`) need no special handling: the engine's
+// default `preferredCodecs` lands the initial pick on AVC/AAC and its sticky
+// codec-family constraint keeps ABR there.
 // SPF only demuxes fmp4/CMAF segments, not MPEG-TS, so TS sources are kept visible
 // but flagged unsupported (disabled in the picker) rather than silently dropped.
 // Unsupported presets sort to the end (stable sort preserves registry order otherwise).

--- a/apps/sandbox/templates/spf-segment-loading/main.ts
+++ b/apps/sandbox/templates/spf-segment-loading/main.ts
@@ -48,7 +48,7 @@ type Preset = { label: string; url: string; unsupported?: string };
 // since the raw SPF HLS engine can't play them). Mixed-codec sources (the Apple
 // bipbop example, `hls-mixed-codec`) need no special handling here anymore: the
 // engine's default `preferredCodecs` lands the initial pick on AVC/AAC and its
-// sticky codec-family rule keeps ABR there.
+// sticky codec-family constraint keeps ABR there.
 // SPF only demuxes fmp4/CMAF segments, not MPEG-TS, so TS sources are kept visible
 // but flagged unsupported (disabled in the picker) rather than silently dropped.
 // Unsupported presets sort to the end (stable sort preserves registry order otherwise).

--- a/packages/spf/src/core/signals/effect.ts
+++ b/packages/spf/src/core/signals/effect.ts
@@ -15,6 +15,34 @@ function runPending() {
   for (const c of pending) {
     pending.delete(c);
     c.get(); // re-run the effect body
+    revalidateSources(c);
+  }
+}
+
+/**
+ * Recover an effect that wrote a signal one of its own dependencies reads.
+ *
+ * When an effect body writes a signal that an intermediate computed in its
+ * own dependency graph consumes (e.g. a track-selection effect writing the
+ * selection slot a candidate-set computed consults), the graph can't tell
+ * the effect: the write marks the intermediate dirty, but the effect is the
+ * in-flight consumer, so no watcher notification fires — and the effect
+ * finishes the run *clean but stale*. Worse, every later external change
+ * routed through that intermediate is deduped against its standing dirty
+ * flag, so the effect never hears about those either (the lost-wakeup).
+ *
+ * Pulling each source once after the run closes the hole: a dirtied
+ * intermediate recomputes and its dirty flag clears, so the *next* change
+ * through it propagates and wakes the effect normally. The guarantee is
+ * liveness, not immediacy — the effect is deliberately not re-run just
+ * because it wrote into its own graph (that would double-run every writing
+ * effect); it catches up on the next genuine change, which is exactly what
+ * used to be lost. Sources that are clean, or whose recomputation is
+ * equals-gated to the same value, cost a cached read and notify no one.
+ */
+function revalidateSources(c: Signal.Computed<void>): void {
+  for (const source of Signal.subtle.introspectSources(c)) {
+    (source as Signal.State<unknown> | Signal.Computed<unknown>).get();
   }
 }
 
@@ -36,6 +64,7 @@ export function effect(fn: () => (() => void) | void): () => void {
   });
   watcher.watch(c);
   c.get(); // initial run
+  revalidateSources(c); // an initial run may self-write too — see the note
   return () => {
     watcher.unwatch(c);
     if (typeof cleanup === 'function') cleanup();

--- a/packages/spf/src/core/signals/effect.ts
+++ b/packages/spf/src/core/signals/effect.ts
@@ -36,9 +36,9 @@ function runPending() {
  * through it propagates and wakes the effect normally. The guarantee is
  * liveness, not immediacy — the effect is deliberately not re-run just
  * because it wrote into its own graph (that would double-run every writing
- * effect); it catches up on the next genuine change, which is exactly what
- * used to be lost. Sources that are clean, or whose recomputation is
- * equals-gated to the same value, cost a cached read and notify no one.
+ * effect); it catches up on the next genuine change. Sources that are clean,
+ * or whose recomputation is equals-gated to the same value, cost a cached
+ * read and notify no one.
  */
 function revalidateSources(c: Signal.Computed<void>): void {
   for (const source of Signal.subtle.introspectSources(c)) {

--- a/packages/spf/src/core/signals/tests/effect.test.ts
+++ b/packages/spf/src/core/signals/tests/effect.test.ts
@@ -7,21 +7,20 @@ const flush = () => Promise.resolve().then(() => Promise.resolve());
 
 describe('effect', () => {
   describe('self-write through an intermediate computed (lost-wakeup regression)', () => {
-    // An effect that writes a signal one of its own dependency computeds
-    // reads used to end its run *clean but stale*: the write marked the
-    // intermediate dirty while the effect was the in-flight consumer, so no
-    // watcher notification fired — and every later external change routed
-    // through that intermediate was deduped against its standing dirty flag,
-    // leaving the effect permanently deaf on that path. The
-    // `revalidateSources` pass in `effect.ts` closes the hole; these tests
-    // pin it for both places a run can happen. The concrete SPF shape: a
-    // track-selection effect writing `selected*TrackId`, which the
-    // candidate-set computed's `stickToSelectedCodecs` constraint reads.
+    // An effect body may write a signal that an intermediate computed in its
+    // own dependency graph reads (the concrete SPF shape: a track-selection
+    // effect writing `selected*TrackId`, which the candidate-set computed's
+    // `stickToSelectedCodecs` constraint reads). The write dirties the
+    // intermediate mid-run with no watcher notification; unless the run
+    // revalidates its sources (`revalidateSources` in `effect.ts`), later
+    // external changes routed through that intermediate are deduped against
+    // the standing dirty flag and the effect goes deaf on that path. These
+    // tests pin the recovery for both places a run can happen.
     //
     // The guarantee is *liveness*, not immediacy: the effect is not re-run
     // just because it wrote into its own graph (deliberately — that would
     // double-run every writing effect); it catches up on the next genuine
-    // change through the path, which is what used to be lost.
+    // change through the path.
     it('recovers when the self-write happens during the initial run', async () => {
       const external = signal(1);
       const own = signal<string | undefined>(undefined);
@@ -34,8 +33,8 @@ describe('effect', () => {
       await flush();
       external.set(2);
       await flush();
-      // The change through the intermediate is heard — before the fix the
-      // effect stayed on '1:none' forever.
+      // The external change routed through the self-written intermediate
+      // still wakes the effect.
       expect(runs.at(-1)).toBe('2:locked');
       stop();
     });

--- a/packages/spf/src/core/signals/tests/effect.test.ts
+++ b/packages/spf/src/core/signals/tests/effect.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { effect } from '../effect';
+import { computed, signal } from '../primitives';
+
+// Drain microtasks so signal-driven re-runs land before assertions.
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+describe('effect', () => {
+  describe('self-write through an intermediate computed (lost-wakeup regression)', () => {
+    // An effect that writes a signal one of its own dependency computeds
+    // reads used to end its run *clean but stale*: the write marked the
+    // intermediate dirty while the effect was the in-flight consumer, so no
+    // watcher notification fired — and every later external change routed
+    // through that intermediate was deduped against its standing dirty flag,
+    // leaving the effect permanently deaf on that path. The
+    // `revalidateSources` pass in `effect.ts` closes the hole; these tests
+    // pin it for both places a run can happen. The concrete SPF shape: a
+    // track-selection effect writing `selected*TrackId`, which the
+    // candidate-set computed's `stickToSelectedCodecs` constraint reads.
+    //
+    // The guarantee is *liveness*, not immediacy: the effect is not re-run
+    // just because it wrote into its own graph (deliberately — that would
+    // double-run every writing effect); it catches up on the next genuine
+    // change through the path, which is what used to be lost.
+    it('recovers when the self-write happens during the initial run', async () => {
+      const external = signal(1);
+      const own = signal<string | undefined>(undefined);
+      const inter = computed(() => `${external.get()}:${own.get() ?? 'none'}`);
+      const runs: string[] = [];
+      const stop = effect(() => {
+        runs.push(inter.get());
+        if (own.get() === undefined) own.set('locked');
+      });
+      await flush();
+      external.set(2);
+      await flush();
+      // The change through the intermediate is heard — before the fix the
+      // effect stayed on '1:none' forever.
+      expect(runs.at(-1)).toBe('2:locked');
+      stop();
+    });
+
+    it('recovers when the self-write happens during a flush run', async () => {
+      const external = signal(1);
+      const trigger = signal(0);
+      const own = signal<string | undefined>(undefined);
+      const inter = computed(() => `${external.get()}:${own.get() ?? 'none'}`);
+      const runs: string[] = [];
+      const stop = effect(() => {
+        const shouldWrite = trigger.get() === 1;
+        runs.push(inter.get());
+        if (shouldWrite && own.get() === undefined) own.set('locked');
+      });
+      await flush();
+      trigger.set(1); // this flush run performs the self-write
+      await flush();
+      external.set(2);
+      await flush();
+      expect(runs.at(-1)).toBe('2:locked');
+      stop();
+    });
+
+    it('converges — a settled self-write causes no further re-runs', async () => {
+      const own = signal<string | undefined>(undefined);
+      const inter = computed(() => own.get() ?? 'none');
+      let runCount = 0;
+      const stop = effect(() => {
+        inter.get();
+        runCount++;
+        if (own.get() === undefined) own.set('locked');
+      });
+      await flush();
+      await flush();
+      const settled = runCount;
+      await flush();
+      // No dirty dependency left behind → no phantom re-runs.
+      expect(runCount).toBe(settled);
+      stop();
+    });
+  });
+});

--- a/packages/spf/src/media/utils/tracks.ts
+++ b/packages/spf/src/media/utils/tracks.ts
@@ -120,6 +120,30 @@ export function hasCodecs(track: PartiallyResolvedTrack | ResolvedTrack | undefi
 }
 
 /**
+ * The family (RFC 6381 4CC) of one codec string: `'avc1.640028'` → `'avc1'`,
+ * `'mp4a.40.2'` → `'mp4a'`, dotless strings (`'ec-3'`) pass through whole.
+ * Lowercased so families compare regardless of manifest casing.
+ *
+ * The family is what a `SourceBuffer`'s bytestream is keyed on: renditions in
+ * one family swap via a new init segment, while crossing families needs
+ * `SourceBuffer.changeType()` (which SPF doesn't implement).
+ */
+export function getCodecFamily(codec: string): string {
+  return codec.trim().split('.', 1)[0]!.toLowerCase();
+}
+
+/**
+ * The distinct codec families a track carries, or `undefined` when it carries
+ * no codecs (unknowable, per `hasCodecs` — not "none"). A demuxed rendition
+ * has one family; a muxed one (bipbop's `CODECS="hvc1…,mp4a…"`) has one per
+ * elementary stream.
+ */
+export function getCodecFamilies(track: { codecs?: string[] }): readonly string[] | undefined {
+  if (!track.codecs?.length) return undefined;
+  return [...new Set(track.codecs.map(getCodecFamily))];
+}
+
+/**
  * Set `mimeType` on every track of one `type` (immutably). Used to propagate a
  * detected container across a type's renditions: an ABR ladder is the same
  * content at different bitrates, so one rendition's container holds for all of

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -1293,8 +1293,7 @@ describe('stickToSelectedCodecs (codec-family sticky constraint)', () => {
     state.userVideoTrackSelection.set({ id: 'hvc-4k' });
     await flush();
     // The constraint prunes the HEVC pick in the pre-pass, so the user filter
-    // never sees it and falls through. (A soft rule couldn't guarantee this:
-    // the filter's single-match early-bail would win.)
+    // never sees it and falls through.
     expect(state.selectedVideoTrackId.get()).toBe('avc-high');
 
     state.userVideoTrackSelection.set({ id: 'avc-low' });
@@ -1364,9 +1363,7 @@ describe('stickToSelectedCodecs (codec-family sticky constraint)', () => {
 
   it('reports and clears when the selected family vanishes, re-picking on recovery', async () => {
     // AVC only on cdn-a, HEVC only on cdn-b: the shape where failover can
-    // remove a whole codec family from the playable set. This is the
-    // observable difference constraint placement buys over the old soft rule,
-    // which would have silently cross-picked HEVC into an AVC buffer.
+    // remove a whole codec family from the playable set.
     const cdnFamilyTrack = (id: string, host: string, bandwidth: number, codecs: string[]) => ({
       ...createVideoTrack(id, bandwidth),
       url: `https://${host}/${id}.m3u8`,

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -1115,7 +1115,9 @@ describe('excludeUnplayableTracks (capability constraint)', () => {
 
   it('passes everything through when no canPlayTrack probe is wired', async () => {
     const state = makeState();
-    const reactor = switchVideoTrack.setup({ state });
+    // preferredCodecs: [] keeps the codec-family preference (its own describe)
+    // out of this test's lens on the constraint.
+    const reactor = switchVideoTrack.setup({ state, config: { preferredCodecs: [] } });
     await flush();
     // No probe → HEVC survives; same-bitrate tie keeps manifest order, so the
     // first 1080p (HEVC) wins.
@@ -1148,8 +1150,9 @@ describe('excludeUnplayableTracks (capability constraint)', () => {
   it('clears a prior pick when a later relabel prunes every rendition to empty', async () => {
     const state = makeState();
     // Accepts fMP4; rejects the non-fMP4 container MIME resolve-track relabels to.
+    // preferredCodecs: [] keeps the codec-family preference out of the picture.
     const canPlayTrack = (track: { mimeType?: string }) => track.mimeType !== 'video/mp2t';
-    const reactor = switchVideoTrack.setup({ state, config: { canPlayTrack } });
+    const reactor = switchVideoTrack.setup({ state, config: { canPlayTrack, preferredCodecs: [] } });
     await flush();
     // Pick made while the tracks are still labeled video/mp4.
     expect(state.selectedVideoTrackId.get()).toBe('1080p-hevc');
@@ -1161,6 +1164,200 @@ describe('excludeUnplayableTracks (capability constraint)', () => {
     await flush();
     expect(state.selectedVideoTrackId.get()).toBeUndefined();
 
+    reactor.destroy();
+  });
+});
+
+// ============================================================================
+// Codec-family policy — preferCodecFamilies (initial-pick scope) +
+// stickToSelectedCodecs (sticky scope)
+//
+// SPF implements no `SourceBuffer.changeType()`, so a mid-stream pick outside
+// the initially-selected codec families would append undecodable data into a
+// buffer created under the initial family's mimetype. The sticky scope keeps
+// re-picks within the selected families; the preference scope narrows which
+// family the *initial* pick lands in on mixed-codec sources (the Apple bipbop
+// advanced example muxes HEVC + AVC renditions of the same content).
+// ============================================================================
+
+const codecFamilyTrack = (id: string, bandwidth: number, codecs: string[]): PartiallyResolvedVideoTrack => ({
+  ...createVideoTrack(id, bandwidth),
+  codecs,
+});
+
+// Mixed-codec ladder (bipbop shape). At most bandwidths the best-fitting rung
+// is HEVC, so a pick that lands on AVC is the preference's doing, not ABR's.
+const mixedFamilyLadder = () => [
+  codecFamilyTrack('avc-low', 1_000_000, ['avc1.640020']),
+  codecFamilyTrack('avc-high', 3_000_000, ['avc1.640028']),
+  codecFamilyTrack('hvc-low', 900_000, ['hvc1.2.4.L123.B0']),
+  codecFamilyTrack('hvc-high', 3_200_000, ['hvc1.2.4.L150.B0']),
+  codecFamilyTrack('hvc-4k', 8_000_000, ['hvc1.2.4.L153.B0']),
+];
+
+describe('preferCodecFamilies (codec-family scope)', () => {
+  it('narrows the initial pick to the default AVC/AAC families on a mixed-codec ladder', async () => {
+    const state = makeState({
+      presentation: createPresentation(mixedFamilyLadder()),
+      bandwidthState: createBandwidthState(4_000_000),
+    });
+    const reactor = switchVideoTrack.setup({ state });
+    await flush();
+    // The best fitting rung overall is hvc-high (3.2M under the 3.4M
+    // threshold); the default preference narrows to AVC first, so the best
+    // fitting AVC rung wins.
+    expect(state.selectedVideoTrackId.get()).toBe('avc-high');
+    reactor.destroy();
+  });
+
+  it('disables the preference for preferredCodecs: []', async () => {
+    const state = makeState({
+      presentation: createPresentation(mixedFamilyLadder()),
+      bandwidthState: createBandwidthState(4_000_000),
+    });
+    const reactor = switchVideoTrack.setup({ state, config: { preferredCodecs: [] } });
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBe('hvc-high');
+    reactor.destroy();
+  });
+
+  it('honors a configured non-default family', async () => {
+    const state = makeState({
+      presentation: createPresentation(mixedFamilyLadder()),
+      bandwidthState: createBandwidthState(4_000_000),
+    });
+    const reactor = switchVideoTrack.setup({ state, config: { preferredCodecs: ['hvc1'] } });
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBe('hvc-high');
+    reactor.destroy();
+  });
+
+  it('falls through on a ladder with no preferred-family rendition', async () => {
+    const state = makeState({
+      presentation: createPresentation([
+        codecFamilyTrack('hvc-low', 900_000, ['hvc1.2.4.L123.B0']),
+        codecFamilyTrack('hvc-high', 3_200_000, ['hvc1.2.4.L150.B0']),
+      ]),
+      bandwidthState: createBandwidthState(4_000_000),
+    });
+    const reactor = switchVideoTrack.setup({ state });
+    await flush();
+    // Nothing matches AVC/AAC → the soft filter is skipped, not applied to
+    // empty — an HEVC-only source plays exactly as before.
+    expect(state.selectedVideoTrackId.get()).toBe('hvc-high');
+    reactor.destroy();
+  });
+
+  it('narrows the audio initial pick to AAC over a higher-bitrate E-AC-3', async () => {
+    const state = makeAudioState({
+      presentation: createAudioPresentation([
+        makeAudioTrack('audio-ec3', { codecs: ['ec-3'], bandwidth: 640_000 }),
+        makeAudioTrack('audio-aac', { codecs: ['mp4a.40.2'], bandwidth: 128_000 }),
+      ]),
+    });
+    const reactor = switchAudioTrack.setup({ state });
+    await flush();
+    // Without the preference the ranker takes E-AC-3 (highest fitting bitrate,
+    // listed first); mp4a is in the default preferred families, ec-3 is not.
+    expect(state.selectedAudioTrackId.get()).toBe('audio-aac');
+    reactor.destroy();
+  });
+});
+
+describe('stickToSelectedCodecs (codec-family sticky scope)', () => {
+  it('keeps re-picks within the selected codec family (upgrades stay in-family)', async () => {
+    // preferredCodecs: [] isolates the sticky scope from the preference.
+    const state = makeState({
+      presentation: createPresentation(mixedFamilyLadder()),
+      bandwidthState: createBandwidthState(12_000_000),
+      selectedVideoTrackId: 'avc-low',
+    });
+    const reactor = switchVideoTrack.setup({ state, config: { preferredCodecs: [] } });
+    await flush();
+    // Everything fits at 12M and the best rung overall is hvc-4k, but the
+    // pick sticks to the AVC family — upgrading within it.
+    expect(state.selectedVideoTrackId.get()).toBe('avc-high');
+    reactor.destroy();
+  });
+
+  it('ignores a cross-family user selection mid-stream, honors an in-family one', async () => {
+    const state = makeState({
+      presentation: createPresentation(mixedFamilyLadder()),
+      bandwidthState: createBandwidthState(12_000_000),
+      selectedVideoTrackId: 'avc-high',
+    });
+    const reactor = switchVideoTrack.setup({ state, config: { preferredCodecs: [] } });
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBe('avc-high');
+
+    state.userVideoTrackSelection.set({ id: 'hvc-4k' });
+    await flush();
+    // The sticky scope runs ahead of the user filter: the HEVC pick is gone
+    // from the narrowed set, so the filter falls through and the pick stands.
+    expect(state.selectedVideoTrackId.get()).toBe('avc-high');
+
+    state.userVideoTrackSelection.set({ id: 'avc-low' });
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBe('avc-low');
+    reactor.destroy();
+  });
+
+  it("locks to the family the user's initial pick landed in", async () => {
+    const state = makeState({
+      presentation: createPresentation(mixedFamilyLadder()),
+      bandwidthState: createBandwidthState(12_000_000),
+      userVideoTrackSelection: { id: 'hvc-4k' },
+    });
+    const reactor = switchVideoTrack.setup({ state });
+    await flush();
+    // No selection yet → the sticky scope passes through, and the user's
+    // explicit pick may land in any family (the default preference sits
+    // behind the user filter).
+    expect(state.selectedVideoTrackId.get()).toBe('hvc-4k');
+
+    state.userVideoTrackSelection.set(undefined);
+    await flush();
+    // Intent withdrawn: re-picks stay in the HEVC family the initial pick
+    // landed in (the AVC-preferring default falls through inside it).
+    expect(state.selectedVideoTrackId.get()).toBe('hvc-4k');
+    reactor.destroy();
+  });
+
+  it('matches the full codec-family set — a shared audio codec is not enough', async () => {
+    const muxed = [
+      codecFamilyTrack('muxed-avc', 1_000_000, ['avc1.640020', 'mp4a.40.2']),
+      codecFamilyTrack('muxed-hvc', 3_000_000, ['hvc1.2.4.L150.B0', 'mp4a.40.2']),
+    ];
+    const state = makeState({
+      presentation: createPresentation(muxed),
+      bandwidthState: createBandwidthState(12_000_000),
+      selectedVideoTrackId: 'muxed-avc',
+    });
+    const reactor = switchVideoTrack.setup({ state, config: { preferredCodecs: [] } });
+    await flush();
+    // {hvc1, mp4a} shares mp4a with {avc1, mp4a} but isn't the same family
+    // set; the buffer's mimetype still can't take it.
+    expect(state.selectedVideoTrackId.get()).toBe('muxed-avc');
+    reactor.destroy();
+  });
+
+  it('keeps an audio pick in-family when the requested language only exists in another family', async () => {
+    const state = makeAudioState({
+      presentation: createAudioPresentation([
+        makeAudioTrack('audio-aac-en', { language: 'en' }),
+        makeAudioTrack('audio-ec3-es', { language: 'es', codecs: ['ec-3'], bandwidth: 640_000 }),
+      ]),
+      selectedAudioTrackId: 'audio-aac-en',
+    });
+    const reactor = switchAudioTrack.setup({ state });
+    await flush();
+    expect(state.selectedAudioTrackId.get()).toBe('audio-aac-en');
+
+    state.userAudioTrackSelection.set({ language: 'es' });
+    await flush();
+    // Spanish exists only as E-AC-3; honoring it would cross codec families,
+    // so the sticky scope narrows it away and the pick stands.
+    expect(state.selectedAudioTrackId.get()).toBe('audio-aac-en');
     reactor.destroy();
   });
 });

--- a/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
+++ b/packages/spf/src/playback/behaviors/tests/track-switching.test.ts
@@ -1170,12 +1170,12 @@ describe('excludeUnplayableTracks (capability constraint)', () => {
 
 // ============================================================================
 // Codec-family policy — preferCodecFamilies (initial-pick scope) +
-// stickToSelectedCodecs (sticky scope)
+// stickToSelectedCodecs (sticky constraint)
 //
 // SPF implements no `SourceBuffer.changeType()`, so a mid-stream pick outside
 // the initially-selected codec families would append undecodable data into a
-// buffer created under the initial family's mimetype. The sticky scope keeps
-// re-picks within the selected families; the preference scope narrows which
+// buffer created under the initial family's mimetype. The sticky constraint
+// prunes such picks in the pre-pass; the preference scope narrows which
 // family the *initial* pick lands in on mixed-codec sources (the Apple bipbop
 // advanced example muxes HEVC + AVC renditions of the same content).
 // ============================================================================
@@ -1264,7 +1264,7 @@ describe('preferCodecFamilies (codec-family scope)', () => {
   });
 });
 
-describe('stickToSelectedCodecs (codec-family sticky scope)', () => {
+describe('stickToSelectedCodecs (codec-family sticky constraint)', () => {
   it('keeps re-picks within the selected codec family (upgrades stay in-family)', async () => {
     // preferredCodecs: [] isolates the sticky scope from the preference.
     const state = makeState({
@@ -1292,8 +1292,9 @@ describe('stickToSelectedCodecs (codec-family sticky scope)', () => {
 
     state.userVideoTrackSelection.set({ id: 'hvc-4k' });
     await flush();
-    // The sticky scope runs ahead of the user filter: the HEVC pick is gone
-    // from the narrowed set, so the filter falls through and the pick stands.
+    // The constraint prunes the HEVC pick in the pre-pass, so the user filter
+    // never sees it and falls through. (A soft rule couldn't guarantee this:
+    // the filter's single-match early-bail would win.)
     expect(state.selectedVideoTrackId.get()).toBe('avc-high');
 
     state.userVideoTrackSelection.set({ id: 'avc-low' });
@@ -1356,8 +1357,52 @@ describe('stickToSelectedCodecs (codec-family sticky scope)', () => {
     state.userAudioTrackSelection.set({ language: 'es' });
     await flush();
     // Spanish exists only as E-AC-3; honoring it would cross codec families,
-    // so the sticky scope narrows it away and the pick stands.
+    // so the constraint prunes it and the pick stands.
     expect(state.selectedAudioTrackId.get()).toBe('audio-aac-en');
+    reactor.destroy();
+  });
+
+  it('reports and clears when the selected family vanishes, re-picking on recovery', async () => {
+    // AVC only on cdn-a, HEVC only on cdn-b: the shape where failover can
+    // remove a whole codec family from the playable set. This is the
+    // observable difference constraint placement buys over the old soft rule,
+    // which would have silently cross-picked HEVC into an AVC buffer.
+    const cdnFamilyTrack = (id: string, host: string, bandwidth: number, codecs: string[]) => ({
+      ...createVideoTrack(id, bandwidth),
+      url: `https://${host}/${id}.m3u8`,
+      codecs,
+    });
+    const state = {
+      presentation: signal<MaybeResolvedPresentation | undefined>(
+        createPresentation([
+          cdnFamilyTrack('avc-low', 'cdn-a.example.com', 1_000_000, ['avc1.640020']),
+          cdnFamilyTrack('avc-high', 'cdn-a.example.com', 3_000_000, ['avc1.640028']),
+          cdnFamilyTrack('hvc-low', 'cdn-b.example.com', 900_000, ['hvc1.2.4.L123.B0']),
+          cdnFamilyTrack('hvc-high', 'cdn-b.example.com', 3_200_000, ['hvc1.2.4.L150.B0']),
+        ])
+      ),
+      bandwidthState: signal<BandwidthState | undefined>(createBandwidthState(4_000_000)),
+      selectedVideoTrackId: signal<string | undefined>(undefined),
+      userVideoTrackSelection: signal<Partial<VideoTrack> | undefined>(undefined),
+      failedCdns: signal<string[] | undefined>(undefined),
+      errors: signal<SvtaError[] | undefined>(undefined),
+    };
+    const reactor = switchVideoTrack.setup({ state });
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBe('avc-high');
+
+    // The only CDN carrying the selected family enters cooldown: the failover
+    // constraint leaves HEVC, this constraint removes it — an explicable
+    // reported stop instead of an opaque decode error at append.
+    state.failedCdns.set(['https://cdn-a.example.com']);
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBeUndefined();
+    expect(state.errors.get()?.map((error) => error.code)).toEqual([SVTA_NO_SUPPORTED_VIDEO_TRACK]);
+
+    // Cooldown ends: the family is playable again and selection recovers.
+    state.failedCdns.set(undefined);
+    await flush();
+    expect(state.selectedVideoTrackId.get()).toBe('avc-high');
     reactor.destroy();
   });
 });

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -569,8 +569,8 @@ function preferActiveCdn<S extends SelectionKey, T extends SwitchableTrack>(
  * Reading the selection here — a slot the picking effect itself writes, from
  * inside the candidate-set computed — is safe only because the effect
  * scheduler revalidates an effect's sources after each run; see
- * `core/signals/effect.ts` (`revalidateSources`) for the lost-wakeup this
- * once caused and the regression test that pins it.
+ * `core/signals/effect.ts` (`revalidateSources`) for the lost-wakeup it
+ * prevents.
  *
  * Composed only into the re-evaluating `switch*` variants: the pinned
  * `selectVideoTrack` (background compositions) evaluates once and never

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -12,18 +12,28 @@
  * time, so the effect subscribes to exactly what was consulted. The chain runs
  * most authoritative first:
  *
- *   1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
+ *   1. **codec-family sticky** — a soft filter on the current selection
+ *      (`stickToSelectedCodecs`): narrow to the tracks sharing the selected
+ *      track's codec families. Physics ahead of preference — SPF implements no
+ *      `SourceBuffer.changeType()`, so a cross-family re-pick would append
+ *      undecodable data; that's why it outranks even user intent.
+ *   2. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
  *      partial-track match; an empty match falls through to the full set.
- *   2. **active CDN** — a soft filter on `cdnPriority` (`preferActiveCdn`):
+ *   3. **codec-family preference** — a soft filter on `preferredCodecs`
+ *      (`preferCodecFamilies`, default AVC/AAC): on a mixed-codec source,
+ *      narrow which family the *initial* pick — the one the sticky rule then
+ *      holds — lands in. Behind user intent so an explicit initial pick may
+ *      land anywhere; inert once sticky narrows to a non-preferred family.
+ *   4. **active CDN** — a soft filter on `cdnPriority` (`preferActiveCdn`):
  *      narrow to the highest-priority CDN that still has tracks; an empty match
  *      falls through. Shared by video and audio, so every type stays on one CDN
  *      (`deriveCdnPriority` owns the list). No-op for non-redundant sources.
- *   3. **player resolution** — a soft filter on `playerResolution`
+ *   5. **player resolution** — a soft filter on `playerResolution`
  *      (`playerResolutionCap`, video only): narrow to the smallest rendition
  *      tier covering the player element, plus everything below it. No-op
  *      without a measurement. Ahead of the ranker but behind the CDN scope, so
  *      the cap chooses *within* a host rather than between hosts.
- *   4. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and
+ *   6. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and
  *      audio. Fitting tracks (within the throughput threshold) first, highest
  *      bitrate first; over-throughput tracks after, least-over first. Hysteresis
  *      via boosting the current track's sort weight by `upgradeMargin`.
@@ -42,10 +52,11 @@
  * **constraints + rule chain (+ optional resolveSelection)** via config;
  * `setupTrackSwitching` owns only the lifecycle and runs what it's given. Video
  * and audio run constraints `[excludeFailedCdns, excludeUnplayableTracks]` then
- * rules `[filterByUserSelection, preferActiveCdn, rankByBandwidth]` and take the
- * head; video inserts `playerResolutionCap` after the active-CDN scope, and
- * `switchVideoTrack` also accepts ABR tuning config, `switchAudioTrack` takes
- * none. `switchTextTrack` differs — selection is *optional* (captions are
+ * rules `[stickToSelectedCodecs, filterByUserSelection, preferCodecFamilies,
+ * preferActiveCdn, rankByBandwidth]` and take the head; video inserts
+ * `playerResolutionCap` after the active-CDN scope, and `switchVideoTrack` also
+ * accepts ABR tuning config, `switchAudioTrack` takes none.
+ * `switchTextTrack` differs — selection is *optional* (captions are
  * opt-in / off-able), so it runs `[excludeFailedCdns]` + `[preferActiveCdn]` and
  * supplies a text terminal (`pickResolvedTextTrack`) that resolves standing user
  * intent (`userTextTrackSelection`, incl. `'off'`) and may yield no selection.
@@ -91,11 +102,17 @@ import {
   type VideoTrack,
 } from '../../media/types';
 import { getCdnId as defaultGetCdnId, type GetCdnId } from '../../media/utils/cdn';
-import { getTracksByType } from '../../media/utils/tracks';
+import { getCodecFamilies, getTracksByType } from '../../media/utils/tracks';
 import type { BandwidthConfig, BandwidthState } from '../../network/bandwidth-estimator';
 import { DEFAULT_BANDWIDTH_CONFIG, getBandwidthEstimate } from '../../network/bandwidth-estimator';
 import type { SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
-import { applyConstraints, applyRules, excludeUnplayableTracks, sameCandidateSet } from '../primitives/selection-rules';
+import {
+  applyConstraints,
+  applyRules,
+  excludeUnplayableTracks,
+  preferCodecFamilies,
+  sameCandidateSet,
+} from '../primitives/selection-rules';
 import { type ErrorEmitterState, emitError } from './collect-errors';
 
 // ============================================================================
@@ -140,6 +157,17 @@ export interface SwitchVideoTrackConfig {
    * filtering (the constraint passes everything through).
    */
   canPlayTrack?: CanPlayTrack;
+  /**
+   * Codec families (RFC 6381 4CCs, e.g. `'avc1'` / `'hvc1'` / `'mp4a'`) the
+   * initial pick prefers on a mixed-codec source, read by the
+   * `preferCodecFamilies` scope. With no `SourceBuffer.changeType()`, the
+   * initial family is the one `stickToSelectedCodecs` holds for the source's
+   * lifetime, so this decides which family that is. Cross-cutting like
+   * `getCdnId` — one list serves video and audio (each type's rule matches
+   * only the families its tracks carry). Defaults to
+   * `DEFAULT_PREFERRED_CODECS` (AVC + AAC); pass `[]` to disable.
+   */
+  preferredCodecs?: string[];
 }
 
 /** Default initial-bandwidth value before bandwidth measurements arrive. */
@@ -153,8 +181,14 @@ export const DEFAULT_INITIAL_BANDWIDTH = 5_000_000;
 // second import; the definitions live in `../primitives/selection-rules` so the
 // simple `selectVideoTrack` variant can share them without pulling the ABR path
 // in with them. See that module's note.
-export type { SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
-export { applyConstraints, applyRules, excludeUnplayableTracks } from '../primitives/selection-rules';
+export type { CodecPreferenceConfig, SelectionRule, SelectionRuleDeps } from '../primitives/selection-rules';
+export {
+  applyConstraints,
+  applyRules,
+  DEFAULT_PREFERRED_CODECS,
+  excludeUnplayableTracks,
+  preferCodecFamilies,
+} from '../primitives/selection-rules';
 
 // ============================================================================
 // Specialization helper
@@ -499,6 +533,60 @@ function preferActiveCdn<S extends SelectionKey, T extends SwitchableTrack>(
 }
 
 /**
+ * Codec-family sticky scope — a soft filter, shared by video and audio, and
+ * the reason the re-evaluating variants can run ABR over a mixed-codec source
+ * at all: SPF implements no `SourceBuffer.changeType()`, so once segments of
+ * the selected track's codec families are what a buffer was created for, a
+ * re-pick outside them would append undecodable data. Narrows the candidates
+ * to the tracks whose codec-family set *equals* the selected track's
+ * (set-equality so a muxed `hvc1,mp4a` rendition can't pass as a match for
+ * `avc1,mp4a` on its audio half).
+ *
+ * Sits at the head of the chain — ahead of even user intent, the one rule
+ * that does, because this is physics rather than preference: a cross-family
+ * user selection mid-stream falls through unhonored instead of killing
+ * playback. Before any selection exists (the initial pick) it passes
+ * everything through, which is what leaves the initial family choice to the
+ * rules behind it (user intent, then `preferCodecFamilies`).
+ *
+ * The selected track's families come from the *presentation's* track list,
+ * not the constraint-pruned candidates: a CDN entering cooldown may prune the
+ * current track itself while same-family renditions survive on another host,
+ * and the lock must carry over to them. Fall-through cases: no selection yet,
+ * a selection the presentation no longer carries, or a selected track without
+ * codecs (then no candidate's compatibility is decidable — same inertness as
+ * `preferCodecFamilies` on a codec-less ladder). When the selected family has
+ * genuinely vanished from the candidates, soft-filter fall-through applies
+ * and the pick crosses families — the pipeline breaks at append exactly as it
+ * would have without this rule, no worse (a changeType-shaped problem this
+ * scope can't solve).
+ *
+ * Composed only into the re-evaluating `switch*` variants: the pinned
+ * `selectVideoTrack` (background compositions) evaluates once and never
+ * re-picks, so it's immune by construction.
+ */
+export function stickToSelectedCodecs<S extends SelectionKey, T extends SwitchableTrack>(
+  tracks: readonly T[],
+  { state, config }: SelectionRuleDeps<TrackSwitchingStateMap<S>, AnySlotMap, TrackSwitchingConfig<S, T>>
+): readonly T[] {
+  const currentId = state[config.selectionKey].get();
+  if (!currentId) return tracks;
+  const presentation = state.presentation.get();
+  if (!isResolvedPresentation(presentation)) return tracks;
+  const current = config.getTracks(presentation).find((track) => track.id === currentId);
+  const families = current && getCodecFamilies(current);
+  if (!families) return tracks;
+  return tracks.filter((track) => {
+    const candidateFamilies = getCodecFamilies(track);
+    return (
+      !!candidateFamilies &&
+      candidateFamilies.length === families.length &&
+      candidateFamilies.every((family) => families.includes(family))
+    );
+  });
+}
+
+/**
  * Bandwidth ranking — the terminal sort, shared by video and audio. Orders by
  * the throughput estimate: tracks within the bandwidth threshold first
  * (fitting), highest bitrate first; then over-threshold tracks, least-over
@@ -768,7 +856,14 @@ export const switchVideoTrack = defineBehavior({
         userSelectionKey: 'userVideoTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'video') as readonly VideoTrackCandidate[],
         constraints: [excludeFailedCdns, excludeUnplayableTracks],
-        rules: [filterByUserSelection, preferActiveCdn, playerResolutionCap, rankByBandwidth],
+        rules: [
+          stickToSelectedCodecs,
+          filterByUserSelection,
+          preferCodecFamilies,
+          preferActiveCdn,
+          playerResolutionCap,
+          rankByBandwidth,
+        ],
         noSupportedTrackCode: SVTA_NO_SUPPORTED_VIDEO_TRACK,
       },
     }),
@@ -820,7 +915,7 @@ export const switchAudioTrack = defineBehavior({
         userSelectionKey: 'userAudioTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'audio') as readonly AudioTrackCandidate[],
         constraints: [excludeFailedCdns, excludeUnplayableTracks],
-        rules: [filterByUserSelection, preferActiveCdn, rankByBandwidth],
+        rules: [stickToSelectedCodecs, filterByUserSelection, preferCodecFamilies, preferActiveCdn, rankByBandwidth],
         noSupportedTrackCode: SVTA_NO_SUPPORTED_AUDIO_TRACK,
       },
     }),

--- a/packages/spf/src/playback/behaviors/track-switching.ts
+++ b/packages/spf/src/playback/behaviors/track-switching.ts
@@ -6,34 +6,32 @@
  *
  * Selection runs in two stages. First a **hard-constraints pre-pass**
  * (`applyConstraints`) prunes the unplayable from the candidate set — the
- * failed-CDN constraint (`excludeFailedCdns`, failover cooldown) and the
- * capability constraint (`excludeUnplayableTracks`, codec support). Then a small
+ * failed-CDN constraint (`excludeFailedCdns`, failover cooldown), the
+ * capability constraint (`excludeUnplayableTracks`, codec support), and the
+ * codec-family sticky constraint (`stickToSelectedCodecs`, no
+ * `SourceBuffer.changeType()` — see its note). Then a small
  * ordered chain of rules (`applyRules`) picks among the survivors. Each constraint/rule reads the signals it needs at apply
  * time, so the effect subscribes to exactly what was consulted. The chain runs
  * most authoritative first:
  *
- *   1. **codec-family sticky** — a soft filter on the current selection
- *      (`stickToSelectedCodecs`): narrow to the tracks sharing the selected
- *      track's codec families. Physics ahead of preference — SPF implements no
- *      `SourceBuffer.changeType()`, so a cross-family re-pick would append
- *      undecodable data; that's why it outranks even user intent.
- *   2. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
+ *   1. **user intent** — a soft filter on `user*TrackSelection`: narrow to the
  *      partial-track match; an empty match falls through to the full set.
- *   3. **codec-family preference** — a soft filter on `preferredCodecs`
+ *   2. **codec-family preference** — a soft filter on `preferredCodecs`
  *      (`preferCodecFamilies`, default AVC/AAC): on a mixed-codec source,
- *      narrow which family the *initial* pick — the one the sticky rule then
- *      holds — lands in. Behind user intent so an explicit initial pick may
- *      land anywhere; inert once sticky narrows to a non-preferred family.
- *   4. **active CDN** — a soft filter on `cdnPriority` (`preferActiveCdn`):
+ *      narrow which family the *initial* pick — the one the sticky constraint
+ *      then holds — lands in. Behind user intent so an explicit initial pick
+ *      may land anywhere; inert once the constraint narrows to a
+ *      non-preferred family.
+ *   3. **active CDN** — a soft filter on `cdnPriority` (`preferActiveCdn`):
  *      narrow to the highest-priority CDN that still has tracks; an empty match
  *      falls through. Shared by video and audio, so every type stays on one CDN
  *      (`deriveCdnPriority` owns the list). No-op for non-redundant sources.
- *   5. **player resolution** — a soft filter on `playerResolution`
+ *   4. **player resolution** — a soft filter on `playerResolution`
  *      (`playerResolutionCap`, video only): narrow to the smallest rendition
  *      tier covering the player element, plus everything below it. No-op
  *      without a measurement. Ahead of the ranker but behind the CDN scope, so
  *      the cap chooses *within* a host rather than between hosts.
- *   6. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and
+ *   5. **ranking** — the terminal sort: `rankByBandwidth`, shared by video and
  *      audio. Fitting tracks (within the throughput threshold) first, highest
  *      bitrate first; over-throughput tracks after, least-over first. Hysteresis
  *      via boosting the current track's sort weight by `upgradeMargin`.
@@ -51,9 +49,10 @@
  * (default: the head, `applyRules(...)[0]`). Each variant supplies its
  * **constraints + rule chain (+ optional resolveSelection)** via config;
  * `setupTrackSwitching` owns only the lifecycle and runs what it's given. Video
- * and audio run constraints `[excludeFailedCdns, excludeUnplayableTracks]` then
- * rules `[stickToSelectedCodecs, filterByUserSelection, preferCodecFamilies,
- * preferActiveCdn, rankByBandwidth]` and take the head; video inserts
+ * and audio run constraints `[excludeFailedCdns, excludeUnplayableTracks,
+ * stickToSelectedCodecs]` then rules `[filterByUserSelection,
+ * preferCodecFamilies, preferActiveCdn, rankByBandwidth]` and take the head;
+ * video inserts
  * `playerResolutionCap` after the active-CDN scope, and `switchVideoTrack` also
  * accepts ABR tuning config, `switchAudioTrack` takes none.
  * `switchTextTrack` differs — selection is *optional* (captions are
@@ -533,33 +532,45 @@ function preferActiveCdn<S extends SelectionKey, T extends SwitchableTrack>(
 }
 
 /**
- * Codec-family sticky scope — a soft filter, shared by video and audio, and
- * the reason the re-evaluating variants can run ABR over a mixed-codec source
- * at all: SPF implements no `SourceBuffer.changeType()`, so once segments of
- * the selected track's codec families are what a buffer was created for, a
- * re-pick outside them would append undecodable data. Narrows the candidates
- * to the tracks whose codec-family set *equals* the selected track's
- * (set-equality so a muxed `hvc1,mp4a` rendition can't pass as a match for
- * `avc1,mp4a` on its audio half).
- *
- * Sits at the head of the chain — ahead of even user intent, the one rule
- * that does, because this is physics rather than preference: a cross-family
- * user selection mid-stream falls through unhonored instead of killing
- * playback. Before any selection exists (the initial pick) it passes
- * everything through, which is what leaves the initial family choice to the
- * rules behind it (user intent, then `preferCodecFamilies`).
+ * Codec-family sticky constraint — a *hard* filter for the constraints
+ * pre-pass, shared by video and audio, and the reason the re-evaluating
+ * variants can run ABR over a mixed-codec source at all: SPF implements no
+ * `SourceBuffer.changeType()`, so once segments of the selected track's codec
+ * families are what a buffer was created for, a pick outside them could
+ * never play — constraint semantics ("can't play here"), not preference.
+ * Removes the candidates whose codec-family set doesn't *equal* the selected
+ * track's (set-equality so a muxed `hvc1,mp4a` rendition can't pass as a
+ * match for `avc1,mp4a` on its audio half). Purely relational: the lock *is*
+ * the current selection's families, no state of its own. Pruned pre-pass, a
+ * cross-family user selection mid-stream never reaches the user filter,
+ * which falls through unhonored instead of killing playback. Before any
+ * selection exists (the initial pick) it removes nothing, which is what
+ * leaves the initial family choice to the rule chain (user intent, then
+ * `preferCodecFamilies`).
  *
  * The selected track's families come from the *presentation's* track list,
- * not the constraint-pruned candidates: a CDN entering cooldown may prune the
+ * not the already-pruned candidates: a CDN entering cooldown may prune the
  * current track itself while same-family renditions survive on another host,
- * and the lock must carry over to them. Fall-through cases: no selection yet,
- * a selection the presentation no longer carries, or a selected track without
- * codecs (then no candidate's compatibility is decidable — same inertness as
- * `preferCodecFamilies` on a codec-less ladder). When the selected family has
- * genuinely vanished from the candidates, soft-filter fall-through applies
- * and the pick crosses families — the pipeline breaks at append exactly as it
- * would have without this rule, no worse (a changeType-shaped problem this
- * scope can't solve).
+ * and the lock must carry over to them. Removes nothing when: no selection
+ * yet, a selection the presentation no longer carries, or a selected track
+ * without codecs (then no candidate's compatibility is decidable — same
+ * inertness as `preferCodecFamilies` on a codec-less ladder).
+ *
+ * When the selected family genuinely vanishes from the playable set, the
+ * pre-pass empties: the behavior reports the type's no-supported-track code
+ * and clears the selection — an explicable stop instead of a cross-family
+ * append surfacing as an opaque decode error. Clearing also releases the
+ * lock (it keys on the live selection), so a following pick may land in the
+ * surviving family on freshly-created buffer actors; whether the append
+ * layer survives that rebuild is the changeType gap, out of this
+ * constraint's hands. If `changeType` support ever lands, this constraint is
+ * what relaxes.
+ *
+ * Reading the selection here — a slot the picking effect itself writes, from
+ * inside the candidate-set computed — is safe only because the effect
+ * scheduler revalidates an effect's sources after each run; see
+ * `core/signals/effect.ts` (`revalidateSources`) for the lost-wakeup this
+ * once caused and the regression test that pins it.
  *
  * Composed only into the re-evaluating `switch*` variants: the pinned
  * `selectVideoTrack` (background compositions) evaluates once and never
@@ -855,15 +866,8 @@ export const switchVideoTrack = defineBehavior({
         selectionKey: 'selectedVideoTrackId',
         userSelectionKey: 'userVideoTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'video') as readonly VideoTrackCandidate[],
-        constraints: [excludeFailedCdns, excludeUnplayableTracks],
-        rules: [
-          stickToSelectedCodecs,
-          filterByUserSelection,
-          preferCodecFamilies,
-          preferActiveCdn,
-          playerResolutionCap,
-          rankByBandwidth,
-        ],
+        constraints: [excludeFailedCdns, excludeUnplayableTracks, stickToSelectedCodecs],
+        rules: [filterByUserSelection, preferCodecFamilies, preferActiveCdn, playerResolutionCap, rankByBandwidth],
         noSupportedTrackCode: SVTA_NO_SUPPORTED_VIDEO_TRACK,
       },
     }),
@@ -914,8 +918,8 @@ export const switchAudioTrack = defineBehavior({
         selectionKey: 'selectedAudioTrackId',
         userSelectionKey: 'userAudioTrackSelection',
         getTracks: (presentation) => getTracksByType(presentation, 'audio') as readonly AudioTrackCandidate[],
-        constraints: [excludeFailedCdns, excludeUnplayableTracks],
-        rules: [stickToSelectedCodecs, filterByUserSelection, preferCodecFamilies, preferActiveCdn, rankByBandwidth],
+        constraints: [excludeFailedCdns, excludeUnplayableTracks, stickToSelectedCodecs],
+        rules: [filterByUserSelection, preferCodecFamilies, preferActiveCdn, rankByBandwidth],
         noSupportedTrackCode: SVTA_NO_SUPPORTED_AUDIO_TRACK,
       },
     }),

--- a/packages/spf/src/playback/engines/hls/engine-audio-only.ts
+++ b/packages/spf/src/playback/engines/hls/engine-audio-only.ts
@@ -161,6 +161,14 @@ export interface HlsAudioEngineConfig extends ShareSignalsConfig<HlsAudioEngineS
    */
   canPlayTrack?: CanPlayTrack;
   /**
+   * Codec families the initial audio pick prefers on a mixed-codec source
+   * (`preferCodecFamilies` scope) — the family it lands in is then sticky for
+   * the source's lifetime (`stickToSelectedCodecs`; SPF implements no
+   * `SourceBuffer.changeType()`). Defaults to `DEFAULT_PREFERRED_CODECS`
+   * (AAC, plus video 4CCs inert here); pass `[]` to disable.
+   */
+  preferredCodecs?: string[];
+  /**
    * Conditions reported about each rendition as it resolves — the *causes* behind
    * a later verdict, and the copy a verdict reuses when they agree. Defaults to
    * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers

--- a/packages/spf/src/playback/engines/hls/engine.ts
+++ b/packages/spf/src/playback/engines/hls/engine.ts
@@ -233,6 +233,18 @@ export interface HlsVideoEngineConfig extends ShareSignalsConfig<HlsVideoEngineS
    */
   canPlayTrack?: CanPlayTrack;
   /**
+   * Codec families (RFC 6381 4CCs, e.g. `'avc1'` / `'hvc1'` / `'mp4a'`) the
+   * initial video/audio picks prefer on a mixed-codec source, read by the
+   * `preferCodecFamilies` selection scope. SPF implements no
+   * `SourceBuffer.changeType()`, so the initial pick's codec family is sticky
+   * for the source's lifetime (`stickToSelectedCodecs`); this decides which
+   * family that is. Soft — a source with no preferred-family rendition is
+   * unaffected. Defaults to `DEFAULT_PREFERRED_CODECS` (AVC + AAC, the
+   * broadest-decode pair); pass `[]` to disable and let ABR pick the initial
+   * family (it then still can't leave it mid-stream).
+   */
+  preferredCodecs?: string[];
+  /**
    * Conditions reported about each rendition as it resolves — the *causes* behind
    * a later verdict, and the copy a verdict reuses when they agree. Defaults to
    * {@link reportUnsupportedTrackConditions}, which reports non-fMP4 containers

--- a/packages/spf/src/playback/engines/hls/index.ts
+++ b/packages/spf/src/playback/engines/hls/index.ts
@@ -21,6 +21,12 @@ export {
 // `[preferHighestResolution]` alone drops the screen-size cap, for one.
 export type { SelectTrackRule } from '../../behaviors/select-tracks';
 export { preferHighestResolution, screenResolutionCap } from '../../behaviors/select-tracks';
+export { stickToSelectedCodecs } from '../../behaviors/track-switching';
+export {
+  type CodecPreferenceConfig,
+  DEFAULT_PREFERRED_CODECS,
+  preferCodecFamilies,
+} from '../../primitives/selection-rules';
 // The Medias over these engines are not here: they live behind
 // `@videojs/spf/hls-video`, `@videojs/spf/hls-audio`, and
 // `@videojs/spf/hls-background-video` so that driving an engine directly doesn't pull

--- a/packages/spf/src/playback/primitives/selection-rules.ts
+++ b/packages/spf/src/playback/primitives/selection-rules.ts
@@ -6,8 +6,9 @@
  * behaviors can share rules. The simple `selectVideoTrack` variant exists
  * specifically to tree-shake the ABR path out, so importing a composer from
  * `behaviors/track-switching.ts` would drag the bandwidth estimator and quality
- * selection back in with it. These four have no dependencies at all — pure
- * generics over a candidate list — so either side can reach them freely.
+ * selection back in with it. Nothing here reaches past pure generics over a
+ * candidate list and small media-layer helpers, so either side can reach
+ * them freely.
  *
  * See `internal/design/spf/track-switching-model.md` for the model these
  * implement: a hard constraints pre-pass, then an ordered chain of soft
@@ -15,6 +16,7 @@
  */
 
 import type { CanPlayTrack } from '../../media/types';
+import { getCodecFamilies, getCodecFamily } from '../../media/utils/tracks';
 
 /**
  * Deps handed to each rule and to `applyRules`, mirroring a behavior's setup
@@ -149,4 +151,60 @@ export function excludeUnplayableTracks<T, State, Context, Config>(
   const canPlay = (config as CapabilityConstraintConfig | undefined)?.canPlayTrack;
   if (!canPlay) return tracks;
   return tracks.filter((track) => canPlay(track as Parameters<CanPlayTrack>[0]));
+}
+
+/**
+ * What {@link preferCodecFamilies} reads off the config it is handed — a cast
+ * view, for the same reason as {@link CapabilityConstraintConfig}.
+ */
+export interface CodecPreferenceConfig {
+  preferredCodecs?: string[];
+}
+
+/**
+ * The codec families {@link preferCodecFamilies} narrows to when the config
+ * carries no `preferredCodecs`: AVC (both its 4CCs) and AAC. The default is
+ * deliberate rather than neutral — SPF implements no
+ * `SourceBuffer.changeType()`, so on a mixed-codec source the *initial*
+ * family choice is the one ABR lives inside for the whole source (see
+ * `stickToSelectedCodecs` in `behaviors/track-switching.ts`), and AVC/AAC is
+ * the family pair with the broadest decode support. The cost, equally
+ * deliberate: on a ladder whose higher rungs are HEVC-only (a common 4K
+ * shape), the default caps quality at the top AVC rung — configure
+ * `preferredCodecs` (or pass `[]`) to trade the other way.
+ */
+export const DEFAULT_PREFERRED_CODECS: readonly string[] = ['avc1', 'avc3', 'mp4a'];
+
+/**
+ * Codec-family preference — a *soft* filter (scope) for a selection-rule
+ * chain; the `hevc-variant-selection` concern from
+ * `internal/design/spf/track-switching-model.md`. Narrows to the tracks whose
+ * codec families are all in `preferredCodecs` (family-compared, so entries
+ * may be 4CCs or full codec strings). Soft-filter semantics: a source with no
+ * preferred-family rendition (an HEVC-only ladder under the AVC default) is
+ * left unnarrowed, and a track without codecs never matches — on a ladder
+ * with no codecs anywhere (DOM-free tests) the rule is inert.
+ *
+ * `preferredCodecs` defaults to {@link DEFAULT_PREFERRED_CODECS}; explicitly
+ * pass `[]` to disable the preference while keeping the rule composed.
+ *
+ * "All families" rather than "any" so a muxed rendition is judged as the unit
+ * it is: `hvc1,mp4a` must not count as preferred just because its audio half
+ * matches.
+ *
+ * Lives here rather than beside `switchVideoTrack` for the module's usual
+ * reason: the pinned `selectVideoTrack` variant can compose it without
+ * dragging the ABR path in.
+ */
+export function preferCodecFamilies<T, State, Context, Config>(
+  tracks: readonly T[],
+  { config }: SelectionRuleDeps<State, Context, Config>
+): readonly T[] {
+  const preferred = (config as CodecPreferenceConfig | undefined)?.preferredCodecs ?? DEFAULT_PREFERRED_CODECS;
+  if (!preferred.length) return tracks;
+  const preferredFamilies = new Set(preferred.map(getCodecFamily));
+  return tracks.filter((track) => {
+    const families = getCodecFamilies(track as { codecs?: string[] });
+    return !!families && families.every((family) => preferredFamilies.has(family));
+  });
 }


### PR DESCRIPTION
Refs #1864

## Summary

SPF implements no `SourceBuffer.changeType()`, so on a mixed-codec source — Apple's bipbop advanced example muxes HEVC + AVC renditions of the same content — a mid-stream re-pick across codec families appends undecodable data into a `SourceBuffer` created under the initial family's mimetype. This adds a hard codec-family sticky constraint (relational: the selected track's families), a configurable preference (default AVC/AAC) for which family the initial pick lands in, and the effect-scheduler fix that makes the constraint expressible.

## Changes

- **`stickToSelectedCodecs`** (new selection *constraint*, video + audio `switch*` pre-passes): prunes candidates whose codec-family set doesn't equal the currently selected track's (set-equality, so a muxed `hvc1,mp4a` rendition can't pass as a match for `avc1,mp4a` on its audio half). Purely relational — no state of its own. Constraint semantics are the point: pruned pre-pass, a cross-family user pick mid-stream never reaches the user filter's early-bail and falls through unhonored instead of killing playback, and a vanished selected family becomes a reported `SVTA` no-supported-track stop (recovering when the family returns) instead of a silent cross-family pick.
- **`fix(core)`: effects that self-write through their own dependencies no longer go deaf.** A constraint reading the selection slot — which the picking effect itself writes — exposed a real signals-engine bug: the self-write left an intermediate computed dirty with no notification, and the standing dirty flag then deduped away every later external change through it (failover and relabel re-picks went unseen). `effect.ts` now pulls an effect's sources after each run; the guarantee is liveness, not immediacy (an effect isn't re-run just for writing into its own graph — it catches up on the next genuine change, which is what used to be lost). Reproduced in ten lines of pure signals; pinned by new `core/signals/tests/effect.test.ts` cases for initial-run, flush-run, and convergence.
- **`preferCodecFamilies`** (new selection scope): narrows the *initial* pick to the `preferredCodecs` families — the family the constraint then holds. Behind the user filter, so an explicit initial pick may land in any family. Soft: an HEVC-only ladder under the AVC default plays exactly as before.
- **`preferredCodecs` config** on `SwitchVideoTrackConfig`, `HlsVideoEngineConfig`, and `HlsAudioEngineConfig`. Default `['avc1', 'avc3', 'mp4a']`; `[]` disables the preference (ABR then picks the initial family and still can't leave it).
- The background compositions are deliberately unwired: the pinned `selectVideoTrack` evaluates once and never re-picks, so it's immune by construction.
- **Sandbox**: Apple's official mixed-codec fMP4 example joins the shared source registry as `hls-mixed-codec`, reachable from every preset picker and `?source=` deep link. The `spf-segment-loading` harness's AVC-only toggle (plus its `avcOnly` query param and harness-local bipbop preset) is removed — it existed solely as the workaround this PR replaces with engine defaults.

<details>
<summary>Implementation details</summary>

- Both selection pieces follow `track-switching-model.md` (`hevc-variant-selection` was already anticipated there as a codec scope); constraint placement is what guarantees a cross-family user pick can't early-bail past the policy.
- A custom `equals` on the candidate-set computed does **not** avoid the scheduler bug — `sameCandidateSet` was in place the whole time. `equals` gates notification after a recomputation; the lost wakeup is the dirty flag set at write time, upstream of any comparison. Only a pull clears it, which is what `revalidateSources` does; it never writes or schedules, so it cannot loop.
- Vanish-case semantics: the pre-pass empties → the type's no-supported-track code is reported and the selection clears; clearing releases the relational lock, so recovery (cooldown expiry, the family returning) re-picks. Whether the append layer survives a cross-family rebuild remains the changeType gap, unchanged by this PR.
- The default's deliberate cost, documented on `DEFAULT_PREFERRED_CODECS`: a ladder whose top rungs are HEVC-only caps at the top AVC rung under the default.
- Bundle: the HLS engine lands a few hundred bytes gzipped over the 20 KB advisory target in `measure-size.js` — main was already at 99.9% of it before this branch.

</details>

## Testing

- `pnpm -F @videojs/spf test` — full suite passes. Constraint coverage: mixed-ladder initial pick lands on AVC over a better-fitting HEVC rung, upgrades stay in-family, cross-family user selections are pruned while in-family ones are honored, a user's initial HEVC pick locks HEVC, muxed family sets compare whole, audio prefers AAC over a higher-bitrate E-AC-3 and holds it against a cross-family language request, and a failover that removes the selected family reports + clears, then recovers when the CDN returns. Scheduler coverage: `effect.test.ts` pins the self-write lost-wakeup for initial-run and flush-run plus convergence.
- `pnpm -F @videojs/spf build`, `pnpm typecheck`, `pnpm -F @videojs/spf size`, lint — all clean (size note above).
- Verified live against the sandbox (Chromium): the bipbop mixed ladder plays with the pick held in AVC/AAC, a programmatic cross-family selection is pruned while an in-family one is honored, and playback never interrupts.

### Sandbox (Vercel preview, this branch)

Base: [v10-sandbox](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app). The mixed-codec source is in the shared registry, so it's also reachable from any preset's picker.

| Scenario | Link | Expect |
|---|---|---|
| Mixed-codec (bipbop adv fMP4), SPF player | [HTML](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app/?platform=html&preset=hls-video&source=hls-mixed-codec) · [React](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app/?platform=react&preset=hls-video&source=hls-mixed-codec) | Plays. Initial pick lands in AVC/AAC and ABR stays there; renditions menu picks within AVC work, HEVC picks are ignored (playback keeps going) |
| Same source, Mux-flavored SPF | [HTML](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app/?platform=html&preset=mux-video-spf&source=hls-mixed-codec) | Identical behavior under the Mux media alias |
| Segment-loading harness (engine state readout) | [spf-segment-loading](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app/spf-segment-loading/?src=https%3A%2F%2Fdevstreaming-cdn.apple.com%2Fvideos%2Fstreaming%2Fexamples%2Fbipbop_adv_example_hevc%2Fmaster.m3u8&preload=auto&muted=true&autoplay=true) | Selected rendition codecs stay `avc1.*`/`mp4a.*` (rendition buttons + `window.state()`). The AVC-only toggle is gone — no workaround needed |
| Control: background preset (pinned, out of scope) | [HTML](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app/?platform=html&preset=hls-background-video&source=hls-mixed-codec) | Unchanged — the pinned variant never re-picks, so the constraint isn't composed there |
| Control: single-codec 4K CMAF | [HTML](https://v10-sandbox-git-feat-sticky-codec-selection-mux.vercel.app/?platform=html&preset=hls-video&source=hls-4k) | Unchanged ABR behavior — one family, constraint and preference both inert |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core effect scheduling and video/audio track selection, so mixed-codec and failover re-picks can change. Default AVC/AAC preference can cap quality on HEVC-top ladders unless `preferredCodecs` is overridden.
> 
> **Overview**
> Keeps ABR inside the codec family of the first pick, because SPF still has no `SourceBuffer.changeType()`. Mixed HEVC+AVC (and AAC vs E-AC-3) sources no longer append undecodable data mid-stream.
> 
> **Selection:** `stickToSelectedCodecs` is a hard pre-pass on video/audio `switch*` — later picks must match the selected track’s full codec-family set. Cross-family user picks are ignored; if the family disappears (e.g. CDN cooldown), selection clears with a no-supported-track error and recovers when it returns. `preferCodecFamilies` (default `avc1`/`avc3`/`mp4a`) only shapes the *initial* pick; `preferredCodecs: []` disables it. HEVC-only ladders are unchanged. Pinned `selectVideoTrack` is left unwired.
> 
> **Signals:** Effects that write a signal an intermediate computed in their own graph reads no longer go deaf. After each run, `revalidateSources` pulls sources so a standing dirty flag cannot swallow later wakeups. Guarantee is liveness, not an extra re-run.
> 
> **Sandbox:** Apple bipbop is a shared `hls-mixed-codec` source. The segment-loading AVC-only toggle/workaround is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856577c4c9faafecd7b34b05369ae59f52ed183e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->