### PR TITLE
docs(site): document thumbnail CORS inheritance

### DIFF
--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -129,6 +129,7 @@ export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
 - `@videojs/react/video` is a <DocsLink slug="concepts/presets">preset</DocsLink>: a player, a skin, and a media element that already fit together. `VideoPlayer` is the piece that owns the state, built from the standard set of <DocsLink slug="concepts/features">features</DocsLink> for video.
 - The poster is a prop on the skin rather than a `poster` attribute on the media, which gives the skin control over how it appears. That's much like Plyr's `data-poster`.
 - This example assumes all your files for a given asset live in the same path, using consistent filenames. This will almost certainly need adjusting for your implementation.
+- If `origin` points somewhere other than your page's origin, add `crossOrigin="anonymous"` to `<Video>` and serve those files with CORS headers. A cross-origin thumbnail track only loads when the media element is CORS-enabled. See <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by switching the CSS import filename to `skin.css` and the `MinimalVideoSkin` import and usage to `VideoSkin`.
 
 </FrameworkCase>

--- a/site/src/content/docs/reference/feature-text-tracks.mdx
+++ b/site/src/content/docs/reference/feature-text-tracks.mdx
@@ -11,6 +11,8 @@ Manages subtitles, captions, chapters, and thumbnail tracks.
 
 A default `kind="chapters"` track can also divide the <DocsLink slug="reference/time-slider">time slider</DocsLink> into chapter ranges and label the chapter at the current interaction position.
 
+When a thumbnail track is present, `thumbnailTrackCrossOrigin` reports the media element's CORS mode, or `null` when the media is not CORS-enabled. <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink> reads it to fetch sprite sheets the same way the browser fetched the track.
+
 <FeatureReference feature="textTrack" />
 
 ### Selector

--- a/site/src/content/docs/reference/mux-video.mdx
+++ b/site/src/content/docs/reference/mux-video.mdx
@@ -77,6 +77,26 @@ MuxVideo fires a `sourcechange` event when the source actually changes. Setting 
 
 `thumbnail` and `storyboard` default to URLs derived from `source`: the poster image and the storyboard VTT that drives hover previews on the time slider. MuxVideo injects the storyboard `<track>` automatically, skipping it for live streams. Set either prop to a URL to override the derived one.
 
