### PR TITLE
fix(html): retarget player state subscriptions

### DIFF
--- a/packages/html/src/player/player-controller.ts
+++ b/packages/html/src/player/player-controller.ts
@@ -1,8 +1,8 @@
 import type { PlayerStore } from '@videojs/core/dom';
-import type { ReactiveController, ReactiveControllerHost } from '@videojs/element';
+import type { ReactiveControllerHost } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
 import type { InferStoreState, Selector } from '@videojs/store';
-import { StoreController } from '@videojs/store/html';
+import { SnapshotController } from '@videojs/store/html';
 
 import type { PlayerContext } from './context';
 
@@ -31,12 +31,12 @@ export type PlayerControllerHost = ReactiveControllerHost & HTMLElement;
  *   }
  *   ```;
  */
-export class PlayerController<Store extends PlayerStore, Result = Store> implements ReactiveController {
+export class PlayerController<Store extends PlayerStore, Result = Store> {
   readonly #host: PlayerControllerHost;
   readonly #selector: Selector<InferStoreState<Store>, Result> | undefined;
 
-  #consumer: ContextConsumer<PlayerContext<Store>, PlayerControllerHost>;
-  #store: StoreController<Store, Result> | null = null;
+  readonly #consumer: ContextConsumer<PlayerContext<Store>, PlayerControllerHost>;
+  #snapshot: SnapshotController<object, Result> | null = null;
 
   /**
    * @param host - The host element that owns this controller.
@@ -65,11 +65,9 @@ export class PlayerController<Store extends PlayerStore, Result = Store> impleme
 
     this.#consumer = new ContextConsumer(host, {
       context,
-      callback: (ctx) => this.#connect(ctx),
+      callback: (store) => this.#connect(store),
       subscribe: true,
     });
-
-    host.addController(this);
   }
 
   get value(): Result | undefined {
@@ -79,28 +77,29 @@ export class PlayerController<Store extends PlayerStore, Result = Store> impleme
     // Without selector: return store directly
     if (!this.#selector) return store as unknown as Result;
 
-    // With selector: use StoreController
-    return this.#store?.value;
+    // With selector: the subscribing context callback has already retargeted the snapshot.
+    return this.#snapshot?.value;
   }
 
   get displayName(): string | undefined {
     return this.#selector?.displayName;
   }
 
-  hostConnected(): void {
-    const store = this.#consumer.value;
+  #connect(store: Store | undefined): void {
+    if (!this.#selector) return;
 
-    if (store) this.#connect(store);
-  }
-
-  hostDisconnected(): void {
-    this.#store = null;
-  }
-
-  #connect(store: Store): void {
-    if (!this.#store && this.#selector) {
-      this.#store = new StoreController(this.#host, store, this.#selector);
+    if (!store) {
+      this.#snapshot?.untrack();
+      return;
     }
+
+    if (!this.#snapshot) {
+      // SAFETY: `store.$state` holds `InferStoreState<Store>`, which is what this selector reads.
+      this.#snapshot = new SnapshotController(this.#host, store.$state, this.#selector as Selector<object, Result>);
+      return;
+    }
+
+    this.#snapshot.track(store.$state);
   }
 }
 

--- a/packages/html/src/player/tests/player-controller.test.ts
+++ b/packages/html/src/player/tests/player-controller.test.ts
@@ -1,0 +1,174 @@
+import type { PlayerTarget } from '@videojs/core/dom';
+import { ReactiveElement } from '@videojs/element';
+import { ContextProvider, createContext } from '@videojs/element/context';
+import { createStore, defineSlice, flush, type Store } from '@videojs/store';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { PLAYER_CONTEXT_KEY, type PlayerContext } from '../context';
+import { PlayerController } from '../player-controller';
+
+interface TestState {
+  count: number;
+  setCount: (count: number) => void;
+}
+
+type TestStore = Store<PlayerTarget, TestState>;
+
+const testSlice = defineSlice<PlayerTarget>()({
+  name: 'playerControllerTest',
+  state: ({ set }): TestState => ({
+    count: 0,
+    setCount: (count) => set({ count }),
+  }),
+});
+
+let tagCounter = 0;
+
+function createTestStore(count: number): TestStore {
+  const store = createStore<PlayerTarget>()(testSlice);
+
+  store.setCount(count);
+  flush();
+  return store;
+}
+
+function defineTestElement(elementClass: CustomElementConstructor): string {
+  const tagName = `test-player-controller-${tagCounter++}`;
+
+  customElements.define(tagName, elementClass);
+  return tagName;
+}
+
+function trackSubscriptions(store: TestStore) {
+  const originalSubscribe = store.$state.subscribe.bind(store.$state);
+  let active = 0;
+  let notifications = 0;
+
+  vi.spyOn(store.$state, 'subscribe').mockImplementation((callback, options) => {
+    active++;
+    let subscribed = true;
+    const unsubscribe = originalSubscribe(() => {
+      notifications++;
+      callback();
+    }, options);
+
+    return () => {
+      if (!subscribed) return;
+
+      subscribed = false;
+      active--;
+      unsubscribe();
+    };
+  });
+
+  return {
+    active: () => active,
+    notifications: () => notifications,
+  };
+}
+
+function createElements(initialStore: TestStore) {
+  // SAFETY: `PlayerContext` is the player-keyed `Context` alias; the test store stands in for a player store.
+  const context = createContext<TestStore, typeof PLAYER_CONTEXT_KEY>(PLAYER_CONTEXT_KEY) as PlayerContext<TestStore>;
+
+  class ProviderElement extends ReactiveElement {
+    readonly #provider = new ContextProvider(this, { context, initialValue: initialStore });
+
+    setStore(store: TestStore): void {
+      this.#provider.setValue(store);
+    }
+  }
+
+  class ConsumerElement extends ReactiveElement {
+    readonly count = new PlayerController<TestStore, number>(this, context, (state) => state.count);
+  }
+
+  // SAFETY: `defineTestElement` registers `ProviderElement` under the tag it returns.
+  const provider = document.createElement(defineTestElement(ProviderElement)) as ProviderElement;
+  // SAFETY: `defineTestElement` registers `ConsumerElement` under the tag it returns.
+  const consumer = document.createElement(defineTestElement(ConsumerElement)) as ConsumerElement;
+
+  provider.append(consumer);
+
+  return { consumer, provider };
+}
+
+describe('PlayerController', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('retargets a selected subscription when the live provider value changes', () => {
+    const storeA = createTestStore(1);
+    const storeB = createTestStore(10);
+    const subscriptionsA = trackSubscriptions(storeA);
+    const subscriptionsB = trackSubscriptions(storeB);
+    const { consumer, provider } = createElements(storeA);
+
+    document.body.append(provider);
+
+    expect(consumer.count.value).toBe(1);
+    expect(subscriptionsA.active()).toBe(1);
+    expect(subscriptionsB.active()).toBe(0);
+
+    provider.setStore(storeB);
+
+    expect(consumer.count.value).toBe(10);
+    expect(subscriptionsA.active()).toBe(0);
+    expect(subscriptionsB.active()).toBe(1);
+
+    storeA.setCount(2);
+    flush();
+    expect(consumer.count.value).toBe(10);
+
+    storeB.setCount(20);
+    flush();
+    expect(consumer.count.value).toBe(20);
+  });
+
+  it('stops tracking when the provider value becomes unavailable', () => {
+    const store = createTestStore(1);
+    const subscriptions = trackSubscriptions(store);
+    const { consumer, provider } = createElements(store);
+
+    document.body.append(provider);
+
+    // SAFETY: Simulates a provider clearing its value; `PlayerController` must treat it as unavailable.
+    provider.setStore(undefined as unknown as TestStore);
+
+    expect(consumer.count.value).toBeUndefined();
+    expect(subscriptions.active()).toBe(0);
+
+    provider.setStore(store);
+
+    expect(consumer.count.value).toBe(1);
+    expect(subscriptions.active()).toBe(1);
+  });
+
+  it('keeps one effective subscription across repeated disconnects and reconnects', () => {
+    const store = createTestStore(1);
+    const subscriptions = trackSubscriptions(store);
+    const { consumer, provider } = createElements(store);
+
+    document.body.append(provider);
+
+    expect(subscriptions.active()).toBe(1);
+
+    for (let i = 0; i < 3; i++) {
+      consumer.remove();
+      expect(subscriptions.active()).toBe(0);
+
+      provider.append(consumer);
+      expect(subscriptions.active()).toBe(1);
+    }
+
+    const notifications = subscriptions.notifications();
+
+    store.setCount(2);
+    flush();
+
+    expect(subscriptions.notifications()).toBe(notifications + 1);
+    expect(consumer.count.value).toBe(2);
+  });
+});

--- a/packages/store/src/html/controllers/snapshot-controller.ts
+++ b/packages/store/src/html/controllers/snapshot-controller.ts
@@ -24,6 +24,8 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
 
   #state: State<T>;
   #cached: R | undefined;
+  #connected = false;
+  #tracking = true;
   #unsubscribe = noop;
 
   /**
@@ -57,15 +59,32 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
 
   /** Switch to tracking a different state container. */
   track(state: State<T>): void {
+    if (this.#tracking && this.#state === state) return;
+
     this.#state = state;
-    this.#subscribe();
+    this.#tracking = true;
+    this.#cached = undefined;
+
+    if (this.#connected) this.#subscribe();
+  }
+
+  /** Stop tracking until {@linkcode track} supplies a state container. */
+  untrack(): void {
+    if (!this.#tracking) return;
+
+    this.#tracking = false;
+    this.#unsubscribe();
+    this.#unsubscribe = noop;
   }
 
   hostConnected(): void {
-    this.#subscribe();
+    this.#connected = true;
+
+    if (this.#tracking) this.#subscribe();
   }
 
   hostDisconnected(): void {
+    this.#connected = false;
     this.#unsubscribe();
     this.#unsubscribe = noop;
     this.#cached = undefined;

--- a/packages/store/src/html/controllers/tests/snapshot-controller.test.ts
+++ b/packages/store/src/html/controllers/tests/snapshot-controller.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { createState, flush } from '../../../core/state';
 import { createTestHost } from '../../tests/test-utils';
@@ -166,6 +166,60 @@ describe('SnapshotController', () => {
       await Promise.resolve();
 
       expect(host.updateCount).toBe(countAfterTrack);
+    });
+
+    it('does not subscribe to a new state until a disconnected host reconnects', () => {
+      const state1 = createState({ volume: 1 });
+      const state2 = createState({ volume: 0.5 });
+      const subscribe = vi.spyOn(state2, 'subscribe');
+      const host = createTestHost();
+
+      const controller = new SnapshotController(host, state1, (s) => s.volume);
+
+      controller.track(state2);
+
+      expect(controller.value).toBe(0.5);
+      expect(subscribe).not.toHaveBeenCalled();
+
+      document.body.appendChild(host);
+
+      expect(subscribe).toHaveBeenCalledOnce();
+    });
+
+    it('does not resubscribe when already tracking the same state', () => {
+      const state = createState({ volume: 1 });
+      const subscribe = vi.spyOn(state, 'subscribe');
+      const host = createTestHost();
+      const controller = new SnapshotController(host, state, (s) => s.volume);
+
+      document.body.appendChild(host);
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      controller.track(state);
+
+      expect(subscribe).toHaveBeenCalledOnce();
+    });
+
+    it('can stop and resume tracking the same state', () => {
+      const state = createState({ volume: 1 });
+      const host = createTestHost();
+      const controller = new SnapshotController(host, state, (s) => s.volume);
+
+      document.body.appendChild(host);
+      controller.untrack();
+
+      const updateCount = host.updateCount;
+
+      state.replace({ volume: 0.5 });
+      flush();
+      expect(host.updateCount).toBe(updateCount);
+
+      controller.track(state);
+      state.replace({ volume: 0.25 });
+      flush();
+
+      expect(host.updateCount).toBe(updateCount + 1);
+      expect(controller.value).toBe(0.25);
     });
   });
 });


### PR DESCRIPTION
Refs #2360

## Summary

Make selector-backed PlayerController instances retain one subscription controller across provider replacement and DOM reconnection. This prevents stale stores and controller accumulation while preserving the unsubscribed no-selector path.

## Changes

- Retarget one durable SnapshotController when the player store changes
- Add explicit suspend and resume support for unavailable contexts
- Make same-state tracking idempotent and connection-aware
- Cover provider replacement and repeated remove/reappend cycles

## Testing

- pnpm -F @videojs/store test
- pnpm -F @videojs/html test
- pnpm -F @videojs/store build
- pnpm -F @videojs/html build
- pnpm typecheck
- Biome and git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription lifecycle for UI elements that read player state via selectors; bugs could cause stale UI or leaked subscriptions, but behavior is heavily tested and scoped to controller wiring.
> 
> **Overview**
> Selector-backed **`PlayerController`** no longer spins up a new **`StoreController`** on each connect. It keeps one **`SnapshotController`** on `store.$state`, **retargets** when the player context store changes, and **untracks** when the provider clears the store. The no-selector path still returns the store without subscribing; **`PlayerController`** itself is no longer a **`ReactiveController`**—lifecycle is driven by the context consumer callback and **`SnapshotController`**.
> 
> **`SnapshotController`** gains **`untrack()`**, **connection-aware** subscribe/unsubscribe (no subscribe while disconnected; **`track`** waits until reconnect), **idempotent** **`track`** for the same state, and clears cache on retarget.
> 
> New **`PlayerController`** tests cover provider swap, unavailable context, and repeated DOM disconnect/reconnect. **`SnapshotController`** tests cover the new tracking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d59d848ed1afb80ee0c7896be93edfa4ecd460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->