### PR TITLE
docs(site): put poster and title on the player, styling on the skin

### DIFF
--- a/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/captions-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/mute-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
+++ b/site/src/components/docs/demos/mute-button/html/css/VolumeLevels.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/play-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
+++ b/site/src/components/docs/demos/playback-rate-button/html/css/BasicUsage.html
@@ -1,11 +1,13 @@
 <video-player class="video-player">
-    <video
-        src="{{VJS10_DEMO_VIDEO_MP4}}"
-        autoplay
-        muted
-        playsinline
-        loop
-    ></video>
-    <media-playback-rate-button class="media-playback-rate-button">
-    </media-playback-rate-button>
+    <media-container>
+        <video
+            src="{{VJS10_DEMO_VIDEO_MP4}}"
+            autoplay
+            muted
+            playsinline
+            loop
+        ></video>
+        <media-playback-rate-button class="media-playback-rate-button">
+        </media-playback-rate-button>
+    </media-container>
 </video-player>

--- a/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
+++ b/site/src/components/docs/demos/seek-button/html/css/BasicUsage.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CurrentDuration.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentDuration.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CurrentTime.css
+++ b/site/src/components/docs/demos/time/html/css/CurrentTime.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
+++ b/site/src/components/docs/demos/time/html/css/CustomNegativeSign.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/CustomSeparator.css
+++ b/site/src/components/docs/demos/time/html/css/CustomSeparator.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/components/docs/demos/time/html/css/Remaining.css
+++ b/site/src/components/docs/demos/time/html/css/Remaining.css
@@ -1,5 +1,6 @@
-.video-player {
+.video-player media-container {
   position: relative;
+  display: block;
 }
 
 .video-player video {

--- a/site/src/content/docs/concepts/overview.mdx
+++ b/site/src/content/docs/concepts/overview.mdx
@@ -143,6 +143,43 @@ DASH, YouTube, Vimeo, Mux, and more media elements are currently under developme
 ```
 </FrameworkCase>
 
+## Which part takes which prop
+
+Three parts means three places a prop can go. Two rules cover nearly all of them.
+
+**What is playing goes on the player.** The poster and the content title describe the content, and the player is what holds content state, so every UI component inside it reads them from one place. See <DocsLink slug="reference/feature-metadata">Metadata</DocsLink>.
+
+**How it looks goes on the skin.** The skin is the element on the page, so its class, its inline style, and its geometry belong to it. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+
+Anything the browser already understands — `src`, `autoplay`, `muted`, `loop`, `preload`, `playsinline`, `crossorigin` — stays on the media, where it always was.
+
+<FrameworkCase frameworks={["react"]}>
+```tsx
+<VideoPlayer poster="poster.jpg" title="Big Buck Bunny">
+  <VideoSkin className="player">
+    <Video src="video.mp4" />
+  </VideoSkin>
+</VideoPlayer>
+```
+
+`VideoPlayer` renders no DOM, so it takes no `className` and no `style`. Passing either is a type error.
+
+A skin forwards props it doesn't recognize to the `div` it renders, so a misplaced prop can reach the DOM rather than fail. `<VideoSkin poster="poster.jpg">` is a type error in TypeScript; in plain JavaScript it puts a `poster` attribute on a `div` and draws no poster.
+</FrameworkCase>
+<FrameworkCase frameworks={["html"]}>
+`title` already means the tooltip on an HTML element, so the title input goes by `content-title` in markup.
+
+```html
+<video-player content-title="Big Buck Bunny" poster="poster.jpg">
+  <video-skin class="player">
+    <video src="video.mp4" playsinline></video>
+  </video-skin>
+</video-player>
+```
+
+Both elements take a `class` and a `style`, so neither one errors when you pick the wrong one. `<video-player>` is `display: contents` and draws no box: custom properties set on it inherit down to the UI, while `width`, `height`, and `aspect-ratio` do nothing at all. Put geometry on the skin.
+</FrameworkCase>
+
 ## Presets
 
 **Presets** preconfigure these parts for a specific use case.

--- a/site/src/content/docs/concepts/sizing.mdx
+++ b/site/src/content/docs/concepts/sizing.mdx
@@ -1,0 +1,160 @@
+---
+title: Sizing
+description: Which element in a player owns its box, and why geometry on any of the others does nothing.
+---
+
+import FrameworkCase from '@/components/docs/FrameworkCase.astro';
+import DocsLink from '@/components/docs/DocsLink.astro';
+import DocsLinkCard from '@/components/docs/DocsLinkCard.astro';
+import Aside from '@/components/Aside.astro';
+
+A player is several elements with separate jobs, and only one of them is the box you size. Put `width`, `height`, `aspect-ratio`, `position`, and `transform` there.
+
+## Where geometry goes
+
+| What you rendered | The box |
+|---|---|
+| A packaged <DocsLink slug="concepts/skins">skin</DocsLink> | The skin |
+| Your own UI | The <DocsLink slug="reference/player-container">container</DocsLink> |
+| A media element on its own, with no player around it | The media element |
+
+<FrameworkCase frameworks={["react"]}>
+```tsx title="App.tsx"
+import '@videojs/react/video/skin.css';
+import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';
+import './App.css';
+
+export default function App() {
+  return (
+    <VideoPlayer>
+      <VideoSkin className="player">
+        <Video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4" />
+      </VideoSkin>
+    </VideoPlayer>
+  );
+}
+```
+
+```css title="App.css"
+.player {
+  width: 100%;
+  max-width: 40rem;
+  aspect-ratio: 16 / 9;
+}
+```
+</FrameworkCase>
+<FrameworkCase frameworks={["html"]}>
+```ts title="main.ts"
+import '@videojs/html/video/player';
+import '@videojs/html/video/skin';
+import '@videojs/html/video/skin.css';
+import './index.css';
+```
+
+```html title="index.html"
+<video-player>
+  <video-skin class="player">
+    <video src="https://stream.mux.com/BV3YZtogl89mg9VcNBhhnHm02Y34zI1nlMuMQfAbl3dM/highest.mp4"></video>
+  </video-skin>
+</video-player>
+```
+
+```css title="index.css"
+.player {
+  width: 100%;
+  max-width: 40rem;
+  aspect-ratio: 16 / 9;
+}
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+## The player renders no DOM
+
+`VideoPlayer` is a context provider and renders nothing, so there's no element to size and nowhere for your geometry to be quietly dropped. `VideoSkin` and `Container` each render a `div` and forward `className` and `style` to it. `Video`, `MuxVideo`, and the other media components render a real `<video>`. Every element you can reach has a box.
+
+The HTML package differs here: several of its elements are `display: contents` and ignore geometry outright. That's worth knowing if you read the HTML examples, share CSS between the two, or port markup across.
+</FrameworkCase>
+<FrameworkCase frameworks={["html"]}>
+## The provider and the media elements have no box
+
+`<video-player>`, `<live-video-player>`, `<background-video-player>`, and `<media-i18n>` are `display: contents`. So are the media elements that wrap a native `<video>`: `<mux-video>`, `<hls-video>`, `<hlsjs-video>`, `<dash-video>`, `<shaka-video>`, and `<native-hls-video>`.
+
+An element with `display: contents` generates no box. Its children lay out as if the element were not in the tree at all, which is what makes the provider composable — it's a state boundary, not a wrapper, so it can sit inside your grid or flex layout without adding a box you have to style around.
+
+The cost is that geometry on those elements is inert, and CSS reports nothing when you set it. The declaration is still in the computed style, `getBoundingClientRect()` on the element returns `0×0`, and the children size themselves against your layout instead. A 124-pixel-wide decorative video becomes as wide as the page.
+
+```css
+/* ❌ Silently ignored — the provider generates no box */
+video-player {
+  width: 640px;
+  aspect-ratio: 16 / 9;
+}
+
+/* ✅ The skin is the box */
+video-skin {
+  width: 640px;
+  aspect-ratio: 16 / 9;
+}
+```
+
+Custom properties are the exception. They inherit through `display: contents`, so `video-player { --media-accent-color: rebeccapurple }` reaches the UI. See <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>.
+
+### What each element does by default
+
+| Element | Default `display` | Size it? |
+|---|---|---|
+| `<video-player>`, `<live-video-player>`, `<media-i18n>` | `contents` | No |
+| `<background-video-player>` | `contents` | No |
+| `<audio-player>`, `<live-audio-player>` | `inline`, because they ship no styles | No, see below |
+| `<video-skin>` and the other skins | `grid`, `width: 100%` | Yes |
+| `<background-video-skin>` | `block`, `width: 100%`, `height: 100%` | Yes |
+| `<media-container>` | `inline`, because it ships no styles | Yes, with a `display` |
+| `<background-video>`, `<mux-background-video>`, `<hls-background-video>` | `inline`, `position: relative` | Yes, with a `display` |
+| `<mux-video>`, `<hls-video>`, `<hlsjs-video>`, `<dash-video>`, `<shaka-video>`, `<native-hls-video>` | `contents` | Yes, with a `display` |
+| `<youtube-video>`, `<vimeo-video>`, `<twitch-video>`, `<tiktok-video>`, `<cloudflare-video>`, `<hls-audio>`, `<mux-audio>`, `<spotify-audio>` | `inline-flex` | Yes |
+
+`<media-container>` is the box for a custom UI, but it ships no styles at all, so `width` on it does nothing until you give it a `display`:
+
+```css
+media-container {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}
+```
+
+The audio providers are `inline` rather than `contents`, which both ignores `width` and disrupts a grid or flex parent. Set `display: contents` on them yourself:
+
+```css
+audio-player,
+live-audio-player {
+  display: contents;
+}
+```
+
+### Give one a box on purpose
+
+A chrome-less video — a decorative background, a thumbnail grid, a hero loop — is a media element with no skin and no container, so the media element has to become the box. Set its `display` along with its size:
+
+```css
+.hero-video {
+  display: block;
+  width: 124px;
+  aspect-ratio: 1 / 1;
+}
+```
+
+Use a class selector rather than a tag selector, as the example above does. On a media element either one works, because any rule in your stylesheet outranks the element's own shadow `:host` rule. On a provider a tag selector is a coin toss: the packaged `video-player { display: contents }` rule lives in a stylesheet we append to `<head>` when the player is defined, so it ties your `video-player { display: block }` on specificity and wins on document order. A class selector is more specific and wins either way.
+
+<Aside type="caution">
+Inline styles beat stylesheets, so code that assigns `element.style.display` after you takes over — a layout library rewriting the property every frame, for example. Have that code write the `display` you want, or mark your declaration `!important`.
+</Aside>
+</FrameworkCase>
+
+## Sizing lives in your CSS
+
+No player element takes a `width`, `height`, or `ratio` attribute, and there are no sizing modes to choose between. Sizing is layout, layout is yours, and CSS already describes it. `width: 100%` and `aspect-ratio` on the box cover what Video.js 8 spelled `fluid`, `fill`, and `aspectRatio`.
+
+<DocsLinkCard slug="reference/player-container">Container reference</DocsLinkCard>

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -40,6 +40,8 @@ In prior versions of Video.js, skins were CSS-only themes applied to the same se
 ```
 </FrameworkCase>
 
+A skin draws the UI; it doesn't hold state. So `poster` and the content title go on the player, and the skin takes the class, inline style, and geometry that decide how it looks. See <DocsLink slug="concepts/overview">Overview</DocsLink> for the full rule and <DocsLink slug="concepts/sizing">Sizing</DocsLink> for geometry.
+
 ## Packaged vs. ejected
 
 When you choose a skin you have two options for how you use it: **packaged** or **ejected**. It's usually easiest to start with a packaged skin and later eject its internal components into your project when you need more customization.

--- a/site/src/content/docs/concepts/skins.mdx
+++ b/site/src/content/docs/concepts/skins.mdx
@@ -101,6 +101,8 @@ Presets are a topic quite a bit bigger than just this guide. To learn more, chec
 
 ## Styling
 
+The skin is the player's box. Its size, aspect ratio, and position are yours to set, and they belong on the skin element rather than on the player wrapped around it — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+
 There are currently two options for styling:
 
 <FrameworkCase frameworks={["react"]}>

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -33,6 +33,8 @@ npm install @videojs/react
 
 Media Chrome wraps a slotted `<video slot="media">` in a single `<media-controller>`. Video.js splits that into two elements. The player owns state and draws nothing. The `<media-container>` is the box everything lives in, with the media as a plain child.
 
+Everything you styled on `<media-controller>` therefore splits too. Colors and custom properties still work on the player, because they inherit. Size, aspect ratio, and position have to move to the container, which generates a box where the player does not — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+
 ```html
 <!-- Media Chrome -->
 <media-controller>

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -45,7 +45,7 @@ So a Mux Player embed becomes a player wrapped around a skin wrapped around a me
 ```
 </FrameworkCase>
 
-Everything else in this guide is about which of those three a given Mux Player attribute now belongs to.
+Everything else in this guide is about which of those three a given Mux Player attribute now belongs to. The short version: what is playing goes on the player, how it looks goes on the skin, and anything the browser already understands stays on the media. See <DocsLink slug="concepts/overview">Overview</DocsLink> for the full rule.
 
 ## Your first player
 
@@ -73,13 +73,17 @@ A <DocsLink slug="concepts/presets">preset</DocsLink> is a player, a skin, and a
 
 <video-player>
   <video-skin class="aspect-video">
-    <mux-video src="https://stream.mux.com/EcHgOK9coz5K….m3u8" playsinline crossorigin="anonymous"></mux-video>
+    <mux-video playsinline crossorigin="anonymous"></mux-video>
     <mux-data player-software-name="my-app"></mux-data>
-    <img slot="poster" src="https://image.mux.com/EcHgOK9coz5K…/thumbnail.webp?time=2" alt="" />
   </video-skin>
 </video-player>
 
 <script type="module">
+  document.querySelector('mux-video').source = {
+    playbackId: 'EcHgOK9coz5K…',
+    poster: { time: 2 },
+  };
+
   document.querySelector('mux-data').metadata = {
     video_title: 'Test VOD',
     viewer_user_id: 'user-id-007',
@@ -134,8 +138,8 @@ import { MuxVideo } from '@videojs/react/media/mux-video';
 export function MyPlayer() {
   return (
     <VideoPlayer>
-      <VideoSkin className="aspect-video" poster="https://image.mux.com/EcHgOK9coz5K…/thumbnail.webp?time=2">
-        <MuxVideo source={{ playbackId: 'EcHgOK9coz5K…' }} playsInline crossOrigin="anonymous" />
+      <VideoSkin className="aspect-video">
+        <MuxVideo source={{ playbackId: 'EcHgOK9coz5K…', poster: { time: 2 } }} playsInline crossOrigin="anonymous" />
         <MuxData playerSoftwareName="my-app" metadata={{ video_title: 'Test VOD', viewer_user_id: 'user-id-007' }} />
       </VideoSkin>
     </VideoPlayer>
@@ -151,10 +155,10 @@ The `'use client'` directive is there because the player owns browser state.
 
 A few things worth calling out:
 
-- **The poster is yours to build.** Mux Player derived one from the playback ID; here you point the skin at an `image.mux.com` URL, and `thumbnail-time="2"` becomes `?time=2`. <DocsLink slug="reference/mux-video">`MuxVideo`</DocsLink> derives the same URL and reports it, but the poster is a skin concern today, so nothing reads it for you.
+- **The poster still comes from the playback ID.** <DocsLink slug="reference/mux-video">`MuxVideo`</DocsLink> builds the `image.mux.com` URL for you and reports it to the player, which hands it to the skin. `thumbnail-time="2"` is `source.poster.time`, so you describe the still you want instead of assembling a URL. Set <DocsLink slug="reference/poster">`poster`</DocsLink> on the player when you want to override it with a URL of your own.
 - **You didn't add a storyboard track, and you get hover previews.** The Mux media adds and maintains the thumbnail track itself, and removes it for live streams, where storyboards don't exist.
 - **Analytics needs no environment key.** Mux resolves the environment from the playback ID. See <DocsLink slug="concepts/mux-data">Mux Data</DocsLink>.
-- **Set the aspect ratio yourself,** in your own CSS on the skin. There's no `ratio` attribute, because sizing belongs to your layout.
+- **Set the aspect ratio yourself,** in your own CSS on the skin. There's no `ratio` attribute, because sizing belongs to your layout. Mux Player was a single sized element; here the player is a state boundary that generates no box, so an `aspect-ratio` on it does nothing. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 
 Two things are opt-in that used to be automatic. Analytics is the <DocsLink slug="reference/mux-data">Mux Data</DocsLink> component, and Chromecast is a <DocsLink slug="concepts/cast">Cast</DocsLink> component. Leave either out and you don't ship its code. That, incidentally, is the answer to Mux Player's `disable-tracking`: don't include Mux Data.
 
@@ -224,8 +228,8 @@ Here's where each Mux Player attribute lands:
 | `playback-token` | `source.playback.token` |
 | `thumbnail-token`, `storyboard-token` | `source.poster.token`, `source.storyboard.token` |
 | `drm-token` | `source.drm.token` |
-| `thumbnail-time` | `?time=` on the poster URL you build |
-| poster size, crop, rotation, format | query parameters on that URL |
+| `thumbnail-time` | `source.poster.time` |
+| poster size, crop, rotation, format | `source.poster.width`, `.height`, `.fitMode`, `.rotate`, `.ext` |
 
 Signed playback behaves the way it does in Mux Player: a token replaces every other parameter in its group, so caps and clipping have to be baked into the token itself.
 

--- a/site/src/content/docs/how-to/migrate-from-mux-player.mdx
+++ b/site/src/content/docs/how-to/migrate-from-mux-player.mdx
@@ -258,7 +258,7 @@ Your metadata keys don't change. They're the same `snake_case` names Mux Data ha
 
 `content-title` reaches player state, so your own UI can read it. No packaged skin draws it, so setting it alone won't put a title on screen ([#1123](https://github.com/videojs/v10/issues/1123)).
 
-The poster is a skin concern. Build an `image.mux.com` URL and hand it over:
+The poster is a player input too, and the skin draws whatever the player resolves. `MuxVideo` reports the URL it derives from `source`, so a `poster` on the player is for the case where you have a URL of your own to use instead:
 
 <FrameworkCase frameworks={["html"]}>
 ```html
@@ -296,7 +296,7 @@ The player supplies the real poster. The slotted image supplies Mux Player's `pl
 `renderPoster` customizes the poster image, so its background can show Mux Player's `placeholder` while the real poster loads.
 </FrameworkCase>
 
-Mux serves the poster from its `thumbnail` endpoint, so every Mux Player poster attribute becomes a query parameter you append: `thumbnail-time` is `?time=`, and the size, crop, rotation, and format options work the same way. See <DocsLink slug="how-to/add-a-poster-placeholder">Add a poster placeholder</DocsLink> for more examples or the <DocsLink slug="reference/poster">Poster</DocsLink> reference for the component itself.
+Mux serves the poster from its `thumbnail` endpoint, and `source.poster` is how you reach that endpoint's options: `thumbnail-time` is `source.poster.time`, and size, crop, rotation, and format are `width`, `height`, `fitMode`, `rotate`, and `ext` beside it. Video.js converts those camel-case keys to the `snake_case` query parameters Mux expects. See <DocsLink slug="how-to/add-a-poster-placeholder">Add a poster placeholder</DocsLink> for more examples or the <DocsLink slug="reference/poster">Poster</DocsLink> reference for the component itself.
 
 ## Customize your player
 

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -62,14 +62,12 @@ The easiest path is the CDN:
 ```html
 <script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video-minimal.js"></script>
 
-<video-player>
+<video-player poster="/path/to/poster.jpg">
   <video-minimal-skin>
     <video src="/path/to/video.mp4" playsinline>
       <track kind="captions" label="English" src="/path/to/captions/en.vtt" srclang="en" default />
       <track kind="metadata" label="thumbnails" src="/path/to/storyboard.vtt" default />
     </video>
-
-    <img slot="poster" src="/path/to/poster.jpg" alt="Video poster" />
   </video-minimal-skin>
 </video-player>
 ```
@@ -85,7 +83,8 @@ import '@videojs/html/video/minimal-skin.css';
 ### Notes
 
 - CSS styles are injected automatically into the Shadow DOM we create for the player.
-- The poster is a slotted `img` rather than a `poster` attribute, which gives the skin control over how it appears. That's much like Plyr's `data-poster`.
+- The poster is an attribute on the player rather than on the media, which gives the skin control over how it appears. That's much like Plyr's `data-poster`. Slot your own `<img slot="poster">` into the skin when you want to describe the image or supply candidates; see <DocsLink slug="reference/poster">Poster</DocsLink>.
+- `<video-player>` is `display: contents`, so it draws no box. Size the skin, not the player. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by removing the `-minimal` suffix from the script `src` if you're using the CDN, or the `minimal-` prefix from the imports.
 
 </FrameworkCase>
@@ -112,10 +111,10 @@ interface AppVideoPlayerProps {
 
 export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
   return (
-    <VideoPlayer>
-      <MinimalVideoSkin poster={`${origin}/poster.jpg`}>
+    <VideoPlayer poster={`${origin}/poster.jpg`}>
+      <MinimalVideoSkin>
         <Video src={`${origin}/video.mp4`} playsInline>
-          <track kind="captions" label="English" src={`${origin}/captions/en.vtt`} srclang="en" default />
+          <track kind="captions" label="English" src={`${origin}/captions/en.vtt`} srcLang="en" default />
           <track kind="metadata" label="thumbnails" src={`${origin}/storyboard.vtt`} default />
         </Video>
       </MinimalVideoSkin>
@@ -127,7 +126,7 @@ export function AppVideoPlayer({ origin }: AppVideoPlayerProps) {
 ### Notes
 
 - `@videojs/react/video` is a <DocsLink slug="concepts/presets">preset</DocsLink>: a player, a skin, and a media element that already fit together. `VideoPlayer` is the piece that owns the state, built from the standard set of <DocsLink slug="concepts/features">features</DocsLink> for video.
-- The poster is a prop on the skin rather than a `poster` attribute on the media, which gives the skin control over how it appears. That's much like Plyr's `data-poster`.
+- The poster is a prop on the player rather than a `poster` attribute on the media, which gives the skin control over how it appears. That's much like Plyr's `data-poster`. `VideoPlayer` takes no `className` and no `style`; those go on the skin, which is the element on the page. See <DocsLink slug="concepts/overview">Overview</DocsLink>.
 - This example assumes all your files for a given asset live in the same path, using consistent filenames. This will almost certainly need adjusting for your implementation.
 - If `origin` points somewhere other than your page's origin, add `crossOrigin="anonymous"` to `<Video>` and serve those files with CORS headers. A cross-origin thumbnail track only loads when the media element is CORS-enabled. See <DocsLink slug="reference/thumbnail">Thumbnail</DocsLink>.
 - There's also a default skin with a modern, frosted appearance that some may prefer. Try it by switching the CSS import filename to `skin.css` and the `MinimalVideoSkin` import and usage to `VideoSkin`.
@@ -358,7 +357,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `controls` | The <DocsLink slug="concepts/skins">skins</DocsLink> include all the common controls, laid out in a familiar way that users would expect. If you want to customize the skin beyond basic colors, you can [eject the skin](#ejecting) and change layout, styles, or icons. |
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
-| `poster` / `data-poster` | The skin owns the poster, as shown in [Basic migration](#basic-migration) above. |
+| `poster` / `data-poster` | `poster` on the player, which the skin draws, as shown in [Basic migration](#basic-migration) above. |
 | `ratio` | Set `aspect-ratio` in CSS on the skin component. The player around it generates no box, so an `aspect-ratio` there is ignored — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>. |
 | `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
 | `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#ejecting) to remove or change them. |

--- a/site/src/content/docs/how-to/migrate-from-plyr.mdx
+++ b/site/src/content/docs/how-to/migrate-from-plyr.mdx
@@ -359,7 +359,7 @@ Here's a matrix for configuration options in Plyr and how each maps to Video.js 
 | `settings` | Included automatically in the skins when quality, speed, audio tracks, or captions are available. |
 | `autoplay`, `muted`, `loop`, `playsinline`, `preload` | These are attributes on your media (e.g. `<video>`) component. |
 | `poster` / `data-poster` | The skin owns the poster, as shown in [Basic migration](#basic-migration) above. |
-| `ratio` | Set `aspect-ratio` in CSS on the skin component. |
+| `ratio` | Set `aspect-ratio` in CSS on the skin component. The player around it generates no box, so an `aspect-ratio` there is ignored — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>. |
 | `hideControls` | Preset skins auto-hide controls based on activity. The delay is currently not configurable. |
 | `clickToPlay` | Preset video skins include click and tap gestures. [Eject the skin](#ejecting) to remove or change them. |
 | `keyboard` | Preset video skins include common hotkeys. [Eject the skin](#ejecting) to remove or change them. |

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -82,14 +82,12 @@ v10 ships web components, so the migration keeps its declarative feel. One scrip
 ```html
 <script type="module" src="https://cdn.jsdelivr.net/npm/@videojs/html/cdn/video.js"></script>
 
-<video-player>
+<video-player poster="/poster.jpg">
   <video-skin class="aspect-video">
     <video src="/video.mp4" preload="auto" playsinline>
       <track kind="captions" src="/captions/en.vtt" srclang="en" label="English" default />
       <track kind="metadata" src="/storyboard.vtt" label="thumbnails" default />
     </video>
-
-    <img slot="poster" src="/poster.jpg" alt="" />
   </video-skin>
 </video-player>
 ```
@@ -106,7 +104,7 @@ Four differences worth understanding, because each one is a pattern you'll see a
 
 - **No `class="video-js"`, no `data-setup`, no `videojs()` call.** The custom elements register themselves and wire up when the browser upgrades them. Nothing scans the page looking for players.
 - **No `controls` attribute.** The skin *is* the controls. Including a skin is how you ask for them, which is also how you opt out: leave it out and you get a player with no UI.
-- **The poster is a slotted image, not an attribute.** That's what lets the skin control how it appears, rather than the browser.
+- **The poster moves from the media to the player.** That's what lets the skin control how it appears, rather than the browser. Sizing goes on the skin, because `<video-player>` is `display: contents` and draws no box.
 - **Your `<track>` elements don't change.** Captions, subtitles, chapters, and thumbnails are all still tracks, and the skin shows the matching controls when it finds them.
 
 There's also a minimal skin, closer to v8's control bar if the default's frosted look is too much of a change. Swap `cdn/video.js` for `cdn/video-minimal.js`.
@@ -160,10 +158,10 @@ import { Video, VideoPlayer, VideoSkin } from '@videojs/react/video';
 
 export function MyPlayer() {
   return (
-    <VideoPlayer>
-      <VideoSkin className="aspect-video" poster="/poster.jpg">
+    <VideoPlayer poster="/poster.jpg">
+      <VideoSkin className="aspect-video">
         <Video src="/video.mp4" preload="auto" playsInline>
-          <track kind="captions" src="/captions/en.vtt" srclang="en" label="English" default />
+          <track kind="captions" src="/captions/en.vtt" srcLang="en" label="English" default />
           <track kind="metadata" src="/storyboard.vtt" label="thumbnails" default />
         </Video>
       </VideoSkin>
@@ -178,7 +176,7 @@ Three differences worth understanding, because each one is a pattern you'll see 
 
 - **No `videojs()` call and no effect.** `VideoPlayer` owns the lifecycle.
 - **No `controls` prop.** The skin *is* the controls. Rendering a skin is how you ask for them, which is also how you opt out.
-- **The poster is a skin prop, not a media attribute.** That's what lets the skin control how it appears, rather than the browser.
+- **The poster is a player prop, not a media attribute.** That's what lets the skin control how it appears, rather than the browser. `className` and `style` go the other way: `VideoPlayer` renders no DOM, so they belong on the skin.
 
 The `'use client'` directive is there because the player owns browser state. There's also a minimal skin, closer to v8's control bar, if the default's frosted look is too much of a change.
 
@@ -189,8 +187,8 @@ The `'use client'` directive is there because the player owns browser state. The
 The v8 options object is gone, and its contents scattered in four directions. This is the biggest conceptual step, so it's worth understanding the four buckets before you go looking for a specific option.
 
 1. **Media attributes.** Anything the browser itself understands stays exactly where it was, on your media element.
-2. **Skin attributes.** The poster belongs to the skin, because the skin is what paints it.
-3. **Your CSS.** Sizing, aspect ratio, and responsive behavior are layout, and layout is yours.
+2. **Player inputs.** The poster and the content title describe what is playing, so they belong to the player. Every UI component inside it reads them from there.
+3. **Your CSS.** Sizing, aspect ratio, and responsive behavior are layout, and layout is yours. It goes on the skin.
 4. **Composition.** Which controls exist, which shortcuts fire, which language you're in. You express these by choosing components rather than by setting flags.
 
 ### Media attributes
@@ -203,34 +201,53 @@ Port these across untouched. They're native attributes and always were.
 | `sources: [{ src, type }]` | `src`, or `<source>` children for progressive fallback |
 | `disablePictureInPicture` | `disablepictureinpicture` |
 
-### Skin attributes
+### Player inputs
 
 | Video.js 8 | Video.js v10 |
 |---|---|
-| `poster` | the skin's poster |
+| `poster` | `poster` on the player |
 | `posterImage: false` | leave the poster unset |
-| the title in `TitleBar` | `content-title` on the player, with no built-in UI yet |
+| the title in `TitleBar` | the player's title input |
 
-The poster belongs to the skin rather than the media, which is what lets the skin control how it appears:
+The poster belongs to the player rather than the media, which is what lets the skin control how it appears:
 
 <FrameworkCase frameworks={["html"]}>
 ```html
-<video-skin>
-  <video src="/video.mp4"></video>
-  <img slot="poster" src="/poster.jpg" alt="" />
-</video-skin>
+<video-player poster="/poster.jpg">
+  <video-skin>
+    <video src="/video.mp4"></video>
+  </video-skin>
+</video-player>
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["react"]}>
 ```jsx
-<VideoSkin poster="/poster.jpg">
-  <Video src="/video.mp4" />
-</VideoSkin>
+<VideoPlayer poster="/poster.jpg">
+  <VideoSkin>
+    <Video src="/video.mp4" />
+  </VideoSkin>
+</VideoPlayer>
 ```
 </FrameworkCase>
 
-`content-title` is the closest thing to v8's `TitleBar`, and it does reach player state, so your own UI can read it. No packaged skin draws it, so v8's `TitleBar` has no visual equivalent ([#1123](https://github.com/videojs/v10/issues/1123)). See the <DocsLink slug="reference/poster">Poster</DocsLink> reference for the poster component itself.
+<FrameworkCase frameworks={["html"]}>
+The title input is the closest thing to v8's `TitleBar`. `title` already means the tooltip on an HTML element, so it goes by `content-title` in markup. It reaches player state, so your own UI can read it, but no packaged skin draws it, which leaves v8's `TitleBar` with no visual equivalent ([#1123](https://github.com/videojs/v10/issues/1123)).
+
+```html
+<video-player content-title="Big Buck Bunny" poster="/poster.jpg"></video-player>
+```
+</FrameworkCase>
+
+<FrameworkCase frameworks={["react"]}>
+The title input is the closest thing to v8's `TitleBar`. It reaches player state, so your own UI can read it, but no packaged skin draws it, which leaves v8's `TitleBar` with no visual equivalent ([#1123](https://github.com/videojs/v10/issues/1123)).
+
+```jsx
+<VideoPlayer title="Big Buck Bunny" poster="/poster.jpg">…</VideoPlayer>
+```
+</FrameworkCase>
+
+See the <DocsLink slug="reference/poster">Poster</DocsLink> reference for the poster component itself and <DocsLink slug="reference/title">Title</DocsLink> for drawing a title of your own.
 
 ### Your CSS
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -236,6 +236,8 @@ The poster belongs to the skin rather than the media, which is what lets the ski
 
 v8 had a small sizing language of its own. v10 doesn't, because CSS already has one.
 
+Every row below goes on the skin. <DocsLink slug="concepts/sizing">Sizing</DocsLink> explains why the player wrapped around it won't take them.
+
 | Video.js 8 | Video.js v10 |
 |---|---|
 | `fluid: true` | `width: 100%` on the skin |

--- a/site/src/content/docs/reference/background-video.mdx
+++ b/site/src/content/docs/reference/background-video.mdx
@@ -7,6 +7,7 @@ description: Decorative background video element with automatic muting and loopi
 
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
 import MarkdownCode from "@/components/typography/MarkdownCode.astro";
 import Table from "@/components/typography/Table.astro";
@@ -27,7 +28,11 @@ import basicUsageHtml from "@/components/docs/demos/background-video/html/css/Ba
 import basicUsageHtmlCss from "@/components/docs/demos/background-video/html/css/BasicUsage.css?raw";
 import basicUsageHtmlTs from "@/components/docs/demos/background-video/html/css/BasicUsage.ts?raw";
 
-Decorative background video. By default it's muted, looped, and autoplaying — use the opt-out attributes below to change that. Renders a `<video>` inside a shadow DOM, positioned to fill its container.
+Decorative background video. By default it's muted, looped, and autoplaying — use the opt-out attributes below to change that. Renders a `<video>` inside a shadow DOM, absolutely positioned to fill the element.
+
+<FrameworkCase frameworks={["html"]}>
+The element ships no `display` of its own, so it needs one before it has a box for that `<video>` to fill. Give it a `display` and a size, or put it in a parent that lays it out — as the example below does with a grid. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
+</FrameworkCase>
 
 ## Examples
 

--- a/site/src/content/docs/reference/player-container.mdx
+++ b/site/src/content/docs/reference/player-container.mdx
@@ -85,7 +85,7 @@ customElements.define('my-container', MyContainer);
 
 ### Layout & fullscreen
 
-The container is the visual box around your media and controls. Sizing, aspect ratio, and visual boundaries all go here — on `Container`, not `Player`.
+The container is the visual box around your media and controls. Sizing, aspect ratio, and visual boundaries all go here — on `Container`, not `Player`. See <DocsLink slug="concepts/sizing">Sizing</DocsLink> for where geometry goes in every other composition.
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
@@ -98,8 +98,10 @@ The container is the visual box around your media and controls. Sizing, aspect r
 ```
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
+`<media-container>` ships no styles, so it lays out as `inline` until you give it a `display`. Set one alongside the size, or the `width` and `aspect-ratio` do nothing:
+
 ```html
-<media-container style="width: 640px; aspect-ratio: 16/9;">
+<media-container style="display: block; width: 640px; aspect-ratio: 16/9;">
   <video src="video.mp4"></video>
   <media-controls>...</media-controls>
 </media-container>

--- a/site/src/content/docs/reference/player-provider.mdx
+++ b/site/src/content/docs/reference/player-provider.mdx
@@ -125,10 +125,10 @@ Everything that needs player state goes inside `Player`: skins, containers, UI c
 ## No visual presence
 
 <FrameworkCase frameworks={["react"]}>
-`Player` renders no visible element of its own — it's purely a state wrapper. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`Container`</DocsLink>, not `Player`.
+`Player` renders no DOM of its own — it's purely a state wrapper. Sizing, borders, and background go on the skin, or on the <DocsLink slug="reference/player-container">`Container`</DocsLink> when you build your own UI. See <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 </FrameworkCase>
 <FrameworkCase frameworks={["html"]}>
-The `<video-player>` element uses `display: contents`, meaning it has no visual box of its own. Sizing, borders, and background go on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink>, not the provider.
+The `<video-player>` element is `display: contents`, so it generates no box. Sizing, borders, and background go on the skin, or on the <DocsLink slug="reference/player-container">`<media-container>`</DocsLink> when you build your own UI. Set them on the provider and they're silently ignored — see <DocsLink slug="concepts/sizing">Sizing</DocsLink>.
 </FrameworkCase>
 
 ## Accessing state

--- a/site/src/content/docs/reference/poster.mdx
+++ b/site/src/content/docs/reference/poster.mdx
@@ -6,6 +6,7 @@ description: Poster image component that displays a thumbnail until video playba
 ---
 
 import ComponentReference from "@/components/docs/api-reference/ComponentReference.astro";
+import DocsLink from "@/components/docs/DocsLink.astro";
 import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 import StyleCase from "@/components/docs/StyleCase.astro";
 import Demo from "@/components/docs/demos/Demo.astro";
@@ -41,19 +42,29 @@ import basicUsageHtmlTs from "@/components/docs/demos/poster/html/css/BasicUsage
 
 The poster shows before playback starts. Once the user plays or seeks, it hides; pausing does not bring it back. Loading a new source shows it again.
 
-You can set the poster URL on the player. This is useful when you want to change the poster from inside a skin, or keep all your media metadata in one place:
+The poster URL is a player input, not a skin one. Set it there and every poster inside the player, including the one a skin draws, picks it up:
 
 <FrameworkCase frameworks={["react"]}>
 ```tsx
-<VideoPlayer poster="poster.jpg" />
+<VideoPlayer poster="poster.jpg">
+  <VideoSkin>
+    <Video src="video.mp4" />
+  </VideoSkin>
+</VideoPlayer>
 ```
 </FrameworkCase>
 
 <FrameworkCase frameworks={["html"]}>
 ```html
-<video-player poster="poster.jpg"></video-player>
+<video-player poster="poster.jpg">
+  <video-skin>
+    <video src="video.mp4" playsinline></video>
+  </video-skin>
+</video-player>
 ```
 </FrameworkCase>
+
+A media that reports a poster of its own, such as <DocsLink slug="reference/mux-video">`MuxVideo`</DocsLink>, fills it in when you set nothing. See <DocsLink slug="reference/feature-metadata">Metadata</DocsLink> for how the two resolve.
 
 ## Supply your own image
 

--- a/site/src/docs.config.ts
+++ b/site/src/docs.config.ts
@@ -50,6 +50,7 @@ export const sidebar: Sidebar = [
     contents: [
       { slug: 'concepts/features' },
       { slug: 'concepts/skins' },
+      { slug: 'concepts/sizing' },
       { slug: 'concepts/presets' },
       { slug: 'concepts/ui-components' },
       { slug: 'concepts/accessibility' },


### PR DESCRIPTION
## Deploy previews

| Page | Read it |
|---|---|
| **Overview** — the new boundary rule | [HTML](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/html/concepts/overview#which-part-takes-which-prop) · [React](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/react/concepts/overview#which-part-takes-which-prop) |
| **Migrate from Mux Player** | [HTML](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/html/how-to/migrate-from-mux-player) · [React](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/react/how-to/migrate-from-mux-player) |
| **Migrate from Plyr** | [HTML](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/html/how-to/migrate-from-plyr) · [React](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/react/how-to/migrate-from-plyr) |
| **Migrate from Video.js 8** | [HTML](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/html/how-to/migrate-from-video-js-8) · [React](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/react/how-to/migrate-from-video-js-8) |
| **Skins** | [HTML](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/html/concepts/skins) · [React](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/react/concepts/skins) |
| **Poster** | [HTML](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/html/reference/poster) · [React](https://deploy-preview-2307--vjs10-site.netlify.app/docs/framework/react/reference/poster) |

## Summary

`poster` and the content title are player inputs; `className`, `style`, and geometry belong to the skin. Several doc examples had it backwards, so the snippet a migrator copies first did not compile. This corrects the examples in both framework variants, replaces the prose that justified the wrong placement, and states the boundary once in the Overview concept for the guides to link to.

The shipped types are the authority here:

- `BaseVideoSkinProps` is `children`, `style`, `className`, and `renderPoster` — nothing else (`packages/react/src/presets/types.ts`).
- `VideoPlayer` is `FC<PlayerProps<{ title, poster }>>`, so it takes no `className` and no `style` (`packages/react/src/presets/video/player.ts`, `packages/core/src/dom/store/features/metadata.ts`).
- `<video-player>`'s only config attributes are `poster` and `content-title`, and it is `display: contents`, so geometry set on it is inert (`packages/html/src/define/global.css`).

There are two failure modes, and the docs were producing both. In typed React a misplaced `poster` is a `TS2322`. In plain JavaScript the skin forwards props it does not recognize to the `div` it renders, so `<VideoSkin poster="…">` puts a stray `poster` attribute on a `div` and draws no poster, with nothing to catch it.

## Changes

- **Overview** gains a "Which part takes which prop" section: what is playing goes on the player, how it looks goes on the skin, native attributes stay on the media. It names both failure modes and links out to Sizing and Metadata rather than restating them.
- **Migrate from Mux Player** — the headline "Your first player" example no longer puts `poster` on the skin. Both variants now let `MuxVideo` derive the poster from `source`, and `thumbnail-time="2"` maps to `source.poster.time`. The stale "the poster is a skin concern today" note is gone, along with the advice to hand-build an `image.mux.com` URL: the mapping table now points `thumbnail-time` and the size, crop, rotation, and format options at the typed `source.poster` params, which is what `MuxPosterParams` has always accepted.
- **Migrate from Plyr** — `poster` moves from `MinimalVideoSkin` to `VideoPlayer` in React and onto `<video-player>` in HTML. The notes say where `className` and `style` go, and the option matrix stops crediting the skin with owning the poster.
- **Migrate from Video.js 8** — same move in both variants. "Skin attributes" becomes "Player inputs", the `TitleBar` row stops naming the HTML-only `content-title` for React readers, and both variants now link the `Title` component for drawing a title.
- **Skins** states that a skin draws the UI but holds no state, so `poster` and the title go on the player.
- **Poster** reference leads with the player as the place the URL goes, and its first example compiles (`VideoPlayer` requires `children`).
- Two React examples were also passing the HTML-cased `srclang` to `<track>`; they now pass `srcLang`.

## Testing

There is no existing harness for typechecking doc snippets, so I built a throwaway one rather than eyeball the examples — eyeballing is what let the last pass miss the headline example. It extracts every `tsx`/`jsx` fence under `site/src/content/docs/` that renders a player or skin (45 snippets), wraps each in a module with real imports for the preset components and `any` stand-ins for everything else, and runs `tsgo` over the set against the built `@videojs/react` types.

Before: four `TS2322` boundary errors — `migrate-from-mux-player.mdx` (the headline example), `migrate-from-plyr.mdx`, and `migrate-from-video-js-8.mdx` twice — plus two `srclang` errors. After: zero. The only remaining diagnostics are harness artifacts from fragments that deliberately omit their imports.

For the HTML variants, which no typechecker covers, I asserted against `combinePlayerFeatureConfigs(videoFeatures)` that the player element's config attributes are exactly `content-title` and `poster`.

- `pnpm -F site astro check` — 0 errors
- `pnpm build:site` — complete, 327 markdown files generated
- `pnpm check:workspace` — 9 passed; the one failure is `.claude/plans` needing to resolve to `.agents/plans`, which is gitignored local state and unrelated to this change

## Reported by

Agent migration friction logs, eight passes across six repositories and all four models. This was the most-reported item in the set, and it survived one previous fix that landed on the secondary example instead of the headline one.

- moosestack — [beta.29](https://app.notion.com/3c297a7f89d0814dbe48fbbfd72b1d2b) · [beta.30 delta](https://app.notion.com/3c297a7f89d08133b681e6ff83abee97)
- subatic — [beta.29](https://app.notion.com/3c297a7f89d08195aef5fe90a31f48f0) · [beta.30](https://app.notion.com/3c297a7f89d081ee90b9d96bc0329bb0)
- [instantdb](https://app.notion.com/3c297a7f89d081e5b71bfd5cf59e8de6)
- [pigeon-pod](https://app.notion.com/3c297a7f89d0811c8b7acf77b2874864)
- [screenity](https://app.notion.com/3c297a7f89d081b3a2aafe83113f12ba)
- [upstash-web](https://app.notion.com/3c297a7f89d081bca39bfb3d976786a3)

<details>
<summary>Two things this deliberately leaves alone</summary>

- **The skin forwarding unknown props to its `div`.** That is what turns a misplaced prop into a silent no-op instead of an error, and it is a code question, not a docs one. Flagged, not touched.
- **CSS selectors that only exist in one framework.** Both the Plyr and Mux Player guides tell you to set `--media-accent-color` on a `video-player` / `video-skin` selector, which matches nothing in React. Real, separately reported, and out of scope here.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and HTML demo CSS only; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Documents a single prop-placement rule: **what is playing** (`poster`, title) goes on the player; **how it looks** (class, style, geometry) goes on the skin. Native media attributes stay on the media.
> 
> Adds a **Sizing** concept page (sidebar: Concepts) explaining which element is the box—especially HTML `display: contents` providers that silently ignore width/aspect-ratio—and that `<media-container>` needs an explicit `display` before size works.
> 
> Migration guides (v8, Mux Player, Plyr, Media Chrome) and poster/container/provider references now put `poster` on the player, Mux poster options on `source.poster`, and CSS on the skin. HTML control demos wrap markup in `media-container` and size that instead of `.video-player`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c59f103e36424f0f09733c63574a675f1a2c7088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->