### PR TITLE
fix(core): reject player feature collisions

### DIFF
--- a/packages/core/src/dom/feature.ts
+++ b/packages/core/src/dom/feature.ts
@@ -1,4 +1,4 @@
-import type { DerivedContext, SliceConfig } from '@videojs/store';
+import { combine, type DerivedContext, type SliceConfig, type StateContext } from '@videojs/store';
 import type { AnyPlayerFeature, PlayerFeature, PlayerFeatureConfig, PlayerTarget } from './player';
 
 type DerivedFunctions<State> = Record<string, (ctx: DerivedContext<State>) => unknown>;
@@ -39,6 +39,46 @@ export function definePlayerFeature<State>(
   } as PlayerFeature<State>;
 }
 
+/**
+ * Strictly compose player features into the slice and configuration consumed by
+ * framework player factories.
+ *
+ * Player state is a flat public namespace, so ambiguous ownership is rejected
+ * before a store can publish an overwritten value. Configuration inputs use
+ * their own flat namespace and are checked independently from player state.
+ * Configuration collisions throw while the features are composed. Source and
+ * derived state collisions throw later, when a store initializes the returned
+ * slice with its real state context; feature state factories are not probed.
+ *
+ * @param features - The player features to validate and combine.
+ * @throws A `TypeError` when an effective key has more than one owner.
+ */
+export function combinePlayerFeatures<const Features extends readonly AnyPlayerFeature[]>(features: Features) {
+  const selectedFeatures = [...features] as [...Features];
+  const selectedDefinitions = selectedFeatures.map((feature, index) => ({
+    derivedKeys: Object.keys(feature.derived ?? {}),
+    owner: { index, name: feature.name },
+  }));
+  const config = combineStrictPlayerFeatureConfigs(selectedFeatures);
+  const slice = combine(...selectedFeatures);
+
+  // Preserve the exact object returned by combine() so any runtime metadata
+  // associated with that slice remains intact.
+  slice.state = ((ctx: StateContext<PlayerTarget>) => {
+    const states = selectedFeatures.map((feature) => feature.state(ctx));
+    const owners = new Map<PropertyKey, FeatureKeyOwner>();
+
+    for (const [index, definition] of selectedDefinitions.entries()) {
+      registerKeys(owners, enumerableOwnKeys(Object(states[index])), 'source state', definition.owner);
+      registerKeys(owners, definition.derivedKeys, 'derived state', definition.owner);
+    }
+
+    return Object.assign({}, ...states);
+  }) as typeof slice.state;
+
+  return { slice, config };
+}
+
 /** Merge the configuration declarations from the selected player features. */
 export function combinePlayerFeatureConfigs(features: readonly AnyPlayerFeature[]): PlayerFeatureConfig {
   const definitions = features.map((feature) => feature.config ?? {});
@@ -65,4 +105,59 @@ export function setPlayerConfigValue(store: object, entry: PlayerFeatureConfig[s
     throw new TypeError(`Missing config action "${String(entry.action)}"`);
   }
   action(value);
+}
+
+type FeatureKeyNamespace = 'source state' | 'derived state' | 'config';
+
+interface FeatureOwner {
+  index: number;
+  name?: string | undefined;
+}
+
+interface FeatureKeyOwner extends FeatureOwner {
+  namespace: FeatureKeyNamespace;
+}
+
+function combineStrictPlayerFeatureConfigs(features: readonly AnyPlayerFeature[]): PlayerFeatureConfig {
+  const owners = new Map<PropertyKey, FeatureKeyOwner>();
+
+  for (const [index, feature] of features.entries()) {
+    registerKeys(owners, Object.keys(feature.config ?? {}), 'config', { index, name: feature.name });
+  }
+
+  return Object.assign({}, ...features.map((feature) => feature.config ?? {}));
+}
+
+function enumerableOwnKeys(object: object): PropertyKey[] {
+  return Reflect.ownKeys(object).filter((key) => Object.prototype.propertyIsEnumerable.call(object, key));
+}
+
+function registerKeys(
+  owners: Map<PropertyKey, FeatureKeyOwner>,
+  keys: readonly PropertyKey[],
+  namespace: FeatureKeyNamespace,
+  owner: FeatureOwner
+): void {
+  for (const key of keys) {
+    const previous = owners.get(key);
+    const next = { ...owner, namespace };
+
+    if (previous) throwFeatureKeyCollision(key, previous, next);
+    owners.set(key, next);
+  }
+}
+
+function throwFeatureKeyCollision(key: PropertyKey, first: FeatureKeyOwner, second: FeatureKeyOwner): never {
+  throw new TypeError(
+    `[vjs-core] Cannot compose player features: key ${formatKey(key)} conflicts between namespace "${first.namespace}" owned by ${formatOwner(first)} and namespace "${second.namespace}" owned by ${formatOwner(second)}.`
+  );
+}
+
+function formatKey(key: PropertyKey): string {
+  return typeof key === 'string' ? JSON.stringify(key) : String(key);
+}
+
+function formatOwner(owner: FeatureOwner): string {
+  const position = owner.index + 1;
+  return owner.name ? `feature ${JSON.stringify(owner.name)} (#${position})` : `anonymous feature #${position}`;
 }

--- a/packages/core/src/dom/tests/feature.test.ts
+++ b/packages/core/src/dom/tests/feature.test.ts
@@ -1,7 +1,12 @@
 import { createSelector, createStore, type StateContext } from '@videojs/store';
-import { assertType, describe, expect, it } from 'vitest';
-import { combinePlayerFeatureConfigs, definePlayerFeature, setPlayerConfigValue } from '../feature';
-import type { PlayerFeatureConfig, PlayerTarget } from '../player';
+import { assertType, describe, expect, it, vi } from 'vitest';
+import {
+  combinePlayerFeatureConfigs,
+  combinePlayerFeatures,
+  definePlayerFeature,
+  setPlayerConfigValue,
+} from '../feature';
+import type { AnyPlayerFeature, PlayerFeatureConfig, PlayerTarget } from '../player';
 
 const stateContext = {
   target: () => {
@@ -129,5 +134,351 @@ describe('definePlayerFeature', () => {
         state: 'size',
       },
     });
+  });
+});
+
+describe('combinePlayerFeatures', () => {
+  it('defers each state factory until store creation and calls it once', () => {
+    const firstState = vi.fn(() => ({ first: 1 }));
+    const secondState = vi.fn(({ set }: StateContext<PlayerTarget>) => ({
+      label: '',
+      setLabel: (value: string | null | undefined) => set({ label: value ?? '' }),
+    }));
+    const first = definePlayerFeature({
+      name: 'first',
+      state: firstState,
+      derived: {
+        doubled: ({ get }) => get().first * 2,
+      },
+    });
+    const second = definePlayerFeature({
+      name: 'second',
+      config: {
+        label: {
+          action: 'setLabel',
+          state: 'label',
+        },
+      } satisfies PlayerFeatureConfig<{
+        label: string;
+        setLabel(value: string | null | undefined): void;
+      }>,
+      state: secondState,
+    });
+
+    const { slice, config } = combinePlayerFeatures([first, second]);
+
+    expect(firstState).not.toHaveBeenCalled();
+    expect(secondState).not.toHaveBeenCalled();
+
+    const store = createStore<PlayerTarget>()(slice);
+
+    expect(firstState).toHaveBeenCalledOnce();
+    expect(secondState).toHaveBeenCalledOnce();
+    expect(store.state).toMatchObject({ first: 1, doubled: 2, label: '' });
+    expect(config).toEqual(second.config);
+  });
+
+  it('snapshots the selected features before deferred state initialization', () => {
+    const firstState = vi.fn(() => ({ count: 2 }));
+    const firstAttach = vi.fn();
+    const secondAttach = vi.fn();
+    const replacementState = vi.fn(() => ({ replacement: true }));
+    const replacementAttach = vi.fn();
+    const first = definePlayerFeature({
+      name: 'first',
+      config: {
+        label: { action: 'setLabel', state: 'label' },
+      },
+      state: ({
+        set,
+      }): {
+        count: number;
+        label: string;
+        setLabel(value: string | null | undefined): void;
+      } => ({
+        ...firstState(),
+        label: '',
+        setLabel: (value) => set({ label: value ?? '' }),
+      }),
+      derived: {
+        doubled: ({ get }) => get().count * 2,
+      },
+      attach: firstAttach,
+    });
+    const second = definePlayerFeature({
+      name: 'second',
+      state: () => ({ enabled: true }),
+      attach: secondAttach,
+    });
+    const replacement = definePlayerFeature({
+      name: 'replacement',
+      config: {
+        replacement: { action: 'setReplacement', state: 'replacement' },
+      },
+      state: ({ set }) => ({
+        ...replacementState(),
+        setReplacement: (value: string | null | undefined) => set({ replacement: value }),
+      }),
+      derived: {
+        replaced: () => true,
+      },
+      attach: replacementAttach,
+    });
+    const selected: AnyPlayerFeature[] = [first, second];
+    const { slice, config } = combinePlayerFeatures(selected);
+
+    selected.splice(0, selected.length, replacement);
+
+    const store = createStore<PlayerTarget>()(slice);
+    store.attach({} as PlayerTarget);
+
+    expect(store.state).toMatchObject({ count: 2, doubled: 4, enabled: true, label: '' });
+    expect(store.state).not.toHaveProperty('replacement');
+    expect(store.state).not.toHaveProperty('replaced');
+    expect(config).toEqual(first.config);
+    expect(firstState).toHaveBeenCalledOnce();
+    expect(replacementState).not.toHaveBeenCalled();
+    expect(firstAttach).toHaveBeenCalledOnce();
+    expect(secondAttach).toHaveBeenCalledOnce();
+    expect(replacementAttach).not.toHaveBeenCalled();
+  });
+
+  it('uses the selected feature snapshot in deferred collision diagnostics', () => {
+    const first = definePlayerFeature({
+      name: 'first',
+      state: () => ({ shared: 1 }),
+    });
+    const second = definePlayerFeature({
+      name: 'second',
+      state: () => ({ shared: 2 }),
+    });
+    const replacement = definePlayerFeature({
+      name: 'replacement',
+      state: () => ({ replacement: true }),
+    });
+    const selected: AnyPlayerFeature[] = [first, second];
+    const { slice } = combinePlayerFeatures(selected);
+
+    selected.splice(0, selected.length, replacement);
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(/key "shared".*feature "first".*feature "second"/);
+  });
+
+  it('snapshots derived keys and their owners before deferred state initialization', () => {
+    const source = definePlayerFeature({
+      name: 'source',
+      state: () => ({ shared: 1 }),
+    });
+    const derived = definePlayerFeature({
+      name: 'derived',
+      state: () => ({ input: 2 }),
+      derived: { shared: ({ get }) => get().input },
+    });
+    const { slice } = combinePlayerFeatures([source, derived]);
+
+    (derived as AnyPlayerFeature).derived = {};
+    (derived as AnyPlayerFeature).name = 'renamed';
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(/key "shared".*feature "source".*feature "derived"/);
+  });
+
+  it('rejects source state collisions', () => {
+    const first = definePlayerFeature({
+      name: 'first',
+      state: () => ({ shared: 1 }),
+    });
+    const second = definePlayerFeature({
+      name: 'second',
+      state: () => ({ shared: 2 }),
+    });
+    const { slice } = combinePlayerFeatures([first, second]);
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(
+      '[vjs-core] Cannot compose player features: key "shared" conflicts between namespace "source state" owned by feature "first" (#1) and namespace "source state" owned by feature "second" (#2).'
+    );
+  });
+
+  it('rejects derived state collisions', () => {
+    const first = definePlayerFeature({
+      name: 'first',
+      state: () => ({ first: 1 }),
+      derived: { shared: () => 1 },
+    });
+    const second = definePlayerFeature({
+      name: 'second',
+      state: () => ({ second: 2 }),
+      derived: { shared: () => 2 },
+    });
+    const { slice } = combinePlayerFeatures([first, second]);
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(
+      /key "shared" conflicts between namespace "derived state" owned by feature "first" \(#1\) and namespace "derived state" owned by feature "second" \(#2\)/
+    );
+  });
+
+  it('rejects source and derived state collisions across features', () => {
+    const source = definePlayerFeature({
+      name: 'source',
+      state: () => ({ shared: 1 }),
+    });
+    const derived = definePlayerFeature({
+      name: 'derived',
+      state: () => ({ input: 2 }),
+      derived: { shared: ({ get }) => get().input },
+    });
+    const { slice } = combinePlayerFeatures([source, derived]);
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(
+      /key "shared" conflicts between namespace "source state" owned by feature "source" \(#1\) and namespace "derived state" owned by feature "derived" \(#2\)/
+    );
+  });
+
+  it('rejects source and derived state collisions within one feature', () => {
+    const feature = definePlayerFeature({
+      name: 'overlapping',
+      state: () => ({ shared: 1 }),
+      derived: { shared: ({ get }) => get().shared + 1 },
+    });
+    const { slice } = combinePlayerFeatures([feature]);
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(
+      /key "shared" conflicts between namespace "source state" owned by feature "overlapping" \(#1\) and namespace "derived state" owned by feature "overlapping" \(#1\)/
+    );
+  });
+
+  it('rejects configuration collisions', () => {
+    const first = definePlayerFeature({
+      name: 'first',
+      config: { shared: { action: 'setFirst', state: 'first' } },
+      state: ({ set }) => ({
+        first: '',
+        setFirst: (value: string | null | undefined) => set({ first: value ?? '' }),
+      }),
+    });
+    const second = definePlayerFeature({
+      name: 'second',
+      config: { shared: { action: 'setSecond', state: 'second' } },
+      state: ({ set }) => ({
+        second: '',
+        setSecond: (value: string | null | undefined) => set({ second: value ?? '' }),
+      }),
+    });
+
+    expect(() => combinePlayerFeatures([first, second])).toThrowError(
+      /key "shared" conflicts between namespace "config" owned by feature "first" \(#1\) and namespace "config" owned by feature "second" \(#2\)/
+    );
+  });
+
+  it('compares symbol keys by identity and formats anonymous owners', () => {
+    const shared = Symbol('shared');
+    const first = definePlayerFeature({
+      state: () => ({ [shared]: 1 }),
+    });
+    const second = definePlayerFeature({
+      state: () => ({ [shared]: 2 }),
+    });
+    const { slice } = combinePlayerFeatures([first, second]);
+
+    expect(() => createStore<PlayerTarget>()(slice)).toThrowError(
+      /key Symbol\(shared\).*anonymous feature #1.*anonymous feature #2/
+    );
+
+    const distinct = combinePlayerFeatures([
+      definePlayerFeature({ state: () => ({ [Symbol('shared')]: 1 }) }),
+      definePlayerFeature({ state: () => ({ [Symbol('shared')]: 2 }) }),
+    ]);
+
+    expect(() => createStore<PlayerTarget>()(distinct.slice)).not.toThrow();
+  });
+
+  it('ignores non-enumerable source, derived, and configuration keys', () => {
+    const hiddenSource = Symbol('hidden-source');
+    const firstState = { first: 1 };
+    const secondState = { second: 2 };
+    Object.defineProperties(firstState, {
+      hidden: { value: 1 },
+      [hiddenSource]: { value: 1 },
+    });
+    Object.defineProperties(secondState, {
+      hidden: { value: 2 },
+      [hiddenSource]: { value: 2 },
+    });
+
+    const hiddenDerived = {} as Record<string, () => number>;
+    Object.defineProperty(hiddenDerived, 'first', { value: () => 2 });
+
+    const hiddenConfig = {} as PlayerFeatureConfig;
+    Object.defineProperty(hiddenConfig, 'label', {
+      value: { action: 'setLabel', state: 'label' },
+    });
+
+    const { slice, config } = combinePlayerFeatures([
+      definePlayerFeature({
+        state: () => firstState,
+      }),
+      definePlayerFeature({
+        config: hiddenConfig,
+        state: () => secondState,
+        derived: hiddenDerived,
+      }),
+      definePlayerFeature({
+        config: {
+          label: { action: 'setLabel', state: 'label' },
+        },
+        state: ({ set }) => ({
+          label: '',
+          setLabel: (value: string | null | undefined) => set({ label: value ?? '' }),
+        }),
+      }),
+    ]);
+
+    const store = createStore<PlayerTarget>()(slice);
+
+    expect(store.state).toMatchObject({ first: 1, second: 2, label: '' });
+    expect(Object.getOwnPropertySymbols(store.state)).toEqual([]);
+    expect(config).toEqual({
+      label: { action: 'setLabel', state: 'label' },
+    });
+  });
+});
+
+describe('combinePlayerFeatureConfigs', () => {
+  it('keeps legacy last-wins behavior and warns in development', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const first = definePlayerFeature({
+      config: { shared: { action: 'setFirst', state: 'first' } },
+      state: () => ({ first: '', setFirst: () => {} }),
+    });
+    const second = definePlayerFeature({
+      config: { shared: { action: 'setSecond', state: 'second' } },
+      state: () => ({ second: '', setSecond: () => {} }),
+    });
+
+    expect(combinePlayerFeatureConfigs([first, second])).toEqual(second.config);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate config key "shared"'));
+
+    warn.mockRestore();
+  });
+
+  it('does not evaluate state factories', () => {
+    const feature = definePlayerFeature({
+      config: {
+        label: {
+          action: 'setLabel',
+          state: 'label',
+        },
+      } satisfies PlayerFeatureConfig<{
+        label: string;
+        setLabel(value: string | null | undefined): void;
+      }>,
+      state: (): {
+        label: string;
+        setLabel(value: string | null | undefined): void;
+      } => {
+        throw new Error('state should not be evaluated');
+      },
+    });
+
+    expect(combinePlayerFeatureConfigs([feature])).toEqual(feature.config);
   });
 });

--- a/packages/html/src/player/create-player.ts
+++ b/packages/html/src/player/create-player.ts
@@ -2,13 +2,13 @@ import {
   type AnyPlayerFeature,
   type AudioFeatures,
   type AudioPlayerStore,
-  combinePlayerFeatureConfigs,
+  combinePlayerFeatures,
   type PlayerStore,
   type PlayerTarget,
   type VideoFeatures,
   type VideoPlayerStore,
 } from '@videojs/core/dom';
-import { combine, createStore } from '@videojs/store';
+import { createStore } from '@videojs/store';
 
 import { createProviderMixin, type ProviderMixin } from '../store/provider-mixin';
 import { containerContext, mediaContext, type PlayerContext, playerContext } from './context';
@@ -78,8 +78,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 ): CreatePlayerResult<PlayerStore<Features>>;
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<PlayerStore> {
-  const slice = combine(...config.features);
-  const featureConfig = combinePlayerFeatureConfigs(config.features);
+  const { slice, config: featureConfig } = combinePlayerFeatures(config.features);
 
   function create(): PlayerStore {
     return createStore<PlayerTarget>()(slice);

--- a/packages/html/src/player/tests/create-player.test.ts
+++ b/packages/html/src/player/tests/create-player.test.ts
@@ -1,6 +1,7 @@
 import {
   audioFeatures,
   backgroundFeatures,
+  definePlayerFeature,
   features,
   metadataFeature,
   type PopupGroup,
@@ -35,6 +36,88 @@ describe('createPlayer', () => {
     expect(result.PlayerController).toBeDefined();
     expect(result.ProviderMixin).toBeInstanceOf(Function);
     expect(result).not.toHaveProperty('ContainerMixin');
+  });
+
+  it('rejects ambiguous player feature state when creating a store', () => {
+    const first = definePlayerFeature({
+      name: 'html-first',
+      state: () => ({ shared: 1 }),
+    });
+    const second = definePlayerFeature({
+      name: 'html-second',
+      state: () => ({ shared: 2 }),
+    });
+    const player = createPlayer({ features: [first, second] });
+
+    expect(() => player.create()).toThrowError(/key "shared".*feature "html-first".*feature "html-second"/);
+  });
+
+  it('rejects configuration aliases that resolve to the same provider attribute', () => {
+    const first = definePlayerFeature({
+      name: 'html-first',
+      config: {
+        firstInput: {
+          action: 'setFirst',
+          state: 'first',
+          html: { attribute: 'shared-input' },
+        },
+      },
+      state: ({ set }) => ({
+        first: '',
+        setFirst: (value: string | null | undefined) => set({ first: value ?? '' }),
+      }),
+    });
+    const second = definePlayerFeature({
+      name: 'html-second',
+      config: {
+        secondInput: {
+          action: 'setSecond',
+          state: 'second',
+          html: { attribute: 'shared-input' },
+        },
+      },
+      state: ({ set }) => ({
+        second: '',
+        setSecond: (value: string | null | undefined) => set({ second: value ?? '' }),
+      }),
+    });
+
+    expect(() => createPlayer({ features: [first, second] })).toThrowError(
+      '[vjs-html] Cannot create player provider: config inputs "firstInput" and "secondInput" resolve to the same provider attribute "shared-input".'
+    );
+  });
+
+  it('rejects configuration aliases that resolve to the same provider property', () => {
+    const first = definePlayerFeature({
+      config: {
+        firstInput: {
+          action: 'setFirst',
+          state: 'first',
+          html: { attribute: 'shared-1input' },
+        },
+      },
+      state: ({ set }) => ({
+        first: '',
+        setFirst: (value: string | null | undefined) => set({ first: value ?? '' }),
+      }),
+    });
+    const second = definePlayerFeature({
+      config: {
+        secondInput: {
+          action: 'setSecond',
+          state: 'second',
+          html: { attribute: 'shared1input' },
+        },
+      },
+      state: ({ set }) => ({
+        second: '',
+        setSecond: (value: string | null | undefined) => set({ second: value ?? '' }),
+      }),
+    });
+
+    expect(() => createPlayer({ features: [first, second] })).toThrowError(
+      '[vjs-html] Cannot create player provider: config inputs "firstInput" and "secondInput" resolve to the same provider property "shared1input".'
+    );
   });
 
   it('create() returns a store instance', () => {

--- a/packages/html/src/store/provider-mixin.ts
+++ b/packages/html/src/store/provider-mixin.ts
@@ -28,6 +28,8 @@ export type ProviderMixin<Store extends PlayerStore> = <Class extends MediaEleme
 
 /** One configuration input, under the names it goes by on the element. */
 interface ConfigInput {
+  /** Key declared by the owning player feature. */
+  key: string;
   /** Reactive property mirroring the attribute. */
   property: string;
   attribute: string;
@@ -39,7 +41,7 @@ interface ConfigInput {
  * an `html.attribute` instead, and the property follows from that.
  */
 function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
-  return Object.entries(config).map(([key, entry]) => {
+  const inputs = Object.entries(config).map(([key, entry]) => {
     const declared = entry.html?.attribute;
     const attribute = declared ?? kebabCase(key);
 
@@ -48,8 +50,30 @@ function resolveInputs(config: PlayerFeatureConfig): ConfigInput[] {
       console.warn(`[vjs-html] config html.attribute "${declared}" is not kebab-case and will never match`);
     }
 
-    return { property: camelCase(attribute), attribute, entry };
+    return { key, property: camelCase(attribute), attribute, entry };
   });
+
+  validateResolvedNames(inputs, 'attribute');
+  validateResolvedNames(inputs, 'property');
+
+  return inputs;
+}
+
+function validateResolvedNames(inputs: readonly ConfigInput[], name: 'attribute' | 'property'): void {
+  const owners = new Map<string, string>();
+
+  for (const input of inputs) {
+    const value = input[name];
+    const previous = owners.get(value);
+
+    if (previous !== undefined) {
+      throw new TypeError(
+        `[vjs-html] Cannot create player provider: config inputs ${JSON.stringify(previous)} and ${JSON.stringify(input.key)} resolve to the same provider ${name} ${JSON.stringify(value)}.`
+      );
+    }
+
+    owners.set(value, input.key);
+  }
 }
 
 /**

--- a/packages/react/src/player/create-player.tsx
+++ b/packages/react/src/player/create-player.tsx
@@ -3,7 +3,7 @@ import {
   type AnyPlayerStore,
   type AudioFeatures,
   type AudioPlayerStore,
-  combinePlayerFeatureConfigs,
+  combinePlayerFeatures,
   type InferPlayerConfig,
   type PlayerFeatureConfig,
   type PlayerStore,
@@ -14,7 +14,7 @@ import {
 } from '@videojs/core/dom';
 import type { Media } from '@videojs/media/dom';
 import type { InferStoreState } from '@videojs/store';
-import { combine, createStore } from '@videojs/store';
+import { createStore } from '@videojs/store';
 import { useStore } from '@videojs/store/react';
 import { pick } from '@videojs/utils/object';
 import type { FC, ReactNode } from 'react';
@@ -72,8 +72,7 @@ export function createPlayer<const Features extends AnyPlayerFeature[]>(
 ): CreatePlayerResult<PlayerStore<Features>>;
 
 export function createPlayer(config: CreatePlayerConfig<AnyPlayerFeature[]>): CreatePlayerResult<AnyPlayerStore> {
-  const slice = combine(...config.features);
-  const featureConfig = combinePlayerFeatureConfigs(config.features);
+  const { slice, config: featureConfig } = combinePlayerFeatures(config.features);
   const configKeys = Object.keys(featureConfig);
 
   function createConfiguredStore(values: Record<string, unknown>) {

--- a/packages/react/src/player/tests/create-player.test.tsx
+++ b/packages/react/src/player/tests/create-player.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
-import { features, metadataFeature, type PlayerStore } from '@videojs/core/dom';
+import { definePlayerFeature, features, metadataFeature, type PlayerStore } from '@videojs/core/dom';
 import { defineSlice } from '@videojs/store';
 import { Component, type ErrorInfo, type ReactNode, StrictMode, useState } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -21,6 +21,22 @@ describe('createPlayer', () => {
       muted: false,
       paused: true,
     }),
+  });
+
+  it('rejects ambiguous player feature state when rendering a player', () => {
+    const first = definePlayerFeature({
+      name: 'react-first',
+      state: () => ({ shared: 1 }),
+    });
+    const second = definePlayerFeature({
+      name: 'react-second',
+      state: () => ({ shared: 2 }),
+    });
+    const { Player } = createPlayer({ features: [first, second] });
+
+    expect(() => render(<Player>{null}</Player>)).toThrowError(
+      /key "shared".*feature "react-first".*feature "react-second"/
+    );
   });
 
   describe('Player', () => {


### PR DESCRIPTION
Refs #2361

## Summary

Reject ambiguous player-feature compositions before flat state and configuration namespaces can silently overwrite another feature, while preserving generic store composition and the legacy config-only helper.

## Changes

- Add one strict player composition boundary shared by HTML and React
- Validate the exact source objects produced during real store initialization, with each state factory called once
- Reject source, derived, cross-namespace, and configuration collisions with owner-aware diagnostics
- Match the enumerable-key semantics used by the actual store and framework adapters
- Snapshot selected features and derived ownership so deferred validation cannot drift after caller mutation
- Reject HTML configuration aliases that collapse to the same provider property or attribute
- Keep generic `combine()` and `combinePlayerFeatureConfigs()` compatibility unchanged

<details>
<summary>Timing and compatibility</summary>

Configuration collisions fail when features are composed. Source and derived collisions fail when the returned slice initializes with the real store context, avoiding speculative state-factory calls. The exact slice returned by `combine()` is retained so runtime slice metadata remains compatible with identity-aware selectors.

</details>

## Testing

- `pnpm -F @videojs/core test src/dom/tests/feature.test.ts`
- `pnpm -F @videojs/html test src/player/tests/create-player.test.ts`
- `pnpm -F @videojs/react test src/player/tests/create-player.test.tsx`
- `pnpm --filter @videojs/html... --filter @videojs/react... build`
- `pnpm typecheck`
- `pnpm -F site api-docs`