### PR TITLE
fix(react): defer external writes until commit

### DIFF
--- a/packages/react/src/extensions/mux-data/mux-data.tsx
+++ b/packages/react/src/extensions/mux-data/mux-data.tsx
@@ -4,6 +4,7 @@ import type { MuxDataProps as MuxDataComponentProps } from '@videojs/media/dom/m
 import { MuxData as MuxDataComponent, muxDataDefaultProps } from '@videojs/media/dom/mux';
 import type { ReactNode } from 'react';
 
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { useMediaComponent } from '../../utils/use-media-component';
 import { useSyncProps } from '../../utils/use-sync-props';
 
@@ -39,7 +40,9 @@ export function MuxData(props: MuxDataProps): ReactNode {
   // omitting it falls back to the default SDK.
   const sdk = 'MuxDataSdk' in props ? MuxDataSdk : muxDataDefaultProps.MuxDataSdk;
 
-  if (component.MuxDataSdk !== sdk) component.MuxDataSdk = sdk;
+  useIsomorphicLayoutEffect(() => {
+    if (component.MuxDataSdk !== sdk) component.MuxDataSdk = sdk;
+  }, [component, sdk]);
 
   useSyncProps(component, rest, muxDataDefaultProps);
 

--- a/packages/react/src/extensions/tests/mux-data.test.tsx
+++ b/packages/react/src/extensions/tests/mux-data.test.tsx
@@ -4,7 +4,7 @@ import { addMediaComponent, getMediaComponents } from '@videojs/media/dom/media-
 import { MuxData as MuxDataComponent, MuxMedia } from '@videojs/media/dom/mux';
 import { describe, expect, it, vi } from 'vite-plus/test';
 
-import { createPlayerWrapper } from '../../testing/mocks';
+import { createPlayerWrapper, MockErrorBoundary } from '../../testing/mocks';
 import { MuxData } from '../mux-data';
 
 function setup() {
@@ -53,6 +53,47 @@ describe('MuxData', () => {
 
     rerender(<MuxData />);
     expect(component.MuxDataSdk).toBeDefined();
+  });
+
+  it('does not apply MuxDataSdk from an abandoned render', () => {
+    const { media, Wrapper } = setup();
+    const committedSdk = {
+      monitor: vi.fn(),
+      utils: { now: () => 0 },
+    } as unknown as NonNullable<MuxDataComponent['MuxDataSdk']>;
+    const abandonedSdk = {
+      monitor: vi.fn(),
+      utils: { now: () => 1 },
+    } as unknown as NonNullable<MuxDataComponent['MuxDataSdk']>;
+
+    function Throw({ fail = false }: { fail?: boolean }) {
+      if (fail) throw new Error('abandon render');
+
+      return null;
+    }
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <MockErrorBoundary>
+        <Wrapper>
+          <MuxData MuxDataSdk={committedSdk} />
+          <Throw />
+        </Wrapper>
+      </MockErrorBoundary>
+    );
+    const component = getMediaComponents(media).get(MuxDataComponent)!;
+
+    rerender(
+      <MockErrorBoundary>
+        <Wrapper>
+          <MuxData MuxDataSdk={abandonedSdk} />
+          <Throw fail />
+        </Wrapper>
+      </MockErrorBoundary>
+    );
+
+    expect(component.MuxDataSdk).toBe(committedSdk);
+    consoleError.mockRestore();
   });
 
   it('resets a removed prop to its default', () => {

--- a/packages/react/src/media/mux-video/storyboard.tsx
+++ b/packages/react/src/media/mux-video/storyboard.tsx
@@ -21,28 +21,11 @@ export interface MuxStoryboardMedia {
 export function MuxStoryboard({ media }: { media: MuxStoryboardMedia }) {
   const subscribe = useCallback(
     (onChange: () => void) => {
-      // `useSyncProps` writes `src` / `source` during render and those setters
-      // dispatch `sourcechange` synchronously. Defer (and coalesce) notifications
-      // so we never schedule an update while another component is rendering.
-      let cancelled = false;
-      let scheduled = false;
-      const notify = () => {
-        if (scheduled) return;
-
-        scheduled = true;
-        queueMicrotask(() => {
-          scheduled = false;
-
-          if (!cancelled) onChange();
-        });
-      };
-
-      media.addEventListener('streamtypechange', notify);
-      media.addEventListener('sourcechange', notify);
+      media.addEventListener('streamtypechange', onChange);
+      media.addEventListener('sourcechange', onChange);
       return () => {
-        cancelled = true;
-        media.removeEventListener('streamtypechange', notify);
-        media.removeEventListener('sourcechange', notify);
+        media.removeEventListener('streamtypechange', onChange);
+        media.removeEventListener('sourcechange', onChange);
       };
     },
     [media]

--- a/packages/react/src/testing/mocks.tsx
+++ b/packages/react/src/testing/mocks.tsx
@@ -6,7 +6,7 @@
  * shared here.
  */
 
-import type { ReactNode } from 'react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
 import type { Mock } from 'vite-plus/test';
 import { vi } from 'vite-plus/test';
 
@@ -65,4 +65,24 @@ export function createPlayerWrapper(storeState: Record<string, unknown> = {}): {
       );
     },
   };
+}
+
+/**
+ * Swallow a render error thrown by a descendant so tests can assert what an abandoned render did not commit.
+ *
+ * Renders `null` once a descendant throws. Pair with a component that throws conditionally to abandon a re-render after
+ * a successful mount.
+ */
+export class MockErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch(_error: Error, _info: ErrorInfo) {}
+
+  override render() {
+    return this.state.failed ? null : this.props.children;
+  }
 }

--- a/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
+++ b/packages/react/src/ui/buffering-indicator/buffering-indicator.tsx
@@ -6,6 +6,7 @@ import { forwardRef, useState, useSyncExternalStore } from 'react';
 import { usePlayer } from '../../player/context';
 import type { UIComponentProps } from '../../utils/types';
 import { useDestroy } from '../../utils/use-destroy';
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { renderElement } from '../../utils/use-render';
 
 export interface BufferingIndicatorProps
@@ -40,15 +41,18 @@ export const BufferingIndicator = forwardRef(function BufferingIndicator(
   const [core] = useState(() => new BufferingIndicatorCore());
 
   useDestroy(core);
-  core.setProps({ delay });
-
-  if (playback) core.update(playback);
 
   const state = useSyncExternalStore(
     (cb) => core.state.subscribe(cb),
     () => core.state.current,
     () => core.state.current
   );
+
+  useIsomorphicLayoutEffect(() => {
+    core.setProps({ delay });
+
+    if (playback) core.update(playback);
+  }, [core, delay, playback]);
 
   if (!playback) {
     if (__DEV__) logMissingFeature('BufferingIndicator', 'playback');

--- a/packages/react/src/ui/buffering-indicator/tests/buffering-indicator.test.tsx
+++ b/packages/react/src/ui/buffering-indicator/tests/buffering-indicator.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { BufferingIndicatorCore } from '@videojs/core';
+import { flush } from '@videojs/store';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { createPlayerWrapper, MockErrorBoundary } from '../../../testing/mocks';
+import { BufferingIndicator } from '../buffering-indicator';
+
+function setup(waiting: boolean) {
+  return createPlayerWrapper({
+    paused: false,
+    ended: false,
+    started: true,
+    waiting,
+    play: vi.fn(async () => {}),
+    pause: vi.fn(),
+    togglePaused: vi.fn(() => true),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+
+  if (vi.isFakeTimers()) {
+    act(() => {
+      vi.runOnlyPendingTimers();
+      flush();
+    });
+  }
+
+  vi.useRealTimers();
+});
+
+describe('BufferingIndicator', () => {
+  it('starts its delay after commit and becomes visible when it elapses', () => {
+    vi.useFakeTimers();
+    const { Wrapper } = setup(true);
+    const { getByTestId } = render(<BufferingIndicator data-testid="buffering" delay={100} />, { wrapper: Wrapper });
+
+    expect(getByTestId('buffering').hasAttribute('data-visible')).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+      flush();
+    });
+
+    expect(getByTestId('buffering').hasAttribute('data-visible')).toBe(true);
+  });
+
+  it('keeps one effective delay under StrictMode effect replay', () => {
+    vi.useFakeTimers();
+    const { Wrapper } = setup(true);
+    const { getByTestId } = render(
+      <StrictMode>
+        <Wrapper>
+          <BufferingIndicator data-testid="buffering" delay={100} />
+        </Wrapper>
+      </StrictMode>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+      flush();
+    });
+
+    expect(getByTestId('buffering').hasAttribute('data-visible')).toBe(true);
+  });
+
+  it('does not update its core during server rendering', () => {
+    const setProps = vi.spyOn(BufferingIndicatorCore.prototype, 'setProps');
+    const update = vi.spyOn(BufferingIndicatorCore.prototype, 'update');
+    const { Wrapper } = setup(true);
+
+    renderToString(
+      <Wrapper>
+        <BufferingIndicator />
+      </Wrapper>
+    );
+
+    expect(setProps).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    setProps.mockRestore();
+    update.mockRestore();
+  });
+
+  it('does not update its core from an abandoned render', () => {
+    const setProps = vi.spyOn(BufferingIndicatorCore.prototype, 'setProps');
+    const update = vi.spyOn(BufferingIndicatorCore.prototype, 'update');
+    const { store, Wrapper } = setup(false);
+
+    function Throw({ fail = false }: { fail?: boolean }) {
+      if (fail) throw new Error('abandon render');
+
+      return null;
+    }
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <MockErrorBoundary>
+        <Wrapper>
+          <BufferingIndicator />
+          <Throw />
+        </Wrapper>
+      </MockErrorBoundary>
+    );
+
+    setProps.mockClear();
+    update.mockClear();
+    store.state.waiting = true;
+
+    rerender(
+      <MockErrorBoundary>
+        <Wrapper>
+          <BufferingIndicator />
+          <Throw fail />
+        </Wrapper>
+      </MockErrorBoundary>
+    );
+
+    expect(setProps).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+    setProps.mockRestore();
+    update.mockRestore();
+  });
+});

--- a/packages/react/src/utils/tests/use-sync-props.test.tsx
+++ b/packages/react/src/utils/tests/use-sync-props.test.tsx
@@ -1,6 +1,9 @@
-import { cleanup, renderHook } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { cleanup, render, renderHook } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { MockErrorBoundary } from '../../testing/mocks';
 import { useSyncProps } from '../use-sync-props';
 
 afterEach(cleanup);
@@ -101,5 +104,69 @@ describe('useSyncProps', () => {
 
     // `volume` was set outside of props; omitting it from props never resets it.
     expect(target.volume).toBe(0.5);
+  });
+
+  it('does not write props from an abandoned render', () => {
+    const target: TargetProps = { ...defaults };
+
+    function Sync({ src, fail = false }: { src: string; fail?: boolean }) {
+      useSyncProps(target, { src }, defaults);
+
+      if (fail) throw new Error('abandon render');
+
+      return null;
+    }
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <MockErrorBoundary>
+        <Sync src="committed.mp4" />
+      </MockErrorBoundary>
+    );
+
+    rerender(
+      <MockErrorBoundary>
+        <Sync src="abandoned.mp4" fail />
+      </MockErrorBoundary>
+    );
+
+    expect(target.src).toBe('committed.mp4');
+    consoleError.mockRestore();
+  });
+
+  it('does not write props during server rendering', () => {
+    const target: TargetProps = { ...defaults };
+
+    function Sync() {
+      const rest = useSyncProps(target, { src: 'server.mp4', id: 'player' }, defaults);
+
+      return <div {...rest} />;
+    }
+
+    expect(renderToString(<Sync />)).toContain('id="player"');
+    expect(target.src).toBe('');
+  });
+
+  it('keeps committed writes idempotent under StrictMode effect replay', () => {
+    let src = '';
+    const write = vi.fn((value: string) => {
+      src = value;
+    });
+    const target = {
+      get src() {
+        return src;
+      },
+      set src(value: string) {
+        write(value);
+      },
+      volume: 1 as number | undefined,
+    };
+
+    renderHook(() => useSyncProps(target, { src: 'video.mp4' }, defaults), {
+      wrapper: StrictMode,
+    });
+
+    expect(write).toHaveBeenCalledOnce();
+    expect(target.src).toBe('video.mp4');
   });
 });