+The storyboard lives on a Mux domain, so MuxVideo has to be CORS-enabled for that cross-origin `<track>` to load at all. <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink> then fetches the sprite sheets its cues point at the same way:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<MuxVideo
+  source={{ playbackId: 'BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM' }}
+  crossOrigin="anonymous"
+/>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```html
+<mux-video
+  src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM.m3u8"
+  crossorigin="anonymous"
+></mux-video>
+```
+</FrameworkCase>
+
 ## Signed playback
 
 For [signed playback](https://www.mux.com/docs/guides/secure-video-playback), put the playback token on `source.playback.token`. The token replaces every other playback param, so bake modifiers like resolution and time bounds into the token when you sign it.

--- a/site/src/content/docs/reference/thumbnail.mdx
+++ b/site/src/content/docs/reference/thumbnail.mdx
@@ -39,9 +39,11 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
 
 `https://image.mux.com/{PLAYBACK_ID}/storyboard.vtt`
 
+That track is cross-origin, and a cross-origin `<track>` only loads when the media element is CORS-enabled:
+
 <FrameworkCase frameworks={["react"]}>
   ```tsx
-  <Video src="video.mp4">
+  <Video src="video.mp4" crossOrigin="anonymous">
     <track
       kind="metadata"
       label="thumbnails"
@@ -55,7 +57,7 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
 
 <FrameworkCase frameworks={["html"]}>
   ```html
-  <video src="video.mp4">
+  <video src="video.mp4" crossorigin="anonymous">
     <track
       kind="metadata"
       label="thumbnails"
@@ -66,6 +68,8 @@ import jsonSpriteHtmlTs from "@/components/docs/demos/thumbnail/html/css/JsonSpr
   <media-thumbnail time="12"></media-thumbnail>
   ```
 </FrameworkCase>
+
+A same-origin track needs none of this.
 
 ## Anatomy
 
@@ -94,6 +98,31 @@ Supported source formats:
 In React, text-track mode needs `Player` because it reads track state from the player store. JSON modes (`thumbnails` prop) work without a player.
 
 The component picks the latest thumbnail whose `startTime` is less than or equal to the current `time`, then scales/clips sprite tiles to fit CSS min/max constraints while preserving aspect ratio.
+
+### Cross-origin images
+
+Leave `crossOrigin` unset and the component follows the media element. A cross-origin thumbnail `<track>` only loads when the media is CORS-enabled, so the images its cues point at are fetched with that same mode. Skins get this for free, with nothing to thread through.
+
+Opt out to fetch them without CORS:
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<Thumbnail time={12} crossOrigin={null} />
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["html"]}>
+```ts
+const thumbnail = document.querySelector('media-thumbnail');
+thumbnail.crossOrigin = null;
+```
+
+Leaving the `crossorigin` attribute off is not the opt out. An absent attribute means "follow the media element"; only the property set to `null` opts out.
+</FrameworkCase>
+
+An empty value does not opt out either. The [CORS settings attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) reads anything other than `use-credentials` as Anonymous, so it is a value like any other.
+
+Thumbnails you supply through `thumbnails` never inherit, since they need not be related to the media element at all. Set `crossOrigin` yourself when those images need it.
 
 ## Styling
 


### PR DESCRIPTION
Closes #2290

## Summary

#2273 gave `Thumbnail` a new `crossOrigin` contract: left unset it inherits the media element's CORS mode, since a cross-origin thumbnail `<track>` only loads when the media is CORS-enabled. The docs never said so, and two copy-pasteable Quick Start snippets paired a cross-origin Mux `storyboard.vtt` with a media element that had no `crossorigin` — so they produced no thumbnails as written.

## Changes

- **Thumbnail Quick Start** now sets `crossOrigin="anonymous"` / `crossorigin="anonymous"` on the media element, matching the page's own demos and `HeroVideo.tsx`, with a line on why and a note that same-origin tracks need none of it.
- **Thumbnail Behavior** gains a "Cross-origin images" subsection: inherit-from-media by default, the `null` opt-out, that leaving the HTML attribute off is *not* the opt-out, that an empty value reads as Anonymous per the CORS settings attribute, and that `thumbnails` sources never inherit.
- **MuxVideo** "Thumbnails and storyboards" now says the element must be CORS-enabled for the auto-injected cross-origin storyboard track and its sprite sheets.
- **Text tracks** prose introduces the new `thumbnailTrackCrossOrigin` state field alongside the generated table.
- **Migrate from Plyr** notes when the React example needs `crossOrigin` on `<Video>`.

<details>
<summary>Two judgment calls</summary>

- `migrate-from-plyr.mdx` gets a note rather than a hardcoded `crossOrigin="anonymous"`. The example's `origin` prop is often same-origin, and adding `crossorigin` unconditionally breaks playback when the host sends no CORS headers. The note says when to add it.
- `poster.mdx` is untouched. #2273's title covers posters, but there is no `crossOrigin` anywhere in the Poster core/React/HTML sources — that half of the fix landed in sandbox templates, so the public API did not move.

</details>

## Testing

- `pnpm -F site astro check` — 0 errors
- `pnpm build:site` — complete; spot-checked the rendered thumbnail reference page for the new prose and snippets
- Confirmed the generated reference JSON already picks up the new JSDoc, so the `ComponentReference` and `FeatureReference` tables need no hand edits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to CORS usage for thumbnails; no runtime or API code changes.
> 
> **Overview**
> Documents `Thumbnail` CORS inheritance so copy-paste examples actually load Mux storyboards.
> 
> Quick Start now sets `crossOrigin="anonymous"` on the media element for the cross-origin Mux VTT, and notes same-origin tracks need none of that. A new **Cross-origin images** section explains inherit-from-media by default, `crossOrigin={null}` as the only opt-out, empty/absent attributes, and that JSON `thumbnails` never inherit.
> 
> MuxVideo storyboard docs require CORS on the element; text-track docs mention `thumbnailTrackCrossOrigin`; the Plyr React migration notes when to add `crossOrigin` on `<Video>` instead of hardcoding it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b101bee62c5328c5b35527c03653c3bbbdc8cdb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->