### PR TITLE
docs(site): document where player geometry goes

### DIFF
--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
@@ -1,11 +1,13 @@
 <video-player class="video-player">
-    <video
-        src="{{VJS10_DEMO_VIDEO_MP4}}"
-        autoplay
-        muted
-        playsinline
-        loop
-    ></video>
-    <media-playback-rate-button class="media-playback-rate-button">
-    </media-playback-rate-button>
+    <media-container>
+        <video
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-playback-rate-button class="media-playback-rate-button">
+        </media-playback-rate-button>
+    </media-container>
 </video-player>

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.css
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/Remaining.css
+++ b/site/src/components/docs/demos/time/html/css/Remaining.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/content/docs/concepts/sizing.mdx
+++ b/site/src/content/docs/concepts/sizing.mdx
@@ -1,0 +1,160 @@
+---
+title: Sizing
+description: Which element in a player owns its box, and why geometry on any of the others does nothing.
+---
+
+import FrameworkCase from '@/components/docs/FrameworkCase.astro';
+import DocsLink from '@/components/docs/DocsLink.astro';
+import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
+import Aside from '@/components/Aside.astro';
+
+A player is several elements with separate jobs, and only one of them is the box you size. Put `width`, `height`, `aspect-ratio`, `position`, and `transform` there.
+
+## Where geometry goes
+
+| What you rendered | The box |
+|---|---|
+| A packaged <DocsLink slug="concepts/skins">skin</DocsLink> | The skin |
+| Your own UI | The <DocsLink slug="reference/player-container">container</DocsLink> |
+| A media element on its own, with no player around it | The media element |
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="App.tsx"
+import '@videojs/react/video/skin.css';
+import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';
+import './App.css';
+
+export default function App() {
+  return (
+    <VideoPlayer>
+      <VideoSkin className="player">
+        <Video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4" />
+      </VideoSkin>
+    </VideoPlayer>
+  );
+}
+```
+
+```css title="App.css"
+.player {
+  width: 100%;
+  max-width: 40rem;
+  aspect-ratio: 16 / 9;
+}
+```
+</FrameworkCase>
+<FrameworkCase frameworks={["html"]}>
+```ts title="main.ts"
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+import '@videojs/html/video/skin.css';
+import './index.css';
+```
+
+```html title="index.html"
+<video-player>
+  <video-skin class="player">
+    <video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"></video>
+  </video-skin>
+</video-player>
+```
+
+```css title="index.css"
+.player {
+  width: 100%;
+  max-width: 40rem;
+  aspect-ratio: 16 / 9;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+## The player renders no DOM
+
+`VideoPlayer` is a context provider and renders nothing, so there's no element to size and nowhere for your geometry to be quietly dropped. `VideoSkin` and `Container` each render a `div` and forward `className` and `style` to it. `Video`, `MuxVideo`, and the other media components render a real `<video>`. Every element you can reach has a box.
+
+The HTML package differs here: several of its elements are `display: contents` and ignore geometry outright. That's worth knowing if you read the HTML examples, share CSS between the two, or port markup across.
+</FrameworkCase>
+<FrameworkCase frameworks={["html"]}>
+## The provider and the media elements have no box
+
+`<video-player>`, `<live-video-player>`, `<background-video-player>`, and `<media-i18n>` are `display: contents`. So are the media elements that wrap a native `<video>`: `<mux-video>`, `<hls-video>`, `<hlsjs-video>`, `<dash-video>`, `<shaka-video>`, and `<native-hls-video>`.
+
+An element with `display: contents` generates no box. Its children lay out as if the element were not in the tree at all, which is what makes the provider composable — it's a state boundary, not a wrapper, so it can sit inside your grid or flex layout without adding a box you have to style around.
+
+The cost is that geometry on those elements is inert, and CSS reports nothing when you set it. The declaration is still in the computed style, `getBoundingClientRect()` on the element returns `0×0`, and the children size themselves against your layout instead. A 124-pixel-wide decorative video becomes as wide as the page.
+
+```css
+/* ❌ Silently ignored — the provider generates no box */
+video-player {
+  width: 640px;
+  aspect-ratio: 16 / 9;
+}
+
+/* ✅ The skin is the box */
+video-skin {
+  width: 640px;
+  aspect-ratio: 16 / 9;
+}
+```
+
+Custom properties are the exception. They inherit through `display: contents`, so `video-player { --media-accent-color: rebeccapurple }` reaches the UI. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>.
+
+### What each element does by default
+
+| Element | Default `display` | Size it? |
+|---|---|---|
+| `<video-player>`, `<live-video-player>`, `<media-i18n>` | `contents` | No |
+| `<background-video-player>` | `contents` | No |
+| `<audio-player>`, `<live-audio-player>` | `inline`, because they ship no styles | No, see below |
+| `<video-skin>` and the other skins | `grid`, `width: 100%` | Yes |
+| `<background-video-skin>` | `block`, `width: 100%`, `height: 100%` | Yes |
+| `<media-container>` | `inline`, because it ships no styles | Yes, with a `display` |
+| `<background-video>`, `<mux-background-video>`, `<hls-background-video>` | `inline`, `position: relative` | Yes, with a `display` |
+| `<mux-video>`, `<hls-video>`, `<hlsjs-video>`, `<dash-video>`, `<shaka-video>`, `<native-hls-video>` | `contents` | Yes, with a `display` |
+| `<youtube-video>`, `<vimeo-video>`, `<twitch-video>`, `<tiktok-video>`, `<cloudflare-video>`, `<hls-audio>`, `<mux-audio>`, `<spotify-audio>` | `inline-flex` | Yes |
+
+`<media-container>` is the box for a custom UI, but it ships no styles at all, so `width` on it does nothing until you give it a `display`:
+
+```css
+media-container {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+```
+
+The audio providers are `inline` rather than `contents`, which both ignores `width` and disrupts a grid or flex parent. Set `display: contents` on them yourself:
+
+```css
+audio-player,
+live-audio-player {
+  display: contents;
+}
+```
+
+### Give one a box on purpose
+
+A chrome-less video — a decorative background, a thumbnail grid, a hero loop — is a media element with no skin and no container, so the media element has to become the box. Set its `display` along with its size:
+
+```css
+.hero-video {
+  display: block;
+  width: 124px;
+  aspect-ratio: 1 / 1;
+}
+```
+
+Use a class selector rather than a tag selector, as the example above does. On a media element either one works, because any rule in your stylesheet outranks the element's own shadow `:host` rule. On a provider a tag selector is a coin toss: the packaged `video-player { display: contents }` rule lives in a stylesheet we append to `<head>` when the player is defined, so it ties your `video-player { display: block }` on specificity and wins on document order. A class selector is more specific and wins either way.
+
+<Aside type="caution">
+Inline styles beat stylesheets, so code that assigns `element.style.display` after you takes over — a layout library rewriting the property every frame, for example. Have that code write the `display` you want, or mark your declaration `!important`.
+</Aside>
+</FrameworkCase>
+
+## Sizing lives in your CSS
+
+No player element takes a `width`, `height`, or `ratio` attribute, and there are no sizing modes to choose between. Sizing is layout, layout is yours, and CSS already describes it. `width: 100%` and `aspect-ratio` on the box cover what Video.js 8 spelled `fluid`, `fill`, and `aspectRatio`.
+
+<DocsLinkCard slug="reference/player-container">Container reference</DocsLinkCard>

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -101,6 +101,8 @@ Presets are a topic quite a bit bigger than just this guide. To learn more, chec
 
 ## Styling
 
+The skin is the player's box. Its size, aspect ratio, and position are yours to set, and they belong on the skin element rather than on the player wrapped around it — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+
 There are currently two options for styling:
 
 <FrameworkCase frameworks={["react"]}>

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -33,6 +33,8 @@ npm install @videojs/react
 
 Media Chrome wraps a slotted `<video slot="media">` in a single `<media-controller>`. Video.js splits that into two elements. The player owns state and draws nothing. The `<media-container>` is the box everything lives in, with the media as a plain child.
 
+Everything you styled on `<media-controller>` therefore splits too. Colors and custom properties still work on the player, because they inherit. Size, aspect ratio, and position have to move to the container, which generates a box where the player does not — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+
 ```html
 <!-- Media Chrome -->
 <media-controller>

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -45,7 +45,7 @@ So a Mux Player embed becomes a player wrapped around a skin wrapped around a me
 ```
 </FrameworkCase>
 
-Everything else in this guide is about which of those three a given Mux Player attribute now belongs to.
+Everything else in this guide is about which of those three a given Mux Player attribute now belongs to. The short version: what is playing goes on the player, how it looks goes on the skin, and anything the browser already understands stays on the media. See <DocsLink slug="concepts/overview">Overview</DocsLink> for the full rule.
 
 ## Your first player
 
@@ -73,13 +73,17 @@ A <DocsLink slug="concepts/presets">preset</DocsLink> is a player, a skin, and a
 
 <video-player>
   <video-skin class="aspect-video">
-    <mux-video src="https://stream.mux.com/EcHgOK9coz5K….m3u8" playsinline crossorigin="anonymous"></mux-video>
+    <mux-video playsinline crossorigin="anonymous"></mux-video>
     <mux-data player-software-name="my-app"></mux-data>
-    <img slot="poster" src="https://image.mux.com/EcHgOK9coz5K…/thumbnail.webp?time=2" alt="" />
   </video-skin>
 </video-player>
 
 <script type="module">
+  document.querySelector('mux-video').source = {
+    playbackId: 'EcHgOK9coz5K…',
+    poster: { time: 2 },
+  };
+
   document.querySelector('mux-data').metadata = {
     video_title: 'Test VOD',
     viewer_user_id: 'user-id-007',
@@ -134,8 +138,8 @@ import { MuxVideo } from '@videojs/react/media/mux-video';
 export function MyPlayer() {
   return (
     <VideoPlayer>
-      <VideoSkin className="aspect-video" poster="https://image.mux.com/EcHgOK9coz5K…/thumbnail.webp?time=2">
-        <MuxVideo source={{ playbackId: 'EcHgOK9coz5K…' }} playsInline crossOrigin="anonymous" />
+      <VideoSkin className="aspect-video">
+        <MuxVideo source={{ playbackId: 'EcHgOK9coz5K…', poster: { time: 2 } }} playsInline crossOrigin="anonymous" />
         <MuxData playerSoftwareName="my-app" metadata={{ video_title: 'Test VOD', viewer_user_id: 'user-id-007' }} />
       </VideoSkin>
     </VideoPlayer>
@@ -151,10 +155,10 @@ The `'use client'` directive is there because the player owns browser state.
 
 A few things worth calling out:
 
-- **The poster is yours to build.** Mux Player derived one from the playback ID; here you point the skin at an `image.mux.com` URL, and `thumbnail-time="2"` becomes `?time=2`. <DocsLink slug="reference/mux-video">`MuxVideo`</DocsLink> derives the same URL and reports it, but the poster is a skin concern today, so nothing reads it for you.
+- **The poster still comes from the playback ID.** <DocsLink slug="reference/mux-video">`MuxVideo`</DocsLink> builds the `image.mux.com` URL for you and reports it to the player, which hands it to the skin. `thumbnail-time="2"` is `source.poster.time`, so you describe the still you want instead of assembling a URL. Set <DocsLink slug="reference/poster">`poster`</DocsLink> on the player when you want to override it with a URL of your own.
 - **You didn't add a storyboard track, and you get hover previews.** The Mux media adds and maintains the thumbnail track itself, and removes it for live streams, where storyboards don't exist.
 - **Analytics needs no environment key.** Mux resolves the environment from the playback ID. See <DocsLink slug="concepts/mux-data">Mux Data</DocsLink>.
-- **Set the aspect ratio yourself,** in your own CSS on the skin. There's no `ratio` attribute, because sizing belongs to your layout.
+- **Set the aspect ratio yourself,** in your own CSS on the skin. There's no `ratio` attribute, because sizing belongs to your layout. Mux Player was a single sized element; here the player is a state boundary that generates no box, so an `aspect-ratio` on it does nothing. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 
 Two things are opt-in that used to be automatic. Analytics is the <DocsLink slug="reference/mux-data">Mux Data</DocsLink> component, and Chromecast is a <DocsLink slug="concepts/cast">Cast</DocsLink> component. Leave either out and you don't ship its code. That, incidentally, is the answer to Mux Player's `disable-tracking`: don't include Mux Data.
 
@@ -224,8 +228,8 @@ Here's where each Mux Player attribute lands:
 | `playback-token` | `source.playback.token` |
 | `thumbnail-token`, `storyboard-token` | `source.poster.token`, `source.storyboard.token` |
 | `drm-token` | `source.drm.token` |
-| `thumbnail-time` | `?time=` on the poster URL you build |
-| poster size, crop, rotation, format | query parameters on that URL |
+| `thumbnail-time` | `source.poster.time` |
+| poster size, crop, rotation, format | `source.poster.width`, `.height`, `.fitMode`, `.rotate`, `.ext` |
 
 Signed playback behaves the way it does in Mux Player: a token replaces every other parameter in its group, so caps and clipping have to be baked into the token itself.
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -359,7 +359,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
 | `poster` / `data-poster` | The skin owns the poster, as shown in [Basic migration](#basic-migration) above. |
-| `ratio` | Set `aspect-ratio` in CSS on the skin component. |
+| `ratio` | Set `aspect-ratio` in CSS on the skin component. The player around it generates no box, so an `aspect-ratio` there is ignored — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>. |
 | `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
 | `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#ejecting) to remove or change them. |
 | `keyboard` | Preset video skins include common hotkeys. [Eject the skin](#ejecting) to remove or change them. |

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -236,6 +236,8 @@ The poster belongs to the skin rather than the media, which is what lets the ski
 
 v8 had a small sizing language of its own. v10 doesn't, because CSS already has one.
 
+Every row below goes on the skin. <DocsLink slug="concepts/sizing">Sizing</DocsLink> explains why the player wrapped around it won't take them.
+
 | Video.js 8 | Video.js v10 |
 |---|---|
 | `fluid: true` | `width: 100%` on the skin |

--- a/site/src/content/docs/reference/background-video.mdx
+++ b/site/src/content/docs/reference/background-video.mdx
@@ -7,6 +7,7 @@ description: Decorative background video element with automatic muting and loopi
 
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 import MarkdownCode from "@/components/typography/MarkdownCode.astro";
 import Table from "@/components/typography/Table.astro";
@@ -27,7 +28,11 @@ import basicUsageHtml from "@/components/docs/demos/background-video/html/css/Ba
 import basicUsageHtmlCss from "@/components/docs/demos/background-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/background-video/html/css/BasicUsage.ts?raw";
 
-Decorative background video. By default it's muted, looped, and autoplaying — use the opt-out attributes below to change that. Renders a `<video>` inside a shadow DOM, positioned to fill its container.
+Decorative background video. By default it's muted, looped, and autoplaying — use the opt-out attributes below to change that. Renders a `<video>` inside a shadow DOM, absolutely positioned to fill the element.
+
+<FrameworkCase frameworks={["html"]}>
+The element ships no `display` of its own, so it needs one before it has a box for that `<video>` to fill. Give it a `display` and a size, or put it in a parent that lays it out — as the example below does with a grid. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+</FrameworkCase>
 
 ## Examples
 

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -85,7 +85,7 @@ customElements.define('my-container', MyContainer);
 
 ### Layout & fullscreen
 
-The container is the visual box around your media and controls. Sizing, aspect ratio, and visual boundaries all go here — on `Container`, not `Player`.
+The container is the visual box around your media and controls. Sizing, aspect ratio, and visual boundaries all go here — on `Container`, not `Player`. See <DocsLink slug="concepts/sizing">Sizing</DocsLink> for where geometry goes in every other composition.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -98,8 +98,10 @@ The container is the visual box around your media and controls. Sizing, aspect r
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
+`<media-container>` ships no styles, so it lays out as `inline` until you give it a `display`. Set one alongside the size, or the `width` and `aspect-ratio` do nothing:
+
 ```html
-<media-container style="width: 640px; aspect-ratio: 16/9;">
+<media-container style="display: block; width: 640px; aspect-ratio: 16/9;">
   <video src="video.mp4"></video>
   <media-controls>...</media-controls>
 </media-container>

--- a/site/src/content/docs/reference/player-provider.mdx
+++ b/site/src/content/docs/reference/player-provider.mdx
@@ -125,10 +125,10 @@ Everything that needs player state goes inside `Player`: skins, containers, UI c
 ## No visual presence
 
 <FrameworkCase frameworks={["react"]}>
-`Player` renders no visible element of its own — it's purely a state wrapper. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`Container`</DocsLink>, not `Player`.
+`Player` renders no DOM of its own — it's purely a state wrapper. Sizing, borders, and background go on the skin, or on the <DocsLink slug="reference/player-container">`Container`</DocsLink> when you build your own UI. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
-The `<video-player>` element uses `display: contents`, meaning it has no visual box of its own. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink>, not the provider.
+The `<video-player>` element is `display: contents`, so it generates no box. Sizing, borders, and background go on the skin, or on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink> when you build your own UI. Set them on the provider and they're silently ignored — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 </FrameworkCase>
 
 ## Accessing state

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -50,6 +50,7 @@ export const sidebar: Sidebar = [
     contents: [
       { slug: 'concepts/features' },
       { slug: 'concepts/skins' },
+      { slug: 'concepts/sizing' },
       { slug: 'concepts/presets' },
       { slug: 'concepts/ui-components' },
       { slug: 'concepts/accessibility' },


### PR DESCRIPTION
## Summary

Four migration friction logs hit the same wall: geometry set on a player element does nothing, with no error and no warning, and DOM measurements still read as correct. The `display: contents` behavior is right — it's what keeps the state boundary out of your layout — but the contract was stated in exactly one sentence, in one reference page, for one element.

This adds a Sizing concept page as the single explanation of which element owns the box, links to it from the places a reader is about to set `width` or `aspect-ratio`, and fixes the examples of ours that make the mistake themselves.

Deploy previews: [Sizing](/docs/framework/html/concepts/sizing), [Player](/docs/framework/html/reference/player-provider), [Container](/docs/framework/html/reference/player-container), [BackgroundVideo](/docs/framework/html/reference/background-video)

## Changes

- **New `concepts/sizing` page.** Where geometry goes for each composition (packaged skin, custom UI, bare media element), a table of what every player, skin, container, and media element does by default, how to give a boxless element a box on purpose, and why a class selector is the reliable way to do it.
- **Two corrections.** The Player reference pointed sizing at `<media-container>`, which is inside the skin's shadow root whenever a packaged skin is used. The Container reference set `width` and `aspect-ratio` on `<media-container>` without a `display`; the element ships no styles, so it lays out as `inline` and both declarations were inert.
- **Cross-links** from the four migration guides, the Skins concept, and the BackgroundVideo reference — the places where a reader is holding an `aspect-ratio` and choosing an element to put it on.
- **Eleven HTML demos fixed.** They set `position: relative` on `<video-player>` and positioned a control absolutely inside it. With no box on the provider, the control resolved against whatever positioned ancestor the page had; it looked correct inside our demo frame and broke when copied out. The rule now targets the `<media-container>` those demos already had, matching their React siblings.

<details>
<summary>Verified contract</summary>

- `packages/html/src/define/global.css:5-9` — `video-player`, `live-video-player`, and `media-i18n` are `display: contents`, injected into `document.head` by `packages/html/src/define/skin-element.ts:28`.
- `packages/html/src/define/background/skin.css:1-3` — same for `background-video-player`.
- `packages/media/src/dom/custom-media-element/custom-media-element.ts:29-31` — shadow `:host { display: contents }` for every media element whose inner tag is `video`. The `iframe` and `audio` template at line 63 is `inline-flex` instead, so the embed and audio elements behave differently.
- `packages/html/src/define/shared.css:9-13` — `:host { display: grid; width: 100% }`, applied to every skin's shadow root. This is where sizing goes.
- `<media-container>` ships no styles at all; `packages/html/src/media/container-element.ts` sets no `display`.
- React differs: `Player` renders no DOM (`packages/react/src/player/create-player.tsx:130`), `VideoSkin` renders a `div` through `Container` (`packages/react/src/presets/video/skin.tsx:392-396`), and the media components render a real `<video>` (`packages/react/src/media/video.tsx:14`). Nothing in the React composition is `display: contents`, so the page says so per framework rather than claiming parity.
- `audio-player` and `live-audio-player` are absent from the `display: contents` rule and lay out as `inline`. The page documents that and the one-line fix rather than asserting a symmetry that doesn't exist. Worth a follow-up issue against the stylesheet.

</details>

## Testing

- `pnpm build:site` — clean. `DocsLink` throws on an unknown slug, so a bad cross-link fails the build.
- `pnpm -F site astro check` — 0 errors.
- `pnpm -F site test src/utils/docs` — 101 passing.
- `pnpm lint:fix:file` on every changed file. Biome skips `.mdx` by config.

## Source friction logs

- [dbco-frontend](https://app.notion.com/3c297a7f89d08156b916ffd82c45e373) — eight 124×124 decorative videos rendered as full-bleed 1280×1280 blocks down 10,000px of page, with `scrollY 0` and a container measuring `1280×1280`.
- [datocms-svelte](https://app.notion.com/3c297a7f89d081cc9e46fbfc0a31546c) — aspect ratio has to move to the skin; documented, but the reason was only discoverable by reading `skin.css`.
- [anarlog](https://app.notion.com/3c297a7f89d081e781a2e5679229bfe1) — filed as environmental: "the host needs explicit `display`/sizing from your stylesheet."
- [litepan](https://app.notion.com/3c297a7f89d0819abc8eeda58fef96b3) — defends the design choice: `display: contents` on the provider "is the right call — it's what let me keep LitePan's audio layout at all," and asks for it to be stated in the docs rather than a code comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and demo CSS/markup only; no runtime player behavior changes.
> 
> **Overview**
> Documents which element actually owns the player box, so `width` / `aspect-ratio` / `position` stop being silently ignored on `display: contents` providers.
> 
> Adds **`concepts/sizing`**: geometry belongs on the skin (packaged UI), the container (custom UI), or the media element (bare video). HTML coverage includes default `display` per element, why `<media-container>` needs an explicit `display`, and how to give a boxless element a box with a class selector.
> 
> Cross-links that page from skins, player/container/background-video references, and the four migration guides. Mux Player examples now set poster via `source.poster` instead of a hand-built URL.
> 
> HTML control demos no longer position against `<video-player>`. They target `media-container` with `display: block` so absolutely placed controls copy-paste correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2688c9d12c997b251ce3d89d03f9d0eebaffb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->