### PR TITLE
docs(site): complete the packaged skins' custom property list

### DIFF
--- a/site/src/content/docs/how-to/customize-skins.mdx
+++ b/site/src/content/docs/how-to/customize-skins.mdx
@@ -3,6 +3,8 @@ title: Customize skins
 description: Learn how to customize Video.js v10 skins by copying and modifying them
 ---
 
+import Aside from '@/components/Aside.astro';
+import DocsLink from '@/components/docs/DocsLink.astro';
 import FrameworkCase from '@/components/docs/FrameworkCase.astro';
 import StyleCase from '@/components/docs/StyleCase.astro';
 import EjectedSkin from '@/components/docs/EjectedSkin.astro';
@@ -11,14 +13,26 @@ Video.js v10 comes with two pre-built skins; Default and Minimal. Basic customiz
 
 ## Basic customization
 
+Both packaged skins read these CSS custom properties from your stylesheet. Set them on the skin, the player, or any ancestor, and the skin picks them up.
+
 | Property Name | Description | Type | Example |
 | ------------- | ----------- | ---- | ------- |
 | `--media-accent-color` | The color of slider fills and accented controls | [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) | `#f5c518` |
 | `--media-accent-text-color` | The color of text and icons shown on the accent color | [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) | `black` |
 | `--media-border-radius` | The border radius of the media player | A valid [border-radius value](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/border-radius#values) | `1rem` |
 | `--media-scale-unit` | The base sizing unit for Vanilla CSS skins | [`<length>`](https://developer.mozilla.org/en-US/docs/Web/CSS/length) | `1rem` |
+| `--media-object-fit` | How the video and the poster fill the player box. Defaults to `contain` | [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-fit#values) | `cover` |
+| `--media-object-position` | Where the video and the poster sit inside the player box. Defaults to `center` | [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-position#values) | `top center` |
 
 If you omit `--media-accent-text-color`, the skins choose a contrasting text color from `--media-accent-color` using [`contrast-color()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color). You only need to set it when you want to override that result.
+
+`--media-object-fit` and `--media-object-position` apply to the media element and the poster together, so the two stay aligned. Fullscreen ignores both and falls back to `contain`, which keeps a cropped player from cropping the whole screen. For worked examples, see <DocsLink slug="how-to/add-a-poster-placeholder">Add a poster placeholder</DocsLink> and <DocsLink slug="reference/background-video">Background video</DocsLink>.
+
+<Aside type="caution">
+Setting a custom property that a skin already sets on itself does nothing, and you get no warning. The skins declare those properties on their own root element, so the value you set on the player or an ancestor is replaced there and the skin's default stands. The table above is what the skins read from you.
+</Aside>
+
+To change anything else — background, control, menu, tooltip, text, and icon colors, spacing, or which controls appear — [eject the skin](#ejecting). That's the normal route once a design outgrows the properties above, and it hands you the same components and CSS the packaged skins are built from.
 
 ### Set the audio color scheme
 

--- a/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
+++ b/site/src/content/docs/how-to/migrate-from-media-chrome.mdx
@@ -206,6 +206,8 @@ media-play-button[data-paused] .play-icon { display: inline; }
 
 Continuous values use CSS custom properties: sliders expose `--media-slider-fill` and `--media-slider-pointer`.
 
+Your Media Chrome theming properties mostly do not carry over, and they fail quietly. Exactly two names mean the same thing in both projects: `--media-object-fit` and `--media-object-position`. Every other name you may have set, from `--media-primary-color` to `--media-control-background`, is read by nothing in Video.js, so it parses, applies to the element, and changes nothing on screen. Rebuild the theme from the properties in <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>, then eject the skin for everything those don't reach.
+
 ## Themes become skins
 
 Media Chrome's `<template>`-based themes (`media-theme`) become Video.js <DocsLink slug="concepts/skins">skins</DocsLink> and <DocsLink slug="concepts/presets">presets</DocsLink>. Start from a preset, then eject and customize with <DocsLink slug="how-to/customize-skins">Customize skins</DocsLink>, rather than authoring a template.


### PR DESCRIPTION
Reported in three friction logs: [litepan](https://app.notion.com/3c297a7f89d0819abc8eeda58fef96b3), [pigeon-pod](https://app.notion.com/3c297a7f89d0811c8b7acf77b2874864), [instantdb](https://app.notion.com/3c297a7f89d081e5b71bfd5cf59e8de6).

## Preview

| Page | |
|---|---|
| **Customize skins** | [HTML](https://deploy-preview-2308--vjs10-site.netlify.app/docs/framework/html/how-to/customize-skins) · [React](https://deploy-preview-2308--vjs10-site.netlify.app/docs/framework/react/how-to/customize-skins) |
| **Migrate from Media Chrome** | [HTML](https://deploy-preview-2308--vjs10-site.netlify.app/docs/framework/html/how-to/migrate-from-media-chrome) · [React](https://deploy-preview-2308--vjs10-site.netlify.app/docs/framework/react/how-to/migrate-from-media-chrome) |

## Summary

The packaged skins read six CSS custom properties from a consumer stylesheet. **Customize skins** listed four, so `--media-object-fit` and `--media-object-position` were reachable only from the poster and background-video pages. The guide also said nothing about what happens when you set a property the skin sets on itself: the value applies, nothing changes, and nothing warns.

## Changes

- **Customize skins** lists all six properties, with `object-fit` and `object-position` defaults and the fullscreen fallback to `contain`, and links the poster and background-video pages for worked examples.
- A caution states that setting a property a skin declares on its own root element has no effect and produces no warning.
- A closing line routes background, control, menu, tooltip, text, and icon colors, spacing, and control layout to ejecting, as the normal next step rather than a fallback.
- **Migrate from Media Chrome** records that `--media-object-fit` and `--media-object-position` are the only two names that mean the same thing in both projects, and that the rest of a Media Chrome theme parses, applies, and changes nothing.

<details>
<summary>How the six were determined</summary>

A property is settable by a consumer when the skins read it through `var()` with a fallback and never declare it themselves. That holds for exactly these six across both skins. The skins read 23 `--media-*` names in total; the other 17 are either declared by the skin on `.media-default-skin` / `.media-minimal-skin` (`--media-icon-size`, the popover and tooltip offsets, the caption-track values) or written by component JS as read-only state (`SliderCSSVars`, `VolumeIndicatorCSSVars`, `MenuCSSVars`, `PopoverCSSVars`).

For the Media Chrome figure, `--media-object-fit` and `--media-object-position` appear in `muxinc/media-chrome`'s `src/js/media-poster-image.ts` driving the same two CSS properties with the same `contain` / `center` fallbacks. A code search over that repo returns no hits for `--media-accent-color`, `--media-accent-text-color`, `--media-border-radius`, or `--media-scale-unit`, and this repo has no hits for `--media-primary-color`, `--media-secondary-color`, `--media-control-background`, `--media-control-hover-background`, `--media-text-color`, or `--media-icon-color`.

</details>

## Testing

- `pnpm -F site astro check` — 0 errors, 0 warnings (run in a fully built tree)
- `pnpm check:workspace` — 10 passed, 0 failed
- Biome does not process `.mdx`, so `pnpm lint:fix:file` reports both files as ignored paths
- Docs only; no source, component, or CSS changes