--- a/packages/react/src/utils/use-isomorphic-layout-effect.ts
+++ b/packages/react/src/utils/use-isomorphic-layout-effect.ts
@@ -1,0 +1,10 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` that degrades to `useEffect` when no DOM is available.
+ *
+ * React 18 warns when `useLayoutEffect` runs during server rendering. Neither effect fires on the server, so swapping
+ * in `useEffect` there keeps commit-phase writes silent under SSR while preserving layout timing in the browser.
+ */
+export const useIsomorphicLayoutEffect: typeof useLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;

--- a/packages/react/src/utils/use-sync-props.ts
+++ b/packages/react/src/utils/use-sync-props.ts
@@ -1,6 +1,8 @@
 import { isUndefined } from '@videojs/utils/predicate';
 import { useRef } from 'react';
 
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect';
+
 export function useSyncProps<Props extends object, Rest extends Record<string, unknown>>(
   target: Props,
   props: Partial<Props> & Rest,
@@ -9,31 +11,38 @@ export function useSyncProps<Props extends object, Rest extends Record<string, u
   const rest: Record<string, unknown> = {};
   const synced = new Set<string>();
   const prevSyncedRef = useRef<Set<string> | null>(null);
-
-  const sync = (key: string, value: unknown) => {
-    if (target[key as keyof Props] !== value) target[key as keyof Props] = value as Props[keyof Props];
-  };
-
-  // Reset props the consumer stopped passing (or passed as `undefined`) back to
-  // their defaults before applying the current ones, so a reset can never wipe a
-  // value another prop derives in the same render (e.g. `source` deriving `src`).
-  // Mirrors react-dom removing absent attributes.
-  for (const key of prevSyncedRef.current ?? []) {
-    if (isUndefined((props as Record<string, unknown>)[key])) sync(key, (defaults as Record<string, unknown>)[key]);
-  }
+  const entries: [string, unknown][] = [];
 
   for (const key in props) {
     if (key in defaults) {
       if (isUndefined(props[key])) continue;
 
       synced.add(key);
-      sync(key, props[key]);
+      entries.push([key, props[key]]);
     } else {
       rest[key] = props[key];
     }
   }
 
-  prevSyncedRef.current = synced;
+  useIsomorphicLayoutEffect(() => {
+    const sync = (key: string, value: unknown) => {
+      if (target[key as keyof Props] !== value) target[key as keyof Props] = value as Props[keyof Props];
+    };
+
+    // Reset props the consumer stopped passing (or passed as `undefined`) back
+    // to their defaults before applying the current ones, so a reset cannot wipe
+    // a value another prop derives in the same commit (for example, `source`
+    // deriving `src`). Mirrors react-dom removing absent attributes.
+    for (const key of prevSyncedRef.current ?? []) {
+      if (!synced.has(key)) {
+        sync(key, (defaults as Record<string, unknown>)[key]);
+      }
+    }
+
+    for (const [key, value] of entries) sync(key, value);
+
+    prevSyncedRef.current = synced;
+  });
 
   return rest as Omit<Rest, keyof Props>;
 }


### PR DESCRIPTION
Refs #1679

## Summary

Keep speculative and server renders pure by deferring live media property writes and buffering timer updates until React commits. This removes the storyboard notification workaround and prevents abandoned renders from mutating the active player. One ordering change to note: media props such as `source` are now written after the element ref has called `attach()` rather than before it during render.

## Changes

- Apply media prop resets and writes in a commit-phase layout effect with committed-key bookkeeping
- Add `useIsomorphicLayoutEffect`, which falls back to `useEffect` when there is no DOM so React 18 SSR stays warning-free, and use it for every new commit-phase effect
- Commit Mux Data SDK changes with the same ordering guarantees
- Notify storyboard subscriptions directly now that source changes are commit-phase
- Start, cancel, and update buffering state only after commit
- Hoist the test error boundary into `testing/mocks` as `MockErrorBoundary`
- Cover SSR, StrictMode, timers, and abandoned renders

## Testing

- `pnpm -F @videojs/react test`: 66 files, 546 tests passed
- `pnpm -F @videojs/react build`
- `pnpm typecheck`
- `pnpm lint:fix:file` on touched files and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Central commit-timing change affects all `useSyncProps` consumers and media prop ordering; behavior is well-tested but could surface subtle attach/source ordering issues in edge cases.
> 
> **Overview**
> React media integrations no longer mutate live player objects during render. **`useSyncProps`** now queues prop resets and assignments and applies them in a commit-phase **`useIsomorphicLayoutEffect`**, so speculative, SSR, and abandoned renders cannot change the active media. Media props such as **`source`** / **`src`** are written after commit (notably after ref **`attach()`**), with the same reset-before-apply ordering preserved.
> 
> Adds **`useIsomorphicLayoutEffect`** (`useLayoutEffect` in the browser, **`useEffect`** when there is no DOM) and uses it for **Mux Data** `MuxDataSdk` assignment and **BufferingIndicator** `setProps` / `update`. **MuxStoryboard** drops the microtask-coalesced event workaround because **`sourcechange`** no longer fires from render-time writes.
> 
> Tests add shared **`MockErrorBoundary`** and cover SSR, StrictMode, timers, and abandoned-render safety for **`useSyncProps`**, Mux Data, and buffering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dea6051b24bd8dba94a48c59b9f055627029dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->