### PR TITLE
fix(store): make slice selectors identity-aware

### DIFF
--- a/packages/core/src/dom/gesture/tests/actions.test.ts
+++ b/packages/core/src/dom/gesture/tests/actions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { AnyPlayerFeature } from '../../player';
+import { playbackRateFeature } from '../../store/features/playback-rate';
+import { timeFeature } from '../../store/features/time';
+import { volumeFeature } from '../../store/features/volume';
+import { createTestPlayerStore } from '../../tests/test-helpers';
 import type { GestureActionContext } from '../actions';
 import { resolveGestureAction } from '../actions';
 
@@ -72,13 +77,15 @@ describe('direct store actions', () => {
 describe('seekStep', () => {
   it('seeks by value offset', () => {
     const seek = vi.fn();
-    resolveGestureAction('seekStep')!(ctx({ currentTime: 10, duration: 60, seeking: false, seek }, 5));
+    resolveGestureAction('seekStep')!(ctx({ currentTime: 10, duration: 60, seeking: false, seek }, 5, timeFeature));
     expect(seek).toHaveBeenCalledWith(15);
   });
 
   it('does nothing without value', () => {
     const seek = vi.fn();
-    resolveGestureAction('seekStep')!(ctx({ currentTime: 10, duration: 60, seeking: false, seek }));
+    resolveGestureAction('seekStep')!(
+      ctx({ currentTime: 10, duration: 60, seeking: false, seek }, undefined, timeFeature)
+    );
     expect(seek).not.toHaveBeenCalled();
   });
 });
@@ -87,7 +94,11 @@ describe('volumeStep', () => {
   it('adjusts volume by value offset', () => {
     const setVolume = vi.fn();
     resolveGestureAction('volumeStep')!(
-      ctx({ volume: 0.5, muted: false, volumeAvailability: 'available', setVolume, toggleMuted: vi.fn() }, 0.1)
+      ctx(
+        { volume: 0.5, muted: false, volumeAvailability: 'available', setVolume, toggleMuted: vi.fn() },
+        0.1,
+        volumeFeature
+      )
     );
     expect(setVolume).toHaveBeenCalledWith(0.6);
   });
@@ -96,13 +107,17 @@ describe('volumeStep', () => {
 describe('speedUp', () => {
   it('cycles to next playback rate', () => {
     const setPlaybackRate = vi.fn();
-    resolveGestureAction('speedUp')!(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1, setPlaybackRate }));
+    resolveGestureAction('speedUp')!(
+      ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1, setPlaybackRate }, undefined, playbackRateFeature)
+    );
     expect(setPlaybackRate).toHaveBeenCalledWith(1.5);
   });
 
   it('wraps to first rate at end', () => {
     const setPlaybackRate = vi.fn();
-    resolveGestureAction('speedUp')!(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 2, setPlaybackRate }));
+    resolveGestureAction('speedUp')!(
+      ctx({ playbackRates: [0.5, 1, 2], playbackRate: 2, setPlaybackRate }, undefined, playbackRateFeature)
+    );
     expect(setPlaybackRate).toHaveBeenCalledWith(0.5);
   });
 });
@@ -110,13 +125,17 @@ describe('speedUp', () => {
 describe('speedDown', () => {
   it('cycles to previous playback rate', () => {
     const setPlaybackRate = vi.fn();
-    resolveGestureAction('speedDown')!(ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1.5, setPlaybackRate }));
+    resolveGestureAction('speedDown')!(
+      ctx({ playbackRates: [0.5, 1, 1.5, 2], playbackRate: 1.5, setPlaybackRate }, undefined, playbackRateFeature)
+    );
     expect(setPlaybackRate).toHaveBeenCalledWith(1);
   });
 
   it('wraps to last rate at beginning', () => {
     const setPlaybackRate = vi.fn();
-    resolveGestureAction('speedDown')!(ctx({ playbackRates: [0.5, 1, 2], playbackRate: 0.5, setPlaybackRate }));
+    resolveGestureAction('speedDown')!(
+      ctx({ playbackRates: [0.5, 1, 2], playbackRate: 0.5, setPlaybackRate }, undefined, playbackRateFeature)
+    );
     expect(setPlaybackRate).toHaveBeenCalledWith(2);
   });
 });
