### PR TITLE
docs(site): reconcile metadata docs with the rest of the merged stack

### DIFF
--- a/site/scripts/api-docs-builder/src/feature-handler.ts
+++ b/site/scripts/api-docs-builder/src/feature-handler.ts
@@ -174,7 +174,7 @@ function parseDerivedKeys(node: ts.Expression): DerivedKeySource[] {
 }
 
 /**
- * Read the `config` map: `{ contentTitle: { action: 'setContentTitle', state: USER_X } }`.
+ * Read the `config` map: `{ title: { action: SET_USER_TITLE, state: USER_TITLE } }`.
  *
  * Each value names a source-state member either as an identifier bound to a
  * private symbol or as a string naming the member outright, which is how an

--- a/site/src/content/docs/reference/feature-metadata.mdx
+++ b/site/src/content/docs/reference/feature-metadata.mdx
@@ -19,6 +19,8 @@ The metadata feature is included by the `videoFeatures`, `audioFeatures`, `liveV
 
 ### Selector
 
+To just show the name of what is playing, drop in the <DocsLink slug="reference/title">Title component</DocsLink> — it reads this feature for you. Reach for the selector when building your own UI.
+
 <FrameworkCase frameworks={["react"]}>
 Pass `selectMetadata` to <DocsLink slug="reference/use-player">`usePlayer`</DocsLink> to subscribe to metadata state. Returns `undefined` if the metadata feature is not configured.
 
@@ -107,4 +109,4 @@ The media tier comes from media that reports content data and announces changes 
 
 `poster` is the feature's own resolved value, not the media element's `poster` attribute. Setting one does not set the other.
 
-A low-resolution stand-in to show while the poster loads is not part of this feature. The <DocsLink slug="reference/poster">poster</DocsLink> renders an `<img>` you control, so give it a `background-image` and that shows until the poster itself paints over it.
+A low-resolution stand-in to show while the poster loads is not part of this feature. The <DocsLink slug="reference/poster">poster</DocsLink> renders an `<img>` you control, so give it a `background-image` and that shows until the poster itself paints over it. <DocsLink slug="how-to/add-a-poster-placeholder">Add a poster placeholder</DocsLink> walks through that technique for each framework.

--- a/site/src/content/docs/reference/title.mdx
+++ b/site/src/content/docs/reference/title.mdx
@@ -6,6 +6,7 @@ description: Displays the resolved content title for the current media
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -69,6 +70,8 @@ If neither has a value, there is nothing to show and the title hides itself.
 
 The title is player input, not player state, so change it the way you set it in the
 first place. The store exposes the resolved `title` to read, and nothing to write.
+That resolution belongs to the <DocsLink slug="reference/feature-metadata">metadata
+feature</DocsLink>, which the video and audio presets include.
 
 <FrameworkCase frameworks={["react"]}>
   ```tsx


### PR DESCRIPTION
The metadata stack (#1998, #2176, #2039, #1997, #2063, #2000, #1999) merged over several days, and a few cross-references were written before the pieces they should point at had landed. This updates them:

- **`site/scripts/api-docs-builder/src/feature-handler.ts`** — the config-map JSDoc example showed the old `{ contentTitle: { action: 'setContentTitle', ... } }` shape; it now mirrors the real metadata config, `{ title: { action: SET_USER_TITLE, state: USER_TITLE } }`. Comment-only; builder behavior unchanged.
- **`feature-metadata.mdx`** — the Selector section taught readers to hand-roll a title component; it now points at the Title component first and frames `selectMetadata` as the build-your-own path. The Title page reciprocally names the metadata feature as the owner of its resolved value.
- **`feature-metadata.mdx`** — the poster stand-in paragraph restated the technique the "Add a poster placeholder" guide owns without linking it; it now does, matching how the Mux Player migration guide already links it.

## Testing

- `pnpm -F site test scripts/api-docs-builder` — 222 passed
- `pnpm -F site astro check` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmoPYutEqmH1i1Xtxucfq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmoPYutEqmH1i1Xtxucfq8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a comment-only JSDoc tweak; no runtime or builder behavior changes.
> 
> **Overview**
> Reconciles leftover docs after the metadata stack landed so Title, metadata, and poster placeholder point at each other instead of restating each other.
> 
> The metadata Selector section now steers readers to the Title component first and treats `selectMetadata` as the custom-UI path. The Title page names the metadata feature as the owner of resolved `title`. The poster stand-in note links the existing how-to.
> 
> Also updates the `parseConfigEntries` JSDoc example to `{ title: { action: SET_USER_TITLE, state: USER_TITLE } }` so it matches the real config map. Comment-only; builder behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1dbe790fe214274a099389b1d2f1202be7f92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->