### PR TITLE
fix(react): defer popup opening until commit

### DIFF
--- a/packages/react/src/ui/alert-dialog/tests/alert-dialog-root.test.tsx
+++ b/packages/react/src/ui/alert-dialog/tests/alert-dialog-root.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { AlertDialog } from '..';
+import { MockErrorBoundary } from '../../../testing/mocks';
+
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('AlertDialogRoot', () => {
+  it('keeps a default-open alert dialog closed during server rendering', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+    const readActiveElement = vi.spyOn(Document.prototype, 'activeElement', 'get');
+
+    const html = renderToString(
+      <AlertDialog.Root defaultOpen onOpenChange={onOpenChange}>
+        <AlertDialog.Popup data-testid="popup">Content</AlertDialog.Popup>
+      </AlertDialog.Root>
+    );
+
+    expect(html).not.toContain('data-testid');
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+    expect(readActiveElement).not.toHaveBeenCalled();
+  });
+
+  it('does not open from an abandoned render', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MockErrorBoundary>
+        <AlertDialog.Root defaultOpen onOpenChange={onOpenChange}>
+          <AlertDialog.Popup data-testid="popup">Content</AlertDialog.Popup>
+        </AlertDialog.Root>
+        <Throw />
+      </MockErrorBoundary>
+    );
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it('opens once under StrictMode effect replay', async () => {
+    const onOpenChange = vi.fn();
+
+    const { getByRole } = render(
+      <StrictMode>
+        <AlertDialog.Root defaultOpen onOpenChange={onOpenChange}>
+          <AlertDialog.Popup>Content</AlertDialog.Popup>
+        </AlertDialog.Root>
+      </StrictMode>
+    );
+
+    await waitFor(() => expect(getByRole('alertdialog')).toBeDefined());
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+});

--- a/packages/react/src/ui/dialog/tests/dialog-root.test.tsx
+++ b/packages/react/src/ui/dialog/tests/dialog-root.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { Dialog } from '..';
+import { MockErrorBoundary } from '../../../testing/mocks';
+
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('DialogRoot', () => {
+  it('keeps a default-open dialog closed during server rendering', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+    const readActiveElement = vi.spyOn(Document.prototype, 'activeElement', 'get');
+
+    const html = renderToString(
+      <Dialog.Root defaultOpen onOpenChange={onOpenChange}>
+        <Dialog.Popup data-testid="popup">Content</Dialog.Popup>
+      </Dialog.Root>
+    );
+
+    expect(html).not.toContain('data-testid');
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+    expect(readActiveElement).not.toHaveBeenCalled();
+  });
+
+  it('does not open from an abandoned render', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MockErrorBoundary>
+        <Dialog.Root defaultOpen onOpenChange={onOpenChange}>
+          <Dialog.Popup data-testid="popup">Content</Dialog.Popup>
+        </Dialog.Root>
+        <Throw />
+      </MockErrorBoundary>
+    );
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it('opens once under StrictMode effect replay', async () => {
+    const onOpenChange = vi.fn();
+
+    const { getByRole } = render(
+      <StrictMode>
+        <Dialog.Root defaultOpen onOpenChange={onOpenChange}>
+          <Dialog.Popup>Content</Dialog.Popup>
+        </Dialog.Root>
+      </StrictMode>
+    );
+
+    await waitFor(() => expect(getByRole('dialog')).toBeDefined());
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+});

--- a/packages/react/src/ui/dialog/use-dialog-root.ts
+++ b/packages/react/src/ui/dialog/use-dialog-root.ts
@@ -1,9 +1,10 @@
 import { DialogCore, DialogDataAttrs, type DialogProps, type DialogState, type StateAttrMap } from '@videojs/core';
 import { createDialog, createTransition } from '@videojs/core/dom';
 import { useSnapshot } from '@videojs/store/react';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { useDestroy } from '../../utils/use-destroy';
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { useSafeId } from '../../utils/use-safe-id';
 import type { DialogContextValue } from './context';
@@ -33,22 +34,19 @@ export function useDialogRoot({
   core.setProps({ open: controlledOpen, defaultOpen, closeOnEscape });
 
   const isControlled = controlledOpen !== undefined;
+  const initialOpenRef = useRef(!isControlled && defaultOpen);
   const onOpenChangeRef = useLatestRef(onOpenChangeProp);
   const onOpenChangeCompleteRef = useLatestRef(onOpenChangeCompleteProp);
   const closeOnEscapeRef = useLatestRef(closeOnEscape);
 
-  const [dialog] = useState(() => {
-    const instance = createDialog({
+  const [dialog] = useState(() =>
+    createDialog({
       transition: createTransition(),
       onOpenChange: (nextOpen: boolean) => onOpenChangeRef.current?.(nextOpen),
       onOpenChangeComplete: (nextOpen: boolean) => onOpenChangeCompleteRef.current?.(nextOpen),
       closeOnEscape: () => closeOnEscapeRef.current,
-    });
-
-    if (!isControlled && defaultOpen) instance.open();
-
-    return instance;
-  });
+    })
+  );
 
   const popupId = useSafeId(`${idPrefix}-popup`);
   const titleId = useSafeId(`${idPrefix}-title`);
@@ -57,19 +55,29 @@ export function useDialogRoot({
   core.setTitleId(titleId);
   core.setDescriptionId(descriptionId);
 
-  useEffect(() => {
-    if (controlledOpen === undefined) return;
-
-    const { active: inputOpen } = dialog.input.current;
-    if (controlledOpen === inputOpen) return;
-
-    if (controlledOpen) dialog.open();
-    else dialog.close();
-  }, [controlledOpen, dialog]);
-
   useLayoutEffect(() => {
     dialog.setInteractionRoot(interactionRoot ?? null);
   }, [dialog, interactionRoot]);
+
+  // Commit the initial uncontrolled default or the current controlled value.
+  // Keeping this out of the initializer prevents server and abandoned renders
+  // from reading focus, scheduling animation frames, or notifying consumers.
+  useIsomorphicLayoutEffect(() => {
+    let nextOpen = controlledOpen;
+
+    if (nextOpen === undefined) {
+      if (!initialOpenRef.current) return;
+
+      initialOpenRef.current = false;
+      nextOpen = true;
+    }
+
+    const { active: inputOpen } = dialog.input.current;
+    if (nextOpen === inputOpen) return;
+
+    if (nextOpen) dialog.open();
+    else dialog.close();
+  }, [controlledOpen, dialog]);
 
   useDestroy(dialog);
 

--- a/packages/react/src/ui/popover/popover-root.tsx
+++ b/packages/react/src/ui/popover/popover-root.tsx
@@ -8,11 +8,12 @@ import {
 import { useSnapshot } from '@videojs/store/react';
 import { isUndefined } from '@videojs/utils/predicate';
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useOptionalContainer } from '../../player/context';
 import { useOptionalPopupGroup } from '../../player/popup-group-context';
 import { useDestroy } from '../../utils/use-destroy';
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { useSafeId } from '../../utils/use-safe-id';
 import { useOptionalControlsContext } from '../controls/context';
@@ -49,6 +50,7 @@ export function PopoverRoot({
   core.setProps(coreProps);
 
   const isControlled = !isUndefined(controlledOpen);
+  const initialOpenRef = useRef(!isControlled && defaultOpen);
 
   // Keep refs that always point to the latest values so the
   // createPopover closure never reads stale props.
@@ -80,25 +82,27 @@ export function PopoverRoot({
       group: () => popupGroupRef.current,
     });
 
-    // Apply defaultOpen on creation (uncontrolled only)
-    if (!isControlled && defaultOpen) {
-      instance.open('click');
-    }
-
     return instance;
   });
 
   const anchorName = useSafeId();
   const popupId = useSafeId('popup');
 
-  // Sync controlled open prop -> internal input state.
-  useEffect(() => {
-    if (isUndefined(controlledOpen)) return;
+  // Commit the initial uncontrolled default or the current controlled value.
+  useIsomorphicLayoutEffect(() => {
+    let nextOpen = controlledOpen;
+
+    if (isUndefined(nextOpen)) {
+      if (!initialOpenRef.current) return;
+
+      initialOpenRef.current = false;
+      nextOpen = true;
+    }
 
     const { active: inputOpen } = popover.input.current;
-    if (controlledOpen === inputOpen) return;
+    if (nextOpen === inputOpen) return;
 
-    if (controlledOpen) {
+    if (nextOpen) {
       popover.open('click');
     } else {
       popover.close('click');

--- a/packages/react/src/ui/popover/tests/popover-root.test.tsx
+++ b/packages/react/src/ui/popover/tests/popover-root.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { MockErrorBoundary } from '../../../testing/mocks';
+import * as Popover from '../index.parts';
+
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('PopoverRoot', () => {
+  it('keeps a default-open popover closed during server rendering', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+    const readActiveElement = vi.spyOn(Document.prototype, 'activeElement', 'get');
+
+    const html = renderToString(
+      <Popover.Root defaultOpen onOpenChange={onOpenChange}>
+        <Popover.Popup data-testid="popup">Content</Popover.Popup>
+      </Popover.Root>
+    );
+
+    expect(html).not.toContain('data-testid');
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+    expect(readActiveElement).not.toHaveBeenCalled();
+  });
+
+  it('does not open from an abandoned render', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MockErrorBoundary>
+        <Popover.Root defaultOpen onOpenChange={onOpenChange}>
+          <Popover.Popup data-testid="popup">Content</Popover.Popup>
+        </Popover.Root>
+        <Throw />
+      </MockErrorBoundary>
+    );
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it('opens once under StrictMode effect replay', async () => {
+    const onOpenChange = vi.fn();
+
+    const { getByTestId } = render(
+      <StrictMode>
+        <Popover.Root defaultOpen onOpenChange={onOpenChange}>
+          <Popover.Popup data-testid="popup">Content</Popover.Popup>
+        </Popover.Root>
+      </StrictMode>
+    );
+
+    await waitFor(() => expect(getByTestId('popup')).toBeDefined());
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(true, expect.any(Object));
+  });
+});

--- a/packages/react/src/ui/tooltip/tests/tooltip-root.test.tsx
+++ b/packages/react/src/ui/tooltip/tests/tooltip-root.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { Tooltip } from '..';
+import { MockErrorBoundary } from '../../../testing/mocks';
+
+function Throw(): null {
+  throw new Error('abandon render');
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('TooltipRoot', () => {
+  it('keeps a default-open tooltip closed during server rendering', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+    const readActiveElement = vi.spyOn(Document.prototype, 'activeElement', 'get');
+
+    const html = renderToString(
+      <Tooltip.Root defaultOpen onOpenChange={onOpenChange}>
+        <Tooltip.Popup data-testid="popup">Content</Tooltip.Popup>
+      </Tooltip.Root>
+    );
+
+    expect(html).not.toContain('data-testid');
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+    expect(readActiveElement).not.toHaveBeenCalled();
+  });
+
+  it('does not open from an abandoned render', () => {
+    const onOpenChange = vi.fn();
+    const requestFrame = vi.spyOn(globalThis, 'requestAnimationFrame');
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MockErrorBoundary>
+        <Tooltip.Root defaultOpen onOpenChange={onOpenChange}>
+          <Tooltip.Popup data-testid="popup">Content</Tooltip.Popup>
+        </Tooltip.Root>
+        <Throw />
+      </MockErrorBoundary>
+    );
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it('opens once under StrictMode effect replay', async () => {
+    const onOpenChange = vi.fn();
+
+    const { getByTestId } = render(
+      <StrictMode>
+        <Tooltip.Root defaultOpen onOpenChange={onOpenChange}>
+          <Tooltip.Popup data-testid="popup">Content</Tooltip.Popup>
+        </Tooltip.Root>
+      </StrictMode>
+    );
+
+    await waitFor(() => expect(getByTestId('popup')).toBeDefined());
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(true, expect.any(Object));
+  });
+});

--- a/packages/react/src/ui/tooltip/tooltip-root.tsx
+++ b/packages/react/src/ui/tooltip/tooltip-root.tsx
@@ -8,11 +8,12 @@ import {
 import { useSnapshot } from '@videojs/store/react';
 import { isUndefined } from '@videojs/utils/predicate';
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useOptionalContainer } from '../../player/context';
 import { useOptionalPopupGroup } from '../../player/popup-group-context';
 import { useDestroy } from '../../utils/use-destroy';
+import { useIsomorphicLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 import { useLatestRef } from '../../utils/use-latest-ref';
 import { useSafeId } from '../../utils/use-safe-id';
 import { useOptionalControlsContext } from '../controls/context';
@@ -52,6 +53,7 @@ export function TooltipRoot({
   core.setProps(coreProps);
 
   const isControlled = !isUndefined(controlledOpen);
+  const initialOpenRef = useRef(!isControlled && defaultOpen);
 
   const groupFromContext = useTooltipGroup();
 
@@ -85,11 +87,6 @@ export function TooltipRoot({
       popupGroup: () => popupGroupRef.current,
     });
 
-    // Apply defaultOpen on creation (uncontrolled only)
-    if (!isControlled && defaultOpen) {
-      instance.open();
-    }
-
     return instance;
   });
 
@@ -98,14 +95,21 @@ export function TooltipRoot({
   const anchorName = useSafeId();
   const popupId = useSafeId('tooltip');
 
-  // Sync controlled open prop -> internal input state.
-  useEffect(() => {
-    if (isUndefined(controlledOpen)) return;
+  // Commit the initial uncontrolled default or the current controlled value.
+  useIsomorphicLayoutEffect(() => {
+    let nextOpen = controlledOpen;
+
+    if (isUndefined(nextOpen)) {
+      if (!initialOpenRef.current) return;
+
+      initialOpenRef.current = false;
+      nextOpen = true;
+    }
 
     const { active: inputOpen } = tooltip.input.current;
-    if (controlledOpen === inputOpen) return;
+    if (nextOpen === inputOpen) return;
 
-    if (controlledOpen) {
+    if (nextOpen) {
       tooltip.open();
     } else {
       tooltip.close();


### PR DESCRIPTION
Refs #1679

Depends on #2316.

## Summary

Keep Popover, Tooltip, Dialog, and AlertDialog initialization render-pure by applying default and controlled open state only after React commits. Server and abandoned renders no longer read focus, schedule transition frames, or invoke consumer callbacks.

## Changes

- Create popup APIs closed during render instead of calling `open()` inside the `useState` initializer
- Commit the initial uncontrolled default or the current controlled value in `useIsomorphicLayoutEffect` (from #2316), which also moves the controlled-open sync from a passive effect to a layout effect
- Retarget the dialog change to `packages/react/src/ui/dialog/use-dialog-root.ts`, the hook now shared by `DialogRoot`, `AlertDialogRoot`, and `ErrorDialogRoot`, replacing the earlier `alert-dialog-root.tsx` hunk that `main` rewrote
- Preserve API-owned uncontrolled interaction after initialization via a one-shot `initialOpenRef`
- Split the lifecycle coverage so each root's SSR, abandoned-render, and StrictMode effect-replay tests live beside that root's existing tests: `popover-root.test.tsx`, `tooltip-root.test.tsx`, `dialog-root.test.tsx`, `alert-dialog-root.test.tsx`

## Testing

- `pnpm -F @videojs/react test`: 70 files, 558 tests passed
- `pnpm build --filter=@videojs/react`
- `pnpm typecheck`
- `pnpm lint:fix:file` on touched files and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches open-state timing for widely used overlay primitives; behavior changes for SSR and first paint but is covered by targeted lifecycle tests.
> 
> **Overview**
> **Popover, Tooltip, Dialog, and AlertDialog** no longer call `open()` during the `useState` initializer. Initial **defaultOpen** and **controlled `open`** are applied in **`useIsomorphicLayoutEffect`** after commit, with a one-shot **`initialOpenRef`** so uncontrolled defaults only open once (including under StrictMode replay).
> 
> For **Dialog** (shared **`useDialogRoot`** for Dialog, AlertDialog, and ErrorDialog), controlled-open sync moves from a passive **`useEffect`** to the same commit-phase layout path.
> 
> New root-level tests assert **SSR** leaves default-open overlays closed (no popup markup, **`onOpenChange`**, **`requestAnimationFrame`**, or **`activeElement`**), **abandoned renders** do not open, and **StrictMode** still opens exactly once with a single **`onOpenChange(true)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7eb0e07ac710843128f7b9c58477c56814f2bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->