@@ -125,9 +144,11 @@ describe('speedDown', () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function ctx(stateProps: Record<string, unknown>, value?: number): GestureActionContext {
+function ctx(stateProps: Record<string, unknown>, value?: number, feature?: AnyPlayerFeature): GestureActionContext {
   return {
-    store: { state: stateProps } as unknown as GestureActionContext['store'],
+    store: (feature
+      ? createTestPlayerStore([feature], stateProps)
+      : { state: stateProps }) as GestureActionContext['store'],
     value,
     event: new Event('pointerup') as PointerEvent,
   };

--- a/packages/core/src/dom/hotkey/tests/actions.test.ts
+++ b/packages/core/src/dom/hotkey/tests/actions.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { AnyPlayerFeature } from '../../player';
+import { fullscreenFeature } from '../../store/features/fullscreen';
+import { playbackFeature } from '../../store/features/playback';
+import { playbackRateFeature } from '../../store/features/playback-rate';
+import { timeFeature } from '../../store/features/time';
+import { volumeFeature } from '../../store/features/volume';
+import { createTestPlayerStore } from '../../tests/test-helpers';
 import type { HotkeyActionContext } from '../actions';
 import { isHotkeyToggleAction, resolveHotkeyAction } from '../actions';
 
-function mockStore(state: Record<string, unknown>) {
-  return { state } as HotkeyActionContext['store'];
+function mockStore(feature: AnyPlayerFeature, state: Record<string, unknown>) {
+  return createTestPlayerStore([feature], state) as HotkeyActionContext['store'];
 }
 
 describe('resolveHotkeyAction', () => {
@@ -50,7 +57,14 @@ describe('isHotkeyToggleAction', () => {
 describe('togglePaused', () => {
   it('calls play() when paused', () => {
     const play = vi.fn();
-    const store = mockStore({ paused: true, ended: false, started: false, waiting: false, play, pause: vi.fn() });
+    const store = mockStore(playbackFeature, {
+      paused: true,
+      ended: false,
+      started: false,
+      waiting: false,
+      play,
+      pause: vi.fn(),
+    });
 
     resolveHotkeyAction('togglePaused')!({ store, key: '' });
 
@@ -59,7 +73,14 @@ describe('togglePaused', () => {
 
   it('calls pause() when playing', () => {
     const pause = vi.fn();
-    const store = mockStore({ paused: false, ended: false, started: true, waiting: false, play: vi.fn(), pause });
+    const store = mockStore(playbackFeature, {
+      paused: false,
+      ended: false,
+      started: true,
+      waiting: false,
+      play: vi.fn(),
+      pause,
+    });
 
     resolveHotkeyAction('togglePaused')!({ store, key: '' });
 
@@ -70,7 +91,7 @@ describe('togglePaused', () => {
 describe('toggleMuted', () => {
   it('calls toggleMuted()', () => {
     const toggleMuted = vi.fn();
-    const store = mockStore({
+    const store = mockStore(volumeFeature, {
       volume: 1,
       muted: false,
       volumeAvailability: 'available',
@@ -87,7 +108,7 @@ describe('toggleMuted', () => {
 describe('toggleFullscreen', () => {
   it('calls requestFullscreen() when not fullscreen', () => {
     const requestFullscreen = vi.fn();
-    const store = mockStore({
+    const store = mockStore(fullscreenFeature, {
       fullscreen: false,
       fullscreenAvailability: 'available',
       requestFullscreen,
@@ -101,7 +122,7 @@ describe('toggleFullscreen', () => {
 
   it('calls exitFullscreen() when fullscreen', () => {
     const exitFullscreen = vi.fn();
-    const store = mockStore({
+    const store = mockStore(fullscreenFeature, {
       fullscreen: true,
       fullscreenAvailability: 'available',
       requestFullscreen: vi.fn(),
@@ -117,7 +138,7 @@ describe('toggleFullscreen', () => {
 describe('seekStep', () => {
   it('seeks forward by value', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 10, duration: 100, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 10, duration: 100, seeking: false, seek });
 
     resolveHotkeyAction('seekStep')!({ store, value: 5, key: '' });
 
@@ -126,7 +147,7 @@ describe('seekStep', () => {
 
   it('seeks backward by negative value', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 10, duration: 100, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 10, duration: 100, seeking: false, seek });
 
     resolveHotkeyAction('seekStep')!({ store, value: -5, key: '' });
 
@@ -135,7 +156,7 @@ describe('seekStep', () => {
 
   it('no-ops without value', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 10, duration: 100, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 10, duration: 100, seeking: false, seek });
 
     resolveHotkeyAction('seekStep')!({ store, key: '' });
 
@@ -146,7 +167,7 @@ describe('seekStep', () => {
 describe('volumeStep', () => {
   it('increases volume by value', () => {
     const setVolume = vi.fn();
-    const store = mockStore({
+    const store = mockStore(volumeFeature, {
       volume: 0.5,
       muted: false,
       volumeAvailability: 'available',
@@ -161,7 +182,7 @@ describe('volumeStep', () => {
 
   it('decreases volume by negative value', () => {
     const setVolume = vi.fn();
-    const store = mockStore({
+    const store = mockStore(volumeFeature, {
       volume: 0.5,
       muted: false,
       volumeAvailability: 'available',
@@ -178,7 +199,7 @@ describe('volumeStep', () => {
 describe('speedUp', () => {
   it('steps to next rate', () => {
     const setPlaybackRate = vi.fn();
-    const store = mockStore({ playbackRates: [1, 1.5, 2], playbackRate: 1, setPlaybackRate });
+    const store = mockStore(playbackRateFeature, { playbackRates: [1, 1.5, 2], playbackRate: 1, setPlaybackRate });
 
     resolveHotkeyAction('speedUp')!({ store, key: '' });
 
@@ -187,7 +208,7 @@ describe('speedUp', () => {
 
   it('wraps to first rate at end', () => {
     const setPlaybackRate = vi.fn();
-    const store = mockStore({ playbackRates: [1, 1.5, 2], playbackRate: 2, setPlaybackRate });
+    const store = mockStore(playbackRateFeature, { playbackRates: [1, 1.5, 2], playbackRate: 2, setPlaybackRate });
 
     resolveHotkeyAction('speedUp')!({ store, key: '' });
 
@@ -198,7 +219,11 @@ describe('speedUp', () => {
 describe('speedDown', () => {
   it('steps to previous rate', () => {
     const setPlaybackRate = vi.fn();
-    const store = mockStore({ playbackRates: [1, 1.5, 2], playbackRate: 1.5, setPlaybackRate });
+    const store = mockStore(playbackRateFeature, {
+      playbackRates: [1, 1.5, 2],
+      playbackRate: 1.5,
+      setPlaybackRate,
+    });
 
     resolveHotkeyAction('speedDown')!({ store, key: '' });
 
@@ -207,7 +232,7 @@ describe('speedDown', () => {
 
   it('wraps to last rate at beginning', () => {
     const setPlaybackRate = vi.fn();
-    const store = mockStore({ playbackRates: [1, 1.5, 2], playbackRate: 1, setPlaybackRate });
+    const store = mockStore(playbackRateFeature, { playbackRates: [1, 1.5, 2], playbackRate: 1, setPlaybackRate });
 
     resolveHotkeyAction('speedDown')!({ store, key: '' });
 
@@ -218,7 +243,7 @@ describe('speedDown', () => {
 describe('seekToPercent', () => {
   it('seeks to explicit value percentage', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 0, duration: 200, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 0, duration: 200, seeking: false, seek });
 
     resolveHotkeyAction('seekToPercent')!({ store, value: 50, key: '' });
 
@@ -227,7 +252,7 @@ describe('seekToPercent', () => {
 
   it('derives percentage from digit key', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 0, duration: 200, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 0, duration: 200, seeking: false, seek });
 
     resolveHotkeyAction('seekToPercent')!({ store, key: '3' });
 
@@ -236,7 +261,7 @@ describe('seekToPercent', () => {
 
   it('no-ops for non-digit key without value', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 0, duration: 200, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 0, duration: 200, seeking: false, seek });
 
     resolveHotkeyAction('seekToPercent')!({ store, key: 'k' });
 
@@ -245,7 +270,7 @@ describe('seekToPercent', () => {
 
   it('no-ops when duration is 0', () => {
     const seek = vi.fn();
-    const store = mockStore({ currentTime: 0, duration: 0, seeking: false, seek });
+    const store = mockStore(timeFeature, { currentTime: 0, duration: 0, seeking: false, seek });
 
     resolveHotkeyAction('seekToPercent')!({ store, value: 50, key: '' });
 

--- a/packages/core/src/dom/tests/test-helpers.ts
+++ b/packages/core/src/dom/tests/test-helpers.ts
@@ -1,5 +1,42 @@
+import type { StateContext } from '@videojs/store';
+import { combine, createStore } from '@videojs/store';
 import type { SliderState } from '../../core/ui/slider/slider-core';
 import type { TimeSliderState } from '../../core/ui/time-slider/time-slider-core';
+import type { AnyPlayerFeature, AnyPlayerStore, PlayerTarget } from '../player';
+
+// ---------------------------------------------------------------------------
+// Mock Player State
+// ---------------------------------------------------------------------------
+
+const SET_TEST_STATE = Symbol('setTestPlayerState');
+
+interface TestStateAction {
+  [SET_TEST_STATE](partial: Record<string, unknown>): void;
+}
+
+export type TestPlayerStore = AnyPlayerStore & {
+  setState(partial: Record<string, unknown>): void;
+};
+
+/** Creates a marked player store from real features with test-only state overrides. */
+export function createTestPlayerStore(
+  features: readonly AnyPlayerFeature[],
+  initialState: Record<string, unknown> = {}
+): TestPlayerStore {
+  const testStateFeature = {
+    name: 'testState',
+    state: ({ set }: StateContext<PlayerTarget>): TestStateAction => ({
+      [SET_TEST_STATE]: (partial) => set(partial),
+    }),
+  };
+  const store = createStore<PlayerTarget>()(combine(...features, testStateFeature)) as AnyPlayerStore & TestStateAction;
+
+  store[SET_TEST_STATE](initialState);
+
+  return Object.assign(store, {
+    setState: (partial: Record<string, unknown>) => store[SET_TEST_STATE](partial),
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Mock Video

--- a/packages/core/src/dom/ui/tests/input-action.test.ts
+++ b/packages/core/src/dom/ui/tests/input-action.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { fullscreenFeature } from '../../store/features/fullscreen';
+import { pipFeature } from '../../store/features/pip';
+import { playbackFeature } from '../../store/features/playback';
+import { playbackRateFeature } from '../../store/features/playback-rate';
+import { textTrackFeature } from '../../store/features/text-track';
+import { timeFeature } from '../../store/features/time';
+import { volumeFeature } from '../../store/features/volume';
+import { createTestPlayerStore } from '../../tests/test-helpers';
 import {
   getIndicatorVisibilityCoordinator,
   getMediaSnapshot,
@@ -9,7 +17,10 @@ import {
 import { isSliderFocused } from '../slider-focus';
 
 function mockStore(state: Record<string, unknown>): MediaSnapshotStore {
-  return { state };
+  return createTestPlayerStore(
+    [playbackFeature, volumeFeature, playbackRateFeature, fullscreenFeature, textTrackFeature, pipFeature, timeFeature],
+    state
+  );
 }
 
 describe('input-action', () => {

--- a/packages/core/src/dom/ui/tests/status-announcer.test.ts
+++ b/packages/core/src/dom/ui/tests/status-announcer.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { StatusAnnouncerCore } from '../../../core/ui/status-announcer/status-announcer-core';
+import { playbackFeature } from '../../store/features/playback';
+import { timeFeature } from '../../store/features/time';
+import { volumeFeature } from '../../store/features/volume';
+import { createTestPlayerStore } from '../../tests/test-helpers';
 import { type StatusAnnouncerStore, subscribeToStatusAnnouncer } from '../status-announcer';
 
 describe('subscribeToStatusAnnouncer', () => {
@@ -47,12 +51,12 @@ describe('subscribeToStatusAnnouncer', () => {
 });
 
 function createStore(initialState: Record<string, unknown>) {
-  let state = initialState;
+  const source = createTestPlayerStore([playbackFeature, volumeFeature, timeFeature], initialState);
   let target: unknown | null = null;
   const listeners = new Set<() => void>();
   const store: StatusAnnouncerStore = {
     get state() {
-      return state;
+      return source.state;
     },
     get target() {
       return target;
@@ -64,7 +68,7 @@ function createStore(initialState: Record<string, unknown>) {
   };
 
   const setState = (partial: Record<string, unknown>) => {
-    state = { ...state, ...partial };
+    source.setState(partial);
     for (const listener of listeners) listener();
   };
 

--- a/packages/html/src/skin/tests/video-menu-composition.test.ts
+++ b/packages/html/src/skin/tests/video-menu-composition.test.ts
@@ -1,4 +1,5 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { audioTrackFeature, playbackRateFeature, qualityFeature, textTrackFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type {
   MediaAudioTrackState,
@@ -6,10 +7,10 @@ import type {
   MediaQualityState,
   MediaTextTrackState,
 } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../player/context';
+import { createTestPlayerStore } from '../../testing/create-test-player-store';
 import { AudioTrackRadioGroupElement } from '../../ui/audio-track-radio-group/audio-track-radio-group-element';
 import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
 import { MediaElement } from '../../ui/media-element';
@@ -27,37 +28,30 @@ function defineElement(tagName: string, Base: CustomElementConstructor): void {
 }
 
 function createMenuStore(overrides: Partial<MenuMediaState> = {}): AnyPlayerStore {
-  return createStore<unknown>()<MenuMediaState>({
-    name: 'videoMenuComposition',
-    state: () => ({
-      audioTrackList: [
-        { id: '0', kind: 'main', label: 'English', language: 'en', enabled: false },
-        { id: '1', kind: 'alternative', label: 'Spanish', language: 'es', enabled: true },
-      ],
-      selectAudioTrack: vi.fn(),
-      playbackRates: [0.5, 1, 1.5, 2],
-      playbackRate: 1.5,
-      setPlaybackRate: vi.fn(),
-      videoRenditionList: [
-        { id: '0', height: 1080, selected: false },
-        { id: '1', height: 720, selected: true },
-      ],
-      activeVideoRendition: null,
-      selectVideoRendition: vi.fn(),
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin: null,
-      textTrackList: [
-        { kind: 'captions', label: 'English', language: 'en', mode: 'showing' },
-        { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
-      ],
-      subtitlesShowing: true,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack: vi.fn(),
-      ...overrides,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([audioTrackFeature, playbackRateFeature, qualityFeature, textTrackFeature], {
+    audioTrackList: [
+      { id: '0', kind: 'main', label: 'English', language: 'en', enabled: false },
+      { id: '1', kind: 'alternative', label: 'Spanish', language: 'es', enabled: true },
+    ],
+    selectAudioTrack: vi.fn(),
+    playbackRates: [0.5, 1, 1.5, 2],
+    playbackRate: 1.5,
+    setPlaybackRate: vi.fn(),
+    videoRenditionList: [
+      { id: '0', height: 1080, selected: false },
+      { id: '1', height: 720, selected: true },
+    ],
+    activeVideoRendition: null,
+    selectVideoRendition: vi.fn(),
+    textTrackList: [
+      { kind: 'captions', label: 'English', language: 'en', mode: 'showing' },
+      { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' },
+    ],
+    subtitlesShowing: true,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack: vi.fn(),
+    ...overrides,
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/testing/create-test-player-store.ts
+++ b/packages/html/src/testing/create-test-player-store.ts
@@ -1,0 +1,46 @@
+import type { AnyPlayerFeature, AnyPlayerStore, PlayerTarget } from '@videojs/core/dom';
+import type { AnySlice, StateContext, Store, UnionSliceState } from '@videojs/store';
+import { combine, createStore } from '@videojs/store';
+
+const SET_TEST_STATE = Symbol('setTestPlayerState');
+const TEST_TARGET = {} as PlayerTarget;
+
+type TestState<Features extends readonly AnyPlayerFeature[]> = UnionSliceState<Features>;
+
+interface TestStateAction<State extends object> {
+  [SET_TEST_STATE](partial: Partial<State>): void;
+}
+
+export type TestPlayerStore<State extends object> = AnyPlayerStore & {
+  setState(partial: Partial<State>): void;
+};
+
+/**
+ * Creates a reactive player store for HTML component tests from the real
+ * feature definitions while allowing their initial state to be overridden.
+ */
+export function createTestPlayerStore<const Features extends readonly AnyPlayerFeature[]>(
+  features: Features,
+  initialState: Partial<TestState<Features>> = {}
+): TestPlayerStore<TestState<Features>> {
+  type State = TestState<Features>;
+
+  const testStateFeature = {
+    name: 'testState',
+    state: ({ set }: StateContext<PlayerTarget>): TestStateAction<State> => ({
+      [SET_TEST_STATE]: (partial) => set(partial),
+    }),
+  };
+  const source = createStore<PlayerTarget>()(
+    combine(...features, testStateFeature) as AnySlice<PlayerTarget>
+  ) as unknown as Store<PlayerTarget, State> & TestStateAction<State>;
+
+  source[SET_TEST_STATE](initialState);
+
+  return Object.create(source, {
+    target: { get: () => source.target ?? TEST_TARGET },
+    setState: {
+      value: (partial: Partial<State>) => source[SET_TEST_STATE](partial),
+    },
+  }) as TestPlayerStore<State>;
+}

--- a/packages/html/src/ui/audio-track-radio-group/tests/audio-track-radio-group-element.test.ts
+++ b/packages/html/src/ui/audio-track-radio-group/tests/audio-track-radio-group-element.test.ts
@@ -1,12 +1,13 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { audioTrackFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaAudioTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
@@ -62,13 +63,10 @@ function createAudioTrackStore({
   audioTrackList?: MediaAudioTrackState['audioTrackList'] | undefined;
   selectAudioTrack?: MediaAudioTrackState['selectAudioTrack'] | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaAudioTrackState>({
-    name: 'audioTrack',
-    state: () => ({
-      audioTrackList,
-      selectAudioTrack,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([audioTrackFeature], {
+    audioTrackList,
+    selectAudioTrack,
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/captions-button/tests/captions-button-element.test.ts
+++ b/packages/html/src/ui/captions-button/tests/captions-button-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { textTrackFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTextTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { CaptionsButtonElement } from '../captions-button-element';
 
@@ -35,19 +36,11 @@ async function waitForAssertion(assertion: () => void): Promise<void> {
 }
 
 function createTextTrackStore(textTrackList: MediaTextTrackState['textTrackList']): AnyPlayerStore {
-  return createStore<unknown>()<MediaTextTrackState>({
-    name: 'textTrack',
-    state: () => ({
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin: null,
-      textTrackList,
-      subtitlesShowing: false,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([textTrackFeature], {
+    textTrackList,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack: vi.fn(),
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
+++ b/packages/html/src/ui/captions-radio-group/tests/captions-radio-group-element.test.ts
@@ -1,12 +1,13 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { textTrackFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTextTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuRadioItemElement } from '../../menu/menu-radio-item-element';
@@ -47,19 +48,12 @@ function createTextTrackStore({
   subtitlesShowing?: boolean | undefined;
   selectSubtitlesTrack?: MediaTextTrackState['selectSubtitlesTrack'] | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaTextTrackState>({
-    name: 'textTrack',
-    state: () => ({
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin: null,
-      textTrackList,
-      subtitlesShowing,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([textTrackFeature], {
+    textTrackList,
+    subtitlesShowing,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack,
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/controls/tests/controls-element.test.ts
+++ b/packages/html/src/ui/controls/tests/controls-element.test.ts
@@ -1,11 +1,13 @@
 import { POPUP_HOST_ATTR } from '@videojs/core';
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaControlsState } from '@videojs/media';
-import { createStore, flush } from '@videojs/store';
+import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { MenuElement } from '../../menu/menu-element';
 import { PopoverElement } from '../../popover/popover-element';
@@ -33,23 +35,7 @@ function defineElement(tagName: string, Base: CustomElementConstructor): void {
 }
 
 function createControlsStore(): AnyPlayerStore {
-  return createStore<unknown>()<MediaControlsState>({
-    name: 'controls',
-    state: ({ get, set }) => {
-      return {
-        userActive: true,
-        controlsVisible: true,
-        requestControlsLock: () => () => {},
-        toggleControls() {
-          const visible = !(get().controlsVisible as boolean);
-
-          set({ userActive: visible, controlsVisible: visible });
-
-          return visible;
-        },
-      };
-    },
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([controlsFeature]);
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/menu/tests/menu-element.test.ts
+++ b/packages/html/src/ui/menu/tests/menu-element.test.ts
@@ -1,10 +1,12 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaControlsState } from '@videojs/media';
-import { createStore, flush } from '@videojs/store';
+import { flush } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { ControlsElement } from '../../controls/controls-element';
 import { MediaElement } from '../../media-element';
 import { MenuCheckboxItemElement } from '../menu-checkbox-item-element';
@@ -38,23 +40,7 @@ function defineElement(tagName: string, Base: CustomElementConstructor): void {
 function createControlsStore(
   requestControlsLock: MediaControlsState['requestControlsLock'] = () => () => {}
 ): AnyPlayerStore {
-  return createStore<unknown>()<MediaControlsState>({
-    name: 'controls',
-    state: ({ get, set }) => {
-      return {
-        userActive: true,
-        controlsVisible: true,
-        requestControlsLock,
-        toggleControls() {
-          const visible = !(get().controlsVisible as boolean);
-
-          set({ userActive: visible, controlsVisible: visible });
-
-          return visible;
-        },
-      };
-    },
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([controlsFeature], { requestControlsLock });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
+++ b/packages/html/src/ui/playback-rate-radio-group/tests/playback-rate-radio-group-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { playbackRateFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaPlaybackRateState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
@@ -60,16 +61,11 @@ function createPlaybackRateStore({
   playbackRate?: number | undefined;
   setPlaybackRate?: ((rate: number) => void) | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaPlaybackRateState>({
-    name: 'playbackRate',
-    state: () => {
-      return {
-        playbackRates,
-        playbackRate,
-        setPlaybackRate,
-      };
-    },
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([playbackRateFeature], {
+    playbackRates,
+    playbackRate,
+    setPlaybackRate,
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
+++ b/packages/html/src/ui/quality-radio-group/tests/quality-radio-group-element.test.ts
@@ -1,12 +1,13 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { qualityFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaQualityState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MediaI18nProviderElement } from '../../../i18n/provider-element';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { MenuElement } from '../../menu/menu-element';
 import { MenuItemIndicatorElement } from '../../menu/menu-item-indicator-element';
@@ -64,14 +65,11 @@ function createQualityStore({
   activeVideoRendition?: MediaQualityState['activeVideoRendition'] | undefined;
   selectVideoRendition?: MediaQualityState['selectVideoRendition'] | undefined;
 } = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaQualityState>({
-    name: 'quality',
-    state: () => ({
-      videoRenditionList,
-      activeVideoRendition,
-      selectVideoRendition,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([qualityFeature], {
+    videoRenditionList,
+    activeVideoRendition,
+    selectVideoRendition,
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/slider/tests/slider-element.test.ts
+++ b/packages/html/src/ui/slider/tests/slider-element.test.ts
@@ -1,9 +1,10 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { controlsFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaControlsState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { SliderBufferElement } from '../slider-buffer-element';
 import { SliderElement } from '../slider-element';
@@ -26,15 +27,7 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 }
 
 function createControlsStore(requestControlsLock: MediaControlsState['requestControlsLock']): AnyPlayerStore {
-  return createStore<unknown>()<MediaControlsState>({
-    name: 'controls',
-    state: () => ({
-      userActive: true,
-      controlsVisible: true,
-      requestControlsLock,
-      toggleControls: () => true,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([controlsFeature], { requestControlsLock });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/status-announcer/tests/status-announcer-element.test.ts
+++ b/packages/html/src/ui/status-announcer/tests/status-announcer-element.test.ts
@@ -1,7 +1,10 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { playbackFeature, timeFeature, volumeFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
+import type { MediaPlaybackState, MediaTimeState, MediaVolumeState } from '@videojs/media';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { containerContext, playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { StatusAnnouncerElement } from '../status-announcer-element';
 
@@ -13,35 +16,18 @@ function defineElement(tagName: string, Base: CustomElementConstructor): void {
   if (!customElements.get(tagName)) customElements.define(tagName, Base);
 }
 
-function createTestStore(initialState: Record<string, unknown> = {}) {
-  let state = initialState;
-  const target = {};
-  const listeners = new Set<() => void>();
-  const store = {
-    get state() {
-      return state;
-    },
-    get target() {
-      return target;
-    },
-    subscribe(callback: () => void) {
-      listeners.add(callback);
-      return () => listeners.delete(callback);
-    },
-  } as unknown as AnyPlayerStore;
+type TestStatusState = MediaPlaybackState & MediaTimeState & MediaVolumeState;
 
-  const setState = (partial: Record<string, unknown>) => {
-    state = { ...state, ...partial };
-    for (const listener of listeners) listener();
-  };
+function createTestStore(initialState: Partial<TestStatusState> = {}) {
+  const store = createTestPlayerStore([playbackFeature, timeFeature, volumeFeature], initialState);
 
-  return { store, setState };
+  return { store, setState: store.setState };
 }
 
 class TestStatusAnnouncerPlayerElement extends MediaElement {
   readonly #provider = new ContextProvider(this, { context: playerContext });
   readonly #containerProvider = new ContextProvider(this, { context: containerContext });
-  #store = createTestStore().store;
+  #store: AnyPlayerStore = createTestStore().store;
 
   get store(): AnyPlayerStore {
     return this.#store;
@@ -141,7 +127,7 @@ describe('StatusAnnouncerElement', () => {
     {
       name: 'completed seeks',
       initialState: { currentTime: 10, duration: 120, seeking: false },
-      update: async (setState: (partial: Record<string, unknown>) => void) => {
+      update: async (setState: (partial: Partial<TestStatusState>) => void) => {
         setState({ currentTime: 45, seeking: true });
         await Promise.resolve();
         setState({ seeking: false });
@@ -150,7 +136,7 @@ describe('StatusAnnouncerElement', () => {
     {
       name: 'volume changes',
       initialState: { volume: 0.5, muted: false },
-      update: async (setState: (partial: Record<string, unknown>) => void) => {
+      update: async (setState: (partial: Partial<TestStatusState>) => void) => {
         setState({ volume: 0.75 });
       },
     },

--- a/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
+++ b/packages/html/src/ui/thumbnail/tests/thumbnail-element.test.ts
@@ -1,29 +1,22 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { textTrackFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTextTrackState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { ThumbnailElement } from '../thumbnail-element';
 
 function createTextTrackStore(
   thumbnailTrackCrossOrigin: MediaTextTrackState['thumbnailTrackCrossOrigin']
 ): AnyPlayerStore {
-  return createStore<unknown>()<MediaTextTrackState>({
-    name: 'textTrack',
-    state: () => ({
-      chaptersCues: [],
-      thumbnailCues: [],
-      thumbnailTrackSrc: null,
-      thumbnailTrackCrossOrigin,
-      textTrackList: [],
-      subtitlesShowing: false,
-      toggleSubtitles: vi.fn(),
-      selectSubtitlesTrack: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([textTrackFeature], {
+    thumbnailTrackCrossOrigin,
+    toggleSubtitles: vi.fn(),
+    selectSubtitlesTrack: vi.fn(),
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/time/tests/time-element.test.ts
+++ b/packages/html/src/ui/time/tests/time-element.test.ts
@@ -1,13 +1,14 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { timeFeature } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaTimeState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { formatTimeAsPhrase } from '@videojs/utils/time';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MediaI18nProviderElement } from '../../../i18n';
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { TimeElement } from '../time-element';
 
@@ -50,16 +51,13 @@ async function waitForAssertion(assertion: () => void): Promise<void> {
 }
 
 function createTimeStore(overrides: Partial<MediaTimeState> = {}): AnyPlayerStore {
-  return createStore<unknown>()<MediaTimeState>({
-    name: 'time',
-    state: () => ({
-      currentTime: 90,
-      duration: 300,
-      seeking: false,
-      seek: vi.fn(),
-      ...overrides,
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([timeFeature], {
+    currentTime: 90,
+    duration: 300,
+    seeking: false,
+    seek: vi.fn(),
+    ...overrides,
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
+++ b/packages/html/src/ui/volume-slider/tests/volume-slider-element.test.ts
@@ -1,10 +1,11 @@
 import type { AnyPlayerStore } from '@videojs/core/dom';
+import { volumeFeature } from '@videojs/core/dom';
 import { ContextProvider } from '@videojs/element/context';
 import type { MediaVolumeState } from '@videojs/media';
-import { createStore } from '@videojs/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { playerContext } from '../../../player/context';
+import { createTestPlayerStore } from '../../../testing/create-test-player-store';
 import { MediaElement } from '../../media-element';
 import { SliderThumbElement } from '../../slider/slider-thumb-element';
 import { VolumeSliderElement } from '../volume-slider-element';
@@ -22,19 +23,14 @@ function createElement<Element extends HTMLElement>(Base: abstract new () => Ele
 }
 
 function createVolumeStore(volumeAvailability: MediaVolumeState['volumeAvailability']): AnyPlayerStore {
-  return createStore<unknown>()<MediaVolumeState>({
-    name: 'volume',
-    state: () => ({
-      volume: 1,
-      muted: false,
-      volumeAvailability,
-      // Mute has an availability of its own, and this slider reads the level's;
-      // these tests vary that one and leave the mute available throughout.
-      mutedAvailability: 'available',
-      setVolume: vi.fn(),
-      toggleMuted: vi.fn(),
-    }),
-  }) as unknown as AnyPlayerStore;
+  return createTestPlayerStore([volumeFeature], {
+    volumeAvailability,
+    // Mute has an availability of its own, and this slider reads the level's;
+    // these tests vary that one and leave the mute available throughout.
+    mutedAvailability: 'available',
+    setVolume: vi.fn(),
+    toggleMuted: vi.fn(),
+  });
 }
 
 class TestPlayerProviderElement extends MediaElement {

--- a/packages/react/src/testing/mocks.tsx
+++ b/packages/react/src/testing/mocks.tsx
@@ -7,6 +7,8 @@
  * can be shared here.
  */
 
+import { type PlayerTarget, videoFeatures } from '@videojs/core/dom';
+import { combine, createStore } from '@videojs/store';
 import type { ReactNode } from 'react';
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
@@ -19,6 +21,18 @@ interface MockStore {
   attach: Mock<() => Mock>;
   subscribe: Mock<() => Mock>;
   destroy: Mock;
+}
+
+const videoStore = createStore<PlayerTarget>()(combine(...videoFeatures));
+
+/**
+ * Create a complete plain-object snapshot for a built-in video player.
+ *
+ * Spreading the canonical store snapshot is intentional: component tests use
+ * the selector fallback for unmarked objects while keeping every feature key.
+ */
+export function createVideoPlayerState(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ...videoStore.state, ...overrides };
 }
 
 /**

--- a/packages/react/src/ui/controls/tests/controls.test.tsx
+++ b/packages/react/src/ui/controls/tests/controls.test.tsx
@@ -1,15 +1,17 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { createPlayerWrapper } from '../../../testing/mocks';
+import { createPlayerWrapper, createVideoPlayerState } from '../../../testing/mocks';
 import { ControlsRoot } from '../controls-root';
 
 describe('ControlsRoot', () => {
   it('marks the controls surface as interactive', () => {
-    const { Wrapper } = createPlayerWrapper({
-      controlsVisible: true,
-      userActive: true,
-    });
+    const { Wrapper } = createPlayerWrapper(
+      createVideoPlayerState({
+        controlsVisible: true,
+        userActive: true,
+      })
+    );
     const { getByTestId } = render(<ControlsRoot data-testid="controls" />, { wrapper: Wrapper });
 
     expect(getByTestId('controls').hasAttribute('data-interactive')).toBe(true);

--- a/packages/react/src/ui/status-announcer/tests/status-announcer.test.tsx
+++ b/packages/react/src/ui/status-announcer/tests/status-announcer.test.tsx
@@ -3,6 +3,7 @@ import type { UnknownStore } from '@videojs/store';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PlayerContextProvider, type PlayerContextValue } from '../../../player/context';
+import { createVideoPlayerState } from '../../../testing/mocks';
 import { StatusAnnouncer } from '../status-announcer';
 
 afterEach(cleanup);
@@ -146,7 +147,7 @@ describe('StatusAnnouncer', () => {
 });
 
 function createTestStore(initialState: Record<string, unknown> = {}) {
-  let state = initialState;
+  let state = createVideoPlayerState(initialState);
   const target = {};
   const listeners = new Set<() => void>();
   const store = {

--- a/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
+++ b/packages/react/src/ui/time-slider/tests/time-slider.test.tsx
@@ -76,12 +76,20 @@ const {
       waiting: false,
       play: vi.fn(() => Promise.resolve()),
       pause: vi.fn(),
+      togglePaused: vi.fn(),
     },
     mockTextTrackState: {
       chaptersCues: [
         { id: 'first', startTime: 0, endTime: 40, text: 'First' },
         { id: 'second', startTime: 60, endTime: 120, text: 'Second' },
       ],
+      thumbnailCues: [],
+      thumbnailTrackSrc: null,
+      thumbnailTrackCrossOrigin: null,
+      textTrackList: [],
+      subtitlesShowing: false,
+      toggleSubtitles: vi.fn(),
+      selectSubtitlesTrack: vi.fn(),
     },
     capturedSliderOptions,
   };

--- a/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
+++ b/packages/react/src/ui/volume-slider/tests/volume-slider.test.tsx
@@ -16,6 +16,7 @@ const { mockSliderApi, mockVolumeState, mutableVolume } = vi.hoisted(() => {
     volume: 0.8,
     muted: false,
     volumeAvailability: 'available' as const,
+    mutedAvailability: 'available' as const,
     setVolume: vi.fn(),
     toggleMuted: vi.fn(),
   };

--- a/packages/store/src/core/combine.ts
+++ b/packages/store/src/core/combine.ts
@@ -9,6 +9,7 @@ import type {
   UnionSliceDerivedState,
   UnionSliceSourceState,
 } from './slice';
+import { registerCombinedSlice } from './slice-identity';
 
 type CombinedTarget<Slices extends readonly AnySlice[]> = Slices extends readonly []
   ? unknown
@@ -32,7 +33,7 @@ export function combine<const Slices extends readonly AnySlice[]>(
     warnDuplicates('derived', derivedDefinitions);
   }
 
-  return {
+  const combined: Slice<Target, SourceState, UnionSliceDerivedState<Slices>> = {
     state: (ctx: StateContext<Target>) => {
       const states = slices.map((slice) => slice.state(ctx));
 
@@ -58,6 +59,10 @@ export function combine<const Slices extends readonly AnySlice[]>(
       }
     },
   };
+
+  registerCombinedSlice(combined, slices);
+
+  return combined;
 }
 
 function warnDuplicates(namespace: string, objects: readonly object[]): void {

--- a/packages/store/src/core/selector.ts
+++ b/packages/store/src/core/selector.ts
@@ -3,6 +3,7 @@ import { AbortControllerRegistry } from './abort-controller-registry';
 import { throwNoTargetError } from './errors';
 import type { Selector } from './shallow-equal';
 import type { AnySlice, InferSliceState, StateContext } from './slice';
+import { snapshotHasSlice } from './slice-identity';
 
 const stateContext: StateContext<unknown> = {
   target: throwNoTargetError,
@@ -17,6 +18,10 @@ const stateContext: StateContext<unknown> = {
  * The selector returns the slice's state, or `undefined` if the slice
  * is not configured in the store.
  *
+ * Store-owned snapshots use exact slice identity. Plain objects and copied
+ * snapshots fall back to requiring every source and derived key, so they
+ * cannot distinguish independently defined slices with the same shape.
+ *
  * @example
  * ```ts
  * const selectPlayback = createSelector(playbackSlice);
@@ -30,16 +35,15 @@ export function createSelector<S extends AnySlice>(slice: S): Selector<object, I
   const initialState = slice.state(stateContext);
   const keys = [...Object.keys(initialState as object), ...Object.keys(slice.derived ?? {})];
 
-  const firstKey = keys[0];
-
-  if (!firstKey) {
-    return Object.assign(() => undefined, { displayName: slice.name });
-  }
-
   return Object.assign(
     (state: object) => {
-      // WARN: Could be the source of a bug if two slices have overlapping state keys
-      if (!(firstKey in state)) return undefined;
+      const isConfigured = snapshotHasSlice(state, slice);
+
+      if (isConfigured === false) return undefined;
+      if (isConfigured === undefined && (keys.length === 0 || !keys.every((key) => Object.hasOwn(state, key)))) {
+        return undefined;
+      }
+
       return pick(state as Record<string, unknown>, keys) as InferSliceState<S>;
     },
     { displayName: slice.name }

--- a/packages/store/src/core/slice-identity.ts
+++ b/packages/store/src/core/slice-identity.ts
@@ -1,0 +1,55 @@
+import type { AnySlice } from './slice';
+
+type SliceIdentity = symbol;
+type SliceMembership = ReadonlySet<SliceIdentity>;
+
+const sliceIdentities = new WeakMap<AnySlice, SliceIdentity>();
+const sliceMemberships = new WeakMap<AnySlice, SliceMembership>();
+const snapshotMemberships = new WeakMap<object, SliceMembership>();
+
+/** Returns the stable runtime membership represented by a slice. */
+export function getSliceMembership(slice: AnySlice): SliceMembership {
+  let membership = sliceMemberships.get(slice);
+
+  if (!membership) {
+    membership = new Set([getSliceIdentity(slice)]);
+    sliceMemberships.set(slice, membership);
+  }
+
+  return membership;
+}
+
+/** Preserves the identity of a combined slice and every slice it contains. */
+export function registerCombinedSlice(slice: AnySlice, children: readonly AnySlice[]): void {
+  const membership = new Set<SliceIdentity>([getSliceIdentity(slice)]);
+
+  for (const child of children) {
+    for (const identity of getSliceMembership(child)) {
+      membership.add(identity);
+    }
+  }
+
+  sliceMemberships.set(slice, membership);
+}
+
+/** Associates slice membership with the final immutable public snapshot. */
+export function registerSnapshot(snapshot: object, membership: SliceMembership): void {
+  snapshotMemberships.set(snapshot, membership);
+}
+
+/** Returns `undefined` for ordinary objects that are not store snapshots. */
+export function snapshotHasSlice(snapshot: object, slice: AnySlice): boolean | undefined {
+  const membership = snapshotMemberships.get(snapshot);
+  return membership?.has(getSliceIdentity(slice));
+}
+
+function getSliceIdentity(slice: AnySlice): SliceIdentity {
+  let identity = sliceIdentities.get(slice);
+
+  if (!identity) {
+    identity = Symbol(slice.name);
+    sliceIdentities.set(slice, identity);
+  }
+
+  return identity;
+}

--- a/packages/store/src/core/store.ts
+++ b/packages/store/src/core/store.ts
@@ -11,6 +11,7 @@ import type {
   Slice,
   StateContext,
 } from './slice';
+import { getSliceMembership, registerSnapshot } from './slice-identity';
 import type { StateChange, State as StateContainer, SubscribeOptions, UnknownState, WritableState } from './state';
 import { createState } from './state';
 
@@ -36,6 +37,8 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
     type DerivedState = InferSliceDerivedState<S>;
     type PublicState = InferSliceState<S>;
     type TargetStore = Store<Target, PublicState>;
+
+    const sliceMembership = getSliceMembership(slice);
 
     // Closure state
     let target: Target | null = null;
@@ -69,6 +72,7 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
     sourceState = initialSourceState;
     const initialDerivedState = derive(sourceState);
     state = createState(publish(sourceState, initialDerivedState));
+    registerSnapshot(state.current as object, sliceMembership);
 
     const store = {
       [STORE_SYMBOL]: true,
@@ -148,6 +152,7 @@ export function createStore<Target = unknown>(): StoreFactory<Target> {
       const nextDerived = derive(patched.next);
       sourceState = patched.next;
       state.replace(publish(sourceState, nextDerived));
+      registerSnapshot(state.current as object, sliceMembership);
     }
 
     function attach(newTarget: Target): () => void {

--- a/packages/store/src/core/tests/selector.test.ts
+++ b/packages/store/src/core/tests/selector.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { combine } from '../combine';
 import { createSelector } from '../selector';
 import { defineSlice } from '../slice';
+import { createStore } from '../store';
 
 const NativeAbortController = globalThis.AbortController;
 
@@ -47,6 +49,42 @@ describe('createSelector', () => {
     });
   });
 
+  it('selects a leaf slice configured directly in a store', () => {
+    const selectVolume = createSelector(volumeSlice);
+    const store = createStore<MockMedia>()(volumeSlice);
+
+    expect(selectVolume(store.state)).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+    });
+  });
+
+  it('registers replacement snapshots without changing public snapshot keys', () => {
+    const countSlice = defineSlice<MockMedia>()({
+      state: ({ set }) => ({
+        count: 0,
+        setCount: (count: number) => set({ count }),
+      }),
+    });
+    const sameShapeSlice = defineSlice<MockMedia>()({
+      state: () => ({
+        count: 1,
+        setCount: (count: number) => count,
+      }),
+    });
+    const selectCount = createSelector(countSlice);
+    const selectSameShape = createSelector(sameShapeSlice);
+    const store = createStore<MockMedia>()(countSlice);
+
+    expect(Object.getOwnPropertySymbols(store.state)).toEqual([]);
+    expect(selectSameShape(store.state)).toBeUndefined();
+    store.setCount(1);
+    expect(Object.getOwnPropertySymbols(store.state)).toEqual([]);
+    expect(selectCount(store.state)).toEqual({ count: 1, setCount: store.setCount });
+    expect(selectSameShape(store.state)).toBeUndefined();
+  });
+
   it('returns undefined when slice is not configured', () => {
     const selectVolume = createSelector(volumeSlice);
     const state = { paused: true, ended: false }; // No volume keys
@@ -54,6 +92,82 @@ describe('createSelector', () => {
     const selected = selectVolume(state);
 
     expect(selected).toBeUndefined();
+  });
+
+  it('requires every slice key when selecting from a plain object', () => {
+    const selectVolume = createSelector(volumeSlice);
+
+    expect(selectVolume({ volume: 0.5 })).toBeUndefined();
+    expect(selectVolume({ volume: 0.5, muted: true })).toBeUndefined();
+  });
+
+  it('falls back to all-key detection for a copied store snapshot', () => {
+    const selectVolume = createSelector(volumeSlice);
+    const store = createStore<MockMedia>()(volumeSlice);
+
+    expect(selectVolume({ ...store.state })).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+    });
+  });
+
+  it('uses slice identity when store keys overlap an unconfigured slice', () => {
+    const sameShapeSlice = defineSlice<MockMedia>()({
+      state: () => ({
+        volume: 0.25,
+        muted: true,
+        setVolume: (value: number) => value,
+      }),
+    });
+    const store = createStore<MockMedia>()(sameShapeSlice);
+
+    const selectVolume = createSelector(volumeSlice);
+
+    expect(selectVolume(store.state)).toBeUndefined();
+    expect(selectVolume({ ...store.state })).toEqual({
+      volume: 0.25,
+      muted: true,
+      setVolume: store.setVolume,
+    });
+    expect(createSelector(sameShapeSlice)(store.state)).toEqual({
+      volume: 0.25,
+      muted: true,
+      setVolume: store.setVolume,
+    });
+  });
+
+  it('preserves leaf and combined membership', () => {
+    const combinedSlice = combine(volumeSlice, playbackSlice);
+    const store = createStore<MockMedia>()(combinedSlice);
+
+    expect(createSelector(volumeSlice)(store.state)).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+    });
+    expect(createSelector(playbackSlice)(store.state)).toEqual({ paused: true, ended: false });
+    expect(createSelector(combinedSlice)(store.state)).toEqual({
+      volume: 1,
+      muted: false,
+      setVolume: store.setVolume,
+      paused: true,
+      ended: false,
+    });
+  });
+
+  it('preserves membership through nested combinations', () => {
+    const presentationSlice = defineSlice<MockMedia>()({
+      state: () => ({ fullscreen: false }),
+    });
+    const mediaSlice = combine(volumeSlice, playbackSlice);
+    const playerSlice = combine(mediaSlice, presentationSlice);
+    const store = createStore<MockMedia>()(playerSlice);
+
+    expect(createSelector(volumeSlice)(store.state)).toBeDefined();
+    expect(createSelector(mediaSlice)(store.state)).toBeDefined();
+    expect(createSelector(presentationSlice)(store.state)).toEqual({ fullscreen: false });
+    expect(createSelector(playerSlice)(store.state)).toBeDefined();
   });
 
   it('creates separate selectors for different slices', () => {
@@ -111,15 +225,26 @@ describe('createSelector', () => {
     expect(selector.displayName).toBeUndefined();
   });
 
-  it('returns undefined for empty-state slice', () => {
+  it('selects an empty slice only from a store that contains it', () => {
     const emptySlice = defineSlice<MockMedia>()({
       name: 'empty',
       state: () => ({}),
     });
     const selector = createSelector(emptySlice);
+    const store = createStore<MockMedia>()(emptySlice);
 
     expect(selector({})).toBeUndefined();
+    expect(selector(store.state)).toEqual({});
     expect(selector.displayName).toBe('empty');
+  });
+
+  it('preserves empty leaf membership when combined', () => {
+    const emptySlice = defineSlice<MockMedia>()({ state: () => ({}) });
+    const combinedSlice = combine(emptySlice, playbackSlice);
+    const store = createStore<MockMedia>()(combinedSlice);
+
+    expect(createSelector(emptySlice)(store.state)).toEqual({});
+    expect(createSelector(combinedSlice)(store.state)).toEqual({ paused: true, ended: false });
   });
 
   // Runtimes such as Cloudflare Workers throw when I/O-bound objects are created during

--- a/site/src/content/docs/reference/create-selector.mdx
+++ b/site/src/content/docs/reference/create-selector.mdx
@@ -9,6 +9,8 @@ import FrameworkCase from "@/components/docs/FrameworkCase.astro";
 
 `createSelector` creates a type-safe selector function for a given slice. The returned selector extracts that slice's state from the full store state, or returns `undefined` if the slice is not configured.
 
+Snapshots returned by `createStore` use exact slice identity. Plain objects and copied snapshots use a compatibility fallback that requires every source and derived key, so independently defined slices with the same shape cannot be distinguished after copying.
+
 The built-in selectors (<DocsLink slug="reference/feature-playback">`selectPlayback`</DocsLink>, <DocsLink slug="reference/feature-buffer">`selectBuffer`</DocsLink>, etc.) are all created with `createSelector`. Use it to create selectors for custom slices.
 
 ```ts title="my-custom-selector.ts"


### PR DESCRIPTION
Refs #2362

## Summary

Make slice selectors use runtime slice membership for store-owned snapshots, preventing overlapping state keys from making an unconfigured UI feature appear present.

## Changes

- Assign internal symbol identities to slice objects and preserve leaf membership through nested combinations
- Track membership on final snapshots with weak maps without exposing metadata in public state
- Use exact membership for store snapshots and all-key compatibility detection for plain or copied objects
- Document the plain-object fallback and cover empty, nested, replacement, and same-shape cases
- Align core and HTML test stores with the actual built-in slices they exercise
- Keep deliberate React plain-object mocks complete enough to satisfy the documented fallback contract

<details>
<summary>Implementation notes</summary>

Identities and snapshot membership are held weakly. The public slice and state shapes remain unchanged. Copied objects lose exact slice provenance and therefore use the documented shape-based fallback.

</details>

## Testing

- `pnpm -F @videojs/store test`
- `pnpm -F @videojs/store build`
- `pnpm -F @videojs/core test`
- `pnpm -F @videojs/html test`
- `pnpm -F @videojs/react test`
- Core, HTML, and React package typechecks
- `pnpm -F site api-docs`
- `pnpm -F site astro check`