### PR TITLE
fix(html): invalidate stale deferred destruction

### DIFF
--- a/packages/element/src/destroy-mixin.ts
+++ b/packages/element/src/destroy-mixin.ts
@@ -10,8 +10,9 @@ export interface Destroyable {
 /**
  * Mixin that adds a deferred destruction lifecycle to a `ReactiveElement`.
  *
- * On disconnect, schedules destruction after two animation frames. If the element reconnects before the frames fire
- * (e.g. DOM shuffling, framework reconciliation), the `isConnected` check prevents destruction.
+ * On disconnect, schedules destruction after two animation frames. Reconnecting before the frames fire (e.g. DOM
+ * shuffling, framework reconciliation) invalidates that work, so a later disconnect receives a new two-frame grace
+ * period.
  *
  * The `keep-alive` attribute prevents automatic destruction entirely — call `destroy()` manually when done.
  *
@@ -25,6 +26,7 @@ export interface Destroyable {
 export function DestroyMixin<Base extends new (...args: any[]) => ReactiveElement>(SuperClass: Base) {
   class DestroyableElement extends SuperClass {
     #destroyed = false;
+    #lifecycleGeneration = 0;
     #trackedControllers = new Set<ReactiveController>();
 
     get destroyed(): boolean {
@@ -57,16 +59,20 @@ export function DestroyMixin<Base extends new (...args: any[]) => ReactiveElemen
     connectedCallback(): void {
       if (this.#destroyed) return;
 
+      this.#lifecycleGeneration++;
       super.connectedCallback();
     }
 
     disconnectedCallback(): void {
       super.disconnectedCallback();
+      const generation = ++this.#lifecycleGeneration;
 
       if (!this.#destroyed && !this.hasAttribute('keep-alive')) {
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
-            if (!this.isConnected) this.destroy();
+            // A later reconnect and disconnect must receive its own full grace
+            // period instead of being destroyed by this stale callback.
+            if (generation === this.#lifecycleGeneration && !this.isConnected) this.destroy();
           });
         });
       }

--- a/packages/element/src/tests/destroy-mixin.test.ts
+++ b/packages/element/src/tests/destroy-mixin.test.ts
@@ -132,6 +132,25 @@ describe('DestroyMixin deferred destruction', () => {
     expect(el.destroyed).toBe(false);
   });
 
+  it('waits 2 new animation frames after a reconnected element disconnects again', () => {
+    const el = createElement(DestroyableElement);
+
+    document.body.appendChild(el);
+    el.remove();
+    vi.advanceTimersByTime(16); // 1st rAF for the original disconnect
+
+    document.body.appendChild(el);
+    el.remove();
+
+    // The original disconnect's 2nd rAF and the latest disconnect's 1st rAF.
+    vi.advanceTimersByTime(16);
+    expect(el.destroyed).toBe(false);
+
+    // The latest disconnect has now received its full grace period.
+    vi.advanceTimersByTime(16);
+    expect(el.destroyed).toBe(true);
+  });
+
   it('keep-alive attribute prevents deferred destruction', () => {
     const el = createElement(DestroyableElement);
 


### PR DESCRIPTION
Refs #2359

## Summary

Prevent deferred destruction from an earlier disconnect from destroying an element during a later disconnect lifecycle. Each connection transition now invalidates stale animation-frame work, so the newest disconnect always receives the full grace period.

## Changes

- Track element lifecycle generations across connect and disconnect
- Ignore stale deferred-destroy callbacks without changing keep-alive or manual destruction
- Cover rapid disconnect, reconnect, and second-disconnect timing

## Testing

- `pnpm -F @videojs/element test` (47 tests pass)
- `pnpm build:packages` (`@videojs/element` has no standalone `build` script)
- `pnpm lint:fix:file packages/element/src/destroy-mixin.ts packages/element/src/tests/destroy-mixin.test.ts`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lifecycle bugfix in element teardown timing with new unit coverage; no auth or data-path changes.
> 
> **Overview**
> Fixes **deferred destruction** in `DestroyMixin` when an element disconnects, reconnects, and disconnects again quickly (e.g. DOM moves or framework reconciliation).
> 
> Previously, a **stale** double-`requestAnimationFrame` callback from the first disconnect could still run after a second disconnect and destroy the element before that disconnect’s full two-frame grace period ended. The mixin now tracks a **`#lifecycleGeneration`** bumped on connect and disconnect; deferred destroy only runs if the captured generation still matches and the element is disconnected.
> 
> **`keep-alive`** and manual **`destroy()`** behavior are unchanged. A new unit test covers disconnect → partial rAF → reconnect → second disconnect timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070b468fe9f1de26844e18d1d380bf7e58ab8733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->