### PR TITLE
fix(html): restore popup APIs after reconnect

### DIFF
--- a/packages/html/src/player/player-controller.ts
+++ b/packages/html/src/player/player-controller.ts
@@ -1,8 +1,8 @@
 import type { PlayerStore } from '@videojs/core/dom';
-import type { ReactiveController, ReactiveControllerHost } from '@videojs/element';
+import type { ReactiveControllerHost } from '@videojs/element';
 import { ContextConsumer } from '@videojs/element/context';
 import type { InferStoreState, Selector } from '@videojs/store';
-import { StoreController } from '@videojs/store/html';
+import { SnapshotController } from '@videojs/store/html';
 
 import type { PlayerContext } from './context';
 
@@ -31,12 +31,12 @@ export type PlayerControllerHost = ReactiveControllerHost & HTMLElement;
  *   }
  *   ```;
  */
-export class PlayerController<Store extends PlayerStore, Result = Store> implements ReactiveController {
+export class PlayerController<Store extends PlayerStore, Result = Store> {
   readonly #host: PlayerControllerHost;
   readonly #selector: Selector<InferStoreState<Store>, Result> | undefined;
 
-  #consumer: ContextConsumer<PlayerContext<Store>, PlayerControllerHost>;
-  #store: StoreController<Store, Result> | null = null;
+  readonly #consumer: ContextConsumer<PlayerContext<Store>, PlayerControllerHost>;
+  #snapshot: SnapshotController<object, Result> | null = null;
 
   /**
    * @param host - The host element that owns this controller.
@@ -65,11 +65,9 @@ export class PlayerController<Store extends PlayerStore, Result = Store> impleme
 
     this.#consumer = new ContextConsumer(host, {
       context,
-      callback: (ctx) => this.#connect(ctx),
+      callback: (store) => this.#connect(store),
       subscribe: true,
     });
-
-    host.addController(this);
   }
 
   get value(): Result | undefined {
@@ -79,28 +77,29 @@ export class PlayerController<Store extends PlayerStore, Result = Store> impleme
     // Without selector: return store directly
     if (!this.#selector) return store as unknown as Result;
 
-    // With selector: use StoreController
-    return this.#store?.value;
+    // With selector: the subscribing context callback has already retargeted the snapshot.
+    return this.#snapshot?.value;
   }
 
   get displayName(): string | undefined {
     return this.#selector?.displayName;
   }
 
-  hostConnected(): void {
-    const store = this.#consumer.value;
+  #connect(store: Store | undefined): void {
+    if (!this.#selector) return;
 
-    if (store) this.#connect(store);
-  }
-
-  hostDisconnected(): void {
-    this.#store = null;
-  }
-
-  #connect(store: Store): void {
-    if (!this.#store && this.#selector) {
-      this.#store = new StoreController(this.#host, store, this.#selector);
+    if (!store) {
+      this.#snapshot?.untrack();
+      return;
     }
+
+    if (!this.#snapshot) {
+      // SAFETY: `store.$state` holds `InferStoreState<Store>`, which is what this selector reads.
+      this.#snapshot = new SnapshotController(this.#host, store.$state, this.#selector as Selector<object, Result>);
+      return;
+    }
+
+    this.#snapshot.track(store.$state);
   }
 }
 

--- a/packages/html/src/player/tests/player-controller.test.ts
+++ b/packages/html/src/player/tests/player-controller.test.ts
@@ -1,0 +1,174 @@
+import type { PlayerTarget } from '@videojs/core/dom';
+import { ReactiveElement } from '@videojs/element';
+import { ContextProvider, createContext } from '@videojs/element/context';
+import { createStore, defineSlice, flush, type Store } from '@videojs/store';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { PLAYER_CONTEXT_KEY, type PlayerContext } from '../context';
+import { PlayerController } from '../player-controller';
+
+interface TestState {
+  count: number;
+  setCount: (count: number) => void;
+}
+
+type TestStore = Store<PlayerTarget, TestState>;
+
+const testSlice = defineSlice<PlayerTarget>()({
+  name: 'playerControllerTest',
+  state: ({ set }): TestState => ({
+    count: 0,
+    setCount: (count) => set({ count }),
+  }),
+});
+
+let tagCounter = 0;
+
+function createTestStore(count: number): TestStore {
+  const store = createStore<PlayerTarget>()(testSlice);
+
+  store.setCount(count);
+  flush();
+  return store;
+}
+
+function defineTestElement(elementClass: CustomElementConstructor): string {
+  const tagName = `test-player-controller-${tagCounter++}`;
+
+  customElements.define(tagName, elementClass);
+  return tagName;
+}
+
+function trackSubscriptions(store: TestStore) {
+  const originalSubscribe = store.$state.subscribe.bind(store.$state);
+  let active = 0;
+  let notifications = 0;
+
+  vi.spyOn(store.$state, 'subscribe').mockImplementation((callback, options) => {
+    active++;
+    let subscribed = true;
+    const unsubscribe = originalSubscribe(() => {
+      notifications++;
+      callback();
+    }, options);
+
+    return () => {
+      if (!subscribed) return;
+
+      subscribed = false;
+      active--;
+      unsubscribe();
+    };
+  });
+
+  return {
+    active: () => active,
+    notifications: () => notifications,
+  };
+}
+
+function createElements(initialStore: TestStore) {
+  // SAFETY: `PlayerContext` is the player-keyed `Context` alias; the test store stands in for a player store.
+  const context = createContext<TestStore, typeof PLAYER_CONTEXT_KEY>(PLAYER_CONTEXT_KEY) as PlayerContext<TestStore>;
+
+  class ProviderElement extends ReactiveElement {
+    readonly #provider = new ContextProvider(this, { context, initialValue: initialStore });
+
+    setStore(store: TestStore): void {
+      this.#provider.setValue(store);
+    }
+  }
+
+  class ConsumerElement extends ReactiveElement {
+    readonly count = new PlayerController<TestStore, number>(this, context, (state) => state.count);
+  }
+
+  // SAFETY: `defineTestElement` registers `ProviderElement` under the tag it returns.
+  const provider = document.createElement(defineTestElement(ProviderElement)) as ProviderElement;
+  // SAFETY: `defineTestElement` registers `ConsumerElement` under the tag it returns.
+  const consumer = document.createElement(defineTestElement(ConsumerElement)) as ConsumerElement;
+
+  provider.append(consumer);
+
+  return { consumer, provider };
+}
+
+describe('PlayerController', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('retargets a selected subscription when the live provider value changes', () => {
+    const storeA = createTestStore(1);
+    const storeB = createTestStore(10);
+    const subscriptionsA = trackSubscriptions(storeA);
+    const subscriptionsB = trackSubscriptions(storeB);
+    const { consumer, provider } = createElements(storeA);
+
+    document.body.append(provider);
+
+    expect(consumer.count.value).toBe(1);
+    expect(subscriptionsA.active()).toBe(1);
+    expect(subscriptionsB.active()).toBe(0);
+
+    provider.setStore(storeB);
+
+    expect(consumer.count.value).toBe(10);
+    expect(subscriptionsA.active()).toBe(0);
+    expect(subscriptionsB.active()).toBe(1);
+
+    storeA.setCount(2);
+    flush();
+    expect(consumer.count.value).toBe(10);
+
+    storeB.setCount(20);
+    flush();
+    expect(consumer.count.value).toBe(20);
+  });
+
+  it('stops tracking when the provider value becomes unavailable', () => {
+    const store = createTestStore(1);
+    const subscriptions = trackSubscriptions(store);
+    const { consumer, provider } = createElements(store);
+
+    document.body.append(provider);
+
+    // SAFETY: Simulates a provider clearing its value; `PlayerController` must treat it as unavailable.
+    provider.setStore(undefined as unknown as TestStore);
+
+    expect(consumer.count.value).toBeUndefined();
+    expect(subscriptions.active()).toBe(0);
+
+    provider.setStore(store);
+
+    expect(consumer.count.value).toBe(1);
+    expect(subscriptions.active()).toBe(1);
+  });
+
+  it('keeps one effective subscription across repeated disconnects and reconnects', () => {
+    const store = createTestStore(1);
+    const subscriptions = trackSubscriptions(store);
+    const { consumer, provider } = createElements(store);
+
+    document.body.append(provider);
+
+    expect(subscriptions.active()).toBe(1);
+
+    for (let i = 0; i < 3; i++) {
+      consumer.remove();
+      expect(subscriptions.active()).toBe(0);
+
+      provider.append(consumer);
+      expect(subscriptions.active()).toBe(1);
+    }
+
+    const notifications = subscriptions.notifications();
+
+    store.setCount(2);
+    flush();
+
+    expect(subscriptions.notifications()).toBe(notifications + 1);
+    expect(consumer.count.value).toBe(2);
+  });
+});

--- a/packages/html/src/ui/dialog/dialog-element.ts
+++ b/packages/html/src/ui/dialog/dialog-element.ts
@@ -11,6 +11,7 @@ import { ContextProvider } from '@videojs/element/context';
 import { SnapshotController } from '@videojs/store/html';
 
 import { PositionController } from '../position-controller';
+import { RestoreGuard } from '../restore-guard';
 import { UIElement } from '../ui-element';
 import { dialogContext } from './context';
 
@@ -38,6 +39,7 @@ export class DialogElementBase extends UIElement {
   readonly #stateAttrMap: StateAttrMap<DialogState>;
   readonly #provider = new ContextProvider(this, { context: dialogContext });
   readonly #position = new PositionController(this);
+  readonly #restoreGuard = new RestoreGuard();
   readonly #popupId: string;
   readonly #titleId: string;
   readonly #descriptionId: string;
@@ -70,10 +72,12 @@ export class DialogElementBase extends UIElement {
 
     if (this.destroyed) return;
 
-    this.#dialog = createDialog({
+    const dialog = createDialog({
       transition: createTransition(),
       closeOnEscape: () => this.closeOnEscape,
       onOpenChange: (nextOpen: boolean) => {
+        if (this.#restoreGuard.active) return;
+
         this.open = nextOpen;
         this.dispatchEvent(new CustomEvent('open-change', { detail: { open: nextOpen } }));
       },
@@ -82,11 +86,20 @@ export class DialogElementBase extends UIElement {
       },
     });
 
+    this.#dialog = dialog;
+
+    // One controller lives for the element's lifetime and retargets each connection's API.
     if (this.#snapshot) {
-      this.#snapshot.track(this.#dialog.input);
+      this.#snapshot.track(dialog.input);
     } else {
-      this.#snapshot = new SnapshotController(this, this.#dialog.input);
+      this.#snapshot = new SnapshotController(this, dialog.input);
     }
+
+    // A reconnect recreates the API closed and schedules no update, so replay
+    // the open state silently and refresh state attributes and the trigger.
+    if (this.hasUpdated && this.open) this.#restoreGuard.run(() => dialog.open());
+
+    this.requestUpdate();
   }
 
   protected override firstUpdated(changed: PropertyValues): void {
@@ -97,9 +110,12 @@ export class DialogElementBase extends UIElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#cleanupTrigger();
-    this.#dialog?.destroy();
-    this.#dialog = null;
+    this.#disposeConnection();
+  }
+
+  override destroyCallback(): void {
+    this.#disposeConnection();
+    super.destroyCallback();
   }
 
   close(): void {
@@ -176,6 +192,13 @@ export class DialogElementBase extends UIElement {
     this.#triggerAbort = null;
     this.#triggerElement = null;
     this.#dialog?.setTriggerElement(null);
+  }
+
+  /** Tear down the API and trigger listeners owned by the current connection. Runs on disconnect and on destroy. */
+  #disposeConnection(): void {
+    this.#cleanupTrigger();
+    this.#dialog?.destroy();
+    this.#dialog = null;
   }
 }
 

--- a/packages/html/src/ui/dialog/tests/dialog-element.test.ts
+++ b/packages/html/src/ui/dialog/tests/dialog-element.test.ts
@@ -92,6 +92,51 @@ describe('DialogElement', () => {
     expect(onOpenChange).toHaveBeenCalledOnce();
     expect((onOpenChange.mock.calls[0]![0] as CustomEvent).detail).toEqual({ open: true });
   });
+
+  it('restores open state and dismissal behavior after rapid remove and reappend cycles', async () => {
+    const dialog = createElement(DialogElement);
+    const onOpenChange = vi.fn();
+
+    dialog.open = true;
+    dialog.addEventListener('open-change', onOpenChange);
+    document.body.append(dialog);
+    await dialog.updateComplete;
+    onOpenChange.mockClear();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      dialog.remove();
+      document.body.append(dialog);
+    }
+
+    await dialog.updateComplete;
+    flush();
+
+    expect(dialog.open).toBe(true);
+    expect(dialog.hasAttribute('data-open')).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(dialog.open).toBe(false);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+  });
+
+  it('releases dismissal behavior when destroyed while connected', async () => {
+    const dialog = createElement(DialogElement);
+    const onOpenChange = vi.fn();
+
+    dialog.open = true;
+    document.body.append(dialog);
+    await dialog.updateComplete;
+    flush();
+    dialog.addEventListener('open-change', onOpenChange);
+
+    dialog.destroy();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(dialog.open).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
 });
 
 describe('DialogBackdropElement', () => {

--- a/packages/html/src/ui/error-dialog/error-dialog-element.ts
+++ b/packages/html/src/ui/error-dialog/error-dialog-element.ts
@@ -65,7 +65,7 @@ export class ErrorDialogElement extends UIElement {
 
     if (this.destroyed) return;
 
-    this.#dialog = createDialog({
+    const dialog = createDialog({
       transition: createTransition(),
       onOpenChange: (nextOpen: boolean) => {
         if (!nextOpen) {
@@ -74,23 +74,34 @@ export class ErrorDialogElement extends UIElement {
       },
     });
 
+    this.#dialog = dialog;
+
+    // One controller per state lives for the element's lifetime and retargets each connection's API.
     if (this.#snapshot) {
-      this.#snapshot.track(this.#dialog.input);
+      this.#snapshot.track(dialog.input);
     } else {
-      this.#snapshot = new SnapshotController(this, this.#dialog.input);
+      this.#snapshot = new SnapshotController(this, dialog.input);
     }
 
     if (this.#modalitySnapshot) {
-      this.#modalitySnapshot.track(this.#dialog.modality);
+      this.#modalitySnapshot.track(dialog.modality);
     } else {
-      this.#modalitySnapshot = new SnapshotController(this, this.#dialog.modality);
+      this.#modalitySnapshot = new SnapshotController(this, dialog.modality);
     }
+
+    // A reconnect recreates the API closed and schedules no update; `willUpdate`
+    // reopens it from the current error state.
+    this.requestUpdate();
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#dialog?.destroy();
-    this.#dialog = null;
+    this.#disposeConnection();
+  }
+
+  override destroyCallback(): void {
+    this.#disposeConnection();
+    super.destroyCallback();
   }
 
   protected override willUpdate(_changed: PropertyValues): void {
@@ -186,5 +197,11 @@ export class ErrorDialogElement extends UIElement {
     }
 
     return this.#authoredCopyParts.has(el);
+  }
+
+  /** Tear down the API owned by the current connection. Runs on disconnect and on destroy. */
+  #disposeConnection(): void {
+    this.#dialog?.destroy();
+    this.#dialog = null;
   }
 }

--- a/packages/html/src/ui/error-dialog/tests/error-dialog-element.test.ts
+++ b/packages/html/src/ui/error-dialog/tests/error-dialog-element.test.ts
@@ -1,9 +1,12 @@
+import { type AnyPlayerStore, errorFeature, type PlayerTarget } from '@videojs/core/dom';
 import { registerI18n, resetI18nRegistry } from '@videojs/core/i18n';
 import { ContextProvider } from '@videojs/element/context';
+import type { ErrorLike } from '@videojs/media';
+import { createStore, flush } from '@videojs/store';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 
 import { MediaI18nProviderElement } from '../../../i18n';
-import { containerContext } from '../../../player/context';
+import { containerContext, playerContext } from '../../../player/context';
 import { DialogCloseElement } from '../../dialog/dialog-close-element';
 import { DialogDescriptionElement } from '../../dialog/dialog-description-element';
 import { DialogPopupElement } from '../../dialog/dialog-popup-element';
@@ -38,6 +41,52 @@ class TestContainerProviderElement extends UIElement {
       registerContainer: () => () => {},
     },
   });
+}
+
+class TestErrorProviderElement extends UIElement {
+  readonly #media = document.createElement('video');
+  readonly #errorStore = createStore<PlayerTarget>()(errorFeature);
+  // SAFETY: The error feature is the only slice the error dialog reads from the player store.
+  readonly store = this.#errorStore as unknown as AnyPlayerStore;
+  readonly provider = new ContextProvider(this, { context: playerContext, initialValue: this.store });
+
+  #error: ErrorLike | null = null;
+
+  constructor() {
+    super();
+    Object.defineProperty(this.#media, 'error', { configurable: true, get: () => this.#error });
+    this.#errorStore.attach({ media: this.#media, container: null });
+  }
+
+  get error(): ErrorLike | null {
+    return this.#errorStore.state.error;
+  }
+
+  setError(error: ErrorLike): void {
+    this.#error = error;
+    this.#media.dispatchEvent(new Event('error'));
+    flush();
+  }
+}
+
+function createErrorDialogWithClose(): {
+  provider: TestErrorProviderElement;
+  dialog: ErrorDialogElement;
+  close: DialogCloseElement;
+} {
+  ensureDefined(DialogCloseElement.tagName, DialogCloseElement);
+
+  const provider = createElement(TestErrorProviderElement);
+  const dialog = createElement(ErrorDialogElement);
+  const popup = createElement(DialogPopupElement);
+  const close = document.createElement(DialogCloseElement.tagName) as DialogCloseElement;
+
+  popup.append(close);
+  dialog.append(popup);
+  provider.append(dialog);
+  document.body.append(provider);
+
+  return { provider, dialog, close };
 }
 
 afterEach(() => {
@@ -175,5 +224,44 @@ describe('ErrorDialogElement', () => {
     document.body.removeChild(el);
 
     expect(el.isConnected).toBe(false);
+  });
+  it('restores the current error and dismissal behavior after rapid remove and reappend cycles', async () => {
+    const { provider, dialog, close } = createErrorDialogWithClose();
+    const error = { code: 4, message: 'Unsupported source' };
+
+    provider.setError(error);
+    await dialog.updateComplete;
+    await close.updateComplete;
+
+    expect(dialog.hasAttribute('data-open')).toBe(true);
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      dialog.remove();
+      provider.append(dialog);
+    }
+
+    await dialog.updateComplete;
+    await close.updateComplete;
+
+    expect(dialog.hasAttribute('data-open')).toBe(true);
+    expect(provider.error).toEqual(error);
+
+    close.click();
+
+    expect(provider.error).toBeNull();
+  });
+
+  it('releases dismissal behavior when destroyed while connected', async () => {
+    const { provider, dialog, close } = createErrorDialogWithClose();
+    const error = { code: 4, message: 'Unsupported source' };
+
+    provider.setError(error);
+    await dialog.updateComplete;
+    await close.updateComplete;
+
+    dialog.destroy();
+    close.click();
+
+    expect(provider.error).toEqual(error);
   });
 });

--- a/packages/html/src/ui/menu/menu-element.ts
+++ b/packages/html/src/ui/menu/menu-element.ts
@@ -108,21 +108,25 @@ export class MenuElement extends UIElement {
 
     applyElementProps(this, { onFocusOut: this.#handleFocusOut }, { signal: this.#disconnect.signal });
 
+    // One controller lives for the element's lifetime and retargets each connection's API.
     if (this.#snapshot) this.#snapshot.track(this.#menu.input);
     else this.#snapshot = new SnapshotController(this, this.#menu.input);
+
+    // A reconnect recreates the API closed and schedules no update. `syncOpen`
+    // commits without the cancelable open-change request, so replay directly.
+    if (this.hasUpdated && this.open) this.#menu.syncOpen(true);
+
+    this.requestUpdate();
   }
 
   override disconnectedCallback(): void {
-    this.#releaseControlsVisibilityLock();
     super.disconnectedCallback();
-    this.#position.cleanup();
-    this.#cleanupTrigger();
-    this.#popup?.destroy();
-    this.#popup = null;
-    this.#menu?.destroy();
-    this.#menu = null;
-    this.#disconnect?.abort();
-    this.#disconnect = null;
+    this.#disposeConnection();
+  }
+
+  override destroyCallback(): void {
+    this.#disposeConnection();
+    super.destroyCallback();
   }
 
   close(reason: MenuOpenChangeReason = 'imperative-action'): void {
@@ -240,5 +244,17 @@ export class MenuElement extends UIElement {
     this.#triggerAbort?.abort();
     this.#triggerAbort = null;
     this.#currentTrigger = null;
+  }
+
+  /** Tear down the APIs, lock, and listeners owned by the current connection. Runs on disconnect and on destroy. */
+  #disposeConnection(): void {
+    this.#releaseControlsVisibilityLock();
+    this.#cleanupTrigger();
+    this.#popup?.destroy();
+    this.#popup = null;
+    this.#menu?.destroy();
+    this.#menu = null;
+    this.#disconnect?.abort();
+    this.#disconnect = null;
   }
 }

--- a/packages/html/src/ui/menu/tests/menu-element.test.ts
+++ b/packages/html/src/ui/menu/tests/menu-element.test.ts
@@ -401,4 +401,52 @@ describe('MenuElement', () => {
     root.open = false;
     await waitForAssertion(() => expect(provider.releaseControlsLock).toHaveBeenCalledOnce());
   });
+
+  it('restores open state and trigger behavior after rapid remove and reappend cycles', async () => {
+    const trigger = document.createElement('button');
+    const root = document.createElement(MenuElement.tagName) as MenuElement;
+    const onOpenChange = vi.fn();
+
+    root.id = 'reconnecting-menu';
+    root.open = true;
+    trigger.setAttribute('commandfor', root.id);
+    root.addEventListener('open-change', onOpenChange);
+    document.body.append(trigger, root);
+    await root.updateComplete;
+    onOpenChange.mockClear();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      root.remove();
+      document.body.append(root);
+    }
+
+    await root.updateComplete;
+
+    expect(root.open).toBe(true);
+    expect(root.hasAttribute('data-open')).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    trigger.click();
+
+    expect(root.open).toBe(false);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+  });
+
+  it('releases trigger behavior when destroyed while connected', async () => {
+    const trigger = document.createElement('button');
+    const root = document.createElement(MenuElement.tagName) as MenuElement;
+    const onOpenChange = vi.fn();
+
+    root.id = 'destroyed-menu';
+    trigger.setAttribute('commandfor', root.id);
+    root.addEventListener('open-change', onOpenChange);
+    document.body.append(trigger, root);
+    await root.updateComplete;
+
+    root.destroy();
+    trigger.click();
+
+    expect(root.open).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/html/src/ui/popover/popover-element.ts
+++ b/packages/html/src/ui/popover/popover-element.ts
@@ -17,6 +17,7 @@ import { tryHidePopover, tryShowPopover } from '@videojs/utils/dom';
 import { containerContext } from '../../player/context';
 import { popupGroupContext } from '../../player/popup-group-context';
 import { PositionController } from '../position-controller';
+import { RestoreGuard } from '../restore-guard';
 import { UIElement } from '../ui-element';
 
 /** @fires open-change - Fired when the popover's open state changes. */
@@ -53,6 +54,7 @@ export class PopoverElement extends UIElement {
   readonly #containerCtx = new ContextConsumer(this, { context: containerContext, subscribe: true });
   readonly #popupGroupCtx = new ContextConsumer(this, { context: popupGroupContext });
   readonly #position = new PositionController(this);
+  readonly #restoreGuard = new RestoreGuard();
   #popover: PopoverApi | null = null;
   #snapshot: SnapshotController<PopoverInput> | null = null;
 
@@ -70,9 +72,11 @@ export class PopoverElement extends UIElement {
 
     this.#disconnect = new AbortController();
 
-    this.#popover = createPopover({
+    const popover = createPopover({
       transition: createTransition(),
       onOpenChange: (nextOpen: boolean, details: PopoverChangeDetails) => {
+        if (this.#restoreGuard.active) return;
+
         this.open = nextOpen;
         this.dispatchEvent(new CustomEvent('open-change', { detail: { open: nextOpen, ...details } }));
       },
@@ -84,20 +88,27 @@ export class PopoverElement extends UIElement {
       group: () => this.#popupGroupCtx.value,
     });
 
+    this.#popover = popover;
+
     // Register self as the popup element — the element IS the popup.
-    this.#popover.setPopupElement(this);
+    popover.setPopupElement(this);
 
     // Apply popup event handlers (pointerenter/leave, focusout) to self.
-    applyElementProps(this, this.#popover.popupProps, { signal: this.#disconnect.signal });
+    applyElementProps(this, popover.popupProps, { signal: this.#disconnect.signal });
 
-    // Subscribe to interaction state for reactive updates.
-    // Reuse the controller across connect/disconnect cycles to avoid
-    // leaking stale controllers in the host's controller set.
+    // Subscribe to interaction state for reactive updates. One controller
+    // lives for the element's lifetime and retargets each connection's API.
     if (this.#snapshot) {
-      this.#snapshot.track(this.#popover.input);
+      this.#snapshot.track(popover.input);
     } else {
-      this.#snapshot = new SnapshotController(this, this.#popover.input);
+      this.#snapshot = new SnapshotController(this, popover.input);
     }
+
+    // A reconnect recreates the API closed and schedules no update, so replay
+    // the open state silently and refresh attributes, popover, and trigger.
+    if (this.hasUpdated && this.open) this.#restoreGuard.run(() => popover.open('imperative-action'));
+
+    this.requestUpdate();
   }
 
   protected override firstUpdated(changed: PropertyValues): void {
@@ -112,13 +123,11 @@ export class PopoverElement extends UIElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#disconnect?.abort();
-    this.#disconnect = null;
+    this.#disposeConnection();
   }
 
   override destroyCallback(): void {
-    this.#cleanupTrigger();
-    this.#popover?.destroy();
+    this.#disposeConnection();
     super.destroyCallback();
   }
 
@@ -225,5 +234,14 @@ export class PopoverElement extends UIElement {
     this.#triggerAbort?.abort();
     this.#triggerAbort = null;
     this.#currentTrigger = null;
+  }
+
+  /** Tear down the API and listeners owned by the current connection. Runs on disconnect and on destroy. */
+  #disposeConnection(): void {
+    this.#cleanupTrigger();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+    this.#popover?.destroy();
+    this.#popover = null;
   }
 }

--- a/packages/html/src/ui/popover/tests/popover-element.test.ts
+++ b/packages/html/src/ui/popover/tests/popover-element.test.ts
@@ -124,4 +124,57 @@ describe('PopoverElement', () => {
 
     expect(popover.getAttribute('data-side')).toBe('bottom');
   });
+
+  it('restores open state and trigger behavior after rapid remove and reappend cycles', async () => {
+    const trigger = document.createElement('button');
+    const popover = createPopover();
+    const onOpenChange = vi.fn();
+
+    popover.id = 'reconnecting-popover';
+    popover.open = true;
+    trigger.setAttribute('commandfor', popover.id);
+    popover.addEventListener('open-change', onOpenChange);
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+    onOpenChange.mockClear();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      popover.remove();
+      document.body.append(popover);
+    }
+
+    await popover.updateComplete;
+
+    expect(popover.open).toBe(true);
+    expect(popover.hasAttribute('data-open')).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    popover.close();
+
+    expect(popover.open).toBe(false);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+
+    trigger.click();
+
+    expect(popover.open).toBe(true);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases trigger behavior when destroyed while connected', async () => {
+    const trigger = document.createElement('button');
+    const popover = createPopover();
+    const onOpenChange = vi.fn();
+
+    popover.id = 'destroyed-popover';
+    trigger.setAttribute('commandfor', popover.id);
+    popover.addEventListener('open-change', onOpenChange);
+    document.body.append(trigger, popover);
+    await popover.updateComplete;
+
+    popover.destroy();
+    trigger.click();
+
+    expect(popover.open).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/html/src/ui/restore-guard.ts
+++ b/packages/html/src/ui/restore-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * Suppresses change notifications while an element replays state it already holds into a recreated imperative API.
+ *
+ * Popup and dialog APIs are created per DOM connection and report every open through `onOpenChange`, including the open
+ * that restores a still-open element after it moves in the DOM. Elements check {@linkcode active} inside that callback
+ * and wrap the replay in {@linkcode run} so restoring emits no duplicate `open-change` event.
+ */
+export class RestoreGuard {
+  #active = false;
+
+  /** True while {@linkcode run} is replaying state. */
+  get active(): boolean {
+    return this.#active;
+  }
+
+  /** Run `restore` with change notifications suppressed. */
+  run(restore: () => void): void {
+    this.#active = true;
+
+    try {
+      restore();
+    } finally {
+      this.#active = false;
+    }
+  }
+}

--- a/packages/html/src/ui/tooltip/tests/tooltip-element.test.ts
+++ b/packages/html/src/ui/tooltip/tests/tooltip-element.test.ts
@@ -98,8 +98,18 @@ function setup() {
 
 defineElement(TestPlayerProviderElement.tagName, TestPlayerProviderElement);
 
+function stubHoverCapableMedia(): void {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query === '(hover: hover)' || query === '(pointer: fine)',
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   resetI18nRegistry();
   document.body.innerHTML = '';
 });
@@ -329,5 +339,52 @@ describe('TooltipElement', () => {
     await tooltip.updateComplete;
 
     expect(tooltip.textContent).toBe('Reproducir');
+  });
+
+  it('restores open state and trigger behavior after rapid remove and reappend cycles', async () => {
+    stubHoverCapableMedia();
+    const { tooltip, trigger } = setup();
+    const onOpenChange = vi.fn();
+
+    tooltip.open = true;
+    tooltip.addEventListener('open-change', onOpenChange);
+    await tooltip.updateComplete;
+    onOpenChange.mockClear();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      tooltip.remove();
+      document.body.append(tooltip);
+    }
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.open).toBe(true);
+    expect(tooltip.hasAttribute('data-open')).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    tooltip.close();
+
+    expect(tooltip.open).toBe(false);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+
+    trigger.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(tooltip.open).toBe(true);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases trigger behavior when destroyed while connected', async () => {
+    stubHoverCapableMedia();
+    const { tooltip, trigger } = setup();
+    const onOpenChange = vi.fn();
+
+    tooltip.addEventListener('open-change', onOpenChange);
+    await tooltip.updateComplete;
+
+    tooltip.destroy();
+    trigger.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(tooltip.open).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/html/src/ui/tooltip/tooltip-element.ts
+++ b/packages/html/src/ui/tooltip/tooltip-element.ts
@@ -30,6 +30,7 @@ import { I18nController } from '../../i18n/controller';
 import { containerContext } from '../../player/context';
 import { popupGroupContext } from '../../player/popup-group-context';
 import { PositionController } from '../position-controller';
+import { RestoreGuard } from '../restore-guard';
 import { UIElement } from '../ui-element';
 import { tooltipGroupContext } from './context';
 import { TooltipLabelElement } from './tooltip-label-element';
@@ -82,6 +83,7 @@ export class TooltipElement extends UIElement {
   readonly #containerCtx = new ContextConsumer(this, { context: containerContext, subscribe: true });
   readonly #popupGroupCtx = new ContextConsumer(this, { context: popupGroupContext });
   readonly #position = new PositionController(this);
+  readonly #restoreGuard = new RestoreGuard();
   #tooltip: TooltipApi | null = null;
   #snapshot: SnapshotController<TooltipInput> | null = null;
 
@@ -99,9 +101,11 @@ export class TooltipElement extends UIElement {
 
     this.#disconnect = new AbortController();
 
-    this.#tooltip = createTooltip({
+    const tooltip = createTooltip({
       transition: createTransition(),
       onOpenChange: (nextOpen: boolean, details: TooltipChangeDetails) => {
+        if (this.#restoreGuard.active) return;
+
         this.open = nextOpen;
         this.dispatchEvent(new CustomEvent('open-change', { detail: { open: nextOpen, ...details } }));
       },
@@ -115,18 +119,27 @@ export class TooltipElement extends UIElement {
       popupGroup: () => this.#popupGroupCtx.value,
     });
 
+    this.#tooltip = tooltip;
+
     // Register self as the popup element — the element IS the popup.
-    this.#tooltip.setPopupElement(this);
+    tooltip.setPopupElement(this);
 
     // Apply popup event handlers (pointerenter/leave, focusout) to self.
-    applyElementProps(this, this.#tooltip.popupProps, { signal: this.#disconnect.signal });
+    applyElementProps(this, tooltip.popupProps, { signal: this.#disconnect.signal });
 
-    // Subscribe to interaction state for reactive updates.
+    // Subscribe to interaction state for reactive updates. One controller
+    // lives for the element's lifetime and retargets each connection's API.
     if (this.#snapshot) {
-      this.#snapshot.track(this.#tooltip.input);
+      this.#snapshot.track(tooltip.input);
     } else {
-      this.#snapshot = new SnapshotController(this, this.#tooltip.input);
+      this.#snapshot = new SnapshotController(this, tooltip.input);
     }
+
+    // A reconnect recreates the API closed and schedules no update, so replay
+    // the open state silently and refresh attributes, popover, and trigger.
+    if (this.hasUpdated && this.open) this.#restoreGuard.run(() => tooltip.open());
+
+    this.requestUpdate();
   }
 
   protected override firstUpdated(changed: PropertyValues): void {
@@ -141,11 +154,12 @@ export class TooltipElement extends UIElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.#cleanupTrigger();
-    this.#tooltip?.destroy();
-    this.#tooltip = null;
-    this.#disconnect?.abort();
-    this.#disconnect = null;
+    this.#disposeConnection();
+  }
+
+  override destroyCallback(): void {
+    this.#disposeConnection();
+    super.destroyCallback();
   }
 
   close(reason: TooltipOpenChangeReason = 'imperative-action'): void {
@@ -277,5 +291,14 @@ export class TooltipElement extends UIElement {
     this.#triggerAbort?.abort();
     this.#triggerAbort = null;
     this.#currentTrigger = null;
+  }
+
+  /** Tear down the API and listeners owned by the current connection. Runs on disconnect and on destroy. */
+  #disposeConnection(): void {
+    this.#cleanupTrigger();
+    this.#disconnect?.abort();
+    this.#disconnect = null;
+    this.#tooltip?.destroy();
+    this.#tooltip = null;
   }
 }

--- a/packages/store/src/html/controllers/snapshot-controller.ts
+++ b/packages/store/src/html/controllers/snapshot-controller.ts
@@ -25,6 +25,7 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
   #state: State<T>;
   #cached: R | undefined;
   #connected = false;
+  #destroyed = false;
   #tracking = true;
   #unsubscribe = noop;
 
@@ -78,6 +79,8 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
   }
 
   hostConnected(): void {
+    if (this.#destroyed) return;
+
     this.#connected = true;
 
     if (this.#tracking) this.#subscribe();
@@ -88,6 +91,15 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
     this.#unsubscribe();
     this.#unsubscribe = noop;
     this.#cached = undefined;
+  }
+
+  /**
+   * Release the subscription for good. A destroyed host may still be in the document, so this also ignores any later
+   * {@linkcode hostConnected} or {@linkcode track} call that would otherwise resubscribe.
+   */
+  hostDestroyed(): void {
+    this.#destroyed = true;
+    this.hostDisconnected();
   }
 
   #subscribe(): void {

--- a/packages/store/src/html/controllers/snapshot-controller.ts
+++ b/packages/store/src/html/controllers/snapshot-controller.ts
@@ -24,6 +24,8 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
 
   #state: State<T>;
   #cached: R | undefined;
+  #connected = false;
+  #tracking = true;
   #unsubscribe = noop;
 
   /**
@@ -57,15 +59,32 @@ export class SnapshotController<T extends object, R = T> implements ReactiveCont
 
   /** Switch to tracking a different state container. */
   track(state: State<T>): void {
+    if (this.#tracking && this.#state === state) return;
+
     this.#state = state;
-    this.#subscribe();
+    this.#tracking = true;
+    this.#cached = undefined;
+
+    if (this.#connected) this.#subscribe();
+  }
+
+  /** Stop tracking until {@linkcode track} supplies a state container. */
+  untrack(): void {
+    if (!this.#tracking) return;
+
+    this.#tracking = false;
+    this.#unsubscribe();
+    this.#unsubscribe = noop;
   }
 
   hostConnected(): void {
-    this.#subscribe();
+    this.#connected = true;
+
+    if (this.#tracking) this.#subscribe();
   }
 
   hostDisconnected(): void {
+    this.#connected = false;
     this.#unsubscribe();
     this.#unsubscribe = noop;
     this.#cached = undefined;

--- a/packages/store/src/html/controllers/tests/snapshot-controller.test.ts
+++ b/packages/store/src/html/controllers/tests/snapshot-controller.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { createState, flush } from '../../../core/state';
 import { createTestHost } from '../../tests/test-utils';
@@ -166,6 +166,60 @@ describe('SnapshotController', () => {
       await Promise.resolve();
 
       expect(host.updateCount).toBe(countAfterTrack);
+    });
+
+    it('does not subscribe to a new state until a disconnected host reconnects', () => {
+      const state1 = createState({ volume: 1 });
+      const state2 = createState({ volume: 0.5 });
+      const subscribe = vi.spyOn(state2, 'subscribe');
+      const host = createTestHost();
+
+      const controller = new SnapshotController(host, state1, (s) => s.volume);
+
+      controller.track(state2);
+
+      expect(controller.value).toBe(0.5);
+      expect(subscribe).not.toHaveBeenCalled();
+
+      document.body.appendChild(host);
+
+      expect(subscribe).toHaveBeenCalledOnce();
+    });
+
+    it('does not resubscribe when already tracking the same state', () => {
+      const state = createState({ volume: 1 });
+      const subscribe = vi.spyOn(state, 'subscribe');
+      const host = createTestHost();
+      const controller = new SnapshotController(host, state, (s) => s.volume);
+
+      document.body.appendChild(host);
+      expect(subscribe).toHaveBeenCalledOnce();
+
+      controller.track(state);
+
+      expect(subscribe).toHaveBeenCalledOnce();
+    });
+
+    it('can stop and resume tracking the same state', () => {
+      const state = createState({ volume: 1 });
+      const host = createTestHost();
+      const controller = new SnapshotController(host, state, (s) => s.volume);
+
+      document.body.appendChild(host);
+      controller.untrack();
+
+      const updateCount = host.updateCount;
+
+      state.replace({ volume: 0.5 });
+      flush();
+      expect(host.updateCount).toBe(updateCount);
+
+      controller.track(state);
+      state.replace({ volume: 0.25 });
+      flush();
+
+      expect(host.updateCount).toBe(updateCount + 1);
+      expect(controller.value).toBe(0.25);
     });
   });
 });

--- a/packages/store/src/html/controllers/tests/snapshot-controller.test.ts
+++ b/packages/store/src/html/controllers/tests/snapshot-controller.test.ts
@@ -127,6 +127,40 @@ describe('SnapshotController', () => {
     });
   });
 
+  describe('hostDestroyed', () => {
+    it('releases the subscription for good', () => {
+      const state = createState({ volume: 1 });
+      const host = createTestHost();
+      const controller = new SnapshotController(host, state, (s) => s.volume);
+
+      document.body.appendChild(host);
+      controller.hostDestroyed();
+
+      const updateCount = host.updateCount;
+
+      state.replace({ volume: 0.5 });
+      flush();
+
+      expect(host.updateCount).toBe(updateCount);
+    });
+
+    it('ignores tracking and reconnection after destruction', () => {
+      const state1 = createState({ volume: 1 });
+      const state2 = createState({ volume: 0.5 });
+      const subscribe = vi.spyOn(state2, 'subscribe');
+      const host = createTestHost();
+      const controller = new SnapshotController(host, state1, (s) => s.volume);
+
+      document.body.appendChild(host);
+      controller.hostDestroyed();
+
+      controller.track(state2);
+      controller.hostConnected();
+
+      expect(subscribe).not.toHaveBeenCalled();
+    });
+  });
+
   describe('track', () => {
     it('switches to a different state container', async () => {
       const state1 = createState({ volume: 1, muted: false });


### PR DESCRIPTION
Refs #2366

Depends on #2318 (stacked on `fix/html-player-rebinding`, which supplies the idempotent `SnapshotController.track()` this change builds on).

## Summary

Re-implementation of the original branch on top of the current `main` (the previous version referenced menu internals and an `AlertDialogElement` implementation that no longer exist). Popup, tooltip, menu, and dialog roots now own their imperative APIs strictly per DOM connection: each connection creates the API, both `disconnectedCallback` and `destroyCallback` tear it down through the same private dispose method, and a reconnect silently replays the open (or current error) state without emitting a duplicate `open-change`.

Bugs fixed, all confirmed on `main`:

- `PopoverElement` recreated `createPopover()` on every connect but only destroyed it in `destroyCallback`, so every reconnect leaked a live API and its listeners.
- `TooltipElement`, `MenuElement`, `DialogElementBase` (`DialogElement`, `AlertDialogElement`), and `ErrorDialogElement` destroyed per connection but had no `destroyCallback`, so `destroy()` while connected left the API and its trigger/document listeners live.
- None of them restored `open` (or the current error) after a reconnect: `willUpdate` only syncs when `changed.has('open')`, and reconnecting schedules no update.

## Changes

- `packages/store`: `SnapshotController.hostDestroyed()` releases the subscription permanently and ignores later `hostConnected()`/`track()` calls. `DestroyMixin.destroyCallback()` already invokes `hostDestroyed()` on tracked controllers, so elements no longer release snapshot controllers by hand.
- `packages/html/src/ui/restore-guard.ts`: small shared `RestoreGuard` that suppresses change notifications while an element replays state it already holds into a recreated API. Popover, tooltip, and dialog roots check `active` inside `onOpenChange` and wrap the replay in `run()`. The menu commits through `MenuApi.syncOpen()`, which already bypasses the cancelable open-change request, and the error dialog reopens from `willUpdate`, so neither needs the guard.
- Each root gets one `#disposeConnection()` (trigger cleanup, lock release, abort controllers, API destroy) called from `disconnectedCallback` and `destroyCallback`; the dispose is idempotent because a destroyed element may still be removed from the DOM afterwards.
- `connectedCallback` replays the held open state after `hasUpdated` and calls `requestUpdate()` so attributes, the Popover API show/hide, trigger ARIA, and positioning are refreshed for the new connection.

## Testing

- `pnpm exec vp run @videojs/store#build` and `pnpm exec vp run @videojs/html#build`, then `pnpm typecheck` from a clean `tsgo --build`: pass (0 errors)
- `pnpm -F @videojs/store test`: 134 passed
- `pnpm -F @videojs/html test`: 462 passed; `create-i18n.test.ts > updates media-text when html lang changes` fails intermittently (2 of 3 isolated runs) in a file this branch does not touch and whose code uses neither `SnapshotController` nor `track()`, so it is unrelated
- New coverage: rapid remove/reappend cycles, destroy-while-connected, and open-state restore with no duplicate `open-change` for `PopoverElement`, `TooltipElement`, `MenuElement`, `DialogElement`, and `ErrorDialogElement`; `hostDestroyed()` for `SnapshotController`. Swapping the element sources back to the base branch makes 8 of the 10 new element tests fail (the error-dialog restore already passes on base when a player provider is present because its context consumer requests an update on reconnect).
- `pnpm lint:fix:file` on touched files: no errors; remaining anti-slop notes are pre-existing casts in the test files and one justified `as unknown as` in the new error-dialog test provider
