### PR TITLE
fix(html): keep preset UI registration scoped

### DIFF
--- a/apps/e2e/scripts/generate-pages.ts
+++ b/apps/e2e/scripts/generate-pages.ts
@@ -427,6 +427,7 @@ video.innerHTML = \`<track kind="metadata" label="thumbnails" src="\${MEDIA.${re
 poster.src = MEDIA.${resource}.poster;
 poster.alt = 'Video poster';
 
+await import('@videojs/html/video/player');
 await import('@videojs/html/video/ui');
 `;
 }

--- a/packages/html/src/define/audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/audio/minimal-skin.tailwind.ts
@@ -22,7 +22,7 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './minimal-ui';
 
 const SEEK_TIME = 10;

--- a/packages/html/src/define/audio/minimal-skin.ts
+++ b/packages/html/src/define/audio/minimal-skin.ts
@@ -4,7 +4,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './minimal-skin.css?inline';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './minimal-ui';
 
 const SEEK_TIME = 10;

--- a/packages/html/src/define/audio/minimal-ui.ts
+++ b/packages/html/src/define/audio/minimal-ui.ts
@@ -1,6 +1,6 @@
-// Registers the audio player, container, and all audio UI custom elements
-// used by the minimal skin without creating a skin element. Use this entry
-// when building an ejected (light DOM) player layout.
+// Registers the container and all audio UI custom elements used by the minimal
+// skin without creating a player or skin element. Use this entry when building
+// an ejected (light DOM) player layout.
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
@@ -20,12 +20,8 @@ import {
   defineVolumeSlider,
 } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { AudioPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(AudioPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.

--- a/packages/html/src/define/audio/skin.tailwind.ts
+++ b/packages/html/src/define/audio/skin.tailwind.ts
@@ -22,7 +22,7 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './ui';
 
 const SEEK_TIME = 10;

--- a/packages/html/src/define/audio/skin.ts
+++ b/packages/html/src/define/audio/skin.ts
@@ -4,7 +4,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './skin.css?inline';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './ui';
 
 const SEEK_TIME = 10;

--- a/packages/html/src/define/audio/ui.ts
+++ b/packages/html/src/define/audio/ui.ts
@@ -1,6 +1,6 @@
-// Registers the audio player, container, and all audio UI custom elements
-// without creating a skin element. Use this entry when building an ejected
-// (light DOM) player layout.
+// Registers the container and all audio UI custom elements without creating a
+// player or skin element. Use this entry when building an ejected (light DOM)
+// player layout.
 import { I18nProviderElement } from '../../i18n/provider-element';
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
@@ -17,12 +17,8 @@ import { TextElement } from '../../ui/text/text-element';
 import { safeDefine } from '../safe-define';
 import { defineErrorDialog, defineMenu, defineSliders, defineTime, defineTooltip } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { AudioPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(AudioPlayerElement);
 safeDefine(MediaContainerElement);
 safeDefine(I18nProviderElement);
 

--- a/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.tailwind.ts
@@ -17,7 +17,7 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the live audio player, container, and minimal UI custom elements.
+// Register the container and all minimal live audio UI custom elements.
 import './minimal-ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-audio/minimal-skin.ts
+++ b/packages/html/src/define/live-audio/minimal-skin.ts
@@ -4,7 +4,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './minimal-skin.css?inline';
 
-// Register the live audio player, container, and minimal UI custom elements.
+// Register the container and all minimal live audio UI custom elements.
 import './minimal-ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-audio/minimal-ui.ts
+++ b/packages/html/src/define/live-audio/minimal-ui.ts
@@ -1,7 +1,6 @@
-// Registers the live audio player, container, and all audio UI custom
-// elements used by the minimal skin without creating a skin element. Use
-// this entry when building an ejected (light DOM) player layout for live
-// HLS / DASH streams.
+// Registers the container and all live audio UI custom elements used by the
+// minimal skin without creating a player or skin element. Use this entry when
+// building an ejected (light DOM) player layout for live HLS / DASH streams.
 import { MediaContainerElement } from '../../media/container-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { HotkeyElement } from '../../ui/hotkey/hotkey-element';
@@ -12,12 +11,8 @@ import { PopoverElement } from '../../ui/popover/popover-element';
 import { safeDefine } from '../safe-define';
 import { defineErrorDialog, defineTime, defineTimeSlider, defineTooltip, defineVolumeSlider } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { LiveAudioPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(LiveAudioPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.

--- a/packages/html/src/define/live-audio/skin.tailwind.ts
+++ b/packages/html/src/define/live-audio/skin.tailwind.ts
@@ -17,7 +17,7 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the live audio player, container, and all UI custom elements.
+// Register the container and all live audio UI custom elements.
 import './ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-audio/skin.ts
+++ b/packages/html/src/define/live-audio/skin.ts
@@ -4,7 +4,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './skin.css?inline';
 
-// Register the live audio player, container, and all UI custom elements.
+// Register the container and all live audio UI custom elements.
 import './ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-audio/ui.ts
+++ b/packages/html/src/define/live-audio/ui.ts
@@ -1,6 +1,6 @@
-// Registers the live audio player, container, and all audio UI custom
-// elements without creating a skin element. Use this entry when building an
-// ejected (light DOM) player layout for live HLS / DASH streams.
+// Registers the container and all live audio UI custom elements without
+// creating a player or skin element. Use this entry when building an ejected
+// (light DOM) player layout for live HLS / DASH streams.
 
 import { I18nProviderElement } from '../../i18n/provider-element';
 import { MediaContainerElement } from '../../media/container-element';
@@ -15,12 +15,8 @@ import { TextElement } from '../../ui/text/text-element';
 import { safeDefine } from '../safe-define';
 import { defineErrorDialog, defineTime, defineTimeSlider, defineTooltip, defineVolumeSlider } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { LiveAudioPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(LiveAudioPlayerElement);
 safeDefine(MediaContainerElement);
 safeDefine(I18nProviderElement);
 

--- a/packages/html/src/define/live-video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/live-video/minimal-skin.tailwind.ts
@@ -24,7 +24,7 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the live video player, container, and minimal UI custom elements.
+// Register the container and all minimal live video UI custom elements.
 import './minimal-ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-video/minimal-skin.ts
+++ b/packages/html/src/define/live-video/minimal-skin.ts
@@ -4,7 +4,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './minimal-skin.css?inline';
 
-// Register the live video player, container, and minimal UI custom elements.
+// Register the container and all minimal live video UI custom elements.
 import './minimal-ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-video/minimal-ui.ts
+++ b/packages/html/src/define/live-video/minimal-ui.ts
@@ -1,9 +1,9 @@
-// Registers the live video player, container, and all video UI custom
-// elements used by the minimal skin without creating a skin element. Use
-// this entry when building an ejected (light DOM) player layout for live
-// HLS / DASH streams.
-import { AirPlayButtonElement } from '@/ui/airplay-button/airplay-button-element';
+// Registers the container and all live video UI custom elements used by the
+// minimal skin without creating a player or skin element. Use this entry when
+// building an ejected (light DOM) player layout for live HLS / DASH streams.
+
 import { MediaContainerElement } from '../../media/container-element';
+import { AirPlayButtonElement } from '../../ui/airplay-button/airplay-button-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
 import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
@@ -29,12 +29,8 @@ import {
   defineVolumeSlider,
 } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { LiveVideoPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(LiveVideoPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.

--- a/packages/html/src/define/live-video/skin.tailwind.ts
+++ b/packages/html/src/define/live-video/skin.tailwind.ts
@@ -25,7 +25,7 @@ import { cn } from '@videojs/utils/style';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the live video player, container, and all UI custom elements.
+// Register the container and all live video UI custom elements.
 import './ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-video/skin.ts
+++ b/packages/html/src/define/live-video/skin.ts
@@ -4,7 +4,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './skin.css?inline';
 
-// Register the live video player, container, and all UI custom elements.
+// Register the container and all live video UI custom elements.
 import './ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/live-video/ui.ts
+++ b/packages/html/src/define/live-video/ui.ts
@@ -1,10 +1,10 @@
-// Registers the live video player, container, and all video UI custom
-// elements without creating a skin element. Use this entry when building an
-// ejected (light DOM) player layout for live HLS / DASH streams.
+// Registers the container and all live video UI custom elements without
+// creating a player or skin element. Use this entry when building an ejected
+// (light DOM) player layout for live HLS / DASH streams.
 
-import { AirPlayButtonElement } from '@/ui/airplay-button/airplay-button-element';
 import { I18nProviderElement } from '../../i18n/provider-element';
 import { MediaContainerElement } from '../../media/container-element';
+import { AirPlayButtonElement } from '../../ui/airplay-button/airplay-button-element';
 import { BufferingIndicatorElement } from '../../ui/buffering-indicator/buffering-indicator-element';
 import { CaptionsButtonElement } from '../../ui/captions-button/captions-button-element';
 import { CaptionsRadioGroupElement } from '../../ui/captions-radio-group/captions-radio-group-element';
@@ -30,12 +30,8 @@ import {
   defineTooltip,
 } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { LiveVideoPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(LiveVideoPlayerElement);
 safeDefine(MediaContainerElement);
 safeDefine(I18nProviderElement);
 

--- a/packages/html/src/define/tests/preset-ui-registration.test.ts
+++ b/packages/html/src/define/tests/preset-ui-registration.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+describe('preset UI registration', () => {
+  it('registers the container and UI without registering players', async () => {
+    await import('../video/ui');
+    await import('../video/minimal-ui');
+    await import('../audio/ui');
+    await import('../audio/minimal-ui');
+    await import('../live-video/ui');
+    await import('../live-video/minimal-ui');
+    await import('../live-audio/ui');
+    await import('../live-audio/minimal-ui');
+
+    expect(customElements.get('media-container')).toBeDefined();
+    expect(customElements.get('media-text')).toBeDefined();
+    expect(customElements.get('media-menu')).toBeDefined();
+    expect(customElements.get('media-menu-item')).toBeDefined();
+
+    expect(customElements.get('video-player')).toBeUndefined();
+    expect(customElements.get('audio-player')).toBeUndefined();
+    expect(customElements.get('live-video-player')).toBeUndefined();
+    expect(customElements.get('live-audio-player')).toBeUndefined();
+  });
+});

--- a/packages/html/src/define/tests/video-ui-ejected.test.ts
+++ b/packages/html/src/define/tests/video-ui-ejected.test.ts
@@ -32,6 +32,7 @@ describe('video/ui ejected registration', () => {
       </video-player>
     `;
 
+    await import('../video/player');
     await import('../video/ui');
 
     const volumeSlider = document.querySelector('media-volume-slider')! as HTMLElement & { orientation: string };

--- a/packages/html/src/define/video/minimal-skin.tailwind.ts
+++ b/packages/html/src/define/video/minimal-skin.tailwind.ts
@@ -30,7 +30,7 @@ import { renderText } from '../../i18n/render-text';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './minimal-ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/video/minimal-skin.ts
+++ b/packages/html/src/define/video/minimal-skin.ts
@@ -6,7 +6,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './minimal-skin.css?inline';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './minimal-ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/video/minimal-ui.ts
+++ b/packages/html/src/define/video/minimal-ui.ts
@@ -1,6 +1,6 @@
-// Registers the video player, container, and all video UI custom elements
-// used by the minimal skin without creating a skin element. Use this entry
-// when building an ejected (light DOM) player layout.
+// Registers the container and all video UI custom elements used by the minimal
+// skin without creating a player or skin element. Use this entry when building
+// an ejected (light DOM) player layout.
 
 import { MediaContainerElement } from '../../media/container-element';
 import { AirPlayButtonElement } from '../../ui/airplay-button/airplay-button-element';
@@ -36,12 +36,8 @@ import {
 } from '../ui/compounds';
 import '../i18n';
 
-// Value import — player.ts body runs before this module's body.
-import { VideoPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(VideoPlayerElement);
 safeDefine(MediaContainerElement);
 
 // Compound groups.

--- a/packages/html/src/define/video/skin.tailwind.ts
+++ b/packages/html/src/define/video/skin.tailwind.ts
@@ -32,7 +32,7 @@ import { renderText } from '../../i18n/render-text';
 import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/video/skin.ts
+++ b/packages/html/src/define/video/skin.ts
@@ -6,7 +6,7 @@ import { safeDefine } from '../safe-define';
 import { SkinElement } from '../skin-element';
 import styles from './skin.css?inline';
 
-// Register the player, container, and all UI custom elements.
+// Register the container and all UI custom elements.
 import './ui';
 
 function getTemplateHTML() {

--- a/packages/html/src/define/video/ui.ts
+++ b/packages/html/src/define/video/ui.ts
@@ -1,6 +1,6 @@
-// Registers the video player, container, and all video UI custom elements
-// without creating a skin element. Use this entry when building an ejected
-// (light DOM) player layout.
+// Registers the container and all video UI custom elements without creating
+// a player or skin element. Use this entry when building an ejected (light DOM)
+// player layout.
 
 import { I18nProviderElement } from '../../i18n/provider-element';
 import { MediaContainerElement } from '../../media/container-element';
@@ -37,12 +37,8 @@ import {
   defineTooltip,
 } from '../ui/compounds';
 
-// Value import — player.ts body runs before this module's body.
-import { VideoPlayerElement } from './player';
-
 // ── Registration (providers / parents first) ────────────────────────────
 
-safeDefine(VideoPlayerElement);
 safeDefine(MediaContainerElement);
 safeDefine(I18nProviderElement);
 

--- a/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
+++ b/site/src/content/docs/how-to/migrate-from-video-js-8.mdx
@@ -354,9 +354,10 @@ This is where v8's `controlBar` config and `addChild` calls end up, and honestly
 
 <FrameworkCase frameworks={["html"]}>
 
-Swap the skin import for `video/ui`, which registers the player, the container, and every UI element without wrapping them in a skin:
+Import the player separately, then swap the skin import for `video/ui`, which registers the container and every UI element without wrapping them in a skin:
 
 ```js
+import '@videojs/html/video/player';
 import '@videojs/html/video/ui';
 ```
 


### PR DESCRIPTION
Refs #2363

## Summary

Keep preset registration paths single-purpose.

Before:

```ts
import "@videojs/html/video/ui";
// registered <video-player>, <media-container>, and video UI
```

After:

```ts
import "@videojs/html/video/player"; // registers <video-player>
import "@videojs/html/video/ui"; // registers <media-container> and video UI
import "@videojs/html/video/skin"; // registers <video-skin>, container, and UI
```

The same boundary applies to audio, live video, live audio, and minimal UI/skin entries. Ejected examples now import the player explicitly.

## Validation

- `pnpm -F @videojs/html test` (398 tests)
- `pnpm -F @videojs/html build`
- `pnpm -F site test` (608 tests)
- `pnpm typecheck`

No generated skin build or generation-script files are changed.